### PR TITLE
refactor: strip unnecessary #[allow(dead_code)] markers + drop binary-only dead code

### DIFF
--- a/src/bin/canonicalize_and_compare.rs
+++ b/src/bin/canonicalize_and_compare.rs
@@ -311,46 +311,6 @@ fn collapse_ws_in_template_interpolations(code: &str) -> String {
     out
 }
 
-#[allow(dead_code)]
-fn canonicalize(code: &str) -> String {
-    let allocator = Allocator::new();
-    let source_type = SourceType::mjs();
-    let parsed = Parser::new(&allocator, code, source_type).parse();
-    if parsed.panicked || !parsed.errors.is_empty() {
-        // On parse failure, normalize whitespace heavily so that two inputs
-        // that only differ in formatting still compare equal.
-        return normalize_whitespace_and_quotes(code);
-    }
-    let options = CodegenOptions {
-        single_quote: true,
-        comments: CommentOptions {
-            normal: false,
-            jsdoc: false,
-            annotation: false,
-            legal: LegalComment::None,
-        },
-        ..Default::default()
-    };
-    let out = Codegen::new()
-        .with_options(options)
-        .build(&parsed.program)
-        .code
-        .trim()
-        .to_string();
-
-    // OXC's `single_quote: true` doesn't always normalize import-source string
-    // literals (it leaves the original quote style for some imports). We
-    // post-process to convert any remaining double-quoted import sources to
-    // single quotes so that two semantically-equal files with different quote
-    // styles compare equal.
-    let out = normalize_import_quotes(&out);
-
-    // Normalize consecutive whitespace inside template literals to a single space.
-    // This handles differences like `/>  <meta` vs `/> <meta` caused by comment
-    // removal and whitespace collapsing differences between compilers.
-    normalize_template_literal_whitespace(&out)
-}
-
 /// On parse-failure fallback: normalize whitespace (collapse runs, unify
 /// indentation) and import quote style so that two superficially-different
 /// inputs that only differ in formatting can still compare equal.

--- a/src/bin/oxc_call_counter.rs
+++ b/src/bin/oxc_call_counter.rs
@@ -16,16 +16,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 use std::fs;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicU64;
 use std::time::Instant;
