### PR TITLE
fix(transform/server): strip trailing comma in $derived.by(fn,) IIFE rewrite

### DIFF
--- a/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/src/compiler/phases/3_transform/server/transform_script.rs
@@ -1267,8 +1267,17 @@ fn transform_rune_call_multiline(script: &str, prefix: &str) -> String {
                 if trimmed_inner.is_empty() {
                     result.push_str("void 0");
                 } else if is_derived_by {
+                    // `$derived.by(fn)` becomes `(fn)()`. Strip a trailing
+                    // comma from `fn` first — Prettier-formatted call
+                    // sites often produce `$derived.by(fn,)` (a legal
+                    // trailing comma in function-call arguments), which
+                    // when rewritten naively would yield `(fn,)()` —
+                    // an invalid parenthesized expression with a
+                    // trailing comma. Preserve leading whitespace so
+                    // multi-line structure (newlines) survives.
+                    let cleaned = inner.trim_end().trim_end_matches(',').trim_end();
                     result.push('(');
-                    result.push_str(&inner);
+                    result.push_str(cleaned);
                     result.push_str(")()");
                 } else {
                     // Strip trailing comma from the extracted expression.


### PR DESCRIPTION
## Summary

Server-side codegen rewrites `\$derived.by(fn)` to `(fn)()`. When the source has the form `\$derived.by(fn,)` — a perfectly legal trailing comma in a function call's argument list, which Prettier emits whenever the call is multi-line — the rewrite was naively wrapping the source slice as `(fn,)()`, producing a **parenthesized expression with a trailing comma**, which oxc / rolldown reject with `Parenthesized expressions may not have a trailing comma.`

### Repro

```js
// .svelte source (legal in TS / JS)
const canSave = \$derived.by(
  () => model.isValid && allowed !== false && hasPermission,
);
```

```js
// Was emitted (syntax error)
const canSave = (
  () => model.isValid && allowed !== false && hasPermission,
)();
```

The sibling `else` branch in `transform_rune_call_multiline` (for plain `\$derived(...)` / `\$state(...)` / `\$bindable(...)`) already calls `inner.trim_end().trim_end_matches(',').trim_end()` for exactly the same reason; the `\$derived.by` branch just forgot to.

### Fix

Apply the same trim and preserve the leading whitespace so multi-line formatting survives. Now emits:

```js
const canSave = (
  () => model.isValid && allowed !== false && hasPermission
)();
```

### Verification

- `cargo build --release --features napi --lib` clean
- `cargo clippy --features napi --lib -- -D warnings` clean
- `cargo test --release --lib` 517/517 pass
- A real-world SvelteKit app that previously crashed at the rolldown bundle phase on this exact pattern now passes that file through cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)