### PR TITLE
review: Tier 2 wave2 — metadata consumption + snippet renderer linking

### DIFF
--- a/src/ast/template.rs
+++ b/src/ast/template.rs
@@ -766,6 +766,17 @@ impl serde::Serialize for BindDirective {
     }
 }
 
+/// Metadata populated during Phase 2 analysis for `on:` directives.
+///
+/// Skipped from (de)serialisation so snapshot output is unchanged.
+#[derive(Debug, Clone, Default)]
+pub struct OnDirectiveMetadata {
+    /// Mirrors `node.metadata.expression` from the official compiler so
+    /// Phase 3 can decide whether the handler needs `$.derived(...)`-style
+    /// memoisation without re-walking the expression.
+    pub expression: ExpressionMetadata,
+}
+
 /// An on directive: `on:event={handler}`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct OnDirective {
@@ -775,6 +786,10 @@ pub struct OnDirective {
     pub name_loc: Option<SourceLocation>,
     pub expression: Option<Expression>,
     pub modifiers: SmallVec<[CompactString; 2]>,
+    /// Internal metadata, populated during Phase 2 analysis. Skipped during
+    /// (de)serialisation so snapshot output is unchanged.
+    #[serde(skip)]
+    pub metadata: OnDirectiveMetadata,
 }
 
 impl serde::Serialize for OnDirective {

--- a/src/ast/template.rs
+++ b/src/ast/template.rs
@@ -814,6 +814,17 @@ impl serde::Serialize for OnDirective {
     }
 }
 
+/// Metadata populated during Phase 2 analysis for `class:` directives.
+///
+/// Skipped from (de)serialisation so snapshot output is unchanged.
+#[derive(Debug, Clone, Default)]
+pub struct ClassDirectiveMetadata {
+    /// Mirrors `node.metadata.expression` from the official compiler so
+    /// Phase 3 can decide whether the directive needs `$.derived(...)`-style
+    /// memoisation without re-walking the expression.
+    pub expression: ExpressionMetadata,
+}
+
 /// A class directive: `class:name={expression}`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ClassDirective {
@@ -822,6 +833,10 @@ pub struct ClassDirective {
     pub name: CompactString,
     pub name_loc: Option<SourceLocation>,
     pub expression: Expression,
+    /// Internal metadata, populated during Phase 2 analysis. Skipped during
+    /// (de)serialisation so snapshot output is unchanged.
+    #[serde(skip)]
+    pub metadata: ClassDirectiveMetadata,
 }
 
 impl serde::Serialize for ClassDirective {

--- a/src/compiler/phases/1_parse/state/element.rs
+++ b/src/compiler/phases/1_parse/state/element.rs
@@ -1553,6 +1553,7 @@ impl Parser<'_> {
                 name: CompactString::from(class_name),
                 name_loc,
                 expression,
+                metadata: Default::default(),
             },
         )))
     }

--- a/src/compiler/phases/1_parse/state/element.rs
+++ b/src/compiler/phases/1_parse/state/element.rs
@@ -1283,6 +1283,7 @@ impl Parser<'_> {
                 name_loc,
                 expression,
                 modifiers,
+                metadata: Default::default(),
             },
         )))
     }

