### PR TITLE
perf(analyze): use get_type_str() in await_expression crosses_function_boundary

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/await_expression.rs
+++ b/src/compiler/phases/2_analyze/visitors/await_expression.rs
@@ -78,12 +78,16 @@ pub fn visit(node: &Value, context: &mut VisitorContext) -> Result<(), AnalysisE
 /// short-circuit in the official `AwaitExpression.js`.
 fn crosses_function_boundary(js_path: &[JsPathEntry]) -> bool {
     for entry in js_path.iter().rev() {
-        let parent_type = entry.as_value().get("type").and_then(|t| t.as_str());
-        match parent_type {
+        // Use the cheap typed type-string lookup — avoids materializing
+        // the entire JsNode subtree into a Value just to read its `type`
+        // field for ancestors above the await expression.
+        if matches!(
+            entry.get_type_str(),
             Some("ArrowFunctionExpression")
-            | Some("FunctionExpression")
-            | Some("FunctionDeclaration") => return true,
-            _ => {}
+                | Some("FunctionExpression")
+                | Some("FunctionDeclaration")
+        ) {
+            return true;
         }
     }
     false


### PR DESCRIPTION
## Summary

Replace \`entry.as_value().get(\"type\").and_then(|t| t.as_str())\` with the cheap typed \`entry.get_type_str()\` helper.

The original code in \`crosses_function_boundary\` triggered a full Value materialization of every \`JsPathEntry\` on the path above the await expression, just to read each ancestor's \`type\` field. \`get_type_str()\` (already defined in \`visitors/mod.rs\`) reads the type directly from the typed JsNode variant without any allocation.

Fires once per await expression — every \`{#await}\` block, every \`await\` inside an instance script, and every \`await\` in a template expression tag.

## Test plan

- [x] \`cargo test --release\` — all suites pass
- [x] \`cargo fmt && cargo clippy --all-targets --all-features -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)