### PR TITLE
fix(transform/client): track `$state.raw` vars in compileModule read/write rewrites

### DIFF
--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -78,7 +78,14 @@ pub(super) static REGEX_DOLLAR_PROPS: LazyLock<Regex> =
 // The optional type annotation handles TypeScript patterns like `const x: string = $derived.by(...)`
 // The optional generic params handle patterns like `let x = $state<SomeType>(...)`
 pub(super) static REGEX_STATE_DERIVED_VAR: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(let|const|var)\s+(\w+)(?:\s*:[^=\n]*)?\s*=\s*\$(?:state|derived)(?:\.by)?(?:<[^(]*>)?\s*\(").unwrap()
+    // Matches `let|const|var <name> [: type] = $state[.raw|.frozen]<T>(...)`
+    // or `$derived[.by]<T>(...)`. The `.raw` / `.frozen` variants must be
+    // tracked too — without them, reassigned `$state.raw(x)` vars get the
+    // `$.state(...)` declaration wrapper at module level but their reads
+    // (`x[key]`) and writes (`x = next`) are never rewritten through
+    // `$.get`/`$.set`, so consumers see the raw source object instead of
+    // the value (see baseballyama/rsvelte#143).
+    Regex::new(r"(let|const|var)\s+(\w+)(?:\s*:[^=\n]*)?\s*=\s*\$(?:state(?:\.raw|\.frozen)?|derived(?:\.by)?)(?:<[^(]*>)?\s*\(").unwrap()
 });
 
 // Regex for sanitizing identifier names - replaces invalid identifier characters

--- a/tests/module_state_raw_reads.rs
+++ b/tests/module_state_raw_reads.rs
@@ -1,0 +1,94 @@
+//! Regression test for `$state.raw` (and `$state.frozen`) reassigned variables
+//! in `compileModule(generate:'client')`.
+//!
+//! Bug (baseballyama/rsvelte#143): `extract_local_reactive_vars`'s regex only
+//! matched `$state(` and `$derived(` — not `$state.raw(` / `$state.frozen(`.
+//! A reassigned `let x = $state.raw(initial)` got its declaration rewritten to
+//! `let x = $.state(initial)` (correct), but reads (`x[key]`) and writes
+//! (`x = next`) were left untransformed. Downstream consumers like
+//! `@testing-library/svelte`'s `createProps()` then saw the reactive source
+//! object instead of the underlying value — `currentProps[key]` returned
+//! undefined for every key.
+
+use svelte_compiler_rust::GenerateMode;
+use svelte_compiler_rust::compile_module;
+use svelte_compiler_rust::compiler::ModuleCompileOptions;
+
+fn compile_mod_client(src: &str) -> String {
+    let result = compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("in.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile_module");
+    result.js.code
+}
+
+#[test]
+fn state_raw_reassigned_read_transformed_to_get() {
+    let src = r#"let x = $state.raw({ label: 'BUTTON' });
+function reassign(next) { x = next; }
+export const value = (key) => x[key];
+"#;
+    let out = compile_mod_client(src);
+    // Read must be rewritten to $.get(x)[key].
+    assert!(
+        out.contains("$.get(x)[key]"),
+        "read `x[key]` should be rewritten to `$.get(x)[key]`. Got:\n{out}"
+    );
+    // Reassignment must be rewritten to $.set(x, next, ...).
+    assert!(
+        out.contains("$.set(x, next"),
+        "reassignment `x = next` should be rewritten to `$.set(x, next, ...)`. Got:\n{out}"
+    );
+    // Declaration must still wrap in $.state(...).
+    assert!(
+        out.contains("$.state({ label: 'BUTTON' })"),
+        "declaration should wrap in $.state(...). Got:\n{out}"
+    );
+}
+
+#[test]
+fn state_raw_property_assignment_uses_get() {
+    // x[key] = value mutates the raw underlying object — the read side has
+    // to go through $.get to grab the object, otherwise the assignment hits
+    // the state source's own properties.
+    let src = r#"let x = $state.raw({ a: 1 });
+function setKey(key, value) { x[key] = value; }
+function reassign(next) { x = next; }
+"#;
+    let out = compile_mod_client(src);
+    assert!(
+        out.contains("$.get(x)[key] = value"),
+        "property assignment `x[key] = value` should become `$.get(x)[key] = value`. Got:\n{out}"
+    );
+}
+
+// Note: `$state.frozen` was renamed to `$state.raw` in Svelte 5.x and the
+// analyzer rejects the legacy spelling with `rune_renamed`, so it can't reach
+// this transform path. The regex still accepts `.frozen` so that any source
+// that survives an analyzer override (e.g. a downstream tool using
+// `compile_module` directly without analysis) still produces the right
+// rewrites — but there's no positive integration test for it.
+
+#[test]
+fn non_reassigned_state_raw_stays_unwrapped() {
+    // No reassignment → the rune is stripped to its raw value, no $.state()
+    // wrapper, and reads are plain property access (no $.get).
+    let src = r#"let x = $state.raw({ a: 1 });
+export const read = (key) => x[key];
+"#;
+    let out = compile_mod_client(src);
+    assert!(
+        !out.contains("$.state("),
+        "non-reassigned $state.raw should not wrap in $.state(). Got:\n{out}"
+    );
+    assert!(
+        !out.contains("$.get("),
+        "non-reassigned $state.raw reads should be plain property access. Got:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

`extract_local_reactive_vars` filters module-level reactive bindings via a regex that only matched `$state(` and `$derived(`, not `$state.raw(` / `$state.frozen(`. Reassigned `$state.raw` declarations therefore got their declaration site rewritten to `$.state(...)` (correctly), but reads (`x[key]`) and writes (`x = next`) on the same variable were left untouched, so downstream code saw the reactive source object instead of the underlying value.

The most visible casualty is `@testing-library/svelte`'s `createProps()` helper, which backs every `render(Component, { ... })` call. Its `currentProps[key]` reads return `undefined` for every key because the `get` trap reaches the source object, not the value.

### Fix

Extend `REGEX_STATE_DERIVED_VAR` to include `$state.raw` and `$state.frozen` so the variable is tracked as reactive and the existing read/write rewrites through `$.get` / `$.set` apply.

### Before

```js
// rsvelte (broken)
let x = $.state({ label: 'BUTTON' });
function reassign(next) { x = next; }
export const value = (key) => x[key];  // ← x[key] === undefined at runtime
```

### After

```js
let x = $.state({ label: 'BUTTON' });
function reassign(next) { $.set(x, next, true); }
export const value = (key) => $.get(x)[key];  // ← matches upstream
```

Matches upstream `svelte/compiler#compileModule` output (modulo a `should_proxy=true` argument that's a separate follow-up).

Fixes #143.

## Test plan
- [x] `cargo test --release` (full suite) — 33 suites, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] New `tests/module_state_raw_reads.rs` covers:
  - Reassigned `$state.raw`: reads → `$.get(x)[key]`, writes → `$.set(x, next, ...)`
  - Property assignment `x[key] = value` → `$.get(x)[key] = value`
  - Non-reassigned `$state.raw`: stays as plain value, no `$.state()` / `$.get()` wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)