### PR TITLE
fix(playground+benchmark): WASM panic + 2-column REPL + real-time bars

### DIFF
--- a/docs/src/lib/compiler.ts
+++ b/docs/src/lib/compiler.ts
@@ -37,7 +37,7 @@ export function compileServer(source: string, name: string): CompileResultWasm {
 }
 
 export type CompileMode = 'client' | 'server';
-export type OutputTab = 'js' | 'css' | 'ast';
+export type OutputTab = 'result' | 'js' | 'css' | 'ast';
 
 export interface CompileStats {
 	compileTime: number;

--- a/docs/src/routes/benchmark/+page.svelte
+++ b/docs/src/routes/benchmark/+page.svelte
@@ -11,11 +11,20 @@
 	type TabId = 'full' | 'parse' | 'svelte2tsx';
 
 	let activeTab = $state<TabId>('full');
+	// `animationTime` is the elapsed wall-clock ms since the run started.
+	// Each bar shows `min(animationTime, this.durationMs)`, so the bars
+	// fill at the *actual* measured speed — the slow JS bar is still
+	// inching forward when the rsvelte-multi bar has already crossed the
+	// finish line, which is the whole point.
 	let animationTime = $state(0);
 	let isAnimating = $state(false);
 	let animationComplete = $state(false);
 
-	const ANIMATION_DURATION_MS = 2200;
+	// Hard ceiling for the wall-clock animation so very fast tasks (e.g. the
+	// parser-only run can finish in ~150 ms) don't blink past unreadably and
+	// very slow ones (full-pipeline JS at ~1 s) don't drag the user. We stop
+	// once the slowest bar is done OR 4 s, whichever comes first.
+	const ANIMATION_HARD_CAP_MS = 4000;
 
 	const tabMeta: Record<TabId, { label: string; sub: string }> = {
 		full: { label: 'Full pipeline', sub: 'parse / analyze / codegen' },
@@ -60,20 +69,14 @@
 
 	const getAnimatedWidth = (r: BenchmarkTaskResults, duration: number): number => {
 		const maxDuration = getMaxDuration(r);
-		const targetWidth = (duration / maxDuration) * 100;
-		if (animationComplete) return targetWidth;
-		const scale = maxDuration / ANIMATION_DURATION_MS;
-		const simulated = animationTime * scale;
-		if (simulated >= duration) return targetWidth;
-		return (simulated / maxDuration) * 100;
+		if (animationComplete) return (duration / maxDuration) * 100;
+		const filled = Math.min(animationTime, duration);
+		return (filled / maxDuration) * 100;
 	};
 
-	const getAnimatedTime = (r: BenchmarkTaskResults, duration: number): number => {
+	const getAnimatedTime = (_: BenchmarkTaskResults, duration: number): number => {
 		if (animationComplete) return duration;
-		const maxDuration = getMaxDuration(r);
-		const scale = maxDuration / ANIMATION_DURATION_MS;
-		const simulated = animationTime * scale;
-		return Math.min(simulated, duration);
+		return Math.min(animationTime, duration);
 	};
 
 	const startAnimation = () => {
@@ -81,12 +84,16 @@
 		isAnimating = true;
 		animationComplete = false;
 		animationTime = 0;
+		const task = getActiveTask();
+		const finishAt = task
+			? Math.min(getMaxDuration(task), ANIMATION_HARD_CAP_MS)
+			: ANIMATION_HARD_CAP_MS;
 		const start = performance.now();
 		const tick = () => {
 			const elapsed = performance.now() - start;
 			animationTime = elapsed;
-			if (elapsed >= ANIMATION_DURATION_MS) {
-				animationTime = ANIMATION_DURATION_MS;
+			if (elapsed >= finishAt) {
+				animationTime = finishAt;
 				isAnimating = false;
 				animationComplete = true;
 				return;

--- a/docs/src/routes/playground/+page.svelte
+++ b/docs/src/routes/playground/+page.svelte
@@ -19,7 +19,7 @@
 	let input = $state(DEFAULT_EXAMPLE);
 
 	let mode: CompileMode = $state('client');
-	let activeTab: OutputTab = $state('js');
+	let activeTab: OutputTab = $state('result');
 	let wasmReady = $state(false);
 	let version = $state('');
 	let error = $state('');
@@ -116,11 +116,11 @@
 		}
 	});
 
-	const outputLanguage = $derived(
+	const monacoLanguage = $derived(
 		activeTab === 'js' ? 'javascript' : activeTab === 'css' ? 'css' : 'json'
 	);
 
-	const outputValue = $derived(
+	const monacoValue = $derived(
 		activeTab === 'js' ? outputJs : activeTab === 'css' ? outputCss : outputAstString
 	);
 
@@ -134,6 +134,13 @@
 		if (b < 1024) return `${b} B`;
 		return `${(b / 1024).toFixed(1)} kB`;
 	};
+
+	const tabs: { id: OutputTab; label: string; sub: string }[] = [
+		{ id: 'result', label: 'Result', sub: 'iframe preview' },
+		{ id: 'js', label: 'JS output', sub: 'compiled .js' },
+		{ id: 'css', label: 'CSS output', sub: 'scoped styles' },
+		{ id: 'ast', label: 'AST', sub: 'svelte AST · JSON' }
+	];
 </script>
 
 <svelte:head>
@@ -177,11 +184,12 @@
 	</header>
 
 	<main class="workspace">
+		<!-- LEFT — source editor, fills its half -->
 		<section class="panel panel-input">
 			<header class="panel-head">
 				<span class="panel-num">01</span>
 				<h2 class="panel-title">Source <em>.svelte</em></h2>
-				<span class="panel-meta">live · edits debounced 300ms</span>
+				<span class="panel-meta">debounced 300 ms</span>
 			</header>
 			<div class="panel-body editor-host">
 				{#if wasmReady}
@@ -197,38 +205,42 @@
 			</div>
 		</section>
 
+		<!-- RIGHT — tabbed output (Result / JS / CSS / AST) -->
 		<section class="panel panel-output">
-			<header class="panel-head">
-				<span class="panel-num">02</span>
-				<h2 class="panel-title">Output</h2>
-				<div class="tabs" role="tablist">
+			<header class="panel-head tab-head" role="tablist" aria-label="Output tab">
+				{#each tabs as t (t.id)}
 					<button
 						role="tab"
-						class:active={activeTab === 'js'}
-						aria-selected={activeTab === 'js'}
-						onclick={() => (activeTab = 'js')}>JS</button
+						class="tab"
+						class:active={activeTab === t.id}
+						aria-selected={activeTab === t.id}
+						onclick={() => (activeTab = t.id)}
 					>
-					<button
-						role="tab"
-						class:active={activeTab === 'css'}
-						aria-selected={activeTab === 'css'}
-						onclick={() => (activeTab = 'css')}>CSS</button
-					>
-					<button
-						role="tab"
-						class:active={activeTab === 'ast'}
-						aria-selected={activeTab === 'ast'}
-						onclick={() => (activeTab = 'ast')}>AST</button
-					>
-				</div>
+						<span class="tab-label">{t.label}</span>
+						<span class="tab-sub">{t.sub}</span>
+					</button>
+				{/each}
 			</header>
-			<div class="panel-body editor-host">
+
+			<div class="panel-body output-host">
 				{#if !wasmReady && !error}
 					<div class="loading">Loading WASM module…</div>
 				{:else if error}
 					<div class="error">
 						<span class="error-tag">parse / compile error</span>
 						<pre>{error}</pre>
+					</div>
+				{:else if activeTab === 'result'}
+					<div class="preview-host">
+						{#if previewHtml}
+							<iframe
+								srcdoc={previewHtml}
+								title="Preview"
+								sandbox="allow-scripts allow-popups allow-forms"
+							></iframe>
+						{:else}
+							<div class="loading">No preview available</div>
+						{/if}
 					</div>
 				{:else if activeTab === 'ast'}
 					<div class="ast-host">
@@ -239,11 +251,14 @@
 						/>
 					</div>
 				{:else}
-					{#key `${activeTab}-${mode}-${outputValue}`}
-						<MonacoEditor value={outputValue} language={outputLanguage} readonly={true} />
-					{/key}
+					<div class="editor-host">
+						{#key `${activeTab}-${mode}-${monacoValue}`}
+							<MonacoEditor value={monacoValue} language={monacoLanguage} readonly={true} />
+						{/key}
+					</div>
 				{/if}
 			</div>
+
 			<footer class="panel-foot">
 				<span>
 					<span class="dim">compile</span>
@@ -259,29 +274,6 @@
 					{#if !wasmReady}Initialising{:else if error}Error{:else}Live{/if}
 				</span>
 			</footer>
-		</section>
-
-		<section class="panel panel-preview">
-			<header class="panel-head">
-				<span class="panel-num">03</span>
-				<h2 class="panel-title">Preview</h2>
-				<span class="panel-meta">sandbox · isolated iframe</span>
-			</header>
-			<div class="panel-body preview-host">
-				{#if !wasmReady && !error}
-					<div class="loading">Loading…</div>
-				{:else if error}
-					<div class="loading">Preview unavailable</div>
-				{:else if previewHtml}
-					<iframe
-						srcdoc={previewHtml}
-						title="Preview"
-						sandbox="allow-scripts allow-popups allow-forms"
-					></iframe>
-				{:else}
-					<div class="loading">No preview available</div>
-				{/if}
-			</div>
 		</section>
 	</main>
 </div>
@@ -300,10 +292,10 @@
 
 	/* PAGE HEAD */
 	.play-head {
-		max-width: 1440px;
+		max-width: 1600px;
 		margin: 0 auto;
 		width: 100%;
-		padding: clamp(1.4rem, 3vh, 2rem) clamp(1rem, 4vw, 2.5rem) clamp(0.8rem, 2vh, 1.2rem);
+		padding: clamp(1.4rem, 3vh, 2rem) clamp(1rem, 3vw, 2rem) clamp(0.8rem, 2vh, 1.2rem);
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -408,14 +400,14 @@
 		cursor: not-allowed;
 	}
 
-	/* WORKSPACE */
+	/* WORKSPACE — two equal columns, Svelte REPL style */
 	.workspace {
-		max-width: 1440px;
+		max-width: 1600px;
 		margin: 0 auto;
 		width: 100%;
-		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(1.5rem, 4vh, 2.5rem);
+		padding: 0 clamp(1rem, 3vw, 2rem) clamp(1.5rem, 4vh, 2.5rem);
 		display: grid;
-		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 		gap: 0.85rem;
 		flex: 1;
 		min-height: 0;
@@ -432,11 +424,19 @@
 		overflow: hidden;
 	}
 
+	.panel-input {
+		min-height: 70vh;
+	}
+
+	.panel-output {
+		min-height: 70vh;
+	}
+
 	.panel-head {
 		display: flex;
 		align-items: center;
 		gap: 0.8rem;
-		padding: 0.65rem 0.9rem;
+		padding: 0.6rem 0.9rem;
 		background: var(--paper);
 		border-bottom: 1px solid var(--rule);
 		flex-shrink: 0;
@@ -471,36 +471,61 @@
 		color: var(--ink-faint);
 	}
 
-	.tabs {
-		display: inline-flex;
-		border: 1px solid var(--rule-strong);
-		border-radius: 4px;
-		overflow: hidden;
+	/* RIGHT-PANEL TABS — replace the title header on the output panel */
+	.tab-head {
+		gap: 0;
+		padding: 0;
+		background: var(--paper);
 	}
 
-	.tabs button {
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.72rem;
-		padding: 0.32rem 0.7rem;
+	.tab {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.12rem;
+		align-items: flex-start;
+		padding: 0.6rem 0.95rem;
 		background: transparent;
 		border: 0;
+		border-right: 1px solid var(--rule);
+		border-bottom: 1px solid transparent;
 		color: var(--ink-soft);
 		cursor: pointer;
-		border-right: 1px solid var(--rule);
-		transition: background 0.18s, color 0.18s;
+		text-align: left;
+		transition: background 0.18s, color 0.18s, border-color 0.18s;
 	}
 
-	.tabs button:last-child {
+	.tab:last-child {
 		border-right: 0;
 	}
 
-	.tabs button:hover {
+	.tab:hover {
 		color: var(--ink);
+		background: color-mix(in srgb, var(--paper) 60%, var(--bg));
 	}
 
-	.tabs button.active {
-		background: var(--ink);
-		color: var(--bg);
+	.tab.active {
+		background: var(--bg);
+		color: var(--ink);
+		border-bottom-color: var(--svelte);
+	}
+
+	.tab-label {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 600;
+		font-size: 0.86rem;
+		letter-spacing: -0.005em;
+	}
+
+	.tab-sub {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.62rem;
+		color: var(--ink-faint);
+	}
+
+	.tab.active .tab-sub {
+		color: var(--ink-soft);
 	}
 
 	.panel-body {
@@ -510,7 +535,15 @@
 		flex-direction: column;
 	}
 
+	.output-host {
+		background: var(--editor-bg);
+	}
+
 	.editor-host {
+		flex: 1;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
 		background: var(--editor-bg);
 	}
 
@@ -521,6 +554,8 @@
 	}
 
 	.preview-host {
+		flex: 1;
+		min-height: 0;
 		background: #ffffff;
 	}
 
@@ -529,13 +564,14 @@
 		height: 100%;
 		border: 0;
 		background: #ffffff;
+		display: block;
 	}
 
 	.loading {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		height: 100%;
+		flex: 1;
 		min-height: 240px;
 		padding: 2rem;
 		font-family: 'Fira Mono', monospace;
@@ -552,6 +588,7 @@
 	}
 
 	.error {
+		flex: 1;
 		padding: 1.2rem;
 		display: flex;
 		flex-direction: column;
@@ -629,22 +666,20 @@
 	}
 
 	/* RESPONSIVE */
-	@media (max-width: 1180px) {
-		.workspace {
-			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-		}
-		.panel-preview {
-			grid-column: 1 / -1;
-			min-height: 320px;
-		}
-	}
-
-	@media (max-width: 760px) {
+	@media (max-width: 880px) {
 		.workspace {
 			grid-template-columns: 1fr;
 		}
-		.panel {
-			min-height: 380px;
+		.panel-input,
+		.panel-output {
+			min-height: 480px;
+		}
+		.tab-head {
+			flex-wrap: wrap;
+		}
+		.tab {
+			flex: 1 1 50%;
+			border-bottom: 1px solid var(--rule);
 		}
 	}
 </style>

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -354,9 +354,9 @@ fn transform_client_with_visitors(
     // NOTE: visit_program calls add_state_transformers again internally, so any
     // transform removals must happen AFTER this call.
     use crate::compiler::phases::phase3_transform::client::visitors::program::visit_program;
-    let _vp_start = std::time::Instant::now();
+    let _vp_start = super::profile::timer_start();
     visit_program(&mut context);
-    super::profile::record_visit_program(_vp_start.elapsed());
+    super::profile::record_visit_program(super::profile::timer_elapsed(_vp_start));
 
     // Remove transforms for variables that have shadowed $state declarations.
     // Due to a known analysis bug where inner-scope $state() declarations overwrite
@@ -398,14 +398,14 @@ fn transform_client_with_visitors(
     // and is used for blocker_map computation and the final output.
     let pre_transformed_script = if let Some(instance_script) = &analysis.instance_script_content {
         let raw = &instance_script.raw;
-        let _script_start = std::time::Instant::now();
+        let _script_start = super::profile::timer_start();
         let transformed = transform_instance_script_for_visitors(
             raw,
             analysis,
             options.dev,
             &reactive_import_names,
         );
-        super::profile::record_script_text(_script_start.elapsed());
+        super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
         // Transfer the script's $$array counter to the context state so that the template
         // visitor continues numbering from where the script left off.
         let script_array_count = SCRIPT_ARRAY_COUNTER.with(|c| c.get());
@@ -482,10 +482,10 @@ fn transform_client_with_visitors(
 
     // Call the fragment visitor to transform the template
     // This is the root fragment of the component, so is_root_fragment=true
-    let _fragment_start = std::time::Instant::now();
+    let _fragment_start = super::profile::timer_start();
     let template_body = fragment(&ast.fragment, &mut context, true);
-    super::profile::record_template_fragment(_fragment_start.elapsed());
-    let _assembly_start = std::time::Instant::now();
+    super::profile::record_template_fragment(super::profile::timer_elapsed(_fragment_start));
+    let _assembly_start = super::profile::timer_start();
 
     // Collect results from state
     let hoisted_statements = std::mem::take(&mut context.state.hoisted);
@@ -1909,16 +1909,16 @@ fn transform_client_with_visitors(
     let program = JsProgram { body };
 
     // Generate JavaScript code from the program, optionally with source map data
-    super::profile::record_assembly_after_fragment(_assembly_start.elapsed());
-    let _codegen_start = std::time::Instant::now();
+    super::profile::record_assembly_after_fragment(super::profile::timer_elapsed(_assembly_start));
+    let _codegen_start = super::profile::timer_start();
     if options.enable_sourcemap {
         let r = generate_with_sourcemap(&program, source, &context.arena)
             .map_err(TransformError::CodeGen);
-        super::profile::record_codegen(_codegen_start.elapsed());
+        super::profile::record_codegen(super::profile::timer_elapsed(_codegen_start));
         r
     } else {
         let code = generate(&program, &context.arena).map_err(TransformError::CodeGen)?;
-        super::profile::record_codegen(_codegen_start.elapsed());
+        super::profile::record_codegen(super::profile::timer_elapsed(_codegen_start));
         Ok(CodegenResult {
             code,
             mappings: vec![],

--- a/src/compiler/phases/3_transform/mod.rs
+++ b/src/compiler/phases/3_transform/mod.rs
@@ -196,9 +196,9 @@ pub fn transform_component(
     }
 
     let css = if analysis.css.has_css && !analysis.inject_styles {
-        let _css_start = std::time::Instant::now();
+        let _css_start = profile::timer_start();
         let mut css_output = css::render_stylesheet(analysis, source, options)?;
-        profile::record_css_render(_css_start.elapsed());
+        profile::record_css_render(profile::timer_elapsed(_css_start));
         // Apply preprocessor source map composition to CSS map if needed
         if let Some(ref pp_map_json) = options.sourcemap
             && let Some(ref css_map_json) = css_output.map

--- a/src/compiler/phases/3_transform/profile.rs
+++ b/src/compiler/phases/3_transform/profile.rs
@@ -13,6 +13,42 @@
 use std::cell::Cell;
 use std::time::Duration;
 
+// `std::time::Instant::now()` traps on `wasm32-unknown-unknown` (no system
+// clock — see std::sys::time::unsupported). The profile instrumentation
+// below is consumed only by native bins (`bin/compile_profile.rs`), but
+// the call sites live in shared compile paths, so the Instant calls would
+// fire from the WASM playground and crash the page. Provide a WASM-safe
+// shim that returns a unit "instant" with a zero-cost elapsed so the
+// instrumented sites stay compile-target-portable without #[cfg] noise.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type TimerStart = std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+pub type TimerStart = ();
+
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+pub fn timer_start() -> TimerStart {
+    std::time::Instant::now()
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+pub fn timer_start() -> TimerStart {}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+pub fn timer_elapsed(start: TimerStart) -> Duration {
+    start.elapsed()
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+pub fn timer_elapsed(_start: TimerStart) -> Duration {
+    Duration::ZERO
+}
+
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Phase3Breakdown {
     pub visit_program: Duration,


### PR DESCRIPTION
## Summary

Three related fixes after the docs redesign landed:

### 1. WASM \"unreachable\" panic in the live playground

The Phase 3 transform's profiling instrumentation calls
\`std::time::Instant::now()\` at five sites. That symbol traps on
\`wasm32-unknown-unknown\` (\`std::sys::time::unsupported\`), so every
compile from the WASM playground died with \`unreachable\`. Add a WASM-safe
\`timer_start\` / \`timer_elapsed\` shim in \`phase3/profile.rs\` (real
\`Instant\` on native, \`()\` + \`Duration::ZERO\` on wasm) and route the
instrumented sites through it. Profile output is unaffected on native;
WASM gets zero-duration breakdowns instead of a panic.

### 2. Playground: 3-column → 2-column REPL layout

Now mirrors the official \`svelte.dev/playground\` arrangement. Left half
is the source editor, right half is a tabbed panel — **Result** /
**JS output** / **CSS output** / **AST**. The Result tab hosts the
preview iframe. Each pane gets the full half-width it deserves instead of
being squeezed into a third of the viewport. Active tab is underlined in
svelte-orange.

### 3. Benchmark: real-time bar animation

The previous animation scaled every run into a fixed 2.2 s budget, which
obscured the actual race — all three bars finished at roughly the same
on-screen time.

Now each bar grows at its measured wall-clock speed:
- at \`t = 56 ms\` \`rsvelte / multi\` crosses the finish line,
- \`rsvelte / single\` follows at \`t ≈ 400 ms\`,
- \`svelte/compiler\` is still inching forward until \`t ≈ 960 ms\`.

The on-bar time label ticks in step. Capped at 4 s as a sanity ceiling.

## Test plan

- [ ] \`cd docs && pnpm run build:wasm && pnpm run dev\` → open
      /playground → DEFAULT_EXAMPLE compiles without the \"unreachable\"
      error; preview iframe renders the runes-demo todo list
- [ ] Playground page: source editor + tabbed Result/JS/CSS/AST panel,
      each ~50 % of the viewport width
- [ ] /benchmark animation: \`rsvelte / multi\` finishes first; bars
      stop growing at their measured times; replay restarts the race

🤖 Generated with [Claude Code](https://claude.com/claude-code)