### PR TITLE
perf(napi): compileBatch — N files in one boundary crossing

### DIFF
--- a/npm/vite-plugin-svelte-native/envelope.js
+++ b/npm/vite-plugin-svelte-native/envelope.js
@@ -207,9 +207,88 @@ function utf8SliceFromUint8Array(u8, off, len) {
 	return cachedDecoder.decode(u8.subarray(off, off + len));
 }
 
+// =============================================================================
+// Batch envelope
+// =============================================================================
+
+const BATCH_MAGIC = 0x42565352; // "RSVB" little-endian
+const BATCH_VERSION = 1;
+const BATCH_HEADER_LEN = 16;
+const BATCH_ENTRY_LEN = 12;
+const BATCH_STATUS_OK = 0;
+const BATCH_STATUS_ERR = 1;
+
+/**
+ * Decode a batch envelope produced by `compileBatch`. Returns an
+ * array the same length as the input, where each slot is either a
+ * `CompileResult` (decoded lazily on first read, like {@link decodeEnvelope})
+ * or an `Error` carrying the per-entry failure message.
+ *
+ * @param {Buffer|Uint8Array} buf
+ * @returns {Array<object|Error>}
+ */
+function decodeBatch(buf) {
+	if (!buf || buf.byteLength < BATCH_HEADER_LEN) {
+		throw new Error(
+			`[rsvelte] batch envelope too small (${buf ? buf.byteLength : 0} bytes, ` +
+				`expected at least ${BATCH_HEADER_LEN})`,
+		);
+	}
+
+	const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+	const magic = view.getUint32(0, true);
+	if (magic !== BATCH_MAGIC) {
+		throw new Error(
+			`[rsvelte] batch magic mismatch (got 0x${magic.toString(16)}, ` +
+				`expected 0x${BATCH_MAGIC.toString(16)})`,
+		);
+	}
+	const version = view.getUint32(4, true);
+	if (version !== BATCH_VERSION) {
+		throw new Error(
+			`[rsvelte] unsupported batch envelope version ${version} (this build expects ${BATCH_VERSION})`,
+		);
+	}
+	const totalLen = view.getUint32(8, true);
+	if (totalLen !== buf.byteLength) {
+		throw new Error(
+			`[rsvelte] batch envelope size mismatch (header says ${totalLen}, buffer is ${buf.byteLength})`,
+		);
+	}
+	const count = view.getUint32(12, true);
+
+	const out = new Array(count);
+	for (let i = 0; i < count; i++) {
+		const entryOff = BATCH_HEADER_LEN + i * BATCH_ENTRY_LEN;
+		const status = view.getUint32(entryOff, true);
+		const payloadOff = view.getUint32(entryOff + 4, true);
+		const payloadLen = view.getUint32(entryOff + 8, true);
+		// Subarray gives a zero-copy view into the same underlying
+		// ArrayBuffer; `decodeEnvelope` walks it without further allocation.
+		const slice = buf.subarray
+			? buf.subarray(payloadOff, payloadOff + payloadLen)
+			: new Uint8Array(buf.buffer, buf.byteOffset + payloadOff, payloadLen);
+		if (status === BATCH_STATUS_OK) {
+			out[i] = decodeEnvelope(slice);
+		} else if (status === BATCH_STATUS_ERR) {
+			const msg = bufferIsNodeBuffer(slice)
+				? slice.toString('utf8')
+				: utf8SliceFromUint8Array(slice, 0, slice.byteLength);
+			out[i] = new Error(msg);
+		} else {
+			out[i] = new Error(`[rsvelte] unknown batch entry status ${status} at index ${i}`);
+		}
+	}
+	return out;
+}
+
 module.exports = {
 	decodeEnvelope,
+	decodeBatch,
 	HEADER_LEN,
 	MAGIC,
 	VERSION,
+	BATCH_HEADER_LEN,
+	BATCH_MAGIC,
+	BATCH_VERSION,
 };

--- a/npm/vite-plugin-svelte-native/index.cjs
+++ b/npm/vite-plugin-svelte-native/index.cjs
@@ -2,7 +2,7 @@
 // Mirrors the loader pattern napi-rs generates: resolve a platform-specific
 // dependency that ships a single `rsvelte.node` artifact.
 
-const { decodeEnvelope } = require('./envelope.js');
+const { decodeEnvelope, decodeBatch } = require('./envelope.js');
 
 const { platform, arch } = process;
 
