### PR TITLE
fix(ecosystem-ci): rewrite .gitmodules to HTTPS (real fix)

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -85,10 +85,12 @@ jobs:
       - name: Init vite-plugin-svelte submodule (only one ecosystem-ci needs)
         # The fork's submodule URL in .gitmodules is the maintainer's SSH URL
         # (git@github.com:.../vite-plugin-svelte.git). CI runners don't have
-        # that SSH key, so override to HTTPS for the duration of this init.
+        # that SSH key, so rewrite .gitmodules to HTTPS in-place before init.
+        # (`git config submodule.<n>.url` doesn't survive `submodule init`,
+        # which re-reads .gitmodules and re-registers the SSH URL.)
         run: |
-          git config submodule.submodules/vite-plugin-svelte.url \
-            https://github.com/baseballyama/vite-plugin-svelte.git
+          sed -i 's|git@github.com:baseballyama/vite-plugin-svelte|https://github.com/baseballyama/vite-plugin-svelte|' .gitmodules
+          git submodule sync submodules/vite-plugin-svelte
           git submodule update --init submodules/vite-plugin-svelte
 
       - name: Install Rust


### PR DESCRIPTION
## Summary

#300 attempted to override the vps submodule URL via \`git config\` but missed two things: the submodule **name** is \`vite-plugin-svelte\` (the \`submodules/\` prefix is the path, not the name), and \`submodule update --init\` re-reads \`.gitmodules\` and re-registers the SSH URL before cloning. The fix landed but didn't take effect — see [run 26369889702](https://github.com/baseballyama/rsvelte/actions/runs/26369889702).

Switch to a direct sed on \`.gitmodules\` (followed by \`git submodule sync\` to propagate the change to the registered config) — bulletproof and obvious.

## Test plan

- [ ] Re-dispatch \`ecosystem-ci\` after merge, confirm submodule init succeeds and the run progresses past the second step on at least one target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)