### PR TITLE
fix(ecosystem-ci): bound pnpm's upward workspace search at each target

### DIFF
--- a/ecosystem-ci/targets/flowbite-svelte.json
+++ b/ecosystem-ci/targets/flowbite-svelte.json
@@ -8,8 +8,8 @@
     "strategy": "vps-shim"
   },
   "commands": {
-    "install": "rm -rf node_modules && pnpm install --no-frozen-lockfile",
-    "build": "pnpm exec vite build"
+    "install": "pnpm install --no-frozen-lockfile",
+    "build": "pnpm build"
   },
   "timeoutMinutes": 30,
   "tags": ["ui-library"],

--- a/scripts/ecosystem-ci.mjs
+++ b/scripts/ecosystem-ci.mjs
@@ -164,6 +164,26 @@ function cloneOrUpdate(target) {
 			{ cwd: dest },
 		);
 	}
+	// Bound pnpm's upward workspace search at the target's checkout root.
+	// Without this, pnpm walking up from `ecosystem-ci/checkout/<name>/`
+	// finds rsvelte's own `pnpm-workspace.yaml` at the repo root and
+	// installs rsvelte's workspace members instead of the target's deps —
+	// "Scope: all 15 workspace projects" while the target's `node_modules`
+	// stays empty. Drop a marker only when the target itself doesn't ship
+	// `pnpm-workspace.yaml` (monorepos already define their own boundary).
+	const targetHasWorkspace = ['pnpm-workspace.yaml', 'pnpm-workspace.yml'].some(
+		(f) => fs.existsSync(path.join(dest, f)),
+	);
+	if (!targetHasWorkspace) {
+		fs.writeFileSync(
+			path.join(dest, 'pnpm-workspace.yaml'),
+			'# Sentinel: bounds pnpm\'s upward workspace search at this target\n' +
+				'# root so pnpm doesn\'t walk into rsvelte\'s own workspace.\n' +
+				'packages: []\n',
+		);
+		log(`bound workspace search: dropped pnpm-workspace.yaml in ${path.relative(ROOT, dest)}`);
+	}
+
 	const sha = runCapture('git', ['rev-parse', 'HEAD'], { cwd: dest }).stdout
 		?.trim();
 	return { path: dest, sha };


### PR DESCRIPTION
## Summary

\`flowbite-svelte\` was hitting \`baseline-build FAILED\` with \`vite: not found\` even though \`pnpm install\` reported success. Reading the install log showed:

\`\`\`
Scope: all 15 workspace projects
../../..    | +103 ++++++++++
../../..    | Progress: resolved 103, ..., added 103, done
\`\`\`

That's rsvelte's own workspace being installed, not flowbite's. pnpm walks upward looking for a workspace manifest, found rsvelte's \`pnpm-workspace.yaml\` at the repo root, and treated the target checkout as a workspace member instead of installing its real deps.

Fix in the runner: after clone/update, if the target doesn't ship its own \`pnpm-workspace.yaml\` (monorepos already define their own boundary), drop a sentinel \`packages: []\` manifest so pnpm stops climbing. Restores \`flowbite-svelte\` to its natural \`pnpm install\` + \`pnpm build\` shape.

## Remaining: shadcn-svelte

After this lands, ecosystem-ci should be **3/4 truly green**: bits-ui ✅ + melt-ui ✅ + flowbite-svelte ✅.

\`shadcn-svelte\` still hits a real rsvelte regression during the docs build:

\`\`\`
FATAL ERROR: threadsafe_function.rs:749
Failed to convert return value in ThreadsafeFunction callback into Rust value: InvalidArg, Failed to call then method
\`\`\`

\`await_tsfn\` in \`src/napi.rs\` uses a two-stage \`call_async\` that tries \`Option<Promise<...>>\` first and falls back to a plain \`Option<Value>\`. napi-rs's threadsafe_function path aborts the process when the JS callback returns a non-Promise inside the typed call — the \`Err\` we expect to fall through to the second stage never arrives. That fix is a separate rework and out of scope here.

## Test plan

- [ ] Re-dispatch ecosystem-ci after merge; expect 3/4 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)