### PR TITLE
review: Tier 1.7 — remove unused helpers in 2_analyze/visitors/shared

### DIFF
--- a/src/compiler/phases/2_analyze/control_flow.rs
+++ b/src/compiler/phases/2_analyze/control_flow.rs
@@ -6,7 +6,7 @@
 //! The algorithm is a faithful port of Svelte's `get_possible_element_siblings()` in css-prune.js.
 
 use super::types::{DomStructure, SiblingCertainty};
-use crate::ast::template::{Attribute, Fragment, IfBlock, TemplateNode};
+use crate::ast::template::{Attribute, Fragment, TemplateNode};
 use rustc_hash::FxHashMap;
 
 /// Node existence values, mirroring Svelte's NODE_DEFINITELY_EXISTS / NODE_PROBABLY_EXISTS.
@@ -556,22 +556,6 @@ fn is_block(node: &TemplateNode) -> bool {
     )
 }
 
-/// Check if an if block is "exhaustive" (always renders something).
-#[allow(dead_code)]
-fn is_if_block_exhaustive(block: &IfBlock) -> bool {
-    match &block.alternate {
-        None => false,
-        Some(alt_fragment) => {
-            if alt_fragment.nodes.len() == 1
-                && let Some(TemplateNode::IfBlock(inner_if)) = alt_fragment.nodes.first()
-            {
-                return is_if_block_exhaustive(inner_if);
-            }
-            !alt_fragment.nodes.is_empty()
-        }
-    }
-}
-
 /// Check if any entry in the map has NODE_DEFINITELY_EXISTS.
 fn has_definite_elements(map: &FxHashMap<usize, u8>) -> bool {
     map.values().any(|&v| v == NODE_DEFINITELY_EXISTS)
@@ -592,10 +576,7 @@ fn add_to_map_entry(map: &mut FxHashMap<usize, u8>, key: usize, value: u8) {
 
 /// Returns the higher existence value (DEFINITELY > PROBABLY > 0).
 fn higher_existence(a: u8, b: u8) -> u8 {
-    if b == 0 {
-        return a;
-    }
-    if a > b { a } else { b }
+    a.max(b)
 }
 
 /// Mark elements that are adjacent to opaque boundaries (slots, render tags, components).

--- a/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -451,30 +451,3 @@ fn is_quoted_single_expression(attr: &AttributeNode) -> bool {
         false
     }
 }
-
-/// Check if a component uses two-way binding.
-pub fn has_two_way_binding(component: &Component) -> bool {
-    component
-        .attributes
-        .iter()
-        .any(|attr| matches!(attr, Attribute::BindDirective(_)))
-}
-
-/// Get the names of props passed to a component.
-pub fn get_prop_names(component: &Component) -> Vec<String> {
-    let mut props = Vec::new();
-
-    for attr in &component.attributes {
-        match attr {
-            Attribute::Attribute(a) => {
-                props.push(a.name.to_string());
-            }
-            Attribute::BindDirective(b) => {
-                props.push(b.name.to_string());
-            }
-            _ => {}
-        }
-    }
-
-    props
-}

--- a/src/compiler/phases/2_analyze/visitors/shared/function.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/function.rs
@@ -45,28 +45,6 @@ where
     context.function_depth = original_depth;
 }
 
-/// Check if we're inside a function context.
-pub fn is_inside_function(context: &VisitorContext) -> bool {
-    context.function_depth > 0
-}
-
-/// Get the current function depth.
-pub fn get_function_depth(context: &VisitorContext) -> usize {
-    context.function_depth
-}
-
-/// Enter a function context (increment depth).
-pub fn enter_function(context: &mut VisitorContext) {
-    context.function_depth += 1;
-}
-
-/// Exit a function context (decrement depth).
-pub fn exit_function(context: &mut VisitorContext) {
-    if context.function_depth > 0 {
-        context.function_depth -= 1;
-    }
-}
-
 /// Check if an identifier is a rune.
 /// Uses first-byte dispatch after '$' for fast rejection.
 #[inline]
@@ -91,75 +69,5 @@ pub fn is_rune(name: &str) -> bool {
         b'i' => matches!(name, "$inspect" | "$inspect().with" | "$inspect.trace"),
         b'h' => name == "$host",
         _ => false,
-    }
-}
-
-/// Get the rune type from a name.
-pub fn get_rune_type(name: &str) -> Option<RuneType> {
-    match name {
-        "$state" => Some(RuneType::State),
-        "$state.raw" => Some(RuneType::StateRaw),
-        "$state.eager" => Some(RuneType::StateEager),
-        "$state.snapshot" => Some(RuneType::StateSnapshot),
-        "$derived" => Some(RuneType::Derived),
-        "$derived.by" => Some(RuneType::DerivedBy),
-        "$props" => Some(RuneType::Props),
-        "$props.id" => Some(RuneType::PropsId),
-        "$bindable" => Some(RuneType::Bindable),
-        "$effect" => Some(RuneType::Effect),
-        "$effect.pre" => Some(RuneType::EffectPre),
-        "$effect.tracking" => Some(RuneType::EffectTracking),
-        "$effect.root" => Some(RuneType::EffectRoot),
-        "$effect.pending" => Some(RuneType::EffectPending),
-        "$inspect" => Some(RuneType::Inspect),
-        "$inspect().with" => Some(RuneType::InspectWith),
-        "$inspect.trace" => Some(RuneType::InspectTrace),
-        "$host" => Some(RuneType::Host),
-        _ => None,
-    }
-}
-
-/// Types of runes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RuneType {
-    State,
-    StateRaw,
-    StateEager,
-    StateSnapshot,
-    Derived,
-    DerivedBy,
-    Props,
-    PropsId,
-    Bindable,
-    Effect,
-    EffectPre,
-    EffectTracking,
-    EffectRoot,
-    EffectPending,
-    Inspect,
-    InspectWith,
-    InspectTrace,
-    Host,
-}
-
-impl RuneType {
-    /// Check if this rune creates reactive state.
-    pub fn is_reactive_state(&self) -> bool {
-        matches!(
-            self,
-            RuneType::State
-                | RuneType::StateRaw
-                | RuneType::StateEager
-                | RuneType::Derived
-                | RuneType::DerivedBy
-        )
-    }
-
-    /// Check if this rune is an effect.
-    pub fn is_effect(&self) -> bool {
-        matches!(
-            self,
-            RuneType::Effect | RuneType::EffectPre | RuneType::EffectRoot
-        )
     }
 }

