### PR TITLE
fix(svelte2tsx): hoist top-level snippet blocks into $$render top (Cluster A, +3 fixtures)

### DIFF
--- a/src/svelte2tsx/svelte2tsx.rs
+++ b/src/svelte2tsx/svelte2tsx.rs
@@ -365,6 +365,25 @@ pub fn svelte2tsx(
     // Step 9: Process template nodes in-place via MagicString
     template::process_template_inplace(&ast.fragment, source, &options, &mut str);
 
+    // Step 9.1: Hoist top-level `{#snippet}` blocks to right after
+    // `function $$render() {`. The official compiler emits top-level snippets
+    // as `const name = ...` declarations at the top of `$$render()` so that
+    // their bodies share scope with the rest of the instance script (which
+    // is what fixtures like `snippet-instance-script.v5` expect). Without an
+    // instance script there's nowhere to hoist to from inside `$$render`, so
+    // skip the move in that case — they stay where the template processor
+    // left them.
+    if let Some(instance) = ast.instance.as_ref() {
+        let target = instance.content_offset;
+        for node in ast.fragment.nodes.iter() {
+            if let crate::ast::template::TemplateNode::SnippetBlock(snippet) = node {
+                if snippet.start < snippet.end {
+                    str.move_range(snippet.start, snippet.end, target);
+                }
+            }
+        }
+    }
+
     // Step 9.5: Collect slot and event information from the template
     let template_info = template::collect_template_info(&ast.fragment, source);
 


### PR DESCRIPTION
Wave 1 / Cluster A — clears `snippet-instance-script.v5`, `snippet-module-hoist-2.v5`, `snippet-module-hoist-7.v5`.

The official svelte2tsx emits top-level `{#snippet}` declarations at the start of `function $$render()` so their bodies see the same scope as the instance script. Add a pass after the template processor that `move_range`s every top-level `SnippetBlock` chunk to `instance.content_offset`.

## Compatibility
- svelte2tsx: 201/245 → **204/245** (82.0% → 83.3%)
- compatibility-report: 3096/3096 (unchanged)

## Out of scope here
The remaining `snippet-module-hoist-*` fixtures (1, 3, 4, 5, 6) expect snippets hoisted *outside* `$$render()` entirely — those are the ones whose body only references module-script vars or globals. That hoistability check needs a separate AST analyser; left as a follow-up.