### PR TITLE
perf(transform): migrate $state.eager(x) to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -1265,6 +1265,33 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
             return;
         }
 
+        // `$state.eager(x)` -> `$.eager(() => x)`. Whole-call rewrite that
+        // wraps the single argument in a thunk; inner state-var refs in
+        // the argument still need `$.get(...)` wrapping, so we walk the
+        // arg first, drain those inner replacements, and bake them into
+        // the outer replacement.
+        if self.is_runes
+            && !self.is_shadowed("$state")
+            && !self.store_sub_vars.contains("$state")
+            && expr.arguments.len() == 1
+            && let Expression::StaticMemberExpression(member) = &expr.callee
+            && let Expression::Identifier(obj) = &member.object
+            && obj.name == "$state"
+            && member.property.name == "eager"
+        {
+            let arg = &expr.arguments[0];
+            self.visit_argument(arg);
+            let arg_span = arg.span();
+            let transformed_arg =
+                self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
+            self.add_replacement(
+                expr.span.start,
+                expr.span.end,
+                format!("$.eager(() => {})", transformed_arg),
+            );
+            return;
+        }
+
         // Normal call expression - walk as usual
         walk::walk_call_expression(self, expr);
     }

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -246,24 +246,11 @@ pub(super) fn transform_client_runes_with_skip_and_state(
         }
     } // end if !derived_is_store_sub
 
-    // Transform $state.eager(x) to $.eager(() => x) - thunk wrapping
-    if !state_is_store_sub
-        && !state_is_func_param
-        && let Some(pos) = memmem::find(result.as_bytes(), b"$state.eager(")
-    {
-        let eager_start = pos + 13; // after "$state.eager("
-        if let Some(content_end) = find_matching_paren(&result[eager_start..]) {
-            let content = &result[eager_start..eager_start + content_end];
-            let wrapped_content =
-                wrap_state_vars_in_expr(content, state_vars, non_reactive_vars, proxy_vars);
-            result = format!(
-                "{}$.eager(() => {}){}",
-                &result[..pos],
-                wrapped_content,
-                &result[eager_start + content_end + 1..]
-            );
-        }
-    } // end state.eager guard
+    // `$state.eager(x)` -> `$.eager(() => x)` is now handled by the AST
+    // pass in `ast_state_transform::visit_call_expression` (precise
+    // lexical-scope shadowing check for `$state`, walks the argument for
+    // inner state-var refs and bakes those `$.get(...)` rewrites into
+    // the outer thunk-wrap span).
 
     // `$effect` rune family — formerly `replace_effect_patterns(&result)` —
     // is now handled by the AST pass in


### PR DESCRIPTION
Eighth AST-migration PR (after #94 `$effect`, #95 `$state.raw`/`.frozen`, #96 plain `$state(...)`, #97 `$derived.by`, #98 plain `$derived`, #99 `$state.snapshot`, #100 `$props.id`).

`$state.eager(x)` → `$.eager(() => x)` is now done by the AST pass in `ast_state_transform::visit_call_expression` instead of the byte-level `memmem` + `find_matching_paren` rewrite in `transform_client_runes_with_skip_and_state`.

Whole-call rewrite that wraps the single argument in a thunk; inner state-var refs in the argument still get `$.get(...)` wrapping via the visitor's normal walk, then `apply_and_drain_inner_replacements` bakes those rewrites into the outer thunk-wrap span.

## Correctness improvement

Precise lexical-scope shadowing check for `$state` (function/catch parameters, let/const/var in any enclosing scope) matches the official Svelte compiler's AST-based scope rules.

## Test plan

- [x] `cargo test --release` for runtime (519 unit + 19 integration), ssr, all 14 test categories — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)