### PR TITLE
feat(bench): pickable larger-runner ARM/x64 + machine info on /benchmark

### DIFF
--- a/.github/workflows/refresh-benchmark.yml
+++ b/.github/workflows/refresh-benchmark.yml
@@ -10,6 +10,29 @@ name: Refresh benchmark
 
 on:
   workflow_dispatch:
+    inputs:
+      runner:
+        description: |
+          Runner size. ARM variants are ~3× cheaper than x64 at the same
+          core count; larger runners need to be enabled in repo settings
+          (Actions → Runners → Larger runners) before this workflow can
+          schedule them. Free-tier accounts cannot use the larger runners.
+        required: true
+        default: ubuntu-22.04-arm-16-cores
+        type: choice
+        options:
+          - ubuntu-latest              # 2-core x64, free for OSS
+          - ubuntu-22.04-arm           # 2-core arm64, free for OSS
+          - ubuntu-22.04-arm-4-cores   # ~$0.005/min  (cheapest larger ARM)
+          - ubuntu-22.04-arm-8-cores   # ~$0.010/min
+          - ubuntu-22.04-arm-16-cores  # ~$0.020/min  (recommended default)
+          - ubuntu-22.04-arm-32-cores  # ~$0.040/min
+          - ubuntu-22.04-arm-64-cores  # ~$0.080/min  (biggest demo)
+          - ubuntu-latest-4-cores      # ~$0.016/min  x64 larger runners
+          - ubuntu-latest-8-cores      # ~$0.032/min
+          - ubuntu-latest-16-cores     # ~$0.064/min
+          - ubuntu-latest-32-cores     # ~$0.128/min
+          - ubuntu-latest-64-cores     # ~$0.256/min  (biggest x64, priciest)
 
 permissions:
   contents: write
@@ -17,8 +40,12 @@ permissions:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 60
+    env:
+      # Surfaced into the benchmark JSON so the site can show users
+      # which hardware produced the numbers they're looking at.
+      BENCHMARK_RUNNER_LABEL: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,24 +69,13 @@ jobs:
           # set on the binaries we exercise (benchmark_runner / lib).
           shared-key: bench
 
-      - name: Build Svelte compiler
-        # `run-benchmark.mjs` imports the upstream `svelte/compiler` for
-        # its JS baseline; that package's workspace deps (acorn,
-        # magic-string, …) need installing before its build runs.
-        run: |
-          cd submodules/svelte
-          pnpm install --frozen-lockfile
-          pnpm build
-
-      - name: Build language-tools svelte2tsx
-        # The benchmark's `svelte2tsx` JS baseline imports
-        # submodules/language-tools/packages/svelte2tsx/index.mjs, which
-        # is a rollup build output rather than a checked-in artifact.
-        run: |
-          cd submodules/language-tools
-          pnpm install --frozen-lockfile
-          cd packages/svelte2tsx
-          pnpm build
+      # The benchmark's JS baselines (svelte/compiler, svelte2tsx,
+      # language-server, svelte-check) all need their rollup / tsc build
+      # outputs in place, since upstream tracks sources but not dist/.
+      # `scripts/run-benchmark.mjs` handles that bootstrap itself via
+      # `ensureBenchDeps`, so we go straight to the script below — no
+      # separate "Build Svelte compiler" / "Build svelte2tsx" steps to
+      # maintain in two places.
 
       - name: Run JS vs Rust benchmark
         run: node scripts/run-benchmark.mjs > docs/static/benchmark-results.json
@@ -73,7 +89,9 @@ jobs:
           body: |
             Automated refresh of `docs/static/benchmark-results.json` from
             the `Refresh benchmark` workflow (`workflow_dispatch`).
-            Triggered by @${{ github.actor }} from `${{ github.sha }}`.
+
+            - Runner: `${{ inputs.runner }}`
+            - Triggered by @${{ github.actor }} from `${{ github.sha }}`
 
             Review the diff and merge when the new numbers look sane.
           branch: ci/refresh-benchmark

--- a/docs/src/lib/types/benchmark.ts
+++ b/docs/src/lib/types/benchmark.ts
@@ -20,9 +20,21 @@ export interface SvelteCheckBenchmarkTaskResults extends BenchmarkTaskResults {
 	filesCount: number;
 }
 
