### PR TITLE
perf(analyze): migrate feature detection to typed JsNode walker

### DIFF
--- a/docs/perf-profile-2026-05-15.md
+++ b/docs/perf-profile-2026-05-15.md
@@ -141,24 +141,117 @@ sits in `analyze_component` after the OXC work finishes. None of
 the analyze visitors have been AST-migrated yet (the 18-PR text→AST
 arc covered Phase 3 only).
 
+## Phase 2 visitor sub-breakdown — measured 2026-05-15
+
+Drilling one level deeper into the "Visitors (rest)" slice. Measured
+by temporarily adding an `analyze-perf-trace` cargo feature with
+atomic-counter instrumentation around every major sub-step inside
+`analyze_component`. (The feature was reverted after the
+measurement — it was throwaway; reproducing requires re-adding it.)
+
+Steady-state (mean of 3 consecutive runs after warm-up):
+
+```
+--- analyze-perf-trace (sub-step breakdown, sorted by time) ---
+  script_visit (instance)            69.3ms ( 35.6%)
+  feature_detect (await/runes)       54.6ms ( 28.1%)
+  analyze_template                   20.8ms ( 10.7%)
+  create_scopes                      15.7ms (  8.1%)
+  build_siblings                      8.2ms (  4.2%)
+  css_analyze                         7.6ms (  3.9%)
+  name_deconflict                     6.9ms (  3.5%)
+  detect_store_subs                   3.3ms (  1.7%)
+  extract_scripts                     2.4ms (  1.2%)
+  script_visit (module)               2.1ms (  1.1%)
+  promote_legacy_state                0.9ms (  0.5%)
+  process_legacy_exports              0.7ms (  0.4%)
+  mark_each_group                     0.5ms (  0.3%)
+  reactive_cycles                     0.4ms (  0.2%)
+  populate_legacy_deps                0.3ms (  0.2%)
+  unused_export_check                 0.3ms (  0.1%)
+  synth_class_style_attrs             0.2ms (  0.1%)
+  runes_warnings                      <0.1ms
+  module_export_check                 <0.1ms
+  (sum of buckets)                  ~195ms
+```
+
+The sum of buckets covers **~98.6%** of the "Visitors (rest)" slice
+(200.3ms in the same run). The remaining ~3ms lives in small
+between-step glue (the `is_module_file` detection, `maybe_runes`
+computation, `slot_snippet_conflict` check, `module_scope_declarations`
+snapshot, etc.) — collectively negligible.
+
+### Reading the result
+
+**Two sub-steps account for ~64% of all visitor time and ~26% of
+total compile time:**
+
+1. **`script_visit (instance)` — 69.3ms, 14.8% of total.**
+   `visitors::visit_script_expr` on the instance script. This is
+   the main AST walk that dispatches to all the per-node analyze
+   visitors (`call_expression`, `assignment_expression`,
+   `identifier`, `function_declaration`, …). It is the single
+   biggest function in the compiler.
+
+2. **`feature_detect (await/runes)` — 54.6ms, 11.7% of total.**
+   `fragment_check_features` (cheap, walks typed template) plus
+   `json_check_features` called twice (instance + module JSON
+   walks). The two JSON walks are the costly half — and the source
+   already has `TODO: migrate json_check_features to JsNode walker`
+   markers in `2_analyze/mod.rs`. The data confirms those TODOs.
+
+The next tier (`analyze_template`, `create_scopes`) is meaningful
+but ~3× smaller per item, and `create_scopes` is data-structure
+heavy (less migratable than JSON walks). Everything below
+`build_siblings` is in the noise.
+
+### Updated next-PR target
+
+Replace the previous "Samply-profile the analyze visitors" item
+with the concrete output:
+
+1. **Migrate `json_check_features` to a typed JsNode walker.**
+   - Bucket #2 (`feature_detect`) — currently ~55ms / 11.7% of total.
+   - Two callsites: `analyze_component` lines ~239-266 (instance +
+     module JSON walks). Both have explicit TODOs.
+   - Mirrors the playbook used for the Phase 3 text→AST migration:
+     replace `inst.content.as_json()` walks with `JsNode`
+     pattern-matching.
+   - Expected savings: cut the JSON-walk half of `feature_detect`
+     (estimate 25–40ms), roughly **5–8% of total compile time** for
+     a single PR.
+
+2. **AST-migrate the analyze visitors run from
+   `visit_script_expr`.** Bucket #1 (~69ms). Bigger surface than #2
+   — the visitor dispatch fans out to many per-node handlers — so
+   this is best attacked one visitor at a time. The text→AST PR arc
+   (#92–#110) is the template.
+
+3. **bumpalo Phase 0–3** — unchanged.
+
+4. **Template transform investigation** — unchanged.
+
 ## Recommended priorities
 
-In rough order of expected ROI (post-2026-05-15 measurement):
+In rough order of expected ROI (post-2026-05-15 measurements):
 
 1. ~~Time-split `ensure_script_parsed` vs. visitors in Analyze.~~
    **Done** — see "Phase 2 sub-breakdown" above. OXC is ~12% of
    analyze; visitors dominate.
-2. **Samply-profile the analyze visitors.** With visitors at
-   ~42% of total compile time, this is now the biggest single
-   lever. Use a long-running scenario or replay the full
-   `compile_profile` workload to find the hot visitor function(s)
-   before deciding what to migrate to AST traversal.
-3. **bumpalo Phase 0–3** — already documented in
+2. ~~Samply-profile the analyze visitors.~~ **Done** via
+   `analyze-perf-trace` instrumentation — see "Phase 2 visitor
+   sub-breakdown" below. Two buckets dominate: `script_visit
+   (instance)` (35.6%) and `feature_detect` (28.1%).
+3. **Migrate `json_check_features` to a typed JsNode walker.**
+   Concrete next-PR target — see "Updated next-PR target" below.
+   Expected savings: ~5–8% of total compile time.
+4. **AST-migrate analyze visitors run from `visit_script_expr`.**
+   Bucket #1 (~14.8% of total compile time). One visitor at a time,
+   mirroring the Phase 3 text→AST arc (#92–#110).
+5. **bumpalo Phase 0–3** — already documented in
    `docs/bumpalo-migration-plan.md`. Expected +10–20% on transform.
-4. **Template transform investigation** — needs its own profile;
+6. **Template transform investigation** — needs its own profile;
    likely has hot spots untouched by the text→AST arc.
-5. **Analyze visitor migration** — once §2 identifies the hot
-   visitor(s), mirror the Phase 3 text→AST treatment for them.
 
 ## Anti-priorities
 

--- a/docs/perf-profile-2026-05-15.md
+++ b/docs/perf-profile-2026-05-15.md
@@ -62,27 +62,20 @@ This is what `analyze_component` does, including:
    - …
 
 A back-of-envelope guess at the split: **JS parsing via OXC is
-~30–40% of analyze**, the rest is our visitors. To get a real number,
-add timing splits around each `ensure_script_parsed` call and around
-the visitor invocations.
+~30–40% of analyze**, the rest is our visitors.
 
-**Plausible perf headroom in Analyze**:
+→ **Measured 2026-05-15** (see §"Phase 2 sub-breakdown" below): the
+30–40% guess was wrong by ~3×. OXC is only **~12% of analyze**;
+visitors are **~86%**.
 
-| Sub-step | Likely cost | Headroom |
+**Measured perf headroom in Analyze**:
+
+| Sub-step | Measured cost | Headroom |
 |---|---|---|
-| `ensure_script_parsed` (OXC) | ~30–40% of analyze | Limited — OXC is already tuned; switching parsers isn't realistic. |
-| Visitors (our code) | ~60% of analyze | Real — these are not yet AST-migrated like the transform-side handlers. |
-| `resolve_lazy_expressions` | small | Small — already memoized |
-| Symbol-table / scope build | medium | Real — `FxHashMap` lookups in tight loops |
-
-**Recommended next investigation** (analyze phase):
-
-1. Time `ensure_script_parsed` separately from the visitors. If it's
-   >40% of analyze, **don't touch the visitors** — focus on reducing
-   OXC parse cost (e.g., is `defer_script_parse` actually deferring,
-   or is something forcing the parse twice?).
-2. If visitors dominate, profile with `samply` against a single
-   long-running scenario to find the hot visitor function.
+| `ensure_script_parsed` (OXC) | ~12% of analyze (5.8% of total) | Limited — already small, and OXC is upstream-tuned. |
+| Visitors (our code) | ~86% of analyze (42% of total) | Real and large — these are not yet AST-migrated like the transform-side handlers. |
+| `resolve_lazy_expressions` | ~3% of analyze (1.3% of total) | Negligible. |
+| Symbol-table / scope build | (within "Visitors") | Real — `FxHashMap` lookups in tight loops. |
 
 ### Phase 3 — Transform (48.0%)
 
@@ -112,19 +105,60 @@ scans, but the remaining cost is:
    `JsNodeId` indirection in the Svelte template AST. Phase 3 of
    the plan is where the +10–20% comes from.
 
+## Phase 2 sub-breakdown — measured 2026-05-15
+
+Added by patching `src/bin/compile_profile.rs` to pre-run
+`resolve_lazy_expressions` and `ensure_script_parsed` with their own
+timers. Both are idempotent (early-return when there is no deferred
+work left), so the subsequent `analyze_component` call skips those
+steps internally and reports visitor-only time.
+
+Steady-state (mean of 3 consecutive runs after a cold-start warm-up):
+
+```
+Phase 1 (Parse):         11.6ms (  2.5%)
+Phase 2 (Analyze):      225.9ms ( 49.4%)
+  Resolve lazy:           5.8ms (  1.3% of total,   2.6% of analyze)
+  Ensure script (OXC):   26.6ms (  5.8% of total,  11.8% of analyze)
+  Visitors (rest):      193.5ms ( 42.4% of total,  85.6% of analyze)
+Phase 3 (Transform):    219.6ms ( 48.1%)
+TOTAL:                  457.1ms
+```
+
+(The very first run after `cargo build` is a ~20% slower cold start —
+file-cache miss on 3,637 inputs. Discard it for steady-state numbers.)
+
+### Conclusion
+
+The doc's prior "30–40% OXC" guess is wrong: **OXC parse is only
+~12% of analyze**, and the conditional in the original
+"Recommended next investigation" §1 ("if >40%, focus on OXC") does
+not fire. We do **not** need to audit `defer_script_parse` or look
+for a doubled parse.
+
+The lever is **our visitors**: 193ms / 42% of total compile time
+sits in `analyze_component` after the OXC work finishes. None of
+the analyze visitors have been AST-migrated yet (the 18-PR text→AST
+arc covered Phase 3 only).
+
 ## Recommended priorities
 
-In rough order of expected ROI:
+In rough order of expected ROI (post-2026-05-15 measurement):
 
-1. **Time-split `ensure_script_parsed` vs. visitors in Analyze.**
-   This is a 1-hour task that tells you which 25% of total compile
-   time is OXC vs. our code. Cheap information; do this first.
-2. **bumpalo Phase 0–3** — already documented in
+1. ~~Time-split `ensure_script_parsed` vs. visitors in Analyze.~~
+   **Done** — see "Phase 2 sub-breakdown" above. OXC is ~12% of
+   analyze; visitors dominate.
+2. **Samply-profile the analyze visitors.** With visitors at
+   ~42% of total compile time, this is now the biggest single
+   lever. Use a long-running scenario or replay the full
+   `compile_profile` workload to find the hot visitor function(s)
+   before deciding what to migrate to AST traversal.
+3. **bumpalo Phase 0–3** — already documented in
    `docs/bumpalo-migration-plan.md`. Expected +10–20% on transform.
-3. **Template transform investigation** — needs its own profile;
+4. **Template transform investigation** — needs its own profile;
    likely has hot spots untouched by the text→AST arc.
-4. **Analyze visitor migration** — only if Step 1 shows visitors
-   dominate analyze.
+5. **Analyze visitor migration** — once §2 identifies the hot
+   visitor(s), mirror the Phase 3 text→AST treatment for them.
 
 ## Anti-priorities
 

--- a/src/bin/compile_profile.rs
+++ b/src/bin/compile_profile.rs
@@ -18,7 +18,9 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use svelte_compiler_rust::compiler::phases::phase1_parse::{ParseOptions, parse};
+use svelte_compiler_rust::compiler::phases::phase1_parse::{
+    ParseOptions, compute_line_offsets, ensure_script_parsed, parse, resolve_lazy_expressions,
+};
 use svelte_compiler_rust::compiler::phases::phase2_analyze::analyze_component;
 use svelte_compiler_rust::compiler::phases::phase3_transform::transform_component;
 use svelte_compiler_rust::{CompileOptions, GenerateMode};
@@ -54,24 +56,64 @@ fn main() {
         .collect();
     let parse_time = start.elapsed();
 
-    // Measure resolve_lazy as part of Phase 2 (it's called inside analyze_component)
-    let resolve_time = std::time::Duration::ZERO;
-
-    // Measure Phase 2 (Analyze) — includes resolve_lazy + ensure_script_parsed
     let compile_opts = CompileOptions {
         generate: GenerateMode::Client,
         ..Default::default()
     };
 
-    // First run: measure full analyze
+    // === Phase 2 breakdown ===
+    //
+    // `resolve_lazy_expressions` and `ensure_script_parsed` are idempotent
+    // (both early-return when there is nothing left to do), so we pre-run
+    // them with timing here. The subsequent `analyze_component` call skips
+    // these steps internally, leaving us with a clean three-way split:
+    //
+    //   2a. resolve_lazy  — finish deferred template-expression + CSS parse
+    //   2b. ensure_script — invoke OXC on the instance + module scripts
+    //   2c. visitors      — everything else analyze_component does
+    //                       (scope build, store subs, fragment walks, …)
+
+    // Phase 2a: resolve_lazy_expressions
+    let start = Instant::now();
+    for (i, (_, content)) in files.iter().enumerate() {
+        if let Some(ref mut ast) = asts[i] {
+            // SAFETY: `ast` is in `asts[i]` for the whole iteration; the
+            // serialize arena pointer is cleared before this borrow ends.
+            unsafe {
+                svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
+            };
+            let _ = resolve_lazy_expressions(ast, content);
+            svelte_compiler_rust::ast::arena::clear_serialize_arena();
+        }
+    }
+    let resolve_lazy_time = start.elapsed();
+
+    // Phase 2b: ensure_script_parsed for instance + module scripts (OXC)
+    let start = Instant::now();
+    for (i, (_, content)) in files.iter().enumerate() {
+        if let Some(ref mut ast) = asts[i] {
+            let line_offsets = compute_line_offsets(content, false);
+            // SAFETY: same lifetime invariant as 2a.
+            unsafe {
+                svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
+            };
+            if let Some(ref mut instance) = ast.instance {
+                ensure_script_parsed(&ast.arena, instance, content, &line_offsets);
+            }
+            if let Some(ref mut module) = ast.module {
+                ensure_script_parsed(&ast.arena, module, content, &line_offsets);
+            }
+            svelte_compiler_rust::ast::arena::clear_serialize_arena();
+        }
+    }
+    let ensure_script_time = start.elapsed();
+
+    // Phase 2c: analyze_component (visitors / scope build / store subs / …)
     let start = Instant::now();
     let mut analyses = Vec::with_capacity(files.len());
     for (i, (_, content)) in files.iter().enumerate() {
         if let Some(ref mut ast) = asts[i] {
-            // SAFETY: `ast` lives until the end of this scope, and we
-            // explicitly clear the thread-local serialize arena before the
-            // borrow could become dangling. No async point or panic-prone
-            // cleanup runs between set and clear.
+            // SAFETY: same lifetime invariant as 2a.
             unsafe {
                 svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
             };
@@ -82,33 +124,8 @@ fn main() {
             analyses.push(None);
         }
     }
-    let analyze_time = start.elapsed();
-
-    // Measure just parse+resolve (deferred work) to isolate analyze cost
-    let start = Instant::now();
-    let mut asts2: Vec<_> = files
-        .iter()
-        .map(|(_, content)| parse(content, parse_opts).ok())
-        .collect();
-    for (i, (_, _content)) in files.iter().enumerate() {
-        if let Some(ref mut ast) = asts2[i] {
-            // SAFETY: `ast` lives until the end of this scope; the serialize
-            // arena pointer is cleared before this borrow ends.
-            unsafe {
-                svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
-            };
-            // Note: `remove_typescript_nodes` would normally run here as part of
-            // the compile flow, but exposing the JSON AST mutation API in this
-            // profiler binary is left intentionally out of scope. The timing
-            // captured here is therefore parse + resolve_lazy only.
-            svelte_compiler_rust::ast::arena::clear_serialize_arena();
-        }
-    }
-    let parse_resolve_time = start.elapsed();
-    println!(
-        "  Parse+resolve:     {:7.2}ms",
-        parse_resolve_time.as_secs_f64() * 1000.0
-    );
+    let analyze_visitor_time = start.elapsed();
+    let analyze_time = resolve_lazy_time + ensure_script_time + analyze_visitor_time;
 
     // Measure Phase 3 (Transform)
     let start = Instant::now();
@@ -127,33 +144,42 @@ fn main() {
     }
     let transform_time = start.elapsed();
 
-    let total = parse_time + resolve_time + analyze_time + transform_time;
+    let total = parse_time + analyze_time + transform_time;
+    let pct = |d: std::time::Duration| d.as_secs_f64() / total.as_secs_f64() * 100.0;
+    let ms = |d: std::time::Duration| d.as_secs_f64() * 1000.0;
 
     println!("=== Compile Phase Breakdown ===");
     println!(
-        "Phase 1 (Parse):     {:7.2}ms ({:5.1}%)",
-        parse_time.as_secs_f64() * 1000.0,
-        parse_time.as_secs_f64() / total.as_secs_f64() * 100.0
+        "Phase 1 (Parse):       {:7.2}ms ({:5.1}%)",
+        ms(parse_time),
+        pct(parse_time)
     );
     println!(
-        "  Resolve lazy:      {:7.2}ms ({:5.1}%)",
-        resolve_time.as_secs_f64() * 1000.0,
-        resolve_time.as_secs_f64() / total.as_secs_f64() * 100.0
+        "Phase 2 (Analyze):     {:7.2}ms ({:5.1}%)",
+        ms(analyze_time),
+        pct(analyze_time)
     );
     println!(
-        "Phase 2 (Analyze):   {:7.2}ms ({:5.1}%)",
-        analyze_time.as_secs_f64() * 1000.0,
-        analyze_time.as_secs_f64() / total.as_secs_f64() * 100.0
+        "  Resolve lazy:        {:7.2}ms ({:5.1}%)",
+        ms(resolve_lazy_time),
+        pct(resolve_lazy_time)
     );
     println!(
-        "Phase 3 (Transform): {:7.2}ms ({:5.1}%)",
-        transform_time.as_secs_f64() * 1000.0,
-        transform_time.as_secs_f64() / total.as_secs_f64() * 100.0
+        "  Ensure script (OXC): {:7.2}ms ({:5.1}%)",
+        ms(ensure_script_time),
+        pct(ensure_script_time)
     );
     println!(
-        "TOTAL:               {:7.2}ms",
-        total.as_secs_f64() * 1000.0
+        "  Visitors (rest):     {:7.2}ms ({:5.1}%)",
+        ms(analyze_visitor_time),
+        pct(analyze_visitor_time)
     );
+    println!(
+        "Phase 3 (Transform):   {:7.2}ms ({:5.1}%)",
+        ms(transform_time),
+        pct(transform_time)
+    );
+    println!("TOTAL:                 {:7.2}ms", ms(total));
     println!();
     println!(
         "Per-file average:    {:.2}µs",

--- a/src/compiler/phases/1_parse/mod.rs
+++ b/src/compiler/phases/1_parse/mod.rs
@@ -63,6 +63,12 @@ pub(crate) mod utils;
 
 // Re-export CSS parsing for external use
 pub use read::style::parse_css;
+// Re-export deferred-work entry points so profiling/diagnostic tools can
+// invoke them outside the analyze_component pipeline.
+#[doc(hidden)]
+pub use read::script::ensure_script_parsed;
+#[doc(hidden)]
+pub use resolve_lazy::resolve_lazy_expressions;
 
 // Re-export expression from read module
 pub(crate) use read::expression;

--- a/src/compiler/phases/2_analyze/mod.rs
+++ b/src/compiler/phases/2_analyze/mod.rs
@@ -39,6 +39,7 @@ pub use types::{
 };
 pub use visitors::AstType;
 
+use crate::ast::arena::ParseArena;
 use crate::ast::template::Root;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::CompileOptions;
@@ -208,35 +209,32 @@ pub fn analyze_component(
 
     // Check the template fragment for both await expressions and rune references
     // in a single traversal (previously done as two separate walks).
-    let fragment_results = fragment_check_features(&ast.fragment, &store_sub_names);
+    let fragment_results = fragment_check_features(&ast.fragment, &ast.arena, &store_sub_names);
 
     // Check the instance script for both await expressions and rune references
-    // in a single traversal (previously done as two separate walks).
-    // For script checks, we use an empty set for store_subs (scripts can have both
-    // runes and stores, but store_subs are created from template/instance references
-    // after scope building, so they are not relevant for script-level rune detection).
-    // TODO: migrate json_check_features to JsNode walker
+    // in a single traversal. For script checks, we use an empty set for store_subs
+    // (scripts can have both runes and stores, but store_subs are created from
+    // template/instance references after scope building, so they are not relevant
+    // for script-level rune detection).
     let (instance_has_await, instance_has_rune_reference) = ast
         .instance
         .as_ref()
         .map(|inst| {
-            let val = inst.content.as_json();
             let empty_subs: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
-            let r = json_check_features(val, &empty_subs);
+            let r = expression_check_features(&inst.content, &ast.arena, &empty_subs);
             (r.has_await, r.has_rune_reference)
         })
         .unwrap_or((false, false));
 
     // Check the module script for rune references (module scripts don't need await check
     // since the original code only checked instance script for await).
-    // TODO: migrate json_check_features to JsNode walker
     let module_has_rune_reference = if needs_rune_detection {
         ast.module
             .as_ref()
             .map(|module| {
-                let val = module.content.as_json();
                 let empty_subs: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
-                json_check_features(val, &empty_subs).has_rune_reference
+                expression_check_features(&module.content, &ast.arena, &empty_subs)
+                    .has_rune_reference
             })
             .unwrap_or(false)
     } else {
@@ -2366,11 +2364,12 @@ impl FragmentCheckResults {
 /// Check a template fragment for both await expressions and rune references in a single walk.
 fn fragment_check_features(
     fragment: &crate::ast::template::Fragment,
+    arena: &ParseArena,
     store_subs: &rustc_hash::FxHashSet<&str>,
 ) -> FragmentCheckResults {
     let mut results = FragmentCheckResults::default();
     for node in &fragment.nodes {
-        let node_results = node_check_features(node, store_subs);
+        let node_results = node_check_features(node, arena, store_subs);
         results.merge(&node_results);
         if results.all_found() {
             return results;
@@ -2386,13 +2385,14 @@ fn fragment_check_features(
 ///   but rune check walks the body (rune references anywhere indicate runes mode).
 fn node_check_features(
     node: &crate::ast::template::TemplateNode,
+    arena: &ParseArena,
     store_subs: &rustc_hash::FxHashSet<&str>,
 ) -> FragmentCheckResults {
     use crate::ast::template::TemplateNode;
 
     match node {
         TemplateNode::ExpressionTag(tag) => {
-            let json_results = expression_check_features(&tag.expression, store_subs);
+            let json_results = expression_check_features(&tag.expression, arena, store_subs);
             FragmentCheckResults {
                 has_await: json_results.has_await,
                 has_rune_reference: json_results.has_rune_reference,
@@ -2401,99 +2401,99 @@ fn node_check_features(
         TemplateNode::RegularElement(elem) => {
             let mut results = FragmentCheckResults::default();
             for attr in &elem.attributes {
-                let attr_results = attribute_check_features(attr, store_subs);
+                let attr_results = attribute_check_features(attr, arena, store_subs);
                 results.merge(&attr_results);
                 if results.all_found() {
                     return results;
                 }
             }
-            let frag_results = fragment_check_features(&elem.fragment, store_subs);
+            let frag_results = fragment_check_features(&elem.fragment, arena, store_subs);
             results.merge(&frag_results);
             results
         }
         TemplateNode::Component(comp) => {
             let mut results = FragmentCheckResults::default();
             for attr in &comp.attributes {
-                let attr_results = attribute_check_features(attr, store_subs);
+                let attr_results = attribute_check_features(attr, arena, store_subs);
                 results.merge(&attr_results);
                 if results.all_found() {
                     return results;
                 }
             }
-            let frag_results = fragment_check_features(&comp.fragment, store_subs);
+            let frag_results = fragment_check_features(&comp.fragment, arena, store_subs);
             results.merge(&frag_results);
             results
         }
         TemplateNode::IfBlock(block) => {
             let mut results = FragmentCheckResults::default();
-            let expr_results = expression_check_features(&block.test, store_subs);
+            let expr_results = expression_check_features(&block.test, arena, store_subs);
             results.merge_json(&expr_results);
             if results.all_found() {
                 return results;
             }
-            let cons_results = fragment_check_features(&block.consequent, store_subs);
+            let cons_results = fragment_check_features(&block.consequent, arena, store_subs);
             results.merge(&cons_results);
             if results.all_found() {
                 return results;
             }
             if let Some(ref alternate) = block.alternate {
-                let alt_results = fragment_check_features(alternate, store_subs);
+                let alt_results = fragment_check_features(alternate, arena, store_subs);
                 results.merge(&alt_results);
             }
             results
         }
         TemplateNode::EachBlock(block) => {
             let mut results = FragmentCheckResults::default();
-            let expr_results = expression_check_features(&block.expression, store_subs);
+            let expr_results = expression_check_features(&block.expression, arena, store_subs);
             results.merge_json(&expr_results);
             if results.all_found() {
                 return results;
             }
-            let body_results = fragment_check_features(&block.body, store_subs);
+            let body_results = fragment_check_features(&block.body, arena, store_subs);
             results.merge(&body_results);
             if results.all_found() {
                 return results;
             }
             if let Some(ref fallback) = block.fallback {
-                let fb_results = fragment_check_features(fallback, store_subs);
+                let fb_results = fragment_check_features(fallback, arena, store_subs);
                 results.merge(&fb_results);
             }
             results
         }
         TemplateNode::KeyBlock(block) => {
             let mut results = FragmentCheckResults::default();
-            let expr_results = expression_check_features(&block.expression, store_subs);
+            let expr_results = expression_check_features(&block.expression, arena, store_subs);
             results.merge_json(&expr_results);
             if results.all_found() {
                 return results;
             }
-            let frag_results = fragment_check_features(&block.fragment, store_subs);
+            let frag_results = fragment_check_features(&block.fragment, arena, store_subs);
             results.merge(&frag_results);
             results
         }
         TemplateNode::AwaitBlock(block) => {
             let mut results = FragmentCheckResults::default();
-            let expr_results = expression_check_features(&block.expression, store_subs);
+            let expr_results = expression_check_features(&block.expression, arena, store_subs);
             results.merge_json(&expr_results);
             if results.all_found() {
                 return results;
             }
             if let Some(ref pending) = block.pending {
-                let p_results = fragment_check_features(pending, store_subs);
+                let p_results = fragment_check_features(pending, arena, store_subs);
                 results.merge(&p_results);
                 if results.all_found() {
                     return results;
                 }
             }
             if let Some(ref then) = block.then {
-                let t_results = fragment_check_features(then, store_subs);
+                let t_results = fragment_check_features(then, arena, store_subs);
                 results.merge(&t_results);
                 if results.all_found() {
                     return results;
                 }
             }
             if let Some(ref catch) = block.catch {
-                let c_results = fragment_check_features(catch, store_subs);
+                let c_results = fragment_check_features(catch, arena, store_subs);
                 results.merge(&c_results);
             }
             results
@@ -2501,7 +2501,7 @@ fn node_check_features(
         TemplateNode::SnippetBlock(block) => {
             // SnippetBlock: await check returns false (awaits in snippets don't affect parent),
             // but rune check walks the body (rune references anywhere indicate runes mode).
-            let body_results = fragment_check_features(&block.body, store_subs);
+            let body_results = fragment_check_features(&block.body, arena, store_subs);
             FragmentCheckResults {
                 has_await: false,
                 has_rune_reference: body_results.has_rune_reference,
@@ -2516,97 +2516,97 @@ fn node_check_features(
         | TemplateNode::SvelteWindow(elem) => {
             let mut results = FragmentCheckResults::default();
             for attr in &elem.attributes {
-                let attr_results = attribute_check_features(attr, store_subs);
+                let attr_results = attribute_check_features(attr, arena, store_subs);
                 results.merge(&attr_results);
                 if results.all_found() {
                     return results;
                 }
             }
-            let frag_results = fragment_check_features(&elem.fragment, store_subs);
+            let frag_results = fragment_check_features(&elem.fragment, arena, store_subs);
             results.merge(&frag_results);
             results
         }
         TemplateNode::SvelteSelf(elem) => {
             let mut results = FragmentCheckResults::default();
             for attr in &elem.attributes {
-                let attr_results = attribute_check_features(attr, store_subs);
+                let attr_results = attribute_check_features(attr, arena, store_subs);
                 results.merge(&attr_results);
                 if results.all_found() {
                     return results;
                 }
             }
-            let frag_results = fragment_check_features(&elem.fragment, store_subs);
+            let frag_results = fragment_check_features(&elem.fragment, arena, store_subs);
             results.merge(&frag_results);
             results
         }
         TemplateNode::SvelteComponent(elem) => {
             let mut results = FragmentCheckResults::default();
             for attr in &elem.attributes {
-                let attr_results = attribute_check_features(attr, store_subs);
+                let attr_results = attribute_check_features(attr, arena, store_subs);
                 results.merge(&attr_results);
                 if results.all_found() {
                     return results;
                 }
             }
-            let frag_results = fragment_check_features(&elem.fragment, store_subs);
+            let frag_results = fragment_check_features(&elem.fragment, arena, store_subs);
             results.merge(&frag_results);
             results
         }
         TemplateNode::SvelteElement(elem) => {
             let mut results = FragmentCheckResults::default();
             for attr in &elem.attributes {
-                let attr_results = attribute_check_features(attr, store_subs);
+                let attr_results = attribute_check_features(attr, arena, store_subs);
                 results.merge(&attr_results);
                 if results.all_found() {
                     return results;
                 }
             }
-            let frag_results = fragment_check_features(&elem.fragment, store_subs);
+            let frag_results = fragment_check_features(&elem.fragment, arena, store_subs);
             results.merge(&frag_results);
             results
         }
         TemplateNode::TitleElement(elem) => {
             let mut results = FragmentCheckResults::default();
             for attr in &elem.attributes {
-                let attr_results = attribute_check_features(attr, store_subs);
+                let attr_results = attribute_check_features(attr, arena, store_subs);
                 results.merge(&attr_results);
                 if results.all_found() {
                     return results;
                 }
             }
-            let frag_results = fragment_check_features(&elem.fragment, store_subs);
+            let frag_results = fragment_check_features(&elem.fragment, arena, store_subs);
             results.merge(&frag_results);
             results
         }
         TemplateNode::SlotElement(elem) => {
             let mut results = FragmentCheckResults::default();
             for attr in &elem.attributes {
-                let attr_results = attribute_check_features(attr, store_subs);
+                let attr_results = attribute_check_features(attr, arena, store_subs);
                 results.merge(&attr_results);
                 if results.all_found() {
                     return results;
                 }
             }
-            let frag_results = fragment_check_features(&elem.fragment, store_subs);
+            let frag_results = fragment_check_features(&elem.fragment, arena, store_subs);
             results.merge(&frag_results);
             results
         }
         TemplateNode::RenderTag(tag) => {
-            let json_results = expression_check_features(&tag.expression, store_subs);
+            let json_results = expression_check_features(&tag.expression, arena, store_subs);
             FragmentCheckResults {
                 has_await: json_results.has_await,
                 has_rune_reference: json_results.has_rune_reference,
             }
         }
         TemplateNode::HtmlTag(tag) => {
-            let json_results = expression_check_features(&tag.expression, store_subs);
+            let json_results = expression_check_features(&tag.expression, arena, store_subs);
             FragmentCheckResults {
                 has_await: json_results.has_await,
                 has_rune_reference: json_results.has_rune_reference,
             }
         }
         TemplateNode::ConstTag(tag) => {
-            let json_results = expression_check_features(&tag.declaration, store_subs);
+            let json_results = expression_check_features(&tag.declaration, arena, store_subs);
             FragmentCheckResults {
                 has_await: json_results.has_await,
                 has_rune_reference: json_results.has_rune_reference,
@@ -2635,15 +2635,437 @@ impl JsonCheckResults {
     }
 }
 
-/// Check if an expression (stored as JSON) contains an AwaitExpression and/or rune references
+/// Check if an expression contains an AwaitExpression and/or rune references
 /// in a single traversal.
+///
+/// Walks the typed `JsNode` tree directly. Falls back to the legacy
+/// `serde_json::Value` walker for `Expression::Value` (test-only / fallback)
+/// and for `JsNode::Raw(Value)` nodes (rare — used when leadingComments
+/// require JSON-side metadata).
 fn expression_check_features(
     expr: &crate::ast::js::Expression,
+    arena: &ParseArena,
     store_subs: &rustc_hash::FxHashSet<&str>,
 ) -> JsonCheckResults {
-    // TODO: migrate json_check_features to JsNode walker
-    let value = expr.as_json();
-    json_check_features(value, store_subs)
+    use crate::ast::js::Expression;
+    match expr {
+        Expression::Typed(te) => {
+            let mut results = JsonCheckResults::default();
+            js_node_check_features(&te.node, arena, store_subs, &mut results, false);
+            results
+        }
+        Expression::Value(v) => json_check_features(v, store_subs),
+        // `resolve_lazy_expressions` runs before analyze, so Lazy should never
+        // reach here. Return empty results defensively rather than panicking.
+        Expression::Lazy { .. } => JsonCheckResults::default(),
+    }
+}
+
+/// Walk a typed `JsNode` tree, accumulating await / rune-reference detection
+/// into `results`. Mirrors `json_check_features` semantics but avoids the
+/// `Expression::as_json()` materialization and `serde_json::Value` field
+/// lookups that dominated the analyze `feature_detect` bucket.
+///
+/// The function boundary suppresses await detection inside
+/// `FunctionExpression` / `ArrowFunctionExpression` / `FunctionDeclaration`
+/// bodies (same as `json_check_features`), while rune detection continues
+/// across boundaries.
+///
+/// Fields skipped for the rune check (a non-computed property identifier is
+/// not a rune reference, and an `$effect:` label is not a rune reference
+/// either):
+/// - `LabeledStatement.label`
+/// - `MemberExpression.property` when `computed == false`
+/// - `Property.key` when `computed == false`
+///
+/// Those fields can't carry an `AwaitExpression`, so skipping them entirely
+/// is safe for the await check too.
+fn js_node_check_features(
+    node: &JsNode,
+    arena: &ParseArena,
+    store_subs: &rustc_hash::FxHashSet<&str>,
+    results: &mut JsonCheckResults,
+    inside_function: bool,
+) {
+    if results.all_found() {
+        return;
+    }
+
+    if !inside_function && matches!(node, JsNode::AwaitExpression { .. }) {
+        results.has_await = true;
+    }
+
+    if let JsNode::Identifier { name, .. } = node
+        && is_rune_name(name.as_str())
+        && !store_subs.contains(name.as_str())
+    {
+        results.has_rune_reference = true;
+    }
+
+    if results.all_found() {
+        return;
+    }
+
+    let child_inside_function = inside_function
+        || matches!(
+            node,
+            JsNode::FunctionExpression { .. }
+                | JsNode::ArrowFunctionExpression { .. }
+                | JsNode::FunctionDeclaration { .. }
+        );
+
+    macro_rules! walk_id {
+        ($id:expr) => {{
+            js_node_check_features(
+                arena.get_js_node($id),
+                arena,
+                store_subs,
+                results,
+                child_inside_function,
+            );
+            if results.all_found() {
+                return;
+            }
+        }};
+    }
+    macro_rules! walk_opt_id {
+        ($opt:expr) => {{
+            if let Some(id) = $opt {
+                walk_id!(*id);
+            }
+        }};
+    }
+    macro_rules! walk_range {
+        ($range:expr) => {{
+            for child in arena.get_js_children($range) {
+                js_node_check_features(child, arena, store_subs, results, child_inside_function);
+                if results.all_found() {
+                    return;
+                }
+            }
+        }};
+    }
+
+    match node {
+        // Leaves — no children to walk.
+        JsNode::Identifier { .. }
+        | JsNode::PrivateIdentifier { .. }
+        | JsNode::Literal { .. }
+        | JsNode::TemplateElement { .. }
+        | JsNode::ThisExpression { .. }
+        | JsNode::Super { .. }
+        | JsNode::EmptyStatement { .. }
+        | JsNode::DebuggerStatement { .. }
+        | JsNode::Decorator { .. }
+        | JsNode::TSEnumDeclaration { .. }
+        | JsNode::Comment { .. }
+        | JsNode::Null => {}
+
+        JsNode::BinaryExpression { left, right, .. }
+        | JsNode::LogicalExpression { left, right, .. }
+        | JsNode::AssignmentExpression { left, right, .. }
+        | JsNode::AssignmentPattern { left, right, .. } => {
+            walk_id!(*left);
+            walk_id!(*right);
+        }
+
+        JsNode::UnaryExpression { argument, .. }
+        | JsNode::UpdateExpression { argument, .. }
+        | JsNode::AwaitExpression { argument, .. }
+        | JsNode::ThrowStatement { argument, .. }
+        | JsNode::SpreadElement { argument, .. }
+        | JsNode::RestElement { argument, .. } => {
+            walk_id!(*argument);
+        }
+
+        JsNode::ConditionalExpression {
+            test,
+            consequent,
+            alternate,
+            ..
+        } => {
+            walk_id!(*test);
+            walk_id!(*consequent);
+            walk_id!(*alternate);
+        }
+
+        JsNode::CallExpression {
+            callee, arguments, ..
+        }
+        | JsNode::NewExpression {
+            callee, arguments, ..
+        } => {
+            walk_id!(*callee);
+            walk_range!(*arguments);
+        }
+
+        JsNode::MemberExpression {
+            object,
+            property,
+            computed,
+            ..
+        } => {
+            walk_id!(*object);
+            if *computed {
+                walk_id!(*property);
+            }
+        }
+
+        JsNode::SequenceExpression { expressions, .. } => walk_range!(*expressions),
+
+        JsNode::ArrayExpression { elements, .. } | JsNode::ArrayPattern { elements, .. } => {
+            for elem in elements.iter().flatten() {
+                js_node_check_features(elem, arena, store_subs, results, child_inside_function);
+                if results.all_found() {
+                    return;
+                }
+            }
+        }
+
+        JsNode::ObjectExpression { properties, .. } | JsNode::ObjectPattern { properties, .. } => {
+            walk_range!(*properties)
+        }
+
+        JsNode::TemplateLiteral {
+            quasis,
+            expressions,
+            ..
+        } => {
+            walk_range!(*quasis);
+            walk_range!(*expressions);
+        }
+
+        JsNode::TaggedTemplateExpression { tag, quasi, .. } => {
+            walk_id!(*tag);
+            walk_id!(*quasi);
+        }
+
+        JsNode::ImportExpression { source, .. } => walk_id!(*source),
+
+        JsNode::YieldExpression { argument, .. } => walk_opt_id!(argument),
+
+        JsNode::ChainExpression { expression, .. } => walk_id!(*expression),
+
+        JsNode::MetaProperty { meta, property, .. } => {
+            walk_id!(*meta);
+            walk_id!(*property);
+        }
+
+        JsNode::Property {
+            key,
+            value,
+            computed,
+            ..
+        } => {
+            if *computed {
+                walk_id!(*key);
+            }
+            walk_id!(*value);
+        }
+
+        // MethodDefinition.key / PropertyDefinition.key: the legacy JSON
+        // walker did NOT skip these (it only special-cased Property.key),
+        // so we preserve that behaviour even when `computed == false`.
+        JsNode::MethodDefinition { key, value, .. } => {
+            walk_id!(*key);
+            walk_id!(*value);
+        }
+        JsNode::PropertyDefinition { key, value, .. } => {
+            walk_id!(*key);
+            walk_opt_id!(value);
+        }
+
+        JsNode::FunctionDeclaration {
+            id, params, body, ..
+        }
+        | JsNode::FunctionExpression {
+            id, params, body, ..
+        } => {
+            walk_opt_id!(id);
+            walk_range!(*params);
+            walk_opt_id!(body);
+        }
+
+        JsNode::ArrowFunctionExpression {
+            id, params, body, ..
+        } => {
+            walk_opt_id!(id);
+            walk_range!(*params);
+            walk_id!(*body);
+        }
+
+        JsNode::ClassDeclaration {
+            id,
+            super_class,
+            body,
+            decorators,
+            ..
+        } => {
+            walk_opt_id!(id);
+            walk_opt_id!(super_class);
+            walk_range!(*decorators);
+            walk_id!(*body);
+        }
+        JsNode::ClassExpression {
+            id,
+            super_class,
+            body,
+            ..
+        } => {
+            walk_opt_id!(id);
+            walk_opt_id!(super_class);
+            walk_id!(*body);
+        }
+
+        JsNode::ClassBody { body, .. }
+        | JsNode::StaticBlock { body, .. }
+        | JsNode::BlockStatement { body, .. }
+        | JsNode::Program { body, .. } => walk_range!(*body),
+
+        JsNode::ExpressionStatement { expression, .. } => walk_id!(*expression),
+
+        JsNode::VariableDeclaration { declarations, .. } => walk_range!(*declarations),
+
+        JsNode::VariableDeclarator { id, init, .. } => {
+            walk_id!(*id);
+            walk_opt_id!(init);
+        }
+
+        JsNode::ReturnStatement { argument, .. } => walk_opt_id!(argument),
+
+        JsNode::IfStatement {
+            test,
+            consequent,
+            alternate,
+            ..
+        } => {
+            walk_id!(*test);
+            walk_id!(*consequent);
+            walk_opt_id!(alternate);
+        }
+
+        JsNode::ForStatement {
+            init,
+            test,
+            update,
+            body,
+            ..
+        } => {
+            walk_opt_id!(init);
+            walk_opt_id!(test);
+            walk_opt_id!(update);
+            walk_id!(*body);
+        }
+
+        JsNode::ForOfStatement {
+            left, right, body, ..
+        }
+        | JsNode::ForInStatement {
+            left, right, body, ..
+        } => {
+            walk_id!(*left);
+            walk_id!(*right);
+            walk_id!(*body);
+        }
+
+        JsNode::WhileStatement { test, body, .. } | JsNode::DoWhileStatement { test, body, .. } => {
+            walk_id!(*test);
+            walk_id!(*body);
+        }
+
+        JsNode::TryStatement {
+            block,
+            handler,
+            finalizer,
+            ..
+        } => {
+            walk_id!(*block);
+            walk_opt_id!(handler);
+            walk_opt_id!(finalizer);
+        }
+        JsNode::CatchClause { param, body, .. } => {
+            walk_opt_id!(param);
+            walk_id!(*body);
+        }
+
+        JsNode::SwitchStatement {
+            discriminant,
+            cases,
+            ..
+        } => {
+            walk_id!(*discriminant);
+            walk_range!(*cases);
+        }
+        JsNode::SwitchCase {
+            test, consequent, ..
+        } => {
+            walk_opt_id!(test);
+            walk_range!(*consequent);
+        }
+
+        JsNode::LabeledStatement { body, .. } => {
+            // Skip `label` — `$effect:` is a label, not a rune reference.
+            walk_id!(*body);
+        }
+        JsNode::BreakStatement { label, .. } | JsNode::ContinueStatement { label, .. } => {
+            // These labels point to LabeledStatement labels and were walked by
+            // the legacy JSON walker (no special case), so we walk them too.
+            walk_opt_id!(label);
+        }
+
+        JsNode::ImportDeclaration {
+            specifiers,
+            source,
+            attributes,
+            ..
+        } => {
+            walk_range!(*specifiers);
+            walk_id!(*source);
+            walk_range!(*attributes);
+        }
+        JsNode::ImportSpecifier {
+            imported, local, ..
+        } => {
+            walk_id!(*imported);
+            walk_id!(*local);
+        }
+        JsNode::ImportDefaultSpecifier { local, .. }
+        | JsNode::ImportNamespaceSpecifier { local, .. } => {
+            walk_id!(*local);
+        }
+        JsNode::ExportNamedDeclaration {
+            declaration,
+            specifiers,
+            source,
+            attributes,
+            ..
+        } => {
+            walk_opt_id!(declaration);
+            walk_range!(*specifiers);
+            walk_opt_id!(source);
+            walk_range!(*attributes);
+        }
+        JsNode::ExportDefaultDeclaration { declaration, .. } => walk_id!(*declaration),
+        JsNode::ExportSpecifier {
+            local, exported, ..
+        } => {
+            walk_id!(*local);
+            walk_id!(*exported);
+        }
+
+        JsNode::TSTypeAnnotation {
+            type_annotation, ..
+        } => walk_id!(*type_annotation),
+        JsNode::TSModuleDeclaration { body, .. } => walk_opt_id!(body),
+
+        // Raw(Value) — fall back to the JSON walker. Used only for statements
+        // that carry leadingComments (rare). The recursion stops at this
+        // boundary; descendants of Raw are not pattern-matched on JsNode.
+        JsNode::Raw(value) => {
+            let sub = json_check_features_inner(value, store_subs, child_inside_function);
+            results.merge(&sub);
+        }
+    }
 }
 
 /// Check if a name is a rune identifier.
@@ -2787,6 +3209,7 @@ fn json_check_features_inner(
 /// than the rune check (which only checks Attribute, OnDirective, BindDirective).
 fn attribute_check_features(
     attr: &crate::ast::template::Attribute,
+    arena: &ParseArena,
     store_subs: &rustc_hash::FxHashSet<&str>,
 ) -> FragmentCheckResults {
     use crate::ast::template::{Attribute, AttributeValue, AttributeValuePart};
@@ -2794,7 +3217,7 @@ fn attribute_check_features(
     match attr {
         Attribute::Attribute(attr_node) => match &attr_node.value {
             AttributeValue::Expression(expr_tag) => {
-                let r = expression_check_features(&expr_tag.expression, store_subs);
+                let r = expression_check_features(&expr_tag.expression, arena, store_subs);
                 FragmentCheckResults {
                     has_await: r.has_await,
                     has_rune_reference: r.has_rune_reference,
@@ -2804,7 +3227,7 @@ fn attribute_check_features(
                 let mut results = FragmentCheckResults::default();
                 for part in parts {
                     if let AttributeValuePart::ExpressionTag(expr_tag) = part {
-                        let r = expression_check_features(&expr_tag.expression, store_subs);
+                        let r = expression_check_features(&expr_tag.expression, arena, store_subs);
                         results.merge_json(&r);
                         if results.all_found() {
                             return results;
@@ -2817,7 +3240,7 @@ fn attribute_check_features(
         },
         Attribute::OnDirective(dir) => {
             if let Some(ref expr) = dir.expression {
-                let r = expression_check_features(expr, store_subs);
+                let r = expression_check_features(expr, arena, store_subs);
                 FragmentCheckResults {
                     has_await: r.has_await,
                     has_rune_reference: r.has_rune_reference,
@@ -2827,7 +3250,7 @@ fn attribute_check_features(
             }
         }
         Attribute::BindDirective(dir) => {
-            let r = expression_check_features(&dir.expression, store_subs);
+            let r = expression_check_features(&dir.expression, arena, store_subs);
             FragmentCheckResults {
                 has_await: r.has_await,
                 has_rune_reference: r.has_rune_reference,
@@ -2835,7 +3258,7 @@ fn attribute_check_features(
         }
         Attribute::ClassDirective(dir) => {
             // Only await check applies here (rune check originally skipped this)
-            let r = expression_check_features(&dir.expression, store_subs);
+            let r = expression_check_features(&dir.expression, arena, store_subs);
             FragmentCheckResults {
                 has_await: r.has_await,
                 has_rune_reference: false,
@@ -2845,7 +3268,7 @@ fn attribute_check_features(
             // Only await check applies here (rune check originally skipped this)
             match &dir.value {
                 crate::ast::template::AttributeValue::Expression(expr_tag) => {
-                    let r = expression_check_features(&expr_tag.expression, store_subs);
+                    let r = expression_check_features(&expr_tag.expression, arena, store_subs);
                     FragmentCheckResults {
                         has_await: r.has_await,
                         has_rune_reference: false,
@@ -2857,7 +3280,8 @@ fn attribute_check_features(
                         if let crate::ast::template::AttributeValuePart::ExpressionTag(expr_tag) =
                             part
                         {
-                            let r = expression_check_features(&expr_tag.expression, store_subs);
+                            let r =
+                                expression_check_features(&expr_tag.expression, arena, store_subs);
                             results.has_await = results.has_await || r.has_await;
                             if results.has_await {
                                 return results;
@@ -2871,7 +3295,7 @@ fn attribute_check_features(
         }
         Attribute::SpreadAttribute(spread) => {
             // Only await check applies here (rune check originally skipped this)
-            let r = expression_check_features(&spread.expression, store_subs);
+            let r = expression_check_features(&spread.expression, arena, store_subs);
             FragmentCheckResults {
                 has_await: r.has_await,
                 has_rune_reference: false,


### PR DESCRIPTION
## Summary

- Replaces the `serde_json::Value` walker in `expression_check_features` (and the two direct script-level call sites in `analyze_component`) with a typed `JsNode` walker that descends the arena directly. Mirrors the same edge cases the JSON walker had: function boundaries for await, plus `LabeledStatement.label` / non-computed `MemberExpression.property` / non-computed `Property.key` skipped for the rune check.
- Threads `&ParseArena` through `fragment_check_features` / `node_check_features` / `attribute_check_features` so embedded template expressions are also walked typed.
- Keeps `json_check_features` as a fallback for `Expression::Value` (test-only) and `JsNode::Raw(Value)` (rare leadingComments nodes).

## Why

Closes the §"Updated next-PR target" item in `docs/perf-profile-2026-05-15.md`. The pre-PR profiling identified the `feature_detect` bucket (28.1% of analyze visitors / ~11.7% of total compile time) as the second-largest visitor hotspot, with the source already carrying `TODO: migrate json_check_features to JsNode walker` markers.

## Perf

Steady-state on the 3,637-file `compile_profile` workload (mean of 3 runs after warm-up):

| | Before | After | Δ |
|---|---|---|---|
| TOTAL | 457.1ms | 452.3ms | **-1.0%** |
| Phase 2 Analyze | 225.9ms | 216.8ms | -4.0% |
| Visitors (rest) | 193.5ms | 183.3ms | **-5.3%** |

Smaller than the doc's 5–8%-of-total projection. Likely reason: `Expression::as_json()` is cached, so the conversion that was previously paid in `feature_detect` is now paid in `MODULE_EXPORT_CHECK` (which still calls `as_json()` on the module script). A follow-up could migrate that too.

## Test plan

- [x] `cargo test --release` — all suites pass, no regressions
- [x] `cargo fmt` + `cargo clippy --release --all-features -- -D warnings` — clean
- [x] `./target/release/compile_profile` — 3 consecutive runs match the numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)