### PR TITLE
fix(transform/server): keep multi-line arrow attached to body across `=>`

### DIFF
--- a/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/src/compiler/phases/3_transform/server/transform_script.rs
@@ -1557,6 +1557,17 @@ fn fix_multiline_declaration_semicolons(script: &str) -> String {
                     // Another declarator follows
                     decl_bracket_depth = 0;
                     result_lines.push(line.to_string());
+                } else if line_ends_with_continuation(trimmed) {
+                    // The closing bracket sits on the same line as a
+                    // continuation operator — most commonly an arrow function
+                    // header like `(args) =>` whose body spans the following
+                    // lines. The statement isn't really over yet, so don't
+                    // emit a terminator; keep tracking until we hit a real
+                    // statement end. (Without this, the bracket-depth heuristic
+                    // turns `(args) =>` into `(args) =>;` and severs the
+                    // arrow function from its body — baseballyama/rsvelte#141.)
+                    decl_bracket_depth = 0;
+                    result_lines.push(line.to_string());
                 } else {
                     in_multiline_decl = false;
                     // End of multi-line declaration: ensure semicolon
@@ -1574,6 +1585,25 @@ fn fix_multiline_declaration_semicolons(script: &str) -> String {
     }
 
     result_lines.join("\n")
+}
+
+/// Does this trimmed line end with an operator/keyword that requires the next
+/// line to continue the same expression? Used by
+/// `fix_multiline_declaration_semicolons` to avoid terminating a declaration on
+/// e.g. `(args) =>` where the arrow body is on the next line.
+fn line_ends_with_continuation(trimmed: &str) -> bool {
+    if let Some(rest) = trimmed.strip_suffix("=>") {
+        // Make sure `=>` is its own token (not the tail of a `===>` typo or
+        // similar) by checking the preceding char is whitespace or `)`.
+        return rest.ends_with(')') || rest.ends_with(' ') || rest.is_empty();
+    }
+    // Other obvious mid-expression operators that demand a following operand.
+    let last = trimmed.chars().last().unwrap_or(' ');
+    matches!(
+        last,
+        '+' | '-' | '*' | '/' | '%' | '&' | '|' | '^' | '<' | '>' | '=' | '?' | '.' | '!'
+    ) && !trimmed.ends_with("++")
+        && !trimmed.ends_with("--")
 }
 
 /// Count bracket depth change for a line (positive = more opens, negative = more closes).

--- a/tests/server_ts_type_guard.rs
+++ b/tests/server_ts_type_guard.rs
@@ -1,0 +1,81 @@
+//! Regression test for `compile(generate:'server')` mangling TypeScript
+//! user-defined type guard arrows (baseballyama/rsvelte#141).
+//!
+//! The TS-strip step in phase 2 correctly removes `): op is Op =>` to leave
+//! `) =>`, but a later text-based pass — `fix_multiline_declaration_semicolons`
+//! — terminated the declaration as soon as bracket depth hit zero. For a
+//! multi-line arrow header like
+//!
+//! ```text
+//! const isOp = (
+//!     op,
+//! ) =>
+//!     op === 'A';
+//! ```
+//!
+//! the closing `)` brought depth to 0 on the `) =>` line. The pass appended a
+//! `;` after `=>`, severing the arrow function from its body and producing
+//! invalid JS that rolldown/oxc rejected with `Unexpected token`.
+//!
+//! The fix teaches the pass to keep tracking when a line ends with a
+//! continuation operator (the arrow `=>`, binary operators, `.`, etc.).
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn compile_server(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Server,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn arrow_type_guard_keeps_arrow_attached_to_body() {
+    let src = r#"<script lang="ts">
+  type Op = 'EQUAL' | 'NOT_EQUAL';
+  const isOp = (
+    op: Op | 'OTHER',
+  ): op is Op =>
+    op === 'EQUAL' ||
+    op === 'NOT_EQUAL';
+</script>"#;
+    let out = compile_server(src);
+    // No stray `;` after `=>` — the arrow body must follow.
+    assert!(
+        !out.contains("=>;"),
+        "found stray `=>;` — arrow body was severed:\n{out}"
+    );
+    // Arrow body must reach `op === 'EQUAL'`.
+    assert!(
+        out.contains("=> op === 'EQUAL'") || out.contains("=>\n\top === 'EQUAL'"),
+        "arrow body should be reachable, got:\n{out}"
+    );
+}
+
+#[test]
+fn arrow_multiline_paren_close_with_no_type_predicate_still_works() {
+    // Make sure the fix doesn't regress the normal "real end of declaration"
+    // case where `)` ends both the paren and the statement (single-arg call).
+    let src = r#"<script lang="ts">
+  const x = doThing(
+    'a',
+    'b',
+  );
+</script>"#;
+    let out = compile_server(src);
+    assert!(out.contains("doThing("));
+    assert!(out.contains("'a'"));
+    assert!(out.contains("'b'"));
+    // The original `;` after the closing `)` must be preserved.
+    assert!(
+        out.contains("'b',\n\t);") || out.contains("'b'\n\t);") || out.contains("'b');"),
+        "expected the trailing `;` after `)` to remain. Got:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

`fix_multiline_declaration_semicolons` tracked bracket depth across the lines of a multi-line declaration and terminated the statement (adding a `;`) the first time depth hit zero. For a multi-line arrow header like

```ts
const isOp = (
  op: Op | 'OTHER',
): op is Op =>
  op === 'EQUAL' || op === 'NOT_EQUAL';
```

the TS-strip leaves the closing `)` and the arrow `=>` on the same line. That line brought depth to 0, so the pass appended a `;` after `=>` and severed the arrow function from its body — emitting `) =>;` followed by orphan expression lines that rolldown / oxc reject with `Unexpected token`.

### Fix

Teach the pass to treat lines ending with a continuation operator as non-terminating:

- The arrow `=>` (when it's a real token boundary, not part of `===>` or similar)
- Binary operators: `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<`, `>`, `=`, `?`, `.`, `!`
- Excluding postfix `++` / `--`

When such a line happens to close the last bracket, the multi-line tracking now continues into the next line instead of forcing a statement terminator.

### Repro

Server output before:
```js
const isOp = (
op,
) =>;            // ← stray `;`, body amputated
op === 'EQUAL' || …
```

After:
```js
const isOp = (op) => op === 'EQUAL' || op === 'NOT_EQUAL';
```

Fixes #141.

## Test plan
- [x] `cargo test --release` (parser_fixtures, compiler_fixtures, ssr, compiler_errors, css, css_nth_child_args, each_block_as_const, server_ts_type_guard, validator, print — 123 tests, 0 failures)
- [x] `cargo clippy --all-targets --features napi -- -D warnings`
- [x] New `tests/server_ts_type_guard.rs` covers:
  - `(args): op is T =>` arrow body must remain reachable after TS-strip
  - Normal `doThing(\n 'a',\n 'b',\n);` call shouldn't regress (the closing `)` is the real statement end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)