### PR TITLE
perf(transform): migrate $state(...) declarators to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -391,13 +391,29 @@ impl<'a, 's> StateVarCollector<'a, 's> {
                     return true;
                 }
             }
-            // AST-level recognition of `$state.raw(...)` / `$state.frozen(...)`
-            // declarators that this pass rewrites in `visit_variable_declarator`.
-            if self.is_state_raw_or_frozen_init(init) {
+            // AST-level recognition of `$state(...)` / `$state.raw(...)` /
+            // `$state.frozen(...)` declarators that this pass rewrites in
+            // `visit_variable_declarator`.
+            if self.is_state_call_init(init) || self.is_state_raw_or_frozen_init(init) {
                 return true;
             }
         }
         false
+    }
+
+    /// Returns true if `init` is a plain `$state(...)` CallExpression whose
+    /// `$state` reference is the rune (not shadowed, not a store sub).
+    fn is_state_call_init(&self, init: &Expression<'_>) -> bool {
+        if !self.is_runes || self.is_shadowed("$state") || self.store_sub_vars.contains("$state") {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        let Expression::Identifier(ident) = &call.callee else {
+            return false;
+        };
+        ident.name == "$state"
     }
 
     /// Returns true if `init` is a `$state.raw(...)` / `$state.frozen(...)`
@@ -486,6 +502,99 @@ impl<'a, 's> StateVarCollector<'a, 's> {
 
         let replacement = if is_non_reactive {
             arg_text
+        } else {
+            format!("$.state({})", arg_text)
+        };
+
+        self.add_replacement(call.span.start, call.span.end, replacement);
+        true
+    }
+
+    /// AST replacement for plain `$state(value)` rune declarators. Mirrors the
+    /// text-pipeline rewrite that used to live in
+    /// `rune_transforms::transform_client_runes_with_skip_and_state`:
+    ///
+    /// |                    | non-reactive (in `non_reactive_vars`)        | reactive                                      |
+    /// | `$state()` (empty) | `void 0`                                     | `$.state(void 0)`                             |
+    /// | `$state(prim)`     | `prim`                                       | `$.state(prim)`                               |
+    /// | `$state(undefined)`| `void 0` (special case, matches text)        | `$.state(undefined)` (literal kept)           |
+    /// | `$state(obj/arr/…)`| `$.proxy(obj/arr/…)` if `should_proxy_ast`   | `$.state($.proxy(obj/arr/…))`                 |
+    ///
+    /// Proxy decision uses `should_proxy_ast(arg, &[])` — the text pipeline
+    /// it replaces used a scope-less `expression_needs_proxy(...)` here, so
+    /// we pass an empty `non_proxy_vars` to keep behaviour byte-identical.
+    fn try_rewrite_state_call_declarator(&mut self, declarator: &VariableDeclarator<'_>) -> bool {
+        let Some(init) = &declarator.init else {
+            return false;
+        };
+        if !self.is_state_call_init(init) {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        // Only simple `let name = $state(...)` bindings — destructured
+        // patterns are handled by the upstream text path's
+        // `transform_state_destructuring` (which produces already-`$.state(…)`
+        // output that we leave untouched).
+        let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+            return false;
+        };
+        if call.arguments.len() > 1 {
+            return false;
+        }
+
+        let var_name = id.name.as_str();
+        let is_non_reactive = self.non_reactive_vars.contains(var_name);
+
+        // Snapshot a few facts from the original argument AST *before* walking,
+        // because the walk drains/replaces inner spans that we want to query
+        // by node kind here (not by post-rewrite text).
+        let (needs_proxy, is_explicit_undefined) = if let Some(arg) = call.arguments.first() {
+            let arg_expr = arg.as_expression();
+            let needs_proxy = arg_expr.map(|e| should_proxy_ast(e, &[])).unwrap_or(false);
+            let is_undef = matches!(
+                arg_expr,
+                Some(Expression::Identifier(id)) if id.name == "undefined"
+            );
+            (needs_proxy, is_undef)
+        } else {
+            (false, false)
+        };
+
+        // Walk the argument first so any inner state-var refs get `$.get(...)`
+        // wrapping, then drain those inner replacements and bake them into
+        // the outer text. This matches the behaviour the old text path
+        // produced indirectly: it emitted `$.state(arg)` (or `$.proxy(arg)`)
+        // which the existing AST pass then re-visited and rewrote inner
+        // refs of.
+        let arg_text = if let Some(arg) = call.arguments.first() {
+            self.visit_argument(arg);
+            let arg_span = arg.span();
+            let transformed = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
+            if transformed.trim().is_empty() {
+                "void 0".to_string()
+            } else {
+                transformed
+            }
+        } else {
+            "void 0".to_string()
+        };
+
+        let replacement = if is_non_reactive {
+            if needs_proxy {
+                format!("$.proxy({})", arg_text)
+            } else if is_explicit_undefined {
+                // Special case from the old text path: in the non-reactive
+                // branch, `$state(undefined)` → `void 0` (not `undefined`).
+                // The reactive branch keeps the literal as-is, so we only
+                // apply this rewrite when non-reactive.
+                "void 0".to_string()
+            } else {
+                arg_text
+            }
+        } else if needs_proxy {
+            format!("$.state($.proxy({}))", arg_text)
         } else {
             format!("$.state({})", arg_text)
         };
@@ -696,13 +805,17 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
     }
 
     fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'ast>) {
-        // Try the `$state.raw(...)` / `$state.frozen(...)` rewrite first. When
-        // it matches, the helper walks into the argument (so inner state-var
-        // refs still get `$.get()` wrapping) and consumes those inner
-        // replacements before emitting the outer span replacement. We then
-        // skip the default walk so `visit_expression(init)` doesn't add the
-        // inner replacements a second time.
+        // Try the `$state.raw(...)` / `$state.frozen(...)` and plain
+        // `$state(...)` rewrites first. When one matches, the helper walks
+        // into the argument (so inner state-var refs still get `$.get()`
+        // wrapping) and consumes those inner replacements before emitting
+        // the outer span replacement. We then skip the default walk so
+        // `visit_expression(init)` doesn't add the inner replacements a
+        // second time.
         if self.try_rewrite_state_raw_or_frozen_declarator(declarator) {
+            return;
+        }
+        if self.try_rewrite_state_call_declarator(declarator) {
             return;
         }
         walk::walk_variable_declarator(self, declarator);
@@ -2027,16 +2140,28 @@ pub(super) fn transform_state_vars_ast(
     let has_stores = !store_sub_vars.is_empty();
     let has_read_only = !read_only_props.is_empty();
     let has_rest = !rest_prop_vars.is_empty();
-    // `$effect` rune transforms also live in this AST pass. The runes are only
-    // valid when `is_runes` is true *and* `$effect` is not used as a store
-    // subscription name. The visitor performs the full per-call shadowing
-    // check; here we just need a cheap script-wide gate to avoid the OXC parse
-    // when there is provably nothing to do.
+    // `$effect` rune transforms and `$state(…)` / `$state.raw(…)` /
+    // `$state.frozen(…)` declarator rewrites also live in this AST pass.
+    // They are only valid when `is_runes` is true *and* the rune name is
+    // not used as a store subscription. The visitor performs the full
+    // per-call shadowing check; here we just need a cheap script-wide
+    // byte probe to avoid the OXC parse when there is provably nothing
+    // to do.
     let has_effect_calls = is_runes
         && !store_sub_vars.iter().any(|v| v == "$effect")
         && memchr::memmem::find(script.as_bytes(), b"$effect").is_some();
+    let has_state_calls = is_runes
+        && !store_sub_vars.iter().any(|v| v == "$state")
+        && memchr::memmem::find(script.as_bytes(), b"$state").is_some();
 
-    if !has_state && !has_props && !has_stores && !has_read_only && !has_rest && !has_effect_calls {
+    if !has_state
+        && !has_props
+        && !has_stores
+        && !has_read_only
+        && !has_rest
+        && !has_effect_calls
+        && !has_state_calls
+    {
         return None;
     }
 
@@ -2082,7 +2207,8 @@ pub(super) fn transform_state_vars_ast(
             && rest_prop_vars
                 .iter()
                 .any(|v| script_ids.contains(v.as_str())))
-        || (has_effect_calls && script_ids.contains("$effect"));
+        || (has_effect_calls && script_ids.contains("$effect"))
+        || (has_state_calls && script_ids.contains("$state"));
 
     if !has_any_match {
         return None;

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4298,19 +4298,27 @@ fn transform_instance_script_for_visitors(
     // prop transforms, store transforms, read-only props, and rest-prop transforms
     // with a single OXC parse + AST walk, eliminating O(M*N) text scanning.
     if analysis.runes {
-        // The AST pass also rewrites the `$effect` rune family (formerly
-        // handled by the text pipeline). A component can use `$effect` without
-        // any state/prop/store binding, so include a script-level byte probe
-        // for `$effect` here — otherwise the AST pass would be skipped and the
-        // rune would leak through untransformed.
+        // The AST pass also rewrites the `$effect` rune family and the
+        // `$state(…)` / `$state.raw(…)` / `$state.frozen(…)` rune
+        // declarators (all formerly handled by the text pipeline). A
+        // component can use these runes without producing any *top-level*
+        // state/prop/store binding — e.g. when every `$state(...)`
+        // declaration is in a *nested* scope (function body) shadowing an
+        // outer name. In that case `state_vars` collected from analysis
+        // is empty even though the script contains runes that the AST
+        // pass must rewrite. Probe the script bytes for `$effect` /
+        // `$state` so we still enter the AST pass in those cases.
         let has_effect_calls = !store_sub_vars.iter().any(|v| v == "$effect")
             && memmem::find(result.as_bytes(), b"$effect").is_some();
+        let has_state_calls = !store_sub_vars.iter().any(|v| v == "$state")
+            && memmem::find(result.as_bytes(), b"$state").is_some();
         let has_transforms = !state_vars.is_empty()
             || !prop_assignment_transform_vars.is_empty()
             || !store_sub_vars.is_empty()
             || !read_only_props.is_empty()
             || !rest_prop_vars.is_empty()
-            || has_effect_calls;
+            || has_effect_calls
+            || has_state_calls;
 
         if has_transforms {
             // Collect $derived / $derived.by binding names so AST assignment transforms

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -5,28 +5,13 @@ use memchr::memmem;
 use super::destructure_transforms::build_fallback_string;
 use super::{
     ARRAY_LOOKUP_COUNTER, DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER,
-    contains_direct_await_in_expression, expression_needs_proxy, extract_enclosing_function_name,
+    contains_direct_await_in_expression, extract_enclosing_function_name,
     extract_local_reactive_vars, extract_trace_call_label, find_matching_brace,
     find_matching_paren, find_trace_source_location, is_function_parameter_in_statement,
     strip_top_level_await_from_expr, transform_props_destructuring, unthunk_string,
     wrap_await_with_save_in_async_derived, wrap_state_vars_in_expr,
 };
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
-
-/// Find the position of `$state(` in the string, but skip occurrences that are
-/// already transformed (i.e., preceded by `.` as in `$.state(`).
-pub(super) fn find_unescaped_state_call(s: &str) -> Option<usize> {
-    let mut search_from = 0;
-    while let Some(pos) = memmem::find(&s.as_bytes()[search_from..], b"$state(") {
-        let abs_pos = search_from + pos;
-        if abs_pos > 0 && s.as_bytes()[abs_pos - 1] == b'.' {
-            search_from = abs_pos + 7;
-            continue;
-        }
-        return Some(abs_pos);
-    }
-    None
-}
 
 /// Find the position of `$derived.by(` in the string, skipping already-transformed occurrences.
 pub(super) fn find_unescaped_derived_by_call(s: &str) -> Option<usize> {
@@ -159,140 +144,18 @@ pub(super) fn transform_client_runes_with_skip_and_state(
         // handled by the upstream `transform_state_destructuring` call above
         // (which emits `$.state(...)` directly).
 
-        // Transform $state(x) to $.state(x) for primitives or $.proxy(x) for objects
-        // Loop to handle multiple $state() calls in a single statement
-        // (e.g., inside a function body with multiple state declarations)
-        while let Some(pos) = find_unescaped_state_call(&result) {
-            // Check if this is a declaration
-            let before_pos = &result.as_bytes()[..pos];
-            if !(memmem::find(before_pos, b"let ").is_some()
-                || memmem::find(before_pos, b"const ").is_some()
-                || memmem::find(before_pos, b"var ").is_some())
-            {
-                break;
-            }
-
-            // Extract variable name by finding identifier after let/const/var keyword
-            let decl_pattern = if memmem::find(before_pos, b"let ").is_some() {
-                // Find the closest declaration keyword before this $state call
-                let let_pos = memmem::rfind(&result.as_bytes()[..pos], b"let ");
-                let const_pos = memmem::rfind(&result.as_bytes()[..pos], b"const ");
-                let var_pos = memmem::rfind(&result.as_bytes()[..pos], b"var ");
-                let max_pos = [let_pos, const_pos, var_pos]
-                    .iter()
-                    .filter_map(|p| *p)
-                    .max();
-                if max_pos == let_pos {
-                    "let "
-                } else if max_pos == const_pos {
-                    "const "
-                } else {
-                    "var "
-                }
-            } else if memmem::find(before_pos, b"const ").is_some() {
-                let const_pos = memmem::rfind(&result.as_bytes()[..pos], b"const ");
-                let var_pos = memmem::rfind(&result.as_bytes()[..pos], b"var ");
-                if var_pos.is_some() && var_pos > const_pos {
-                    "var "
-                } else {
-                    "const "
-                }
-            } else {
-                "var "
-            };
-
-            let var_name = if let Some(decl_pos) =
-                memmem::rfind(&result.as_bytes()[..pos], decl_pattern.as_bytes())
-            {
-                let after_keyword = &result[decl_pos + decl_pattern.len()..pos];
-                // Extract valid identifier characters only (before any '=' sign)
-                let before_eq = if let Some(eq_pos) = after_keyword.find('=') {
-                    &after_keyword[..eq_pos]
-                } else {
-                    after_keyword
-                };
-                before_eq
-                    .trim()
-                    .chars()
-                    .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '$')
-                    .collect::<String>()
-            } else {
-                String::new()
-            };
-
-            // Check if we should skip this state variable
-            let state_start = pos + 7; // after "$state("
-            if let Some(content_end) = find_matching_paren(&result[state_start..]) {
-                let content = result[state_start..state_start + content_end].to_string();
-                let trimmed_content = content.trim();
-                let is_object_or_array =
-                    trimmed_content.starts_with('{') || trimmed_content.starts_with('[');
-
-                if skip_state_vars.contains(&var_name.to_string()) {
-                    // Variable is not reassigned, so doesn't need $.state() wrapping
-                    // But we still need $.proxy() if the value might return an object
-                    let needs_proxy = is_object_or_array || expression_needs_proxy(trimmed_content);
-
-                    if needs_proxy {
-                        // Wrap with $.proxy() for deep reactivity
-                        result = format!(
-                            "{}$.proxy({}){}",
-                            &result[..pos],
-                            content,
-                            &result[state_start + content_end + 1..]
-                        );
-                    } else {
-                        // Primitives - just extract the value
-                        // Empty $state() should become "void 0" (not "undefined")
-                        // to match the official Svelte compiler output
-                        let extracted_value = if trimmed_content.is_empty() {
-                            "void 0".to_string()
-                        } else if trimmed_content == "undefined" {
-                            // Explicit undefined should also become void 0
-                            "void 0".to_string()
-                        } else {
-                            content.to_string()
-                        };
-                        result = format!(
-                            "{}{}{}",
-                            &result[..pos],
-                            extracted_value,
-                            &result[state_start + content_end + 1..]
-                        );
-                    }
-                } else if is_object_or_array || expression_needs_proxy(trimmed_content) {
-                    // Objects/arrays or function calls need $.proxy() for deep reactivity
-                    // AND we need $.state() for the reactivity tracking (since variable is reassigned)
-                    // Expected: $.state($.proxy([...]))
-                    result = format!(
-                        "{}$.state($.proxy({})){}",
-                        &result[..pos],
-                        content,
-                        &result[state_start + content_end + 1..]
-                    );
-                } else if trimmed_content.is_empty() {
-                    // Empty $state() - use void 0 explicitly
-                    // Example: $state() -> $.state(void 0)
-                    result = format!(
-                        "{}$.state(void 0){}",
-                        &result[..pos],
-                        &result[state_start + content_end + 1..]
-                    );
-                } else {
-                    // Primitives that ARE reassigned need $.state()
-                    result = format!(
-                        "{}$.state({}){}",
-                        &result[..pos],
-                        content,
-                        &result[state_start + content_end + 1..]
-                    );
-                }
-            } else {
-                // Fallback for unparseable content
-                result = format!("{}$.state({}", &result[..pos], &result[pos + 7..]);
-                break;
-            }
-        }
+        // Plain `$state(...)` rune declarators — formerly rewritten here by a
+        // per-statement byte-level loop — are now rewritten in
+        // `ast_state_transform::transform_state_vars_ast` via
+        // `try_rewrite_state_call_declarator`. The AST visit gets precise
+        // lexical scope checks for `$state` (matching `is_shadowed`),
+        // uses `should_proxy_ast` for the proxy decision, and produces the
+        // same `$.state(...)` / `$.state($.proxy(...))` / `$.proxy(...)` /
+        // bare-`arg` / `void 0` outputs.
+        //
+        // Destructured `$state(...)` patterns are still handled by the
+        // upstream `transform_state_destructuring` call further above (which
+        // emits `$.state(...)` directly).
     } // end if !state_is_store_sub
 
     // Skip all $derived rune transforms if $derived is actually a store subscription or function param


### PR DESCRIPTION
Third AST-migration PR (after #94 `$effect` and #95 `$state.raw`/`$state.frozen`) in the `PERF_ROADMAP.md` "text transform pipeline elimination" track.

Plain `$state(value)` rune declarators are now rewritten by `ast_state_transform::transform_state_vars_ast` via a new `try_rewrite_state_call_declarator` helper in `visit_variable_declarator`, replacing the per-rune byte-level loop in `transform_client_runes_with_skip_and_state` (lines 165–295, removed).

## Behaviour (unchanged)

|                     | non-reactive (in `non_reactive_vars`)          | reactive                              |
|---|---|---|
| `$state()`          | `void 0`                                       | `$.state(void 0)`                     |
| `$state(prim)`      | `prim`                                         | `$.state(prim)`                       |
| `$state(undefined)` | `void 0` (special case, matches text)          | `$.state(undefined)` (literal kept)   |
| `$state(obj/arr/…)` | `$.proxy(value)` if `should_proxy_ast` says so | `$.state($.proxy(value))`             |

Proxy decision uses `should_proxy_ast(arg, &[])` — the text pipeline it replaces used a scope-less `expression_needs_proxy(...)` here, so we pass an empty `non_proxy_vars` to keep behaviour byte-identical.

Inner state-var refs in the argument (e.g. `let count = $state(otherStateVar)`) still get `$.get(...)` wrapping — the helper walks the argument first, then `apply_and_drain_inner_replacements` bakes those inner transforms into the outer-span replacement.

Destructured `$state(...)` patterns remain handled by the upstream `transform_state_destructuring` text helper above the removed loop. They emit `$.state(...)` directly and the AST visitor recognises that as `is_dollar_helper_call`.

## Correctness improvements

- Lexical scope for `$state` shadowing via `is_shadowed("$state")` (function/catch parameters, let/const/var in any enclosing scope) — matches the official Svelte compiler's AST-based scope rules.
- `is_known_transform_declaration` now recognises the untransformed `$state(...)` AST pattern in addition to the existing `$state.raw`/`$state.frozen` recognition, so bound names are not registered as local shadows.
- **The script-wide gate for the AST pass (`has_transforms` in `transform_client_with_visitors` + `has_state_calls` in `transform_state_vars_ast`) now triggers on raw `$state` byte presence too.** Without this, components whose only `$state` use is a *nested-scope* declarator (shadowing an outer name with the same identifier, e.g. the `wrapped-$state` fixture) would skip the AST pass entirely and leak `$state(...)` untransformed into output — this caught a real regression in local test runs before merging.

## Numbers (median, 500 iters, warmup 50)

| Fixture | Phase | Before | After | Δ |
|---|---|---|---|---|
| `form-default-value-spread/main.svelte` | Transform | 758 µs | 752 µs | within noise |

No measurable per-fixture speedup — the removed text loop was already a tight `memmem` byte scan and runes components still pay the AST visit cost. Same shape as #94 / #95: the win is structural — another slice off the text pipeline, with a clearer path to `$derived(...)` / `$inspect(...)` migration next.

## Test plan

- [x] `cargo test --release` for runtime (519 unit + 19 integration including `wrapped-$state`, `form-default-value-spread`, and ~100 other `$state(...)` fixtures), ssr (16/16), compiler_fixtures (17/17), compiler_errors, parser_fixtures, validator, print, css, preprocess, sourcemaps, real_world, svelte2tsx_fixtures, svelte_check_golden, compatibility_report — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)