### PR TITLE
perf(analyze): don't allocate Vec<char> just to read second char (-48% phase 2)

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -666,9 +666,17 @@ pub fn validate_opening_tag(
     source: &str,
     expected: char,
 ) -> Result<(), AnalysisError> {
+    // Only the second char matters — collecting `source[start..]` into a
+    // `Vec<char>` (the previous implementation) allocates ~4 bytes per
+    // byte of remaining source for every tag opening. On template-heavy
+    // input that single hot-path accounts for ~33% of phase-2 analyze
+    // self time (jemalloc dominated by `Vec::from_iter`).
     if start + 1 < source.len() {
-        let chars: Vec<char> = source[start..].chars().collect();
-        if chars.len() > 1 && chars[1] != expected {
+        let mut chars = source[start..].chars();
+        chars.next();
+        if let Some(second) = chars.next()
+            && second != expected
+        {
             return Err(errors::block_unexpected_character(&expected.to_string()));
         }
     }


### PR DESCRIPTION
## Summary

`validate_opening_tag` (fired on every Svelte control-flow tag — `{#each}`, `{#if}`, `{:else}`, `{/if}`, `{@html}` …) used to collect the **entire remaining source** into a `Vec<char>` just to read `chars[1]`. On a 38 KB template-heavy synthetic with ~150 control blocks that's ~9 MB of throwaway allocation per analyze pass.

Replaced with a two-step iterator pull — same observable behavior, no allocation, no UTF-8 decoding past the second char.

## Profile evidence (samply, 5788 samples, M1 Pro `release+debuginfo`)

Before:
- **37% inclusive time** spent in `validate_opening_tag`
- **33% self time** in its `Vec::from_iter`
- jemalloc internals (`_rjem_malloc` / `_rjem_sdallocx`) crowding the next ranks — all driven by this one hot allocation

## Measured impact (38 KB synthetic, client mode, 100 iters × 20 warmup, M1 Pro)

| Phase     | Before  | After   | Δ    |
|-----------|---------|---------|------|
| Parse     | 0.28 ms | 0.27 ms | -3%  |
| **Analyze**   | **2.72 ms** | **1.41 ms** | **-48%** |
| Transform | 1.64 ms | 1.57 ms | -4%  |
| **Total**     | **4.64 ms** | **3.25 ms** | **-30%** |

Phase 2 analyze gets a **1.93× speedup**; full-compile a **1.43× speedup** on template-heavy input.

## Test plan

- [x] `cargo test --release --test compatibility_report` — still 3087/3087 in-scope passing (every category 100%)
- [x] `cargo clippy --release --all-targets --all-features -- -D warnings` — clean
- [x] Re-ran profiler — analyze now down to 1.41 ms

## Follow-ups (separate PRs)

A grep for `chars().collect::<Vec<char>>` shows similar patterns in `transform_legacy.rs` (20+ sites), `transform/css.rs`, `bind_directive.rs`, `store_subscriptions.rs`. None of those showed up in the current profile because the synthetic doesn't exercise them, but they're worth a profile-driven follow-up on legacy SSR + bind/store-heavy inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)