### PR TITLE
ci(deploy-docs): scope LD_PRELOAD to node, not bash

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -114,15 +114,15 @@ jobs:
         # NAPI-on-Linux gotcha: when node `dlopen`s a Rust cdylib with
         # thread_local!s after the process has already started, glibc can't
         # fit the .so's TLS into the static TLS block ("cannot allocate
-        # memory in static TLS block"). LD_PRELOAD'ing the .node forces the
-        # library to be loaded at process startup, so its TLS lives in the
-        # initial static TLS block and never needs to grow on dlopen.
-        # (Trying to grow the surplus via GLIBC_TUNABLES instead either
-        # under-allocated and re-hit the original error or over-allocated
-        # and broke pthread_create.)
-        env:
-          LD_PRELOAD: ${{ github.workspace }}/npm/vite-plugin-svelte-native-linux-x64-gnu/rsvelte.node
-        run: pnpm build
+        # memory in static TLS block"). Forcing the .node to be present in
+        # `node`'s LD_PRELOAD makes it part of the initial static TLS block
+        # so the dlopen-time growth never happens. We can't set LD_PRELOAD
+        # on the whole step — bash itself would then try to load the
+        # binding and fail on the napi_* symbols — so we set it only for
+        # the node invocation, bypassing `pnpm build`'s shell wrapper.
+        run: |
+          LD_PRELOAD="${{ github.workspace }}/npm/vite-plugin-svelte-native-linux-x64-gnu/rsvelte.node" \
+            node --import ./rsvelte-shim/loader-register.mjs ./node_modules/vite/bin/vite.js build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary

Follow-up to #156. Setting \`LD_PRELOAD\` as a step-level env makes bash
itself try to load the NAPI binding at startup, which fails with
\`undefined symbol: napi_call_threadsafe_function\` — those symbols only
exist inside node.

Invoke node directly with an inline \`LD_PRELOAD=...\` prefix so bash
launches normally, and only the node child gets the preload — which is
what makes the binding land in the initial static TLS block instead of
being dlopen'd later.

## Test plan

- [ ] Deploy Docs workflow runs to completion on push to main
- [ ] GitHub Pages serves the redesigned homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)