### PR TITLE
fix(transform/client): paren-wrap object-literal `$derived` bodies

### DIFF
--- a/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -26,7 +26,16 @@ pub(super) fn unthunk_string(expr: &str) -> String {
         }
     }
 
-    // No optimization possible, wrap in arrow
+    // No optimization possible, wrap in arrow.
+    //
+    // If the expression begins with `{`, an arrow body `() => { … }` parses
+    // as a block (and the contents become labelled statements), not as an
+    // object-literal return. Wrap the body in parens to disambiguate, so
+    // `$derived({ a: 1 }[k])` becomes `() => ({ a: 1 }[k])` rather than
+    // `() => { a: 1 }[k]`. See baseballyama/rsvelte#150.
+    if expr.trim_start().starts_with('{') {
+        return format!("() => ({})", expr);
+    }
     format!("() => {}", expr)
 }
 

--- a/tests/derived_object_literal.rs
+++ b/tests/derived_object_literal.rs
@@ -1,0 +1,99 @@
+//! Regression test for client-side `$derived(objectLiteral…)` losing its
+//! object-literal interpretation (baseballyama/rsvelte#150).
+//!
+//! Bug: `$derived(expr)` is rewritten to `$.derived(() => expr)`. When `expr`
+//! starts with `{`, the resulting `() => { … }` is parsed as an arrow with a
+//! block body — the object contents become labelled statements and the build
+//! fails. Wrap the body in parens (`() => ({ … })`) so the arrow returns the
+//! object expression.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn compile_client(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn derived_with_object_literal_index_is_paren_wrapped() {
+    let src = r#"<script>
+  let pos = $state('center');
+  const cls = $derived({ center: 'a', left: 'b' }[pos] ?? 'c');
+</script>
+<div>{cls}</div>"#;
+    let out = compile_client(src);
+    // Must wrap in parens so the body is an object-returning expression,
+    // not a block.
+    assert!(
+        out.contains("() => ({"),
+        "expected arrow body to be paren-wrapped (`() => ({{ … }})`). Got:\n{out}"
+    );
+    assert!(
+        !out.contains("() => { center:"),
+        "unwrapped arrow body would be parsed as a block. Got:\n{out}"
+    );
+}
+
+#[test]
+fn derived_with_object_literal_alone_is_paren_wrapped() {
+    // The bare object case — `$derived({ a, b })` should still work.
+    let src = r#"<script>
+  let a = $state(1);
+  let b = $state(2);
+  const obj = $derived({ a, b });
+</script>
+<pre>{JSON.stringify(obj)}</pre>"#;
+    let out = compile_client(src);
+    assert!(
+        out.contains("() => ({"),
+        "expected arrow body to be paren-wrapped. Got:\n{out}"
+    );
+}
+
+#[test]
+fn derived_with_non_object_expression_stays_unwrapped() {
+    // Regression guard: simple expression bodies must NOT acquire spurious
+    // outer parens. They already work today, so unthunk_string's default
+    // `() => expr` path produces compact output without the extra parens.
+    let src = r#"<script>
+  let n = $state(0);
+  const doubled = $derived(n * 2);
+</script>
+<span>{doubled}</span>"#;
+    let out = compile_client(src);
+    // The arrow body must not be paren-wrapped — only object-literal bodies
+    // need the disambiguation.
+    assert!(
+        out.contains("() => n * 2"),
+        "expected `() => n * 2` (no extra parens). Got:\n{out}"
+    );
+    assert!(
+        !out.contains("() => (n * 2)"),
+        "expression body should not be unnecessarily paren-wrapped. Got:\n{out}"
+    );
+}
+
+#[test]
+fn derived_with_simple_identifier_call_still_unthunks() {
+    // `$derived(foo())` should unthunk to `$.derived(foo)` — make sure the
+    // paren-wrap branch doesn't intercept that.
+    let src = r#"<script>
+  import { getX } from './x.js';
+  const x = $derived(getX());
+</script>
+<span>{x}</span>"#;
+    let out = compile_client(src);
+    assert!(
+        out.contains("$.derived(getX)"),
+        "expected unthunked `$.derived(getX)`. Got:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

`$derived(expr)` is rewritten to `$.derived(() => expr)`. When `expr` starts with `{` the resulting `() => { … }` is parsed by every JS engine as an arrow with a **block** body (and the object contents become labelled statements), not as an arrow returning the object literal. rolldown / oxc reject the output with `Expected a semicolon after a statement`.

`$derived.by(() => { … })` was already guarded against this in #148 by emitting an IIFE. The bare `$derived(expr)` path went through `unthunk_string`, whose fallback `format!("() => {}", expr)` produced the broken `() => { obj }` directly.

### Fix

Teach `unthunk_string` to wrap object-literal bodies in parens (`() => ({ … })`) so the arrow returns the object expression as intended. Other arrow callers (e.g. `$.async_derived`) already had explicit `is_object` checks for the same reason; centralising the wrap in `unthunk_string` makes them redundant going forward.

### Repro

```svelte
<script>
  let pos = $state('center');
  const cls = $derived({ center: 'a', left: 'b' }[pos] ?? 'c');
</script>
<div>{cls}</div>
```

Before: `const cls = $.derived(() => { center: 'a', left: 'b' }[pos] ?? 'c');` ← parses as block body, rolldown rejects.

After: `const cls = $.derived(() => ({ center: 'a', left: 'b' }[pos] ?? 'c'));` ✓

Fixes #150.

## Test plan
- [x] `cargo test --release` — targeted suites (compiler_fixtures, parser_fixtures, ssr, compiler_errors, css, css_nth_child_args, each_block_as_const, validator, print) 121 tests pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] New `tests/derived_object_literal.rs` covers:
  - `$derived({ … }[k] ?? fallback)` (the regression)
  - `$derived({ a, b })` (bare object)
  - `$derived(n * 2)` (regression guard: no spurious parens on plain expressions)
  - `$derived(getX())` (regression guard: still unthunks to `$.derived(getX)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)