### PR TITLE
fix(update-docs): read Svelte version from package.json

### DIFF
--- a/scripts/update-docs.mjs
+++ b/scripts/update-docs.mjs
@@ -34,27 +34,33 @@ function getSvelteCommitHash() {
 	}
 }
 
-// Get the closest Svelte release tag for the submodule HEAD (e.g. "5.51.3")
+// Get the Svelte release version (e.g. "5.51.3"). We read the version field
+// from `packages/svelte/package.json` because CI checks out submodules with
+// shallow depth and no tags, so `git describe` can't resolve `svelte@<ver>`.
 function getSvelteVersion() {
+	try {
+		const pkgPath = path.join(
+			rootDir,
+			'submodules',
+			'svelte',
+			'packages',
+			'svelte',
+			'package.json'
+		);
+		const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+		if (pkg && typeof pkg.version === 'string') return pkg.version;
+	} catch {
+		// Fall through to git-describe.
+	}
 	try {
 		const result = execSync('git describe --tags --exact-match HEAD 2>/dev/null', {
 			cwd: path.join(rootDir, 'submodules', 'svelte'),
 			encoding: 'utf-8'
 		}).trim();
-		// Tag format is e.g. "svelte@5.51.3" — strip the prefix.
 		const match = /^svelte@(.+)$/.exec(result);
 		return match ? match[1] : result || 'unknown';
 	} catch {
-		// No exact tag — fall back to nearest tag with a -gSHORT suffix.
-		try {
-			const result = execSync('git describe --tags --always', {
-				cwd: path.join(rootDir, 'submodules', 'svelte'),
-				encoding: 'utf-8'
-			}).trim();
-			return result.replace(/^svelte@/, '');
-		} catch {
-			return 'unknown';
-		}
+		return 'unknown';
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix CI failure introduced in #288. The new `node scripts/update-docs.mjs --check` step on the Compatibility Report job fails because `actions/checkout@v4 with submodules: true` does a shallow clone of submodules without tags, so `git describe --tags --exact-match HEAD` finds no tag and falls back to a short SHA that never matches the version literal in the README marker.

Read the version directly from `submodules/svelte/packages/svelte/package.json` (always in the working tree regardless of fetch depth). Keep `git describe` as a last-resort fallback.

## Test plan

- [x] `node scripts/update-docs.mjs --check` succeeds locally with the current submodule pointer (Svelte v5.51.5 @ 8ea33bf7fe86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)