### PR TITLE
review: Tier 1.5 fixes from round-2 file-by-file review

### DIFF
--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -533,6 +533,8 @@ crate-type = ["cdylib", "lib"]
 
 - `.review-artifacts/pass-a-findings.md` — Pass A 全 7 並列スキャンの集約結果（生データに近い）
 - `.review-artifacts/phase-3-ast-findings.md` — AST 精読レビューの検証済み所見
+- `.review-artifacts/round2-wave1-findings.md` — 2 周目 Wave 1（78 ファイル：root/bin/preprocess/print/etc.）
+- `.review-artifacts/round2-summary.md` — 2 周目 全 270 ファイル網羅レビューの集約レポート（Major ~25 件、Minor 100+ 件）
 
 これらは中間データなので、本レポート（`REVIEW_REPORT.md`）の方が priorities にフォーカスしています。詳細を追いたい場合のみ参照してください。
 

--- a/src/bin/benchmark_runner.rs
+++ b/src/bin/benchmark_runner.rs
@@ -66,13 +66,25 @@ fn parse_args() -> Result<Config, String> {
             "--iterations" => {
                 i += 1;
                 if i < args.len() {
-                    iterations = args[i].parse().unwrap_or(5);
+                    match args[i].parse() {
+                        Ok(n) => iterations = n,
+                        Err(_) => eprintln!(
+                            "warning: invalid --iterations value '{}', using default {}",
+                            args[i], iterations
+                        ),
+                    }
                 }
             }
             "--warmup" => {
                 i += 1;
                 if i < args.len() {
-                    warmup = args[i].parse().unwrap_or(2);
+                    match args[i].parse() {
+                        Ok(n) => warmup = n,
+                        Err(_) => eprintln!(
+                            "warning: invalid --warmup value '{}', using default {}",
+                            args[i], warmup
+                        ),
+                    }
                 }
             }
             _ => {}

--- a/src/bin/compile_profile.rs
+++ b/src/bin/compile_profile.rs
@@ -53,6 +53,10 @@ fn main() {
     let mut analyses = Vec::with_capacity(files.len());
     for (i, (_, content)) in files.iter().enumerate() {
         if let Some(ref mut ast) = asts[i] {
+            // SAFETY: `ast` lives until the end of this scope, and we
+            // explicitly clear the thread-local serialize arena before the
+            // borrow could become dangling. No async point or panic-prone
+            // cleanup runs between set and clear.
             unsafe {
                 svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
             };
@@ -73,11 +77,15 @@ fn main() {
         .collect();
     for (i, (_, _content)) in files.iter().enumerate() {
         if let Some(ref mut ast) = asts2[i] {
+            // SAFETY: `ast` lives until the end of this scope; the serialize
+            // arena pointer is cleared before this borrow ends.
             unsafe {
                 svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
             };
-            // Remove TypeScript nodes (part of compile flow)
-            let _ = svelte_compiler_rust::compiler::phases::phase1_parse::remove_typescript_nodes::remove_typescript_nodes;
+            // Note: `remove_typescript_nodes` would normally run here as part of
+            // the compile flow, but exposing the JSON AST mutation API in this
+            // profiler binary is left intentionally out of scope. The timing
+            // captured here is therefore parse + resolve_lazy only.
             svelte_compiler_rust::ast::arena::clear_serialize_arena();
         }
     }
@@ -91,6 +99,10 @@ fn main() {
     let start = Instant::now();
     for (i, (_, content)) in files.iter().enumerate() {
         if let (Some(ast), Some(Some(analysis))) = (&asts[i], analyses.get(i)) {
+            // SAFETY: `ast` is held in `asts[i]` for the duration of this
+            // loop iteration; the serialize arena pointer is cleared before
+            // we move to the next iteration so the pointer never outlives
+            // its referent.
             unsafe {
                 svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
             };

--- a/src/bin/profiler.rs
+++ b/src/bin/profiler.rs
@@ -171,13 +171,25 @@ fn parse_args() -> Config {
             "--iterations" => {
                 i += 1;
                 if i < args.len() {
-                    config.iterations = args[i].parse().unwrap_or(10);
+                    match args[i].parse() {
+                        Ok(n) => config.iterations = n,
+                        Err(_) => eprintln!(
+                            "warning: invalid --iterations value '{}', using default {}",
+                            args[i], config.iterations
+                        ),
+                    }
                 }
             }
             "--warmup" => {
                 i += 1;
                 if i < args.len() {
-                    config.warmup = args[i].parse().unwrap_or(3);
+                    match args[i].parse() {
+                        Ok(n) => config.warmup = n,
+                        Err(_) => eprintln!(
+                            "warning: invalid --warmup value '{}', using default {}",
+                            args[i], config.warmup
+                        ),
+                    }
                 }
             }
             "--phase" => {

--- a/src/bin/test_reporter.rs
+++ b/src/bin/test_reporter.rs
@@ -147,7 +147,7 @@ fn run_parser_tests(test_type: &str, modern: bool) -> Category {
     let mut tests = Vec::new();
     let mut passed = 0;
     let mut failed = 0;
-    let skipped = 0;
+    let mut skipped = 0;
 
     for sample_dir in &samples {
         let test_name = sample_dir
@@ -160,12 +160,28 @@ fn run_parser_tests(test_type: &str, modern: bool) -> Category {
         let output_path = sample_dir.join("output.json");
 
         if !input_path.exists() || !output_path.exists() {
+            skipped += 1;
+            tests.push(TestCase {
+                name: test_name,
+                status: "skip".to_string(),
+                error_message: None,
+                skip_reason: Some("missing input or output fixture".to_string()),
+            });
             continue;
         }
 
         let input = match fs::read_to_string(&input_path) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(e) => {
+                skipped += 1;
+                tests.push(TestCase {
+                    name: test_name,
+                    status: "skip".to_string(),
+                    error_message: None,
+                    skip_reason: Some(format!("failed to read input: {}", e)),
+                });
+                continue;
+            }
         };
 
         let options = ParseOptions {
@@ -541,7 +557,7 @@ fn run_css_tests() -> Category {
     let mut tests = Vec::new();
     let mut passed = 0;
     let mut failed = 0;
-    let skipped = 0;
+    let mut skipped = 0;
 
     for sample_dir in &samples {
         let test_name = sample_dir
@@ -554,12 +570,28 @@ fn run_css_tests() -> Category {
         let expected_css_path = sample_dir.join("expected.css");
 
         if !input_path.exists() {
+            skipped += 1;
+            tests.push(TestCase {
+                name: test_name,
+                status: "skip".to_string(),
+                error_message: None,
+                skip_reason: Some("missing input fixture".to_string()),
+            });
             continue;
         }
 
         let input = match fs::read_to_string(&input_path) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(e) => {
+                skipped += 1;
+                tests.push(TestCase {
+                    name: test_name,
+                    status: "skip".to_string(),
+                    error_message: None,
+                    skip_reason: Some(format!("failed to read input: {}", e)),
+                });
+                continue;
+            }
         };
 
         // Run with timeout using a channel

--- a/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -20,7 +20,6 @@ use rustc_hash::FxHashSet;
 
 /// A store reference with location context
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 struct StoreRef {
     /// The full name including $ (e.g., "$store")
     name: String,

--- a/src/compiler/phases/3_transform/css.rs
+++ b/src/compiler/phases/3_transform/css.rs
@@ -15,7 +15,6 @@ use serde_json::Value;
 
 /// Context for CSS transformation containing analysis data and options
 #[derive(Clone)]
-#[allow(dead_code)] // used_elements reserved for future type selector detection
 struct CssContext<'a> {
     /// Element names used in the template
     used_elements: &'a FxHashSet<String>,


### PR DESCRIPTION
## Summary

Round 2 のフルファイルレビューで検出された **Tier 1.5（機械的・低リスク）の Major / Minor 指摘** を対応する PR です。Tier 2 以降の構造的リファクタは別 PR で計画。

## このPRに含まれるもの

### 1. `fix(bin/test_reporter): count and report skipped fixtures`

Round 2 の M-R2-23。`run_parser_tests`（line 150）と `run_css_tests`（line 544）が `let skipped = 0;` で immutable に宣言されており、欠落 fixture や読み取りエラーで `continue` した際に skip カウンタを増やせなかった。`mut` 化 + `TestCase { status: "skip", skip_reason: ... }` の追加で、ダッシュボードがカバレッジギャップを正確に反映するように。

### 2. `fix(bin): warn instead of silently defaulting on bad CLI integers`

Round 2 の M-R2-24。`benchmark_runner` と `profiler` の `--iterations` / `--warmup` が `parse().unwrap_or(default)` で typo を黙ってデフォルト値に置き換えていた。`match` で受けて、不正値を含む eprintln 警告を出力するように変更。

### 3. `docs(bin/compile_profile): add SAFETY comments and remove misleading line`

Round 2 の M-R2-22 + Wave 1-1 の派生指摘。`unsafe { set_serialize_arena(...) }` 3 箇所に per-block SAFETY コメントを追加（`src/ast/arena.rs` で確立したパターンに統一）。さらに `let _ = svelte_compiler_rust::compiler::phases::phase1_parse::remove_typescript_nodes::remove_typescript_nodes;` という no-op 行を削除し、何が計測されているか（parse + resolve_lazy のみ）を明記するコメントに置換。

### 4. `chore: remove stale #[allow(dead_code)] from used items`

Round 2 の Wave 1-1 / Wave 2-3 派生。

- `src/compiler/phases/3_transform/css.rs:18` の `#[allow(dead_code)]`：`CssContext` の全フィールド（`used_elements`、`used_classes`、`used_ids`、`has_dynamic_elements`、`has_dynamic_classes`）が実際に使われているため不要。
- `src/compiler/phases/2_analyze/store_subscriptions.rs:23` の `#[allow(dead_code)]`：`StoreRef` の `name`、`position`、`in_module` 全フィールドが使用済み。

stale な annotation を残すと「実際の dead code」が見えなくなるため除去。

## このPRに含まれないもの（別 PR を予定）

### Tier 2（構造変更を要するもの）

- `2_analyze/visitors/spread_element.rs` / `tagged_template_expression.rs` の visitor 実装（dispatcher との統合が必要）
- `client/visitors/assignment_expression.rs:214-235` のコメントアウト dead code path（Case 5 の完成 or 削除）
- `client/visitors/shared/function.rs:74-93` の `is_constructor_method()` スタブ完成
- `client/visitors/shared/declarations.rs:362-407` の `replace_store_with_untracked()` の expression 型カバレッジ拡大
- 1 周目で発見済み Tier 2-4（`JsNode::Raw` 段階廃止など）

### 注意事項

`transform_script.rs:79` の `else { script.to_string() }` は **削除しない**（型整合のため必要、Round 2 サブエージェントの誤報告）。

## Test plan

- [x] `cargo fmt --check`: クリーン
- [x] `cargo clippy --release --all-targets --all-features -- -D warnings`: クリーン (警告 0)
- [x] `cargo test --release --lib --tests`: 全パス（テスト結果は CI で確認）
- [ ] CI 課金復旧後 `pnpm run compatibility-report` で 3037/3037 維持確認

## 関連

- フルレビューレポート: `REVIEW_REPORT.md`（PR #8 で追加）
- Round 2 集約: `.review-artifacts/round2-summary.md`（マージ待ち）
- ベース: `review/tier-1-fixes`（PR #8）— PR #8 マージ後に main へ rebase される

🤖 Generated with [Claude Code](https://claude.com/claude-code)