### PR TITLE
test(release): patch-bump all packages to validate CI release pipeline

### DIFF
--- a/.changeset/test-github-actions-release.md
+++ b/.changeset/test-github-actions-release.md
@@ -1,0 +1,29 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+test(release): patch-bump every package to validate the GitHub Actions release pipeline end-to-end
+
+The local one-shot `publish-all-local.sh` is the manual escape hatch; the
+intended steady-state path is `release.yml` (changesets/action + matrix
+binary builds + `pnpm publish`). This changeset bumps each of the four
+top-level packages by `patch` so we can:
+
+1. Watch changesets/action open the "Version Packages" PR.
+2. Merge it.
+3. Watch the release workflow build the 5-triple matrix for both
+   `svelte_check` and the NAPI cdylib, stage them via
+   `scripts/stage-svelte-check-binaries.mjs` /
+   `scripts/stage-vps-binaries.mjs`, and publish all 14 npm packages.
+4. Confirm every `@rsvelte/*` on the registry shows the new patch version.
+
+`fixed` groups in `.changeset/config.json` make the 5 svelte-check
+platform packages and the 5 vps-native platform packages follow their
+main package automatically, so this changeset only names the four
+top-level packages.
+
+The submodule fork (`@rsvelte/vite-plugin-svelte`) lives in a separate
+repo and isn't part of this pipeline — it's published independently.


### PR DESCRIPTION
Patch changeset that touches every top-level \`@rsvelte/*\` package (compiler, svelte2tsx, svelte-check, vite-plugin-svelte-native). The two \`fixed\` groups in \`.changeset/config.json\` drag along the 10 platform packages, so the final cycle should publish 14 packages.

Also bumps the submodule pointer to \`89ad99ff\` — the "@rsvelte/vite-plugin-svelte 0.3.0" version commit the local \`publish-all-local.sh\` script pushed to the fork's \`rsvelte\` branch (so the parent repo records the shim's published state).

## What this validates end-to-end on merge

1. **changesets/action sees the changeset on main → opens a "Version Packages" PR** that:
   - Bumps the 4 top-level \`package.json\`s by patch.
   - Bumps the 10 platform \`package.json\`s (via \`fixed\` groups).
   - Rewrites \`CHANGELOG.md\` with the changeset body.
   - \`sync-version\` mirrors the compiler bump into \`Cargo.toml\`/\`.lock\`.
2. **Merging the Version Packages PR triggers \`release.yml\`**:
   - 5-triple matrix builds for \`svelte_check\` (uploads each triple as an artifact).
   - 5-triple matrix builds for the NAPI cdylib (\`rsvelte.node\`).
   - \`release\` job downloads all artifacts, stages them via \`scripts/stage-svelte-check-binaries.mjs\` and \`scripts/stage-vps-binaries.mjs\` into the per-triple package directories.
   - \`pnpm run release\` = \`sync-version\` + \`build:wasm\` + \`finalize-pkg\` + \`changeset publish\` (publishes 14 packages).
3. **Verification**: \`npm view @rsvelte/<pkg> version\` shows the patch bump for all 14 names.

## Expected bumps

- \`@rsvelte/compiler\`: 0.3.0 → 0.3.1
- \`@rsvelte/svelte2tsx\`: 0.1.0 → 0.1.1
- \`@rsvelte/svelte-check\` + 5 platforms: 0.1.0 → 0.1.1 (via \`fixed\`)
- \`@rsvelte/vite-plugin-svelte-native\` + 5 platforms: 0.1.0 → 0.1.1 (via \`fixed\`)

The submodule fork's \`@rsvelte/vite-plugin-svelte\` is published from its own repo and not part of this pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)