### PR TITLE
perf(transform/client): leaf short-circuit for has_call / has_member / has_await

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -4954,6 +4954,14 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
 /// Pure calls with only pure arguments are not counted.
 #[inline]
 pub fn expression_has_call(expr: &crate::ast::js::Expression, context: &ComponentContext) -> bool {
+    // Fast path: a leaf expression (Identifier, Literal, …) trivially
+    // contains no call. Returning early here avoids the `as_json()`
+    // serialization for `Expression::Typed` inputs, which would
+    // otherwise lower the whole JsNode into a `serde_json::Value`
+    // just to discover there's no CallExpression to find.
+    if is_call_member_await_free_leaf(expr) {
+        return false;
+    }
     has_call_json(expr.as_json(), context)
 }
 
@@ -5207,6 +5215,10 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
 /// Returns true if the expression contains a MemberExpression at any level.
 #[inline]
 pub fn expression_has_member(expr: &crate::ast::js::Expression) -> bool {
+    // Leaf short-circuit — see `expression_has_call` for the rationale.
+    if is_call_member_await_free_leaf(expr) {
+        return false;
+    }
     has_member_json(expr.as_json())
 }
 
@@ -5327,7 +5339,39 @@ fn has_member_json(json_value: &serde_json::Value) -> bool {
 /// Returns true if the expression contains an AwaitExpression at any level.
 #[inline]
 pub fn expression_has_await(expr: &crate::ast::js::Expression) -> bool {
+    // Leaf short-circuit — see `expression_has_call` for the rationale.
+    if is_call_member_await_free_leaf(expr) {
+        return false;
+    }
     has_await_json(expr.as_json())
+}
+
+/// Type-dispatch fast path used by `expression_has_call` /
+/// `expression_has_member` / `expression_has_await` to skip the
+/// full `as_json()` serialization for expressions that can't
+/// possibly contain a CallExpression / MemberExpression /
+/// AwaitExpression.
+///
+/// Only types listed here are leaves in *all three* predicates — a
+/// `MemberExpression` for instance is a leaf for `has_call` /
+/// `has_await` but not for `has_member`, so it's intentionally
+/// excluded.
+///
+/// `node_type()` is O(1) for both `Expression::Typed` (enum dispatch)
+/// and `Expression::Value` (single HashMap lookup) — no allocation.
+#[inline]
+fn is_call_member_await_free_leaf(expr: &crate::ast::js::Expression) -> bool {
+    matches!(
+        expr.node_type(),
+        Some(
+            "Identifier"
+                | "PrivateIdentifier"
+                | "Literal"
+                | "ThisExpression"
+                | "Super"
+                | "MetaProperty"
+        )
+    )
 }
 
 /// Internal helper that checks for AwaitExpression in JSON values.


### PR DESCRIPTION
## Summary

\`expression_has_call\`, \`expression_has_member\`, and
\`expression_has_await\` were unconditionally calling \`expr.as_json()\`,
then walking the resulting \`serde_json::Value\` looking for a
CallExpression / MemberExpression / AwaitExpression somewhere in the
tree. For \`Expression::Typed\` inputs (the common case after the
typed-options PR series) \`as_json()\` triggers a full serialization
of the JsNode tree the first time it's called — meaningful for big
AST nodes, and entirely wasted when the expression is a leaf that
trivially contains none of those node kinds.

Add a \`node_type()\`-based fast path. Six expression shapes are
leaves for *all three* predicates (Identifier, PrivateIdentifier,
Literal, ThisExpression, Super, MetaProperty) — they short-circuit
to \`false\` without paying the serialization. \`node_type()\` is O(1)
for both \`Expression::Typed\` (enum dispatch) and \`Expression::Value\`
(single HashMap lookup), so the optimisation costs essentially nothing
on the non-leaf path either.

## Correctness notes

- \`MemberExpression\` is intentionally *not* in the leaf list — it's a
  leaf for \`has_call\` / \`has_await\` but not for \`has_member\`. The
  shared list is the intersection.
- For \`Expression::Value\` the JSON-walk path still runs unchanged,
  so any existing JSON-shaped expression with a non-standard \`type\`
  string falls back to the legacy behaviour.

## Test plan

- [x] \`cargo test --lib --release\` clean (524/524)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --all-features -D warnings\` clean
- [x] Logic preserved: leaf types previously returned false via the
  catch-all arm of \`has_*_json\`; the short-circuit returns false
  directly without changing semantics

## Scope

One small, mechanical step in the larger Phase 3 JSON-dispatch
elimination (PERF_ROADMAP.md). A full conversion needs JsNode-based
walkers threaded with arena access — properly done after the arena
migration in the same roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)