### PR TITLE
fix(compile_module): strip TS from source + emit IIFE for block-bodied `$derived`

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -867,8 +867,27 @@ pub fn compile_module(
 
     // Phase 3: Generate module output using the module-specific transform.
     // Unlike transform_component, this does NOT generate a component wrapper.
-    let transform_result =
-        phases::phase3_transform::transform_module(&analysis, source, &compile_options);
+    //
+    // The text-based rune rewrites inside `transform_module` work on the raw
+    // source string, not the AST. If the file is TypeScript, those rewrites
+    // would otherwise run against TS annotations (`(x: T) => …`, return-type
+    // `: T`, optional parameter `?`, etc.), corrupting the output and leaking
+    // TS into the emitted JS. Feed the TS-stripped source to the transform so
+    // every downstream string operation sees pure JS — matching what the
+    // analyzer has already stripped from the AST.
+    let stripped_source: String;
+    let source_for_transform: &str = if is_typescript {
+        stripped_source = phases::phase2_analyze::types::strip_typescript(source);
+        &stripped_source
+    } else {
+        source
+    };
+
+    let transform_result = phases::phase3_transform::transform_module(
+        &analysis,
+        source_for_transform,
+        &compile_options,
+    );
 
     let js_code = match transform_result {
         Ok(result) => result.js,

--- a/src/compiler/phases/3_transform/server/mod.rs
+++ b/src/compiler/phases/3_transform/server/mod.rs
@@ -483,9 +483,19 @@ fn post_process_for_server(source: &str) -> String {
                 let content = result[call_start..call_start + content_end]
                     .trim()
                     .to_string();
-                // If content is an arrow function () => expr, extract just the expr
-                let value = if content.starts_with("() =>") {
-                    content.trim_start_matches("() =>").trim().to_string()
+                // If content is an arrow function `() => expr`, extract just
+                // the expression. For block-bodied arrows `() => { … }` keep
+                // the IIFE wrap (`(() => { … })()`) so the block actually
+                // runs — without this, `$.derived(() => { return X })` was
+                // emitted as a bare block `{ return X }` which is invalid
+                // JS at expression position. (baseballyama/rsvelte#140)
+                let value = if let Some(arrow_body) = content.strip_prefix("() =>") {
+                    let body = arrow_body.trim();
+                    if body.starts_with('{') {
+                        format!("({})()", content)
+                    } else {
+                        body.to_string()
+                    }
                 } else {
                     content
                 };

--- a/tests/module_compile_ts_strip.rs
+++ b/tests/module_compile_ts_strip.rs
@@ -1,0 +1,126 @@
+//! Regression test for `compile_module` leaking TypeScript syntax through the
+//! text-based rune rewrites and mis-handling `$derived.by(() => { block })`
+//! on the server side (baseballyama/rsvelte#140).
+//!
+//! Two issues, one root cause:
+//!
+//! 1. `compile_module` parsed the TS source, stripped TS annotations from the
+//!    AST, then handed the **raw source text** to `transform_module`, whose
+//!    text-based rune rewrites then ran against TS-annotated input. TS
+//!    annotations leaked through to the emitted JS, and byte offsets in
+//!    multi-line rune calls shifted relative to what the rune scanner
+//!    expected.
+//!
+//! 2. The server-side post-processor for `$.derived(arrow)` always stripped
+//!    the arrow head. For expression-bodied arrows that worked, but for
+//!    block-bodied arrows (`$derived.by(() => { return X })`) it left a
+//!    naked block `{ return X }` at expression position — invalid JS that
+//!    rolldown/oxc reject.
+
+use svelte_compiler_rust::GenerateMode;
+use svelte_compiler_rust::compile_module;
+use svelte_compiler_rust::compiler::ModuleCompileOptions;
+
+fn compile_mod(src: &str, generate: GenerateMode) -> String {
+    let result = compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("foo.svelte.ts".to_string()),
+            generate,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile_module");
+    result.js.code
+}
+
+#[test]
+fn server_strips_ts_annotations() {
+    let src = r#"export const useFoo = (
+  getEl: () => HTMLElement | undefined,
+): string => {
+  return 'ok';
+};
+"#;
+    let out = compile_mod(src, GenerateMode::Server);
+    assert!(
+        !out.contains("HTMLElement"),
+        "TS param annotation should be stripped, got:\n{out}"
+    );
+    assert!(
+        !out.contains("): string"),
+        "TS return annotation should be stripped, got:\n{out}"
+    );
+}
+
+#[test]
+fn client_strips_ts_annotations() {
+    let src = r#"export const useFoo = (getEl: () => HTMLElement): string => 'ok';
+"#;
+    let out = compile_mod(src, GenerateMode::Client);
+    assert!(!out.contains("HTMLElement"), "got:\n{out}");
+    assert!(!out.contains(": string"), "got:\n{out}");
+}
+
+#[test]
+fn server_derived_by_block_body_becomes_iife() {
+    let src = r#"export const useFoo = () => {
+  let pos = $state({ x: 0 });
+  const style = $derived.by(() => {
+    return `transform: translate(${pos.x}px);`;
+  });
+  return style;
+};
+"#;
+    let out = compile_mod(src, GenerateMode::Server);
+    // The arrow + block must survive as `(() => { … })()` — not stripped to a
+    // bare `{ … }`, which would be invalid JS at expression position.
+    assert!(
+        out.contains("(() =>") && out.contains("})()"),
+        "expected an IIFE wrap around the block body, got:\n{out}"
+    );
+    assert!(
+        !out.contains("const style = {"),
+        "the block must not be emitted as a bare object literal, got:\n{out}"
+    );
+}
+
+#[test]
+fn server_derived_expression_body_extracts_value() {
+    // Regression guard: expression-bodied $derived (no block) should still
+    // be extracted to just the expression on the server.
+    let src = r#"export const useFoo = () => {
+  let n = $state(0);
+  const doubled = $derived(n * 2);
+  return doubled;
+};
+"#;
+    let out = compile_mod(src, GenerateMode::Server);
+    assert!(
+        out.contains("const doubled = n * 2;") || out.contains("const doubled = n * 2"),
+        "expected `const doubled = n * 2`, got:\n{out}"
+    );
+}
+
+#[test]
+fn server_ts_with_derived_by_works_together() {
+    // The original reproducer from #140 — TS annotations *and* a block-bodied
+    // `$derived.by`. Both fixes must combine.
+    let src = r#"export const useFoo = (
+  getEl: () => HTMLElement | undefined,
+): string => {
+  let pos = $state({ x: 0 });
+  const style = $derived.by(() => {
+    return `transform: translate(${pos.x}px);`;
+  });
+  return style;
+};
+"#;
+    let out = compile_mod(src, GenerateMode::Server);
+    assert!(!out.contains("HTMLElement"), "TS leak. Got:\n{out}");
+    assert!(
+        out.contains("(() =>") && out.contains("})()"),
+        "IIFE missing. Got:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

Two interlocking bugs that together broke `compileModule` for any non-trivial `.svelte.ts` / `.svelte.js` rune module:

### 1. TS leaked through text-based rune rewrites

`compile_module` parsed the source, stripped TS from the **AST**, then handed the **raw source text** to `transform_module`. The text-based rune rewrites (`$state(` → ..., `$derived.by(` → ..., etc.) then ran against TS-annotated input. Output kept the TS:

```ts
// Input
export const useFoo = (
  getEl: () => HTMLElement | undefined,
): string => { … };

// Before
export const useFoo = (
  getEl: () => HTMLElement | undefined,  // ← TS still there
): string => { … };                       // ← TS still there
```

Fix: when the file is TypeScript, call `strip_typescript(source)` and pass the result to `transform_module` so every downstream string op sees pure JS — matching what the analyzer already stripped from the AST.

### 2. Server post-processor stripped arrow head from block-bodied `$.derived`

The CLIENT module transform emits `$.derived(() => …)`. The SERVER post-processor then rewrites that to just `…`. For expression-bodied arrows that works (`$.derived(() => n * 2)` → `n * 2`). For block-bodied arrows (`$derived.by(() => { return X })` → `$.derived(() => { return X })` → ... → `{ return X }`) it left a naked block at expression position — invalid JS that rolldown / oxc reject with `Unexpected token`.

Fix: preserve the IIFE wrap for block-bodied arrows (`(() => { … })()`).

### Output after both fixes

```js
export const useFoo = (getEl) => {
  let pos = { x: 0 };
  const style = (() => {
    return `transform: translate(${pos.x}px);`;
  })();
  return style;
};
```

Matches upstream `svelte/compiler#compileModule`.

Fixes #140.

## Test plan
- [x] `cargo test --release` (compiler_fixtures, ssr, compiler_errors, parser_fixtures, validator, print, css — 114 tests, 0 failures)
- [x] New `tests/module_compile_ts_strip.rs` covers:
  - TS annotations stripped on server
  - TS annotations stripped on client
  - `$derived.by(() => { block })` → IIFE wrap on server
  - `$derived(expr)` → bare expression on server (regression guard)
  - Combined: TS + block-body works end-to-end (the original #140 reproducer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)