### PR TITLE
perf(transform): migrate $state.raw / $state.frozen declarators to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -366,13 +366,19 @@ impl<'a, 's> StateVarCollector<'a, 's> {
     /// This includes state variables ($.state, $.derived, etc.) as well as
     /// prop declarations ($.prop, $.rest_props) and store subscriptions ($.store_get).
     /// These are the already-transformed rune calls (e.g., `$state()` -> `$.state()`).
+    ///
+    /// Also recognises yet-untransformed rune calls that the AST pass rewrites
+    /// here (currently `$state.raw(...)` and `$state.frozen(...)`). Recognising
+    /// them means the declarator name is *not* registered as a local shadow,
+    /// which would otherwise prevent state-var transforms inside any later
+    /// references to the same name.
     fn is_known_transform_declaration(&self, declarator: &VariableDeclarator<'_>) -> bool {
         if let Some(ref init) = declarator.init {
             let init_start = init.span().start as usize;
             let init_end = init.span().end as usize;
             if init_end <= self.source.len() {
                 let init_text = &self.source[init_start..init_end];
-                return init_text.starts_with("$.state(")
+                if init_text.starts_with("$.state(")
                     || init_text.starts_with("$.state.raw(")
                     || init_text.starts_with("$.derived(")
                     || init_text.starts_with("$.derived_by(")
@@ -380,15 +386,112 @@ impl<'a, 's> StateVarCollector<'a, 's> {
                     || init_text.starts_with("$.prop(")
                     || init_text.starts_with("$.prop_source(")
                     || init_text.starts_with("$.rest_props(")
-                    || init_text.starts_with("$.store_get(");
+                    || init_text.starts_with("$.store_get(")
+                {
+                    return true;
+                }
+            }
+            // AST-level recognition of `$state.raw(...)` / `$state.frozen(...)`
+            // declarators that this pass rewrites in `visit_variable_declarator`.
+            if self.is_state_raw_or_frozen_init(init) {
+                return true;
             }
         }
         false
     }
 
+    /// Returns true if `init` is a `$state.raw(...)` / `$state.frozen(...)`
+    /// CallExpression whose `$state` reference is the rune (not shadowed).
+    fn is_state_raw_or_frozen_init(&self, init: &Expression<'_>) -> bool {
+        if !self.is_runes || self.is_shadowed("$state") {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return false;
+        };
+        let Expression::Identifier(obj) = &member.object else {
+            return false;
+        };
+        if obj.name != "$state" {
+            return false;
+        }
+        matches!(member.property.name.as_str(), "raw" | "frozen")
+    }
+
     /// Add a replacement.
     fn add_replacement(&mut self, start: u32, end: u32, text: String) {
         self.replacements.push(Replacement { start, end, text });
+    }
+
+    /// AST replacement for `$state.raw(value)` / `$state.frozen(value)` rune
+    /// declarators. Mirrors the text-pipeline rewrite that used to live in
+    /// `rune_transforms::transform_client_runes_with_skip_and_state`:
+    /// - Non-reactive binding (in `non_reactive_vars`): replace the whole call
+    ///   span with the argument text (or `void 0` for empty calls).
+    /// - Reactive binding: replace with `$.state(arg)`.
+    ///
+    /// Returns `true` when this declarator matched and was handled — the caller
+    /// then skips the default walk so the init expression is not re-visited
+    /// (which would double-add inner replacements). Returns `false` for
+    /// destructured patterns and for any other declarator shape; those still
+    /// walk normally (and destructured cases are handled by the upstream text
+    /// pipeline's `transform_state_destructuring` helper).
+    fn try_rewrite_state_raw_or_frozen_declarator(
+        &mut self,
+        declarator: &VariableDeclarator<'_>,
+    ) -> bool {
+        let Some(init) = &declarator.init else {
+            return false;
+        };
+        if !self.is_state_raw_or_frozen_init(init) {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        // Only simple `let name = $state.raw(...)` bindings — destructured
+        // patterns are handled by the upstream text path's
+        // `transform_state_destructuring` (which produces already-`$.state(…)`
+        // output that we leave untouched).
+        let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+            return false;
+        };
+        if call.arguments.len() > 1 {
+            return false;
+        }
+
+        let var_name = id.name.as_str();
+        let is_non_reactive = self.non_reactive_vars.contains(var_name);
+
+        // Walk the (optional) argument first so any inner state-var refs get
+        // `$.get(...)` wrapping, then drain those inner replacements and bake
+        // them into the outer text — matching the behaviour the text pipeline
+        // produced indirectly (it emitted `$.state(arg)` which the AST then
+        // visited and rewrote inner refs of).
+        let arg_text = if let Some(arg) = call.arguments.first() {
+            self.visit_argument(arg);
+            let arg_span = arg.span();
+            let transformed = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
+            if transformed.trim().is_empty() {
+                "void 0".to_string()
+            } else {
+                transformed
+            }
+        } else {
+            "void 0".to_string()
+        };
+
+        let replacement = if is_non_reactive {
+            arg_text
+        } else {
+            format!("$.state({})", arg_text)
+        };
+
+        self.add_replacement(call.span.start, call.span.end, replacement);
+        true
     }
 
     /// Apply any pending replacements that fall within [range_start, range_end)
@@ -590,6 +693,19 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         }
         // Then walk the declaration normally (to visit initializers, etc.)
         walk::walk_variable_declaration(self, decl);
+    }
+
+    fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'ast>) {
+        // Try the `$state.raw(...)` / `$state.frozen(...)` rewrite first. When
+        // it matches, the helper walks into the argument (so inner state-var
+        // refs still get `$.get()` wrapping) and consumes those inner
+        // replacements before emitting the outer span replacement. We then
+        // skip the default walk so `visit_expression(init)` doesn't add the
+        // inner replacements a second time.
+        if self.try_rewrite_state_raw_or_frozen_declarator(declarator) {
+            return;
+        }
+        walk::walk_variable_declarator(self, declarator);
     }
 
     fn visit_formal_parameters(&mut self, params: &FormalParameters<'ast>) {

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4365,6 +4365,16 @@ fn transform_instance_script_for_visitors(
             if !store_sub_vars.is_empty() {
                 result = wrap_store_unsub_for_state_sets(&result, &state_vars, &store_sub_vars);
             }
+            // In dev mode the per-statement `wrap_state_derived_with_tag` call
+            // inside `transform_client_runes_with_skip_and_state` tags
+            // `$.state(...)` / `$.derived(...)` declarations that came out of
+            // the *text* rune pipeline. Any declarations produced by the AST
+            // pass — currently `$state.raw(...)` / `$state.frozen(...)` after
+            // their migration — would otherwise miss the `$.tag(...)` wrap, so
+            // run the same idempotent pass once more on the post-AST result.
+            if dev {
+                result = wrap_state_derived_with_tag(&result);
+            }
         }
     }
 

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -145,80 +145,19 @@ pub(super) fn transform_client_runes_with_skip_and_state(
             result = result.replace("$state.snapshot(", "$.snapshot(");
         }
 
