### PR TITLE
fix(svelte2tsx): hoist types referenced by $$Generic<X> constraints

### DIFF
--- a/src/svelte2tsx/script/mod.rs
+++ b/src/svelte2tsx/script/mod.rs
@@ -59,6 +59,14 @@ pub struct ExportedNames {
     /// Type/interface declarations from instance script that should be hoisted
     /// before $$render(). Each entry is (start, end) relative to source (absolute positions).
     pub hoistable_type_ranges: Vec<(u32, u32)>,
+    /// Type/interface declarations referenced by `$$Generic<X>` constraints that
+    /// must be moved before $$render() so the generic constraint sees the type.
+    /// Mirrors `nodesToMove` in the JS reference (`processInstanceScriptContent`).
+    /// Each entry is `(start, end)` in absolute source positions; processing
+    /// differs from `hoistable_type_ranges` (no `;` markers, no leading-trivia
+    /// walk-back, append `\n` after the chunk to mirror `moveNode`'s
+    /// `originalEndChar + '\n'` overwrite).
+    pub dollar_generic_referenced_ranges: Vec<(u32, u32)>,
     /// Absolute source position of the `let` keyword in `let { ... } = $props()`.
     /// Used to insert `;type $$ComponentProps = ...;` right before the `$props()`
     /// statement when the type can't be hoisted out of $$render (matches JS reference's
@@ -135,6 +143,7 @@ impl ExportedNames {
             dollar_generics: Vec::new(),
             dollar_generic_positions: Vec::new(),
             hoistable_type_ranges: Vec::new(),
+            dollar_generic_referenced_ranges: Vec::new(),
             props_let_abs_pos: None,
             instance_type_names: HashSet::new(),
             instance_value_names: HashSet::new(),
@@ -979,6 +988,13 @@ pub fn process_instance_script(
             exported_names.instance_value_names.insert(name.clone());
         }
 
+        // Unconditionally hoist instance-script type/interface declarations whose
+        // names appear as `$$Generic<X>` constraints. Mirrors the JS reference's
+        // `nodesToMove = interfacesAndTypes.getNodesWithNames(generics.getTypeReferences())`
+        // path in `processInstanceScriptContent`, which moves these regardless of
+        // whether the component uses the `$props()` rune.
+        hoist_dollar_generic_referenced_types(&candidates, raw_content, offset, exported_names);
+
         // Resolve which instance-script type/interface declarations are
         // hoistable above `function $$render()`. Mirrors
         // `HoistableInterfaces.moveHoistableInterfaces` in the JS reference,
@@ -1708,6 +1724,54 @@ fn resolve_hoistable_type_decls(
 #[inline]
 fn is_ident_char_for_str(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || ch == '_' || ch == '$'
+}
+
+/// Hoist instance-script type/interface declarations whose names appear as
+/// `$$Generic<X>` constraints. Mirrors the JS reference's `nodesToMove` path
+/// (`interfacesAndTypes.getNodesWithNames(generics.getTypeReferences())`) which
+/// moves these unconditionally regardless of `$props()` rune usage — without
+/// hoisting, the constraint references the type before it's defined.
+fn hoist_dollar_generic_referenced_types(
+    candidates: &[HoistCandidate],
+    raw_content: &str,
+    offset: u32,
+    exported_names: &mut ExportedNames,
+) {
+    if candidates.is_empty() || exported_names.dollar_generics.is_empty() {
+        return;
+    }
+    // Constraint text is a single identifier matching a candidate name. Inline
+    // type expressions like `{a: string}` won't match (correct: only named
+    // type references can be hoisted by name).
+    let referenced: HashSet<&str> = exported_names
+        .dollar_generics
+        .iter()
+        .filter_map(|(_, c)| c.as_deref())
+        .filter(|s| s.chars().all(is_ident_char_for_str) && !s.is_empty())
+        .collect();
+    if referenced.is_empty() {
+        return;
+    }
+    for c in candidates {
+        if !referenced.contains(c.name.as_str()) {
+            continue;
+        }
+        if exported_names
+            .hoistable_instance_type_names
+            .contains(&c.name)
+        {
+            continue;
+        }
+        // Use `c.rel_start` directly (no trivia walk-back) so the moved chunk
+        // starts with the declaration keyword — mirrors `node.getStart()` in
+        // the JS reference's `moveNode`.
+        exported_names
+            .dollar_generic_referenced_ranges
+            .push((c.rel_start + offset, c.rel_end + offset));
+        exported_names
+            .hoistable_instance_type_names
+            .insert(c.name.clone());
+    }
 }
 
 /// Walk backwards from `from` through whitespace, `//` line comments and

--- a/src/svelte2tsx/svelte2tsx.rs
+++ b/src/svelte2tsx/svelte2tsx.rs
@@ -826,7 +826,8 @@ pub fn svelte2tsx(
             );
 
             let has_hoistable_chunks = !hoistable_snippet_ranges.is_empty()
-                || !exported_names.hoistable_type_ranges.is_empty();
+                || !exported_names.hoistable_type_ranges.is_empty()
+                || !exported_names.dollar_generic_referenced_ranges.is_empty();
             // Split position: right after the `<` of `<script>`. This matches
             // the JS reference's `scriptTag.start + 1`, so moved chunks land
             // between the `;` (from the `<` overwrite) and the function
@@ -861,6 +862,20 @@ pub fn svelte2tsx(
                         // semicolon stranded at the original location.
                         str.prepend_right(s, ";");
                         str.append_left(e, ";");
+                        str.move_range(s, e, sp);
+                    }
+                }
+                // Move `$$Generic<X>`-referenced types. Mirrors the JS
+                // reference's `nodesToMove` path (`moveNode`) — uses
+                // `node.getStart()` (no leading trivia) and ends the chunk
+                // with `\n` so the following text in `part_b` (`function
+                // $$render`) starts on its own line.
+                let mut nodes_to_move = exported_names.dollar_generic_referenced_ranges.clone();
+                nodes_to_move.sort_by_key(|(s, _)| *s);
+                for (s, e) in nodes_to_move {
+                    if s < e && (e as usize) <= source.len() {
+                        str.prepend_right(s, "\n");
+                        str.append_left(e, "\n");
                         str.move_range(s, e, sp);
                     }
                 }
@@ -989,7 +1004,8 @@ pub fn svelte2tsx(
                 trailing_newline
             );
             let has_hoistable_chunks = !hoistable_snippet_ranges.is_empty()
-                || !exported_names.hoistable_type_ranges.is_empty();
+                || !exported_names.hoistable_type_ranges.is_empty()
+                || !exported_names.dollar_generic_referenced_ranges.is_empty();
             // Split position: right after the `<` of `<script>`. This matches
             // the JS reference's `scriptTag.start + 1`, so moved chunks land
             // between the `;` (from the `<` overwrite) and the function
@@ -1024,6 +1040,20 @@ pub fn svelte2tsx(
                         // semicolon stranded at the original location.
                         str.prepend_right(s, ";");
                         str.append_left(e, ";");
+                        str.move_range(s, e, sp);
+                    }
+                }
+                // Move `$$Generic<X>`-referenced types. Mirrors the JS
+                // reference's `nodesToMove` path (`moveNode`) — uses
+                // `node.getStart()` (no leading trivia) and ends the chunk
+                // with `\n` so the following text in `part_b` (`function
+                // $$render`) starts on its own line.
+                let mut nodes_to_move = exported_names.dollar_generic_referenced_ranges.clone();
+                nodes_to_move.sort_by_key(|(s, _)| *s);
+                for (s, e) in nodes_to_move {
+                    if s < e && (e as usize) <= source.len() {
+                        str.prepend_right(s, "\n");
+                        str.append_left(e, "\n");
                         str.move_range(s, e, sp);
                     }
                 }


### PR DESCRIPTION
## Summary
- Add a path that mirrors the JS reference's `nodesToMove = interfacesAndTypes.getNodesWithNames(generics.getTypeReferences())` in `processInstanceScriptContent`. Interfaces / type aliases referenced by a `$$Generic<X>` constraint are now moved before `function $$render` regardless of whether `$props()` is in use, so the generic constraint sees its referenced type.
- Mirrors `moveNode` semantics (uses `node.getStart()` rather than walking back through leading trivia, terminates the moved chunk with `\n`).

## Test plan
- [x] `cargo test --release --test svelte2tsx_fixtures --no-default-features` — 230→231 (`ts-\$\$generics-interface-references` now passes; no regressions)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)