### PR TITLE
perf(transform/client): AST member-chain reads for non-this private fields

### DIFF
--- a/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -1531,6 +1531,22 @@ pub(super) fn transform_class_methods_non_this(
                 result = result.replacen(&pre_dec, &format!("$.update_pre({}, -1)", qualified), 1);
             }
 
+            // AST-based pre-pass for member-chain reads (`q.foo`, `q[i]`,
+            // `q?.foo`). Mirrors the pre-pass already used in
+            // `transform_class_methods` (with-this) — see PR #210. The
+            // helper rewrites just the `q` span so the surrounding member
+            // chain is preserved; idempotent vs the text replaces below
+            // because after wrap the bytes between `q` and the next `.`
+            // are `)`, not `.`/`?.`.
+            if let Some(rewritten) =
+                super::private_member_read_wrap_ast::transform_private_member_read_wrap_ast(
+                    &result,
+                    std::slice::from_ref(&qualified),
+                )
+            {
+                result = rewritten;
+            }
+
             // Handle reads
             let property_access_pattern = format!("{}.", qualified);
             let getter_wrapped = format!("$.get({}).", qualified);


### PR DESCRIPTION
## Summary

Mirrors the AST pre-pass added to `transform_class_methods` in
PR #210 (private-field member-chain reads). Adds the same call
to `transform_class_methods_non_this` so non-\`this\` prefixes like
\`obj.#field.foo\` get the precise AST rewrite instead of relying
on the unguarded substring \`result.replace("obj.#field.", ...)\`
that follows.

Idempotent vs the existing text replaces — after AST wrap,
\`obj.#field.foo\` becomes \`\$.get(obj.#field).foo\`. The bytes
between \`obj.#field\` and \`.foo\` are \`)\`, not \`.\`, so the
subsequent string replace finds no match. Optional-chain shape
behaves the same way.

## Test plan

- [x] \`cargo test --release --test runtime test_runtime_legacy\` — 100%
- [x] \`cargo test --release --test runtime test_runtime_runes\` — 100%
- [x] \`cargo test --release --test ssr\` — 100%
- [x] \`cargo fmt -- --check\`, \`cargo clippy --all-targets --all-features -- -D warnings\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)