### PR TITLE
fix(2_analyze/attribute): populate ExpressionTag metadata for attribute values (+12 tests, runtime-runes 100%)

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/attribute.rs
+++ b/src/compiler/phases/2_analyze/visitors/attribute.rs
@@ -28,8 +28,11 @@ pub fn visit(
 ) -> Result<(), AnalysisError> {
     // Visit children (expressions in attribute value)
     // In JS: context.next();
-    // Walk through all expressions in the attribute value
-    visit_attribute_value_expressions(&attribute.value, context)?;
+    // Walk through all expressions in the attribute value, populating each
+    // inner `ExpressionTag.metadata.expression` so Phase 3 can read
+    // `has_call` / `has_state` / `has_await` for memoisation decisions
+    // without re-walking the JSON.
+    visit_attribute_value_expressions(&mut attribute.value, context)?;
 
     // Validate slot attribute must be a static value
     // Corresponds to validate_slot_attribute in shared/attribute.js
@@ -151,11 +154,13 @@ fn is_text_attribute(attribute: &AttributeNode) -> bool {
 
 /// Visit all JavaScript expressions within an attribute value.
 ///
-/// This walks through the JS AST of expressions in the attribute value,
-/// triggering visitors for CallExpression, MemberExpression, etc.
-/// which set `needs_context` when appropriate.
+/// Walks each inner `ExpressionTag` expression with
+/// `walk_js_expression_node`, populating `expr_tag.metadata.expression` so
+/// Phase 3 (`build_attribute_value`, `extract_metadata_from_tag`, etc.) can
+/// read `has_call` / `has_state` / `has_await` / dependencies / references
+/// without re-walking the JSON.
 pub fn visit_attribute_value_expressions(
-    value: &AttributeValue,
+    value: &mut AttributeValue,
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
     match value {
@@ -163,14 +168,22 @@ pub fn visit_attribute_value_expressions(
             // No expressions to visit
         }
         AttributeValue::Expression(expr_tag) => {
-            // Visit the expression
-            super::script::walk_expression(&expr_tag.expression, context)?;
+            let node = expr_tag.expression.as_node();
+            super::shared::utils::walk_js_expression_node(
+                &node,
+                context,
+                &mut expr_tag.metadata.expression,
+            )?;
         }
         AttributeValue::Sequence(parts) => {
-            // Visit each expression tag in the sequence
             for part in parts {
                 if let AttributeValuePart::ExpressionTag(expr_tag) = part {
-                    super::script::walk_expression(&expr_tag.expression, context)?;
+                    let node = expr_tag.expression.as_node();
+                    super::shared::utils::walk_js_expression_node(
+                        &node,
+                        context,
+                        &mut expr_tag.metadata.expression,
+                    )?;
                 }
             }
         }

--- a/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -194,11 +194,11 @@ pub fn visit_component(
     // This corresponds to the context.visit(attribute, ...) calls in the official Svelte compiler.
     // The official Svelte walks through all attributes using zimmerframe which triggers
     // MemberExpression and CallExpression visitors on the expressions inside attributes.
-    for attr in &component.attributes {
+    for attr in &mut component.attributes {
         match attr {
             Attribute::Attribute(a) => {
                 // Visit expressions in the attribute value
-                visit_attribute_value_expressions(&a.value, context)?;
+                visit_attribute_value_expressions(&mut a.value, context)?;
             }
             Attribute::BindDirective(bind) => {
                 // Visit the bind expression

--- a/src/compiler/phases/2_analyze/visitors/slot_element.rs
+++ b/src/compiler/phases/2_analyze/visitors/slot_element.rs
@@ -76,10 +76,10 @@ pub fn visit(slot: &mut SlotElement, context: &mut VisitorContext) -> Result<(),
     // Visit attribute expressions to register template references
     // (e.g., <slot dummy={dummy}> needs `dummy` tracked as template reference)
     // This corresponds to context.next() in the official SlotElement.js visitor
-    for attr in &slot.attributes {
+    for attr in &mut slot.attributes {
         match attr {
             Attribute::Attribute(a) => {
-                super::attribute::visit_attribute_value_expressions(&a.value, context)?;
+                super::attribute::visit_attribute_value_expressions(&mut a.value, context)?;
             }
             Attribute::SpreadAttribute(spread) => {
                 super::script::walk_expression(&spread.expression, context)?;

--- a/src/compiler/phases/2_analyze/visitors/svelte_component.rs
+++ b/src/compiler/phases/2_analyze/visitors/svelte_component.rs
@@ -28,7 +28,7 @@ pub fn visit(
     super::script::walk_expression(&component.expression, context)?;
 
     // Analyze attributes (mirrors visit_component logic from shared/component.rs)
-    for attr in &component.attributes {
+    for attr in &mut component.attributes {
         match attr {
             Attribute::BindDirective(bind) => {
                 // Track component bindings (skip bind:this)
@@ -60,7 +60,7 @@ pub fn visit(
                     context.emit_warning(warnings::attribute_quoted());
                 }
                 // Walk attribute value expressions
-                super::attribute::visit_attribute_value_expressions(&a.value, context)?;
+                super::attribute::visit_attribute_value_expressions(&mut a.value, context)?;
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

`visit_attribute_value_expressions` was walking attribute-value `ExpressionTag`s via `script::walk_expression`, which threads through binding tracking but does **not** populate `expr_tag.metadata.expression`. Phase 3's `extract_metadata_from_tag` and `build_attribute_value` then read all-default flags off the `ExpressionTag` and skipped memoisation for things like `<button data-foo={fn(true)}>`, leaving the call un-wrapped in `$.template_effect(..., [() => fn(true)])` even though `fn` is a local binding (which is what the narrow has_call check correctly flags).

## Fix

Switch `visit_attribute_value_expressions` to take `&mut AttributeValue` and walk via `walk_js_expression_node` directly into `expr_tag.metadata.expression`, mirroring what `expression_tag::visit` does for standalone `{...}` tags. Thread the mutable borrow through the four call sites (`attribute::visit`, `slot_element::visit`, `svelte_component::visit`, `shared/component.rs::visit_component`).

## Compatibility report

| Category | origin/main | this branch | Δ |
|---|---|---|---|
| compiler-errors | 142/144 | 142/144 | = |
| css | 179/179 | 179/179 | = |
| hydration | 78/78 | 78/78 | = |
| runtime-browser | 31/31 | 31/31 | = |
| runtime-legacy | 1192/1202 | **1200/1202** | **+8** |
| runtime-runes | 861/865 | **865/865** | **+4 → 100%** |
| snapshot | 28/28 | 28/28 | = |
| validator | 323/324 | 323/324 | = |

+12 tests, zero regressions. `runtime-runes` now joins `runtime-browser`, `snapshot`, and `hydration` at 100%.

## Test plan

- [ ] `pnpm run compatibility-report` matches the table above
- [ ] `cargo build --release` clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean