### PR TITLE
fix(parse): take the LAST top-level `as` in each-block headers

### DIFF
--- a/src/compiler/phases/1_parse/state/tag.rs
+++ b/src/compiler/phases/1_parse/state/tag.rs
@@ -243,8 +243,15 @@ impl Parser<'_> {
         // Parse the iterable expression (up to " as " or closing "}")
         let expr_start = self.index;
 
-        // Find " as " to get the expression, tracking brace depth (byte-level)
-        let mut found_as = false;
+        // Scan the whole header recording every top-level ` as `. The alias
+        // separator is the LAST one — upstream Svelte parses the iterable
+        // greedily (acorn consumes TypeScript assertions like `as const` /
+        // `as MyType` as TSAsExpression nodes), then unwraps any trailing
+        // TSAsExpression. The byte-level equivalent is "the right-most ` as `
+        // wins", since any earlier ` as ` is part of a cast inside the
+        // iterable. Without this, `{#each items as const as item}` splits at
+        // the first ` as ` and the codegen emits `let const as item = …`.
+        let mut last_as: Option<usize> = None;
         let mut depth: i32 = 0;
         while self.index < self.bytes.len() {
             let b = self.bytes[self.index];
@@ -260,12 +267,12 @@ impl Parser<'_> {
                     }
                     depth -= 1;
                 }
-                b' ' if depth == 0
-                    // Check for " as " at top level
-                    && self.match_str(" as ") =>
-                {
-                    found_as = true;
-                    break;
+                b' ' if depth == 0 && self.match_str(" as ") => {
+                    last_as = Some(self.index);
+                    // Skip past this ` as ` and keep scanning. If there's a
+                    // later top-level ` as `, that one's the alias separator.
+                    self.index += 4;
+                    continue;
                 }
                 _ => {}
             }
@@ -275,6 +282,12 @@ impl Parser<'_> {
             } else {
                 self.advance();
             }
+        }
+
+        // Rewind to the last ` as ` (or stay at the closing `}` if there was none).
+        let found_as = last_as.is_some();
+        if let Some(pos) = last_as {
+            self.index = pos;
         }
 
         let expr_end = self.index;

--- a/tests/each_block_as_const.rs
+++ b/tests/each_block_as_const.rs
@@ -1,0 +1,77 @@
+//! Regression test for parsing `{#each ... as const as alias}` (and related
+//! TypeScript-cast cases) in each-block headers.
+//!
+//! Bug: rsvelte's each-block header scanner stopped at the FIRST top-level
+//! ` as `, treating `as const as item` as alias = `const as item`. Upstream
+//! Svelte parses the iterable greedily so the alias separator is the LAST
+//! top-level ` as `. We mirror that with a right-most-` as ` scan.
+
+use svelte_compiler_rust::ast::arena::with_serialize_arena;
+use svelte_compiler_rust::{ParseOptions, convert_to_legacy, parse};
+
+/// Compile-time invariant: `serialize_to_json` produces a JSON tree where the
+/// each-block context (alias) is recognisable. We just check the rendered
+/// JSON contains the alias name and the iterable expression text.
+fn compile_each_alias(source: &str) -> String {
+    let ast = parse(source, ParseOptions::default()).expect("parse");
+    let arena_ptr = &ast.arena as *const _;
+    // SAFETY: `ast` is owned for the duration of the closure; the raw
+    // pointer just satisfies the borrow checker since we then move
+    // `ast` into the closure via the `convert_to_legacy` call below.
+    let arena_ref = unsafe { &*arena_ptr };
+    with_serialize_arena(arena_ref, || {
+        let legacy = convert_to_legacy(source, ast);
+        serde_json::to_string(&legacy).expect("serialize")
+    })
+}
+
+#[test]
+fn each_block_with_as_const_alias() {
+    // The TypeScript `as const` is part of the iterable expression; the alias
+    // is `tab`. Prior to the fix the parser split at the first ` as ` and
+    // produced `context = (const as tab)`.
+    let src = r#"{#each ['a', 'b'] as const as tab (tab)}<span>{tab}</span>{/each}"#;
+    let out = compile_each_alias(src);
+    // Alias appears as `"name":"tab"` in the AST output.
+    assert!(
+        out.contains(r#""name":"tab""#),
+        "alias should be `tab`, got:\n{out}"
+    );
+    // The stray `const` should NOT appear as an identifier — it would mean
+    // the alias was parsed as `const as tab`.
+    assert!(
+        !out.contains(r#""name":"const""#),
+        "`const` should not be parsed as an alias identifier:\n{out}"
+    );
+}
+
+#[test]
+fn each_block_with_as_typeannotation_alias() {
+    // Same shape with a named TS type annotation instead of `const`.
+    let src = r#"{#each items as readonly string[] as item}<p>{item}</p>{/each}"#;
+    let out = compile_each_alias(src);
+    assert!(
+        out.contains(r#""name":"item""#),
+        "alias should be `item`, got:\n{out}"
+    );
+}
+
+#[test]
+fn each_block_without_typescript_cast_still_works() {
+    // Plain case — single ` as ` is the alias separator (no regression).
+    let src = r#"{#each items as item}<p>{item}</p>{/each}"#;
+    let out = compile_each_alias(src);
+    assert!(
+        out.contains(r#""name":"item""#),
+        "alias should be `item`, got:\n{out}"
+    );
+}
+
+#[test]
+fn each_block_destructured_alias_still_works() {
+    // Object-pattern alias.
+    let src = r#"{#each items as { name, age }}<p>{name}</p>{/each}"#;
+    let out = compile_each_alias(src);
+    assert!(out.contains(r#""name":"name""#));
+    assert!(out.contains(r#""name":"age""#));
+}


### PR DESCRIPTION
## Summary

`{#each items as const as item}` (and the named variant `{#each items as ReadonlyArray<X> as item}`) was being misparsed: the header scanner stopped at the first top-level ` as `, so the parser treated `const as item` (or `ReadonlyArray<X> as item`) as the alias. Codegen then emitted invalid JS like `let const as item = each_array[$$index]` and the build broke.

Upstream Svelte handles this by parsing the iterable greedily (acorn consumes `as const` / `as Type` as `TSAsExpression` nodes) and unwrapping any trailing `TSAsExpression` to find the real separator. The byte-level equivalent is "right-most top-level ` as ` wins" — any earlier ` as ` must be part of a TS cast inside the iterable. The scanner now records every top-level ` as ` and rewinds to the last one.

Reproducer from the docs site:

```svelte
{#each ['full', 'parse', 'svelte2tsx'] as const as tab (tab)}
  …
{/each}
```

## Test plan
- [x] `cargo test --release` (full suite) — 30 suites, 0 failures
- [x] New `tests/each_block_as_const.rs` covers four cases:
  - `as const as alias` (the regression)
  - `as <NamedType> as alias`
  - `as alias` (single — no regression)
  - `as { destructured }` (object pattern — no regression)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)