### PR TITLE
fix(bench-deps): build language-server with tsc, not rollup

### DIFF
--- a/scripts/run-benchmark.mjs
+++ b/scripts/run-benchmark.mjs
@@ -50,25 +50,36 @@ function ensureBenchDeps() {
 	}
 
 	// 2. language-tools — svelte2tsx → language-server → svelte-check is a
-	// hard dependency chain (each package's rollup config imports the
+	// hard dependency chain (each package's build config imports the
 	// previous package's `dist/`). Walk it explicitly so we don't end up
-	// re-running upstream's `pnpm build` script, which tail-runs a slow
-	// `test:sanity` fixture pass.
+	// re-running upstream's recursive `pnpm build` script, which
+	// rebuilds everything and tail-runs a slow `test:sanity` pass.
+	// Each package's own build command differs: svelte2tsx and
+	// svelte-check use rollup, language-server uses tsc — call each
+	// package's defined `pnpm build` for the first two, and rollup
+	// directly for svelte-check (skipping the recursive cd dance).
 	const langPkgs = [
 		{
 			name: 'svelte2tsx',
 			marker: 'submodules/language-tools/packages/svelte2tsx/index.mjs',
 			cwd: 'submodules/language-tools/packages/svelte2tsx',
+			cmd: 'pnpm build',
 		},
 		{
 			name: 'language-server',
 			marker: 'submodules/language-tools/packages/language-server/dist/src/index.js',
 			cwd: 'submodules/language-tools/packages/language-server',
+			cmd: 'pnpm build',
 		},
 		{
 			name: 'svelte-check',
 			marker: 'submodules/language-tools/packages/svelte-check/dist/src/index.js',
 			cwd: 'submodules/language-tools/packages/svelte-check',
+			// Upstream's `pnpm build` recursively rebuilds svelte2tsx +
+			// language-server (idempotent but slow) and runs a fixture
+			// `test:sanity` pass. Invoke rollup directly — it's in
+			// svelte-check's own devDeps.
+			cmd: 'pnpm exec rollup -c',
 		},
 	];
 	const langPending = langPkgs.filter((p) => !built(p.marker));
@@ -79,7 +90,7 @@ function ensureBenchDeps() {
 		}
 		for (const pkg of langPending) {
 			console.error(`[run-benchmark] building language-tools/${pkg.name} (one-time)…`);
-			run('pnpm exec rollup -c', pkg.cwd);
+			run(pkg.cmd, pkg.cwd);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Hotfix on top of #238. The dependency-ordered walk landed in main but assumed all three language-tools packages built with rollup. Only svelte2tsx and svelte-check do — language-server's `pnpm build` is `tsc`, so the workflow crashed with \`Command "rollup" not found\` once it got past svelte2tsx.

Call each package's own `pnpm build` for svelte2tsx + language-server, and `pnpm exec rollup -c` directly for svelte-check (rollup is in its own devDeps; this skips upstream's recursive cd build script and trailing `test:sanity`).

## Test plan
- [ ] After merge, re-run `Refresh benchmark` — should get past language-server build and produce a JSON with `svelteCheck` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)