### PR TITLE
fix(2_analyze): const_tag_invalid_reference for template identifiers (compiler-errors → 100%, total 3037/3037)

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/identifier.rs
+++ b/src/compiler/phases/2_analyze/visitors/identifier.rs
@@ -585,6 +585,17 @@ fn validate_rune_usage(
     Ok(())
 }
 
+/// Public alias used by the template-side walker (`walk_js_expression_node`)
+/// so it can perform the same `const_tag_invalid_reference` check that the
+/// JS-side identifier visitor does. See `check_const_tag_snippet_reference`.
+pub(super) fn check_const_tag_snippet_reference_public(
+    name: &str,
+    binding_idx: usize,
+    context: &VisitorContext,
+) -> Result<(), AnalysisError> {
+    check_const_tag_snippet_reference(name, binding_idx, context)
+}
+
 /// Check if a {@const} binding referenced from within a named snippet of a
 /// Component or SvelteBoundary is invalid.
 ///

--- a/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -3004,6 +3004,20 @@ pub fn walk_js_expression_node(
                 }
 
                 metadata.dependencies.insert(binding_idx);
+
+                // Mirror `Identifier.js` L162-191: a `{@const}` binding cannot
+                // be referenced from inside a named snippet declared at the
+                // same level when `experimental.async` is on. The JS-side
+                // identifier visitor performs this check for script
+                // identifiers; template expression tags walk through here
+                // and never hit it, so re-run the check.
+                if binding.kind == BindingKind::Template && context.analysis.experimental_async {
+                    super::super::identifier::check_const_tag_snippet_reference_public(
+                        name.as_str(),
+                        binding_idx,
+                        context,
+                    )?;
+                }
             }
         }
         JsNode::MemberExpression {


### PR DESCRIPTION
## Summary

`check_const_tag_snippet_reference` was only invoked from the JS-side `Identifier` visitor (`visit_identifier_inner`), so the error fired for `{@const foo}` references inside `<script>` but not for the template-side `{foo}` references inside `{#snippet ...}`. Both `compiler-errors/const-tag-snippet-invalid-reference-{1,2}` fixtures compiled cleanly even though the official Svelte compiler errors with `const_tag_invalid_reference`.

## Fix

Template ExpressionTags walk through `walk_js_expression_node` (`shared/utils.rs`) instead of the JS visitor, so re-run the same check in the walker's `JsNode::Identifier` arm when the binding is `BindingKind::Template` and `experimental.async` is enabled.

## Compatibility report

| Category | origin/main | this branch | Δ |
|---|---|---|---|
| compiler-errors | 142/144 | **144/144** | **+2 → 100%** |

**Total: 3037/3037 (100%)** — every implemented category at 100%, zero failures across the entire compatibility report.

Zero regressions.