### PR TITLE
perf(analyze): migrate two Phase 2 JSON walks to typed JsNode

### DIFF
--- a/src/compiler/phases/2_analyze/mod.rs
+++ b/src/compiler/phases/2_analyze/mod.rs
@@ -898,44 +898,52 @@ fn validate_script_attributes(
 /// Corresponds to the `instance.ast.body.some(...)` check in Svelte's
 /// 2-analyze/index.js L498-510
 fn instance_has_legacy_patterns(ast: &Root) -> bool {
+    use crate::ast::typed_expr::JsNode;
     let Some(ref instance) = ast.instance else {
         return false;
     };
 
-    // TODO: migrate instance_has_legacy_patterns to JsNode
-    let script_ast = instance.content.as_json();
-    let Some(body) = script_ast.get("body").and_then(|v| v.as_array()) else {
+    let node = instance.content.as_node();
+    let JsNode::Program { body, .. } = node.as_ref() else {
         return false;
     };
 
-    for node in body {
-        match node.get("type").and_then(|v| v.as_str()) {
-            Some("LabeledStatement") => return true,
-            Some("ExportNamedDeclaration") => {
+    let arena = &ast.arena;
+    for stmt in arena.get_js_children(*body) {
+        // Fast typed dispatch
+        match stmt {
+            JsNode::LabeledStatement { .. } => return true,
+            JsNode::ExportNamedDeclaration {
+                declaration,
+                specifiers,
+                ..
+            } => {
                 // Check: export let x = ...
-                if let Some(decl) = node.get("declaration").filter(|d| !d.is_null())
-                    && decl.get("type").and_then(|v| v.as_str()) == Some("VariableDeclaration")
-                    && decl.get("kind").and_then(|v| v.as_str()) == Some("let")
-                {
-                    return true;
+                if let Some(decl_id) = declaration {
+                    let decl = arena.get_js_node(*decl_id);
+                    if matches_let_variable_declaration(decl) {
+                        return true;
+                    }
                 }
                 // Check: export { x } where x is declared with let
-                if let Some(specifiers) = node.get("specifiers").and_then(|v| v.as_array()) {
-                    for spec in specifiers {
-                        if let Some(name) = spec
-                            .get("local")
-                            .filter(|l| {
-                                l.get("type").and_then(|v| v.as_str()) == Some("Identifier")
-                            })
-                            .and_then(|l| l.get("name"))
-                            .and_then(|v| v.as_str())
-                            && body_has_let_declaration(body, name)
-                        {
-                            return true;
-                        }
+                for spec in arena.get_js_children(*specifiers) {
+                    if let Some(name) = export_specifier_local_name(spec, arena)
+                        && body_has_let_declaration_typed(*body, name, arena)
+                    {
+                        return true;
                     }
                 }
             }
+            // Raw fallback: nodes that carry leadingComments arrive as Raw(Value)
+            JsNode::Raw(value) => match value.get("type").and_then(|v| v.as_str()) {
+                Some("LabeledStatement") => return true,
+                Some("ExportNamedDeclaration")
+                    if export_named_raw_has_legacy_let(value, *body, arena) =>
+                {
+                    return true;
+                }
+                _ => {}
+            },
             _ => {}
         }
     }
@@ -943,26 +951,118 @@ fn instance_has_legacy_patterns(ast: &Root) -> bool {
     false
 }
 
-/// Check if the body contains a `let` declaration for the given name.
-fn body_has_let_declaration(body: &[serde_json::Value], name: &str) -> bool {
-    for node in body {
-        if node.get("type").and_then(|v| v.as_str()) != Some("VariableDeclaration") {
-            continue;
+/// True if `node` is a `let` `VariableDeclaration` (typed or Raw).
+fn matches_let_variable_declaration(node: &crate::ast::typed_expr::JsNode) -> bool {
+    use crate::ast::typed_expr::JsNode;
+    match node {
+        JsNode::VariableDeclaration { kind, .. } => kind == "let",
+        JsNode::Raw(value) => {
+            value.get("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
+                && value.get("kind").and_then(|k| k.as_str()) == Some("let")
         }
-        if node.get("kind").and_then(|v| v.as_str()) != Some("let") {
-            continue;
+        _ => false,
+    }
+}
+
+/// Get the local identifier name of an `ExportSpecifier` (typed or Raw).
+fn export_specifier_local_name<'a>(
+    spec: &'a crate::ast::typed_expr::JsNode,
+    arena: &'a crate::ast::arena::ParseArena,
+) -> Option<&'a str> {
+    use crate::ast::typed_expr::JsNode;
+    match spec {
+        JsNode::ExportSpecifier { local, .. } => match arena.get_js_node(*local) {
+            JsNode::Identifier { name, .. } => Some(name.as_str()),
+            _ => None,
+        },
+        JsNode::Raw(value) => value
+            .get("local")
+            .filter(|l| l.get("type").and_then(|t| t.as_str()) == Some("Identifier"))
+            .and_then(|l| l.get("name"))
+            .and_then(|n| n.as_str()),
+        _ => None,
+    }
+}
+
+/// Raw-variant handler for `ExportNamedDeclaration`. Returns true if it is
+/// either `export let ...` or `export { x }` where `x` is declared with `let`
+/// in `body`.
+fn export_named_raw_has_legacy_let(
+    value: &serde_json::Value,
+    body: crate::ast::arena::IdRange,
+    arena: &crate::ast::arena::ParseArena,
+) -> bool {
+    if let Some(decl) = value.get("declaration").filter(|d| !d.is_null())
+        && decl.get("type").and_then(|v| v.as_str()) == Some("VariableDeclaration")
+        && decl.get("kind").and_then(|v| v.as_str()) == Some("let")
+    {
+        return true;
+    }
+    let Some(specifiers) = value.get("specifiers").and_then(|s| s.as_array()) else {
+        return false;
+    };
+    for spec in specifiers {
+        if let Some(name) = spec
+            .get("local")
+            .filter(|l| l.get("type").and_then(|v| v.as_str()) == Some("Identifier"))
+            .and_then(|l| l.get("name"))
+            .and_then(|v| v.as_str())
+            && body_has_let_declaration_typed(body, name, arena)
+        {
+            return true;
         }
-        if let Some(decls) = node.get("declarations").and_then(|v| v.as_array()) {
-            for decl in decls {
-                if decl
-                    .get("id")
-                    .and_then(|id| id.get("name"))
-                    .and_then(|v| v.as_str())
-                    == Some(name)
-                {
-                    return true;
+    }
+    false
+}
+
+/// Check if `body` contains a `let` declaration for the given name.
+fn body_has_let_declaration_typed(
+    body: crate::ast::arena::IdRange,
+    name: &str,
+    arena: &crate::ast::arena::ParseArena,
+) -> bool {
+    use crate::ast::typed_expr::JsNode;
+    for node in arena.get_js_children(body) {
+        match node {
+            JsNode::VariableDeclaration {
+                kind, declarations, ..
+            } if kind == "let" => {
+                for decl in arena.get_js_children(*declarations) {
+                    if let JsNode::VariableDeclarator { id, .. } = decl
+                        && let JsNode::Identifier { name: id_name, .. } = arena.get_js_node(*id)
+                        && id_name == name
+                    {
+                        return true;
+                    }
+                    // Raw fallback for declarators with leadingComments
+                    if let JsNode::Raw(v) = decl
+                        && v.get("id")
+                            .and_then(|id| id.get("name"))
+                            .and_then(|n| n.as_str())
+                            == Some(name)
+                    {
+                        return true;
+                    }
                 }
             }
+            JsNode::Raw(v) => {
+                if v.get("type").and_then(|t| t.as_str()) == Some("VariableDeclaration")
+                    && v.get("kind").and_then(|k| k.as_str()) == Some("let")
+                    && let Some(decls) = v.get("declarations").and_then(|d| d.as_array())
+                {
+                    for decl in decls {
+                        if decl
+                            .get("id")
+                            .and_then(|id| id.get("name"))
+                            .and_then(|n| n.as_str())
+                            == Some(name)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
     }
     false

--- a/src/compiler/phases/2_analyze/mod.rs
+++ b/src/compiler/phases/2_analyze/mod.rs
@@ -383,70 +383,63 @@ pub fn analyze_component(
     // This mirrors the official Svelte compiler's index.js post-walk checks.
     // Must run AFTER analyze_template so that analysis.template.snippets is populated.
     // Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/index.js
-    // TODO: migrate post-analysis module export checks to JsNode
     if let Some(ref module) = ast.module {
-        let module_json = module.content.as_json();
-        if let Some(body) = module_json.get("body").and_then(|b| b.as_array()) {
-            for node in body {
-                let node_type = node.get("type").and_then(|t| t.as_str());
-                if node_type != Some("ExportNamedDeclaration") {
-                    continue;
-                }
-                // Only check `export { x, y }` (specifiers), not `export function f() {}` (declaration)
-                let has_declaration = node.get("declaration").is_some_and(|d| !d.is_null());
-                if has_declaration {
-                    continue;
-                }
-                // Skip re-exports: `export { x } from 'module'`
-                if node.get("source").is_some_and(|s| !s.is_null()) {
-                    continue;
-                }
-                let Some(specifiers) = node.get("specifiers").and_then(|s| s.as_array()) else {
-                    continue;
-                };
-                for specifier in specifiers {
-                    let Some(local) = specifier.get("local") else {
-                        continue;
-                    };
-                    if local.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
-                        continue;
-                    }
-                    let Some(name) = local.get("name").and_then(|n| n.as_str()) else {
-                        continue;
-                    };
-                    if name.is_empty() {
-                        continue;
-                    }
-                    // Check if the binding exists in the module scope.
-                    // This matches the official compiler's check:
-                    //   const binding = analysis.module.scope.get(name);
-                    //   if (!binding) { ... }
-                    //
-                    // Note: analysis.root.scope.declarations contains ALL bindings
-                    // from ALL scopes (merged by the scope builder), so we cannot
-                    // simply check if the name exists there. Instead, we check:
-                    // 1. The binding's scope_index is 0 (truly in module scope), OR
-                    // 2. The name is a snippet that was explicitly hoisted to module scope.
-                    let is_in_module_scope =
-                        if let Some(&binding_idx) = analysis.root.scope.declarations.get(name) {
-                            let binding = &analysis.root.bindings[binding_idx];
-                            // scope_index 0 = module scope (truly module-level)
-                            binding.scope_index == 0
-                                // Also allow hoisted snippets (they have non-zero scope_index
-                                // but were explicitly promoted to module scope)
-                                || analysis.template.hoisted_snippets.contains(name)
-                        } else {
-                            false
+        use crate::ast::typed_expr::JsNode;
+        let module_node = module.content.as_node();
+        if let JsNode::Program { body, .. } = module_node.as_ref() {
+            let arena = &ast.arena;
+            for stmt in arena.get_js_children(*body) {
+                // Typed ExportNamedDeclaration with no declaration AND no source
+                if let JsNode::ExportNamedDeclaration {
+                    declaration: None,
+                    specifiers,
+                    source: None,
+                    ..
+                } = stmt
+                {
+                    for specifier in arena.get_js_children(*specifiers) {
+                        let Some(name) = export_specifier_local_name(specifier, arena) else {
+                            continue;
                         };
-
-                    if !is_in_module_scope {
-                        // Not in module scope - check if it's a snippet
-                        if analysis.template.snippets.contains(name) {
+                        if name.is_empty() {
+                            continue;
+                        }
+                        if !is_in_module_scope_or_hoisted(name, &analysis) {
+                            // Not in module scope - check if it's a snippet
+                            if analysis.template.snippets.contains(name) {
+                                return Err(errors::snippet_invalid_export());
+                            }
+                            // If not a snippet and not in any scope at all, export_undefined
+                            // is already raised by the export_named_declaration visitor.
+                        }
+                    }
+                    continue;
+                }
+                // Raw fallback (statements with leadingComments)
+                if let JsNode::Raw(value) = stmt
+                    && value.get("type").and_then(|t| t.as_str()) == Some("ExportNamedDeclaration")
+                    && value.get("declaration").is_none_or(|d| d.is_null())
+                    && value.get("source").is_none_or(|s| s.is_null())
+                    && let Some(specifiers) = value.get("specifiers").and_then(|s| s.as_array())
+                {
+                    for specifier in specifiers {
+                        let Some(local) = specifier.get("local") else {
+                            continue;
+                        };
+                        if local.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+                            continue;
+                        }
+                        let Some(name) = local.get("name").and_then(|n| n.as_str()) else {
+                            continue;
+                        };
+                        if name.is_empty() {
+                            continue;
+                        }
+                        if !is_in_module_scope_or_hoisted(name, &analysis)
+                            && analysis.template.snippets.contains(name)
+                        {
                             return Err(errors::snippet_invalid_export());
                         }
-                        // If not a snippet and not in any scope at all, export_undefined
-                        // is already raised by the export_named_declaration visitor.
-                        // We only need to handle the snippet case here.
                     }
                 }
             }
@@ -961,6 +954,18 @@ fn matches_let_variable_declaration(node: &crate::ast::typed_expr::JsNode) -> bo
                 && value.get("kind").and_then(|k| k.as_str()) == Some("let")
         }
         _ => false,
+    }
+}
+
+/// Check if `name` resolves to a binding in the module scope (or is a
+/// hoisted snippet promoted to module scope). Used by the post-analysis
+/// module export check.
+fn is_in_module_scope_or_hoisted(name: &str, analysis: &ComponentAnalysis) -> bool {
+    if let Some(&binding_idx) = analysis.root.scope.declarations.get(name) {
+        let binding = &analysis.root.bindings[binding_idx];
+        binding.scope_index == 0 || analysis.template.hoisted_snippets.contains(name)
+    } else {
+        false
     }
 }
 


### PR DESCRIPTION
## Summary

Migrate two Phase 2 JSON-walk sites to typed `JsNode` dispatch, eliminating their full-`Program`-tree `Value` materializations:

### 1. `instance_has_legacy_patterns` (`mod.rs:900`)

Walks the instance script body looking for `LabeledStatement` (legacy `$:` reactive) or `ExportNamedDeclaration` with `let` declarations. Gated on "wannabe-runes" detection in non-runes-mode components.

### 2. Post-analysis module export check (`mod.rs:386`)

Walks the module script body looking for `ExportNamedDeclaration` with no inline declaration and no re-export source (i.e., `export { x }` style), then errors if any specifier names a snippet (`errors::snippet_invalid_export`). Gated on `if let Some(ref module) = ast.module` — only fires for components with `<script context="module">` or `.svelte.js`/`.svelte.ts` module files.

### Shared helpers

Five small helpers added, reused across both migrations:
- `matches_let_variable_declaration` — typed/Raw `let VariableDeclaration` check
- `export_specifier_local_name` — local Identifier name from ExportSpecifier (typed/Raw)
- `export_named_raw_has_legacy_let` — Raw fallback for the legacy-pattern check
- `body_has_let_declaration_typed` — typed equivalent of `body_has_let_declaration`
- `is_in_module_scope_or_hoisted` — extracts the module-scope binding check

Both branches preserve the existing semantics; tests pass unchanged.

## Result (3637 .svelte files, release, default options)

Three consecutive runs after warmup:

```
Phase 2 (Analyze):      ~211ms  (was ~223ms baseline post-#119)
TOTAL:                  ~402ms  (was ~420ms baseline post-#119)
```

Net: **-12ms Phase 2 (-5.4%), -18ms total compile time (-4.3%)**.

## Test plan

- [x] `cargo test --release` — all suites pass
- [x] `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] CI green (9/9 checks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)