### PR TITLE
fix(napi/envelope): make compiled.js.code / map writable

### DIFF
--- a/npm/vite-plugin-svelte-native/envelope.js
+++ b/npm/vite-plugin-svelte-native/envelope.js
@@ -121,12 +121,22 @@ function decodeEnvelope(buf) {
 function makeCodeMapObject(buf, slice, codeOff, codeLen, mapOff, mapLen) {
 	const obj = {};
 	let codeCache = null;
+	// `code` and `map` need setters as well as getters — upstream
+	// `svelte/compiler` returns them as plain writable strings, and
+	// vite-plugin-svelte mutates `compiled.js.code` to wire the CSS
+	// import (see compile.js:131, `compiled.js.code += ...`). Without
+	// a setter the assignment throws `Cannot set property code of
+	// #<Object> which has only a getter` under the strict-mode rolldown
+	// runtime and the docs build fails.
 	Object.defineProperty(obj, 'code', {
 		enumerable: true,
 		configurable: true,
 		get() {
 			if (codeCache === null) codeCache = slice(codeOff, codeLen);
 			return codeCache;
+		},
+		set(value) {
+			codeCache = value;
 		},
 	});
 	const hasMap = mapOff !== 0;
@@ -143,6 +153,9 @@ function makeCodeMapObject(buf, slice, codeOff, codeLen, mapOff, mapLen) {
 				mapCache = JSON.parse(slice(mapOff, mapLen));
 			}
 			return mapCache;
+		},
+		set(value) {
+			mapCache = value;
 		},
 	});
 	// `mapBytes` returns a zero-copy view into the envelope (Node Buffer


### PR DESCRIPTION
## Summary
Unblocks the docs deploy. `npm/vite-plugin-svelte-native/envelope.js` defines `code` and `map` as **getter-only** properties on the compiled JS/CSS results, but the upstream `svelte/compiler` contract returns them as plain writable strings. vite-plugin-svelte relies on that and does `compiled.js.code += \`\nimport \${JSON.stringify(cssId)};\n\`` to wire the CSS import (`compile.js:131`). Under the strict rolldown runtime introduced by the Vite 8 beta bump, the assignment throws:

```
RolldownError: Cannot set property code of #<Object> which has only a getter
TypeError: Cannot set property code of #<Object> which has only a getter
    at compileSvelte (vite-plugin-svelte/src/utils/compile.js:131:22)
```

That's been failing the `Deploy Docs to GitHub Pages` workflow on every push to `main` since the bump (last green: 2026-05-17), which is why the site benchmark page hasn't been updating despite the fix in #223/#224.

Add setters to both `code` and `map` that just replace the lazy decoder cache.

## Test plan
- [ ] Once merged, confirm `Deploy Docs to GitHub Pages` passes the `Build docs` step
- [ ] Confirm `/benchmark` on the deployed site reflects the new (current main) numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)