### PR TITLE
feat(skills): add ci-fix-and-verify and review-response skills

### DIFF
--- a/.claude/skills/ci-fix-and-verify/SKILL.md
+++ b/.claude/skills/ci-fix-and-verify/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: ci-fix-and-verify
+description: PR の CI 失敗を修正し、全 CI がパスするまでプッシュ→待機→修正を繰り返す。「/ci-fix-and-verify [PR番号]」「CI直して」「CIが落ちてる」「CI修正」などの依頼時に使用。
+argument-hint: "[pr-number]"
+allowed-tools: Read, Grep, Glob, Bash, Edit, Write, Agent, Skill
+---
+
+# CI Fix and Verify スキル
+
+PR の CI 失敗を検出・修正し、全 CI チェックがパスするまで自動的にサイクルを回す。
+
+## 使い方
+
+```bash
+/ci-fix-and-verify [PR番号]
+```
+
+引数として PR 番号を受け取る。省略時は現在のブランチに紐づく PR を自動検出する。
+
+## ワークフロー
+
+### Phase 0: 初期化
+
+現在のブランチの PR を特定する。
+
+```bash
+# 引数がない場合、現在のブランチから PR を検出
+CURRENT_BRANCH=$(git branch --show-current)
+PR_NUMBER=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number')
+
+# PR の owner/repo を取得
+REPO_INFO=$(gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"')
+OWNER=$(echo "$REPO_INFO" | cut -d'/' -f1)
+REPO=$(echo "$REPO_INFO" | cut -d'/' -f2)
+```
+
+### Phase 1: CI 状態確認
+
+```bash
+gh pr checks "$PR_NUMBER" --repo "$OWNER/$REPO"
+```
+
+- 全てパスしている場合 → 完了メッセージを出力して終了
+- 失敗がある場合 → Phase 2 へ
+- まだ実行中の場合 → wait-ci.sh で待機してから再確認
+
+### Phase 2: 失敗分析と修正
+
+失敗した各ジョブのログを取得して分析する。
+
+```bash
+# 失敗ジョブのログを取得
+gh run view <run_id> --repo "$OWNER/$REPO" --log-failed
+```
+
+失敗の種類に応じて修正:
+
+| 失敗タイプ      | 修正方法                                                                             |
+| --------------- | ------------------------------------------------------------------------------------ |
+| fmt エラー      | `cargo fmt --all` を実行                                                             |
+| clippy エラー   | `cargo clippy --all-targets --all-features -- -D warnings` の出力を見て修正          |
+| ビルドエラー    | `cargo build --all-targets` の出力を見て修正                                         |
+| テスト失敗      | 該当する `cargo test --test <suite>` を実行し、テストコード or 実装コードを修正      |
+| fixtures ずれ   | `pnpm run generate-fixtures` を再実行してから再度テスト                              |
+| docs / report   | `pnpm run test-and-update` でドキュメントを再生成                                    |
+| Node 側エラー   | `pnpm install` で依存解決、`node scripts/...` の出力を確認                           |
+
+ローカルでは可能な限り **CI と同じコマンド** を流して再現させる。CI ワークフローは `.github/workflows/` を参照。
+
+### Phase 3: プッシュと待機
+
+修正をコミットしてプッシュし、CI の完了を待つ。
+
+```bash
+# pre-commit hook で fmt / clippy が走るので、必ず通してからコミット
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+
+# 変更をコミット（atomic commit、英語の Conventional Commits）
+git add <修正ファイル>
+git commit -m "fix(ci): <修正内容の要約>"
+
+# プッシュ
+git push origin HEAD
+
+# CI 完了まで待機（最大20分）
+bash .claude/skills/ci-fix-and-verify/wait-ci.sh "$OWNER" "$REPO" "$PR_NUMBER"
+```
+
+**wait-ci.sh の出力に応じた分岐**:
+
+| 出力         | アクション                                             |
+| ------------ | ------------------------------------------------------ |
+| `ALL_PASSED` | Phase 4 へ（成功）                                     |
+| `FAILED`     | Phase 2 に戻って再修正                                 |
+| `TIMEOUT`    | 手動で `gh pr checks` を確認し、状況に応じて待機を延長 |
+| `API_ERROR`  | エラーメッセージを表示して終了                         |
+
+### Phase 4: 完了報告
+
+```text
+CI が全てパスしました！
+- 修正回数: X回
+- 修正内容:
+  - [修正1の要約]
+  - [修正2の要約]
+```
+
+## 注意事項
+
+- 修正のたびに **ローカルで** 以下を必ず実行する（pre-commit hook と同じ）:
+  - `cargo fmt --all`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - 関連するテストスイート（最低限 `cargo test --release`）
+- 最大 5 回まで修正サイクルを回す（無限ループ防止）。それを超えても直らない場合はユーザーに状況を報告する。
+- CI 待機は wait-ci.sh を使い、Bash tool の `timeout` を `600000`（10分）に設定する
+- タイムアウト時は再度 wait-ci.sh を実行して待機を延長する
+- `cargo test` をフルで流すと時間がかかるため、CI ログから失敗テストを特定して個別実行を優先する
+- 互換性レポート系の差分の場合は `pnpm run test-and-update` でドキュメントを再生成すること
+- `--no-verify` などのフック回避フラグは使わない

