### PR TITLE
chore: add Nix flake for reproducible dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ language-tools
 compat-targets/.cache/
 compat-targets/*/.compat-meta.json
 compat-targets/*/.rsvelte/
+
+# Nix / direnv
+.direnv/
+result
+result-*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,34 @@ debug a failure. For the higher-level project goals, see [`AGENTS.md`](AGENTS.md
 
 ## Environment setup
 
-### Native (recommended for daily work)
+### Nix (recommended — everyone gets the same toolchain)
+
+The repo ships a `flake.nix` that pins Rust (stable, latest channel via
+[fenix]), Node 22, pnpm, and `wasm-pack`. `flake.lock` pins the exact builds,
+so every contributor and CI run uses the same compiler versions byte-for-byte.
+
+Prerequisites: install Nix with flakes enabled. The
+[Determinate Systems installer](https://install.determinate.systems/) does this
+in one command.
+
+```bash
+git clone <repo-url>
+cd rsvelte
+git submodule update --init --recursive
+
+nix develop                      # drops you into a shell with the full toolchain
+git config core.hooksPath .githooks
+pnpm install
+pnpm run generate-fixtures
+cargo test
+```
+
+If you use [direnv](https://direnv.net/), `direnv allow` activates the shell
+automatically when you `cd` into the repo.
+
+[fenix]: https://github.com/nix-community/fenix
+
+### Native (without Nix)
 
 You need:
 - Rust **1.90+** (see `Cargo.toml` `rust-version`). Use `rustup update stable`.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+{
+  description = "rsvelte — high-performance Rust port of the Svelte compiler";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, fenix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Match CI: rsvelte builds on stable Rust (edition 2024 + rust-version 1.90
+        # are both stable since 1.85). `nix flake update` advances the channel
+        # when a newer stable lands; flake.lock pins the exact build for everyone.
+        rustToolchain = with fenix.packages.${system};
+          combine [
+            stable.cargo
+            stable.clippy
+            stable.rust-analyzer
+            stable.rust-src
+            stable.rustc
+            stable.rustfmt
+            targets.wasm32-unknown-unknown.stable.rust-std
+          ];
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            rustToolchain
+
+            # Node + pnpm — pinned via nixpkgs revision in flake.lock
+            pkgs.nodejs_22
+            pkgs.pnpm
+
+            # WASM tooling (used by the optional `wasm` feature)
+            pkgs.wasm-pack
+            pkgs.binaryen        # wasm-opt
+
+            # Native build deps. jemalloc + napi-rs link against system libs;
+            # `pkg-config` lets cargo find them in the Nix store.
+            pkgs.pkg-config
+            pkgs.openssl
+
+            # Misc dev tooling
+            pkgs.git
+            pkgs.cargo-watch
+            pkgs.cargo-nextest
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            # macOS frameworks needed by some native crates (sourcemap, etc.)
+            pkgs.libiconv
+            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            pkgs.darwin.apple_sdk.frameworks.CoreServices
+          ];
+
+          # Quiet down a few common Rust + Node ergonomics issues.
+          env = {
+            # Use rust-src from the Nix-provided toolchain for rust-analyzer.
+            RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+            # Avoid pnpm trying to install Node — use the one from nixpkgs.
+            PNPM_HOME = "$HOME/.local/share/pnpm";
+          };
+
+          shellHook = ''
+            echo "rsvelte dev shell"
+            echo "  $(rustc --version)"
+            echo "  node $(node --version)"
+            echo "  pnpm $(pnpm --version)"
+            echo ""
+            echo "First-time setup:"
+            echo "  git submodule update --init --recursive"
+            echo "  git config core.hooksPath .githooks"
+            echo "  pnpm install"
+            echo "  pnpm run generate-fixtures"
+          '';
+        };
+
+        # `nix fmt` runs nixpkgs-fmt across .nix files.
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}


### PR DESCRIPTION
## Summary

Add a `flake.nix` that pins the full toolchain (Rust stable via fenix, Node 22, pnpm, `wasm-pack`) so every contributor — and eventually CI — runs against the same compiler builds.

- `nix develop` drops you into a shell with everything ready.
- direnv users get auto-activation via `.envrc` (`use flake`).
- Toolchain components: cargo, clippy, rust-analyzer, rust-src, rustc, rustfmt, plus the `wasm32-unknown-unknown` rust-std for the optional `wasm` feature.
- macOS: pulls in `SystemConfiguration` / `CoreServices` frameworks for native crates.

## Follow-up

`flake.lock` is **not** included in this commit — Nix isn't available in the environment that authored this branch. The first contributor with Nix should:

```bash
nix develop                # creates flake.lock
git add flake.lock
git commit -m "chore: lock Nix flake inputs"
```

Once that's in, every contributor and CI run uses byte-for-byte the same toolchain.

## Test plan

- [ ] Run `nix develop` on Linux / macOS — shell starts, `rustc --version` / `node --version` / `pnpm --version` all print.
- [ ] Inside the shell: `cargo build --release` succeeds.
- [ ] Inside the shell: `pnpm install && pnpm run generate-fixtures && cargo test` matches the existing CI baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)