### PR TITLE
fix(napi): disable jemalloc initial-exec TLS for dlopen safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,14 @@ crate-type = ["cdylib", "rlib"]
 default = ["native"]
 native = ["rayon", "miette/fancy", "jemalloc"]
 trace-fastpath = []
-napi = ["dep:napi", "dep:napi-derive", "dep:napi-build"]
+# `napi` opts the cdylib into the NAPI build. When the cdylib gets
+# dlopen'd by Node (post-program-start), jemalloc's default
+# initial-exec TLS model can exhaust the static TLS reserve on Linux —
+# producing "cannot allocate memory in static TLS block" at load time.
+# Pull in the `disable_initial_exec_tls` feature transitively so the
+# NAPI build is always dlopen-safe. The `?` makes it a no-op when
+# jemalloc is disabled (e.g. `--no-default-features --features napi`).
+napi = ["dep:napi", "dep:napi-derive", "dep:napi-build", "tikv-jemallocator?/disable_initial_exec_tls"]
 jemalloc = ["dep:tikv-jemallocator"]
 wasm = ["wasm-bindgen", "console_error_panic_hook", "getrandom/js"]
 


### PR DESCRIPTION
## Summary

When the NAPI cdylib (\`@rsvelte/vite-plugin-svelte-native-<triple>\`) is dlopen'd by Node post-program-start on Linux, jemalloc's thread-local arena caches use the initial-exec TLS model, which requires space in the static TLS block — and dlopen has only a small reserve. With realistic Svelte projects (shadcn-svelte docs, melt-ui packaging), the .node fails to load:

\`\`\`
Couldn't load the native binding "@rsvelte/vite-plugin-svelte-native-linux-x64-gnu".
Original error: ... rsvelte.node: cannot allocate memory in static TLS block
\`\`\`

Enable \`tikv-jemallocator/disable_initial_exec_tls\` whenever the \`napi\` feature is on. tikv-jemalloc-sys swaps the TLS model to local-dynamic for that build, which dlopen tolerates. \`?/\` syntax keeps it a no-op under \`--no-default-features --features napi\` (where jemalloc isn't pulled in at all).

## Background

Surfaced by ecosystem-ci [run 26370625070](https://github.com/baseballyama/rsvelte/actions/runs/26370625070) — \`shadcn-svelte\` and \`melt-ui\` both crashed at load time after baseline-build succeeded. The macOS Darwin build doesn't hit this because dyld's TLS reserve is larger on Mach-O.

The current published \`@rsvelte/vite-plugin-svelte-native-linux-x64-gnu@0.1.0\` on npm likely has the same latent issue; this fix should be picked up by the next release.

## Test plan

- [x] Local: \`cargo build --release --features napi --lib\` succeeds (rebuilt tikv-jemallocator with the new feature)
- [x] Full \`cargo test --release\` (unchanged code path; only the cdylib's allocator changes)
- [ ] Post-merge: re-dispatch ecosystem-ci on main, confirm shadcn-svelte and melt-ui targets advance past the \`rsvelte-build\` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)