### PR TITLE
perf(transform/client): AST-based $state<T>/$derived<T> generic strip for module scripts

### DIFF
--- a/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -111,6 +111,10 @@ pub(super) fn extract_var_name_before_rune(before_rune: &str) -> String {
     }
 }
 
+/// Kept for reference + rolling Phase A migration fallback; the
+/// live module-script path now goes through
+/// `strip_rune_generics_ast::strip_rune_generic_params_ast`.
+#[allow(dead_code)]
 pub(super) fn strip_rune_generic_params(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
     let len = chars.len();

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -19,6 +19,7 @@ mod state;
 mod state_transforms;
 mod store_transforms;
 mod strict_equals_ast;
+mod strip_rune_generics_ast;
 pub mod transform_client;
 pub mod transform_template;
 pub mod types;
@@ -2424,7 +2425,22 @@ pub(crate) fn transform_module_script_runes(
     // Strip TypeScript generic parameters from $state<...>() and $derived<...>() calls.
     // These are type-only annotations that have no runtime meaning.
     // e.g., $state<ReturnType<typeof autoUpdate>>() → $state()
-    result = strip_rune_generic_params(&result);
+    //
+    // AST-based rewrite via `strip_rune_generics_ast`. The text predecessor
+    // tracked angle-bracket depth + string-literal context + the `=>` arrow
+    // operator by hand to avoid mistaking `=>` for a closing `>`. The OXC
+    // parser already knows about all of that, so the visitor just walks
+    // CallExpressions and asks "is the callee `$state`/`$derived` with type
+    // arguments?". Falls back to the original `result` when the source isn't
+    // TS (generics aren't legal) or fails to parse.
+    {
+        let is_ts = analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
+        if let Some(rewritten) =
+            strip_rune_generics_ast::strip_rune_generic_params_ast(&result, is_ts)
+        {
+            result = rewritten;
+        }
+    }
 
     // Extract local reactive variable names from the module script
     // These are variables declared with $state() or $derived() inside functions

--- a/src/compiler/phases/3_transform/client/strip_rune_generics_ast.rs
+++ b/src/compiler/phases/3_transform/client/strip_rune_generics_ast.rs
@@ -1,0 +1,206 @@
+//! AST-based stripping of TypeScript generic parameters from
+//! `$state<...>()` / `$derived<...>()` calls in module scripts
+//! (`.svelte.js` / `.svelte.ts`).
+//!
+//! The rune calls accept type arguments for IDE type narrowing
+//! (`$state<ReturnType<typeof autoUpdate>>()`), but those are purely
+//! type-level — the runtime needs `$state()` / `$derived()` without
+//! the angle-bracketed payload.
+//!
+//! Replaces the text-based `expression_utils::strip_rune_generic_params`,
+//! a ~70 LOC char-by-char scanner that tracked angle-bracket depth
+//! while also paying attention to string literals (to skip `<` / `>`
+//! inside them) and the `=>` arrow operator (which it must not
+//! mistake for a closing `>`). All of that complexity is replaced by
+//! one OXC parse + targeted visitor: the parser knows about strings,
+//! arrows, and nested generics, so the visitor just asks "does this
+//! `CallExpression` have type arguments?".
+//!
+//! Only `$state` and `$derived` qualify — other generic call
+//! expressions (`fn<T>(...)`) are left untouched so the text remains
+//! valid TypeScript downstream.
+
+use std::cell::RefCell;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_ast_visit::walk;
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+
+thread_local! {
+    static MODULE_STRIP_GENERICS_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+}
+
+/// AST-based rewrite of `$state<...>()` / `$derived<...>()` →
+/// `$state()` / `$derived()`. Returns `None` when nothing changed
+/// (no `$state` / `$derived` in source, no generics on those calls,
+/// or parse failure).
+pub fn strip_rune_generic_params_ast(source: &str, is_ts: bool) -> Option<String> {
+    // Generic arguments are TS-only syntax — if the file is plain JS,
+    // there's nothing to strip. (Even in `.svelte.js` files, anyone
+    // writing `$state<T>` is mistaken; we leave it to whatever
+    // downstream pass yells about it.)
+    if !is_ts {
+        return None;
+    }
+    // Fast probe — most module scripts don't use either rune.
+    if memchr::memmem::find(source.as_bytes(), b"$state").is_none()
+        && memchr::memmem::find(source.as_bytes(), b"$derived").is_none()
+    {
+        return None;
+    }
+
+    MODULE_STRIP_GENERICS_ALLOC.with(|cell| {
+        let allocator = std::mem::take(&mut *cell.borrow_mut());
+        let parser_ret =
+            Parser::new(&allocator, source, SourceType::ts().with_module(true)).parse();
+        if !parser_ret.errors.is_empty() {
+            *cell.borrow_mut() = allocator;
+            return None;
+        }
+
+        let mut collector = StripGenericsCollector {
+            spans_to_strip: Vec::new(),
+        };
+        collector.visit_program(&parser_ret.program);
+        let mut spans = collector.spans_to_strip;
+
+        if spans.is_empty() {
+            *cell.borrow_mut() = allocator;
+            return None;
+        }
+
+        // Spans are guaranteed non-overlapping (each is the type-args
+        // region of a distinct call); right-to-left splice preserves
+        // offsets.
+        spans.sort_by_key(|s| std::cmp::Reverse(s.0));
+        let mut out = source.to_string();
+        for (start, end) in &spans {
+            out.replace_range(*start as usize..*end as usize, "");
+        }
+
+        *cell.borrow_mut() = allocator;
+        Some(out)
+    })
+}
+
+struct StripGenericsCollector {
+    /// `(start, end)` byte offsets of `<...>` regions to delete.
+    spans_to_strip: Vec<(u32, u32)>,
+}
+
+impl<'a> Visit<'a> for StripGenericsCollector {
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        walk::walk_call_expression(self, call);
+
+        let Some(type_args) = &call.type_arguments else {
+            return;
+        };
+        // Match `$state` or `$derived` (bare identifier callee only;
+        // member expressions like `$state.raw<T>(...)` aren't a thing
+        // the runtime accepts but if they appear leave them be).
+        let Expression::Identifier(id) = &call.callee else {
+            return;
+        };
+        if id.name != "$state" && id.name != "$derived" {
+            return;
+        }
+        self.spans_to_strip
+            .push((type_args.span().start, type_args.span().end));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_state_generic() {
+        let out = strip_rune_generic_params_ast("let x = $state<number>(0);", true).unwrap();
+        assert_eq!(out, "let x = $state(0);");
+    }
+
+    #[test]
+    fn strips_derived_generic() {
+        let out =
+            strip_rune_generic_params_ast("let y = $derived<string>(x.toString());", true).unwrap();
+        assert_eq!(out, "let y = $derived(x.toString());");
+    }
+
+    #[test]
+    fn strips_nested_generic() {
+        let out = strip_rune_generic_params_ast(
+            "let z = $state<ReturnType<typeof setup>>(setup());",
+            true,
+        )
+        .unwrap();
+        assert_eq!(out, "let z = $state(setup());");
+    }
+
+    #[test]
+    fn leaves_non_rune_generic_alone() {
+        // `fn<T>()` is unrelated — only $state / $derived are stripped.
+        let src = "fn<number>(0)";
+        assert!(strip_rune_generic_params_ast(src, true).is_none());
+    }
+
+    #[test]
+    fn leaves_state_without_generic_alone() {
+        assert!(strip_rune_generic_params_ast("let x = $state(0);", true).is_none());
+    }
+
+    #[test]
+    fn skips_js_source_type() {
+        // No-op for plain JS — generics aren't legal there.
+        assert!(strip_rune_generic_params_ast("let x = $state<T>(0);", false).is_none());
+    }
+
+    #[test]
+    fn leaves_string_literal_alone() {
+        // Text-version specifically had to handle this; AST descends
+        // only into expressions, so the string is untouched
+        // automatically. The whole source has no rune to strip, so
+        // the function returns None.
+        let src = r#"let s = "$state<T>(x)";"#;
+        assert!(strip_rune_generic_params_ast(src, true).is_none());
+    }
+
+    #[test]
+    fn leaves_arrow_operator_alone() {
+        // The text version tracked `=>` to avoid mistaking the `>`
+        // for a closing angle bracket. AST has no such concern —
+        // arrow expressions are their own AST node.
+        let src = "let cb = () => $state<T>(0);";
+        let out = strip_rune_generic_params_ast(src, true).unwrap();
+        assert_eq!(out, "let cb = () => $state(0);");
+    }
+
+    #[test]
+    fn multiple_calls_in_one_file() {
+        let src = r#"
+let a = $state<number>(1);
+let b = $derived<string>(a.toString());
+let c = $state(2);
+        "#;
+        let out = strip_rune_generic_params_ast(src, true).unwrap();
+        assert!(out.contains("let a = $state(1);"));
+        assert!(out.contains("let b = $derived(a.toString());"));
+        assert!(out.contains("let c = $state(2);"));
+        // The original generic bytes are gone:
+        assert!(!out.contains("<number>"));
+        assert!(!out.contains("<string>"));
+    }
+
+    #[test]
+    fn parse_error_returns_none() {
+        // Falls through cleanly without mutation.
+        assert!(strip_rune_generic_params_ast("let x = $state<T>(", true).is_none());
+    }
+
+    #[test]
+    fn no_op_without_runes() {
+        assert!(strip_rune_generic_params_ast("let x = 1;", true).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Phase A continuation (after #180, #181, #182). Replace the
text-based `expression_utils::strip_rune_generic_params`
char-by-char scanner with an OXC-AST visitor for module scripts.

The text predecessor (~70 LOC) tracked angle-bracket depth while
also paying attention to string literals (to skip `<` / `>` inside
them) and the `=>` arrow operator (which it must not mistake for a
closing `>`). All of that complexity is replaced by one OXC parse +
targeted visitor: the parser already knows about strings, arrows,
nested generics, and TS type-argument syntax in general, so the
visitor just asks "does this `CallExpression` have type arguments
and is the callee `$state` / `$derived`?".

## Implementation

`src/compiler/phases/3_transform/client/strip_rune_generics_ast.rs` (new, ~210 LOC):

- Source must be TypeScript (`.svelte.ts`) — generic arguments
  aren't legal JS, so short-circuit early for `.svelte.js`.
- Visit each `CallExpression`. If `call.type_arguments` is `Some`
  and `call.callee` is an `Identifier` whose name is `$state` or
  `$derived`, splice out the `<...>` span. Other generic call
  expressions (`fn<T>(...)`) are left untouched.
- Spans are non-overlapping by construction; right-to-left splice
  preserves offsets.

## Test plan

- [x] 11 unit tests cover: $state generic, $derived generic, nested
  generic (`$state<ReturnType<typeof setup>>`), non-rune generic
  left alone, no-generic call left alone, JS source-type skip,
  string-literal safety, arrow-operator safety, multiple calls in
  one file, parse-error fallback, no-op probe
- [x] Full lib suite passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)