### PR TITLE
fix(2_analyze): emit global_reference_invalid for bare $ in template (validator → 100%)

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -2935,6 +2935,21 @@ pub fn walk_js_expression_node(
                 context.analysis.uses_slots = true;
             }
 
+            // Bare `$` and `$$xxx` (other than the reserved `$$props` /
+            // `$$restProps` / `$$slots`) are illegal as variable names.
+            // Mirrors `visit_identifier_inner` for the JS-side identifier
+            // visitor, but we re-check here because template
+            // ExpressionTags walk straight through `walk_js_expression_node`
+            // and never hit the JS identifier visitor.
+            if name == "$"
+                || (name.starts_with("$$")
+                    && name != "$$props"
+                    && name != "$$restProps"
+                    && name != "$$slots")
+            {
+                return Err(super::super::super::errors::global_reference_invalid(name));
+            }
+
             // Check for store scoped subscription errors
             if name.starts_with('$') && !name.starts_with("$$") && name != "$" {
                 let store_name = &name[1..];


### PR DESCRIPTION
## Summary

`walk_js_expression_node` is the entry point for analysing JavaScript expressions inside template `ExpressionTag`s (e.g. `{$}`). It dispatched to per-node-kind logic but never re-ran the bare-`$` / illegal-`$$xxx` check that `visit_identifier_inner` performs in the JS-side identifier visitor.

The validator/dollar-global-in-markup fixture (`{$}`) compiled cleanly even though the official compiler emits the `global_reference_invalid` error.

## Fix

Add the same check in the `JsNode::Identifier` arm of the walker.

## Compatibility report

| Category | origin/main | this branch | Δ |
|---|---|---|---|
| validator | 323/324 | **324/324** | **+1 → 100%** |

Zero regressions. **validator now joins runtime-legacy / runtime-runes / runtime-browser / hydration / snapshot at 100%.**