### PR TITLE
perf(transform): migrate $effect rune family from text scan to AST visit

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -678,6 +678,82 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
             }
         }
 
+        // $effect rune family. The runes are valid only when `$effect` is the
+        // global rune binding (not shadowed by a local declaration, function
+        // parameter, or store subscription).
+        //
+        //   $effect(fn)            -> $.user_effect(fn)
+        //   $effect.pre(fn)        -> $.user_pre_effect(fn)
+        //   $effect.root(fn)       -> $.effect_root(fn)
+        //   $effect.tracking()     -> $.effect_tracking()
+        //   $effect.pending()      -> $.eager($.pending)        (whole-call rewrite)
+        //
+        // The visitor's `scoped_vars` already tracks function/catch parameters
+        // and let/const/var declarations, so `is_shadowed("$effect")` is the
+        // precise replacement for the old statement-wide
+        // `is_function_parameter_in_statement` check used by the text pipeline.
+        if self.is_runes && !self.store_sub_vars.contains("$effect") && !self.is_shadowed("$effect")
+        {
+            match &expr.callee {
+                Expression::Identifier(callee_ident) if callee_ident.name == "$effect" => {
+                    let start = callee_ident.span.start;
+                    let end = callee_ident.span.end;
+                    self.add_replacement(start, end, "$.user_effect".to_string());
+                    for arg in &expr.arguments {
+                        self.visit_argument(arg);
+                    }
+                    return;
+                }
+                Expression::StaticMemberExpression(member) => {
+                    if let Expression::Identifier(obj) = &member.object
+                        && obj.name == "$effect"
+                    {
+                        let prop = member.property.name.as_str();
+                        match prop {
+                            "pre" | "root" => {
+                                let replacement = if prop == "pre" {
+                                    "$.user_pre_effect"
+                                } else {
+                                    "$.effect_root"
+                                };
+                                self.add_replacement(
+                                    member.span.start,
+                                    member.span.end,
+                                    replacement.to_string(),
+                                );
+                                for arg in &expr.arguments {
+                                    self.visit_argument(arg);
+                                }
+                                return;
+                            }
+                            "tracking" if expr.arguments.is_empty() => {
+                                self.add_replacement(
+                                    member.span.start,
+                                    member.span.end,
+                                    "$.effect_tracking".to_string(),
+                                );
+                                return;
+                            }
+                            "pending" if expr.arguments.is_empty() => {
+                                // Whole-call rewrite: `$effect.pending()` becomes
+                                // `$.eager($.pending)`. The empty-arg call is
+                                // restructured into a different call shape, so we
+                                // replace the entire CallExpression span.
+                                self.add_replacement(
+                                    expr.span.start,
+                                    expr.span.end,
+                                    "$.eager($.pending)".to_string(),
+                                );
+                                return;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
         // Normal call expression - walk as usual
         walk::walk_call_expression(self, expr);
     }
@@ -1835,8 +1911,16 @@ pub(super) fn transform_state_vars_ast(
     let has_stores = !store_sub_vars.is_empty();
     let has_read_only = !read_only_props.is_empty();
     let has_rest = !rest_prop_vars.is_empty();
+    // `$effect` rune transforms also live in this AST pass. The runes are only
+    // valid when `is_runes` is true *and* `$effect` is not used as a store
+    // subscription name. The visitor performs the full per-call shadowing
+    // check; here we just need a cheap script-wide gate to avoid the OXC parse
+    // when there is provably nothing to do.
+    let has_effect_calls = is_runes
+        && !store_sub_vars.iter().any(|v| v == "$effect")
+        && memchr::memmem::find(script.as_bytes(), b"$effect").is_some();
 
-    if !has_state && !has_props && !has_stores && !has_read_only && !has_rest {
+    if !has_state && !has_props && !has_stores && !has_read_only && !has_rest && !has_effect_calls {
         return None;
     }
 
@@ -1881,7 +1965,8 @@ pub(super) fn transform_state_vars_ast(
         || (has_rest
             && rest_prop_vars
                 .iter()
-                .any(|v| script_ids.contains(v.as_str())));
+                .any(|v| script_ids.contains(v.as_str())))
+        || (has_effect_calls && script_ids.contains("$effect"));
 
     if !has_any_match {
         return None;

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4298,11 +4298,19 @@ fn transform_instance_script_for_visitors(
     // prop transforms, store transforms, read-only props, and rest-prop transforms
     // with a single OXC parse + AST walk, eliminating O(M*N) text scanning.
     if analysis.runes {
+        // The AST pass also rewrites the `$effect` rune family (formerly
+        // handled by the text pipeline). A component can use `$effect` without
+        // any state/prop/store binding, so include a script-level byte probe
+        // for `$effect` here — otherwise the AST pass would be skipped and the
+        // rune would leak through untransformed.
+        let has_effect_calls = !store_sub_vars.iter().any(|v| v == "$effect")
+            && memmem::find(result.as_bytes(), b"$effect").is_some();
         let has_transforms = !state_vars.is_empty()
             || !prop_assignment_transform_vars.is_empty()
             || !store_sub_vars.is_empty()
             || !read_only_props.is_empty()
-            || !rest_prop_vars.is_empty();
+            || !rest_prop_vars.is_empty()
+            || has_effect_calls;
 
         if has_transforms {
             // Collect $derived / $derived.by binding names so AST assignment transforms

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -603,16 +603,17 @@ pub(super) fn transform_client_runes_with_skip_and_state(
         }
     } // end state.eager guard
 
-    // Skip all $effect rune transforms if $effect is actually a store subscription or function param
-    if !effect_is_store_sub && !effect_is_func_param {
-        // Single-pass replacement of all $effect patterns:
-        //   $effect.pending() -> $.eager($.pending)
-        //   $effect.pre( -> $.user_pre_effect(
-        //   $effect.root( -> $.effect_root(
-        //   $effect.tracking() -> $.effect_tracking()
-        //   $effect( -> $.user_effect(
-        result = replace_effect_patterns(&result);
-    } // end if !effect_is_store_sub
+    // `$effect` rune family — formerly `replace_effect_patterns(&result)` —
+    // is now handled by the AST pass in
+    // `phase3_transform::client::ast_state_transform::transform_state_vars_ast`.
+    // The AST pass runs once per component after this per-statement loop and
+    // performs the same five rewrites (`$effect`, `$effect.pre`, `$effect.root`,
+    // `$effect.tracking()`, `$effect.pending()`) with precise scope-aware
+    // shadowing checks. `effect_is_store_sub` / `effect_is_func_param` no
+    // longer have a consumer in this branch; the AST visitor consults the
+    // same `store_sub_vars` set and uses true lexical scope tracking instead
+    // of the statement-wide `is_function_parameter_in_statement` heuristic.
+    let _ = (effect_is_store_sub, effect_is_func_param);
 
     // Transform $props.id() to $.props_id()
     if memmem::find(result.as_bytes(), b"$props.id()").is_some() {


### PR DESCRIPTION
First step of the `PERF_ROADMAP.md` "text transform pipeline elimination" track. The runes-mode component path now rewrites the `$effect` family at the AST level (`ast_state_transform::transform_state_vars_ast`) instead of the byte-level `replace_effect_patterns` scan, with no behavioral change and lexically precise shadowing detection.

## Mapping (unchanged)

```text
$effect(fn)        -> $.user_effect(fn)
$effect.pre(fn)    -> $.user_pre_effect(fn)
$effect.root(fn)   -> $.effect_root(fn)
$effect.tracking() -> $.effect_tracking()
$effect.pending()  -> $.eager($.pending)
```

## What changed

- **`ast_state_transform::StateVarCollector::visit_call_expression`** learns to detect `$effect(...)` (Identifier callee) and `$effect.X(...)` (StaticMemberExpression callee) and emit the same `$.X` rewrites the text pipeline used to produce.
- **`transform_state_vars_ast`** gates on `$effect` byte presence in addition to the existing state/prop/store/read-only/rest conditions, so the AST pass runs even for components that use `$effect` without any other reactive binding.
- **`transform_client_with_visitors`** extends `has_transforms` likewise so the AST pass is actually invoked in that case.
- **`transform_client_runes_with_skip_and_state`** drops the `result = replace_effect_patterns(&result);` call. The helper functions themselves are kept — `transform_module_script_runes` (the `.svelte.js` / `.svelte.ts` module path) and the `$state` / `$derived` destructuring paths still use them, and migrating those belongs to later PRs.

## Correctness

The text version checked `$effect` shadowing via `is_function_parameter_in_statement(line, "$effect")`, which scans the entire statement for any `function name($effect, ...)` declaration and disables ALL `$effect` transforms in that statement when found. The AST version uses the existing `is_shadowed("$effect")` (already implemented for state vars and tracking `scoped_vars` for function parameters, catch parameters, and let/const/var declarations) — this is lexically precise per-scope and matches the official Svelte compiler's AST-based scope rules.

Store-subscription shadowing (`$effect` used as a store name) is preserved via the same `store_sub_vars` check.

## Numbers (median, 1000 iters, warmup 100)

| Fixture | Phase | Before | After | Δ |
|---|---|---|---|---|
| `array-sort-in-effect/main.svelte` | Transform | 33.4 µs | 33.5 µs | within noise |
| `form-default-value-spread/main.svelte` | Transform | 823 µs | 830 µs | within noise |

No per-fixture speedup yet, and that is expected: `replace_effect_patterns` was already a tight single-pass byte scan, and runes components already paid the AST visit cost for state/prop rewrites. The win here is **structural** — one rewrite slice removed from the text pipeline, with a clearer path to migrate the remaining `$state` / `$state.raw` / `$state.frozen` / `$derived` / `$inspect` / `$props` slices in subsequent PRs. The cumulative speedup arrives once enough slices are off the text path that `transform_client_runes_with_skip_and_state` itself can be deleted.

## Test plan

- [x] `cargo test --release` for all 14 test categories (runtime including 105 `$effect` fixtures, ssr, compiler_fixtures, compiler_errors, parser_fixtures, validator, print, css, preprocess, sourcemaps, real_world, svelte2tsx_fixtures, svelte_check_golden, compatibility_report) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`
- [x] No regression on `form-default-value-spread` (the heaviest fixture seen in earlier perf PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)