### PR TITLE
fix(ci): use pnpm in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,20 +37,25 @@ jobs:
       - name: Build WASM
         run: wasm-pack build --target web --no-default-features --features wasm
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
           cache-dependency-path: docs/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: docs
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build docs
         working-directory: docs
-        run: npm run build
+        run: pnpm build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- `Deploy Docs to GitHub Pages` has been failing on every push to `main` because the workflow runs `npm ci` against the docs workspace, which only ships `pnpm-lock.yaml`.
- Switch the docs build to `pnpm/action-setup` + `pnpm install --frozen-lockfile` + `pnpm build`, matching how the rest of the workflows install Node deps.
- Update the `actions/setup-node` cache from `npm` → `pnpm` (the dependency path was already pointed at `docs/pnpm-lock.yaml`).

## Test plan
- [ ] Wait for `Deploy Docs to GitHub Pages` to pass on this PR
- [ ] After merge, confirm the same workflow succeeds on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)