### PR TITLE
perf(transform): migrate $derived destructuring to AST

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -27,9 +27,10 @@ use super::destructure_transforms::unthunk_string;
 use super::expression_utils::{
     contains_direct_await_in_expression, extract_enclosing_function_name, extract_trace_call_label,
     find_trace_source_location, strip_top_level_await_from_expr,
+    wrap_await_with_save_in_async_derived,
 };
-use super::rune_transforms::wrap_state_value;
-use super::{SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER, VAR_STATE_VARS};
+use super::rune_transforms::{process_derived_destructuring_pattern, wrap_state_value};
+use super::{DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER, VAR_STATE_VARS};
 
 thread_local! {
     static AST_TRANSFORM_ALLOCATOR: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -961,6 +962,172 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         self.non_reactive_vars.contains(name)
     }
 
+    /// AST replacement for destructured `$derived(...)` rune declarators.
+    /// Mirrors `rune_transforms::transform_derived_destructuring` — uses the
+    /// shared text-based pattern processor `process_derived_destructuring_pattern`
+    /// for the recursive pattern walk (which itself only operates on strings,
+    /// not the script), but performs detection and source-argument walking
+    /// at the AST level so we avoid scanning the whole script for
+    /// `let|const|var ... = $derived(...)` shapes.
+    ///
+    /// Output shape depends on the source expression:
+    ///   - simple identifier `name` → `base_expr` is just `wrapped_name`
+    ///     (no `$$d` temp needed)
+    ///   - top-level `await` → `$$d = await $.async_derived(...)`, base
+    ///     becomes `$.get($$d)`
+    ///   - object literal → `$$d = $.derived(() => (obj))`,
+    ///     base = `$.get($$d)`
+    ///   - default → `$$d = $.derived(unthunked)`, base = `$.get($$d)`
+    ///
+    /// The pattern (object or array) is then processed by the shared text
+    /// helper, which recursively emits `name = $.derived(() => base.key)`,
+    /// `$$array = $.derived(() => $.to_array(base, count))` for nested
+    /// array patterns, and the `$.exclude_from_object(...)` form for rest
+    /// elements.
+    fn try_rewrite_derived_destructuring_declarator(
+        &mut self,
+        declarator: &VariableDeclarator<'_>,
+    ) -> bool {
+        let Some(init) = &declarator.init else {
+            return false;
+        };
+        if !self.is_derived_call_init(init) {
+            return false;
+        }
+        let Expression::CallExpression(call) = init else {
+            return false;
+        };
+        // Destructured pattern only — simple BindingIdentifier is handled by
+        // try_rewrite_derived_call_declarator.
+        let is_destructured = matches!(
+            &declarator.id,
+            BindingPattern::ObjectPattern(_) | BindingPattern::ArrayPattern(_)
+        );
+        if !is_destructured {
+            return false;
+        }
+        if call.arguments.len() != 1 {
+            return false;
+        }
+
+        // Snapshot the original (pre-walk) source-text shape — the text
+        // version inspects the raw bytes to decide which init shape to
+        // emit. We reuse that.
+        let arg = &call.arguments[0];
+        let arg_span = arg.span();
+        let source_orig = self.source[arg_span.start as usize..arg_span.end as usize].to_string();
+        let source_orig_trimmed = source_orig.trim();
+        let source_is_identifier = !source_orig_trimmed.is_empty()
+            && source_orig_trimmed
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '$');
+        let contains_await = contains_direct_await_in_expression(source_orig_trimmed);
+
+        // Walk the source argument so inner state-var refs get `$.get(...)`
+        // wraps; drain those into the wrapped source text we embed in the
+        // generated declarations.
+        self.visit_argument(arg);
+        let wrapped_source = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
+
+        // Extract the destructured pattern's source text — the recursive
+        // text helper walks this string.
+        let pattern_span = declarator.id.span();
+        let pattern_text =
+            self.source[pattern_span.start as usize..pattern_span.end as usize].to_string();
+        let pattern_text = pattern_text.trim().to_string();
+
+        let mut declarations: Vec<String> = Vec::new();
+
+        let d_name = if source_is_identifier {
+            String::new()
+        } else {
+            DERIVED_TMP_COUNTER.with(|c| {
+                let n = c.get();
+                c.set(n + 1);
+                if n == 0 {
+                    "$$d".to_string()
+                } else {
+                    format!("$$d_{}", n)
+                }
+            })
+        };
+
+        let base_expr = if source_is_identifier {
+            wrapped_source.clone()
+        } else if contains_await {
+            // Async derived destructuring — mirror the text path's
+            // `await $.async_derived(...)` emission.
+            let saved_content = wrap_await_with_save_in_async_derived(wrapped_source.trim());
+            let inner_expr = strip_top_level_await_from_expr(&saved_content);
+            let inner_has_nested_await = contains_direct_await_in_expression(&inner_expr);
+
+            if inner_has_nested_await {
+                let is_object = saved_content.trim().starts_with('{');
+                let stmt = if is_object {
+                    format!(
+                        "{} = await $.async_derived(async () => ({}))",
+                        d_name, saved_content
+                    )
+                } else {
+                    format!(
+                        "{} = await $.async_derived(async () => {})",
+                        d_name, saved_content
+                    )
+                };
+                declarations.push(stmt);
+            } else {
+                let inner_trimmed = inner_expr.trim();
+                let inner_is_object = inner_trimmed.starts_with('{');
+                if inner_is_object {
+                    declarations.push(format!(
+                        "{} = await $.async_derived(() => ({}))",
+                        d_name, inner_expr
+                    ));
+                } else {
+                    let thunk_arg = unthunk_string(&inner_expr);
+                    declarations.push(format!("{} = await $.async_derived({})", d_name, thunk_arg));
+                }
+            }
+            format!("$.get({})", d_name)
+        } else {
+            // Object literal needs paren-wrap so the arrow body isn't
+            // parsed as a block.
+            if wrapped_source.trim_start().starts_with('{') {
+                declarations.push(format!(
+                    "{} = $.derived(() => ({}))",
+                    d_name, wrapped_source
+                ));
+            } else {
+                let derived_arg = unthunk_string(&wrapped_source);
+                declarations.push(format!("{} = $.derived({})", d_name, derived_arg));
+            }
+            format!("$.get({})", d_name)
+        };
+
+        let mut array_counter: usize = 0;
+        if process_derived_destructuring_pattern(
+            &pattern_text,
+            &base_expr,
+            &mut declarations,
+            &mut array_counter,
+        )
+        .is_none()
+        {
+            return false;
+        }
+        if declarations.is_empty() {
+            return false;
+        }
+
+        // Replacement covers [pattern_start, init_end] so the keyword and
+        // optional trailing pieces of the VariableDeclaration remain.
+        let replacement = declarations.join(",\n\t");
+        let start = pattern_span.start;
+        let end = call.span.end;
+        self.add_replacement(start, end, replacement);
+        true
+    }
+
     /// AST replacement for `$derived.by(fn)` rune declarators. Mirrors the
     /// text-pipeline rewrite that lived in
     /// `transform_client_runes_with_skip_and_state`'s `$derived.by` loop.
