### PR TITLE
perf(transform): migrate $inspect.trace() dev-mode block rewrite to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -26,7 +26,8 @@ use rustc_hash::FxHashSet;
 use super::VAR_STATE_VARS;
 use super::destructure_transforms::unthunk_string;
 use super::expression_utils::{
-    contains_direct_await_in_expression, strip_top_level_await_from_expr,
+    contains_direct_await_in_expression, extract_enclosing_function_name, extract_trace_call_label,
+    find_trace_source_location, strip_top_level_await_from_expr,
 };
 
 thread_local! {
@@ -127,10 +128,16 @@ struct StateVarCollector<'a, 's> {
     non_proxy_vars: &'a [String],
     /// Whether the component is in runes mode.
     is_runes: bool,
-    /// Whether dev-mode rewrites should fire (currently only used by the
-    /// `$inspect(...)` AST migration; non-dev behaviour stays in the text
-    /// path).
+    /// Whether dev-mode rewrites should fire (currently used by the
+    /// `$inspect(...)` and `$inspect.trace(...)` AST migrations; non-dev
+    /// behaviour for those calls stays in the text path).
     dev: bool,
+    /// Original component source for `$inspect.trace()` label suffix
+    /// generation. See `AstTransformConfig::analysis_source`.
+    analysis_source: Option<&'s str>,
+    /// Component filename for `$inspect.trace()` label suffix generation.
+    /// See `AstTransformConfig::filename`.
+    filename: Option<&'s str>,
     /// Var-declared state vars that need $.safe_get() instead of $.get().
     var_state_vars: Vec<String>,
     /// Collected replacements.
@@ -178,6 +185,8 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         non_proxy_vars: &'a [String],
         is_runes: bool,
         dev: bool,
+        analysis_source: Option<&'s str>,
+        filename: Option<&'s str>,
         prop_source_vars: &[String],
         non_bindable_prop_vars: &[String],
         store_sub_vars: &[String],
@@ -206,6 +215,8 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             non_proxy_vars,
             is_runes,
             dev,
+            analysis_source,
+            filename,
             var_state_vars,
             replacements: Vec::new(),
             scoped_vars: vec![FxHashSet::default()],
@@ -847,6 +858,115 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         true
     }
 
+    /// Detect a `$inspect.trace(...)`-leading function body and emit the
+    /// dev-mode `{ return $.trace(thunk, () => { ...remaining... }); }`
+    /// block rewrite. Mirrors the dev-mode arm of the text-path loop in
+    /// `transform_client_runes_with_skip_and_state`.
+    fn try_rewrite_inspect_trace_function_body(&mut self, body: &FunctionBody<'_>) -> bool {
+        if !self.dev
+            || !self.is_runes
+            || self.is_shadowed("$inspect")
+            || self.store_sub_vars.contains("$inspect")
+        {
+            return false;
+        }
+        let Some(first_stmt) = body.statements.first() else {
+            return false;
+        };
+        // The trace call must be the *first* statement of the block, used
+        // as an expression statement (`$inspect.trace(...);`).
+        let Statement::ExpressionStatement(expr_stmt) = first_stmt else {
+            return false;
+        };
+        let Expression::CallExpression(call) = &expr_stmt.expression else {
+            return false;
+        };
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return false;
+        };
+        let Expression::Identifier(obj) = &member.object else {
+            return false;
+        };
+        if obj.name != "$inspect" || member.property.name != "trace" {
+            return false;
+        }
+        if call.arguments.len() > 1 {
+            return false;
+        }
+
+        // Walk the whole body so state-var refs in both the trace
+        // argument and the remaining statements get `$.get(...)` wraps,
+        // then drain those replacements out of the trace-arg range and
+        // the remaining-stmts range so the outer rewrite below carries
+        // the wrapped text.
+        walk::walk_function_body(self, body);
+
+        // Drain trace-arg replacements.
+        let trace_arg_walked = if let Some(arg) = call.arguments.first() {
+            let span = arg.span();
+            let txt = self.apply_and_drain_inner_replacements(span.start, span.end);
+            Some(txt)
+        } else {
+            None
+        };
+
+        // Drain anything else collected inside the trace statement
+        // (callee identifier, etc.) — those go to /dev/null because the
+        // statement itself is being removed.
+        let trace_stmt_span = expr_stmt.span;
+        let _ = self.apply_and_drain_inner_replacements(trace_stmt_span.start, trace_stmt_span.end);
+
+        // Drain remaining statements (everything after the trace stmt,
+        // up to — but not including — the closing `}`). `body.span.end`
+        // is the byte *after* the `}`, so we use `end - 1`.
+        let remaining_start = trace_stmt_span.end;
+        let remaining_end = body.span.end.saturating_sub(1);
+        let remaining_walked = if remaining_start < remaining_end {
+            self.apply_and_drain_inner_replacements(remaining_start, remaining_end)
+        } else {
+            String::new()
+        };
+        let remaining_trimmed = remaining_walked.trim();
+
+        // Build the trace thunk. Non-empty arg → `() => arg`. Empty arg →
+        // fall back to the official compiler's `get_function_label()`
+        // heuristic. When we don't have the original source available we
+        // emit just the bare label without the `(filename:line:col)`
+        // suffix.
+        let trace_thunk = if let Some(arg_txt) = trace_arg_walked
+            && !arg_txt.trim().is_empty()
+        {
+            format!("() => {}", arg_txt.trim())
+        } else {
+            let before_block_post = &self.source[..body.span.start as usize];
+            let default_label_owned = extract_enclosing_function_name(before_block_post)
+                .map(str::to_string)
+                .or_else(|| {
+                    self.analysis_source.and_then(|src| {
+                        extract_trace_call_label(before_block_post, src).map(str::to_string)
+                    })
+                })
+                .unwrap_or_else(|| "trace".to_string());
+            let default_label = default_label_owned.as_str();
+            let source_pos = self
+                .analysis_source
+                .and_then(|src| find_trace_source_location(before_block_post, src, default_label));
+            match (source_pos, self.filename) {
+                (Some((line, col)), Some(filename)) => {
+                    format!("() => '{} ({}:{}:{})'", default_label, filename, line, col)
+                }
+                _ => format!("() => '{}'", default_label),
+            }
+        };
+
+        let replacement = format!(
+            "{{return $.trace({}, () => {{\n{}\n}});\n}}",
+            trace_thunk, remaining_trimmed
+        );
+        self.add_replacement(body.span.start, body.span.end, replacement);
+        true
+    }
+
     /// Walk every argument of a `CallExpression` so inner state-var refs
     /// get `$.get(...)` wrapping, then drain the inner replacements and
     /// return the comma-joined transformed text — the contents that
