### PR TITLE
fix(ecosystem-ci): override vps submodule URL to HTTPS for CI

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -83,7 +83,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Init vite-plugin-svelte submodule (only one ecosystem-ci needs)
-        run: git submodule update --init submodules/vite-plugin-svelte
+        # The fork's submodule URL in .gitmodules is the maintainer's SSH URL
+        # (git@github.com:.../vite-plugin-svelte.git). CI runners don't have
+        # that SSH key, so override to HTTPS for the duration of this init.
+        run: |
+          git config submodule.submodules/vite-plugin-svelte.url \
+            https://github.com/baseballyama/vite-plugin-svelte.git
+          git submodule update --init submodules/vite-plugin-svelte
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

First post-merge dispatch of \`ecosystem-ci\` (run [26368220735](https://github.com/baseballyama/rsvelte/actions/runs/26368220735)) failed all 4 target jobs within seconds at the submodule init step:

\`\`\`
fatal: clone of 'git@github.com:baseballyama/vite-plugin-svelte.git' ... failed
git@github.com: Permission denied (publickey).
\`\`\`

The fork's URL in \`.gitmodules\` is the maintainer's SSH form. GH runners don't carry that key. Override the URL to the public HTTPS form just for the init step — local \`.gitmodules\` stays untouched so the maintainer can keep pushing via SSH.

Supersedes #296 (closed — pre-squash ancestor caused apparent merge conflicts).

## Test plan

- [ ] Re-dispatch \`ecosystem-ci\` after this merges and verify the submodule clones successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)