### PR TITLE
perf(analyze): use to_json_string() for variable_declarator binding.initial fallback

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -1517,8 +1517,8 @@ fn process_props_object_pattern_typed(
                         }
                     }
                 } else {
-                    binding.initial = extract_literal_string_typed(init)
-                        .or_else(|| Some(init.to_value().to_string()));
+                    binding.initial =
+                        extract_literal_string_typed(init).or_else(|| Some(init.to_json_string()));
                     binding.initial_node_type = Some(init.type_str().to_string());
                     if binding.initial_node_type.as_deref() == Some("Identifier")
                         && let JsNode::Identifier { name, .. } = init


### PR DESCRIPTION
## Summary

Replace `init.to_value().to_string()` with `init.to_json_string()` at the non-\$bindable fallback site in \`variable_declarator\`. Mirrors the optimization landed in PR #116 — skips the intermediate \`serde_json::Value\` allocation by serializing directly to a String.

The other site in this function uses \`format!(\"{:?}\", arg.to_value())\` which produces *pretty-JSON* (whereas \`to_json_string()\` is *compact-JSON*); keeping that one as-is to avoid changing the persisted string representation downstream callers may compare against.

## Test plan

- [x] \`cargo test --release\` — all suites pass
- [x] \`cargo fmt && cargo clippy --all-targets --all-features -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)