--- a/.claude/skills/ci-fix-and-verify/wait-ci.sh
+++ b/.claude/skills/ci-fix-and-verify/wait-ci.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# CI 完了待機スクリプト
+# 指定された PR の CI チェックが全て完了するまでポーリングする。
+# macOS 標準コマンド（gh, sleep）のみ使用。
+#
+# Usage: bash wait-ci.sh <owner> <repo> <pr_number>
+# Exit codes:
+#   0 - CI が全てパス
+#   1 - CI に失敗あり（stdout に FAILED + 失敗ジョブ一覧を出力）
+#   2 - 連続 API エラー（stdout に API_ERROR を出力）
+#   3 - タイムアウト（stdout に TIMEOUT を出力）
+
+set -euo pipefail
+
+OWNER="${1:?Usage: wait-ci.sh <owner> <repo> <pr_number>}"
+REPO="${2:?}"
+PR="${3:?}"
+
+POLL_INTERVAL=30
+MAX_CONSECUTIVE_ERRORS=3
+MAX_WAIT_SECONDS=1200 # 20分
+consecutive_errors=0
+elapsed=0
+
+while true; do
+  if [ "$elapsed" -ge "$MAX_WAIT_SECONDS" ]; then
+    echo "TIMEOUT"
+    exit 3
+  fi
+
+  sleep "$POLL_INTERVAL"
+  elapsed=$((elapsed + POLL_INTERVAL))
+
+  # CI チェック一覧を取得
+  # gh pr checks は pending (exit 8) や fail (exit 1) で非ゼロを返すので、出力をキャプチャしつつ exit code を別途取得
+  CHECK_EXIT=0
+  CHECKS=$(gh pr checks "$PR" --repo "${OWNER}/${REPO}" 2>&1) || CHECK_EXIT=$?
+
+  # 出力が空 = API エラー（非ゼロ exit code かつ出力なしの場合のみエラー扱い）
+  if [ -z "$CHECKS" ]; then
+    consecutive_errors=$((consecutive_errors + 1))
+    if [ "$consecutive_errors" -ge "$MAX_CONSECUTIVE_ERRORS" ]; then
+      echo "API_ERROR"
+      exit 2
+    fi
+    continue
+  fi
+  consecutive_errors=0
+
+  # "pending" or "skipping" 以外の未完了チェックがあるか確認
+  # gh pr checks の出力: <name>\t<status>\t<duration>\t<url>
+  HAS_PENDING=false
+  HAS_FAIL=false
+  FAILED_JOBS=""
+
+  while IFS=$'\t' read -r name status _duration _url; do
+    case "$status" in
+      pass|skipping)
+        ;;
+      fail)
+        HAS_FAIL=true
+        FAILED_JOBS="${FAILED_JOBS}${name}\n"
+        ;;
+      *)
+        HAS_PENDING=true
+        ;;
+    esac
+  done <<< "$CHECKS"
+
+  if [ "$HAS_PENDING" = true ]; then
+    # まだ実行中のチェックがある
+    continue
+  fi
+
+  if [ "$HAS_FAIL" = true ]; then
+    echo "FAILED"
+    printf '%b' "$FAILED_JOBS"
+    exit 1
+  fi
+
+  # 全てパス
+  echo "ALL_PASSED"
+  exit 0
+done

