### PR TITLE
feat(docs): show all benchmark tasks on /benchmark without tabs

### DIFF
--- a/docs/src/routes/benchmark/+page.svelte
+++ b/docs/src/routes/benchmark/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { base } from '$app/paths';
 	import type { PageData } from './$types';
 	import type { BenchmarkTaskResults } from '$lib/types/benchmark';
 	import SiteNav from '$lib/components/SiteNav.svelte';
@@ -8,14 +7,13 @@
 
 	let { data }: { data: PageData } = $props();
 
-	type TabId = 'full' | 'parse' | 'svelte2tsx';
+	type TaskId = 'full' | 'parse' | 'svelte2tsx';
 
-	let activeTab = $state<TabId>('full');
 	// `animationTime` is the elapsed wall-clock ms since the run started.
-	// Each bar shows `min(animationTime, this.durationMs)`, so the bars
-	// fill at the *actual* measured speed — the slow JS bar is still
-	// inching forward when the rsvelte-multi bar has already crossed the
-	// finish line, which is the whole point.
+	// Each bar across every task shows `min(animationTime, this.durationMs)`,
+	// so all three breakdowns fill in parallel at their *actual* measured
+	// speeds — the slow JS bar is still inching forward when the multi-
+	// threaded rsvelte bar has already crossed the finish line.
 	let animationTime = $state(0);
 	let isAnimating = $state(false);
 	let animationComplete = $state(false);
@@ -23,14 +21,9 @@
 	// Hard ceiling for the wall-clock animation so very fast tasks (e.g. the
 	// parser-only run can finish in ~150 ms) don't blink past unreadably and
 	// very slow ones (full-pipeline JS at ~1 s) don't drag the user. We stop
-	// once the slowest bar is done OR 4 s, whichever comes first.
+	// once the slowest bar across every task is done OR 4 s, whichever
+	// comes first.
 	const ANIMATION_HARD_CAP_MS = 4000;
-
-	const tabMeta: Record<TabId, { label: string; sub: string }> = {
-		full: { label: 'Full pipeline', sub: 'parse / analyze / codegen' },
-		parse: { label: 'Parser only', sub: 'phase 1, isolated' },
-		svelte2tsx: { label: 'svelte2tsx', sub: '.svelte / .tsx generation' }
-	};
 
 	const formatDate = (iso: string): string =>
 		new Date(iso).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
@@ -47,22 +40,30 @@
 		return v.toFixed(0);
 	};
 
-	const getActiveTask = (): BenchmarkTaskResults | null => {
-		if (!data.results) return null;
+	type TaskPanel = {
+		id: TaskId;
+		label: string;
+		sub: string;
+		data: BenchmarkTaskResults;
+	};
+
+	const tasks: TaskPanel[] = $derived.by(() => {
+		if (!data.results) return [];
 		const r = data.results;
-		if (activeTab === 'full') return r;
-		if (activeTab === 'parse') return r.parse;
-		if (activeTab === 'svelte2tsx' && r.svelte2tsx) return r.svelte2tsx;
-		return null;
-	};
-
-	const hasTab = (tab: TabId): boolean => {
-		if (!data.results) return false;
-		if (tab === 'full' || tab === 'parse') return true;
-		return Boolean(data.results.svelte2tsx);
-	};
-
-	const activeTask = $derived(getActiveTask());
+		const list: TaskPanel[] = [
+			{ id: 'full', label: 'Full pipeline', sub: 'parse / analyze / codegen', data: r },
+			{ id: 'parse', label: 'Parser only', sub: 'phase 1, isolated', data: r.parse }
+		];
+		if (r.svelte2tsx) {
+			list.push({
+				id: 'svelte2tsx',
+				label: 'svelte2tsx',
+				sub: '.svelte / .tsx generation',
+				data: r.svelte2tsx
+			});
+		}
+		return list;
+	});
 
 	const getMaxDuration = (r: BenchmarkTaskResults): number =>
 		Math.max(r.javascript.durationMs, r.rustSingleThread.durationMs, r.rustMultiThread.durationMs);
@@ -74,20 +75,21 @@
 		return (filled / maxDuration) * 100;
 	};
 