@@ -68,6 +68,15 @@ function compileModule(source, options) {
 	return decodeEnvelope(binding.compileModuleEnvelope(source, options));
 }
 
+// `compileBatch([{source, options}, …])` compiles N files in
+// parallel (rayon on the Rust side) and crosses the NAPI boundary
+// exactly once. The returned array is the same length as the input;
+// each slot is either a `CompileResult` or an `Error` (parse
+// failures don't abort the whole batch).
+function compileBatch(inputs) {
+	return decodeBatch(binding.compileBatch(inputs));
+}
+
 // Re-export every NAPI function as its own named binding so node's
 // `cjs-module-lexer` can pick them up when this file is imported via
 // ESM (e.g. `import { compile, preprocess, VERSION } from …`). A bare
@@ -93,7 +102,10 @@ module.exports.compileEnvelopeZeroCopy = binding.compileEnvelopeZeroCopy;
 module.exports.compileModuleEnvelopeZeroCopy = binding.compileModuleEnvelopeZeroCopy;
 module.exports.compileBuffers = binding.compileBuffers;
 module.exports.compileModuleBuffers = binding.compileModuleBuffers;
+module.exports.compileBatch = compileBatch;
+module.exports.compileBatchRaw = binding.compileBatch;
 module.exports.decodeEnvelope = decodeEnvelope;
+module.exports.decodeBatch = decodeBatch;
 module.exports.preprocess = binding.preprocess;
 module.exports.svelte2tsx = binding.svelte2tsx;
 module.exports.hmrDiff = binding.hmrDiff;

