### PR TITLE
perf(transform): migrate plain $derived(expr) declarators to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -24,6 +24,10 @@ use oxc_syntax::scope::ScopeId;
 use rustc_hash::FxHashSet;
 
 use super::VAR_STATE_VARS;
+use super::destructure_transforms::unthunk_string;
+use super::expression_utils::{
+    contains_direct_await_in_expression, strip_top_level_await_from_expr,
+};
 
 thread_local! {
     static AST_TRANSFORM_ALLOCATOR: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -392,16 +396,36 @@ impl<'a, 's> StateVarCollector<'a, 's> {
                 }
             }
             // AST-level recognition of `$state(...)` / `$state.raw(...)` /
-            // `$state.frozen(...)` / `$derived.by(...)` declarators that this
-            // pass rewrites in `visit_variable_declarator`.
+            // `$state.frozen(...)` / `$derived(...)` / `$derived.by(...)`
+            // declarators that this pass rewrites in
+            // `visit_variable_declarator`.
             if self.is_state_call_init(init)
                 || self.is_state_raw_or_frozen_init(init)
+                || self.is_derived_call_init(init)
                 || self.is_derived_by_init(init)
             {
                 return true;
             }
         }
         false
+    }
+
+    /// Returns true if `init` is a plain `$derived(...)` CallExpression whose
+    /// `$derived` reference is the rune (not shadowed, not a store sub).
+    fn is_derived_call_init(&self, init: &Expression<'_>) -> bool {
+        if !self.is_runes
+            || self.is_shadowed("$derived")
+            || self.store_sub_vars.contains("$derived")
+        {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        let Expression::Identifier(ident) = &call.callee else {
+            return false;
+        };
+        ident.name == "$derived"
     }
 
     /// Returns true if `init` is a plain `$state(...)` CallExpression whose
@@ -678,6 +702,145 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         true
     }
 
+    /// AST replacement for plain `$derived(expr)` rune declarators. Mirrors
+    /// the per-rune text loop that previously lived in
+    /// `transform_client_runes_with_skip_and_state`:
+    ///
+    /// The argument shapes we have to keep behaviour-identical with:
+    ///
+    /// 1. Existing function/arrow: `$derived(() => expr)` /
+    ///    `$derived(async () => expr)` / `$derived(function(){…})` —
+    ///    wrapped *again* in a thunk to match the official compiler's
+    ///    `b.thunk()` treatment, giving `$.derived(() => () => expr)`.
+    /// 2. Top-level `await` somewhere in the expression (async derived):
+    ///    rewritten to `await $.async_derived(…)`. Whether the inner
+    ///    thunk is `async () => (…)` or `() => (…)` (and whether the
+    ///    inner is paren-wrapped) is decided by `strip_top_level_await_from_expr`
+    ///    plus a second `contains_direct_await_in_expression` probe.
+    /// 3. Object literal: `$.derived(() => (obj))` — parens required so
+    ///    `() => { … }` is not parsed as a block.
+    /// 4. Bare store-subscription or prop-source identifier: passed
+    ///    through, `$.derived(name)` — store subs and prop getters are
+    ///    already callable, no thunk needed.
+    /// 5. Anything else: `unthunk_string` is applied (`() => name()`
+    ///    -> `name`, `() => $.foo()` -> `$.foo`); the result is what
+    ///    goes inside `$.derived(...)`.
+    ///
+    /// We use the existing text helpers (`contains_direct_await_in_expression`,
+    /// `strip_top_level_await_from_expr`, `unthunk_string`) on the post-walk
+    /// argument text to keep byte-identical output with the old text loop.
+    fn try_rewrite_derived_call_declarator(&mut self, declarator: &VariableDeclarator<'_>) -> bool {
+        let Some(init) = &declarator.init else {
+            return false;
+        };
+        if !self.is_derived_call_init(init) {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        // Destructured patterns are still handled by the text helper
+        // `transform_derived_destructuring`. Only simple `BindingIdentifier`
+        // targets are migrated here.
+        let BindingPattern::BindingIdentifier(_) = &declarator.id else {
+            return false;
+        };
+        if call.arguments.len() != 1 {
+            return false;
+        }
+
+        let arg = &call.arguments[0];
+        let arg_expr_opt = arg.as_expression();
+        let arg_span = arg.span();
+
+        // Snapshot the original *source-level* arg text before any walk —
+        // both the await probe and the function-shape check are run against
+        // the original (pre-`$.get(...)`-wrap) tokens to match the text path.
+        let arg_source_text =
+            self.source[arg_span.start as usize..arg_span.end as usize].to_string();
+        let arg_source_trimmed = arg_source_text.trim();
+
+        // Drop a trailing comma inside `$derived(expr,)` — the old text
+        // path stripped it because `() => (expr,)` is a SyntaxError.
+        let arg_for_check = arg_source_trimmed
+            .strip_suffix(',')
+            .map_or(arg_source_trimmed, |s| s.trim_end());
+
+        // Walk the argument once so inner state-var refs get `$.get(...)`,
+        // then drain those inner replacements into a transformed string we
+        // can feed to the text helpers (mirroring `wrap_state_vars_in_expr`
+        // in the old path).
+        self.visit_argument(arg);
+        let walked_arg = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
+        let walked_trimmed = walked_arg.trim();
+        let walked_for_emit = walked_trimmed
+            .strip_suffix(',')
+            .map_or(walked_trimmed, |s| s.trim_end());
+
+        // Case 1: arg is already a function/arrow. The old text path's
+        // condition was `starts_with("()") || starts_with("function")`,
+        // which is broader than just `Expression::ArrowFunctionExpression`
+        // (it also catches e.g. `(x) => x` because that starts with `(`).
+        // Mirror the old check on the original source bytes so we stay
+        // byte-identical in edge cases.
+        let starts_as_function =
+            arg_source_trimmed.starts_with("()") || arg_source_trimmed.starts_with("function");
+        if starts_as_function {
+            let replacement = format!("$.derived(() => {})", walked_for_emit);
+            self.add_replacement(call.span.start, call.span.end, replacement);
+            return true;
+        }
+
+        // Case 2: top-level `await` somewhere in the expression → async derived.
+        if contains_direct_await_in_expression(arg_for_check) {
+            let inner_expr = strip_top_level_await_from_expr(walked_for_emit);
+            let inner_trimmed = inner_expr.trim();
+            let inner_has_nested_await = contains_direct_await_in_expression(inner_trimmed);
+            let replacement = if inner_has_nested_await {
+                let is_obj = walked_for_emit.starts_with('{');
+                if is_obj {
+                    format!("await $.async_derived(async () => ({}))", walked_for_emit)
+                } else {
+                    format!("await $.async_derived(async () => {})", walked_for_emit)
+                }
+            } else {
+                let inner_is_object = inner_trimmed.starts_with('{');
+                if inner_is_object {
+                    format!("await $.async_derived(() => ({}))", inner_expr)
+                } else {
+                    let thunk_arg = unthunk_string(&inner_expr);
+                    format!("await $.async_derived({})", thunk_arg)
+                }
+            };
+            self.add_replacement(call.span.start, call.span.end, replacement);
+            return true;
+        }
+
+        // Case 3: object literal — paren-wrap so the body isn't parsed as a block.
+        if matches!(arg_expr_opt, Some(Expression::ObjectExpression(_))) {
+            let replacement = format!("$.derived(() => ({}))", walked_for_emit);
+            self.add_replacement(call.span.start, call.span.end, replacement);
+            return true;
+        }
+
+        // Case 4: bare store-sub / prop-source identifier — already callable.
+        if let Some(Expression::Identifier(ident)) = arg_expr_opt {
+            let name = ident.name.as_str();
+            if self.store_sub_vars.contains(name) || self.prop_source_vars.contains(name) {
+                let replacement = format!("$.derived({})", walked_for_emit);
+                self.add_replacement(call.span.start, call.span.end, replacement);
+                return true;
+            }
+        }
+
+        // Case 5: default — unthunk if the walked arg is a `name()` /
+        // `$.foo()` shape, otherwise wrap in a thunk.
+        let derived_arg = unthunk_string(walked_for_emit);
+        let replacement = format!("$.derived({})", derived_arg);
+        self.add_replacement(call.span.start, call.span.end, replacement);
+        true
+    }
+
     /// Apply any pending replacements that fall within [range_start, range_end)
     /// to the given source text, remove them from the replacements list, and
     /// return the transformed substring.
@@ -893,6 +1056,9 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
             return;
         }
         if self.try_rewrite_derived_by_declarator(declarator) {
+            return;
+        }
+        if self.try_rewrite_derived_call_declarator(declarator) {
             return;
         }
         walk::walk_variable_declarator(self, declarator);
@@ -1132,11 +1298,17 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         // 4. Store subscription reads: $store -> $store()
         if self.is_active_store_sub(name) {
             // Don't transform inside $.untrack() or $.derived() context
-            // (checked by looking at the source text immediately before)
+            // (checked by looking at the source text immediately before).
+            // Also accept the *raw* `$derived(` / `untrack(` shapes — after
+            // the `$derived(...)` and `$.untrack(...)` text replaces moved
+            // into this AST pass, the source we see here may still have the
+            // pre-rewrite tokens around the store-sub reference.
             let before_start = start as usize;
             let trimmed_before = self.source[..before_start].trim_end();
-            let in_getter_context =
-                trimmed_before.ends_with("$.untrack(") || trimmed_before.ends_with("$.derived(");
+            let in_getter_context = trimmed_before.ends_with("$.untrack(")
+                || trimmed_before.ends_with("$.derived(")
+                || trimmed_before.ends_with("$derived(")
+                || trimmed_before.ends_with("untrack(");
             if !in_getter_context {
                 if self.in_shorthand_property {
                     self.add_replacement(start, end, format!("{}: {}()", name, name));

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -5131,34 +5131,11 @@ let { foo = false, bar = true } = $props();
         assert_eq!(find_matching_paren("abc"), None);
     }
 
-    #[test]
-    fn test_derived_object_literal_wrapped_in_parens() {
-        // Test that object literals in $derived() are wrapped in parentheses
-        let input = "let count = $derived({ value: 1 });";
-        let options = crate::compiler::CompileOptions::default();
-        let analysis =
-            crate::compiler::phases::phase2_analyze::types::ComponentAnalysis::new("", &options);
-        let result = transform_client_runes_with_skip_and_state(
-            input,
-            &[],   // skip_state_vars
-            &[],   // state_vars
-            &[],   // non_reactive_vars
-            &[],   // prop_source_vars
-            &[],   // exported_names
-            &[],   // proxy_vars
-            false, // dev
-            &analysis,
-            &[], // store_sub_vars
-            &[], // read_only_props
-        );
-        println!("Input:  {}", input);
-        println!("Result: {}", result);
-        assert!(
-            result.contains("$.derived(() => ({"),
-            "Object literal should be wrapped in parentheses: {}",
-            result
-        );
-    }
+    // `test_derived_object_literal_wrapped_in_parens` was deleted along
+    // with the text-based `$derived(...)` rewrite — the paren wrap is
+    // now produced by `ast_state_transform::try_rewrite_derived_call_declarator`
+    // and is exercised by the runtime/snapshot fixtures that round-trip
+    // through the full compile pipeline.
 
     #[test]
     fn test_transform_prop_reads_in_expr() {
@@ -5223,47 +5200,11 @@ let { foo = false, bar = true } = $props();
     }
 }
 
-#[test]
-fn test_derived_object_literal_double_wrap() {
-    // Test that the double wrapping preserves parentheses
-    let input = "let count = $derived({ value: 1 });";
-
-    let options = crate::compiler::CompileOptions::default();
-    let analysis =
-        crate::compiler::phases::phase2_analyze::types::ComponentAnalysis::new("", &options);
-
-    // First transform
-    let result1 = transform_client_runes_with_skip_and_state(
-        input,
-        &[],   // skip_state_vars
-        &[],   // state_vars
-        &[],   // non_reactive_vars
-        &[],   // prop_source_vars
-        &[],   // exported_names
-        &[],   // proxy_vars
-        false, // dev
-        &analysis,
-        &[], // store_sub_vars
-        &[], // read_only_props
-    );
-    println!("After first transform: {}", result1);
-
-    // Second wrap (simulating what happens in the actual code)
-    // Note: "count" is a state variable after $derived transformation
-    let result2 = wrap_state_vars_in_expr(
-        &result1,
-        &["count".to_string()], // state_vars
-        &[],                    // non_reactive_vars
-        &[],                    // proxy_vars
-    );
-    println!("After second wrap: {}", result2);
-
-    assert!(
-        result2.contains("$.derived(() => ({"),
-        "Object literal should still be wrapped in parentheses: {}",
-        result2
-    );
-}
+// `test_derived_object_literal_double_wrap` was deleted along with the
+// text-based `$derived(...)` rewrite — the paren wrap around object
+// literals is now produced by
+// `ast_state_transform::try_rewrite_derived_call_declarator` and is
+// exercised by the runtime/snapshot fixtures end-to-end.
 
 #[test]
 fn test_mutation_wrap_state_vars() {

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -206,154 +206,40 @@ pub(super) fn transform_client_runes_with_skip_and_state(
         // Handle destructuring patterns specially
         // Loop to handle multiple $derived() calls in a single statement
         // (e.g., inside a function body with multiple derived declarations)
-        while let Some(pos) = find_unescaped_derived_call(&result) {
+        // Simple `let x = $derived(expr)` declarators are now rewritten in
+        // `ast_state_transform::transform_state_vars_ast` via
+        // `try_rewrite_derived_call_declarator`. The AST visit handles the
+        // same five cases the old text loop did (already-a-function thunk
+        // wrap, top-level `await` → `await $.async_derived(...)`, object
+        // literal paren wrap, bare store-sub / prop-source pass-through,
+        // and default `unthunk_string` thunk wrap) and reuses the same
+        // text helpers (`contains_direct_await_in_expression`,
+        // `strip_top_level_await_from_expr`, `unthunk_string`) on the
+        // walked argument text.
+        //
+        // *Destructured* `$derived({...})` / `$derived([...])` patterns are
+        // still handled by the text helper `transform_derived_destructuring`,
+        // which produces a complete IIFE/`$$d`-temp form and returns the
+        // rewritten script.
+        if let Some(pos) = find_unescaped_derived_call(&result) {
             let before_pos_bytes = &result.as_bytes()[..pos];
-            if !(memmem::find(before_pos_bytes, b"let ").is_some()
+            let has_decl = memmem::find(before_pos_bytes, b"let ").is_some()
                 || memmem::find(before_pos_bytes, b"const ").is_some()
-                || memmem::find(before_pos_bytes, b"var ").is_some())
-            {
-                break;
-            }
-
-            // Check if this is a destructuring pattern
-            let before_derived = result[..pos].trim();
-            let has_destructuring = before_derived.contains('{') || before_derived.contains('[');
-
-            if has_destructuring {
-                // Handle destructuring pattern for $derived
-                if let Some(transformed) = transform_derived_destructuring(
-                    &result,
-                    state_vars,
-                    non_reactive_vars,
-                    proxy_vars,
-                ) {
+                || memmem::find(before_pos_bytes, b"var ").is_some();
+            if has_decl {
+                let before_derived = result[..pos].trim();
+                let has_destructuring =
+                    before_derived.contains('{') || before_derived.contains('[');
+                if has_destructuring
+                    && let Some(transformed) = transform_derived_destructuring(
+                        &result,
+                        state_vars,
+                        non_reactive_vars,
+                        proxy_vars,
+                    )
+                {
                     return apply_effect_rune_transforms(transformed);
                 }
-            }
-
-            // Find the content inside $derived(...)
-            let derived_start = pos + 9; // after "$derived("
-            if let Some(content_end) = find_matching_paren(&result[derived_start..]) {
-                let content = &result[derived_start..derived_start + content_end];
-                // Strip trailing comma from $derived(expr,) - the trailing comma is valid
-                // in function call syntax but NOT in arrow function body grouping: () => (expr,) is a SyntaxError
-                let content = content
-                    .trim_end()
-                    .strip_suffix(',')
-                    .map_or(content, |stripped| stripped);
-                // Wrap in arrow function if not already a function
-                let trimmed_content = content.trim();
-                if !trimmed_content.starts_with("()") && !trimmed_content.starts_with("function") {
-                    // Check if the derived expression contains await (async derived)
-                    // Note: We need to check for await NOT inside an inner async function
-                    let contains_direct_await =
-                        contains_direct_await_in_expression(trimmed_content);
-
-                    // Wrap state variables inside the derived expression with $.get()
-                    let wrapped_content =
-                        wrap_state_vars_in_expr(content, state_vars, non_reactive_vars, proxy_vars);
-
-                    // Check if the content is an object literal - if so, wrap in parentheses
-                    // to disambiguate from a block statement
-                    let wrapped_trimmed = wrapped_content.trim();
-                    let is_object_literal = wrapped_trimmed.starts_with('{');
-
-                    let new_derived = if contains_direct_await {
-                        // For async derived in instance script:
-                        // Strip the top-level `await` and check if there are remaining awaits.
-                        // No $.save wrapping (that's only for nested contexts).
-                        let inner_expr = strip_top_level_await_from_expr(wrapped_trimmed);
-                        let inner_has_nested_await =
-                            contains_direct_await_in_expression(&inner_expr);
-
-                        if inner_has_nested_await {
-                            // Still has await after stripping → use async thunk
-                            let is_obj = wrapped_trimmed.starts_with('{');
-                            if is_obj {
-                                format!("await $.async_derived(async () => ({}))", wrapped_trimmed)
-                            } else {
-                                format!("await $.async_derived(async () => {})", wrapped_trimmed)
-                            }
-                        } else {
-                            // No more await → use sync thunk
-                            let inner_trimmed = inner_expr.trim();
-                            let inner_is_object = inner_trimmed.starts_with('{');
-                            if inner_is_object {
-                                format!("await $.async_derived(() => ({}))", inner_expr)
-                            } else {
-                                let thunk_arg = unthunk_string(&inner_expr);
-                                format!("await $.async_derived({})", thunk_arg)
-                            }
-                        }
-                    } else if is_object_literal {
-                        format!("$.derived(() => ({}))", wrapped_content)
-                    } else {
-                        // Check if the content is a store subscription variable (e.g., $store1).
-                        // Store subs are already getter functions, so they can be passed directly
-                        // to $.derived() without wrapping: $.derived($store1) instead of
-                        // $.derived(() => $store1())
-                        let trimmed_wrapped = wrapped_content.trim();
-                        if store_sub_vars.contains(&trimmed_wrapped.to_string()) {
-                            format!("$.derived({})", trimmed_wrapped)
-                        } else if prop_source_vars.iter().any(|p| p == trimmed_wrapped) {
-                            // Prop source: $.derived(propName) - the prop getter IS the derived fn
-                            format!("$.derived({})", trimmed_wrapped)
-                        } else {
-                            // Apply unthunk optimization: $.derived(() => name()) -> $.derived(name)
-                            // This matches the official compiler's b.thunk() + unthunk() behavior
-                            let derived_arg = unthunk_string(&wrapped_content);
-                            format!("$.derived({})", derived_arg)
-                        }
-                    };
-
-                    result = format!(
-                        "{}{}{}",
-                        &result[..pos],
-                        new_derived,
-                        &result[derived_start + content_end + 1..]
-                    );
-                } else {
-                    // The content is already a function - check if it's async
-                    // $derived(async () => { ... }) should become $.derived(() => async () => { ... })
-                    // Note: returns the async function, NOT invokes it
-                    if trimmed_content.starts_with("async ") {
-                        // Wrap: $.derived(() => async () => {...})
-                        let wrapped_content = wrap_state_vars_in_expr(
-                            content,
-                            state_vars,
-                            non_reactive_vars,
-                            proxy_vars,
-                        );
-                        let new_derived = format!("$.derived(() => {})", wrapped_content);
-                        result = format!(
-                            "{}{}{}",
-                            &result[..pos],
-                            new_derived,
-                            &result[derived_start + content_end + 1..]
-                        );
-                    } else {
-                        // Sync arrow function inside $derived():
-                        // $derived(() => { ... }) should become $.derived(() => () => { ... })
-                        // The official compiler wraps ALL $derived() args in b.thunk(), which
-                        // wraps the arrow function: () => (() => { ... })
-                        let wrapped_content = wrap_state_vars_in_expr(
-                            content,
-                            state_vars,
-                            non_reactive_vars,
-                            proxy_vars,
-                        );
-                        let new_derived = format!("$.derived(() => {})", wrapped_content);
-                        result = format!(
-                            "{}{}{}",
-                            &result[..pos],
-                            new_derived,
-                            &result[derived_start + content_end + 1..]
-                        );
-                    }
-                }
-            } else {
-                result = format!("{}$.derived({}", &result[..pos], &result[pos + 9..]);
-                break;
             }
         }
     } // end if !derived_is_store_sub


### PR DESCRIPTION
Fifth AST-migration PR (after #94 `$effect`, #95 `$state.raw`/`$state.frozen`, #96 plain `$state(...)`, #97 `$derived.by(fn)`) in the `PERF_ROADMAP.md` "text transform pipeline elimination" track.

Plain `$derived(expr)` rune declarators with a simple `BindingIdentifier` target are now rewritten by `ast_state_transform::transform_state_vars_ast` via a new `try_rewrite_derived_call_declarator` helper in `visit_variable_declarator`. The text path keeps only its destructuring branch — which delegates to `transform_derived_destructuring` and remains in text for now (the AST visitor only matches `BindingPattern::BindingIdentifier`).

## Cases handled (byte-identical with removed text loop)

| Arg shape | Output |
|---|---|
| Already a function (`() => …` / `function …`) | `$.derived(() => …)` (thunk-wraps the function — matches official `b.thunk()` treatment) |
| Top-level `await`, inner still has `await` | `await $.async_derived(async () => …)` (paren-wrapped for object literal) |
| Top-level `await`, inner has no more `await` | `await $.async_derived(() => …)` (paren-wrapped for object literal) or `await $.async_derived(name)` after `unthunk_string` |
| Object literal | `$.derived(() => (obj))` (parens disambiguate from block) |
| Bare store-sub / prop-source identifier | `$.derived(name)` (already callable, no thunk) |
| Default | `$.derived(unthunk_string(...))` (`() => name()` → `name`, `() => $.foo()` → `$.foo`) |

Inner state-var refs in the expression still get `$.get(...)` wrapping via the visitor's normal walk; we drain those inner replacements before emitting the outer span replacement so the outer rewrite doesn't clobber them.

We reuse the existing text helpers (`contains_direct_await_in_expression`, `strip_top_level_await_from_expr`, `unthunk_string`) on the walked argument text, which keeps the output byte-identical to what the old text path produced indirectly.

## Visitor adjustment

When a bare store-sub identifier (e.g. `$value1`) appears as the sole argument to `$derived(...)`, the visitor's `visit_identifier_reference` previously decided whether to keep it unwrapped by checking that the immediately-preceding source text was `$.derived(` (i.e. *already* the text-rewritten form). With this PR the source still has the raw `$derived(`, so the check is extended to also accept `$derived(` and `untrack(` shapes. Caught by the `store-async-first-value` and `store-no-mutation-validation` runtime fixtures during local testing.

## Correctness improvements

- Lexical scope for `$derived` shadowing via `is_shadowed("$derived")` (function/catch parameters, let/const/var in any enclosing scope) — matches the official Svelte compiler's AST-based scope rules.
- `is_known_transform_declaration` now recognises the untransformed `$derived(...)` AST pattern, so bound names are not registered as local shadows.

## Numbers

Per-fixture timings stay within noise on `form-default-value-spread` and `array-sort-in-effect` (those fixtures don't use `$derived`). The win is structural — this is the *most complex* remaining slice off the text pipeline.

## Test plan

- [x] `cargo test --release` for runtime (19/19 incl. all `$derived` fixtures), ssr (16/16), compiler_fixtures (17/17), compiler_errors (16/16), parser_fixtures, validator, print, css, preprocess, sourcemaps, real_world, svelte2tsx_fixtures, svelte_check_golden, compatibility_report — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)