### PR TITLE
fix(svelte2tsx): place force-inside-render $$ComponentProps before $props()

### DIFF
--- a/src/svelte2tsx/script/mod.rs
+++ b/src/svelte2tsx/script/mod.rs
@@ -59,6 +59,11 @@ pub struct ExportedNames {
     /// Type/interface declarations from instance script that should be hoisted
     /// before $$render(). Each entry is (start, end) relative to source (absolute positions).
     pub hoistable_type_ranges: Vec<(u32, u32)>,
+    /// Absolute source position of the `let` keyword in `let { ... } = $props()`.
+    /// Used to insert `;type $$ComponentProps = ...;` right before the `$props()`
+    /// statement when the type can't be hoisted out of $$render (matches JS reference's
+    /// `move(generic_arg.pos, generic_arg.end, node.parent.pos)`).
+    pub props_let_abs_pos: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -97,6 +102,7 @@ impl ExportedNames {
             dollar_generics: Vec::new(),
             dollar_generic_positions: Vec::new(),
             hoistable_type_ranges: Vec::new(),
+            props_let_abs_pos: None,
         }
     }
     /// Build the generics string for `$$render` from `$$Generic` declarations.
@@ -879,7 +885,7 @@ fn apply_props_typedef(
     offset: u32,
     str: &mut MagicString,
     exported_names: &mut ExportedNames,
-    _raw_content: &str,
+    raw_content: &str,
     is_ts: bool,
 ) {
     if info.has_type_annotation && info.is_hoistable_type {
@@ -897,6 +903,24 @@ fn apply_props_typedef(
             );
         }
         exported_names.has_component_props_typedef = true;
+        // Track the position right BEFORE the leading whitespace of the
+        // `let { ... } = $props()` declaration so the caller can insert
+        // `;type $$ComponentProps = ...;` there when the type cannot be
+        // hoisted out of $$render (e.g. when it references `typeof <runtime-var>`
+        // or a generic). This matches the JS reference's
+        // `move(generic_arg.pos, generic_arg.end, node.parent.pos)` — TypeScript's
+        // `pos` lands right after the previous statement's trailing trivia.
+        let raw_bytes = raw_content.as_bytes();
+        let mut p = info.let_pos as usize;
+        while p > 0 {
+            let prev = raw_bytes[p - 1];
+            if prev == b' ' || prev == b'\t' || prev == b'\n' || prev == b'\r' {
+                p -= 1;
+            } else {
+                break;
+            }
+        }
+        exported_names.props_let_abs_pos = Some(p as u32 + offset);
     } else if info.has_type_annotation && !info.is_hoistable_type {
         // TS case with named type reference: `: Props` or `: Props<T>`
         // Keep the type annotation as-is, use it directly in props_type_text

--- a/src/svelte2tsx/svelte2tsx.rs
+++ b/src/svelte2tsx/svelte2tsx.rs
@@ -597,10 +597,20 @@ pub fn svelte2tsx(
                 String::new()
             };
 
-            // For best-effort auto-generated types, insert INSIDE $$render
+            // For best-effort auto-generated types, insert INSIDE $$render.
+            //
+            // If we have an explicit `props_let_abs_pos` (TS hoistable inline-object
+            // type case), defer the insertion to a `str.append_left` after the
+            // overwrite so the `;type $$ComponentProps = ...;` lands right before
+            // the `let { ... } = $props()` statement, matching the JS reference's
+            // `move(generic_arg.pos, generic_arg.end, node.parent.pos)`.
+            let inline_type_at_let = force_inside_render
+                && exported_names.props_let_abs_pos.is_some()
+                && exported_names.props_type_text.is_some();
             let ts_component_props_inside_render = if (exported_names.type_already_inserted
                 || force_inside_render)
                 && exported_names.props_type_text.is_some()
+                && !inline_type_at_let
             {
                 let type_text = exported_names.props_type_text.as_ref().unwrap();
                 if force_inside_render {
@@ -642,6 +652,18 @@ pub fn svelte2tsx(
             if script_start < content_start {
                 str.overwrite(script_start, content_start, &script_replacement);
             }
+
+            if inline_type_at_let {
+                if let (Some(let_pos), Some(type_text)) = (
+                    exported_names.props_let_abs_pos,
+                    exported_names.props_type_text.as_ref(),
+                ) {
+                    str.append_left(
+                        let_pos,
+                        &format!(";type $$ComponentProps =  {};", type_text),
+                    );
+                }
+            }
         } else {
             // No imports: overwrite the entire <script> tag at once
             let force_inside_render_no_imports = exported_names.has_component_props_typedef
@@ -673,10 +695,15 @@ pub fn svelte2tsx(
                 String::new()
             };
 
-            // For best-effort auto-generated types, insert INSIDE $$render
+            // For best-effort auto-generated types, insert INSIDE $$render.
+            // See the imports branch above for the `inline_type_at_let` rationale.
+            let inline_type_at_let = force_inside_render_no_imports
+                && exported_names.props_let_abs_pos.is_some()
+                && exported_names.props_type_text.is_some();
             let ts_component_props_inside_render = if (exported_names.type_already_inserted
                 || force_inside_render_no_imports)
                 && exported_names.props_type_text.is_some()
+                && !inline_type_at_let
             {
                 let type_text = exported_names.props_type_text.as_ref().unwrap();
                 if force_inside_render_no_imports {
@@ -710,6 +737,18 @@ pub fn svelte2tsx(
                         trailing_newline
                     ),
                 );
+            }
+
+            if inline_type_at_let {
+                if let (Some(let_pos), Some(type_text)) = (
+                    exported_names.props_let_abs_pos,
+                    exported_names.props_type_text.as_ref(),
+                ) {
+                    str.append_left(
+                        let_pos,
+                        &format!(";type $$ComponentProps =  {};", type_text),
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- For TS inline-object types like `let { x }: { x: typeof runtime } = $props()`, the type can't be hoisted out of `$$render` (it references a runtime value or generic param). The JS reference moves the synthesised `;type $$ComponentProps = ...;` chunk to `node.parent.pos` of the `let { ... }` declaration — right after the previous statement's trailing trivia.
- Previously rsvelte placed it at the start of the `$$render` body, producing a different layout from the reference output.
- Track the let-statement's leading position, walk back through whitespace to land on the previous statement's end (or the `function $$render() {` boundary for the first statement), and `append_left` there.

## Test plan
- [x] `cargo test --release --no-default-features --test svelte2tsx_fixtures`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- Pass rate: 205 → 207 / 245 (+2): `ts-runes-hoistable-props-false-3.v5`, `false-4.v5`, `false-6.v5` (false-3 and `ts-runes-generics.v5` regressed temporarily without the position fix; both still pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)