### PR TITLE
fix(svelte2tsx): JSDoc emit polish for snippet returns + @template generics

### DIFF
--- a/src/svelte2tsx/script/mod.rs
+++ b/src/svelte2tsx/script/mod.rs
@@ -1085,12 +1085,15 @@ fn apply_props_typedef(
 
         if is_inline_object_type {
             // Inline object type: transform `/** @type {{ a: number }} */` to
-            // `/** @typedef {{ a: number }}  $$ComponentProps *//** @type {$$ComponentProps} */`
+            // `/** @typedef {{ a: number }} $$ComponentProps *//** @type {$$ComponentProps} */`.
+            // Mirrors the JS reference's `overwrite(end, end + 2, ' $$ComponentProps */' + ...)`
+            // which produces a single space between the closing `}}` and the
+            // alias name.
             if let (Some(jsdoc_start), Some(jsdoc_end)) = (info.jsdoc_start, info.jsdoc_end) {
                 let abs_start = jsdoc_start + offset;
                 let abs_end = jsdoc_end + offset;
                 let typedef = format!(
-                    "/** @typedef {}  $$ComponentProps *//** @type {{$$ComponentProps}} */",
+                    "/** @typedef {} $$ComponentProps *//** @type {{$$ComponentProps}} */",
                     jsdoc_type
                 );
                 str.overwrite(abs_start, abs_end, &typedef);

--- a/src/svelte2tsx/svelte2tsx.rs
+++ b/src/svelte2tsx/svelte2tsx.rs
@@ -609,9 +609,26 @@ pub fn svelte2tsx(
         // Detect `generics` attribute on the script tag
         let script_tag_text = &source[script_start as usize..content_start as usize];
         let generics_param = extract_generics_from_script_tag(script_tag_text);
+        let use_jsdoc_generics = options.emit_jsdoc && !options.is_ts_file;
+        // For JS files emitting JSDoc, the generics live on a `/** @template T */`
+        // line *before* `function $$render()`, not as `<T>` on the function.
+        let template_comment = if use_jsdoc_generics {
+            generics_param
+                .as_ref()
+                .filter(|g| !g.is_empty())
+                .map(|g| format!("\n/** @template {} */\n", g))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
         let render_generics = if !exported_names.dollar_generics.is_empty() {
             // Use $$Generic declarations (wrapped in ignore markers)
             exported_names.build_dollar_generics_str()
+        } else if use_jsdoc_generics {
+            // JSDoc-emit branch: keep render_generics empty; the `@template`
+            // comment is emitted before the function declaration via
+            // `template_comment`.
+            String::new()
         } else {
             generics_param
                 .as_ref()
@@ -620,7 +637,7 @@ pub fn svelte2tsx(
                         // TS files: no ignore markers around generics
                         format!("<{}>", g)
                     } else {
-                        // JS files: wrap generics content in ignore markers
+                        // JS files (non-JSDoc): wrap content in ignore markers
                         format!(
                             "</*\u{03A9}ignore_start\u{03A9}*/{}>/*\u{03A9}ignore_end\u{03A9}*/",
                             g
@@ -785,8 +802,9 @@ pub fn svelte2tsx(
                 ""
             };
             let part_b = format!(
-                "{}{}function $$render{}() {{{}{}{}",
+                "{}{}{}function $$render{}() {{{}{}{}",
                 ts_component_props_before_render,
+                template_comment,
                 async_prefix,
                 render_generics,
                 dollar_decls,
@@ -930,8 +948,9 @@ pub fn svelte2tsx(
             // part_b so it follows any hoisted type/interface declarations.
             let part_a = String::from(";");
             let part_b = format!(
-                "{}{}function $$render{}() {{{}{}{}",
+                "{}{}{}function $$render{}() {{{}{}{}",
                 ts_component_props_before_render,
+                template_comment,
                 async_prefix,
                 render_generics,
                 dollar_decls,

--- a/src/svelte2tsx/template/mod.rs
+++ b/src/svelte2tsx/template/mod.rs
@@ -1168,15 +1168,31 @@ fn handle_snippet_block(
     // Position markers are added to help the language server:
     // - `/*Ωignore_positionΩ*/` after the name and after `async ()`
     // - Return type wrapped in `/*Ωignore_startΩ*/.../*Ωignore_endΩ*/`
+    //
+    // Two emission modes match the JS reference (`SnippetBlock.ts`):
+    // - TS syntax (TS file or non-JSDoc emit): `: ReturnType<...>` after the
+    //   parameter list, with `<typeParams>` if the snippet declared generics
+    // - JSDoc syntax (JS file + JSDoc emit): `/** @returns {ReturnType<...>} */`
+    //   before the `(params)` arrow, no generic-params syntax
     let use_ts_syntax = options.is_ts_file || !options.emit_jsdoc;
     let type_params_str = match (use_ts_syntax, block.type_params.as_ref()) {
         (true, Some(tp)) => format!("<{}>", tp),
         _ => String::new(),
     };
-    let header = format!(
-        "  const {}/*\u{03A9}ignore_position\u{03A9}*/ = {}({})/*\u{03A9}ignore_start\u{03A9}*/: ReturnType<import('svelte').Snippet>/*\u{03A9}ignore_end\u{03A9}*/ => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
-        name_text, type_params_str, params_text
-    );
+    let header = if use_ts_syntax {
+        format!(
+            "  const {}/*\u{03A9}ignore_position\u{03A9}*/ = {}({})/*\u{03A9}ignore_start\u{03A9}*/: ReturnType<import('svelte').Snippet>/*\u{03A9}ignore_end\u{03A9}*/ => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
+            name_text, type_params_str, params_text
+        )
+    } else {
+        // JSDoc emission uses one fewer leading space (the `/** @returns */`
+        // marker takes the visual slot otherwise occupied by the TS `:` and
+        // its surrounding `/*Ωignore*/` comments).
+        format!(
+            " const {}/*\u{03A9}ignore_position\u{03A9}*/ = /** @returns {{ReturnType<import('svelte').Snippet>}} */ ({}) => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
+            name_text, params_text
+        )
+    };
     if has_body_nodes {
         str.overwrite(block.start, body_start, &header);
         // Process body


### PR DESCRIPTION
Cosmetic JSDoc-mode fixes: snippet headers use /** @returns */, generics become /** @template T */, typedef injection uses 1 space. No fixture flip yet — narrows jsdoc-various.v5 diff.