### PR TITLE
docs(perf): handover plans for bumpalo migration and remaining text→AST work

### DIFF
--- a/docs/bumpalo-migration-plan.md
+++ b/docs/bumpalo-migration-plan.md
@@ -1,0 +1,203 @@
+# bumpalo migration plan (PERF_ROADMAP §7.2 B)
+
+> **Scope**: This is a multi-PR effort, not a single-session change. Each
+> phase below is a separate PR with its own test+bench gate. Phases must
+> land in order — half-migrated state offers no perf win and adds
+> complexity.
+
+## Current state (as of 2026-05-15)
+
+The Svelte template AST already uses an **arena pattern**, just not bumpalo:
+
+- `src/ast/arena.rs` defines `ParseArena` — a Vec-backed arena that
+  stores all `JsNode` instances in a single contiguous `Vec<JsNode>`,
+  referenced by `JsNodeId(u32)` indices.
+- `JsNode` children (`Vec<JsNode>` fields like `arguments`, `body`) live
+  in a second `Vec<JsNode>` referenced by `IdRange { start: u32, len: u32 }`.
+- `Root.arena` owns one `ParseArena` per parse unit.
+
+This pattern gives:
+- ✅ Contiguous storage (cache-friendly)
+- ✅ Bulk deallocation on arena drop
+- ✅ Cheap allocation (Vec push)
+- ❌ One pointer indirection per node access (`arena.get(id)` → vec index)
+- ❌ Lost cache lines when chasing children IDs
+
+OXC's `Allocator` (which wraps `bumpalo::Bump`) gives the same arena
+benefits AND lets nodes hold **direct references** to their children
+(`&'a JsNode<'a>`), eliminating the indirection.
+
+`bumpalo = "3.16"` is in `Cargo.toml` with the `collections` feature.
+The OXC AST transforms in `src/compiler/phases/3_transform/client/ast_state_transform.rs`
+already use `oxc_allocator::Allocator` (bumpalo under the hood) via the
+`AST_TRANSFORM_ALLOCATOR` thread-local. So bumpalo is proven in-tree —
+just not for the Svelte template AST.
+
+## Why this is a multi-PR effort
+
+Touching `JsNode` cascades widely. Current usage:
+
+| Symbol | Files | Notes |
+|---|---|---|
+| `JsNodeId` | 10 | Every consumer that reaches into a JsNode child |
+| `IdRange` | 12 | Every consumer that iterates over JsNode children |
+| `ParseArena` | 33 | Every site that allocates, queries, or threads the arena |
+
+Every consumer would need a `'a` lifetime parameter on its types and
+function signatures. Visitors, serializers, transforms, analysis —
+all of them.
+
+Half-migrated states are net-negative: you pay for the lifetime
+plumbing without realizing the indirection win.
+
+## Phased plan
+
+Each phase is its own PR. Tests + compatibility report must stay at
+100% after every phase. Run `./scripts/bench.sh` after each phase and
+log the delta in the PR description.
+
+### Phase 0 — Preparation (no behavior change)
+
+- [ ] Add a `Bump` field to `ParseArena` alongside the existing `Vec`s
+      (not used yet). This gives later phases a place to allocate from
+      without changing public APIs.
+- [ ] Add `ParseArena::bump(&self) -> &Bump` accessor.
+- [ ] Confirm `ParseArena: Send` is still upheld (Bump is `Send`).
+- [ ] Run bench, confirm zero regression.
+
+**Risk**: low. **Reviewer focus**: the `unsafe impl Send` on
+`ParseArena` — Bump is `Send` but not `Sync`, same as the current
+`UnsafeCell<Vec<JsNode>>`.
+
+### Phase 1 — Bump-allocated leaf data (Loc)
+
+- [ ] Replace `Option<Box<Loc>>` in every `JsNode` variant with
+      `Option<LocId>` where `LocId(u32)` indexes a new
+      `ParseArena::locs: UnsafeCell<Vec<Loc>>` (still Vec-backed, mirrors
+      `js_nodes`).
+- [ ] Update every site that reads `loc.as_deref()` to go through
+      `arena.get_loc(id)`.
+- [ ] Migration window: this affects every JsNode variant signature
+      and every Loc consumer. Estimate ~30 sites.
+
+**Risk**: medium. `loc` is touched by error reporting, source map
+generation, and any user-facing diagnostic. **Reviewer focus**: error
+messages still surface the right span info after the indirection.
+
+**Why this phase**: validates the "ID-indexed Bump-allocated leaf"
+pattern before tackling the larger JsNode storage migration. If this
+phase is sound, we can copy the pattern to JsNode itself.
+
+**Decision point**: at the end of Phase 1, profile. If `Loc` allocs
+weren't actually hot, **stop here** — the original `Box<Loc>` was
+already cheap and we just added complexity. The roadmap's "+20%"
+number comes from the JsNode storage migration, not Loc.
+
+### Phase 2 — Bump-allocated JsNode storage
+
+- [ ] Change `ParseArena::js_nodes` from `UnsafeCell<Vec<JsNode>>` to
+      a Bump-allocated `bumpalo::collections::Vec<'arena, JsNode>`.
+- [ ] This requires adding `'arena` lifetime to `ParseArena<'arena>`
+      and `Root<'arena>` (the arena owner).
+- [ ] All `ParseArena` consumers gain `'arena`.
+
+**Risk**: high. **Reviewer focus**: serialization (Serde traits)
+needs to handle the lifetime. `Root` is serialized at multiple points
+(N-API boundary, ecosystem testing). Check the `#[serde(skip)]`
+boundaries hold.
+
+**Bench gate**: this phase should show measurable improvement
+(allocation count down, single-threaded compile time down ~5–10%).
+If not, revert and re-investigate.
+
+### Phase 3 — Direct references for JsNode children
+
+- [ ] Replace `JsNodeId` fields in `JsNode` variants (`left`, `right`,
+      `callee`, …) with `&'arena JsNode<'arena>` direct references.
+- [ ] Replace `IdRange` fields with `bumpalo::collections::Vec<'arena, JsNode<'arena>>`
+      or `&'arena [JsNode<'arena>]`.
+- [ ] Remove `arena.get_js_node(id)` / `arena.get_js_children(range)`
+      call sites — replaced by direct field access.
+
+**Risk**: very high. This is the biggest mechanical change — every
+consumer touching JsNode children switches from `arena.get_js_node(child)`
+to just `child` (the reference). Visitor patterns may need
+restructuring.
+
+**Bench gate**: this is where the +20% comes from. If we don't see
+≥10% improvement on the `compile-client` bench, the migration isn't
+paying off and something is fundamentally off (maybe the original
+pattern was already near-optimal for our workload).
+
+### Phase 4 — Drop the JsNodeId / IdRange types
+
+- [ ] Once Phase 3 lands and is verified, remove `JsNodeId`,
+      `IdRange`, and the now-empty arena accessor methods.
+- [ ] Audit serializers: the JSON shape must still match the
+      official Svelte compiler output (snapshot tests catch this).
+
+**Risk**: medium — mostly mechanical, but the serializers are
+load-bearing for the test fixture comparison.
+
+## Cross-phase concerns
+
+### Serialization
+
+`Root` is serialized via Serde at several points. The `'arena`
+lifetime needs to either:
+
+- Be erased at the serialization boundary (own a separate
+  Serde-friendly snapshot of the AST), or
+- Use a `DeserializeSeed`-style pattern that owns the arena.
+
+The simpler path is to serialize through a `Cow<'arena, Root<'static>>`
+wrapper that copies on the rare serialize path. We deserialize back
+into a fresh arena.
+
+### Send / parallelism
+
+`compile_batch` parallelizes per file with `rayon`. Each thread needs
+its own arena. The thread-local pattern from `AST_TRANSFORM_ALLOCATOR`
+already exists — Phase 0 should reuse it (one bump per thread,
+reset between files).
+
+### Concurrent borrow checking
+
+The current `ParseArena` uses `UnsafeCell` and documents that
+allocation is `&self`-callable. With bumpalo, allocation is naturally
+`&self` (no UnsafeCell needed), so the safety story improves.
+However, holding a `&'arena JsNode<'arena>` across an allocation is
+fine (bumpalo never moves), so visitors can drop the `get_*` shim
+indirection entirely.
+
+## Estimate
+
+| Phase | Estimate | Cumulative perf delta |
+|---|---|---|
+| 0 (prep) | 0.5 day | 0% |
+| 1 (Loc) | 1–2 days | 0–5% |
+| 2 (Vec → bumpalo) | 2–3 days | 0–5% |
+| 3 (refs over IDs) | 3–5 days | +10–20% |
+| 4 (cleanup) | 0.5 day | (no change) |
+| **Total** | **7–10 days** | **+10–20%** |
+
+These are calendar-day estimates assuming focused work and that each
+phase's bench-gate passes on the first try. Plan for ~50% buffer.
+
+## Recommendation
+
+Don't start until the remaining text-to-AST migrations
+(`docs/text-to-ast-remaining-handover.md`) have landed. Those are
+simpler, lower-risk, and already proven; the bumpalo migration
+should build on a stable AST architecture.
+
+Once those are done, do **Phase 0** first as a standalone PR to
+unblock everyone, then sequence Phase 1 → 2 → 3 with at least one
+bench cycle between each.
+
+If after Phase 1 the `Loc` allocations weren't actually hot enough
+to move the needle (very possible — `Option<Box<Loc>>` is rare),
+**reconsider whether Phases 2–3 are worth it**. The +20% in the
+PERF_ROADMAP is OXC's number; rsvelte's existing arena pattern
+already captures some of that win, so our marginal headroom may be
+smaller.

