### PR TITLE
feat(wave3): preprocess NAPI pass-through + ecosystem status table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,17 @@ Source: `pnpm run compatibility-report` (generated 2026-05-05, Svelte commit `04
 
 **Compatibility report total: 3341/3341 in-scope passing — every in-scope category at 100%. The 76 `migrate` fixtures are intentionally out of scope and do not count against the total.**
 
+### Ecosystem port (`docs/ecosystem-implementation-plan.md`)
+
+| Wave | Scope | Status |
+|---|---|---|
+| 1 | svelte2tsx | ✅ 245/245 (100%), wired into compatibility report |
+| 2 | svelte-check | 🟡 v0.4 — walker + Svelte diagnostics + overlay materialisation + tsgo subprocess + sourcemap-mapped TS diagnostics + `--compiler-warnings` / `--diagnostic-sources`. Watch mode + incremental cache deferred. |
+| 3 | vite-plugin-svelte NAPI shim | 🟡 v0.2 — Rust-side `hmr_diff` + `resolve_id` + NAPI bindings. `preprocess` NAPI is a pass-through; bridging JS preprocessor callbacks via `ThreadsafeFunction` is the documented next step. JS shim package fork is out of scope for the rsvelte repo. |
+| 4 | svelte-language-server | ⛔ Deferred (waiting on tsgo `tsserver` mode upstream) |
+
+`migrate` (Svelte 4→5 migrator) remains intentionally out of scope.
+
 ## Implementation Status
 
 ### Fully passing in compatibility report

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -436,3 +436,21 @@ pub fn napi_resolve_id(importer: Option<String>, specifier: String) -> napi::Res
         None => Ok(Value::Null),
     }
 }
+
+/// Run rsvelte's preprocessor pipeline. v0.1 only supports the empty
+/// pipeline (no preprocessors → input passed through unchanged) — the
+/// JS shim should keep using its existing JS preprocessor path until
+/// `napi_preprocess` learns to bridge JS callbacks via
+/// `napi::ThreadsafeFunction` (tracked in
+/// `docs/ecosystem-implementation-plan.md` Wave 3 tradeoffs).
+///
+/// Shape mirrors `svelte/preprocess`: `{ code, map, dependencies }`.
+#[napi(js_name = "preprocess")]
+pub fn napi_preprocess(source: String, filename: Option<String>) -> napi::Result<Value> {
+    let _ = filename;
+    Ok(serde_json::json!({
+        "code": source,
+        "map": Value::Null,
+        "dependencies": Value::Array(vec![]),
+    }))
+}


### PR DESCRIPTION
## Summary
- **\`napi_preprocess\` pass-through** — exposes a \`preprocess(source, filename?)\` NAPI binding that returns \`{ code, map: null, dependencies: [] }\`. Currently a no-op on the source; the JS shim should keep handling JS preprocessor callbacks until the \`ThreadsafeFunction\` bridge lands (documented as a Wave 3 tradeoff in the implementation plan).
- **Ecosystem-port status table in AGENTS.md** — captures Wave 1 ✅, Wave 2 🟡 v0.4, Wave 3 🟡 v0.2, Wave 4 ⛔ deferred so the next contributor (and the autonomous loop) doesn't have to reconstruct context.

## Test plan
- [x] \`cargo build --release\` (exercises the new NAPI export)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)