### PR TITLE
perf(transform): migrate $inspect(...) dev-mode rewrite to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -127,6 +127,10 @@ struct StateVarCollector<'a, 's> {
     non_proxy_vars: &'a [String],
     /// Whether the component is in runes mode.
     is_runes: bool,
+    /// Whether dev-mode rewrites should fire (currently only used by the
+    /// `$inspect(...)` AST migration; non-dev behaviour stays in the text
+    /// path).
+    dev: bool,
     /// Var-declared state vars that need $.safe_get() instead of $.get().
     var_state_vars: Vec<String>,
     /// Collected replacements.
@@ -173,6 +177,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         derived_vars: &[String],
         non_proxy_vars: &'a [String],
         is_runes: bool,
+        dev: bool,
         prop_source_vars: &[String],
         non_bindable_prop_vars: &[String],
         store_sub_vars: &[String],
@@ -200,6 +205,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             derived_vars: derived_vars.iter().cloned().collect(),
             non_proxy_vars,
             is_runes,
+            dev,
             var_state_vars,
             replacements: Vec::new(),
             scoped_vars: vec![FxHashSet::default()],
@@ -841,6 +847,29 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         true
     }
 
+    /// Walk every argument of a `CallExpression` so inner state-var refs
+    /// get `$.get(...)` wrapping, then drain the inner replacements and
+    /// return the comma-joined transformed text — the contents that
+    /// would have been inside the original `(...)` if the call were
+    /// preserved verbatim. Used by `$inspect(args)` etc. where we want
+    /// the args as a list expression `[arg, arg, ...]`.
+    fn walk_and_drain_args_as_text(&mut self, call: &CallExpression<'_>) -> String {
+        if call.arguments.is_empty() {
+            return String::new();
+        }
+        for arg in &call.arguments {
+            self.visit_argument(arg);
+        }
+        // Source spans of each argument; join their transformed text with
+        // `, ` so the result is a valid argument list.
+        let mut parts: Vec<String> = Vec::with_capacity(call.arguments.len());
+        for arg in &call.arguments {
+            let span = arg.span();
+            parts.push(self.apply_and_drain_inner_replacements(span.start, span.end));
+        }
+        parts.join(", ")
+    }
+
     /// Apply any pending replacements that fall within [range_start, range_end)
     /// to the given source text, remove them from the replacements list, and
     /// return the transformed substring.
@@ -1290,6 +1319,68 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
                 format!("$.eager(() => {})", transformed_arg),
             );
             return;
+        }
+
+        // `$inspect(args)` / `$inspect(args).with(cb)` — *dev mode only*.
+        // Non-dev mode still uses the text path in
+        // `transform_client_runes_with_skip_and_state`, because the
+        // standalone-statement detection (which produces the
+        // `/* $$async_hole:... */` marker in async mode) is statement-
+        // shaped rather than expression-shaped and is awkward to do at
+        // the AST level.
+        //
+        // Output shapes:
+        //   $inspect(args)              -> $.inspect(() => [args], (...$$args) => console.log(...$$args), true)
+        //   $inspect(args).with(cb)     -> $.inspect(() => [args], (...$$args) => (cb)(...$$args))
+        //
+        // We match the *outer* `$inspect(...).with(cb)` call first so a
+        // chained pattern isn't double-rewritten by the inner-call branch.
+        if self.dev
+            && self.is_runes
+            && !self.is_shadowed("$inspect")
+            && !self.store_sub_vars.contains("$inspect")
+        {
+            // Outer: `$inspect(args).with(cb)` — CallExpression whose
+            // callee is `<$inspect(args)>.with`.
+            if expr.arguments.len() == 1
+                && let Expression::StaticMemberExpression(member) = &expr.callee
+                && member.property.name == "with"
+                && let Expression::CallExpression(inner) = &member.object
+                && let Expression::Identifier(inner_callee) = &inner.callee
+                && inner_callee.name == "$inspect"
+            {
+                let args_text = self.walk_and_drain_args_as_text(inner);
+                let cb_arg = &expr.arguments[0];
+                self.visit_argument(cb_arg);
+                let cb_span = cb_arg.span();
+                let cb_text = self.apply_and_drain_inner_replacements(cb_span.start, cb_span.end);
+                self.add_replacement(
+                    expr.span.start,
+                    expr.span.end,
+                    format!(
+                        "$.inspect(() => [{}], (...$$args) => ({})(...$$args))",
+                        args_text, cb_text
+                    ),
+                );
+                return;
+            }
+
+            // Inner / simple: `$inspect(args)` — CallExpression with
+            // identifier callee `$inspect`.
+            if let Expression::Identifier(callee_ident) = &expr.callee
+                && callee_ident.name == "$inspect"
+            {
+                let args_text = self.walk_and_drain_args_as_text(expr);
+                self.add_replacement(
+                    expr.span.start,
+                    expr.span.end,
+                    format!(
+                        "$.inspect(() => [{}], (...$$args) => console.log(...$$args), true)",
+                        args_text
+                    ),
+                );
+                return;
+            }
         }
 
         // Normal call expression - walk as usual
