### PR TITLE
feat(wave2): --compiler-warnings + --diagnostic-sources filters

### DIFF
--- a/src/bin/svelte_check.rs
+++ b/src/bin/svelte_check.rs
@@ -5,9 +5,14 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use std::collections::{HashMap, HashSet};
+
 use clap::Parser;
 use svelte_compiler_rust::svelte_check::{
-    OutputFormat, RunOptions, run, writers::write_diagnostic, writers::write_summary,
+    OutputFormat, RunOptions, run,
+    runner::{DiagnosticSource, WarningOverride},
+    writers::write_diagnostic,
+    writers::write_summary,
 };
 
 #[derive(Parser, Debug)]
@@ -50,6 +55,16 @@ struct Cli {
     /// original `.svelte` source. Implies `--emit-overlay`.
     #[arg(long = "tsgo", default_value_t = false)]
     tsgo: bool,
+
+    /// Comma-separated `code:error|ignore` overrides for compiler
+    /// warnings. Example: `css-unused-selector:ignore,a11y-no-noninteractive-element-to-interactive-role:error`.
+    #[arg(long = "compiler-warnings")]
+    compiler_warnings: Option<String>,
+
+    /// Comma-separated list of diagnostic sources to surface (any
+    /// subset of `svelte`, `ts`/`js`, `css`). Default: all sources.
+    #[arg(long = "diagnostic-sources")]
+    diagnostic_sources: Option<String>,
 }
 
 fn main() -> ExitCode {
@@ -80,6 +95,9 @@ fn main() -> ExitCode {
         })
         .unwrap_or_default();
 
+    let compiler_warnings = parse_compiler_warnings(cli.compiler_warnings.as_deref());
+    let diagnostic_sources = parse_diagnostic_sources(cli.diagnostic_sources.as_deref());
+
     let options = RunOptions {
         workspace: workspace.clone(),
         ignore,
@@ -87,6 +105,8 @@ fn main() -> ExitCode {
         emit_overlay: cli.emit_overlay || cli.tsgo,
         tsconfig: cli.tsconfig,
         use_tsgo: cli.tsgo,
+        compiler_warnings,
+        diagnostic_sources,
     };
 
     let result = run(&options);
@@ -101,4 +121,44 @@ fn main() -> ExitCode {
     print!("{}", out);
 
     ExitCode::from(result.exit_code(cli.fail_on_warnings) as u8)
+}
+
+fn parse_compiler_warnings(raw: Option<&str>) -> HashMap<String, WarningOverride> {
+    let mut map = HashMap::new();
+    let Some(raw) = raw else {
+        return map;
+    };
+    for entry in raw.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let (code, level) = match entry.split_once(':') {
+            Some(pair) => pair,
+            None => continue,
+        };
+        let level = match level.trim() {
+            "error" => WarningOverride::Error,
+            "ignore" => WarningOverride::Ignore,
+            _ => continue,
+        };
+        // Accept both hyphenated (`css-unused-selector`) and
+        // underscored (`css_unused_selector`) codes — the JS reference
+        // documents hyphens, the rsvelte compiler emits underscores.
+        let normalised = code.trim().replace('-', "_");
+        map.insert(normalised, level);
+    }
+    map
+}
+
+fn parse_diagnostic_sources(raw: Option<&str>) -> Option<HashSet<DiagnosticSource>> {
+    let raw = raw?;
+    let mut set = HashSet::new();
+    for entry in raw.split(',') {
+        let entry = entry.trim();
+        if let Some(s) = DiagnosticSource::parse(entry) {
+            set.insert(s);
+        }
+    }
+    if set.is_empty() { None } else { Some(set) }
 }

--- a/src/svelte_check/runner.rs
+++ b/src/svelte_check/runner.rs
@@ -6,6 +6,7 @@
 //! transform errors + compiler warnings). The TypeScript pipeline
 //! (svelte2tsx → tsgo → diagnostic mapper) is the next milestone.
 
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::compiler::{CompileOptions, GenerateMode, compile};
@@ -15,6 +16,41 @@ use super::mapper::map_tsgo_diagnostics;
 use super::overlay::{OverlayLayout, materialize_overlay};
 use super::tsgo::{TsgoError, find_compiler, run_tsgo};
 use super::walker::find_svelte_files;
+
+/// Per-warning override: promote to error or drop entirely. Mirrors
+/// the JS reference's `--compiler-warnings code:error,code:ignore`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarningOverride {
+    Error,
+    Ignore,
+}
+
+/// Diagnostic sources the run should keep. Mirrors the JS reference's
+/// `--diagnostic-sources svelte,ts,css` filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DiagnosticSource {
+    Svelte,
+    Ts,
+    Css,
+}
+
+impl DiagnosticSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DiagnosticSource::Svelte => "svelte",
+            DiagnosticSource::Ts => "ts",
+            DiagnosticSource::Css => "css",
+        }
+    }
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "svelte" => DiagnosticSource::Svelte,
+            "ts" | "js" => DiagnosticSource::Ts,
+            "css" => DiagnosticSource::Css,
+            _ => return None,
+        })
+    }
+}
 
 /// Inputs to a `svelte-check` run.
 #[derive(Debug, Clone)]
