### PR TITLE
feat(svelte2tsx): add rewriteExternalImports option

### DIFF
--- a/src/svelte2tsx/mod.rs
+++ b/src/svelte2tsx/mod.rs
@@ -8,6 +8,6 @@ pub mod svelte2tsx;
 pub mod template;
 
 pub use svelte2tsx::{
-    Svelte2TsxError, Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, Svelte2TsxResult,
-    SvelteVersion, svelte2tsx,
+    RewriteExternalImportsOptions, Svelte2TsxError, Svelte2TsxMode, Svelte2TsxNamespace,
+    Svelte2TsxOptions, Svelte2TsxResult, SvelteVersion, svelte2tsx,
 };

--- a/src/svelte2tsx/svelte2tsx.rs
+++ b/src/svelte2tsx/svelte2tsx.rs
@@ -67,6 +67,23 @@ pub struct Svelte2TsxOptions {
     /// Whether to emit JSDoc format for component export instead of TypeScript syntax.
     /// When true and not a TS file, uses `export const` + `/** @typedef */` format.
     pub emit_jsdoc: bool,
+    /// When set, rewrites relative import specifiers that escape the workspace
+    /// so they remain valid from the generated `.tsx` location. Mirrors
+    /// `helpers/rewriteExternalImports.ts` in the JS reference.
+    pub rewrite_external_imports: Option<RewriteExternalImportsOptions>,
+}
+
+/// Inputs for the optional external-import rewrite pass — mirrors the JS
+/// reference's `RewriteExternalImportsOptions`.
+#[derive(Debug, Clone)]
+pub struct RewriteExternalImportsOptions {
+    /// Absolute path of the `.svelte` source file we are converting.
+    pub source_path: String,
+    /// Absolute path the generated `.tsx` will live at.
+    pub generated_path: String,
+    /// Workspace root — `../` specifiers that resolve *inside* this directory
+    /// stay unchanged.
+    pub workspace_path: String,
 }
 
 impl Default for Svelte2TsxOptions {
@@ -80,6 +97,7 @@ impl Default for Svelte2TsxOptions {
             version: SvelteVersion::V5,
             runes: None,
             emit_jsdoc: false,
+            rewrite_external_imports: None,
         }
     }
 }
