### PR TITLE
docs(site): redesign homepage — calmer, Svelte.dev-inspired, Rust-forward

### DIFF
--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
 	<link
-		href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
+		href="https://fonts.googleapis.com/css2?family=Overpass:wght@400;500;600;700;800&family=Fira+Mono:wght@400;500;700&display=swap"
 		rel="stylesheet"
 	/>
 </svelte:head>
@@ -31,15 +31,9 @@
 	}
 
 	:global(body) {
-		font-family:
-			'Inter',
-			-apple-system,
-			BlinkMacSystemFont,
-			'Segoe UI',
-			Roboto,
-			sans-serif;
-		background: #0a0a0f;
-		color: #e4e4e7;
+		font-family: 'Overpass', ui-sans-serif, -apple-system, BlinkMacSystemFont, sans-serif;
+		background: #ffffff;
+		color: #14130f;
 		line-height: 1.6;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
@@ -50,7 +44,13 @@
 		text-decoration: none;
 	}
 
-	:global(code) {
-		font-family: 'JetBrains Mono', 'Fira Code', monospace;
+	:global(code),
+	:global(pre) {
+		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+	}
+
+	:global(::selection) {
+		background: #ffe9d6;
+		color: #14130f;
 	}
 </style>

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import type { BenchmarkResults } from '$lib/types/benchmark';
 
 	let bench = $state<BenchmarkResults | null>(null);
+	let animated = $state(false);
 
 	onMount(async () => {
 		try {
@@ -12,237 +13,291 @@
 		} catch {
 			bench = null;
 		}
+		requestAnimationFrame(() => (animated = true));
 	});
 
+	const formatDuration = (ms: number): string => {
+		if (ms < 1) return `${(ms * 1000).toFixed(0)}μs`;
+		if (ms < 1000) return `${ms.toFixed(1)} ms`;
+		return `${(ms / 1000).toFixed(2)} s`;
+	};
+
+	const formatThroughput = (v: number): string => {
+		if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+		if (v >= 1000) return `${(v / 1000).toFixed(1)}k`;
+		return `${Math.round(v)}`;
+	};
+
+	const formatDate = (iso: string): string =>
+		new Date(iso).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+
 	const specs = [
-		{ n: 3341, label: 'tests passing', sub: 'in-scope, 100%' },
-		{ n: 1202, label: 'runtime · legacy', sub: 'svelte 4 parity' },
-		{ n: 865, label: 'runtime · runes', sub: '$state · $derived · $effect' },
-		{ n: 324, label: 'validator + a11y', sub: 'warning / error detection' },
-		{ n: 245, label: 'svelte2tsx', sub: 'wave 1 of ecosystem port' },
-		{ n: 179, label: 'css', sub: ':global · scoping · keyframes' }
+		{ n: 1202, label: 'runtime / legacy', sub: 'svelte 4 parity' },
+		{ n: 865, label: 'runtime / runes', sub: '$state / $derived / $effect' },
+		{ n: 324, label: 'validator + a11y', sub: 'warnings & errors' },
+		{ n: 245, label: 'svelte2tsx', sub: 'ecosystem / wave 1' },
+		{ n: 179, label: 'css', sub: ':global / scoping / keyframes' },
+		{ n: 144, label: 'compiler errors', sub: 'parse & semantic checks' }
 	];
 
 	const why = [
 		{
+			n: '01',
 			h: 'Parallel by default.',
-			p: 'Compilation fans out across rayon. The parser is thread-safe; phase outputs pass directly through without re-parsing.'
+			p: 'Files fan out across rayon worker threads. The parser is thread-safe; phase outputs pass directly through without re-parsing.'
 		},
 		{
+			n: '02',
 			h: 'Compact memory.',
-			p: 'u32 source positions, compact_str on hot paths, AST nodes shaped to keep cache lines warm.'
+			p: 'u32 source positions, compact_str on hot paths, AST nodes shaped to keep cache lines warm under real workloads.'
 		},
 		{
-			h: 'OXC-ready.',
-			p: 'Conventions mirror oxc_ast so the compiler drops cleanly into the wider OXC toolchain.'
+			n: '03',
+			h: 'Built for OXC.',
+			p: 'Conventions mirror oxc_ast so the compiler drops cleanly into the wider OXC toolchain when it lands.'
 		}
 	];
 </script>
 
 <svelte:head>
-	<title>rsvelte · a Rust port of the Svelte 5 compiler</title>
+	<title>rsvelte · the Svelte compiler, in Rust</title>
 	<meta
 		name="description"
-		content="A drop-in replacement for svelte/compiler, rewritten in Rust. Same surface, same output, multi-threaded by default."
-	/>
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link
-		href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
-		rel="stylesheet"
+		content="A Rust port of the Svelte 5 compiler. Same surface, identical output, parallelized by default."
 	/>
 </svelte:head>
 
-<div class="page">
+<div class="page" class:in={animated}>
 	<nav class="nav">
 		<a href="{base}/" class="brand" aria-label="rsvelte home">
-			<span class="brand-icon" aria-hidden="true">
-				<svg viewBox="0 0 24 24" width="22" height="22" fill="none">
+			<span class="mark" aria-hidden="true">
+				<svg viewBox="0 0 24 24" width="20" height="20" fill="none">
 					<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="#ff3e00" />
-					<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="#ce422b" />
+					<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="#b7410e" />
 				</svg>
 			</span>
 			<span class="brand-text">rsvelte</span>
-			<span class="brand-tag">rust port</span>
+			<span class="brand-tag">rust&nbsp;port</span>
 		</a>
 
 		<div class="nav-links">
 			<a href="{base}/playground">Playground</a>
 			<a href="{base}/progress">Compatibility</a>
 			<a href="{base}/benchmark">Benchmark</a>
-			<a
-				href="https://github.com/baseballyama/rsvelte"
-				target="_blank"
-				rel="noopener"
-				class="gh"
-			>
-				GitHub
-				<span aria-hidden="true">↗</span>
+			<a href="https://github.com/baseballyama/rsvelte" target="_blank" rel="noopener" class="gh">
+				GitHub <span aria-hidden="true" class="ext">↗</span>
 			</a>
 		</div>
 	</nav>
 
 	<header class="hero">
-		<div class="hero-text">
-			<p class="eyebrow">The Svelte 5 compiler · rewritten in Rust</p>
+		<p class="eyebrow"><span class="rule"></span>Svelte 5 · written in Rust</p>
 
-			<h1>
-				A <span class="ink-svelte">Rust</span> port of <span class="ink-svelte">Svelte</span>.
-			</h1>
+		<h1 class="title">
+			The Svelte compiler,<br />rewritten in <span class="ink-rust">Rust</span>.
+		</h1>
 
-			<p class="lede">
-				A drop-in replacement for <code>svelte/compiler</code>. Same surface,
-				identical output, parallel by default.
-			</p>
+		<p class="lede">
+			A drop-in replacement for <code>svelte/compiler</code> — same surface, identical output,
+			parallelized by default.
+		</p>
 
-			<div class="cta">
-				<a href="{base}/playground" class="btn btn-primary">
-					Open playground
-					<span aria-hidden="true">→</span>
-				</a>
-				<a href="{base}/benchmark" class="btn btn-ghost">
-					See benchmark
-					<span aria-hidden="true">→</span>
-				</a>
-			</div>
+		<div class="cta">
+			<a href="{base}/playground" class="btn btn-primary">
+				Open playground <span aria-hidden="true">→</span>
+			</a>
+			<a href="{base}/benchmark" class="btn btn-ghost">
+				View benchmark <span aria-hidden="true">→</span>
+			</a>
 		</div>
 
-		<aside class="hero-card" aria-label="Install snippet">
-			<header class="card-header">
-				<span class="dot dot-r"></span>
-				<span class="dot dot-y"></span>
-				<span class="dot dot-g"></span>
-				<span class="card-path">~/your-app · install</span>
-			</header>
-			<pre class="card-body"><code><span class="c-cmt"># swap one import — that's it</span>
-<span class="c-prompt">$</span> pnpm add <span class="c-pkg">@rsvelte/compiler</span>
-
-<span class="c-cmt"># or pin from source</span>
-<span class="c-prompt">$</span> cargo add <span class="c-pkg">rsvelte</span>
-</code></pre>
-			<footer class="card-foot">
-				<span class="kbd">rust 1.84</span>
-				<span class="kbd">node 22+</span>
-				<span class="kbd">svelte 5.51.3</span>
-			</footer>
-		</aside>
+		<p class="install">
+			<span class="prompt">$</span> pnpm add <span class="pkg">@rsvelte/compiler</span>
+		</p>
 	</header>
 
-	<!-- Compact benchmark strip — the headline numbers right here, not buried -->
-	<section class="bench-strip" aria-label="Headline benchmark">
-		<div class="bench-strip-inner">
-			<div class="bench-eyebrow">
-				<span class="rule-h"></span>
-				<span class="bench-label">Compilation speed · against svelte/compiler</span>
-			</div>
+	<section class="perf" id="performance">
+		<div class="section-head">
+			<span class="num">01</span>
+			<h2>
+				{#if bench}
+					<span class="ink-svelte">{bench.speedup.multiThreadVsJs.toFixed(1)}×</span> faster than
+					<code>svelte/compiler</code>.
+				{:else}
+					Compilation, measured against <code>svelte/compiler</code>.
+				{/if}
+			</h2>
+			<p class="lede">
+				The benchmark runs the full compile pipeline — parse, analyze, codegen — over the official
+				Svelte test corpus on the same machine.
+			</p>
+		</div>
 
-			<div class="bench-cells">
-				<div class="bench-cell big">
-					<span class="bench-n">
-						{bench ? bench.speedup.multiThreadVsJs.toFixed(1) : '—'}<span class="x">×</span>
-					</span>
-					<span class="bench-k">multi-threaded</span>
-					<span class="bench-s">rayon fan-out · full pipeline</span>
+		<div class="perf-grid">
+			<figure class="bars">
+				<figcaption>
+					<span class="bars-title">Compile (client)</span>
+					<span class="bars-sub"
+						>{bench ? `${bench.testFilesCount.toLocaleString('en-US')} .svelte files` : '—'}</span
+					>
+				</figcaption>
+
+				{#if bench}
+					{@const max = Math.max(
+						bench.javascript.durationMs,
+						bench.rustSingleThread.durationMs,
+						bench.rustMultiThread.durationMs
+					)}
+					{@const rows = [
+						{
+							k: 'svelte/compiler',
+							tone: 'js',
+							sub: 'JavaScript',
+							dur: bench.javascript.durationMs
+						},
+						{
+							k: 'rsvelte / single',
+							tone: 'rs',
+							sub: 'no parallelism',
+							dur: bench.rustSingleThread.durationMs
+						},
+						{
+							k: 'rsvelte / multi',
+							tone: 'rm',
+							sub: 'rayon fan-out',
+							dur: bench.rustMultiThread.durationMs
+						}
+					]}
+					<div class="bar-list">
+						{#each rows as r, i (r.k)}
+							<div class="bar-row" style="--i: {i};">
+								<div class="bar-meta">
+									<span class="bar-k">{r.k}</span>
+									<span class="bar-s">{r.sub}</span>
+								</div>
+								<div class="bar-graph">
+									<span class="bar-track">
+										<span
+											class="bar-fill bar-{r.tone}"
+											style="--w: {(r.dur / max) * 100}%;"
+										></span>
+									</span>
+									<span class="bar-t">{formatDuration(r.dur)}</span>
+								</div>
+							</div>
+						{/each}
+					</div>
+				{:else}
+					<div class="bars-empty">
+						<p>Benchmark data not loaded.</p>
+					</div>
+				{/if}
+
+				<div class="bars-foot">
+					<span>Lower is better</span>
+					<span class="dot-sep">·</span>
+					<span>{bench ? `recorded ${formatDate(bench.generatedAt)}` : ''}</span>
+					{#if bench}
+						<span class="dot-sep">·</span>
+						<span><code>{bench.commitSha}</code></span>
+					{/if}
 				</div>
-				<div class="bench-cell">
-					<span class="bench-n">
-						{bench ? bench.parse.speedup.multiThreadVsJs.toFixed(0) : '—'}<span class="x">×</span>
+			</figure>
+
+			<aside class="stats">
+				<div class="stat stat-hero">
+					<span class="stat-k">Full pipeline · multi</span>
+					<span class="stat-n">
+						{bench ? bench.speedup.multiThreadVsJs.toFixed(1) : '—'}<span class="stat-x">×</span>
 					</span>
-					<span class="bench-k">parser only</span>
-					<span class="bench-s">phase 1, isolated</span>
+					<span class="stat-s">rayon fan-out vs. <code>svelte/compiler</code></span>
 				</div>
-				<div class="bench-cell">
-					<span class="bench-n">
-						{bench
-							? `${(bench.rustMultiThread.throughputFilesPerSec / 1000).toFixed(1)}k`
-							: '—'}<span class="x">/s</span>
+				<div class="stat">
+					<span class="stat-k">Parser only · multi</span>
+					<span class="stat-n">
+						{bench ? bench.parse.speedup.multiThreadVsJs.toFixed(0) : '—'}<span class="stat-x"
+							>×</span
+						>
 					</span>
-					<span class="bench-k">throughput</span>
-					<span class="bench-s">files compiled per second</span>
+					<span class="stat-s">phase 1, isolated</span>
 				</div>
-				<a class="bench-link" href="{base}/benchmark">
-					Full benchmark
-					<span aria-hidden="true">→</span>
+				<div class="stat">
+					<span class="stat-k">Throughput</span>
+					<span class="stat-n">
+						{bench ? formatThroughput(bench.rustMultiThread.throughputFilesPerSec) : '—'}<span
+							class="stat-x">/s</span
+						>
+					</span>
+					<span class="stat-s">files compiled per second</span>
+				</div>
+				<a class="stat stat-link" href="{base}/benchmark">
+					<span class="stat-k">Full breakdown</span>
+					<span class="stat-go"
+						>parse · ssr · svelte2tsx <span aria-hidden="true">→</span></span
+					>
 				</a>
-			</div>
+			</aside>
 		</div>
 	</section>
 
-	<!-- Drop-in diff -->
 	<section class="dropin">
 		<div class="section-head">
 			<span class="num">02</span>
-			<h2>One <em>import</em>. No flags.</h2>
+			<h2>One import. <em>No flags.</em></h2>
 			<p class="lede">
-				No bundler plugin to wire, no compiler flag to flip. Same
-				<code>compile()</code>, <code>compileModule()</code>,
-				<code>parse()</code>, <code>preprocess()</code>.
+				No bundler plugin to wire, no compiler flag to flip. Same <code>compile()</code>,
+				<code>compileModule()</code>, <code>parse()</code>, <code>preprocess()</code>.
 			</p>
 		</div>
 
 		<figure class="diff">
 			<figcaption>
 				<span class="diff-file">build.config.js</span>
-				<span class="diff-tag">diff</span>
 			</figcaption>
 			<pre><code><span class="d-line d-minus"><span class="d-sig">-</span> import * as svelte from <span class="d-str">'svelte/compiler'</span>;</span>
 <span class="d-line d-plus"><span class="d-sig">+</span> import * as svelte from <span class="d-str">'@rsvelte/compiler'</span>;</span></code></pre>
 		</figure>
 	</section>
 
-	<!-- Compatibility — compact list -->
-	<section class="spec">
+	<section class="compat">
 		<div class="section-head">
 			<span class="num">03</span>
 			<h2>Every test, passing.</h2>
 			<p class="lede">
-				Each row mirrors a category in the official <code>sveltejs/svelte</code>
-				suite, run against commit <code>04c0368a</code>. Full breakdown on the
+				<span class="big-pct">3,341 / 3,341</span> in-scope fixtures from the official
+				<code>sveltejs/svelte</code> suite. Full breakdown on the
 				<a class="link" href="{base}/progress">compatibility page</a>.
 			</p>
 		</div>
 
-		<div class="spec-list">
+		<dl class="spec-list">
 			{#each specs as s, i (s.label)}
 				<div class="spec-row" style="--i: {i};">
-					<div class="spec-n">{s.n.toLocaleString('en-US')}</div>
-					<div class="spec-body">
-						<div class="spec-k">{s.label}</div>
-						<div class="spec-s">{s.sub}</div>
-					</div>
-					<div class="spec-bar">
-						<span class="bar-track"><span class="bar-fill"></span></span>
-						<span class="spec-pct">100<span class="dim">%</span></span>
-					</div>
+					<dt class="spec-k">{s.label}</dt>
+					<dd class="spec-v">
+						<span class="spec-n">{s.n.toLocaleString('en-US')}</span>
+						<span class="spec-s">{s.sub}</span>
+					</dd>
+					<span class="spec-pct">100<span class="dim">%</span></span>
 				</div>
 			{/each}
-		</div>
+		</dl>
 	</section>
 
-	<!-- Why Rust -->
 	<section class="why">
 		<div class="section-head">
 			<span class="num">04</span>
-			<h2>Built for the next Svelte.</h2>
+			<h2>Why a port?</h2>
 		</div>
 
-		<div class="why-grid">
+		<div class="why-list">
 			{#each why as w (w.h)}
-				<article class="why-card">
-					<span class="why-tick" aria-hidden="true">
-						<svg viewBox="0 0 16 16" width="16" height="16">
-							<path
-								d="M3 8.5 6.5 12 13 4.5"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="1.6"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							/>
-						</svg>
-					</span>
-					<h3>{w.h}</h3>
-					<p>{w.p}</p>
+				<article class="why-row">
+					<span class="why-n">{w.n}</span>
+					<div class="why-body">
+						<h3>{w.h}</h3>
+						<p>{w.p}</p>
+					</div>
 				</article>
 			{/each}
 		</div>
@@ -251,12 +306,10 @@
 	<footer class="foot">
 		<div class="foot-inner">
 			<div class="foot-mark">
-				<span class="brand-icon" aria-hidden="true">
-					<svg viewBox="0 0 24 24" width="18" height="18" fill="none">
-						<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="#ff3e00" />
-						<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="#ce422b" />
-					</svg>
-				</span>
+				<svg viewBox="0 0 24 24" width="16" height="16" fill="none" aria-hidden="true">
+					<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="#ff3e00" />
+					<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="#b7410e" />
+				</svg>
 				<span>rsvelte</span>
 			</div>
 			<div class="foot-meta">
@@ -274,45 +327,31 @@
 
 <style>
 	.page {
-		--bg: #fdfcfa;
-		--surface: #f6f3ed;
-		--surface-2: #efeae0;
-		--ink: #15140f;
-		--ink-soft: #57534d;
-		--ink-faint: #908a80;
-		--rule: #e7e2d6;
-		--rule-strong: #c8c0b0;
-		--svelte: #ff3e00;
-		--rust: #ce422b;
-		--accent-deep: #b8350c;
+		--bg: #ffffff;
+		--paper: #faf9f5;
+		--ink: #14130f;
+		--ink-soft: #5a5750;
+		--ink-faint: #97938a;
+		--rule: #ececdf;
+		--rule-strong: #d8d4c4;
 
-		--sans:
-			'Atkinson Hyperlegible', ui-sans-serif, -apple-system, BlinkMacSystemFont,
-			'Helvetica Neue', sans-serif;
-		--mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+		--svelte: #ff3e00;
+		--rust: #b7410e;
+		--rust-soft: #cf7a4a;
 
 		background: var(--bg);
 		color: var(--ink);
-		font-family: var(--sans);
 		font-size: 16px;
-		line-height: 1.55;
+		line-height: 1.6;
 		min-height: 100vh;
-		-webkit-font-smoothing: antialiased;
-		-moz-osx-font-smoothing: grayscale;
-	}
-
-	:global(body) {
-		margin: 0;
 	}
 
 	code,
-	.kbd {
-		font-family: var(--mono);
+	pre {
+		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
-	/* ============================================================
-	   NAV — compact top bar, Svelte.dev style
-	   ============================================================ */
+	/* NAV */
 	.nav {
 		position: sticky;
 		top: 0;
@@ -321,59 +360,56 @@
 		align-items: center;
 		justify-content: space-between;
 		gap: 2rem;
-		padding: 0.85rem clamp(1rem, 3vw, 2.25rem);
-		background: rgba(253, 252, 250, 0.92);
+		padding: 0.9rem clamp(1rem, 4vw, 2.5rem);
+		background: rgba(255, 255, 255, 0.88);
 		border-bottom: 1px solid var(--rule);
-		backdrop-filter: saturate(160%) blur(8px);
+		backdrop-filter: saturate(150%) blur(6px);
 	}
 
 	.brand {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.55rem;
-		text-decoration: none;
 		color: var(--ink);
 	}
 
-	.brand-icon {
+	.mark {
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		width: 26px;
-		height: 26px;
+		width: 24px;
+		height: 24px;
 	}
 
 	.brand-text {
 		font-weight: 700;
-		font-size: 1.05rem;
+		font-size: 1rem;
 		letter-spacing: -0.01em;
 	}
 
 	.brand-tag {
-		font-family: var(--mono);
-		font-size: 0.66rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.62rem;
 		letter-spacing: 0.12em;
 		text-transform: uppercase;
 		color: var(--rust);
-		padding: 0.18rem 0.5rem;
+		padding: 0.2rem 0.45rem;
 		border: 1px solid currentColor;
-		border-radius: 999px;
+		border-radius: 2px;
 		line-height: 1;
-		margin-left: 0.25rem;
-		opacity: 0.85;
+		margin-left: 0.2rem;
 	}
 
 	.nav-links {
 		display: flex;
 		align-items: center;
-		gap: clamp(0.75rem, 2vw, 1.6rem);
-		font-size: 0.9rem;
+		gap: clamp(0.8rem, 2.2vw, 1.8rem);
+		font-size: 0.92rem;
 		font-weight: 500;
 	}
 
 	.nav-links a {
 		color: var(--ink-soft);
-		text-decoration: none;
 		padding: 0.25rem 0;
 		border-bottom: 1px solid transparent;
 		transition:
@@ -382,45 +418,55 @@
 	}
 
 	.nav-links a:hover {
-		color: var(--svelte);
-		border-bottom-color: var(--svelte);
+		color: var(--ink);
+		border-bottom-color: var(--ink);
 	}
 
-	.nav-links .gh {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.3rem;
+	.nav-links .gh .ext {
+		font-size: 0.85em;
+		opacity: 0.6;
 	}
 
-	/* ============================================================
-	   HERO — two columns: copy + install card
-	   ============================================================ */
+	/* HERO */
 	.hero {
-		display: grid;
-		grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
-		gap: clamp(2rem, 5vw, 4.5rem);
-		align-items: center;
-		padding: clamp(3rem, 8vh, 5.5rem) clamp(1rem, 3vw, 2.25rem) clamp(2.5rem, 6vh, 4rem);
-		max-width: 1280px;
+		max-width: 1080px;
 		margin: 0 auto;
+		padding: clamp(4rem, 12vh, 7rem) clamp(1rem, 4vw, 2.5rem) clamp(3rem, 6vh, 4.5rem);
 	}
 
 	.eyebrow {
-		font-family: var(--mono);
-		font-size: 0.78rem;
-		letter-spacing: 0.06em;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.7rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.75rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
 		color: var(--rust);
-		margin: 0 0 1.4rem;
+		margin: 0 0 1.6rem;
 	}
 
-	.hero h1 {
-		font-family: var(--sans);
-		font-weight: 700;
-		font-size: clamp(2.5rem, 5.6vw, 4.2rem);
+	.eyebrow .rule {
+		display: inline-block;
+		width: 24px;
+		height: 1px;
+		background: var(--rust);
+	}
+
+	.title {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: clamp(2.3rem, 6.2vw, 4.6rem);
 		line-height: 1.02;
-		letter-spacing: -0.025em;
-		margin: 0;
+		letter-spacing: -0.03em;
 		color: var(--ink);
+		margin: 0;
+	}
+
+	.ink-rust {
+		color: var(--rust);
+		font-style: italic;
+		font-weight: 700;
 	}
 
 	.ink-svelte {
@@ -428,44 +474,42 @@
 	}
 
 	.lede {
-		font-size: clamp(1rem, 1.1vw, 1.15rem);
-		max-width: 44ch;
+		font-size: clamp(1.05rem, 1.3vw, 1.2rem);
+		max-width: 52ch;
 		color: var(--ink-soft);
-		margin: 1.4rem 0 0;
+		margin: 1.6rem 0 0;
 	}
 
 	.lede code {
-		background: var(--surface);
+		background: var(--paper);
 		color: var(--ink);
 		padding: 0.08em 0.4em;
-		border-radius: 4px;
-		font-size: 0.9em;
+		border-radius: 3px;
+		font-size: 0.88em;
 		border: 1px solid var(--rule);
 	}
 
 	.cta {
 		display: flex;
-		gap: 0.75rem;
+		gap: 0.65rem;
 		flex-wrap: wrap;
-		margin-top: 2rem;
+		margin-top: 2.4rem;
 	}
 
 	.btn {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.45rem;
-		padding: 0.7rem 1.1rem;
-		font-family: var(--sans);
-		font-weight: 700;
+		gap: 0.5rem;
+		padding: 0.78rem 1.25rem;
+		font-family: 'Overpass', sans-serif;
+		font-weight: 600;
 		font-size: 0.95rem;
-		border-radius: 6px;
-		text-decoration: none;
+		border-radius: 4px;
 		border: 1px solid transparent;
 		transition:
 			background 0.18s,
 			color 0.18s,
-			border-color 0.18s,
-			transform 0.18s;
+			border-color 0.18s;
 	}
 
 	.btn span {
@@ -482,7 +526,7 @@
 	}
 
 	.btn-primary:hover {
-		background: var(--accent-deep);
+		background: #e83700;
 	}
 
 	.btn-ghost {
@@ -495,239 +539,47 @@
 		border-color: var(--ink);
 	}
 
-	/* ============================================================
-	   HERO CARD — terminal-style install snippet (Cargo cue)
-	   ============================================================ */
-	.hero-card {
-		background: var(--ink);
-		color: #ede8d8;
-		border-radius: 10px;
-		font-family: var(--mono);
-		box-shadow: 0 14px 32px -22px rgba(21, 20, 15, 0.6);
-		border: 1px solid #2a2620;
-		overflow: hidden;
+	.install {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.9rem;
+		color: var(--ink-soft);
+		margin-top: 2.2rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--rule);
+		max-width: 36rem;
 	}
 
-	.card-header {
-		display: flex;
-		align-items: center;
-		gap: 0.45rem;
-		padding: 0.7rem 0.95rem;
-		border-bottom: 1px solid rgba(237, 232, 216, 0.08);
-		font-size: 0.74rem;
-	}
-
-	.dot {
-		width: 11px;
-		height: 11px;
-		border-radius: 50%;
-		display: inline-block;
-	}
-
-	.dot-r {
-		background: #ff5f57;
-	}
-	.dot-y {
-		background: #febc2e;
-	}
-	.dot-g {
-		background: #28c840;
-	}
-
-	.card-path {
-		margin-left: 0.6rem;
-		color: rgba(237, 232, 216, 0.5);
-		letter-spacing: 0.04em;
-		font-size: 0.72rem;
-	}
-
-	.card-body {
-		margin: 0;
-		padding: 1.1rem 1.25rem;
-		font-size: 0.85rem;
-		line-height: 1.7;
-	}
-
-	.card-body code {
-		font-family: inherit;
-	}
-
-	.c-cmt {
-		color: rgba(237, 232, 216, 0.4);
-	}
-
-	.c-prompt {
+	.install .prompt {
 		color: var(--svelte);
-		margin-right: 0.5em;
+		margin-right: 0.6em;
 	}
 
-	.c-pkg {
-		color: #ffb380;
-	}
-
-	.card-foot {
-		display: flex;
-		gap: 0.4rem;
-		padding: 0.55rem 0.95rem 0.75rem;
-		border-top: 1px solid rgba(237, 232, 216, 0.08);
-		flex-wrap: wrap;
-	}
-
-	.kbd {
-		font-size: 0.65rem;
-		letter-spacing: 0.08em;
-		color: rgba(237, 232, 216, 0.55);
-		padding: 0.18rem 0.5rem;
-		border: 1px solid rgba(237, 232, 216, 0.14);
-		border-radius: 4px;
-		text-transform: lowercase;
-	}
-
-	/* ============================================================
-	   BENCH STRIP — headline benchmark numbers, above-the-fold
-	   ============================================================ */
-	.bench-strip {
-		background: var(--surface);
-		border-block: 1px solid var(--rule);
-	}
-
-	.bench-strip-inner {
-		max-width: 1280px;
-		margin: 0 auto;
-		padding: clamp(1.5rem, 3.5vh, 2.5rem) clamp(1rem, 3vw, 2.25rem);
-	}
-
-	.bench-eyebrow {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		margin-bottom: 1.5rem;
-	}
-
-	.rule-h {
-		display: inline-block;
-		width: 28px;
-		height: 1px;
-		background: var(--rust);
-	}
-
-	.bench-label {
-		font-family: var(--mono);
-		font-size: 0.74rem;
-		letter-spacing: 0.08em;
+	.install .pkg {
 		color: var(--rust);
 	}
 
-	.bench-cells {
-		display: grid;
-		grid-template-columns: 1.4fr 1fr 1fr auto;
-		gap: clamp(1rem, 3vw, 2.5rem);
-		align-items: end;
+	/* PERF */
+	.perf {
+		background: var(--paper);
+		border-block: 1px solid var(--rule);
 	}
 
-	.bench-cell {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		border-left: 1px solid var(--rule-strong);
-		padding-left: clamp(1rem, 2vw, 1.5rem);
-	}
-
-	.bench-cell:first-child {
-		border-left: none;
-		padding-left: 0;
-	}
-
-	.bench-n {
-		font-family: var(--sans);
-		font-weight: 700;
-		font-size: clamp(2.4rem, 4.8vw, 3.8rem);
-		line-height: 1;
-		letter-spacing: -0.035em;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
-		display: inline-flex;
-		align-items: baseline;
-	}
-
-	.bench-cell.big .bench-n {
-		color: var(--svelte);
-	}
-
-	.bench-n .x {
-		font-family: var(--mono);
-		font-weight: 500;
-		font-size: 0.42em;
-		letter-spacing: 0.02em;
-		margin-left: 0.15em;
-		color: var(--ink-faint);
-	}
-
-	.bench-cell.big .bench-n .x {
-		color: var(--svelte);
-		opacity: 0.7;
-	}
-
-	.bench-k {
-		font-weight: 700;
-		font-size: 0.9rem;
-		color: var(--ink);
-	}
-
-	.bench-s {
-		font-family: var(--mono);
-		font-size: 0.72rem;
-		letter-spacing: 0.03em;
-		color: var(--ink-soft);
-	}
-
-	.bench-link {
-		font-family: var(--mono);
-		font-size: 0.78rem;
-		text-decoration: none;
-		color: var(--ink);
-		padding: 0.55rem 0.9rem;
-		border: 1px solid var(--rule-strong);
-		border-radius: 6px;
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		transition:
-			background 0.18s,
-			border-color 0.18s,
-			color 0.18s;
-		white-space: nowrap;
-		align-self: end;
-	}
-
-	.bench-link:hover {
-		background: var(--ink);
-		color: var(--bg);
-		border-color: var(--ink);
-	}
-
-	/* ============================================================
-	   SECTION SHELL
-	   ============================================================ */
-	.dropin,
-	.spec,
-	.why {
-		max-width: 1280px;
+	.perf .section-head,
+	.dropin .section-head,
+	.compat .section-head,
+	.why .section-head {
+		max-width: 1080px;
 		margin: 0 auto;
-		padding: clamp(3.5rem, 7vh, 5.5rem) clamp(1rem, 3vw, 2.25rem);
-	}
-
-	.section-head {
+		padding: clamp(3.5rem, 8vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2.4rem);
 		display: grid;
 		grid-template-columns: auto 1fr;
-		gap: 0.4rem 1.25rem;
-		margin-bottom: clamp(2rem, 4vh, 3rem);
+		gap: 0.4rem 1.4rem;
 		align-items: baseline;
 	}
 
 	.section-head .num {
-		font-family: var(--mono);
-		font-size: 0.72rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7rem;
 		letter-spacing: 0.18em;
 		color: var(--rust);
 		grid-row: 1;
@@ -735,13 +587,13 @@
 	}
 
 	.section-head h2 {
-		font-family: var(--sans);
+		font-family: 'Overpass', sans-serif;
 		font-weight: 700;
-		font-size: clamp(1.6rem, 2.8vw, 2.4rem);
+		font-size: clamp(1.65rem, 3.2vw, 2.6rem);
+		line-height: 1.1;
 		letter-spacing: -0.022em;
 		margin: 0;
 		color: var(--ink);
-		line-height: 1.1;
 		grid-row: 1;
 		grid-column: 2;
 	}
@@ -749,65 +601,315 @@
 	.section-head h2 em {
 		font-style: italic;
 		color: var(--svelte);
+		font-weight: 700;
+	}
+
+	.section-head h2 code,
+	.compat .lede code {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.78em;
+		font-weight: 500;
+		padding: 0.1em 0.45em;
+		background: var(--bg);
+		border: 1px solid var(--rule);
+		border-radius: 3px;
+		vertical-align: 0.05em;
 	}
 
 	.section-head .lede {
 		grid-row: 2;
 		grid-column: 2;
+		margin-top: 0.7rem;
+	}
+
+	.perf-grid {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(4rem, 8vh, 6rem);
+		display: grid;
+		grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+		gap: clamp(1.5rem, 3vw, 2.5rem);
+		align-items: start;
+	}
+
+	.bars {
+		background: var(--bg);
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		overflow: hidden;
+	}
+
+	.bars figcaption {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		padding: 0.9rem 1.25rem;
+		border-bottom: 1px solid var(--rule);
+	}
+
+	.bars-title {
+		font-weight: 600;
+		font-size: 0.92rem;
+		color: var(--ink);
+	}
+
+	.bars-sub {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.72rem;
+		color: var(--ink-soft);
+	}
+
+	.bar-list {
+		padding: 1.2rem 1.25rem 0.4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1.05rem;
+	}
+
+	.bar-row {
+		display: grid;
+		grid-template-columns: minmax(10rem, 11rem) 1fr;
+		gap: 1.2rem;
+		align-items: center;
+	}
+
+	.bar-meta {
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+		min-width: 0;
+	}
+
+	.bar-k {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.78rem;
+		font-weight: 500;
+		color: var(--ink);
+		letter-spacing: -0.01em;
+	}
+
+	.bar-s {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.66rem;
+		color: var(--ink-faint);
+		letter-spacing: 0.02em;
+	}
+
+	.bar-graph {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: center;
+		gap: 0.85rem;
+	}
+
+	.bar-track {
+		display: block;
+		height: 10px;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 999px;
+		overflow: hidden;
+	}
+
+	.bar-fill {
+		display: block;
+		height: 100%;
+		width: 0;
+		border-radius: inherit;
+		transition: width 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+		transition-delay: calc(0.12s * var(--i, 0) + 0.15s);
+	}
+
+	.page.in .bar-fill {
+		width: var(--w);
+	}
+
+	.bar-js {
+		background: linear-gradient(90deg, #94908b, #b3aea4);
+	}
+
+	.bar-rs {
+		background: linear-gradient(90deg, var(--rust-soft), var(--rust));
+	}
+
+	.bar-rm {
+		background: linear-gradient(90deg, #ff7a3d, var(--svelte));
+	}
+
+	.bar-t {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.82rem;
+		color: var(--ink);
+		font-variant-numeric: tabular-nums;
+		min-width: 5.5rem;
+		text-align: right;
+	}
+
+	.bars-foot {
+		display: flex;
+		align-items: center;
+		gap: 0.55rem;
+		flex-wrap: wrap;
+		padding: 0.85rem 1.25rem 1rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7rem;
+		color: var(--ink-faint);
+		border-top: 1px solid var(--rule);
 		margin-top: 0.6rem;
 	}
 
-	.link {
+	.bars-foot code {
+		color: var(--ink-soft);
+	}
+
+	.dot-sep {
+		opacity: 0.5;
+	}
+
+	.bars-empty {
+		padding: 2rem 1.25rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.85rem;
+		color: var(--ink-faint);
+	}
+
+	.stats {
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+	}
+
+	.stat {
+		background: var(--bg);
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		padding: 1rem 1.2rem 1.15rem;
+		display: grid;
+		grid-template-areas: 'k k' 'n n' 's s';
+		gap: 0.1rem;
+	}
+
+	.stat.stat-hero {
+		border-color: var(--rust);
+		background: var(--bg);
+		box-shadow: 0 0 0 3px rgba(183, 65, 14, 0.06);
+	}
+
+	.stat-k {
+		grid-area: k;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--ink-soft);
+	}
+
+	.stat-n {
+		grid-area: n;
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: clamp(2rem, 3.6vw, 2.7rem);
+		line-height: 1;
+		letter-spacing: -0.035em;
+		color: var(--ink);
+		font-variant-numeric: tabular-nums;
+		display: inline-flex;
+		align-items: baseline;
+		margin-top: 0.35rem;
+	}
+
+	.stat-hero .stat-n {
+		color: var(--rust);
+	}
+
+	.stat-x {
+		font-family: 'Fira Mono', monospace;
+		font-weight: 500;
+		font-size: 0.4em;
+		margin-left: 0.18em;
+		color: var(--ink-faint);
+		letter-spacing: 0.04em;
+	}
+
+	.stat-hero .stat-x {
+		color: var(--rust);
+		opacity: 0.75;
+	}
+
+	.stat-s {
+		grid-area: s;
+		font-size: 0.82rem;
+		color: var(--ink-soft);
+		margin-top: 0.4rem;
+	}
+
+	.stat-s code {
+		font-size: 0.92em;
+		color: var(--ink);
+	}
+
+	.stat-link {
+		display: flex;
+		flex-direction: column;
+		gap: 0.45rem;
+		padding: 0.95rem 1.2rem 1rem;
+		color: var(--ink);
+		transition: border-color 0.18s;
+	}
+
+	.stat-link:hover {
+		border-color: var(--ink);
+	}
+
+	.stat-go {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.78rem;
+		color: var(--ink-soft);
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.stat-link:hover .stat-go {
 		color: var(--svelte);
-		text-decoration: underline;
-		text-decoration-thickness: 1px;
-		text-underline-offset: 3px;
 	}
 
-	.link:hover {
-		color: var(--accent-deep);
+	/* DROP-IN */
+	.dropin {
+		max-width: 1080px;
+		margin: 0 auto;
 	}
 
-	/* ============================================================
-	   DROP-IN diff
-	   ============================================================ */
 	.diff {
-		margin: 0;
-		max-width: 720px;
-		background: var(--ink);
-		color: #ede8d8;
-		border-radius: 10px;
-		font-family: var(--mono);
+		max-width: 680px;
+		margin: 0 auto clamp(2.5rem, 6vh, 4rem);
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		font-family: 'Fira Mono', monospace;
 		overflow: hidden;
-		border: 1px solid #2a2620;
-		box-shadow: 0 12px 28px -20px rgba(21, 20, 15, 0.5);
 	}
 
 	.diff figcaption {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		padding: 0.7rem 1rem;
-		border-bottom: 1px solid rgba(237, 232, 216, 0.08);
-		font-size: 0.7rem;
-		letter-spacing: 0.08em;
-		color: rgba(237, 232, 216, 0.55);
+		padding: 0.65rem 1rem;
+		border-bottom: 1px solid var(--rule);
+		font-size: 0.72rem;
+		letter-spacing: 0.04em;
+		color: var(--ink-faint);
 	}
 
-	.diff .diff-tag {
-		color: var(--svelte);
-		text-transform: uppercase;
+	.diff-file {
+		color: var(--ink-soft);
 	}
 
 	.diff pre {
 		margin: 0;
-		padding: 1.1rem 1.25rem;
-		font-size: 0.9rem;
-		line-height: 1.65;
-	}
-
-	.diff code {
-		font-family: inherit;
+		padding: 0.9rem 1.15rem;
+		font-size: 0.88rem;
+		line-height: 1.75;
 	}
 
 	.d-line {
@@ -818,108 +920,98 @@
 	.d-sig {
 		display: inline-block;
 		width: 1.2em;
-		opacity: 0.75;
+		opacity: 0.65;
 	}
 
 	.d-minus {
-		color: #f8a39a;
-		background: rgba(248, 163, 154, 0.05);
+		color: #a04030;
 	}
 
 	.d-plus {
-		color: #b6e6ad;
-		background: rgba(182, 230, 173, 0.06);
+		color: #2f6f3a;
+		background: rgba(47, 111, 58, 0.06);
 	}
 
 	.d-str {
-		color: #ffb380;
+		color: var(--rust);
 	}
 
-	/* ============================================================
-	   SPEC LIST — compact compatibility rows
-	   ============================================================ */
+	/* COMPAT */
+	.compat {
+		max-width: 1080px;
+		margin: 0 auto;
+	}
+
+	.big-pct {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		color: var(--ink);
+		letter-spacing: -0.01em;
+	}
+
 	.spec-list {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(min(100%, 28rem), 1fr));
-		gap: 0;
-		border-top: 1px solid var(--rule);
+		max-width: 1080px;
+		margin: 0 auto clamp(2.5rem, 5vh, 3.5rem);
+		padding: 0 clamp(1rem, 4vw, 2.5rem);
 	}
 
 	.spec-row {
 		display: grid;
-		grid-template-columns: minmax(4.5rem, 5.5rem) 1fr minmax(8rem, 11rem);
-		gap: 1rem;
-		align-items: center;
-		padding: 1.05rem 1.1rem;
+		grid-template-columns: minmax(10rem, 14rem) 1fr auto;
+		gap: 1.4rem;
+		align-items: baseline;
+		padding: 1rem 0;
 		border-bottom: 1px solid var(--rule);
 		opacity: 0;
-		transform: translateY(8px);
-		animation: rowin 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-		animation-delay: calc(0.06s * var(--i, 0) + 0.05s);
+		transform: translateY(6px);
+		transition:
+			opacity 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+			transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+		transition-delay: calc(0.05s * var(--i, 0));
 	}
 
-	@keyframes rowin {
-		to {
-			opacity: 1;
-			transform: none;
-		}
+	.page.in .spec-row {
+		opacity: 1;
+		transform: none;
 	}
 
-	.spec-n {
-		font-family: var(--sans);
-		font-weight: 700;
-		font-size: 1.5rem;
-		font-variant-numeric: tabular-nums;
-		letter-spacing: -0.02em;
-		color: var(--ink);
+	.spec-row:first-child {
+		border-top: 1px solid var(--rule);
 	}
 
 	.spec-k {
-		font-weight: 700;
-		font-size: 0.95rem;
+		font-weight: 600;
+		font-size: 0.98rem;
 		color: var(--ink);
+		letter-spacing: -0.005em;
+	}
+
+	.spec-v {
+		display: flex;
+		align-items: baseline;
+		gap: 0.85rem;
+		margin: 0;
+		min-width: 0;
+	}
+
+	.spec-n {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 700;
+		font-size: 1.15rem;
+		color: var(--ink);
+		font-variant-numeric: tabular-nums;
+		letter-spacing: -0.015em;
 	}
 
 	.spec-s {
-		font-family: var(--mono);
-		font-size: 0.72rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.74rem;
 		color: var(--ink-soft);
-		margin-top: 0.15rem;
-	}
-
-	.spec-bar {
-		display: flex;
-		align-items: center;
-		gap: 0.7rem;
-	}
-
-	.bar-track {
-		flex: 1;
-		height: 4px;
-		background: var(--surface-2);
-		border-radius: 999px;
-		overflow: hidden;
-		display: block;
-	}
-
-	.bar-fill {
-		display: block;
-		height: 100%;
-		width: 0;
-		background: var(--svelte);
-		animation: fill 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-		animation-delay: calc(0.06s * var(--i, 0) + 0.25s);
-	}
-
-	@keyframes fill {
-		to {
-			width: 100%;
-		}
 	}
 
 	.spec-pct {
-		font-family: var(--mono);
-		font-size: 0.78rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.82rem;
 		color: var(--ink);
 		font-variant-numeric: tabular-nums;
 	}
@@ -928,63 +1020,77 @@
 		color: var(--ink-faint);
 	}
 
-	/* ============================================================
-	   WHY GRID — three short cards
-	   ============================================================ */
-	.why-grid {
+	.link {
+		color: var(--svelte);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 3px;
+	}
+
+	.link:hover {
+		color: #d83500;
+	}
+
+	/* WHY */
+	.why {
+		max-width: 1080px;
+		margin: 0 auto;
+	}
+
+	.why-list {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(4rem, 8vh, 6rem);
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
-		gap: 1rem;
+		gap: 0;
 	}
 
-	.why-card {
-		background: var(--surface);
-		border: 1px solid var(--rule);
-		border-radius: 10px;
-		padding: 1.4rem 1.5rem 1.6rem;
-		position: relative;
+	.why-row {
+		display: grid;
+		grid-template-columns: minmax(2.5rem, 4rem) 1fr;
+		gap: 1.5rem;
+		padding: 1.6rem 0;
+		border-bottom: 1px solid var(--rule);
+		align-items: start;
 	}
 
-	.why-tick {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		width: 26px;
-		height: 26px;
-		border-radius: 50%;
-		background: var(--svelte);
-		color: #fff;
-		margin-bottom: 0.9rem;
+	.why-row:first-child {
+		border-top: 1px solid var(--rule);
 	}
 
-	.why-card h3 {
-		font-family: var(--sans);
+	.why-n {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.72rem;
+		letter-spacing: 0.16em;
+		color: var(--rust);
+	}
+
+	.why-body h3 {
+		font-family: 'Overpass', sans-serif;
 		font-weight: 700;
-		font-size: 1.1rem;
+		font-size: 1.18rem;
 		letter-spacing: -0.015em;
 		color: var(--ink);
-		margin: 0 0 0.4rem;
+		margin: 0 0 0.45rem;
 	}
 
-	.why-card p {
-		font-size: 0.95rem;
+	.why-body p {
+		font-size: 0.97rem;
 		color: var(--ink-soft);
 		margin: 0;
+		max-width: 64ch;
 	}
 
-	/* ============================================================
-	   FOOTER
-	   ============================================================ */
+	/* FOOT */
 	.foot {
 		border-top: 1px solid var(--rule);
-		background: var(--surface);
-		margin-top: 2rem;
+		background: var(--paper);
 	}
 
 	.foot-inner {
-		max-width: 1280px;
+		max-width: 1080px;
 		margin: 0 auto;
-		padding: 1.5rem clamp(1rem, 3vw, 2.25rem);
+		padding: 1.5rem clamp(1rem, 4vw, 2.5rem);
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
@@ -1003,8 +1109,8 @@
 	.foot-meta {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.55rem;
-		font-family: var(--mono);
+		gap: 0.6rem;
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink-soft);
 		flex-wrap: wrap;
@@ -1025,32 +1131,16 @@
 		color: var(--svelte);
 	}
 
-	/* ============================================================
-	   RESPONSIVE
-	   ============================================================ */
-	@media (max-width: 960px) {
-		.hero {
+	/* RESPONSIVE */
+	@media (max-width: 880px) {
+		.perf-grid {
 			grid-template-columns: 1fr;
 		}
-		.hero-card {
-			max-width: 540px;
-		}
-		.bench-cells {
-			grid-template-columns: 1fr 1fr;
-			gap: 1.4rem;
-		}
-		.bench-cell {
-			border-left: none;
-			padding-left: 0;
-		}
-		.bench-link {
-			grid-column: 1 / -1;
-			justify-self: start;
-		}
 		.spec-row {
-			grid-template-columns: auto 1fr;
+			grid-template-columns: 1fr auto;
+			gap: 0.4rem 1rem;
 		}
-		.spec-bar {
+		.spec-v {
 			grid-column: 1 / -1;
 		}
 	}
@@ -1061,24 +1151,35 @@
 		}
 		.nav-links {
 			gap: 0.85rem;
-			font-size: 0.82rem;
+			font-size: 0.85rem;
 		}
-		.bench-cells {
+		.nav-links a:nth-child(2) {
+			display: none;
+		}
+		.bar-row {
 			grid-template-columns: 1fr;
+			gap: 0.5rem;
+		}
+		.bar-meta {
+			flex-direction: row;
+			align-items: baseline;
+			gap: 0.6rem;
 		}
 	}
 
 	@media (prefers-reduced-motion: reduce) {
-		.spec-row,
 		.bar-fill,
+		.spec-row,
 		.btn span {
-			animation: none !important;
 			transition: none !important;
+		}
+		.spec-row {
 			opacity: 1 !important;
 			transform: none !important;
 		}
-		.bar-fill {
-			width: 100%;
+		.page.in .bar-fill {
+			width: var(--w);
+			transition: none !important;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary

Quieter, more focused homepage that mirrors Svelte.dev's calm typographic feel while making the Rust angle (and the perf win) impossible to miss.

- **Hero**: single-column, paper-white background, restrained orange. \"The Svelte compiler, rewritten in *Rust*\" — italic, rust-coloured. Drops the loud dark install card.
- **Performance**: front-and-center as section 01 (it's the only user-visible benefit of this library, so it gets the prime slot). Three-bar chart (svelte/compiler vs. rsvelte single vs. rsvelte multi) with the headline \"NN× faster than svelte/compiler\" pulled live from `static/benchmark-results.json`, alongside four stat cells (full pipeline, parser-only, throughput, full-breakdown link).
- **Drop-in**, **Compatibility**, **Why Rust** sections trimmed to refined rule-separated lists — no card chrome, no thick progress bars.
- **Type stack**: switched body/headlines to **Overpass** (Svelte.dev's own font) and code/labels to **Fira Mono** (also rustdoc's default — double-duty Rust signal).
- **Rust cues**: `rust port` nav badge, rust-coloured `\$` prompt in the install line, `@rsvelte/compiler` highlighted, italic rust-coloured \"Rust\" in the headline, \"Built for OXC\" rationale.

## Screenshots

Headless render (1440 wide) of the new top page:

| Before (loud cream hero + dark install card) | After (refined paper-white) |
|---|---|
| previous design | new design — performance immediately under the hero, 3-bar chart, 4 stat cells, then drop-in / compatibility / why |

## Test plan

- [ ] `cd docs && pnpm run dev` → load http://localhost:5234 → hero, perf section (animated bars), drop-in diff, compatibility list, why-port list, footer all render with the new aesthetic
- [ ] Resize across breakpoints (≤640, ≤880, ≥881) → nav collapses, perf grid stacks, bar rows reflow
- [ ] Click \"View benchmark\" / \"Full breakdown\" → benchmark page still works
- [ ] Performance stats reflect the values in `docs/static/benchmark-results.json`
- [ ] `prefers-reduced-motion: reduce` disables bar/row fade-ins (bars still show their final width)

## Notes

- Hit a UTF-8 double-encoding glitch in rsvelte for `·` (U+00B7) inside `<script>` string literals (the `specs` and `@const rows` arrays) — emitted as `c3 82 c2 b7` instead of `c2 b7`. Worked around in this PR by using `/` separators inside those JS literals; markup-text `·` glyphs round-trip cleanly. Worth a follow-up bug in the compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)