### PR TITLE
fix(gitignore): exclude CI's artifacts/ staging directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,10 @@ REVIEW_REPORT.md
 # so it doesn't show up in `git status` for everyone who has the same
 # pattern in their shell history.
 pbcopy
+
+# CI matrix-build artifacts staged into `artifacts/` by the release
+# workflow before `stage-*-binaries.mjs` copies them into the per-triple
+# npm package dirs. They are downloaded fresh on every run; without this
+# entry, `changesets/action` includes them in the "Version Packages" PR
+# (~70 MB per run, baked into git history forever).
+artifacts/


### PR DESCRIPTION
\`release.yml\` downloads the 5 platform binaries from the \`build-svelte-check\` and \`build-vps-native\` matrix jobs into \`./artifacts/\`. The next step (\`scripts/stage-svelte-check-binaries.mjs\` and \`scripts/stage-vps-binaries.mjs\`) copies them into the per-triple npm package directories for \`pnpm publish\` to pick up — but the download leaves the originals sitting under \`artifacts/\`.

\`changesets/action\` then opens the "Version Packages" PR with \`git add -A\` semantics: anything not gitignored is committed. The result was PR #283 carrying **~70 MB of binaries** (5× svelte-check ~50 MB + 5× rsvelte.node ~50 MB) on top of the actual version bumps — a fresh copy on every release cycle, baked into git history forever.

Ignoring \`artifacts/\` keeps the staging tree out of the diff. The staging script's destination (the per-triple npm package dirs) is unaffected — those \`bin\`/\`.node\` files were never tracked, only shipped in the npm tarball.

## Effect on PR #283

After this lands and the next release.yml run completes, \`changesets/action\` will force-push to \`changeset-release/main\` without the \`artifacts/\` files — leaving only the actual version bumps and CHANGELOGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)