### PR TITLE
perf(transform): migrate $props.id() to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -1250,6 +1250,21 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
             return;
         }
 
+        // `$props.id()` -> `$.props_id()`. Zero-arg rune call, callee
+        // rename only.
+        if self.is_runes
+            && !self.is_shadowed("$props")
+            && !self.store_sub_vars.contains("$props")
+            && expr.arguments.is_empty()
+            && let Expression::StaticMemberExpression(member) = &expr.callee
+            && let Expression::Identifier(obj) = &member.object
+            && obj.name == "$props"
+            && member.property.name == "id"
+        {
+            self.add_replacement(member.span.start, member.span.end, "$.props_id".to_string());
+            return;
+        }
+
         // Normal call expression - walk as usual
         walk::walk_call_expression(self, expr);
     }
@@ -2429,6 +2444,9 @@ pub(super) fn transform_state_vars_ast(
     let has_derived_calls = is_runes
         && !store_sub_vars.iter().any(|v| v == "$derived")
         && memchr::memmem::find(script.as_bytes(), b"$derived").is_some();
+    let has_props_calls = is_runes
+        && !store_sub_vars.iter().any(|v| v == "$props")
+        && memchr::memmem::find(script.as_bytes(), b"$props").is_some();
 
     if !has_state
         && !has_props
@@ -2438,6 +2456,7 @@ pub(super) fn transform_state_vars_ast(
         && !has_effect_calls
         && !has_state_calls
         && !has_derived_calls
+        && !has_props_calls
     {
         return None;
     }
@@ -2486,7 +2505,8 @@ pub(super) fn transform_state_vars_ast(
                 .any(|v| script_ids.contains(v.as_str())))
         || (has_effect_calls && script_ids.contains("$effect"))
         || (has_state_calls && script_ids.contains("$state"))
-        || (has_derived_calls && script_ids.contains("$derived"));
+        || (has_derived_calls && script_ids.contains("$derived"))
+        || (has_props_calls && script_ids.contains("$props"));
 
     if !has_any_match {
         return None;

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4322,6 +4322,8 @@ fn transform_instance_script_for_visitors(
             && memmem::find(result.as_bytes(), b"$state").is_some();
         let has_derived_calls = !store_sub_vars.iter().any(|v| v == "$derived")
             && memmem::find(result.as_bytes(), b"$derived").is_some();
+        let has_props_calls = !store_sub_vars.iter().any(|v| v == "$props")
+            && memmem::find(result.as_bytes(), b"$props").is_some();
         let has_transforms = !state_vars.is_empty()
             || !prop_assignment_transform_vars.is_empty()
             || !store_sub_vars.is_empty()
@@ -4329,7 +4331,8 @@ fn transform_instance_script_for_visitors(
             || !rest_prop_vars.is_empty()
             || has_effect_calls
             || has_state_calls
-            || has_derived_calls;
+            || has_derived_calls
+            || has_props_calls;
 
         if has_transforms {
             // Collect $derived / $derived.by binding names so AST assignment transforms

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -277,10 +277,9 @@ pub(super) fn transform_client_runes_with_skip_and_state(
     // of the statement-wide `is_function_parameter_in_statement` heuristic.
     let _ = (effect_is_store_sub, effect_is_func_param);
 
-    // Transform $props.id() to $.props_id()
-    if memmem::find(result.as_bytes(), b"$props.id()").is_some() {
-        result = result.replace("$props.id()", "$.props_id()");
-    }
+    // `$props.id()` -> `$.props_id()` is now handled by the AST pass in
+    // `ast_state_transform::visit_call_expression` (precise lexical-scope
+    // shadowing check for `$props`).
 
     // Transform $inspect.trace(...) - in non-dev mode, remove the entire statement
     // In dev mode, transform the enclosing block body to wrap remaining statements in $.trace()


### PR DESCRIPTION
Seventh AST-migration PR. `$props.id()` → `$.props_id()` is now done by the AST pass in `ast_state_transform::visit_call_expression` instead of the byte-level `result.replace("$props.id()", "$.props_id()")` in `transform_client_runes_with_skip_and_state`.

Trivial whole-call rewrite: zero arguments, single callee rename (`$props.id` MemberExpression span → `$.props_id`). The new AST check guards against `$props` being shadowed or used as a store subscription (precise lexical-scope check, matches the rest of the rune AST handlers).

Added `has_props_calls` to the AST-pass gate (both in `transform_state_vars_ast`'s early-out and `transform_client_with_visitors`'s `has_transforms` check) so components whose only rune use is `$props.id()` still enter the AST pass.

## Test plan

- [x] `cargo test --release` for runtime (519 unit + 19 integration), ssr (16/16), all 14 categories — green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)