-	const getAnimatedTime = (_: BenchmarkTaskResults, duration: number): number => {
+	const getAnimatedTime = (duration: number): number => {
 		if (animationComplete) return duration;
 		return Math.min(animationTime, duration);
 	};
 
 	const startAnimation = () => {
-		if (isAnimating || !data.results) return;
+		if (isAnimating || tasks.length === 0) return;
 		isAnimating = true;
 		animationComplete = false;
 		animationTime = 0;
-		const task = getActiveTask();
-		const finishAt = task
-			? Math.min(getMaxDuration(task), ANIMATION_HARD_CAP_MS)
-			: ANIMATION_HARD_CAP_MS;
+		// Run until the slowest bar across *every* visible task is done,
+		// so users still see fast bars finish early and the slow JS bar
+		// crawl on.
+		const slowest = Math.max(...tasks.map((t) => getMaxDuration(t.data)));
+		const finishAt = Math.min(slowest, ANIMATION_HARD_CAP_MS);
 		const start = performance.now();
 		const tick = () => {
 			const elapsed = performance.now() - start;
@@ -101,12 +103,6 @@
 			requestAnimationFrame(tick);
 		};
 		requestAnimationFrame(tick);
-	};
-
-	const switchTab = (tab: TabId) => {
-		if (!hasTab(tab)) return;
-		activeTab = tab;
-		startAnimation();
 	};
 
 	onMount(() => {
@@ -136,7 +132,6 @@
 		</section>
 	{:else if data.results}
 		{@const r = data.results}
-		{@const task = activeTask}
 
 		<header class="hero">
 			<p class="eyebrow"><span class="rule"></span>Compilation speed · against svelte/compiler</p>
@@ -195,74 +190,64 @@
 
 		<section class="chart">
 			<header class="chart-head">
-				<div class="tabs" role="tablist" aria-label="Benchmark task">
-					{#each ['full', 'parse', 'svelte2tsx'] as const as tab (tab)}
-						<button
-							role="tab"
-							type="button"
-							aria-selected={activeTab === tab}
-							class="tab"
-							class:active={activeTab === tab}
-							disabled={!hasTab(tab)}
-							onclick={() => switchTab(tab)}
-						>
-							<span class="tab-label">{tabMeta[tab].label}</span>
-							<span class="tab-sub">{tabMeta[tab].sub}</span>
-						</button>
-					{/each}
+				<div class="chart-head-meta">
+					<h2 class="chart-title">Per-phase breakdown</h2>
+					<p class="chart-sub">Lower is better · same machine, same corpus</p>
 				</div>
-				<button class="replay" onclick={startAnimation} disabled={isAnimating || !task}>
+				<button class="replay" onclick={startAnimation} disabled={isAnimating}>
 					<span class="replay-i" aria-hidden="true">↻</span>
 					Replay
 				</button>
 			</header>
 
-			{#if task}
-				{@const t = task}
-				<div class="bars">
-					{#each [
-						{ name: 'svelte/compiler', sub: 'JavaScript', dur: t.javascript.durationMs, tone: 'js' },
-						{ name: 'rsvelte / single', sub: 'no parallelism', dur: t.rustSingleThread.durationMs, tone: 'rs' },
-						{ name: 'rsvelte / multi', sub: 'rayon fan-out', dur: t.rustMultiThread.durationMs, tone: 'rm' }
-					] as bar (bar.name)}
-						<div class="bar-row">
-							<div class="bar-meta">
-								<span class="bar-name">{bar.name}</span>
-								<span class="bar-sub">{bar.sub}</span>
+			<div class="task-panels">
+				{#each tasks as task (task.id)}
+					{@const t = task.data}
+					<article class="task-panel">
+						<header class="task-panel-head">
+							<div class="task-panel-meta">
+								<span class="task-panel-label">{task.label}</span>
+								<span class="task-panel-sub">{task.sub}</span>
 							</div>
-							<div class="bar-graph">
-								<span class="bar-track">
-									<span
-										class="bar-fill bar-{bar.tone}"
-										style="width: {getAnimatedWidth(t, bar.dur)}%;"
-									></span>
+							<span class="task-panel-speedup">
+								<span class="task-panel-speedup-k">multi · </span>
+								<span class="task-panel-speedup-n">
+									{t.speedup.multiThreadVsJs.toFixed(1)}<span class="x">×</span>
 								</span>
-								<span class="bar-time">
-									{formatDuration(getAnimatedTime(t, bar.dur))}
+								<span class="task-panel-speedup-sep">·</span>
+								<span class="task-panel-speedup-st">
+									single {t.speedup.singleThreadVsJs.toFixed(1)}×
 								</span>
-							</div>
-						</div>
-					{/each}
-				</div>
-
-				<footer class="chart-foot">
-					<span>Lower is better · same machine, same corpus</span>
-					<span class="speedup">
-						<span class="speedup-k">Speedup vs JS</span>
-						<span class="speedup-v">
-							{t.speedup.multiThreadVsJs.toFixed(1)}<span class="x">×</span>
-							<span class="speedup-sep">·</span>
-							<span class="speedup-st">
-								single {t.speedup.singleThreadVsJs.toFixed(1)}×
 							</span>
-						</span>
-					</span>
-				</footer>
-			{:else}
-				<div class="missing">
-					<p>No data for this benchmark task.</p>
-				</div>
-			{/if}
+						</header>
+						<div class="bars">
+							{#each [
+								{ name: 'svelte/compiler', sub: 'JavaScript', dur: t.javascript.durationMs, tone: 'js' },
+								{ name: 'rsvelte / single', sub: 'no parallelism', dur: t.rustSingleThread.durationMs, tone: 'rs' },
+								{ name: 'rsvelte / multi', sub: 'rayon fan-out', dur: t.rustMultiThread.durationMs, tone: 'rm' }
+							] as bar (bar.name)}
+								<div class="bar-row">
+									<div class="bar-meta">
+										<span class="bar-name">{bar.name}</span>
+										<span class="bar-sub">{bar.sub}</span>
+									</div>
+									<div class="bar-graph">
+										<span class="bar-track">
+											<span
+												class="bar-fill bar-{bar.tone}"
+												style="width: {getAnimatedWidth(t, bar.dur)}%;"
+											></span>
+										</span>
+										<span class="bar-time">
+											{formatDuration(getAnimatedTime(bar.dur))}
+										</span>
+									</div>
+								</div>
+							{/each}
+						</div>
+					</article>
+				{/each}
+			</div>
 		</section>
 
 		<section class="repro">
@@ -466,68 +451,120 @@
 
 	.chart-head {
 		display: flex;
-		align-items: stretch;
+		align-items: center;
 		justify-content: space-between;
 		gap: 1rem;
 		flex-wrap: wrap;
+		padding: 0 0.1rem 1rem;
+	}
+
+	.chart-head-meta {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.chart-title {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 700;
+		font-size: clamp(1.2rem, 2.2vw, 1.5rem);
+		line-height: 1.1;
+		letter-spacing: -0.015em;
+		color: var(--ink);
+		margin: 0;
+	}
+
+	.chart-sub {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.72rem;
+		color: var(--ink-soft);
+		margin: 0;
+	}
+
+	.task-panels {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.task-panel {
 		background: var(--bg);
 		border: 1px solid var(--rule);
-		border-bottom: 0;
-		border-top-left-radius: 6px;
-		border-top-right-radius: 6px;
-		padding: 0.55rem;
+		border-radius: 6px;
+		overflow: hidden;
 	}
 
-	.tabs {
+	.task-panel-head {
 		display: flex;
-		gap: 0.4rem;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
 		flex-wrap: wrap;
+		padding: 0.9rem 1.2rem;
+		background: var(--paper);
+		border-bottom: 1px solid var(--rule);
 	}
 
-	.tab {
-		background: transparent;
-		border: 1px solid transparent;
-		border-radius: 4px;
-		padding: 0.45rem 0.85rem;
-		text-align: left;
-		cursor: pointer;
-		color: var(--ink-soft);
+	.task-panel-meta {
 		display: flex;
 		flex-direction: column;
 		gap: 0.18rem;
-		transition: background 0.18s, color 0.18s, border-color 0.18s;
 	}
 
-	.tab:hover:not(:disabled) {
-		color: var(--ink);
-		background: var(--paper);
-	}
-
-	.tab.active {
-		background: var(--paper);
-		color: var(--ink);
-		border-color: var(--rule-strong);
-	}
-
-	.tab:disabled {
-		opacity: 0.45;
-		cursor: not-allowed;
-	}
-
-	.tab-label {
+	.task-panel-label {
 		font-family: 'Overpass', sans-serif;
-		font-weight: 600;
-		font-size: 0.9rem;
+		font-weight: 700;
+		font-size: 0.98rem;
+		color: var(--ink);
 		letter-spacing: -0.005em;
 	}
 
-	.tab-sub {
+	.task-panel-sub {
 		font-family: 'Fira Mono', monospace;
-		font-size: 0.66rem;
+		font-size: 0.7rem;
 		color: var(--ink-faint);
 	}
 
-	.tab.active .tab-sub {
+	.task-panel-speedup {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.4rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.72rem;
+		color: var(--ink-soft);
+	}
+
+	.task-panel-speedup-k {
+		color: var(--ink-faint);
+		letter-spacing: 0.04em;
+	}
+
+	.task-panel-speedup-n {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 700;
+		font-size: 0.95rem;
+		color: var(--rust);
+		font-variant-numeric: tabular-nums;
+		display: inline-flex;
+		align-items: baseline;
+	}
+
+	.task-panel-speedup-n .x {
+		font-family: 'Fira Mono', monospace;
+		font-weight: 500;
+		font-size: 0.72em;
+		margin-left: 0.06em;
+		color: var(--rust);
+		opacity: 0.75;
+	}
+
+	.task-panel-speedup-sep {
+		color: var(--ink-faint);
+	}
+
+	.task-panel-speedup-st {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.74rem;
 		color: var(--ink-soft);
 	}
 
@@ -558,13 +595,10 @@
 	}
 
 	.bars {
-		background: var(--bg);
-		border: 1px solid var(--rule);
-		border-top: 0;
-		padding: 1.4rem 1.4rem 0.6rem;
+		padding: 1.1rem 1.2rem 1.2rem;
 		display: flex;
 		flex-direction: column;
-		gap: 1.1rem;
+		gap: 1rem;
 	}
 
 	.bar-row {
@@ -635,74 +669,6 @@
 		font-variant-numeric: tabular-nums;
 		min-width: 5.5rem;
 		text-align: right;
-	}
-
-	.chart-foot {
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-top: 0;
-		border-bottom-left-radius: 6px;
-		border-bottom-right-radius: 6px;
-		padding: 0.7rem 1rem;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 1rem;
-		flex-wrap: wrap;
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.72rem;
-		color: var(--ink-soft);
-	}
-
-	.speedup {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.55rem;
-	}
-
-	.speedup-k {
-		color: var(--ink-faint);
-		letter-spacing: 0.04em;
-	}
-
-	.speedup-v {
-		font-family: 'Overpass', sans-serif;
-		font-weight: 700;
-		font-size: 0.92rem;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
-		display: inline-flex;
-		align-items: baseline;
-		gap: 0.45rem;
-	}
-
-	.speedup-v .x {
-		font-family: 'Fira Mono', monospace;
-		font-weight: 500;
-		font-size: 0.72em;
-		color: var(--rust);
-	}
-
-	.speedup-sep {
-		color: var(--ink-faint);
-	}
-
-	.speedup-st {
-		font-family: 'Fira Mono', monospace;
-		font-weight: 400;
-		font-size: 0.76rem;
-		color: var(--ink-soft);
-	}
-
-	.missing {
-		padding: 3rem 1.5rem;
-		background: var(--bg);
-		border: 1px solid var(--rule);
-		border-top: 0;
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.85rem;
-		color: var(--ink-faint);
-		text-align: center;
 	}
 
 	/* REPRO */
@@ -841,9 +807,14 @@
 		}
 		.chart-head {
 			flex-direction: column;
+			align-items: flex-start;
 		}
 		.replay {
 			align-self: flex-end;
+		}
+		.task-panel-head {
+			flex-direction: column;
+			align-items: flex-start;
 		}
 	}
 


### PR DESCRIPTION
## Summary
The Full pipeline / Parser only / svelte2tsx breakdowns on `/benchmark` were hidden behind a tab strip that most visitors don't notice — the parser and svelte2tsx panels effectively became invisible. Stack all three task panels vertically instead so every breakdown is visible at a glance.

The wall-clock animation still runs in parallel across every panel, so fast tasks finish first while the slow JS bar visibly crawls on.

### Before
- Header + 4 stat cards + **one** bars panel hidden behind 3 tabs

### After
- Header + 4 stat cards + **three** stacked panels (Full pipeline / Parser only / svelte2tsx), each with its own header, bars, and speedup chip

## Test plan
- [ ] After deploy, open `/benchmark` and confirm all three task panels render with bars animating in parallel
- [ ] Replay button still works and animates every panel from zero
- [ ] Mobile (≤640px) layout stacks each panel header above its speedup chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)