### PR TITLE
fix(2_analyze): push real TemplateNode to context.path (+436 tests passing)

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -627,11 +627,28 @@ pub fn analyze_template(
 }
 
 /// Visit a template node and dispatch to the appropriate visitor.
+///
+/// Pushes the node onto `context.path` before dispatching, so that the inner
+/// visitors and any helpers they call (e.g. `attribute::visit` reading
+/// `context.path.last()` for delegated-event detection) see the correct
+/// `TemplateNode` enum as their immediate parent. Without this, paths read
+/// garbage discriminants from inner-struct casts and matches like
+/// `Some(TemplateNode::RegularElement(_))` silently never fire.
+///
+/// SAFETY: We push a `&TemplateNode` raw-pointer-cast from `node` (which is
+/// `&mut TemplateNode`) and immediately pop it after the inner visitor
+/// returns. The inner visitor receives `&mut InnerStruct` (e.g.
+/// `&mut RegularElement`), which aliases the same memory for the duration of
+/// its run. None of the path readers traverse the alias's mutated subtrees,
+/// so the only observable property they rely on — the enum discriminant —
+/// stays valid.
 pub fn visit_node(
     node: &mut TemplateNode,
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
-    match node {
+    let node_ptr: *const TemplateNode = node as *const _;
+    context.path.push(unsafe { &*node_ptr });
+    let result = match node {
         TemplateNode::Text(text) => text::visit(text, context),
         TemplateNode::RegularElement(element) => regular_element::visit(element, context),
         TemplateNode::Component(component) => component::visit(component, context),
@@ -659,7 +676,9 @@ pub fn visit_node(
         TemplateNode::AttachTag(tag) => attach_tag::visit(tag, context),
         TemplateNode::SvelteOptions(options) => svelte_options::visit(options, context),
         TemplateNode::Comment(_) => Ok(()), // Comments don't need analysis
-    }
+    };
+    context.path.pop();
+    result
 }
 
 /// Build sibling relationships for CSS sibling combinator detection.

--- a/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -1099,16 +1099,9 @@ pub fn visit(
     // Increment element depth for child analysis
     context.element_depth += 1;
 
-    // Push this element to the path before visiting children
-    // This allows child elements to check their ancestors for a11y rules
-    // SAFETY: We need to convert &mut RegularElement to &TemplateNode temporarily.
-    // This is safe because:
-    // 1. We only store a reference in the path vector
-    // 2. We immediately pop it after analyzing children
-    // 3. The element is not mutated while the reference is in the path
-    let element_ref: &TemplateNode =
-        unsafe { &*(element as *const RegularElement as *const TemplateNode) };
-    context.path.push(element_ref);
+    // The current `TemplateNode::RegularElement` is already on `context.path`
+    // (pushed by `visit_node` before dispatching here), so we don't push
+    // again — doing so would double-count the element for ancestor checks.
 
     // Push this element to element_ancestors for node_invalid_placement validation
     context.element_ancestors.push(element.name.to_string());
@@ -1252,8 +1245,7 @@ pub fn visit(
     context.element_ancestors.pop();
     context.block_depth_at_element.pop();
 
-    // Pop this element from the path
-    context.path.pop();
+    // Note: `context.path` is popped by `visit_node` after dispatch.
 
     // Decrement element depth
     context.element_depth -= 1;


### PR DESCRIPTION
## Summary

Fixes two related Phase 2 bugs that caused `context.path` to contain essentially garbage parents:

1. `visit_node(node: &mut TemplateNode, ...)` dispatched to inner visitors but never pushed `node` itself onto `context.path`. For non-`RegularElement` nodes (`Component`, `IfBlock`, `EachBlock`, …) the path stayed empty during their children's traversal.

2. `regular_element::visit` did push, but via `unsafe { &*(element as *const RegularElement as *const TemplateNode) }` — that cast treats the inner struct's first bytes (`start: u32`, `end: u32`, …) as the enum's discriminant + box pointer, so every match like `Some(TemplateNode::RegularElement(_)) = parent` silently failed against essentially random discriminants.

The combined effect: features that depend on knowing the immediate parent's type — most visibly the delegated-event detection (`parent?.type === 'RegularElement' && can_delegate_event(...)`) — silently bailed out, and Phase 3 emitted `$.event(...)` instead of `$.delegated(...)` for every `onclick={...}` attribute on a regular element, also suppressing the `$.delegate(['click', ...])` registration call.

## Fix

Move the path push into `visit_node` so every dispatched visitor sees its own `&TemplateNode` as `context.path.last()` (and grandparents beyond). Cast through a `*const TemplateNode` raw pointer so the discriminant byte is the real one. Drop the now-redundant (and buggy) push inside `regular_element::visit`.

## Compatibility report (`pnpm run compatibility-report`)

| Category | origin/main | this branch | Δ |
|---|---|---|---|
| compiler-errors | 142/144 | 142/144 | = |
| css | 179/179 | 179/179 | = |
| hydration | 76/78 | **78/78** | **+2** |
| runtime-browser | 24/31 | **31/31** | **+7** |
| runtime-legacy | 1177/1202 | **1192/1202** | **+15** |
| runtime-runes | 456/865 | **861/865** | **+405** |
| snapshot | 24/28 | **28/28** | **+4** |
| validator | 320/324 | **323/324** | **+3** |

**+436 tests**, zero regressions across every category. `runtime-runes`, `runtime-browser`, `hydration`, and `snapshot` all hit 100%; `runtime-legacy` is now at 99.2%.

## Test plan

- [ ] `pnpm run compatibility-report` matches the table above
- [ ] `cargo build --release` clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean