### PR TITLE
perf(transform): migrate $state.snapshot to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -1226,6 +1226,30 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
             }
         }
 
+        // `$state.snapshot(x)` -> `$.snapshot(x)`. Only the callee identifier
+        // is rewritten; arguments are visited normally so any inner
+        // state-var refs still get `$.get()` wrapping. The dev-mode
+        // svelte-ignore handler (`mod.rs`) scans the per-statement output
+        // for `$state.snapshot(` and prepends a second `true` argument
+        // *before* this AST rewrite runs, so by the time we get here the
+        // call shape is either `$state.snapshot(x)` or
+        // `$state.snapshot(x, true)` — in both cases we only need to
+        // rename the callee.
+        if self.is_runes
+            && !self.is_shadowed("$state")
+            && !self.store_sub_vars.contains("$state")
+            && let Expression::StaticMemberExpression(member) = &expr.callee
+            && let Expression::Identifier(obj) = &member.object
+            && obj.name == "$state"
+            && member.property.name == "snapshot"
+        {
+            self.add_replacement(member.span.start, member.span.end, "$.snapshot".to_string());
+            for arg in &expr.arguments {
+                self.visit_argument(arg);
+            }
+            return;
+        }
+
         // Normal call expression - walk as usual
         walk::walk_call_expression(self, expr);
     }

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -3798,9 +3798,17 @@ fn transform_instance_script_for_visitors(
             read_only_props,
         );
 
-        // In dev mode, if the previous output line has a svelte-ignore state_snapshot_uncloneable
-        // comment, add `true` as second argument to $.snapshot() calls to suppress warning
-        if dev && memmem::find(transformed.as_bytes(), b"$.snapshot(").is_some() {
+        // In dev mode, if the previous output line carries a
+        // `<!-- svelte-ignore state_snapshot_uncloneable -->` comment,
+        // add `true` as the second argument to the `$state.snapshot()`
+        // call to suppress the runtime warning. We scan the raw
+        // `$state.snapshot(` shape (not the post-AST `$.snapshot(` shape)
+        // because this per-statement handler runs *before*
+        // `ast_state_transform::transform_state_vars_ast` renames the
+        // callee — see the matching comment in
+        // `rune_transforms::transform_client_runes_with_skip_and_state`
+        // for the migration rationale.
+        if dev && memmem::find(transformed.as_bytes(), b"$state.snapshot(").is_some() {
             let prev_has_ignore = {
                 let mut found = false;
                 for line in result.lines().rev() {
@@ -3820,15 +3828,15 @@ fn transform_instance_script_for_visitors(
             if prev_has_ignore {
                 let mut new_transformed = String::new();
                 let mut remaining = transformed.as_str();
-                while let Some(pos) = memmem::find(remaining.as_bytes(), b"$.snapshot(") {
+                while let Some(pos) = memmem::find(remaining.as_bytes(), b"$state.snapshot(") {
                     new_transformed.push_str(&remaining[..pos]);
-                    let call_start = pos + "$.snapshot(".len();
+                    let call_start = pos + "$state.snapshot(".len();
                     if let Some(content_end) = find_matching_paren(&remaining[call_start..]) {
                         let content = &remaining[call_start..call_start + content_end];
-                        new_transformed.push_str(&format!("$.snapshot({}, true)", content));
+                        new_transformed.push_str(&format!("$state.snapshot({}, true)", content));
                         remaining = &remaining[call_start + content_end + 1..];
                     } else {
-                        new_transformed.push_str("$.snapshot(");
+                        new_transformed.push_str("$state.snapshot(");
                         remaining = &remaining[call_start..];
                     }
                 }

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -123,12 +123,14 @@ pub(super) fn transform_client_runes_with_skip_and_state(
             }
         }
 
-        // Transform $state.snapshot(x) to $.snapshot(x)
-        // In dev mode, if preceded by svelte-ignore state_snapshot_uncloneable comment,
-        // add `true` as second argument to suppress runtime warning
-        if memmem::find(result.as_bytes(), b"$state.snapshot(").is_some() {
-            result = result.replace("$state.snapshot(", "$.snapshot(");
-        }
+        // `$state.snapshot(x)` -> `$.snapshot(x)` is now done by the AST pass
+        // in `ast_state_transform::visit_call_expression`. The dev-mode
+        // `svelte-ignore state_snapshot_uncloneable` handler in
+        // `mod.rs::transform_client_with_visitors`'s `process_accumulated`
+        // closure still runs *before* that AST rewrite; it now matches the
+        // un-renamed `$state.snapshot(` shape and emits
+        // `$state.snapshot(x, true)`, which the AST then renames to
+        // `$.snapshot(x, true)` at the callee site.
 
         // `$state.raw(x)` / `$state.frozen(x)` rune declarators — formerly
         // rewritten here via a per-rune text loop — are now rewritten in


### PR DESCRIPTION
Sixth AST-migration PR (after #94 `$effect`, #95 `$state.raw`/`$state.frozen`, #96 plain `$state(...)`, #97 `$derived.by(fn)`, #98 plain `$derived(expr)`).

`$state.snapshot(x)` → `$.snapshot(x)` is now done by the AST pass in `ast_state_transform::visit_call_expression` instead of the byte-level `result.replace("$state.snapshot(", "$.snapshot(")` in `transform_client_runes_with_skip_and_state`.

## Correctness improvement

The AST visit uses precise lexical-scope shadowing checks for `$state` (so a function parameter named `$state` correctly disables the rewrite inside that function) and only rewrites the callee `StaticMemberExpression` span, leaving the argument (and any trailing dev-mode `, true`) untouched.

## Dev-mode `svelte-ignore state_snapshot_uncloneable` interaction

The dev handler in `mod.rs::transform_client_with_visitors`'s `process_accumulated` closure still runs per-statement, but now matches the *un-renamed* `$state.snapshot(` shape (the AST renames `$state.snapshot` → `$.snapshot` *after* the per-statement loop completes). The handler emits `$state.snapshot(x, true)` and the AST then renames the callee, giving the same final `$.snapshot(x, true)` output as before.

## Out of scope

The module-script path (`transform_module_script_runes` in mod.rs:2460) still uses the text replace because the AST pass is only wired up for component scripts at this point. Migrating module scripts is a separate, larger workstream.

## Test plan

- [x] `cargo test --release` for runtime (519 unit + 19 integration), ssr (16/16), compiler_fixtures (17/17), compiler_errors, parser_fixtures, validator, print, css, preprocess, sourcemaps, real_world, svelte2tsx_fixtures, svelte_check_golden, compatibility_report — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)