### PR TITLE
ci: mark windows test job as non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    # Windows is currently a known-failing target (737 runtime fixture
+    # `client=MISMATCH` regressions vs. macOS/Ubuntu — see issue tracking).
+    # We still run it as a signal so the gap can be closed later, but it
+    # must not block merges to main while the Windows-specific divergence
+    # is under investigation.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- The `Test (windows-latest)` matrix entry on `main` currently produces ~1488 unique runtime-fixture mismatches that don't repro on macOS or Ubuntu (both clean).
- Windows-only divergence in code generation needs investigation, but in the meantime it must not block merges. This PR adds `continue-on-error: ${{ matrix.os == 'windows-latest' }}` so the Windows job still runs as a signal but its failure no longer fails the workflow.
- macOS and Ubuntu remain blocking, so the cross-platform regression stays detectable while we drive the Windows gap to zero.

## Why now
Latest run on `main` ([run 25252295100](https://github.com/baseballyama/rsvelte/actions/runs/25252295100)) showed:
- 737 `client=MISMATCH | server=OK` (runtime-legacy)
- 750 `client=MISMATCH | server=MISMATCH` (runtime-runes)
- macOS / Ubuntu: 0 failures, ~3.5min
- Windows: 11+ minutes for the test step, then fails

Sample diffs from the failure artifact (Windows actual vs. fixture):

```diff
- 			tick: (t) => {
+ 			tick: t => {
```
```diff
- 	const arr = Array.from({ length: 10001 });
+ 	const arr = Array.from({length: 10001});
```
```diff
- 		intro_count(intro_count() + 1);
+ 		intro_count(intro_count() + (1));
```

These look like JS-printer divergences (single-arg arrow paren emission, object literal spacing, operator-side parenthesization). Tracking and fix to be done as a separate effort.

## Test plan
- [ ] Confirm Windows still runs but no longer blocks the workflow on this branch.
- [ ] On a follow-up regression touching `src/compiler/print/`, confirm Windows still surfaces the failure (visible, just not blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)