### PR TITLE
perf(transform/client): extend console.METHOD AST rewrite to instance scripts

### DIFF
--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4139,9 +4139,18 @@ fn transform_instance_script_for_visitors(
 
         // In dev mode, wrap console.METHOD() calls with $.log_if_contains_state
         // to detect when state proxies are logged directly.
-        // Reference: CallExpression.js in the official Svelte compiler
+        // Reference: CallExpression.js in the official Svelte compiler.
+        //
+        // Try the AST-based rewrite first (same helper as the module-script
+        // path); fall back to the legacy text scanner if the statement
+        // fragment fails to parse standalone (rare — the parser is lenient
+        // for any complete expression / statement). The AST path fixes the
+        // quote-counting string-skip heuristic that the text version uses.
         let transformed = if dev {
-            transform_console_calls_dev(&transformed)
+            let is_ts =
+                analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
+            console_dev_ast::transform_console_calls_dev_ast(&transformed, is_ts)
+                .unwrap_or_else(|| transform_console_calls_dev(&transformed))
         } else {
             transformed
         };


### PR DESCRIPTION
## Summary

Phase A continuation. The instance-script per-statement loop in
`transform_client_with_visitors` still called the legacy text-based
`transform_console_calls_dev`. Swap it for the AST-based
`console_dev_ast::transform_console_calls_dev_ast` already used by
module scripts (#182), with a fallback to the text version on parse
failure.

## Why the fallback

The instance-script call site receives a single transformed
statement (a fragment of the broader script). Most fragments parse
standalone, but edge cases (e.g. a free expression at the top of a
class body) might not. If AST parse fails, keep the legacy text
scanner — the worst case stays equivalent to today's behaviour. When
the AST path succeeds (the common case), we get the same fragility
improvements as #182: string-literal safety, regex-literal safety,
template-literal interpolation correctness.

## Test plan

- [x] 584/584 lib tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -D warnings` clean
- [x] CI's compatibility report (3341 fixtures) is the gate — local
  can't regenerate without `pnpm run generate-fixtures`

🤖 Generated with [Claude Code](https://claude.com/claude-code)