### PR TITLE
perf(transform): migrate dev-mode `===` / `!==` rewrite to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -18,7 +18,7 @@ use oxc_ast_visit::walk;
 use oxc_parser::Parser;
 use oxc_span::GetSpan;
 use oxc_span::SourceType;
-use oxc_syntax::operator::{AssignmentOperator, UpdateOperator};
+use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UpdateOperator};
 use oxc_syntax::scope::ScopeFlags;
 use oxc_syntax::scope::ScopeId;
 use rustc_hash::FxHashSet;
@@ -967,6 +967,54 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         true
     }
 
+    /// Dev-mode rewrite of `a === b` / `a !== b` BinaryExpressions to
+    /// `$.strict_equals(a, b)` / `!$.strict_equals(a, b)`. Mirrors the
+    /// official Svelte compiler's `BinaryExpression` visitor — runtime
+    /// hook that surfaces signal-vs-proxy comparison footguns to the user.
+    /// Replaces the text-based pass formerly in
+    /// `rune_transforms::transform_strict_equals` for component instance
+    /// scripts. Returns `true` when the expression was rewritten.
+    fn try_rewrite_strict_equals_binary(&mut self, expr: &BinaryExpression<'_>) -> bool {
+        if !self.dev {
+            return false;
+        }
+        let is_neq = match expr.operator {
+            BinaryOperator::StrictEquality => false,
+            BinaryOperator::StrictInequality => true,
+            _ => return false,
+        };
+
+        // Walk both operands so inner state-var refs (and nested
+        // `===` / `!==` rewrites) register their replacements, then
+        // drain those into the operand-local text. Each drain yields
+        // the fully-transformed operand substring that the outer
+        // replacement carries verbatim.
+        self.visit_expression(&expr.left);
+        self.visit_expression(&expr.right);
+
+        let left_span = expr.left.span();
+        let right_span = expr.right.span();
+        let left_text = self.apply_and_drain_inner_replacements(left_span.start, left_span.end);
+        let right_text = self.apply_and_drain_inner_replacements(right_span.start, right_span.end);
+
+        let replacement = if is_neq {
+            format!(
+                "!$.strict_equals({}, {})",
+                left_text.trim(),
+                right_text.trim()
+            )
+        } else {
+            format!(
+                "$.strict_equals({}, {})",
+                left_text.trim(),
+                right_text.trim()
+            )
+        };
+
+        self.add_replacement(expr.span.start, expr.span.end, replacement);
+        true
+    }
+
     /// Walk every argument of a `CallExpression` so inner state-var refs
     /// get `$.get(...)` wrapping, then drain the inner replacements and
     /// return the comma-joined transformed text — the contents that
@@ -1222,6 +1270,15 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         //   { return $.trace(thunk, () => { …remaining body… }); }
         if !self.try_rewrite_inspect_trace_function_body(body) {
             walk::walk_function_body(self, body);
+        }
+    }
+
+    fn visit_binary_expression(&mut self, expr: &BinaryExpression<'ast>) {
+        // Dev-mode `===` / `!==` rewrite. When matched the helper walks
+        // and drains inner replacements itself, so we skip the default
+        // walk to avoid double-visiting the operands.
+        if !self.try_rewrite_strict_equals_binary(expr) {
+            walk::walk_binary_expression(self, expr);
         }
     }
 
