### PR TITLE
fix(svelte2tsx): emit <typeParams> for generic snippets

### DIFF
--- a/src/svelte2tsx/template/mod.rs
+++ b/src/svelte2tsx/template/mod.rs
@@ -1146,9 +1146,14 @@ fn handle_snippet_block(
     // Position markers are added to help the language server:
     // - `/*Ωignore_positionΩ*/` after the name and after `async ()`
     // - Return type wrapped in `/*Ωignore_startΩ*/.../*Ωignore_endΩ*/`
+    let use_ts_syntax = options.is_ts_file || !options.emit_jsdoc;
+    let type_params_str = match (use_ts_syntax, block.type_params.as_ref()) {
+        (true, Some(tp)) => format!("<{}>", tp),
+        _ => String::new(),
+    };
     let header = format!(
-        "  const {}/*\u{03A9}ignore_position\u{03A9}*/ = ({})/*\u{03A9}ignore_start\u{03A9}*/: ReturnType<import('svelte').Snippet>/*\u{03A9}ignore_end\u{03A9}*/ => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
-        name_text, params_text
+        "  const {}/*\u{03A9}ignore_position\u{03A9}*/ = {}({})/*\u{03A9}ignore_start\u{03A9}*/: ReturnType<import('svelte').Snippet>/*\u{03A9}ignore_end\u{03A9}*/ => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
+        name_text, type_params_str, params_text
     );
     str.overwrite(block.start, body_start, &header);
 


### PR DESCRIPTION
## Summary
- Match JS reference svelte2tsx behavior: when `usTSSyntax && snippetBlock.typeParams` (TS file or non-JSDoc mode + generic), emit `<T extends string>` between the `=` and `(params)` in the generated arrow function.
- Previously the generic parameter list was silently dropped, breaking type-checking for snippets that take a generic argument.

## Test plan
- [x] `cargo test --release --no-default-features --test svelte2tsx_fixtures` (Wave 1 svelte2tsx)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- Pass rate: 204 → 205 / 245 (+1: `snippet-generics.v5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)