### PR TITLE
fix(transform/client): don't IIFE-rewrite nested binding sub-patterns; paren-wrap object-literal defaults

### DIFF
--- a/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -234,6 +234,24 @@ pub(super) fn find_and_transform_one_destructure(
                         continue;
                     }
 
+                    // Skip nested binding patterns. When `{ a, b } = default`
+                    // appears *inside* an outer destructure pattern (e.g.
+                    // `let { prop: { a, b } = default } = expr`), the inner
+                    // `} =` is the sub-pattern's default-value form — not a
+                    // destructure assignment — and rewriting it to an IIFE
+                    // would plant a function call in an LValue slot, which is
+                    // not valid JavaScript. (baseballyama/rsvelte#163)
+                    //
+                    // Detect this by scanning back through the bytes before
+                    // the inner pattern's opening bracket and tracking
+                    // brace/bracket depth. If we encounter an unmatched
+                    // opening `{` or `[` before hitting a statement boundary,
+                    // we're nested inside another pattern and should skip.
+                    if is_inside_enclosing_pattern(statement, b(pattern_start)) {
+                        i = j + 1;
+                        continue;
+                    }
+
                     // Extract target identifiers from the pattern
                     let targets = extract_destructure_targets(pattern_str);
 
@@ -369,6 +387,51 @@ pub(super) fn find_and_transform_one_destructure(
     new_statement.push_str(&statement[actual_end..]);
 
     Some(new_statement)
+}
+
+/// Returns true when the byte position `pattern_open_byte` (the `{` or `[`
+/// of a destructure pattern) is itself nested inside another *binding*
+/// pattern introduced by `let` / `const` / `var`. Used to suppress the IIFE
+/// rewrite for sub-patterns with default values:
+///
+/// ```ignore
+/// let { prop: { a, b } = default } = expr;
+/// //          ^^^^^^^^^^^^^^^^^^^^^
+/// // inner `} = default` is a sub-pattern's default form, NOT an assignment
+/// ```
+///
+/// Walks the bytes backward, tracking `{`/`[`/`}`/`]` depth. When depth
+/// goes negative we've found the immediate outer `{` or `[`. We then check
+/// what precedes that bracket: if it's `let` / `const` / `var`, the inner
+/// pattern is part of a binding declaration and should not be IIFE-rewritten.
+/// Anything else (e.g. `(` for a `({ x: a } = obj)` assignment expression,
+/// `{` of a function body, …) leaves the inner pattern eligible for the
+/// usual destructure-assignment rewrite.
+fn is_inside_enclosing_pattern(statement: &str, pattern_open_byte: usize) -> bool {
+    let bytes = statement.as_bytes();
+    let mut depth: i32 = 0;
+    let mut i = pattern_open_byte;
+    while i > 0 {
+        i -= 1;
+        let b = bytes[i];
+        match b {
+            b'}' | b']' => depth += 1,
+            b'{' | b'[' => {
+                depth -= 1;
+                if depth < 0 {
+                    // Found the outer unmatched bracket — check what
+                    // precedes it.
+                    let before = statement[..i].trim_end();
+                    return before.ends_with("let")
+                        || before.ends_with("const")
+                        || before.ends_with("var");
+                }
+            }
+            b';' if depth == 0 => return false,
+            _ => {}
+        }
+    }
+    false
 }
 
 /// Find the matching opening bracket, respecting nesting and strings.
@@ -1129,17 +1192,38 @@ pub(super) fn build_fallback_string(access: &str, default_val: &str) -> String {
             let inner = inner.trim();
             if !string_expr_has_await(inner) {
                 // Optimized: sync thunk wrapping the non-await inner expression
-                return format!("await $.fallback({}, () => {}, true)", access, inner);
+                return format!(
+                    "await $.fallback({}, () => {}, true)",
+                    access,
+                    wrap_arrow_body(inner)
+                );
             }
         }
         return format!(
             "await $.fallback({}, async () => {}, true)",
-            access, default_val
+            access,
+            wrap_arrow_body(default_val)
         );
     }
 
     // Case 4: Non-simple, no await -> sync thunk
-    format!("$.fallback({}, () => {}, true)", access, default_val)
+    format!(
+        "$.fallback({}, () => {}, true)",
+        access,
+        wrap_arrow_body(default_val)
+    )
+}
+
+/// Wrap an arrow function body that starts with `{` in parens so it's parsed
+/// as an object-literal-returning expression rather than a block statement.
+/// Mirrors `unthunk_string`'s disambiguation (baseballyama/rsvelte#150) for
+/// callers that build the `() => expr` form directly.
+fn wrap_arrow_body(body: &str) -> String {
+    if body.trim_start().starts_with('{') {
+        format!("({})", body)
+    } else {
+        body.to_string()
+    }
 }
 
 /// Generate an IIFE for a destructure assignment.

