### PR TITLE
ci(deploy-docs): LD_PRELOAD NAPI cdylib instead of growing static TLS

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -113,11 +113,15 @@ jobs:
         working-directory: docs
         # NAPI-on-Linux gotcha: when node `dlopen`s a Rust cdylib with
         # thread_local!s after the process has already started, glibc can't
-        # always fit the .so's TLS into the static TLS block ("cannot allocate
-        # memory in static TLS block"). Bumping `glibc.rtld.optional_static_tls`
-        # reserves enough slack on first load that the dlopen succeeds.
+        # fit the .so's TLS into the static TLS block ("cannot allocate
+        # memory in static TLS block"). LD_PRELOAD'ing the .node forces the
+        # library to be loaded at process startup, so its TLS lives in the
+        # initial static TLS block and never needs to grow on dlopen.
+        # (Trying to grow the surplus via GLIBC_TUNABLES instead either
+        # under-allocated and re-hit the original error or over-allocated
+        # and broke pthread_create.)
         env:
-          GLIBC_TUNABLES: glibc.rtld.optional_static_tls=2000000
+          LD_PRELOAD: ${{ github.workspace }}/npm/vite-plugin-svelte-native-linux-x64-gnu/rsvelte.node
         run: pnpm build
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary

#155 tried to fix the dlopen-time \"cannot allocate memory in static TLS
block\" by setting \`GLIBC_TUNABLES=glibc.rtld.optional_static_tls=2000000\`,
but 2 MB turned out to be too aggressive — \`pthread_create\` then fails
with \`Invalid argument\` and node segfaults before vite even starts.

Switch to LD_PRELOAD'ing the .node binary: the library is loaded at
process startup so its TLS lives in the initial static TLS block, and
there is nothing to grow on dlopen.

## Test plan

- [ ] Deploy Docs workflow runs to completion on push to main (the
      \"Build docs\" step is the one to watch)
- [ ] GitHub Pages serves the redesigned homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)