### PR TITLE
feat(bench): record full provenance + median + variance in benchmark JSON

### DIFF
--- a/scripts/run-benchmark.mjs
+++ b/scripts/run-benchmark.mjs
@@ -310,28 +310,59 @@ function getCommitSha() {
  * of how many cores were available. In CI the workflow sets
  * `BENCHMARK_RUNNER_LABEL` to the GitHub-hosted runner label
  * (e.g. `ubuntu-22.04-arm-16-cores`); locally it's just "local".
+ *
+ * Also records the Node + V8 versions and a 1-minute load average so
+ * that JS-baseline regressions between snapshots are diagnosable. V8
+ * inlining heuristics and per-version optimizations can move the JS
+ * Svelte compiler's wall-clock time by 2× between Node releases, and
+ * background CPU contention can move it another 2× — without these
+ * fields recorded, a future "why did the speedup ratio change?" review
+ * can't tell environmental drift from real regressions.
  */
 function getRunnerInfo() {
 	const cpuList = cpus();
+	const loadAvg = typeof process.loadavg === 'function' ? process.loadavg()[0] : null;
 	return {
 		label: process.env.BENCHMARK_RUNNER_LABEL || 'local',
 		os: nodePlatform(),
 		arch: nodeArch(),
 		cpus: cpuList.length,
 		cpuModel: cpuList[0]?.model?.trim() ?? 'unknown',
+		nodeVersion: process.versions.node,
+		v8Version: process.versions.v8,
+		loadAvg1min: loadAvg,
+		warmupIterations: WARMUP_ITERATIONS,
+		benchmarkIterations: BENCHMARK_ITERATIONS,
 	};
 }
 
 /**
- * Calculate statistics from timing results
+ * Calculate statistics from timing results.
+ *
+ * Headline `durationMs` uses the **median** rather than the mean —
+ * median ignores a single warmup-jitter outlier without us having to
+ * over-warm. `min` is the best-case (mostly-JIT-warm) time, `max` is
+ * the worst case, and `stdDev` lets the page render an error bar so
+ * apples-to-apples comparisons between snapshots are obvious.
  */
 function calculateStats(times, filesCount) {
 	const sum = times.reduce((a, b) => a + b, 0);
-	const avg = sum / times.length;
+	const mean = sum / times.length;
+	const sorted = times.slice().sort((a, b) => a - b);
+	const median = sorted.length % 2 === 0
+		? (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2
+		: sorted[(sorted.length - 1) / 2];
+	const variance = times.reduce((acc, t) => acc + (t - mean) ** 2, 0) / times.length;
+	const stdDev = Math.sqrt(variance);
 
 	return {
-		durationMs: avg,
-		throughputFilesPerSec: (filesCount / avg) * 1000,
+		durationMs: median,
+		throughputFilesPerSec: (filesCount / median) * 1000,
+		minMs: sorted[0],
+		maxMs: sorted[sorted.length - 1],
+		meanMs: mean,
+		stdDevMs: stdDev,
+		samples: times.length,
 	};
 }
 
@@ -465,11 +496,11 @@ function timeSvelteCheckRun(label, bin, args, env) {
 		const t1 = process.hrtime.bigint();
 		samples.push(Number(t1 - t0) / 1e6);
 	}
-	const avg = samples.reduce((a, b) => a + b, 0) / samples.length;
+	const stats = calculateStats(samples, SVELTE_CHECK_FILES);
 	console.error(
-		`    ${label.padEnd(28)} ${avg.toFixed(2)}ms (${((SVELTE_CHECK_FILES / avg) * 1000).toFixed(0)} files/sec)`,
+		`    ${label.padEnd(28)} ${stats.durationMs.toFixed(2)}ms (${stats.throughputFilesPerSec.toFixed(0)} files/sec)`,
 	);
-	return avg;
+	return stats;
 }
 
 async function runSvelteCheckTask() {
@@ -482,10 +513,10 @@ async function runSvelteCheckTask() {
 		const jsArgs = [JS_SVELTE_CHECK_BIN, '--workspace', fixture, '--output', 'machine'];
 
 		console.error('  Benchmarking JavaScript (svelte-check)...');
-		const jsMs = timeSvelteCheckRun('JS svelte-check', 'node', jsArgs);
+		const jsStats = timeSvelteCheckRun('JS svelte-check', 'node', jsArgs);
 
 		console.error('  Benchmarking Rust (single-threaded)...');
-		const rsSingleMs = timeSvelteCheckRun(
+		const rsSingleStats = timeSvelteCheckRun(
 			'rsvelte (RAYON=1)',
 			RSVELTE_SVELTE_CHECK_BIN,
 			rsArgs,
@@ -493,25 +524,20 @@ async function runSvelteCheckTask() {
 		);
 
 		console.error('  Benchmarking Rust (multi-threaded)...');
-		const rsMultiMs = timeSvelteCheckRun(
+		const rsMultiStats = timeSvelteCheckRun(
 			'rsvelte (default)',
 			RSVELTE_SVELTE_CHECK_BIN,
 			rsArgs,
 			{},
 		);
 
-		const toStats = (ms) => ({
-			durationMs: ms,
-			throughputFilesPerSec: (SVELTE_CHECK_FILES / ms) * 1000,
-		});
-
 		const result = {
-			javascript: toStats(jsMs),
-			rustSingleThread: toStats(rsSingleMs),
-			rustMultiThread: toStats(rsMultiMs),
+			javascript: jsStats,
+			rustSingleThread: rsSingleStats,
+			rustMultiThread: rsMultiStats,
 			speedup: {
-				singleThreadVsJs: jsMs / rsSingleMs,
-				multiThreadVsJs: jsMs / rsMultiMs,
+				singleThreadVsJs: jsStats.durationMs / rsSingleStats.durationMs,
+				multiThreadVsJs: jsStats.durationMs / rsMultiStats.durationMs,
 			},
 		};
 		console.error(


### PR DESCRIPTION
## Motivation

\`docs/static/benchmark-results.json\` previously stored only the **mean** duration per task, with no record of the Node/V8 version, machine load, or per-iteration variance. That left us unable to diagnose why the JS-side baseline of the **same fixture corpus + same Svelte SHA + same machine** reported:

- PR #247 (May 21): JS compile = **2567 ms** (4.3× speedup ratio)
- PR #268 (May 24): JS compile = **869 ms** (2.3× speedup ratio)

A 3× swing in the JS baseline with no recorded cause. The Rust side itself only got *faster* over that span (598 ms → 380 ms = -36%), so the headline speedup-ratio drop was an artifact of environmental drift on the JS side that the JSON couldn't explain.

## What this PR adds to the JSON

### \`runner.*\`

- \`nodeVersion\` / \`v8Version\` — V8 minor-version regressions / improvements are attributable.
- \`loadAvg1min\` — a high 1-min load average at capture time warns the reader that the numbers should be re-taken on a quiet box.
- \`warmupIterations\` / \`benchmarkIterations\` — the iteration depth used for the snapshot is part of the artifact.

### Per-task timing stats

- Headline \`durationMs\` is now the **median** of the measured iterations (was the mean). Median ignores a single warmup-jitter outlier without us having to over-warm — V8's per-process inlining can move iter-1 by ±25% from steady state.
- New fields: \`minMs\`, \`maxMs\`, \`meanMs\`, \`stdDevMs\`, \`samples\` — so the /benchmark page can render an error bar, and PR reviewers can tell \`n=3, stddev=80ms\` from \`n=10, stddev=12ms\` at a glance.

## Backward compatibility

All previously-published fields (\`durationMs\`, \`throughputFilesPerSec\`, \`speedup.*\`, \`runner.cpus/cpuModel/os/arch\`) are preserved. New fields are pure additions. The site's existing reads keep working unchanged.

The svelte-check task is now routed through the shared \`calculateStats\` (it had its own ad-hoc mean-only \`timeSvelteCheckRun\` helper), so its shape matches the per-file tasks for free.

## Test plan

No new benchmark numbers in this PR — \`docs/static/benchmark-results.json\` regenerates from the next \`node scripts/run-benchmark.mjs\` invocation. CI / docs deploy unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)