### PR TITLE
chore(svelte): upgrade submodule to 5.51.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ A single-threaded **100× speedup** over the JS compiler is one of this project'
 ## Compatibility
 
 <!-- svelte-target-version -->
-**Targeting Svelte `v5.51.4`** ([`b8f2b86105e0`](https://github.com/sveltejs/svelte/commit/b8f2b86105e0)) — automatically maintained by `pnpm run update-docs`.
+**Targeting Svelte `v5.51.5`** ([`8ea33bf7fe86`](https://github.com/sveltejs/svelte/commit/8ea33bf7fe86)) — automatically maintained by `pnpm run update-docs`.
 <!-- /svelte-target-version -->
 
 Current compatibility with the official Svelte compiler test suite:

--- a/docs/rsvelte-shim/compiler.mjs
+++ b/docs/rsvelte-shim/compiler.mjs
@@ -79,8 +79,8 @@ function logOnce() {
 
 // The upstream svelte version we mirror. vite-plugin-svelte does
 // `gte(VERSION, '5.36.0')` to decide whether async features are available.
-// rsvelte targets sveltejs/svelte@5.51.4, so report that.
-export const VERSION = '5.51.4';
+// rsvelte targets sveltejs/svelte@5.51.5, so report that.
+export const VERSION = '5.51.5';
 
 // The NAPI compile binding deserialises `options` via serde_json, which can't
 // represent JS functions. vite-plugin-svelte sets `options.cssHash = () => …`

--- a/docs/src/lib/preview.ts
+++ b/docs/src/lib/preview.ts
@@ -7,9 +7,9 @@
 
 const IMPORT_MAP = {
 	imports: {
-		svelte: 'https://esm.sh/svelte@5.51.4',
-		'svelte/internal/disclose-version': 'https://esm.sh/svelte@5.51.4/internal/disclose-version',
-		'svelte/internal/client': 'https://esm.sh/svelte@5.51.4/internal/client'
+		svelte: 'https://esm.sh/svelte@5.51.5',
+		'svelte/internal/disclose-version': 'https://esm.sh/svelte@5.51.5/internal/disclose-version',
+		'svelte/internal/client': 'https://esm.sh/svelte@5.51.5/internal/client'
 	}
 };
 

--- a/docs/static/test-results.json
+++ b/docs/static/test-results.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-05-24T16:46:53.429956+00:00",
-  "commit_sha": "b8f2b86105e0",
+  "generated_at": "2026-05-24T17:02:05.824055+00:00",
+  "commit_sha": "8ea33bf7fe86",
   "summary": {
-    "total": 3413,
-    "passed": 3333,
+    "total": 3416,
+    "passed": 3336,
     "failed": 0,
     "skipped": 80,
     "percentage": 100
@@ -11920,8 +11920,8 @@
     {
       "id": "server-side-rendering",
       "name": "SSR",
-      "total": 82,
-      "passed": 82,
+      "total": 85,
+      "passed": 85,
       "failed": 0,
       "skipped": 0,
       "percentage": 100,
@@ -11992,6 +11992,10 @@
         },
         {
           "name": "falsy-dynamic-component",
+          "status": "pass"
+        },
+        {
+          "name": "dynamic-element-xss-prevention",
           "status": "pass"
         },
         {
@@ -12116,6 +12120,10 @@
         },
         {
           "name": "dynamic-element-variable",
+          "status": "pass"
+        },
+        {
+          "name": "spread-attributes-event-handler-xss",
           "status": "pass"
         },
         {
@@ -12252,6 +12260,10 @@
         },
         {
           "name": "store-init-props",
+          "status": "pass"
+        },
+        {
+          "name": "option-body-escaped",
           "status": "pass"
         }
       ]


### PR DESCRIPTION
## Summary

- Bump Svelte submodule **5.51.4 → 5.51.5**.
- The only compiler-side upstream commit ([`73098bb26`](https://github.com/sveltejs/svelte/commit/73098bb26)) factors the element-name parse regex into a shared `REGEX_VALID_TAG_NAME` in `src/utils.js` and adds a runtime guard inside the SSR `\$.element(...)` helper. Compiled output is unchanged (validation happens inside the runtime helper, not in the emitted code), so rsvelte's transform needs no compiler-side change.
- 3 new SSR fixtures land with the upstream commit: `dynamic-element-xss-prevention`, `option-body-escaped`, `spread-attributes-event-handler-xss`. SSR suite goes **82 → 85 / 85 (100%)**.

## Test plan

- [x] `pnpm run generate-fixtures -- --force` succeeds; new SSR fixtures use `$.element(...)` (validation is runtime-side, no compile-time output change).
- [x] `pnpm run compatibility-report` ⇒ **3,336 / 3,336 (100%)**; every in-scope category at 100%.
- [x] `node scripts/update-docs.mjs --check` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)