### PR TITLE
docs(npm): rewrite published-package READMEs from a user perspective

### DIFF
--- a/npm/svelte-check-darwin-arm64/README.md
+++ b/npm/svelte-check-darwin-arm64/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/svelte-check-darwin-arm64
+
+Prebuilt [`@rsvelte/svelte-check`](https://www.npmjs.com/package/@rsvelte/svelte-check) binary for **macOS arm64** (Apple Silicon).
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/svelte-check
+```
+
+The loader will pull in the correct platform binary (this one, if you're on Apple Silicon macOS) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/svelte-check-darwin-x64/README.md
+++ b/npm/svelte-check-darwin-x64/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/svelte-check-darwin-x64
+
+Prebuilt [`@rsvelte/svelte-check`](https://www.npmjs.com/package/@rsvelte/svelte-check) binary for **macOS x64** (Intel).
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/svelte-check
+```
+
+The loader will pull in the correct platform binary (this one, if you're on Intel macOS) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/svelte-check-linux-arm64-gnu/README.md
+++ b/npm/svelte-check-linux-arm64-gnu/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/svelte-check-linux-arm64-gnu
+
+Prebuilt [`@rsvelte/svelte-check`](https://www.npmjs.com/package/@rsvelte/svelte-check) binary for **Linux arm64 (glibc)**.
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/svelte-check
+```
+
+The loader will pull in the correct platform binary (this one, if you're on arm64 Linux with glibc) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/svelte-check-linux-x64-gnu/README.md
+++ b/npm/svelte-check-linux-x64-gnu/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/svelte-check-linux-x64-gnu
+
+Prebuilt [`@rsvelte/svelte-check`](https://www.npmjs.com/package/@rsvelte/svelte-check) binary for **Linux x64 (glibc)**.
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/svelte-check
+```
+
+The loader will pull in the correct platform binary (this one, if you're on x64 Linux with glibc) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/svelte-check-win32-x64-msvc/README.md
+++ b/npm/svelte-check-win32-x64-msvc/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/svelte-check-win32-x64-msvc
+
+Prebuilt [`@rsvelte/svelte-check`](https://www.npmjs.com/package/@rsvelte/svelte-check) binary for **Windows x64 (MSVC)**.
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/svelte-check
+```
+
+The loader will pull in the correct platform binary (this one, if you're on x64 Windows) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/svelte-check/README.md
+++ b/npm/svelte-check/README.md
@@ -1,18 +1,95 @@
 # @rsvelte/svelte-check
 
-Workspace package and changesets version anchor for the Rust port of `svelte-check`.
+A Rust-powered drop-in replacement for [`svelte-check`](https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check). Type-checks `.svelte`, `.svelte.ts` / `.svelte.js`, and the surrounding `.ts` / `.js` files in a Svelte project, and reports compiler warnings, A11y warnings, CSS warnings, and TypeScript diagnostics from a single CLI.
 
-## Status
+> **⚠️ Early stage.** Output and flags are stabilising. Not yet recommended for production CI gates without a fallback to the official `svelte-check`.
 
-`private: true` until the cross-platform binary distribution is wired up. The CLI is built from `src/bin/svelte_check.rs`.
+## Install
 
-The simplest path to shipping is the **prebuilt-binary loader** pattern (the same one napi-rs and `@biomejs/biome` use):
+```bash
+npm install -D @rsvelte/svelte-check
+# pnpm add -D @rsvelte/svelte-check
+# yarn add -D @rsvelte/svelte-check
+```
 
-1. A GitHub Actions matrix builds `target/release/svelte-check` for `darwin-arm64`, `darwin-x64`, `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc`, etc.
-2. Each binary is uploaded as a per-platform npm package (`@rsvelte/svelte-check-<triple>`).
-3. This package becomes the loader: a `bin` field pointing at a tiny Node script that resolves the platform package via `optionalDependencies` and execs the bundled binary.
-4. Flip `private` to `false` and let changesets/action publish all of them together.
+The package ships a small loader that resolves the right prebuilt native binary for your platform via `optionalDependencies`. Supported targets:
 
-## Release flow
+| OS | Architecture |
+|---|---|
+| macOS | arm64, x64 |
+| Linux | x64 (glibc), arm64 (glibc) |
+| Windows | x64 (MSVC) |
 
-Versioning is handled by the same changesets pipeline as `@rsvelte/compiler`. See `.github/workflows/release.yml`. While this package is `private`, `changeset version` still updates its `version` and `CHANGELOG.md`, but `changeset publish` skips it. The matrix-build step in CI will need to be added when the binary release is enabled.
+If your platform isn't listed, please [open an issue](https://github.com/baseballyama/rsvelte/issues).
+
+## Usage
+
+From your project root:
+
+```bash
+# Compiler + A11y + CSS diagnostics only (fast — no TypeScript)
+npx svelte-check
+
+# Plus TypeScript diagnostics via tsgo
+npx svelte-check --tsgo
+
+# Watch mode with incremental cache
+npx svelte-check --tsgo --watch --incremental
+```
+
+Add it to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "check": "svelte-check --tsgo",
+    "check:watch": "svelte-check --tsgo --watch --incremental"
+  }
+}
+```
+
+## CLI flags
+
+| Flag | Description |
+|---|---|
+| `--workspace <dir>` | Project root to scan. Defaults to the current directory. |
+| `--output <format>` | `human`, `human-verbose` (default), `machine`, `machine-verbose`, or `github-actions`. |
+| `--ignore <list>` | Comma-separated path components to skip while walking the workspace. |
+| `--fail-on-warnings` | Exit non-zero when any warning is reported (default: errors only). |
+| `--tsgo` | Run [tsgo](https://github.com/microsoft/typescript-go) (or `tsc`) against the generated overlay and surface TypeScript diagnostics. Implies `--emit-overlay`. |
+| `--tsconfig <path>` | Base `tsconfig.json` for the overlay to `extends`. |
+| `--emit-overlay` | Materialise `.tsx` shadow files + an overlay tsconfig under `<workspace>/.svelte-check/` without running a type-checker. Useful for inspecting what gets handed to TS. |
+| `--compiler-warnings <list>` | Per-code overrides, e.g. `--compiler-warnings css-unused-selector:ignore,a11y-no-noninteractive-element-to-interactive-role:error`. |
+| `--diagnostic-sources <list>` | Restrict output to any subset of `svelte`, `ts` / `js`, `css`. |
+| `--incremental` | Reuse `<workspace>/.svelte-check/manifest.json` between runs — unchanged files skip the overlay regeneration step. |
+| `--watch` | Stay alive and re-check on file changes. Composes with `--incremental`. |
+| `--preserve-watch-output` | In watch mode, don't clear the terminal between runs. |
+
+Run `svelte-check --help` for the authoritative list.
+
+## How it works
+
+`svelte-check` walks your project, parses every `.svelte` file with the rsvelte compiler, and reports compiler / A11y / CSS warnings directly. For TypeScript diagnostics, it generates `.tsx` shadow files (via [`@rsvelte/svelte2tsx`](https://www.npmjs.com/package/@rsvelte/svelte2tsx)) plus an overlay `tsconfig.json` under `.svelte-check/`, then hands the overlay to `tsgo` (preferred) or `tsc`. Diagnostics are remapped back onto the original `.svelte` source via high-resolution source maps so error positions point at the line and column you actually wrote.
+
+Highlights:
+
+- **SvelteKit-aware.** Honours `svelte.config.js`'s `kit.files` overrides; injects SvelteKit-generated kit-file augmentations for both `.ts` (real TS annotations) and `.js` (JSDoc) files.
+- **Incremental.** A per-file overlay manifest and a per-file warning cache (`<cacheDir>/warnings.json`) make warm runs near-instant.
+- **Parallel compile.** Files are compiled across rayon workers; the TS pass is the long pole.
+- **Watch mode.** Composes with `--incremental` for an editor-like inner loop.
+
+## Compatibility status
+
+- **Compiler / A11y / CSS warnings** — full coverage; matches the official `svelte-check`'s set.
+- **TypeScript diagnostics via tsgo** — covered for the standard project shapes (plain Svelte 5, SvelteKit). Edge cases around custom preprocessors are still being shaken out.
+- **LSP integration (editor hover / completion)** — out of scope for this package. Wait on the upstream `tsgo` `tsserver` mode before assuming editor support.
+
+If you hit a diagnostic the official `svelte-check` produces and this one doesn't (or vice-versa), please [open an issue](https://github.com/baseballyama/rsvelte/issues) with a minimal repro.
+
+## Performance
+
+`svelte-check` is part of the [rsvelte](https://github.com/baseballyama/rsvelte) project. The underlying compiler runs **2.1× faster single-threaded** and **15.8× faster multi-threaded** than the official JS compiler on a 3,654-file corpus. The TypeScript pass via `tsgo` dominates wall-clock time on most projects; the Svelte side rarely registers.
+
+## License
+
+MIT

--- a/npm/svelte2tsx/README.md
+++ b/npm/svelte2tsx/README.md
@@ -1,18 +1,98 @@
 # @rsvelte/svelte2tsx
 
-Workspace package and changesets version anchor for the Rust port of `svelte2tsx`.
+A Rust-powered drop-in replacement for [`svelte2tsx`](https://github.com/sveltejs/language-tools/tree/master/packages/svelte2tsx) — converts a Svelte component into a TypeScript / TSX module that TypeScript can type-check. Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project.
 
-## Status
+`svelte2tsx` is the bridge that makes TypeScript-aware tooling work for `.svelte` files: editors, `svelte-check`, the Svelte VS Code extension, etc. This package exposes the same surface, backed by the rsvelte Rust compiler compiled to WebAssembly. **245 / 245** upstream `svelte2tsx` fixtures pass.
 
-`private: true` until a runtime artifact is in place. The Rust implementation lives in `src/svelte2tsx/` and is already reachable through the napi binding (`napi_svelte2tsx`). To ship this package to npm:
+> **⚠️ Early stage.** Output is byte-identical against the upstream fixtures, but tooling integrations beyond `@rsvelte/svelte-check` are not yet validated. Open an issue if you hit a mismatch.
 
-1. Decide on a distribution channel:
-   - **wasm** — add a `#[wasm_bindgen]` export for `svelte2tsx` in `src/wasm.rs` and re-export it through this package, OR depend on `@rsvelte/compiler` once that bundle exposes it.
-   - **napi prebuilt binaries** — switch to a `napi-rs` style platform-package layout (this directory becomes the loader, plus a sibling matrix of `@rsvelte/svelte2tsx-<triple>` packages).
-2. Add the entrypoint files (`index.js`, `index.d.ts`, etc.) and a `files` field.
-3. Flip `private` to `false`.
-4. Open a changeset (`pnpm changeset`) — the next merge to `main` will publish.
+## Install
 
-## Release flow
+```bash
+npm install @rsvelte/svelte2tsx
+# pnpm add @rsvelte/svelte2tsx
+# yarn add @rsvelte/svelte2tsx
+```
 
-Versioning is handled by the same changesets pipeline as `@rsvelte/compiler`. See `.github/workflows/release.yml`. While this package is `private`, `changeset version` still updates its `version` and `CHANGELOG.md`, but `changeset publish` skips it.
+Requires Node.js 18+. The WebAssembly bundle ships with the package — no native binaries, no `optionalDependencies`, runs anywhere Node does.
+
+## Usage
+
+```js
+import { svelte2tsx } from '@rsvelte/svelte2tsx';
+
+const source = `
+<script lang="ts">
+  let { name }: { name: string } = $props();
+</script>
+
+<h1>Hello, {name}!</h1>
+`;
+
+const result = await svelte2tsx(source, {
+  filename: 'Hello.svelte',
+  isTsFile: true,
+  version: '5',
+});
+
+console.log(result.code);          // TSX source
+console.log(result.map);           // source map (string | null)
+console.log(result.exportedNames); // { props: ['name'], all: [...] }
+console.log(result.events);        // { eventName: type, ... }
+```
+
+## API
+
+```ts
+function svelte2tsx(
+  source: string,
+  options?: Svelte2TsxOptions
+): Promise<Svelte2TsxResult>;
+
+interface Svelte2TsxOptions {
+  /** Source filename used in the generated TSX `// @filename:` directive and source maps. */
+  filename?: string;
+  /** `<script lang="ts">` — emit real TS annotations. Otherwise JSDoc only. Default: false. */
+  isTsFile?: boolean;
+  /** `'ts'` (default) for type-check TSX, `'dts'` for ambient declarations. */
+  mode?: 'ts' | 'dts';
+  /** Generate accessor getters/setters on the component class. */
+  accessors?: boolean;
+  /** HTML namespace for element type inference. */
+  namespace?: 'html' | 'svg' | 'mathml';
+  /** Svelte version this component targets. Default: '5'. */
+  version?: '4' | '5';
+}
+
+interface Svelte2TsxResult {
+  /** Generated TSX source. */
+  code: string;
+  /** Source map (v3 JSON, as a string), or `null` if not produced. */
+  map: string | null;
+  /** Names exported by the component — `props` is the prop list, `all` is everything. */
+  exportedNames: { props: string[]; all: string[] };
+  /** Inferred event-handler types — `{ eventName: type }`. */
+  events: Record<string, unknown>;
+}
+```
+
+The async signature differs slightly from the upstream package, which is synchronous. The async-ness exists purely so we can lazily initialise the WebAssembly module on first call. On subsequent calls it resolves immediately.
+
+## When to use this
+
+- You're writing a tool that needs to type-check `.svelte` source (linter, type-check CLI, editor extension, monorepo gate).
+- You're already using `svelte2tsx` and want to test whether the Rust port produces equivalent output for your project.
+- You're using [`@rsvelte/svelte-check`](https://www.npmjs.com/package/@rsvelte/svelte-check) — this package powers its `.tsx` shadow-file generation.
+
+If you just want to *compile* a Svelte component to JS, use [`@rsvelte/compiler`](https://www.npmjs.com/package/@rsvelte/compiler) instead — `svelte2tsx` is for TS tooling, not runtime output.
+
+## Compatibility
+
+- 245 / 245 upstream `svelte2tsx` fixtures pass.
+- 2 fixtures around `expected.error.json` (error-path assertions) are skipped pending a structured error-fixture runner.
+
+If you hit a divergence from the official `svelte2tsx`, please file an issue at [github.com/baseballyama/rsvelte](https://github.com/baseballyama/rsvelte/issues) with a minimal repro.
+
+## License
+
+MIT

--- a/npm/vite-plugin-svelte-native-darwin-arm64/README.md
+++ b/npm/vite-plugin-svelte-native-darwin-arm64/README.md
@@ -1,0 +1,19 @@
+# @rsvelte/vite-plugin-svelte-native-darwin-arm64
+
+Prebuilt N-API binding (`rsvelte.node`) for the rsvelte Svelte compiler — **macOS arm64** (Apple Silicon).
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install @rsvelte/vite-plugin-svelte-native
+```
+
+The loader will pull in the correct platform binary (this one, if you're on Apple Silicon macOS) via `optionalDependencies` and expose the compiler API transparently.
+
+If you're building a SvelteKit / Vite app and want to use the Rust compiler, you probably want [`@rsvelte/vite-plugin-svelte`](https://github.com/baseballyama/vite-plugin-svelte/tree/rsvelte) (the Vite plugin) instead — that fork depends on this binding for you.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/vite-plugin-svelte-native-darwin-x64/README.md
+++ b/npm/vite-plugin-svelte-native-darwin-x64/README.md
@@ -1,0 +1,19 @@
+# @rsvelte/vite-plugin-svelte-native-darwin-x64
+
+Prebuilt N-API binding (`rsvelte.node`) for the rsvelte Svelte compiler — **macOS x64** (Intel).
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install @rsvelte/vite-plugin-svelte-native
+```
+
+The loader will pull in the correct platform binary (this one, if you're on Intel macOS) via `optionalDependencies` and expose the compiler API transparently.
+
+If you're building a SvelteKit / Vite app and want to use the Rust compiler, you probably want [`@rsvelte/vite-plugin-svelte`](https://github.com/baseballyama/vite-plugin-svelte/tree/rsvelte) (the Vite plugin) instead — that fork depends on this binding for you.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/vite-plugin-svelte-native-linux-arm64-gnu/README.md
+++ b/npm/vite-plugin-svelte-native-linux-arm64-gnu/README.md
@@ -1,0 +1,19 @@
+# @rsvelte/vite-plugin-svelte-native-linux-arm64-gnu
+
+Prebuilt N-API binding (`rsvelte.node`) for the rsvelte Svelte compiler — **Linux arm64 (glibc)**.
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install @rsvelte/vite-plugin-svelte-native
+```
+
+The loader will pull in the correct platform binary (this one, if you're on arm64 Linux with glibc) via `optionalDependencies` and expose the compiler API transparently.
+
+If you're building a SvelteKit / Vite app and want to use the Rust compiler, you probably want [`@rsvelte/vite-plugin-svelte`](https://github.com/baseballyama/vite-plugin-svelte/tree/rsvelte) (the Vite plugin) instead — that fork depends on this binding for you.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/vite-plugin-svelte-native-linux-x64-gnu/README.md
+++ b/npm/vite-plugin-svelte-native-linux-x64-gnu/README.md
@@ -1,0 +1,19 @@
+# @rsvelte/vite-plugin-svelte-native-linux-x64-gnu
+
+Prebuilt N-API binding (`rsvelte.node`) for the rsvelte Svelte compiler — **Linux x64 (glibc)**.
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install @rsvelte/vite-plugin-svelte-native
+```
+
+The loader will pull in the correct platform binary (this one, if you're on x64 Linux with glibc) via `optionalDependencies` and expose the compiler API transparently.
+
+If you're building a SvelteKit / Vite app and want to use the Rust compiler, you probably want [`@rsvelte/vite-plugin-svelte`](https://github.com/baseballyama/vite-plugin-svelte/tree/rsvelte) (the Vite plugin) instead — that fork depends on this binding for you.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/vite-plugin-svelte-native-win32-x64-msvc/README.md
+++ b/npm/vite-plugin-svelte-native-win32-x64-msvc/README.md
@@ -1,0 +1,19 @@
+# @rsvelte/vite-plugin-svelte-native-win32-x64-msvc
+
+Prebuilt N-API binding (`rsvelte.node`) for the rsvelte Svelte compiler — **Windows x64 (MSVC)**.
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install @rsvelte/vite-plugin-svelte-native
+```
+
+The loader will pull in the correct platform binary (this one, if you're on x64 Windows) via `optionalDependencies` and expose the compiler API transparently.
+
+If you're building a SvelteKit / Vite app and want to use the Rust compiler, you probably want [`@rsvelte/vite-plugin-svelte`](https://github.com/baseballyama/vite-plugin-svelte/tree/rsvelte) (the Vite plugin) instead — that fork depends on this binding for you.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/npm/vite-plugin-svelte-native/README.md
+++ b/npm/vite-plugin-svelte-native/README.md
@@ -1,23 +1,84 @@
-# @rsvelte/vite-plugin-svelte
+# @rsvelte/vite-plugin-svelte-native
 
-Workspace package and changesets version anchor for the Vite plugin that delegates to the rsvelte compiler.
+Native (N-API) bindings to the [rsvelte](https://github.com/baseballyama/rsvelte) Svelte 5 compiler, packaged for Node.js. Exposes the same `compile` / `compileModule` / `preprocess` / `hmrDiff` / `resolveId` surface as the official [`svelte/compiler`](https://svelte.dev/docs/svelte-compiler), plus a few low-overhead extras for tooling authors.
 
-## Status
+> **⚠️ Most users should not depend on this directly.** It's the engine that powers [`@rsvelte/vite-plugin-svelte`](https://github.com/baseballyama/vite-plugin-svelte/tree/rsvelte) — if you want to build a SvelteKit / Vite app with the Rust compiler, use that fork instead. Depend on this package if you're writing a build tool, language server, batch compiler, or any other Node.js program that needs to compile `.svelte` files at maximum speed.
 
-`private: true` until distribution is decided. The Rust side already exposes the napi bindings the plugin will use (`compile`, `preprocess`, `hmrDiff`, `resolveId` in `src/napi.rs`; helpers in `src/vps/`).
+## Install
 
-The plan in `docs/ecosystem-implementation-plan.md` (Wave 3) splits this into two npm packages:
+```bash
+npm install @rsvelte/vite-plugin-svelte-native
+# pnpm add @rsvelte/vite-plugin-svelte-native
+# yarn add @rsvelte/vite-plugin-svelte-native
+```
 
-- `@rsvelte/vite-plugin-svelte` (this directory) — the JS-side Vite plugin façade. Maintains the same public API as `@sveltejs/vite-plugin-svelte`, loads the native module, and translates Vite hooks into NAPI calls.
-- `@rsvelte/vite-plugin-svelte-native` — the napi-rs prebuilt-binary package set (one per platform triple), produced by a matrix build.
+The package ships a loader that resolves the right prebuilt `.node` binary for your platform via `optionalDependencies`. Supported targets:
 
-To go live:
+| OS | Architecture |
+|---|---|
+| macOS | arm64, x64 |
+| Linux | x64 (glibc), arm64 (glibc) |
+| Windows | x64 (MSVC) |
 
-1. Add the napi-rs platform matrix build to CI (target the rsvelte crate with `--features napi`).
-2. Create the `@rsvelte/vite-plugin-svelte-native` workspace package and its per-triple siblings.
-3. Add the JS entrypoint here that imports from `@rsvelte/vite-plugin-svelte-native`.
-4. Flip `private` to `false` on both packages.
+If your platform isn't listed, please [open an issue](https://github.com/baseballyama/rsvelte/issues).
 
-## Release flow
+## Quick start
 
-Versioning is handled by the same changesets pipeline as `@rsvelte/compiler`. See `.github/workflows/release.yml`. While this package is `private`, `changeset version` still updates its `version` and `CHANGELOG.md`, but `changeset publish` skips it.
+```js
+const { compile, compileModule, preprocess, VERSION } = require('@rsvelte/vite-plugin-svelte-native');
+
+// Component
+const result = compile('<h1>Hello {name}!</h1>', {
+  filename: 'App.svelte',
+  generate: 'client', // 'client' | 'server' | false
+});
+console.log(result.js.code);
+console.log(result.css?.code);
+
+// Module (.svelte.js / .svelte.ts)
+const mod = compileModule('export const count = $state(0);', {
+  filename: 'counter.svelte.js',
+});
+
+// Pre-process pipeline (markup / script / style)
+const pre = await preprocess(source, [/* PreprocessorGroup[] */], {
+  filename: 'App.svelte',
+});
+
+console.log(VERSION); // upstream Svelte version this binding targets
+```
+
+The shape of `CompileOptions`, `CompileResult`, `Warning`, `PreprocessorGroup`, etc. matches the upstream `svelte/compiler` types. See [`index.d.ts`](./index.d.ts) for the complete surface.
+
+## Why use this over `svelte/compiler`?
+
+- **Faster.** ~2× single-threaded vs the JS compiler on real corpora; ~15× with `compileBatch` across rayon worker threads.
+- **Drop-in.** Same options, same output shape — wire it into an existing build tool with minimal changes.
+- **Zero-overhead batching.** `compileBatch([...inputs])` compiles N files in parallel across rayon workers and crosses the N-API boundary exactly once.
+- **Async-friendly.** `compileAsync` / `compileBatchAsync` run on libuv worker threads — the JS event loop stays free.
+
+## Performance tips for tool authors
+
+This package exposes several levels of compile entry points; pick based on how your tool consumes the result:
+
+| Entry point | When to use |
+|---|---|
+| `compile(source, options)` | Default. Returns the upstream `CompileResult` shape; lazy-decodes the underlying envelope so heavy strings (generated code, source map JSON) are read only when accessed. |
+| `compileAsync(source, options)` | Same shape, runs on a libuv worker thread. Use inside Vite middleware, SSR pre-render, or anywhere you don't want to block the event loop. |
+| `compileBatch([{source, options}, …])` | Compile many files in one N-API call. Per-file failures surface as `Error` instances at the corresponding slot — they don't abort the batch. |
+| `compileBatchAsync([...])` | Same, async / off-thread. |
+| `compileEnvelope(source, options)` | Returns a single `Buffer` containing the raw envelope. Useful for `postMessage` across worker threads with `transfer:` — no copy. Pair with `decodeEnvelope(buf)` on the receiving side. |
+| `compileEnvelopeZeroCopy(...)` | Same as `compileEnvelope` but the returned `Buffer` is a view into `bumpalo` arena memory — skips Rust's `Vec` allocation. Faster, but with subtle GC / detach semantics. |
+| `compileBuffers(...)` | Returns `js.code` / `js.map` / `css.code` / `css.map` as raw `Buffer`s. Skip when you can use `compile()` — kept as an escape hatch. |
+| `compileLegacy(...)` | The old JSON-on-the-boundary path. Kept for parity tests; production callers should not use it. |
+
+For Svelte source-to-TSX conversion use the bundled `svelte2tsx(source, options)`; for HMR-update diffs use `hmrDiff(prev, curr)`. See [`index.d.ts`](./index.d.ts) for full type signatures.
+
+## Compatibility
+
+- **3,341 / 3,341** in-scope tests from the official Svelte 5 compiler test suite pass.
+- `VERSION` tracks the upstream Svelte version (currently `5.51.3`) — it's the *Svelte* compatibility line, not the rsvelte release version.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- The README files for the published `@rsvelte` packages (`@rsvelte/svelte-check`, `@rsvelte/svelte2tsx`, `@rsvelte/vite-plugin-svelte-native`) described internal release plumbing — "private: true until X is wired up", changesets anchor notes, distribution-channel decisions. They were written when the packages were still in-repo only and are not useful to anyone who lands on the npm page now that the packages actually publish.
- Rewrite the three published-package READMEs as user-facing docs: install, quick start, API / CLI reference, supported platforms, compatibility status, and pointers to the right package for the user's situation (e.g. SvelteKit users want the JS-side Vite plugin fork, not the native bindings directly).
- Add minimal "this is a platform binary, install the loader package instead" READMEs to the per-triple `svelte-check-*` and `vite-plugin-svelte-native-*` packages, which previously shipped with no README at all and showed up on npm as bare placeholders.

`@rsvelte/compiler`'s npm README comes from `pkg/README.md` (regenerated by `wasm-pack` from the repo-root `README.md` on each build) and is already user-facing, so no change is needed there. `npm/compiler/README.md` itself is a workspace-internal anchor that never ships to npm — left as-is.

Replaces #281 (rebased onto current main to clear merge dirtiness).

## Test plan

- [ ] Confirm the three rewritten READMEs render readably on GitHub.
- [ ] Spot-check that the documented CLI flags for `@rsvelte/svelte-check` match `src/bin/svelte_check.rs`.
- [ ] Spot-check that the documented `@rsvelte/svelte2tsx` API matches `npm/svelte2tsx/index.d.ts`.
- [ ] Spot-check that the documented `@rsvelte/vite-plugin-svelte-native` exports match `npm/vite-plugin-svelte-native/index.d.ts`.
- [ ] After the next release, verify the new READMEs appear on npmjs.com for each package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)