### PR TITLE
perf(transform/client): extend tag_declarator AST to instance script path

### DIFF
--- a/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -275,8 +275,20 @@ pub(super) fn transform_client_runes_with_skip_and_state(
     // In dev mode, wrap $.state() and $.derived() declarations with $.tag() for debugging
     // This allows $inspect.trace() to show variable names in the output.
     // Pattern: `let name = $.state(...)` -> `let name = $.tag($.state(...), 'name')`
-    // Also handles $.derived(), $.state($.proxy(...))
+    // Also handles $.derived(), $.state($.proxy(...)).
+    //
+    // The declarator shape (`let/const/var X = $.X(...)`) goes through the
+    // AST helper (`tag_declarator_ast`); class fields, `this.field` shapes,
+    // and the assignment form are still picked up by the text scanner that
+    // follows. Both passes emit byte-identical output, so the text
+    // version's "already wrapped" guard skips the AST's emissions cleanly.
+    // Idempotent chain.
     if dev {
+        if let Some(rewritten) =
+            super::tag_declarator_ast::wrap_state_derived_with_tag_declarators_ast(&result, false)
+        {
+            result = rewritten;
+        }
         result = wrap_state_derived_with_tag(&result);
     }
 


### PR DESCRIPTION
## Summary

Phase A continuation. The instance-script `wrap_state_derived_with_tag`
call (rune_transforms.rs:280) was still text-only. Plug in the same
AST helper (`tag_declarator_ast::wrap_state_derived_with_tag_declarators_ast`,
introduced in #188 for the module-script path) before the text
scanner runs, keeping the text scanner as the fallback for class
fields / this.field / assignment shapes the AST helper doesn't yet
handle.

Both passes emit byte-identical output (`$.tag(call, 'name')` with
single-quoted name + `, ` separator), and the text version's
"already wrapped" guard (`before.ends_with("$.tag(")` /
`"$.tag_proxy("`) skips the AST's emissions cleanly. Chain stays
idempotent.

Instance-script declarators now benefit from the string-literal /
template / regex safety the AST visitor provides; the text
scanner's walk-backwards-for-var_name heuristic is only the
*fallback* path for class fields / this.field / assignment shapes.

## Test plan

- [x] 658/658 lib tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -D warnings` clean
- [x] CI's compatibility report (3341 fixtures) is the gate

`is_ts = false` here because the instance script source at this
stage has already had TS stripping applied; the input is plain JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)