### PR TITLE
fix(napi): align preprocess() with upstream Svelte contract

### DIFF
--- a/npm/vite-plugin-svelte-native/index.d.ts
+++ b/npm/vite-plugin-svelte-native/index.d.ts
@@ -1,18 +1,133 @@
 // Public surface of the rsvelte NAPI binding. Mirrors the `#[napi]` exports in
-// `src/napi.rs`. All options/results are loosely typed via `unknown`/records to
-// keep this file shim-friendly — the JS shim above can layer richer types over
-// the boundary where they're actually consumed.
+// `src/napi.rs`. The structural types below match the upstream Svelte
+// (`svelte/compiler`) names where they map cleanly, so consumers — including
+// the `@rsvelte/vite-plugin-svelte` fork — can stay drop-in compatible with
+// the official surface.
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/**
+ * Component compile options. Loosely follows `svelte/compiler#CompileOptions`.
+ */
+export interface CompileOptions {
+	/** Enable dev mode (instrumentation, warnings, etc.). */
+	dev?: boolean;
+	/** Generate client- or server-side code, or skip codegen. */
+	generate?: 'client' | 'server' | false;
+	/** Source filename. Used in source maps and error frames. */
+	filename?: string;
+	/** Project root, used to compute relative source-map paths. */
+	rootDir?: string;
+	/** Component identifier hint. */
+	name?: string;
+	/** Compile as a custom element. */
+	customElement?: boolean;
+	/** Generate `accessors`. */
+	accessors?: boolean;
+	/** HTML namespace. */
+	namespace?: 'html' | 'svg' | 'mathml';
+	/** Hint that bindings are immutable. */
+	immutable?: boolean;
+	/** Output CSS injected into the bundle or as an external asset. */
+	css?: 'injected' | 'external';
+	/** Custom hash function for CSS scoping — currently honored as a string-mapper. */
+	cssHash?: (args: {
+		hash: (input: string) => string;
+		css: string;
+		name: string;
+		filename: string | undefined;
+	}) => string;
+	/** Preserve HTML comments in output. */
+	preserveComments?: boolean;
+	/** Preserve whitespace in the template. */
+	preserveWhitespace?: boolean;
+	/** Force runes mode (`true`), legacy (`false`), or auto-detect (`undefined`). */
+	runes?: boolean;
+	/** Disclose the compiler version in the output banner. */
+	discloseVersion?: boolean;
+	/** Source-map options (forwarded through magic-string). */
+	sourcemap?: object | string;
+	/** Output JS filename for `file` in the JS source map. */
+	outputFilename?: string;
+	/** Output CSS filename for `file` in the CSS source map. */
+	cssOutputFilename?: string;
+	/** Enable HMR-friendly output (used by `@rsvelte/vite-plugin-svelte`). */
+	hmr?: boolean;
+	/** Emit the modern AST shape (default). */
+	modernAst?: boolean;
+	/** Filter compiler warnings. */
+	warningFilter?: (warning: Warning) => boolean;
+}
+
+/**
+ * Module compile options. Subset of {@link CompileOptions} that applies to
+ * `.svelte.js` / `.svelte.ts` modules.
+ */
+export interface ModuleCompileOptions {
+	dev?: boolean;
+	generate?: 'client' | 'server' | false;
+	filename?: string;
+	rootDir?: string;
+	warningFilter?: (warning: Warning) => boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+export interface SourcePosition {
+	line: number;
+	column: number;
+	character: number;
+}
+
+/** Compiler warning matching `svelte/compiler#Warning`. */
+export interface Warning {
+	code: string;
+	message: string;
+	filename?: string;
+	start?: SourcePosition;
+	end?: SourcePosition;
+	position?: [number, number];
+	frame?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Compile result
+// ---------------------------------------------------------------------------
+
+export interface CompileResultJs {
+	code: string;
+	/** A standard SourceMap v3 JSON object. */
+	map: unknown;
+}
+
+export interface CompileResultCss {
+	code: string;
+	/** A standard SourceMap v3 JSON object. */
+	map: unknown;
+	hasGlobal: boolean;
+}
 
 export interface CompileResult {
-	js: { code: string; map: unknown };
-	css: { code: string; map: unknown; hasGlobal: boolean } | null;
-	warnings: unknown[];
-	metadata: Record<string, unknown>;
+	js: CompileResultJs;
+	css: CompileResultCss | null;
+	warnings: Warning[];
+	metadata: { runes?: boolean } & Record<string, unknown>;
 	ast: unknown;
 }
 
-export function compile(source: string, options?: Record<string, unknown>): CompileResult;
-export function compileModule(source: string, options?: Record<string, unknown>): CompileResult;
+export function compile(source: string, options?: CompileOptions): CompileResult;
+export function compileModule(
+	source: string,
+	options?: ModuleCompileOptions,
+): CompileResult;
+
+// ---------------------------------------------------------------------------
+// svelte2tsx
+// ---------------------------------------------------------------------------
 
 export interface Svelte2TsxResult {
 	code: string;
@@ -20,7 +135,14 @@ export interface Svelte2TsxResult {
 	exportedNames: { props: string[]; all: string[] };
 	events: Record<string, unknown>;
 }
-export function svelte2tsx(source: string, options?: Record<string, unknown>): Svelte2TsxResult;
+export function svelte2tsx(
+	source: string,
+	options?: Record<string, unknown>,
+): Svelte2TsxResult;
+
+// ---------------------------------------------------------------------------
+// HMR / resolver
+// ---------------------------------------------------------------------------
 
 export interface HmrDiff {
 	change: 'hot-update' | 'full-reload' | 'unchanged';
@@ -35,22 +157,53 @@ export function resolveId(
 	options?: Record<string, unknown>,
 ): string | null;
 
-export interface PreprocessGroup {
-	markup?: (input: { content: string; filename?: string }) => unknown;
-	script?: (input: {
-		content: string;
-		filename?: string;
-		attributes: Record<string, unknown>;
-	}) => unknown;
-	style?: (input: {
-		content: string;
-		filename?: string;
-		attributes: Record<string, unknown>;
-	}) => unknown;
+// ---------------------------------------------------------------------------
+// Preprocess
+// ---------------------------------------------------------------------------
+
+/** Options the preprocessor pipeline forwards to each callback. */
+export interface MarkupPreprocessorOptions {
+	content: string;
+	filename?: string;
 }
 
+export interface PreprocessorOptions {
+	content: string;
+	filename?: string;
+	attributes: Record<string, string | boolean>;
+	markup?: string;
+}
+
+/** Result returned by a preprocessor callback. `undefined`/`null` is a no-op. */
+export interface Processed {
+	code: string;
+	map?: string | object;
+	dependencies?: string[];
+	attributes?: Record<string, string | boolean>;
+	toString?: () => string;
+}
+
+export type MarkupPreprocessor = (
+	options: MarkupPreprocessorOptions,
+) => Processed | void | null | undefined | Promise<Processed | void | null | undefined>;
+
+export type Preprocessor = (
+	options: PreprocessorOptions,
+) => Processed | void | null | undefined | Promise<Processed | void | null | undefined>;
+
+export interface PreprocessorGroup {
+	name?: string;
+	markup?: MarkupPreprocessor;
+	script?: Preprocessor;
+	style?: Preprocessor;
+}
+
+/**
+ * Run the preprocessor pipeline. Accepts a single group or an array of
+ * groups, matching the upstream `svelte/compiler#preprocess` contract.
+ */
 export function preprocess(
 	source: string,
-	groups: PreprocessGroup | PreprocessGroup[],
+	groups: PreprocessorGroup | PreprocessorGroup[],
 	options?: { filename?: string },
-): Promise<{ code: string; map?: unknown; dependencies?: string[] }>;
+): Promise<Processed>;

--- a/src/compiler/phases/2_analyze/visitors/await_expression.rs
+++ b/src/compiler/phases/2_analyze/visitors/await_expression.rs
@@ -78,12 +78,16 @@ pub fn visit(node: &Value, context: &mut VisitorContext) -> Result<(), AnalysisE
 /// short-circuit in the official `AwaitExpression.js`.
 fn crosses_function_boundary(js_path: &[JsPathEntry]) -> bool {
     for entry in js_path.iter().rev() {
-        let parent_type = entry.as_value().get("type").and_then(|t| t.as_str());
-        match parent_type {
+        // Use the cheap typed type-string lookup — avoids materializing
+        // the entire JsNode subtree into a Value just to read its `type`
+        // field for ancestors above the await expression.
+        if matches!(
+            entry.get_type_str(),
             Some("ArrowFunctionExpression")
-            | Some("FunctionExpression")
-            | Some("FunctionDeclaration") => return true,
-            _ => {}
+                | Some("FunctionExpression")
+                | Some("FunctionDeclaration")
+        ) {
+            return true;
         }
     }
     false

--- a/src/compiler/preprocess/types.rs
+++ b/src/compiler/preprocess/types.rs
@@ -141,15 +141,19 @@ pub struct Source {
 
 /// Simplified decoded source map structure.
 ///
-/// This matches the JavaScript DecodedSourceMap format.
+/// This matches the JavaScript DecodedSourceMap format. JSON-side keys
+/// follow the SourceMap v3 spec (`sourcesContent`, `sourceRoot`), so
+/// user-supplied maps round-trip correctly.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SimpleDecodedMap {
     pub version: Option<u32>,
     pub file: Option<String>,
     pub sources: Vec<String>,
+    #[serde(rename = "sourcesContent")]
     pub sources_content: Option<Vec<Option<String>>>,
     pub names: Vec<String>,
     pub mappings: Vec<Vec<Vec<i64>>>,
+    #[serde(rename = "sourceRoot")]
     pub source_root: Option<String>,
 }
 

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -453,29 +453,49 @@ pub fn napi_resolve_id(importer: Option<String>, specifier: String) -> napi::Res
     }
 }
 
+/// Options accepted by `preprocess()`. Mirrors the upstream Svelte
+/// signature `preprocess(source, preprocessors, options?: { filename? })`.
+#[napi(object)]
+pub struct PreprocessOptions {
+    pub filename: Option<String>,
+}
+
 /// Run rsvelte's preprocessor pipeline, bridging JS preprocessor
 /// callbacks through `napi::threadsafe_function::ThreadsafeFunction`.
 ///
-/// `preprocessors` is an array of `{ name?, markup?, script?, style? }`
-/// JS objects matching `svelte/preprocess`'s `PreprocessorGroup`. Each
-/// callback may be sync or `async` and may return either a
-/// `{ code, map?, dependencies?, attributes? }` object or
-/// `undefined`/`null` to skip the file. Callbacks are invoked on the
-/// JS thread via N-API's ThreadsafeFunction machinery — the heavy
-/// lifting (tag extraction, source-map chaining) stays in Rust.
+/// `preprocessors` is a `PreprocessorGroup | PreprocessorGroup[]` —
+/// each group is a `{ name?, markup?, script?, style? }` object matching
+/// `svelte/preprocess`'s contract. Callbacks may be sync or `async` and
+/// may return either a `{ code, map?, dependencies?, attributes? }`
+/// object or `undefined`/`null` to skip the file. Callbacks are invoked
+/// on the JS thread via N-API's ThreadsafeFunction machinery — the
+/// heavy lifting (tag extraction, source-map chaining) stays in Rust.
 ///
 /// Shape mirrors `svelte/preprocess`: `{ code, map, dependencies }`.
 #[napi(js_name = "preprocess")]
 pub fn napi_preprocess(
     env: Env,
     source: String,
-    preprocessors: Vec<napi::bindgen_prelude::Object>,
-    filename: Option<String>,
+    preprocessors: napi::bindgen_prelude::Either<
+        Vec<napi::bindgen_prelude::Object>,
+        napi::bindgen_prelude::Object,
+    >,
+    options: Option<PreprocessOptions>,
 ) -> napi::Result<napi::JsObject> {
+    use napi::bindgen_prelude::Either;
+    // Accept both `PreprocessorGroup[]` and `PreprocessorGroup` — matches
+    // the upstream Svelte API which allows a single group or an array.
+    // We probe `Vec` first since JS arrays satisfy `typeof === "object"`
+    // and would otherwise match the single-group branch.
+    let groups: Vec<napi::bindgen_prelude::Object> = match preprocessors {
+        Either::A(list) => list,
+        Either::B(single) => vec![single],
+    };
     // Extract ThreadsafeFunctions synchronously so the JS-bound `Object`
     // values never cross the await boundary (they're not Send).
-    let extracted = preprocess_bridge::extract_groups(preprocessors)?;
+    let extracted = preprocess_bridge::extract_groups(groups)?;
     let rust_groups = preprocess_bridge::build_groups(extracted);
+    let filename = options.and_then(|o| o.filename);
 
     env.execute_tokio_future(
         async move {
@@ -498,7 +518,12 @@ mod preprocess_bridge {
     use rustc_hash::FxHashMap;
     use serde_json::Value;
 
-    pub(super) type Tsfn = ThreadsafeFunction<Value, ErrorStrategy::CalleeHandled>;
+    // Fatal strategy: the user-supplied JS callback receives the options
+    // object as its sole argument — matching the upstream Svelte
+    // preprocessor contract `(opts) => Processed | undefined`. Using
+    // CalleeHandled would inject an `err` as the first argument, breaking
+    // every preprocessor that destructures `{ content, filename }`.
+    pub(super) type Tsfn = ThreadsafeFunction<Value, ErrorStrategy::Fatal>;
 
     pub(super) struct Extracted {
         pub name: Option<String>,
@@ -566,17 +591,32 @@ mod preprocess_bridge {
     }
 
     async fn await_tsfn(tsfn: &Tsfn, arg: Value) -> Result<Value, PreprocessError> {
-        // Callbacks are expected to return a Promise (matching the JS
-        // `(opts) => Promise<Processed | void>` contract). Sync callers
-        // should `async (opts) => …` — `Promise.resolve(...)` is not
-        // injected on the Rust side.
-        let promise: Promise<Value> = tsfn
-            .call_async(Ok(arg))
+        // The upstream Svelte preprocessor contract allows the callback to
+        // return `Processed | Promise<Processed> | undefined | null`,
+        // sync or async. The outer `Option<Promise<…>>` handles the case
+        // where the JS callback returns `undefined`/`null` directly (sync
+        // no-op); the inner `Option<Value>` handles the case where an
+        // async callback resolves to `undefined`/`null` (async no-op).
+        // Sync object returns fall through to the raw `Value` path.
+        match tsfn
+            .call_async::<Option<Promise<Option<Value>>>>(arg.clone())
             .await
-            .map_err(|e| PreprocessError::Other(format!("{e}")))?;
-        promise
-            .await
-            .map_err(|e| PreprocessError::Other(format!("{e}")))
+        {
+            Ok(Some(promise)) => match promise.await {
+                Ok(Some(v)) => Ok(v),
+                Ok(None) => Ok(Value::Null),
+                Err(e) => Err(PreprocessError::Other(format!("{e}"))),
+            },
+            Ok(None) => Ok(Value::Null),
+            Err(_) => {
+                // Not a Promise — accept a sync object/undefined return.
+                match tsfn.call_async::<Option<Value>>(arg).await {
+                    Ok(Some(v)) => Ok(v),
+                    Ok(None) => Ok(Value::Null),
+                    Err(e) => Err(PreprocessError::Other(format!("{e}"))),
+                }
+            }
+        }
     }
 
     fn attrs_to_json(attrs: &FxHashMap<String, RsAttrValue>) -> Value {
@@ -658,9 +698,7 @@ mod preprocess_bridge {
             Some(SourceMapInput::Json(s)) => {
                 serde_json::from_str::<Value>(&s).unwrap_or(Value::Null)
             }
-            Some(SourceMapInput::Decoded(decoded)) => {
-                serde_json::to_value(&decoded).unwrap_or(Value::Null)
-            }
+            Some(SourceMapInput::Decoded(decoded)) => decoded_to_v3_json(&decoded),
         };
         let deps: Vec<Value> = p.dependencies.into_iter().map(Value::String).collect();
         serde_json::json!({
@@ -668,5 +706,119 @@ mod preprocess_bridge {
             "map": map,
             "dependencies": deps,
         })
+    }
+
+    /// Serialize a `SimpleDecodedMap` to a standard [Source Map v3] JSON
+    /// object — camelCase keys (`sourcesContent`, `sourceRoot`) and a
+    /// VLQ-encoded `mappings` string — so downstream tools (Vite,
+    /// Rolldown, magic-string consumers) can ingest it directly.
+    ///
+    /// [Source Map v3]: https://sourcemaps.info/spec.html
+    fn decoded_to_v3_json(map: &SimpleDecodedMap) -> Value {
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "version".to_string(),
+            Value::Number(serde_json::Number::from(map.version.unwrap_or(3))),
+        );
+        if let Some(ref file) = map.file {
+            obj.insert("file".to_string(), Value::String(file.clone()));
+        }
+        if let Some(ref source_root) = map.source_root {
+            obj.insert("sourceRoot".to_string(), Value::String(source_root.clone()));
+        }
+        obj.insert(
+            "sources".to_string(),
+            Value::Array(map.sources.iter().cloned().map(Value::String).collect()),
+        );
+        if let Some(ref contents) = map.sources_content {
+            obj.insert(
+                "sourcesContent".to_string(),
+                Value::Array(
+                    contents
+                        .iter()
+                        .map(|c| c.clone().map_or(Value::Null, Value::String))
+                        .collect(),
+                ),
+            );
+        }
+        obj.insert(
+            "names".to_string(),
+            Value::Array(map.names.iter().cloned().map(Value::String).collect()),
+        );
+        obj.insert(
+            "mappings".to_string(),
+            Value::String(encode_mappings(&map.mappings)),
+        );
+        Value::Object(obj)
+    }
+
+    /// VLQ-encode a decoded `mappings` array (`Vec<Vec<Vec<i64>>>`) into
+    /// the Source Map v3 string form: lines separated by `;`, segments
+    /// within a line separated by `,`, fields within a segment as
+    /// relative-encoded VLQs.
+    fn encode_mappings(mappings: &[Vec<Vec<i64>>]) -> String {
+        let mut out = String::new();
+        // Source index / original line / original column / name index
+        // run relative to the *previous segment*, regardless of line.
+        // Generated column resets at each `;` (per spec).
+        let mut prev_source: i64 = 0;
+        let mut prev_orig_line: i64 = 0;
+        let mut prev_orig_col: i64 = 0;
+        let mut prev_name: i64 = 0;
+        for (i, line) in mappings.iter().enumerate() {
+            if i > 0 {
+                out.push(';');
+            }
+            let mut prev_gen_col: i64 = 0;
+            for (j, segment) in line.iter().enumerate() {
+                if j > 0 {
+                    out.push(',');
+                }
+                if segment.is_empty() {
+                    continue;
+                }
+                let gen_col = segment[0];
+                vlq_encode(&mut out, gen_col - prev_gen_col);
+                prev_gen_col = gen_col;
+                if segment.len() >= 4 {
+                    let src = segment[1];
+                    let orig_line = segment[2];
+                    let orig_col = segment[3];
+                    vlq_encode(&mut out, src - prev_source);
+                    vlq_encode(&mut out, orig_line - prev_orig_line);
+                    vlq_encode(&mut out, orig_col - prev_orig_col);
+                    prev_source = src;
+                    prev_orig_line = orig_line;
+                    prev_orig_col = orig_col;
+                    if segment.len() >= 5 {
+                        let name = segment[4];
+                        vlq_encode(&mut out, name - prev_name);
+                        prev_name = name;
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    const BASE64: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    fn vlq_encode(out: &mut String, value: i64) {
+        let mut vlq: u64 = if value < 0 {
+            ((-value as u64) << 1) | 1
+        } else {
+            (value as u64) << 1
+        };
+        loop {
+            let mut digit = (vlq & 0x1f) as u8;
+            vlq >>= 5;
+            if vlq > 0 {
+                digit |= 0x20;
+            }
+            out.push(BASE64[digit as usize] as char);
+            if vlq == 0 {
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #123, #124, #125, #127.

The NAPI-exposed `preprocess()` diverged from the public Svelte preprocessor contract in four orthogonal ways that, combined, made every realistic caller (including `@rsvelte/vite-plugin-svelte`) crash before producing any output. This PR realigns the binding shape with the upstream `svelte/compiler#preprocess` API.

### #123 — third argument shape & single-group support

Was: `preprocess(source, preprocessors, filename: Option<String>)`
Now: `preprocess(source, preprocessors, options?: { filename?: string })`

Plus `preprocessors` accepts either a `PreprocessorGroup` or `PreprocessorGroup[]` — matching upstream. The `Either<Vec, Object>` is probed in array-first order because JS arrays satisfy `typeof === 'object'` and would otherwise hit the single-group branch.

### #124 — ErrorStrategy::CalleeHandled → Fatal

`CalleeHandled` invokes user callbacks as `(err, opts)` rather than `(opts)`. Every preprocessor that destructures `{ content, filename, attributes }` was destructuring the injected `null` err slot and crashing. Switching to `Fatal` lets the JS contract `(opts) => Processed | undefined` work as documented; Rust still surfaces JS errors through the awaited Promise.

### #125 — `undefined`/`null` return now a no-op

`Option<Promise<Option<Value>>>` handles both the sync no-op (callback returns `undefined` directly) and the async no-op (async callback resolves to `undefined`). Sync object returns fall through to a `Value` receive. All four paths normalize to `Value::Null` on the Rust side and the engine treats it as "skip this block", matching upstream.

### #127 — result sourcemap is standard SourceMap v3 JSON

Was: decoded Rust representation (`sources_content` snake_case, nested `i64` array mappings) — rejected by Rolldown's `BindingJsonSourcemap`.
Now: camelCase keys (`sourcesContent`, `sourceRoot`), VLQ-encoded `mappings` string.

`SimpleDecodedMap` stays decoded internally (the chaining engine needs decoded form) but now serdes with the spec-compliant key names, so user-supplied JSON maps round-trip without losing fields.

## Verification

- `cargo build --release --features napi --lib` — clean
- `cargo clippy --features napi --lib -- -D warnings` — clean
- `cargo test --release --lib` — 517/517 pass
- Smoke tests for all four behaviors (see PR description on each issue for repros) — all pass

## Out of scope

- Thread-safety of concurrent `compile()` / `compileModule()` (#128) — separate PR
- Re-wiring the vite-plugin-svelte fork to import from `@rsvelte/vite-plugin-svelte-native` (#126) — separate PR in the fork's repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)