### PR TITLE
docs(site): unify other pages on homepage aesthetic + add dark mode

### DIFF
--- a/docs/src/app.html
+++ b/docs/src/app.html
@@ -4,7 +4,33 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#0d0c09" media="(prefers-color-scheme: dark)" />
 		<title>Svelte Compiler Rust - Playground</title>
+		<script>
+			// Resolve theme before first paint to avoid a flash of the wrong palette.
+			// Order: explicit `?theme=…` query (used for shareable links and CI
+			// screenshots), then localStorage, then OS preference.
+			(function () {
+				try {
+					var t = null;
+					var qs = window.location && window.location.search;
+					if (qs) {
+						var m = qs.match(/[?&]theme=(light|dark)\b/);
+						if (m) t = m[1];
+					}
+					if (t !== 'light' && t !== 'dark') {
+						t = localStorage.getItem('rsvelte:theme');
+					}
+					if (t !== 'light' && t !== 'dark') {
+						t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+					}
+					document.documentElement.setAttribute('data-theme', t);
+				} catch (_) {
+					document.documentElement.setAttribute('data-theme', 'light');
+				}
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/docs/src/lib/components/SiteFooter.svelte
+++ b/docs/src/lib/components/SiteFooter.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	// Compact site-wide footer. Kept identical across all pages.
+</script>
+
+<footer class="foot">
+	<div class="inner">
+		<div class="mark">
+			<svg viewBox="0 0 24 24" width="16" height="16" fill="none" aria-hidden="true">
+				<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="var(--svelte)" />
+				<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="var(--rust)" />
+			</svg>
+			<span>rsvelte</span>
+		</div>
+		<div class="meta">
+			<span>MIT licensed</span>
+			<span class="sep">·</span>
+			<span>Mirrors sveltejs/svelte@5.51.3</span>
+			<span class="sep">·</span>
+			<a href="https://github.com/baseballyama/rsvelte" target="_blank" rel="noopener">
+				github.com/baseballyama/rsvelte
+			</a>
+		</div>
+	</div>
+</footer>
+
+<style>
+	.foot {
+		border-top: 1px solid var(--rule);
+		background: var(--paper);
+	}
+
+	.inner {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: 1.4rem clamp(1rem, 4vw, 2.5rem);
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.mark {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-weight: 700;
+		font-size: 0.95rem;
+		color: var(--ink);
+	}
+
+	.meta {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.55rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.74rem;
+		color: var(--ink-soft);
+		flex-wrap: wrap;
+	}
+
+	.meta .sep {
+		opacity: 0.5;
+	}
+
+	.meta a {
+		color: var(--ink-soft);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 3px;
+	}
+
+	.meta a:hover {
+		color: var(--svelte);
+	}
+</style>

--- a/docs/src/lib/components/SiteNav.svelte
+++ b/docs/src/lib/components/SiteNav.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import { page } from '$app/state';
+	import { themeStore } from '$lib/theme.svelte';
+
+	type Active = 'home' | 'playground' | 'progress' | 'benchmark';
+
+	interface Props {
+		// Each page passes its own slug so the link gets the `active` style
+		// even when SvelteKit's `page.url` isn't reachable (e.g. during SSR
+		// in some contexts).
+		active?: Active;
+	}
+
+	let { active }: Props = $props();
+
+	const isActive = (slug: Active): boolean => {
+		if (active) return active === slug;
+		const path = page.url.pathname;
+		const root = `${base}/`;
+		if (slug === 'home') return path === root || path === base;
+		return path.startsWith(`${base}/${slug}`);
+	};
+
+	const current = $derived(themeStore.current);
+</script>
+
+<nav class="nav">
+	<a href="{base}/" class="brand" aria-label="rsvelte home">
+		<span class="mark" aria-hidden="true">
+			<svg viewBox="0 0 24 24" width="20" height="20" fill="none">
+				<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="var(--svelte)" />
+				<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="var(--rust)" />
+			</svg>
+		</span>
+		<span class="brand-text">rsvelte</span>
+		<span class="brand-tag">rust&nbsp;port</span>
+	</a>
+
+	<div class="links">
+		<a href="{base}/playground" class:active={isActive('playground')}>Playground</a>
+		<a href="{base}/progress" class:active={isActive('progress')}>Compatibility</a>
+		<a href="{base}/benchmark" class:active={isActive('benchmark')}>Benchmark</a>
+		<a href="https://github.com/baseballyama/rsvelte" target="_blank" rel="noopener" class="gh">
+			GitHub <span class="ext" aria-hidden="true">↗</span>
+		</a>
+		<button
+			type="button"
+			class="theme-toggle"
+			aria-label="Toggle dark mode"
+			aria-pressed={current === 'dark'}
+			title="{current === 'dark' ? 'Switch to light' : 'Switch to dark'} mode"
+			onclick={() => themeStore.toggle()}
+		>
+			<span class="theme-icon" aria-hidden="true">
+				{#if current === 'dark'}
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none">
+						<circle cx="12" cy="12" r="4" fill="currentColor" />
+						<g stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+							<path d="M12 3v2" />
+							<path d="M12 19v2" />
+							<path d="M3 12h2" />
+							<path d="M19 12h2" />
+							<path d="m5.6 5.6 1.4 1.4" />
+							<path d="m17 17 1.4 1.4" />
+							<path d="m5.6 18.4 1.4-1.4" />
+							<path d="m17 7 1.4-1.4" />
+						</g>
+					</svg>
+				{:else}
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none">
+						<path
+							d="M20 14.5A8 8 0 0 1 9.5 4a7.5 7.5 0 1 0 10.5 10.5Z"
+							fill="currentColor"
+						/>
+					</svg>
+				{/if}
+			</span>
+		</button>
+	</div>
+</nav>
+
+<style>
+	.nav {
+		position: sticky;
+		top: 0;
+		z-index: 30;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 2rem;
+		padding: 0.9rem clamp(1rem, 4vw, 2.5rem);
+		background: color-mix(in srgb, var(--bg) 88%, transparent);
+		border-bottom: 1px solid var(--rule);
+		backdrop-filter: saturate(150%) blur(6px);
+		-webkit-backdrop-filter: saturate(150%) blur(6px);
+	}
+
+	.brand {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.55rem;
+		color: var(--ink);
+	}
+
+	.mark {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+	}
+
+	.brand-text {
+		font-weight: 700;
+		font-size: 1rem;
+		letter-spacing: -0.01em;
+	}
+
+	.brand-tag {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.62rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--rust);
+		padding: 0.2rem 0.45rem;
+		border: 1px solid currentColor;
+		border-radius: 2px;
+		line-height: 1;
+		margin-left: 0.2rem;
+	}
+
+	.links {
+		display: flex;
+		align-items: center;
+		gap: clamp(0.6rem, 2vw, 1.6rem);
+		font-size: 0.92rem;
+		font-weight: 500;
+	}
+
+	.links a {
+		color: var(--ink-soft);
+		padding: 0.25rem 0;
+		border-bottom: 1px solid transparent;
+		transition:
+			color 0.18s,
+			border-color 0.18s;
+	}
+
+	.links a:hover,
+	.links a.active {
+		color: var(--ink);
+		border-bottom-color: var(--ink);
+	}
+
+	.links .gh {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+	}
+
+	.links .ext {
+		font-size: 0.85em;
+		opacity: 0.6;
+	}
+
+	.theme-toggle {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		padding: 0;
+		margin-left: 0.2rem;
+		background: transparent;
+		border: 1px solid var(--rule-strong);
+		border-radius: 4px;
+		color: var(--ink-soft);
+		cursor: pointer;
+		transition:
+			color 0.18s,
+			border-color 0.18s,
+			background 0.18s;
+	}
+
+	.theme-toggle:hover {
+		color: var(--ink);
+		border-color: var(--ink);
+		background: var(--paper);
+	}
+
+	.theme-icon {
+		display: inline-flex;
+		line-height: 0;
+	}
+
+	@media (max-width: 640px) {
+		.brand-tag {
+			display: none;
+		}
+		.links {
+			gap: 0.7rem;
+			font-size: 0.84rem;
+		}
+		.links a:nth-child(2) {
+			display: none;
+		}
+	}
+</style>

--- a/docs/src/lib/monaco/MonacoEditor.svelte
+++ b/docs/src/lib/monaco/MonacoEditor.svelte
@@ -2,7 +2,13 @@
 	import { onMount, onDestroy } from 'svelte';
 	import loader from '@monaco-editor/loader';
 	import type * as Monaco from 'monaco-editor';
-	import { registerSvelteLanguage, SVELTE_LANGUAGE_ID } from './svelte-language';
+	import {
+		registerSvelteLanguage,
+		SVELTE_LANGUAGE_ID,
+		SVELTE_THEME_LIGHT,
+		SVELTE_THEME_DARK
+	} from './svelte-language';
+	import { themeStore } from '$lib/theme.svelte';
 
 	interface Props {
 		value: string;
@@ -37,12 +43,12 @@
 		editor = monaco.editor.create(container, {
 			value,
 			language,
-			theme: 'svelte-cream',
+			theme: themeStore.current === 'dark' ? SVELTE_THEME_DARK : SVELTE_THEME_LIGHT,
 			readOnly: readonly,
 			automaticLayout: true,
 			minimap: { enabled: false },
 			fontSize: 14,
-			fontFamily: "'JetBrains Mono', 'Fira Code', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace",
+			fontFamily: "'Fira Mono', 'Fira Code', 'JetBrains Mono', Menlo, monospace",
 			lineNumbers: 'on',
 			lineHeight: 22,
 			padding: { top: 16 },
@@ -126,6 +132,12 @@
 		if (editor) {
 			editor.updateOptions({ readOnly: readonly });
 		}
+	});
+
+	// React to global theme changes — flip Monaco's theme to match.
+	$effect(() => {
+		const next = themeStore.current === 'dark' ? SVELTE_THEME_DARK : SVELTE_THEME_LIGHT;
+		if (monaco) monaco.editor.setTheme(next);
 	});
 
 	// Update highlight range

--- a/docs/src/lib/monaco/svelte-language.ts
+++ b/docs/src/lib/monaco/svelte-language.ts
@@ -359,85 +359,157 @@ export const svelteTokensProvider: Monaco.languages.IMonarchLanguage = {
 	}
 };
 
-export const svelteCreamTheme: Monaco.editor.IStandaloneThemeData = {
+// Light theme tuned to the rsvelte site palette: paper-white background,
+// rust/svelte-orange accents on Svelte-specific tokens.
+export const svelteLightTheme: Monaco.editor.IStandaloneThemeData = {
 	base: 'vs',
 	inherit: true,
 	rules: [
-		{ token: 'keyword.svelte', foreground: 'C52F00', fontStyle: 'bold' },
+		{ token: 'keyword.svelte', foreground: 'B7410E', fontStyle: 'bold' },
 		{ token: 'keyword.svelte.rune', foreground: 'FF3E00', fontStyle: 'bold' },
-		{ token: 'keyword.css', foreground: 'C52F00', fontStyle: 'bold' },
-		{ token: 'tag', foreground: '3A2A1A' },
+		{ token: 'keyword.css', foreground: 'B7410E', fontStyle: 'bold' },
+		{ token: 'tag', foreground: '2A2722' },
 		{ token: 'tag.css', foreground: '5A3A8A' },
-		{ token: 'attribute.name', foreground: '1A1612' },
-		{ token: 'attribute.name.svelte', foreground: 'C52F00' },
+		{ token: 'attribute.name', foreground: '14130F' },
+		{ token: 'attribute.name.svelte', foreground: 'B7410E' },
 		{ token: 'attribute.name.css', foreground: '1D5D4A' },
-		{ token: 'attribute.name.css.class', foreground: 'C52F00' },
-		{ token: 'attribute.name.css.id', foreground: 'C52F00' },
+		{ token: 'attribute.name.css.class', foreground: 'B7410E' },
+		{ token: 'attribute.name.css.id', foreground: 'B7410E' },
 		{ token: 'attribute.name.css.pseudo', foreground: 'FF3E00', fontStyle: 'italic' },
 		{ token: 'attribute.value', foreground: '7A4520' },
 		{ token: 'attribute.value.css', foreground: '7A4520' },
 		{ token: 'attribute.value.css.function', foreground: '5A3A8A' },
-		{ token: 'operator.css', foreground: '7A7062' },
-		{ token: 'delimiter.curly', foreground: '7A7062' },
-		{ token: 'delimiter.parenthesis', foreground: '7A7062' },
-		{ token: 'delimiter.square', foreground: '7A7062' },
-		{ token: 'delimiter.angle', foreground: '7A7062' },
-		{ token: 'delimiter', foreground: '7A7062' },
+		{ token: 'operator.css', foreground: '6E6A60' },
+		{ token: 'delimiter.curly', foreground: '6E6A60' },
+		{ token: 'delimiter.parenthesis', foreground: '6E6A60' },
+		{ token: 'delimiter.square', foreground: '6E6A60' },
+		{ token: 'delimiter.angle', foreground: '6E6A60' },
+		{ token: 'delimiter', foreground: '6E6A60' },
 		{ token: 'keyword.js', foreground: '5A3A8A' },
 		{ token: 'keyword.type', foreground: '1D5D4A' },
 		{ token: 'string', foreground: '7A4520' },
-		{ token: 'string.escape', foreground: 'C52F00' },
+		{ token: 'string.escape', foreground: 'B7410E' },
 		{ token: 'number', foreground: '2E5A3A' },
 		{ token: 'number.float', foreground: '2E5A3A' },
 		{ token: 'number.hex', foreground: '2E5A3A' },
-		{ token: 'comment', foreground: '9A8B75', fontStyle: 'italic' },
-		{ token: 'comment.html', foreground: '9A8B75', fontStyle: 'italic' },
-		{ token: 'operator', foreground: '1A1612' },
-		{ token: 'identifier', foreground: '1A1612' }
+		{ token: 'comment', foreground: '97938A', fontStyle: 'italic' },
+		{ token: 'comment.html', foreground: '97938A', fontStyle: 'italic' },
+		{ token: 'operator', foreground: '14130F' },
+		{ token: 'identifier', foreground: '14130F' }
 	],
 	colors: {
-		'editor.background': '#F1E8D6',
-		'editor.foreground': '#1A1612',
-		'editor.lineHighlightBackground': '#E6DAC1',
+		'editor.background': '#FBF9F2',
+		'editor.foreground': '#14130F',
+		'editor.lineHighlightBackground': '#F3F1E9',
 		'editor.lineHighlightBorder': '#00000000',
-		'editorLineNumber.foreground': '#B8AB93',
-		'editorLineNumber.activeForeground': '#7A7062',
+		'editorLineNumber.foreground': '#B8B3A4',
+		'editorLineNumber.activeForeground': '#6E6A60',
 		'editor.selectionBackground': '#FF3E0033',
-		'editor.inactiveSelectionBackground': '#1A161214',
+		'editor.inactiveSelectionBackground': '#14130F14',
 		'editorCursor.foreground': '#FF3E00',
-		'editorWhitespace.foreground': '#1A161214',
-		'editorIndentGuide.background': '#1A16120F',
-		'editorIndentGuide.activeBackground': '#1A161229',
+		'editorWhitespace.foreground': '#14130F14',
+		'editorIndentGuide.background': '#14130F0F',
+		'editorIndentGuide.activeBackground': '#14130F29',
 		'editorBracketMatch.background': '#FF3E0020',
 		'editorBracketMatch.border': '#FF3E0080',
 		'scrollbar.shadow': '#00000000',
-		'scrollbarSlider.background': '#1A161220',
-		'scrollbarSlider.hoverBackground': '#1A161240',
-		'scrollbarSlider.activeBackground': '#1A161260',
-		'editorGutter.background': '#F1E8D6',
-		'editorWidget.background': '#E6DAC1',
-		'editorWidget.border': '#1A161229',
-		'editorSuggestWidget.background': '#E6DAC1',
-		'editorSuggestWidget.border': '#1A161229',
-		'editorSuggestWidget.foreground': '#1A1612',
+		'scrollbarSlider.background': '#14130F1A',
+		'scrollbarSlider.hoverBackground': '#14130F33',
+		'scrollbarSlider.activeBackground': '#14130F55',
+		'editorGutter.background': '#FBF9F2',
+		'editorWidget.background': '#F3F1E9',
+		'editorWidget.border': '#D8D4C4',
+		'editorSuggestWidget.background': '#F3F1E9',
+		'editorSuggestWidget.border': '#D8D4C4',
+		'editorSuggestWidget.foreground': '#14130F',
 		'editorSuggestWidget.selectedBackground': '#FF3E0020',
-		'editorSuggestWidget.highlightForeground': '#C52F00',
-		'editorHoverWidget.background': '#E6DAC1',
-		'editorHoverWidget.border': '#1A161229',
+		'editorSuggestWidget.highlightForeground': '#B7410E',
+		'editorHoverWidget.background': '#F3F1E9',
+		'editorHoverWidget.border': '#D8D4C4',
 		'editorOverviewRuler.border': '#00000000'
 	}
 };
 
+// Dark theme — same token map, darker surfaces tuned to the dark palette.
+export const svelteDarkTheme: Monaco.editor.IStandaloneThemeData = {
+	base: 'vs-dark',
+	inherit: true,
+	rules: [
+		{ token: 'keyword.svelte', foreground: 'E58050', fontStyle: 'bold' },
+		{ token: 'keyword.svelte.rune', foreground: 'FF6634', fontStyle: 'bold' },
+		{ token: 'keyword.css', foreground: 'E58050', fontStyle: 'bold' },
+		{ token: 'tag', foreground: 'C9C1AA' },
+		{ token: 'tag.css', foreground: 'B19BE0' },
+		{ token: 'attribute.name', foreground: 'F1ECDF' },
+		{ token: 'attribute.name.svelte', foreground: 'E58050' },
+		{ token: 'attribute.name.css', foreground: '6CC0A0' },
+		{ token: 'attribute.name.css.class', foreground: 'E58050' },
+		{ token: 'attribute.name.css.id', foreground: 'E58050' },
+		{ token: 'attribute.name.css.pseudo', foreground: 'FF6634', fontStyle: 'italic' },
+		{ token: 'attribute.value', foreground: 'D9A66E' },
+		{ token: 'attribute.value.css', foreground: 'D9A66E' },
+		{ token: 'attribute.value.css.function', foreground: 'B19BE0' },
+		{ token: 'operator.css', foreground: '8A8472' },
+		{ token: 'delimiter.curly', foreground: '8A8472' },
+		{ token: 'delimiter.parenthesis', foreground: '8A8472' },
+		{ token: 'delimiter.square', foreground: '8A8472' },
+		{ token: 'delimiter.angle', foreground: '8A8472' },
+		{ token: 'delimiter', foreground: '8A8472' },
+		{ token: 'keyword.js', foreground: 'B19BE0' },
+		{ token: 'keyword.type', foreground: '6CC0A0' },
+		{ token: 'string', foreground: 'D9A66E' },
+		{ token: 'string.escape', foreground: 'E58050' },
+		{ token: 'number', foreground: '8CCC95' },
+		{ token: 'number.float', foreground: '8CCC95' },
+		{ token: 'number.hex', foreground: '8CCC95' },
+		{ token: 'comment', foreground: '75705F', fontStyle: 'italic' },
+		{ token: 'comment.html', foreground: '75705F', fontStyle: 'italic' },
+		{ token: 'operator', foreground: 'F1ECDF' },
+		{ token: 'identifier', foreground: 'F1ECDF' }
+	],
+	colors: {
+		'editor.background': '#14110B',
+		'editor.foreground': '#EFE9DA',
+		'editor.lineHighlightBackground': '#1D1A13',
+		'editor.lineHighlightBorder': '#00000000',
+		'editorLineNumber.foreground': '#4F4A3D',
+		'editorLineNumber.activeForeground': '#A09A87',
+		'editor.selectionBackground': '#FF663433',
+		'editor.inactiveSelectionBackground': '#EFE9DA14',
+		'editorCursor.foreground': '#FF6634',
+		'editorWhitespace.foreground': '#EFE9DA14',
+		'editorIndentGuide.background': '#EFE9DA10',
+		'editorIndentGuide.activeBackground': '#EFE9DA29',
+		'editorBracketMatch.background': '#FF663425',
+		'editorBracketMatch.border': '#FF663480',
+		'scrollbar.shadow': '#00000000',
+		'scrollbarSlider.background': '#EFE9DA1A',
+		'scrollbarSlider.hoverBackground': '#EFE9DA33',
+		'scrollbarSlider.activeBackground': '#EFE9DA55',
+		'editorGutter.background': '#14110B',
+		'editorWidget.background': '#1D1A13',
+		'editorWidget.border': '#3A3528',
+		'editorSuggestWidget.background': '#1D1A13',
+		'editorSuggestWidget.border': '#3A3528',
+		'editorSuggestWidget.foreground': '#EFE9DA',
+		'editorSuggestWidget.selectedBackground': '#FF663425',
+		'editorSuggestWidget.highlightForeground': '#FF6634',
+		'editorHoverWidget.background': '#1D1A13',
+		'editorHoverWidget.border': '#3A3528',
+		'editorOverviewRuler.border': '#00000000'
+	}
+};
+
+// Backwards-compat alias — the old name was 'svelte-cream'. We now have two
+// themes; consumers should use SVELTE_THEME_LIGHT / SVELTE_THEME_DARK.
+export const svelteCreamTheme = svelteLightTheme;
+export const SVELTE_THEME_LIGHT = 'svelte-light';
+export const SVELTE_THEME_DARK = 'svelte-dark';
+
 export function registerSvelteLanguage(monaco: typeof Monaco): void {
-	// Register Svelte language
 	monaco.languages.register({ id: SVELTE_LANGUAGE_ID });
-
-	// Set language configuration
 	monaco.languages.setLanguageConfiguration(SVELTE_LANGUAGE_ID, svelteLanguageConfiguration);
-
-	// Set tokenizer
 	monaco.languages.setMonarchTokensProvider(SVELTE_LANGUAGE_ID, svelteTokensProvider);
-
-	// Define and apply theme
-	monaco.editor.defineTheme('svelte-cream', svelteCreamTheme);
+	monaco.editor.defineTheme(SVELTE_THEME_LIGHT, svelteLightTheme);
+	monaco.editor.defineTheme(SVELTE_THEME_DARK, svelteDarkTheme);
 }

--- a/docs/src/lib/theme.svelte.ts
+++ b/docs/src/lib/theme.svelte.ts
@@ -1,0 +1,36 @@
+// Theme state shared across the site. The actual `data-theme` attribute on
+// <html> is set by the inline bootstrap in app.html before first paint —
+// this module just exposes a reactive view of it and persists user choices.
+
+import { browser } from '$app/environment';
+
+export type Theme = 'light' | 'dark';
+
+function readInitial(): Theme {
+	if (!browser) return 'light';
+	const t = document.documentElement.getAttribute('data-theme');
+	return t === 'dark' ? 'dark' : 'light';
+}
+
+let theme = $state<Theme>(readInitial());
+
+export const themeStore = {
+	get current(): Theme {
+		return theme;
+	},
+	toggle(): void {
+		this.set(theme === 'dark' ? 'light' : 'dark');
+	},
+	set(next: Theme): void {
+		theme = next;
+		if (!browser) return;
+		document.documentElement.setAttribute('data-theme', next);
+		try {
+			localStorage.setItem('rsvelte:theme', next);
+		} catch {
+			// localStorage can throw under private-browsing quotas — falling
+			// back to in-memory state is fine, the OS preference will still
+			// reapply on next load.
+		}
+	}
+};

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -30,13 +30,77 @@
 		scroll-behavior: smooth;
 	}
 
+	/* =================================================================
+	   THEME TOKENS — light (default)
+	   =================================================================
+	   Anything off-white/colored on the site should resolve through one
+	   of these names. Dark mode just overrides the same names in the
+	   `data-theme="dark"` block below, so pages never need to special-case.
+	*/
+	:global(:root),
+	:global(:root[data-theme='light']) {
+		--bg: #ffffff;
+		--paper: #faf9f5;
+		--paper-2: #f3f1e9;
+		--ink: #14130f;
+		--ink-soft: #5a5750;
+		--ink-faint: #97938a;
+		--rule: #ececdf;
+		--rule-strong: #d8d4c4;
+		--selection: #ffe9d6;
+
+		--svelte: #ff3e00;
+		--svelte-hover: #e83700;
+		--rust: #b7410e;
+		--rust-soft: #cf7a4a;
+
+		--ok: #2c7a3a;
+		--warn: #b07a00;
+		--bad: #b1280a;
+
+		/* Editor / monaco surface — slightly off-white in light, lifted ink in dark */
+		--editor-bg: #fbf9f2;
+		--editor-ink: #14130f;
+
+		color-scheme: light;
+	}
+
+	:global(:root[data-theme='dark']) {
+		--bg: #0d0c09;
+		--paper: #16140f;
+		--paper-2: #1d1a13;
+		--ink: #f1ecdf;
+		--ink-soft: #b0a994;
+		--ink-faint: #75705f;
+		--rule: #2a2620;
+		--rule-strong: #3a3528;
+		--selection: #5a2a10;
+
+		--svelte: #ff6634;
+		--svelte-hover: #ff7d50;
+		--rust: #e58050;
+		--rust-soft: #c46640;
+
+		--ok: #6cc870;
+		--warn: #e0b240;
+		--bad: #e85a3c;
+
+		--editor-bg: #14110b;
+		--editor-ink: #efe9da;
+
+		color-scheme: dark;
+	}
+
 	:global(body) {
 		font-family: 'Overpass', ui-sans-serif, -apple-system, BlinkMacSystemFont, sans-serif;
-		background: #ffffff;
-		color: #14130f;
+		background: var(--bg);
+		color: var(--ink);
 		line-height: 1.6;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
+		transition:
+			background-color 0.2s ease,
+			color 0.2s ease;
 	}
 
 	:global(a) {
@@ -50,7 +114,15 @@
 	}
 
 	:global(::selection) {
-		background: #ffe9d6;
-		color: #14130f;
+		background: var(--selection);
+		color: var(--ink);
+	}
+
+	/* Don't animate theme transitions on first paint or for users who
+	   asked the OS not to. */
+	@media (prefers-reduced-motion: reduce) {
+		:global(body) {
+			transition: none;
+		}
 	}
 </style>

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -2,6 +2,8 @@
 	import { base } from '$app/paths';
 	import { onMount } from 'svelte';
 	import type { BenchmarkResults } from '$lib/types/benchmark';
+	import SiteNav from '$lib/components/SiteNav.svelte';
+	import SiteFooter from '$lib/components/SiteFooter.svelte';
 
 	let bench = $state<BenchmarkResults | null>(null);
 	let animated = $state(false);
@@ -68,27 +70,7 @@
 </svelte:head>
 
 <div class="page" class:in={animated}>
-	<nav class="nav">
-		<a href="{base}/" class="brand" aria-label="rsvelte home">
-			<span class="mark" aria-hidden="true">
-				<svg viewBox="0 0 24 24" width="20" height="20" fill="none">
-					<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="#ff3e00" />
-					<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="#b7410e" />
-				</svg>
-			</span>
-			<span class="brand-text">rsvelte</span>
-			<span class="brand-tag">rust&nbsp;port</span>
-		</a>
-
-		<div class="nav-links">
-			<a href="{base}/playground">Playground</a>
-			<a href="{base}/progress">Compatibility</a>
-			<a href="{base}/benchmark">Benchmark</a>
-			<a href="https://github.com/baseballyama/rsvelte" target="_blank" rel="noopener" class="gh">
-				GitHub <span aria-hidden="true" class="ext">↗</span>
-			</a>
-		</div>
-	</nav>
+	<SiteNav active="home" />
 
 	<header class="hero">
 		<p class="eyebrow"><span class="rule"></span>Svelte 5 · written in Rust</p>
@@ -303,128 +285,17 @@
 		</div>
 	</section>
 
-	<footer class="foot">
-		<div class="foot-inner">
-			<div class="foot-mark">
-				<svg viewBox="0 0 24 24" width="16" height="16" fill="none" aria-hidden="true">
-					<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="#ff3e00" />
-					<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="#b7410e" />
-				</svg>
-				<span>rsvelte</span>
-			</div>
-			<div class="foot-meta">
-				<span>MIT licensed</span>
-				<span class="sep">·</span>
-				<span>Mirrors sveltejs/svelte@5.51.3</span>
-				<span class="sep">·</span>
-				<a href="https://github.com/baseballyama/rsvelte" target="_blank" rel="noopener">
-					github.com/baseballyama/rsvelte
-				</a>
-			</div>
-		</div>
-	</footer>
+	<SiteFooter />
 </div>
 
 <style>
 	.page {
-		--bg: #ffffff;
-		--paper: #faf9f5;
-		--ink: #14130f;
-		--ink-soft: #5a5750;
-		--ink-faint: #97938a;
-		--rule: #ececdf;
-		--rule-strong: #d8d4c4;
-
-		--svelte: #ff3e00;
-		--rust: #b7410e;
-		--rust-soft: #cf7a4a;
-
-		background: var(--bg);
-		color: var(--ink);
-		font-size: 16px;
-		line-height: 1.6;
 		min-height: 100vh;
 	}
 
 	code,
 	pre {
 		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-	}
-
-	/* NAV */
-	.nav {
-		position: sticky;
-		top: 0;
-		z-index: 30;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 2rem;
-		padding: 0.9rem clamp(1rem, 4vw, 2.5rem);
-		background: rgba(255, 255, 255, 0.88);
-		border-bottom: 1px solid var(--rule);
-		backdrop-filter: saturate(150%) blur(6px);
-	}
-
-	.brand {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.55rem;
-		color: var(--ink);
-	}
-
-	.mark {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		width: 24px;
-		height: 24px;
-	}
-
-	.brand-text {
-		font-weight: 700;
-		font-size: 1rem;
-		letter-spacing: -0.01em;
-	}
-
-	.brand-tag {
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.62rem;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: var(--rust);
-		padding: 0.2rem 0.45rem;
-		border: 1px solid currentColor;
-		border-radius: 2px;
-		line-height: 1;
-		margin-left: 0.2rem;
-	}
-
-	.nav-links {
-		display: flex;
-		align-items: center;
-		gap: clamp(0.8rem, 2.2vw, 1.8rem);
-		font-size: 0.92rem;
-		font-weight: 500;
-	}
-
-	.nav-links a {
-		color: var(--ink-soft);
-		padding: 0.25rem 0;
-		border-bottom: 1px solid transparent;
-		transition:
-			color 0.18s,
-			border-color 0.18s;
-	}
-
-	.nav-links a:hover {
-		color: var(--ink);
-		border-bottom-color: var(--ink);
-	}
-
-	.nav-links .gh .ext {
-		font-size: 0.85em;
-		opacity: 0.6;
 	}
 
 	/* HERO */
@@ -526,7 +397,7 @@
 	}
 
 	.btn-primary:hover {
-		background: #e83700;
+		background: var(--svelte-hover);
 	}
 
 	.btn-ghost {
@@ -725,7 +596,11 @@
 	}
 
 	.bar-js {
-		background: linear-gradient(90deg, #94908b, #b3aea4);
+		background: linear-gradient(
+			90deg,
+			color-mix(in srgb, var(--ink-faint) 70%, transparent),
+			var(--ink-faint)
+		);
 	}
 
 	.bar-rs {
@@ -733,7 +608,7 @@
 	}
 
 	.bar-rm {
-		background: linear-gradient(90deg, #ff7a3d, var(--svelte));
+		background: linear-gradient(90deg, var(--rust-soft), var(--svelte));
 	}
 
 	.bar-t {
@@ -792,7 +667,7 @@
 	.stat.stat-hero {
 		border-color: var(--rust);
 		background: var(--bg);
-		box-shadow: 0 0 0 3px rgba(183, 65, 14, 0.06);
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--rust) 8%, transparent);
 	}
 
 	.stat-k {
@@ -924,12 +799,12 @@
 	}
 
 	.d-minus {
-		color: #a04030;
+		color: var(--bad);
 	}
 
 	.d-plus {
-		color: #2f6f3a;
-		background: rgba(47, 111, 58, 0.06);
+		color: var(--ok);
+		background: color-mix(in srgb, var(--ok) 8%, transparent);
 	}
 
 	.d-str {
@@ -1028,7 +903,7 @@
 	}
 
 	.link:hover {
-		color: #d83500;
+		color: var(--svelte-hover);
 	}
 
 	/* WHY */
@@ -1081,56 +956,6 @@
 		max-width: 64ch;
 	}
 
-	/* FOOT */
-	.foot {
-		border-top: 1px solid var(--rule);
-		background: var(--paper);
-	}
-
-	.foot-inner {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: 1.5rem clamp(1rem, 4vw, 2.5rem);
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 1rem;
-		flex-wrap: wrap;
-	}
-
-	.foot-mark {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.45rem;
-		font-weight: 700;
-		font-size: 0.95rem;
-	}
-
-	.foot-meta {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.6rem;
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.74rem;
-		color: var(--ink-soft);
-		flex-wrap: wrap;
-	}
-
-	.foot-meta .sep {
-		opacity: 0.5;
-	}
-
-	.foot-meta a {
-		color: var(--ink-soft);
-		text-decoration: underline;
-		text-decoration-thickness: 1px;
-		text-underline-offset: 3px;
-	}
-
-	.foot-meta a:hover {
-		color: var(--svelte);
-	}
-
 	/* RESPONSIVE */
 	@media (max-width: 880px) {
 		.perf-grid {
@@ -1146,16 +971,6 @@
 	}
 
 	@media (max-width: 640px) {
-		.brand-tag {
-			display: none;
-		}
-		.nav-links {
-			gap: 0.85rem;
-			font-size: 0.85rem;
-		}
-		.nav-links a:nth-child(2) {
-			display: none;
-		}
 		.bar-row {
 			grid-template-columns: 1fr;
 			gap: 0.5rem;

--- a/docs/src/routes/benchmark/+page.svelte
+++ b/docs/src/routes/benchmark/+page.svelte
@@ -3,6 +3,8 @@
 	import { base } from '$app/paths';
 	import type { PageData } from './$types';
 	import type { BenchmarkTaskResults } from '$lib/types/benchmark';
+	import SiteNav from '$lib/components/SiteNav.svelte';
+	import SiteFooter from '$lib/components/SiteFooter.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -16,22 +18,18 @@
 	const ANIMATION_DURATION_MS = 2200;
 
 	const tabMeta: Record<TabId, { label: string; sub: string }> = {
-		full: { label: 'Full pipeline', sub: 'parse → analyze → codegen' },
+		full: { label: 'Full pipeline', sub: 'parse / analyze / codegen' },
 		parse: { label: 'Parser only', sub: 'phase 1, isolated' },
-		svelte2tsx: { label: 'svelte2tsx', sub: '.svelte → .tsx generation' }
+		svelte2tsx: { label: 'svelte2tsx', sub: '.svelte / .tsx generation' }
 	};
 
 	const formatDate = (iso: string): string =>
-		new Date(iso).toLocaleString('en-US', {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric'
-		});
+		new Date(iso).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 
 	const formatDuration = (ms: number): string => {
 		if (ms < 1) return `${(ms * 1000).toFixed(1)}μs`;
-		if (ms < 1000) return `${ms.toFixed(1)}ms`;
-		return `${(ms / 1000).toFixed(2)}s`;
+		if (ms < 1000) return `${ms.toFixed(1)} ms`;
+		return `${(ms / 1000).toFixed(2)} s`;
 	};
 
 	const formatThroughput = (v: number): string => {
@@ -78,13 +76,6 @@
 		return Math.min(simulated, duration);
 	};
 
-	const isBarComplete = (r: BenchmarkTaskResults, duration: number): boolean => {
-		if (animationComplete) return true;
-		const maxDuration = getMaxDuration(r);
-		const scale = maxDuration / ANIMATION_DURATION_MS;
-		return animationTime * scale >= duration;
-	};
-
 	const startAnimation = () => {
 		if (isAnimating || !data.results) return;
 		isAnimating = true;
@@ -122,596 +113,409 @@
 		name="description"
 		content="Compilation speed benchmark — rsvelte (Rust, single + multi-threaded) against the official svelte/compiler."
 	/>
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link
-		href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
-		rel="stylesheet"
-	/>
 </svelte:head>
 
 <div class="page">
-	<nav class="nav">
-		<a href="{base}/" class="brand" aria-label="rsvelte home">
-			<span class="brand-icon" aria-hidden="true">
-				<svg viewBox="0 0 24 24" width="22" height="22" fill="none">
-					<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="#ff3e00" />
-					<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="#ce422b" />
-				</svg>
-			</span>
-			<span class="brand-text">rsvelte</span>
-			<span class="brand-tag">rust port</span>
-		</a>
-		<div class="nav-links">
-			<a href="{base}/playground">Playground</a>
-			<a href="{base}/progress">Compatibility</a>
-			<a href="{base}/benchmark" class="active">Benchmark</a>
-			<a
-				href="https://github.com/baseballyama/rsvelte"
-				target="_blank"
-				rel="noopener"
-				class="gh"
-			>
-				GitHub
-				<span aria-hidden="true">↗</span>
-			</a>
-		</div>
-	</nav>
+	<SiteNav active="benchmark" />
 
 	{#if data.error}
 		<section class="empty">
-			<p class="eyebrow">Benchmark · unavailable</p>
+			<p class="eyebrow"><span class="rule"></span>Benchmark · unavailable</p>
 			<h1>No benchmark data yet.</h1>
 			<p class="lede">{data.error}</p>
 			<pre class="empty-code"><code><span class="c-cmt"># From the repo root</span>
-<span class="c-prompt">$</span> cargo build --release
+<span class="c-prompt">$</span> cargo build <span class="c-flag">--release</span>
 <span class="c-prompt">$</span> node scripts/run-benchmark.mjs &gt; docs/static/benchmark-results.json</code></pre>
 		</section>
 	{:else if data.results}
 		{@const r = data.results}
 		{@const task = activeTask}
 
-		<!-- Single-viewport dashboard. Everything you need is right here. -->
-		<main class="dash">
-			<header class="dash-head">
-				<div class="dash-title">
-					<p class="eyebrow">
-						<span class="rule-h"></span>
-						Compilation speed
-					</p>
-					<h1>
-						<span class="ink-svelte">{r.speedup.multiThreadVsJs.toFixed(1)}×</span>
-						faster than <code>svelte/compiler</code>.
-					</h1>
-				</div>
+		<header class="hero">
+			<p class="eyebrow"><span class="rule"></span>Compilation speed · against svelte/compiler</p>
 
-				<dl class="dash-meta">
-					<div>
-						<dt>Corpus</dt>
-						<dd>{r.testFilesCount.toLocaleString('en-US')} .svelte files</dd>
-					</div>
-					<div>
-						<dt>Recorded</dt>
-						<dd>{formatDate(r.generatedAt)}</dd>
-					</div>
-					<div>
-						<dt>Commit</dt>
-						<dd><code>{r.commitSha}</code></dd>
-					</div>
-				</dl>
+			<h1 class="title">
+				<span class="ink-svelte">{r.speedup.multiThreadVsJs.toFixed(1)}×</span> faster than
+				<code>svelte/compiler</code>.
+			</h1>
+
+			<dl class="hero-meta">
+				<div>
+					<dt>Corpus</dt>
+					<dd>{r.testFilesCount.toLocaleString('en-US')} .svelte files</dd>
+				</div>
+				<div>
+					<dt>Recorded</dt>
+					<dd>{formatDate(r.generatedAt)}</dd>
+				</div>
+				<div>
+					<dt>Commit</dt>
+					<dd><code>{r.commitSha}</code></dd>
+				</div>
+			</dl>
+		</header>
+
+		<section class="stats">
+			<article class="stat stat-hero">
+				<span class="stat-k">Multi-threaded</span>
+				<span class="stat-n">
+					{r.speedup.multiThreadVsJs.toFixed(1)}<span class="stat-x">×</span>
+				</span>
+				<span class="stat-s">rayon fan-out · full pipeline</span>
+			</article>
+			<article class="stat">
+				<span class="stat-k">Single-threaded</span>
+				<span class="stat-n">
+					{r.speedup.singleThreadVsJs.toFixed(1)}<span class="stat-x">×</span>
+				</span>
+				<span class="stat-s">no parallelism</span>
+			</article>
+			<article class="stat">
+				<span class="stat-k">Throughput</span>
+				<span class="stat-n">
+					{formatThroughput(r.rustMultiThread.throughputFilesPerSec)}<span class="stat-x">/s</span>
+				</span>
+				<span class="stat-s">files compiled per second</span>
+			</article>
+			<article class="stat">
+				<span class="stat-k">Parser alone</span>
+				<span class="stat-n">
+					{r.parse.speedup.multiThreadVsJs.toFixed(0)}<span class="stat-x">×</span>
+				</span>
+				<span class="stat-s">phase 1, isolated</span>
+			</article>
+		</section>
+
+		<section class="chart">
+			<header class="chart-head">
+				<div class="tabs" role="tablist" aria-label="Benchmark task">
+					{#each ['full', 'parse', 'svelte2tsx'] as const as tab (tab)}
+						<button
+							role="tab"
+							type="button"
+							aria-selected={activeTab === tab}
+							class="tab"
+							class:active={activeTab === tab}
+							disabled={!hasTab(tab)}
+							onclick={() => switchTab(tab)}
+						>
+							<span class="tab-label">{tabMeta[tab].label}</span>
+							<span class="tab-sub">{tabMeta[tab].sub}</span>
+						</button>
+					{/each}
+				</div>
+				<button class="replay" onclick={startAnimation} disabled={isAnimating || !task}>
+					<span class="replay-i" aria-hidden="true">↻</span>
+					Replay
+				</button>
 			</header>
 
-			<!-- Top stats: the only numbers most readers need. -->
-			<section class="stats">
-				<article class="stat stat-accent">
-					<span class="stat-k">Multi-threaded</span>
-					<span class="stat-n">
-						{r.speedup.multiThreadVsJs.toFixed(1)}<span class="stat-x">×</span>
-					</span>
-					<span class="stat-s">rayon fan-out · full pipeline</span>
-				</article>
-				<article class="stat">
-					<span class="stat-k">Single-threaded</span>
-					<span class="stat-n">
-						{r.speedup.singleThreadVsJs.toFixed(1)}<span class="stat-x">×</span>
-					</span>
-					<span class="stat-s">no parallelism</span>
-				</article>
-				<article class="stat">
-					<span class="stat-k">Throughput</span>
-					<span class="stat-n">
-						{formatThroughput(r.rustMultiThread.throughputFilesPerSec)}<span class="stat-x">/s</span>
-					</span>
-					<span class="stat-s">files compiled per second</span>
-				</article>
-				<article class="stat stat-quiet">
-					<span class="stat-k">Parser alone</span>
-					<span class="stat-n">
-						{r.parse.speedup.multiThreadVsJs.toFixed(0)}<span class="stat-x">×</span>
-					</span>
-					<span class="stat-s">phase 1, isolated</span>
-				</article>
-			</section>
-
-			<!-- Tabbed chart — three benchmarks in one viewport. -->
-			<section class="chart-card">
-				<header class="chart-head">
-					<div class="tabs" role="tablist" aria-label="Benchmark task">
-						{#each ['full', 'parse', 'svelte2tsx'] as const as tab (tab)}
-							<button
-								role="tab"
-								type="button"
-								aria-selected={activeTab === tab}
-								class="tab"
-								class:active={activeTab === tab}
-								disabled={!hasTab(tab)}
-								onclick={() => switchTab(tab)}
-							>
-								<span class="tab-label">{tabMeta[tab].label}</span>
-								<span class="tab-sub">{tabMeta[tab].sub}</span>
-							</button>
-						{/each}
-					</div>
-					<button class="replay" onclick={startAnimation} disabled={isAnimating || !task}>
-						<span class="replay-i" aria-hidden="true">↻</span>
-						Replay
-					</button>
-				</header>
-
-				{#if task}
-					{@const t = task}
-					<div class="chart">
-						{#each [
-							{ name: 'JavaScript', sub: 'svelte/compiler', dur: t.javascript.durationMs, tone: 'js' },
-							{ name: 'Rust · single', sub: 'no parallelism', dur: t.rustSingleThread.durationMs, tone: 'rs' },
-							{ name: 'Rust · multi', sub: 'rayon fan-out', dur: t.rustMultiThread.durationMs, tone: 'rm' }
-						] as bar (bar.name)}
-							<div class="bar-row">
-								<div class="bar-meta">
-									<span class="bar-name">{bar.name}</span>
-									<span class="bar-sub">{bar.sub}</span>
-								</div>
-								<div class="bar-graph">
-									<span class="bar-track">
-										<span
-											class="bar-fill bar-{bar.tone}"
-											class:complete={isBarComplete(t, bar.dur)}
-											style="width: {getAnimatedWidth(t, bar.dur)}%;"
-										></span>
-									</span>
-									<span class="bar-time" class:complete={isBarComplete(t, bar.dur)}>
-										{formatDuration(getAnimatedTime(t, bar.dur))}
-									</span>
-								</div>
+			{#if task}
+				{@const t = task}
+				<div class="bars">
+					{#each [
+						{ name: 'svelte/compiler', sub: 'JavaScript', dur: t.javascript.durationMs, tone: 'js' },
+						{ name: 'rsvelte / single', sub: 'no parallelism', dur: t.rustSingleThread.durationMs, tone: 'rs' },
+						{ name: 'rsvelte / multi', sub: 'rayon fan-out', dur: t.rustMultiThread.durationMs, tone: 'rm' }
+					] as bar (bar.name)}
+						<div class="bar-row">
+							<div class="bar-meta">
+								<span class="bar-name">{bar.name}</span>
+								<span class="bar-sub">{bar.sub}</span>
 							</div>
-						{/each}
-					</div>
-
-					<footer class="chart-foot">
-						<span class="hint">Lower is better · same machine, same corpus</span>
-						<span class="speedup">
-							<span class="speedup-k">Speedup vs JS</span>
-							<span class="speedup-v">
-								{t.speedup.multiThreadVsJs.toFixed(1)}<span class="x">×</span>
-								<span class="speedup-sep">·</span>
-								<span class="speedup-st">
-									single {t.speedup.singleThreadVsJs.toFixed(1)}×
+							<div class="bar-graph">
+								<span class="bar-track">
+									<span
+										class="bar-fill bar-{bar.tone}"
+										style="width: {getAnimatedWidth(t, bar.dur)}%;"
+									></span>
 								</span>
+								<span class="bar-time">
+									{formatDuration(getAnimatedTime(t, bar.dur))}
+								</span>
+							</div>
+						</div>
+					{/each}
+				</div>
+
+				<footer class="chart-foot">
+					<span>Lower is better · same machine, same corpus</span>
+					<span class="speedup">
+						<span class="speedup-k">Speedup vs JS</span>
+						<span class="speedup-v">
+							{t.speedup.multiThreadVsJs.toFixed(1)}<span class="x">×</span>
+							<span class="speedup-sep">·</span>
+							<span class="speedup-st">
+								single {t.speedup.singleThreadVsJs.toFixed(1)}×
 							</span>
 						</span>
-					</footer>
-				{:else}
-					<div class="missing">
-						<p>No data for this benchmark task.</p>
-					</div>
-				{/if}
-			</section>
-		</main>
+					</span>
+				</footer>
+			{:else}
+				<div class="missing">
+					<p>No data for this benchmark task.</p>
+				</div>
+			{/if}
+		</section>
 
-		<!-- Reproduce — scrolls into view, doesn't crowd the dashboard. -->
 		<section class="repro">
-			<div class="repro-head">
+			<div class="section-head">
 				<span class="num">02</span>
 				<h2>Reproduce it yourself.</h2>
 			</div>
 			<figure class="diff">
 				<figcaption>
-					<span>your-shell</span>
-					<span class="diff-tag">bash</span>
+					<span class="diff-file">your-shell</span>
 				</figcaption>
 				<pre><code><span class="c-cmt"># 1. Build the Rust compiler in release mode</span>
-<span class="line"><span class="c-prompt">$</span> cargo build <span class="c-flag">--release</span></span>
+<span class="c-prompt">$</span> cargo build <span class="c-flag">--release</span>
 
 <span class="c-cmt"># 2. Run the corpus benchmark</span>
-<span class="line"><span class="c-prompt">$</span> node scripts/run-benchmark.mjs <span class="c-op">&gt;</span> docs/static/benchmark-results.json</span>
+<span class="c-prompt">$</span> node scripts/run-benchmark.mjs <span class="c-op">&gt;</span> docs/static/benchmark-results.json
 
 <span class="c-cmt"># 3. View the report locally</span>
-<span class="line"><span class="c-prompt">$</span> cd docs <span class="c-op">&amp;&amp;</span> pnpm dev</span></code></pre>
+<span class="c-prompt">$</span> cd docs <span class="c-op">&amp;&amp;</span> pnpm dev</code></pre>
 			</figure>
 		</section>
 	{/if}
+
+	<SiteFooter />
 </div>
 
 <style>
 	.page {
-		--bg: #fdfcfa;
-		--surface: #f6f3ed;
-		--surface-2: #efeae0;
-		--ink: #15140f;
-		--ink-soft: #57534d;
-		--ink-faint: #908a80;
-		--rule: #e7e2d6;
-		--rule-strong: #c8c0b0;
-		--svelte: #ff3e00;
-		--rust: #ce422b;
-		--accent-deep: #b8350c;
-
-		--bar-js: #c79100;
-		--bar-rs: #ce422b;
-		--bar-rm: #ff3e00;
-
-		--sans:
-			'Atkinson Hyperlegible', ui-sans-serif, -apple-system, BlinkMacSystemFont,
-			'Helvetica Neue', sans-serif;
-		--mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-
-		background: var(--bg);
-		color: var(--ink);
-		font-family: var(--sans);
-		font-size: 16px;
-		line-height: 1.55;
 		min-height: 100vh;
-		-webkit-font-smoothing: antialiased;
 	}
 
-	:global(body) {
-		margin: 0;
+	code,
+	pre {
+		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
-	code {
-		font-family: var(--mono);
+	/* HERO */
+	.hero {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: clamp(3.5rem, 9vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
 	}
 
-	/* ============================================================
-	   NAV (mirrors landing)
-	   ============================================================ */
-	.nav {
-		position: sticky;
-		top: 0;
-		z-index: 30;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 2rem;
-		padding: 0.85rem clamp(1rem, 3vw, 2.25rem);
-		background: rgba(253, 252, 250, 0.92);
-		border-bottom: 1px solid var(--rule);
-		backdrop-filter: saturate(160%) blur(8px);
-	}
-
-	.brand {
+	.eyebrow {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.55rem;
-		text-decoration: none;
-		color: var(--ink);
-	}
-
-	.brand-icon {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		width: 26px;
-		height: 26px;
-	}
-
-	.brand-text {
-		font-weight: 700;
-		font-size: 1.05rem;
-		letter-spacing: -0.01em;
-	}
-
-	.brand-tag {
-		font-family: var(--mono);
-		font-size: 0.66rem;
-		letter-spacing: 0.12em;
+		gap: 0.7rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.75rem;
+		letter-spacing: 0.08em;
 		text-transform: uppercase;
 		color: var(--rust);
-		padding: 0.18rem 0.5rem;
-		border: 1px solid currentColor;
-		border-radius: 999px;
-		line-height: 1;
-		margin-left: 0.25rem;
-		opacity: 0.85;
+		margin: 0 0 1.4rem;
 	}
 
-	.nav-links {
-		display: flex;
-		align-items: center;
-		gap: clamp(0.75rem, 2vw, 1.6rem);
-		font-size: 0.9rem;
-		font-weight: 500;
+	.eyebrow .rule {
+		display: inline-block;
+		width: 24px;
+		height: 1px;
+		background: var(--rust);
 	}
 
-	.nav-links a {
-		color: var(--ink-soft);
-		text-decoration: none;
-		padding: 0.25rem 0;
-		border-bottom: 1px solid transparent;
-		transition:
-			color 0.18s,
-			border-color 0.18s;
-	}
-
-	.nav-links a:hover,
-	.nav-links a.active {
-		color: var(--svelte);
-		border-bottom-color: var(--svelte);
-	}
-
-	.nav-links .gh {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.3rem;
-	}
-
-	/* ============================================================
-	   DASHBOARD — fits a 13" laptop without scrolling
-	   ============================================================ */
-	.dash {
-		max-width: 1280px;
-		margin: 0 auto;
-		padding: clamp(1.5rem, 3.5vh, 2.25rem) clamp(1rem, 3vw, 2.25rem) clamp(1.25rem, 2.5vh, 1.75rem);
-		display: grid;
-		gap: clamp(1.1rem, 2.5vh, 1.6rem);
-	}
-
-	.dash-head {
-		display: grid;
-		grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
-		gap: 2rem;
-		align-items: end;
-	}
-
-	.dash-title h1 {
-		font-family: var(--sans);
-		font-weight: 700;
-		font-size: clamp(1.65rem, 3vw, 2.45rem);
-		line-height: 1.1;
-		letter-spacing: -0.022em;
+	.title {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: clamp(2rem, 4.6vw, 3.4rem);
+		line-height: 1.05;
+		letter-spacing: -0.025em;
+		color: var(--ink);
 		margin: 0;
-		color: var(--ink);
+		max-width: 22ch;
 	}
 
-	.dash-title h1 code {
-		font-size: 0.6em;
-		background: var(--surface);
-		padding: 0.05em 0.4em;
-		border-radius: 4px;
-		border: 1px solid var(--rule);
+	.title code {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7em;
 		font-weight: 500;
+		padding: 0.06em 0.42em;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 4px;
 		color: var(--ink);
-		vertical-align: 0.06em;
+		vertical-align: 0.08em;
 	}
 
 	.ink-svelte {
 		color: var(--svelte);
+		font-style: italic;
+		font-weight: 800;
 	}
 
-	.eyebrow {
-		font-family: var(--mono);
-		font-size: 0.75rem;
-		letter-spacing: 0.06em;
-		color: var(--rust);
-		margin: 0 0 0.7rem;
-		display: inline-flex;
-		align-items: center;
-		gap: 0.55rem;
-	}
-
-	.rule-h {
-		display: inline-block;
-		width: 22px;
-		height: 1px;
-		background: currentColor;
-	}
-
-	.dash-meta {
+	.hero-meta {
 		display: flex;
-		gap: clamp(1rem, 2vw, 1.75rem);
-		margin: 0;
-		justify-self: end;
-		text-align: right;
+		flex-wrap: wrap;
+		gap: 2.5rem;
+		margin-top: 2rem;
+		padding-top: 1.4rem;
+		border-top: 1px solid var(--rule);
 	}
 
-	.dash-meta > div {
+	.hero-meta > div {
 		display: flex;
 		flex-direction: column;
-		gap: 0.15rem;
+		gap: 0.18rem;
 	}
 
-	.dash-meta dt {
-		font-family: var(--mono);
-		font-size: 0.65rem;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: var(--ink-faint);
-	}
-
-	.dash-meta dd {
-		font-family: var(--mono);
-		font-size: 0.78rem;
-		color: var(--ink);
-		margin: 0;
-	}
-
-	.dash-meta dd code {
-		font: inherit;
-	}
-
-	/* ============================================================
-	   STAT CARDS
-	   ============================================================ */
-	.stats {
-		display: grid;
-		grid-template-columns: repeat(4, 1fr);
-		gap: 0;
-		border: 1px solid var(--rule);
-		border-radius: 10px;
-		overflow: hidden;
-		background: var(--bg);
-	}
-
-	.stat {
-		padding: clamp(0.85rem, 1.8vh, 1.25rem) clamp(0.9rem, 1.5vw, 1.4rem);
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		border-left: 1px solid var(--rule);
-	}
-
-	.stat:first-child {
-		border-left: none;
-	}
-
-	.stat-accent {
-		background: var(--ink);
-		color: #ede8d8;
-	}
-
-	.stat-quiet {
-		background: var(--surface);
-	}
-
-	.stat-k {
-		font-family: var(--mono);
+	.hero-meta dt {
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.66rem;
 		letter-spacing: 0.14em;
 		text-transform: uppercase;
 		color: var(--ink-faint);
 	}
 
-	.stat-accent .stat-k {
-		color: rgba(237, 232, 216, 0.65);
+	.hero-meta dd {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.86rem;
+		color: var(--ink);
+		margin: 0;
+	}
+
+	.hero-meta code {
+		font-size: 0.92em;
+		color: var(--rust);
+	}
+
+	/* STATS */
+	.stats {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: 0.7rem;
+	}
+
+	.stat {
+		background: var(--bg);
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		padding: 1.05rem 1.2rem 1.2rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.stat.stat-hero {
+		border-color: var(--rust);
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--rust) 8%, transparent);
+	}
+
+	.stat-k {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--ink-soft);
 	}
 
 	.stat-n {
-		font-family: var(--sans);
-		font-weight: 700;
-		font-size: clamp(1.9rem, 3.3vw, 2.6rem);
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: clamp(1.9rem, 3vw, 2.5rem);
 		line-height: 1;
-		letter-spacing: -0.035em;
+		letter-spacing: -0.03em;
 		color: var(--ink);
 		font-variant-numeric: tabular-nums;
 		display: inline-flex;
 		align-items: baseline;
 	}
 
-	.stat-accent .stat-n {
-		color: #fff;
+	.stat.stat-hero .stat-n {
+		color: var(--rust);
 	}
 
-	.stat-n .stat-x {
-		font-family: var(--mono);
+	.stat-x {
+		font-family: 'Fira Mono', monospace;
 		font-weight: 500;
-		font-size: 0.4em;
+		font-size: 0.42em;
 		margin-left: 0.18em;
-		color: var(--svelte);
-		letter-spacing: 0.02em;
+		color: var(--ink-faint);
+		letter-spacing: 0.04em;
 	}
 
-	.stat-accent .stat-n .stat-x {
-		color: var(--svelte);
+	.stat.stat-hero .stat-x {
+		color: var(--rust);
+		opacity: 0.75;
 	}
 
 	.stat-s {
-		font-family: var(--mono);
-		font-size: 0.7rem;
+		font-size: 0.82rem;
 		color: var(--ink-soft);
-		letter-spacing: 0.02em;
 	}
 
-	.stat-accent .stat-s {
-		color: rgba(237, 232, 216, 0.55);
-	}
-
-	/* ============================================================
-	   CHART CARD
-	   ============================================================ */
-	.chart-card {
-		background: var(--bg);
-		border: 1px solid var(--rule);
-		border-radius: 10px;
-		overflow: hidden;
+	/* CHART */
+	.chart {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: 0 clamp(1rem, 4vw, 2.5rem);
 	}
 
 	.chart-head {
 		display: flex;
-		justify-content: space-between;
 		align-items: stretch;
-		border-bottom: 1px solid var(--rule);
+		justify-content: space-between;
 		gap: 1rem;
+		flex-wrap: wrap;
+		background: var(--bg);
+		border: 1px solid var(--rule);
+		border-bottom: 0;
+		border-top-left-radius: 6px;
+		border-top-right-radius: 6px;
+		padding: 0.55rem;
 	}
 
 	.tabs {
 		display: flex;
-		gap: 0;
-		flex: 1;
+		gap: 0.4rem;
+		flex-wrap: wrap;
 	}
 
 	.tab {
-		appearance: none;
 		background: transparent;
-		border: none;
-		border-right: 1px solid var(--rule);
-		padding: 0.85rem 1.1rem;
-		cursor: pointer;
+		border: 1px solid transparent;
+		border-radius: 4px;
+		padding: 0.45rem 0.85rem;
 		text-align: left;
+		cursor: pointer;
+		color: var(--ink-soft);
 		display: flex;
 		flex-direction: column;
-		gap: 0.2rem;
-		font-family: var(--sans);
-		color: var(--ink-soft);
-		position: relative;
-		min-width: 8.5rem;
-		transition:
-			background 0.18s,
-			color 0.18s;
+		gap: 0.18rem;
+		transition: background 0.18s, color 0.18s, border-color 0.18s;
 	}
 
 	.tab:hover:not(:disabled) {
-		background: var(--surface);
 		color: var(--ink);
+		background: var(--paper);
 	}
 
 	.tab.active {
-		background: var(--bg);
+		background: var(--paper);
 		color: var(--ink);
-	}
-
-	.tab.active::after {
-		content: '';
-		position: absolute;
-		left: 0;
-		right: 0;
-		bottom: -1px;
-		height: 2px;
-		background: var(--svelte);
+		border-color: var(--rule-strong);
 	}
 
 	.tab:disabled {
-		opacity: 0.35;
+		opacity: 0.45;
 		cursor: not-allowed;
 	}
 
 	.tab-label {
-		font-weight: 700;
-		font-size: 0.92rem;
-		letter-spacing: -0.01em;
+		font-family: 'Overpass', sans-serif;
+		font-weight: 600;
+		font-size: 0.9rem;
+		letter-spacing: -0.005em;
 	}
 
 	.tab-sub {
-		font-family: var(--mono);
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.66rem;
 		color: var(--ink-faint);
 	}
@@ -721,280 +525,244 @@
 	}
 
 	.replay {
-		appearance: none;
+		align-self: center;
 		background: transparent;
-		border: none;
-		border-left: 1px solid var(--rule);
-		padding: 0 1.2rem;
-		font-family: var(--mono);
-		font-size: 0.75rem;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		color: var(--ink-soft);
+		border: 1px solid var(--rule-strong);
+		color: var(--ink);
+		padding: 0.45rem 0.85rem;
+		border-radius: 4px;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.76rem;
 		cursor: pointer;
 		display: inline-flex;
 		align-items: center;
 		gap: 0.4rem;
-		transition:
-			color 0.18s,
-			background 0.18s;
+		transition: border-color 0.18s, background 0.18s;
 	}
 
 	.replay:hover:not(:disabled) {
-		color: var(--ink);
-		background: var(--surface);
+		border-color: var(--ink);
+		background: var(--paper);
 	}
 
 	.replay:disabled {
-		opacity: 0.4;
+		opacity: 0.5;
 		cursor: not-allowed;
 	}
 
-	.replay-i {
-		font-family: var(--mono);
-		display: inline-block;
-		font-size: 1rem;
-		transition: transform 0.4s;
-	}
-
-	.replay:hover:not(:disabled) .replay-i {
-		transform: rotate(180deg);
-	}
-
-	.chart {
-		padding: clamp(1rem, 2vh, 1.4rem) clamp(1rem, 2vw, 1.5rem);
+	.bars {
+		background: var(--bg);
+		border: 1px solid var(--rule);
+		border-top: 0;
+		padding: 1.4rem 1.4rem 0.6rem;
 		display: flex;
 		flex-direction: column;
-		gap: clamp(0.7rem, 1.4vh, 1rem);
+		gap: 1.1rem;
 	}
 
 	.bar-row {
 		display: grid;
-		grid-template-columns: minmax(8.5rem, 11rem) 1fr;
-		gap: clamp(0.75rem, 2vw, 1.5rem);
+		grid-template-columns: minmax(11rem, 12rem) 1fr;
+		gap: 1.2rem;
 		align-items: center;
 	}
 
 	.bar-meta {
 		display: flex;
 		flex-direction: column;
-		gap: 0.1rem;
+		gap: 0.15rem;
 	}
 
 	.bar-name {
-		font-weight: 700;
-		font-size: 0.95rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.82rem;
+		font-weight: 500;
 		color: var(--ink);
-		letter-spacing: -0.01em;
 	}
 
 	.bar-sub {
-		font-family: var(--mono);
-		font-size: 0.68rem;
-		color: var(--ink-soft);
-		letter-spacing: 0.02em;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.66rem;
+		color: var(--ink-faint);
 	}
 
 	.bar-graph {
-		display: flex;
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: 0.85rem;
 		align-items: center;
-		gap: 0.9rem;
 	}
 
 	.bar-track {
-		flex: 1;
-		height: 16px;
-		background: var(--surface-2);
-		border-radius: 3px;
-		position: relative;
-		overflow: hidden;
 		display: block;
+		height: 12px;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 999px;
+		overflow: hidden;
 	}
 
 	.bar-fill {
-		position: absolute;
-		inset: 0;
-		width: 0;
-		border-radius: 3px;
-		opacity: 0.9;
-		transition: opacity 0.3s;
-	}
-
-	.bar-fill.complete {
-		opacity: 1;
+		display: block;
+		height: 100%;
+		border-radius: inherit;
+		transition: width 60ms linear;
 	}
 
 	.bar-js {
-		background: var(--bar-js);
+		background: linear-gradient(90deg, color-mix(in srgb, var(--ink-faint) 70%, transparent), var(--ink-faint));
 	}
+
 	.bar-rs {
-		background: var(--bar-rs);
+		background: linear-gradient(90deg, var(--rust-soft), var(--rust));
 	}
+
 	.bar-rm {
-		background: var(--bar-rm);
+		background: linear-gradient(90deg, var(--rust-soft), var(--svelte));
 	}
 
 	.bar-time {
-		font-family: var(--sans);
-		font-feature-settings: 'tnum' 1, 'lnum' 1;
-		font-weight: 700;
-		font-size: clamp(1rem, 1.5vw, 1.25rem);
-		letter-spacing: -0.015em;
-		color: var(--ink-faint);
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.84rem;
+		color: var(--ink);
+		font-variant-numeric: tabular-nums;
 		min-width: 5.5rem;
 		text-align: right;
-		font-variant-numeric: tabular-nums;
-		transition: color 0.3s;
-	}
-
-	.bar-time.complete {
-		color: var(--ink);
 	}
 
 	.chart-foot {
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-top: 0;
+		border-bottom-left-radius: 6px;
+		border-bottom-right-radius: 6px;
+		padding: 0.7rem 1rem;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		padding: 0.75rem clamp(1rem, 2vw, 1.5rem);
-		border-top: 1px solid var(--rule);
-		background: var(--surface);
-		font-family: var(--mono);
-		font-size: 0.74rem;
 		gap: 1rem;
 		flex-wrap: wrap;
-	}
-
-	.hint {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.72rem;
 		color: var(--ink-soft);
 	}
 
 	.speedup {
 		display: inline-flex;
-		align-items: baseline;
-		gap: 0.5rem;
+		align-items: center;
+		gap: 0.55rem;
 	}
 
 	.speedup-k {
 		color: var(--ink-faint);
-		letter-spacing: 0.06em;
-		text-transform: uppercase;
-		font-size: 0.66rem;
+		letter-spacing: 0.04em;
 	}
 
 	.speedup-v {
-		font-family: var(--sans);
+		font-family: 'Overpass', sans-serif;
 		font-weight: 700;
-		color: var(--svelte);
-		font-size: 1rem;
-		letter-spacing: -0.01em;
+		font-size: 0.92rem;
+		color: var(--ink);
+		font-variant-numeric: tabular-nums;
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.45rem;
 	}
 
 	.speedup-v .x {
-		font-family: var(--mono);
+		font-family: 'Fira Mono', monospace;
 		font-weight: 500;
-		font-size: 0.7em;
-		margin-left: 0.1em;
+		font-size: 0.72em;
+		color: var(--rust);
 	}
 
 	.speedup-sep {
 		color: var(--ink-faint);
-		margin: 0 0.3em;
-		font-weight: 400;
 	}
 
 	.speedup-st {
-		font-family: var(--mono);
+		font-family: 'Fira Mono', monospace;
+		font-weight: 400;
+		font-size: 0.76rem;
 		color: var(--ink-soft);
-		font-weight: 500;
-		font-size: 0.8em;
 	}
 
 	.missing {
-		padding: 2rem;
+		padding: 3rem 1.5rem;
+		background: var(--bg);
+		border: 1px solid var(--rule);
+		border-top: 0;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.85rem;
+		color: var(--ink-faint);
 		text-align: center;
-		color: var(--ink-soft);
 	}
 
-	/* ============================================================
-	   REPRODUCE
-	   ============================================================ */
+	/* REPRO */
 	.repro {
-		max-width: 1280px;
+		max-width: 1080px;
 		margin: 0 auto;
-		padding: clamp(3rem, 6vh, 5rem) clamp(1rem, 3vw, 2.25rem);
-		border-top: 1px solid var(--rule);
+		padding: clamp(3.5rem, 7vh, 5rem) clamp(1rem, 4vw, 2.5rem) clamp(4rem, 8vh, 6rem);
 	}
 
-	.repro-head {
-		display: flex;
+	.section-head {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: 0.4rem 1.4rem;
+		margin-bottom: 1.6rem;
 		align-items: baseline;
-		gap: 1rem;
-		margin-bottom: 1.5rem;
 	}
 
-	.repro-head .num {
-		font-family: var(--mono);
-		font-size: 0.72rem;
+	.section-head .num {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7rem;
 		letter-spacing: 0.18em;
 		color: var(--rust);
 	}
 
-	.repro-head h2 {
-		font-family: var(--sans);
+	.section-head h2 {
+		font-family: 'Overpass', sans-serif;
 		font-weight: 700;
-		font-size: clamp(1.4rem, 2.4vw, 2rem);
+		font-size: clamp(1.6rem, 3vw, 2.4rem);
+		line-height: 1.1;
 		letter-spacing: -0.022em;
 		margin: 0;
 		color: var(--ink);
 	}
 
 	.diff {
-		margin: 0;
-		max-width: 780px;
-		background: var(--ink);
-		color: #ede8d8;
-		border-radius: 10px;
-		font-family: var(--mono);
+		max-width: 720px;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 6px;
 		overflow: hidden;
-		border: 1px solid #2a2620;
-		box-shadow: 0 12px 28px -20px rgba(21, 20, 15, 0.5);
+		font-family: 'Fira Mono', monospace;
 	}
 
 	.diff figcaption {
 		display: flex;
-		align-items: center;
 		justify-content: space-between;
-		padding: 0.7rem 1rem;
-		border-bottom: 1px solid rgba(237, 232, 216, 0.08);
-		font-size: 0.7rem;
-		letter-spacing: 0.08em;
-		color: rgba(237, 232, 216, 0.55);
-		text-transform: uppercase;
+		align-items: center;
+		padding: 0.65rem 1rem;
+		border-bottom: 1px solid var(--rule);
+		font-size: 0.72rem;
+		color: var(--ink-faint);
+		letter-spacing: 0.04em;
 	}
 
-	.diff .diff-tag {
-		color: var(--svelte);
+	.diff-file {
+		color: var(--ink-soft);
 	}
 
 	.diff pre {
 		margin: 0;
-		padding: 1.1rem 1.25rem;
+		padding: 1rem 1.2rem;
 		font-size: 0.85rem;
 		line-height: 1.7;
-		white-space: pre-wrap;
-	}
-
-	.diff code {
-		font-family: inherit;
-	}
-
-	.diff .line {
-		display: block;
 	}
 
 	.c-cmt {
-		color: rgba(237, 232, 216, 0.4);
-		display: block;
+		color: var(--ink-faint);
 	}
 
 	.c-prompt {
@@ -1002,117 +770,78 @@
 		margin-right: 0.5em;
 	}
 
-	.c-flag {
-		color: #ffb380;
-	}
-
+	.c-flag,
 	.c-op {
-		color: rgba(237, 232, 216, 0.5);
+		color: var(--rust);
 	}
 
-	/* ============================================================
-	   EMPTY STATE
-	   ============================================================ */
+	/* EMPTY */
 	.empty {
-		max-width: 720px;
-		padding: clamp(3rem, 8vh, 5rem) clamp(1rem, 3vw, 2.25rem);
+		max-width: 1080px;
 		margin: 0 auto;
+		padding: clamp(4rem, 10vh, 7rem) clamp(1rem, 4vw, 2.5rem);
 	}
 
 	.empty h1 {
-		font-family: var(--sans);
+		font-family: 'Overpass', sans-serif;
 		font-weight: 700;
-		font-size: clamp(1.8rem, 3.5vw, 2.6rem);
-		letter-spacing: -0.022em;
+		font-size: clamp(2rem, 4.6vw, 3rem);
+		line-height: 1.05;
+		letter-spacing: -0.025em;
+		color: var(--ink);
 		margin: 0 0 1rem;
 	}
 
 	.empty .lede {
 		font-size: 1.05rem;
 		color: var(--ink-soft);
+		max-width: 56ch;
 		margin: 0 0 1.5rem;
 	}
 
 	.empty-code {
-		font-family: var(--mono);
-		background: var(--ink);
-		color: #ede8d8;
-		padding: 1.1rem 1.25rem;
-		border-radius: 10px;
+		max-width: 640px;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		padding: 1rem 1.2rem;
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.85rem;
+		color: var(--ink);
 		line-height: 1.7;
-		border: 1px solid #2a2620;
+		overflow-x: auto;
 	}
 
-	/* ============================================================
-	   RESPONSIVE
-	   ============================================================ */
-	@media (max-width: 1000px) {
-		.dash-head {
-			grid-template-columns: 1fr;
-			gap: 1rem;
-		}
-		.dash-meta {
-			justify-self: start;
-			text-align: left;
-		}
+	/* RESPONSIVE */
+	@media (max-width: 880px) {
 		.stats {
-			grid-template-columns: repeat(2, 1fr);
-		}
-		.stat:nth-child(3) {
-			border-left: none;
-			border-top: 1px solid var(--rule);
-		}
-		.stat:nth-child(4) {
-			border-top: 1px solid var(--rule);
+			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}
 	}
 
-	@media (max-width: 700px) {
-		.brand-tag {
-			display: none;
-		}
-		.nav-links {
-			gap: 0.85rem;
-			font-size: 0.82rem;
-		}
+	@media (max-width: 640px) {
 		.stats {
 			grid-template-columns: 1fr;
-		}
-		.stat {
-			border-left: none;
-			border-top: 1px solid var(--rule);
-		}
-		.stat:first-child {
-			border-top: none;
-		}
-		.chart-head {
-			flex-direction: column;
-			align-items: stretch;
-		}
-		.tabs {
-			overflow-x: auto;
-		}
-		.replay {
-			border-left: none;
-			border-top: 1px solid var(--rule);
-			padding: 0.65rem 1rem;
-			justify-content: center;
 		}
 		.bar-row {
 			grid-template-columns: 1fr;
 			gap: 0.5rem;
 		}
-		.bar-time {
-			min-width: 4rem;
+		.bar-meta {
+			flex-direction: row;
+			align-items: baseline;
+			gap: 0.6rem;
+		}
+		.chart-head {
+			flex-direction: column;
+		}
+		.replay {
+			align-self: flex-end;
 		}
 	}
 
 	@media (prefers-reduced-motion: reduce) {
 		.bar-fill {
-			transition: none !important;
-		}
-		.replay-i {
 			transition: none !important;
 		}
 	}

--- a/docs/src/routes/playground/+page.svelte
+++ b/docs/src/routes/playground/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount, untrack } from 'svelte';
-	import { base } from '$app/paths';
 	import {
 		initCompiler,
 		getVersion,
@@ -15,6 +14,7 @@
 	import { DEFAULT_EXAMPLE } from '$lib/examples';
 	import MonacoEditor from '$lib/monaco/MonacoEditor.svelte';
 	import AstViewer from '$lib/components/AstViewer.svelte';
+	import SiteNav from '$lib/components/SiteNav.svelte';
 
 	let input = $state(DEFAULT_EXAMPLE);
 
@@ -142,62 +142,46 @@
 		name="description"
 		content="A live playground for the Rust port of the Svelte 5 compiler — edit a component and see the generated JS, CSS, AST and rendered preview."
 	/>
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link
-		href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,200..900,0..100,0..1;1,9..144,200..900,0..100,0..1&family=Instrument+Sans:ital,wght@0,400..700;1,400..700&family=JetBrains+Mono:wght@400..700&display=swap"
-		rel="stylesheet"
-	/>
 </svelte:head>
 
 <div class="page">
-	<div class="grain" aria-hidden="true"></div>
+	<SiteNav active="playground" />
 
-	<nav class="strip">
-		<div class="strip-l">
-			<a href="{base}/" class="mark">rsvelte</a>
-			<span class="strip-sep">/</span>
-			<span class="strip-here">playground</span>
+	<header class="play-head">
+		<div class="play-head-l">
+			<p class="eyebrow"><span class="rule"></span>Live · WASM-compiled</p>
+			<h1 class="title">Playground</h1>
 			{#if version}
-				<span class="strip-version mono">v{version}</span>
+				<span class="version">v{version}</span>
 			{/if}
 		</div>
-
-		<div class="strip-c">
+		<div class="play-head-r" role="radiogroup" aria-label="Compilation mode">
 			<span class="mode-label">Generate</span>
-			<div class="mode-switch" role="radiogroup" aria-label="Compilation mode">
+			<div class="mode-switch">
 				<button
 					class:active={mode === 'client'}
 					onclick={() => (mode = 'client')}
-					disabled={!wasmReady}>Client</button
+					disabled={!wasmReady}
 				>
+					Client
+				</button>
 				<button
 					class:active={mode === 'server'}
 					onclick={() => (mode = 'server')}
-					disabled={!wasmReady}>Server</button
+					disabled={!wasmReady}
 				>
+					Server
+				</button>
 			</div>
 		</div>
-
-		<div class="strip-r">
-			<a href="{base}/progress">Compat</a>
-			<a href="{base}/benchmark">Speed</a>
-			<a
-				href="https://github.com/baseballyama/rsvelte"
-				target="_blank"
-				rel="noopener"
-				class="ext">GitHub <span class="chev">↗</span></a
-			>
-		</div>
-	</nav>
+	</header>
 
 	<main class="workspace">
-		<!-- INPUT -->
 		<section class="panel panel-input">
 			<header class="panel-head">
-				<span class="panel-kicker">§ 01</span>
+				<span class="panel-num">01</span>
 				<h2 class="panel-title">Source <em>.svelte</em></h2>
-				<span class="panel-meta mono">live · edits debounced 300ms</span>
+				<span class="panel-meta">live · edits debounced 300ms</span>
 			</header>
 			<div class="panel-body editor-host">
 				{#if wasmReady}
@@ -213,10 +197,9 @@
 			</div>
 		</section>
 
-		<!-- OUTPUT -->
 		<section class="panel panel-output">
 			<header class="panel-head">
-				<span class="panel-kicker">§ 02</span>
+				<span class="panel-num">02</span>
 				<h2 class="panel-title">Output</h2>
 				<div class="tabs" role="tablist">
 					<button
@@ -261,7 +244,7 @@
 					{/key}
 				{/if}
 			</div>
-			<footer class="panel-foot mono">
+			<footer class="panel-foot">
 				<span>
 					<span class="dim">compile</span>
 					<strong>{stats.compileTime.toFixed(2)}<span class="unit">ms</span></strong>
@@ -278,12 +261,11 @@
 			</footer>
 		</section>
 
-		<!-- PREVIEW -->
 		<section class="panel panel-preview">
 			<header class="panel-head">
-				<span class="panel-kicker">§ 03</span>
+				<span class="panel-num">03</span>
 				<h2 class="panel-title">Preview</h2>
-				<span class="panel-meta mono">sandbox · isolated iframe</span>
+				<span class="panel-meta">sandbox · isolated iframe</span>
 			</header>
 			<div class="panel-body preview-host">
 				{#if !wasmReady && !error}
@@ -305,148 +287,115 @@
 </div>
 
 <style>
-	:global(body) {
-		margin: 0;
-		padding: 0;
-	}
-
 	.page {
-		--bg: #f1e8d6;
-		--surface: #e6dac1;
-		--ink: #1a1612;
-		--ink-soft: #7a7062;
-		--ink-faint: #b8ab93;
-		--accent: #ff3e00;
-		--accent-deep: #c52f00;
-		--hairline: rgba(26, 22, 18, 0.16);
-		--hairline-strong: rgba(26, 22, 18, 0.4);
-		--ok: #2c7a3a;
-		--err: #b1280a;
-
-		--display: 'Fraunces', 'Source Serif Pro', Georgia, serif;
-		--body: 'Instrument Sans', system-ui, -apple-system, sans-serif;
-		--mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-
-		background: var(--bg);
-		color: var(--ink);
-		font-family: var(--body);
-		-webkit-font-smoothing: antialiased;
-		height: 100vh;
+		min-height: 100vh;
 		display: flex;
 		flex-direction: column;
-		position: relative;
-		overflow: hidden;
-		font-feature-settings: 'ss01';
 	}
 
-	.mono {
-		font-family: var(--mono);
+	code,
+	pre {
+		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
-	.grain {
-		position: fixed;
-		inset: 0;
-		pointer-events: none;
-		z-index: 80;
-		opacity: 0.05;
-		mix-blend-mode: multiply;
-		background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.4' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
-	}
-
-	/* ============================================================
-	   TOP STRIP — three-column masthead with the mode switch centered
-	   ============================================================ */
-	.strip {
-		display: grid;
-		grid-template-columns: 1fr auto 1fr;
+	/* PAGE HEAD */
+	.play-head {
+		max-width: 1440px;
+		margin: 0 auto;
+		width: 100%;
+		padding: clamp(1.4rem, 3vh, 2rem) clamp(1rem, 4vw, 2.5rem) clamp(0.8rem, 2vh, 1.2rem);
+		display: flex;
 		align-items: center;
-		gap: 1rem;
-		padding: 0.9rem 2rem;
-		background: var(--bg);
-		border-bottom: 1px solid var(--hairline-strong);
-		font-family: var(--mono);
-		font-size: 0.78rem;
-		letter-spacing: 0.04em;
-		flex-shrink: 0;
-		z-index: 60;
-		position: relative;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 1.2rem;
 	}
 
-	.strip-l {
+	.play-head-l {
 		display: flex;
 		align-items: baseline;
-		gap: 0.7rem;
-		min-width: 0;
+		gap: 1rem;
+		flex-wrap: wrap;
 	}
 
-	.strip .mark {
-		font-family: var(--display);
-		font-style: italic;
-		font-weight: 500;
-		font-size: 1.45rem;
+	.eyebrow {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--rust);
+		margin: 0;
+	}
+
+	.eyebrow .rule {
+		display: inline-block;
+		width: 20px;
+		height: 1px;
+		background: var(--rust);
+	}
+
+	.title {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: clamp(1.5rem, 2.5vw, 2rem);
 		letter-spacing: -0.025em;
-		font-variation-settings: 'opsz' 96, 'SOFT' 80, 'WONK' 1;
 		color: var(--ink);
-		text-decoration: none;
+		margin: 0;
+	}
+
+	.version {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.74rem;
+		color: var(--rust);
+		padding: 0.2rem 0.5rem;
+		border: 1px solid currentColor;
+		border-radius: 2px;
 		line-height: 1;
 	}
 
-	.strip-sep {
-		color: var(--ink-faint);
-		font-size: 1rem;
-	}
-
-	.strip-here {
-		font-family: var(--body);
-		font-size: 0.95rem;
-		color: var(--ink);
-		letter-spacing: -0.01em;
-	}
-
-	.strip-version {
-		font-size: 0.66rem;
-		color: var(--ink-soft);
-		padding: 0.18rem 0.45rem;
-		border: 1px solid var(--hairline);
-		margin-left: 0.4rem;
-		letter-spacing: 0.08em;
-	}
-
-	.strip-c {
-		display: flex;
+	.play-head-r {
+		display: inline-flex;
 		align-items: center;
-		gap: 0.8rem;
-		justify-self: center;
+		gap: 0.7rem;
 	}
 
 	.mode-label {
-		font-size: 0.66rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.1em;
 		text-transform: uppercase;
-		letter-spacing: 0.2em;
 		color: var(--ink-soft);
 	}
 
 	.mode-switch {
 		display: inline-flex;
-		border: 1px solid var(--ink);
+		border: 1px solid var(--rule-strong);
+		border-radius: 4px;
+		overflow: hidden;
+		background: var(--bg);
 	}
 
 	.mode-switch button {
-		font-family: var(--mono);
-		font-size: 0.72rem;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.78rem;
 		padding: 0.45rem 0.95rem;
 		background: transparent;
 		border: 0;
-		color: var(--ink);
+		color: var(--ink-soft);
 		cursor: pointer;
-		transition: background 0.2s ease, color 0.2s ease;
-		border-right: 1px solid var(--ink);
+		border-right: 1px solid var(--rule);
+		transition: background 0.18s, color 0.18s;
 	}
 
 	.mode-switch button:last-child {
 		border-right: 0;
+	}
+
+	.mode-switch button:hover:not(:disabled) {
+		color: var(--ink);
 	}
 
 	.mode-switch button.active {
@@ -455,138 +404,90 @@
 	}
 
 	.mode-switch button:disabled {
-		opacity: 0.35;
+		opacity: 0.5;
 		cursor: not-allowed;
 	}
 
-	.strip-r {
-		display: flex;
-		gap: 1.4rem;
-		align-items: center;
-		justify-self: end;
-	}
-
-	.strip-r a {
-		text-decoration: none;
-		color: var(--ink);
-		text-transform: uppercase;
-		font-size: 0.7rem;
-		letter-spacing: 0.16em;
-		padding-bottom: 2px;
-		border-bottom: 1px solid transparent;
-		transition: border-color 0.25s ease, color 0.25s ease;
-	}
-
-	.strip-r a:hover {
-		border-bottom-color: var(--accent);
-		color: var(--accent);
-	}
-
-	.strip-r .chev {
-		font-family: var(--mono);
-	}
-
-	/* ============================================================
-	   WORKSPACE GRID
-	   ============================================================ */
+	/* WORKSPACE */
 	.workspace {
-		flex: 1;
+		max-width: 1440px;
+		margin: 0 auto;
+		width: 100%;
+		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(1.5rem, 4vh, 2.5rem);
 		display: grid;
-		grid-template-columns: 1fr 1fr 1fr;
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+		gap: 0.85rem;
+		flex: 1;
 		min-height: 0;
-		min-width: 0;
-		background: var(--bg);
 	}
 
 	.panel {
 		display: flex;
 		flex-direction: column;
-		min-width: 0;
 		min-height: 0;
-		border-right: 1px solid var(--hairline-strong);
+		min-width: 0;
 		background: var(--bg);
-	}
-
-	.panel:last-child {
-		border-right: 0;
-	}
-
-	.panel-input {
-		background: var(--surface);
-	}
-
-	.panel-output {
-		background: var(--bg);
-	}
-
-	.panel-preview {
-		background: var(--surface);
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		overflow: hidden;
 	}
 
 	.panel-head {
 		display: flex;
 		align-items: center;
-		gap: 0.9rem;
-		padding: 0.85rem 1.25rem;
-		border-bottom: 1px solid var(--hairline-strong);
-		background: inherit;
+		gap: 0.8rem;
+		padding: 0.65rem 0.9rem;
+		background: var(--paper);
+		border-bottom: 1px solid var(--rule);
+		flex-shrink: 0;
 	}
 
-	.panel-kicker {
-		font-family: var(--mono);
+	.panel-num {
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.66rem;
-		letter-spacing: 0.2em;
-		text-transform: uppercase;
-		color: var(--accent);
-		flex-shrink: 0;
+		letter-spacing: 0.16em;
+		color: var(--rust);
 	}
 
 	.panel-title {
-		font-family: var(--display);
-		font-weight: 400;
-		font-size: 1.35rem;
-		line-height: 1;
-		letter-spacing: -0.02em;
+		font-family: 'Overpass', sans-serif;
+		font-weight: 700;
+		font-size: 0.92rem;
+		letter-spacing: -0.01em;
+		color: var(--ink);
 		margin: 0;
-		flex-shrink: 0;
+		flex: 1;
 	}
 
 	.panel-title em {
 		font-style: italic;
-		color: var(--accent);
-		font-variation-settings: 'opsz' 96, 'SOFT' 100, 'WONK' 1;
-		font-weight: 400;
-		font-family: var(--display);
-		padding-right: 0.02em;
+		color: var(--svelte);
+		font-weight: 700;
 	}
 
 	.panel-meta {
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.66rem;
-		color: var(--ink-soft);
-		text-transform: lowercase;
-		letter-spacing: 0.08em;
-		margin-left: auto;
-		text-align: right;
+		color: var(--ink-faint);
 	}
 
 	.tabs {
 		display: inline-flex;
-		margin-left: auto;
-		border: 1px solid var(--hairline-strong);
+		border: 1px solid var(--rule-strong);
+		border-radius: 4px;
+		overflow: hidden;
 	}
 
 	.tabs button {
-		font-family: var(--mono);
-		font-size: 0.7rem;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
-		padding: 0.42rem 0.85rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.72rem;
+		padding: 0.32rem 0.7rem;
 		background: transparent;
 		border: 0;
 		color: var(--ink-soft);
 		cursor: pointer;
-		transition: background 0.2s ease, color 0.2s ease;
-		border-right: 1px solid var(--hairline-strong);
+		border-right: 1px solid var(--rule);
+		transition: background 0.18s, color 0.18s;
 	}
 
 	.tabs button:last-child {
@@ -605,13 +506,18 @@
 	.panel-body {
 		flex: 1;
 		min-height: 0;
-		position: relative;
-		overflow: hidden;
-		background: var(--bg);
+		display: flex;
+		flex-direction: column;
 	}
 
 	.editor-host {
-		background: var(--bg);
+		background: var(--editor-bg);
+	}
+
+	.editor-host :global(.editor-container) {
+		flex: 1;
+		height: 100%;
+		min-height: 0;
 	}
 
 	.preview-host {
@@ -621,14 +527,8 @@
 	.preview-host iframe {
 		width: 100%;
 		height: 100%;
-		border: none;
-		display: block;
-	}
-
-	.ast-host {
-		position: absolute;
-		inset: 0;
-		overflow: auto;
+		border: 0;
+		background: #ffffff;
 	}
 
 	.loading {
@@ -636,152 +536,115 @@
 		align-items: center;
 		justify-content: center;
 		height: 100%;
-		color: var(--ink-soft);
-		font-family: var(--mono);
-		font-size: 0.78rem;
-		letter-spacing: 0.08em;
+		min-height: 240px;
+		padding: 2rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.82rem;
+		color: var(--ink-faint);
+	}
+
+	.ast-host {
+		flex: 1;
+		min-height: 0;
+		overflow: auto;
+		padding: 0.6rem 0.8rem;
+		background: var(--editor-bg);
 	}
 
 	.error {
+		padding: 1.2rem;
 		display: flex;
 		flex-direction: column;
-		gap: 0.5rem;
-		padding: 1.5rem;
-		font-family: var(--mono);
-		font-size: 0.82rem;
-		color: var(--err);
-		max-height: 100%;
-		overflow: auto;
+		gap: 0.55rem;
+		background: color-mix(in srgb, var(--bad) 5%, var(--bg));
+		font-family: 'Fira Mono', monospace;
 	}
 
 	.error-tag {
-		font-size: 0.66rem;
+		font-size: 0.7rem;
+		letter-spacing: 0.16em;
 		text-transform: uppercase;
-		letter-spacing: 0.2em;
-		color: var(--err);
-		opacity: 0.75;
+		color: var(--bad);
 	}
 
 	.error pre {
-		margin: 0;
-		padding: 1rem;
-		background: rgba(177, 40, 10, 0.06);
-		border-left: 3px solid var(--err);
+		font-size: 0.8rem;
+		color: var(--ink);
 		white-space: pre-wrap;
 		word-break: break-word;
-		line-height: 1.55;
+		margin: 0;
 	}
 
 	.panel-foot {
 		display: flex;
 		align-items: center;
-		gap: 1.5rem;
-		padding: 0.7rem 1.25rem;
-		border-top: 1px solid var(--hairline-strong);
-		background: inherit;
-		font-size: 0.72rem;
-		color: var(--ink-soft);
-	}
-
-	.panel-foot strong {
+		gap: 1rem;
+		padding: 0.55rem 0.9rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.76rem;
 		color: var(--ink);
-		font-weight: 500;
-		font-variant-numeric: tabular-nums;
-	}
-
-	.panel-foot .unit {
-		color: var(--ink-soft);
-		font-weight: 400;
-		margin-left: 0.1em;
+		background: var(--paper);
+		border-top: 1px solid var(--rule);
+		flex-shrink: 0;
 	}
 
 	.panel-foot .dim {
-		color: var(--ink-soft);
+		color: var(--ink-faint);
 		margin-right: 0.4em;
-		text-transform: uppercase;
-		font-size: 0.62rem;
-		letter-spacing: 0.16em;
 	}
 
-	.panel-foot .grow {
+	.panel-foot strong {
+		font-weight: 600;
+		color: var(--ink);
+	}
+
+	.unit {
+		font-weight: 400;
+		color: var(--ink-soft);
+		margin-left: 0.15em;
+	}
+
+	.grow {
 		flex: 1;
 	}
 
 	.status-dot {
+		display: inline-block;
 		width: 7px;
 		height: 7px;
 		border-radius: 999px;
 		background: var(--ink-faint);
-		display: inline-block;
 	}
 
 	.status-dot.ok {
 		background: var(--ok);
-		box-shadow: 0 0 0 3px rgba(44, 122, 58, 0.18);
 	}
 
 	.status-dot.err {
-		background: var(--err);
-		box-shadow: 0 0 0 3px rgba(177, 40, 10, 0.18);
+		background: var(--bad);
 	}
 
 	.status-text {
-		text-transform: uppercase;
-		letter-spacing: 0.18em;
-		font-size: 0.62rem;
-		color: var(--ink);
+		color: var(--ink-soft);
 	}
 
-	/* AstViewer reads the page's CSS variables and themes itself; we only
-	   provide the scroll container here. */
-
-	@media (max-width: 1100px) {
+	/* RESPONSIVE */
+	@media (max-width: 1180px) {
 		.workspace {
-			grid-template-columns: 1fr 1fr;
-			grid-template-rows: 1fr 1fr;
+			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 		}
 		.panel-preview {
 			grid-column: 1 / -1;
-			border-right: 0;
-			border-top: 1px solid var(--hairline-strong);
+			min-height: 320px;
 		}
 	}
 
-	@media (max-width: 720px) {
+	@media (max-width: 760px) {
 		.workspace {
 			grid-template-columns: 1fr;
-			grid-template-rows: 1fr 1fr 1fr;
 		}
 		.panel {
-			border-right: 0;
-			border-bottom: 1px solid var(--hairline-strong);
-		}
-		.strip {
-			grid-template-columns: 1fr;
-			gap: 0.5rem;
-			padding: 0.7rem 1rem;
-		}
-		.strip-c,
-		.strip-r {
-			justify-self: stretch;
-			justify-content: space-between;
-		}
-		.strip-r {
-			gap: 1rem;
-		}
-		.strip-r a {
-			font-size: 0.62rem;
-			letter-spacing: 0.12em;
-		}
-		.panel-head {
-			padding: 0.65rem 1rem;
-			gap: 0.5rem;
-		}
-		.panel-title {
-			font-size: 1.1rem;
-		}
-		.panel-meta {
-			display: none;
+			min-height: 380px;
 		}
 	}
 </style>

--- a/docs/src/routes/progress/+page.svelte
+++ b/docs/src/routes/progress/+page.svelte
@@ -2,6 +2,8 @@
 	import { base } from '$app/paths';
 	import type { PageData } from './$types';
 	import type { TestCase } from '$lib/types/test-results';
+	import SiteNav from '$lib/components/SiteNav.svelte';
+	import SiteFooter from '$lib/components/SiteFooter.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -66,72 +68,32 @@
 		name="description"
 		content="Live compatibility report — every category of the official Svelte test suite run against rsvelte."
 	/>
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link
-		href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,200..900,0..100,0..1;1,9..144,200..900,0..100,0..1&family=Instrument+Sans:ital,wght@0,400..700;1,400..700&family=JetBrains+Mono:wght@400..700&display=swap"
-		rel="stylesheet"
-	/>
 </svelte:head>
 
 <div class="page">
-	<div class="grain" aria-hidden="true"></div>
-	<div class="spine" aria-hidden="true"></div>
-
-	<nav class="strip">
-		<div class="strip-l">
-			<a href="{base}/" class="mark">rsvelte</a>
-		</div>
-		<div class="strip-r">
-			<a href="{base}/playground">Playground</a>
-			<a href="{base}/progress" class="active">Compat</a>
-			<a href="{base}/benchmark">Speed</a>
-			<a
-				href="https://github.com/baseballyama/rsvelte"
-				target="_blank"
-				rel="noopener"
-				class="ext">GitHub <span class="chev">↗</span></a
-			>
-		</div>
-	</nav>
+	<SiteNav active="progress" />
 
 	{#if data.error}
 		<section class="empty">
-			<span class="kicker">§ Compatibility — unavailable</span>
-			<h1 class="empty-title"><em>Test</em> results<br />not generated.</h1>
-			<p class="empty-sub">{data.error}</p>
-			<pre class="empty-code"><code>cargo run --release --bin test_reporter -- \
-  --output docs/static/test-results.json</code></pre>
+			<p class="eyebrow"><span class="rule"></span>Compatibility · unavailable</p>
+			<h1>Test results not generated.</h1>
+			<p class="lede">{data.error}</p>
+			<pre class="empty-code"><code><span class="c-cmt"># From the repo root</span>
+<span class="c-prompt">$</span> cargo run <span class="c-flag">--release --bin</span> test_reporter <span class="c-op">--</span> <span class="c-op">\</span>
+    <span class="c-flag">--output</span> docs/static/test-results.json</code></pre>
 		</section>
 	{:else if data.results}
 		{@const r = data.results}
-		<!-- HERO: overall percentage as the main display -->
+
 		<header class="hero">
-			<aside class="margin margin-tl" aria-hidden="true">
-				<span class="serif-italic">№ 002</span>
-				<span class="rule"></span>
-				<span class="meta">The compatibility report</span>
-			</aside>
+			<p class="eyebrow"><span class="rule"></span>Compatibility · live report</p>
 
-			<aside class="margin margin-tr" aria-hidden="true">
-				<span class="meta">Generated</span><br />
-				<span class="strong mono">{formatDate(r.generated_at)}</span><br />
-				<span class="meta">Against</span><br />
-				<span class="strong mono">sveltejs/svelte@{r.commit_sha}</span>
-			</aside>
-
-			<div class="hero-figure" aria-hidden="true">
-				<span class="num">{Math.round(r.summary.percentage)}</span>
-				<span class="x">%</span>
-			</div>
-
-			<h1 class="hero-title">
-				<span class="line">Every</span>
-				<span class="line"><em>test,</em></span>
-				<span class="line">passing.</span>
+			<h1 class="title">
+				<span class="ink-svelte">{Math.round(r.summary.percentage)}%</span> of the official
+				<code>sveltejs/svelte</code> suite, passing.
 			</h1>
 
-			<dl class="hero-stats">
+			<dl class="hero-meta">
 				<div>
 					<dt>In-scope passing</dt>
 					<dd>
@@ -155,22 +117,28 @@
 						</dd>
 					</div>
 				{/if}
+				<div>
+					<dt>Recorded</dt>
+					<dd class="mono">{formatDate(r.generated_at)}</dd>
+				</div>
+				<div>
+					<dt>Against</dt>
+					<dd class="mono"><code>sveltejs/svelte@{r.commit_sha}</code></dd>
+				</div>
 			</dl>
 		</header>
 
-		<!-- CATEGORIES: spec-sheet rows mirroring the landing page -->
 		<section class="spec">
-			<header class="spec-head">
-				<span class="kicker">§ 02 — By category</span>
-				<h2>Every row, <em>verified</em>.</h2>
+			<div class="section-head">
+				<span class="num">01</span>
+				<h2>Every <em>category</em>, verified.</h2>
 				<p class="lede">
-					Click any row to filter the fixture list to that suite. Numbers reflect the
-					official Svelte test fixtures we run locally against
-					<span class="chip">{r.commit_sha}</span>.
+					Click any row to filter the fixture list below. Numbers reflect the official Svelte
+					test fixtures run locally against <code>{r.commit_sha}</code>.
 				</p>
-			</header>
+			</div>
 
-			<div class="spec-grid">
+			<div class="spec-list">
 				{#each r.categories as cat, i (cat.id)}
 					<button
 						class="spec-row"
@@ -178,14 +146,14 @@
 						style="--i: {i};"
 						onclick={() => toggleCategory(cat.id)}
 					>
-						<span class="row-num">
-							{cat.passed}<span class="row-num-sep">/</span><span class="row-num-tot"
-								>{cat.total - cat.skipped}</span
-							>
-						</span>
-						<span class="row-label">
-							<strong>{cat.name}</strong>
-							<span class="row-sub">
+						<span class="spec-k">{cat.name}</span>
+						<span class="spec-v">
+							<span class="spec-n">
+								{cat.passed}<span class="spec-n-sep">/</span><span class="spec-n-tot"
+									>{cat.total - cat.skipped}</span
+								>
+							</span>
+							<span class="spec-s">
 								{#if cat.skipped > 0}
 									{cat.skipped} skipped — out of scope
 								{:else if cat.percentage >= 100}
@@ -195,7 +163,7 @@
 								{/if}
 							</span>
 						</span>
-						<span class="row-bar">
+						<span class="spec-bar">
 							<span class="bar-track">
 								<span
 									class="bar-fill"
@@ -204,7 +172,7 @@
 									style="width: {Math.max(2, cat.percentage)}%;"
 								></span>
 							</span>
-							<span class="bar-pct"
+							<span class="spec-pct"
 								>{Math.round(cat.percentage)}<span class="dim">%</span></span
 							>
 						</span>
@@ -213,23 +181,20 @@
 			</div>
 		</section>
 
-		<!-- FIXTURE LIST: filterable -->
 		<section class="fixtures">
-			<header class="fix-head">
-				<div>
-					<span class="kicker">§ 03 — Fixtures</span>
-					<h2>The <em>full</em> list.</h2>
-				</div>
+			<div class="section-head">
+				<span class="num">02</span>
+				<h2>The <em>full</em> fixture list.</h2>
 				{#if selectedCategoryId}
 					<button class="clear-filter" onclick={() => (selectedCategoryId = null)}>
-						<span class="chev">←</span> Clear filter
+						<span aria-hidden="true">←</span> Clear filter
 					</button>
 				{/if}
-			</header>
+			</div>
 
 			<div class="filters">
 				<label class="search">
-					<span class="search-sigil">⌕</span>
+					<span class="search-sigil" aria-hidden="true">⌕</span>
 					<input
 						type="text"
 						placeholder="Filter by name or category…"
@@ -260,7 +225,11 @@
 				</div>
 				<div class="fix-tbody">
 					{#each filteredTests as test (test.categoryId + '/' + test.name)}
-						<div class="fix-row" class:fail={test.status === 'fail'} class:skip={test.status === 'skip'}>
+						<div
+							class="fix-row"
+							class:fail={test.status === 'fail'}
+							class:skip={test.status === 'skip'}
+						>
 							<span class="fix-name" title={test.name}>{test.name}</span>
 							<span class="fix-cat">{test.categoryName}</span>
 							<span class="fix-status">
@@ -283,400 +252,228 @@
 			</div>
 		</section>
 	{/if}
+
+	<SiteFooter />
 </div>
 
 <style>
-	:global(body) {
-		margin: 0;
-		padding: 0;
-	}
-
 	.page {
-		--bg: #f1e8d6;
-		--surface: #e6dac1;
-		--ink: #1a1612;
-		--ink-soft: #7a7062;
-		--ink-faint: #b8ab93;
-		--accent: #ff3e00;
-		--accent-deep: #c52f00;
-		--warn: #c79100;
-		--bad: #b1280a;
-		--hairline: rgba(26, 22, 18, 0.16);
-		--hairline-strong: rgba(26, 22, 18, 0.4);
-
-		--display: 'Fraunces', 'Source Serif Pro', Georgia, 'Times New Roman', Times, serif;
-		--body: 'Instrument Sans', system-ui, -apple-system, sans-serif;
-		--mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-
-		background: var(--bg);
-		color: var(--ink);
-		font-family: var(--body);
-		-webkit-font-smoothing: antialiased;
-		-moz-osx-font-smoothing: grayscale;
 		min-height: 100vh;
-		position: relative;
-		overflow-x: hidden;
-		font-feature-settings: 'ss01';
 	}
 
-	.grain {
-		position: fixed;
-		inset: 0;
-		pointer-events: none;
-		z-index: 80;
-		opacity: 0.07;
-		mix-blend-mode: multiply;
-		background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.4' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+	code,
+	pre {
+		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
-	.spine {
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		left: 3rem;
-		width: 1px;
-		background: var(--hairline);
-		z-index: 0;
+	.mono {
+		font-family: 'Fira Mono', monospace;
 	}
 
-	/* ============================================================
-	   TOP STRIP — matches landing page
-	   ============================================================ */
-	.strip {
-		position: sticky;
-		top: 0;
-		z-index: 60;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 1.1rem 2.5rem;
-		background: var(--bg);
-		border-bottom: 1px solid var(--hairline);
-		font-family: var(--mono);
-		font-size: 0.78rem;
-		letter-spacing: 0.04em;
-	}
-
-	.strip-l {
-		display: flex;
-		align-items: baseline;
-		gap: 0.9rem;
-	}
-
-	.strip .mark {
-		font-family: var(--display);
-		font-style: italic;
-		font-weight: 500;
-		font-size: 1.45rem;
-		letter-spacing: -0.025em;
-		font-variation-settings: 'opsz' 96, 'SOFT' 80, 'WONK' 1;
-		color: var(--ink);
-		text-decoration: none;
-		line-height: 1;
-	}
-
-	.strip-r {
-		display: flex;
-		gap: 1.7rem;
-		align-items: center;
-	}
-
-	.strip-r a {
-		text-decoration: none;
-		color: var(--ink);
-		text-transform: uppercase;
-		font-size: 0.72rem;
-		letter-spacing: 0.16em;
-		padding-bottom: 2px;
-		border-bottom: 1px solid transparent;
-		transition: border-color 0.25s ease, color 0.25s ease;
-	}
-
-	.strip-r a:hover,
-	.strip-r a.active {
-		border-bottom-color: var(--accent);
-		color: var(--accent);
-	}
-
-	.strip-r .chev {
-		display: inline-block;
-		margin-left: 0.25em;
-		font-family: var(--mono);
-	}
-
-	/* ============================================================
-	   HERO
-	   ============================================================ */
+	/* HERO */
 	.hero {
-		position: relative;
-		padding: clamp(3rem, 8vh, 7rem) clamp(1.5rem, 6vw, 6rem) clamp(4rem, 9vh, 8rem);
-		isolation: isolate;
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: clamp(3.5rem, 9vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
 	}
 
-	.margin {
-		position: absolute;
-		font-family: var(--mono);
-		font-size: 0.73rem;
-		letter-spacing: 0.06em;
-		color: var(--ink-soft);
-		line-height: 1.55;
-		z-index: 3;
-	}
-
-	.margin-tl {
-		top: clamp(2rem, 6vh, 5rem);
-		left: clamp(1.5rem, 6vw, 6rem);
-		display: flex;
+	.eyebrow {
+		display: inline-flex;
 		align-items: center;
 		gap: 0.7rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.75rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--rust);
+		margin: 0 0 1.4rem;
 	}
 
-	.margin-tl .serif-italic {
-		font-family: var(--display);
-		font-style: italic;
-		font-size: 1rem;
-		color: var(--ink);
-		font-variation-settings: 'opsz' 14, 'SOFT' 100, 'WONK' 1;
-	}
-
-	.margin-tr {
-		top: clamp(2rem, 6vh, 5rem);
-		right: clamp(1.5rem, 6vw, 6rem);
-		text-align: right;
-	}
-
-	.margin-tr .strong {
-		color: var(--ink);
-		font-weight: 500;
-	}
-
-	.margin .rule {
+	.eyebrow .rule {
 		display: inline-block;
-		width: 2.2rem;
+		width: 24px;
 		height: 1px;
-		background: var(--ink);
+		background: var(--rust);
 	}
 
-	.meta {
+	.title {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: clamp(2rem, 4.6vw, 3.4rem);
+		line-height: 1.06;
+		letter-spacing: -0.025em;
+		color: var(--ink);
+		margin: 0;
+		max-width: 28ch;
+	}
+
+	.title code {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7em;
+		font-weight: 500;
+		padding: 0.06em 0.42em;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 4px;
+		color: var(--ink);
+		vertical-align: 0.08em;
+	}
+
+	.ink-svelte {
+		color: var(--svelte);
+		font-style: italic;
+		font-weight: 800;
+	}
+
+	.hero-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 2rem 2.4rem;
+		margin-top: 2rem;
+		padding-top: 1.4rem;
+		border-top: 1px solid var(--rule);
+	}
+
+	.hero-meta > div {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+	}
+
+	.hero-meta dt {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.66rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--ink-faint);
+	}
+
+	.hero-meta dd {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.45rem;
+		margin: 0;
+		font-size: 0.95rem;
+		color: var(--ink);
+	}
+
+	.hero-meta .big {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: 1.6rem;
+		font-variant-numeric: tabular-nums;
+		line-height: 1;
+		letter-spacing: -0.02em;
+	}
+
+	.hero-meta .dim {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.78rem;
 		color: var(--ink-soft);
 	}
 
-	.hero-figure {
-		position: absolute;
-		top: 14vh;
-		right: -3vw;
-		z-index: 0;
-		font-family: var(--display);
-		font-style: italic;
-		font-variation-settings: 'opsz' 144, 'SOFT' 100, 'WONK' 1;
-		color: var(--accent);
-		opacity: 0.13;
-		font-size: clamp(14rem, 38vw, 50rem);
-		line-height: 0.8;
-		pointer-events: none;
-		user-select: none;
-		letter-spacing: -0.05em;
-		display: flex;
+	.hero-meta code {
+		color: var(--rust);
+		font-size: 0.88em;
+	}
+
+	/* SPEC / CATEGORIES */
+	.spec {
+		max-width: 1080px;
+		margin: 0 auto;
+	}
+
+	.section-head {
+		max-width: 1080px;
+		padding: clamp(3rem, 7vh, 4.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2rem);
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		gap: 0.4rem 1.4rem;
 		align-items: baseline;
 	}
 
-	.hero-figure .num {
-		display: inline-block;
-		transform: rotate(-5deg);
-		transform-origin: bottom left;
-	}
-
-	.hero-figure .x {
-		display: inline-block;
-		transform: rotate(2deg) translateY(-0.05em);
-		font-size: 0.78em;
-	}
-
-	.hero-title {
-		font-family: var(--display);
-		font-weight: 300;
-		line-height: 0.86;
-		letter-spacing: -0.035em;
-		font-size: clamp(3rem, 11vw, 13rem);
-		margin: clamp(4rem, 10vh, 8rem) 0 0;
-		position: relative;
-		z-index: 2;
-	}
-
-	.hero-title .line {
-		display: block;
-	}
-
-	.hero-title em {
-		font-style: italic;
-		font-weight: 400;
-		font-variation-settings: 'opsz' 144, 'SOFT' 100, 'WONK' 1;
-		color: var(--accent);
-		padding-right: 0.04em;
-	}
-
-	.hero-stats {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
-		gap: clamp(1rem, 3vw, 3rem);
-		margin: clamp(3rem, 6vh, 5rem) 0 0;
-		padding: clamp(1.5rem, 3vh, 2.5rem) 0;
-		border-top: 1px solid var(--hairline-strong);
-		border-bottom: 1px solid var(--hairline);
-		position: relative;
-		z-index: 2;
-	}
-
-	.hero-stats > div {
-		display: flex;
-		flex-direction: column;
-		gap: 0.4rem;
-	}
-
-	.hero-stats dt {
-		font-family: var(--mono);
+	.section-head .num {
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.7rem;
 		letter-spacing: 0.18em;
-		text-transform: uppercase;
-		color: var(--accent);
+		color: var(--rust);
+		grid-row: 1;
+		grid-column: 1;
 	}
 
-	.hero-stats dd {
+	.section-head h2 {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 700;
+		font-size: clamp(1.65rem, 3.2vw, 2.6rem);
+		line-height: 1.1;
+		letter-spacing: -0.022em;
 		margin: 0;
-		display: flex;
-		align-items: baseline;
-		gap: 0.7rem;
-		flex-wrap: wrap;
-	}
-
-	.hero-stats .big {
-		font-family: var(--display);
-		font-feature-settings: 'tnum' 1, 'lnum' 1;
-		font-size: clamp(2rem, 4vw, 3.4rem);
-		letter-spacing: -0.03em;
-		font-weight: 400;
-		line-height: 1;
 		color: var(--ink);
+		grid-row: 1;
+		grid-column: 2;
 	}
 
-	.hero-stats .dim {
-		font-family: var(--mono);
-		font-size: 0.85rem;
-		color: var(--ink-soft);
-		letter-spacing: 0.04em;
-	}
-
-	/* ============================================================
-	   SPEC SHEET
-	   ============================================================ */
-	.spec {
-		padding: clamp(4rem, 9vh, 8rem) clamp(1.5rem, 6vw, 6rem);
-		border-top: 1px solid var(--hairline);
-		position: relative;
-		z-index: 1;
-	}
-
-	.spec-head,
-	.fix-head {
-		display: flex;
-		flex-direction: column;
-		gap: 1.5rem;
-		margin-bottom: clamp(2.5rem, 5vh, 4rem);
-		max-width: 100%;
-	}
-
-	.kicker {
-		font-family: var(--mono);
-		font-size: 0.74rem;
-		letter-spacing: 0.18em;
-		text-transform: uppercase;
-		color: var(--accent);
-		display: inline-block;
-	}
-
-	.spec-head h2,
-	.fix-head h2,
-	.empty-title {
-		font-family: var(--display);
-		font-weight: 300;
-		font-size: clamp(2.4rem, 6.5vw, 6rem);
-		line-height: 0.92;
-		letter-spacing: -0.028em;
-		margin: 0;
-	}
-
-	.spec-head em,
-	.fix-head em,
-	.empty-title em {
+	.section-head h2 em {
 		font-style: italic;
-		color: var(--accent);
-		font-variation-settings: 'opsz' 144, 'SOFT' 100, 'WONK' 1;
-		font-weight: 400;
-		padding-right: 0.03em;
+		color: var(--svelte);
+		font-weight: 700;
 	}
 
-	.lede {
-		font-size: clamp(1.05rem, 1.3vw, 1.25rem);
-		max-width: 56ch;
+	.section-head .lede {
+		grid-row: 2;
+		grid-column: 2;
+		margin-top: 0.7rem;
+		font-size: clamp(1rem, 1.2vw, 1.1rem);
 		color: var(--ink-soft);
-		line-height: 1.55;
-		margin: 0;
+		max-width: 64ch;
 	}
 
-	.chip {
-		font-family: var(--mono);
-		font-size: 0.84em;
-		background: var(--surface);
-		color: var(--ink);
-		padding: 0.12em 0.5em;
+	.section-head .lede code {
+		font-size: 0.88em;
+		padding: 0.06em 0.4em;
+		background: var(--paper);
+		border: 1px solid var(--rule);
 		border-radius: 3px;
-		white-space: nowrap;
-		border: 1px solid var(--hairline);
+		color: var(--rust);
 	}
 
-	.spec-grid {
-		display: flex;
-		flex-direction: column;
-		border-top: 1px solid var(--hairline-strong);
+	.spec-list {
+		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(2.5rem, 5vh, 3.5rem);
 	}
 
 	.spec-row {
 		display: grid;
-		grid-template-columns: minmax(9rem, 14rem) 1fr minmax(11rem, 22rem);
-		gap: clamp(1rem, 3vw, 3rem);
-		align-items: center;
-		padding: clamp(1.25rem, 2.4vh, 1.8rem) 0;
+		grid-template-columns: minmax(10rem, 14rem) minmax(0, 1fr) minmax(10rem, 14rem);
+		gap: 1.4rem;
+		align-items: baseline;
+		width: 100%;
+		padding: 1rem 0;
 		border: 0;
-		border-bottom: 1px solid var(--hairline);
+		border-bottom: 1px solid var(--rule);
 		background: transparent;
 		text-align: left;
 		font: inherit;
 		color: inherit;
 		cursor: pointer;
-		transition: padding-left 0.3s cubic-bezier(0.22, 1, 0.36, 1), background 0.25s ease;
 		opacity: 0;
-		transform: translateY(14px);
-		animation: rowIn 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+		transform: translateY(6px);
+		animation: rowIn 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 		animation-delay: calc(0.04s * var(--i, 0) + 0.05s);
+		transition: padding-left 0.2s ease;
+	}
+
+	.spec-row:first-child {
+		border-top: 1px solid var(--rule);
 	}
 
 	.spec-row:hover {
-		padding-left: 0.5rem;
-		background: linear-gradient(to right, var(--surface), transparent 70%);
+		padding-left: 0.4rem;
 	}
 
 	.spec-row.active {
-		padding-left: 1rem;
-		background: linear-gradient(to right, rgba(255, 62, 0, 0.08), transparent 70%);
-	}
-
-	.spec-row.active::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		width: 3px;
-		height: calc(100% - 2px);
-		background: var(--accent);
+		padding-left: 0.6rem;
+		background: color-mix(in srgb, var(--svelte) 5%, transparent);
+		border-left: 2px solid var(--svelte);
 	}
 
 	@keyframes rowIn {
@@ -686,153 +483,145 @@
 		}
 	}
 
-	.row-num {
-		font-family: var(--display);
-		font-feature-settings: 'tnum' 1, 'lnum' 1;
-		font-variation-settings: 'opsz' 96;
-		font-weight: 400;
-		font-size: clamp(1.7rem, 3.5vw, 2.8rem);
-		letter-spacing: -0.03em;
-		line-height: 1;
+	.spec-k {
+		font-weight: 600;
+		font-size: 0.98rem;
 		color: var(--ink);
+		letter-spacing: -0.005em;
 	}
 
-	.row-num-sep {
+	.spec-v {
+		display: flex;
+		align-items: baseline;
+		gap: 0.85rem;
+		min-width: 0;
+	}
+
+	.spec-n {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 700;
+		font-size: 1.2rem;
+		color: var(--ink);
+		font-variant-numeric: tabular-nums;
+		letter-spacing: -0.015em;
+	}
+
+	.spec-n-sep {
 		color: var(--ink-faint);
 		margin: 0 0.1em;
 	}
 
-	.row-num-tot {
+	.spec-n-tot {
 		color: var(--ink-soft);
-		font-size: 0.6em;
-		vertical-align: 0.18em;
+		font-size: 0.78em;
 	}
 
-	.row-label strong {
-		display: block;
-		font-weight: 500;
-		font-size: clamp(0.95rem, 1.05vw, 1.1rem);
-		letter-spacing: -0.01em;
-		color: var(--ink);
-		line-height: 1.3;
-	}
-
-	.row-sub {
-		font-family: var(--mono);
-		color: var(--ink-soft);
+	.spec-s {
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.74rem;
-		letter-spacing: 0.04em;
-		display: block;
-		margin-top: 0.35rem;
-		text-transform: lowercase;
+		color: var(--ink-soft);
 	}
 
-	.row-bar {
+	.spec-bar {
 		display: flex;
 		align-items: center;
-		gap: 1rem;
-		font-family: var(--mono);
-		font-size: 0.85rem;
-		letter-spacing: 0.04em;
+		gap: 0.7rem;
 	}
 
 	.bar-track {
 		flex: 1;
-		height: 5px;
-		background: var(--surface);
-		position: relative;
+		height: 6px;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 999px;
 		overflow: hidden;
 		display: block;
-		border: 1px solid var(--hairline);
-		border-radius: 999px;
 	}
 
 	.bar-fill {
-		position: absolute;
-		inset: 0;
-		background: var(--accent);
+		display: block;
+		height: 100%;
+		background: var(--svelte);
 		transform-origin: left;
 		width: 0;
-		transition: width 0.8s cubic-bezier(0.22, 1, 0.36, 1) 0.2s;
+		animation: barIn 0.8s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+		animation-delay: calc(0.04s * var(--i, 0) + 0.25s);
 	}
 
-	.spec-row .bar-fill {
-		animation: barIn 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-		animation-delay: calc(0.04s * var(--i, 0) + 0.3s);
+	.bar-fill.warn {
+		background: var(--warn);
+	}
+
+	.bar-fill.bad {
+		background: var(--bad);
 	}
 
 	@keyframes barIn {
-		from { transform: scaleX(0); }
-		to { transform: scaleX(1); }
+		from {
+			transform: scaleX(0);
+		}
+		to {
+			transform: scaleX(1);
+		}
 	}
 
-	.bar-fill.warn { background: var(--warn); }
-	.bar-fill.bad { background: var(--bad); }
-
-	.bar-pct {
+	.spec-pct {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.82rem;
 		color: var(--ink);
-		font-weight: 500;
 		font-variant-numeric: tabular-nums;
+		min-width: 3.4rem;
+		text-align: right;
 	}
 
-	.dim {
-		color: var(--ink-soft);
+	.spec-pct .dim {
+		color: var(--ink-faint);
 	}
 
-	/* ============================================================
-	   FIXTURES
-	   ============================================================ */
+	/* FIXTURES */
 	.fixtures {
-		padding: clamp(4rem, 9vh, 8rem) clamp(1.5rem, 6vw, 6rem) clamp(5rem, 10vh, 9rem);
-		border-top: 1px solid var(--hairline);
-		background: var(--surface);
-		position: relative;
-		z-index: 1;
+		max-width: 1080px;
+		margin: 0 auto;
+		padding-bottom: clamp(4rem, 8vh, 6rem);
 	}
 
-	.fix-head {
-		flex-direction: row;
-		justify-content: space-between;
-		align-items: flex-end;
-		gap: 2rem;
+	.fixtures .section-head h2 em {
+		color: var(--svelte);
 	}
 
 	.clear-filter {
-		font-family: var(--mono);
-		font-size: 0.72rem;
-		text-transform: uppercase;
-		letter-spacing: 0.16em;
-		padding: 0.55rem 1rem;
+		grid-row: 1;
+		grid-column: 3;
+		justify-self: end;
+		align-self: center;
 		background: transparent;
-		border: 1px solid var(--ink);
+		border: 1px solid var(--rule-strong);
+		border-radius: 4px;
+		padding: 0.45rem 0.85rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.74rem;
 		color: var(--ink);
 		cursor: pointer;
 		display: inline-flex;
 		align-items: center;
-		gap: 0.55em;
-		transition: background 0.25s ease, color 0.25s ease;
+		gap: 0.4em;
+		transition: background 0.18s, color 0.18s, border-color 0.18s;
 	}
 
 	.clear-filter:hover {
 		background: var(--ink);
 		color: var(--bg);
-	}
-
-	.clear-filter .chev {
-		font-family: var(--mono);
-		transition: transform 0.3s ease;
-	}
-
-	.clear-filter:hover .chev {
-		transform: translateX(-0.3em);
+		border-color: var(--ink);
 	}
 
 	.filters {
+		max-width: 1080px;
+		margin: 0 auto 1.4rem;
+		padding: 0 clamp(1rem, 4vw, 2.5rem);
 		display: flex;
-		gap: 1rem;
-		align-items: stretch;
-		margin-bottom: 1.5rem;
+		gap: 0.75rem;
 		flex-wrap: wrap;
+		align-items: stretch;
 	}
 
 	.search {
@@ -843,28 +632,29 @@
 		gap: 0.65rem;
 		padding: 0 1rem;
 		background: var(--bg);
-		border: 1px solid var(--hairline-strong);
-		font-family: var(--mono);
+		border: 1px solid var(--rule-strong);
+		border-radius: 4px;
+		font-family: 'Fira Mono', monospace;
 	}
 
 	.search:focus-within {
-		border-color: var(--accent);
-		outline: 1px solid var(--accent);
+		border-color: var(--svelte);
+		outline: 2px solid color-mix(in srgb, var(--svelte) 30%, transparent);
 		outline-offset: -1px;
 	}
 
 	.search-sigil {
-		color: var(--ink-soft);
-		font-size: 1.05rem;
+		color: var(--ink-faint);
+		font-size: 1rem;
 	}
 
 	.search input {
 		flex: 1;
-		padding: 0.85rem 0;
+		padding: 0.7rem 0;
 		background: transparent;
 		border: 0;
 		font: inherit;
-		font-size: 0.85rem;
+		font-size: 0.86rem;
 		color: var(--ink);
 	}
 
@@ -879,24 +669,25 @@
 	.status-tabs {
 		display: flex;
 		gap: 0;
-		border: 1px solid var(--hairline-strong);
+		border: 1px solid var(--rule-strong);
+		border-radius: 4px;
 		background: var(--bg);
+		overflow: hidden;
 	}
 
 	.status-tabs button {
-		font-family: var(--mono);
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.72rem;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
-		padding: 0 1.1rem;
+		letter-spacing: 0.06em;
+		padding: 0 1rem;
 		background: transparent;
 		border: 0;
 		color: var(--ink-soft);
 		cursor: pointer;
 		display: inline-flex;
 		align-items: center;
-		gap: 0.5em;
-		border-right: 1px solid var(--hairline-strong);
+		gap: 0.45em;
+		border-right: 1px solid var(--rule);
 		transition: color 0.2s ease, background 0.2s ease;
 	}
 
@@ -920,48 +711,62 @@
 		border-radius: 999px;
 	}
 
-	.dot.pass { background: #2c7a3a; }
-	.dot.fail { background: var(--bad); }
-	.dot.skip { background: var(--warn); }
+	.dot.pass {
+		background: var(--ok);
+	}
+
+	.dot.fail {
+		background: var(--bad);
+	}
+
+	.dot.skip {
+		background: var(--warn);
+	}
 
 	.fix-table {
-		border: 1px solid var(--hairline-strong);
-		background: var(--bg);
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: 0 clamp(1rem, 4vw, 2.5rem);
 	}
 
 	.fix-thead {
 		display: grid;
 		grid-template-columns: 1fr 12rem 7rem;
 		gap: 1rem;
-		padding: 0.75rem 1rem;
-		font-family: var(--mono);
+		padding: 0.7rem 1rem;
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.66rem;
 		letter-spacing: 0.18em;
 		text-transform: uppercase;
-		color: var(--ink-soft);
-		border-bottom: 1px solid var(--hairline-strong);
-		background: var(--surface);
+		color: var(--ink-faint);
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-top-left-radius: 6px;
+		border-top-right-radius: 6px;
+		border-bottom: 0;
 	}
 
 	.fix-tbody {
-		max-height: 520px;
+		max-height: 540px;
 		overflow-y: auto;
-		font-feature-settings: 'tnum' 1;
+		font-variant-numeric: tabular-nums;
+		border-inline: 1px solid var(--rule);
+		background: var(--bg);
 	}
 
 	.fix-row {
 		display: grid;
 		grid-template-columns: 1fr 12rem 7rem;
 		gap: 1rem;
-		padding: 0.7rem 1rem;
-		font-family: var(--mono);
-		font-size: 0.82rem;
-		border-bottom: 1px solid var(--hairline);
+		padding: 0.65rem 1rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.8rem;
+		border-bottom: 1px solid var(--rule);
 		align-items: center;
 	}
 
 	.fix-row:hover {
-		background: var(--surface);
+		background: var(--paper);
 	}
 
 	.fix-name {
@@ -973,19 +778,23 @@
 
 	.fix-cat {
 		color: var(--ink-soft);
-		font-size: 0.78rem;
+		font-size: 0.76rem;
 	}
 
 	.fix-status {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.45em;
-		text-transform: lowercase;
-		color: #2c7a3a;
+		color: var(--ok);
 	}
 
-	.fix-row.fail .fix-status { color: var(--bad); }
-	.fix-row.skip .fix-status { color: var(--warn); }
+	.fix-row.fail .fix-status {
+		color: var(--bad);
+	}
+
+	.fix-row.skip .fix-status {
+		color: var(--warn);
+	}
 
 	.fix-glyph {
 		font-size: 0.9em;
@@ -996,102 +805,118 @@
 		grid-column: 1 / -1;
 		margin: 0.4rem 0 0;
 		padding: 0.55rem 0.7rem;
-		background: var(--surface);
-		font-family: var(--mono);
-		font-size: 0.75rem;
+		background: var(--paper);
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.74rem;
 		color: var(--ink-soft);
 		white-space: pre-wrap;
 		word-break: break-word;
-		border-left: 2px solid var(--hairline-strong);
+		border-left: 2px solid var(--rule-strong);
 	}
 
-	.fix-row.fail .fix-msg { border-left-color: var(--bad); }
-	.fix-row.skip .fix-msg { border-left-color: var(--warn); }
+	.fix-row.fail .fix-msg {
+		border-left-color: var(--bad);
+	}
+
+	.fix-row.skip .fix-msg {
+		border-left-color: var(--warn);
+	}
 
 	.fix-empty {
 		padding: 3rem 1rem;
 		text-align: center;
-		color: var(--ink-soft);
-		font-family: var(--mono);
+		color: var(--ink-faint);
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.82rem;
 	}
 
 	.fix-foot {
-		padding: 0.75rem 1rem;
-		border-top: 1px solid var(--hairline-strong);
-		background: var(--surface);
-		font-family: var(--mono);
+		padding: 0.7rem 1rem;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-top: 0;
+		border-bottom-left-radius: 6px;
+		border-bottom-right-radius: 6px;
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.78rem;
 		color: var(--ink);
 		display: flex;
 		gap: 0.5em;
 	}
 
-	/* ============================================================
-	   EMPTY STATE
-	   ============================================================ */
-	.empty {
-		padding: clamp(5rem, 12vh, 10rem) clamp(1.5rem, 6vw, 6rem);
-		display: flex;
-		flex-direction: column;
-		gap: 1.5rem;
-		max-width: 60rem;
+	.fix-foot .dim {
+		color: var(--ink-soft);
 	}
 
-	.empty-sub {
-		font-size: clamp(1.05rem, 1.3vw, 1.25rem);
+	/* EMPTY */
+	.empty {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: clamp(4rem, 10vh, 7rem) clamp(1rem, 4vw, 2.5rem);
+	}
+
+	.empty h1 {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 700;
+		font-size: clamp(2rem, 4.6vw, 3rem);
+		line-height: 1.05;
+		letter-spacing: -0.025em;
+		color: var(--ink);
+		margin: 0 0 1rem;
+	}
+
+	.empty .lede {
+		font-size: 1.05rem;
 		color: var(--ink-soft);
-		line-height: 1.55;
 		max-width: 56ch;
-		margin: 0;
+		margin: 0 0 1.5rem;
 	}
 
 	.empty-code {
-		font-family: var(--mono);
-		background: #15110d;
-		color: #f0e6d2;
-		padding: 1.25rem 1.5rem;
+		max-width: 700px;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		padding: 1rem 1.2rem;
+		font-family: 'Fira Mono', monospace;
 		font-size: 0.85rem;
-		line-height: 1.6;
-		margin: 1rem 0 0;
-		max-width: 70ch;
-		border: 1px solid var(--hairline-strong);
+		color: var(--ink);
+		line-height: 1.7;
 		overflow-x: auto;
 	}
 
+	.c-cmt {
+		color: var(--ink-faint);
+	}
+
+	.c-prompt {
+		color: var(--svelte);
+		margin-right: 0.5em;
+	}
+
+	.c-flag,
+	.c-op {
+		color: var(--rust);
+	}
+
+	/* RESPONSIVE */
 	@media (max-width: 880px) {
-		.spine,
-		.margin-tr,
-		.margin-tl {
-			display: none;
+		.section-head {
+			grid-template-columns: auto 1fr;
 		}
-		.strip {
-			padding: 0.85rem 1.25rem;
-		}
-		.strip-r {
-			gap: 1rem;
-		}
-		.strip-r a {
-			font-size: 0.65rem;
-			letter-spacing: 0.1em;
-		}
-		.hero {
-			padding-top: 3rem;
-		}
-		.hero-figure {
-			top: 6vh;
-			right: -8vw;
-			opacity: 0.08;
+		.clear-filter {
+			grid-column: 1 / -1;
+			justify-self: start;
 		}
 		.spec-row {
-			grid-template-columns: minmax(5rem, 7rem) 1fr;
+			grid-template-columns: 1fr auto;
+			gap: 0.4rem 1rem;
 		}
-		.row-bar {
+		.spec-v {
 			grid-column: 1 / -1;
 		}
-		.fix-head {
-			flex-direction: column;
-			align-items: flex-start;
+		.spec-bar {
+			grid-column: 1 / -1;
 		}
 		.fix-thead,
 		.fix-row {
@@ -1101,8 +926,14 @@
 		.fix-thead {
 			display: none;
 		}
-		.fix-cat {
-			font-size: 0.72rem;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.spec-row,
+		.bar-fill {
+			animation: none !important;
+			opacity: 1 !important;
+			transform: none !important;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary

The homepage redesign (#152) only touched the top page; the Playground,
Compatibility and Benchmark routes were still each running their own
ad-hoc design system (cream paper + Fraunces + Instrument Sans on
playground/progress, Atkinson Hyperlegible + IBM Plex on benchmark).
This PR pulls them onto the homepage's calm paper-white / Overpass /
Fira Mono palette and adds a **site-wide dark mode**.

### Theme system

- Design tokens (\`--bg\`, \`--paper\`, \`--ink\`, \`--rule\`, \`--svelte\`,
  \`--rust\`, \`--ok\`/\`--warn\`/\`--bad\`, \`--editor-bg\`, …) live in
  \`+layout.svelte\`'s \`:root\` block; \`:root[data-theme='dark']\` flips
  them. Individual pages no longer declare local palettes.
- An inline script in \`app.html\` sets \`data-theme\` **before first paint**
  to avoid FOUC. Resolution order: \`?theme=light|dark\` query →
  \`localStorage\` → \`prefers-color-scheme\`.
- New \`themeStore\` (\`$state\` rune in \`docs/src/lib/theme.svelte.ts\`)
  exposes the current theme reactively and persists user choices.
- New \`SiteNav.svelte\` / \`SiteFooter.svelte\` carry the chrome on every
  page; the nav houses the sun/moon dark-mode toggle (with
  \`aria-pressed\` for accessibility).
- \`MonacoEditor\` registers both \`svelte-light\` and \`svelte-dark\` themes
  and swaps reactively via \`monaco.editor.setTheme\` when \`themeStore.current\`
  flips.

### Page rewrites

- **Playground**: 3-panel workspace (Source / Output / Preview) with
  numbered headers (01 / 02 / 03), refined tabs, paper-toned footer with
  compile-time + bundle-size + Live status dot.
- **Compatibility**: hero with passing-percentage stat, hero meta strip,
  category list reusing the homepage's spec-row pattern (clickable for
  filter), fixture table with search + status tabs.
- **Benchmark**: hero with the live multiplier headline, 4-stat strip,
  tabbed bar chart, replay button, "Reproduce it yourself" diff block.

## Screenshots

Captured at 1440×2400 via headless Chrome using \`?theme=light\` /
\`?theme=dark\`. All four pages render correctly in both palettes; Monaco
flips between \`svelte-light\` and \`svelte-dark\` themes when the toggle is
clicked.

## Test plan

- [ ] \`pnpm run dev\` in \`docs/\`, visit /, /playground, /progress, /benchmark
- [ ] Click the sun/moon button in the nav → all pages flip palettes,
      including Monaco editor surfaces
- [ ] Open the page with \`?theme=dark\` in URL — dark from first paint, no flash
- [ ] Reload after toggling — theme persists via localStorage
- [ ] System pref dark → first visit auto-uses dark; user toggle wins
      after that
- [ ] Nav layout collapses correctly at ≤640 px (Compatibility link hides,
      rust-port badge hides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)