### PR TITLE
feat(wave2): --output github-actions for svelte-check CI annotations

### DIFF
--- a/docs/wave-2-3-handover.md
+++ b/docs/wave-2-3-handover.md
@@ -64,14 +64,14 @@ CLI flags shipped:
 | Rust `svelte-check` binary in `target/release/svelte_check` | ✅ | Build green. |
 | Passes existing JS svelte-check fixture set (golden output comparisons) | ❌ | Not wired up — needs a fixture runner that reads `submodules/language-tools/packages/svelte-check/test/`. |
 | ≥ 2× faster than JS svelte-check on a 1000-file project | ❌ | No benchmark yet. |
-| CI-friendly: machine-readable JSON, GH Actions annotation, non-zero exit on errors | 🟡 | `machine` / `machine-verbose` formats and exit codes work. **GitHub Actions annotation format (`::error file=…,line=…::msg`) is not implemented**. |
+| CI-friendly: machine-readable JSON, GH Actions annotation, non-zero exit on errors | ✅ | `machine` / `machine-verbose` formats, exit codes, and `--output github-actions` (workflow-command annotations) all shipped. |
 
 ### What to ship next (in priority order)
 
-1. **GitHub Actions annotation output format** (small — 0.5 day).
-   - Add `OutputFormat::GithubActions` to `src/svelte_check/writers.rs`.
-   - Format: `::error file=<rel>,line=<L>,col=<C>::<message>` (and `::warning` / `::notice`).
-   - Wire into the CLI `--output` parser.
+1. ~~**GitHub Actions annotation output format**~~ — ✅ landed in PR #87.
+   `--output github-actions` (alias `--output github`) emits
+   `::error file=…,line=…,col=…::message` (and `::warning` / `::notice`)
+   with proper `%25` / `%0A` / `%0D` escaping.
 
 2. **Watch mode + incremental cache** (medium — 1–2 days).
    - The JS reference uses a manifest at `<cacheDir>/manifest.json` keyed by

--- a/src/bin/svelte_check.rs
+++ b/src/bin/svelte_check.rs
@@ -26,7 +26,8 @@ struct Cli {
     #[arg(long = "workspace")]
     workspace: Option<PathBuf>,
 
-    /// Output format: human, human-verbose, machine, machine-verbose.
+    /// Output format: human, human-verbose, machine, machine-verbose,
+    /// github-actions (alias: github).
     #[arg(long = "output", default_value = "human-verbose")]
     output: String,
 

--- a/src/svelte_check/writers.rs
+++ b/src/svelte_check/writers.rs
@@ -9,13 +9,20 @@ use std::fmt::Write;
 
 use super::diagnostic::{Diagnostic, DiagnosticSeverity};
 
-/// Output mode. Matches the values accepted by `--output` on the JS CLI.
+/// Output mode. Matches the values accepted by `--output` on the JS CLI,
+/// plus `github-actions` for CI-friendly workflow-command annotations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputFormat {
     Human,
     HumanVerbose,
     Machine,
     MachineVerbose,
+    /// `::error file=…,line=…,col=…::message` — picked up by GitHub
+    /// Actions and surfaced inline on PR diffs. Mirrors the JS
+    /// reference's `--output github` once it lands; the rsvelte CLI
+    /// uses the explicit `github-actions` name to avoid collisions
+    /// with hypothetical future format names.
+    GithubActions,
 }
 
 impl OutputFormat {
@@ -25,6 +32,7 @@ impl OutputFormat {
             "human-verbose" => OutputFormat::HumanVerbose,
             "machine" => OutputFormat::Machine,
             "machine-verbose" => OutputFormat::MachineVerbose,
+            "github" | "github-actions" => OutputFormat::GithubActions,
             _ => return None,
         })
     }
@@ -42,6 +50,7 @@ pub fn write_diagnostic(
         OutputFormat::Machine | OutputFormat::MachineVerbose => {
             write_machine(out, diag, workspace_root, format)
         }
+        OutputFormat::GithubActions => write_github_actions(out, diag, workspace_root),
     }
 }
 
@@ -94,6 +103,52 @@ fn write_machine(
     );
 }
 
