### PR TITLE
chore(release): add changesets for the next @rsvelte release

### DIFF
--- a/.changeset/compiler-fixes-and-improvements.md
+++ b/.changeset/compiler-fixes-and-improvements.md
@@ -1,0 +1,8 @@
+---
+'@rsvelte/compiler': minor
+---
+
+Compiler fixes since 0.2.0:
+
+- Set the serialize arena before serializing the parsed AST in the wasm bindings.
+- Compiler improvements that bring `svelte2tsx` to 245/245 fixture compatibility.

--- a/.changeset/svelte-check-initial-release.md
+++ b/.changeset/svelte-check-initial-release.md
@@ -1,0 +1,7 @@
+---
+'@rsvelte/svelte-check': minor
+---
+
+Initial public release of `@rsvelte/svelte-check` and its prebuilt-binary platform packages (`darwin-arm64`, `darwin-x64`, `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc`).
+
+Wave 2 (v0.10) of the rsvelte ecosystem port: a Rust-powered `svelte-check` CLI with walker + overlay + tsgo backend, an incremental cache (including the per-file `warnings.json`), watch mode, parallel compile, hi-res `svelte2tsx` source maps, and SvelteKit kit-file `addedCode` augmentation for both `.ts` and `.js` files. `svelte.config.js` `kit.files` overrides are statically parsed and applied.

--- a/.changeset/svelte2tsx-initial-release.md
+++ b/.changeset/svelte2tsx-initial-release.md
@@ -1,0 +1,7 @@
+---
+'@rsvelte/svelte2tsx': minor
+---
+
+Initial public release of `@rsvelte/svelte2tsx`.
+
+A Rust/wasm port of `svelte2tsx` that passes 245/245 of the upstream fixture suite (Wave 1 of the rsvelte ecosystem port).

--- a/.changeset/vps-native-initial-release.md
+++ b/.changeset/vps-native-initial-release.md
@@ -1,0 +1,7 @@
+---
+'@rsvelte/vite-plugin-svelte-native': minor
+---
+
+Initial public release of `@rsvelte/vite-plugin-svelte-native` and its prebuilt-binary platform packages (`darwin-arm64`, `darwin-x64`, `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc`).
+
+Wave 3 (v0.3) of the rsvelte ecosystem port: NAPI bindings for the rsvelte compiler exposing `compile`, `compileModule`, `svelte2tsx`, `hmrDiff`, `resolveId`, and `preprocess` (which bridges JS preprocessor groups through `ThreadsafeFunction` and resolves the returned `Promise<Processed>`). Intended to back a future `vite-plugin-svelte` shim.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "svelte-compiler-rust"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bumpalo",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svelte-compiler-rust"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90"
 description = "A high-performance Rust implementation of the Svelte compiler"

--- a/npm/compiler/package.json
+++ b/npm/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsvelte/compiler",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A high-performance Rust implementation of the Svelte compiler",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Adds changesets so the **Release** workflow can open a "Version Packages" PR and publish:

- `@rsvelte/compiler` — **minor** bump (`0.2.0` → `0.3.0`). Local manifest, `Cargo.toml`, and `Cargo.lock` are also synced from `0.1.0` to `0.2.0` in this PR, because the previous compiler release was cut manually (before changesets were set up) and never updated the in-tree version. Without this sync, `changeset version` would try to bump `0.1.0` → `0.2.0` and collide with the already-published `@rsvelte/compiler@0.2.0`.
- `@rsvelte/svelte2tsx` — **minor** (initial public release at 245/245 fixture compatibility).
- `@rsvelte/svelte-check` + 5 platform packages — **minor** (initial release of Wave 2 / v0.10 of the ecosystem port). The fixed group in `.changeset/config.json` propagates to all platform packages automatically.
- `@rsvelte/vite-plugin-svelte-native` + 5 platform packages — **minor** (initial release of Wave 3 / v0.3 NAPI shim). Fixed group also propagates.

`pnpm changeset status` reports 14 packages bumped at minor (4 main + 10 platform packages).

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, the **Release** workflow opens a "Version Packages" PR bumping the 14 packages above and updating `CHANGELOG.md` files
- [ ] Merging the "Version Packages" PR triggers the matrix builds (svelte-check / vps-native binaries) followed by `pnpm publish` of all 14 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)