@@ -2424,6 +2515,10 @@ pub(super) struct AstTransformConfig<'a> {
     pub derived_vars: &'a [String],
     pub non_proxy_vars: &'a [String],
     pub is_runes: bool,
+    /// Whether dev-mode rune rewrites should fire (e.g. the `$inspect(...)`
+    /// expansion into `$.inspect(() => [args], ...)` — non-dev removal of
+    /// the same call remains in the text path).
+    pub dev: bool,
     pub prop_source_vars: &'a [String],
     pub prop_assignment_transform_vars: &'a [String],
     pub non_bindable_prop_vars: &'a [String],
@@ -2560,6 +2655,7 @@ pub(super) fn transform_state_vars_ast(
             derived_vars,
             non_proxy_vars,
             is_runes,
+            config.dev,
             prop_source_vars,
             non_bindable_prop_vars,
             store_sub_vars,
@@ -2603,6 +2699,7 @@ mod tests {
             derived_vars: &[],
             non_proxy_vars: &[],
             is_runes: true,
+            dev: false,
             prop_source_vars: &[],
             prop_assignment_transform_vars: &[],
             non_bindable_prop_vars: &[],
@@ -2628,6 +2725,7 @@ mod tests {
             derived_vars: &[],
             non_proxy_vars: &[],
             is_runes: true,
+            dev: false,
             prop_source_vars: &[],
             prop_assignment_transform_vars: &[],
             non_bindable_prop_vars: &[],
@@ -2838,6 +2936,7 @@ mod tests {
             derived_vars: &[],
             non_proxy_vars: &[],
             is_runes: true,
+            dev: false,
             prop_source_vars: &[],
             prop_assignment_transform_vars: &[],
             non_bindable_prop_vars: &[],

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4371,6 +4371,7 @@ fn transform_instance_script_for_visitors(
                 derived_vars: &derived_vars,
                 non_proxy_vars: &non_proxy_vars,
                 is_runes: true,
+                dev,
                 prop_source_vars: &prop_source_vars,
                 prop_assignment_transform_vars: &prop_assignment_transform_vars,
                 non_bindable_prop_vars: &non_bindable_prop_vars,

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -399,50 +399,15 @@ pub(super) fn transform_client_runes_with_skip_and_state(
         }
     }
 
-    // Transform $inspect(...) - in non-dev mode, remove the entire call
-    // In dev mode, transform to $.inspect(() => [args], (...$$args) => console.log(...$$args), true)
-    if let Some(pos) = memmem::find(result.as_bytes(), b"$inspect(") {
-        if dev {
-            // Find the matching closing paren to get the arguments
-            let inspect_start = pos + 9; // after "$inspect("
-            if let Some(content_end) = find_matching_paren(&result[inspect_start..]) {
-                let args_content = &result[inspect_start..inspect_start + content_end];
-
-                // Check if this is $inspect().with() pattern
-                let after_inspect = &result[inspect_start + content_end + 1..];
-                if after_inspect.trim_start().starts_with(".with(") {
-                    // $inspect(...).with(callback) pattern
-                    let with_start_offset =
-                        memmem::find(after_inspect.as_bytes(), b".with(").unwrap();
-                    let with_content_start =
-                        inspect_start + content_end + 1 + with_start_offset + 6;
-                    if let Some(with_end) = find_matching_paren(&result[with_content_start..]) {
-                        let callback = &result[with_content_start..with_content_start + with_end];
-                        let rest = &result[with_content_start + with_end + 1..];
-
-                        // Build: $.inspect(() => [args], (...$$args) => (callback)(...$$args))
-                        // Note: No third argument for $inspect().with
-                        // The callback must be wrapped in parens so arrow functions are valid call targets
-                        result = format!(
-                            "{}$.inspect(() => [{}], (...$$args) => ({})(...$$args)){}",
-                            &result[..pos],
-                            args_content,
-                            callback,
-                            rest
-                        );
-                    }
-                } else {
-                    // Simple $inspect(...) pattern
-                    // Build: $.inspect(() => [args], (...$$args) => console.log(...$$args), true)
-                    result = format!(
-                        "{}$.inspect(() => [{}], (...$$args) => console.log(...$$args), true){}",
-                        &result[..pos],
-                        args_content,
-                        &result[inspect_start + content_end + 1..]
-                    );
-                }
-            }
-        } else {
+    // `$inspect(args)` and `$inspect(args).with(cb)` in *dev mode* are now
+    // handled by the AST pass in
+    // `ast_state_transform::visit_call_expression`. The non-dev branch
+    // below stays here because the standalone-statement detection (which
+    // emits the `/* $$async_hole:... */` async-mode marker or just
+    // strips the call) is statement-shaped rather than expression-shaped
+    // and is awkward to do at the AST level.
+    if !dev && let Some(pos) = memmem::find(result.as_bytes(), b"$inspect(") {
+        {
             // In non-dev mode, remove the entire $inspect(...) call
             // Find matching closing paren
             let inspect_start = pos + 9; // after "$inspect("


### PR DESCRIPTION
Ninth AST-migration PR. `$inspect(args)` and `$inspect(args).with(cb)` in **dev mode** are now rewritten by the AST pass in `ast_state_transform::visit_call_expression` instead of the byte-level `memmem` + `find_matching_paren` rewrite in `transform_client_runes_with_skip_and_state`.

## Output shapes (unchanged)

```text
$inspect(args)            -> $.inspect(() => [args], (...$$args) => console.log(...$$args), true)
$inspect(args).with(cb)   -> $.inspect(() => [args], (...$$args) => (cb)(...$$args))
```

The outer `.with` pattern is matched first so we don't double-rewrite the inner `$inspect(args)` call. A new helper `walk_and_drain_args_as_text` walks each argument so inner state-var refs still get `$.get(...)` wrapping and then drains those inner replacements into a comma-joined string usable inside the outer rewrite.

## Non-dev mode stays in text

The standalone-statement detection (which produces the `/* $$async_hole:... */` async-mode marker or just strips the call) is statement-shaped rather than expression-shaped and is awkward to do at the AST level. Leaving the non-dev branch on the text path keeps this PR focused. Happy to migrate it if it ever shows up as a bottleneck.

## Plumbing

Threaded a new `dev: bool` field through `AstTransformConfig` and `StateVarCollector` so the visitor knows when to enable dev-mode rune rewrites.

## Correctness improvement

Precise lexical-scope shadowing check for `$inspect` (function/catch parameters, let/const/var in any enclosing scope) matches the official Svelte compiler's AST-based scope rules.

## Test plan

- [x] `cargo test --release` for runtime (519 unit + 19 integration), ssr (16/16), all 14 test categories — green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)