### PR TITLE
fix(ecosystem-ci): point melt-ui target at the real repo (next-gen)

### DIFF
--- a/ecosystem-ci/targets/melt-ui.json
+++ b/ecosystem-ci/targets/melt-ui.json
@@ -1,6 +1,6 @@
 {
   "name": "melt-ui",
-  "repo": "https://github.com/melt-ui/melt",
+  "repo": "https://github.com/melt-ui/next-gen",
   "license": "MIT",
   "branch": "main",
   "type": "tool",
@@ -9,8 +9,7 @@
   },
   "commands": {
     "install": "pnpm install --no-frozen-lockfile",
-    "build": "pnpm -F melt build",
-    "test": "pnpm -F melt test -- --run"
+    "build": "pnpm --filter melt build"
   },
   "timeoutMinutes": 30,
   "tags": ["ui-library", "headless", "runes"],


### PR DESCRIPTION
## Summary

\`ecosystem-ci\` [run 26370150649](https://github.com/baseballyama/rsvelte/actions/runs/26370150649) (post #301) had 3 of 4 targets pass on the first real attempt:

| target | result |
|---|---|
| shadcn-svelte | ✅ pass |
| bits-ui | ✅ pass |
| flowbite-svelte | ✅ pass |
| melt-ui | ❌ clone failed — \`melt-ui/melt\` doesn't exist |

The Svelte 5 / runes-era repo is **\`melt-ui/next-gen\`** (the older \`melt-ui/melt-ui\` repo still ships Svelte 4 and isn't a useful rsvelte exercise). Build script is \`pnpm --filter melt build\` (svelte-package + publint).

Dropping the \`test\` command for now — vitest runs in browser mode by default for this repo, which adds heavy CI setup. Build alone exercises rsvelte through svelte-package's compile path.

After this, the matrix should be 4/4 green (modulo any new rsvelte bugs that melt-ui happens to surface, which is exactly what ecosystem-ci is for).

## Test plan

- [ ] Re-dispatch \`ecosystem-ci\` after merge; verify melt-ui clones, builds baseline, builds with rsvelte, and turns green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)