### PR TITLE
docs: reflect preprocess being wired into the compat report (3096/3096)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Use the `Agent` tool for substantial work — feature implementation, multi-file
 
 ## Test Status
 
-Source: `pnpm run compatibility-report` (generated 2026-05-03, Svelte commit `04c0368aa8d8`). Re-run `pnpm run test-and-update` to refresh.
+Source: `pnpm run compatibility-report` (generated 2026-05-04, Svelte commit `04c0368aa8d8`). Re-run `pnpm run test-and-update` to refresh.
 
 | Suite | Pass/Total | Notes |
 |-------|------------|-------|
@@ -117,11 +117,11 @@ Source: `pnpm run compatibility-report` (generated 2026-05-03, Svelte commit `04
 | Runtime Runes | 865/865 | |
 | Runtime Browser | 31/31 | |
 | Print | 40/40 | |
+| Preprocess | 19/19 | Each fixture's `_config.js` JS preprocessor hand-ported in `tests/common/preprocess_fixtures.rs` |
 | Sourcemaps | 0/0 | No fixtures yet |
-| Preprocess | 0/19 | Not implemented |
 | Migrate | 0/76 | Not implemented |
 
-**Compatibility report total: 3077/3077 implemented passing (97 skipped, 0 failing) — every implemented category at 100%.**
+**Compatibility report total: 3096/3096 implemented passing (78 skipped, 0 failing) — every implemented category at 100%.**
 
 ## Implementation Status
 
@@ -134,10 +134,10 @@ Source: `pnpm run compatibility-report` (generated 2026-05-03, Svelte commit `04
 **Validator** - Warning/error detection including A11y
 **Compiler Errors** - Error detection patterns
 **Print** - `src/compiler/print/` provides AST-to-source conversion (40/40 fixtures).
+**Preprocess** - `src/compiler/preprocess/` provides the markup/script/style preprocessor pipeline (19/19 fixtures). Each fixture's `_config.js` JS preprocessor is hand-ported into Rust closures in `tests/common/preprocess_fixtures.rs`.
 
 ### Not implemented
 
-**Preprocess** - `src/compiler/preprocess/` has scaffolding only; 19 official fixtures still skipped.
 **Migrate** - Svelte 4 → 5 migrator not started; 76 official fixtures skipped.
 **Sourcemaps** - No fixtures collected yet.
 

--- a/docs/static/test-results.json
+++ b/docs/static/test-results.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-05-03T14:49:39.371962+00:00",
+  "generated_at": "2026-05-03T15:46:35.706331+00:00",
   "commit_sha": "04c0368aa8d8",
   "summary": {
     "total": 3174,
-    "passed": 3077,
+    "passed": 3096,
     "failed": 0,
-    "skipped": 97,
+    "skipped": 78,
     "percentage": 100
   },
   "categories": [
@@ -12302,105 +12302,86 @@
       "id": "preprocess",
       "name": "Preprocess",
       "total": 19,
-      "passed": 0,
+      "passed": 19,
       "failed": 0,
-      "skipped": 19,
-      "percentage": 0,
+      "skipped": 0,
+      "percentage": 100,
       "tests": [
         {
           "name": "comments",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "script-self-closing",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "style-attributes-modified",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "style-self-closing",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "script-multiple",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "ignores-null",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "attributes-with-equals",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "dependencies",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "style",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "attributes-with-closing-tag",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "script",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "markup",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "style-attributes",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "style-attributes-modified-longer",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "style-async",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "partial-names",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "filename",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "empty-sourcemap",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         },
         {
           "name": "multiple-preprocessors",
-          "status": "skip",
-          "skip_reason": "Preprocess API not implemented"
+          "status": "pass"
         }
       ]
     },


### PR DESCRIPTION
Update CLAUDE.md/AGENTS.md and docs/static/test-results.json after PR #24 — preprocess now at 19/19 (hand-ported), moved to "Fully passing", headline total bumped to 3096/3096 implemented passing.