### PR TITLE
docs: mark migrate as out of scope (not "not implemented")

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,9 +119,9 @@ Source: `pnpm run compatibility-report` (generated 2026-05-04, Svelte commit `04
 | Print | 40/40 | |
 | Preprocess | 19/19 | Each fixture's `_config.js` JS preprocessor hand-ported in `tests/common/preprocess_fixtures.rs` |
 | Sourcemaps | 0/0 | No fixtures yet |
-| Migrate | 0/76 | Not implemented |
+| Migrate | 0/76 | **Out of scope** — rsvelte is a Svelte 5 compiler port, not a Svelte 4 → 5 migration tool |
 
-**Compatibility report total: 3096/3096 implemented passing (78 skipped, 0 failing) — every implemented category at 100%.**
+**Compatibility report total: 3096/3096 in-scope passing — every in-scope category at 100%. The 76 `migrate` fixtures are intentionally out of scope and do not count against the total.**
 
 ## Implementation Status
 
@@ -136,9 +136,12 @@ Source: `pnpm run compatibility-report` (generated 2026-05-04, Svelte commit `04
 **Print** - `src/compiler/print/` provides AST-to-source conversion (40/40 fixtures).
 **Preprocess** - `src/compiler/preprocess/` provides the markup/script/style preprocessor pipeline (19/19 fixtures). Each fixture's `_config.js` JS preprocessor is hand-ported into Rust closures in `tests/common/preprocess_fixtures.rs`.
 
+### Out of scope
+
+**Migrate** — Svelte 4 → 5 migrator. rsvelte is a port of the Svelte 5 compiler, not a migration tool, so the 76 `migrate` fixtures are intentionally not implemented and the category is reported as skipped (out of scope) rather than as an implementation gap. Do not start work on this without an explicit scope change.
+
 ### Not implemented
 
-**Migrate** - Svelte 4 → 5 migrator not started; 76 official fixtures skipped.
 **Sourcemaps** - No fixtures collected yet.
 
 ## Quick Reference

--- a/docs/static/test-results.json
+++ b/docs/static/test-results.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T15:46:35.706331+00:00",
+  "generated_at": "2026-05-03T16:22:13.577580+00:00",
   "commit_sha": "04c0368aa8d8",
   "summary": {
     "total": 3174,
@@ -12568,382 +12568,382 @@
         {
           "name": "props-interface",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "import-type-$-prefix",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-with-errors",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "props-and-labeled",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "remove-blocks-whitespace",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slot-usages",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "svelte-self-skip-filename",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "self-closing-named-slot",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "svelte-self",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slots-multiple",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "unused-beforeUpdate-afterUpdate-extra-imports",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-$props-props-var-1",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "derivations",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "props-rest-props",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "reactive-statements-reorder-1",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "jsdoc-with-comments",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "svelte-element",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slot-non-identifier",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "state-ts",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "named-slots",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "each-block-const",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "$$slots-used-as-variable",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slot-use_ts",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "props",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "accessors",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "event-handlers-with-alias",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-beforeUpdate-afterUpdate",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slots-with-$$props",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slot-use_ts-2",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "state-no-initial",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-$state-state-var-2",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-$bindable-bindable-var-1",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-$derived-derived-var-4",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-$derived-derived-var-3",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "not-blank-css-if-error",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "props-ts",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "reactive-statements-reorder-not-deleting-additions",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-$state-state-var-3",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "$$slots-used-as-variable-$$props",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-prop-and-$$props",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slot-use_ts-3",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slot-dont-mess-with-attributes",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-$derived-derived-var-2",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "props-export-alias",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "effects-with-alias-run",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "single-assignment-labeled",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "shadowed-forwarded-slot",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "props-rest-props-ts",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "props-rest-props-jsdoc",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "svelte-self-name-conflict",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "unused-beforeUpdate-afterUpdate",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "state-and-derivations-sequence",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "not-prepend-props-to-export-let",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "reactive-statements-reorder-with-comments",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "svelte-component",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "reactive-statements-inner-block",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "reactive-statements-reorder-2",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-slot-non-identifier",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slot-shadow-props",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-slot-change-name",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slots-custom-element",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "is-not-where-has",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "self-closing-elements",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "export-props-multiple-declarations",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-prop-non-identifier",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "effects",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "css-ignore",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slots",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "reassigned-deriveds",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-$state-state-var-1",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "svelte-ignore",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "labeled-statement-reassign-state",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "impossible-migrate-$derived-derived-var-1",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "event-handlers",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "slots-below-imports",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         },
         {
           "name": "script-context-module",
           "status": "skip",
-          "skip_reason": "Migrate API not implemented"
+          "skip_reason": "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"
         }
       ]
     }

--- a/scripts/update-docs.mjs
+++ b/scripts/update-docs.mjs
@@ -100,7 +100,17 @@ function generateReadmeTable(report) {
 
 		let notes = '';
 		if (stats.skipped > 0 && stats.skipped === stats.total) {
-			notes = 'Not implemented';
+			// Whole category skipped — surface the reason recorded by the
+			// test runner (e.g. "out of scope" vs "not implemented") rather
+			// than always saying "Not implemented".
+			const firstReason = cat.samples?.find((s) => s.skip_reason)?.skip_reason;
+			if (firstReason && /out of scope/i.test(firstReason)) {
+				notes = 'Out of scope';
+			} else if (firstReason) {
+				notes = firstReason;
+			} else {
+				notes = 'Not implemented';
+			}
 		} else if (stats.skipped > 0) {
 			notes = `${stats.skipped} skipped`;
 		}

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1485,10 +1485,17 @@ fn generate_compatibility_report() {
     );
     report.add_category(pre);
 
-    // Migrate is the only remaining unimplemented category.
+    // Migrate (Svelte 4 → 5 migrator) is intentionally out of scope for
+    // rsvelte — the project is a port of the Svelte 5 compiler, not a
+    // migration tool, so its 76 fixtures are reported as skipped rather
+    // than as implementation gaps. They do not count against the
+    // 100% implemented-passing total.
     print!("Running migrate tests... ");
-    let migrate = run_not_implemented_tests("migrate", "Migrate API not implemented");
-    println!("all {} skipped", migrate.stats.total);
+    let migrate = run_not_implemented_tests(
+        "migrate",
+        "Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte",
+    );
+    println!("all {} skipped (out of scope)", migrate.stats.total);
     report.add_category(migrate);
 
     // Finalize and save


### PR DESCRIPTION
## Summary

rsvelte is a port of the Svelte 5 compiler, not a Svelte 4 → 5 migration tool, so the 76 `migrate` fixtures will never count toward the implemented total. Make that explicit so future contributors don't mistake the 0/76 row as an implementation gap waiting to be filled.

## Changes

- `tests/compatibility_report.rs` — the per-sample `skip_reason` is now `"Migrate (Svelte 4 → 5 migrator) is out of scope for rsvelte"`, and the live progress line says `"all N skipped (out of scope)"`. A header comment spells out the policy.
- `scripts/update-docs.mjs` — the README/docs table now reads the first sample's `skip_reason` and surfaces **"Out of scope"** when it matches that phrase, instead of always saying "Not implemented" for fully-skipped categories.
- `AGENTS.md` (== `CLAUDE.md`) — the test-status table flags migrate as **Out of scope**, the headline total wording shifts from "implemented passing" to "in-scope passing", and the Implementation Status section moves migrate from "Not implemented" into a new "Out of scope" section that explicitly says not to start work without an explicit scope change.
- `docs/static/test-results.json` — regenerated via `pnpm run update-docs` so the dashboard JSON carries the new skip_reason strings.

No behaviour change for any test or compiler code path.

## Test plan

- [ ] `pnpm run compatibility-report` line for migrate reads `all 76 skipped (out of scope)`
- [ ] `cat fixtures/.../compatibility-report.json | jq '.categories.migrate.samples[0].skip_reason'` shows the new phrasing
- [ ] `cargo build --release` clean