--- a/docs/perf-profile-2026-05-15.md
+++ b/docs/perf-profile-2026-05-15.md
@@ -1,0 +1,159 @@
+# Perf profile snapshot — 2026-05-15
+
+Captured immediately after the 18-PR text→AST migration arc landed
+(PRs #92–#110). Used to identify the next perf direction.
+
+## Method
+
+```bash
+cargo build --release --bin compile_profile
+./target/release/compile_profile
+```
+
+`compile_profile` runs `parse` + `analyze` + `transform` over every
+`input.svelte` under `submodules/svelte/packages/svelte/tests/runtime-runes/samples`
+and `runtime-legacy/samples` — **3,637 files, 850 KB total** —
+warming up with 100 full compiles first, then measuring each phase
+in isolation across all files.
+
+## Results
+
+```
+Files: 3637, Total: 849936 bytes
+
+  Parse+resolve:       11.95ms
+=== Compile Phase Breakdown ===
+Phase 1 (Parse):       11.59ms (  2.5%)
+  Resolve lazy:         0.00ms (  0.0%)
+Phase 2 (Analyze):    226.50ms ( 49.5%)
+Phase 3 (Transform):  219.80ms ( 48.0%)
+TOTAL:                457.90ms
+
+Per-file average:    125.90µs
+Throughput:          1.9 MB/s
+```
+
+## Reading the numbers
+
+### Phase 1 — Parse (2.5%)
+
+The Svelte template parser (`src/compiler/phases/1_parse/`) is no
+longer the bottleneck. Past optimization work (recent commits show
+"perf(svelte2tsx): cut single-thread runtime ~45%" — same tree)
+has already taken parse below the noise floor. Don't touch parse
+without strong evidence it regressed.
+
+`defer_script_parse: true` is on by default in this binary, so the
+JS parse cost is moved into Phase 2 below.
+
+### Phase 2 — Analyze (49.5%)
+
+This is what `analyze_component` does, including:
+
+1. `resolve_lazy::resolve_lazy_expressions` — finish the deferred
+   JS expression parses from Phase 1.
+2. `ensure_script_parsed(ast.instance)` and `ensure_script_parsed(ast.module)`
+   — invoke OXC to produce the full JS AST. **This is OXC's work,
+   not ours.**
+3. Visitor passes:
+   - `template_element` visitor (scope tracking through template tags)
+   - `call_expression` visitor
+   - Binding analysis / scope resolution
+   - …
+
+A back-of-envelope guess at the split: **JS parsing via OXC is
+~30–40% of analyze**, the rest is our visitors. To get a real number,
+add timing splits around each `ensure_script_parsed` call and around
+the visitor invocations.
+
+**Plausible perf headroom in Analyze**:
+
+| Sub-step | Likely cost | Headroom |
+|---|---|---|
+| `ensure_script_parsed` (OXC) | ~30–40% of analyze | Limited — OXC is already tuned; switching parsers isn't realistic. |
+| Visitors (our code) | ~60% of analyze | Real — these are not yet AST-migrated like the transform-side handlers. |
+| `resolve_lazy_expressions` | small | Small — already memoized |
+| Symbol-table / scope build | medium | Real — `FxHashMap` lookups in tight loops |
+
+**Recommended next investigation** (analyze phase):
+
+1. Time `ensure_script_parsed` separately from the visitors. If it's
+   >40% of analyze, **don't touch the visitors** — focus on reducing
+   OXC parse cost (e.g., is `defer_script_parse` actually deferring,
+   or is something forcing the parse twice?).
+2. If visitors dominate, profile with `samply` against a single
+   long-running scenario to find the hot visitor function.
+
+### Phase 3 — Transform (48.0%)
+
+After 18 AST migration PRs, transform is still nearly half the
+compile time. Sub-phases:
+
+- `transform_client` / `transform_server` — script transform
+  (rune handling, state-var wrapping, …)
+- Template transform (HTML → JS conversion)
+- Codegen (OXC formatting + sourcemap)
+
+The text→AST migrations have eliminated most per-statement byte
+scans, but the remaining cost is:
+
+- The AST walk itself (oxc visitor traversal)
+- String allocations in replacement building
+- OXC codegen for the final output
+- Template-to-JS transformation (separate from script transform)
+
+**Likely next targets in Transform**:
+
+1. **Template transform** — not yet AST-migrated; uses different
+   architecture. Search for hot spots there.
+2. **Codegen** — `String::push_str` patterns; check
+   `String::with_capacity` is used.
+3. **bumpalo** (`docs/bumpalo-migration-plan.md`) — eliminates the
+   `JsNodeId` indirection in the Svelte template AST. Phase 3 of
+   the plan is where the +10–20% comes from.
+
+## Recommended priorities
+
+In rough order of expected ROI:
+
+1. **Time-split `ensure_script_parsed` vs. visitors in Analyze.**
+   This is a 1-hour task that tells you which 25% of total compile
+   time is OXC vs. our code. Cheap information; do this first.
+2. **bumpalo Phase 0–3** — already documented in
+   `docs/bumpalo-migration-plan.md`. Expected +10–20% on transform.
+3. **Template transform investigation** — needs its own profile;
+   likely has hot spots untouched by the text→AST arc.
+4. **Analyze visitor migration** — only if Step 1 shows visitors
+   dominate analyze.
+
+## Anti-priorities
+
+Skip these unless profiling proves otherwise:
+
+- **Parse phase** — 2.5% of total, already well-optimized.
+- **Non-dev `$inspect` migration** — cold code (dev-only feature),
+  see `docs/text-to-ast-remaining-handover.md` §1.
+- **Class-field `$.tag` wrap** — dev-mode only, likely cold.
+
+## How to reproduce
+
+```bash
+git checkout main
+cargo build --release --bin compile_profile
+./target/release/compile_profile
+```
+
+For a single-file deeper sample:
+
+```bash
+./target/release/profiler \
+  --file submodules/svelte/packages/svelte/tests/runtime-runes/samples/form-default-value-spread/main.svelte \
+  --iterations 20 --warmup 5
+```
+
+For function-level breakdown (samply, view in Firefox Profiler):
+
+```bash
+RUSTFLAGS="-C force-frame-pointers=yes" cargo build --release --bin compile_profile
+samply record ./target/release/compile_profile
+```

--- a/docs/text-to-ast-remaining-handover.md
+++ b/docs/text-to-ast-remaining-handover.md
@@ -1,0 +1,288 @@
+# Remaining text→AST migrations (handover)
+
+Context: the `/perf-loop` arc through 2026-05-15 migrated 18 text-based
+rune handlers to the AST pass (`ast_state_transform.rs`). The remaining
+text passes listed below are deferred. Each entry is a tractable
+single-PR migration; reasons for deferral are noted.
+
+If you're picking this up, start with the one that has the highest
+"perf impact" in the table — those are the production-hot paths.
+
+## Status snapshot
+
+| Pass | Where it lives | Perf impact | Why deferred |
+|---|---|---|---|
+| Non-dev `$inspect(...)` statement removal | `rune_transforms.rs:184`–`260` | **cold** (dev-only feature) | Multiple edge cases (`$inspect.trace` vs `$inspect`, `.with(cb)` chain, async-hole markers); attempted once, abandoned per perf-loop rule 4. |
+| Per-statement `wrap_state_derived_with_tag` class-field branch | `rune_transforms.rs:wrap_state_derived_with_tag` (call sites at L116 + L401) | **medium** (dev-mode classes) | Class-field declaration (`#field = $.state(...)`) and `this.#field = $.state(...)` rewrites. Only runs in dev mode + when classes have state. |
+| `transform_module_script_runes` text passes | `mod.rs:transform_module_script_runes` | **medium** (every component with module script) | Separate code path from the per-component AST pass; has its own `transform_state_assignments`, `wrap_state_vars_in_expr`, `transform_strict_equals`, etc. |
+
+The other text helpers (state / derived / derived.by / props
+destructuring, strict-equals, $.tag wrap, $inspect dev-mode) have
+already migrated to AST in PRs #104–#110.
+
+## 1. Non-dev `$inspect(...)` statement removal
+
+**Goal**: in non-dev mode, `$inspect(args);` and `$inspect.trace(args);`
+statements should be removed (or replaced with `/* $$async_hole:args */`
+in async mode, which the formatting layer later converts to `;;`).
+
+**Current text path** (in `rune_transforms.rs:transform_client_runes_with_skip_and_state`):
+
+```rust
+if !dev {
+    // $inspect.trace(...) — always strip, no marker
+    while let Some(pos) = memmem::find(result.as_bytes(), b"$inspect.trace(") {
+        // walk to closing paren, consume trailing ;/whitespace,
+        // consume leading spaces, splice out
+    }
+}
+if !dev && let Some(pos) = memmem::find(result.as_bytes(), b"$inspect(") {
+    // $inspect(args) — strip; standalone-statement + async-mode → emit marker
+    // $inspect(args).with(cb) — same
+}
+```
+
+**AST entrypoint** (mostly designed during the abandoned attempt):
+
+```rust
+fn visit_expression_statement(&mut self, stmt: &ExpressionStatement<'ast>) {
+    if !self.try_rewrite_nondev_inspect_statement(stmt) {
+        walk::walk_expression_statement(self, stmt);
+    }
+}
+
+fn try_rewrite_nondev_inspect_statement(&mut self, stmt: &ExpressionStatement<'_>) -> bool {
+    // Guard: !dev && is_runes && !is_shadowed("$inspect") && !store_sub
+    // Resolve outer call to inner $inspect call (3 shapes):
+    //   - $inspect(args)            — direct
+    //   - $inspect.trace(args)      — member call
+    //   - $inspect(args).with(cb)   — peeled through .with()
+    // is_trace flag distinguishes whether to emit the async-hole marker
+    // Extend replacement span to consume leading spaces/tabs and
+    // (for the strip path) trailing ;/whitespace/newline.
+}
+```
+
+### What broke last time
+
+The attempt at `perf/inspect-nondev-ast` (abandoned, branch deleted)
+failed on these fixtures:
+
+- `inspect-derived` — `$inspect(y).with(push)` not replaced
+- `inspect-state-unsafe-mutation`
+- `inspect-console-trace`
+- `inspect-with-untracked`
+- `async-top-level-inspect-server` (snapshot)
+
+Root-cause investigation didn't get far; the replacement appears to
+register but doesn't apply. Possibilities:
+
+- Inner replacements drained by outer walk before the outer can emit
+- `visit_expression_statement` firing at the wrong nesting level (e.g.,
+  inside a callback rather than top-level)
+- Span miscalculation when the outer call has `.with(cb)` chain
+
+### Gates needed
+
+In `mod.rs:transform_instance_script_for_visitors` and
+`ast_state_transform::transform_state_vars_ast`, add:
+
+```rust
+let has_inspect_calls = is_runes
+    && !store_sub_vars.iter().any(|v| v == "$inspect")
+    && memmem::find(result.as_bytes(), b"$inspect").is_some();
+```
+
+…and include `has_inspect_calls` in `has_transforms` and `has_any_match`.
+(Currently `$inspect` doesn't have its own gate; dev-mode `$inspect(...)`
+rewrites only run when *other* state/derived/props transforms are also
+present, which has been correct because non-dev `$inspect` was handled
+by the text loop. After this migration, the gate is required.)
+
+### Fixtures to exercise
+
+- `runtime-runes/samples/inspect-trace`
+- `runtime-runes/samples/inspect-derived`
+- `runtime-runes/samples/inspect-state-unsafe-mutation`
+- `runtime-runes/samples/inspect-console-trace`
+- `runtime-runes/samples/inspect-trace-store`
+- `runtime-runes/samples/inspect-trace-nested`
+- `runtime-runes/samples/inspect-trace-circular-reference`
+- `runtime-runes/samples/inspect-trace-null`
+- `runtime-runes/samples/inspect-trace-reassignment`
+- `runtime-runes/samples/inspect-with-untracked`
+- `snapshot/samples/async-top-level-inspect-server`
+
+The snapshot fixture is especially load-bearing because it tests the
+async-hole marker → `;;` conversion path (`formatting.rs:373`).
+
+### Recommendation
+
+Honestly evaluate cost vs. benefit before picking this up. `$inspect`
+is a dev-only debugging tool; in production builds (where this code
+runs) it's essentially never present. Removing the text loop saves a
+`memmem::find` per statement when `$inspect` is absent, which is the
+overwhelmingly common case — and `memmem::find` is SIMD-fast already.
+
+This migration is **cold-path cleanup**, not a perf win. Only attempt
+if you're driven by code-uniformity (full text→AST migration) rather
+than measured perf.
+
+## 2. Class-field `wrap_state_derived_with_tag` branch
+
+**Goal**: in dev mode, `#field = $.state(...)` and
+`this.#field = $.state(...)` declarations inside classes get wrapped
+with `$.tag(...)` / `$.tag_proxy(...)` for `$inspect.trace()` labels.
+
+**Current text path** (in `rune_transforms.rs:wrap_state_derived_with_tag`):
+
+Two scan loops at the end of the function (the comment says "Handle
+class field declarations" around L562):
+
+1. `#field = $.X(...)` (private field, no `this.`)
+2. `this.#field = $.X(...)` / `this.field = $.X(...)` (class constructor)
+
+Both emit `$.tag(..., 'ClassName.field')` or
+`$.tag_proxy(..., 'ClassName.field')` depending on whether the field
+was originally public (compiler-converted to private with a
+getter/setter) or originally private.
+
+The class name comes from `extract_enclosing_class_name(before_text)`
+which scans backwards for `class NAME` — straightforward at the AST
+level (just `ClassDeclaration::id`).
+
+### AST design
+
+Two new visitors:
+
+```rust
+fn visit_property_definition(&mut self, prop: &PropertyDefinition<'ast>) {
+    // Match: prop.value = Some(CallExpression { $state | $derived | $proxy })
+    // prop.key = PrivateIdentifier or IdentifierName
+    // Walk inner so state-var refs register, drain, emit $.tag wrap
+}
+
+fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'ast>) {
+    // Match: lhs = StaticMemberExpression { object = ThisExpression, property = X }
+    //         OR lhs = PrivateFieldExpression { object = ThisExpression, field = #X }
+    //        rhs = CallExpression { $state | $derived | $proxy }
+    // Walk inner, drain, emit $.tag wrap
+}
+```
+
+Both need access to the enclosing class name, which is awkward without
+parent tracking. Options:
+
+- Track `current_class_name: Option<&str>` in `StateVarCollector`,
+  push/pop in `visit_class` override
+- Or do a brief upward scan in the source text via `extract_enclosing_class_name`
+  (reuses the existing text helper)
+
+The second option is cheaper and works because by the time we're
+inside `visit_property_definition`, the class header is already in the
+source bytes preceding the field.
+
+### Fixtures to exercise
+
+Grep for `#\w+ *= *\$state(` and `this\.#?\w+ *= *\$state(` in
+`runtime-runes/samples` to find them. Class-based components are
+relatively rare in the test corpus.
+
+### Recommendation
+
+This is **dev-mode-only** work — same caveat as #1. Run `samply` first
+on a dev-mode workload with classes to confirm it's actually hot.
+If not, leave the text path alone.
+
+## 3. `transform_module_script_runes` text passes
+
+**Goal**: migrate the module-script (`<script context="module">`)
+transform from text-based to AST-based, matching what the instance
+script already does.
+
+**Current**: `mod.rs:transform_module_script_runes` runs its own
+sequence of text helpers (`transform_state_assignments`,
+`wrap_state_vars_in_expr`, `transform_strict_equals`,
+`transform_console_calls_dev`, `wrap_state_derived_with_tag`,
+`apply_effect_rune_transforms`). None of these go through the AST
+pass.
+
+### Why this is a real migration (not just a port)
+
+Module-script and instance-script have different binding scoping:
+the module script's bindings are visible to the instance script as
+imports (sort of), so the AST pass would need to know what runs in
+module vs instance context.
+
+Two approaches:
+
+**Approach A: extend the existing AST pass to cover both scripts.**
+Currently `transform_state_vars_ast` is called once for the instance
+script (`transform_instance_script_for_visitors` at L4308+). Add a
+second call for the module script with its own
+`AstTransformConfig`. The challenge: the module script's
+`analysis.module_root` has different bindings than `analysis.root`.
+
+**Approach B: lift the module-script transform into the same flow.**
+Treat module + instance as concatenated input to a single AST pass,
+then split the output. Cleaner data flow but requires fixing up
+positions.
+
+Approach A is the safer first step.
+
+### Test coverage
+
+Module scripts are exercised by:
+
+- `runtime-runes/samples/module-script-*`
+- `runtime-legacy/samples/module-script-*` (legacy mode — different path, may not be in scope)
+
+Run with the existing module-script fixtures before claiming the
+migration is correctness-preserving.
+
+### Recommendation
+
+**Medium-priority**. Module scripts run in every component that has
+one (often: stores, constants, helpers). Removing the text-pass loop
+saves per-statement work, but the per-component count is 1 module
+script vs N instance statements, so the multiplier is small.
+
+Still worth doing for code uniformity — having one AST pipeline for
+the whole script-transform phase makes future changes much easier.
+
+## Cross-cutting: gates
+
+All three of these migrations need new byte-presence gates in:
+
+- `mod.rs:transform_instance_script_for_visitors` — outer gate before
+  entering the AST pass
+- `ast_state_transform::transform_state_vars_ast` — inner gate before
+  parsing with OXC
+
+The gate is always shaped:
+
+```rust
+let has_X = condition_for_entering
+    && memmem::find(result.as_bytes(), b"PROBE_BYTES").is_some();
+```
+
+Add to both `has_transforms` (outer) and `has_any_match` (inner).
+Without these, the AST pass won't enter for components that only need
+the new rune family, and the migration silently no-ops.
+
+Reference recent gate additions:
+
+- `has_strict_equals` (PR #104)
+- `has_inspect_calls` (attempted in the abandoned non-dev `$inspect`
+  branch — see Section 1 for shape)
+
+## Recommended order
+
+1. **Class-field `$.tag` wrap** (#2) — if profiling shows dev-mode
+   classes are hot. Otherwise skip.
+2. **Module-script transform** (#3) — code uniformity, modest perf.
+3. **Non-dev `$inspect`** (#1) — only for code uniformity. No perf win.
+
+Or skip all three and prioritize the **bumpalo migration**
+(`docs/bumpalo-migration-plan.md`) — that has a measurable perf
+ceiling (+10–20%), but is also the largest single effort.


### PR DESCRIPTION
## Summary

Captures the next-up perf work in two handover docs so the plans survive past this session.

**`docs/bumpalo-migration-plan.md`** — Phased plan for PERF_ROADMAP §7.2 B (bumpalo migration). The Svelte template AST already uses an arena pattern (Vec-backed \`ParseArena\` with \`JsNodeId\` indirection), so the actual win is the *direct-reference* version, not the bump allocator itself. Phases:
- **0**: add Bump field (foundation)
- **1**: Bump-allocate \`Loc\` (validate the pattern)
- **2**: Bump-allocate JsNode storage (adds \`'arena\` lifetime)
- **3**: Replace \`JsNodeId\` / \`IdRange\` fields with direct \`&'arena JsNode<'arena>\` — this is where the +10–20% comes from
- **4**: Cleanup

Each phase is a separate PR with its own bench gate. Half-migrated state buys nothing. Estimated 7–10 focused calendar days.

**\`docs/text-to-ast-remaining-handover.md\`** — Status of the three remaining text passes that didn't make it into the 18-PR migration arc:

1. Non-dev \`\$inspect(...)\` statement removal — attempted at \`perf/inspect-nondev-ast\`, abandoned. Notes which fixtures broke, what likely went wrong. **Cold path, code-uniformity only.**
2. Per-statement \`wrap_state_derived_with_tag\` class-field branch — dev-mode class state. AST design sketched.
3. \`transform_module_script_runes\` text passes — module-script transform. Two approaches outlined; Approach A safer.

Both docs include byte-presence gate patterns needed for new migrations.

## Test plan

- [x] Docs only — no code changes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` (pre-commit hook) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)