### PR TITLE
perf(transform/client): AST-based $state.snapshot rewrite for module scripts

### DIFF
--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -16,6 +16,7 @@ mod props_transforms;
 mod reactive_transforms;
 mod rune_transforms;
 mod state;
+mod state_snapshot_ast;
 mod state_transforms;
 mod store_transforms;
 mod strict_equals_ast;
@@ -2494,10 +2495,20 @@ pub(crate) fn transform_module_script_runes(
         .cloned()
         .collect();
 
-    // Transform $state.snapshot(x) to $.snapshot(x)
-    // Module scripts don't need dev-mode handling for state_snapshot_uncloneable
-    if memmem::find(result.as_bytes(), b"$state.snapshot(").is_some() {
-        result = result.replace("$state.snapshot(", "$.snapshot(");
+    // Transform $state.snapshot(x) to $.snapshot(x).
+    // Module scripts don't need dev-mode handling for state_snapshot_uncloneable.
+    //
+    // AST-based rewrite via `state_snapshot_ast::transform_state_snapshot_ast`.
+    // The text version was `String::replace("$state.snapshot(", "$.snapshot(")`
+    // — rewrites byte patterns regardless of lexical context, so anything inside
+    // a string / template literal got (incorrectly) rewritten too. The AST
+    // visitor descends only into expression positions and can't make that
+    // mistake.
+    {
+        let is_ts = analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
+        if let Some(rewritten) = state_snapshot_ast::transform_state_snapshot_ast(&result, is_ts) {
+            result = rewritten;
+        }
     }
 
     // Transform $state.raw(x) / $state.frozen(x).

--- a/src/compiler/phases/3_transform/client/state_snapshot_ast.rs
+++ b/src/compiler/phases/3_transform/client/state_snapshot_ast.rs
@@ -1,0 +1,180 @@
+//! AST-based `$state.snapshot(x)` → `$.snapshot(x)` rewrite for
+//! module scripts (`.svelte.js` / `.svelte.ts`).
+//!
+//! Replaces the text-based `result.replace("$state.snapshot(",
+//! "$.snapshot(")` call in `mod.rs`. The bare `String::replace`
+//! rewrites byte patterns indiscriminately — `let s =
+//! "$state.snapshot("` would (incorrectly) become `let s =
+//! "$.snapshot("`. The AST visitor only descends into expression
+//! positions, so it can't make that class of mistake.
+//!
+//! The companion `$state.raw(...)` / `$state.frozen(...)` rewrites
+//! intentionally aren't here — they depend on per-variable
+//! analysis (which module bindings are reassigned vs not) to choose
+//! between wrapping in `$.state(...)` and emitting the raw value.
+//! That plumbing belongs in a follow-up PR.
+
+use std::cell::RefCell;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_ast_visit::walk;
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+
+thread_local! {
+    static MODULE_SNAPSHOT_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+}
+
+/// AST-based rewrite of `$state.snapshot(x)` → `$.snapshot(x)`.
+/// Returns `None` when nothing changed.
+pub fn transform_state_snapshot_ast(source: &str, is_ts: bool) -> Option<String> {
+    // Fast probe — most module scripts don't reference $state.snapshot.
+    memchr::memmem::find(source.as_bytes(), b"$state.snapshot")?;
+
+    MODULE_SNAPSHOT_ALLOC.with(|cell| {
+        let allocator = std::mem::take(&mut *cell.borrow_mut());
+        let source_type = if is_ts {
+            SourceType::ts().with_module(true)
+        } else {
+            SourceType::mjs()
+        };
+        let parser_ret = Parser::new(&allocator, source, source_type).parse();
+        if !parser_ret.errors.is_empty() {
+            *cell.borrow_mut() = allocator;
+            return None;
+        }
+
+        let mut collector = SnapshotCollector { spans: Vec::new() };
+        collector.visit_program(&parser_ret.program);
+        let mut spans = collector.spans;
+
+        if spans.is_empty() {
+            *cell.borrow_mut() = allocator;
+            return None;
+        }
+
+        // Each replacement is a callee swap on a distinct call, so
+        // spans don't overlap. Right-to-left splice preserves offsets.
+        spans.sort_by_key(|s| std::cmp::Reverse(s.0));
+        let mut out = source.to_string();
+        for (start, end) in &spans {
+            out.replace_range(*start as usize..*end as usize, "$.snapshot");
+        }
+
+        *cell.borrow_mut() = allocator;
+        Some(out)
+    })
+}
+
+struct SnapshotCollector {
+    /// `(start, end)` byte offsets of `$state.snapshot` callee
+    /// chains to overwrite with `$.snapshot`.
+    spans: Vec<(u32, u32)>,
+}
+
+impl<'a> Visit<'a> for SnapshotCollector {
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        walk::walk_call_expression(self, call);
+
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+        let Expression::Identifier(obj) = &member.object else {
+            return;
+        };
+        if obj.name != "$state" || member.property.name != "snapshot" {
+            return;
+        }
+        // Swap just the callee text (`$state.snapshot`) — the call's
+        // argument list stays verbatim.
+        self.spans.push((member.span().start, member.span().end));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_snapshot_call() {
+        let out = transform_state_snapshot_ast("let s = $state.snapshot(x);", false).unwrap();
+        assert_eq!(out, "let s = $.snapshot(x);");
+    }
+
+    #[test]
+    fn rewrites_snapshot_with_complex_arg() {
+        let out =
+            transform_state_snapshot_ast("let s = $state.snapshot(obj.field);", false).unwrap();
+        assert_eq!(out, "let s = $.snapshot(obj.field);");
+    }
+
+    #[test]
+    fn rewrites_multiple_calls() {
+        let src = "let a = $state.snapshot(x); let b = $state.snapshot(y);";
+        let out = transform_state_snapshot_ast(src, false).unwrap();
+        assert_eq!(out, "let a = $.snapshot(x); let b = $.snapshot(y);");
+    }
+
+    #[test]
+    fn does_not_rewrite_inside_string_literal() {
+        // This is the bug class the AST migration fixes.
+        let src = r#"let s = "$state.snapshot(x)";"#;
+        assert!(transform_state_snapshot_ast(src, false).is_none());
+    }
+
+    #[test]
+    fn does_not_rewrite_inside_template_static() {
+        let src = "let s = `$state.snapshot(x)`;";
+        assert!(transform_state_snapshot_ast(src, false).is_none());
+    }
+
+    #[test]
+    fn rewrites_inside_template_expression() {
+        let src = "let s = `${$state.snapshot(x)}`;";
+        let out = transform_state_snapshot_ast(src, false).unwrap();
+        assert_eq!(out, "let s = `${$.snapshot(x)}`;");
+    }
+
+    #[test]
+    fn leaves_other_state_methods_alone() {
+        for src in [
+            "$state.raw(x)",
+            "$state.frozen(x)",
+            "$state(x)",
+            "$state.bogus(x)",
+        ] {
+            assert!(
+                transform_state_snapshot_ast(src, false).is_none(),
+                "should not rewrite: {src}"
+            );
+        }
+    }
+
+    #[test]
+    fn handles_chained_member_access_after_call() {
+        // `$state.snapshot(x).foo` is a member access on the call
+        // result. The callee swap is still applied to the inner call.
+        let src = "let s = $state.snapshot(x).foo;";
+        let out = transform_state_snapshot_ast(src, false).unwrap();
+        assert_eq!(out, "let s = $.snapshot(x).foo;");
+    }
+
+    #[test]
+    fn ts_source_works() {
+        let src = "let s: number = $state.snapshot(x);";
+        let out = transform_state_snapshot_ast(src, true).unwrap();
+        assert!(out.contains("$.snapshot(x)"));
+    }
+
+    #[test]
+    fn parse_error_returns_none() {
+        assert!(transform_state_snapshot_ast("let x = $state.snapshot(", false).is_none());
+    }
+
+    #[test]
+    fn no_op_without_keyword() {
+        assert!(transform_state_snapshot_ast("let x = 1;", false).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Phase A continuation (after #180, #181, #182, #183). Replace the
text-based `result.replace("$state.snapshot(", "$.snapshot(")` in
`transform_module_script_runes` with an OXC-AST visitor.

The text version was a bare `String::replace` — rewrites byte
patterns indiscriminately, so `let s = "$state.snapshot("` would
be (incorrectly) rewritten to `let s = "$.snapshot("`. Same
fragility class as the previous AST migrations.

## Implementation

`src/compiler/phases/3_transform/client/state_snapshot_ast.rs` (new, ~180 LOC):

- Walk `CallExpression`s.
- If callee is `$state.snapshot` (a `StaticMemberExpression` whose
  `object` is `Identifier($state)` and `property` is `snapshot`),
  splice the member-expression span with `$.snapshot`.
- Argument list / surrounding source preserved verbatim.

## Scope

The companion `$state.raw(...)` / `$state.frozen(...)` rewrites
intentionally aren't in this PR — they depend on per-variable
analysis (which module bindings are reassigned vs not) to choose
between wrapping in `$.state(...)` and emitting the raw value.
Follow-up.

## Test plan

- [x] 11 unit tests cover: basic call, complex argument, multiple
  calls in one source, string-literal safety, static-template
  safety, template-literal expression interpolation, other $state
  methods left alone, chained `.foo` after call, TypeScript source,
  parse-error fallback, no-op probe
- [x] Full lib suite passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)