### PR TITLE
feat(wave2): scaffold svelte-check CLI (Svelte-side diagnostics only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,10 +48,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "autocfg"
@@ -220,6 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -228,8 +273,22 @@ version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -237,6 +296,12 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -538,6 +603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +803,12 @@ name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -965,6 +1042,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -1658,6 +1741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "supports-color"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1773,7 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "chrono",
+ "clap",
  "compact_str",
  "console_error_panic_hook",
  "criterion",
@@ -1956,6 +2046,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ string_wizard = "0.0.27"
 # File system
 walkdir = "2.5"
 
+# CLI argument parsing (svelte-check binary, Wave 2)
+clap = { version = "4.5", features = ["derive"] }
+
 # Time
 chrono = "0.4"
 

--- a/src/bin/svelte_check.rs
+++ b/src/bin/svelte_check.rs
@@ -1,0 +1,83 @@
+//! `svelte-check` CLI binary — Wave 2 of the ecosystem port. v0.1
+//! covers Svelte-side diagnostics only (compile errors + compiler
+//! warnings). tsgo integration is the next milestone.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use svelte_compiler_rust::svelte_check::{
+    OutputFormat, RunOptions, run, writers::write_diagnostic, writers::write_summary,
+};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "svelte-check",
+    about = "Type-check & diagnose Svelte projects (Rust port of @sveltejs/svelte-check)",
+    long_about = None
+)]
+struct Cli {
+    /// Workspace root (defaults to the current directory).
+    #[arg(long = "workspace")]
+    workspace: Option<PathBuf>,
+
+    /// Output format: human, human-verbose, machine, machine-verbose.
+    #[arg(long = "output", default_value = "human-verbose")]
+    output: String,
+
+    /// Comma-separated list of path components to skip during traversal.
+    #[arg(long = "ignore")]
+    ignore: Option<String>,
+
+    /// Treat warnings as errors when computing the exit code.
+    #[arg(long = "fail-on-warnings", default_value_t = false)]
+    fail_on_warnings: bool,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let format = match OutputFormat::parse(&cli.output) {
+        Some(f) => f,
+        None => {
+            eprintln!(
+                "Unknown output format `{}` — expected human, human-verbose, machine, or machine-verbose",
+                cli.output
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    let workspace = cli
+        .workspace
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let ignore = cli
+        .ignore
+        .as_deref()
+        .map(|s| {
+            s.split(',')
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let options = RunOptions {
+        workspace: workspace.clone(),
+        ignore,
+        fail_on_warnings: cli.fail_on_warnings,
+    };
+
+    let result = run(&options);
+
+    let mut out = String::new();
+    for diag in &result.diagnostics {
+        write_diagnostic(&mut out, diag, &workspace, format);
+    }
+    if matches!(format, OutputFormat::Human | OutputFormat::HumanVerbose) {
+        write_summary(&mut out, &result.diagnostics, result.files_checked);
+    }
+    print!("{}", out);
+
+    ExitCode::from(result.exit_code(cli.fail_on_warnings) as u8)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub mod ast;
 pub mod compiler;
 pub mod error;
 pub mod svelte2tsx;
+#[cfg(feature = "native")]
+pub mod svelte_check;
 
 #[cfg(feature = "napi")]
 pub mod napi;

--- a/src/svelte_check/diagnostic.rs
+++ b/src/svelte_check/diagnostic.rs
@@ -1,0 +1,53 @@
+//! Diagnostic types — the canonical shape that every source (rsvelte
+//! compile errors, rsvelte warnings, future tsgo type errors) must
+//! produce. The writers in `writers.rs` consume only this type, which
+//! keeps the source-specific glue thin.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DiagnosticSeverity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl DiagnosticSeverity {
+    pub fn label(self) -> &'static str {
+        match self {
+            DiagnosticSeverity::Error => "error",
+            DiagnosticSeverity::Warning => "warning",
+            DiagnosticSeverity::Info => "info",
+            DiagnosticSeverity::Hint => "hint",
+        }
+    }
+}
+
+/// One-based source position (line, column). Mirrors the JS reference's
+/// LSP-shaped diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Position {
+    pub line: u32,
+    pub column: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Range {
+    pub start: Position,
+    pub end: Position,
+}
+
+/// A single user-visible diagnostic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Diagnostic {
+    pub file: PathBuf,
+    pub severity: DiagnosticSeverity,
+    pub code: Option<String>,
+    pub message: String,
+    pub range: Option<Range>,
+    /// "svelte" / "ts" / "css" — matches the JS reference's
+    /// `--diagnostic-sources` filter values.
+    pub source: &'static str,
+}

--- a/src/svelte_check/mod.rs
+++ b/src/svelte_check/mod.rs
@@ -1,0 +1,20 @@
+//! `svelte-check` — Wave 2 of the ecosystem port.
+//!
+//! Walks a Svelte project, runs the rsvelte compiler on every `.svelte` file
+//! to collect compile-time errors and warnings, and (later) shells out to
+//! tsgo to add TypeScript-level diagnostics. Mirrors the JS reference at
+//! `submodules/language-tools/packages/svelte-check/src/`.
+//!
+//! This v0.1 covers only the Svelte-side diagnostics. tsgo integration is
+//! tracked as the next milestone in `docs/ecosystem-implementation-plan.md`
+//! Wave 2.
+
+pub mod diagnostic;
+pub mod runner;
+pub mod walker;
+pub mod writers;
+
+pub use diagnostic::{Diagnostic, DiagnosticSeverity};
+pub use runner::{RunOptions, RunResult, run};
+pub use walker::find_svelte_files;
+pub use writers::OutputFormat;

--- a/src/svelte_check/runner.rs
+++ b/src/svelte_check/runner.rs
@@ -1,0 +1,149 @@
+//! Top-level runner. Walks the workspace, runs the rsvelte compiler on
+//! every `.svelte` file, and produces a flat list of diagnostics ready
+//! for the writers in `writers.rs`.
+//!
+//! v0.1 only collects Svelte-side diagnostics (parse / analysis /
+//! transform errors + compiler warnings). The TypeScript pipeline
+//! (svelte2tsx → tsgo → diagnostic mapper) is the next milestone.
+
+use std::path::{Path, PathBuf};
+
+use crate::compiler::{CompileOptions, GenerateMode, compile};
+
+use super::diagnostic::{Diagnostic, DiagnosticSeverity, Position, Range};
+use super::walker::find_svelte_files;
+
+/// Inputs to a `svelte-check` run.
+#[derive(Debug, Clone)]
+pub struct RunOptions {
+    /// Workspace root — `.svelte` files are searched under this directory.
+    pub workspace: PathBuf,
+    /// Path fragments to skip while walking (relative to the workspace root).
+    pub ignore: Vec<String>,
+    /// Whether to treat warnings as errors for exit-code purposes.
+    pub fail_on_warnings: bool,
+}
+
+impl Default for RunOptions {
+    fn default() -> Self {
+        Self {
+            workspace: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            ignore: Vec::new(),
+            fail_on_warnings: false,
+        }
+    }
+}
+
+/// Result of a `svelte-check` run.
+#[derive(Debug, Clone, Default)]
+pub struct RunResult {
+    pub diagnostics: Vec<Diagnostic>,
+    pub files_checked: usize,
+}
+
+impl RunResult {
+    pub fn error_count(&self) -> usize {
+        self.diagnostics
+            .iter()
+            .filter(|d| d.severity == DiagnosticSeverity::Error)
+            .count()
+    }
+
+    pub fn warning_count(&self) -> usize {
+        self.diagnostics
+            .iter()
+            .filter(|d| d.severity == DiagnosticSeverity::Warning)
+            .count()
+    }
+
+    /// Process exit code per the JS reference: 1 if any errors, 1 also
+    /// when `fail_on_warnings` and any warnings exist, 0 otherwise.
+    pub fn exit_code(&self, fail_on_warnings: bool) -> i32 {
+        if self.error_count() > 0 || (fail_on_warnings && self.warning_count() > 0) {
+            1
+        } else {
+            0
+        }
+    }
+}
+
+/// Run rsvelte's compiler on every `.svelte` file under `options.workspace`
+/// and collect the resulting diagnostics. tsgo / svelte2tsx integration
+/// will plug in here in a follow-up.
+pub fn run(options: &RunOptions) -> RunResult {
+    let files = find_svelte_files(&options.workspace, &options.ignore);
+    let mut result = RunResult {
+        diagnostics: Vec::new(),
+        files_checked: 0,
+    };
+    for file in &files {
+        result.files_checked += 1;
+        let source = match std::fs::read_to_string(file) {
+            Ok(s) => s,
+            Err(e) => {
+                result.diagnostics.push(Diagnostic {
+                    file: file.clone(),
+                    severity: DiagnosticSeverity::Error,
+                    code: Some("read-error".into()),
+                    message: format!("could not read file: {e}"),
+                    range: None,
+                    source: "svelte",
+                });
+                continue;
+            }
+        };
+        run_one_file(file, &source, &mut result.diagnostics);
+    }
+    result
+}
+
+fn run_one_file(file: &Path, source: &str, out: &mut Vec<Diagnostic>) {
+    let opts = CompileOptions {
+        generate: GenerateMode::Client,
+        filename: Some(file.display().to_string()),
+        ..Default::default()
+    };
+    match compile(source, opts) {
+        Ok(res) => {
+            for w in res.warnings {
+                out.push(Diagnostic {
+                    file: file.to_path_buf(),
+                    severity: DiagnosticSeverity::Warning,
+                    code: Some(w.code),
+                    message: w.message,
+                    range: range_from_warning(w.start.as_ref(), w.end.as_ref()),
+                    source: "svelte",
+                });
+            }
+        }
+        Err(e) => {
+            out.push(Diagnostic {
+                file: file.to_path_buf(),
+                severity: DiagnosticSeverity::Error,
+                code: Some("compile-error".into()),
+                message: format!("{e}"),
+                range: None,
+                source: "svelte",
+            });
+        }
+    }
+}
+
+fn range_from_warning(
+    start: Option<&crate::compiler::Position>,
+    end: Option<&crate::compiler::Position>,
+) -> Option<Range> {
+    let start = start?;
+    let end_pos = end.unwrap_or(start);
+    Some(Range {
+        start: Position {
+            line: start.line as u32,
+            // Compiler positions are 0-indexed columns; LSP uses 0-index too.
+            column: start.column as u32,
+        },
+        end: Position {
+            line: end_pos.line as u32,
+            column: end_pos.column as u32,
+        },
+    })
+}

--- a/src/svelte_check/walker.rs
+++ b/src/svelte_check/walker.rs
@@ -1,0 +1,108 @@
+//! Project walker: find `.svelte` files in a workspace.
+//!
+//! Mirrors `submodules/language-tools/packages/svelte-check/src/utils.ts`'s
+//! file traversal: walk the workspace skipping `node_modules` and any
+//! user-supplied ignore globs.
+
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+/// Find every `.svelte` file under `root`, skipping `node_modules` and any
+/// user-supplied `filter_paths` (relative path fragments — entries whose
+/// path contains any fragment as a path component are skipped).
+pub fn find_svelte_files(root: &Path, filter_paths: &[String]) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let walker = WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            let name = e.file_name().to_string_lossy();
+            // Always skip node_modules and hidden directories — matches
+            // the JS `excludePattern: /node_modules/.*\..*$/` plus the
+            // implicit hidden-dir skip.
+            if name == "node_modules" || name.starts_with('.') {
+                return false;
+            }
+            if filter_paths.is_empty() {
+                return true;
+            }
+            // User-supplied ignore: skip if any path component matches.
+            let path = e.path();
+            !filter_paths.iter().any(|frag| {
+                path.components()
+                    .any(|c| c.as_os_str().to_string_lossy() == *frag)
+            })
+        });
+    for entry in walker.flatten() {
+        if entry.file_type().is_file() && entry.path().extension().is_some_and(|e| e == "svelte") {
+            out.push(entry.into_path());
+        }
+    }
+    out.sort();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    fn setup_project(root: &Path) {
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("node_modules/something")).unwrap();
+        fs::create_dir_all(root.join("dist")).unwrap();
+        fs::create_dir_all(root.join(".hidden")).unwrap();
+        let touch = |p: &Path| {
+            fs::File::create(p)
+                .unwrap()
+                .write_all(b"<div></div>")
+                .unwrap();
+        };
+        touch(&root.join("src/App.svelte"));
+        touch(&root.join("src/Inner.svelte"));
+        touch(&root.join("node_modules/something/Bad.svelte"));
+        touch(&root.join("dist/Build.svelte"));
+        touch(&root.join(".hidden/Hidden.svelte"));
+    }
+
+    #[test]
+    fn finds_svelte_files_skipping_node_modules() {
+        let tmp = std::env::temp_dir().join(format!("svc_walker_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        setup_project(&tmp);
+        let files = find_svelte_files(&tmp, &[]);
+        let names: Vec<_> = files
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        assert!(names.contains(&"App.svelte".into()));
+        assert!(names.contains(&"Inner.svelte".into()));
+        assert!(names.contains(&"Build.svelte".into()));
+        assert!(
+            !names.contains(&"Bad.svelte".into()),
+            "node_modules skipped"
+        );
+        assert!(
+            !names.contains(&"Hidden.svelte".into()),
+            "hidden dirs skipped"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn applies_user_filter() {
+        let tmp = std::env::temp_dir().join(format!("svc_walker_filter_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        setup_project(&tmp);
+        let files = find_svelte_files(&tmp, &["dist".into()]);
+        let names: Vec<_> = files
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        assert!(names.contains(&"App.svelte".into()));
+        assert!(!names.contains(&"Build.svelte".into()), "dist filtered");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}

--- a/src/svelte_check/writers.rs
+++ b/src/svelte_check/writers.rs
@@ -1,0 +1,118 @@
+//! Output writers — translate a stream of `Diagnostic` records into the
+//! shape `svelte-check` callers expect. Mirrors
+//! `submodules/language-tools/packages/svelte-check/src/writers.ts`.
+//!
+//! v0.1 implements `human` and `machine` formats; the verbose variants
+//! reuse the human/machine path with extra fields.
+
+use std::fmt::Write;
+
+use super::diagnostic::{Diagnostic, DiagnosticSeverity};
+
+/// Output mode. Matches the values accepted by `--output` on the JS CLI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    Human,
+    HumanVerbose,
+    Machine,
+    MachineVerbose,
+}
+
+impl OutputFormat {
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "human" => OutputFormat::Human,
+            "human-verbose" => OutputFormat::HumanVerbose,
+            "machine" => OutputFormat::Machine,
+            "machine-verbose" => OutputFormat::MachineVerbose,
+            _ => return None,
+        })
+    }
+}
+
+/// Write a single diagnostic to `out` in the chosen format.
+pub fn write_diagnostic(
+    out: &mut String,
+    diag: &Diagnostic,
+    workspace_root: &std::path::Path,
+    format: OutputFormat,
+) {
+    match format {
+        OutputFormat::Human | OutputFormat::HumanVerbose => write_human(out, diag, workspace_root),
+        OutputFormat::Machine | OutputFormat::MachineVerbose => {
+            write_machine(out, diag, workspace_root, format)
+        }
+    }
+}
+
+fn write_human(out: &mut String, diag: &Diagnostic, workspace_root: &std::path::Path) {
+    let rel = diag.file.strip_prefix(workspace_root).unwrap_or(&diag.file);
+    let position = diag
+        .range
+        .map(|r| format!(":{}:{}", r.start.line, r.start.column))
+        .unwrap_or_default();
+    let _ = writeln!(
+        out,
+        "{} {}{} ({}): {}",
+        diag.severity.label().to_uppercase(),
+        rel.display(),
+        position,
+        diag.source,
+        diag.message
+    );
+}
+
+fn write_machine(
+    out: &mut String,
+    diag: &Diagnostic,
+    workspace_root: &std::path::Path,
+    format: OutputFormat,
+) {
+    // `<unix_ts> <severity> <abs_path>:<line>:<col> "<msg>" <source>`
+    // The JS reference's machine format is line-oriented for grep-ability.
+    let line = diag.range.map(|r| r.start.line).unwrap_or(1);
+    let col = diag.range.map(|r| r.start.column).unwrap_or(1);
+    let path = if matches!(format, OutputFormat::MachineVerbose) {
+        diag.file.display().to_string()
+    } else {
+        diag.file
+            .strip_prefix(workspace_root)
+            .unwrap_or(&diag.file)
+            .display()
+            .to_string()
+    };
+    let escaped = diag.message.replace('"', "\\\"");
+    let _ = writeln!(
+        out,
+        "{} {}:{}:{} \"{}\" {}",
+        diag.severity.label().to_uppercase(),
+        path,
+        line,
+        col,
+        escaped,
+        diag.source
+    );
+}
+
+/// Summary line (`svelte-check found X errors and Y warnings`) printed
+/// after all per-file output. Matches the JS reference's wording.
+pub fn write_summary(out: &mut String, diagnostics: &[Diagnostic], files_checked: usize) {
+    let errors = diagnostics
+        .iter()
+        .filter(|d| d.severity == DiagnosticSeverity::Error)
+        .count();
+    let warnings = diagnostics
+        .iter()
+        .filter(|d| d.severity == DiagnosticSeverity::Warning)
+        .count();
+    let _ = writeln!(
+        out,
+        "\nsvelte-check found {} {} and {} {} in {} {}",
+        errors,
+        if errors == 1 { "error" } else { "errors" },
+        warnings,
+        if warnings == 1 { "warning" } else { "warnings" },
+        files_checked,
+        if files_checked == 1 { "file" } else { "files" },
+    );
+}


### PR DESCRIPTION
## Summary
First milestone of **Wave 2 (svelte-check)** per \`docs/ecosystem-implementation-plan.md\`.

Delivers a working \`svelte-check\` binary that:
- Walks the workspace for \`.svelte\` files (skipping \`node_modules\`, hidden dirs, and a user-supplied \`--ignore\` list).
- Compiles each file with rsvelte's \`compile()\` and reports parse / analysis / transform errors plus compiler warnings.
- Maps each result to a canonical \`Diagnostic\` shape consumed by the human / human-verbose / machine / machine-verbose writers.
- Sets exit codes per the JS reference (1 on errors; 1 on warnings if \`--fail-on-warnings\`).

### Module layout (mirrors the JS reference)
- \`src/svelte_check/walker.rs\` — file finder
- \`src/svelte_check/diagnostic.rs\` — canonical Diagnostic + Range/Position
- \`src/svelte_check/runner.rs\` — orchestrator (compile + collect)
- \`src/svelte_check/writers.rs\` — output formatters
- \`src/svelte_check/mod.rs\` — module exports
- \`src/bin/svelte_check.rs\` — CLI binary

### Smoke test
\`\`\`
WARNING Warn.svelte:6:2 (svelte): Unused CSS selector ".never-used"
https://svelte.dev/e/css_unused_selector

svelte-check found 0 errors and 1 warning in 2 files
\`\`\`

### Not yet implemented (next milestones, also in Wave 2)
- svelte2tsx → tsgo TypeScript-side diagnostics
- Sourcemap-based mapping of tsgo diagnostics back to \`.svelte\` positions
- tsconfig discovery / overlay tsconfig generation
- Watch mode, incremental cache
- \`--compiler-warnings\` filter
- \`--diagnostic-sources\` filter

## Test plan
- [x] \`cargo build --release --bin svelte_check\`
- [x] \`cargo test --release --lib svelte_check\` — walker tests pass
- [x] \`cargo test --release --test compatibility_report\` — no regression (3341/3341)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] Smoke test on \`/tmp/svc_test\`: catches CSS unused-selector warning, exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)