### PR TITLE
refactor(transform/client): symbol-identity-based state-var matching

### DIFF
--- a/src/compiler/phases/3_transform/client/scope_analysis.rs
+++ b/src/compiler/phases/3_transform/client/scope_analysis.rs
@@ -29,6 +29,8 @@ use oxc_ast::ast::{IdentifierReference, Program};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::SourceType;
+use oxc_syntax::symbol::SymbolId;
+use rustc_hash::FxHashSet;
 
 /// Run `f` with a fully-built `Semantic` over `source`. Returns
 /// `None` if the source fails to parse; semantic errors do *not*
@@ -91,6 +93,154 @@ pub fn is_locally_shadowed(semantic: &Semantic, ident: &IdentifierReference) -> 
     let symbol_scope = semantic.scoping().symbol_scope_id(symbol_id);
     let root_scope = semantic.scoping().root_scope_id();
     symbol_scope != root_scope
+}
+
+/// For each name in `names`, find the SymbolId of the OUTERMOST
+/// declaration. Returns the set of all such "canonical" symbol ids.
+///
+/// This is the precise answer to "which symbol is the state var?"
+/// — when multiple bindings share a name (e.g., outer `let count`
+/// plus a nested `function f(count)` parameter), the outermost
+/// declaration is the state var, and the others are shadows.
+///
+/// A reference is to the state var iff its resolved
+/// `Reference.symbol_id()` is in this set. See
+/// [`is_state_var_reference`].
+#[allow(dead_code)]
+pub fn find_state_var_symbols(semantic: &Semantic, names: &[String]) -> FxHashSet<SymbolId> {
+    if names.is_empty() {
+        return FxHashSet::default();
+    }
+    let scoping = semantic.scoping();
+    let root_scope = scoping.root_scope_id();
+    let mut out = FxHashSet::default();
+    for symbol_id in scoping.symbol_ids() {
+        let name = scoping.symbol_name(symbol_id);
+        if !names.iter().any(|n| n == name) {
+            continue;
+        }
+        let scope = scoping.symbol_scope_id(symbol_id);
+        // Rule 1: root-scope bindings (top-level `let`/`const`/
+        // `var`/`function`/`class`/import). Legacy bare `let foo;`
+        // declarations are caught here.
+        if scope == root_scope {
+            out.insert(symbol_id);
+            continue;
+        }
+        // Rule 2: state-var-shaped initializer. Catches function-
+        // local rune declarations like
+        // `function createCounter() { let count = $state(0); ... }`.
+        let decl_id = scoping.symbol_declaration(symbol_id);
+        if declaration_has_state_var_init(semantic, decl_id) {
+            out.insert(symbol_id);
+        }
+    }
+    out
+}
+
+/// Returns `true` if the declaration node identified by `decl_id`
+/// (a `BindingIdentifier` inside a `VariableDeclarator`) is
+/// initialized with a call to one of the state-creating runtime/
+/// runes functions: `$state`/`$derived`/`$state.*`/`$derived.*`/
+/// `$.state`/`$.derived`/`$.mutable_source`/`$.proxy`/
+/// `$.source`/`$.snapshot`.
+fn declaration_has_state_var_init(semantic: &Semantic, decl_id: oxc_syntax::node::NodeId) -> bool {
+    use oxc_ast::AstKind;
+    let nodes = semantic.nodes();
+    let mut cur = decl_id;
+    // BindingIdentifier -> (BindingPattern) -> VariableDeclarator
+    // is at most 2 hops; bound the walk conservatively.
+    for _ in 0..4 {
+        if let AstKind::VariableDeclarator(decl) = nodes.parent_kind(cur) {
+            let Some(init) = &decl.init else {
+                return false;
+            };
+            return is_state_var_init_expression(init);
+        }
+        let parent = nodes.parent_id(cur);
+        if parent == cur {
+            return false;
+        }
+        cur = parent;
+    }
+    false
+}
+
+fn is_state_var_init_expression(expr: &oxc_ast::ast::Expression) -> bool {
+    use oxc_ast::ast::Expression;
+    let Expression::CallExpression(call) = expr else {
+        return false;
+    };
+    match &call.callee {
+        // Raw rune forms: `$state(...)` / `$derived(...)`.
+        Expression::Identifier(id) => matches!(id.name.as_str(), "$state" | "$derived"),
+        // `$.state(...)` / `$.mutable_source(...)` / etc. and
+        // `$state.raw(...)` / `$derived.by(...)` etc.
+        Expression::StaticMemberExpression(member) => {
+            let Expression::Identifier(obj) = &member.object else {
+                return false;
+            };
+            if obj.name == "$" {
+                return matches!(
+                    member.property.name.as_str(),
+                    "state" | "derived" | "mutable_source" | "proxy" | "source" | "snapshot"
+                );
+            }
+            matches!(obj.name.as_str(), "$state" | "$derived")
+        }
+        _ => false,
+    }
+}
+
+/// Returns true if `ident` resolves to one of the symbols in
+/// `state_var_symbols`. Use [`find_state_var_symbols`] to build the
+/// set.
+#[allow(dead_code)]
+pub fn is_state_var_reference(
+    semantic: &Semantic,
+    ident: &IdentifierReference,
+    state_var_symbols: &FxHashSet<SymbolId>,
+) -> bool {
+    let Some(reference_id) = ident.reference_id.get() else {
+        return false;
+    };
+    let reference = semantic.scoping().get_reference(reference_id);
+    let Some(symbol_id) = reference.symbol_id() else {
+        return false;
+    };
+    state_var_symbols.contains(&symbol_id)
+}
+
+/// Returns true if the identifier reference should be treated as
+/// referring to a state var with the given name. Combines two
+/// signals:
+///
+/// 1. **Symbol-identity match** (precise): if the reference
+///    resolves to a symbol in `state_var_symbols`, it's the state
+///    var.
+/// 2. **Unresolved name fallback** (line-by-line transformers):
+///    when the helper runs on a script fragment, the state var's
+///    declaration may live on a different line, so the reference
+///    here is *unresolved*. If the name is in `names` and the
+///    reference is unresolved, treat it as the state var.
+///
+/// Shadowing case: the reference resolves to a non-state-var
+/// symbol (e.g. function parameter) → returns `false`.
+#[allow(dead_code)]
+pub fn is_state_var_reference_or_unresolved(
+    semantic: &Semantic,
+    ident: &IdentifierReference,
+    state_var_symbols: &FxHashSet<SymbolId>,
+    names: &[String],
+) -> bool {
+    let Some(reference_id) = ident.reference_id.get() else {
+        return false;
+    };
+    let reference = semantic.scoping().get_reference(reference_id);
+    match reference.symbol_id() {
+        Some(symbol_id) => state_var_symbols.contains(&symbol_id),
+        None => names.iter().any(|n| n.as_str() == ident.name.as_str()),
+    }
 }
 
 #[cfg(test)]

