### PR TITLE
perf(transform/client): AST-based $effect rune rewrite in class transforms

### DIFF
--- a/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -1520,14 +1520,28 @@ pub(super) fn transform_constructor_assignment(line: &str, fields: &[ClassStateF
         }
     }
 
-    // Transform $effect.pre -> $.user_pre_effect
-    if memmem::find(result.as_bytes(), b"$effect.pre(").is_some() {
-        result = result.replace("$effect.pre(", "$.user_pre_effect(");
-    }
-
-    // Transform $effect -> $.user_effect
-    if memmem::find(result.as_bytes(), b"$effect(").is_some() {
-        result = result.replace("$effect(", "$.user_effect(");
+    // Transform `$effect.pre(...)` / `$effect(...)` (and the other
+    // members of the `$effect` family — `.root`, `.tracking`,
+    // `.pending`). Bare `String::replace` was the predecessor; it
+    // rewrites byte patterns regardless of lexical context, so
+    // string literals containing `$effect(` would be mangled. The
+    // AST helper (shared with the module-script path) only touches
+    // expression positions. Fall back to the legacy text scanner
+    // for the rare case where this constructor-line fragment fails
+    // to parse standalone (e.g. an incomplete partial statement
+    // produced by an earlier text pass).
+    if memmem::find(result.as_bytes(), b"$effect").is_some() {
+        result = super::effect_rune_ast::apply_effect_rune_transforms_ast(&result, false)
+            .unwrap_or_else(|| {
+                let mut r = result.clone();
+                if memmem::find(r.as_bytes(), b"$effect.pre(").is_some() {
+                    r = r.replace("$effect.pre(", "$.user_pre_effect(");
+                }
+                if memmem::find(r.as_bytes(), b"$effect(").is_some() {
+                    r = r.replace("$effect(", "$.user_effect(");
+                }
+                r
+            });
     }
 
     // Check for private field assignment: this.#name = value


### PR DESCRIPTION
## Summary

Phase A continuation. The class-transform pipeline
(`class_transforms.rs::transform_constructor_assignment`) had its own
bare `String::replace("$effect.pre(", "$.user_pre_effect(")` and
`String::replace("$effect(", "$.user_effect(")` calls. Swap them for
the AST-based `effect_rune_ast::apply_effect_rune_transforms_ast`
already used by module scripts (#181), with a fallback to the legacy
text replacements on parse failure.

## Why the fallback

The input is a constructor-assignment line — a fragment, not a full
module. While most fragments parse standalone, edge cases (incomplete
continuations from an earlier text pass) might not. When AST succeeds
(the common case) we get the same fragility improvements as #181:
string-literal safety, regex-literal safety, template-literal
interpolation correctness.

## Test plan

- [x] 627/627 lib tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -D warnings` clean
- [x] CI's compatibility report (3341 fixtures) is the gate — local
  can't regenerate without `pnpm run generate-fixtures`

🤖 Generated with [Claude Code](https://claude.com/claude-code)