### PR TITLE
ci(deploy-docs): widen glibc static TLS for NAPI dlopen on Linux

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -111,6 +111,13 @@ jobs:
 
       - name: Build docs
         working-directory: docs
+        # NAPI-on-Linux gotcha: when node `dlopen`s a Rust cdylib with
+        # thread_local!s after the process has already started, glibc can't
+        # always fit the .so's TLS into the static TLS block ("cannot allocate
+        # memory in static TLS block"). Bumping `glibc.rtld.optional_static_tls`
+        # reserves enough slack on first load that the dlopen succeeds.
+        env:
+          GLIBC_TUNABLES: glibc.rtld.optional_static_tls=2000000
         run: pnpm build
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary

Follow-up to #153. The cdylib is now built and staged, but \`node\` fails
to dlopen it on Ubuntu with:

\`\`\`
cannot allocate memory in static TLS block
\`\`\`

This happens because the Rust .so's \`thread_local!\`s don't fit into
glibc's static TLS surplus once the host process is already running.
The standard napi-rs workaround is to set
\`GLIBC_TUNABLES=glibc.rtld.optional_static_tls=2000000\` for the build
command — that reserves enough slack on first dlopen for everything to
fit.

## Test plan

- [ ] Deploy Docs workflow runs to completion on push to main
- [ ] GitHub Pages serves the redesigned homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)