### PR TITLE
perf(transform): migrate $derived.by(fn) declarators to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -392,9 +392,12 @@ impl<'a, 's> StateVarCollector<'a, 's> {
                 }
             }
             // AST-level recognition of `$state(...)` / `$state.raw(...)` /
-            // `$state.frozen(...)` declarators that this pass rewrites in
-            // `visit_variable_declarator`.
-            if self.is_state_call_init(init) || self.is_state_raw_or_frozen_init(init) {
+            // `$state.frozen(...)` / `$derived.by(...)` declarators that this
+            // pass rewrites in `visit_variable_declarator`.
+            if self.is_state_call_init(init)
+                || self.is_state_raw_or_frozen_init(init)
+                || self.is_derived_by_init(init)
+            {
                 return true;
             }
         }
@@ -435,6 +438,30 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             return false;
         }
         matches!(member.property.name.as_str(), "raw" | "frozen")
+    }
+
+    /// Returns true if `init` is a `$derived.by(...)` CallExpression whose
+    /// `$derived` reference is the rune (not shadowed, not a store sub).
+    fn is_derived_by_init(&self, init: &Expression<'_>) -> bool {
+        if !self.is_runes
+            || self.is_shadowed("$derived")
+            || self.store_sub_vars.contains("$derived")
+        {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return false;
+        };
+        let Expression::Identifier(obj) = &member.object else {
+            return false;
+        };
+        if obj.name != "$derived" {
+            return false;
+        }
+        member.property.name == "by"
     }
 
     /// Add a replacement.
@@ -599,6 +626,54 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             format!("$.state({})", arg_text)
         };
 
+        self.add_replacement(call.span.start, call.span.end, replacement);
+        true
+    }
+
+    /// AST replacement for `$derived.by(fn)` rune declarators. Mirrors the
+    /// text-pipeline rewrite that lived in
+    /// `transform_client_runes_with_skip_and_state`'s `$derived.by` loop.
+    ///
+    /// `$derived.by(fn)` becomes `$.derived(fn)` — the function is passed
+    /// through, no arrow wrap is added (unlike plain `$derived(expr)`,
+    /// which wraps the expression in an arrow and is handled by a later
+    /// migration).
+    ///
+    /// Inner state-var refs inside the function body still get `$.get(...)`
+    /// wrapping via the visitor's normal walk; we drain those inner
+    /// replacements before emitting the outer span replacement to avoid
+    /// the outer replacement clobbering them.
+    fn try_rewrite_derived_by_declarator(&mut self, declarator: &VariableDeclarator<'_>) -> bool {
+        let Some(init) = &declarator.init else {
+            return false;
+        };
+        if !self.is_derived_by_init(init) {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        // Only simple `let name = $derived.by(...)` bindings — destructured
+        // patterns are still handled by the upstream text helper
+        // `transform_derived_by_destructuring`.
+        let BindingPattern::BindingIdentifier(_) = &declarator.id else {
+            return false;
+        };
+        if call.arguments.len() != 1 {
+            return false;
+        }
+
+        // Walk the function arg so any state-var refs inside the callback
+        // body get `$.get(...)` wrapping, then drain those inner
+        // replacements and bake them into the outer text. The argument
+        // itself is typically an ArrowFunctionExpression or
+        // FunctionExpression; the walker descends into its body for us.
+        let arg = &call.arguments[0];
+        self.visit_argument(arg);
+        let arg_span = arg.span();
+        let transformed_arg = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
+
+        let replacement = format!("$.derived({})", transformed_arg);
         self.add_replacement(call.span.start, call.span.end, replacement);
         true
     }
@@ -805,17 +880,19 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
     }
 
     fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'ast>) {
-        // Try the `$state.raw(...)` / `$state.frozen(...)` and plain
-        // `$state(...)` rewrites first. When one matches, the helper walks
-        // into the argument (so inner state-var refs still get `$.get()`
-        // wrapping) and consumes those inner replacements before emitting
-        // the outer span replacement. We then skip the default walk so
-        // `visit_expression(init)` doesn't add the inner replacements a
-        // second time.
+        // Try the rune-declarator rewrites first. When one matches, the
+        // helper walks into the argument (so inner state-var refs still
+        // get `$.get()` wrapping) and consumes those inner replacements
+        // before emitting the outer span replacement. We then skip the
+        // default walk so `visit_expression(init)` doesn't add the inner
+        // replacements a second time.
         if self.try_rewrite_state_raw_or_frozen_declarator(declarator) {
             return;
         }
         if self.try_rewrite_state_call_declarator(declarator) {
+            return;
+        }
+        if self.try_rewrite_derived_by_declarator(declarator) {
             return;
         }
         walk::walk_variable_declarator(self, declarator);
