### PR TITLE
perf(transform): skip token+rune mapping generation when no preprocessor (-5% total / -17% Phase 3)

### DIFF
--- a/docs/perf-profile-2026-05-15.md
+++ b/docs/perf-profile-2026-05-15.md
@@ -508,6 +508,54 @@ Optimization targets, in order:
 The other Pre-frag candidates (state_init+ctx, add_state_xform,
 shadowed_state_names, etc.) sum to ~4.4ms and are NOT worth pursuing.
 
+## Result after #119 (2026-05-16, post-merge)
+
+Re-measured after landing the no-preprocessor skip
+(`options.sourcemap.is_none()` branch in `transform_component`):
+
+```
+Phase 1 (Parse):         12.36ms (  2.9%)
+Phase 2 (Analyze):      223.73ms ( 53.2%)
+  Resolve lazy:           6.25ms (  1.5%)
+  Ensure script (OXC):   28.76ms (  6.8%)
+  Visitors (rest):      188.72ms ( 44.9%)
+Phase 3 (Transform):    184.34ms ( 43.8%)  <-- was 223.04ms
+  visit_program:          1.25ms (  0.3%)
+  Script-text xform:     62.82ms ( 14.9%)
+  Template fragment:     55.60ms ( 13.2%)
+  Assembly (post-frag):  13.00ms (  3.1%)
+  CSS render:             9.95ms (  2.4%)
+  JS codegen:            19.45ms (  4.6%)
+  Pre-frag setup:        22.28ms (  5.3%)  <-- was 66.20ms
+TOTAL:                  420.44ms          <-- was 443.57ms (-5.2%)
+```
+
+Net wins from PR #119:
+- Total compile time: -23.13ms (-5.2%)
+- Phase 3: -38.70ms (-17.4%)
+- Pre-frag setup: -43.92ms (-66.3%)
+- Throughput: 1.9 → 2.1 MB/s in the smaller sample (run-to-run noise ±0.1 MB/s)
+
+Compatibility report: 3341/3341 in-scope tests pass.
+
+### Updated next-PR ranking
+
+With sourcemap-merge eliminated, the new top-3 buckets are:
+1. **Phase 2 Visitors (rest)** — 188.72ms (44.9%). Largest single bucket
+   overall. Most documented easy wins are exhausted by #112-#116; further
+   work needs a fresh sub-breakdown or samply-driven hot-visitor target.
+2. **Phase 3 Script-text xform** — 62.82ms (14.9%). The text-regex
+   transform of the instance script. AST migration is the documented
+   path (see `docs/text-to-ast-remaining-handover.md` and
+   `docs/script-transform-rune-runes-handover.md`). Multi-day scope.
+3. **Phase 3 Template fragment** — 55.60ms (13.2%). Already typed AST;
+   optimization is allocation reduction or hot-visitor inlining, needs
+   samply-level drill-down, not text-to-AST migration.
+
+The Bumpalo Phase 1 (Loc migration) plan stays viable but its expected
+win (~5%) is now smaller in absolute terms than what's still on the
+table in Visitors-rest and Script-text xform.
+
 ## Anti-priorities
 
 Skip these unless profiling proves otherwise:

--- a/src/compiler/phases/3_transform/mod.rs
+++ b/src/compiler/phases/3_transform/mod.rs
@@ -104,25 +104,34 @@ pub fn transform_component(
                 // $$props) that confuse the sequential source scanner in emit_raw_mapped,
                 // causing it to advance past user code and produce wrong source positions.
                 // Token-level mappings match by token name and handle this correctly.
-                let token_mappings = generate_token_mappings(&result.code, source);
-                let rune_mappings = generate_rune_mappings(&result.code, source);
-                let mut mappings = if options.sourcemap.is_some() {
+                //
+                // When NO preprocessor is present, codegen-tracked mappings are already
+                // precise. Generating token+rune scanners here only adds mappings at
+                // positions codegen didn't cover; the bulk are deduped away against
+                // existing codegen mappings (~44ms of token+rune scan + sort + dedup
+                // per 3637-file workload, measured 2026-05-16). Skip the scanners
+                // entirely in this branch.
+                let mappings = if options.sourcemap.is_some() {
                     // Preprocessor present: token mappings take priority
+                    let token_mappings = generate_token_mappings(&result.code, source);
+                    let rune_mappings = generate_rune_mappings(&result.code, source);
                     let mut m = token_mappings;
                     m.extend(rune_mappings);
                     m.extend(result.mappings);
+                    m.sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
+                    m.dedup_by(|a, b| a.gen_line == b.gen_line && a.gen_col == b.gen_col);
                     m
                 } else {
-                    // No preprocessor: codegen mappings take priority (more precise)
+                    // No preprocessor: codegen mappings are produced in emit order.
+                    // Run a sort + dedup defensively — Rust's TimSort is O(n) on
+                    // already-sorted input, so the cost is negligible vs. the
+                    // safety against any future sub-emitter that produces
+                    // out-of-order mappings.
                     let mut m = result.mappings;
-                    m.extend(token_mappings);
-                    m.extend(rune_mappings);
+                    m.sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
+                    m.dedup_by(|a, b| a.gen_line == b.gen_line && a.gen_col == b.gen_col);
                     m
                 };
-                // Sort and dedup
-                mappings
-                    .sort_by(|a, b| a.gen_line.cmp(&b.gen_line).then(a.gen_col.cmp(&b.gen_col)));
-                mappings.dedup_by(|a, b| a.gen_line == b.gen_line && a.gen_col == b.gen_col);
                 (result.code, mappings)
             } else {
                 (result.code, Vec::new())


### PR DESCRIPTION
## Summary

When `options.sourcemap.is_none()` (the common case — no preprocessor source map provided), the codegen-tracked mappings produced by `generate_with_sourcemap` are already precise. The token+rune scanners running afterward only add mappings at positions codegen didn't cover; most are deduped away against existing codegen mappings.

This PR skips the scanners and the merged sort+extend entirely when there's no preprocessor. The preprocessor-present branch is unchanged — token+rune mappings remain necessary there because the sequential codegen scanner gets confused by framework tokens (`$.prop`, `$$props`) injected by preprocessor-transformed script content.

Sort+dedup is kept defensively in the no-preprocessor branch; TimSort is O(n) on already-sorted codegen-emit-order input, so the cost is negligible vs. the safety against any future sub-emitter producing out-of-order mappings.

## Background

PR #118 added Phase 3 sub-phase instrumentation and identified a 65ms "Pre-frag setup" residual that turned out to be source-map post-processing in `transform_component`, not setup work in `transform_client_with_visitors`. Drilling further pinpointed `generate_token_mappings` + `generate_rune_mappings` + sort + dedup as the culprit (~44ms / 10% of total compile time on the 3637-file workload). Findings recorded in `docs/perf-profile-2026-05-15.md`.

## Result (3637 .svelte files, release, default options)

Before:
```
Phase 3 (Transform):    223.04ms ( 50.3%)
  Pre-frag setup:        66.20ms ( 14.9%)
TOTAL:                  443.57ms
```

After:
```
Phase 3 (Transform):    184.34ms ( 43.8%)
  Pre-frag setup:        22.28ms (  5.3%)
TOTAL:                  420.44ms
```

**-38.7ms Phase 3 (-17.4%), -23.1ms total (-5.2%), -43.9ms Pre-frag setup (-66.3%).**

## Test plan

- [x] `cargo test --release` — all suites pass
- [x] `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `pnpm run compatibility-report` — 3341/3341 in-scope tests pass (100% across all categories)
- [x] No regressions in JS codegen / sourcemap-dependent tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)