@@ -1601,7 +1619,19 @@ pub fn svelte2tsx(
 
     str.append_str(&closing);
 
-    let code = str.to_string();
+    let mut code = str.to_string();
+
+    // Final post-pass: rewrite `../`-relative import specifiers in the
+    // assembled output. We apply this here (rather than as a pre-pass on
+    // the source) because earlier overwrites — e.g. opening-tag rewrites
+    // for `<button onclick={() => import('...')}>` — replace whole ranges
+    // wholesale and would otherwise mask any source-level rewrite.
+    // Mirrors `helpers/rewriteExternalImports.ts` semantically; the AST
+    // walk is unnecessary because we only target specifiers adjacent to
+    // `from`/`import(` tokens.
+    if let Some(ref rewrite_opts) = options.rewrite_external_imports {
+        code = rewrite_external_specifiers_in_text(&code, rewrite_opts);
+    }
 
     Ok(Svelte2TsxResult {
         code,
@@ -2022,6 +2052,211 @@ fn find_last_two_byte_sequence(buf: &[u8], a: u8, b: u8) -> Option<usize> {
         i -= 1;
     }
     None
+}
+
+// =============================================================================
+// External import rewriting (mirrors helpers/rewriteExternalImports.ts)
+// =============================================================================
+
+fn parent_dir(path: &str) -> String {
+    match path.rfind('/') {
+        Some(0) => "/".to_string(),
+        Some(i) => path[..i].to_string(),
+        None => "".to_string(),
+    }
+}
+
+/// POSIX-style `path.resolve(base, rel)` — joins `base` and `rel` and
+/// normalises away `.` / `..` components.
+fn resolve_posix(base: &str, rel: &str) -> String {
+    let abs = base.starts_with('/');
+    let mut parts: Vec<&str> = base
+        .split('/')
+        .filter(|s| !s.is_empty() && *s != ".")
+        .collect();
+    for p in rel.split('/') {
+        if p.is_empty() || p == "." {
+            continue;
+        }
+        if p == ".." {
+            parts.pop();
+        } else {
+            parts.push(p);
+        }
+    }
+    let joined = parts.join("/");
+    if abs { format!("/{}", joined) } else { joined }
+}
+
+/// POSIX-style `path.relative(from, to)`.
+fn relative_posix(from: &str, to: &str) -> String {
+    let from_parts: Vec<&str> = from.split('/').filter(|s| !s.is_empty()).collect();
+    let to_parts: Vec<&str> = to.split('/').filter(|s| !s.is_empty()).collect();
+    let common = from_parts
+        .iter()
+        .zip(to_parts.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let mut result: Vec<String> = Vec::new();
+    for _ in common..from_parts.len() {
+        result.push("..".to_string());
+    }
+    for p in to_parts.iter().skip(common) {
+        result.push((*p).to_string());
+    }
+    if result.is_empty() {
+        ".".to_string()
+    } else {
+        result.join("/")
+    }
+}
+
+fn is_within_dir(target: &str, dir: &str) -> bool {
+    let dir = dir.trim_end_matches('/');
+    target == dir || target.starts_with(&format!("{}/", dir))
+}
+
+fn split_specifier(spec: &str) -> (&str, &str) {
+    let q = spec.find('?');
+    let h = spec.find('#');
+    let cut = match (q, h) {
+        (None, None) => return (spec, ""),
+        (Some(q), None) => q,
+        (None, Some(h)) => h,
+        (Some(q), Some(h)) => q.min(h),
+    };
+    (&spec[..cut], &spec[cut..])
+}
+
+fn compute_rewrite(specifier: &str, opts: &RewriteExternalImportsOptions) -> Option<String> {
+    let (path_part, suffix) = split_specifier(specifier);
+    if !path_part.starts_with("../") {
+        return None;
+    }
+    let source_dir = parent_dir(&opts.source_path);
+    let generated_dir = parent_dir(&opts.generated_path);
+    let target = resolve_posix(&source_dir, path_part);
+    if is_within_dir(&target, &opts.workspace_path) {
+        return None;
+    }
+    let rewritten = relative_posix(&generated_dir, &target);
+    let full = format!("{}{}", rewritten, suffix);
+    if full == specifier {
+        return None;
+    }
+    Some(full)
+}
+
+#[inline]
+fn is_ws_byte(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+#[inline]
+fn is_ident_byte_local(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
+}
+
+/// String-level version of `rewrite_external_imports` — same scanner, but
+/// returns a freshly-rewritten `String` instead of mutating a MagicString.
+/// Used for the synthesised `import_text` chunk that is generated from the
+/// original source (not from the MagicString) and therefore needs its own
+/// pass so the hoisted imports also pick up the rewrite.
+fn rewrite_external_specifiers_in_text(text: &str, opts: &RewriteExternalImportsOptions) -> String {
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(text.len());
+    let mut copied = 0usize;
+    let mut i = 0;
+
+    let try_rewrite_specifier =
+        |spec_start: usize, spec_end: usize, out: &mut String, copied: &mut usize| {
+            let spec = &text[spec_start..spec_end];
+            if let Some(rewrite) = compute_rewrite(spec, opts) {
+                out.push_str(&text[*copied..spec_start]);
+                out.push_str(&rewrite);
+                *copied = spec_end;
+            }
+        };
+
+    while i < len {
+        let b = bytes[i];
+
+        if b == b'\'' || b == b'"' {
+            let q = b;
+            i += 1;
+            while i < len && bytes[i] != q {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                i += 1;
+            }
+            i = (i + 1).min(len);
+            continue;
+        }
+
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        if b == b'f' && i + 4 <= len && &bytes[i..i + 4] == b"from" {
+            let prev_ok = i == 0 || !is_ident_byte_local(bytes[i - 1]);
+            if prev_ok {
+                let mut j = i + 4;
+                while j < len && is_ws_byte(bytes[j]) {
+                    j += 1;
+                }
+                if j < len && (bytes[j] == b'\'' || bytes[j] == b'"') {
+                    let q = bytes[j];
+                    let spec_start = j + 1;
+                    let mut spec_end = spec_start;
+                    while spec_end < len && bytes[spec_end] != q {
+                        spec_end += 1;
+                    }
+                    try_rewrite_specifier(spec_start, spec_end, &mut out, &mut copied);
+                    i = spec_end + 1;
+                    continue;
+                }
+            }
+        }
+
+        if b == b'i' && i + 6 <= len && &bytes[i..i + 6] == b"import" {
+            let prev_ok = i == 0 || !is_ident_byte_local(bytes[i - 1]);
+            if prev_ok {
+                let mut j = i + 6;
+                while j < len && is_ws_byte(bytes[j]) {
+                    j += 1;
+                }
+                if j < len && bytes[j] == b'(' {
+                    j += 1;
+                    while j < len && is_ws_byte(bytes[j]) {
+                        j += 1;
+                    }
+                    if j < len && (bytes[j] == b'\'' || bytes[j] == b'"') {
+                        let q = bytes[j];
+                        let spec_start = j + 1;
+                        let mut spec_end = spec_start;
+                        while spec_end < len && bytes[spec_end] != q {
+                            spec_end += 1;
+                        }
+                        try_rewrite_specifier(spec_start, spec_end, &mut out, &mut copied);
+                        i = spec_end + 1;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        i += 1;
+    }
+    if copied < text.len() {
+        out.push_str(&text[copied..]);
+    }
+    out
 }
 
 /// Decide whether a top-level `{#snippet}` block is module-hoistable.

--- a/tests/svelte2tsx_fixtures.rs
+++ b/tests/svelte2tsx_fixtures.rs
@@ -16,7 +16,8 @@ mod svelte2tsx_tests {
     use std::path::{Path, PathBuf};
 
     use svelte_compiler_rust::svelte2tsx::{
-        Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion, svelte2tsx,
+        RewriteExternalImportsOptions, Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions,
+        SvelteVersion, svelte2tsx,
     };
 
     // =========================================================================
@@ -77,12 +78,30 @@ mod svelte2tsx_tests {
 
         // Read config.json overrides if present
         let mut filename = svelte_filename.to_string();
+        let mut rewrite_external_imports: Option<RewriteExternalImportsOptions> = None;
         let config_path = sample_dir.join("config.json");
         if config_path.exists() {
             if let Ok(config_str) = fs::read_to_string(&config_path) {
                 if let Ok(config) = serde_json::from_str::<serde_json::Value>(&config_str) {
                     if let Some(f) = config.get("filename").and_then(|v| v.as_str()) {
                         filename = f.to_string();
+                    }
+                    if let Some(rew) = config.get("rewriteExternalImports") {
+                        let workspace = rew
+                            .get("workspacePath")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        let generated = rew
+                            .get("generatedPath")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        if !workspace.is_empty() && !generated.is_empty() {
+                            rewrite_external_imports = Some(RewriteExternalImportsOptions {
+                                source_path: filename.clone(),
+                                generated_path: generated.to_string(),
+                                workspace_path: workspace.to_string(),
+                            });
+                        }
                     }
                 }
             }
@@ -97,6 +116,7 @@ mod svelte2tsx_tests {
             version,
             runes: None,
             emit_jsdoc,
+            rewrite_external_imports,
         }
     }
 


### PR DESCRIPTION
## Summary
- Mirror `helpers/rewriteExternalImports.ts`: when the generated `.tsx` lives in a different directory than the source `.svelte` (e.g. SvelteKit's `.svelte-kit/types` emit), `../`-relative imports that escape the workspace root must be lengthened so they resolve correctly from the new location.
- New `RewriteExternalImportsOptions` struct on `Svelte2TsxOptions`.
- POSIX path resolution helpers (`resolve_posix`, `relative_posix`, `is_within_dir`) mirror `path.resolve` / `path.relative` semantics without bringing in an extra crate.
- The actual rewrite is a lexical post-pass on the assembled output. Doing it as a post-pass (not pre-pass) avoids being clobbered by earlier opening-tag overwrites for `<button onclick={() => import('…')}>`-style template arrow bodies.
- The fixture test runner now reads `rewriteExternalImports` from `config.json`.

## Test plan
- [x] `cargo test --release --test svelte2tsx_fixtures --no-default-features` — 234→235 (\`rewrite-imports\` now passes; no regressions)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)