@@ -2153,6 +2230,9 @@ pub(super) fn transform_state_vars_ast(
     let has_state_calls = is_runes
         && !store_sub_vars.iter().any(|v| v == "$state")
         && memchr::memmem::find(script.as_bytes(), b"$state").is_some();
+    let has_derived_calls = is_runes
+        && !store_sub_vars.iter().any(|v| v == "$derived")
+        && memchr::memmem::find(script.as_bytes(), b"$derived").is_some();
 
     if !has_state
         && !has_props
@@ -2161,6 +2241,7 @@ pub(super) fn transform_state_vars_ast(
         && !has_rest
         && !has_effect_calls
         && !has_state_calls
+        && !has_derived_calls
     {
         return None;
     }
@@ -2208,7 +2289,8 @@ pub(super) fn transform_state_vars_ast(
                 .iter()
                 .any(|v| script_ids.contains(v.as_str())))
         || (has_effect_calls && script_ids.contains("$effect"))
-        || (has_state_calls && script_ids.contains("$state"));
+        || (has_state_calls && script_ids.contains("$state"))
+        || (has_derived_calls && script_ids.contains("$derived"));
 
     if !has_any_match {
         return None;

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4312,13 +4312,16 @@ fn transform_instance_script_for_visitors(
             && memmem::find(result.as_bytes(), b"$effect").is_some();
         let has_state_calls = !store_sub_vars.iter().any(|v| v == "$state")
             && memmem::find(result.as_bytes(), b"$state").is_some();
+        let has_derived_calls = !store_sub_vars.iter().any(|v| v == "$derived")
+            && memmem::find(result.as_bytes(), b"$derived").is_some();
         let has_transforms = !state_vars.is_empty()
             || !prop_assignment_transform_vars.is_empty()
             || !store_sub_vars.is_empty()
             || !read_only_props.is_empty()
             || !rest_prop_vars.is_empty()
             || has_effect_calls
-            || has_state_calls;
+            || has_state_calls
+            || has_derived_calls;
 
         if has_transforms {
             // Collect $derived / $derived.by binding names so AST assignment transforms

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -5,11 +5,11 @@ use memchr::memmem;
 use super::destructure_transforms::build_fallback_string;
 use super::{
     ARRAY_LOOKUP_COUNTER, DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER,
-    contains_direct_await_in_expression, extract_enclosing_function_name,
-    extract_local_reactive_vars, extract_trace_call_label, find_matching_brace,
-    find_matching_paren, find_trace_source_location, is_function_parameter_in_statement,
-    strip_top_level_await_from_expr, transform_props_destructuring, unthunk_string,
-    wrap_await_with_save_in_async_derived, wrap_state_vars_in_expr,
+    contains_direct_await_in_expression, extract_enclosing_function_name, extract_trace_call_label,
+    find_matching_brace, find_matching_paren, find_trace_source_location,
+    is_function_parameter_in_statement, strip_top_level_await_from_expr,
+    transform_props_destructuring, unthunk_string, wrap_await_with_save_in_async_derived,
+    wrap_state_vars_in_expr,
 };
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 
@@ -160,12 +160,27 @@ pub(super) fn transform_client_runes_with_skip_and_state(
 
     // Skip all $derived rune transforms if $derived is actually a store subscription or function param
     if !derived_is_store_sub && !derived_is_func_param {
-        // Transform $derived.by() to $.derived() - must be processed BEFORE $derived()
-        // $derived.by() already has a callback, so pass it directly
-        // But we need to wrap state variable references inside the callback with $.get()
-        // Loop to handle multiple $derived.by() calls in a single statement
-        while let Some(pos) = find_unescaped_derived_by_call(&result) {
-            // Check if this is a destructuring pattern: let { a, b } = $derived.by(expr)
+        // Simple `let x = $derived.by(fn)` declarators are now rewritten in
+        // `ast_state_transform::transform_state_vars_ast` via
+        // `try_rewrite_derived_by_declarator` (precise lexical scope checks
+        // for `$derived`, walks the callback so inner state-var refs still
+        // get `$.get(...)` wrapping, emits the same `$.derived(fn)` text).
+        //
+        // The "inner `const x = $state(...)` is non-reactive inside the
+        // callback" behaviour that the old text path implemented via an
+        // explicit `effective_non_reactive.push(var)` is preserved
+        // structurally: those inner const $state vars are added to
+        // `non_reactive_state_vars` upstream in
+        // `transform_instance_script_for_visitors`, so the AST visitor
+        // already treats their declarations and references as non-reactive
+        // without a $derived.by-specific carve-out here.
+        //
+        // *Destructured* `$derived.by({ ... })` / `[...]` patterns are NOT
+        // handled by the AST migration (which only matches a
+        // `BindingPattern::BindingIdentifier`) — they still need the text
+        // `transform_derived_by_destructuring` helper, which produces a
+        // complete IIFE/`$$d`-temp form and returns the rewritten script.
+        if let Some(pos) = find_unescaped_derived_by_call(&result) {
             let before_derived_by = result[..pos].trim();
             let has_destructuring_by = (memmem::find(before_derived_by.as_bytes(), b"let ")
                 .is_some()
@@ -173,61 +188,18 @@ pub(super) fn transform_client_runes_with_skip_and_state(
                 || memmem::find(before_derived_by.as_bytes(), b"var ").is_some())
                 && (before_derived_by.contains('{') || before_derived_by.contains('['));
 
-            if has_destructuring_by {
-                // Handle destructuring pattern for $derived.by()
-                // $derived.by() always creates a $$d temp (unlike $derived(identifier) which skips it)
-                if let Some(transformed) = transform_derived_by_destructuring(
+            if has_destructuring_by
+                && let Some(transformed) = transform_derived_by_destructuring(
                     &result,
                     state_vars,
                     non_reactive_vars,
                     proxy_vars,
-                ) {
-                    return apply_effect_rune_transforms(transformed);
-                }
+                )
+            {
+                return apply_effect_rune_transforms(transformed);
             }
-
-            let derived_start = pos + 12; // after "$derived.by("
-            if let Some(content_end) = find_matching_paren(&result[derived_start..]) {
-                let content = &result[derived_start..derived_start + content_end];
-
-                // Extract local const $state() declarations from the callback body.
-                // In runes mode, const $state() vars are non-reactive (never reassigned),
-                // so they should not be wrapped with $.get() inside the callback.
-                let local_callback_vars = extract_local_reactive_vars(content);
-                let mut effective_non_reactive = non_reactive_vars.to_vec();
-                if analysis.runes {
-                    for (var, is_const, is_state) in &local_callback_vars {
-                        // Only $state vars can be non-reactive; $derived always needs $.get()
-                        if *is_const && *is_state {
-                            let state_check = format!("const {} = $state(", var);
-                            let raw_check = format!("const {} = $state.raw(", var);
-                            if (content.contains(&state_check) || content.contains(&raw_check))
-                                && !effective_non_reactive.contains(var)
-                            {
-                                effective_non_reactive.push(var.clone());
-                            }
-                        }
-                    }
-                }
-
-                // Wrap state variables inside the callback with $.get()
-                let wrapped_content = wrap_state_vars_in_expr(
-                    content,
-                    state_vars,
-                    &effective_non_reactive,
-                    proxy_vars,
-                );
-                let new_derived = format!("$.derived({})", wrapped_content);
-                result = format!(
-                    "{}{}{}",
-                    &result[..pos],
-                    new_derived,
-                    &result[derived_start + content_end + 1..]
-                );
-            } else {
-                result = format!("{}$.derived({}", &result[..pos], &result[pos + 12..]);
-                break;
-            }
+            // Simple-declarator and "destructuring helper bailed" cases both
+            // fall through to the AST pass without further text rewriting.
         }
 
         // Transform $derived(x) to $.derived(() => x) or $.async_derived() for async


### PR DESCRIPTION
Fourth AST-migration PR (after #94 `$effect`, #95 `$state.raw`/`$state.frozen`, and #96 plain `$state(...)`) in the `PERF_ROADMAP.md` "text transform pipeline elimination" track.

`$derived.by(fn)` rune declarators with a simple `BindingIdentifier` target are now rewritten by `ast_state_transform::transform_state_vars_ast` via a new `try_rewrite_derived_by_declarator` helper in `visit_variable_declarator`. The text path in `transform_client_runes_with_skip_and_state` keeps only its destructuring branch — which delegates to `transform_derived_by_destructuring` and remains in text for now (the AST visitor only matches `BindingPattern::BindingIdentifier`).

## Behaviour (unchanged)

```text
let x = $derived.by(fn)  ->  let x = $.derived(fn)
```

Inner state-var refs inside the callback still get `$.get(...)` wrapping via the visitor's normal walk; we drain those inner replacements before emitting the outer span replacement so the outer rewrite doesn't clobber them.

## Why no `effective_non_reactive` carve-out

The text path special-cased `const x = $state(...)` declarations inside the `$derived.by` callback by pushing them onto an `effective_non_reactive` list before calling `wrap_state_vars_in_expr`. That carve-out is no longer needed at this layer — those inner const-$state vars are already added to `non_reactive_state_vars` upstream in `transform_instance_script_for_visitors`, so the AST visitor reads them via the shared `non_reactive_vars` config and produces the correct non-reactive output for their declarations *and* their references automatically.

## Correctness improvements

- Lexical scope for `$derived` shadowing via `is_shadowed("$derived")` (function/catch parameters, let/const/var in any enclosing scope) — matches the official Svelte compiler's AST-based scope rules.
- `is_known_transform_declaration` now recognises the untransformed `$derived.by(...)` AST pattern, so bound names are not registered as local shadows.
- The script-wide gate for the AST pass (`has_transforms` in `transform_client_with_visitors` + `has_derived_calls` in `transform_state_vars_ast`) now also triggers on raw `$derived` byte presence.

## Numbers

Within noise on the `form-default-value-spread` fixture (which has no `$derived`). Same shape as #94/#95/#96 — the win is structural: another slice off the text pipeline, with a clearer path to plain `$derived(...)` (arrow-wrapped) migration next.

## Test plan

- [x] `cargo test --release` for runtime (519 unit + 19 integration incl. all `$derived.by` fixtures), ssr (16/16), compiler_fixtures (17/17), compiler_errors, parser_fixtures, validator, print, css, preprocess, sourcemaps, real_world, svelte2tsx_fixtures, svelte_check_golden, compatibility_report — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)