### PR TITLE
ci(release): fix Trusted Publishing auth in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,8 +166,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      # npm OIDC trusted publishing requires npm >= 11.5.1. Node 22 ships an
+      # older bundled npm, so pin to a known-good version that supports
+      # `npm publish` against a Trusted Publisher with no NPM_TOKEN.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -192,14 +198,13 @@ jobs:
       - name: Stage vps-native binaries
         run: pnpm run stage-vps-native
 
-      # changesets/action runs `pnpm publish` via the `publish` script when no
-      # changesets remain on main. pnpm authenticates against npmjs.org from
-      # ~/.npmrc, so we write the token there before the action runs.
-      - name: Configure npm auth
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+      # Authentication: every publish in this job (changesets/action's
+      # `changeset publish`, and the bare `npm publish` in
+      # publish-platform-binaries.mjs) goes through npm OIDC trusted
+      # publishing. Each @rsvelte package needs a Trusted Publisher config
+      # on npmjs.com pointing at this repo + workflow. No NPM_TOKEN is set
+      # on purpose — writing an empty token to ~/.npmrc silently disables
+      # the OIDC fallback.
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
@@ -217,4 +222,3 @@ jobs:
           title: 'chore(release): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/publish-platform-binaries.mjs
+++ b/scripts/publish-platform-binaries.mjs
@@ -65,7 +65,11 @@ for (const relDir of platformDirs) {
 		continue;
 	}
 	console.log(`[publish-platform] publishing ${name}@${version}${dryRun ? ' (dry-run)' : ''}`);
-	const args = ['publish', '--access', 'public'];
+	// --provenance is required when publishing via npm OIDC trusted
+	// publishing from CI; it links each tarball back to the workflow run
+	// that produced it. Locally (where OIDC isn't available) npm will fail
+	// fast, which is the correct behaviour — these packages are CI-only.
+	const args = ['publish', '--access', 'public', '--provenance'];
 	if (dryRun) args.push('--dry-run');
 	const result = spawnSync('npm', args, {
 		cwd: absDir,


### PR DESCRIPTION
## Summary

Release run [26367065163](https://github.com/baseballyama/rsvelte/actions/runs/26367065163/job/77613173169) failed with `npm error code E404 - 404 Not Found - PUT https://registry.npmjs.org/...` for every platform sub-package, even though Trusted Publisher was already configured on npmjs.com. The 404 is npm's standard \"unauthenticated PUT to a scoped package\" response — three issues compounded to keep the publish from authenticating at all:

1. **\`Configure npm auth\` wrote an empty token to \`~/.npmrc\`.** With \`NPM_TOKEN\` cleared (the Trusted Publishing migration), the substitution produced \`_authToken=\`, which the bare \`npm publish\` in \`publish-platform-binaries.mjs\` happily read and used. \`changesets/action\` works around this by checking the env var directly, but never gets to run — the platform-binary script fails first. → Step removed.

2. **Node 22 still ships an older bundled \`npm\`; OIDC trusted publishing requires \`npm >= 11.5.1\`.** Added an explicit \`npm install -g npm@latest\` step. (Node 22 also replaces the original Node 20 in CI so we're on a supported pairing.)

3. **\`scripts/publish-platform-binaries.mjs\` now passes \`--provenance\`** so each platform tarball is linked back to its workflow run, matching what \`changesets/action\` does for the workspace packages.

## Operator-side follow-up (not in this PR)

Every \`@rsvelte\` package that this workflow publishes needs its own Trusted Publisher entry on npmjs.com. Configure each against repo \`baseballyama/rsvelte\` + workflow \`.github/workflows/release.yml\` (no environment):

**Platform sub-packages (publish-platform-binaries.mjs)**
- \`@rsvelte/svelte-check-darwin-arm64\`
- \`@rsvelte/svelte-check-darwin-x64\`
- \`@rsvelte/svelte-check-linux-x64-gnu\`
- \`@rsvelte/svelte-check-linux-arm64-gnu\`
- \`@rsvelte/svelte-check-win32-x64-msvc\`
- The matching 5 \`@rsvelte/vite-plugin-svelte-native-<triple>\` sub-packages (if any) staged by \`stage-vps-native\`

**Workspace packages (changesets/action → pnpm publish)**
- \`@rsvelte/compiler\`
- \`@rsvelte/svelte-check\`
- \`@rsvelte/svelte2tsx\`
- \`@rsvelte/vite-plugin-svelte-native\`

## Test plan

- [ ] After merge, the next \`Release\` run on \`main\` no longer fails on \`publish-platform-binaries.mjs\`.
- [ ] Tarballs land on npm with provenance attestations attached.
- [ ] If a publish 404s again, the missing Trusted Publisher entry will be named in the error — add it on npmjs.com.

Refs: https://github.com/baseballyama/rsvelte/actions/runs/26367065163/job/77613173169

🤖 Generated with [Claude Code](https://claude.com/claude-code)