### PR TITLE
ci: drop windows-latest from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,43 +53,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
-      # Force LF line endings on Windows checkouts so the Svelte test
-      # fixtures (input.svelte, expected output.json/.css) parse with
-      # the same byte offsets / scoped-selector decisions as on Linux.
-      # Must run before `actions/checkout` because Git applies
-      # autocrlf during the initial checkout.
-      - name: Configure git for LF line endings
-        shell: bash
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
       - uses: actions/checkout@v4
         with:
           submodules: true
-
-      # Belt-and-suspenders: even with `core.autocrlf=false` set globally,
-      # `actions/checkout` and `git submodule update` sometimes apply
-      # CRLF conversion on Windows runners (the official compiler then
-      # reads files with `\r\n` line endings, which leak into template
-      # literals in the generated client.js and diff against our LF
-      # output). Explicitly strip `\r\n` → `\n` on every source file in
-      # the submodule before fixture generation.
-      - name: Normalize line endings in svelte submodule
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Get-ChildItem -Path svelte -Recurse -File -Include *.svelte,*.js,*.ts,*.json,*.html,*.css,*.md `
-            | Where-Object { $_.FullName -notlike '*\node_modules\*' -and $_.FullName -notlike '*\.git\*' } `
-            | ForEach-Object {
-              $content = [System.IO.File]::ReadAllText($_.FullName)
-              if ($content -match "`r`n") {
-                $normalized = $content -replace "`r`n", "`n"
-                [System.IO.File]::WriteAllText($_.FullName, $normalized)
-              }
-            }
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Windows produces 1,488 unique runtime-fixture mismatches on `main` while macOS and Ubuntu pass cleanly. Sample diffs point at a JS-printer divergence (single-arg arrow paren stripping, object-literal whitespace collapse, operator-side parenthesization).
- Investigating that divergence is a sizeable effort and shouldn't gate every push to main in the meantime — drop `windows-latest` from the matrix entirely.
- The Windows-only scaffolding (`Configure git for LF line endings` + PowerShell `Normalize line endings in svelte submodule`) is removed alongside since it had no other purpose.

Windows compatibility remains a goal of the project — this is a temporary removal until the printer divergence is fixed and Windows can re-join the matrix.

## Sample diffs (Windows actual vs. fixture, from run [25252295100](https://github.com/baseballyama/rsvelte/actions/runs/25252295100/job/74046132226))

```diff
- 			tick: (t) => {
+ 			tick: t => {
```
```diff
- 	const arr = Array.from({ length: 10001 });
+ 	const arr = Array.from({length: 10001});
```
```diff
- 		intro_count(intro_count() + 1);
+ 		intro_count(intro_count() + (1));
```

## Test plan
- [ ] CI on this PR shows only `Test (ubuntu-latest)` and `Test (macos-latest)` (no Windows job).
- [ ] All other jobs (Format, Clippy, Build, Documentation, Compatibility Report, Coverage) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)