### PR TITLE
fix(3_transform/client/events): match official handler-not-wrapped rule (runtime-legacy → 100%)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/shared/events.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/events.rs
@@ -202,18 +202,27 @@ pub fn build_event_handler(
 
     // Function declared in the script
     if let JsExpr::Identifier(name) = &handler {
-        // If the identifier refers to a binding whose initial value is a
-        // function (and which has not been reassigned), we can attach it
-        // directly. Otherwise fall through so the handler gets wrapped in
-        // a `function (...$$args) { handler?.apply(this, $$args); }`
-        // shim that copes with the value being undefined or a non-function
-        // assigned to e.g. a `$state` variable.
+        // Mirrors the official compiler in `events.js`:
+        //
+        //   if (binding?.is_function()) return handler;
+        //   if (!dev && binding?.declaration_kind !== 'import') return handler;
+        //
+        // i.e. attach the handler directly when (a) it's a function
+        // declaration / hoisted function, or (b) it's any locally-declared
+        // const/let/var binding (the value won't change between mounts), or
+        // (c) it isn't in scope at all (assume a global like `window.alert`
+        // or an untracked helper). Only imports get wrapped in
+        // `function (...$$args) { handler?.apply(this, $$args); }`, which
+        // copes with hot-reload swapping the imported binding.
+        use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
         match context.state.get_binding(name) {
             Some(binding) if binding.is_function() => return handler,
-            // Not in scope at all — assume it's a global function (window.alert,
-            // user-imported helpers without scope tracking, etc.).
             None => return handler,
-            Some(_) => {
+            Some(binding) => {
+                let is_import = matches!(binding.declaration_kind, DeclarationKind::Import);
+                if !context.state.options.dev && !is_import {
+                    return handler;
+                }
                 // Falls through to the wrapping path below.
             }
         }


### PR DESCRIPTION
## Summary

`build_event_handler`'s identifier-handler shortcut in `events.rs` returned the bare identifier only when the binding was `is_function()` (initial value is a function expression / declaration that hasn't been reassigned) or absent (assumed global). Local `const`/`let`/`var` bindings pointing at a function *returned by another call* — e.g. `const { handle_click } = get_handlers()` from the `event-handler-destructured` fixture — fell through and got wrapped in:

```js
function (...$$args) { handle_click?.apply(this, $$args); }
```

The official compiler only does that wrapping for imports (and for everything in dev mode):

```js
if (binding?.is_function()) return handler;
if (!dev && binding?.declaration_kind !== 'import') return handler;
```

## Fix

Add the same `declaration_kind !== Import` short-circuit in non-dev mode.

## Compatibility report

| Category | origin/main | this branch | Δ |
|---|---|---|---|
| runtime-legacy | 1200/1202 | **1202/1202** | **+2 → 100%** |

Zero regressions. **runtime-legacy joins runtime-runes / runtime-browser / hydration / snapshot at 100%.**

After this PR, only 3 fixtures fail across the whole compatibility report (out of 3037 implemented):
- `compiler-errors/const-tag-snippet-invalid-reference-{1,2}` (missing error)
- `validator/dollar-global-in-markup` (missing error)