### PR TITLE
fix(ecosystem-ci): override vps submodule URL to HTTPS for CI

### DIFF
--- a/.github/workflows/ecosystem-ci-poll.yml
+++ b/.github/workflows/ecosystem-ci-poll.yml
@@ -1,0 +1,79 @@
+name: ecosystem-ci-poll
+
+# Hourly poll of each target's upstream branch HEAD. If the SHA changed since
+# the last poll, dispatch ecosystem-ci for just that target. The "state" of
+# the last-seen SHA per target lives in this workflow's cache so we don't
+# need to commit anything to rsvelte/main for this to work.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 * * * *'  # Hourly at :17 to avoid contention with other crons
+
+concurrency:
+  group: ecosystem-ci-poll
+  cancel-in-progress: false
+
+jobs:
+  poll:
+    name: Poll upstream HEADs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write       # needed to dispatch ecosystem-ci.yml
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Restore state cache
+        id: state-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ecosystem-ci/state
+          key: ecosystem-ci-state-${{ github.run_id }}
+          restore-keys: |
+            ecosystem-ci-state-
+
+      - name: Run poll
+        id: poll
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p ecosystem-ci/state
+          node scripts/ecosystem-ci.mjs poll > changed.txt
+          if [ -s changed.txt ]; then
+            echo "Changed targets:"
+            cat changed.txt
+            {
+              echo 'changed<<EOF'
+              cat changed.txt
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "No upstream changes detected."
+          fi
+
+      - name: Save state cache
+        if: steps.poll.outputs.changed != ''
+        uses: actions/cache/save@v4
+        with:
+          path: ecosystem-ci/state
+          key: ecosystem-ci-state-${{ github.run_id }}
+
+      - name: Dispatch ecosystem-ci runs
+        if: steps.poll.outputs.changed != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          while IFS= read -r target; do
+            [ -z "$target" ] && continue
+            echo "Dispatching ecosystem-ci for $target"
+            gh workflow run ecosystem-ci.yml \
+              --ref "${{ github.ref_name }}" \
+              -f target="$target"
+          done <<< "${{ steps.poll.outputs.changed }}"

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -83,7 +83,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Init vite-plugin-svelte submodule (only one ecosystem-ci needs)
-        run: git submodule update --init submodules/vite-plugin-svelte
+        # The fork's submodule URL in .gitmodules is the maintainer's SSH URL
+        # (git@github.com:.../vite-plugin-svelte.git). CI runners don't have
+        # that SSH key, so override to HTTPS for the duration of this init.
+        run: |
+          git config submodule.submodules/vite-plugin-svelte.url \
+            https://github.com/baseballyama/vite-plugin-svelte.git
+          git submodule update --init submodules/vite-plugin-svelte
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -1,0 +1,151 @@
+name: ecosystem-ci
+
+# Verifies rsvelte against real-world MIT-licensed Svelte projects by running
+# each target's own test/build suite under (1) the official svelte/compiler
+# (baseline) and (2) rsvelte (swap). See ecosystem-ci/README.md for design.
+#
+# Triggers:
+#   - workflow_dispatch: manual run, optional `target` input selects one target
+#   - PR with label `ecosystem-ci`: opt-in verification for a rsvelte change
+#   - schedule: nightly full sweep
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Single target to run (empty = all)'
+        required: false
+        type: string
+      tag:
+        description: 'Tag filter (e.g. "ui-library"). Ignored if target is set.'
+        required: false
+        type: string
+  pull_request:
+    types: [labeled, synchronize]
+  schedule:
+    # Nightly at 02:00 UTC. Adjust if the matrix grows past 4–5 targets.
+    - cron: '0 2 * * *'
+
+concurrency:
+  group: ecosystem-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  discover:
+    name: Discover targets
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ecosystem-ci'))
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.list.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute target matrix
+        id: list
+        shell: bash
+        run: |
+          set -euo pipefail
+          INPUT_TARGET='${{ github.event.inputs.target }}'
+          INPUT_TAG='${{ github.event.inputs.tag }}'
+          if [ -n "$INPUT_TARGET" ]; then
+            targets=$(printf '%s' "$INPUT_TARGET" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          else
+            mapfile -t all < <(find ecosystem-ci/targets -name '*.json' -exec basename {} .json \; | sort)
+            if [ -n "$INPUT_TAG" ]; then
+              filtered=()
+              for t in "${all[@]}"; do
+                if jq -e --arg tag "$INPUT_TAG" '.tags | index($tag)' "ecosystem-ci/targets/${t}.json" > /dev/null; then
+                  filtered+=("$t")
+                fi
+              done
+              targets=$(printf '%s\n' "${filtered[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            else
+              targets=$(printf '%s\n' "${all[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            fi
+          fi
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+          echo "Targets: $targets"
+
+  run:
+    name: ${{ matrix.target }}
+    needs: discover
+    if: needs.discover.outputs.targets != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.discover.outputs.targets) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Init vite-plugin-svelte submodule (only one ecosystem-ci needs)
+        run: git submodule update --init submodules/vite-plugin-svelte
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Run ecosystem-ci
+        run: node scripts/ecosystem-ci.mjs run "${{ matrix.target }}"
+
+      - name: Upload result JSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-${{ matrix.target }}
+          path: ecosystem-ci/results/${{ matrix.target }}.json
+          if-no-files-found: warn
+
+      - name: Upload phase logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ matrix.target }}
+          path: ecosystem-ci/.cache/${{ matrix.target }}-*.log
+          if-no-files-found: warn
+
+  summary:
+    name: Summary
+    needs: run
+    if: always() && needs.run.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ecosystem-ci/results
+          pattern: result-*
+          merge-multiple: true
+
+      - name: Aggregate
+        run: node scripts/ecosystem-ci.mjs report | tee summary.md
+
+      - name: Post summary to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('summary.md', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '## ecosystem-ci results\n\n' + body,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,13 @@ language-tools
 # the skill bisects against), so nothing inside it should be tracked.
 compat-targets/
 
+# ecosystem-ci: per-target clones, logs, and per-run result JSON. Only
+# ecosystem-ci/targets/*.json and ecosystem-ci/README.md are tracked.
+/ecosystem-ci/checkout/
+/ecosystem-ci/results/
+/ecosystem-ci/.cache/
+/ecosystem-ci/state/
+
 # Tool / review scratch artefacts. None of these are inputs to a build;
 # they're outputs of local tooling (benchmarks, profilers, code-review
 # skills) that get regenerated on demand and should not pollute git.

--- a/ecosystem-ci/README.md
+++ b/ecosystem-ci/README.md
@@ -1,0 +1,105 @@
+# ecosystem-ci
+
+Real-world compatibility verification for rsvelte. Modeled after
+[vite-ecosystem-ci](https://github.com/vitejs/vite-ecosystem-ci): for each
+target repo (UI library, app, tool), clone it, run its own test/build suite
+under the official `svelte/compiler`, then re-run it with `svelte/compiler`
+swapped out for the rsvelte NAPI binding, and compare results.
+
+The goal is to keep rsvelte honest against codebases that are actually
+shipped in production, not just the fixtures vendored in `svelte/`.
+
+## Layout
+
+```
+ecosystem-ci/
+├── README.md             # this file
+├── targets/              # one JSON file per verified repo (tracked)
+│   └── shadcn-svelte.json
+├── checkout/             # per-target git clones (gitignored)
+├── results/              # per-run JSON results (gitignored)
+├── state/                # last-verified upstream HEAD SHA per target (gitignored)
+└── .cache/               # baseline logs etc. (gitignored)
+```
+
+## Running locally
+
+```bash
+# Build rsvelte NAPI once (or every time you change rsvelte)
+.claude/skills/verify-svelte-compat/scripts/build-rsvelte.sh
+
+# Run a single target end-to-end
+node scripts/ecosystem-ci.mjs run shadcn-svelte
+
+# Run every tracked target
+node scripts/ecosystem-ci.mjs run-all
+
+# Just list known targets
+node scripts/ecosystem-ci.mjs list
+
+# Aggregate the latest results/ into a markdown summary
+node scripts/ecosystem-ci.mjs report
+```
+
+Use `--filter <tag>` with `run-all` to narrow to a tag (e.g. `ui-library`).
+
+## Target JSON schema
+
+See `targets/shadcn-svelte.json` for a worked example. Required fields:
+
+| field | meaning |
+|---|---|
+| `name` | unique identifier; also used as the checkout directory name |
+| `repo` | git URL (https or ssh) |
+| `branch` | upstream branch to follow (the one that "merges to develop" semantically) |
+| `license` | must be `MIT` (or another permissive license we explicitly opt in to) |
+| `type` | `app` or `tool` — controls verification strategy |
+| `commands.install` | how to install deps |
+| `commands.test` and/or `commands.build` | what to run for verification (at least one required) |
+| `swap.strategy` | `vps-shim` (preferred when the target uses vite-plugin-svelte), `loader-hook` (require-hook fallback), or `pnpm-override` (already-forked targets). The runner stages a renamed copy of `submodules/vite-plugin-svelte/packages/vite-plugin-svelte` and uses three pnpm.overrides — `@sveltejs/vite-plugin-svelte`, `@rsvelte/vite-plugin-svelte-native`, and `@rsvelte/vite-plugin-svelte-native-<triple>` — so the target picks up the *local* NAPI binary, not the last npm-published one. |
+| `subPath` | optional; if the verification target is a sub-package of a monorepo |
+| `timeoutMinutes` | per-phase timeout |
+| `tags` | free-form labels for grouping (`ui-library`, `sveltekit`, …) |
+| `allowList.expectedBaselineFailures` | regex patterns of test names the official compiler is *expected* to fail; these are excluded from regression comparison |
+
+## How a run works
+
+1. Resolve the target JSON.
+2. Clone or fast-forward `ecosystem-ci/checkout/<name>/` to the latest commit on `branch`.
+3. `pnpm install` (or whatever `commands.install` says).
+4. **Baseline**: run `commands.build` and/or `commands.test` against the unmodified target. Save log + exit code under `.cache/<name>-baseline.{log,json}`.
+5. Build rsvelte NAPI via `.claude/skills/verify-svelte-compat/scripts/build-rsvelte.sh`, drop the `.node` into `checkout/<name>/.rsvelte/`.
+6. **Swap**: invoke the swap script that matches `swap.strategy`. This injects a `svelte/compiler` shim or a `pnpm.overrides` entry.
+7. **rsvelte run**: re-run the same commands. Save log + exit code under `.cache/<name>-rsvelte.{log,json}`.
+8. **Compare**: exit codes + log diff. Write final verdict to `results/<name>.json`:
+
+   ```jsonc
+   {
+     "name": "shadcn-svelte",
+     "targetCommit": "abc123",
+     "rsvelteCommit": "def456",
+     "result": "pass" | "baseline-failure" | "regression",
+     "baseline": { "exitCode": 0, "durationSeconds": 145 },
+     "rsvelte":  { "exitCode": 0, "durationSeconds": 162 },
+     "verifiedAt": "2026-05-25T12:34:56Z"
+   }
+   ```
+
+If baseline itself fails, the run is classified `baseline-failure` and does
+**not** count as a regression — the target is broken for everyone.
+
+## Adding a target
+
+1. Confirm the repo is MIT-licensed (or another license you explicitly accept).
+2. Create `ecosystem-ci/targets/<name>.json` following the schema above.
+3. Run it locally once: `node scripts/ecosystem-ci.mjs run <name>`.
+4. If it produces a green `results/<name>.json`, commit the target JSON.
+
+## Triggers (CI)
+
+- **`workflow_dispatch` / PR label `ecosystem-ci`** — opt-in run against a
+  specific rsvelte change. (`T1`)
+- **`schedule: cron` nightly** — full sweep over all targets. (`T2`)
+- **`ecosystem-ci-poll` workflow** runs hourly, polls each target's upstream
+  `branch` HEAD SHA against `state/<name>.json`, and triggers a per-target
+  run when the SHA changes. (`T3`)

--- a/ecosystem-ci/targets/bits-ui.json
+++ b/ecosystem-ci/targets/bits-ui.json
@@ -1,0 +1,20 @@
+{
+  "name": "bits-ui",
+  "repo": "https://github.com/huntabyte/bits-ui",
+  "license": "MIT",
+  "branch": "main",
+  "type": "tool",
+  "swap": {
+    "strategy": "vps-shim"
+  },
+  "commands": {
+    "install": "pnpm install --no-frozen-lockfile",
+    "build": "pnpm -F bits-ui build",
+    "test": "pnpm -F bits-ui test:unit -- --run"
+  },
+  "timeoutMinutes": 30,
+  "tags": ["ui-library", "headless"],
+  "allowList": {
+    "expectedBaselineFailures": []
+  }
+}

--- a/ecosystem-ci/targets/flowbite-svelte.json
+++ b/ecosystem-ci/targets/flowbite-svelte.json
@@ -1,0 +1,20 @@
+{
+  "name": "flowbite-svelte",
+  "repo": "https://github.com/themesberg/flowbite-svelte",
+  "license": "MIT",
+  "branch": "main",
+  "type": "tool",
+  "swap": {
+    "strategy": "vps-shim"
+  },
+  "commands": {
+    "install": "pnpm install --no-frozen-lockfile",
+    "build": "pnpm build",
+    "test": "pnpm test:unit -- --run"
+  },
+  "timeoutMinutes": 30,
+  "tags": ["ui-library"],
+  "allowList": {
+    "expectedBaselineFailures": []
+  }
+}

--- a/ecosystem-ci/targets/melt-ui.json
+++ b/ecosystem-ci/targets/melt-ui.json
@@ -1,0 +1,20 @@
+{
+  "name": "melt-ui",
+  "repo": "https://github.com/melt-ui/melt",
+  "license": "MIT",
+  "branch": "main",
+  "type": "tool",
+  "swap": {
+    "strategy": "vps-shim"
+  },
+  "commands": {
+    "install": "pnpm install --no-frozen-lockfile",
+    "build": "pnpm -F melt build",
+    "test": "pnpm -F melt test -- --run"
+  },
+  "timeoutMinutes": 30,
+  "tags": ["ui-library", "headless", "runes"],
+  "allowList": {
+    "expectedBaselineFailures": []
+  }
+}

--- a/ecosystem-ci/targets/shadcn-svelte.json
+++ b/ecosystem-ci/targets/shadcn-svelte.json
@@ -1,0 +1,19 @@
+{
+  "name": "shadcn-svelte",
+  "repo": "https://github.com/huntabyte/shadcn-svelte",
+  "license": "MIT",
+  "branch": "main",
+  "type": "app",
+  "swap": {
+    "strategy": "vps-shim"
+  },
+  "commands": {
+    "install": "pnpm install --no-frozen-lockfile",
+    "build": "pnpm -F docs build"
+  },
+  "timeoutMinutes": 30,
+  "tags": ["ui-library", "sveltekit"],
+  "allowList": {
+    "expectedBaselineFailures": []
+  }
+}

--- a/scripts/ecosystem-ci.mjs
+++ b/scripts/ecosystem-ci.mjs
@@ -1,0 +1,548 @@
+#!/usr/bin/env node
+// ecosystem-ci runner.
+//
+// Verifies rsvelte against real-world Svelte projects by cloning each target,
+// running its own test/build suite under the official `svelte/compiler` as a
+// baseline, then re-running it with `svelte/compiler` swapped for the rsvelte
+// NAPI binding. Modeled after vite-ecosystem-ci.
+//
+// Usage:
+//   node scripts/ecosystem-ci.mjs list
+//   node scripts/ecosystem-ci.mjs run <target>
+//   node scripts/ecosystem-ci.mjs run-all [--tag <tag>]
+//   node scripts/ecosystem-ci.mjs report
+//   node scripts/ecosystem-ci.mjs poll              # update state/, print targets whose upstream HEAD changed
+//
+// Target schema: see ecosystem-ci/README.md.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+const ECO_DIR = path.join(ROOT, 'ecosystem-ci');
+const TARGETS_DIR = path.join(ECO_DIR, 'targets');
+const CHECKOUT_DIR = path.join(ECO_DIR, 'checkout');
+const RESULTS_DIR = path.join(ECO_DIR, 'results');
+const CACHE_DIR = path.join(ECO_DIR, '.cache');
+const STATE_DIR = path.join(ECO_DIR, 'state');
+const SKILL_SCRIPTS = path.join(
+	ROOT,
+	'.claude/skills/verify-svelte-compat/scripts',
+);
+const VPS_FORK = path.join(
+	ROOT,
+	'submodules/vite-plugin-svelte/packages/vite-plugin-svelte',
+);
+
+function log(msg) {
+	console.log(`[ecosystem-ci] ${msg}`);
+}
+
+function ensureDirs() {
+	for (const d of [CHECKOUT_DIR, RESULTS_DIR, CACHE_DIR, STATE_DIR]) {
+		fs.mkdirSync(d, { recursive: true });
+	}
+}
+
+function listTargets() {
+	if (!fs.existsSync(TARGETS_DIR)) return [];
+	return fs
+		.readdirSync(TARGETS_DIR)
+		.filter((f) => f.endsWith('.json'))
+		.map((f) => f.slice(0, -'.json'.length))
+		.sort();
+}
+
+function loadTarget(name) {
+	const p = path.join(TARGETS_DIR, `${name}.json`);
+	if (!fs.existsSync(p)) {
+		console.error(`[ecosystem-ci] target not found: ${p}`);
+		process.exit(2);
+	}
+	const target = JSON.parse(fs.readFileSync(p, 'utf8'));
+	if (!target.commands?.build && !target.commands?.test) {
+		console.error(
+			`[ecosystem-ci] target ${name}: commands.build or commands.test is required`,
+		);
+		process.exit(2);
+	}
+	if (target.license && target.license !== 'MIT') {
+		log(`WARNING: target ${name} license is ${target.license} (not MIT)`);
+	}
+	return target;
+}
+
+function runCapture(cmd, args, opts = {}) {
+	return spawnSync(cmd, args, { encoding: 'utf8', ...opts });
+}
+
+function runInteractive(cmd, args, opts = {}) {
+	return spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+}
+
+function runPhase(target, phaseName, command, env = {}, timeoutMinutes) {
+	// Always run at the repo root. If a target needs to scope work to a
+	// sub-package, encode that in the command itself (`pnpm -F <pkg> build`,
+	// `cd packages/foo && pnpm test`, etc.). Per-phase cwd switching turned
+	// out to break install for monorepos, which always installs at the root.
+	const cwd = path.join(CHECKOUT_DIR, target.name);
+	const logFile = path.join(CACHE_DIR, `${target.name}-${phaseName}.log`);
+	fs.mkdirSync(CACHE_DIR, { recursive: true });
+	log(`[${target.name}] ${phaseName}: ${command}`);
+	log(`  cwd: ${cwd}`);
+	const start = Date.now();
+	const child = spawnSync('sh', ['-c', command], {
+		cwd,
+		env: { ...process.env, ...env },
+		stdio: ['inherit', 'pipe', 'pipe'],
+		encoding: 'utf8',
+		maxBuffer: 200 * 1024 * 1024,
+		timeout: timeoutMinutes ? timeoutMinutes * 60 * 1000 : undefined,
+	});
+	const durationMs = Date.now() - start;
+	const combined = (child.stdout ?? '') + (child.stderr ?? '');
+	fs.writeFileSync(logFile, combined);
+	const tail = combined.split('\n').slice(-20).join('\n');
+	// child.status === null means the process didn't exit cleanly (signal /
+	// timeout / spawn error). Surface child.error so the result JSON
+	// records *why* — otherwise it just looks like "exit null".
+	const exitCode = child.status ?? -1;
+	if (exitCode !== 0) {
+		log(`[${target.name}] ${phaseName} FAILED (exit ${exitCode}${child.signal ? `, signal ${child.signal}` : ''}${child.error ? `, ${child.error.code ?? child.error.message}` : ''}) — tail:`);
+		console.log(tail);
+	} else {
+		log(`[${target.name}] ${phaseName} ok (${(durationMs / 1000).toFixed(1)}s)`);
+	}
+	return {
+		exitCode,
+		signal: child.signal ?? null,
+		spawnError: child.error?.code ?? child.error?.message ?? null,
+		durationMs,
+		logFile: path.relative(ROOT, logFile),
+	};
+}
+
+function cloneOrUpdate(target) {
+	const dest = path.join(CHECKOUT_DIR, target.name);
+	if (!fs.existsSync(dest)) {
+		log(`cloning ${target.repo} -> ${dest}`);
+		const r = runInteractive('git', [
+			'clone',
+			'--branch',
+			target.branch,
+			'--depth',
+			'1',
+			target.repo,
+			dest,
+		]);
+		if (r.status !== 0) throw new Error(`clone failed: ${target.repo}`);
+	} else {
+		log(`updating ${dest} (branch ${target.branch})`);
+		const fetch = runInteractive(
+			'git',
+			['fetch', '--depth', '1', 'origin', target.branch],
+			{ cwd: dest },
+		);
+		if (fetch.status !== 0) throw new Error(`fetch failed: ${target.repo}`);
+		runInteractive('git', ['reset', '--hard', `origin/${target.branch}`], {
+			cwd: dest,
+		});
+		// Preserve .rsvelte (NAPI binding + loader) and node_modules across runs to
+		// avoid re-downloading on every iteration.
+		runInteractive(
+			'git',
+			['clean', '-fdx', '-e', '.rsvelte', '-e', 'node_modules'],
+			{ cwd: dest },
+		);
+	}
+	const sha = runCapture('git', ['rev-parse', 'HEAD'], { cwd: dest }).stdout
+		?.trim();
+	return { path: dest, sha };
+}
+
+function rsvelteNodeName() {
+	const platform = process.platform;
+	const arch = process.arch;
+	if (platform === 'darwin' && arch === 'arm64')
+		return { ext: 'dylib', node: 'rsvelte.darwin-arm64.node', triple: 'darwin-arm64' };
+	if (platform === 'darwin' && arch === 'x64')
+		return { ext: 'dylib', node: 'rsvelte.darwin-x64.node', triple: 'darwin-x64' };
+	if (platform === 'linux' && arch === 'x64')
+		return { ext: 'so', node: 'rsvelte.linux-x64-gnu.node', triple: 'linux-x64-gnu' };
+	if (platform === 'linux' && arch === 'arm64')
+		return { ext: 'so', node: 'rsvelte.linux-arm64-gnu.node', triple: 'linux-arm64-gnu' };
+	throw new Error(`unsupported platform: ${platform}-${arch}`);
+}
+
+function buildRsvelte(checkoutPath) {
+	const { ext, node: nodeName, triple } = rsvelteNodeName();
+	log(`building rsvelte NAPI (triple=${triple})`);
+	// We bypass build-rsvelte.sh because that script also copies into ./svelte/
+	// (the svelte submodule), which we don't need here and isn't always
+	// initialized in every worktree.
+	const r = spawnSync(
+		'cargo',
+		['build', '--release', '--features', 'napi', '--lib'],
+		{ stdio: 'inherit', cwd: ROOT },
+	);
+	if (r.status !== 0) throw new Error('cargo build failed');
+	const srcPath = path.join(ROOT, 'target', 'release', `libsvelte_compiler_rust.${ext}`);
+	if (!fs.existsSync(srcPath)) throw new Error(`cargo output missing: ${srcPath}`);
+
+	// Stage A: drop a copy under checkout/<name>/.rsvelte/ for the loader-hook
+	// path (used by the verify-svelte-compat swap script).
+	const stageADir = path.join(checkoutPath, '.rsvelte');
+	fs.mkdirSync(stageADir, { recursive: true });
+	const stageAPath = path.join(stageADir, nodeName);
+	fs.copyFileSync(srcPath, stageAPath);
+
+	// Stage B: drop the *same* binary into npm/vite-plugin-svelte-native-<triple>/
+	// so the vps-shim swap can point pnpm at our local rsvelte rather than the
+	// last npm-published version. Without this, ecosystem-ci would verify
+	// whatever version was published to npm, not the rsvelte at HEAD.
+	const platformPkg = path.join(ROOT, 'npm', `vite-plugin-svelte-native-${triple}`);
+	if (!fs.existsSync(platformPkg)) {
+		throw new Error(`platform npm package missing: ${platformPkg}`);
+	}
+	const stageBPath = path.join(platformPkg, 'rsvelte.node');
+	fs.copyFileSync(srcPath, stageBPath);
+	log(`staged NAPI -> ${path.relative(ROOT, stageAPath)} + ${path.relative(ROOT, stageBPath)}`);
+	return { nodeName, bindingPath: stageAPath, triple };
+}
+
+function applySwap(target, checkoutPath, bindingPath, triple) {
+	const strategy = target.swap?.strategy ?? 'loader-hook';
+
+	if (strategy === 'loader-hook') {
+		const r = runInteractive('node', [
+			path.join(SKILL_SCRIPTS, 'swap-compiler.mjs'),
+			'--target',
+			checkoutPath,
+			'--rsvelte-binding',
+			bindingPath,
+		]);
+		if (r.status !== 0) throw new Error('loader-hook swap failed');
+		return {
+			strategy,
+			env: {
+				NODE_OPTIONS: `--import ${path.join(checkoutPath, '.rsvelte/loader.mjs')}`,
+			},
+			needsReinstall: false,
+		};
+	}
+
+	if (strategy === 'vps-shim') {
+		if (!fs.existsSync(VPS_FORK)) {
+			throw new Error(
+				`vps-shim swap requested but fork not found: ${VPS_FORK}\n  hint: \`git submodule update --init submodules/vite-plugin-svelte\``,
+			);
+		}
+
+		// pnpm's aliased file: dep syntax (npm:@rsvelte/...@file:...) produces
+		// a broken symlink in node_modules because the encoded version string
+		// contains "npm:" and "file:" verbatim. Workaround: stage a renamed
+		// copy of the fork whose package.json#name is @sveltejs/vite-plugin-svelte,
+		// then use a plain file: override.
+		const forkStage = path.join(CACHE_DIR, 'vite-plugin-svelte-stage');
+		fs.rmSync(forkStage, { recursive: true, force: true });
+		fs.mkdirSync(forkStage, { recursive: true });
+		const copyR = spawnSync(
+			'rsync',
+			['-a', '--exclude=node_modules', '--exclude=.git', `${VPS_FORK}/`, `${forkStage}/`],
+			{ stdio: 'inherit' },
+		);
+		if (copyR.status !== 0) throw new Error('failed to stage fork copy');
+		const stagedPkgPath = path.join(forkStage, 'package.json');
+		const stagedPkg = JSON.parse(fs.readFileSync(stagedPkgPath, 'utf8'));
+		stagedPkg.name = '@sveltejs/vite-plugin-svelte';
+		fs.writeFileSync(stagedPkgPath, JSON.stringify(stagedPkg, null, 2) + '\n');
+
+		const pkgPath = path.join(checkoutPath, 'package.json');
+		const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+		pkg.pnpm = pkg.pnpm ?? {};
+		pkg.pnpm.overrides = pkg.pnpm.overrides ?? {};
+		// All three overrides use plain file: refs (package.json#name matches
+		// the override key in each case).
+		pkg.pnpm.overrides['@sveltejs/vite-plugin-svelte'] = `file:${forkStage}`;
+		pkg.pnpm.overrides['@rsvelte/vite-plugin-svelte-native'] =
+			`file:${path.join(ROOT, 'npm', 'vite-plugin-svelte-native')}`;
+		pkg.pnpm.overrides[`@rsvelte/vite-plugin-svelte-native-${triple}`] =
+			`file:${path.join(ROOT, 'npm', `vite-plugin-svelte-native-${triple}`)}`;
+		fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+		log(`vps-shim: staged fork -> ${path.relative(ROOT, forkStage)} and injected 3 pnpm.overrides`);
+		return { strategy, env: {}, needsReinstall: true };
+	}
+
+	if (strategy === 'pnpm-override') {
+		// Target already imports @rsvelte/compiler — point that package at our
+		// local wrapper around the NAPI binding.
+		const r = runInteractive('node', [
+			path.join(SKILL_SCRIPTS, 'provide-rsvelte-compiler.mjs'),
+			'--target',
+			checkoutPath,
+			'--rsvelte-binding',
+			bindingPath,
+		]);
+		if (r.status !== 0) throw new Error('pnpm-override swap failed');
+		return { strategy, env: {}, needsReinstall: true };
+	}
+
+	throw new Error(`unknown swap.strategy: ${strategy}`);
+}
+
+function restoreTarget(target) {
+	const dest = path.join(CHECKOUT_DIR, target.name);
+	for (const f of ['package.json', 'pnpm-lock.yaml']) {
+		spawnSync('git', ['checkout', '--', f], { cwd: dest, stdio: 'ignore' });
+	}
+	fs.rmSync(path.join(dest, '.rsvelte'), { recursive: true, force: true });
+}
+
+function writeResult(target, targetSha, extra) {
+	const rsvelteSha = runCapture('git', ['rev-parse', 'HEAD'], { cwd: ROOT })
+		.stdout?.trim();
+	const out = path.join(RESULTS_DIR, `${target.name}.json`);
+	const payload = {
+		name: target.name,
+		targetSha,
+		rsvelteSha,
+		verifiedAt: new Date().toISOString(),
+		...extra,
+	};
+	fs.writeFileSync(out, JSON.stringify(payload, null, 2));
+	log(`wrote ${path.relative(ROOT, out)} -> ${payload.result}`);
+}
+
+async function runTarget(name) {
+	ensureDirs();
+	const target = loadTarget(name);
+	log(`=== ${target.name} (${target.type}, swap=${target.swap?.strategy ?? 'loader-hook'}) ===`);
+
+	const { sha: targetSha } = cloneOrUpdate(target);
+
+	const baseline = {};
+	baseline.install = runPhase(
+		target,
+		'baseline-install',
+		target.commands.install,
+		{},
+		target.timeoutMinutes,
+	);
+	if (baseline.install.exitCode !== 0) {
+		writeResult(target, targetSha, { result: 'baseline-failure', baseline });
+		return;
+	}
+	if (target.commands.build) {
+		baseline.build = runPhase(
+			target,
+			'baseline-build',
+			target.commands.build,
+			{},
+			target.timeoutMinutes,
+		);
+	}
+	if (target.commands.test) {
+		baseline.test = runPhase(
+			target,
+			'baseline-test',
+			target.commands.test,
+			{},
+			target.timeoutMinutes,
+		);
+	}
+	const baselineFailed = ['install', 'build', 'test'].some(
+		(k) => baseline[k] && baseline[k].exitCode !== 0,
+	);
+	if (baselineFailed) {
+		writeResult(target, targetSha, { result: 'baseline-failure', baseline });
+		return;
+	}
+
+	// Build rsvelte NAPI and stage it under the target's .rsvelte/
+	const checkoutPath = path.join(CHECKOUT_DIR, target.name);
+	const { bindingPath, triple } = buildRsvelte(checkoutPath);
+
+	let swap;
+	try {
+		swap = applySwap(target, checkoutPath, bindingPath, triple);
+	} catch (e) {
+		writeResult(target, targetSha, {
+			result: 'swap-failure',
+			baseline,
+			error: e.message,
+		});
+		restoreTarget(target);
+		return;
+	}
+
+	const rsvelte = {};
+	if (swap.needsReinstall) {
+		rsvelte.install = runPhase(
+			target,
+			'rsvelte-install',
+			target.commands.install,
+			swap.env,
+			target.timeoutMinutes,
+		);
+		if (rsvelte.install.exitCode !== 0) {
+			writeResult(target, targetSha, {
+				result: 'rsvelte-install-failure',
+				baseline,
+				rsvelte,
+				swap: { strategy: swap.strategy },
+			});
+			restoreTarget(target);
+			return;
+		}
+	}
+	if (target.commands.build) {
+		rsvelte.build = runPhase(
+			target,
+			'rsvelte-build',
+			target.commands.build,
+			swap.env,
+			target.timeoutMinutes,
+		);
+	}
+	if (target.commands.test) {
+		rsvelte.test = runPhase(
+			target,
+			'rsvelte-test',
+			target.commands.test,
+			swap.env,
+			target.timeoutMinutes,
+		);
+	}
+
+	const rsvelteFailed = ['build', 'test'].some(
+		(k) => rsvelte[k] && rsvelte[k].exitCode !== 0,
+	);
+	const result = rsvelteFailed ? 'regression' : 'pass';
+	writeResult(target, targetSha, {
+		result,
+		baseline,
+		rsvelte,
+		swap: { strategy: swap.strategy },
+	});
+	restoreTarget(target);
+}
+
+async function runAll(filterTag) {
+	const targets = listTargets();
+	for (const name of targets) {
+		const t = loadTarget(name);
+		if (filterTag && !(t.tags ?? []).includes(filterTag)) continue;
+		await runTarget(name);
+	}
+}
+
+function cmdList() {
+	for (const name of listTargets()) {
+		const t = loadTarget(name);
+		const tags = (t.tags ?? []).join(',');
+		console.log(`${name.padEnd(28)} ${t.type.padEnd(6)} [${tags}]`);
+	}
+}
+
+function cmdReport() {
+	if (!fs.existsSync(RESULTS_DIR)) {
+		console.log('No results yet.');
+		return;
+	}
+	const files = fs.readdirSync(RESULTS_DIR).filter((f) => f.endsWith('.json'));
+	const rows = files.map((f) => JSON.parse(fs.readFileSync(path.join(RESULTS_DIR, f), 'utf8')));
+	console.log('# ecosystem-ci summary');
+	console.log('');
+	console.log('| Target | Result | Target SHA | rsvelte SHA | Verified |');
+	console.log('|---|---|---|---|---|');
+	for (const r of rows) {
+		console.log(
+			`| ${r.name} | ${r.result} | ${(r.targetSha ?? '').slice(0, 8)} | ${(r.rsvelteSha ?? '').slice(0, 8)} | ${r.verifiedAt ?? ''} |`,
+		);
+	}
+}
+
+async function cmdPoll() {
+	// Print one line per target whose upstream HEAD changed since the last run.
+	// Intended for the GitHub Actions polling workflow to feed downstream
+	// workflow_dispatch invocations.
+	ensureDirs();
+	const changed = [];
+	for (const name of listTargets()) {
+		const t = loadTarget(name);
+		const m = /github\.com[:/](.+?)\/(.+?)(?:\.git)?$/.exec(t.repo);
+		if (!m) {
+			log(`poll: cannot parse repo url: ${t.repo}`);
+			continue;
+		}
+		const owner = m[1];
+		const repo = m[2];
+		const r = runCapture('gh', [
+			'api',
+			`repos/${owner}/${repo}/commits/${t.branch}`,
+			'--jq',
+			'.sha',
+		]);
+		if (r.status !== 0) {
+			log(`poll: gh api failed for ${name}: ${r.stderr?.trim()}`);
+			continue;
+		}
+		const currentSha = (r.stdout ?? '').trim();
+		const stateFile = path.join(STATE_DIR, `${name}.json`);
+		const prev = fs.existsSync(stateFile)
+			? JSON.parse(fs.readFileSync(stateFile, 'utf8'))
+			: { sha: null };
+		if (prev.sha !== currentSha) {
+			log(`poll: ${name} changed ${prev.sha?.slice(0, 8) ?? '(new)'} -> ${currentSha.slice(0, 8)}`);
+			changed.push(name);
+			fs.writeFileSync(
+				stateFile,
+				JSON.stringify({ sha: currentSha, at: new Date().toISOString() }, null, 2),
+			);
+		}
+	}
+	// Output changed target names (one per line) for downstream consumption.
+	for (const name of changed) {
+		console.log(name);
+	}
+}
+
+async function main() {
+	const [, , cmd, ...rest] = process.argv;
+	switch (cmd) {
+		case 'list':
+			return cmdList();
+		case 'run': {
+			const name = rest[0];
+			if (!name) {
+				console.error('usage: ecosystem-ci run <target>');
+				process.exit(64);
+			}
+			return runTarget(name);
+		}
+		case 'run-all': {
+			let tag = null;
+			const i = rest.indexOf('--tag');
+			if (i >= 0) tag = rest[i + 1];
+			return runAll(tag);
+		}
+		case 'report':
+			return cmdReport();
+		case 'poll':
+			return cmdPoll();
+		default:
+			console.error(
+				'usage: ecosystem-ci [list | run <target> | run-all [--tag T] | report | poll]',
+			);
+			process.exit(64);
+	}
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

First post-merge dispatch of \`ecosystem-ci\` (run [26368220735](https://github.com/baseballyama/rsvelte/actions/runs/26368220735)) failed all 4 target jobs within seconds at the submodule init step:

\`\`\`
fatal: clone of 'git@github.com:baseballyama/vite-plugin-svelte.git' ... failed
git@github.com: Permission denied (publickey).
\`\`\`

The fork's URL in \`.gitmodules\` is the maintainer's SSH form. GH runners don't carry that key. Override the URL to the public HTTPS form just for the init step — local \`.gitmodules\` stays untouched so the maintainer can keep pushing via SSH.

## Test plan

- [ ] Re-dispatch \`ecosystem-ci\` after this merges and verify the submodule clones successfully on at least one matrix job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)