--- a/.claude/skills/review-response/SKILL.md
+++ b/.claude/skills/review-response/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: review-response
+description: GitHub PR のコードレビューコメントに対応する。未 resolve のみを抽出 → 対応方針をユーザー承認 → 1 件ずつ修正＋返信 → AI レビュー由来の指摘はナレッジに反映するワークフロー。「/review-response [PR番号]」「レビュー対応」「レビューに返信」などの依頼時に使用。
+argument-hint: "[pr-number]"
+allowed-tools: Read, Grep, Glob, Bash, Edit, Write, Agent, Skill
+---
+
+# Review Response — GitHub PR レビュー対応スキル
+
+GitHub PR でレビューコメントを受け取った際の対応手順。
+
+- [対応の基本原則](#対応の基本原則)
+- [対応ワークフロー](#対応ワークフロー)
+  - [0. レビューコメントを全件取得する](#0-レビューコメントを全件取得する)
+  - [1. 対応方針をユーザーに確認する（必須）](#1-対応方針をユーザーに確認する必須)
+  - [2. コメントを 1 つずつ対応](#2-コメントを-1-つずつ対応)
+  - [3. コードを修正してコミット](#3-コードを修正してコミット)
+  - [4. GitHub コメントに返信](#4-github-コメントに返信)
+  - [5. ナレッジフィードバック（AI レビューコメントの場合）](#5-ナレッジフィードバックai-レビューコメントの場合)
+- [返信のフォーマット](#返信のフォーマット)
+- [GitHub API でコメント返信](#github-api-でコメント返信)
+- [対応例](#対応例)
+
+## 対応の基本原則
+
+| 原則                   | 内容                                               |
+| ---------------------- | -------------------------------------------------- |
+| 未 resolve に着目      | resolve 済みは対応不要。未 resolve のみ対応        |
+| 1 つずつ対応           | 複数コメントがあっても 1 つずつ順番に対応          |
+| 必ず返信               | 対応したら必ずそのコメントに返信（スレッド形式）   |
+| コミットハッシュを記載 | 返信には対応したコミットハッシュを必ず含める       |
+| 変更不要でも説明       | 変更しない場合も、なぜ不要なのか理由を明記して返信 |
+| ページングで全件確認   | コメントが多い場合、API のページングで全件取得する |
+
+## 対応ワークフロー
+
+### 0. レビューコメントを全件取得する
+
+未 resolve のレビュースレッドのみを GraphQL で取得する（REST API では resolve 状態が取れない）。
+
+```bash
+# 引数から PR 番号を取得（省略時は現在ブランチから）
+PR_NUMBER="${1:-$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number')}"
+
+# owner/repo
+REPO_INFO=$(gh repo view --json owner,name --jq '"\(.owner.login)|\(.name)"')
+OWNER="${REPO_INFO%|*}"
+REPO="${REPO_INFO#*|}"
+
+# 未 resolve のレビュースレッドを取得
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            path
+            line
+            comments(first: 20) {
+              nodes {
+                databaseId
+                body
+                author { login }
+                url
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER"
+```
+
+スレッド数が 100 を超える場合は `pageInfo` を使ってページングする。
+
+### 1. 対応方針をユーザーに確認する（必須）
+
+**コードの修正やコメントへの返信を行う前に、必ずこのステップを実行すること。**
+
+未 resolve のコメントを全件取得したら、各コメントについて現在のコードを読んで検証し、以下の情報を表形式でユーザーに提示する：
+
+| #   | ファイル              | 指摘内容（要約） | 判定                      | 対応方針                               |
+| --- | --------------------- | ---------------- | ------------------------- | -------------------------------------- |
+| 1   | path/to/file.rs:L42   | 指摘の要約       | **要修正** / **対応不要** | 具体的な修正内容 or 不要と判断した理由 |
+
+判定の基準：
+
+- **要修正**: 指摘が正しく、コード修正が必要
+- **対応不要**: 指摘が現在のコードに該当しない（既に修正済み、コード削除済み等）、または指摘内容が技術的に誤り
+
+**ユーザーの承認を得てから、次のステップに進むこと。** ユーザーが方針を修正した場合はそれに従う。
+
+### 2. コメントを 1 つずつ対応
+
+ユーザーの承認後、未 resolve のコメントのみを対象に 1 つずつ順番に対応する。これにより：
+
+- 各コメントへの対応が明確になる
+- コミット履歴が追跡しやすくなる
+- レビュアーが確認しやすくなる
+
+### 3. コードを修正してコミット
+
+各コメントに対応したら、その変更をコミットする。
+
+- pre-commit hook（`cargo fmt && cargo clippy`）を必ず通す
+- コミットメッセージは英語の Conventional Commits（`fix:`, `refactor:`, `perf:` など）
+- 関連するテストスイートをローカルで実行してから push
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --release --test <関連スイート>
+
+git add <修正ファイル>
+git commit -m "fix(<scope>): <変更内容の要約>"
+git push origin HEAD
+```
+
+### 4. GitHub コメントに返信
+
+コミット後、GitHub コメントにスレッド形式で返信する（[返信のフォーマット](#返信のフォーマット)参照）。
+
+### 5. ナレッジフィードバック（AI レビューコメントの場合）
+
+レビューコメントの投稿者が AI ボット（`coderabbitai[bot]`、`devin-ai-integration[bot]`、`chatgpt-codex-connector[bot]`、`claude[bot]` など）の場合、対応後に以下のフィードバックループを実行する。
+
+#### 要修正だった場合 → ナレッジへの反映を検討
+
+指摘が正しく、実際にコード修正を行った場合：
+
+1. 以下を横断検索し、同じパターンが既に記述されているか確認：
+   - `CLAUDE.md`（プロジェクト全体の方針）
+   - `.claude/skills/*/SKILL.md`（rsvelte 固有のスキル群: `full-code-review`, `verify-svelte-compat`, `perf` など）
+2. **記述がない場合**: 最も適したスキルファイル or `CLAUDE.md` に新しいパターンとして追記する
+3. **記述がある場合**: スキルに書いてあるのに指摘された理由を考える
+   - スキルの記述が不明確 → 記述を改善
+   - スキルのコード例が不足 → 例を追加
+   - 特に問題なし → スキップ
+4. 追記・改善した場合はユーザーに報告する
+
+#### 対応不要だった場合 → 再発防止
+
+指摘が的外れで、変更不要と判断した場合：
+
+1. 該当するスキルファイル or `CLAUDE.md` に「これは問題ない」という文脈を追記する
+   - 例: 「公式 Svelte コンパイラと意図的に異なる挙動」「Rust 固有の最適化のため意図的にこの形」など
+2. 追記した場合はユーザーに報告する
+
+**注意**: スキル / `CLAUDE.md` の追記・改善はユーザーに確認してから行うこと。
+
+## 返信のフォーマット
+
+返信は **指摘者の言語に合わせる**（日本語の指摘には日本語、英語の指摘には英語）。OSS なので英語が多い。
+
+### コード修正を行った場合（英語）
+
+```markdown
+Thanks for the catch!
+
+[summary of the fix]
+
+Fixed in: abc1234
+```
+
+### 変更不要と判断した場合（英語）
+
+```markdown
+Thanks for the review!
+
+[reasoning for keeping the current implementation]
+
+- [reason 1]
+- [reason 2]
+- [link to spec / official Svelte source if relevant]
+
+I'll keep the current implementation for the reasons above.
+```
+
+### コード修正を行った場合（日本語）
+
+```markdown
+ご指摘ありがとうございます！
+
+[対応内容の説明]
+
+対応コミット: abc1234
+```
+
+### 変更不要と判断した場合（日本語）
+
+```markdown
+ご指摘ありがとうございます！
+
+[変更不要と判断した理由の説明]
+
+- [根拠 1]
+- [根拠 2]
+- [必要に応じて参考リンクや仕様書への参照]
+
+上記の理由から、現状の実装を維持させていただきます。
+```
+
+## GitHub API でコメント返信
+
+```bash
+# スレッド形式で返信（pull request review comment への reply）
+gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies" \
+  -f body="返信内容"
+```
+
+`COMMENT_ID` は GraphQL で取得した `databaseId` を使う。
+
+## 対応例
+
+### 修正対応の例
+
+**レビューコメント** (`coderabbitai[bot]`):
+
+> The `unwrap()` on line 42 will panic if the iterator is empty. Consider using `unwrap_or_default()` or handling the error explicitly.
+
+**返信**:
+
+```markdown
+Good catch — switched to `unwrap_or_default()` since an empty iterator is a valid state in this code path.
+
+Fixed in: 7f8e9a1
+```
+
+**追加対応** (`unwrap_or_default` 系の指摘なので、ナレッジに同じパターンが既にあるか `CLAUDE.md` を確認 → なければユーザーに追記提案)
+
+### 変更不要の場合の例
+
+**レビューコメント**:
+
+> Why use `compact_str` instead of `String` here?
+
+**返信**:
+
+```markdown
+This matches the official Svelte compiler's intent of keeping symbol names compact in memory. `CompactString` inlines small strings (≤24 bytes) without heap allocation, which is the common case for Svelte identifiers.
+
+See `CLAUDE.md` → "Memory-efficient layout (u32 positions, compact_str)".
+
+Keeping the current implementation.
+```
+
+## 注意事項
+
+- 指摘者の言語（英語/日本語）に合わせて返信する
+- 必ず未 resolve のスレッドのみを対象にする
+- 1 件ずつ対応＋コミット＋返信（バッチで対応すると追跡が困難）
+- AI ボットからの指摘は「ナレッジ反映が必要か」を毎回検討する
+- 公式 Svelte と意図的に挙動を変えている箇所は、その旨を明記して返信する


### PR DESCRIPTION
## Summary

Borrowed two skills from `flyle-nexus` and adapted them for the rsvelte stack.

- **`ci-fix-and-verify`** — detect failing PR CI checks, push fixes, and loop until all checks pass. Swapped pnpm/lint commands for `cargo fmt`, `cargo clippy`, `cargo test`, plus the rsvelte fixtures / compatibility-report flow.
- **`review-response`** — structured workflow for replying to GitHub PR review comments: fetch unresolved threads, get user approval on the plan, fix one-by-one, feed AI-bot findings back into `CLAUDE.md` or the relevant skill. Reply templates cover both English and Japanese since rsvelte is OSS.

Skipped from the source repo: `pr-workflow` (Japanese-only conventions), `qa` (Playwright + nexus DB-specific), `run-check-and-test` (monorepo-specific), and the `guide-*` / `nexus-*` / `figma-*` skills (project-specific domain knowledge).

## Test plan

- [ ] `Skill` tool picks up `ci-fix-and-verify` and `review-response`
- [ ] `wait-ci.sh` is executable (`chmod +x` applied)
- [ ] `/ci-fix-and-verify` runs end-to-end on a future failing PR
- [ ] `/review-response` correctly fetches unresolved threads via GraphQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)