@@ -1091,6 +1211,18 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
             return;
         }
         walk::walk_variable_declarator(self, declarator);
+    }
+
+    fn visit_function_body(&mut self, body: &FunctionBody<'ast>) {
+        // `$inspect.trace(arg)` *dev mode* block rewrite (non-dev removal
+        // remains in the text path because the standalone-line whitespace/
+        // semicolon trimming is statement-shaped). The rune call is always
+        // the first statement of its enclosing function body; we detect
+        // that here and emit a whole-body replacement of the form
+        //   { return $.trace(thunk, () => { …remaining body… }); }
+        if !self.try_rewrite_inspect_trace_function_body(body) {
+            walk::walk_function_body(self, body);
+        }
     }
 
     fn visit_formal_parameters(&mut self, params: &FormalParameters<'ast>) {
@@ -2519,6 +2651,15 @@ pub(super) struct AstTransformConfig<'a> {
     /// expansion into `$.inspect(() => [args], ...)` — non-dev removal of
     /// the same call remains in the text path).
     pub dev: bool,
+    /// The original component source (pre-transform). Used by the
+    /// `$inspect.trace()` empty-arg label builder, which needs to compute
+    /// line/column relative to the user's source (not the in-flight
+    /// post-rune-transform script the visitor walks). `None` disables the
+    /// `(filename:line:col)` suffix and falls back to the bare label.
+    pub analysis_source: Option<&'a str>,
+    /// The component filename (used in the `$inspect.trace()` label
+    /// suffix together with `analysis_source`).
+    pub filename: Option<&'a str>,
     pub prop_source_vars: &'a [String],
     pub prop_assignment_transform_vars: &'a [String],
     pub non_bindable_prop_vars: &'a [String],
@@ -2656,6 +2797,8 @@ pub(super) fn transform_state_vars_ast(
             non_proxy_vars,
             is_runes,
             config.dev,
+            config.analysis_source,
+            config.filename,
             prop_source_vars,
             non_bindable_prop_vars,
             store_sub_vars,
@@ -2700,6 +2843,8 @@ mod tests {
             non_proxy_vars: &[],
             is_runes: true,
             dev: false,
+            analysis_source: None,
+            filename: None,
             prop_source_vars: &[],
             prop_assignment_transform_vars: &[],
             non_bindable_prop_vars: &[],
@@ -2726,6 +2871,8 @@ mod tests {
             non_proxy_vars: &[],
             is_runes: true,
             dev: false,
+            analysis_source: None,
+            filename: None,
             prop_source_vars: &[],
             prop_assignment_transform_vars: &[],
             non_bindable_prop_vars: &[],
@@ -2937,6 +3084,8 @@ mod tests {
             non_proxy_vars: &[],
             is_runes: true,
             dev: false,
+            analysis_source: None,
+            filename: None,
             prop_source_vars: &[],
             prop_assignment_transform_vars: &[],
             non_bindable_prop_vars: &[],

--- a/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -3535,6 +3535,14 @@ pub(super) fn rfind_matching_paren(s: &str, close_pos: usize) -> Option<usize> {
 /// Find the position of the matching closing brace `}` for a string that starts
 /// right after the opening `{`. Returns the index of the `}` within the string.
 /// Handles nested braces, strings, and comments.
+///
+/// No longer called by any client transform — `$inspect.trace`, which was
+/// its last user, now does the same scope-finding through the OXC AST in
+/// `ast_state_transform::try_rewrite_inspect_trace_function_body`. The
+/// function is left here `#[allow(dead_code)]` because `svelte2tsx` and
+/// other modules still keep their own brace-matching helpers and we may
+/// want to point them at a single shared implementation in a follow-up.
+#[allow(dead_code)]
 pub(super) fn find_matching_brace(s: &str) -> Option<usize> {
     let mut depth = 1i32;
     let bytes = s.as_bytes();

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4372,6 +4372,8 @@ fn transform_instance_script_for_visitors(
                 non_proxy_vars: &non_proxy_vars,
                 is_runes: true,
                 dev,
+                analysis_source: Some(&analysis.source),
+                filename: Some(analysis.filename.as_str()),
                 prop_source_vars: &prop_source_vars,
                 prop_assignment_transform_vars: &prop_assignment_transform_vars,
                 non_bindable_prop_vars: &non_bindable_prop_vars,

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -5,11 +5,9 @@ use memchr::memmem;
 use super::destructure_transforms::build_fallback_string;
 use super::{
     ARRAY_LOOKUP_COUNTER, DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER,
-    contains_direct_await_in_expression, extract_enclosing_function_name, extract_trace_call_label,
-    find_matching_brace, find_matching_paren, find_trace_source_location,
-    is_function_parameter_in_statement, strip_top_level_await_from_expr,
-    transform_props_destructuring, unthunk_string, wrap_await_with_save_in_async_derived,
-    wrap_state_vars_in_expr,
+    contains_direct_await_in_expression, find_matching_paren, is_function_parameter_in_statement,
+    strip_top_level_await_from_expr, transform_props_destructuring, unthunk_string,
+    wrap_await_with_save_in_async_derived, wrap_state_vars_in_expr,
 };
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 
@@ -268,134 +266,40 @@ pub(super) fn transform_client_runes_with_skip_and_state(
     // `ast_state_transform::visit_call_expression` (precise lexical-scope
     // shadowing check for `$props`).
 
-    // Transform $inspect.trace(...) - in non-dev mode, remove the entire statement
-    // In dev mode, transform the enclosing block body to wrap remaining statements in $.trace()
-    while let Some(pos) = memmem::find(result.as_bytes(), b"$inspect.trace(") {
-        let trace_start = pos + 15; // after "$inspect.trace("
-        if let Some(content_end) = find_matching_paren(&result[trace_start..]) {
-            let trace_arg = result[trace_start..trace_start + content_end]
-                .trim()
-                .to_string();
-            let mut end = trace_start + content_end + 1;
-            // Also consume trailing semicolons and whitespace/newline
-            while end < result.len()
-                && (result.as_bytes()[end] == b';'
-                    || result.as_bytes()[end] == b' '
-                    || result.as_bytes()[end] == b'\t'
-                    || result.as_bytes()[end] == b'\n'
-                    || result.as_bytes()[end] == b'\r')
-            {
-                end += 1;
-            }
-            // Remove leading whitespace/tabs on the same line as $inspect.trace
-            let mut start = pos;
-            while start > 0
-                && (result.as_bytes()[start - 1] == b' ' || result.as_bytes()[start - 1] == b'\t')
-            {
-                start -= 1;
-            }
-
-            if !dev {
-                // In non-dev mode, just remove the $inspect.trace() statement
+    // `$inspect.trace(...)` *dev mode* is now handled by the AST pass in
+    // `ast_state_transform::visit_function_body` (whole-body rewrite to
+    // `{ return $.trace(thunk, () => { …remaining… }); }`).
+    //
+    // The non-dev branch — strip the `$inspect.trace(arg);` statement and
+    // its surrounding whitespace/semicolons — stays here. It does fine
+    // text trimming around the call site (leading tabs/spaces on the
+    // same line, trailing `;`/newlines) that's statement-shaped rather
+    // than expression-shaped and is awkward to express at the AST level.
+    if !dev {
+        while let Some(pos) = memmem::find(result.as_bytes(), b"$inspect.trace(") {
+            let trace_start = pos + 15; // after "$inspect.trace("
+            if let Some(content_end) = find_matching_paren(&result[trace_start..]) {
+                let mut end = trace_start + content_end + 1;
+                while end < result.len()
+                    && (result.as_bytes()[end] == b';'
+                        || result.as_bytes()[end] == b' '
+                        || result.as_bytes()[end] == b'\t'
+                        || result.as_bytes()[end] == b'\n'
+                        || result.as_bytes()[end] == b'\r')
+                {
+                    end += 1;
+                }
+                let mut start = pos;
+                while start > 0
+                    && (result.as_bytes()[start - 1] == b' '
+                        || result.as_bytes()[start - 1] == b'\t')
+                {
+                    start -= 1;
+                }
                 result = format!("{}{}", &result[..start], &result[end..]);
             } else {
-                // In dev mode, transform the enclosing function body:
-                // Remove $inspect.trace(...); and wrap remaining body in:
-                //   return $.trace(() => arg, () => { ...remaining... });
-                //
-                // The $inspect.trace() is always the first statement in a block body.
-                // We need to find the enclosing block's closing brace to wrap everything.
-
-                // Remove the $inspect.trace line first
-                let before_trace = &result[..start];
-                let after_trace = &result[end..];
-
-                // Find the opening brace of the enclosing block before $inspect.trace
-                // This is the `{` after the arrow/function that contains $inspect.trace
-                let mut brace_pos = None;
-                let before_bytes = before_trace.as_bytes();
-                let mut i = before_bytes.len();
-                while i > 0 {
-                    i -= 1;
-                    if before_bytes[i] == b'{' {
-                        brace_pos = Some(i);
-                        break;
-                    }
-                    // Skip whitespace and newlines
-                    if before_bytes[i] != b' '
-                        && before_bytes[i] != b'\t'
-                        && before_bytes[i] != b'\n'
-                        && before_bytes[i] != b'\r'
-                    {
-                        break;
-                    }
-                }
-
-                if let Some(brace_idx) = brace_pos {
-                    // Find the matching closing brace for this block
-                    let body_start = brace_idx + 1;
-                    let combined = format!("{}{}", before_trace, after_trace);
-                    let body_content = &combined[body_start..];
-
-                    if let Some(close_brace) = find_matching_brace(body_content) {
-                        // Extract the remaining body (everything between { and } after removing $inspect.trace)
-                        let remaining_body = combined[body_start..body_start + close_brace].trim();
-                        // Skip past the closing brace itself
-                        let after_block = &combined[body_start + close_brace + 1..];
-
-                        // Build the trace argument thunk
-                        let trace_thunk = if trace_arg.is_empty() {
-                            // No argument - extract the label from context
-                            // Uses the same logic as the official compiler's get_function_label():
-                            // 1. Named function -> function name
-                            // 2. Call expression parent (e.g. $effect(() => ...)) -> "$effect(...)"
-                            // 3. Fallback -> "trace"
-                            let before_block = &combined[..brace_idx];
-                            let default_label = extract_enclosing_function_name(before_block)
-                                .unwrap_or_else(|| {
-                                    // Check if the enclosing context is a call expression
-                                    // e.g., $effect(() => { ... }) or $.user_effect(() => { ... })
-                                    extract_trace_call_label(before_block, &analysis.source)
-                                        .unwrap_or("trace")
-                                });
-
-                            // Find source location of the enclosing function/arrow
-                            let trace_source_pos = find_trace_source_location(
-                                before_block,
-                                &analysis.source,
-                                default_label,
-                            );
-                            if let Some((line, col)) = trace_source_pos {
-                                format!(
-                                    "() => '{} ({}:{}:{})'",
-                                    default_label, analysis.filename, line, col
-                                )
-                            } else {
-                                format!("() => '{}'", default_label)
-                            }
-                        } else {
-                            format!("() => {}", trace_arg)
-                        };
-
-                        // Build: { return $.trace(thunk, () => { remaining_body }); }
-                        result = format!(
-                            "{}{{return $.trace({}, () => {{\n{}\n}});\n}}{}",
-                            &combined[..brace_idx],
-                            trace_thunk,
-                            remaining_body,
-                            after_block
-                        );
-                    } else {
-                        // Couldn't find matching brace, just remove the trace call
-                        result = format!("{}{}", before_trace, after_trace);
-                    }
-                } else {
-                    // No enclosing brace found, just remove the trace call
-                    result = format!("{}{}", before_trace, after_trace);
-                }
+                break;
             }
-        } else {
-            break;
         }
     }
 


### PR DESCRIPTION
Tenth AST-migration PR. The dev-mode `$inspect.trace(arg);` block rewrite — which removes the trace call and wraps the remaining body of the enclosing function in `return $.trace(thunk, () => { …remaining… });` — is now handled by a new `visit_function_body` override in `ast_state_transform.rs` instead of the byte-level backwards-brace-scan + `find_matching_brace` rewrite in `transform_client_runes_with_skip_and_state`.

Detection now uses the OXC AST directly: the trace call is the first `ExpressionStatement` of a `FunctionBody` whose expression is a `$inspect.trace(...)` member call. The visitor walks the body so state-var refs in both the trace arg and the remaining statements still get `$.get(...)` wraps, then drains those inner replacements into the outer block-span rewrite.

## New config plumbing

Threaded `analysis_source` and `filename` through `AstTransformConfig` / `StateVarCollector` so the empty-arg `$inspect.trace()` label generator (which needs to compute line/col against the *original* user source, not the in-flight post-rune-transform script the visitor walks) keeps working. When those aren't available the helper falls back to the bare label without the `(filename:line:col)` suffix.

## Non-dev stays in text

The non-dev branch — strip the trace statement and its surrounding whitespace/semicolons — stays in the text path because the trimming is statement-shaped (leading tabs on the same line, trailing `;`/newlines) and is awkward to express at the AST level. Future PR if it ever becomes a bottleneck.

## Cleanup

`find_matching_brace` in `expression_utils.rs`, which was only used by the text `$inspect.trace` loop, is left `#[allow(dead_code)]` for now in case it gets pointed at by a future shared-helper consolidation; the only other in-repo brace finder lives in `svelte2tsx/script/mod.rs` and is module-local.

## Test plan

- [x] `cargo test --release` for runtime (519 unit + 19 integration including `inspect-trace`, `inspect-trace-nested`, `inspect-trace-circular-reference`), ssr (16/16), all 14 categories — green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)