-        // Transform $state.raw(x) / $state.frozen(x).
-        // Like $state(), whether we wrap in $.state() depends on whether the
-        // variable is reassigned (is_state_source logic).
-        for rune_call in &["$state.raw(", "$state.frozen("] {
-            while let Some(pos) = memmem::find(result.as_bytes(), rune_call.as_bytes()) {
-                let call_start = pos + rune_call.len();
-                if let Some(content_end) = find_matching_paren(&result[call_start..]) {
-                    let content = result[call_start..call_start + content_end].to_string();
-                    let trimmed_content = content.trim();
-
-                    // Extract variable name
-                    let var_name = {
-                        let before = &result[..pos];
-                        let mut name = String::new();
-                        if memmem::find(before.as_bytes(), b"let ").is_some()
-                            || memmem::find(before.as_bytes(), b"const ").is_some()
-                            || memmem::find(before.as_bytes(), b"var ").is_some()
-                        {
-                            let decl_pattern = if memmem::find(before.as_bytes(), b"let ").is_some()
-                            {
-                                "let "
-                            } else if memmem::find(before.as_bytes(), b"const ").is_some() {
-                                "const "
-                            } else {
-                                "var "
-                            };
-                            if let Some(decl_pos) =
-                                memmem::rfind(before.as_bytes(), decl_pattern.as_bytes())
-                            {
-                                let after_keyword = &before[decl_pos + decl_pattern.len()..];
-                                let before_eq = if let Some(eq_pos) = after_keyword.find('=') {
-                                    &after_keyword[..eq_pos]
-                                } else {
-                                    after_keyword
-                                };
-                                name = before_eq
-                                    .trim()
-                                    .chars()
-                                    .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '$')
-                                    .collect::<String>();
-                            }
-                        }
-                        name
-                    };
-
-                    let is_non_reactive = non_reactive_vars.contains(&var_name);
-                    let value = if trimmed_content.is_empty() {
-                        "void 0".to_string()
-                    } else {
-                        content.clone()
-                    };
-
-                    if is_non_reactive {
-                        // Non-reassigned: just use the raw value
-                        result = format!(
-                            "{}{}{}",
-                            &result[..pos],
-                            value,
-                            &result[call_start + content_end + 1..]
-                        );
-                    } else {
-                        // Reassigned: wrap in $.state()
-                        result = format!(
-                            "{}$.state({}){}",
-                            &result[..pos],
-                            value,
-                            &result[call_start + content_end + 1..]
-                        );
-                    }
-                } else {
-                    break;
-                }
-            }
-        }
+        // `$state.raw(x)` / `$state.frozen(x)` rune declarators — formerly
+        // rewritten here via a per-rune text loop — are now rewritten in
+        // `ast_state_transform::transform_state_vars_ast` via
+        // `try_rewrite_state_raw_or_frozen_declarator`. The AST visit gets
+        // precise lexical scope checks for `$state` (matching `is_shadowed`),
+        // produces the same `$.state(arg)` / bare-`arg` / `void 0` outputs,
+        // and lets the dev-mode `wrap_state_derived_with_tag` pass (now run a
+        // second time after `transform_state_vars_ast`) tag the resulting
+        // declarations.
+        //
+        // Destructured `$state.raw` / `$state.frozen` patterns are still
+        // handled by the upstream `transform_state_destructuring` call above
+        // (which emits `$.state(...)` directly).
 
         // Transform $state(x) to $.state(x) for primitives or $.proxy(x) for objects
         // Loop to handle multiple $state() calls in a single statement