--- a/npm/vite-plugin-svelte-native/index.d.ts
+++ b/npm/vite-plugin-svelte-native/index.d.ts
@@ -173,6 +173,41 @@ export function compileModuleEnvelopeZeroCopy(
 export function decodeEnvelope(buf: Buffer | Uint8Array): CompileResult;
 
 /**
+ * Single entry in a {@link compileBatch} worklist. `options` is
+ * forwarded to the underlying compile as if you had called
+ * `compile(source, options)`.
+ */
+export interface CompileBatchInput {
+	source: string;
+	options?: CompileOptions;
+}
+
+/**
+ * Compile multiple Svelte components in one NAPI call. The Rust side
+ * dispatches across rayon workers; the JS side gets one `Buffer`
+ * back containing all N results. Per-entry failures surface as
+ * `Error` instances at the corresponding slot — they don't abort
+ * the rest of the batch.
+ *
+ * Use this when you'd otherwise loop `compile()` over many files
+ * (Vite dev server, SSR pre-render). For one-off compiles the
+ * per-call overhead of `compile()` is already small.
+ */
+export function compileBatch(
+	inputs: CompileBatchInput[],
+): Array<CompileResult | Error>;
+
+/**
+ * Lower-level entry point: returns the raw batch envelope as a single
+ * `Buffer`. Pair with {@link decodeBatch} to obtain the same array
+ * {@link compileBatch} would, or pass through worker `postMessage`.
+ */
+export function compileBatchRaw(inputs: CompileBatchInput[]): Buffer;
+
+/** Decode a batch envelope produced by {@link compileBatchRaw}. */
+export function decodeBatch(buf: Buffer | Uint8Array): Array<CompileResult | Error>;
+
+/**
  * Step-1 variant of {@link compile}: returns the same shape but with
  * `js.code` / `js.map` / `css.code` / `css.map` as raw `Buffer`s. The
  * envelope path ({@link compile}) supersedes this for most callers; it

--- a/scripts/test-raw-transfer.mjs
+++ b/scripts/test-raw-transfer.mjs
@@ -53,7 +53,7 @@ function triple() {
 }
 
 const binding = loadBinding();
-const { decodeEnvelope } = await import(
+const { decodeEnvelope, decodeBatch } = await import(
 	`file://${join(repoRoot, 'npm/vite-plugin-svelte-native/envelope.js')}`
 ).then((m) => m.default ?? m);
 
@@ -294,3 +294,60 @@ if (BIG_SOURCE) {
 		void binding.compileEnvelopeZeroCopy(BIG_SOURCE, BIG_OPTS).byteLength;
 	});
 }
+
+// --- compileBatch sanity + benchmark --------------------------------------
+console.log('\n=== compileBatch ===');
+const BATCH = [
+	{ source: SOURCE, options: { filename: 'a.svelte', generate: 'client' } },
+	{ source: SOURCE, options: { filename: 'b.svelte', generate: 'client' } },
+	{ source: '<bogus invalid svelte', options: { filename: 'bad.svelte' } },
+	{ source: SOURCE, options: { filename: 'd.svelte', generate: 'client' } },
+];
+
+const batchResults = binding.compileBatch(BATCH);
+const decoded = decodeBatch(batchResults);
+console.log(`batch buffer size: ${batchResults.byteLength}b for ${BATCH.length} entries`);
+console.log(`decoded length: ${decoded.length}`);
+for (let i = 0; i < decoded.length; i++) {
+	const r = decoded[i];
+	if (r instanceof Error) {
+		console.log(`  [${i}] ERR: ${r.message.slice(0, 60).replace(/\n/g, ' ')}`);
+	} else {
+		console.log(`  [${i}] OK: js.code=${r.js.code.length}b`);
+	}
+}
+
+const expectedOks = BATCH.filter((b) => !b.source.startsWith('<bogus')).length;
+const actualOks = decoded.filter((r) => !(r instanceof Error)).length;
+assertEq('compileBatch ok count', expectedOks, actualOks);
+assertEq('compileBatch err count', BATCH.length - expectedOks, decoded.length - actualOks);
+
+// Per-file vs batch micro-benchmark
+console.log('\n=== Batch vs loop (16 files, 200 iter) ===');
+const LOOP_FILES = Array.from({ length: 16 }, (_, i) => ({
+	source: SOURCE,
+	options: { filename: `f${i}.svelte`, generate: 'client' },
+}));
+for (let i = 0; i < 50; i++) binding.compileBatch(LOOP_FILES); // warm-up
+
+function microBench(label, fn) {
+	const ITER = 200;
+	const t0 = process.hrtime.bigint();
+	for (let i = 0; i < ITER; i++) fn();
+	const t1 = process.hrtime.bigint();
+	const ns = Number(t1 - t0);
+	console.log(`${label.padEnd(40)}  ${(ns / ITER / 1000).toFixed(1)} µs/iter`);
+}
+
+microBench('loop: 16x binding.compile()', () => {
+	for (const f of LOOP_FILES) binding.compile(f.source, f.options);
+});
+microBench('loop: 16x compileEnvelope+decode', () => {
+	for (const f of LOOP_FILES) decodeEnvelope(binding.compileEnvelope(f.source, f.options));
+});
+microBench('batch: 1x compileBatch(16)', () => {
+	binding.compileBatch(LOOP_FILES);
+});
+microBench('batch: compileBatch+decodeBatch(16)', () => {
+	decodeBatch(binding.compileBatch(LOOP_FILES));
+});

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -1186,3 +1186,74 @@ pub fn napi_compile_module_envelope(source: String, options: Value) -> napi::Res
         Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
     }
 }
+
+// =============================================================================
+// Batch compile: one NAPI call → N files in parallel → one Buffer
+// =============================================================================
+//
+// `compileBatch([{source, options}, …])` hands the whole worklist to
+// `crate::compiler::compile_batch`, which uses rayon to compile in
+// parallel, and packs the resulting `Result<CompileResult, _>`s into
+// one batch envelope (`crate::napi_raw::encode_batch_to_vec`). One
+// `napi_create_external_buffer` per call regardless of N — the
+// per-file boundary cost goes from O(N) to O(1).
+//
+// Use case: Vite's dev server / SSR pre-render, which compile many
+// `.svelte` files in quick succession. With the legacy `compile()`
+// loop, each file pays the NAPI crossing + serde_json round-trip;
+// with `compileBatch` they share one.
+
+/// Single entry in a `compileBatch` worklist.
+#[napi(object)]
+pub struct CompileBatchInput {
+    pub source: String,
+    pub options: Option<Value>,
+}
+
+/// Compile multiple Svelte components in parallel via rayon, packing
+/// the results into one batch envelope. See `src/napi_raw.rs` for the
+/// byte format.
+#[napi(js_name = "compileBatch")]
+pub fn napi_compile_batch(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer> {
+    // Pre-parse every entry's options up front. Doing this here
+    // (rather than inside the rayon par_iter) keeps the NAPI/Value
+    // touchpoint single-threaded — `serde_json::Value` is `Send` but
+    // building it from a JS object isn't safe off the main thread.
+    let parsed: Vec<(String, crate::compiler::CompileOptions)> = inputs
+        .into_iter()
+        .map(|item| {
+            let opts = parse_options(&item.options.unwrap_or(Value::Null))?;
+            Ok::<_, napi::Error>((item.source, opts))
+        })
+        .collect::<napi::Result<_>>()?;
+
+    // Compile in parallel. `compile_batch` takes `&[(&str, CompileOptions)]`,
+    // so we materialise the borrowed view once.
+    let borrowed: Vec<(&str, crate::compiler::CompileOptions)> = parsed
+        .iter()
+        .map(|(s, o)| (s.as_str(), o.clone()))
+        .collect();
+    let results = crate::compiler::compile_batch(&borrowed);
+
+    // Build the BatchEntry view over the results so the encoder can
+    // walk them without taking ownership. Error messages format
+    // lazily and stay on the stack until encode time.
+    let err_strings: Vec<Option<String>> = results
+        .iter()
+        .map(|r| match r {
+            Ok(_) => None,
+            Err(e) => Some(format!("{e:?}")),
+        })
+        .collect();
+
+    let entries: Vec<crate::napi_raw::BatchEntry<'_>> = results
+        .iter()
+        .zip(err_strings.iter())
+        .map(|(r, e)| match r {
+            Ok(cr) => crate::napi_raw::BatchEntry::Ok(cr),
+            Err(_) => crate::napi_raw::BatchEntry::Err(e.as_deref().unwrap_or("unknown error")),
+        })
+        .collect();
+
+    Ok(Buffer::from(crate::napi_raw::encode_batch_to_vec(&entries)))
+}

--- a/src/napi_raw.rs
+++ b/src/napi_raw.rs
@@ -57,6 +57,19 @@ pub const FLAG_HAS_CSS: u32 = 1 << 0;
 pub const FLAG_RUNES: u32 = 1 << 1;
 pub const FLAG_CSS_HAS_GLOBAL: u32 = 1 << 2;
 
+// Batch envelope ("RSVB" — RSv Batch). Wraps N standard v1 envelopes
+// in a single buffer so a `compileBatch([…])` call crosses the
+// NAPI boundary exactly once instead of N times. Per-item slots
+// carry a status byte so individual failures can ride along
+// alongside successes without aborting the whole batch.
+pub const BATCH_MAGIC: u32 = 0x4256_5352; // "RSVB" little-endian read
+pub const BATCH_VERSION: u32 = 1;
+pub const BATCH_HEADER_LEN: usize = 16;
+pub const BATCH_ENTRY_LEN: usize = 12; // u32 status + u32 offset + u32 len
+
+pub const BATCH_STATUS_OK: u32 = 0;
+pub const BATCH_STATUS_ERR: u32 = 1;
+
 const WARN_HAS_FILENAME: u8 = 1 << 0;
 const WARN_HAS_START: u8 = 1 << 1;
 const WARN_HAS_END: u8 = 1 << 2;
@@ -246,6 +259,114 @@ fn write_position<W: Writer>(w: &mut W, p: &Position) {
 pub fn encode_to_vec(result: &CompileResult) -> Vec<u8> {
     let mut buf = Vec::with_capacity(estimate_size(result));
     encode_into(&mut buf, result);
+    buf
+}
+
+// =============================================================================
+// Batch envelope
+// =============================================================================
+//
+// ## Batch envelope layout
+//
+// ```text
+// offset  size  field
+// 0       4     magic       "RSVB" (0x4256_5352 LE)
+// 4       4     version     u32 LE
+// 8       4     total_len   u32 LE
+// 12      4     count       u32 LE — N entries
+// 16      12*N  entries     N × (u32 status, u32 offset, u32 len)
+// 16+12N  var   payloads    N concatenated payloads
+// ```
+//
+// Per-entry `status`:
+//   - 0 (`BATCH_STATUS_OK`) → payload is a standard v1 envelope
+//   - 1 (`BATCH_STATUS_ERR`) → payload is a UTF-8 error message
+//
+// Errors are encoded as plain UTF-8 (not an envelope) so the JS side
+// can lift them with one `buf.toString('utf8', off, off+len)` without
+// the v1 header overhead. The status byte tells the decoder which
+// branch to take per entry.
+
+/// A single entry to encode in a batch — either a successful
+/// `CompileResult` or an error message describing why that input failed.
+pub enum BatchEntry<'a> {
+    Ok(&'a CompileResult),
+    Err(&'a str),
+}
+
+/// Estimate the byte size of an encoded batch envelope. Used to
+/// pre-size the backing buffer in one shot.
+pub fn estimate_batch_size(entries: &[BatchEntry<'_>]) -> usize {
+    let mut n = BATCH_HEADER_LEN + entries.len() * BATCH_ENTRY_LEN;
+    for entry in entries {
+        n += match entry {
+            BatchEntry::Ok(r) => estimate_size(r),
+            BatchEntry::Err(msg) => msg.len(),
+        };
+    }
+    n
+}
+
+/// Encode a batch of compile results into `writer`. Mirrors
+/// `encode_into` for the single-result case but reserves index slots
+/// for `count` entries and then streams each payload.
+pub fn encode_batch_into<W: Writer>(writer: &mut W, entries: &[BatchEntry<'_>]) {
+    debug_assert_eq!(
+        writer.position(),
+        0,
+        "encode_batch_into expects an empty writer"
+    );
+    writer.write_bytes(&BATCH_MAGIC.to_le_bytes());
+    writer.write_bytes(&BATCH_VERSION.to_le_bytes());
+    writer.write_bytes(&[0u8; 4]); // total_len — patched at the end
+    writer.write_bytes(&(entries.len() as u32).to_le_bytes());
+
+    // Reserve the entry table — 12 bytes per entry, patched as
+    // payloads land below.
+    let entry_table_start = writer.position();
+    for _ in entries {
+        writer.write_bytes(&[0u8; BATCH_ENTRY_LEN]);
+    }
+    debug_assert_eq!(
+        writer.position(),
+        BATCH_HEADER_LEN + entries.len() * BATCH_ENTRY_LEN
+    );
+
+    // Stream payloads and patch each entry's (status, offset, len) triple.
+    for (i, entry) in entries.iter().enumerate() {
+        let off = writer.position();
+        match entry {
+            BatchEntry::Ok(result) => {
+                // Inline a v1 envelope for the entry. We can't call
+                // `encode_into` because it asserts the writer is empty,
+                // and the v1 header's offsets are relative to the v1
+                // envelope start, not the outer batch start. So we
+                // encode into a side vec, then splice it in.
+                let inner = encode_to_vec(result);
+                writer.write_bytes(&inner);
+                let entry_off = entry_table_start + i * BATCH_ENTRY_LEN;
+                writer.patch_u32(entry_off, BATCH_STATUS_OK);
+                writer.patch_u32(entry_off + 4, off as u32);
+                writer.patch_u32(entry_off + 8, inner.len() as u32);
+            }
+            BatchEntry::Err(msg) => {
+                writer.write_bytes(msg.as_bytes());
+                let entry_off = entry_table_start + i * BATCH_ENTRY_LEN;
+                writer.patch_u32(entry_off, BATCH_STATUS_ERR);
+                writer.patch_u32(entry_off + 4, off as u32);
+                writer.patch_u32(entry_off + 8, msg.len() as u32);
+            }
+        }
+    }
+
+    let total = writer.position();
+    writer.patch_u32(8, total as u32);
+}
+
+/// Encode a batch of results into a fresh `Vec<u8>`.
+pub fn encode_batch_to_vec(entries: &[BatchEntry<'_>]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(estimate_batch_size(entries));
+    encode_batch_into(&mut buf, entries);
     buf
 }
 
@@ -478,5 +599,90 @@ mod tests {
         let estimated = estimate_size(&result);
         let actual = encode_to_vec(&result).len();
         assert_eq!(estimated, actual, "size estimate must match actual");
+    }
+
+    fn make_result(code: &str) -> CompileResult {
+        CompileResult {
+            js: CompileOutput {
+                code: code.to_string(),
+                map: None,
+            },
+            css: None,
+            warnings: vec![],
+            metadata: CompileMetadata { runes: false },
+            ast: None,
+        }
+    }
+
+    #[test]
+    fn batch_envelope_roundtrips_mixed_ok_err() {
+        let a = make_result("// a");
+        let c = make_result("// c");
+        let entries = vec![
+            BatchEntry::Ok(&a),
+            BatchEntry::Err("parse error: unexpected token"),
+            BatchEntry::Ok(&c),
+        ];
+        let buf = encode_batch_to_vec(&entries);
+
+        let read_u32 = |o: usize| u32::from_le_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]);
+        assert_eq!(read_u32(0), BATCH_MAGIC, "batch magic");
+        assert_eq!(read_u32(4), BATCH_VERSION);
+        assert_eq!(read_u32(8) as usize, buf.len(), "total_len");
+        assert_eq!(read_u32(12), 3, "count");
+
+        let entry = |i: usize| {
+            let off = BATCH_HEADER_LEN + i * BATCH_ENTRY_LEN;
+            (
+                read_u32(off),
+                read_u32(off + 4) as usize,
+                read_u32(off + 8) as usize,
+            )
+        };
+
+        // Entry 0: success — payload should be a valid v1 envelope
+        let (status0, off0, len0) = entry(0);
+        assert_eq!(status0, BATCH_STATUS_OK);
+        let inner = &buf[off0..off0 + len0];
+        assert_eq!(
+            u32::from_le_bytes([inner[0], inner[1], inner[2], inner[3]]),
+            MAGIC,
+            "inner v1 magic"
+        );
+
+        // Entry 1: error — payload should be raw UTF-8
+        let (status1, off1, len1) = entry(1);
+        assert_eq!(status1, BATCH_STATUS_ERR);
+        assert_eq!(
+            std::str::from_utf8(&buf[off1..off1 + len1]).unwrap(),
+            "parse error: unexpected token"
+        );
+
+        // Entry 2: success
+        let (status2, _, _) = entry(2);
+        assert_eq!(status2, BATCH_STATUS_OK);
+    }
+
+    #[test]
+    fn batch_size_estimate_is_exact() {
+        let a = make_result("aaa");
+        let b = make_result("bbbb");
+        let entries = vec![
+            BatchEntry::Ok(&a),
+            BatchEntry::Err("oops"),
+            BatchEntry::Ok(&b),
+        ];
+        assert_eq!(
+            estimate_batch_size(&entries),
+            encode_batch_to_vec(&entries).len()
+        );
+    }
+
+    #[test]
+    fn batch_empty_is_valid() {
+        let buf = encode_batch_to_vec(&[]);
+        assert_eq!(buf.len(), BATCH_HEADER_LEN);
+        let read_u32 = |o: usize| u32::from_le_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]);
+        assert_eq!(read_u32(12), 0, "empty batch count is 0");
     }
 }


### PR DESCRIPTION
## Summary

Vite dev server / SSR pre-render / HMR all compile many `.svelte`
files per round. `compile()` pays the NAPI crossing + per-file
allocator setup N times. `compileBatch([{source, options}, …])`
collapses that to a single call:

- **Rust side** uses the existing `compile_batch` (rayon `par_iter`),
  so the N compiles run in parallel across cores.
- **Results pack into one \"RSVB\" envelope** (format documented in
  `src/napi_raw.rs`): 16-byte header + 12-byte-per-entry index + N
  concatenated v1 envelopes. Per-entry failures ride along as UTF-8
  error messages without aborting the batch.
- **JS decoder** (`decodeBatch`) returns `Array<CompileResult | Error>`;
  each successful slot's `js.code` / `js.map` / `warnings` defer to
  the existing v1 lazy decoder.

## Benchmark (Apple M-series, Node 24)

16 copies of a 50-line component, 200 iter, with warm-up:

| Path | µs/iter |
|---|---|
| loop: 16x `binding.compile()` | 2693 |
| loop: 16x `compileEnvelope+decode` | 2622 |
| **batch: 1x `compileBatch(16)`** | **846 (3.2x faster)** |
| batch: `compileBatch+decodeBatch(16)` | 897 |

The win scales with batch size (rayon utilises all cores).

## Test plan

- [x] 3 new unit tests in `napi_raw::tests` (batch round-trip with mixed OK/ERR, exact size estimate, empty batch)
- [x] `cargo test --lib` — 524 pre-existing tests still pass (no regressions)
- [x] E2E script: parse error mid-batch surfaces as `Error` at the right slot; the other entries decode correctly
- [x] Released cdylib loads, exports include `compileBatch`

## Notes

- Errors are encoded as raw UTF-8 (status byte = 1) inside the batch envelope rather than as a synthetic v1 envelope, so `Error` slots cost one `buf.toString('utf8')` to materialize.
- `compileBatch` is sync today; an async variant (next PR in the perf series) will release the JS thread while rayon works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)