### PR TITLE
docs(bench): publish self-explanatory benchmark-results.json with full provenance

### DIFF
--- a/docs/static/benchmark-results.json
+++ b/docs/static/benchmark-results.json
@@ -1,82 +1,147 @@
 {
-  "generatedAt": "2026-05-24T06:41:15.767Z",
-  "commitSha": "e4896e4",
+  "generatedAt": "2026-05-24T08:54:00.811Z",
+  "commitSha": "da6b3c8",
   "runner": {
     "label": "local",
     "os": "darwin",
     "arch": "arm64",
     "cpus": 10,
-    "cpuModel": "Apple M1 Pro"
+    "cpuModel": "Apple M1 Pro",
+    "nodeVersion": "24.13.0",
+    "v8Version": "13.6.233.17-node.37",
+    "loadAvg1min": 3.12109375,
+    "warmupIterations": 3,
+    "benchmarkIterations": 10
   },
   "testFilesCount": 3637,
   "javascript": {
-    "durationMs": 868.7699539999998,
-    "throughputFilesPerSec": 4186.378664748345
+    "durationMs": 864.7678960000007,
+    "throughputFilesPerSec": 4205.752800055377,
+    "minMs": 846.929916000001,
+    "maxMs": 906.0594999999998,
+    "meanMs": 866.9728543000001,
+    "stdDevMs": 15.58554022613731,
+    "samples": 10
   },
   "rustSingleThread": {
-    "durationMs": 379.78966,
-    "throughputFilesPerSec": 9576.353395192486
+    "durationMs": 381.11879999999996,
+    "throughputFilesPerSec": 9542.95615960168,
+    "minMs": 377.2322,
+    "maxMs": 402.2978,
+    "meanMs": 384.48970999999995,
+    "stdDevMs": 8.571990819226302,
+    "samples": 10
   },
   "rustMultiThread": {
-    "durationMs": 52.09932,
-    "throughputFilesPerSec": 69808.97255472816
+    "durationMs": 50.113150000000005,
+    "throughputFilesPerSec": 72575.76105273765,
+    "minMs": 48.1451,
+    "maxMs": 58.8999,
+    "meanMs": 51.50852000000001,
+    "stdDevMs": 3.367595714690231,
+    "samples": 10
   },
   "speedup": {
-    "singleThreadVsJs": 2.2875029141130376,
-    "multiThreadVsJs": 16.67526474433831
+    "singleThreadVsJs": 2.2690245036455847,
+    "multiThreadVsJs": 17.25630689749099
   },
   "parse": {
     "javascript": {
-      "durationMs": 188.1086832999892,
-      "throughputFilesPerSec": 19334.567316065037
+      "durationMs": 187.48202049999963,
+      "throughputFilesPerSec": 19399.19353493423,
+      "minMs": 185.91391699999804,
+      "maxMs": 197.68029200000456,
+      "meanMs": 189.3381710000045,
+      "stdDevMs": 3.907803400003908,
+      "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 8.65458,
-      "throughputFilesPerSec": 420239.91921040654
+      "durationMs": 8.65385,
+      "throughputFilesPerSec": 420275.36876650277,
+      "minMs": 8.5485,
+      "maxMs": 8.9628,
+      "meanMs": 8.67866,
+      "stdDevMs": 0.11830958710096129,
+      "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 1.8270000000000004,
-      "throughputFilesPerSec": 1990695.1286261627
+      "durationMs": 1.8849,
+      "throughputFilesPerSec": 1929545.3339699719,
+      "minMs": 1.4472,
+      "maxMs": 1.9417,
+      "meanMs": 1.8140899999999998,
+      "stdDevMs": 0.16557500686999832,
+      "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 21.735160261964094,
-      "multiThreadVsJs": 102.96041778871874
+      "singleThreadVsJs": 21.664579406853555,
+      "multiThreadVsJs": 99.46523449519849
     }
   },
   "svelte2tsx": {
     "javascript": {
-      "durationMs": 309.9156376000377,
-      "throughputFilesPerSec": 11735.451712487442
+      "durationMs": 306.05604150000727,
+      "throughputFilesPerSec": 11883.44455536557,
+      "minMs": 297.6431660000235,
+      "maxMs": 324.47320799995214,
+      "meanMs": 308.82014159997925,
+      "stdDevMs": 8.489191501299034,
+      "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 114.97493,
-      "throughputFilesPerSec": 31632.982946804143
+      "durationMs": 115.31625,
+      "throughputFilesPerSec": 31539.353733753916,
+      "minMs": 114.7892,
+      "maxMs": 116.2603,
+      "meanMs": 115.33953,
+      "stdDevMs": 0.45297648515127115,
+      "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 17.752499999999998,
-      "throughputFilesPerSec": 204872.5531615266
+      "durationMs": 16.01135,
+      "throughputFilesPerSec": 227151.36450080722,
+      "minMs": 14.7869,
+      "maxMs": 17.1429,
+      "meanMs": 16.086229999999997,
+      "stdDevMs": 0.879831208869065,
+      "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 2.6955062081797982,
-      "multiThreadVsJs": 17.457577107451783
+      "singleThreadVsJs": 2.6540582224968925,
+      "multiThreadVsJs": 19.1149429311087
     }
   },
   "svelteCheck": {
     "javascript": {
-      "durationMs": 2088.9896543,
-      "throughputFilesPerSec": 239.3501561727672
+      "durationMs": 2087.9697085,
+      "throughputFilesPerSec": 239.46707558281614,
+      "minMs": 2068.028625,
+      "maxMs": 2097.983291,
+      "meanMs": 2086.8648458,
+      "stdDevMs": 8.418588180578206,
+      "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 47.067037600000006,
-      "throughputFilesPerSec": 10623.145740534135
+      "durationMs": 46.8917915,
+      "throughputFilesPerSec": 10662.847035818626,
+      "minMs": 45.800708,
+      "maxMs": 47.750375,
+      "meanMs": 46.7948,
+      "stdDevMs": 0.5972524083971537,
+      "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 13.9306666,
-      "throughputFilesPerSec": 35892.03692521074
+      "durationMs": 13.7850415,
+      "throughputFilesPerSec": 36271.20019914339,
+      "minMs": 13.431709,
+      "maxMs": 14.265917,
+      "meanMs": 13.798795899999998,
+      "stdDevMs": 0.2869505560348161,
+      "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 44.383283096193836,
-      "multiThreadVsJs": 149.95618761703764
+      "singleThreadVsJs": 44.52740323431661,
+      "multiThreadVsJs": 151.46633461350115
     },
     "filesCount": 500
   }


### PR DESCRIPTION
First snapshot under the new format from PR #269 / #271. Captures all the metadata needed to investigate any future "why did this number move?" question without re-bisecting the worktree.

## Snapshot (M1 Pro 10-core · Node v24.13.0 · 3 warmup + 10 measured iters · load avg 3.12)

| Task              | JS       | Rust×1   | Rust×N   | ×1 vs JS | ×N vs JS |
|-------------------|----------|----------|----------|----------|----------|
| **parse**         | 187 ms   | 8.65 ms  | 1.88 ms  | **21.7×**| **99.5×** |
| **svelte-check** (500 files) | 2088 ms | 46.9 ms | 13.8 ms | **44.5×** | **151.5×** |
| svelte2tsx        | 306 ms   | 115 ms   | 16.0 ms  | 2.7×     | 19.1×    |
| compile (client)  | 865 ms   | 381 ms   | 50.1 ms  | 2.3×     | 17.3×    |

## Variance (typical CV across the 10 measured iterations)

- JS compile-client: median 865 ms, stdDev 16 ms → **CV 1.8%**
- Rust×1 compile:    median 381 ms, stdDev  9 ms → **CV 2.2%**
- Parse JS:          median 187 ms, stdDev  4 ms → **CV 2.1%**

The 10-iter median is highly reproducible — the iteration depth bump from 3 to 10 was the right call.

## On the unsolved 2567 ms → 869 ms JS shift

Investigated systematically:

- Node 24 vs Node 25 across both versions, fresh clean reruns × 5
- Identical Svelte SHA (\`04c0368aa8d8\`), identical machine, identical \`testFilesCount\` (3637)
- Same \`compiler/index.js\` build artifact (mtime May 18)

Current JS compile baseline is reproducibly in the **850–950 ms range**; the May-21 PR #247 figure of **2567 ms is not explainable** from any captured artifact. Best hypothesis: that run was on a heavily-loaded machine state which \`runner.loadAvg1min\` would now expose. This snapshot's \`loadAvg1min: 3.12\` documents a moderate-load capture, so any future snapshot captured at higher load is now visibly comparable.

## What's in the JSON now (every snapshot, from PR #269 onward)

\`\`\`json
"runner": {
  "label": "local",
  "os": "darwin", "arch": "arm64", "cpus": 10, "cpuModel": "Apple M1 Pro",
  "nodeVersion": "24.13.0",
  "v8Version": "13.6.233.17-node.37",
  "loadAvg1min": 3.12109375,
  "warmupIterations": 3,
  "benchmarkIterations": 10
}
\`\`\`

And per-task: \`durationMs\` (median), \`throughputFilesPerSec\`, \`minMs\`, \`maxMs\`, \`meanMs\`, \`stdDevMs\`, \`samples\`, \`speedup.*\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)