-
-// Global counters (only works single-threaded)
-#[allow(dead_code)]
-static OXC_EXPR_CALLS: AtomicU64 = AtomicU64::new(0);
-#[allow(dead_code)]
-static OXC_PROGRAM_CALLS: AtomicU64 = AtomicU64::new(0);
-#[allow(dead_code)]
-static FAST_PATH_HITS: AtomicU64 = AtomicU64::new(0);
 
 fn main() {
     let files = collect_files();

--- a/src/bin/test_reporter.rs
+++ b/src/bin/test_reporter.rs
@@ -746,15 +746,6 @@ fn run_ssr_tests(expected_outputs: &serde_json::Value) -> Category {
 // Compiler Error Tests
 // ============================================================================
 
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct ExpectedError {
-    code: String,
-    message: String,
-    #[serde(default)]
-    position: Option<[u32; 2]>,
-}
-
 fn extract_string_field(content: &str, field: &str) -> Option<String> {
     let patterns = [
         format!("{}: '", field),
@@ -954,9 +945,9 @@ fn run_compiler_error_tests() -> Category {
 // ============================================================================
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 struct ValidatorError {
     code: String,
+    #[allow(dead_code)]
     message: String,
 }
 

--- a/src/compiler/phases/1_parse/mod.rs
+++ b/src/compiler/phases/1_parse/mod.rs
@@ -51,11 +51,9 @@
 //! Note: Legacy AST conversion is in `compiler/legacy.rs` (matches Svelte's
 //! `svelte/packages/svelte/src/compiler/legacy.js`).
 
-#[allow(dead_code)]
 pub mod estree_compat;
 mod parser;
 pub(crate) mod read;
-#[allow(dead_code)]
 pub mod remove_typescript_nodes;
 pub(crate) mod resolve_lazy;
 mod state;

--- a/src/compiler/phases/1_parse/parser.rs
+++ b/src/compiler/phases/1_parse/parser.rs
@@ -33,10 +33,10 @@ use super::ParseOptions;
 ///
 /// Corresponds to `LastAutoClosedTag` in `svelte/packages/svelte/src/compiler/phases/1-parse/index.js`.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct LastAutoClosedTag {
     pub tag: CompactString,
     pub reason: CompactString,
+    #[allow(dead_code)]
     pub depth: usize,
 }
 
@@ -51,7 +51,6 @@ pub struct Parser<'a> {
     /// Current byte position in the source.
     pub(crate) index: usize,
     /// Parser options.
-    #[allow(dead_code)]
     pub(crate) options: ParseOptions,
     /// Stack of open elements/blocks for validation.
     pub(crate) stack: Vec<StackEntry>,
@@ -70,17 +69,14 @@ pub struct Parser<'a> {
     /// Whether we're in TypeScript mode.
     ///
     /// Corresponds to `ts` field in JavaScript Parser.
-    #[allow(dead_code)]
     pub(crate) ts: bool,
     /// Meta tags (e.g., svelte:head, svelte:options).
     ///
     /// Corresponds to `meta_tags` field in JavaScript Parser.
-    #[allow(dead_code)]
     pub(crate) meta_tags: FxHashMap<String, bool>,
     /// Last auto-closed tag.
     ///
     /// Corresponds to `last_auto_closed_tag` field in JavaScript Parser.
-    #[allow(dead_code)]
     pub(crate) last_auto_closed_tag: Option<LastAutoClosedTag>,
     /// Parser-level warnings (e.g., element_implicitly_closed).
     pub(crate) parse_warnings: Vec<crate::ast::template::ParseWarning>,
@@ -90,7 +86,6 @@ pub struct Parser<'a> {
 
 /// An entry on the parser stack.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum StackEntry {
     Root,
     Element {

--- a/src/compiler/phases/1_parse/read/acorn.rs
+++ b/src/compiler/phases/1_parse/read/acorn.rs
@@ -18,20 +18,24 @@ use oxc_span::{GetSpan, SourceType};
 use serde_json::{Map, Value as JsonValue};
 
 /// Parse result containing the AST and any comments
+#[allow(dead_code)]
 pub struct ParseResult {
     pub ast: JsonValue,
     pub comments: Vec<Comment>,
 }
 
 /// Comment with location information
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Comment {
     pub kind: CommentKind,
+    #[allow(dead_code)]
     pub value: String,
     pub start: usize,
     pub end: usize,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommentKind {
     Line,
@@ -59,6 +63,7 @@ impl CommentKind {
 ///
 /// # Returns
 /// A JSON representation of the Program AST with comments attached
+#[allow(dead_code)]
 pub fn parse(source: &str, typescript: bool, _is_script: bool) -> Result<ParseResult, String> {
     let source_type = if typescript {
         SourceType::default()
@@ -97,6 +102,7 @@ pub fn parse(source: &str, typescript: bool, _is_script: bool) -> Result<ParseRe
 ///
 /// # Returns
 /// A JSON representation of the expression with comments
+#[allow(dead_code)]
 pub fn parse_expression_at(
     source: &str,
     typescript: bool,
@@ -151,6 +157,7 @@ pub fn parse_expression_at(
 }
 
 /// Extract comments from OXC parser result
+#[allow(dead_code)]
 fn extract_comments(source: &str, result: &ParserReturn) -> Vec<Comment> {
     let mut comments = Vec::new();
 
@@ -177,6 +184,7 @@ fn extract_comments(source: &str, result: &ParserReturn) -> Vec<Comment> {
 }
 
 /// Extract the value from a comment, removing delimiters
+#[allow(dead_code)]
 fn extract_comment_value(raw: &str, kind: oxc_ast::ast::CommentKind) -> String {
     match kind {
         oxc_ast::ast::CommentKind::Line => raw.strip_prefix("//").unwrap_or(raw).to_string(),
@@ -188,6 +196,7 @@ fn extract_comment_value(raw: &str, kind: oxc_ast::ast::CommentKind) -> String {
 }
 
 /// Convert OXC Program to JSON representation
+#[allow(dead_code)]
 fn program_to_json(program: &Program, source: &str) -> JsonValue {
     let mut obj = Map::new();
     obj.insert("type".to_string(), JsonValue::String("Program".to_string()));
@@ -219,6 +228,7 @@ fn program_to_json(program: &Program, source: &str) -> JsonValue {
 }
 
 /// Convert OXC Statement to JSON
+#[allow(dead_code)]
 fn statement_to_json(stmt: &Statement, source: &str) -> JsonValue {
     // Basic conversion - would need full implementation for all statement types
     let mut obj = Map::new();
@@ -282,6 +292,7 @@ fn statement_to_json(stmt: &Statement, source: &str) -> JsonValue {
 }
 
 /// Convert OXC Expression to JSON
+#[allow(dead_code)]
 fn expression_to_json(expr: &oxc_ast::ast::Expression, source: &str) -> JsonValue {
     let mut obj = Map::new();
     let span = expr.span();
@@ -422,6 +433,7 @@ fn expression_to_json(expr: &oxc_ast::ast::Expression, source: &str) -> JsonValu
 }
 
 /// Recursively adjust positions in AST JSON
+#[allow(dead_code)]
 fn adjust_positions_recursive(obj: &mut Map<String, JsonValue>, offset: usize) {
     if let Some(JsonValue::Number(start)) = obj.get("start")
         && let Some(start_num) = start.as_u64()

--- a/src/compiler/phases/1_parse/read/context.rs
+++ b/src/compiler/phases/1_parse/read/context.rs
@@ -119,6 +119,7 @@ pub fn read_pattern(
 ///
 /// # Returns
 /// A tuple of (Option<TypeAnnotation>, end position)
+#[allow(dead_code)]
 fn read_type_annotation(
     source: &str,
     start: usize,
@@ -178,26 +179,29 @@ fn read_type_annotation(
 
 /// Simple type annotation placeholder.
 /// Full TypeScript type parsing would require more complex implementation.
-#[derive(Debug, Clone)]
 #[allow(dead_code)]
+#[derive(Debug, Clone)]
 struct TypeAnnotation {
     start: usize,
     end: usize,
 }
 
 /// Check if a byte is a whitespace character.
+#[allow(dead_code)]
 #[inline]
 fn is_whitespace(b: u8) -> bool {
     matches!(b, b' ' | b'\t' | b'\n' | b'\r')
 }
 
 /// Check if a byte is valid in an identifier.
+#[allow(dead_code)]
 #[inline]
 fn is_identifier_char(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
 }
 
 /// Create a simple identifier expression.
+#[allow(dead_code)]
 fn create_simple_identifier(
     name: &str,
     start: usize,

--- a/src/compiler/phases/1_parse/read/expression.rs
+++ b/src/compiler/phases/1_parse/read/expression.rs
@@ -2706,7 +2706,6 @@ fn convert_ts_type_name_adjusted(
 }
 
 /// Convert oxc TSType to a serde_json::Value.
-#[allow(dead_code)]
 fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: &[usize]) -> Value {
     use oxc_ast::ast::TSType;
 
@@ -8596,7 +8595,6 @@ fn convert_assignment_target_property_for_program(
 }
 
 /// Convert a SimpleAssignmentTarget to JsNode (no -1 offset adjustment).
-#[allow(dead_code)]
 fn convert_simple_assignment_target_for_program(
     arena: &ParseArena,
     target: &oxc_ast::ast::SimpleAssignmentTarget,

--- a/src/compiler/phases/1_parse/read/mod.rs
+++ b/src/compiler/phases/1_parse/read/mod.rs
@@ -6,7 +6,6 @@
 //! The context module provides pattern parsing for {#each} and {#snippet} blocks.
 //! The acorn module provides OXC-based parsing equivalent to the original acorn.js.
 
-#[allow(dead_code)]
 pub mod acorn;
 pub mod context;
 pub mod expression;

--- a/src/compiler/phases/1_parse/utils/create.rs
+++ b/src/compiler/phases/1_parse/utils/create.rs
@@ -23,8 +23,8 @@ use crate::ast::template::{Fragment, FragmentMetadata, FragmentType};
 /// let fragment = create_fragment(false);
 /// assert_eq!(fragment.nodes.len(), 0);
 /// ```
-#[inline]
 #[allow(dead_code)]
+#[inline]
 pub fn create_fragment(transparent: bool) -> Fragment {
     Fragment {
         node_type: FragmentType::Fragment,
@@ -40,8 +40,8 @@ pub fn create_fragment(transparent: bool) -> Fragment {
 // with existing Rust code, but they don't correspond to the JS implementation.
 
 /// Create an empty Fragment (backward compatibility).
-#[inline]
 #[allow(dead_code)]
+#[inline]
 pub fn create_empty_fragment() -> Fragment {
     create_fragment(false)
 }

--- a/src/compiler/phases/1_parse/utils/mod.rs
+++ b/src/compiler/phases/1_parse/utils/mod.rs
@@ -79,7 +79,6 @@ const RESERVED_WORDS: &[&str] = &[
 ///
 /// Corresponds to `is_reserved()` in `svelte/packages/svelte/src/utils.js`.
 /// Uses first-byte dispatch and match for O(1) lookup instead of linear scan.
-#[allow(dead_code)]
 pub fn is_reserved(word: &str) -> bool {
     matches!(
         word,

--- a/src/compiler/phases/2_analyze/css_scoping.rs
+++ b/src/compiler/phases/2_analyze/css_scoping.rs
@@ -283,13 +283,9 @@ fn sequence_possible_values(
 
 /// Info about a template element for CSS matching.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct ElementInfo {
     pub tag_name: String,
     pub has_spread: bool,
-    pub classes: Vec<String>,
-    pub ids: Vec<String>,
-    pub has_dynamic_class: bool,
     /// Whether this is a dynamic element (<svelte:element>), which matches any type selector
     pub is_dynamic: bool,
     /// All attributes on the element (name, value pairs)
@@ -318,10 +314,7 @@ impl ElementInfo {
     ) -> Self {
         use template::Attribute;
 
-        let mut classes = Vec::new();
-        let mut ids = Vec::new();
         let mut has_spread = false;
-        let mut has_dynamic_class = false;
         let mut attr_pairs: Vec<(String, AttrValue)> = Vec::new();
         let mut bind_names = Vec::new();
         let mut has_style_directive = false;
@@ -348,41 +341,18 @@ impl ElementInfo {
                             }
                             if is_all_text && !static_parts.is_empty() {
                                 let full_value = static_parts.join("");
-                                attr_pairs.push((
-                                    attr_name.clone(),
-                                    AttrValue::Static(full_value.clone()),
-                                ));
-                                if attr_name == "class" {
-                                    for class in full_value.split_whitespace() {
-                                        classes.push(class.to_string());
-                                    }
-                                } else if attr_name == "id" {
-                                    ids.push(full_value);
-                                }
+                                attr_pairs.push((attr_name.clone(), AttrValue::Static(full_value)));
                             } else if attr_name == "class" {
-                                has_dynamic_class = true;
                                 // Try to compute possible values across all chunks, so
                                 // selectors like `.foo` can be pruned when `foo` isn't
                                 // a candidate token. Mirrors the official compiler's
                                 // `attribute_matches` logic in css-prune.js.
                                 if let Some(possible) = sequence_possible_values(parts, true) {
-                                    for value in &possible {
-                                        for class in value.split_whitespace() {
-                                            classes.push(class.to_string());
-                                        }
-                                    }
                                     attr_pairs.push((
                                         attr_name.clone(),
                                         AttrValue::PossibleValues(possible),
                                     ));
                                 } else {
-                                    for part in parts {
-                                        if let template::AttributeValuePart::Text(text) = part {
-                                            for class in text.data.split_whitespace() {
-                                                classes.push(class.to_string());
-                                            }
-                                        }
-                                    }
                                     attr_pairs.push((attr_name.clone(), AttrValue::Dynamic));
                                 }
                             } else {
@@ -391,16 +361,9 @@ impl ElementInfo {
                         }
                         template::AttributeValue::Expression(expr_tag) => {
                             if attr_name == "class" {
-                                has_dynamic_class = true;
                                 if let Some(possible) =
                                     get_possible_class_values(&expr_tag.expression)
                                 {
-                                    // Extract class tokens from each possible value.
-                                    for value in &possible {
-                                        for class in value.split_whitespace() {
-                                            classes.push(class.to_string());
-                                        }
-                                    }
                                     attr_pairs.push((
                                         attr_name.clone(),
                                         AttrValue::PossibleValues(possible),
@@ -415,7 +378,6 @@ impl ElementInfo {
                     }
                 }
                 Attribute::ClassDirective(cd) => {
-                    classes.push(cd.name.to_string());
                     class_directive_names.push(cd.name.to_string());
                 }
                 Attribute::SpreadAttribute(_) => {
@@ -434,9 +396,6 @@ impl ElementInfo {
         Self {
             tag_name: tag_name.to_string(),
             has_spread,
-            classes,
-            ids,
-            has_dynamic_class,
             is_dynamic,
             attributes: attr_pairs,
             bind_names,

--- a/src/compiler/phases/2_analyze/mod.rs
+++ b/src/compiler/phases/2_analyze/mod.rs
@@ -2642,7 +2642,6 @@ pub fn order_reactive_statements(
 ///
 /// Corresponds to `has_await` from `create_scopes()` in the official Svelte compiler,
 /// which tracks AwaitExpression nodes not nested inside function bodies.
-#[allow(dead_code)]
 /// Results from a combined fragment AST check for both await expressions and rune references.
 /// This allows a single traversal of the template AST to detect both features simultaneously.
 #[derive(Default)]

--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -3487,7 +3487,6 @@ pub(super) struct AstTransformConfig<'a> {
     pub exported_names: &'a [String],
 }
 
-#[allow(dead_code)]
 pub(super) fn transform_state_vars_ast(
     script: &str,
     config: &AstTransformConfig,

--- a/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -1052,8 +1052,8 @@ pub(super) fn is_shadowed_by_function_param(
 
 /// Check if chars at position `end` are preceded by the given pattern string.
 /// Compares chars[end - pattern.len() .. end] against the ASCII pattern.
-#[inline]
 #[allow(dead_code)]
+#[inline]
 pub(super) fn chars_match(chars: &[char], end: usize, pattern: &str) -> bool {
     let pat_bytes = pattern.as_bytes();
     let pat_len = pat_bytes.len();

--- a/src/compiler/phases/3_transform/client/scope_analysis.rs
+++ b/src/compiler/phases/3_transform/client/scope_analysis.rs
@@ -106,7 +106,6 @@ pub fn is_locally_shadowed(semantic: &Semantic, ident: &IdentifierReference) -> 
 /// A reference is to the state var iff its resolved
 /// `Reference.symbol_id()` is in this set. See
 /// [`is_state_var_reference`].
-#[allow(dead_code)]
 pub fn find_state_var_symbols(semantic: &Semantic, names: &[String]) -> FxHashSet<SymbolId> {
     if names.is_empty() {
         return FxHashSet::default();
@@ -218,7 +217,6 @@ fn is_state_var_init_expression(expr: &oxc_ast::ast::Expression) -> bool {
 ///
 /// Shadowing case: the reference resolves to a non-state-var
 /// symbol (e.g. function parameter) → returns `false`.
-#[allow(dead_code)]
 pub fn is_state_var_reference_or_unresolved(
     semantic: &Semantic,
     ident: &IdentifierReference,

--- a/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -2239,9 +2239,9 @@ pub fn build_each_block_getter_setter(
 
 /// Information about how a binding expression references an each block item.
 #[derive(Debug)]
-#[allow(dead_code)]
 enum EachBindingExprInfo {
     /// Direct reference to the each item (bind:value={item})
+    #[allow(dead_code)]
     DirectItem { item_name: String },
     /// Property access on the each item (bind:value={item.prop})
     ItemProperty {

--- a/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -682,7 +682,6 @@ pub fn build_style_directives_object_with_memoizer(
 }
 
 /// Check if an AttributeValue contains an await expression.
-#[allow(dead_code)]
 fn attr_has_await_expr(attr_value: &AttributeValue) -> bool {
     match attr_value {
         AttributeValue::True(_) => false,

--- a/src/compiler/phases/3_transform/css.rs
+++ b/src/compiler/phases/3_transform/css.rs
@@ -997,7 +997,6 @@ fn is_global_block(node: &Value) -> bool {
 
 /// Check if a rule starts with :global (with or without arguments)
 /// This includes both `:global { ... }` and `:global(.x) { ... }`
-#[allow(dead_code)]
 fn is_global_selector_rule(node: &Value) -> bool {
     if let Some(prelude) = node.get("prelude")
         && let Some(children) = prelude.get("children").and_then(|c| c.as_array())
@@ -2578,7 +2577,6 @@ fn is_descendant_selector_unused(rel_selectors: &[Value], ctx: &CssContext) -> b
 }
 
 /// Get the type selector name from a relative selector
-#[allow(dead_code)]
 fn get_type_selector_name(rel_selector: &Value) -> Option<String> {
     rel_selector
         .get("selectors")
@@ -2830,7 +2828,6 @@ fn decode_css_escape(name: &str) -> String {
 /// Check if a selector with :has() is unused by checking if the :has() argument
 /// can match within the subject element's subtree.
 /// For example, `x:has(> z)` is unused if no `x` element has a direct child `z`.
-#[allow(dead_code)]
 fn is_has_selector_unused(rel_selectors: &[Value], ctx: &CssContext) -> bool {
     if ctx.dom_structure.elements.is_empty() {
         return false;
@@ -3058,7 +3055,6 @@ fn is_has_argument_unused_globally(has_complex: &Value, ctx: &CssContext) -> boo
 
 /// Check if a :has() argument is unused relative to the subject elements.
 /// Returns true if the argument cannot match within any subject element's context.
-#[allow(dead_code)]
 fn is_has_argument_unused(
     has_complex: &Value,
     subject_elements: &[usize],
@@ -3189,7 +3185,6 @@ fn is_has_argument_unused(
 }
 
 /// Check if a multi-part :has() argument (like > h > i) is unused
-#[allow(dead_code)]
 fn is_multi_part_has_unused(
     rel_selectors: &[Value],
     subject_elements: &[usize],
@@ -3265,7 +3260,6 @@ fn is_multi_part_has_unused(
     false
 }
 
-#[allow(dead_code)]
 /// Check if an element has a matching descendant
 fn has_matching_descendant(parent_idx: usize, info: &SelectorInfo, ctx: &CssContext) -> bool {
     let parent = &ctx.dom_structure.elements[parent_idx];
@@ -3292,7 +3286,6 @@ fn has_matching_descendant(parent_idx: usize, info: &SelectorInfo, ctx: &CssCont
     false
 }
 
-#[allow(dead_code)]
 /// Collect all matching descendants
 fn collect_matching_descendants(
     parent_idx: usize,
@@ -3312,7 +3305,6 @@ fn collect_matching_descendants(
 }
 
 /// Extract SelectorInfo from a set of simple selectors (not the relative selector)
-#[allow(dead_code)]
 fn extract_selector_info_from_selectors(selectors: &[Value]) -> SelectorInfo {
     let mut info = SelectorInfo {
         tag_name: None,

--- a/src/compiler/phases/3_transform/server/types.rs
+++ b/src/compiler/phases/3_transform/server/types.rs
@@ -269,7 +269,6 @@ pub(crate) enum OutputPart {
         /// Interleaved props and spreads, preserving source order.
         props_and_spreads: Vec<ComponentPropItem>,
         bindings: Vec<ComponentBinding>,
-        #[allow(dead_code)]
         // Always true for component bindings - comment marker handled in build_parts
         has_prior_content: bool,
         children: Option<Vec<OutputPart>>,
@@ -280,10 +279,8 @@ pub(crate) enum OutputPart {
         /// Whether this component is dynamic (could be undefined/null)
         dynamic: bool,
         /// CSS custom properties (e.g., --color="red") to wrap in $.css_props()
-        #[allow(dead_code)]
         css_custom_props: Vec<(String, String)>,
         /// Whether CSS custom props should use HTML wrapper or SVG wrapper
-        #[allow(dead_code)]
         css_props_is_html: bool,
         /// Whether SequenceExpression bind_get/bind_set declarations have been
         /// hoisted out (e.g., when wrapped in an AsyncBlock). When true, the
@@ -305,7 +302,6 @@ pub(crate) enum OutputPart {
         index_alias: Option<String>,
         body: Vec<OutputPart>,
         /// Fallback content (for {:else} clause)
-        #[allow(dead_code)]
         fallback: Option<Vec<OutputPart>>,
     },
     /// If block - produces an if statement
@@ -357,10 +353,8 @@ pub(crate) enum OutputPart {
         then_body: Vec<OutputPart>,
         /// Catch param - populated by the visitor but not used in server-side output
         /// (the official Svelte compiler only passes 4 args to $.await on the server)
-        #[allow(dead_code)]
         catch_param: String,
         /// Catch body - populated by the visitor but not used in server-side output
-        #[allow(dead_code)]
         catch_body: Vec<OutputPart>,
     },
     /// svelte:boundary - async error boundary

--- a/src/compiler/phases/3_transform/server/visitors/svelte_element.rs
+++ b/src/compiler/phases/3_transform/server/visitors/svelte_element.rs
@@ -279,7 +279,6 @@ impl<'a> ServerCodeGenerator<'a> {
     }
 
     /// Build $.attributes() call for svelte:element with spread.
-    #[allow(dead_code)]
     fn build_svelte_element_spread_attributes(
         &mut self,
         elem: &SvelteDynamicElement,

--- a/src/compiler/print/context.rs
+++ b/src/compiler/print/context.rs
@@ -24,7 +24,6 @@ const INDENT_STRING: &str = "\t";
 /// - Measuring output length
 pub struct Context<'a> {
     /// The allocator for string allocations
-    #[allow(dead_code)]
     allocator: &'a Allocator,
     /// The output buffer
     buffer: String,
@@ -42,7 +41,6 @@ pub struct Context<'a> {
     needs_margin: bool,
     /// Source map mappings (line, column) -> (original_line, original_column)
     /// TODO: Implement proper source map support
-    #[allow(dead_code)]
     mappings: Vec<(usize, usize, usize, usize)>,
 }
 
@@ -255,7 +253,6 @@ impl<'a> Context<'a> {
     ///
     /// * `line` - The line number in the original source (1-indexed)
     /// * `column` - The column number in the original source (0-indexed)
-    #[allow(dead_code)]
     pub fn location(&mut self, line: usize, column: usize) {
         let current_line = self.buffer.lines().count();
         let current_column = self.buffer.lines().last().map(|l| l.len()).unwrap_or(0);

--- a/src/compiler/print/helpers.rs
+++ b/src/compiler/print/helpers.rs
@@ -94,7 +94,6 @@ pub fn is_void_element(name: &str) -> bool {
 /// # Returns
 ///
 /// Returns the formatted JavaScript code as a string.
-#[allow(dead_code)]
 pub fn estree_to_string(node: &serde_json::Value) -> String {
     let mut generator = EstreeGenerator::new();
     generator.generate_node(node);
@@ -102,7 +101,6 @@ pub fn estree_to_string(node: &serde_json::Value) -> String {
 }
 
 /// ESTree to JavaScript code generator.
-#[allow(dead_code)]
 struct EstreeGenerator {
     output: String,
 }


### PR DESCRIPTION
## Summary

Two-part cleanup:

### Part 1: Strip stale \`#[allow(dead_code)]\` markers

Many items had \`#[allow(dead_code)]\` from earlier refactors,
but the items ARE used somewhere now. The markers were just
dead noise. Removed.

### Part 2: Delete binary-only dead code

- \`canonicalize\` (~40 LOC) in
  \`bin/canonicalize_and_compare.rs\` — defined but never
  called by the binary or any test
- 3 atomic counters in \`bin/oxc_call_counter.rs\` (plus their
  \`AtomicU64\` import)
- \`ExpectedError\` struct in \`bin/test_reporter.rs\` —
  only the definition existed, never constructed or
  deserialized
- 3 unused fields in \`css_scoping::ElementInfo\`
  (\`classes\`, \`ids\`, \`has_dynamic_class\`) — populated
  but never read; the loop bodies that filled them are
  removed too

**LOC delta**: 143 lines removed, 24 added.

## Test plan

- [x] compatibility report: 3087 / 3087 in-scope, 100%
- [x] runtime-legacy / runtime-runes / ssr all pass
- [x] \`cargo fmt -- --check\` + \`cargo clippy --lib --tests
      -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)