### PR DESCRIPTION
Second step of the `PERF_ROADMAP.md` "text transform pipeline elimination" track (after #94 which migrated the `$effect` family).

`$state.raw(arg)` and `$state.frozen(arg)` rune declarators are now rewritten by `ast_state_transform::transform_state_vars_ast` via a new `visit_variable_declarator` override instead of the per-rune byte-level loop in `transform_client_runes_with_skip_and_state` (lines 148–221, removed).

## Behaviour (unchanged)

| Binding kind | `let x = $state.raw(value)` | `let x = $state.raw()` |
|---|---|---|
| non-reactive (immutable + not reassigned) | `let x = value` | `let x = void 0` |
| reactive | `let x = $.state(value)` | `let x = $.state(void 0)` |

`$state.frozen(...)` follows the same rules — it is an alias of `$state.raw`.

Inner state-var refs in the argument (e.g. `let derived = $state.raw(otherStateVar)`) still get `$.get(...)` wrapping: the helper walks the argument first, then `apply_and_drain_inner_replacements` bakes those inner transforms into the outer-span replacement before it is added, matching the behaviour the old text path produced indirectly (text emitted `$.state(arg)` which the existing AST pass then re-visited).

Destructured patterns (`let { foo } = $state.raw({…})`) remain handled by the upstream `transform_state_destructuring` text helper above the removed loop. They emit `$.state(...)` directly and the AST visitor recognises that as `is_dollar_helper_call`, so no overlap with this PR.

## Correctness improvements

- Lexical scope for `$state` shadowing via `is_shadowed("$state")` (function/catch parameters, let/const/var in any enclosing scope) — matches the official Svelte compiler's AST-based scope rules. The old text path always processed `$state.raw(` regardless of shadowing.
- `is_known_transform_declaration` now also recognises the untransformed `$state.raw(...)` / `$state.frozen(...)` AST patterns, so their bound names are not registered as local shadows (which would otherwise have prevented state-var transforms in later references).

## Dev mode

`wrap_state_derived_with_tag` was previously called once per statement inside the text rune pipeline, where it tagged `$.state(...)` declarations as they appeared. Declarations produced by the AST pass would otherwise miss the `$.tag(...)` wrap, so we now re-run the same idempotent pass once more on the post-AST result inside `transform_client_with_visitors`.

## Numbers (median, 500 iters, warmup 50)

| Fixture | Phase | Before | After | Δ |
|---|---|---|---|---|
| `form-default-value-spread/main.svelte` | Transform | 760 µs | 758 µs | within noise |

No measurable per-fixture speedup — the removed text loop was a tight `memmem` byte scan and runes components still pay the AST visit cost. Same shape as #94: the win is structural — another slice off the text pipeline, with a clearer path to `$state(...)` / `$derived(...)` migration next.

## Test plan

- [x] `cargo test --release` for runtime (519 unit + 19 integration including `$state.raw` fixtures like `bind-this-raw`, `class-raw-state`, `state-raw-bindable`), ssr (16/16), compiler_fixtures (17/17), compiler_errors, parser_fixtures, validator, print, css, preprocess, sourcemaps, real_world, svelte2tsx_fixtures, svelte_check_golden, compatibility_report — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)