### PR TITLE
fix(transform/client): walk full call+member chain in strict-equals operand extraction

### DIFF
--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -813,52 +813,62 @@ pub(super) fn extract_operand_backward(s: &str) -> (String, usize) {
         return (String::new(), 0);
     }
 
-    let last_char = trimmed.chars().last().unwrap();
-
-    // Handle parenthesized expressions: scan backward to find matching open paren
-    if last_char == ')' {
-        let mut depth = 0;
-        let mut start = trimmed.len();
-        for (i, c) in trimmed.char_indices().rev() {
-            match c {
-                ')' => depth += 1,
-                '(' => {
+    // Walk the operand backward through the entire chain. Each iteration peels
+    // off either an identifier/property segment OR a parenthesised group (call
+    // arguments / parenthesised expression). A `.length` member access on a
+    // call like `$.get(items).length` must include the call itself, so we keep
+    // walking left as long as the next byte to the left is still part of the
+    // same chain. (baseballyama/rsvelte#166)
+    let bytes = trimmed.as_bytes();
+    let mut end = trimmed.len();
+    loop {
+        if end == 0 {
+            break;
+        }
+        let last = bytes[end - 1];
+        if last == b')' || last == b']' {
+            // Walk backward through the matching paren/bracket, then continue
+            // — what's *before* the call may be `obj.method`, `$.get`, etc.
+            let close = last;
+            let open = if close == b')' { b'(' } else { b'[' };
+            let mut depth: i32 = 0;
+            let mut start = end; // fallback: no match found
+            let mut i = end;
+            while i > 0 {
+                i -= 1;
+                let b = bytes[i];
+                if b == close {
+                    depth += 1;
+                } else if b == open {
                     depth -= 1;
                     if depth == 0 {
                         start = i;
                         break;
                     }
                 }
-                _ => {}
             }
+            if start == end {
+                // Unbalanced — bail.
+                break;
+            }
+            end = start;
+            continue;
         }
-        // Include function name/method call before the paren
-        // Include `?` to handle optional chaining (`?.`)
-        let before_paren = &trimmed[..start];
-        let func_start = before_paren
-            .rfind(|c: char| {
-                !c.is_alphanumeric() && c != '_' && c != '$' && c != '.' && c != '#' && c != '?'
-            })
-            .map(|p| p + 1)
-            .unwrap_or(0);
-        let expr = trimmed[func_start..].to_string();
-        // Find where this starts in the original (untrimmed) string
-        let original_start = s.len() - trimmed.len() + func_start;
-        return (expr, original_start);
+        if last.is_ascii_alphanumeric()
+            || last == b'_'
+            || last == b'$'
+            || last == b'.'
+            || last == b'#'
+            || last == b'?'
+        {
+            end -= 1;
+            continue;
+        }
+        break;
     }
 
-    // Handle string/number/boolean literals and identifiers
-    // Find the start of the identifier/literal
-    // Include `?` to handle optional chaining (`?.`)
-    let expr_start = trimmed
-        .rfind(|c: char| {
-            !c.is_alphanumeric() && c != '_' && c != '$' && c != '.' && c != '#' && c != '?'
-        })
-        .map(|p| p + 1)
-        .unwrap_or(0);
-
-    let expr = trimmed[expr_start..].to_string();
-    let original_start = s.len() - trimmed.len() + expr_start;
+    let expr = trimmed[end..].to_string();
+    let original_start = s.len() - trimmed.len() + end;
     (expr, original_start)
 }
 

--- a/tests/strict_equals_member_after_call.rs
+++ b/tests/strict_equals_member_after_call.rs
@@ -1,0 +1,118 @@
+//! Regression test for `transform_strict_equals` mangling `X.member !== Y`
+//! when `X` is wrapped in a call expression like `$.get(items)` (which the
+//! dev-mode `$state` lowering produces). (baseballyama/rsvelte#166)
+//!
+//! Bug: `extract_operand_backward` walked the LHS backward looking for the
+//! start of the operand. When it hit a `)`, it parsed the call expression
+//! correctly — but it only did that when the operand *ends* with `)`. For a
+//! member access on a call (`$.get(items).length`), the operand ends with
+//! `h`, not `)`, so the fallback "scan identifier chars" path took over —
+//! and that path stopped at the `)` of `$.get(items)` because `)` is not
+//! an identifier char. The result was `left_expr = ".length"` and the
+//! replacement landed in the middle of the chain:
+//!
+//!     $.get(items).length !== 0   →   $.get(items)!$.strict_equals(.length, 0)
+//!
+//! Now the extractor walks the entire chain — peeling off identifier runs
+//! and matched `(...)` / `[...]` groups in turn — so `$.get(items).length`
+//! is returned as a single operand.
+
+use svelte_compiler_rust::GenerateMode;
+use svelte_compiler_rust::compile_module;
+use svelte_compiler_rust::compiler::ModuleCompileOptions;
+
+fn compile_mod_client_dev(src: &str) -> String {
+    let result = compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("x.svelte.ts".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile_module");
+    result.js.code
+}
+
+#[test]
+fn neq_after_member_on_tagged_state_call_chain() {
+    let src = r#"export const fn = () => {
+  let items = $state.raw([]);
+  if (items.length !== 0) items[0];
+};"#;
+    let out = compile_mod_client_dev(src);
+    // The arrow body should test the full member chain — `!$.strict_equals($.get(items).length, 0)`.
+    assert!(
+        out.contains("!$.strict_equals($.get(items).length, 0)"),
+        "expected `!$.strict_equals($.get(items).length, 0)`. Got:\n{out}"
+    );
+    // No mangled `!$.strict_equals(.length, ...)` floating around.
+    assert!(
+        !out.contains("$.strict_equals(.length"),
+        "found mangled `$.strict_equals(.length, …)` — operand was split:\n{out}"
+    );
+    // And the `$.get(items)` shouldn't be stranded with a bare `!` either.
+    assert!(
+        !out.contains("$.get(items)!"),
+        "found stranded `$.get(items)!`:\n{out}"
+    );
+}
+
+#[test]
+fn eq_after_member_on_tagged_state_call_chain() {
+    // Mirror case with `===`.
+    let src = r#"export const fn = () => {
+  let items = $state.raw([]);
+  if (items.length === 0) items[0];
+};"#;
+    let out = compile_mod_client_dev(src);
+    assert!(
+        out.contains("$.strict_equals($.get(items).length, 0)")
+            && !out.contains("!$.strict_equals($.get(items).length"),
+        "expected `$.strict_equals($.get(items).length, 0)` (no `!`). Got:\n{out}"
+    );
+}
+
+#[test]
+fn neq_after_bracket_index_chain() {
+    // `arr[0].length !== 0` — the chain ends with a bracket-index too.
+    let src = r#"export const fn = () => {
+  let arr = $state.raw([[1, 2]]);
+  if (arr[0].length !== 0) arr[0][0];
+};"#;
+    let out = compile_mod_client_dev(src);
+    assert!(
+        out.contains("!$.strict_equals($.get(arr)[0].length, 0)")
+            || out.contains("!$.strict_equals(($.get(arr))[0].length, 0)"),
+        "expected `!$.strict_equals($.get(arr)[0].length, 0)`. Got:\n{out}"
+    );
+}
+
+#[test]
+fn plain_identifier_neq_still_works() {
+    // Regression guard: simple `a !== b` shouldn't regress.
+    let src = r#"export const fn = (a: number, b: number) => {
+  if (a !== b) return a;
+  return b;
+};"#;
+    let out = compile_mod_client_dev(src);
+    assert!(
+        out.contains("!$.strict_equals(a, b)"),
+        "expected `!$.strict_equals(a, b)`. Got:\n{out}"
+    );
+}
+
+#[test]
+fn call_left_operand_still_works() {
+    // Regression guard: when LHS *does* end with `)` the call form still works.
+    let src = r#"export const fn = (a: number) => {
+  if (Math.abs(a) !== 0) return a;
+  return 0;
+};"#;
+    let out = compile_mod_client_dev(src);
+    assert!(
+        out.contains("!$.strict_equals(Math.abs(a), 0)"),
+        "expected `!$.strict_equals(Math.abs(a), 0)`. Got:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

`transform_strict_equals`'s `extract_operand_backward` peeled off the LHS of an `===` / `!==` comparison by scanning bytes leftward. It special-cased the "operand ends with `)`" shape (a call expression like `Math.abs(a)`) but for `obj.method().member` shapes — where the LHS ends with an identifier character — it fell through to the generic identifier scan, which stopped at the first non-identifier byte. A `)` halfway through the chain (e.g. `$.get(items)`) tripped that stop and the operand boundary landed at the `)`, leaving the trailing `.length` attached to the *replacement* instead of the operand.

The dev-mode lowering of `let X = $state.raw(…)` introduces exactly this shape (`$.get(items)` wrapping every read), so any `X.member !== Y` in a dev `.svelte.ts` module broke the build.

### Repro

```ts
// x.svelte.ts
export const fn = () => {
  let items = $state.raw([]);
  if (items.length !== 0) items[0];
};
```

```js
svelte.compileModule(src, { filename: 'x.svelte.ts', generate: 'client', dev: true });
```

Before:
```js
if ($.get(items)!$.strict_equals(.length, 0)) $.get(items)[0];
//              ^                ^^^^^^^^ stranded ↑ floating
```

After:
```js
if (!$.strict_equals($.get(items).length, 0)) $.get(items)[0];
```

### Fix

Rewrite `extract_operand_backward` to walk the entire chain — alternating identifier runs and matched `(...)` / `[...]` groups — so the LHS of comparisons like `$.get(items).length`, `arr[0].length`, `obj.foo(bar).baz`, etc. is returned as a single operand.

Fixes #166.

## Test plan
- [x] `cargo test --release` — targeted suites (compiler_fixtures, ssr, compiler_errors, parser_fixtures, validator, print, css, strict_equals_member_after_call) 119 tests pass
- [x] `cargo clippy --all-targets --features napi -- -D warnings`
- [x] New `tests/strict_equals_member_after_call.rs` covers:
  - `items.length !== 0` on a `$state.raw` binding in dev mode (the regression)
  - Mirror `===` case
  - `arr[0].length !== 0` — bracket-index in the chain
  - Plain `a !== b` (regression guard)
  - `Math.abs(a) !== 0` — call expression as full LHS (regression guard for the existing call-extraction path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