--- a/src/compiler/phases/2_analyze/visitors/shared/snippets.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/snippets.rs
@@ -34,20 +34,6 @@ pub fn get_snippet_name(snippet: &SnippetBlock) -> Option<String> {
     snippet.expression.identifier_name().map(String::from)
 }
 
-/// Check if a snippet has parameters.
-pub fn has_parameters(snippet: &SnippetBlock) -> bool {
-    !snippet.parameters.is_empty()
-}
-
-/// Get parameter names from a snippet.
-pub fn get_parameter_names(snippet: &SnippetBlock) -> Vec<String> {
-    snippet
-        .parameters
-        .iter()
-        .filter_map(|param| param.identifier_name().map(String::from))
-        .collect()
-}
-
 /// Returns `true` if a binding unambiguously resolves to a specific
 /// snippet declaration, or is external to the current component.
 ///

--- a/src/compiler/phases/2_analyze/visitors/shared/special_element.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/special_element.rs
@@ -7,23 +7,6 @@
 use super::super::super::AnalysisError;
 use super::super::VisitorContext;
 
-/// Check if a tag name is a special Svelte element.
-pub fn is_special_element(name: &str) -> bool {
-    matches!(
-        name,
-        "svelte:self"
-            | "svelte:component"
-            | "svelte:element"
-            | "svelte:fragment"
-            | "svelte:head"
-            | "svelte:body"
-            | "svelte:window"
-            | "svelte:document"
-            | "svelte:options"
-            | "svelte:boundary"
-    )
-}
-
 /// Validate special element placement.
 pub fn validate_special_element_placement(
     name: &str,
@@ -60,30 +43,6 @@ pub fn validate_special_element_placement(
     }
 
     Ok(())
-}
-
-/// Get the allowed attributes for a special element.
-pub fn get_allowed_attributes(name: &str) -> &'static [&'static str] {
-    match name {
-        "svelte:head" => &[],
-        "svelte:body" => &["on:", "use:"],
-        "svelte:window" => &["on:", "bind:"],
-        "svelte:document" => &["on:", "bind:"],
-        "svelte:fragment" => &["slot"],
-        "svelte:self" => &[], // Accepts all props like a component
-        "svelte:component" => &["this"],
-        "svelte:element" => &["this"],
-        "svelte:options" => &[
-            "runes",
-            "namespace",
-            "customElement",
-            "css",
-            "immutable",
-            "accessors",
-        ],
-        "svelte:boundary" => &["onerror", "failed"],
-        _ => &[],
-    }
 }
 
 /// Disallow children for specific special elements.


### PR DESCRIPTION
## Summary

Tier 1.6 (PR #10) で削除しきれなかった残りの dead helper を 5 ファイルから掃除する PR です。

195 行の dead code を削除（実挙動変更ゼロ）:

- \`special_element.rs\`: \`is_special_element\` + \`get_allowed_attributes\`
- \`function.rs\`: \`is_inside_function\`、\`enter_function\`、\`exit_function\`、\`get_function_depth\`、\`get_rune_type\` + \`RuneType\` enum
- \`component.rs\`: \`has_two_way_binding\`、\`get_prop_names\`
- \`snippets.rs\`: \`has_parameters\`、\`get_parameter_names\`
- \`control_flow.rs\`: \`is_if_block_exhaustive\` 削除 + \`higher_existence\` を \`a.max(b)\` に置換

## なぜこれらが安全か

- すべての関数を grep で全 src/ から検索して呼び出しなしを確認済み
- 削除した \`#[allow(dead_code)]\` annotation も実体がない fn のものだけ
- \`higher_existence\` の \`a.max(b)\` 置換は \`u8: Ord\` に依存した同値変換

## Test plan

- [x] \`cargo build --release\`: 成功
- [x] \`cargo clippy --release --all-targets --all-features -- -D warnings\`: クリーン
- [x] \`cargo test --release --lib --tests\`: 全パス

## ベースブランチ

\`review/tier-1-6-cleanup\`（PR #10）

🤖 Generated with [Claude Code](https://claude.com/claude-code)