@@ -2710,6 +2767,13 @@ pub(super) fn transform_state_vars_ast(
     let has_props_calls = is_runes
         && !store_sub_vars.iter().any(|v| v == "$props")
         && memchr::memmem::find(script.as_bytes(), b"$props").is_some();
+    // Dev-mode `===` / `!==` → `$.strict_equals(...)` rewrite (formerly
+    // `rune_transforms::transform_strict_equals`). The visitor walks
+    // every BinaryExpression so we only need a byte probe to know
+    // whether to enter the AST pass at all.
+    let has_strict_equals = config.dev
+        && (memchr::memmem::find(script.as_bytes(), b"===").is_some()
+            || memchr::memmem::find(script.as_bytes(), b"!==").is_some());
 
     if !has_state
         && !has_props
@@ -2720,6 +2784,7 @@ pub(super) fn transform_state_vars_ast(
         && !has_state_calls
         && !has_derived_calls
         && !has_props_calls
+        && !has_strict_equals
     {
         return None;
     }
@@ -2769,7 +2834,8 @@ pub(super) fn transform_state_vars_ast(
         || (has_effect_calls && script_ids.contains("$effect"))
         || (has_state_calls && script_ids.contains("$state"))
         || (has_derived_calls && script_ids.contains("$derived"))
-        || (has_props_calls && script_ids.contains("$props"));
+        || (has_props_calls && script_ids.contains("$props"))
+        || has_strict_equals;
 
     if !has_any_match {
         return None;

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4324,6 +4324,11 @@ fn transform_instance_script_for_visitors(
             && memmem::find(result.as_bytes(), b"$derived").is_some();
         let has_props_calls = !store_sub_vars.iter().any(|v| v == "$props")
             && memmem::find(result.as_bytes(), b"$props").is_some();
+        // Dev-mode `===` / `!==` rewrite is now part of the AST pass
+        // (replaces `transform_strict_equals` from rune_transforms.rs).
+        let has_strict_equals = dev
+            && (memmem::find(result.as_bytes(), b"===").is_some()
+                || memmem::find(result.as_bytes(), b"!==").is_some());
         let has_transforms = !state_vars.is_empty()
             || !prop_assignment_transform_vars.is_empty()
             || !store_sub_vars.is_empty()
@@ -4332,7 +4337,8 @@ fn transform_instance_script_for_visitors(
             || has_effect_calls
             || has_state_calls
             || has_derived_calls
-            || has_props_calls;
+            || has_props_calls
+            || has_strict_equals;
 
         if has_transforms {
             // Collect $derived / $derived.by binding names so AST assignment transforms

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -367,11 +367,12 @@ pub(super) fn transform_client_runes_with_skip_and_state(
         return transformed;
     }
 
-    // In dev mode, transform === to $.strict_equals() and !== to !$.strict_equals()
-    // This is the BinaryExpression visitor from the official Svelte compiler
-    if dev {
-        result = transform_strict_equals(&result);
-    }
+    // Dev-mode `===` / `!==` → `$.strict_equals(...)` rewrite now lives in
+    // the AST pass (`ast_state_transform::try_rewrite_strict_equals_binary`),
+    // run from `transform_client_with_visitors` after this per-statement
+    // pipeline completes. Component-instance scripts no longer need the
+    // text-based pass. Module scripts (`transform_module_script_runes`)
+    // still call `transform_strict_equals` until that path is migrated.
 
     // In dev mode, wrap $.state() and $.derived() declarations with $.tag() for debugging
     // This allows $inspect.trace() to show variable names in the output.


### PR DESCRIPTION
## Summary

The dev-mode `BinaryExpression` rewrite that turns `a === b` into `\$.strict_equals(a, b)` (and `a !== b` into `!\$.strict_equals(a, b)`) used to run as a per-statement text scan over the already-mostly-transformed script in `transform_client_runes_with_skip_and_state`. Every statement walked the buffer with quote-counting heuristics to skip operators inside string/template literals — work the AST gets for free.

Moved into `StateVarCollector` as a `BinaryExpression` visitor (`try_rewrite_strict_equals_binary`), gated by `dev` and operator kind. The helper walks both operands so inner state-var refs (and nested `===` rewrites) register their replacements, drains them into operand-local substrings via `apply_and_drain_inner_replacements`, then emits a single outer-span replacement.

This is the 13th AST migration in the rune transform pipeline (after `\$effect` family, `\$state` declarators, `\$state.raw`, `\$state.frozen`, `\$state.snapshot`, `\$state.eager`, `\$props.id`, `\$inspect` dev-mode rewrite, and `\$inspect.trace` block rewrite).

- Removes the per-statement text pass at `rune_transforms.rs:373`.
- Adds `has_strict_equals` byte probes to both gates (`transform_client_with_visitors` and `transform_state_vars_ast`) so the AST pass still runs when a dev component has `===` / `!==` but no other rune transforms.
- Module scripts still call the text-based `transform_strict_equals` at `mod.rs:2725` — that path hasn't joined the AST pipeline yet.

## Test plan

- [x] `cargo test --release` — all suites pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `pnpm run compatibility-report` — **3341/3341 in-scope still 100%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)