### PR TITLE
perf(arena): add Bump field to ParseArena (bumpalo Phase 0)

### DIFF
--- a/src/ast/arena.rs
+++ b/src/ast/arena.rs
@@ -20,6 +20,8 @@
 
 use std::cell::UnsafeCell;
 
+use bumpalo::Bump;
+
 use super::typed_expr::JsNode;
 
 /// Handle to a `JsNode` stored in the parse arena.
@@ -56,6 +58,11 @@ pub struct ParseArena {
     /// JsNode children for `Vec<JsNode>` fields (arguments, body, properties, etc.).
     /// Referenced by IdRange.
     js_children: UnsafeCell<Vec<JsNode>>,
+    /// Bump arena reserved for subsequent migration phases (see
+    /// `docs/bumpalo-migration-plan.md`). Currently unused — Phase 0 adds it
+    /// to ParseArena without changing public APIs so that Phase 1+ have a
+    /// place to allocate from.
+    bump: Bump,
 }
 
 // ParseArena is explicitly NOT Sync - it's single-threaded only.
@@ -65,7 +72,9 @@ pub struct ParseArena {
 // between threads is sound because no shared references exist when ownership
 // transfers, and all internal mutation happens through `&self` methods that
 // are documented as single-threaded (UnsafeCell is `!Sync`, so the type
-// remains non-shareable across threads).
+// remains non-shareable across threads). `bumpalo::Bump` is also `Send`
+// (the same constraint applies — single-threaded mutation only), so adding
+// it does not change Send safety.
 unsafe impl Send for ParseArena {}
 
 impl ParseArena {
@@ -75,7 +84,16 @@ impl ParseArena {
         Self {
             js_nodes: UnsafeCell::new(Vec::new()),
             js_children: UnsafeCell::new(Vec::new()),
+            bump: Bump::new(),
         }
+    }
+
+    /// Access the bump allocator used by Phase 1+ of the bumpalo migration.
+    /// Returns a shared reference; the `Bump`'s own allocation APIs take
+    /// `&self`, so callers can append without taking `&mut self`.
+    #[inline]
+    pub fn bump(&self) -> &Bump {
+        &self.bump
     }
 
     // -- JsNode allocation ---------------------------------------------------
@@ -243,10 +261,15 @@ impl Clone for ParseArena {
         // SAFETY: Single-threaded `Clone` — we read both Vecs and clone their
         // contents. No outstanding mutable borrow on `self` during clone (the
         // `&self` parameter prevents concurrent mutation per the borrow checker).
+        //
+        // The `bump` field gets a fresh empty `Bump` on clone (Bump isn't
+        // Clone). This matches the not-yet-used status — Phase 1+ will need
+        // to revisit if it ever stores user-visible state.
         unsafe {
             Self {
                 js_nodes: UnsafeCell::new((*self.js_nodes.get()).clone()),
                 js_children: UnsafeCell::new((*self.js_children.get()).clone()),
+                bump: Bump::new(),
             }
         }
     }


### PR DESCRIPTION
## Summary

Phase 0 of the bumpalo migration plan in [`docs/bumpalo-migration-plan.md`](../blob/main/docs/bumpalo-migration-plan.md). Adds a `bumpalo::Bump` field to `ParseArena` plus a `bump()` accessor so subsequent phases have an allocation target without touching public APIs.

- The `Bump` is allocated but **unread** — no behavior change, no perf change.
- Sets up the indirection-elimination work documented in Phase 1+ (Loc migration, then JsNode storage).
- `bumpalo` is already a transitive dependency (the OXC AST transforms in `phase3_transform/client/ast_state_transform.rs` use `oxc_allocator::Allocator` which wraps `bumpalo::Bump`).

## Why this matters

The current `ParseArena` is Vec-backed with `JsNodeId(u32)` indirection. OXC's `Allocator` (bumpalo under the hood) lets nodes hold direct `&'a JsNode<'a>` references, eliminating that indirection — roughly the +10-20% transform-side perf headroom flagged in the perf doc. Phase 0 is the no-risk preparation step that lets the cascading lifetime changes in later phases happen incrementally.

## Reviewer focus

1. **`unsafe impl Send for ParseArena`** is preserved. `bumpalo::Bump` is `Send` but not `Sync` — same constraint as the existing `UnsafeCell<Vec<JsNode>>`. Send safety unchanged.
2. **`Clone` returns a fresh empty `Bump`.** `Bump` isn't `Clone`. Since nothing currently allocates into the bump, this is fine. Phase 1+ must revisit if it ever stores Clone-relevant state.

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — all 31 test suites pass (no regressions)
- [x] `cargo fmt` + `cargo clippy --release --all-features -- -D warnings` — clean (pre-commit hook passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)