### PR TITLE
docs: reflect print category being wired into the compat report (3077/3077)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,12 +116,12 @@ Source: `pnpm run compatibility-report` (generated 2026-05-03, Svelte commit `04
 | Runtime Legacy | 1202/1202 | |
 | Runtime Runes | 865/865 | |
 | Runtime Browser | 31/31 | |
+| Print | 40/40 | |
 | Sourcemaps | 0/0 | No fixtures yet |
-| Print | 0/40 | Skipped in compatibility report; standalone test in `tests/print.rs` |
 | Preprocess | 0/19 | Not implemented |
 | Migrate | 0/76 | Not implemented |
 
-**Compatibility report total: 3037/3037 implemented passing (137 skipped, 0 failing) — every implemented category at 100%.**
+**Compatibility report total: 3077/3077 implemented passing (97 skipped, 0 failing) — every implemented category at 100%.**
 
 ## Implementation Status
 
@@ -133,10 +133,7 @@ Source: `pnpm run compatibility-report` (generated 2026-05-03, Svelte commit `04
 **CSS** - Selector scoping, combinators, pseudo-classes, `:global()`, keyframe prefixing
 **Validator** - Warning/error detection including A11y
 **Compiler Errors** - Error detection patterns
-
-### Implemented but not in the compatibility report
-
-**Print** - `src/compiler/print/` provides AST-to-source conversion; tested standalone via `cargo test --test print`. Not yet wired into `compatibility_report.rs` (currently hardcoded as "Print API not implemented").
+**Print** - `src/compiler/print/` provides AST-to-source conversion (40/40 fixtures).
 
 ### Not implemented
 

--- a/docs/static/test-results.json
+++ b/docs/static/test-results.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-05-03T14:27:03.089010+00:00",
+  "generated_at": "2026-05-03T14:49:39.371962+00:00",
   "commit_sha": "04c0368aa8d8",
   "summary": {
     "total": 3174,
-    "passed": 3037,
+    "passed": 3077,
     "failed": 0,
-    "skipped": 137,
+    "skipped": 97,
     "percentage": 100
   },
   "categories": [
@@ -12408,210 +12408,170 @@
       "id": "print",
       "name": "Print",
       "total": 40,
-      "passed": 0,
+      "passed": 40,
       "failed": 0,
-      "skipped": 40,
-      "percentage": 0,
+      "skipped": 0,
+      "percentage": 100,
       "tests": [
         {
           "name": "style-directive",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "svelte-window",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "svelte-self",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "html-document",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "attribute",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "svelte-element",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "await-block",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "key-block",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "svelte-head",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "spread-attribute",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "comment",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "block-element-separation",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "svelte-fragment",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "slot-element",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "const-tag",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "use-directive",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "svelte-options",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "component",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "regular-element",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "style",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "expression-tag",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "class-directive",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "script",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "svelte-boundary",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "snippet-block",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "let-directive",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "transition-directive",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "formatting",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "svelte-document",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "render-tag",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "each-block",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "if-block",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "svelte-component",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "bind-directive",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "on-directive",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "text",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "html-tag",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "attach-tag",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "animate-directive",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         },
         {
           "name": "block",
-          "status": "skip",
-          "skip_reason": "Print API not implemented"
+          "status": "pass"
         }
       ]
     },


### PR DESCRIPTION
Update CLAUDE.md/AGENTS.md test status — print now at 40/40 (was 0/40 "skipped"), moved to "Fully passing" section, headline total bumped to 3077/3077 implemented passing. Regenerate `docs/static/test-results.json` via `pnpm run update-docs`.