### PR TITLE
fix(ci): unbreak Release and Deploy Docs on main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -90,8 +90,11 @@ jobs:
           cache-dependency-path: docs/pnpm-lock.yaml
 
       - name: Install docs dependencies
+        # `--ignore-workspace` because the repo root became a pnpm workspace
+        # (npm/* publishing packages), and without this `pnpm install` walks
+        # up to the workspace root and skips installing docs/'s own deps.
         working-directory: docs
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: Build docs
         working-directory: docs

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -27,14 +27,13 @@ function patchCargoToml() {
 	// Replace the version line in the top-level [package] table only.
 	// `[package]` is the very first table in Cargo.toml; we match from it up
 	// to the next `[` (start of any other table) to scope the replacement.
-	const updated = original.replace(
-		/(\[package\][\s\S]*?\nversion\s*=\s*")([^"]+)(")/,
-		`$1${targetVersion}$3`,
-	);
-	if (updated === original) {
+	const re = /(\[package\][\s\S]*?\nversion\s*=\s*")([^"]+)(")/;
+	const match = original.match(re);
+	if (!match) {
 		throw new Error('Failed to find [package].version in Cargo.toml');
 	}
-	writeFileSync(cargoTomlPath, updated);
+	if (match[2] === targetVersion) return;
+	writeFileSync(cargoTomlPath, original.replace(re, `$1${targetVersion}$3`));
 }
 
 function patchCargoLock() {
@@ -46,11 +45,12 @@ function patchCargoLock() {
 	// Match exactly the entry whose name is the crate we publish.
 	const re =
 		/(\[\[package\]\]\nname = "svelte-compiler-rust"\nversion = ")([^"]+)(")/;
-	const updated = original.replace(re, `$1${targetVersion}$3`);
-	if (updated === original) {
+	const match = original.match(re);
+	if (!match) {
 		throw new Error('Failed to find svelte-compiler-rust entry in Cargo.lock');
 	}
-	writeFileSync(cargoLockPath, updated);
+	if (match[2] === targetVersion) return;
+	writeFileSync(cargoLockPath, original.replace(re, `$1${targetVersion}$3`));
 }
 
 patchCargoToml();


### PR DESCRIPTION
## Summary

Two CI workflows are failing on `main` since commit `28493cd` (the changesets release setup):

- **Release** — `scripts/sync-version.mjs` aborts with *"Failed to find [package].version in Cargo.toml"* whenever the npm and Cargo versions already match. The old check (`updated === original`) couldn't tell "regex didn't match" from "version already in sync". This fires on every push to `main` with no pending changeset, because `changesets/action` falls through to `pnpm run release` to publish any unreleased packages.
- **Deploy Docs to GitHub Pages** — `pnpm install` inside `docs/` walks up to the new workspace root (`pnpm-workspace.yaml` declares `npm/*`), installs the workspace instead of `docs/`'s own deps, and leaves `docs/node_modules` empty — so `vite build` fails with `sh: 1: vite: not found`. `docs/` is not in the workspace, so `--ignore-workspace` is the right scope.

## Test plan

- [ ] Watch CI on this PR: `Release` should be skipped/clean (no changesets) and `Deploy Docs` should succeed end-to-end.
- [ ] After merge, the next push to `main` should pass both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)