### PR TITLE
ci(docs): refresh benchmark-results.json on every docs deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -76,6 +76,25 @@ jobs:
       - name: Update docs test-results.json
         run: node scripts/update-docs.mjs
 
+      - name: Install language-tools dependencies
+        # `scripts/run-benchmark.mjs` imports svelte2tsx from the
+        # language-tools submodule for its JS baseline; the package's
+        # runtime deps (typescript, dedent-js, scule, …) live in its
+        # own node_modules and aren't installed by the svelte submodule
+        # bootstrap above.
+        run: |
+          cd submodules/language-tools
+          pnpm install --frozen-lockfile
+
+      - name: Run JS vs Rust benchmark
+        # Refreshes docs/static/benchmark-results.json so the /benchmark
+        # page on the deployed site reflects current main rather than
+        # whatever was last hand-committed. Mirrors the compatibility-
+        # report flow: regenerated on every deploy, bundled into
+        # docs/build by the subsequent docs build step.
+        run: node scripts/run-benchmark.mjs > docs/static/benchmark-results.json
+        timeout-minutes: 30
+
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 

--- a/docs/static/benchmark-results.json
+++ b/docs/static/benchmark-results.json
@@ -1,57 +1,57 @@
 {
-  "generatedAt": "2026-05-13T09:25:35.205Z",
-  "commitSha": "1a845bf",
+  "generatedAt": "2026-05-20T08:44:41.752Z",
+  "commitSha": "b6932b4",
   "testFilesCount": 3637,
   "javascript": {
-    "durationMs": 959.4235419999999,
-    "throughputFilesPerSec": 3790.817965982328
+    "durationMs": 954.4623613333333,
+    "throughputFilesPerSec": 3810.5221822674116
   },
   "rustSingleThread": {
-    "durationMs": 404.14090000000004,
-    "throughputFilesPerSec": 8999.33661750147
+    "durationMs": 382.95053333333334,
+    "throughputFilesPerSec": 9497.310183491061
   },
   "rustMultiThread": {
-    "durationMs": 55.585633333333334,
-    "throughputFilesPerSec": 65430.57588621521
+    "durationMs": 50.904066666666665,
+    "throughputFilesPerSec": 71448.12267782142
   },
   "speedup": {
-    "singleThreadVsJs": 2.3739827916451905,
-    "multiThreadVsJs": 17.26027904092724
+    "singleThreadVsJs": 2.4923907352350816,
+    "multiThreadVsJs": 18.75021827987548
   },
   "parse": {
     "javascript": {
-      "durationMs": 216.3832499999747,
-      "throughputFilesPerSec": 16808.14018645355
+      "durationMs": 206.9982220000044,
+      "throughputFilesPerSec": 17570.1992261553
     },
     "rustSingleThread": {
-      "durationMs": 8.566033333333332,
-      "throughputFilesPerSec": 424583.9186554649
+      "durationMs": 8.568566666666667,
+      "throughputFilesPerSec": 424458.388606418
     },
     "rustMultiThread": {
-      "durationMs": 1.6194,
-      "throughputFilesPerSec": 2245893.5408175867
+      "durationMs": 2.0837333333333334,
+      "throughputFilesPerSec": 1745424.8784233425
     },
     "speedup": {
-      "singleThreadVsJs": 25.260612652294306,
-      "multiThreadVsJs": 133.61939607260388
+      "singleThreadVsJs": 24.157858607235482,
+      "multiThreadVsJs": 99.34007326593505
     }
   },
   "svelte2tsx": {
     "javascript": {
-      "durationMs": 343.5215273333403,
-      "throughputFilesPerSec": 10587.400528383167
+      "durationMs": 342.8509446666576,
+      "throughputFilesPerSec": 10608.108440640677
     },
     "rustSingleThread": {
-      "durationMs": 192.62973333333335,
-      "throughputFilesPerSec": 18880.781990734555
+      "durationMs": 113.55810000000001,
+      "throughputFilesPerSec": 32027.658088678832
     },
     "rustMultiThread": {
-      "durationMs": 25.08583333333333,
-      "throughputFilesPerSec": 144982.22768494836
+      "durationMs": 14.965333333333334,
+      "throughputFilesPerSec": 243028.3321454027
     },
     "speedup": {
-      "singleThreadVsJs": 1.783325561370624,
-      "multiThreadVsJs": 13.693845556921517
+      "singleThreadVsJs": 3.0191676742271802,
+      "multiThreadVsJs": 22.909676452244582
     }
   }
 }


### PR DESCRIPTION
## Summary
- `deploy-docs.yml` now runs `scripts/run-benchmark.mjs` (after the compatibility-report step) so `/benchmark` reflects current `main` instead of whatever was last hand-committed. Mirrors the existing flow for `test-results.json`.
- Adds a `pnpm install` step for `submodules/language-tools` since `run-benchmark.mjs` imports the upstream `svelte2tsx` for its JS baseline.
- Refreshes the checked-in `docs/static/benchmark-results.json` to current main (`b6932b4`):
  - Full pipeline: 17.3× → **18.8×** (multi-thread)
  - svelte2tsx: 13.7× → **22.9×** (multi-thread)
  - Parser: 133× → 99× (closer to the JS warm-up baseline)

## Test plan
- [ ] Trigger `deploy-docs` (push to `main` or `workflow_dispatch`) and verify the "Run JS vs Rust benchmark" step writes a fresh JSON
- [ ] After deploy, confirm `/benchmark` page shows the new `generatedAt` timestamp / commit SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)