### PR TITLE
feat(wave3): vite-plugin-svelte NAPI shim — hmrDiff + resolveId

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod error;
 pub mod svelte2tsx;
 #[cfg(feature = "native")]
 pub mod svelte_check;
+pub mod vps;
 
 #[cfg(feature = "napi")]
 pub mod napi;

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -395,3 +395,44 @@ fn parse_svelte2tsx_options(options: &Value) -> Svelte2TsxOptions {
 
     opts
 }
+
+// =============================================================================
+// vite-plugin-svelte (Wave 3) NAPI surface
+// =============================================================================
+
+use crate::vps::{ResolveOptions, hmr_diff as rust_hmr_diff, resolve_id as rust_resolve_id};
+
+/// Diff two `.svelte` source versions. Returns `{ change, instanceChanged,
+/// moduleChanged }` so the JS shim can decide between Vite's hot-update
+/// patch and a full reload. Mirrors the JS reference's
+/// `vite-plugin-svelte/src/plugins/hot-update.js`.
+#[napi(js_name = "hmrDiff")]
+pub fn napi_hmr_diff(prev: String, curr: String) -> napi::Result<Value> {
+    let diff = rust_hmr_diff(&prev, &curr);
+    let kind = match diff.change {
+        crate::vps::HmrChange::HotUpdate => "hot-update",
+        crate::vps::HmrChange::FullReload => "full-reload",
+        crate::vps::HmrChange::Unchanged => "unchanged",
+    };
+    Ok(serde_json::json!({
+        "change": kind,
+        "instanceChanged": diff.instance_changed,
+        "moduleChanged": diff.module_changed,
+    }))
+}
+
+/// Resolve a relative module specifier from an importer's directory.
+/// Returns `null` for bare specifiers — the JS shim falls back to
+/// Vite's main resolver in that case.
+#[napi(js_name = "resolveId")]
+pub fn napi_resolve_id(importer: Option<String>, specifier: String) -> napi::Result<Value> {
+    let importer_path = importer.as_ref().map(std::path::Path::new);
+    let res = rust_resolve_id(ResolveOptions {
+        importer: importer_path,
+        specifier: &specifier,
+    });
+    match res {
+        Some(r) => Ok(serde_json::json!({ "resolved": r.resolved })),
+        None => Ok(Value::Null),
+    }
+}

