### PR TITLE
fix(css): preserve `:nth-child(N)` argument during scope rewrite

### DIFF
--- a/src/compiler/phases/3_transform/css.rs
+++ b/src/compiler/phases/3_transform/css.rs
@@ -5635,6 +5635,17 @@ fn format_simple_selector_with_scope(
             format!("::{}", name)
         }
         "NestingSelector" => "&".to_string(),
+        "Nth" => {
+            // `:nth-child(3)` / `:nth-of-type(2n+1)` etc. The argument is
+            // stored verbatim on the `Nth` node (e.g. `"3"`, `"2n+1"`).
+            // Without this arm the value got dropped during scoping and
+            // selectors like `.foo:nth-child(3)` were emitted as
+            // `.foo.svelte-xxx:nth-child()`.
+            sel.get("value")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string()
+        }
         _ => String::new(),
     }
 }

--- a/tests/css_nth_child_args.rs
+++ b/tests/css_nth_child_args.rs
@@ -1,0 +1,77 @@
+//! Regression test for the CSS scope rewriter losing the argument of
+//! `:nth-child(N)` / `:nth-of-type(N)` / `:nth-last-child(N)` /
+//! `:nth-last-of-type(N)`.
+//!
+//! Bug: when scoping a selector like `.foo:nth-child(3)`, the parser
+//! produces a PseudoClassSelector whose `args` is a SelectorList wrapping
+//! an `Nth` node (`{ type: "Nth", value: "3" }`). The transformer walks
+//! that tree via `get_selector_text` → `format_simple_selector`, but the
+//! latter had no match arm for `"Nth"` and silently returned an empty
+//! string. The emitted CSS therefore had `:nth-child()` (no argument).
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_css(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.css.map(|c| c.code).unwrap_or_default()
+}
+
+#[test]
+fn nth_child_argument_preserved_after_scoping() {
+    let src = r#"<div class="x"></div><div class="x"></div><div class="x"></div>
+<style>
+@media (max-width: 999px) {
+  .x:nth-child(3) { color: red }
+}
+</style>"#;
+    let out = compile_css(src);
+    assert!(
+        out.contains(":nth-child(3)"),
+        "expected `:nth-child(3)` in output, got:\n{out}"
+    );
+    assert!(
+        !out.contains(":nth-child()"),
+        "argument should not be dropped, got:\n{out}"
+    );
+}
+
+#[test]
+fn nth_child_an_plus_b_preserved() {
+    let src = r#"<div class="x"></div><div class="x"></div>
+<style>
+@media (max-width: 999px) {
+  .x:nth-child(2n+1) { color: red }
+}
+</style>"#;
+    let out = compile_css(src);
+    assert!(
+        out.contains(":nth-child(2n+1)"),
+        "expected `:nth-child(2n+1)`, got:\n{out}"
+    );
+}
+
+#[test]
+fn nth_of_type_argument_preserved() {
+    let src = r#"<div class="x"></div><div class="x"></div>
+<style>
+@media (max-width: 999px) {
+  .x:nth-of-type(odd) { color: green }
+  .x:nth-last-child(3) { color: blue }
+  .x:nth-last-of-type(2n) { color: yellow }
+}
+</style>"#;
+    let out = compile_css(src);
+    assert!(out.contains(":nth-of-type(odd)"), "got:\n{out}");
+    assert!(out.contains(":nth-last-child(3)"), "got:\n{out}");
+    assert!(out.contains(":nth-last-of-type(2n)"), "got:\n{out}");
+}


### PR DESCRIPTION
## Summary

The CSS scope rewriter dropped the argument of `:nth-child(N)` (and the other `:nth-*` pseudo-classes) when scoping selectors. So `.foo:nth-child(3)` came out of the transform as `.foo.svelte-xxxxx:nth-child()` — a syntactically invalid selector that lightningcss rejects during the production build.

### Root cause

`format_simple_selector_with_scope` walks the parsed `args` of a `PseudoClassSelector` via `get_selector_text` → `format_simple_selector`, but had no match arm for the `Nth` node that wraps the `(N)` / `(2n+1)` argument. The fall-through `_ => String::new()` silently returned an empty string.

### Fix

Add an `Nth` arm that emits the `value` field verbatim. The `Nth` representation is shared across all `:nth-*` pseudo-classes, so this fixes them all at once.

### Reproducer

From the docs site (now removed in favour of `.stat + .stat + .stat` workaround):

```svelte
<style>
@media (max-width: 1000px) {
  .stat:nth-child(3) { border-left: none }
}
</style>
```

Before: `.stat.svelte-xxx:nth-child() { … }` → build fails with `Unexpected end of input`.
After: `.stat.svelte-xxx:nth-child(3) { … }` ✓

## Test plan
- [x] `cargo test --release` (full suite) — 32 suites, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] New `tests/css_nth_child_args.rs` covers:
  - `:nth-child(3)` (the regression)
  - `:nth-child(2n+1)` (An+B form)
  - `:nth-of-type(odd)`, `:nth-last-child(3)`, `:nth-last-of-type(2n)` (other `:nth-*` variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)