--- a/src/compiler/phases/3_transform/client/state_compound_assigns_ast.rs
+++ b/src/compiler/phases/3_transform/client/state_compound_assigns_ast.rs
@@ -59,16 +59,24 @@ use oxc_parser::{ParseOptions, Parser};
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::{GetSpan, SourceType};
 use oxc_syntax::operator::AssignmentOperator;
+use oxc_syntax::symbol::SymbolId;
+use rustc_hash::FxHashSet;
 
 use super::expression_utils::needs_compound_assignment_parens;
-use super::scope_analysis::is_locally_shadowed;
+use super::scope_analysis::{find_state_var_symbols, is_state_var_reference_or_unresolved};
 
 thread_local! {
     static STATE_COMPOUND_ASSIGN_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
 
+const MAX_FIXED_POINT_ITERS: usize = 16;
+
 /// AST-based rewrite of `name <op>= expr` for state vars. See
 /// module docs for the precise contract.
+///
+/// Uses fixed-point iteration and symbol-identity-based shadow
+/// detection — see `state_simple_assigns_ast` for the same
+/// architecture.
 pub fn transform_state_compound_assigns_ast(source: &str, state_vars: &[String]) -> Option<String> {
     if state_vars.is_empty() {
         return None;
@@ -79,9 +87,23 @@ pub fn transform_state_compound_assigns_ast(source: &str, state_vars: &[String])
     {
         return None;
     }
-    // Cheapest probe — at least one `=` token must appear.
     memchr::memchr(b'=', source.as_bytes())?;
 
+    let mut current = source.to_string();
+    let mut any_changed = false;
+    for _ in 0..MAX_FIXED_POINT_ITERS {
+        match single_pass(&current, state_vars) {
+            Some(next) => {
+                current = next;
+                any_changed = true;
+            }
+            None => break,
+        }
+    }
+    if any_changed { Some(current) } else { None }
+}
+
+fn single_pass(source: &str, state_vars: &[String]) -> Option<String> {
     STATE_COMPOUND_ASSIGN_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs())
@@ -97,11 +119,13 @@ pub fn transform_state_compound_assigns_ast(source: &str, state_vars: &[String])
         let program: &Program = allocator.alloc(parser_ret.program);
         let semantic_ret = SemanticBuilder::new().build(program);
         let semantic = &semantic_ret.semantic;
+        let state_var_symbols = find_state_var_symbols(semantic, state_vars);
 
         let mut collector = StateCompoundAssignCollector {
             source,
             semantic,
             state_vars,
+            state_var_symbols,
             replacements: Vec::new(),
         };
         collector.visit_program(program);
@@ -138,6 +162,7 @@ struct StateCompoundAssignCollector<'a, 'sem> {
     source: &'a str,
     semantic: &'sem Semantic<'sem>,
     state_vars: &'a [String],
+    state_var_symbols: FxHashSet<SymbolId>,
     replacements: Vec<(u32, u32, String)>,
 }
 
@@ -171,7 +196,12 @@ impl<'a, 'sem, 'ast> Visit<'ast> for StateCompoundAssignCollector<'a, 'sem> {
             return;
         }
         let ident_ref: &IdentifierReference = id;
-        if is_locally_shadowed(self.semantic, ident_ref) {
+        if !is_state_var_reference_or_unresolved(
+            self.semantic,
+            ident_ref,
+            &self.state_var_symbols,
+            self.state_vars,
+        ) {
             return;
         }
 
@@ -273,8 +303,10 @@ mod tests {
 
     #[test]
     fn skips_function_param_shadow() {
+        // Need outer `let x` so the symbol-identity check sees a
+        // real outermost binding.
         assert!(
-            transform_state_compound_assigns_ast("function f(x) { x += 1; }", &ssv(&["x"]))
+            transform_state_compound_assigns_ast("let x; function f(x) { x += 1; }", &ssv(&["x"]))
                 .is_none()
         );
     }
@@ -282,23 +314,29 @@ mod tests {
     #[test]
     fn skips_arrow_param_shadow() {
         assert!(
-            transform_state_compound_assigns_ast("const f = (x) => { x += 1; };", &ssv(&["x"]))
-                .is_none()
+            transform_state_compound_assigns_ast(
+                "let x; const f = (x) => { x += 1; };",
+                &ssv(&["x"])
+            )
+            .is_none()
         );
     }
 
     #[test]
     fn skips_for_loop_var_shadow() {
         assert!(
-            transform_state_compound_assigns_ast("for (let x of items) { x += 1; }", &ssv(&["x"]))
-                .is_none()
+            transform_state_compound_assigns_ast(
+                "let x; for (let x of items) { x += 1; }",
+                &ssv(&["x"])
+            )
+            .is_none()
         );
     }
 
     #[test]
     fn skips_nested_let_shadow() {
         let out = transform_state_compound_assigns_ast(
-            "x += 1; { let x = 0; x += 2; } x += 3;",
+            "let x; x += 1; { let x = 0; x += 2; } x += 3;",
             &ssv(&["x"]),
         )
         .unwrap();

--- a/src/compiler/phases/3_transform/client/state_reads_ast.rs
+++ b/src/compiler/phases/3_transform/client/state_reads_ast.rs
@@ -66,9 +66,10 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::SourceType;
+use oxc_syntax::symbol::SymbolId;
 use rustc_hash::FxHashSet;
 
-use super::scope_analysis::is_locally_shadowed;
+use super::scope_analysis::{find_state_var_symbols, is_state_var_reference_or_unresolved};
 
 thread_local! {
     static STATE_READS_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -125,10 +126,14 @@ pub fn transform_state_reads_ast(
         let program: &Program = allocator.alloc(parser_ret.program);
         let semantic_ret = SemanticBuilder::new().build(program);
         let semantic = &semantic_ret.semantic;
+        let effective_names: Vec<String> = effective.iter().map(|s| s.to_string()).collect();
+        let state_var_symbols = find_state_var_symbols(semantic, &effective_names);
 
         let mut collector = StateReadsCollector {
             semantic,
             effective: &effective,
+            effective_names: &effective_names,
+            state_var_symbols,
             replacements: Vec::new(),
             skip_spans: FxHashSet::default(),
         };
@@ -154,6 +159,8 @@ pub fn transform_state_reads_ast(
 struct StateReadsCollector<'a, 'sem> {
     semantic: &'sem Semantic<'sem>,
     effective: &'a [&'a str],
+    effective_names: &'a [String],
+    state_var_symbols: FxHashSet<SymbolId>,
     replacements: Vec<(u32, u32, String)>,
     /// Spans of identifier references claimed by a parent-context
     /// handler (assignment LHS, update target, first arg of $.set
@@ -181,7 +188,12 @@ impl<'a, 'sem, 'ast> Visit<'ast> for StateReadsCollector<'a, 'sem> {
         if !self.is_effective(name) {
             return;
         }
-        if is_locally_shadowed(self.semantic, ident) {
+        if !is_state_var_reference_or_unresolved(
+            self.semantic,
+            ident,
+            &self.state_var_symbols,
+            self.effective_names,
+        ) {
             return;
         }
         self.replacements
@@ -241,11 +253,17 @@ impl<'a, 'sem, 'ast> Visit<'ast> for StateReadsCollector<'a, 'sem> {
         // `{ $.get(count) }` would be invalid JS, so we replace
         // the whole ObjectProperty span and skip the inner
         // identifier from re-wrapping.
-        if prop.shorthand
+        let shorthand_eligible = prop.shorthand
+            && matches!(&prop.key, PropertyKey::StaticIdentifier(k) if self.is_effective(&k.name));
+        if shorthand_eligible
             && let PropertyKey::StaticIdentifier(key) = &prop.key
-            && self.is_effective(&key.name)
             && let Expression::Identifier(value_ident) = &prop.value
-            && !is_locally_shadowed(self.semantic, value_ident)
+            && is_state_var_reference_or_unresolved(
+                self.semantic,
+                value_ident,
+                &self.state_var_symbols,
+                self.effective_names,
+            )
         {
             let name = key.name.as_str();
             self.replacements.push((
@@ -319,31 +337,43 @@ mod tests {
     #[test]
     fn skips_function_param_shadow() {
         assert!(
-            transform_state_reads_ast("function f(count) { return count; }", &ssv(&["count"]), &[])
-                .is_none()
+            transform_state_reads_ast(
+                "let count; function f(count) { return count; }",
+                &ssv(&["count"]),
+                &[]
+            )
+            .is_none()
         );
     }
 
     #[test]
     fn skips_arrow_param_shadow() {
         assert!(
-            transform_state_reads_ast("const f = (count) => count;", &ssv(&["count"]), &[])
-                .is_none()
+            transform_state_reads_ast(
+                "let count; const f = (count) => count;",
+                &ssv(&["count"]),
+                &[]
+            )
+            .is_none()
         );
     }
 
     #[test]
     fn skips_for_loop_var_shadow() {
         assert!(
-            transform_state_reads_ast("for (let count of items) { count; }", &ssv(&["count"]), &[])
-                .is_none()
+            transform_state_reads_ast(
+                "let count; for (let count of items) { count; }",
+                &ssv(&["count"]),
+                &[]
+            )
+            .is_none()
         );
     }
 
     #[test]
     fn skips_nested_let_shadow() {
         let out = transform_state_reads_ast(
-            "count; { let count = 0; count; } count;",
+            "let count; count; { let count = 0; count; } count;",
             &ssv(&["count"]),
             &[],
         )
@@ -497,8 +527,11 @@ mod tests {
 
     #[test]
     fn complex_smoke() {
-        // Multiple state-var cases in one snippet.
+        // Multiple state-var cases in one snippet. Need an outer
+        // `let count` so symbol-identity matching has an outermost
+        // binding.
         let src = r#"
+            let count;
             let r = count + 1;
             function inner(count) { return count + 1; }
             $.set(count, 5);

--- a/src/compiler/phases/3_transform/client/state_simple_assigns_ast.rs
+++ b/src/compiler/phases/3_transform/client/state_simple_assigns_ast.rs
@@ -56,15 +56,31 @@ use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::{GetSpan, SourceType};
 use oxc_syntax::operator::AssignmentOperator;
 
+use rustc_hash::FxHashSet;
+
 use super::expression_utils::expression_needs_proxy_with_scope;
-use super::scope_analysis::is_locally_shadowed;
+use super::scope_analysis::{find_state_var_symbols, is_state_var_reference_or_unresolved};
+use oxc_syntax::symbol::SymbolId;
 
 thread_local! {
     static STATE_SIMPLE_ASSIGN_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
 
+const MAX_FIXED_POINT_ITERS: usize = 16;
+
 /// AST-based rewrite of `name = expr` for state vars. See module
 /// docs for the precise contract.
+///
+/// Uses fixed-point iteration so nested AssignmentExpressions
+/// (e.g. `outer = (inner = 1)`) are all wrapped: pass 1 wraps the
+/// innermost; pass 2 picks up the now-outermost; and so on.
+///
+/// Shadow detection uses [`find_state_var_symbols`] +
+/// [`is_state_var_reference`]: a reference is "to the state var"
+/// iff it resolves to the outermost-scope SymbolId for its name.
+/// This correctly handles function-local state vars (the binding
+/// itself, not a shadow) and rejects function-param / for-loop /
+/// nested-let shadows.
 pub fn transform_state_simple_assigns_ast(
     source: &str,
     state_vars: &[String],
@@ -81,9 +97,35 @@ pub fn transform_state_simple_assigns_ast(
     {
         return None;
     }
-    // Cheapest probe — bail if there's no `=` token at all.
     memchr::memchr(b'=', source.as_bytes())?;
 
+    let mut current = source.to_string();
+    let mut any_changed = false;
+    for _ in 0..MAX_FIXED_POINT_ITERS {
+        match single_pass(
+            &current,
+            state_vars,
+            raw_state_vars,
+            is_runes,
+            non_proxy_vars,
+        ) {
+            Some(next) => {
+                current = next;
+                any_changed = true;
+            }
+            None => break,
+        }
+    }
+    if any_changed { Some(current) } else { None }
+}
+
+fn single_pass(
+    source: &str,
+    state_vars: &[String],
+    raw_state_vars: &[String],
+    is_runes: bool,
+    non_proxy_vars: &[String],
+) -> Option<String> {
     STATE_SIMPLE_ASSIGN_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs())
@@ -100,6 +142,8 @@ pub fn transform_state_simple_assigns_ast(
         let semantic_ret = SemanticBuilder::new().build(program);
         let semantic = &semantic_ret.semantic;
 
+        let state_var_symbols = find_state_var_symbols(semantic, state_vars);
+
         let mut collector = StateSimpleAssignCollector {
             source,
             semantic,
@@ -107,6 +151,7 @@ pub fn transform_state_simple_assigns_ast(
             raw_state_vars,
             is_runes,
             non_proxy_vars,
+            state_var_symbols,
             replacements: Vec::new(),
         };
         collector.visit_program(program);
@@ -117,9 +162,6 @@ pub fn transform_state_simple_assigns_ast(
             return None;
         }
 
-        // Innermost-only: defer outer span when its range strictly
-        // contains an inner replacement. Right-to-left splice then
-        // preserves offsets.
         let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
         replacements.retain(|(s, e, _)| {
             !spans
@@ -149,6 +191,11 @@ struct StateSimpleAssignCollector<'a, 'sem> {
     raw_state_vars: &'a [String],
     is_runes: bool,
     non_proxy_vars: &'a [String],
+    /// Symbols whose name matches a state_var AND whose declaration
+    /// is the OUTERMOST one for that name. References resolving to
+    /// these symbols are to "the state var"; references resolving to
+    /// other symbols of the same name are shadows.
+    state_var_symbols: FxHashSet<SymbolId>,
     replacements: Vec<(u32, u32, String)>,
 }
 
@@ -171,23 +218,24 @@ impl<'a, 'sem, 'ast> Visit<'ast> for StateSimpleAssignCollector<'a, 'sem> {
         if !self.state_vars.iter().any(|s| s.as_str() == name) {
             return;
         }
-        // The text version's `is_in_function_param_or_shadowed` /
-        // `is_shadowed_by_for_loop_var` are unified into
-        // `is_locally_shadowed`: any binding declared in a scope
-        // strictly inside the program root counts as a shadow.
-        // We need an IdentifierReference to query the semantic
-        // info — `AssignmentTargetIdentifier` wraps one indirectly,
-        // but oxc exposes the wrapped reference via the same
-        // `reference_id` slot. We can construct a synthetic check
-        // using the symbol resolution directly: look up the
-        // reference for this AssignmentTarget. Easiest path is to
-        // peek at the `id.reference_id` Cell that SemanticBuilder
-        // populates for IdentifierReference / AssignmentTarget
-        // both — but the AssignmentTargetIdentifier struct *is* an
-        // IdentifierReference in oxc's AST. So we just borrow
-        // `id` as an IdentifierReference.
+        // Symbol-identity check: when at least one declaration for
+        // this name exists in the source, match by the outermost
+        // SymbolId. Function-param / for-loop / nested-let shadows
+        // resolve to a *different* SymbolId, so they're skipped.
+        //
+        // When no declaration is found (only happens in unit tests
+        // or trivially short fragments), fall back to the broader
+        // shadow check.
+        // The AssignmentTargetIdentifier struct *is* an
+        // IdentifierReference in oxc's AST, so we borrow `id` as
+        // one.
         let ident_ref: &IdentifierReference = id;
-        if is_locally_shadowed(self.semantic, ident_ref) {
+        if !is_state_var_reference_or_unresolved(
+            self.semantic,
+            ident_ref,
+            &self.state_var_symbols,
+            self.state_vars,
+        ) {
             return;
         }
 
@@ -340,57 +388,49 @@ mod tests {
     #[test]
     fn skips_function_param_shadow() {
         // Inner `x = 1` is shadowed by the function param.
-        assert!(
-            transform_state_simple_assigns_ast(
-                "function f(x) { x = 1; }",
-                &ssv(&["x"]),
-                &[],
-                false,
-                &[]
-            )
-            .is_none()
+        // (Need an outer `let x` so the symbol-identity check has
+        // an outermost binding to compare against.)
+        let out = transform_state_simple_assigns_ast(
+            "let x; function f(x) { x = 1; }",
+            &ssv(&["x"]),
+            &[],
+            false,
+            &[],
         );
+        // Outer assignment to x? None. Inner is shadowed → no wrap.
+        assert!(out.is_none(), "got {:?}", out);
     }
 
     #[test]
     fn skips_arrow_param_shadow() {
-        assert!(
-            transform_state_simple_assigns_ast(
-                "const f = (x) => { x = 1; };",
-                &ssv(&["x"]),
-                &[],
-                false,
-                &[]
-            )
-            .is_none()
+        let out = transform_state_simple_assigns_ast(
+            "let x; const f = (x) => { x = 1; };",
+            &ssv(&["x"]),
+            &[],
+            false,
+            &[],
         );
+        assert!(out.is_none(), "got {:?}", out);
     }
 
     #[test]
     fn skips_for_loop_var_shadow() {
-        // `for (let x of items) { x = …; }` — inner `x` is
-        // shadowed by the for-loop binding.
-        assert!(
-            transform_state_simple_assigns_ast(
-                "for (let x of items) { x = 5; }",
-                &ssv(&["x"]),
-                &[],
-                false,
-                &[]
-            )
-            .is_none()
+        let out = transform_state_simple_assigns_ast(
+            "let x; for (let x of items) { x = 5; }",
+            &ssv(&["x"]),
+            &[],
+            false,
+            &[],
         );
-        // for-in too.
-        assert!(
-            transform_state_simple_assigns_ast(
-                "for (let x in obj) { x = 5; }",
-                &ssv(&["x"]),
-                &[],
-                false,
-                &[]
-            )
-            .is_none()
+        assert!(out.is_none(), "got {:?}", out);
+        let out2 = transform_state_simple_assigns_ast(
+            "let x; for (let x in obj) { x = 5; }",
+            &ssv(&["x"]),
+            &[],
+            false,
+            &[],
         );
+        assert!(out2.is_none(), "got {:?}", out2);
     }
 
     #[test]
@@ -529,10 +569,12 @@ mod tests {
         assert_eq!(out, r#"$.set(x, "hello");"#);
     }
 
-    /// Smoke: complex realistic body.
+    /// Smoke: complex realistic body. Need an outer `let count`
+    /// so the symbol-identity check sees a real outermost binding.
     #[test]
     fn smoke_complex_body() {
         let src = r#"
+            let count;
             count = 1;
             function inner(count) { count = 99; }
             for (let count of items) { count = 0; }

--- a/src/compiler/phases/3_transform/client/state_update_assigns_ast.rs
+++ b/src/compiler/phases/3_transform/client/state_update_assigns_ast.rs
@@ -50,7 +50,10 @@ use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::SourceType;
 use oxc_syntax::operator::UpdateOperator;
 
-use super::scope_analysis::is_locally_shadowed;
+use oxc_syntax::symbol::SymbolId;
+use rustc_hash::FxHashSet;
+
+use super::scope_analysis::{find_state_var_symbols, is_state_var_reference_or_unresolved};
 
 thread_local! {
     static STATE_UPDATE_ASSIGN_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -90,10 +93,12 @@ pub fn transform_state_update_assigns_ast(source: &str, state_vars: &[String]) -
         let program: &Program = allocator.alloc(parser_ret.program);
         let semantic_ret = SemanticBuilder::new().build(program);
         let semantic = &semantic_ret.semantic;
+        let state_var_symbols = find_state_var_symbols(semantic, state_vars);
 
         let mut collector = StateUpdateCollector {
             semantic,
             state_vars,
+            state_var_symbols,
             replacements: Vec::new(),
         };
         collector.visit_program(program);
@@ -129,6 +134,7 @@ pub fn transform_state_update_assigns_ast(source: &str, state_vars: &[String]) -
 struct StateUpdateCollector<'a, 'sem> {
     semantic: &'sem Semantic<'sem>,
     state_vars: &'a [String],
+    state_var_symbols: FxHashSet<SymbolId>,
     replacements: Vec<(u32, u32, String)>,
 }
 
@@ -146,7 +152,12 @@ impl<'a, 'sem, 'ast> Visit<'ast> for StateUpdateCollector<'a, 'sem> {
             return;
         }
         let ident_ref: &IdentifierReference = id;
-        if is_locally_shadowed(self.semantic, ident_ref) {
+        if !is_state_var_reference_or_unresolved(
+            self.semantic,
+            ident_ref,
+            &self.state_var_symbols,
+            self.state_vars,
+        ) {
             return;
         }
 
@@ -213,14 +224,15 @@ mod tests {
     #[test]
     fn skips_function_param_shadow() {
         assert!(
-            transform_state_update_assigns_ast("function f(x) { x++; }", &ssv(&["x"])).is_none()
+            transform_state_update_assigns_ast("let x; function f(x) { x++; }", &ssv(&["x"]))
+                .is_none()
         );
     }
 
     #[test]
     fn skips_arrow_param_shadow() {
         assert!(
-            transform_state_update_assigns_ast("const f = (x) => { x++; };", &ssv(&["x"]))
+            transform_state_update_assigns_ast("let x; const f = (x) => { x++; };", &ssv(&["x"]))
                 .is_none()
         );
     }
@@ -228,15 +240,21 @@ mod tests {
     #[test]
     fn skips_for_loop_var_shadow() {
         assert!(
-            transform_state_update_assigns_ast("for (let x of items) { x++; }", &ssv(&["x"]))
-                .is_none()
+            transform_state_update_assigns_ast(
+                "let x; for (let x of items) { x++; }",
+                &ssv(&["x"])
+            )
+            .is_none()
         );
     }
 
     #[test]
     fn skips_nested_let_shadow() {
-        let out = transform_state_update_assigns_ast("x++; { let x = 0; x++; } x--;", &ssv(&["x"]))
-            .unwrap();
+        let out = transform_state_update_assigns_ast(
+            "let x; x++; { let x = 0; x++; } x--;",
+            &ssv(&["x"]),
+        )
+        .unwrap();
         assert!(out.contains("$.update(x);"));
         assert!(out.contains("$.update(x, -1);"));
         assert!(out.contains("{ let x = 0; x++; }"));
@@ -303,7 +321,7 @@ mod tests {
     /// Mixed: top-level wraps, inner shadow preserved, other vars unchanged.
     #[test]
     fn smoke_mixed_pattern() {
-        let src = "x++; function inner(x) { x++; } y++;";
+        let src = "let x; x++; function inner(x) { x++; } y++;";
         let out = transform_state_update_assigns_ast(src, &ssv(&["x"])).unwrap();
         assert!(out.contains("$.update(x);"));
         assert!(out.contains("function inner(x) { x++; }"));


### PR DESCRIPTION
## Summary

Replaces the overly-broad \`is_locally_shadowed\` shadow check
(\"any binding in a non-root scope is a shadow\") with precise
**symbol-identity matching**.

### Why the previous check was wrong

\`is_locally_shadowed\` flagged any non-root-scope binding as a
shadow. But this incorrectly captured function-local rune
declarations:

\`\`\`js
function createCounter() {
  let count = \$state(0);    // ← this IS the state var
  …
  set count(value) { count = value; }
}
\`\`\`

The \`count\` inside the setter resolves to the \`createCounter\`-
scope binding (non-root). Old check: shadow → skip wrap. The
expected output requires the wrap.

### What the new architecture does

1. **\`find_state_var_symbols\`** returns the SymbolIds of bindings
   that look like state vars — either at root scope, or with a
   state-var-shaped initializer (\`\$state(...)\` / \`\$.state(...)\`
   / \`\$.mutable_source(...)\` etc.).
2. **\`is_state_var_reference_or_unresolved\`** returns \`true\` for
   references whose resolved symbol is in that set, OR whose name
   matches and is unresolved (line-by-line transformers see
   fragments where the declaration lives elsewhere).

Genuine shadows (function parameters, for-loop variables, nested
lets with non-state-var initializers) resolve to *different*
SymbolIds and are correctly skipped.

### Fixed-point iteration

Added to \`state_simple_assigns_ast\` and
\`state_compound_assigns_ast\`. Each pass wraps innermost
AssignmentExpressions; outers get picked up on the next iteration
once their inner contents are no longer assignments. Handles
nested cases like \`outer = (inner = 1)\`.

## Test plan

- [x] All affected unit tests updated to include outer
  declarations (so the symbol-identity check has a real outermost
  binding to compare against).
- [x] \`cargo test --release --test runtime test_runtime_legacy\` — 100%
- [x] \`cargo test --release --test runtime test_runtime_runes\` — 100%
- [x] \`cargo test --release --test ssr\` — 100%
- [x] \`cargo test --release --test compatibility_report\` — 3087/3087 in-scope, every category at 100%
- [x] \`cargo fmt -- --check\`, \`cargo clippy --all-targets --all-features -- -D warnings\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)