--- a/src/vps/hmr.rs
+++ b/src/vps/hmr.rs
@@ -1,0 +1,161 @@
+//! Decide whether a `.svelte` source change is a template-only edit
+//! (Vite can patch the running module) or an instance/module-script
+//! edit (full module reload).
+//!
+//! Mirrors the JS reference's
+//! `submodules/vite-plugin-svelte/packages/vite-plugin-svelte/src/plugins/hot-update.js`
+//! but at a coarser level: we compare the verbatim text of the
+//! `<script>` and `<script context="module">` blocks. A subsequent
+//! milestone may swap this for an AST-based diff that ignores
+//! whitespace / comments.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HmrChange {
+    /// Both `<script>` blocks are byte-identical to the previous version.
+    /// Vite can apply a module-level patch without re-running side
+    /// effects.
+    HotUpdate,
+    /// At least one `<script>` block changed (or was added/removed) →
+    /// the whole module has to re-execute, which means a full reload.
+    FullReload,
+    /// `prev` and `curr` are byte-identical → no change at all.
+    Unchanged,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmrDiff {
+    pub change: HmrChange,
+    /// True when the instance `<script>` body changed.
+    pub instance_changed: bool,
+    /// True when the `<script context="module">` body changed.
+    pub module_changed: bool,
+}
+
+/// Diff two versions of a `.svelte` source.
+///
+/// The check is intentionally conservative: any whitespace-level change
+/// inside a script block triggers `FullReload`. This is the same
+/// trade-off the JS reference makes — it parses both versions and
+/// compares the script-tag body strings.
+pub fn hmr_diff(prev: &str, curr: &str) -> HmrDiff {
+    if prev == curr {
+        return HmrDiff {
+            change: HmrChange::Unchanged,
+            instance_changed: false,
+            module_changed: false,
+        };
+    }
+    let prev_module = extract_script(prev, true);
+    let curr_module = extract_script(curr, true);
+    let prev_instance = extract_script(prev, false);
+    let curr_instance = extract_script(curr, false);
+
+    let module_changed = prev_module != curr_module;
+    let instance_changed = prev_instance != curr_instance;
+
+    let change = if module_changed || instance_changed {
+        HmrChange::FullReload
+    } else {
+        HmrChange::HotUpdate
+    };
+    HmrDiff {
+        change,
+        instance_changed,
+        module_changed,
+    }
+}
+
+/// Lexically pull out the body of `<script>` (when `module=false`) or
+/// `<script context="module">` (when `module=true`). Returns `None`
+/// when the requested script tag is absent.
+fn extract_script(source: &str, module: bool) -> Option<String> {
+    let needle = if module { "context=\"module\"" } else { "" };
+    let bytes = source.as_bytes();
+    let mut i = 0;
+    while let Some(open) = source[i..].find("<script") {
+        let abs_open = i + open;
+        let after_open = abs_open + "<script".len();
+        // Find the closing `>` of the opening tag.
+        let close_attrs = match source[after_open..].find('>') {
+            Some(p) => after_open + p,
+            None => return None,
+        };
+        let tag_attrs = &source[after_open..close_attrs];
+        let is_module = tag_attrs.contains("context=\"module\"")
+            || tag_attrs.contains("context='module'")
+            || tag_attrs.contains("context=module");
+        let body_start = close_attrs + 1;
+        // Find the closing `</script>`.
+        let body_end = match source[body_start..].find("</script>") {
+            Some(p) => body_start + p,
+            None => bytes.len(),
+        };
+        let next_i = (body_end + "</script>".len()).min(bytes.len());
+        if module == is_module {
+            // Found the kind we're looking for.
+            return Some(source[body_start..body_end].to_string());
+        }
+        i = next_i;
+        if needle.is_empty() {
+            // Caller wanted instance-script; don't loop forever if we
+            // somehow stay at the same position.
+            if i <= abs_open {
+                break;
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unchanged_is_unchanged() {
+        let s = "<script>let x = 1;</script><div>hi</div>";
+        let d = hmr_diff(s, s);
+        assert_eq!(d.change, HmrChange::Unchanged);
+    }
+
+    #[test]
+    fn template_only_change_is_hot_update() {
+        let prev = "<script>let x = 1;</script><div>old</div>";
+        let curr = "<script>let x = 1;</script><div>new</div>";
+        let d = hmr_diff(prev, curr);
+        assert_eq!(d.change, HmrChange::HotUpdate);
+        assert!(!d.instance_changed && !d.module_changed);
+    }
+
+    #[test]
+    fn instance_script_change_forces_full_reload() {
+        let prev = "<script>let x = 1;</script><div>{x}</div>";
+        let curr = "<script>let x = 2;</script><div>{x}</div>";
+        let d = hmr_diff(prev, curr);
+        assert_eq!(d.change, HmrChange::FullReload);
+        assert!(d.instance_changed);
+        assert!(!d.module_changed);
+    }
+
+    #[test]
+    fn module_script_change_forces_full_reload() {
+        let prev = "<script context=\"module\">let MOD = 1;</script><div>x</div>";
+        let curr = "<script context=\"module\">let MOD = 2;</script><div>x</div>";
+        let d = hmr_diff(prev, curr);
+        assert_eq!(d.change, HmrChange::FullReload);
+        assert!(d.module_changed);
+        assert!(!d.instance_changed);
+    }
+
+    #[test]
+    fn distinguishes_instance_and_module_blocks() {
+        let prev = "<script context=\"module\">let A = 1;</script><script>let B = 1;</script><p />";
+        let curr = "<script context=\"module\">let A = 1;</script><script>let B = 2;</script><p />";
+        let d = hmr_diff(prev, curr);
+        assert!(d.instance_changed);
+        assert!(!d.module_changed);
+    }
+}

--- a/src/vps/mod.rs
+++ b/src/vps/mod.rs
@@ -1,0 +1,20 @@
+//! `vite-plugin-svelte` (Wave 3) Rust-side helpers.
+//!
+//! The plan's Wave 3 keeps the public Vite plugin API as a thin JS shim
+//! (loaded by the user from `vite.config.js`) and delegates the hot
+//! paths to Rust over NAPI. The reusable helpers are:
+//!
+//! - `hmr` — given a previous + current `.svelte` source, decide whether
+//!   the change is template-only (Vite can patch the running module) or
+//!   needs a full reload.
+//! - `resolver` — turn an `import` specifier from a Svelte file plus its
+//!   importer into the actual filesystem path Vite should hand back.
+//!
+//! Compile + preprocess + svelte2tsx already have NAPI bindings via
+//! `crate::napi`; those don't need anything here.
+
+pub mod hmr;
+pub mod resolver;
+
+pub use hmr::{HmrChange, HmrDiff, hmr_diff};
+pub use resolver::{ResolveOptions, ResolveResult, resolve_id};

--- a/src/vps/resolver.rs
+++ b/src/vps/resolver.rs
@@ -1,0 +1,181 @@
+//! Resolve a module specifier from a Svelte file context.
+//!
+//! Mirrors the JS reference's
+//! `submodules/vite-plugin-svelte/packages/vite-plugin-svelte/src/utils/id.js`.
+//! The Vite plugin asks Rust to map an `import` specifier to an absolute
+//! filesystem path so it can register the dependency graph.
+//!
+//! Scope for v0.1:
+//! - Relative specifiers (`./`, `../`) — resolved against the importer.
+//! - Bare specifiers — left to Vite's main resolver (we return `None`).
+//! - Implicit `.svelte`/`.ts`/`.js` extensions and `index.<ext>` lookups.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct ResolveOptions<'a> {
+    pub importer: Option<&'a Path>,
+    pub specifier: &'a str,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolveResult {
+    /// Absolute path (POSIX-normalised) the importer should consume.
+    pub resolved: String,
+}
+
+/// Try to resolve `specifier` against `importer`. Returns `None` for
+/// bare specifiers or anything that doesn't exist on disk; the JS shim
+/// falls back to Vite's resolver for those cases.
+pub fn resolve_id(opts: ResolveOptions<'_>) -> Option<ResolveResult> {
+    if !is_relative(opts.specifier) {
+        return None;
+    }
+    let importer_dir = opts.importer.and_then(|p| p.parent())?;
+    let combined = combine(importer_dir, opts.specifier);
+    let normalised = normalise(&combined);
+    if let Some(found) = first_existing(&normalised, &candidate_extensions()) {
+        return Some(ResolveResult {
+            resolved: to_posix_string(&found),
+        });
+    }
+    None
+}
+
+fn is_relative(spec: &str) -> bool {
+    spec.starts_with("./") || spec.starts_with("../") || spec == "." || spec == ".."
+}
+
+fn combine(base: &Path, spec: &str) -> PathBuf {
+    base.join(spec)
+}
+
+/// Lexical path normalisation (resolves `.` and `..` without touching
+/// the filesystem). Avoids `Path::canonicalize` because the target
+/// might not exist yet and on Windows it can return UNC prefixes.
+fn normalise(p: &Path) -> PathBuf {
+    let mut out: Vec<Component<'_>> = Vec::new();
+    for c in p.components() {
+        match c {
+            Component::ParentDir => {
+                let pop_ok = out
+                    .last()
+                    .is_some_and(|c| matches!(c, Component::Normal(_)));
+                if pop_ok {
+                    out.pop();
+                } else {
+                    out.push(c);
+                }
+            }
+            Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out.into_iter().collect()
+}
+
+fn candidate_extensions() -> Vec<&'static str> {
+    vec!["", ".svelte", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
+}
+
+/// Try `path`, `path<.ext>` for each extension, and `path/index<.ext>`.
+fn first_existing(path: &Path, exts: &[&str]) -> Option<PathBuf> {
+    for ext in exts {
+        let candidate = if ext.is_empty() {
+            path.to_path_buf()
+        } else {
+            let mut s = path.as_os_str().to_owned();
+            s.push(ext);
+            PathBuf::from(s)
+        };
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    if path.is_dir() {
+        for ext in exts {
+            let candidate = path.join(format!("index{ext}"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn to_posix_string(p: &Path) -> String {
+    p.display().to_string().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    #[test]
+    fn returns_none_for_bare_specifiers() {
+        let r = resolve_id(ResolveOptions {
+            importer: Some(Path::new("/tmp/App.svelte")),
+            specifier: "lodash",
+        });
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn resolves_relative_svelte_import() {
+        let tmp = std::env::temp_dir().join(format!("vps_resolver_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::File::create(tmp.join("src/Foo.svelte"))
+            .unwrap()
+            .write_all(b"<div />")
+            .unwrap();
+        let importer = tmp.join("src/App.svelte");
+        fs::File::create(&importer)
+            .unwrap()
+            .write_all(b"<div />")
+            .unwrap();
+
+        let r = resolve_id(ResolveOptions {
+            importer: Some(&importer),
+            specifier: "./Foo.svelte",
+        })
+        .expect("relative .svelte resolves");
+        assert!(r.resolved.ends_with("/src/Foo.svelte"), "{}", r.resolved);
+
+        // Implicit extension
+        let r2 = resolve_id(ResolveOptions {
+            importer: Some(&importer),
+            specifier: "./Foo",
+        })
+        .expect("implicit extension");
+        assert!(r2.resolved.ends_with("/src/Foo.svelte"), "{}", r2.resolved);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolves_index_lookup() {
+        let tmp = std::env::temp_dir().join(format!("vps_resolver_idx_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("pkg")).unwrap();
+        fs::File::create(tmp.join("pkg/index.ts"))
+            .unwrap()
+            .write_all(b"export const x = 1;")
+            .unwrap();
+        let importer = tmp.join("App.svelte");
+        fs::File::create(&importer)
+            .unwrap()
+            .write_all(b"<div />")
+            .unwrap();
+        let r = resolve_id(ResolveOptions {
+            importer: Some(&importer),
+            specifier: "./pkg",
+        })
+        .expect("dir/index.ts");
+        assert!(r.resolved.ends_with("/pkg/index.ts"), "{}", r.resolved);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}


### PR DESCRIPTION
## Summary
First milestone of **Wave 3 (vite-plugin-svelte NAPI shim)** per \`docs/ecosystem-implementation-plan.md\`. Adds two Rust-side helpers and their NAPI wrappers so a thin JS Vite plugin shim can route hot paths through Rust:

### \`src/vps/hmr.rs\` — \`hmr_diff(prev, curr)\`
Returns \`{ change, instanceChanged, moduleChanged }\` with \`change ∈ { "unchanged", "hot-update", "full-reload" }\`. Lexically extracts \`<script>\` and \`<script context="module">\` bodies and compares them. Mirrors \`vite-plugin-svelte/src/plugins/hot-update.js\`.

### \`src/vps/resolver.rs\` — \`resolve_id(importer, specifier)\`
Resolves relative specifiers (\`./\`, \`../\`) against the importer's directory. Tries implicit \`.svelte\` / \`.ts\` / \`.tsx\` / \`.js\` / \`.jsx\` / \`.mjs\` / \`.cjs\` extensions and \`dir/index.<ext>\` lookups. Returns \`None\` for bare specifiers — the JS shim falls back to Vite's main resolver. Mirrors \`vite-plugin-svelte/src/utils/id.js\`.

### NAPI wrappers
\`src/napi.rs\` now exposes \`hmrDiff(prev, curr)\` and \`resolveId(importer, specifier)\` so the eventual JS shim only needs the existing single native binding.

## Test plan
- [x] \`cargo test --release --lib vps\` — 8/8 passing (5 hmr + 3 resolver)
- [x] \`cargo build --release\` green
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean

## Next (still in Wave 3)
- \`napi_preprocess\` (async wrapper around \`compiler::preprocess::preprocess\`; needs a JS-callable callback shape via \`napi::ThreadsafeFunction\`)
- Patching the \`submodules/vite-plugin-svelte\` JS shim to load these NAPI exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)