### PR TITLE
docs: drop compatibility workarounds, use NAPI preprocess directly

### DIFF
--- a/docs/rsvelte-shim/compiler.mjs
+++ b/docs/rsvelte-shim/compiler.mjs
@@ -102,71 +102,12 @@ export function compileModule(source, options) {
 	return binding.compileModule(source, sanitiseOptions(options));
 }
 
-// preprocess: run the chain in plain JS instead of crossing the NAPI bridge.
-//
-// The Rust-side `napi_preprocess` is a v0.3 Wave-3 component with several
-// brittle edges around JS callback marshalling (CalleeHandled signature,
-// `undefined` not being a valid `serde_json::Value`, callback return values
-// containing function references that fail serde conversion). For a static
-// docs site whose only preprocessor is SvelteKit's dev-only warning logger,
-// running the pipeline directly in JS is both simpler and avoids those bugs.
-//
-// This implementation mirrors svelte/preprocess for the markup / script /
-// style fields: feed each block through every group in order. Source maps and
-// dependency tracking are dropped — this site has no preprocessors that emit
-// either.
-const SCRIPT_RE = /<script(?<attrs>\s+[^>]*?)?>(?<content>[\s\S]*?)<\/script>/g;
-const STYLE_RE = /<style(?<attrs>\s+[^>]*?)?>(?<content>[\s\S]*?)<\/style>/g;
-
-function parseAttrs(raw) {
-	const out = {};
-	if (!raw) return out;
-	const re = /(\w[\w-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
-	let m;
-	while ((m = re.exec(raw))) {
-		out[m[1]] = m[2] ?? m[3] ?? m[4] ?? true;
-	}
-	return out;
-}
-
-async function runTag(source, re, fn, filename) {
-	let out = '';
-	let lastIndex = 0;
-	let m;
-	while ((m = re.exec(source))) {
-		const attrs = parseAttrs(m.groups?.attrs ?? '');
-		const content = m.groups?.content ?? '';
-		out += source.slice(lastIndex, m.index);
-		const tagStart = m[0].indexOf(content);
-		const open = source.slice(m.index, m.index + tagStart);
-		const close = m[0].slice(tagStart + content.length);
-		const result = await fn({ content, attributes: attrs, filename, markup: source });
-		out += open + (result && typeof result.code === 'string' ? result.code : content) + close;
-		lastIndex = m.index + m[0].length;
-	}
-	out += source.slice(lastIndex);
-	return out;
-}
-
-export async function preprocess(source, groups, options) {
+export function preprocess(source, groups, options) {
 	logOnce();
-	const groupsArr = Array.isArray(groups) ? groups : groups ? [groups] : [];
-	const filename = typeof options === 'string' ? options : options?.filename;
-	let code = source;
-	for (const group of groupsArr) {
-		if (!group) continue;
-		if (typeof group.markup === 'function') {
-			const r = await group.markup({ content: code, filename });
-			if (r && typeof r.code === 'string') code = r.code;
-		}
-		if (typeof group.script === 'function') {
-			code = await runTag(code, new RegExp(SCRIPT_RE.source, 'g'), group.script, filename);
-		}
-		if (typeof group.style === 'function') {
-			code = await runTag(code, new RegExp(STYLE_RE.source, 'g'), group.style, filename);
-		}
-	}
-	return { code };
+	// The NAPI binding now matches the upstream svelte/compiler contract
+	// (PR #133): `preprocess(source, group | group[], { filename? })`. Pass
+	// arguments through as-is.
+	return binding.preprocess(source, groups, options);
 }
 
 // Some consumers do `import * as svelte from 'svelte/compiler'` and access

--- a/docs/src/routes/benchmark/+page.svelte
+++ b/docs/src/routes/benchmark/+page.svelte
@@ -21,8 +21,6 @@
 		svelte2tsx: { label: 'svelte2tsx', sub: '.svelte → .tsx generation' }
 	};
 
-	const TABS: TabId[] = ['full', 'parse', 'svelte2tsx'];
-
 	const formatDate = (iso: string): string =>
 		new Date(iso).toLocaleString('en-US', {
 			year: 'numeric',
@@ -239,7 +237,7 @@
 			<section class="chart-card">
 				<header class="chart-head">
 					<div class="tabs" role="tablist" aria-label="Benchmark task">
-						{#each TABS as tab (tab)}
+						{#each ['full', 'parse', 'svelte2tsx'] as const as tab (tab)}
 							<button
 								role="tab"
 								type="button"
@@ -1061,13 +1059,11 @@
 		.stats {
 			grid-template-columns: repeat(2, 1fr);
 		}
-		/* 3rd card starts a new row in 2-col layout */
-		.stat + .stat + .stat {
+		.stat:nth-child(3) {
 			border-left: none;
 			border-top: 1px solid var(--rule);
 		}
-		/* 4th card */
-		.stat + .stat + .stat + .stat {
+		.stat:nth-child(4) {
 			border-top: 1px solid var(--rule);
 		}
 	}


### PR DESCRIPTION
## Summary

Now that the underlying compiler bugs are fixed on main, the docs site no longer needs the local workarounds it accumulated while compiling itself through rsvelte:

- **`#142` (each-block parser)** lets `{#each [...] as const as tab (tab)}` parse correctly, so the hoisted `TABS` constant is no longer needed.
- **`#144` (CSS `:nth-child` arg)** preserves `:nth-child(N)`, so the `.stat + .stat + .stat` sibling-combinator workaround can revert to plain `.stat:nth-child(3)` / `:nth-child(4)` rules.
- **`#133` (NAPI preprocess contract)** makes the binding signature match upstream `(source, group | group[], { filename? })` with `(value)` callbacks, sync/async returns and `undefined` / `null` resolutions. The shim's regex-based JS-side preprocess walker is gone — `binding.preprocess(source, groups, options)` is called straight through.

The `cssHash`-stripping `sanitiseOptions` helper stays. That's a separate gap (function values cant cross serde_json on the NAPI boundary) tracked independently of these fixes.

## Test plan
- [x] `pnpm build` succeeds from clean state and emits `.stat.svelte-xxx:nth-child(3)` / `:nth-child(4)` in the static CSS bundle
- [x] No leftover workaround constants in the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)