### PR TITLE
perf(analyze): borrow Raw declaration via Cow in ExportNamedDeclaration

### DIFF
--- a/docs/perf-profile-2026-05-15.md
+++ b/docs/perf-profile-2026-05-15.md
@@ -321,9 +321,18 @@ attribution is meaningful even with that overlap.
 
 In decreasing ROI:
 
-1. **`ExportNamedDeclaration` to typed pattern matching.** Single
+1. ~~**`ExportNamedDeclaration` to typed pattern matching.** Single
    function, one to_value() callsite, no downstream contract
-   change. Expected ~10–15ms cut.
+   change. Expected ~10–15ms cut.~~ **Plan invalidated by probe:**
+   declaration source breakdown on the same workload showed 1960
+   Raw, **0 typed**, 21 None — the `to_value()` arm is dead in
+   practice. The remaining cost is `.get(...)` introspection on
+   the cloned Raw Value, which cannot be migrated to typed pattern
+   matching without changing the parser to stop boxing
+   declarations as `JsNode::Raw(Value)`. The only quick win is
+   borrowing the Raw Value via `Cow` instead of `.clone()` — see
+   PR following this doc note. Net win: ~3ms, within measurement
+   noise but a clean unallocation.
 
 2. **`VariableDeclarator.binding.initial` source-span migration.**
    Larger PR — touches ~20 downstream consumers — but ~29ms is on
@@ -331,6 +340,12 @@ In decreasing ROI:
 
 3. **Raw fallback elimination.** Parse-phase: model leadingComments
    off-tree so statements stay typed. ~16ms but cross-phase change.
+   *Doubles as a prerequisite for any further "JsNode pattern
+   matching" migration of analyze visitors* — as the
+   ExportNamedDeclaration probe demonstrates, declarations and many
+   other statements currently come through as `Raw(Value)`, so
+   "migrate to typed" PRs that don't first address this are
+   migrating dead code.
 
 4. **`visit_children_typed` dispatch hot path.** Structural — no
    obvious low-effort win.

--- a/src/compiler/phases/2_analyze/visitors/export_named_declaration.rs
+++ b/src/compiler/phases/2_analyze/visitors/export_named_declaration.rs
@@ -563,13 +563,16 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
             }
         }
 
-        // For declaration-based operations, the parser stores declarations as Raw(Value),
-        // so we need to get the Value representation for declaration handling.
-        let decl_value: Option<Value> = declaration.map(|decl_id| {
+        // For declaration-based operations, the parser stores declarations as
+        // Raw(Value). Borrow the existing Value via `Cow::Borrowed` to avoid
+        // a deep `.clone()` per export (measured: 1960 of 1960 declarations
+        // are Raw across the runtime fixture set; the to_value() arm is dead
+        // in practice but kept defensively for any future typed paths).
+        let decl_value: Option<std::borrow::Cow<'_, Value>> = declaration.map(|decl_id| {
             let decl_node = arena.get_js_node(decl_id);
             match decl_node {
-                JsNode::Raw(v) => v.clone(),
-                other => other.to_value(),
+                JsNode::Raw(v) => std::borrow::Cow::Borrowed(v),
+                other => std::borrow::Cow::Owned(other.to_value()),
             }
         });
 


### PR DESCRIPTION
## Summary

- `ExportNamedDeclaration::visit_typed` previously materialised the export declaration into an owned `Value` by either `.clone()`-ing a `JsNode::Raw(Value)` or `.to_value()`-ing a typed JsNode.
- A throwaway probe on the 3,637-file `compile_profile` workload showed **1960 Raw / 0 typed / 21 None** declarations — the `to_value()` arm is dead in practice.
- Switched the owned `Value` to `Cow<'_, Value>` so the Raw path borrows the existing Value directly and skips the deep clone. Cow auto-derefs to `&Value`, so the downstream `.get(...)` introspection is unchanged.

## Why this matters (and what it doesn't)

The cost saved per call is ~1.5µs (3ms / 1960 calls on the fixture set) — within measurement noise on the full compile-time number, so this PR is a **clean unallocation**, not a perf win you can read off a microbenchmark.

The more important contribution is the **doc update invalidating the previously-recommended ExportNamedDeclaration migration plan**: declarations come through as Raw because the parser boxes statements that carry leadingComments as `JsNode::Raw(Value)`. Migrating analyze visitors to typed pattern matching is therefore gated on a parse-phase change to model leadingComments off-tree first.

## Test plan

- [x] `cargo test --release` — all 31 test suites pass (no regressions)
- [x] `cargo fmt` + `cargo clippy --release --all-features -- -D warnings` — clean
- [x] `./target/release/compile_profile` — no regression (full-compile numbers stable within ±5ms noise on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)