### PR TITLE
fix(svelte-check): ship svelte-check binary with execute bit

### DIFF
--- a/.changeset/svelte-check-binary-exec-bit.md
+++ b/.changeset/svelte-check-binary-exec-bit.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): restore execute bit on the platform binary so `pnpm dlx`/`npx` work
+
+The 0.1.0 platform tarballs ship `svelte-check` without the execute bit
+because `pnpm pack` (used by `pnpm publish` and therefore `changeset
+publish` when pnpm is detected) normalises file modes to 0644. Running
+`pnpm dlx @rsvelte/svelte-check` (or `npx`) on a fresh install fails with
+`spawnSync ... EACCES`.
+
+Three layers, so a single regression can't break this again:
+
+- `bin/svelte-check.cjs` chmods the binary +x best-effort before
+  `spawnSync`, so already-published 0.x tarballs become usable for any
+  end user on their next install.
+- Each non-Windows platform package gains a `prepack` hook that runs
+  `chmod +x svelte-check` so the source mode is right before pack.
+- A new `scripts/publish-platform-binaries.mjs` step runs `npm publish`
+  for the platform packages before `changeset publish`. `npm pack`
+  preserves modes, so the tarballs that actually hit the registry ship
+  `-rwxr-xr-x`. `changeset publish` then skips those already-published
+  versions and continues with the rest of the workspace as before.
+
+The Windows platform package (`svelte-check.exe`) is unaffected — Windows
+ignores POSIX mode bits.

--- a/npm/svelte-check-darwin-arm64/package.json
+++ b/npm/svelte-check-darwin-arm64/package.json
@@ -11,6 +11,9 @@
   "os": ["darwin"],
   "cpu": ["arm64"],
   "files": ["svelte-check"],