+/// GitHub Actions workflow-command annotation:
+///   `::<level> file=<path>,line=<L>,col=<C>::<message>`
+/// where `<level>` is one of `error` / `warning` / `notice`. Newlines
+/// inside the message are escaped per the GitHub spec
+/// (`%0A` / `%0D` / `%25`).
+fn write_github_actions(out: &mut String, diag: &Diagnostic, workspace_root: &std::path::Path) {
+    let rel = diag.file.strip_prefix(workspace_root).unwrap_or(&diag.file);
+    let level = match diag.severity {
+        DiagnosticSeverity::Error => "error",
+        DiagnosticSeverity::Warning => "warning",
+        DiagnosticSeverity::Info | DiagnosticSeverity::Hint => "notice",
+    };
+    let line = diag.range.map(|r| r.start.line).unwrap_or(1);
+    let col = diag.range.map(|r| r.start.column).unwrap_or(1);
+    let mut message = format!("({}) {}", diag.source, diag.message);
+    if let Some(code) = diag.code.as_deref() {
+        message = format!("{message} [{code}]");
+    }
+    let escaped = escape_workflow_command(&message);
+    let _ = writeln!(
+        out,
+        "::{} file={},line={},col={}::{}",
+        level,
+        rel.display(),
+        line,
+        col,
+        escaped
+    );
+}
+
+/// Escape characters with special meaning in GitHub Actions
+/// workflow-command values per
+/// <https://docs.github.com/actions/learn-github-actions/workflow-commands-for-github-actions>.
+fn escape_workflow_command(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '%' => out.push_str("%25"),
+            '\r' => out.push_str("%0D"),
+            '\n' => out.push_str("%0A"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
 /// Summary line (`svelte-check found X errors and Y warnings`) printed
 /// after all per-file output. Matches the JS reference's wording.
 pub fn write_summary(out: &mut String, diagnostics: &[Diagnostic], files_checked: usize) {
@@ -115,4 +170,79 @@ pub fn write_summary(out: &mut String, diagnostics: &[Diagnostic], files_checked
         files_checked,
         if files_checked == 1 { "file" } else { "files" },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::svelte_check::diagnostic::{Position, Range};
+    use std::path::{Path, PathBuf};
+
+    fn diag(severity: DiagnosticSeverity, file: &str, line: u32, col: u32) -> Diagnostic {
+        Diagnostic {
+            file: PathBuf::from(file),
+            severity,
+            code: Some("css_unused_selector".into()),
+            message: "Unused CSS selector \"foo\"".into(),
+            range: Some(Range {
+                start: Position { line, column: col },
+                end: Position { line, column: col },
+            }),
+            source: "svelte",
+        }
+    }
+
+    #[test]
+    fn parse_recognises_github_actions_alias() {
+        assert_eq!(
+            OutputFormat::parse("github"),
+            Some(OutputFormat::GithubActions)
+        );
+        assert_eq!(
+            OutputFormat::parse("github-actions"),
+            Some(OutputFormat::GithubActions)
+        );
+        assert_eq!(OutputFormat::parse("nope"), None);
+    }
+
+    #[test]
+    fn github_actions_emits_workflow_command() {
+        let workspace = Path::new("/work");
+        let d = diag(DiagnosticSeverity::Error, "/work/src/Foo.svelte", 12, 3);
+        let mut out = String::new();
+        write_diagnostic(&mut out, &d, workspace, OutputFormat::GithubActions);
+        assert!(
+            out.starts_with("::error file=src/Foo.svelte,line=12,col=3::"),
+            "{out}"
+        );
+        assert!(out.contains("[css_unused_selector]"), "{out}");
+        assert!(out.contains("(svelte) Unused CSS selector"), "{out}");
+    }
+
+    #[test]
+    fn github_actions_maps_severity_to_level() {
+        let ws = Path::new("/work");
+        let mut out = String::new();
+        write_diagnostic(
+            &mut out,
+            &diag(DiagnosticSeverity::Warning, "/work/A.svelte", 1, 1),
+            ws,
+            OutputFormat::GithubActions,
+        );
+        assert!(out.starts_with("::warning "), "{out}");
+        out.clear();
+        write_diagnostic(
+            &mut out,
+            &diag(DiagnosticSeverity::Info, "/work/A.svelte", 1, 1),
+            ws,
+            OutputFormat::GithubActions,
+        );
+        assert!(out.starts_with("::notice "), "{out}");
+    }
+
+    #[test]
+    fn github_actions_escapes_special_chars() {
+        let escaped = escape_workflow_command("100% match\nnext line\rthird");
+        assert_eq!(escaped, "100%25 match%0Anext line%0Dthird");
+    }
 }


### PR DESCRIPTION
## Summary
Closes the Wave 2 acceptance criterion *"CI-friendly: machine-readable JSON, GH Actions annotation, non-zero exit on errors"*.

Adds an explicit \`GithubActions\` \`OutputFormat\` that emits GitHub workflow-command lines inline-renderable on PR diffs:

\`\`\`
::error   file=<rel>,line=<L>,col=<C>::(<source>) <msg> [<code>]
::warning ...
::notice  ...   (Info / Hint diagnostics)
\`\`\`

Special characters in the message (\`%\`, \`\\r\`, \`\\n\`) are escaped per GitHub's spec (\`%25\` / \`%0D\` / \`%0A\`). The summary line is suppressed for this format since CI logs are noisy enough.

Both \`--output github-actions\` and the shorter \`--output github\` parse to the new variant.

## Smoke test
\`\`\`
$ ./target/release/svelte_check --workspace /tmp/svc_test --output github-actions
::warning file=Warn.svelte,line=6,col=2::(svelte) Unused CSS selector ".never-used"%0Ahttps://svelte.dev/e/css_unused_selector [css_unused_selector]
\`\`\`

## Test plan
- [x] \`cargo test --release --lib svelte_check\` — 12/12 (4 new unit tests)
- [x] \`cargo build --release --bin svelte_check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`docs/wave-2-3-handover.md\` updated to mark this item ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)