+export interface RunnerInfo {
+	// Free-form label that names the host. In CI this is the GitHub-hosted
+	// runner label (e.g. "ubuntu-22.04-arm-16-cores"); locally it's "local".
+	label: string;
+	os: string; // process.platform — "linux" / "darwin" / "win32"
+	arch: string; // process.arch — "x64" / "arm64" / …
+	cpus: number;
+	cpuModel: string;
+}
+
 export interface BenchmarkResults extends BenchmarkTaskResults {
 	generatedAt: string;
 	commitSha: string;
+	// Optional — older JSON files don't have this field.
+	runner?: RunnerInfo;
 	testFilesCount: number;
 	parse: BenchmarkTaskResults;
 	svelte2tsx?: BenchmarkTaskResults;

--- a/docs/src/routes/benchmark/+page.svelte
+++ b/docs/src/routes/benchmark/+page.svelte
@@ -172,6 +172,15 @@
 					<dt>Corpus</dt>
 					<dd>{r.testFilesCount.toLocaleString('en-US')} .svelte files</dd>
 				</div>
+				{#if r.runner}
+					<div>
+						<dt>Machine</dt>
+						<dd>
+							{r.runner.cpus}-core {r.runner.arch}
+							<span class="hero-meta-aside">· {r.runner.label}</span>
+						</dd>
+					</div>
+				{/if}
 				<div>
 					<dt>Recorded</dt>
 					<dd>{formatDate(r.generatedAt)}</dd>
@@ -367,6 +376,11 @@
 	.hero-meta code {
 		font-size: 0.92em;
 		color: var(--rust);
+	}
+
+	.hero-meta-aside {
+		color: var(--ink-faint);
+		font-size: 0.82em;
 	}
 
 	/* STATS */

--- a/scripts/run-benchmark.mjs
+++ b/scripts/run-benchmark.mjs
@@ -16,7 +16,7 @@
 
 import { execSync, spawn, spawnSync } from 'child_process';
 import { mkdirSync, mkdtempSync, rmSync } from 'fs';
-import { tmpdir } from 'os';
+import { arch as nodeArch, cpus, platform as nodePlatform, tmpdir } from 'os';
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -300,6 +300,25 @@ function getCommitSha() {
 }
 
 /**
+ * Capture hardware / OS info for the machine running this benchmark.
+ * Surfaced into the JSON output so the /benchmark page can credit the
+ * runner — multi-threaded numbers only mean something in the context
+ * of how many cores were available. In CI the workflow sets
+ * `BENCHMARK_RUNNER_LABEL` to the GitHub-hosted runner label
+ * (e.g. `ubuntu-22.04-arm-16-cores`); locally it's just "local".
+ */
+function getRunnerInfo() {
+	const cpuList = cpus();
+	return {
+		label: process.env.BENCHMARK_RUNNER_LABEL || 'local',
+		os: nodePlatform(),
+		arch: nodeArch(),
+		cpus: cpuList.length,
+		cpuModel: cpuList[0]?.model?.trim() ?? 'unknown',
+	};
+}
+
+/**
  * Calculate statistics from timing results
  */
 function calculateStats(times, filesCount) {
@@ -520,6 +539,7 @@ async function main() {
 	const output = {
 		generatedAt: new Date().toISOString(),
 		commitSha: getCommitSha(),
+		runner: getRunnerInfo(),
 		testFilesCount: files.length,
 		...asTaskResults(compileClient),
 		parse: asTaskResults(parse),


### PR DESCRIPTION
## Summary
Three related changes:

### 1. Pickable runner size on `Refresh benchmark`
The 2-core default runner mutes the multi-thread story (e.g. 9× compile vs 18× on a 10-core Mac). Add a `workflow_dispatch.inputs.runner` choice covering both ARM and x64 GitHub-hosted larger runners; everything else stays on the default 2-core because **only this workflow** uses the input, and the workflow itself is manually-triggered. Costs:

| Runner | Per-minute | ~10-min run |
|---|---|---|
| `ubuntu-latest` (2-core x64) | free | free |
| `ubuntu-22.04-arm` (2-core ARM) | free | free |
| `ubuntu-22.04-arm-16-cores` (**default**) | ~$0.020 | ~$0.20 |
| `ubuntu-22.04-arm-64-cores` | ~$0.080 | ~$0.80 |
| `ubuntu-latest-16-cores` (x64) | ~$0.064 | ~$0.64 |
| `ubuntu-latest-64-cores` (x64, priciest) | ~$0.256 | ~$2.56 |

ARM larger runners are ~3× cheaper at the same core count, so the default is `ubuntu-22.04-arm-16-cores`.

⚠️ **Prerequisite**: larger runners must be enabled in Settings → Actions → Runners → Larger runners. Free-tier accounts can't use them; they only get the two free 2-core options.

### 2. Machine info captured in the JSON
`scripts/run-benchmark.mjs` now emits a `runner: { label, os, arch, cpus, cpuModel }` field via Node's `os` module + the workflow's `BENCHMARK_RUNNER_LABEL` env var (falls back to "local" off-CI).

### 3. Hero shows where the numbers came from
A new "Machine" row in the hero meta — e.g. `16-core arm64 · ubuntu-22.04-arm-16-cores` — so the speedup figures are honest about the hardware.

Also dropped the now-redundant explicit `Build Svelte compiler` / `Build svelte2tsx` steps from the workflow — `ensureBenchDeps` in the script handles bootstrap for all four upstream packages.

## Test plan
- [ ] Manually run `Refresh benchmark`, leave runner on default → PR opens with `runner.cpus === 16` and `arch === "arm64"`
- [ ] After merge of the auto-PR + next Deploy Docs, the hero shows "Machine: 16-core arm64 · ubuntu-22.04-arm-16-cores"
- [ ] Locally: `pnpm run generate-benchmark` writes `runner.label === "local"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)