### PR TITLE
perf(transform): fold Memoizer::generate_id's contains+insert into one HashSet probe

### DIFF
--- a/src/compiler/phases/3_transform/client/types.rs
+++ b/src/compiler/phases/3_transform/client/types.rs
@@ -3008,15 +3008,26 @@ impl Memoizer {
             return self.generate_id_slow(base);
         };
 
-        let mut conflicts = self.conflicts.borrow_mut();
-        let mut next_suffix = self.next_suffix.borrow_mut();
-
-        if !conflicts.contains(sanitized) {
+        // Fast path: most calls succeed on the first attempt. Only borrow the
+        // shared `conflicts` set (skip the `next_suffix` borrow), and use
+        // `HashSet::insert` to combine the lookup + insert into a single
+        // hash. This function is ~33% of phase-3 transform inclusive time
+        // on template-heavy input, so trimming a redundant hash lookup +
+        // a RefCell borrow per call matters.
+        {
+            let mut conflicts = self.conflicts.borrow_mut();
             let owned = sanitized.to_string();
-            conflicts.insert(owned.clone());
-            return owned;
+            if conflicts.insert(owned.clone()) {
+                return owned;
+            }
         }
 
+        // Conflict path: fall through to the suffix loop. The loop body uses
+        // `contains` rather than `insert` so we don't allocate a String per
+        // candidate when the suffix tracker keeps us close to the next free
+        // slot — only the winning name gets cloned for insertion at the end.
+        let mut conflicts = self.conflicts.borrow_mut();
+        let mut next_suffix = self.next_suffix.borrow_mut();
         let start_n = next_suffix.get(sanitized).copied().unwrap_or(1);
         let mut name = String::with_capacity(sanitized.len() + 4);
         let mut itoa_buf = itoa::Buffer::new();
@@ -3044,14 +3055,18 @@ impl Memoizer {
     fn generate_id_slow(&mut self, base: &str) -> String {
         let sanitized = sanitize_identifier(base);
 
-        let mut conflicts = self.conflicts.borrow_mut();
-        let mut next_suffix = self.next_suffix.borrow_mut();
-
-        if !conflicts.contains(sanitized.as_str()) {
-            conflicts.insert(sanitized.clone());
-            return sanitized;
+        // Mirror the fast-path optimization in `generate_id`: skip the
+        // `next_suffix` borrow on the no-conflict path and combine the
+        // lookup + insert into a single `HashSet::insert`.
+        {
+            let mut conflicts = self.conflicts.borrow_mut();
+            if conflicts.insert(sanitized.clone()) {
+                return sanitized;
+            }
         }
 
+        let mut conflicts = self.conflicts.borrow_mut();
+        let mut next_suffix = self.next_suffix.borrow_mut();
         let start_n = next_suffix.get(sanitized.as_str()).copied().unwrap_or(1);
         let mut n = start_n;
         let mut name = String::with_capacity(sanitized.len() + 4);


### PR DESCRIPTION
## Summary

\`Memoizer::generate_id\` is the hottest function in phase-3 transform — samply on the 38 KB synthetic puts it at ~33% inclusive, with the inner \`HashSet::contains_key\` at ~28%. On the no-conflict fast path (most generated identifiers don't clash with existing scope names), it used to do:

\`\`\`rust
let mut conflicts = self.conflicts.borrow_mut();
let mut next_suffix = self.next_suffix.borrow_mut();    // unused on fast path
if !conflicts.contains(sanitized) {                     // hash + lookup
    let owned = sanitized.to_string();
    conflicts.insert(owned.clone());                    // hash + insert again
    return owned;
}
\`\`\`

Two redundancies:

1. \`HashSet::insert\` already returns \`true\` iff the value was newly inserted — folding \`contains\` + \`insert\` into one call halves the hash work on the fast path.
2. \`next_suffix.borrow_mut()\` is only needed in the conflict branch.

Restructured to take the \`conflicts\` borrow alone, try \`insert\`, and only fall through to the suffix loop (with both borrows) when a collision actually occurs. Same change applied to \`generate_id_slow\` for non-identifier bases.

The conflict-path loop **kept** its \`contains\` + final \`insert\` pattern — switching that to per-iteration \`insert(clone)\` would allocate a fresh \`String\` per failed probe instead of just per success.

## Test plan

- [x] \`cargo test --release --test compatibility_report\` — 3332/3332 in-scope passing (100%).
- [x] \`cargo clippy --release --all-targets --all-features -- -D warnings\` — clean.

## On the per-iteration profiler numbers

This is a small-overhead optimization (1 hash + 1 borrow per call avoided). The 38 KB synthetic's transform mean is in the 1.5–3 ms range with high variance (criterion-style synthetic runs can swing ±25% just from background load), so the per-run delta on a single \`profiler\` invocation is in the noise. The merit is visible in the call-counted profile: 33% inclusive in \`generate_id\` is the largest single function in transform, and this trims roughly one HashSet hash + one RefCell borrow off **every** call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)