### PR TITLE
feat(svelte2tsx): module-only snippet hoist + empty-body snippet emission

### DIFF
--- a/src/svelte2tsx/svelte2tsx.rs
+++ b/src/svelte2tsx/svelte2tsx.rs
@@ -388,8 +388,9 @@ pub fn svelte2tsx(
     // imports / `;type` block and the `function $$render() {` declaration.
     let mut hoistable_snippet_ranges: Vec<(u32, u32)> = Vec::new();
     let mut nonhoistable_snippet_ranges: Vec<(u32, u32)> = Vec::new();
-    if let Some(instance) = ast.instance.as_ref() {
+    {
         let module_script_present = ast.module.is_some();
+        let has_instance = ast.instance.is_some();
 
         // Collect every top-level snippet first so we can run a fixed-point
         // pass over their inter-dependencies (a snippet that references the
@@ -452,8 +453,6 @@ pub fn svelte2tsx(
                             continue; // self-reference
                         }
                         if snippet_name_set.contains(&ident) {
-                            // Find the index of this snippet by name and check
-                            // if it's blocked.
                             for (j, name) in snippet_names.iter().enumerate() {
                                 if name == &ident && blocked[j] {
                                     blocked[i] = true;
@@ -484,14 +483,14 @@ pub fn svelte2tsx(
             }
         }
 
-        let inside_target = instance.content_offset;
-        // Reserve outside target for now; the actual move happens in Step 10
-        // after the script-tag overwrite has been split. To keep `move_range`
-        // behaviour predictable, do the inside-render moves here (target is
-        // already valid because `instance.content_offset` is a chunk start).
-        for (s, e) in nonhoistable_snippet_ranges.iter() {
-            str.move_range(*s, *e, inside_target);
+        // Inside-target moves require an instance script to anchor against.
+        if let Some(instance) = ast.instance.as_ref() {
+            let inside_target = instance.content_offset;
+            for (s, e) in nonhoistable_snippet_ranges.iter() {
+                str.move_range(*s, *e, inside_target);
+            }
         }
+        let _ = has_instance;
     }
 
     // Step 9.5: Collect slot and event information from the template
@@ -1005,7 +1004,30 @@ pub fn svelte2tsx(
     } else if has_module_script {
         // Module script but no instance script
         let module = ast.module.as_ref().unwrap();
+        let mod_content_start = module.content_offset;
         let mod_end = module.end;
+
+        // Module-hoistable snippets land either:
+        // - right after the last top-level import in the module script, or
+        // - at `mod_content_start` (right after `<script module ...>`'s `>`)
+        //   if the module has no imports.
+        //
+        // Mirrors the JS reference's `snippetHoistTargetForModule = lastImport
+        // ? lastImport.end + moduleAst.astOffset : moduleAst.astOffset` and the
+        // accompanying `appendLeft(target, '\n')` for the no-imports case.
+        if !hoistable_snippet_ranges.is_empty() {
+            let module_imports = find_instance_imports(module, source);
+            let module_hoist_target = match module_imports.last() {
+                Some(&(_, last_end)) => mod_content_start + last_end,
+                None => mod_content_start,
+            };
+            // JS reference: `str.appendLeft(snippetHoistTargetForModule, '\n')`
+            // for both the imports-present and no-imports branches.
+            str.append_left(module_hoist_target, "\n");
+            for (s, e) in hoistable_snippet_ranges.iter() {
+                str.move_range(*s, *e, module_hoist_target);
+            }
+        }
 
         // For module-script-only components, inject store subscriptions for
         // module-level imports at the start of the $$render async wrapper.

--- a/src/svelte2tsx/template/mod.rs
+++ b/src/svelte2tsx/template/mod.rs
@@ -1136,7 +1136,8 @@ fn handle_snippet_block(
         String::new()
     };
 
-    let body_start = if !block.body.nodes.is_empty() {
+    let has_body_nodes = !block.body.nodes.is_empty();
+    let body_start = if has_body_nodes {
         block.body.nodes[0].start()
     } else {
         block.end
@@ -1155,20 +1156,24 @@ fn handle_snippet_block(
         "  const {}/*\u{03A9}ignore_position\u{03A9}*/ = {}({})/*\u{03A9}ignore_start\u{03A9}*/: ReturnType<import('svelte').Snippet>/*\u{03A9}ignore_end\u{03A9}*/ => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
         name_text, type_params_str, params_text
     );
-    str.overwrite(block.start, body_start, &header);
+    if has_body_nodes {
+        str.overwrite(block.start, body_start, &header);
+        // Process body
+        process_fragment_inplace(&block.body, source, options, str, counter);
 
-    // Process body
-    process_fragment_inplace(&block.body, source, options, str, counter);
-
-    let body_end = if !block.body.nodes.is_empty() {
-        block.body.nodes.last().unwrap().end()
+        let body_end = block.body.nodes.last().unwrap().end();
+        if body_end < block.end {
+            // Overwrite `{/snippet}` with closing
+            str.overwrite(body_end, block.end, "};return __sveltets_2_any(0)};");
+        }
     } else {
-        body_start
-    };
-
-    // Overwrite `{/snippet}` with closing
-    if body_end < block.end {
-        str.overwrite(body_end, block.end, "};return __sveltets_2_any(0)};");
+        // Empty body: collapse the whole `{#snippet name(params)}{/snippet}`
+        // into a single declaration. Without this branch the closing
+        // `};return __sveltets_2_any(0)};` was never emitted because both the
+        // body-start overwrite and the would-be closing overwrite landed at
+        // the same offset.
+        let combined = format!("{}}};return __sveltets_2_any(0)}};", header);
+        str.overwrite(block.start, block.end, &combined);
     }
 }
 


### PR DESCRIPTION
## Summary

Two fixes that together close out Cluster A:

1. Run the snippet hoist analysis even when the component has no instance script. Module-only fixtures now correctly hoist their snippets to either right after the last module-script import or at `module.content_offset`, mirroring the JS reference's branch in `index.ts`.
2. Fix empty-body snippet emission — `{#snippet foo()}{/snippet}` with zero children left `body_start == block.end`, so `};return __sveltets_2_any(0)};` was never emitted. Detect the empty-body case and write the combined header + closing in a single overwrite.

## Test plan
- [x] `cargo test --release --no-default-features --test svelte2tsx_fixtures`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- Pass rate: 214 → 216 / 245 (+2). All five `snippet-module-hoist-*.v5` fixtures now pass; Cluster A is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)