### PR TITLE
perf(transform/server): AST-based SSR template rune simplifications

### DIFF
--- a/src/compiler/phases/3_transform/server/mod.rs
+++ b/src/compiler/phases/3_transform/server/mod.rs
@@ -7,6 +7,7 @@
 pub mod bridge;
 pub mod build;
 pub mod helpers;
+mod template_rune_ast;
 pub mod transform_legacy;
 pub mod transform_script;
 pub mod transform_store;
@@ -1012,23 +1013,23 @@ impl<'a> ServerCodeGenerator<'a> {
     pub(crate) fn transform_rune_in_template_expr(expr: &str) -> String {
         use crate::compiler::phases::phase3_transform::server::transform_script::remove_effect_blocks;
 
-        let result_bytes = expr.as_bytes();
+        // AST-based pass: handles `$state.snapshot(x)` → `$.snapshot(x)`,
+        // `$state.eager(x)` → `x` (whole-call unwrap), `$effect.tracking()` →
+        // `false`, `$effect.pending()` → `0` in one parse. Replaces the
+        // text-based byte scanners (`String::replace` + a custom
+        // brace/quote tracker) that could be tripped by the same byte
+        // patterns inside string literals. The AST visitor descends only
+        // into expression positions. Returns `None` on parse failure, in
+        // which case we leave the source untouched — the legacy text
+        // helpers below covered cases that were already malformed
+        // anyway.
         let mut result = expr.to_string();
-        // $state.eager(x) -> x (unwrap the rune call)
-        if memmem::find(result_bytes, b"$state.eager(").is_some() {
-            result = transform_rune_call_simple(&result, "$state.eager(");
-        }
-        // $state.snapshot(x) -> $.snapshot(x)
-        if memmem::find(result.as_bytes(), b"$state.snapshot(").is_some() {
-            result = result.replace("$state.snapshot(", "$.snapshot(");
-        }
-        // $effect.tracking() -> false
-        if memmem::find(result.as_bytes(), b"$effect.tracking()").is_some() {
-            result = result.replace("$effect.tracking()", "false");
-        }
-        // $effect.pending() -> 0 (number, matching official compiler)
-        if memmem::find(result.as_bytes(), b"$effect.pending()").is_some() {
-            result = result.replace("$effect.pending()", "0");
+        if let Some(rewritten) =
+            crate::compiler::phases::phase3_transform::server::template_rune_ast::transform_template_rune_ast(
+                &result,
+            )
+        {
+            result = rewritten;
         }
         // Remove $effect(), $effect.pre(), $effect.root(), $inspect(), $inspect.trace() blocks
         // These are client-side only and should be stripped in SSR template expressions too

--- a/src/compiler/phases/3_transform/server/template_rune_ast.rs
+++ b/src/compiler/phases/3_transform/server/template_rune_ast.rs
@@ -1,0 +1,265 @@
+//! AST-based simplification of rune calls inside SSR template
+//! expressions.
+//!
+//! Server-side rendering doesn't have a reactivity runtime, so the
+//! rune calls that gate reactivity in the client collapse to
+//! constant values:
+//!
+//! | Source                 | Replacement            |
+//! |------------------------|------------------------|
+//! | `$state.snapshot(x)`   | `$.snapshot(x)`        |
+//! | `$state.eager(x)`      | `x` (unwrap)           |
+//! | `$effect.tracking()`   | `false`                |
+//! | `$effect.pending()`    | `0`                    |
+//!
+//! Replaces the text-based byte scanners in
+//! `server::mod.rs::transform_rune_in_template_expr`
+//! (`String::replace` for the static-output rewrites, and
+//! `transform_rune_call_simple` — a brace tracker with quote-aware
+//! skip — for `$state.eager(x)` unwrap). Same fragility class as
+//! the client-side AST migrations: bare `String::replace` rewrites
+//! byte patterns regardless of lexical context, so a string literal
+//! containing `$state.snapshot(` would be (incorrectly) rewritten.
+//! The AST visitor descends only into expression positions.
+
+use std::cell::RefCell;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_ast_visit::walk;
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+
+thread_local! {
+    static SSR_TEMPLATE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+}
+
+/// AST-based simplification of `$state.snapshot` / `$state.eager` /
+/// `$effect.tracking()` / `$effect.pending()` in an SSR template
+/// expression. Returns `None` when there's nothing to rewrite.
+pub fn transform_template_rune_ast(source: &str) -> Option<String> {
+    // Fast probe — most expressions don't reference these runes.
+    if memchr::memmem::find(source.as_bytes(), b"$state").is_none()
+        && memchr::memmem::find(source.as_bytes(), b"$effect").is_none()
+    {
+        return None;
+    }
+
+    // Nested cases (`$state.snapshot($state.eager(x))`) need the
+    // outer rewrite to use the *already-rewritten* inner text.
+    // Same fixed-point strategy as the other AST helpers.
+    let mut current: Option<String> = None;
+    loop {
+        let src = current.as_deref().unwrap_or(source);
+        match single_pass(src) {
+            None => break,
+            Some(rewritten) => current = Some(rewritten),
+        }
+    }
+    current
+}
+
+fn single_pass(source: &str) -> Option<String> {
+    SSR_TEMPLATE_ALLOC.with(|cell| {
+        let allocator = std::mem::take(&mut *cell.borrow_mut());
+        // Template expressions don't have module-level imports/exports
+        // syntax inside them, but parsing them as a Program is the
+        // shape OXC expects. `mjs()` is permissive enough; on parse
+        // failure we just return None and the caller keeps the source.
+        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
+        if !parser_ret.errors.is_empty() {
+            *cell.borrow_mut() = allocator;
+            return None;
+        }
+
+        let mut collector = TemplateRuneCollector {
+            source,
+            replacements: Vec::new(),
+        };
+        collector.visit_program(&parser_ret.program);
+        let mut replacements = collector.replacements;
+
+        if replacements.is_empty() {
+            *cell.borrow_mut() = allocator;
+            return None;
+        }
+
+        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
+        let mut out = source.to_string();
+        for (start, end, rewrite) in &replacements {
+            out.replace_range(*start as usize..*end as usize, rewrite);
+        }
+
+        *cell.borrow_mut() = allocator;
+        Some(out)
+    })
+}
+
+struct TemplateRuneCollector<'src> {
+    source: &'src str,
+    replacements: Vec<(u32, u32, String)>,
+}
+
+impl<'a, 'src> Visit<'a> for TemplateRuneCollector<'src> {
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        walk::walk_call_expression(self, call);
+
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+        let Expression::Identifier(obj) = &member.object else {
+            return;
+        };
+
+        let prop = member.property.name.as_str();
+        match (obj.name.as_str(), prop) {
+            // `$state.snapshot(x)` → `$.snapshot(x)` — callee swap.
+            ("$state", "snapshot") => {
+                self.replacements.push((
+                    member.span().start,
+                    member.span().end,
+                    "$.snapshot".to_string(),
+                ));
+            }
+            // `$state.eager(x)` → `x` — whole-call unwrap to the
+            // single argument's source text.
+            ("$state", "eager") => {
+                let Some(arg) = call.arguments.first() else {
+                    return;
+                };
+                let arg_span = arg.span();
+                let arg_text = &self.source[arg_span.start as usize..arg_span.end as usize];
+                self.replacements
+                    .push((call.span.start, call.span.end, arg_text.to_string()));
+            }
+            // `$effect.tracking()` → `false` — SSR has no
+            // reactivity, so the runtime-tracker call collapses to a
+            // constant.
+            ("$effect", "tracking") => {
+                self.replacements
+                    .push((call.span.start, call.span.end, "false".to_string()));
+            }
+            // `$effect.pending()` → `0` — matches the official
+            // compiler's SSR behaviour.
+            ("$effect", "pending") => {
+                self.replacements
+                    .push((call.span.start, call.span.end, "0".to_string()));
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_state_snapshot() {
+        let out = transform_template_rune_ast("$state.snapshot(x)").unwrap();
+        assert_eq!(out, "$.snapshot(x)");
+    }
+
+    #[test]
+    fn unwraps_state_eager() {
+        let out = transform_template_rune_ast("$state.eager(x.y)").unwrap();
+        assert_eq!(out, "x.y");
+    }
+
+    #[test]
+    fn unwraps_state_eager_with_complex_arg() {
+        let out = transform_template_rune_ast("$state.eager(fn() + 1)").unwrap();
+        assert_eq!(out, "fn() + 1");
+    }
+
+    #[test]
+    fn rewrites_effect_tracking() {
+        let out = transform_template_rune_ast("if ($effect.tracking()) {}").unwrap();
+        assert_eq!(out, "if (false) {}");
+    }
+
+    #[test]
+    fn rewrites_effect_pending() {
+        let out = transform_template_rune_ast("let p = $effect.pending();").unwrap();
+        assert_eq!(out, "let p = 0;");
+    }
+
+    #[test]
+    fn handles_nested_eager_inside_snapshot() {
+        // `$state.snapshot($state.eager(x))` — fixed-point iteration
+        // first unwraps the inner eager, then the outer snapshot
+        // operates on the unwrapped text.
+        let out = transform_template_rune_ast("$state.snapshot($state.eager(x))").unwrap();
+        assert_eq!(out, "$.snapshot(x)");
+    }
+
+    #[test]
+    fn does_not_rewrite_inside_string_literal() {
+        for src in [
+            r#""$state.snapshot(x)""#,
+            r#""$state.eager(x)""#,
+            r#""$effect.tracking()""#,
+            r#""$effect.pending()""#,
+        ] {
+            assert!(
+                transform_template_rune_ast(src).is_none(),
+                "should not rewrite inside string: {src}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrites_inside_template_expression() {
+        let src = "`result: ${$effect.tracking()}`";
+        let out = transform_template_rune_ast(src).unwrap();
+        assert_eq!(out, "`result: ${false}`");
+    }
+
+    #[test]
+    fn leaves_other_state_methods_alone() {
+        for src in ["$state(x)", "$state.raw(x)", "$state.frozen(x)"] {
+            assert!(
+                transform_template_rune_ast(src).is_none(),
+                "should not rewrite: {src}"
+            );
+        }
+    }
+
+    #[test]
+    fn leaves_other_effect_methods_alone() {
+        for src in ["$effect(fn)", "$effect.pre(fn)", "$effect.root(fn)"] {
+            assert!(
+                transform_template_rune_ast(src).is_none(),
+                "should not rewrite: {src}"
+            );
+        }
+    }
+
+    #[test]
+    fn multiple_calls_in_one_expression() {
+        let src = "[$state.snapshot(a), $effect.tracking(), $effect.pending()]";
+        let out = transform_template_rune_ast(src).unwrap();
+        assert_eq!(out, "[$.snapshot(a), false, 0]");
+    }
+
+    #[test]
+    fn parse_error_returns_none() {
+        // Malformed source falls through without mutation.
+        assert!(transform_template_rune_ast("$state.snapshot(").is_none());
+    }
+
+    #[test]
+    fn no_op_without_keyword() {
+        assert!(transform_template_rune_ast("x + 1").is_none());
+    }
+
+    #[test]
+    fn eager_with_no_args_left_alone() {
+        // `$state.eager()` has no arg to unwrap to. Leave it alone
+        // (the official compiler would have rejected this earlier
+        // anyway).
+        let src = "$state.eager()";
+        assert!(transform_template_rune_ast(src).is_none());
+    }
+}

--- a/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/src/compiler/phases/3_transform/server/transform_script.rs
@@ -1070,6 +1070,10 @@ fn has_svelte_ignore_before(before: &str, code: &str) -> bool {
 }
 
 /// Simple rune call transformation for template expressions.
+///
+/// Kept for reference; the live SSR template path now goes through
+/// `server::template_rune_ast::transform_template_rune_ast`.
+#[allow(dead_code)]
 pub(crate) fn transform_rune_call_simple(expr: &str, prefix: &str) -> String {
     let mut result = String::new();
     let mut i = 0;


### PR DESCRIPTION
## Summary

Phase A first migration on the server (SSR) side. Replace the
text-based byte scanners in
`server::mod::transform_rune_in_template_expr` (a mix of bare
`String::replace` and the custom `transform_rune_call_simple`
brace-tracker) with one AST visitor that handles all four
template-expression rewrites in one parse:

| Source | Replacement |
|---|---|
| `$state.snapshot(x)` | `$.snapshot(x)` |
| `$state.eager(x)` | `x` (unwrap) |
| `$effect.tracking()` | `false` |
| `$effect.pending()` | `0` |

Server-side rendering has no reactivity runtime, so the tracker /
pending runes collapse to constants and the cell wrappers unwrap.

## Why AST

Same fragility class as the client-side AST migrations: bare
`String::replace` rewrites byte patterns regardless of lexical
context, so anything inside a string literal got (incorrectly)
rewritten too. The AST visitor descends only into expression
positions.

Nested cases (`$state.snapshot($state.eager(x))`) handled via the
fixed-point iteration pattern used in the other AST helpers.

## Test plan

- [x] 14 unit tests cover: each rewrite, complex arg shapes,
  nested inner/outer, string-literal safety, template-literal
  expression interpolation, other $state/$effect methods left
  alone, multiple calls in one expression, parse-error fallback,
  no-op probe, eager-with-no-args left alone
- [x] Full lib suite passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -D warnings` clean

## Notes

`transform_rune_call_simple` in `transform_script.rs` is now dead;
marked `#[allow(dead_code)]` for this PR, to be removed in a
follow-up cleanup once we confirm no other callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)