### PR TITLE
ci(deploy-docs): build & stage NAPI cdylib before pnpm build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -82,6 +82,19 @@ jobs:
       - name: Build WASM
         run: wasm-pack build --target web --no-default-features --features wasm
 
+      - name: Build NAPI cdylib
+        # docs/rsvelte-shim/compiler.mjs loads
+        # npm/vite-plugin-svelte-native-<triple>/rsvelte.node at build time so
+        # vite-plugin-svelte compiles every .svelte through rsvelte. Ubuntu CI
+        # is linux-x64-gnu; the cdylib is named libsvelte_compiler_rust.so.
+        run: cargo build --release --features napi --lib
+
+      - name: Stage NAPI binding
+        run: |
+          mkdir -p npm/vite-plugin-svelte-native-linux-x64-gnu
+          cp target/release/libsvelte_compiler_rust.so \
+             npm/vite-plugin-svelte-native-linux-x64-gnu/rsvelte.node
+
       - name: Setup pnpm cache for docs
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

The Deploy Docs workflow has been failing since #149 — that PR switched
`docs/` from the WASM shim to the NAPI shim, but the workflow was never
updated to build the NAPI binding. Loading \`vite.config.ts\` now requires
\`npm/vite-plugin-svelte-native-<triple>/rsvelte.node\`, which Ubuntu CI has
never produced.

This adds two steps after **Build WASM**: \`cargo build --release --features napi --lib\`
and a copy of \`target/release/libsvelte_compiler_rust.so\` into
\`npm/vite-plugin-svelte-native-linux-x64-gnu/rsvelte.node\` — mirroring the
matrix logic in \`.github/workflows/release.yml\`'s \`build-vps-native\`, narrowed
to the single triple this job runs on.

## Test plan

- [ ] CI **Deploy Docs to GitHub Pages** workflow goes green on the merge to \`main\`
- [ ] GitHub Pages picks up the new build (page accessible & shows the redesigned homepage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)