### PR TITLE
perf(transform/client): AST-based store compound + simple assignments

### DIFF
--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -21,6 +21,7 @@ mod state_call_ast;
 mod state_raw_frozen_ast;
 mod state_snapshot_ast;
 mod state_transforms;
+mod store_assign_ast;
 mod store_transforms;
 mod store_update_ast;
 mod strict_equals_ast;

--- a/src/compiler/phases/3_transform/client/store_assign_ast.rs
+++ b/src/compiler/phases/3_transform/client/store_assign_ast.rs
@@ -1,0 +1,499 @@
+//! AST-based rewrite of store-subscription `AssignmentExpression`s.
+//!
+//! Covers:
+//!
+//! | Source           | Replacement                                  |
+//! |------------------|----------------------------------------------|
+//! | `$count = expr`  | `$.store_set(<access>, expr)`                |
+//! | `$count += expr` | `$.store_set(<access>, $count() + expr)`     |
+//! | `$count -= expr` | `$.store_set(<access>, $count() - expr)`     |
+//! | `$count *= expr` | `$.store_set(<access>, $count() * expr)`     |
+//! | `$count /= expr` | `$.store_set(<access>, $count() / expr)`     |
+//! | `$count %= expr` | `$.store_set(<access>, $count() % expr)`     |
+//! | `$count ??= expr`| `$.store_set(<access>, $count() ?? expr)`    |
+//! | `$count &&= expr`| `$.store_set(<access>, $count() && expr)`    |
+//! | `$count \|\|= expr`| `$.store_set(<access>, $count() \|\| expr)` |
+//!
+//! `<access>` follows the same three-way classification used by
+//! `store_update_ast` (prop getter / reactive-state read / plain
+//! identifier).
+//!
+//! Member-expression mutations (`$store.prop = expr`,
+//! `$store[0]++` etc.) and member updates remain on the text path
+//! in `transform_store_member_mutations` — they have a different
+//! call shape (`$.store_mutate` with `$.untrack`).
+//!
+//! Replaces the text loops in
+//! `store_transforms.rs::transform_store_assignments_client` at
+//! lines 78–147 (compound + simple assignment). The text version
+//! had to hand-roll boundary checks (`==` vs `=`, `obj.$x =` member
+//! access, identifier neighbours) and an expression-end finder; the
+//! AST drops all of that.
+
+use std::cell::RefCell;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_ast_visit::walk;
+use oxc_parser::Parser;
+use oxc_span::GetSpan;
+use oxc_span::SourceType;
+use oxc_syntax::operator::AssignmentOperator;
+
+thread_local! {
+    static MODULE_STORE_ASSIGN_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+}
+
+const MAX_FIXED_POINT_ITERS: usize = 16;
+
+/// AST-based rewrite of `$count = expr` / `$count <op>= expr` for
+/// the bindings listed in `store_sub_vars`. The underlying
+/// store-binding classification (prop / reactive state / regular)
+/// comes from the three other slices, matching the text version in
+/// `transform_store_assignments_client`.
+///
+/// Returns `None` if there's nothing to rewrite (no `$<store>` in
+/// source, no matching `AssignmentExpression`, or parse failure).
+pub fn transform_store_assign_ast(
+    source: &str,
+    store_sub_vars: &[String],
+    prop_vars: &[String],
+    state_vars: &[String],
+    non_reactive_state_vars: &[String],
+) -> Option<String> {
+    if store_sub_vars.is_empty() {
+        return None;
+    }
+    if !store_sub_vars
+        .iter()
+        .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
+    {
+        return None;
+    }
+
+    let mut current = source.to_string();
+    let mut any_changed = false;
+    for _ in 0..MAX_FIXED_POINT_ITERS {
+        match single_pass(
+            &current,
+            store_sub_vars,
+            prop_vars,
+            state_vars,
+            non_reactive_state_vars,
+        ) {
+            Some(next) => {
+                current = next;
+                any_changed = true;
+            }
+            None => break,
+        }
+    }
+
+    if any_changed { Some(current) } else { None }
+}
+
+fn single_pass(
+    source: &str,
+    store_sub_vars: &[String],
+    prop_vars: &[String],
+    state_vars: &[String],
+    non_reactive_state_vars: &[String],
+) -> Option<String> {
+    MODULE_STORE_ASSIGN_ALLOC.with(|cell| {
+        let allocator = std::mem::take(&mut *cell.borrow_mut());
+        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
+        if !parser_ret.errors.is_empty() {
+            *cell.borrow_mut() = allocator;
+            return None;
+        }
+
+        let mut collector = StoreAssignCollector {
+            source,
+            store_sub_vars,
+            prop_vars,
+            state_vars,
+            non_reactive_state_vars,
+            replacements: Vec::new(),
+        };
+        collector.visit_program(&parser_ret.program);
+        let mut replacements = collector.replacements;
+
+        if replacements.is_empty() {
+            *cell.borrow_mut() = allocator;
+            return None;
+        }
+
+        // Filter out any replacement whose span strictly contains
+        // another replacement's span — only emit the innermost set
+        // this pass. The outer is picked up by the next fixed-point
+        // iteration once its RHS has been rewritten.
+        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
+        replacements.retain(|(s, e, _)| {
+            !spans
+                .iter()
+                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
+        });
+
+        if replacements.is_empty() {
+            *cell.borrow_mut() = allocator;
+            return None;
+        }
+
+        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
+        let mut out = source.to_string();
+        for (start, end, rewrite) in &replacements {
+            out.replace_range(*start as usize..*end as usize, rewrite);
+        }
+
+        *cell.borrow_mut() = allocator;
+        Some(out)
+    })
+}
+
+struct StoreAssignCollector<'a> {
+    source: &'a str,
+    store_sub_vars: &'a [String],
+    prop_vars: &'a [String],
+    state_vars: &'a [String],
+    non_reactive_state_vars: &'a [String],
+    replacements: Vec<(u32, u32, String)>,
+}
+
+impl<'a, 'ast> Visit<'ast> for StoreAssignCollector<'a> {
+    fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'ast>) {
+        walk::walk_assignment_expression(self, expr);
+
+        // LHS must be a bare `$name` identifier — member, array, or
+        // object targets go through the member-mutation path.
+        let AssignmentTarget::AssignmentTargetIdentifier(id) = &expr.left else {
+            return;
+        };
+        let name = id.name.as_str();
+        if !self.store_sub_vars.iter().any(|s| s == name) {
+            return;
+        }
+
+        let store_sub = name;
+        let store_name = &name[1..];
+
+        let store_access = if self.prop_vars.iter().any(|p| p == store_name) {
+            format!("{}()", store_name)
+        } else if self.state_vars.iter().any(|s| s == store_name)
+            && !self.non_reactive_state_vars.iter().any(|s| s == store_name)
+        {
+            format!("$.get({})", store_name)
+        } else {
+            store_name.to_string()
+        };
+
+        let rhs_span = expr.right.span();
+        let rhs_text = &self.source[rhs_span.start as usize..rhs_span.end as usize];
+
+        let rewrite = match expr.operator {
+            AssignmentOperator::Assign => {
+                format!("$.store_set({}, {})", store_access, rhs_text)
+            }
+            AssignmentOperator::Addition => {
+                format!(
+                    "$.store_set({}, {}() + {})",
+                    store_access, store_sub, rhs_text
+                )
+            }
+            AssignmentOperator::Subtraction => {
+                format!(
+                    "$.store_set({}, {}() - {})",
+                    store_access, store_sub, rhs_text
+                )
+            }
+            AssignmentOperator::Multiplication => {
+                format!(
+                    "$.store_set({}, {}() * {})",
+                    store_access, store_sub, rhs_text
+                )
+            }
+            AssignmentOperator::Division => {
+                format!(
+                    "$.store_set({}, {}() / {})",
+                    store_access, store_sub, rhs_text
+                )
+            }
+            AssignmentOperator::Remainder => {
+                format!(
+                    "$.store_set({}, {}() % {})",
+                    store_access, store_sub, rhs_text
+                )
+            }
+            AssignmentOperator::LogicalNullish => {
+                format!(
+                    "$.store_set({}, {}() ?? {})",
+                    store_access, store_sub, rhs_text
+                )
+            }
+            AssignmentOperator::LogicalAnd => {
+                format!(
+                    "$.store_set({}, {}() && {})",
+                    store_access, store_sub, rhs_text
+                )
+            }
+            AssignmentOperator::LogicalOr => {
+                format!(
+                    "$.store_set({}, {}() || {})",
+                    store_access, store_sub, rhs_text
+                )
+            }
+            // Other operators (**=, <<=, >>=, >>>=, &=, |=, ^=) are
+            // not in the text version's allowlist — leave them
+            // untouched and the existing text path (if any) handles.
+            _ => return,
+        };
+
+        self.replacements
+            .push((expr.span.start, expr.span.end, rewrite));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ssv(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn simple_assignment_regular() {
+        let out =
+            transform_store_assign_ast("$count = 5;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(count, 5);");
+    }
+
+    #[test]
+    fn simple_assignment_prop() {
+        let out = transform_store_assign_ast(
+            "$count = 5;",
+            &ssv(&["$count"]),
+            &ssv(&["count"]),
+            &[],
+            &[],
+        )
+        .unwrap();
+        assert_eq!(out, "$.store_set(count(), 5);");
+    }
+
+    #[test]
+    fn simple_assignment_state() {
+        let out = transform_store_assign_ast(
+            "$count = 5;",
+            &ssv(&["$count"]),
+            &[],
+            &ssv(&["count"]),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(out, "$.store_set($.get(count), 5);");
+    }
+
+    #[test]
+    fn compound_addition() {
+        let out =
+            transform_store_assign_ast("$count += 3;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(count, $count() + 3);");
+    }
+
+    #[test]
+    fn compound_subtraction() {
+        let out =
+            transform_store_assign_ast("$count -= 3;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(count, $count() - 3);");
+    }
+
+    #[test]
+    fn compound_multiplication() {
+        let out =
+            transform_store_assign_ast("$count *= 2;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(count, $count() * 2);");
+    }
+
+    #[test]
+    fn compound_division() {
+        let out =
+            transform_store_assign_ast("$count /= 2;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(count, $count() / 2);");
+    }
+
+    #[test]
+    fn compound_remainder() {
+        let out =
+            transform_store_assign_ast("$count %= 2;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(count, $count() % 2);");
+    }
+
+    #[test]
+    fn compound_nullish() {
+        let out =
+            transform_store_assign_ast("$count ??= 5;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(count, $count() ?? 5);");
+    }
+
+    #[test]
+    fn compound_logical_and() {
+        let out =
+            transform_store_assign_ast("$count &&= 5;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(count, $count() && 5);");
+    }
+
+    #[test]
+    fn compound_logical_or() {
+        let out =
+            transform_store_assign_ast("$count ||= 5;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(count, $count() || 5);");
+    }
+
+    #[test]
+    fn leaves_equality_alone() {
+        // `==` and `===` are BinaryExpression, not AssignmentExpression
+        assert!(
+            transform_store_assign_ast("if ($count == 5) {}", &ssv(&["$count"]), &[], &[], &[])
+                .is_none()
+        );
+        assert!(
+            transform_store_assign_ast("if ($count === 5) {}", &ssv(&["$count"]), &[], &[], &[])
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn leaves_member_assignment_alone() {
+        // `obj.$count = 5` and `$store.prop = 5` go through the
+        // member-mutation path.
+        assert!(
+            transform_store_assign_ast("obj.$count = 5;", &ssv(&["$count"]), &[], &[], &[])
+                .is_none()
+        );
+        assert!(
+            transform_store_assign_ast("$store.prop = 5;", &ssv(&["$store"]), &[], &[], &[])
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn leaves_declaration_alone() {
+        // `let $count = expr` is a VariableDeclarator, not an
+        // AssignmentExpression.
+        assert!(
+            transform_store_assign_ast("let $count = 5;", &ssv(&["$count"]), &[], &[], &[])
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn leaves_destructuring_alone() {
+        // Array/object destructuring targets go through different
+        // assignment-target variants.
+        assert!(
+            transform_store_assign_ast("[$count] = arr;", &ssv(&["$count"]), &[], &[], &[])
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_inside_string_literal() {
+        let src = r#"let s = "$count = 5";"#;
+        assert!(transform_store_assign_ast(src, &ssv(&["$count"]), &[], &[], &[]).is_none());
+    }
+
+    #[test]
+    fn rewrites_inside_template_expression() {
+        let src = "let s = `${$count = 5}`;";
+        let out = transform_store_assign_ast(src, &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "let s = `${$.store_set(count, 5)}`;");
+    }
+
+    #[test]
+    fn rewrites_for_loop_init() {
+        let src = "for ($count = 0; cond; step()) {}";
+        let out = transform_store_assign_ast(src, &ssv(&["$count"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "for ($.store_set(count, 0); cond; step()) {}");
+    }
+
+    #[test]
+    fn multiple_assignments_in_one_source() {
+        let out =
+            transform_store_assign_ast("$a = 1; $b += 2;", &ssv(&["$a", "$b"]), &[], &[], &[])
+                .unwrap();
+        assert_eq!(out, "$.store_set(a, 1); $.store_set(b, $b() + 2);");
+    }
+
+    #[test]
+    fn nested_assignment_chain() {
+        // `$a = $b = 5` — inner picked up first, outer on next pass.
+        let out =
+            transform_store_assign_ast("$a = $b = 5;", &ssv(&["$a", "$b"]), &[], &[], &[]).unwrap();
+        assert_eq!(out, "$.store_set(a, $.store_set(b, 5));");
+    }
+
+    #[test]
+    fn rhs_with_complex_expression() {
+        let out = transform_store_assign_ast(
+            "$count = foo(1, 2) + bar.baz;",
+            &ssv(&["$count"]),
+            &[],
+            &[],
+            &[],
+        )
+        .unwrap();
+        assert_eq!(out, "$.store_set(count, foo(1, 2) + bar.baz);");
+    }
+
+    #[test]
+    fn rhs_with_arrow_function() {
+        let out = transform_store_assign_ast("$cb = (x) => x + 1;", &ssv(&["$cb"]), &[], &[], &[])
+            .unwrap();
+        assert_eq!(out, "$.store_set(cb, (x) => x + 1);");
+    }
+
+    #[test]
+    fn non_reactive_state_falls_back_to_regular() {
+        let out = transform_store_assign_ast(
+            "$count = 5;",
+            &ssv(&["$count"]),
+            &[],
+            &ssv(&["count"]),
+            &ssv(&["count"]),
+        )
+        .unwrap();
+        assert_eq!(out, "$.store_set(count, 5);");
+    }
+
+    #[test]
+    fn empty_store_subs_is_no_op() {
+        assert!(transform_store_assign_ast("$count = 5;", &[], &[], &[], &[]).is_none());
+    }
+
+    #[test]
+    fn parse_error_returns_none() {
+        assert!(
+            transform_store_assign_ast("$count = (", &ssv(&["$count"]), &[], &[], &[]).is_none()
+        );
+    }
+
+    #[test]
+    fn no_op_without_prefix_dollar() {
+        assert!(
+            transform_store_assign_ast("let x = 1;", &ssv(&["$count"]), &[], &[], &[]).is_none()
+        );
+    }
+
+    #[test]
+    fn leaves_unsupported_operator_alone() {
+        // `**=`, `<<=`, `>>=`, `>>>=`, `&=`, `|=`, `^=` not in the
+        // text version's allowlist either.
+        assert!(
+            transform_store_assign_ast("$count **= 2;", &ssv(&["$count"]), &[], &[], &[]).is_none()
+        );
+        assert!(
+            transform_store_assign_ast("$count &= 7;", &ssv(&["$count"]), &[], &[], &[]).is_none()
+        );
+    }
+}

--- a/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -30,22 +30,33 @@ pub(super) fn transform_store_assignments_client(
         return line.to_string();
     }
 
-    // AST-based pass for the four UpdateExpression shapes
-    // (`++$x` / `--$x` / `$x++` / `$x--`) — same output as the text
-    // loop below, but driven by the parser so string / template /
-    // regex contents can't be (incorrectly) rewritten. The text
-    // loop runs afterwards as fallback: once the AST helper has
-    // rewritten an update site the literal `++$x` / `$x++` byte
-    // pattern is no longer present, so the text loop's
-    // `result.contains(&pattern)` guard skips it. Idempotent chain.
-    let mut result = super::store_update_ast::transform_store_update_ast(
+    // AST-based pre-passes — both target store-subscription names
+    // but cover disjoint syntactic forms:
+    //
+    // 1. UpdateExpressions (`++$x` / `--$x` / `$x++` / `$x--`)
+    // 2. AssignmentExpressions (`$x = expr` / `$x <op>= expr`)
+    //
+    // Both replace the same fragility class as the text loops below
+    // (string / template / regex contents wrongly rewritten) and are
+    // idempotent vs them: once a span has been rewritten the literal
+    // byte pattern (`++$x`, `$x +=`) is gone and the text loop's
+    // `result.contains(...)` / `result.find(...)` guard skips it.
+    let after_updates = super::store_update_ast::transform_store_update_ast(
         line,
         store_sub_vars,
         prop_vars,
         state_vars,
         non_reactive_state_vars,
-    )
-    .unwrap_or_else(|| line.to_string());
+    );
+    let stage1: &str = after_updates.as_deref().unwrap_or(line);
+    let after_assigns = super::store_assign_ast::transform_store_assign_ast(
+        stage1,
+        store_sub_vars,
+        prop_vars,
+        state_vars,
+        non_reactive_state_vars,
+    );
+    let mut result = after_assigns.unwrap_or_else(|| stage1.to_string());
 
     for store_sub in store_sub_vars {
         // store_sub is like "$count", store_name is "count"


### PR DESCRIPTION
## Summary

Phase A continuation, sibling to #194 (store UpdateExpressions). Migrates the compound (`$count += expr`) and simple (`$count = expr`) assignment text rewrites in `transform_store_assignments_client` (store_transforms.rs lines 78–147) to an OXC-AST visitor.

| Source | Replacement |
|---|---|
| `$count = expr` | `$.store_set(<access>, expr)` |
| `$count += expr` | `$.store_set(<access>, $count() + expr)` |
| ... `-=, *=, /=, %=, ??=, &&=, \|\|=` | analogous |

`<access>` follows the same three-way classification as store_update_ast (prop getter / reactive-state read / plain identifier).

## What the AST drops on the floor

- Hand-rolled `==` / `!=` / `obj.\$x` boundary checks — AssignmentExpression only matches `=`-family operators and an AssignmentTargetIdentifier LHS.
- The expression-end finder (`find_statement_end_client`) — the RHS span is exact.
- The text loop's nested-assignment offset-bump trick — fixed-point iteration. `\$a = \$b = 5` walks as two AssignmentExpressions; the outer is filtered out on pass 1 because its span contains the inner's, then picked up on pass 2.

## Scope

Member-expression mutations (`\$store.prop = expr`, `\$store[0]++`, etc.) stay on the `transform_store_member_mutations` text path — they emit `\$.store_mutate` with `\$.untrack`, a different shape.

Idempotent vs the remaining text loops below: once a span is rewritten to `\$.store_set(...)`, the `\$count =` / `\$count +=` bytes are gone and the text loop guards skip it.

## Test plan

- [x] 27 unit tests: simple/compound × regular/prop/state access; non-reactive-state fallback; equality / member / declaration / destructuring left alone; string-literal safety; template interpolation; for-loop init; multiple assignments; nested chain fixed-point; complex RHS; arrow-function RHS; empty store_subs no-op; parse-error fallback; unsupported operator (`**=`, `&=`, etc.) left alone
- [x] Full lib suite 685/685 passing
- [x] cargo fmt + cargo clippy --all-targets --all-features -D warnings clean
- [ ] Compatibility Report on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)