@@ -1549,10 +1716,14 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         // default walk so `visit_expression(init)` doesn't add the inner
         // replacements a second time.
         //
-        // Destructured `$state(...)` / `$state.raw(...)` is checked first
-        // — the other rune-declarator handlers bail for non-Identifier
-        // binding patterns, so the destructure matcher catches them.
+        // Destructured `$state(...)` / `$state.raw(...)` / `$derived(...)`
+        // are checked first — the other rune-declarator handlers bail for
+        // non-Identifier binding patterns, so the destructure matchers
+        // catch them.
         if self.try_rewrite_state_destructuring_declarator(declarator) {
+            return;
+        }
+        if self.try_rewrite_derived_destructuring_declarator(declarator) {
             return;
         }
         if self.try_rewrite_state_raw_or_frozen_declarator(declarator) {

--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -4,10 +4,8 @@ use memchr::memmem;
 
 use super::destructure_transforms::build_fallback_string;
 use super::{
-    ARRAY_LOOKUP_COUNTER, DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER,
-    contains_direct_await_in_expression, find_matching_paren, is_function_parameter_in_statement,
-    strip_top_level_await_from_expr, transform_props_destructuring, unthunk_string,
-    wrap_await_with_save_in_async_derived, wrap_state_vars_in_expr,
+    ARRAY_LOOKUP_COUNTER, DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER, find_matching_paren,
+    is_function_parameter_in_statement, transform_props_destructuring, wrap_state_vars_in_expr,
 };
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 
@@ -17,24 +15,6 @@ pub(super) fn find_unescaped_derived_by_call(s: &str) -> Option<usize> {
     while let Some(pos) = memmem::find(&s.as_bytes()[search_from..], b"$derived.by(") {
         let abs_pos = search_from + pos;
         if abs_pos > 0 && s.as_bytes()[abs_pos - 1] == b'.' {
-            search_from = abs_pos + 12;
-            continue;
-        }
-        return Some(abs_pos);
-    }
-    None
-}
-
-/// Find the position of `$derived(` in the string, skipping already-transformed occurrences.
-pub(super) fn find_unescaped_derived_call(s: &str) -> Option<usize> {
-    let mut search_from = 0;
-    while let Some(pos) = memmem::find(&s.as_bytes()[search_from..], b"$derived(") {
-        let abs_pos = search_from + pos;
-        if abs_pos > 0 && s.as_bytes()[abs_pos - 1] == b'.' {
-            search_from = abs_pos + 9;
-            continue;
-        }
-        if s[abs_pos..].starts_with("$derived.by(") {
             search_from = abs_pos + 12;
             continue;
         }
@@ -197,27 +177,11 @@ pub(super) fn transform_client_runes_with_skip_and_state(
         // still handled by the text helper `transform_derived_destructuring`,
         // which produces a complete IIFE/`$$d`-temp form and returns the
         // rewritten script.
-        if let Some(pos) = find_unescaped_derived_call(&result) {
-            let before_pos_bytes = &result.as_bytes()[..pos];
-            let has_decl = memmem::find(before_pos_bytes, b"let ").is_some()
-                || memmem::find(before_pos_bytes, b"const ").is_some()
-                || memmem::find(before_pos_bytes, b"var ").is_some();
-            if has_decl {
-                let before_derived = result[..pos].trim();
-                let has_destructuring =
-                    before_derived.contains('{') || before_derived.contains('[');
-                if has_destructuring
-                    && let Some(transformed) = transform_derived_destructuring(
-                        &result,
-                        state_vars,
-                        non_reactive_vars,
-                        proxy_vars,
-                    )
-                {
-                    return apply_effect_rune_transforms(transformed);
-                }
-            }
-        }
+        // Destructured `$derived(...)` declarators are now rewritten in the
+        // AST pass (`ast_state_transform::try_rewrite_derived_destructuring_declarator`).
+        // The recursive pattern processor `process_derived_destructuring_pattern`
+        // is shared with the AST handler — only the per-statement byte
+        // scan that used to detect the shape is removed here.
     } // end if !derived_is_store_sub
 
     // `$state.eager(x)` -> `$.eager(() => x)` is now handled by the AST
@@ -1141,116 +1105,6 @@ fn replace_effect_patterns(input: &str) -> String {
     // Append remaining tail
     out.push_str(&input[last_copied..]);
     out
-}
-
-/// Transform `export let x = value` to `let x = $.prop($$props, 'x', 12, value)`.
-/// Transform `$derived()` with destructuring patterns.
-pub(super) fn transform_derived_destructuring(
-    line: &str,
-    state_vars: &[String],
-    non_reactive_vars: &[String],
-    proxy_vars: &[String],
-) -> Option<String> {
-    let trimmed = line.trim();
-    let decl_keyword = if trimmed.starts_with("let ") {
-        "let"
-    } else if trimmed.starts_with("const ") {
-        "const"
-    } else if trimmed.starts_with("var ") {
-        "var"
-    } else {
-        return None;
-    };
-    let derived_pos = memmem::find(trimmed.as_bytes(), b"$derived(")?;
-    let pattern_start = decl_keyword.len() + 1;
-    let eq_pos = trimmed[..derived_pos].rfind('=')?;
-    let pattern = trimmed[pattern_start..eq_pos].trim();
-    let source_start = derived_pos + 9;
-    let source_end = find_matching_paren(&trimmed[source_start..])?;
-    let source = trimmed[source_start..source_start + source_end].trim();
-    let source_is_identifier = source
-        .chars()
-        .all(|c| c.is_alphanumeric() || c == '_' || c == '$');
-    let mut declarations = Vec::new();
-    let mut array_counter = 0;
-    let wrapped_source = wrap_state_vars_in_expr(source, state_vars, non_reactive_vars, proxy_vars);
-    let contains_await = contains_direct_await_in_expression(source);
-    // Only allocate a unique $$d name if we actually need a temp (i.e., source is not a plain identifier)
-    let d_name = if source_is_identifier {
-        String::new()
-    } else {
-        DERIVED_TMP_COUNTER.with(|c| {
-            let n = c.get();
-            c.set(n + 1);
-            if n == 0 {
-                "$$d".to_string()
-            } else {
-                format!("$$d_{}", n)
-            }
-        })
-    };
-    let base_expr = if source_is_identifier {
-        wrapped_source.clone()
-    } else if contains_await {
-        // Async derived destructuring: use $.async_derived()
-        // Apply $.save() wrapping for non-final await expressions
-        let saved_content = wrap_await_with_save_in_async_derived(wrapped_source.trim());
-        let inner_expr = strip_top_level_await_from_expr(&saved_content);
-        let inner_has_nested_await = contains_direct_await_in_expression(&inner_expr);
-
-        if inner_has_nested_await {
-            let is_object = saved_content.trim().starts_with('{');
-            if is_object {
-                declarations.push(format!(
-                    "{} = await $.async_derived(async () => ({}))",
-                    d_name, saved_content
-                ));
-            } else {
-                declarations.push(format!(
-                    "{} = await $.async_derived(async () => {})",
-                    d_name, saved_content
-                ));
-            }
-        } else {
-            let inner_trimmed = inner_expr.trim();
-            let inner_is_object = inner_trimmed.starts_with('{');
-            if inner_is_object {
-                declarations.push(format!(
-                    "{} = await $.async_derived(() => ({}))",
-                    d_name, inner_expr
-                ));
-            } else {
-                let thunk_arg = unthunk_string(&inner_expr);
-                declarations.push(format!("{} = await $.async_derived({})", d_name, thunk_arg));
-            }
-        }
-        format!("$.get({})", d_name)
-    } else {
-        // When the source is an object literal (starts with {), we must wrap it in
-        // parentheses to avoid the arrow function body being parsed as a block:
-        // () => ({a, b}) instead of () => {a, b}
-        if wrapped_source.trim_start().starts_with('{') {
-            declarations.push(format!(
-                "{} = $.derived(() => ({}))",
-                d_name, wrapped_source
-            ));
-        } else {
-            // Apply unthunk optimization: $.derived(() => name()) -> $.derived(name)
-            let derived_arg = unthunk_string(&wrapped_source);
-            declarations.push(format!("{} = $.derived({})", d_name, derived_arg));
-        }
-        format!("$.get({})", d_name)
-    };
-    process_derived_destructuring_pattern(
-        pattern,
-        &base_expr,
-        &mut declarations,
-        &mut array_counter,
-    )?;
-    if declarations.is_empty() {
-        return None;
-    }
-    Some(format!("{} {};", decl_keyword, declarations.join(",\n\t")))
 }
 
 /// Transform `$derived.by()` with destructuring patterns.


### PR DESCRIPTION
## Summary

Continues the AST migration arc (depends on #106). Migrates `let { foo, bar: [a, b, { baz }] } = \$derived(stuff)` and similar destructured `\$derived(...)` declarators from `transform_derived_destructuring` to a new AST handler `try_rewrite_derived_destructuring_declarator` on `StateVarCollector`.

Detection becomes precise (VariableDeclarator + destructured id + `\$derived(...)` init). The per-statement byte-scan in `transform_client_runes_with_skip_and_state` is removed. The source argument is walked first (`visit_argument` + drain) so inner state-var refs get `\$.get(...)` wraps inside the embedded source text.

The recursive pattern walker (`process_derived_destructuring_pattern` → `process_derived_object_pattern` / `process_derived_array_pattern` → `collect_array_helpers_only` → `process_nested_pattern_elements`) stays in `rune_transforms.rs` — it's pure string-shaped pattern code that runs once per match, not per script, so the perf benefit comes from removing the script-wide detection scan, not the pattern walk itself.

Init-shape decisions mirror the text path:
- simple identifier → no `\$\$d` temp, base = wrapped name
- top-level `await` → `\$\$d = await \$.async_derived(...)` with `\$.save()` wrapping
- object literal → `\$\$d = \$.derived(() => (obj))`
- default → `\$\$d = \$.derived(unthunk_string(wrapped))`

Counters (`DERIVED_TMP_COUNTER`, `SCRIPT_ARRAY_COUNTER`) are shared thread-locals — module-script (text) and component (AST) handlers stay in sync.

Removes `transform_derived_destructuring` (~106 lines) and the now-unused `find_unescaped_derived_call` byte scanner.

16th AST migration in the rune transform pipeline.

## Test plan

- [x] `cargo test --release` — all suites pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `pnpm run compatibility-report` — **3341/3341 in-scope still 100%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)