### PR TITLE
feat(svelte2tsx): inject Snapshot autotype on export const snapshot

### DIFF
--- a/src/svelte2tsx/script/mod.rs
+++ b/src/svelte2tsx/script/mod.rs
@@ -627,6 +627,7 @@ pub fn process_instance_script(
     _events: &mut ComponentEvents,
     is_ts: bool,
     basename: &str,
+    emit_jsdoc: bool,
 ) {
     let offset = script.content_offset;
     with_parsed_script(script, source, |program, raw_content| {
@@ -834,6 +835,8 @@ pub fn process_instance_script(
                     &possible_exports,
                     raw_content,
                     is_ts,
+                    basename,
+                    emit_jsdoc,
                 );
             }
         }
@@ -1354,6 +1357,8 @@ fn handle_export_named_decl(
     possible_exports: &HashMap<String, PossibleExport>,
     raw_content: &str,
     is_ts: bool,
+    basename: &str,
+    emit_jsdoc: bool,
 ) {
     let node_start = export.span.start + offset;
 
@@ -1453,6 +1458,42 @@ fn handle_export_named_decl(
                                 );
                                 let inject_pos = declarator.span.end + offset;
                                 str.append_left(inject_pos, &inject);
+                            }
+                        }
+
+                        // SvelteKit `+page.svelte` / `+layout.svelte`:
+                        // `export const snapshot = ...` should get a Snapshot
+                        // type annotation injected. Matches the JS reference's
+                        // `emitKitType(...)` call from `handleVariableStatement`
+                        // for the const branch.
+                        if is_instance
+                            && !is_let
+                            && classify_kit_route_file(basename).is_some()
+                            && !has_type_annotation
+                        {
+                            if let Some(name) = binding_pattern_simple_name(&declarator.id) {
+                                if name == "snapshot" {
+                                    if let oxc::BindingPattern::BindingIdentifier(id) =
+                                        &declarator.id
+                                    {
+                                        let name_start = id.span.start + offset;
+                                        let name_end = id.span.end + offset;
+                                        // Match the JS reference's
+                                        // `if (this.emitJsDoc && !this.isTsFile)` —
+                                        // JSDoc form only when JS file under JSDoc emit.
+                                        if emit_jsdoc && !is_ts {
+                                            // JSDoc path: `/** @type {...} */ ` before the name.
+                                            let inject =
+                                                "/** @type {import('./$types.js').Snapshot} */ ";
+                                            str.append_left(name_start, inject);
+                                        } else {
+                                            // TS path: `: import('./$types.js').Snapshot` after the name,
+                                            // wrapped in /*Ωignore*/ markers.
+                                            let inject = "/*\u{03A9}ignore_start\u{03A9}*/: import('./$types.js').Snapshot/*\u{03A9}ignore_end\u{03A9}*/";
+                                            str.append_left(name_end, inject);
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/svelte2tsx/svelte2tsx.rs
+++ b/src/svelte2tsx/svelte2tsx.rs
@@ -217,6 +217,7 @@ pub fn svelte2tsx(
             &mut events,
             options.is_ts_file,
             &basename,
+            options.emit_jsdoc,
         );
     }
 


### PR DESCRIPTION
## Summary
- Inject `import('./\$types.js').Snapshot` type annotation on `export const snapshot = ...` for SvelteKit `+page.svelte` / `+layout.svelte` route files. Mirrors `emitKitType(...)` in the JS reference.
- Plumb `basename` and `emit_jsdoc` through `process_instance_script` so `handle_export_named_decl` can pick between the JSDoc form (`/** @type {...} */`) and the TS form (`:` + ignore markers).

## Test plan
- [x] `cargo test --release --no-default-features --test svelte2tsx_fixtures` — 210 → 211 / 245.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- New pass: `jsdoc-sveltekit-autotypes-runes.v5`. The legacy `export let` JSDoc fixture (`jsdoc-sveltekit-autotypes.v5`) hits the incomplete V4 codegen path and is deferred to Cluster C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)