### PR TITLE
fix(analyze): avoid panic on attribute expressions without serialize arena

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -465,30 +465,24 @@ pub fn visit(
                                     }
                                 }
                                 AttributeValuePart::ExpressionTag(expr_tag) => {
-                                    if let Ok(expr_json) =
-                                        serde_json::to_value(&expr_tag.expression)
+                                    let expr_json = expr_tag.expression.as_json();
+                                    use super::super::css::get_possible_values;
+                                    if let Some(possible_vals) =
+                                        get_possible_values(expr_json, false)
                                     {
-                                        use super::super::css::get_possible_values;
-                                        if let Some(possible_vals) =
-                                            get_possible_values(&expr_json, false)
-                                        {
-                                            if possible_vals.len() > 20 {
-                                                // Too many combinations, bail out
-                                                all_resolved = false;
-                                                break;
+                                        if possible_vals.len() > 20 {
+                                            // Too many combinations, bail out
+                                            all_resolved = false;
+                                            break;
+                                        }
+                                        let prev = computed_values.clone();
+                                        computed_values.clear();
+                                        for pv in &prev {
+                                            for ev in &possible_vals {
+                                                computed_values.push(format!("{}{}", pv, ev));
                                             }
-                                            let prev = computed_values.clone();
-                                            computed_values.clear();
-                                            for pv in &prev {
-                                                for ev in &possible_vals {
-                                                    computed_values.push(format!("{}{}", pv, ev));
-                                                }
-                                            }
-                                            if computed_values.len() > 100 {
-                                                all_resolved = false;
-                                                break;
-                                            }
-                                        } else {
+                                        }
+                                        if computed_values.len() > 100 {
                                             all_resolved = false;
                                             break;
                                         }
@@ -513,18 +507,13 @@ pub fn visit(
                     // Expression or other dynamic value
                     // Try to statically determine the value for CSS attribute selector matching
                     if let AttributeValue::Expression(expr_tag) = &attr_node.value {
-                        if let Ok(expr_json) = serde_json::to_value(&expr_tag.expression) {
-                            use super::super::css::get_possible_values;
-                            if let Some(possible_values) = get_possible_values(&expr_json, false) {
-                                // We can determine the possible values statically
-                                for value in &possible_values {
-                                    static_attributes.push((
-                                        attr_node.name.to_string(),
-                                        Some(value.to_string()),
-                                    ));
-                                }
-                            } else {
-                                dynamic_attribute_names.insert(attr_node.name.to_string());
+                        let expr_json = expr_tag.expression.as_json();
+                        use super::super::css::get_possible_values;
+                        if let Some(possible_values) = get_possible_values(expr_json, false) {
+                            // We can determine the possible values statically
+                            for value in &possible_values {
+                                static_attributes
+                                    .push((attr_node.name.to_string(), Some(value.to_string())));
                             }
                         } else {
                             dynamic_attribute_names.insert(attr_node.name.to_string());
@@ -554,14 +543,9 @@ pub fn visit(
                                         Some(vec![text.data.to_string()])
                                     }
                                     AttributeValuePart::ExpressionTag(expr_tag) => {
-                                        if let Ok(expr_json) =
-                                            serde_json::to_value(&expr_tag.expression)
-                                        {
-                                            use super::super::css::get_possible_values;
-                                            get_possible_values(&expr_json, true)
-                                        } else {
-                                            None
-                                        }
+                                        let expr_json = expr_tag.expression.as_json();
+                                        use super::super::css::get_possible_values;
+                                        get_possible_values(expr_json, true)
                                     }
                                 };
 
@@ -666,28 +650,23 @@ pub fn visit(
                         }
                         AttributeValue::Expression(expr_tag) => {
                             // Expression as attribute value: class={{ ... }}
-                            // Serialize the expression to JSON to analyze it
-                            if let Ok(expr_json) = serde_json::to_value(&expr_tag.expression) {
-                                use super::super::css::get_possible_values;
-                                if let Some(possible_values) = get_possible_values(&expr_json, true)
-                                {
-                                    // We can statically determine the classes
-                                    for value in &possible_values {
-                                        for class_name in value.split_whitespace() {
-                                            context
-                                                .analysis
-                                                .css
-                                                .used_classes
-                                                .insert(class_name.to_string());
-                                            element_classes.insert(class_name.to_string());
-                                        }
+                            // Use the cached JSON view of the expression to analyze it
+                            let expr_json = expr_tag.expression.as_json();
+                            use super::super::css::get_possible_values;
+                            if let Some(possible_values) = get_possible_values(expr_json, true) {
+                                // We can statically determine the classes
+                                for value in &possible_values {
+                                    for class_name in value.split_whitespace() {
+                                        context
+                                            .analysis
+                                            .css
+                                            .used_classes
+                                            .insert(class_name.to_string());
+                                        element_classes.insert(class_name.to_string());
                                     }
-                                } else {
-                                    // Unknown expression - mark as dynamic
-                                    context.analysis.css.has_dynamic_classes = true;
                                 }
                             } else {
-                                // Failed to serialize - mark as dynamic
+                                // Unknown expression - mark as dynamic
                                 context.analysis.css.has_dynamic_classes = true;
                             }
                         }

--- a/tests/analyze_attribute_expression_no_arena.rs
+++ b/tests/analyze_attribute_expression_no_arena.rs
@@ -1,0 +1,62 @@
+//! Regression: phase 2 analyze must not panic when an attribute value is a
+//! complex expression (arena-allocated `JsNode`) and no serialize arena has
+//! been installed on the calling thread.
+//!
+//! The previous implementation called `serde_json::to_value(&expr_tag.expression)`
+//! directly in `regular_element::visit`. That goes through `JsNode::serialize`,
+//! which dereferences `SERIALIZE_ARENA` via `expect("serialize arena not set")`
+//! for every nested child id. WASM and the `compile_profile` binary set up
+//! the arena explicitly, but `analyze_component` itself does not — so any
+//! direct caller (the `profiler` binary, downstream embedders, future bench
+//! harnesses) hit the panic on the first non-trivial expression attribute.
+//!
+//! The fix is to use `Expression::as_json()` which falls back to a
+//! per-thread deserialization arena when no serialize arena is active.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn compile_client(src: &str) {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile must not panic");
+}
+
+#[test]
+fn arrow_function_attribute_value_does_not_panic() {
+    // Arrow function as event handler — `JsNode::ArrowFunctionExpression`
+    // owns arena-allocated children, so serializing it requires the arena.
+    let src = r#"<script>
+  let count = $state(0);
+</script>
+<button onclick={() => count++}>{count}</button>"#;
+    compile_client(src);
+}
+
+#[test]
+fn class_attribute_with_arrow_expression_does_not_panic() {
+    // Complex `class={…}` expression. Was the second regression path
+    // (`AttributeValue::Expression` branch in `regular_element::visit`).
+    let src = r#"<script>
+  let active = $state(true);
+</script>
+<div class={active ? 'on' : 'off'}>x</div>"#;
+    compile_client(src);
+}
+
+#[test]
+fn sequence_class_with_member_expression_does_not_panic() {
+    // `class="a-{obj.x}"` — sequence with an `ExpressionTag` whose
+    // expression is a `MemberExpression` (also arena-allocated).
+    let src = r#"<script>
+  let obj = $state({ x: 1 });
+</script>
+<div class="a-{obj.x}">y</div>"#;
+    compile_client(src);
+}


### PR DESCRIPTION
## Summary

- Replaced four direct `serde_json::to_value(&expr_tag.expression)` calls in `regular_element::visit` with `expr_tag.expression.as_json()`.
- Without this, phase-2 analyze panics with `serialize arena not set` whenever an attribute value is anything other than a plain `Identifier` / `Literal` — because `JsNode::serialize` dereferences `SERIALIZE_ARENA` for nested arena ids, and `analyze_component` itself never installs the arena.
- Triggering shapes (all reproducible without the fix):
  - `<button onclick={() => count++}>`
  - `<div class={active ? 'on' : 'off'}>`
  - `<div class="a-{obj.x}">`
- The criterion bench escapes by using only `onclick={identifier}` (a bare `Identifier`, which serializes inline) — so the bug never showed in CI, but the `profiler` binary panicked on its `create_large_file` synthetic (`onclick={() => removeItem(item.id)}`).

## Why `as_json()`

`Expression::as_json()` is the infallible cached accessor used by every other phase-2 visitor (`bind_directive`, `render_tag`, `await_block`, `css_scoping`). It internally falls back to a per-thread deserialization arena (`DESER_ARENA`) when no serialize arena is active, so it works regardless of how the analyzer was invoked.

## Test plan

- [x] `cargo test --release --test compatibility_report` — still 3087/3087 in-scope passing (100%)
- [x] `cargo test --release --test svelte2tsx_fixtures` — 245/245 passing
- [x] New `tests/analyze_attribute_expression_no_arena.rs` (3 cases, all pass; would panic on `origin/main`)
- [x] `cargo clippy --release --all-targets --all-features -- -D warnings` — clean
- [x] `target/release/profiler --mode server --phase transform` — no longer panics on `create_large_file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)