### PR TITLE
perf(transform): migrate $state destructuring to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -23,12 +23,13 @@ use oxc_syntax::scope::ScopeFlags;
 use oxc_syntax::scope::ScopeId;
 use rustc_hash::FxHashSet;
 
-use super::VAR_STATE_VARS;
 use super::destructure_transforms::unthunk_string;
 use super::expression_utils::{
     contains_direct_await_in_expression, extract_enclosing_function_name, extract_trace_call_label,
     find_trace_source_location, strip_top_level_await_from_expr,
 };
+use super::rune_transforms::wrap_state_value;
+use super::{SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER, VAR_STATE_VARS};
 
 thread_local! {
     static AST_TRANSFORM_ALLOCATOR: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -699,6 +700,267 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         true
     }
 
+    /// AST replacement for destructured `$state(...)` / `$state.raw(...)` rune
+    /// declarators. Mirrors `rune_transforms::transform_state_destructuring`:
+    ///
+    /// - `let { a, b } = $state(expr)` →
+    ///   `let tmp = wrapped_expr, a = $.state($.proxy(tmp.a)), b = $.state($.proxy(tmp.b))`
+    /// - `let { a: b } = $state(expr)` (renamed) →
+    ///   `let tmp = wrapped_expr, b = $.state($.proxy(tmp.a))`
+    /// - `let [a, b] = $state(expr)` →
+    ///   `let tmp = wrapped_expr, $$array = $.derived(() => $.to_array(tmp, 2)), a = $.state($.proxy($.get($$array)[0])), b = ...`
+    /// - `$state.raw(...)` skips the inner `$.proxy(...)` wrap (raw → reactive
+    ///   but not proxied; raw + skip → just the member access).
+    ///
+    /// Returns `true` if matched; the caller then skips the default walk so
+    /// the init expression is not re-visited.
+    fn try_rewrite_state_destructuring_declarator(
+        &mut self,
+        declarator: &VariableDeclarator<'_>,
+    ) -> bool {
+        let Some(init) = &declarator.init else {
+            return false;
+        };
+
+        // Determine $state vs $state.raw (text path doesn't handle frozen
+        // destructuring, so we match the same shapes only).
+        let (is_raw, call) = if self.is_state_call_init(init) {
+            let Expression::CallExpression(c) = init else {
+                return false;
+            };
+            (false, c)
+        } else if self.is_state_raw_init(init) {
+            let Expression::CallExpression(c) = init else {
+                return false;
+            };
+            (true, c)
+        } else {
+            return false;
+        };
+
+        if call.arguments.len() > 1 {
+            return false;
+        }
+
+        // Destructured pattern only — simple BindingIdentifier is handled by
+        // try_rewrite_state_call_declarator / try_rewrite_state_raw_or_frozen_declarator.
+        let is_destructured = matches!(
+            &declarator.id,
+            BindingPattern::ObjectPattern(_) | BindingPattern::ArrayPattern(_)
+        );
+        if !is_destructured {
+            return false;
+        }
+
+        // Walk source so inner state-var refs get `$.get(...)` wraps, then
+        // drain those inner replacements into the source substring we'll
+        // embed in the tmp declaration.
+        let source_text = if let Some(arg) = call.arguments.first() {
+            self.visit_argument(arg);
+            let arg_span = arg.span();
+            self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end)
+        } else {
+            "void 0".to_string()
+        };
+
+        let tmp_idx = STATE_TMP_COUNTER.with(|c| {
+            let cur = c.get();
+            c.set(cur + 1);
+            cur
+        });
+        let tmp_name = if tmp_idx == 0 {
+            "tmp".to_string()
+        } else {
+            format!("tmp_{}", tmp_idx)
+        };
+
+        let mut declarations = vec![format!("{} = {}", tmp_name, source_text.trim())];
+
+        match &declarator.id {
+            BindingPattern::ObjectPattern(obj) => {
+                if !self.collect_state_object_pattern(obj, &tmp_name, is_raw, &mut declarations) {
+                    return false;
+                }
+            }
+            BindingPattern::ArrayPattern(arr) => {
+                if !self.collect_state_array_pattern(arr, &tmp_name, is_raw, &mut declarations) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+
+        if declarations.len() <= 1 {
+            return false;
+        }
+
+        let replacement = declarations.join(", ");
+        let start = declarator.id.span().start;
+        let end = call.span.end;
+        self.add_replacement(start, end, replacement);
+        true
+    }
+
+    /// Returns true if `init` is a `$state.raw(...)` CallExpression (not
+    /// `$state.frozen(...)`) — the destructuring text path only matched
+    /// `$state.raw(` so the destructuring AST migration narrows to the same.
+    fn is_state_raw_init(&self, init: &Expression<'_>) -> bool {
+        if !self.is_runes || self.is_shadowed("$state") {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return false;
+        };
+        let Expression::Identifier(obj) = &member.object else {
+            return false;
+        };
+        obj.name == "$state" && member.property.name == "raw"
+    }
+
+    /// Walk an ObjectPattern and append `name = $.state(...)` declarations
+    /// for each property. Returns false if any property is unsupported
+    /// (computed key, nested pattern beyond simple identifier targets,
+    /// etc.) so the caller can bail back to the text path.
+    fn collect_state_object_pattern(
+        &mut self,
+        obj: &ObjectPattern<'_>,
+        tmp_name: &str,
+        is_raw: bool,
+        declarations: &mut Vec<String>,
+    ) -> bool {
+        for prop in &obj.properties {
+            // Inner target must be a plain BindingIdentifier; nested
+            // destructuring inside state isn't supported by the text path
+            // either (it only handles flat patterns).
+            let value_pattern = match &prop.value {
+                BindingPattern::BindingIdentifier(_) => &prop.value,
+                BindingPattern::AssignmentPattern(_) => &prop.value,
+                _ => return false,
+            };
+            // Drop AssignmentPattern wrapper — the text path ignores the
+            // default value, only using the left-hand identifier.
+            let var_ident = match value_pattern {
+                BindingPattern::BindingIdentifier(id) => id,
+                BindingPattern::AssignmentPattern(assign) => match &assign.left {
+                    BindingPattern::BindingIdentifier(id) => id,
+                    _ => return false,
+                },
+                _ => return false,
+            };
+            let var_name = var_ident.name.as_str();
+
+            // Resolve the source-side key text.
+            let key_text = match &prop.key {
+                PropertyKey::StaticIdentifier(id) => id.name.as_str().to_string(),
+                PropertyKey::StringLiteral(s) => s.value.as_str().to_string(),
+                _ => return false,
+            };
+
+            let is_skip = self.is_state_destructure_skip(var_name);
+            let member_access = format!("{}.{}", tmp_name, key_text);
+            let value_expr = wrap_state_value(&member_access, is_raw, is_skip);
+            let value_expr = self.maybe_tag_declarator(var_name, value_expr);
+            declarations.push(format!("{} = {}", var_name, value_expr));
+        }
+
+        if let Some(rest) = &obj.rest {
+            let var_ident = match &rest.argument {
+                BindingPattern::BindingIdentifier(id) => id,
+                _ => return false,
+            };
+            let var_name = var_ident.name.as_str();
+            let is_skip = self.is_state_destructure_skip(var_name);
+            let access = format!("{}.{}", tmp_name, var_name);
+            let value_expr = if is_raw {
+                access
+            } else if is_skip {
+                format!("$.proxy({})", access)
+            } else {
+                format!("$.state($.proxy({}))", access)
+            };
+            let value_expr = self.maybe_tag_declarator(var_name, value_expr);
+            declarations.push(format!("{} = {}", var_name, value_expr));
+        }
+        true
+    }
+
+    /// Walk an ArrayPattern and append the `$$array = $.derived(() => $.to_array(...))`
+    /// helper plus per-element declarations. Mirrors
+    /// `process_state_array_pattern` in the text path.
+    fn collect_state_array_pattern(
+        &mut self,
+        arr: &ArrayPattern<'_>,
+        tmp_name: &str,
+        is_raw: bool,
+        declarations: &mut Vec<String>,
+    ) -> bool {
+        let has_rest = arr.rest.is_some();
+        let element_count = arr.elements.len();
+        let global_counter = SCRIPT_ARRAY_COUNTER.with(|c| {
+            let cur = c.get();
+            c.set(cur + 1);
+            cur
+        });
+        let array_var = if global_counter == 0 {
+            "$$array".to_string()
+        } else {
+            format!("$$array_{}", global_counter)
+        };
+
+        let to_array_args = if has_rest {
+            format!("$.to_array({})", tmp_name)
+        } else {
+            format!("$.to_array({}, {})", tmp_name, element_count)
+        };
+        declarations.push(format!(
+            "{} = $.derived(() => {})",
+            array_var, to_array_args
+        ));
+
+        for (index, elem_opt) in arr.elements.iter().enumerate() {
+            let Some(elem) = elem_opt else { continue };
+            let var_ident = match elem {
+                BindingPattern::BindingIdentifier(id) => id,
+                BindingPattern::AssignmentPattern(assign) => match &assign.left {
+                    BindingPattern::BindingIdentifier(id) => id,
+                    _ => return false,
+                },
+                _ => return false,
+            };
+            let var_name = var_ident.name.as_str();
+            let is_skip = self.is_state_destructure_skip(var_name);
+            let element_access = format!("$.get({})[{}]", array_var, index);
+            let value_expr = wrap_state_value(&element_access, is_raw, is_skip);
+            let value_expr = self.maybe_tag_declarator(var_name, value_expr);
+            declarations.push(format!("{} = {}", var_name, value_expr));
+        }
+
+        if let Some(rest) = &arr.rest {
+            let var_ident = match &rest.argument {
+                BindingPattern::BindingIdentifier(id) => id,
+                _ => return false,
+            };
+            let var_name = var_ident.name.as_str();
+            let is_skip = self.is_state_destructure_skip(var_name);
+            let access = format!("$.get({}).slice({})", array_var, element_count);
+            let value_expr = wrap_state_value(&access, is_raw, is_skip);
+            let value_expr = self.maybe_tag_declarator(var_name, value_expr);
+            declarations.push(format!("{} = {}", var_name, value_expr));
+        }
+        true
+    }
+
+    /// The text destructuring helper passes the `skip_state_vars` list as
+    /// `non_reactive_state_vars` — vars whose binding kind is RawState (i.e.
+    /// non-proxied state). We reuse the same `non_reactive_vars` source the
+    /// rest of the visitor uses.
+    fn is_state_destructure_skip(&self, name: &str) -> bool {
+        self.non_reactive_vars.contains(name)
+    }
+
     /// AST replacement for `$derived.by(fn)` rune declarators. Mirrors the
     /// text-pipeline rewrite that lived in
     /// `transform_client_runes_with_skip_and_state`'s `$derived.by` loop.
@@ -1286,6 +1548,13 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         // before emitting the outer span replacement. We then skip the
         // default walk so `visit_expression(init)` doesn't add the inner
         // replacements a second time.
+        //
+        // Destructured `$state(...)` / `$state.raw(...)` is checked first
+        // — the other rune-declarator handlers bail for non-Identifier
+        // binding patterns, so the destructure matcher catches them.
+        if self.try_rewrite_state_destructuring_declarator(declarator) {
+            return;
+        }
         if self.try_rewrite_state_raw_or_frozen_declarator(declarator) {
             return;
         }

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -4,7 +4,7 @@ use memchr::memmem;
 
 use super::destructure_transforms::build_fallback_string;
 use super::{
-    ARRAY_LOOKUP_COUNTER, DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER,
+    ARRAY_LOOKUP_COUNTER, DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER,
     contains_direct_await_in_expression, find_matching_paren, is_function_parameter_in_statement,
     strip_top_level_await_from_expr, transform_props_destructuring, unthunk_string,
     wrap_await_with_save_in_async_derived, wrap_state_vars_in_expr,
@@ -47,7 +47,7 @@ pub(super) fn find_unescaped_derived_call(s: &str) -> Option<usize> {
 #[allow(clippy::too_many_arguments)]
 pub(super) fn transform_client_runes_with_skip_and_state(
     line: &str,
-    skip_state_vars: &[String],
+    _skip_state_vars: &[String],
     state_vars: &[String],
     non_reactive_vars: &[String],
     prop_source_vars: &[String],
@@ -89,37 +89,13 @@ pub(super) fn transform_client_runes_with_skip_and_state(
 
     // Skip all $state rune transforms if $state is actually a store subscription or function param
     if !state_is_store_sub && !state_is_func_param {
-        // Handle destructuring patterns with $state/$state.raw BEFORE other $state transforms.
-        // e.g. `let { num } = $state(setup())` -> `let tmp = setup(), num = $.state($.proxy(tmp.num))`
-        if let Some(state_pos) = memmem::find(result.as_bytes(), b"$state(")
-            .or_else(|| memmem::find(result.as_bytes(), b"$state.raw("))
-        {
-            let before_state = &result[..state_pos];
-            if (memmem::find(before_state.as_bytes(), b"let ").is_some()
-                || memmem::find(before_state.as_bytes(), b"const ").is_some()
-                || memmem::find(before_state.as_bytes(), b"var ").is_some())
-                && (before_state.contains('{') || before_state.contains('['))
-            {
-                let is_raw = result[state_pos..].starts_with("$state.raw(");
-                if let Some(transformed) = transform_state_destructuring(
-                    &result,
-                    is_raw,
-                    skip_state_vars,
-                    state_vars,
-                    non_reactive_vars,
-                    proxy_vars,
-                ) {
-                    let mut transformed = apply_effect_rune_transforms(transformed);
-
-                    // In dev mode, wrap $.state() and $.derived() declarations with $.tag()
-                    if dev {
-                        transformed = wrap_state_derived_with_tag(&transformed);
-                    }
-
-                    return transformed;
-                }
-            }
-        }
+        // Destructured `$state(...)` / `$state.raw(...)` declarators are now
+        // rewritten in the AST pass (`ast_state_transform::try_rewrite_state_destructuring_declarator`).
+        // The AST visit handles the same shapes the text helper did
+        // (object pattern with shorthand / renamed / rest, array pattern with
+        // optional rest), emits the same `tmp = wrapped_source, name = $.state(...)`
+        // form, and threads `maybe_tag_declarator` for dev-mode `$.tag(...)`
+        // wrapping. The `wrap_state_value` text helper is shared.
 
         // `$state.snapshot(x)` -> `$.snapshot(x)` is now done by the AST pass
         // in `ast_state_transform::visit_call_expression`. The dev-mode
@@ -1333,263 +1309,6 @@ pub(super) fn transform_derived_by_destructuring(
         return None;
     }
     Some(format!("{} {};", decl_keyword, declarations.join(",\n\t")))
-}
-
-/// Transform `$state()` or `$state.raw()` with destructuring patterns.
-///
-/// Transforms:
-///   `let { a, b } = $state(expr)` -> `let tmp = expr, a = $.state($.proxy(tmp.a)), b = $.state($.proxy(tmp.b))`
-///   `let { a, b } = $state.raw(expr)` -> `let tmp = expr, a = $.state(tmp.a), b = $.state(tmp.b)`
-///
-/// When a variable is not reassigned (in skip_state_vars), the $.state() wrapper is omitted:
-///   `let { foo } = $state(data)` -> `let tmp = data, foo = $.proxy(tmp.foo)`
-///
-/// Corresponds to the official Svelte compiler's VariableDeclaration.js handling of
-/// ObjectPattern/ArrayPattern with $state/$state.raw init.
-pub(super) fn transform_state_destructuring(
-    line: &str,
-    is_raw: bool,
-    skip_state_vars: &[String],
-    state_vars: &[String],
-    non_reactive_vars: &[String],
-    proxy_vars: &[String],
-) -> Option<String> {
-    let trimmed = line.trim();
-
-    // Determine declaration keyword
-    let decl_keyword = if trimmed.starts_with("let ") {
-        "let"
-    } else if trimmed.starts_with("const ") {
-        "const"
-    } else if trimmed.starts_with("var ") {
-        "var"
-    } else {
-        return None;
-    };
-
-    // Find the $state( or $state.raw( position
-    let rune_str = if is_raw { "$state.raw(" } else { "$state(" };
-    let rune_pos = trimmed.find(rune_str)?;
-    let rune_len = rune_str.len();
-
-    // Extract the destructuring pattern between the keyword and the = sign
-    let eq_pos = trimmed[..rune_pos].rfind('=')?;
-    let pattern_start = decl_keyword.len() + 1; // skip "let "/"const "/"var "
-    let pattern = trimmed[pattern_start..eq_pos].trim();
-
-    // Must be a destructuring pattern
-    if !pattern.starts_with('{') && !pattern.starts_with('[') {
-        return None;
-    }
-
-    // Extract the source expression inside $state(...) or $state.raw(...)
-    let source_start = rune_pos + rune_len;
-    let source_end = find_matching_paren(&trimmed[source_start..])?;
-    let source = trimmed[source_start..source_start + source_end].trim();
-
-    // Wrap state variables in the source expression with $.get()
-    let wrapped_source = wrap_state_vars_in_expr(source, state_vars, non_reactive_vars, proxy_vars);
-
-    // Generate a unique tmp variable name: tmp, tmp_1, tmp_2, ...
-    let tmp_idx = STATE_TMP_COUNTER.with(|c| {
-        let current = c.get();
-        c.set(current + 1);
-        current
-    });
-    let tmp_name = if tmp_idx == 0 {
-        "tmp".to_string()
-    } else {
-        format!("tmp_{}", tmp_idx)
-    };
-
-    // Build declarations
-    let mut declarations = Vec::new();
-
-    // First declaration: tmp = <source expression>
-    declarations.push(format!("{} = {}", tmp_name, wrapped_source));
-
-    // Process the destructuring pattern
-    if pattern.starts_with('{') && pattern.ends_with('}') {
-        let inner = &pattern[1..pattern.len() - 1];
-        process_state_object_pattern(inner, &tmp_name, is_raw, skip_state_vars, &mut declarations)?;
-    } else if pattern.starts_with('[') && pattern.ends_with(']') {
-        let inner = &pattern[1..pattern.len() - 1];
-        process_state_array_pattern(
-            inner,
-            &tmp_name,
-            is_raw,
-            skip_state_vars,
-            state_vars,
-            non_reactive_vars,
-            proxy_vars,
-            &mut declarations,
-        )?;
-    } else {
-        return None;
-    }
-
-    if declarations.len() <= 1 {
-        // Only the tmp declaration, no actual properties
-        return None;
-    }
-
-    // Check for trailing semicolon
-    let trailing = if trimmed.ends_with(';') { "" } else { ";" };
-
-    Some(format!(
-        "{} {}{}",
-        decl_keyword,
-        declarations.join(", "),
-        trailing
-    ))
-}
-
-/// Process object destructuring pattern for $state()/$state.raw().
-///
-/// For `{ a, b: c, d = defaultVal }`, generates:
-///   `a = $.state($.proxy(tmp.a)), c = $.state($.proxy(tmp.b)), d = $.state($.proxy(tmp.d))`
-pub(super) fn process_state_object_pattern(
-    inner: &str,
-    tmp_name: &str,
-    is_raw: bool,
-    skip_state_vars: &[String],
-    declarations: &mut Vec<String>,
-) -> Option<()> {
-    let properties = split_derived_object_properties(inner);
-
-    for prop in &properties {
-        let prop = prop.trim();
-        if prop.is_empty() {
-            continue;
-        }
-
-        if let Some(rest_name) = prop.strip_prefix("...") {
-            // Rest element: ...rest
-            let rest_name = rest_name.trim();
-            // Rest elements get the remaining properties
-            // For now, generate a simple spread
-            let is_skip = skip_state_vars.contains(&rest_name.to_string());
-            let value = if is_raw {
-                format!("{}.{}", tmp_name, rest_name)
-            } else if is_skip {
-                format!("$.proxy({}.{})", tmp_name, rest_name)
-            } else {
-                format!("$.state($.proxy({}.{}))", tmp_name, rest_name)
-            };
-            declarations.push(format!("{} = {}", rest_name, value));
-            continue;
-        }
-
-        if let Some(colon_pos) = find_derived_property_colon(prop) {
-            // Renamed property: key: value or key: value = default
-            let key = prop[..colon_pos].trim();
-            let value_part = prop[colon_pos + 1..].trim();
-
-            // Check for default value: key: varname = defaultVal
-            let (var_name, _default_expr) = if let Some(eq_pos) = value_part.find('=') {
-                let vn = value_part[..eq_pos].trim();
-                let de = value_part[eq_pos + 1..].trim();
-                (vn, Some(de))
-            } else {
-                (value_part, None)
-            };
-
-            let is_skip = skip_state_vars.contains(&var_name.to_string());
-            let member_access = format!("{}.{}", tmp_name, key);
-            let wrapped = wrap_state_value(&member_access, is_raw, is_skip);
-            declarations.push(format!("{} = {}", var_name, wrapped));
-        } else {
-            // Shorthand property: name or name = defaultVal
-            let (var_name, _default_expr) = if let Some(eq_pos) = prop.find('=') {
-                let vn = prop[..eq_pos].trim();
-                let de = prop[eq_pos + 1..].trim();
-                (vn, Some(de))
-            } else {
-                (prop, None)
-            };
-
-            let is_skip = skip_state_vars.contains(&var_name.to_string());
-            let member_access = format!("{}.{}", tmp_name, var_name);
-            let wrapped = wrap_state_value(&member_access, is_raw, is_skip);
-            declarations.push(format!("{} = {}", var_name, wrapped));
-        }
-    }
-
-    Some(())
-}
-
-/// Process array destructuring pattern for $state()/$state.raw().
-///
-/// For `[a, b]`, generates:
-///   `$$array = $.derived(() => $.to_array(tmp, 2))`
-///   `a = $.state($.proxy($.get($$array)[0]))`
-///   `b = $.state($.proxy($.get($$array)[1]))`
-#[allow(clippy::too_many_arguments)]
-pub(super) fn process_state_array_pattern(
-    inner: &str,
-    tmp_name: &str,
-    is_raw: bool,
-    skip_state_vars: &[String],
-    state_vars: &[String],
-    non_reactive_vars: &[String],
-    proxy_vars: &[String],
-    declarations: &mut Vec<String>,
-) -> Option<()> {
-    let elements = split_derived_array_elements(inner);
-
-    // For array destructuring, we need an intermediate $$array derived
-    // to handle iterables (like the official compiler's extract_paths does)
-    let has_rest = elements.iter().any(|e| e.trim().starts_with("..."));
-    let element_count = elements.len();
-
-    let global_counter = SCRIPT_ARRAY_COUNTER.with(|c| {
-        let current = c.get();
-        c.set(current + 1);
-        current
-    });
-
-    let array_var = if global_counter == 0 {
-        "$$array".to_string()
-    } else {
-        format!("$$array_{}", global_counter)
-    };
-
-    // Create the $$array derived declaration
-    let to_array_args = if has_rest {
-        format!("$.to_array({})", tmp_name)
-    } else {
-        format!("$.to_array({}, {})", tmp_name, element_count)
-    };
-
-    let wrapped_to_array =
-        wrap_state_vars_in_expr(&to_array_args, state_vars, non_reactive_vars, proxy_vars);
-    declarations.push(format!(
-        "{} = $.derived(() => {})",
-        array_var, wrapped_to_array
-    ));
-
-    for (index, element) in elements.iter().enumerate() {
-        let element = element.trim();
-        if element.is_empty() {
-            continue;
-        }
-
-        if let Some(rest_name) = element.strip_prefix("...") {
-            let rest_name = rest_name.trim();
-            let is_skip = skip_state_vars.contains(&rest_name.to_string());
-            let access = format!("$.get({}).slice({})", array_var, index);
-            let wrapped = wrap_state_value(&access, is_raw, is_skip);
-            declarations.push(format!("{} = {}", rest_name, wrapped));
-            continue;
-        }
-
-        let is_skip = skip_state_vars.contains(&element.to_string());
-        let element_access = format!("$.get({})[{}]", array_var, index);
-        let wrapped = wrap_state_value(&element_access, is_raw, is_skip);
-        declarations.push(format!("{} = {}", element, wrapped));
-    }
-
-    Some(())
 }
 
 /// Wrap a member access expression for $state destructuring.


### PR DESCRIPTION
## Summary

Migrates `let { a, b } = \$state(expr)` and `let [a, b] = \$state(expr)` (plus `\$state.raw(...)` variants) from the text-pipeline helper `transform_state_destructuring` to a new AST handler `try_rewrite_state_destructuring_declarator` on `StateVarCollector`.

The handler mirrors the text version's output exactly:
- Object: `let { a, b } = \$state(expr)` → `let tmp = wrapped_expr, a = \$.state(\$.proxy(tmp.a)), b = \$.state(\$.proxy(tmp.b))`
- Renamed: `let { a: b } = \$state(expr)` → uses the key text for the access, the value identifier for the binding name
- Rest: `let { ...rest } = \$state(expr)` → wraps `tmp.rest`
- Array: `let [a, b] = \$state(expr)` → emits `\$\$array = \$.derived(() => \$.to_array(tmp, 2))` helper + `\$.get(\$\$array)[i]` per-element accesses
- Array rest: `let [a, ...rest] = \$state(expr)` → `\$.get(\$\$array).slice(i)` for rest
- `\$state.raw(...)`: skips inner `\$.proxy(...)` wrap; raw + skip falls through to bare member access
- Dev-mode `\$.tag(...)` / `\$.tag_proxy(...)` wrap threaded through `maybe_tag_declarator` per-property

Removes ~260 lines of text helpers (`transform_state_destructuring`, `process_state_object_pattern`, `process_state_array_pattern`) and the per-statement byte-probe in `transform_client_runes_with_skip_and_state`. `wrap_state_value` is kept and reused by the AST handler.

15th AST migration in the rune transform pipeline.

## Test plan

- [x] `cargo test --release` — all suites pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `pnpm run compatibility-report` — **3341/3341 in-scope still 100%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)