### PR TITLE
fix(svelte2tsx): skip __sveltets_createSlot binding in dts mode

### DIFF
--- a/src/svelte2tsx/svelte2tsx.rs
+++ b/src/svelte2tsx/svelte2tsx.rs
@@ -918,9 +918,15 @@ pub fn svelte2tsx(
             }
         }
 
-        // Overwrite `</script>` with slot declaration + `async () => {`
+        // Overwrite `</script>` with slot declaration + `async () => {`.
+        //
+        // In DTS mode the JS reference skips `slotsDeclaration` entirely
+        // (`slots.size > 0 && mode !== 'dts' ? ... : ''`) — the .d.ts output
+        // doesn't need runtime slot helpers, so the createSlot binding would
+        // just be dead code.
         if content_end < script_end {
-            if has_slot_elements {
+            let emit_slot_decl = has_slot_elements && !matches!(options.mode, Svelte2TsxMode::Dts);
+            if emit_slot_decl {
                 let slot_generic = if exported_names.has_slots_type {
                     "<$$Slots>"
                 } else {


### PR DESCRIPTION
## Summary
- Match `createRenderFunction.ts`'s `slots.size > 0 && mode !== 'dts'` gate so the synthesised `__sveltets_createSlot = __sveltets_2_createCreateSlot()` binding isn't emitted into the .d.ts output.

## Test plan
- [x] `cargo test --release --no-default-features --test svelte2tsx_fixtures` — 216 → 219 / 245 (+3).
- [x] `cargo clippy --all-targets --all-features -- -D warnings`.
- New passes: `creates-dts`, `ts-creates-dts`, `ts-\$\$generics-dts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)