@@ -37,6 +73,13 @@ pub struct RunOptions {
     /// tsconfig and surface mapped TypeScript diagnostics on the
     /// original `.svelte` source. Implies `emit_overlay`.
     pub use_tsgo: bool,
+    /// Compiler-warning overrides keyed by warning code (e.g.
+    /// `css-unused-selector` → `Ignore`). Empty = pass all warnings
+    /// through unchanged. Mirrors the JS `--compiler-warnings`.
+    pub compiler_warnings: HashMap<String, WarningOverride>,
+    /// Subset of diagnostic sources to surface. `None` = all sources.
+    /// Mirrors the JS `--diagnostic-sources`.
+    pub diagnostic_sources: Option<HashSet<DiagnosticSource>>,
 }
 
 impl Default for RunOptions {
@@ -48,6 +91,8 @@ impl Default for RunOptions {
             emit_overlay: false,
             tsconfig: None,
             use_tsgo: false,
+            compiler_warnings: HashMap::new(),
+            diagnostic_sources: None,
         }
     }
 }
@@ -142,7 +187,38 @@ pub fn run(options: &RunOptions) -> RunResult {
         }
     }
 
+    apply_filters(&mut result.diagnostics, options);
+
     result
+}
+
+/// Apply compiler-warnings + diagnostic-source filters in place.
+fn apply_filters(diagnostics: &mut Vec<Diagnostic>, options: &RunOptions) {
+    if !options.compiler_warnings.is_empty() {
+        diagnostics.retain_mut(|d| {
+            if d.severity != DiagnosticSeverity::Warning {
+                return true;
+            }
+            let Some(code) = d.code.as_deref() else {
+                return true;
+            };
+            match options.compiler_warnings.get(code) {
+                Some(WarningOverride::Ignore) => false,
+                Some(WarningOverride::Error) => {
+                    d.severity = DiagnosticSeverity::Error;
+                    true
+                }
+                None => true,
+            }
+        });
+    }
+    if let Some(allowed) = &options.diagnostic_sources {
+        diagnostics.retain(|d| {
+            DiagnosticSource::parse(d.source)
+                .map(|s| allowed.contains(&s))
+                .unwrap_or(true)
+        });
+    }
 }
 
 fn run_tsgo_phase(layout: &OverlayLayout, workspace: &Path, out: &mut Vec<Diagnostic>) {
@@ -240,4 +316,72 @@ fn range_from_warning(
             column: end_pos.column as u32,
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn diag(severity: DiagnosticSeverity, code: &str, source: &'static str) -> Diagnostic {
+        Diagnostic {
+            file: PathBuf::from("Foo.svelte"),
+            severity,
+            code: Some(code.into()),
+            message: "msg".into(),
+            range: None,
+            source,
+        }
+    }
+
+    #[test]
+    fn compiler_warnings_ignore_drops_warning_keeps_error() {
+        let mut diags = vec![
+            diag(DiagnosticSeverity::Warning, "css-unused-selector", "svelte"),
+            diag(DiagnosticSeverity::Error, "css-unused-selector", "svelte"),
+            diag(DiagnosticSeverity::Warning, "a11y-foo", "svelte"),
+        ];
+        let mut overrides = HashMap::new();
+        overrides.insert("css-unused-selector".into(), WarningOverride::Ignore);
+        let opts = RunOptions {
+            compiler_warnings: overrides,
+            ..RunOptions::default()
+        };
+        apply_filters(&mut diags, &opts);
+        assert_eq!(diags.len(), 2);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
+        assert_eq!(diags[1].code.as_deref(), Some("a11y-foo"));
+    }
+
+    #[test]
+    fn compiler_warnings_error_promotes_warning() {
+        let mut diags = vec![diag(DiagnosticSeverity::Warning, "a11y-foo", "svelte")];
+        let mut overrides = HashMap::new();
+        overrides.insert("a11y-foo".into(), WarningOverride::Error);
+        let opts = RunOptions {
+            compiler_warnings: overrides,
+            ..RunOptions::default()
+        };
+        apply_filters(&mut diags, &opts);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
+    }
+
+    #[test]
+    fn diagnostic_sources_filter_keeps_only_listed() {
+        let mut diags = vec![
+            diag(DiagnosticSeverity::Warning, "x", "svelte"),
+            diag(DiagnosticSeverity::Error, "x", "ts"),
+            diag(DiagnosticSeverity::Warning, "x", "css"),
+        ];
+        let mut allowed = HashSet::new();
+        allowed.insert(DiagnosticSource::Svelte);
+        allowed.insert(DiagnosticSource::Ts);
+        let opts = RunOptions {
+            diagnostic_sources: Some(allowed),
+            ..RunOptions::default()
+        };
+        apply_filters(&mut diags, &opts);
+        let sources: Vec<_> = diags.iter().map(|d| d.source).collect();
+        assert_eq!(sources, vec!["svelte", "ts"]);
+    }
 }


### PR DESCRIPTION
## Summary
Last functional milestone of **Wave 2 (svelte-check)** before watch-mode / incremental-cache work. Mirrors \`submodules/language-tools/packages/svelte-check/src/options.ts\`.

- **WarningOverride { Error, Ignore }** applied per-code at the end of \`run()\` — either drop a warning or promote it to an error. Hyphenated codes on the CLI (\`css-unused-selector\`) are normalised to underscores to match what rsvelte's compiler emits, so users typing either form work.
- **DiagnosticSource { Svelte, Ts, Css }**; \`--diagnostic-sources\` keeps only the listed sources. \`js\` is an alias of \`ts\` (matches the JS reference).

### Smoke tests
\`\`\`
$ svelte_check --compiler-warnings 'css-unused-selector:ignore'
svelte-check found 0 errors and 0 warnings in 2 files       ← warning suppressed

$ svelte_check --diagnostic-sources ts
svelte-check found 0 errors and 0 warnings in 2 files       ← all svelte / css filtered
\`\`\`

### Test plan
- [x] \`cargo test --release --lib svelte_check\` — 8/8 (3 new filter tests)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] Compatibility report unaffected (3341/3341)

🤖 Generated with [Claude Code](https://claude.com/claude-code)