### PR TITLE
feat(docs): toolchain-wide hero on /benchmark + fix bench-deps chain

### DIFF
--- a/docs/src/routes/benchmark/+page.svelte
+++ b/docs/src/routes/benchmark/+page.svelte
@@ -75,6 +75,20 @@
 		return list;
 	});
 
+	const headlineSpeedups: { id: TaskId; label: string; sub: string; x: number; precision: number }[] = $derived(
+		tasks.map((t) => ({
+			id: t.id,
+			label: t.label,
+			sub: t.sub,
+			x: t.data.speedup.multiThreadVsJs,
+			precision: t.data.speedup.multiThreadVsJs >= 50 ? 0 : 1
+		}))
+	);
+
+	const maxHeadlineSpeedup = $derived(
+		headlineSpeedups.reduce((m, s) => Math.max(m, s.x), 0)
+	);
+
 	const getMaxDuration = (r: BenchmarkTaskResults): number =>
 		Math.max(r.javascript.durationMs, r.rustSingleThread.durationMs, r.rustMultiThread.durationMs);
 
@@ -144,11 +158,13 @@
 		{@const r = data.results}
 
 		<header class="hero">
-			<p class="eyebrow"><span class="rule"></span>Compilation speed · against svelte/compiler</p>
+			<p class="eyebrow">
+				<span class="rule"></span>Across the Svelte toolchain · multi-threaded vs official JS
+			</p>
 
 			<h1 class="title">
-				<span class="ink-svelte">{r.speedup.multiThreadVsJs.toFixed(1)}×</span> faster than
-				<code>svelte/compiler</code>.
+				Up to <span class="ink-svelte">{maxHeadlineSpeedup.toFixed(0)}×</span> faster across the
+				Svelte toolchain.
 			</h1>
 
 			<dl class="hero-meta">
@@ -168,34 +184,15 @@
 		</header>
 
 		<section class="stats">