--- a/tests/derived_destructure_nested_default.rs
+++ b/tests/derived_destructure_nested_default.rs
@@ -1,0 +1,105 @@
+//! Regression test for `let { prop: { a, b } = default } = $derived(expr)`
+//! (baseballyama/rsvelte#163).
+//!
+//! Two bugs landed together:
+//!
+//! 1. `find_and_transform_one_destructure` interpreted the inner sub-pattern's
+//!    default-value form (`{ a, b } = default`) as a destructure *assignment*
+//!    and wrapped it in an `(($$value) => { … })(rhs)` IIFE — which is
+//!    invalid JavaScript at LValue position. Now suppressed when the inner
+//!    `{`/`[` is nested inside an enclosing binding pattern.
+//!
+//! 2. The fallback emitter built `() => default` arrow bodies without
+//!    paren-wrapping object-literal defaults, so `default = { width: 0, … }`
+//!    became `() => { width: 0, … }` — an arrow with a *block* body, not
+//!    one returning the object. Mirrors the same fix from #150 / #151.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn compile_client(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn nested_pattern_with_object_default_emits_per_leaf_derived() {
+    let src = r#"<script>
+  let { node } = $props();
+  let {
+    measured: { width: measuredWidth, height: measuredHeight } = { width: 0, height: 0 },
+  } = $derived(node);
+</script>
+<p>{measuredWidth} {measuredHeight}</p>"#;
+    let out = compile_client(src);
+    // No IIFE inside the destructure LHS slot.
+    assert!(
+        !out.contains("(($$value) =>"),
+        "found IIFE in destructure LHS (invalid JS):\n{out}"
+    );
+    // Each leaf should be its own `$.derived(...)` declaration.
+    assert!(
+        out.contains("measuredWidth = $.derived"),
+        "expected `measuredWidth = $.derived(...)`. Got:\n{out}"
+    );
+    assert!(
+        out.contains("measuredHeight = $.derived"),
+        "expected `measuredHeight = $.derived(...)`. Got:\n{out}"
+    );
+    // Default object literal must be paren-wrapped in the arrow body.
+    assert!(
+        out.contains("() => ({"),
+        "default-value arrow body must be paren-wrapped to return the object:\n{out}"
+    );
+    // $.fallback wires the default and the property access.
+    assert!(
+        out.contains("$.fallback"),
+        "expected `$.fallback` call. Got:\n{out}"
+    );
+}
+
+#[test]
+fn nested_pattern_with_object_default_no_iife_remnants() {
+    // Make sure `$derived(node)` itself was rewritten to `$.derived(...)` and
+    // not left as the raw rune call.
+    let src = r#"<script>
+  let { node } = $props();
+  let {
+    measured: { width: measuredWidth } = { width: 0 },
+  } = $derived(node);
+</script>
+<p>{measuredWidth}</p>"#;
+    let out = compile_client(src);
+    assert!(
+        !out.contains("$derived(node)"),
+        "the `$derived(node)` rune was not rewritten:\n{out}"
+    );
+}
+
+#[test]
+fn destructure_assignment_with_reactive_target_still_rewrites() {
+    // Regression guard: top-level destructure ASSIGNMENT (no `let`) of state
+    // variables must still be rewritten so reactivity is honoured — the
+    // exact form is a comma-separated sequence of `$.set(...)` calls.
+    let src = r#"<script>
+  let a = $state(0);
+  let b = $state(0);
+  function pull(obj) {
+    ({ x: a, y: b } = obj);
+  }
+</script>
+<button onclick={() => pull({ x: 1, y: 2 })}>go</button>"#;
+    let out = compile_client(src);
+    assert!(
+        out.contains("$.set(a,") && out.contains("$.set(b,"),
+        "destructure assignment of reactive targets should rewrite to $.set calls:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

Two interlocking bugs that together corrupted client output for `let { prop: { a, b } = default } = $derived(expr)`:

### 1. Inner sub-pattern with default got IIFE-rewritten into LValue position

`find_and_transform_one_destructure` scans the script for `} =` / `] =` and rewrites the pattern to an `(($$value) => { … })(rhs)` IIFE when any LHS target is a reactive variable. The skip check for declaration destructures only looked at the byte *immediately before* the inner pattern bracket (`let`/`const`/`var`), so a sub-pattern's default-value form (`{ a, b } = default`) sitting inside an outer `let { … }` was wrongly treated as a destructure assignment.

Result before fix:

```js
let {
  measured: (($$value) => {     // ← IIFE in LValue position — invalid JS
    measuredWidth = $$value.width;
    measuredHeight = $$value.height;
    return $$value;
  })({ width: 0, height: 0 }),
} = $derived(node);             // ← `$derived` also leaked, since the
                                //   above failed before reaching it
```

rolldown / oxc rejected this with `Invalid destructuring assignment target` / `Unexpected token`.

### 2. Fallback emitted unwrapped object-literal arrow body

`build_fallback_string` produced `() => default` arrow bodies without paren-wrapping object literals, so a default like `{ width: 0, height: 0 }` came out as `() => { width: 0, height: 0 }` — an arrow with a *block* body, not one returning the object. Same shape as #150 / #151.

### Fix

- Add a backward bracket-depth walker that, on finding the inner `} =` / `] =`, looks for the *immediate enclosing* `{`/`[` and checks whether *that* bracket is preceded by `let`/`const`/`var`. If it is, the inner pattern is a nested binding sub-pattern and the IIFE rewrite is suppressed. Top-level destructure assignments (`({ x: a, y: b } = obj)` inside a function body) keep working — their enclosing `{` is a block statement, not a binding pattern.
- Centralise an `wrap_arrow_body` helper in `build_fallback_string` that wraps object-literal defaults in parens (`() => ({ … })`) before they're spliced into the emitted arrow.

### Output (matches upstream)

```js
let measuredWidth = $.derived(() => $.fallback($$props.node.measured, () => ({ width: 0, height: 0 }), true).width),
    measuredHeight = $.derived(() => $.fallback($$props.node.measured, () => ({ width: 0, height: 0 }), true).height);
```

Fixes #163.

## Test plan
- [x] `cargo test --release` — targeted suites (compiler_fixtures, ssr, compiler_errors, parser_fixtures, validator, print, css, derived_destructure_nested_default) 121 tests pass
- [x] `cargo clippy --all-targets --features napi -- -D warnings`
- [x] New `tests/derived_destructure_nested_default.rs` covers:
  - The reproducer from the issue
  - Single-leaf variant (regression guard for `$derived(node)` getting rewritten)
  - Destructure assignment regression guard: `({ x: a, y: b } = obj)` inside a function body must still be rewritten to `$.set` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