+  "scripts": {
+    "prepack": "chmod +x svelte-check"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/npm/svelte-check-darwin-x64/package.json
+++ b/npm/svelte-check-darwin-x64/package.json
@@ -11,6 +11,9 @@
   "os": ["darwin"],
   "cpu": ["x64"],
   "files": ["svelte-check"],
+  "scripts": {
+    "prepack": "chmod +x svelte-check"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/npm/svelte-check-linux-arm64-gnu/package.json
+++ b/npm/svelte-check-linux-arm64-gnu/package.json
@@ -12,6 +12,9 @@
   "cpu": ["arm64"],
   "libc": ["glibc"],
   "files": ["svelte-check"],
+  "scripts": {
+    "prepack": "chmod +x svelte-check"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/npm/svelte-check-linux-x64-gnu/package.json
+++ b/npm/svelte-check-linux-x64-gnu/package.json
@@ -12,6 +12,9 @@
   "cpu": ["x64"],
   "libc": ["glibc"],
   "files": ["svelte-check"],
+  "scripts": {
+    "prepack": "chmod +x svelte-check"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/npm/svelte-check/bin/svelte-check.cjs
+++ b/npm/svelte-check/bin/svelte-check.cjs
@@ -4,6 +4,7 @@
 // platform and execs its binary.
 
 const { spawnSync } = require('node:child_process');
+const { chmodSync, statSync, constants } = require('node:fs');
 const path = require('node:path');
 
 function resolveTriple() {
@@ -54,6 +55,22 @@ try {
 			`Original error: ${err.message}`,
 	);
 	process.exit(1);
+}
+
+// `pnpm pack` (used by `pnpm publish` and therefore `changeset publish` when
+// pnpm is detected) normalises file modes to 0644, dropping the execute bit
+// the staging script set before pack. On POSIX, re-apply +x best-effort right
+// before spawn so the binary can actually run.
+if (process.platform !== 'win32') {
+	try {
+		const mode = statSync(binPath).mode;
+		if (!(mode & constants.S_IXUSR)) {
+			chmodSync(binPath, (mode & 0o777) | 0o111);
+		}
+	} catch {
+		// Read-only filesystems and similar are not fatal here — spawn will
+		// surface a clear error below if the binary really isn't executable.
+	}
 }
 
 const result = spawnSync(binPath, process.argv.slice(2), {

--- a/package.json
+++ b/package.json
@@ -31,13 +31,14 @@
     "finalize-pkg": "node scripts/finalize-pkg.mjs",
     "stage-svelte-check": "node scripts/stage-svelte-check-binaries.mjs",
     "stage-vps-native": "node scripts/stage-vps-binaries.mjs",
+    "publish-platform-binaries": "node scripts/publish-platform-binaries.mjs",
     "test:vps-shim": "node scripts/test-vps-shim.mjs",
     "test:vps-fixture": "node scripts/test-vps-vite-fixture.mjs",
     "test:vps": "node scripts/test-vps-shim.mjs && node scripts/test-vps-vite-fixture.mjs",
     "build:vps-native": "node scripts/build-vps-native-local.mjs",
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm run sync-version",
-    "release": "pnpm run sync-version && pnpm run build:wasm && pnpm run finalize-pkg && changeset publish"
+    "release": "pnpm run sync-version && pnpm run build:wasm && pnpm run finalize-pkg && pnpm run publish-platform-binaries && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",

--- a/scripts/publish-platform-binaries.mjs
+++ b/scripts/publish-platform-binaries.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Publish the platform packages that ship an executable `svelte-check`
+// binary via `npm publish` rather than `pnpm publish`.
+//
+// Why: `pnpm pack` (which `pnpm publish` uses) normalises file modes to 0644,
+// dropping the execute bit even when the source file has +x set. The
+// resulting tarball ships a non-executable binary and `pnpm dlx
+// @rsvelte/svelte-check` fails with EACCES. `npm pack` preserves modes, so
+// publishing these tarballs with npm yields a working install.
+//
+// This runs *before* `changeset publish`; changesets sees the already-
+// published versions and skips them, while every other workspace package
+// continues to publish through changesets/pnpm.
+//
+// The Windows platform package ships `svelte-check.exe` and is excluded —
+// Windows ignores POSIX mode bits, so pnpm's normalisation is harmless
+// there.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+
+const platformDirs = [
+	'npm/svelte-check-darwin-arm64',
+	'npm/svelte-check-darwin-x64',
+	'npm/svelte-check-linux-x64-gnu',
+	'npm/svelte-check-linux-arm64-gnu',
+];
+
+const dryRun = process.argv.includes('--dry-run');
+
+function readPackageJson(dir) {
+	const pkgPath = resolve(dir, 'package.json');
+	return JSON.parse(readFileSync(pkgPath, 'utf8'));
+}
+
+function isAlreadyPublished(name, version) {
+	const result = spawnSync('npm', ['view', `${name}@${version}`, 'version'], {
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	if (result.status === 0 && result.stdout.trim() === version) {
+		return true;
+	}
+	// `npm view` exits non-zero ("404 Not Found") for missing versions. Treat
+	// any other failure as not-yet-published; the subsequent `npm publish`
+	// will surface real registry errors.
+	return false;
+}
+
+let failures = 0;
+for (const relDir of platformDirs) {
+	const absDir = resolve(repoRoot, relDir);
+	if (!existsSync(absDir)) {
+		console.warn(`[publish-platform] skipping missing dir: ${relDir}`);
+		continue;
+	}
+	const { name, version } = readPackageJson(absDir);
+	if (isAlreadyPublished(name, version)) {
+		console.log(`[publish-platform] ${name}@${version} already published — skipping`);
+		continue;
+	}
+	console.log(`[publish-platform] publishing ${name}@${version}${dryRun ? ' (dry-run)' : ''}`);
+	const args = ['publish', '--access', 'public'];
+	if (dryRun) args.push('--dry-run');
+	const result = spawnSync('npm', args, {
+		cwd: absDir,
+		stdio: 'inherit',
+	});
+	if (result.status !== 0) {
+		console.error(`[publish-platform] FAILED: ${name}@${version} (exit ${result.status})`);
+		failures += 1;
+	}
+}
+
+if (failures > 0) {
+	console.error(`[publish-platform] ${failures} platform package(s) failed to publish`);
+	process.exit(1);
+}

--- a/scripts/stage-svelte-check-binaries.mjs
+++ b/scripts/stage-svelte-check-binaries.mjs
@@ -41,8 +41,10 @@ for (const { triple, binary } of targets) {
 		continue;
 	}
 	copyFileSync(src, dest);
-	// Make sure the binary is executable. `pnpm publish` preserves the file
-	// mode in the tarball, so this is what end users will receive.
+	// Make sure the binary is executable. The platform packages are
+	// published via `scripts/publish-platform-binaries.mjs` (`npm publish`),
+	// which preserves the file mode in the tarball — without that hop
+	// `pnpm publish` would normalise it back to 0644.
 	if (!binary.endsWith('.exe')) {
 		chmodSync(dest, 0o755);
 	}


### PR DESCRIPTION
## Summary
- `pnpm dlx @rsvelte/svelte-check` currently fails with `spawnSync ... EACCES` on a fresh install because the 0.1.0 platform tarballs ship `svelte-check` as `-rw-r--r--`. Root cause: `pnpm pack` (used by `pnpm publish` and therefore `changeset publish` when pnpm is detected) normalises file modes to 0644, dropping the +x that `stage-svelte-check-binaries.mjs` sets.
- Three layered fixes so a regression in any one layer is caught by the next:
  1. **Loader fallback** — `npm/svelte-check/bin/svelte-check.cjs` chmods the binary +x best-effort before `spawnSync`. This rescues the already-published 0.1.0 tarballs on every user's next install.
  2. **prepack hook** — each non-Windows platform package gains `"prepack": "chmod +x svelte-check"` so the source mode is correct before pack regardless of caller.
  3. **Use `npm publish` for platform binaries** — new `scripts/publish-platform-binaries.mjs` runs `npm publish` (which preserves file modes) for each non-Windows platform package before `changeset publish`. `changeset publish` then sees those versions are already published and skips them, continuing with the rest of the workspace as before.
- Windows package (`svelte-check.exe`) is unaffected — Windows ignores POSIX mode bits.

## Verification
- Confirmed locally: `pnpm pack` strips +x → tarball ships `-rw-r--r--`; `npm pack` preserves +x → tarball ships `-rwxr-xr-x`.
- Loader fallback: simulated the broken install by `chmod 0644 svelte-check`, ran the new loader code path against it, `--help` output rendered cleanly and the file mode is `0755` after.
- prepack: starting from `-rw-r--r--`, ran `npm pack` in the platform dir — tarball ships `-rwxr-xr-x`.
- `node scripts/publish-platform-binaries.mjs --dry-run` correctly detects all four 0.1.0 platform packages as already published and reports skip.

## Test plan
- [ ] CI passes on this PR (no test changes; this is publish-pipeline + loader code).
- [ ] After release: `pnpm --config.minimum-release-age=0 dlx @rsvelte/svelte-check@<next> --help` prints the help output.
- [ ] After release: `tar -tvzf` the new platform tarball shows `-rwxr-xr-x` on the `svelte-check` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)