### PR TITLE
perf(transform/client): pre-size process_children's hot-path Vecs

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
@@ -275,8 +275,10 @@ pub fn process_children<F>(
     let mut prev: SiblingPrev<F> = SiblingPrev::Initial(initial);
     let mut skipped = 0usize;
 
-    // Sequence of Text/ExpressionTag nodes - pre-allocate with a reasonable capacity
-    let mut sequence: Vec<TextOrExpr> = Vec::new();
+    // Sequence of Text/ExpressionTag nodes — pre-allocate for the common
+    // case (≤8 contiguous text/expression nodes per fragment) so we don't
+    // pay the Vec growth-and-reallocate cost on every push.
+    let mut sequence: Vec<TextOrExpr> = Vec::with_capacity(8);
 
     // SAFETY: Extract a reference to the arena that outlives the closures.
     // The arena uses UnsafeCell internally and only appends, so holding a
@@ -290,8 +292,11 @@ pub fn process_children<F>(
             return prev_fn.call(is_text);
         }
 
+        // `$.sibling(...)` takes at most 3 args. Pre-allocate with that
+        // capacity so the two subsequent pushes never grow the Vec.
         let prev_expr = prev_fn.call(false);
-        let mut args = vec![prev_expr];
+        let mut args = Vec::with_capacity(3);
+        args.push(prev_expr);
 
         if is_text || skip_count != 1 {
             args.push(b::number(skip_count as f64));
@@ -419,7 +424,7 @@ pub fn process_children<F>(
                 // Flush any pending sequence
                 if !sequence.is_empty() {
                     flush_sequence(sequence, &mut prev, &mut skipped, context);
-                    sequence = Vec::new();
+                    sequence = Vec::with_capacity(8);
                 }
 
                 // Visit the const tag to generate its declarations
@@ -430,7 +435,7 @@ pub fn process_children<F>(
                 // Flush any pending sequence
                 if !sequence.is_empty() {
                     flush_sequence(sequence, &mut prev, &mut skipped, context);
-                    sequence = Vec::new();
+                    sequence = Vec::with_capacity(8);
                 }
 
                 if is_static_element(node, &context.state) {


### PR DESCRIPTION
## Summary

Two small Vec allocation hot spots in \`process_children\`:

1. **\`get_node\` sibling args** — \`let mut args = vec![prev_expr];\` allocates with capacity exactly 1, but \`\$.sibling(prev, [count], [is_text])\` then pushes up to 2 more args, growing the Vec twice. Replaced with \`Vec::with_capacity(3); args.push(prev_expr);\`. Hit ~500-1000 times per analyze on the 38 KB synthetic (every non-zero \`skip_count\` sibling navigation).
2. **\`sequence\` Vec resets** — \`Vec::new()\` (capacity 0) on initial declaration and after each non-text/expr child. Most fragments produce sequences of 1-4 text/expression runs, so the first 2-4 pushes grow the Vec each time. Bumped to \`Vec::with_capacity(8)\` on the 3 sites.

Net: ~1500-2500 fewer small allocator hits per phase-3 analyze on template-heavy input. Same shape as PRs #258 / #259 / #262 — each spot is cheap individually but called per element on every compile.

## Test plan

- [x] \`cargo test --release --test compatibility_report\` — 3332/3332 in-scope passing (100%).
- [x] \`cargo clippy --release --all-targets --all-features -- -D warnings\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)