-			<article class="stat stat-hero">
-				<span class="stat-k">Multi-threaded</span>
-				<span class="stat-n">
-					{r.speedup.multiThreadVsJs.toFixed(1)}<span class="stat-x">×</span>
-				</span>
-				<span class="stat-s">rayon fan-out · full pipeline</span>
-			</article>
-			<article class="stat">
-				<span class="stat-k">Single-threaded</span>
-				<span class="stat-n">
-					{r.speedup.singleThreadVsJs.toFixed(1)}<span class="stat-x">×</span>
-				</span>
-				<span class="stat-s">no parallelism</span>
-			</article>
-			<article class="stat">
-				<span class="stat-k">Throughput</span>
-				<span class="stat-n">
-					{formatThroughput(r.rustMultiThread.throughputFilesPerSec)}<span class="stat-x">/s</span>
-				</span>
-				<span class="stat-s">files compiled per second</span>
-			</article>
-			<article class="stat">
-				<span class="stat-k">Parser alone</span>
-				<span class="stat-n">
-					{r.parse.speedup.multiThreadVsJs.toFixed(0)}<span class="stat-x">×</span>
-				</span>
-				<span class="stat-s">phase 1, isolated</span>
-			</article>
+			{#each headlineSpeedups as s, i (s.id)}
+				<article class="stat" class:stat-hero={i === 0}>
+					<span class="stat-k">{s.label}</span>
+					<span class="stat-n">
+						{s.x.toFixed(s.precision)}<span class="stat-x">×</span>
+					</span>
+					<span class="stat-s">{s.sub}</span>
+				</article>
+			{/each}
 		</section>
 
 		<section class="chart">
@@ -329,18 +326,6 @@
 		color: var(--ink);
 		margin: 0;
 		max-width: 22ch;
-	}
-
-	.title code {
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.7em;
-		font-weight: 500;
-		padding: 0.06em 0.42em;
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-radius: 4px;
-		color: var(--ink);
-		vertical-align: 0.08em;
 	}
 
 	.ink-svelte {

--- a/scripts/run-benchmark.mjs
+++ b/scripts/run-benchmark.mjs
@@ -34,37 +34,53 @@ const SVELTE_TESTS = join(REPO_ROOT, 'submodules/svelte/packages/svelte/tests');
  * cost nothing.
  */
 function ensureBenchDeps() {
-	const deps = [
-		{
-			name: 'svelte/compiler',
-			marker: 'submodules/svelte/packages/svelte/compiler/index.js',
-			cwd: 'submodules/svelte',
-			build: 'pnpm install --frozen-lockfile && pnpm build',
-		},
+	// Stdio used for every shell-out below: stdin ignored, child stdout
+	// redirected to *our* stderr so it can never corrupt the JSON the
+	// parent script pipes from our stdout, stderr inherited so build
+	// logs still surface in the terminal.
+	const sio = { stdio: ['ignore', 2, 'inherit'] };
+	const run = (cmd, cwd) =>
+		execSync(cmd, { ...sio, cwd: join(REPO_ROOT, cwd) });
+	const built = (marker) => existsSync(join(REPO_ROOT, marker));
+
+	// 1. svelte/compiler — self-contained, has its own install + build.
+	if (!built('submodules/svelte/packages/svelte/compiler/index.js')) {
+		console.error('[run-benchmark] building svelte/compiler (one-time)…');
+		run('pnpm install --frozen-lockfile && pnpm build', 'submodules/svelte');
+	}
+
+	// 2. language-tools — svelte2tsx → language-server → svelte-check is a
+	// hard dependency chain (each package's rollup config imports the
+	// previous package's `dist/`). Walk it explicitly so we don't end up
+	// re-running upstream's `pnpm build` script, which tail-runs a slow
+	// `test:sanity` fixture pass.
+	const langPkgs = [
 		{
 			name: 'svelte2tsx',
 			marker: 'submodules/language-tools/packages/svelte2tsx/index.mjs',
-			cwd: 'submodules/language-tools',
-			build: 'pnpm install --frozen-lockfile && (cd packages/svelte2tsx && pnpm build)',
+			cwd: 'submodules/language-tools/packages/svelte2tsx',
+		},
+		{
+			name: 'language-server',
+			marker: 'submodules/language-tools/packages/language-server/dist/src/index.js',
+			cwd: 'submodules/language-tools/packages/language-server',
 		},
 		{
 			name: 'svelte-check',
-			// The CLI entrypoint is `bin/svelte-check`, which requires the
-			// rollup-bundled dist; build it if missing. svelte-check's own
-			// `pnpm build` script also builds svelte2tsx + language-server
-			// transitively, but the cheaper path here is just `rollup -c`
-			// (svelte2tsx is already covered above).
 			marker: 'submodules/language-tools/packages/svelte-check/dist/src/index.js',
 			cwd: 'submodules/language-tools/packages/svelte-check',
-			build: 'pnpm exec rollup -c',
 		},
 	];
-	for (const dep of deps) {
-		if (existsSync(join(REPO_ROOT, dep.marker))) continue;
-		console.error(`[run-benchmark] ${dep.name}: ${dep.marker} missing — building (one-time setup)…`);
-		// Route the build's stdout to our stderr so it never lands in
-		// the benchmark JSON the parent pipes to a file.
-		execSync(dep.build, { cwd: join(REPO_ROOT, dep.cwd), stdio: ['ignore', 2, 'inherit'] });
+	const langPending = langPkgs.filter((p) => !built(p.marker));
+	if (langPending.length > 0) {
+		if (!built('submodules/language-tools/node_modules/.modules.yaml')) {
+			console.error('[run-benchmark] installing language-tools workspace (one-time)…');
+			run('pnpm install --frozen-lockfile', 'submodules/language-tools');
+		}
+		for (const pkg of langPending) {
+			console.error(`[run-benchmark] building language-tools/${pkg.name} (one-time)…`);
+			run('pnpm exec rollup -c', pkg.cwd);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Two related fixes packaged together.

### 1. `/benchmark` top section — toolchain-wide

The old hero centred on `svelte/compiler` (one big number, one product) and the stats grid mixed compile / single-threaded / throughput / parser-only. Hard to read, and svelte2tsx + svelte-check weren't represented at all.

- **Hero**: \`Up to {max}× faster across the Svelte toolchain\`
- **Stats grid**: 4 cards, one per task (compile / parse / svelte2tsx / svelte-check), each showing its multi-threaded speedup. Driven by the existing `tasks` array — the svelte-check card only appears once that field is populated in the JSON.

### 2. `scripts/run-benchmark.mjs` `ensureBenchDeps` — dependency-ordered build

The previous `Refresh benchmark` workflow run (#26198965755) failed because building `svelte-check` blew up: rollup tried to load `language-server/dist/src/index.js`, which doesn't exist on a fresh checkout. svelte-check imports language-server, which imports svelte2tsx — that's a hard chain. Replaced the flat prereq list with an explicit dependency-ordered walk (svelte2tsx → language-server → svelte-check), all via `pnpm exec rollup -c` so we skip upstream's tail `test:sanity` pass. Workspace `pnpm install` runs once if any of the three markers are missing.

## Test plan
- [ ] After merge, re-run `Refresh benchmark` from the Actions UI — should complete instead of failing in svelte-check rollup
- [ ] Open `/benchmark` after the refresh PR lands — hero says "Up to N× faster across the Svelte toolchain" and the stats grid shows 4 task cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)