--- a/src/compiler/phases/2_analyze/visitors/class_directive.rs
+++ b/src/compiler/phases/2_analyze/visitors/class_directive.rs
@@ -17,7 +17,7 @@ use crate::compiler::phases::phase2_analyze::AnalysisError;
 /// This function marks the subtree as dynamic (since class: directives require runtime evaluation)
 /// and tracks the expression for dependency analysis.
 pub fn visit(
-    directive: &ClassDirective,
+    directive: &mut ClassDirective,
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
     // Mark the subtree containing this directive as dynamic
@@ -31,12 +31,11 @@ pub fn visit(
         .used_classes
         .insert(directive.name.to_string());
 
-    // Walk the expression to track dependencies and references
-    // This is important for legacy state promotion - if a class directive
-    // references a mutable variable, it needs to be tracked as a template reference
+    // Walk the expression to track dependencies and references and populate
+    // `directive.metadata.expression` so Phase 3 can read `has_call` /
+    // `has_state` / `has_await` without re-walking the expression.
     let node = directive.expression.as_node();
-    let mut metadata = crate::ast::template::ExpressionMetadata::default();
-    walk_js_expression_node(&node, context, &mut metadata)?;
+    walk_js_expression_node(&node, context, &mut directive.metadata.expression)?;
 
     Ok(())
 }

--- a/src/compiler/phases/2_analyze/visitors/on_directive.rs
+++ b/src/compiler/phases/2_analyze/visitors/on_directive.rs
@@ -60,19 +60,12 @@ pub fn visit(
     // Mark the subtree as dynamic (event handlers require runtime evaluation)
     mark_subtree_dynamic(&context.path);
 
-    // Walk the expression to track dependencies and references
+    // Walk the expression to track dependencies and references and populate
+    // `directive.metadata.expression` so Phase 3 can read `has_call` /
+    // `has_state` without re-walking the expression.
     if let Some(ref expression) = directive.expression {
-        // Create metadata for tracking expression dependencies
-        // Note: In the full implementation, this metadata would be attached to
-        // the parent element's metadata.expression field
-        let mut metadata = crate::ast::template::ExpressionMetadata::default();
-
         let node = expression.as_node();
-        walk_js_expression_node(&node, context, &mut metadata)?;
-
-        // The metadata tracking is handled by the parent element visitor
-        // (RegularElement, SvelteElement, etc.) which creates and manages
-        // the metadata.expression field
+        walk_js_expression_node(&node, context, &mut directive.metadata.expression)?;
     }
 
     Ok(())

--- a/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -1036,10 +1036,8 @@ pub fn visit(
                 }
             }
             Attribute::ClassDirective(_) => {
-                // Re-borrow the class directive for the visit call
-                if let Attribute::ClassDirective(class_dir) = &element.attributes[i] {
-                    super::class_directive::visit(class_dir, context)?;
-                }
+                // Visit happens in a second mutable pass below so that
+                // `class_directive::visit` can populate `directive.metadata`.
             }
             Attribute::StyleDirective(_) => {
                 // Re-borrow the style directive for the visit call
@@ -1067,23 +1065,30 @@ pub fn visit(
         }
     }
 
-    // Second pass for OnDirective which requires mutable borrow
+    // Second pass for OnDirective / ClassDirective which require mutable borrow
+    // (they need to populate `metadata.expression`).
     for attr in &mut element.attributes {
-        if let Attribute::OnDirective(on) = attr {
-            // In runes mode, warn about deprecated event directive usage
-            // on RegularElement (not components). This is done here because
-            // on_directive::visit doesn't have access to the parent type.
-            // Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/visitors/OnDirective.js
-            if context.analysis.runes {
-                context.emit_warning(warnings::event_directive_deprecated(&on.name));
-            }
+        match attr {
+            Attribute::OnDirective(on) => {
+                // In runes mode, warn about deprecated event directive usage
+                // on RegularElement (not components). This is done here because
+                // on_directive::visit doesn't have access to the parent type.
+                // Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/visitors/OnDirective.js
+                if context.analysis.runes {
+                    context.emit_warning(warnings::event_directive_deprecated(&on.name));
+                }
 
-            // Track event directive for mixed_event_handler_syntaxes check
-            // This is a RegularElement, so we track it
-            if context.event_directive_node.is_none() {
-                context.event_directive_node = Some(on.name.to_string());
+                // Track event directive for mixed_event_handler_syntaxes check
+                // This is a RegularElement, so we track it
+                if context.event_directive_node.is_none() {
+                    context.event_directive_node = Some(on.name.to_string());
+                }
+                on_directive::visit(on, context)?;
             }
-            on_directive::visit(on, context)?;
+            Attribute::ClassDirective(class_dir) => {
+                super::class_directive::visit(class_dir, context)?;
+            }
+            _ => {}
         }
     }
 

--- a/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -62,48 +62,57 @@ pub fn visit_component(
         }
     }
 
-    // TODO: Link this node to all snippets it could render
-    // node.metadata.snippets = new Set()
+    // Determine which snippets this component might render. `resolved` is
+    // true when we can list those candidates exactly; if false, the official
+    // compiler treats every locally-defined snippet as a possible render
+    // target, so Phase 3 must not rely on the set being a precise list.
     //
-    // 'resolved' means we know which snippets this component might render.
-    // If false, then node.metadata.snippets is populated with every locally
-    // defined snippet once analysis is complete.
+    // We currently only resolve the easy cases — an expression attribute
+    // whose value is a literal can never reference a snippet, so it doesn't
+    // taint resolution. Identifier / member / call expressions, spreads,
+    // and bind directives all leave us with no static knowledge of which
+    // snippet the component will receive, so they fall back to "unresolved".
     let mut resolved = true;
-
-    // Analyze attributes to determine which snippets might be rendered
     for attr in &component.attributes {
         match attr {
             Attribute::SpreadAttribute(_) | Attribute::BindDirective(_) => {
-                // Can't resolve snippets if there are spreads or bindings
                 resolved = false;
             }
             Attribute::Attribute(a) => {
-                // Check if this is an expression attribute
-                if matches!(
-                    &a.value,
-                    crate::ast::template::AttributeValue::Expression(_)
-                ) {
-                    // TODO: Analyze the expression to see if it references snippets
-                    // For now, we conservatively mark as unresolved
-                    // The full implementation would:
-                    // 1. Extract the expression
-                    // 2. If it's an Identifier, check if it resolves to a snippet
-                    // 3. If it's a Literal, it doesn't reference snippets
-                    // 4. Otherwise, mark as unresolved
+                if let crate::ast::template::AttributeValue::Expression(expr_tag) = &a.value {
+                    let expr_type = expr_tag.expression.node_type().unwrap_or("");
+                    if expr_type != "Literal" {
+                        // Identifier / member / call etc. — could reference a
+                        // snippet binding we can't statically resolve here.
+                        resolved = false;
+                    }
                 }
             }
             _ => {}
         }
     }
 
-    // If resolved, collect snippet blocks from children
-    if resolved {
-        // TODO: Iterate over component.fragment.nodes and add SnippetBlocks
-        // to node.metadata.snippets
+    // Even when `resolved` is false, the official compiler still seeds the
+    // metadata set with the locally-defined snippets (so the runtime can
+    // pick from the right pool). When `resolved` is true, the same seed
+    // is the actually-rendered set. We use the SnippetBlock's `start`
+    // offset as a stable identity within a single parse.
+    component.metadata.snippets.clear();
+    for node in &component.fragment.nodes {
+        if let TemplateNode::SnippetBlock(snippet) = node {
+            component.metadata.snippets.insert(snippet.start as usize);
+        }
     }
 
-    // TODO: context.state.analysis.snippet_renderers.set(node, resolved)
-    // This requires tracking snippet renderers in the analysis
+    // Track this component as a snippet renderer in the analysis so Phase 3
+    // can decide whether to emit the resolved-set fast path or the
+    // every-local-snippet fallback. The key is encoded with the component's
+    // `start` offset (unique within a parse) so multiple components on the
+    // same name remain distinct.
+    context
+        .analysis
+        .snippet_renderers
+        .insert(format!("Component@{}", component.start), resolved);
 
     // Mark the subtree as dynamic
     super::super::shared::fragment::mark_subtree_dynamic(&context.path);

--- a/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -257,7 +257,7 @@ pub fn visit(
                 super::attribute::visit(attr_node, context)?;
             }
             Attribute::ClassDirective(cd) => {
-                super::script::walk_expression(&cd.expression, context)?;
+                super::class_directive::visit(cd, context)?;
             }
             Attribute::StyleDirective(sd) => {
                 super::style_directive::visit(sd, context)?;

--- a/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -330,13 +330,13 @@ pub fn build_event_handler(
         }
     }
 
-    // Check if the expression contains a call
-    // TODO: This should check metadata.has_call from the expression tag
-    // For now, we'll do a simple check
-    // `expr_tag.metadata.expression.has_call()` is populated by Phase 2's
-    // ExpressionTag visitor (`walk_js_expression_node`), so we can read it
-    // directly instead of re-walking the expression here.
-    let has_call = expr_tag.metadata.expression.has_call();
+    // Memoisation here uses the same broad "any CallExpression in the tree"
+    // semantics as the rest of Phase 3 — see `expression_tag_has_call` in
+    // `shared/element.rs` for why we don't read Phase 2's narrower flag.
+    let has_call =
+        crate::compiler::phases::phase3_transform::client::visitors::shared::element::expression_tag_has_call(
+            expr_tag,
+        );
 
     let mut js_expr = js_expr;
 

--- a/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -882,13 +882,14 @@ pub fn visit_regular_element(
                 // Special case: $effect.pending() is inherently reactive (tracks async
                 // pending state) even though it has no local bindings or transforms.
                 // It must NOT use the textContent optimization - it needs to be in a
-                // template_effect callback for proper reactivity.
-                // Phase 2 already cached has_call on the tag metadata.
+                // template_effect callback for proper reactivity. Use the
+                // broad "any CallExpression in the tree" check that the rest
+                // of Phase 3 uses for memoisation decisions.
                 !super::shared::utils::is_effect_pending_expr(
                     &expr_tag.expression,
                     context.state.parse_arena,
                 ) && !expression_has_reactive_state(&expr_tag.expression, context)
-                    && !expr_tag.metadata.expression.has_call()
+                    && !super::shared::element::expression_tag_has_call(expr_tag)
             }
             _ => false,
         }

--- a/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -882,14 +882,17 @@ pub fn visit_regular_element(
                 // Special case: $effect.pending() is inherently reactive (tracks async
                 // pending state) even though it has no local bindings or transforms.
                 // It must NOT use the textContent optimization - it needs to be in a
-                // template_effect callback for proper reactivity. Use the
-                // broad "any CallExpression in the tree" check that the rest
-                // of Phase 3 uses for memoisation decisions.
+                // template_effect callback for proper reactivity. Phase 2's
+                // narrow `has_call` (non-pure callee only) is what we want
+                // here — pure calls like `(7.36).toString()` are still
+                // eligible for the static textContent shortcut, while
+                // `$effect.tracking()` / `$effect.pending()` correctly drop
+                // out because Phase 2 marks them as has_call.
                 !super::shared::utils::is_effect_pending_expr(
                     &expr_tag.expression,
                     context.state.parse_arena,
                 ) && !expression_has_reactive_state(&expr_tag.expression, context)
-                    && !super::shared::element::expression_tag_has_call(expr_tag)
+                    && !expr_tag.metadata.expression.has_call()
             }
             _ => false,
         }

--- a/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -84,10 +84,13 @@ where
             let has_reactive_state =
                 super::utils::expression_has_reactive_state(&expr_tag.expression, context);
 
-            // Phase 3 needs the broad "any CallExpression in the tree" check
-            // for memoisation decisions; Phase 2's cached has_call follows the
-            // narrower official semantics. See `expression_tag_has_call`.
-            let has_call = expression_tag_has_call(expr_tag);
+            // The Phase 2 cached `has_call` is the narrow "non-pure callee"
+            // flag (matches the official compiler). Component prop / dynamic
+            // CSS prop memoisation reads this through the closure passed to
+            // `build_attribute_value`, so feeding it the broad walk would
+            // wrap pure calls like `<Child prop={encodeURIComponent('x')}>`
+            // in `$.derived(...)` (regresses the `purity` snapshot fixture).
+            let has_call = expr_tag.metadata.expression.has_call();
 
             // Apply transforms via build_expression (handles props: x -> x())
             let transformed = build_expression(context, &expression, &metadata);
@@ -131,9 +134,10 @@ where
                     let has_reactive_state =
                         super::utils::expression_has_reactive_state(&expr_tag.expression, context);
 
-                    // Phase 3 needs the broad "any CallExpression in the tree"
-                    // check for memoisation decisions; see `expression_tag_has_call`.
-                    let has_call = expression_tag_has_call(expr_tag);
+                    // Use Phase 2's narrow has_call (matches the official
+                    // compiler) — see the matching comment in the
+                    // `AttributeValue::Expression` arm above for why.
+                    let has_call = expr_tag.metadata.expression.has_call();
 
                     // Apply transforms via build_expression (handles props: x -> x())
                     let transformed = build_expression(context, &expression, &metadata);
@@ -347,7 +351,6 @@ fn extract_expression_from_tag(expr_tag: &ExpressionTag) -> JsExpr {
 /// later in the pipeline are accounted for.
 fn extract_metadata_from_tag(expr_tag: &ExpressionTag) -> ExpressionMetadata {
     let mut metadata = ExpressionMetadata::default();
-    metadata.references = expr_tag.metadata.expression.references.clone();
 
     let val = expr_tag.expression.as_json();
     if !is_literal_value(val) {

--- a/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -329,113 +329,28 @@ fn extract_expression_from_tag(expr_tag: &ExpressionTag) -> JsExpr {
 
 /// Extract metadata from an ExpressionTag.
 ///
-/// Walks the JSON AST to determine has_call and has_member_expression flags.
+/// Phase 2's `ExpressionTag` visitor (`walk_js_expression_node`) already
+/// populates `expr_tag.metadata.expression` with `has_call`, `has_await`,
+/// `has_member_expression`, `has_assignment`, dependencies, and
+/// references. Convert that template-level metadata into the Phase 3
+/// shape via the existing `from_template_metadata` bit-copy and reset
+/// `has_state`/`dynamic` to match the previous behaviour — the caller
+/// recomputes `has_state` via `expression_has_reactive_state(...)` so
+/// that transforms registered later in the pipeline are accounted for.
 fn extract_metadata_from_tag(expr_tag: &ExpressionTag) -> ExpressionMetadata {
-    let val = expr_tag.expression.as_json();
-    // Single-pass extraction of all metadata flags from the AST.
-    // Replaces 4+ separate walks (ast_contains_node_type * 4 + expression_has_await)
-    // with one combined walk.
-    let mut has_call = false;
-    let mut has_member = false;
-    let mut has_assignment = false;
-    let mut has_await = false;
-
-    if !is_literal_value(val) {
-        ast_extract_metadata_flags(
-            val,
-            &mut has_call,
-            &mut has_member,
-            &mut has_assignment,
-            &mut has_await,
-        );
-    }
-
-    let mut metadata = ExpressionMetadata::default();
-    metadata.set_has_call(has_call);
-    metadata.set_has_await(has_await);
-    // has_state is set by the caller using expression_has_reactive_state
+    let mut metadata = ExpressionMetadata::from_template_metadata(&expr_tag.metadata.expression);
     metadata.set_has_state(false);
-    metadata.set_has_member_expression(has_member);
-    metadata.set_has_assignment(has_assignment);
     metadata.set_dynamic(false);
-    // blockers defaults to empty Vec
     metadata
-}
-
-/// Single-pass AST walk to extract metadata flags (has_call, has_member, has_assignment, has_await).
-///
-/// Replaces multiple calls to `ast_contains_node_type` + `expression_has_await` with
-/// a single recursive walk. Skips function bodies (matching Phase 2 behavior).
-/// Short-circuits once all flags are set.
-fn ast_extract_metadata_flags(
-    val: &serde_json::Value,
-    has_call: &mut bool,
-    has_member: &mut bool,
-    has_assignment: &mut bool,
-    has_await: &mut bool,
-) {
-    // Short-circuit if all flags already true
-    if *has_call && *has_member && *has_assignment && *has_await {
-        return;
-    }
-
-    match val {
-        serde_json::Value::Object(obj) => {
-            let this_type = obj.get("type").and_then(|t| t.as_str());
-
-            // Check each flag
-            if let Some(t) = this_type {
-                if !*has_call && t == "CallExpression" {
-                    *has_call = true;
-                }
-                if !*has_member && t == "MemberExpression" {
-                    *has_member = true;
-                }
-                if !*has_assignment && (t == "AssignmentExpression" || t == "UpdateExpression") {
-                    *has_assignment = true;
-                }
-                if !*has_await && t == "AwaitExpression" {
-                    *has_await = true;
-                }
-
-                // Short-circuit after checking this node
-                if *has_call && *has_member && *has_assignment && *has_await {
-                    return;
-                }
-
-                // Do NOT recurse into function bodies (matches Phase 2 behavior)
-                if matches!(
-                    t,
-                    "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration"
-                ) {
-                    return;
-                }
-            }
-
-            // Recurse into all fields
-            for v in obj.values() {
-                ast_extract_metadata_flags(v, has_call, has_member, has_assignment, has_await);
-                if *has_call && *has_member && *has_assignment && *has_await {
-                    return;
-                }
-            }
-        }
-        serde_json::Value::Array(arr) => {
-            for v in arr {
-                ast_extract_metadata_flags(v, has_call, has_member, has_assignment, has_await);
-                if *has_call && *has_member && *has_assignment && *has_await {
-                    return;
-                }
-            }
-        }
-        _ => {}
-    }
 }
 
 /// Check if a JSON value represents a literal (non-reactive) value.
 ///
-/// Literals include: numbers, strings, booleans, null, undefined
-/// These never have state and don't need reactive wrappers.
+/// Literals include: numbers, strings, booleans, null, undefined.
+/// Only used by the test module now that `extract_metadata_from_tag`
+/// reads the cached Phase 2 metadata directly; kept around because the
+/// tests cover what counts as "literal" for snapshot stability.
+#[cfg(test)]
 fn is_literal_value(val: &serde_json::Value) -> bool {
     match val {
         serde_json::Value::Null => true,

--- a/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -84,12 +84,10 @@ where
             let has_reactive_state =
                 super::utils::expression_has_reactive_state(&expr_tag.expression, context);
 
-            // Phase 2's ExpressionTag visitor sets `has_call` (and `has_state`)
-            // on `expr_tag.metadata.expression` after running the same
-            // non-pure-call check the official compiler does. Read the cached
-            // result instead of re-walking the expression.
-            // See: 2-analyze/visitors/CallExpression.js
-            let has_call = expr_tag.metadata.expression.has_call();
+            // Phase 3 needs the broad "any CallExpression in the tree" check
+            // for memoisation decisions; Phase 2's cached has_call follows the
+            // narrower official semantics. See `expression_tag_has_call`.
+            let has_call = expression_tag_has_call(expr_tag);
 
             // Apply transforms via build_expression (handles props: x -> x())
             let transformed = build_expression(context, &expression, &metadata);
@@ -133,9 +131,9 @@ where
                     let has_reactive_state =
                         super::utils::expression_has_reactive_state(&expr_tag.expression, context);
 
-                    // Include non-pure function calls in has_state (matches official compiler behavior).
-                    // Phase 2 already cached this on `expr_tag.metadata.expression`.
-                    let has_call = expr_tag.metadata.expression.has_call();
+                    // Phase 3 needs the broad "any CallExpression in the tree"
+                    // check for memoisation decisions; see `expression_tag_has_call`.
+                    let has_call = expression_tag_has_call(expr_tag);
 
                     // Apply transforms via build_expression (handles props: x -> x())
                     let transformed = build_expression(context, &expression, &metadata);
@@ -222,10 +220,9 @@ where
                 let expression = extract_expression_from_tag_with_context(expr_tag, context);
                 let mut metadata = extract_metadata_from_tag(expr_tag);
 
-                // Use the purity-aware has_call check so that pure calls (like
-                // encodeURIComponent('hello')) are not treated as needing memoization.
-                // Phase 2 already cached this on `expr_tag.metadata.expression`.
-                let chunk_has_call = expr_tag.metadata.expression.has_call();
+                // Phase 3 needs the broad "any CallExpression in the tree" check
+                // for memoisation decisions; see `expression_tag_has_call`.
+                let chunk_has_call = expression_tag_has_call(expr_tag);
                 metadata.set_has_call(chunk_has_call);
 
                 // Update metadata.has_state with comprehensive reactive state check
@@ -329,28 +326,76 @@ fn extract_expression_from_tag(expr_tag: &ExpressionTag) -> JsExpr {
 
 /// Extract metadata from an ExpressionTag.
 ///
-/// Phase 2's `ExpressionTag` visitor (`walk_js_expression_node`) already
-/// populates `expr_tag.metadata.expression` with `has_call`, `has_await`,
-/// `has_member_expression`, `has_assignment`, dependencies, and
-/// references. Convert that template-level metadata into the Phase 3
-/// shape via the existing `from_template_metadata` bit-copy and reset
-/// `has_state`/`dynamic` to match the previous behaviour — the caller
-/// recomputes `has_state` via `expression_has_reactive_state(...)` so
-/// that transforms registered later in the pipeline are accounted for.
+/// Phase 2's `ExpressionTag` visitor populates `expr_tag.metadata.expression`
+/// with `has_await`, `has_member_expression`, `has_assignment`, dependencies
+/// and references — copy those across via `from_template_metadata`.
+///
+/// `has_call` is recomputed from the JSON because Phase 2's
+/// `walk_js_expression_node` follows the official compiler and only sets
+/// `has_call` for *non-pure* calls (callee binds to a local) or calls that
+/// touch dependencies. Several Phase 3 consumers of this metadata
+/// (attribute memoisation, etc.) historically expect `has_call` to mean
+/// "any `CallExpression` in the tree" so they wrap things like
+/// `class={fn()}` in `$.derived(...)`. Until those consumers are migrated
+/// to the narrower official semantics, we preserve the broad check here to
+/// avoid regressing 22+ runtime fixtures that depend on it.
 fn extract_metadata_from_tag(expr_tag: &ExpressionTag) -> ExpressionMetadata {
     let mut metadata = ExpressionMetadata::from_template_metadata(&expr_tag.metadata.expression);
     metadata.set_has_state(false);
     metadata.set_dynamic(false);
+    let val = expr_tag.expression.as_json();
+    if !is_literal_value(val) {
+        metadata.set_has_call(json_contains_call(val));
+    }
     metadata
+}
+
+/// True when the ExpressionTag contains a `CallExpression` somewhere in
+/// its tree (excluding nested function bodies). Phase 3 uses this broad
+/// definition for memoisation decisions; the cached
+/// `expr_tag.metadata.expression.has_call()` set by Phase 2 follows the
+/// official compiler's narrower "non-pure callee" semantics, which is
+/// not yet what the rest of Phase 3 expects.
+pub fn expression_tag_has_call(expr_tag: &ExpressionTag) -> bool {
+    let val = expr_tag.expression.as_json();
+    if is_literal_value(val) {
+        false
+    } else {
+        json_contains_call(val)
+    }
+}
+
+/// True when `val` (or any descendant, except inside function bodies)
+/// contains a `CallExpression`. Mirrors the broad recursive check that
+/// `extract_metadata_from_tag` used before bd01699.
+fn json_contains_call(val: &serde_json::Value) -> bool {
+    match val {
+        serde_json::Value::Object(obj) => {
+            if let Some(t) = obj.get("type").and_then(|t| t.as_str()) {
+                if t == "CallExpression" {
+                    return true;
+                }
+                // Don't recurse into function bodies — matches Phase 2's
+                // walker, which also stops at function boundaries.
+                if matches!(
+                    t,
+                    "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration"
+                ) {
+                    return false;
+                }
+            }
+            obj.values().any(json_contains_call)
+        }
+        serde_json::Value::Array(arr) => arr.iter().any(json_contains_call),
+        _ => false,
+    }
 }
 
 /// Check if a JSON value represents a literal (non-reactive) value.
 ///
 /// Literals include: numbers, strings, booleans, null, undefined.
-/// Only used by the test module now that `extract_metadata_from_tag`
-/// reads the cached Phase 2 metadata directly; kept around because the
-/// tests cover what counts as "literal" for snapshot stability.
-#[cfg(test)]
+/// `extract_metadata_from_tag` short-circuits on these so it never walks
+/// the JSON looking for `CallExpression`.
 fn is_literal_value(val: &serde_json::Value) -> bool {
     match val {
         serde_json::Value::Null => true,

--- a/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -326,28 +326,94 @@ fn extract_expression_from_tag(expr_tag: &ExpressionTag) -> JsExpr {
 
 /// Extract metadata from an ExpressionTag.
 ///
-/// Phase 2's `ExpressionTag` visitor populates `expr_tag.metadata.expression`
-/// with `has_await`, `has_member_expression`, `has_assignment`, dependencies
-/// and references — copy those across via `from_template_metadata`.
+/// Compute Phase-3 metadata flags by walking the expression's JSON.
 ///
-/// `has_call` is recomputed from the JSON because Phase 2's
-/// `walk_js_expression_node` follows the official compiler and only sets
-/// `has_call` for *non-pure* calls (callee binds to a local) or calls that
-/// touch dependencies. Several Phase 3 consumers of this metadata
-/// (attribute memoisation, etc.) historically expect `has_call` to mean
-/// "any `CallExpression` in the tree" so they wrap things like
-/// `class={fn()}` in `$.derived(...)`. Until those consumers are migrated
-/// to the narrower official semantics, we preserve the broad check here to
-/// avoid regressing 22+ runtime fixtures that depend on it.
+/// `expr_tag.metadata.expression` (set by Phase 2) is **not** reliable
+/// for the ExpressionTags that live inside attribute / style-directive
+/// `AttributeValue::Sequence` parts, because the parent visitors only
+/// walk the inner expression with a scratch `ExpressionMetadata` and
+/// throw it away. Reading the field would yield all-default flags and
+/// silently break things like `<p style:font-size="{settings.fontSize}px">`,
+/// which then loses its `($.get(...), $.untrack(() => ...))` legacy-state
+/// untrack wrapper.
+///
+/// The cheaper "use the cached metadata" path is fine for the
+/// standalone-expression call sites (where the ExpressionTag visitor
+/// did run in Phase 2) but we don't currently distinguish those, so do
+/// the broad walk here for every consumer.
+///
+/// `has_state` / `dynamic` are reset; the caller recomputes `has_state`
+/// via `expression_has_reactive_state(...)` so transforms registered
+/// later in the pipeline are accounted for.
 fn extract_metadata_from_tag(expr_tag: &ExpressionTag) -> ExpressionMetadata {
-    let mut metadata = ExpressionMetadata::from_template_metadata(&expr_tag.metadata.expression);
-    metadata.set_has_state(false);
-    metadata.set_dynamic(false);
+    let mut metadata = ExpressionMetadata::default();
+    metadata.references = expr_tag.metadata.expression.references.clone();
+
     let val = expr_tag.expression.as_json();
     if !is_literal_value(val) {
-        metadata.set_has_call(json_contains_call(val));
+        let mut has_call = false;
+        let mut has_member = false;
+        let mut has_assignment = false;
+        let mut has_await = false;
+        walk_metadata_flags(
+            val,
+            &mut has_call,
+            &mut has_member,
+            &mut has_assignment,
+            &mut has_await,
+        );
+        metadata.set_has_call(has_call);
+        metadata.set_has_member_expression(has_member);
+        metadata.set_has_assignment(has_assignment);
+        metadata.set_has_await(has_await);
     }
     metadata
+}
+
+/// Single-pass walk that sets the four AST-derived flags on which
+/// Phase 3 memoisation / untrack wrapping decisions depend. Mirrors the
+/// pre-bd01699 `ast_extract_metadata_flags` helper.
+fn walk_metadata_flags(
+    val: &serde_json::Value,
+    has_call: &mut bool,
+    has_member: &mut bool,
+    has_assignment: &mut bool,
+    has_await: &mut bool,
+) {
+    if *has_call && *has_member && *has_assignment && *has_await {
+        return;
+    }
+    match val {
+        serde_json::Value::Object(obj) => {
+            if let Some(t) = obj.get("type").and_then(|t| t.as_str()) {
+                match t {
+                    "CallExpression" => *has_call = true,
+                    "MemberExpression" => *has_member = true,
+                    "AssignmentExpression" | "UpdateExpression" => *has_assignment = true,
+                    "AwaitExpression" => *has_await = true,
+                    "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration" => {
+                        return;
+                    }
+                    _ => {}
+                }
+            }
+            for v in obj.values() {
+                walk_metadata_flags(v, has_call, has_member, has_assignment, has_await);
+                if *has_call && *has_member && *has_assignment && *has_await {
+                    return;
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr {
+                walk_metadata_flags(v, has_call, has_member, has_assignment, has_await);
+                if *has_call && *has_member && *has_assignment && *has_await {
+                    return;
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 /// True when the ExpressionTag contains a `CallExpression` somewhere in

--- a/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -437,13 +437,13 @@ pub fn build_class_directives_object_with_memoizer(
         let directive_has_state =
             super::utils::expression_has_reactive_state(&directive.expression, context);
 
-        // Check if directive has calls (non-pure function calls)
-        // In the official compiler, the CallExpression analyze visitor sets has_state = true
-        // when there are non-pure calls, so we include has_call in has_state.
-        let directive_has_call = super::utils::expression_has_call(&directive.expression, context);
+        // Phase 2's `ClassDirective` visitor already cached this on
+        // `directive.metadata.expression.has_call()`, so consume the cached
+        // value rather than re-walking the expression.
+        let directive_has_call = directive.metadata.expression.has_call();
 
         // Check if directive has await
-        has_await = has_await || super::utils::expression_has_await(&directive.expression);
+        has_await = has_await || directive.metadata.expression.has_await();
 
         if directive_has_state || directive_has_call {
             has_state = true;

--- a/src/compiler/phases/3_transform/client/visitors/shared/events.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/events.rs
@@ -99,125 +99,6 @@ pub fn convert_arrow_to_named_function(handler: JsExpr, name: CompactString) -> 
     }
 }
 
-/// Check if a JSON expression contains a call expression.
-/// This is used to determine if an event handler needs to be memoized.
-fn expression_has_call(expr: &Expression) -> bool {
-    json_value_has_call(expr.as_json())
-}
-
-/// Check if a JSON value contains a call expression.
-fn json_value_has_call(value: &serde_json::Value) -> bool {
-    match value {
-        serde_json::Value::Object(obj) => {
-            let node_type = obj
-                .get("type")
-                .and_then(|t| t.as_str())
-                .unwrap_or("Unknown");
-
-            // If this is a CallExpression, return true
-            if node_type == "CallExpression" {
-                return true;
-            }
-
-            // Recurse into child expressions based on node type
-            match node_type {
-                "MemberExpression" => {
-                    if let Some(object) = obj.get("object")
-                        && json_value_has_call(object)
-                    {
-                        return true;
-                    }
-                    if let Some(property) = obj.get("property")
-                        && obj
-                            .get("computed")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false)
-                        && json_value_has_call(property)
-                    {
-                        return true;
-                    }
-                }
-                "BinaryExpression" | "LogicalExpression" => {
-                    if let Some(left) = obj.get("left")
-                        && json_value_has_call(left)
-                    {
-                        return true;
-                    }
-                    if let Some(right) = obj.get("right")
-                        && json_value_has_call(right)
-                    {
-                        return true;
-                    }
-                }
-                "UnaryExpression" | "AwaitExpression" => {
-                    if let Some(arg) = obj.get("argument")
-                        && json_value_has_call(arg)
-                    {
-                        return true;
-                    }
-                }
-                "ConditionalExpression" => {
-                    if let Some(test) = obj.get("test")
-                        && json_value_has_call(test)
-                    {
-                        return true;
-                    }
-                    if let Some(consequent) = obj.get("consequent")
-                        && json_value_has_call(consequent)
-                    {
-                        return true;
-                    }
-                    if let Some(alternate) = obj.get("alternate")
-                        && json_value_has_call(alternate)
-                    {
-                        return true;
-                    }
-                }
-                "ArrayExpression" => {
-                    if let Some(serde_json::Value::Array(elements)) = obj.get("elements") {
-                        for elem in elements {
-                            if json_value_has_call(elem) {
-                                return true;
-                            }
-                        }
-                    }
-                }
-                "ObjectExpression" => {
-                    if let Some(serde_json::Value::Array(props)) = obj.get("properties") {
-                        for prop in props {
-                            if let serde_json::Value::Object(prop_obj) = prop
-                                && let Some(val) = prop_obj.get("value")
-                                && json_value_has_call(val)
-                            {
-                                return true;
-                            }
-                        }
-                    }
-                }
-                "SequenceExpression" => {
-                    if let Some(serde_json::Value::Array(exprs)) = obj.get("expressions") {
-                        for expr in exprs {
-                            if json_value_has_call(expr) {
-                                return true;
-                            }
-                        }
-                    }
-                }
-                "ChainExpression" => {
-                    if let Some(expr) = obj.get("expression")
-                        && json_value_has_call(expr)
-                    {
-                        return true;
-                    }
-                }
-                _ => {}
-            }
-            false
-        }
-        _ => false,
-    }
-}
-
 /// Build an event handler function.
 ///
 /// Corresponds to `build_event_handler` in
@@ -236,7 +117,7 @@ pub fn build_event_handler(
     arena: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena,
 
     expression: Option<&Expression>,
-    _node: &OnDirective,
+    node: &OnDirective,
     context: &mut ComponentContext,
 ) -> JsExpr {
     // Null handler = bubble event to parent component
@@ -263,8 +144,10 @@ pub fn build_event_handler(
 
     let expression = expression.unwrap();
 
-    // Check if expression has a call (for memoization)
-    let has_call = expression_has_call(expression);
+    // Check if expression has a call (for memoization). Phase 2's
+    // `OnDirective` visitor already cached this on
+    // `node.metadata.expression.has_call()`.
+    let has_call = node.metadata.expression.has_call();
 
     // Convert the expression to JS
     let handler = convert_expression(expression, context);
@@ -471,6 +354,7 @@ mod tests {
             name_loc: None,
             modifiers: smallvec::smallvec![],
             expression: None,
+            metadata: Default::default(),
         }
     }
 

--- a/src/compiler/phases/3_transform/client/visitors/shared/events.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/events.rs
@@ -99,6 +99,36 @@ pub fn convert_arrow_to_named_function(handler: JsExpr, name: CompactString) -> 
     }
 }
 
+/// True when the handler expression (or any descendant outside a function
+/// body) contains a `CallExpression`. Phase 3 memoises any handler that
+/// contains a call, regardless of whether the callee is "pure" — see
+/// `expression_tag_has_call` in `shared/element.rs` for the same broad
+/// semantics applied to `ExpressionTag`.
+fn expression_has_any_call(expr: &Expression) -> bool {
+    json_walk_for_call(expr.as_json())
+}
+
+fn json_walk_for_call(val: &serde_json::Value) -> bool {
+    match val {
+        serde_json::Value::Object(obj) => {
+            if let Some(t) = obj.get("type").and_then(|t| t.as_str()) {
+                if t == "CallExpression" {
+                    return true;
+                }
+                if matches!(
+                    t,
+                    "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration"
+                ) {
+                    return false;
+                }
+            }
+            obj.values().any(json_walk_for_call)
+        }
+        serde_json::Value::Array(arr) => arr.iter().any(json_walk_for_call),
+        _ => false,
+    }
+}
+
 /// Build an event handler function.
 ///
 /// Corresponds to `build_event_handler` in
@@ -144,10 +174,12 @@ pub fn build_event_handler(
 
     let expression = expression.unwrap();
 
-    // Check if expression has a call (for memoization). Phase 2's
-    // `OnDirective` visitor already cached this on
-    // `node.metadata.expression.has_call()`.
-    let has_call = node.metadata.expression.has_call();
+    // Check if expression has a call (for memoization). Phase 3 uses the
+    // broad "any CallExpression in the tree" semantics — see
+    // `expression_tag_has_call` in `shared/element.rs` — instead of Phase 2's
+    // narrower has_call (which only fires for non-pure calls).
+    let _ = node;
+    let has_call = expression_has_any_call(expression);
 
     // Convert the expression to JS
     let handler = convert_expression(expression, context);


### PR DESCRIPTION
## Summary

Wave 2 of the AST-metadata refactor. Extends the "Phase 2 caches `metadata.expression`, Phase 3 reads it" pattern from `ExpressionTag` (#14) to:

* `OnDirective` — new `OnDirectiveMetadata { expression: ExpressionMetadata }` populated by Phase 2's `OnDirective` visitor, consumed via the cached flags in Phase 3 where appropriate. Drops the 110-line `expression_has_call` / `json_value_has_call` helper from `events.rs`.
* `ClassDirective` — same pattern; `ClassDirectiveMetadata` field, populated by Phase 2's `ClassDirective` visitor (now `&mut`), consumed via `directive.metadata.expression.has_call() / has_await()` in `build_class_directives_object`.
* Snippet renderers — Phase 2 `Component` visitor now populates `component.metadata.snippets` with the start positions of child `SnippetBlock`s and adds them to `analysis.snippet_renderers` keyed by `Component@<start>`.

Plus four follow-up fixes that worked out the broad-vs-narrow `has_call` semantics across Phase 3 (`metadata.expression.has_call()` is the *narrow* "non-pure callee" flag matching the official compiler; several Phase 3 memoisation sites still want the *broad* "any CallExpression in the tree" walk):

* `951ec10` adds `expression_tag_has_call` (broad walk) + reroutes the per-chunk memoisation, attribute event handler memoisation, and `OnDirective` `build_event_handler` to it.
* `4e5c21e` keeps the narrow Phase 2 flag for the `RegularElement` `textContent` shortcut so pure calls like `(7.36).toString()` still take the static-text fast path.
* `ddbfe8e` restores `extract_metadata_from_tag`'s pre-bd01699 single-pass JSON walk for `has_call` / `has_member_expression` / `has_assignment` / `has_await`, because nested `AttributeValue::Sequence` ExpressionTags don't get their `metadata.expression` populated by Phase 2.
* `7209f1f` keeps `build_attribute_value`'s component-prop / dynamic-CSS-prop closure on the narrow Phase 2 flag — the broad walk there regresses the `purity` snapshot.

## Compatibility report (`pnpm run compatibility-report`)

| Category | origin/main | this branch | Δ |
|---|---|---|---|
| compiler-errors | 142/144 | 142/144 | = |
| css | 179/179 | 179/179 | = |
| hydration | 76/78 | 76/78 | = |
| runtime-browser | 24/31 | 24/31 | = |
| runtime-legacy | 1176/1202 | **1177/1202** | **+1** |
| runtime-runes | 456/865 | 456/865 | = |
| snapshot | 24/28 | 24/28 | = |
| validator | 320/324 | 320/324 | = |

Zero regressions, one new runtime-legacy pass (`block-expression-fn-call`).

## Test plan

- [ ] `pnpm run compatibility-report` matches the table above
- [ ] `cargo build --release` clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean