### PR TITLE
fix(parse): account for trimmed leading whitespace in call-expression arg offsets

### DIFF
--- a/src/compiler/phases/1_parse/read/expression.rs
+++ b/src/compiler/phases/1_parse/read/expression.rs
@@ -372,10 +372,27 @@ fn try_parse_call_expression(
     }
     let callee = try_parse_ident_or_member(arena, callee_str, callee_bytes, offset, line_offsets)?;
 
-    // Parse arguments between parens
+    // Parse arguments between parens.
+    //
+    // `args_region` is the raw byte slice between `(` and `)`. `args_str` is
+    // its trimmed form, used for the comma-split scan. We must add the byte
+    // count of the *leading* whitespace that `.trim()` stripped back into
+    // every per-argument offset — otherwise multi-line argument lists like
+    //
+    //     {@render fn(
+    //           a,
+    //           b,
+    //         )}
+    //
+    // record each argument's source offset 7 bytes (`\n` + 6 spaces) earlier
+    // than its real position, and the SSR render-tag visitor slices the
+    // *wrong* bytes out of source when it re-emits the call.
+    // (baseballyama/rsvelte#159)
     let args_start = paren_pos + 1;
     let args_end = bytes.len() - 1;
-    let args_str = content[args_start..args_end].trim();
+    let args_region = &content[args_start..args_end];
+    let args_str = args_region.trim();
+    let args_leading_ws = args_region.len() - args_region.trim_start().len();
 
     let arguments = if args_str.is_empty() {
         Vec::new()
@@ -408,6 +425,7 @@ fn try_parse_call_expression(
                     let arg_bytes = arg_str.as_bytes();
                     let arg_offset = offset
                         + args_start
+                        + args_leading_ws
                         + start
                         + (args_str[start..i].len() - args_str[start..i].trim_start().len());
                     let arg = try_parse_atom(arena, arg_str, arg_bytes, arg_offset, line_offsets)?;
@@ -426,6 +444,7 @@ fn try_parse_call_expression(
             let arg_bytes = arg_str.as_bytes();
             let arg_offset = offset
                 + args_start
+                + args_leading_ws
                 + start
                 + (args_str[start..].len() - args_str[start..].trim_start().len());
             let arg = try_parse_atom(arena, arg_str, arg_bytes, arg_offset, line_offsets)?;

--- a/tests/render_tag_multiline_args.rs
+++ b/tests/render_tag_multiline_args.rs
@@ -1,0 +1,105 @@
+//! Regression test for `{@render snippet(arg, arg, …,)}` multi-line
+//! trailing-comma argument truncation (baseballyama/rsvelte#159).
+//!
+//! Bug: `try_parse_call_expression` in the simple-expression fast path
+//! computed each argument's source offset as
+//!
+//!     offset + args_start + start + (...trim_start delta inside the slice)
+//!
+//! but `args_str` was already `content[args_start..args_end].trim()` — i.e.
+//! the leading whitespace of the args region was stripped *before* the
+//! per-argument offsets were computed. The fix re-adds the leading-whitespace
+//! byte count so positions point at the real source bytes.
+//!
+//! When the offsets were short by N bytes, the SSR `{@render}` visitor
+//! sliced `source[a_start..a_end]` and got "N bytes shifted left" — so each
+//! argument lost N characters off the end, and the first argument lost
+//! anywhere up to its full length (saturating at empty).
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn compile_server(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Server,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn multiline_trailing_comma_render_args_preserved() {
+    let src = r#"<script>
+  let items = $state([1, 2]);
+  let currentChain = [];
+  let binaryCondition = 1;
+  let fieldDropdown = 2;
+  let onSelectField = 3;
+</script>
+
+{#snippet drilldown(arg1, arg2, arg3, arg4, arg5)}
+  {#each items as nested}
+    {@render drilldown(
+      nested,
+      currentChain,
+      binaryCondition,
+      fieldDropdown,
+      onSelectField,
+    )}
+  {/each}
+{/snippet}
+
+{@render drilldown(0, 1, 2, 3, 4)}"#;
+    let out = compile_server(src);
+    // Every argument name must reach the call site untruncated.
+    for name in [
+        "nested",
+        "currentChain",
+        "binaryCondition",
+        "fieldDropdown",
+        "onSelectField",
+    ] {
+        assert!(
+            out.contains(name),
+            "expected arg {} to be preserved:\n{out}",
+            name
+        );
+    }
+    // No empty argument slot in the call (the pre-fix bug emitted
+    // `drilldown($$renderer, , curre, ...)`).
+    assert!(
+        !out.contains("$$renderer, ,"),
+        "found empty argument slot — first arg truncated to empty:\n{out}"
+    );
+}
+
+#[test]
+fn single_line_render_call_still_works() {
+    // Regression guard: the original (non-multi-line) case must keep working.
+    let src = r#"<script>
+  let a = 1;
+  let b = 2;
+</script>
+
+{#snippet show(x, y)}
+  <span>{x}-{y}</span>
+{/snippet}
+
+{@render show(a, b)}"#;
+    let out = compile_server(src);
+    assert!(out.contains("show($$renderer, a, b)"), "got:\n{out}");
+}
+
+#[test]
+fn multiline_render_call_with_tab_indent_preserved() {
+    // Different indentation widths (4 spaces) — the offset adjustment must
+    // scale with the actual leading-whitespace length, not a hard-coded 7.
+    let src = "<script>\n    let a = 1;\n    let b = 2;\n</script>\n\n{#snippet show(x, y)}\n    <span>{x}-{y}</span>\n{/snippet}\n\n{@render show(\n    a,\n    b,\n)}";
+    let out = compile_server(src);
+    assert!(out.contains("show($$renderer, a, b)"), "got:\n{out}");
+}


### PR DESCRIPTION
## Summary

`try_parse_call_expression` in the simple-expression fast path computed each argument's source offset as

```rust
offset + args_start + start + (args_str[start..i].len() - args_str[start..i].trim_start().len())
```

but `args_str` was already `content[args_start..args_end].trim()` — i.e. the leading whitespace of the args region was stripped *before* the per-argument offsets were computed. The `args_start + start` math is therefore short by the number of leading-whitespace bytes that `.trim()` removed.

### Repro

```svelte
{#snippet drilldown(arg1, arg2, arg3, arg4, arg5)}
  {#each items as nested}
    {@render drilldown(
      nested,
      currentChain,
      binaryCondition,
      fieldDropdown,
      onSelectField,
    )}
  {/each}
{/snippet}
```

Every argument's recorded `start`/`end` ended up 7 bytes (`\n` + 6 spaces) earlier than the real source position. The SSR `{@render}` visitor then sliced `source[a_start..a_end]` and emitted the *wrong* bytes — each argument lost 7 characters off the end, and the first argument (whose real length was less than 7) lost everything and became an empty token in the call:

Before:
```js
drilldown($$renderer, , curre, binaryCo, fieldD, onSele)  // ← rolldown: Unexpected token
```

After:
```js
drilldown($$renderer, nested, currentChain, binaryCondition, fieldDropdown, onSelectField)
```

### Fix

Capture the leading-whitespace byte count of the args region into `args_leading_ws` and add it to every per-argument offset so positions point at the real source bytes.

Fixes #159.

## Test plan
- [x] `cargo test --release` — targeted suites (compiler_fixtures, ssr, compiler_errors, parser_fixtures, validator, print, css, render_tag_multiline_args) 117 tests pass
- [x] `cargo clippy --all-targets --features napi -- -D warnings`
- [x] New `tests/render_tag_multiline_args.rs` covers:
  - The reproducer from the issue (5 named args, 6-space indent, trailing comma)
  - Regression guard: single-line `{@render show(a, b)}` still works
  - Regression guard: 4-space indent variant (the leading-whitespace count must scale, not be hard-coded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
