### PR TITLE
perf(transform): byte-level fast path for destructure-free statements

### DIFF
--- a/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -71,6 +71,16 @@ pub(super) fn transform_destructure_assignments_with_props(
         return statement.to_string();
     }
 
+    // Byte-level fast path: a destructure assignment requires either `]` or `}`
+    // (the close of the destructuring pattern) somewhere in the statement. If
+    // neither byte appears at all, no destructure can match — skip the per-call
+    // hashset construction and the char-vec allocations in the slow path. This
+    // is the common case for plain declarations like `let x = $state(0);` which
+    // call this function once per statement when `state_vars` is non-empty.
+    if memchr::memchr2(b']', b'}', statement.as_bytes()).is_none() {
+        return statement.to_string();
+    }
+
     let mut result = statement.to_string();
 
     // Build HashSets once for O(1) lookups across all iterations


### PR DESCRIPTION
## Summary

- `transform_destructure_assignments_with_props` is called per statement inside `transform_instance_script_for_visitors` whenever a component has any reactive binding. Every call unconditionally builds two `FxHashSet`s and calls `find_and_transform_one_destructure`, which itself allocates `Vec<char>` + `Vec<usize>` for the statement — even when the statement obviously cannot contain a destructure.
- A destructure pattern (`[a, b] = ...` / `{a, b} = ...`) requires either a `]` or `}` byte somewhere in the statement. Add a `memchr::memchr2(b']', b'}', …)` fast path that returns immediately when neither byte is present.
- Strict reduction of work for the no-destructure case; no-op for fixtures that actually destructure.

## Numbers

`runtime-runes/form-default-value-spread/main.svelte` (46 `let xN = $state(...)` statements, no destructures — exactly the case the fast path targets), median of 500 iterations after 30 warmup:

| Phase     | Before  | After   | Δ     |
|-----------|---------|---------|-------|
| Transform | 827 µs  | 791 µs  | -4.4% |
| Total     | 1.22 ms | 1.19 ms | -2.5% |

Destructure-heavy regression check on `runtime-runes/destructure-async-assignments/main.svelte`:

| Phase     | Before  | After   | Δ           |
|-----------|---------|---------|-------------|
| Transform | 2.09 ms | 2.07 ms | within noise |
| Total     | 2.58 ms | 2.55 ms | within noise |

## Test plan

- [x] `cargo test --release` for runtime, ssr, compiler_fixtures, compiler_errors, parser_fixtures, css, validator, print
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`
- [x] Confirmed numbers via `profiler --iterations 500 --warmup 30`

🤖 Generated with [Claude Code](https://claude.com/claude-code)