### PR TITLE
refactor(transform/client): whole-script AST for module-script state assigns

### DIFF
--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -2764,33 +2764,32 @@ pub(crate) fn transform_module_script_runes(
             .map(|(name, _, _)| name.clone())
             .collect();
 
-        // Process line by line for assignment transforms
-        let lines: Vec<&str> = result.lines().collect();
-        let mut transformed_lines: Vec<String> = Vec::with_capacity(lines.len());
-        for line in &lines {
-            let trimmed = line.trim();
-            // Skip declaration lines - they've already been transformed
-            let is_declaration = reactive_module_state_vars.iter().any(|var| {
-                trimmed.contains(&format!("let {} = ", var))
-                    || trimmed.contains(&format!("const {} = ", var))
-                    || trimmed.contains(&format!("var {} = ", var))
-            });
-            if is_declaration {
-                transformed_lines.push(line.to_string());
-            } else {
-                let transformed = transform_state_assignments(
-                    line,
-                    &reactive_module_state_vars,
-                    &module_non_reactive_vars,
-                    &module_proxy_vars,
-                    &derived_vars, // derived vars are treated like raw_state for proxy skipping
-                    analysis.runes,
-                    &[],
-                );
-                transformed_lines.push(transformed);
-            }
-        }
-        result = transformed_lines.join("\n");
+        // Whole-script AST pass for assignment transforms. The
+        // three helpers (simple / compound / update) visit
+        // AssignmentExpression / UpdateExpression nodes throughout
+        // the parsed program — VariableDeclarators are naturally
+        // skipped, so we don't need a per-line declaration
+        // heuristic. The symbol-identity match (PR #226) correctly
+        // distinguishes the module-local state var from same-name
+        // shadows.
+        result = state_simple_assigns_ast::transform_state_simple_assigns_ast(
+            &result,
+            &reactive_module_state_vars,
+            &derived_vars, // raw_state treatment for proxy skip
+            analysis.runes,
+            &[],
+        )
+        .unwrap_or(result);
+        result = state_compound_assigns_ast::transform_state_compound_assigns_ast(
+            &result,
+            &reactive_module_state_vars,
+        )
+        .unwrap_or(result);
+        result = state_update_assigns_ast::transform_state_update_assigns_ast(
+            &result,
+            &reactive_module_state_vars,
+        )
+        .unwrap_or(result);
 
         // Wrap state variable reads in $.get() (only for reactive vars, not non-reactive)
         result = wrap_state_vars_in_expr(

--- a/src/compiler/phases/3_transform/client/scope_analysis.rs
+++ b/src/compiler/phases/3_transform/client/scope_analysis.rs
@@ -147,9 +147,20 @@ pub fn find_state_var_symbols(semantic: &Semantic, names: &[String]) -> FxHashSe
 fn declaration_has_state_var_init(semantic: &Semantic, decl_id: oxc_syntax::node::NodeId) -> bool {
     use oxc_ast::AstKind;
     let nodes = semantic.nodes();
+    // `Scoping::symbol_declaration` returns the `VariableDeclarator`
+    // NodeId directly for variable bindings (verified via debug
+    // traces). Check that kind first, then walk a few parents as
+    // a safety net in case other binding shapes report a deeper
+    // descendant (e.g. a BindingIdentifier inside a
+    // BindingPattern).
+    let kind = nodes.get_node(decl_id).kind();
+    if let AstKind::VariableDeclarator(decl) = kind {
+        let Some(init) = &decl.init else {
+            return false;
+        };
+        return is_state_var_init_expression(init);
+    }
     let mut cur = decl_id;
-    // BindingIdentifier -> (BindingPattern) -> VariableDeclarator
-    // is at most 2 hops; bound the walk conservatively.
     for _ in 0..4 {
         if let AstKind::VariableDeclarator(decl) = nodes.parent_kind(cur) {
             let Some(init) = &decl.init else {


### PR DESCRIPTION
## Summary

Replaces the per-line iteration at Site 1 (mod.rs:2768-2793,
module-script state-assignment processing) with three
whole-script AST passes. The per-line loop was a historical
workaround for \`transform_state_assignments\`'s overly-broad
declaration guard (\"skip ALL assignments if any declaration
for the variable exists in the text\"). With the symbol-identity
matching from #226 the guard isn't needed — \`VariableDeclarator\`s
are naturally not \`AssignmentExpression\`s, so the AST visitors
skip declarations without any heuristic.

Also fixes a bug in \`find_state_var_symbols\`: oxc_semantic's
\`symbol_declaration(symbol_id)\` returns the \`VariableDeclarator\`
NodeId directly (not the inner \`BindingIdentifier\` as I assumed).
The walk-up loop never matched because \`cur\` already was the
\`VariableDeclarator\`. Added a check on the start node itself,
keeping the parent walk as a safety net for other binding shapes.

**Result**: the \`runes-in-module-context\` runtime fixture (with
a function-local rune declaration \`function createCounter() {
let count = \$state(0); ... set count(value) { count = value; }
}\`) now passes via the AST path. The text fallback at Site 1
is removed entirely.

Sites 2/3/4 still use the text version; they take whole
statements as input (not per-line) so the parse-failure problem
doesn't apply, but removing them is a separate concern.

## Test plan

- [x] \`cargo test --release --test runtime test_runtime_legacy\` — 100%
- [x] \`cargo test --release --test runtime test_runtime_runes\` — 100%
- [x] \`cargo test --release --test ssr\` — 100%
- [x] \`cargo test --release --test compatibility_report\` — 3087/3087 in-scope, every category at 100%
- [x] \`cargo fmt -- --check\`, \`cargo clippy --all-targets --all-features -- -D warnings\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)