### PR TITLE
perf(analyze): typed-walk bind:get/set expressions in bind_directive

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/bind_directive.rs
+++ b/src/compiler/phases/2_analyze/visitors/bind_directive.rs
@@ -173,9 +173,9 @@ fn visit_common(
             let expressions = node.expressions();
             let arena = context.parse_arena;
             for expr in arena.get_js_children(expressions) {
-                // Walk the expression to track mutations (e.g., assignments in setters)
-                let expr_value = expr.to_value();
-                super::script::walk_js_node(&expr_value, context)?;
+                // Walk the expression to track mutations (e.g., assignments in setters).
+                // Use typed dispatch to skip the `to_value()` materialization.
+                super::script::walk_js_node_typed(expr, context)?;
             }
         }
 


### PR DESCRIPTION
## Summary

Replace \`expr.to_value()\` + \`walk_js_node\` with \`walk_js_node_typed\` for the getter/setter walk in the \`bind:directive\` visitor (the \`bind:checked={()=>check, (v)=>{ check = v }}\` syntax). Skips the per-expression Value materialization on every \`bind:\` directive with a SequenceExpression target.

## Test plan

- [x] \`cargo test --release\` — all suites pass
- [x] \`cargo fmt && cargo clippy --all-targets --all-features -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)