### PR TITLE
fix(svelte2tsx): wrap CSS custom prop attrs on components in __sveltets_2_cssProp

### DIFF
--- a/src/svelte2tsx/template/mod.rs
+++ b/src/svelte2tsx/template/mod.rs
@@ -2392,7 +2392,17 @@ fn build_component_props_string(attributes: &[Attribute], source: &str) -> Strin
                     continue;
                 }
                 if let Some(s) = format_attribute_node(node, source) {
-                    parts.push(s);
+                    if node.name.starts_with("--") {
+                        // CSS custom properties on components must be wrapped
+                        // with `__sveltets_2_cssProp` so TS does not flag the
+                        // `--xx` key as an invalid prop. Mirrors the JS
+                        // reference's `name.unshift('...__sveltets_2_cssProp({')`
+                        // / `value.push('})')` in `htmlxtojsx_v2/nodes/Attribute.ts`.
+                        let inner = s.strip_suffix(',').unwrap_or(&s);
+                        parts.push(format!("...__sveltets_2_cssProp({{{}}}),", inner));
+                    } else {
+                        parts.push(s);
+                    }
                 }
             }
             Attribute::SpreadAttribute(spread) => {


### PR DESCRIPTION
## Summary
- Mirror `htmlxtojsx_v2/nodes/Attribute.ts`: when an attribute name on an InlineComponent starts with `--`, wrap the synthesized prop in `...__sveltets_2_cssProp({...})` so TypeScript does not flag `--xx` keys as invalid component props.

## Test plan
- [x] `cargo test --release --test svelte2tsx_fixtures --no-default-features` — 231→232 (`custom-css-properties-with-\$store` now passes; no regressions)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)