### PR TITLE
feat(preprocess): hand-port 19 official fixtures, wire into compat report (preprocess → 100%, total 3096/3096)

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,6 +16,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
+pub mod preprocess_fixtures;
+
 // ============================================================================
 // Path utilities
 // ============================================================================

--- a/tests/common/preprocess_fixtures.rs
+++ b/tests/common/preprocess_fixtures.rs
@@ -1,0 +1,363 @@
+//! Shared per-fixture preprocessor closures for the Svelte preprocess test
+//! suite. Both `tests/preprocess.rs` (the standalone runner) and
+//! `tests/compatibility_report.rs` (the dashboard) hand-port each fixture's
+//! `_config.js` JS preprocessor into Rust closures here.
+
+use rustc_hash::FxHashMap;
+use svelte_compiler_rust::compiler::preprocess::types::{
+    AttributeValue, MarkupPreprocessorFn, MarkupPreprocessorOptions, PreprocessorFn,
+    PreprocessorGroup, PreprocessorOptions, PreprocessorResult, Processed,
+};
+
+/// Read a string attribute value, panicking if it isn't a `String`.
+pub fn attr_str<'a>(attrs: &'a FxHashMap<String, AttributeValue>, name: &str) -> Option<&'a str> {
+    match attrs.get(name)? {
+        AttributeValue::String(s) => Some(s.as_str()),
+        AttributeValue::Boolean(_) => None,
+    }
+}
+
+fn ok<F>(f: F) -> PreprocessorResult
+where
+    F: std::future::Future<
+            Output = Result<
+                Option<Processed>,
+                svelte_compiler_rust::compiler::preprocess::types::PreprocessError,
+            >,
+        > + Send
+        + 'static,
+{
+    Box::pin(f)
+}
+
+fn processed_code(code: impl Into<String>) -> Processed {
+    Processed {
+        code: code.into(),
+        ..Default::default()
+    }
+}
+
+/// Returns `Some(...)` if `name` matches a hand-ported fixture, otherwise
+/// `None` (caller treats unknown fixtures as failures).
+pub fn build_preprocessors(name: &str) -> Option<Vec<PreprocessorGroup>> {
+    let groups = match name {
+        "attributes-with-closing-tag" => vec![PreprocessorGroup {
+            script: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    let generics_has_gt =
+                        attr_str(&opts.attributes, "generics").is_some_and(|v| v.contains('>'));
+                    if generics_has_gt {
+                        Ok(Some(processed_code("")))
+                    } else {
+                        Ok(None)
+                    }
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "attributes-with-equals" => vec![PreprocessorGroup {
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    if attr_str(&opts.attributes, "foo").is_some_and(|v| v.contains('=')) {
+                        Ok(Some(processed_code("")))
+                    } else {
+                        Ok(None)
+                    }
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "comments" => vec![PreprocessorGroup {
+            script: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move { Ok(Some(processed_code(opts.content.replace("one", "two")))) })
+            }) as PreprocessorFn),
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move { Ok(Some(processed_code(opts.content.replace("one", "three")))) })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "dependencies" => vec![PreprocessorGroup {
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    use regex::Regex;
+                    let re = Regex::new(r"@import '(.+)';").unwrap();
+                    let mut deps = Vec::new();
+                    let mut last = 0;
+                    let mut out = String::new();
+                    for cap in re.captures_iter(&opts.content) {
+                        let m = cap.get(0).unwrap();
+                        out.push_str(&opts.content[last..m.start()]);
+                        out.push_str("/* removed */");
+                        deps.push(cap[1].to_string());
+                        last = m.end();
+                    }
+                    out.push_str(&opts.content[last..]);
+                    Ok(Some(Processed {
+                        code: out,
+                        dependencies: deps,
+                        ..Default::default()
+                    }))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "empty-sourcemap" => vec![PreprocessorGroup {
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    use svelte_compiler_rust::compiler::preprocess::types::{
+                        SimpleDecodedMap, SourceMapInput,
+                    };
+                    Ok(Some(Processed {
+                        code: opts.content,
+                        map: Some(SourceMapInput::Decoded(SimpleDecodedMap {
+                            mappings: vec![],
+                            ..SimpleDecodedMap::default()
+                        })),
+                        ..Default::default()
+                    }))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "filename" => vec![PreprocessorGroup {
+            markup: Some(Box::new(|opts: MarkupPreprocessorOptions| {
+                ok(async move {
+                    let filename = opts.filename.unwrap_or_default();
+                    Ok(Some(processed_code(
+                        opts.content.replace("__MARKUP_FILENAME__", &filename),
+                    )))
+                })
+            }) as MarkupPreprocessorFn),
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    let filename = opts.filename.unwrap_or_default();
+                    Ok(Some(processed_code(
+                        opts.content.replace("__STYLE_FILENAME__", &filename),
+                    )))
+                })
+            }) as PreprocessorFn),
+            script: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    let filename = opts.filename.unwrap_or_default();
+                    Ok(Some(processed_code(
+                        opts.content.replace("__SCRIPT_FILENAME__", &filename),
+                    )))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "ignores-null" => vec![PreprocessorGroup {
+            // `() => {}` returns `undefined`, which the Rust `Ok(None)` path
+            // already handles as a no-op.
+            script: Some(
+                Box::new(|_opts: PreprocessorOptions| ok(async move { Ok(None) }))
+                    as PreprocessorFn,
+            ),
+            ..Default::default()
+        }],
+
+        "markup" => vec![PreprocessorGroup {
+            markup: Some(Box::new(|opts: MarkupPreprocessorOptions| {
+                ok(async move {
+                    Ok(Some(processed_code(
+                        opts.content.replace("__NAME__", "world"),
+                    )))
+                })
+            }) as MarkupPreprocessorFn),
+            ..Default::default()
+        }],
+
+        "multiple-preprocessors" => vec![
+            PreprocessorGroup {
+                markup: Some(Box::new(|opts: MarkupPreprocessorOptions| {
+                    ok(async move { Ok(Some(processed_code(opts.content.replace("one", "two")))) })
+                }) as MarkupPreprocessorFn),
+                script: Some(Box::new(|opts: PreprocessorOptions| {
+                    ok(
+                        async move { Ok(Some(processed_code(opts.content.replace("two", "three")))) },
+                    )
+                }) as PreprocessorFn),
+                style: Some(Box::new(|opts: PreprocessorOptions| {
+                    ok(
+                        async move { Ok(Some(processed_code(opts.content.replace("three", "style")))) },
+                    )
+                }) as PreprocessorFn),
+                ..Default::default()
+            },
+            PreprocessorGroup {
+                markup: Some(Box::new(|opts: MarkupPreprocessorOptions| {
+                    ok(
+                        async move { Ok(Some(processed_code(opts.content.replace("two", "three")))) },
+                    )
+                }) as MarkupPreprocessorFn),
+                script: Some(Box::new(|opts: PreprocessorOptions| {
+                    ok(async move {
+                        Ok(Some(processed_code(
+                            opts.content.replace("three", "script"),
+                        )))
+                    })
+                }) as PreprocessorFn),
+                style: Some(Box::new(|opts: PreprocessorOptions| {
+                    ok(
+                        async move { Ok(Some(processed_code(opts.content.replace("three", "style")))) },
+                    )
+                }) as PreprocessorFn),
+                ..Default::default()
+            },
+        ],
+
+        "partial-names" => vec![PreprocessorGroup {
+            script: Some(Box::new(|_opts: PreprocessorOptions| {
+                ok(async move { Ok(Some(processed_code(""))) })
+            }) as PreprocessorFn),
+            style: Some(Box::new(|_opts: PreprocessorOptions| {
+                ok(async move { Ok(Some(processed_code(""))) })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "script" => vec![PreprocessorGroup {
+            script: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    // The official fixture uses MagicString to splice `42`
+                    // into the position of `__THE_ANSWER__`. The textual
+                    // result is identical to a plain replace.
+                    Ok(Some(processed_code(
+                        opts.content.replace("__THE_ANSWER__", "42"),
+                    )))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "script-multiple" => vec![PreprocessorGroup {
+            script: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move { Ok(Some(processed_code(opts.content.to_lowercase()))) })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "script-self-closing" => vec![PreprocessorGroup {
+            script: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    assert_eq!(opts.content, "");
+                    let answer = attr_str(&opts.attributes, "the-answer").unwrap_or("");
+                    Ok(Some(processed_code(format!(
+                        "console.log(\"{}\");",
+                        answer
+                    ))))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "style" => vec![PreprocessorGroup {
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    Ok(Some(processed_code(
+                        opts.content.replace("$brand", "purple"),
+                    )))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "style-async" => vec![PreprocessorGroup {
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    Ok(Some(processed_code(
+                        opts.content.replace("$brand", "purple"),
+                    )))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "style-attributes" => vec![PreprocessorGroup {
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    assert_eq!(attr_str(&opts.attributes, "type"), Some("text/scss"));
+                    assert_eq!(attr_str(&opts.attributes, "data-foo"), Some("bar"));
+                    assert!(matches!(
+                        opts.attributes.get("bool"),
+                        Some(AttributeValue::Boolean(true))
+                    ));
+                    Ok(Some(processed_code("PROCESSED")))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "style-attributes-modified" => vec![PreprocessorGroup {
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    assert_eq!(attr_str(&opts.attributes, "lang"), Some("scss"));
+                    assert_eq!(attr_str(&opts.attributes, "data-foo"), Some("bar"));
+                    assert!(matches!(
+                        opts.attributes.get("bool"),
+                        Some(AttributeValue::Boolean(true))
+                    ));
+                    let mut new_attrs = FxHashMap::default();
+                    new_attrs.insert(
+                        "sth".to_string(),
+                        AttributeValue::String("else".to_string()),
+                    );
+                    Ok(Some(Processed {
+                        code: "PROCESSED".to_string(),
+                        attributes: Some(new_attrs),
+                        ..Default::default()
+                    }))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "style-attributes-modified-longer" => vec![PreprocessorGroup {
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    assert_eq!(attr_str(&opts.attributes, "lang"), Some("scss"));
+                    let mut new_attrs = FxHashMap::default();
+                    new_attrs.insert(
+                        "sth".to_string(),
+                        AttributeValue::String("wayyyyyyyyyyyyy looooooonger".to_string()),
+                    );
+                    Ok(Some(Processed {
+                        code: "PROCESSED".to_string(),
+                        attributes: Some(new_attrs),
+                        ..Default::default()
+                    }))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        "style-self-closing" => vec![PreprocessorGroup {
+            style: Some(Box::new(|opts: PreprocessorOptions| {
+                ok(async move {
+                    assert_eq!(opts.content, "");
+                    let color = attr_str(&opts.attributes, "color").unwrap_or("");
+                    Ok(Some(processed_code(format!("div {{ color: {}; }}", color))))
+                })
+            }) as PreprocessorFn),
+            ..Default::default()
+        }],
+
+        _ => return None,
+    };
+    Some(groups)
+}
+
+/// Filename override expected by certain fixtures (currently only `filename`).
+pub fn filename_for(name: &str) -> Option<String> {
+    if name == "filename" {
+        Some("file.svelte".to_string())
+    } else {
+        None
+    }
+}

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1120,6 +1120,99 @@ fn normalize_print_output(s: &str) -> String {
     output
 }
 
+/// Run the `preprocess` category by feeding each official Svelte fixture
+/// through the rsvelte `preprocess` API with hand-ported preprocessor
+/// closures (see `tests/common/preprocess_fixtures.rs`). Mirrors
+/// `tests/preprocess.rs` so the compat dashboard stays in lock-step.
+fn run_preprocess_tests() -> CategoryResult {
+    use svelte_compiler_rust::compiler::preprocess::preprocess;
+
+    let samples = get_svelte_test_samples("preprocess");
+    let mut result = CategoryResult::new("preprocess");
+
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            // Mark every fixture as errored and bail; this should never
+            // happen in practice but the report should still be writable.
+            for sample_dir in &samples {
+                let name = sample_dir
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                result.add_sample(SampleResult {
+                    name,
+                    status: TestStatus::Error,
+                    error: Some(format!("tokio runtime build failed: {}", e)),
+                    skip_reason: None,
+                    details: None,
+                });
+            }
+            return result;
+        }
+    };
+
+    for sample_dir in &samples {
+        let name = sample_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let input = match fs::read_to_string(sample_dir.join("input.svelte")) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let expected = match fs::read_to_string(sample_dir.join("output.svelte")) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        let preprocessors = match common::preprocess_fixtures::build_preprocessors(&name) {
+            Some(g) => g,
+            None => {
+                result.add_sample(SampleResult {
+                    name,
+                    status: TestStatus::Failed,
+                    error: Some("no Rust preprocessor wired up".to_string()),
+                    skip_reason: None,
+                    details: None,
+                });
+                continue;
+            }
+        };
+        let filename = common::preprocess_fixtures::filename_for(&name);
+
+        let (status, error) = match runtime.block_on(preprocess(input, preprocessors, filename)) {
+            Ok(processed) => {
+                if processed.code == expected {
+                    (TestStatus::Passed, None)
+                } else {
+                    (TestStatus::Failed, Some("Output mismatch".to_string()))
+                }
+            }
+            Err(e) => (
+                TestStatus::Failed,
+                Some(format!("preprocess error: {:?}", e)),
+            ),
+        };
+
+        result.add_sample(SampleResult {
+            name,
+            status,
+            error,
+            skip_reason: None,
+            details: None,
+        });
+    }
+
+    result
+}
+
 fn run_not_implemented_tests(category: &str, reason: &str) -> CategoryResult {
     let samples = get_svelte_test_samples(category);
     let mut result = CategoryResult::new(category);
@@ -1378,16 +1471,25 @@ fn generate_compatibility_report() {
     );
     report.add_category(print);
 
-    // Not yet implemented categories
-    for (category, reason) in &[
-        ("preprocess", "Preprocess API not implemented"),
-        ("migrate", "Migrate API not implemented"),
-    ] {
-        print!("Running {} tests... ", category);
-        let result = run_not_implemented_tests(category, reason);
-        println!("all {} skipped", result.stats.total);
-        report.add_category(result);
-    }
+    // Preprocess category — implemented in `src/compiler/preprocess` and
+    // exercised standalone in `tests/preprocess.rs`. Each fixture's
+    // `_config.js` JS preprocessor is hand-ported in
+    // `tests/common/preprocess_fixtures.rs`.
+    print!("Running preprocess tests... ");
+    let pre = run_preprocess_tests();
+    println!(
+        "{}/{} passed ({:.1}%)",
+        pre.stats.passed,
+        pre.stats.run_count(),
+        pre.stats.pass_percentage()
+    );
+    report.add_category(pre);
+
+    // Migrate is the only remaining unimplemented category.
+    print!("Running migrate tests... ");
+    let migrate = run_not_implemented_tests("migrate", "Migrate API not implemented");
+    println!("all {} skipped", migrate.stats.total);
+    report.add_category(migrate);
 
     // Finalize and save
     report.finalize();

--- a/tests/preprocess.rs
+++ b/tests/preprocess.rs
@@ -1,0 +1,148 @@
+//! Preprocess tests.
+//!
+//! The official Svelte preprocess fixtures define their preprocessor functions
+//! in `_config.js` modules. Rather than embedding a JS engine, this runner
+//! hand-ports each fixture's preprocessor closures into Rust (in
+//! `tests/common/preprocess_fixtures.rs`) so we can drive the rsvelte
+//! `preprocess` API directly. The closures are kept as faithful to the JS
+//! originals as practical — string replacements stay textual, attribute
+//! reads use the same keys, and assertions on attribute shape are
+//! re-implemented as Rust panics.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+use common::get_svelte_test_samples;
+use common::preprocess_fixtures::{build_preprocessors, filename_for};
+use svelte_compiler_rust::compiler::preprocess::preprocess;
+
+#[derive(Debug, Clone)]
+pub struct PreprocessFixture {
+    pub name: String,
+    pub input: String,
+    pub expected_output: String,
+    pub filename: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct PreprocessResult {
+    pub name: String,
+    pub passed: bool,
+    pub error: Option<String>,
+}
+
+fn load_fixture(sample_dir: &Path) -> Option<PreprocessFixture> {
+    let name = sample_dir.file_name()?.to_str()?.to_string();
+    let input = fs::read_to_string(sample_dir.join("input.svelte")).ok()?;
+    let expected_output = fs::read_to_string(sample_dir.join("output.svelte")).ok()?;
+    let filename = filename_for(&name);
+    Some(PreprocessFixture {
+        name,
+        input,
+        expected_output,
+        filename,
+    })
+}
+
+pub fn run_preprocess_fixture(fixture: &PreprocessFixture) -> PreprocessResult {
+    let preprocessors = match build_preprocessors(&fixture.name) {
+        Some(g) => g,
+        None => {
+            return PreprocessResult {
+                name: fixture.name.clone(),
+                passed: false,
+                error: Some(format!(
+                    "no Rust preprocessor wired up for {}",
+                    fixture.name
+                )),
+            };
+        }
+    };
+
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            return PreprocessResult {
+                name: fixture.name.clone(),
+                passed: false,
+                error: Some(format!("tokio runtime build failed: {}", e)),
+            };
+        }
+    };
+
+    let result = runtime.block_on(preprocess(
+        fixture.input.clone(),
+        preprocessors,
+        fixture.filename.clone(),
+    ));
+
+    match result {
+        Ok(processed) => {
+            if processed.code == fixture.expected_output {
+                PreprocessResult {
+                    name: fixture.name.clone(),
+                    passed: true,
+                    error: None,
+                }
+            } else {
+                PreprocessResult {
+                    name: fixture.name.clone(),
+                    passed: false,
+                    error: Some(format!(
+                        "Output mismatch.\nExpected:\n{}\n\nActual:\n{}",
+                        fixture.expected_output, processed.code
+                    )),
+                }
+            }
+        }
+        Err(e) => PreprocessResult {
+            name: fixture.name.clone(),
+            passed: false,
+            error: Some(format!("preprocess error: {:?}", e)),
+        },
+    }
+}
+
+pub fn load_preprocess_fixtures() -> Vec<PreprocessFixture> {
+    get_svelte_test_samples("preprocess")
+        .into_iter()
+        .filter_map(|d| load_fixture(d.as_path()))
+        .collect()
+}
+
+#[test]
+fn test_preprocess_fixtures() {
+    let fixtures = load_preprocess_fixtures();
+    if fixtures.is_empty() {
+        panic!(
+            "No preprocess fixtures found. Run `git submodule update --init --recursive` and `pnpm run generate-fixtures`."
+        );
+    }
+
+    println!("Running {} preprocess tests...", fixtures.len());
+    let results: Vec<PreprocessResult> = fixtures.iter().map(run_preprocess_fixture).collect();
+
+    let passed = results.iter().filter(|r| r.passed).count();
+    let failed = results.len() - passed;
+
+    println!("\n=== Preprocess Tests ===");
+    println!("Total: {}/{} passed", passed, results.len());
+
+    if failed > 0 {
+        println!("\nFailed tests:");
+        for r in results.iter().filter(|r| !r.passed) {
+            println!("  - {}", r.name);
+            if let Some(err) = &r.error {
+                for line in err.lines().take(20) {
+                    println!("      {}", line);
+                }
+            }
+        }
+        panic!("{} preprocess tests failed", failed);
+    }
+}


### PR DESCRIPTION
## Summary

The compatibility report listed `preprocess` as 0/19 because each fixture's preprocessor is defined as JS callbacks in `_config.js` and rsvelte's `preprocess` API takes Rust closures. Rather than embed a JS engine, hand-port each fixture's `_config.js` preprocessor into Rust.

## Architecture

- `tests/common/preprocess_fixtures.rs::build_preprocessors(name)` returns the per-fixture `Vec<PreprocessorGroup>` keyed by sample directory name. The closures replicate the JS textually (`content.replace(...)`, regex-based dependency tracking, attribute asserts, etc.).
- The standalone `tests/preprocess.rs` runner and the `run_preprocess_tests` helper inside `tests/compatibility_report.rs` both consume this shared module, so the dashboard and the standalone runner can't drift.

## Compatibility report

| Category | origin/main | this branch | Δ |
|---|---|---|---|
| preprocess | 0/19 (skipped) | **19/19** | **+19 → 100%** |

**Total implemented passing: 3077 → 3096.** Every implemented category at 100%; `migrate` is the only remaining unimplemented category (76 fixtures).

## Test plan

- [ ] `cargo test --release --test preprocess` reports 19/19
- [ ] `pnpm run compatibility-report` shows `preprocess 19/19 (100%)`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean