### PR TITLE
perf(transform): drop Vec<char> allocations + add no-op fast paths in SSR helpers

### DIFF
--- a/src/compiler/phases/3_transform/css.rs
+++ b/src/compiler/phases/3_transform/css.rs
@@ -5267,20 +5267,30 @@ fn ends_with_css_hex_escape(text: &str) -> bool {
     // Return true if the string ends with hex digits that are part of a CSS escape
     // (i.e., \HH where HH are hex digits and the escape has consumed fewer than 6 digits
     // without a whitespace terminator).
-    let chars: Vec<char> = text.chars().collect();
-    let len = chars.len();
+    //
+    // All tokens we test (`\\`, hex digits 0-9/a-f/A-F, space/tab/newline)
+    // are ASCII, so byte indexing is UTF-8 safe and avoids allocating a
+    // `Vec<char>` on every CSS selector emission. The single-char-escape
+    // branch advances by exactly one *byte*: a non-hex char after `\\`
+    // could be a multi-byte UTF-8 sequence in pathological CSS, but this
+    // function only checks whether the *tail* of the string is a hex
+    // escape — over-skipping into a multi-byte sequence's leading byte
+    // just falls through the loop normally and produces the correct
+    // `false` answer.
+    let bytes = text.as_bytes();
+    let len = bytes.len();
     if len < 2 {
         return false;
     }
 
     let mut i = 0;
     while i < len {
-        if chars[i] == '\\' && i + 1 < len {
+        if bytes[i] == b'\\' && i + 1 < len {
             i += 1; // skip backslash
-            if chars[i].is_ascii_hexdigit() {
+            if bytes[i].is_ascii_hexdigit() {
                 // Hex escape: consume up to 6 hex digits
                 let mut hex_count = 0;
-                while i < len && hex_count < 6 && chars[i].is_ascii_hexdigit() {
+                while i < len && hex_count < 6 && bytes[i].is_ascii_hexdigit() {
                     i += 1;
                     hex_count += 1;
                 }
@@ -5289,7 +5299,7 @@ fn ends_with_css_hex_escape(text: &str) -> bool {
                     return true;
                 }
                 // Consume optional single whitespace terminator
-                if chars[i] == ' ' || chars[i] == '\t' || chars[i] == '\n' {
+                if matches!(bytes[i], b' ' | b'\t' | b'\n') {
                     i += 1;
                 }
                 // Otherwise the escape is fully terminated, continue

--- a/src/compiler/phases/3_transform/server/helpers.rs
+++ b/src/compiler/phases/3_transform/server/helpers.rs
@@ -1896,65 +1896,76 @@ fn extract_imports_with_options(script: &str, strip_exports: bool) -> (Vec<Strin
 
 /// Strip `export { ... }` statements from script content.
 fn strip_export_specifiers(script: &str) -> String {
-    let mut result = String::new();
-    let chars: Vec<char> = script.chars().collect();
-    let len = chars.len();
+    // The previous implementation collected `script.chars()` into a `Vec<char>`
+    // AND, more wastefully, allocated a fresh `String` per byte position by
+    // doing `chars[i..i+6].iter().collect()` just to compare against "export".
+    // Switch to byte-indexing + a segment-flush emit pattern. All tokens we
+    // look at (`export`, space/tab/newline, `{}`, `;`) are pure ASCII, so
+    // byte indexing is UTF-8 safe (continuation bytes 0x80-0xFF never collide
+    // with ASCII).
+    let bytes = script.as_bytes();
+    let len = bytes.len();
+    let mut result = String::with_capacity(len);
+    let mut segment_start = 0;
     let mut i = 0;
 
     while i < len {
-        if i + 6 <= len {
-            let potential: String = chars[i..i + 6].iter().collect();
-            if potential == "export" {
-                let mut j = i + 6;
+        if i + 6 <= len && &bytes[i..i + 6] == b"export" {
+            let mut j = i + 6;
 
-                while j < len && (chars[j] == ' ' || chars[j] == '\t' || chars[j] == '\n') {
-                    j += 1;
+            while j < len && matches!(bytes[j], b' ' | b'\t' | b'\n') {
+                j += 1;
+            }
+
+            if j < len && bytes[j] == b'{' {
+                let mut depth = 1;
+                let start = j + 1;
+                let mut end = start;
+
+                while end < len && depth > 0 {
+                    match bytes[end] {
+                        b'{' => depth += 1,
+                        b'}' => depth -= 1,
+                        _ => {}
+                    }
+                    if depth > 0 {
+                        end += 1;
+                    }
                 }
 
-                if j < len && chars[j] == '{' {
-                    let mut depth = 1;
-                    let start = j + 1;
-                    let mut end = start;
-
-                    while end < len && depth > 0 {
-                        match chars[end] {
-                            '{' => depth += 1,
-                            '}' => depth -= 1,
-                            _ => {}
-                        }
-                        if depth > 0 {
-                            end += 1;
-                        }
-                    }
-
-                    if end < len {
-                        end += 1; // skip '}'
-                    }
-
-                    // Skip trailing semicolons, whitespace, and newline
-                    while end < len && (chars[end] == ' ' || chars[end] == '\t') {
-                        end += 1;
-                    }
-                    if end < len && chars[end] == ';' {
-                        end += 1; // skip trailing semicolon
-                    }
-                    while end < len && (chars[end] == ' ' || chars[end] == '\t') {
-                        end += 1;
-                    }
-                    if end < len && chars[end] == '\n' {
-                        end += 1;
-                    }
-
-                    i = end;
-                    continue;
+                if end < len {
+                    end += 1; // skip '}'
                 }
+
+                // Skip trailing semicolons, whitespace, and newline
+                while end < len && matches!(bytes[end], b' ' | b'\t') {
+                    end += 1;
+                }
+                if end < len && bytes[end] == b';' {
+                    end += 1; // skip trailing semicolon
+                }
+                while end < len && matches!(bytes[end], b' ' | b'\t') {
+                    end += 1;
+                }
+                if end < len && bytes[end] == b'\n' {
+                    end += 1;
+                }
+
+                // Flush the bytes before the `export` and skip to `end`. Both
+                // segment_start and i / end point at ASCII or UTF-8 char
+                // boundaries (we only advance through ASCII control tokens
+                // or stay at the original position), so the slice is valid.
+                result.push_str(&script[segment_start..i]);
+                segment_start = end;
+                i = end;
+                continue;
             }
         }
 
-        result.push(chars[i]);
         i += 1;
     }
 
+    result.push_str(&script[segment_start..]);
     result
 }
 
@@ -2604,38 +2615,40 @@ pub fn update_template_literal_state_full(
     currently_in_template: bool,
     current_brace_depth: i32,
 ) -> (bool, i32) {
+    // All tokens we test (`'`, `"`, `` ` ``, `\`, `{`, `}`, `$`, `/`) are
+    // ASCII, so byte indexing is UTF-8 safe.
     let mut in_template = currently_in_template;
     let mut brace_depth = current_brace_depth;
-    let chars: Vec<char> = line.chars().collect();
+    let bytes = line.as_bytes();
     let mut i = 0;
-    while i < chars.len() {
-        let c = chars[i];
+    while i < bytes.len() {
+        let c = bytes[i];
 
         // If we're inside a ${...} expression (brace_depth > 0)
         if brace_depth > 0 {
-            if c == '\'' || c == '"' {
+            if c == b'\'' || c == b'"' {
                 // Skip string literals inside the expression
                 let quote = c;
                 i += 1;
-                while i < chars.len() {
-                    if chars[i] == '\\' {
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' {
                         i += 2;
                         continue;
                     }
-                    if chars[i] == quote {
+                    if bytes[i] == quote {
                         break;
                     }
                     i += 1;
                 }
-            } else if c == '`' {
+            } else if c == b'`' {
                 // Nested template literal inside ${...}
                 // For simplicity, skip it by counting backticks
                 // (nested template literals are rare in practice)
                 i += 1;
                 continue;
-            } else if c == '{' {
+            } else if c == b'{' {
                 brace_depth += 1;
-            } else if c == '}' {
+            } else if c == b'}' {
                 brace_depth -= 1;
                 if brace_depth == 0 {
                     // Closed the ${...} expression, back to template literal text
@@ -2647,32 +2660,32 @@ pub fn update_template_literal_state_full(
         }
 
         if in_template {
-            if c == '\\' {
+            if c == b'\\' {
                 i += 2;
                 continue;
-            } else if c == '`' {
+            } else if c == b'`' {
                 in_template = false;
-            } else if c == '$' && i + 1 < chars.len() && chars[i + 1] == '{' {
+            } else if c == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
                 brace_depth = 1;
                 i += 2;
                 continue;
             }
-        } else if c == '\'' || c == '"' {
+        } else if c == b'\'' || c == b'"' {
             let quote = c;
             i += 1;
-            while i < chars.len() {
-                if chars[i] == '\\' {
+            while i < bytes.len() {
+                if bytes[i] == b'\\' {
                     i += 2;
                     continue;
                 }
-                if chars[i] == quote {
+                if bytes[i] == quote {
                     break;
                 }
                 i += 1;
             }
-        } else if c == '/' && i + 1 < chars.len() && chars[i + 1] == '/' {
+        } else if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
             break;
-        } else if c == '`' {
+        } else if c == b'`' {
             in_template = true;
         }
         i += 1;

--- a/src/compiler/phases/3_transform/server/transform_store.rs
+++ b/src/compiler/phases/3_transform/server/transform_store.rs
@@ -6,6 +6,13 @@
 
 /// Replace store identifier in an expression with $.store_get() call.
 pub(crate) fn replace_store_identifier(expr: &str, store_ref: &str, store_name: &str) -> String {
+    // Fast path: if `store_ref` doesn't appear in `expr` at all, there is
+    // nothing to replace. Skips the `Vec<char>` allocation and the full
+    // state-machine walk for the (very common) case where most expressions
+    // don't reference a given store.
+    if !expr.contains(store_ref) {
+        return expr.to_string();
+    }
     let mut result = String::with_capacity(expr.len() * 2);
     let chars: Vec<char> = expr.chars().collect();
     let store_ref_chars: Vec<char> = store_ref.chars().collect();
@@ -83,6 +90,10 @@ pub(crate) fn replace_store_identifier_in_script(
     store_ref: &str,
     store_name: &str,
 ) -> String {
+    // Fast path: skip the full lexer if the store ref doesn't appear at all.
+    if !script.contains(store_ref) {
+        return script.to_string();
+    }
     let mut result = String::with_capacity(script.len() * 2);
     let chars: Vec<char> = script.chars().collect();
     let store_ref_chars: Vec<char> = store_ref.chars().collect();

--- a/src/compiler/print/visitors.rs
+++ b/src/compiler/print/visitors.rs
@@ -1150,29 +1150,31 @@ fn extract_and_reformat_css(source: &str, stylesheet: &StyleSheet) -> Option<Str
 /// Split CSS content into top-level blocks (rules, at-rules).
 /// Returns trimmed block strings.
 fn split_css_top_level_blocks(css: &str) -> Vec<String> {
+    // Byte-indexing is safe here: every token we test (`{`, `}`) is ASCII,
+    // and `current_start..=i` is sliced when `i` points at an ASCII `}`,
+    // so the slice is always on a UTF-8 char boundary.
     let mut blocks = Vec::new();
     let mut depth = 0;
     let mut current_start = 0;
     let mut in_block = false;
-    let chars: Vec<char> = css.chars().collect();
+    let bytes = css.as_bytes();
 
     let mut i = 0;
-    while i < chars.len() {
-        match chars[i] {
-            '{' => {
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' => {
                 if depth == 0 {
                     in_block = true;
                 }
                 depth += 1;
             }
-            '}' => {
+            b'}' => {
                 depth -= 1;
                 if depth == 0 && in_block {
                     // End of top-level block
-                    let block_text: String = chars[current_start..=i].iter().collect();
-                    let trimmed = block_text.trim().to_string();
+                    let trimmed = css[current_start..=i].trim();
                     if !trimmed.is_empty() {
-                        blocks.push(trimmed);
+                        blocks.push(trimmed.to_string());
                     }
                     current_start = i + 1;
                     in_block = false;
@@ -1184,10 +1186,9 @@ fn split_css_top_level_blocks(css: &str) -> Vec<String> {
     }
 
     // Handle any remaining text (shouldn't happen in valid CSS)
-    let remaining: String = chars[current_start..].iter().collect();
-    let trimmed = remaining.trim().to_string();
+    let trimmed = css[current_start..].trim();
     if !trimmed.is_empty() {
-        blocks.push(trimmed);
+        blocks.push(trimmed.to_string());
     }
 
     blocks
@@ -1300,32 +1301,30 @@ fn split_css_declarations_and_blocks(inner: &str) -> Vec<String> {
     let mut parts = Vec::new();
     let mut depth = 0;
     let mut current_start = 0;
-    let chars: Vec<char> = inner.chars().collect();
+    let bytes = inner.as_bytes();
 
     let mut i = 0;
-    while i < chars.len() {
-        match chars[i] {
-            '{' => {
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' => {
                 depth += 1;
             }
-            '}' => {
+            b'}' => {
                 depth -= 1;
                 if depth == 0 {
-                    // End of a nested block - collect everything from current_start
-                    let block_text: String = chars[current_start..=i].iter().collect();
-                    let trimmed = block_text.trim().to_string();
+                    // End of a nested block - slice from current_start
+                    let trimmed = inner[current_start..=i].trim();
                     if !trimmed.is_empty() {
-                        parts.push(trimmed);
+                        parts.push(trimmed.to_string());
                     }
                     current_start = i + 1;
                 }
             }
-            ';' if depth == 0 => {
+            b';' if depth == 0 => {
                 // End of a declaration
-                let decl: String = chars[current_start..=i].iter().collect();
-                let trimmed = decl.trim().to_string();
+                let trimmed = inner[current_start..=i].trim();
                 if !trimmed.is_empty() {
-                    parts.push(trimmed);
+                    parts.push(trimmed.to_string());
                 }
                 current_start = i + 1;
             }
@@ -1335,10 +1334,9 @@ fn split_css_declarations_and_blocks(inner: &str) -> Vec<String> {
     }
 
     // Handle remaining text
-    let remaining: String = chars[current_start..].iter().collect();
-    let trimmed = remaining.trim().to_string();
+    let trimmed = inner[current_start..].trim();
     if !trimmed.is_empty() {
-        parts.push(trimmed);
+        parts.push(trimmed.to_string());
     }
 
     parts
@@ -1418,21 +1416,20 @@ fn split_css_inner_blocks(inner: &str) -> Vec<String> {
     let mut blocks = Vec::new();
     let mut depth = 0;
     let mut current_start = 0;
-    let chars: Vec<char> = inner.chars().collect();
+    let bytes = inner.as_bytes();
 
     let mut i = 0;
-    while i < chars.len() {
-        match chars[i] {
-            '{' => {
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' => {
                 depth += 1;
             }
-            '}' => {
+            b'}' => {
                 depth -= 1;
                 if depth == 0 {
-                    let block_text: String = chars[current_start..=i].iter().collect();
-                    let trimmed = block_text.trim().to_string();
+                    let trimmed = inner[current_start..=i].trim();
                     if !trimmed.is_empty() {
-                        blocks.push(trimmed);
+                        blocks.push(trimmed.to_string());
                     }
                     current_start = i + 1;
                 }
@@ -1443,12 +1440,11 @@ fn split_css_inner_blocks(inner: &str) -> Vec<String> {
     }
 
     // Handle remaining declarations without braces
-    let remaining: String = chars[current_start..].iter().collect();
-    let trimmed = remaining.trim().to_string();
+    let trimmed = inner[current_start..].trim();
     if !trimmed.is_empty() {
         // These are standalone declarations, add them to the previous block
         // or create a new one
-        blocks.push(trimmed);
+        blocks.push(trimmed.to_string());
     }
 
     blocks


### PR DESCRIPTION
## Summary

Five mechanical wins in the server-side / CSS / print emitters that each opened a function with \`let chars: Vec<char> = s.chars().collect();\` and then iterated \`chars[i]\` to read ASCII tokens. Switched to \`s.as_bytes()\` indexing throughout — UTF-8 safe because every token tested (\`{\`, \`}\`, \`;\`, \`'\`, \`\"\`, \`\` \\\` \`\`, \`\\\`, whitespace, hex digits) is ASCII and continuation/leading bytes never collide with ASCII.

## Functions converted

- \`server::helpers::strip_export_specifiers\` — previously also did \`let potential: String = chars[i..i+6].iter().collect();\` per byte position just to compare against \`\"export\"\`. Now \`&bytes[i..i+6] == b\"export\"\` plus segment-flush emission — the common case (no \`export {}\` blocks in the script) allocates nothing beyond the final result \`String\`.
- \`server::helpers::update_template_literal_state_full\` — line-by-line template-literal state tracker.
- \`transform::css::ends_with_css_hex_escape\` — called on every CSS selector emit during scope-modifier append.
- \`print::visitors::split_css_top_level_blocks\`, \`split_css_declarations_and_blocks\`, \`split_css_inner_blocks\` — the CSS reformatter trio. Also dropped the per-block \`chars[..=i].iter().collect()\` String allocations in favor of \`inner[..=i]\` byte-slicing (\`i\` always points at an ASCII \`;\` or \`}\` on the slice boundaries the original code used).

## Fast paths added

- \`transform_store::replace_store_identifier\` and \`replace_store_identifier_in_script\` — both lex the entire input looking for an identifier they may not even reference. Added a leading \`if !script.contains(store_ref) { return script.to_string(); }\` guard so the (very common) case where a given expression / script doesn't mention a particular store skips the \`Vec<char>\` allocation and the full state-machine walk.

## Intentionally not converted

Sites that scan **JavaScript identifiers** via \`c.is_alphabetic()\` / \`c.is_alphanumeric()\` / \`is_js_identifier_char\` accept non-ASCII code points (\`let π = 3.14\`). Byte-iterating those would silently miss Unicode identifiers and is out of scope here.

## Test plan

- [x] \`cargo test --release --test compatibility_report\` — still 3087/3087 in-scope passing (100% across every category, including all SSR / CSS / print fixtures).
- [x] \`cargo clippy --release --all-targets --all-features -- -D warnings\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)