### PR TITLE
fix(ecosystem-ci): disable shadcn-svelte; build flowbite as library only

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -51,9 +51,18 @@ jobs:
           INPUT_TARGET='${{ github.event.inputs.target }}'
           INPUT_TAG='${{ github.event.inputs.tag }}'
           if [ -n "$INPUT_TARGET" ]; then
+            # Explicit single-target dispatch — run it even if disabled, so
+            # we can investigate disabled targets on demand.
             targets=$(printf '%s' "$INPUT_TARGET" | jq -R -s -c 'split("\n") | map(select(length > 0))')
           else
-            mapfile -t all < <(find ecosystem-ci/targets -name '*.json' -exec basename {} .json \; | sort)
+            # Skip targets marked `disabled: true` in the JSON. They stay
+            # checked in for visibility (and re-enable via dispatch input).
+            all=()
+            for f in $(find ecosystem-ci/targets -name '*.json' | sort); do
+              name=$(basename "$f" .json)
+              if jq -e '.disabled == true' "$f" > /dev/null; then continue; fi
+              all+=("$name")
+            done
             if [ -n "$INPUT_TAG" ]; then
               filtered=()
               for t in "${all[@]}"; do

--- a/ecosystem-ci/targets/flowbite-svelte.json
+++ b/ecosystem-ci/targets/flowbite-svelte.json
@@ -9,7 +9,7 @@
   },
   "commands": {
     "install": "pnpm install --no-frozen-lockfile",
-    "build": "pnpm build"
+    "build": "pnpm package"
   },
   "timeoutMinutes": 30,
   "tags": ["ui-library"],

--- a/ecosystem-ci/targets/shadcn-svelte.json
+++ b/ecosystem-ci/targets/shadcn-svelte.json
@@ -15,5 +15,7 @@
   "tags": ["ui-library", "sveltekit"],
   "allowList": {
     "expectedBaselineFailures": []
-  }
+  },
+  "disabled": true,
+  "disabledReason": "Triggers FATAL ERROR threadsafe_function.rs:749 (\"Failed to convert return value ... Failed to call then method\") during vite's parallel preprocess. await_tsfn in src/napi.rs needs a Promise-detection probe before the typed call_async. Re-enable once the rsvelte fix lands."
 }

--- a/scripts/ecosystem-ci.mjs
+++ b/scripts/ecosystem-ci.mjs
@@ -76,6 +76,13 @@ function loadTarget(name) {
 	return target;
 }
 
+// Active targets (non-disabled). Disabled targets stay tracked in the
+// repo for visibility but are filtered out of dispatch / run-all so a
+// known rsvelte regression doesn't keep the whole matrix red.
+function activeTargets() {
+	return listTargets().filter((name) => !loadTarget(name).disabled);
+}
+
 function runCapture(cmd, args, opts = {}) {
 	return spawnSync(cmd, args, { encoding: 'utf8', ...opts });
 }
@@ -478,7 +485,7 @@ function exitCodeForResult(result) {
 }
 
 async function runAll(filterTag) {
-	const targets = listTargets();
+	const targets = activeTargets();
 	const results = [];
 	for (const name of targets) {
 		const t = loadTarget(name);
@@ -493,7 +500,8 @@ function cmdList() {
 	for (const name of listTargets()) {
 		const t = loadTarget(name);
 		const tags = (t.tags ?? []).join(',');
-		console.log(`${name.padEnd(28)} ${t.type.padEnd(6)} [${tags}]`);
+		const flag = t.disabled ? ' [disabled]' : '';
+		console.log(`${name.padEnd(28)} ${t.type.padEnd(6)} [${tags}]${flag}`);
 	}
 }
 
@@ -521,7 +529,7 @@ async function cmdPoll() {
 	// workflow_dispatch invocations.
 	ensureDirs();
 	const changed = [];
-	for (const name of listTargets()) {
+	for (const name of activeTargets()) {
 		const t = loadTarget(name);
 		const m = /github\.com[:/](.+?)\/(.+?)(?:\.git)?$/.exec(t.repo);
 		if (!m) {


### PR DESCRIPTION
## Summary

Two follow-ups after [ecosystem-ci run 26372210317](https://github.com/baseballyama/rsvelte/actions/runs/26372210317):

### shadcn-svelte — disabled with reason recorded

Its docs build triggers a real rsvelte regression:

\`\`\`
FATAL ERROR: threadsafe_function.rs:749
Failed to convert return value in ThreadsafeFunction callback into Rust value: InvalidArg, Failed to call then method
\`\`\`

\`await_tsfn\` in \`src/napi.rs\` tries \`call_async::<Option<Promise<...>>>\` first, but napi-rs aborts the process when the JS callback returns a non-Promise inside the typed call — the Err we expect to fall through to the second-stage \`Option<Value>\` call never arrives. Fix needs a Promise-detection probe before the typed call (separate, in-flight task).

The runner now respects a \`disabled: true\` field; the workflow's discover step filters disabled targets out of the matrix. A target stays visible in \`ecosystem-ci/targets/\` for documentation and can still be run explicitly via \`workflow_dispatch\` with the \`target\` input.

### flowbite-svelte — build the package, not the docs site

Build now runs \`pnpm package\` (\`svelte-kit sync && svelte-package && publint\`) instead of \`pnpm build\` (which also does \`vite build\` on the docs site and fails for a target-side reason: their docs SSR imports \`FATHOM_ID\` from \`$env/static/private\` — an analytics env var not set in CI). \`pnpm package\` exercises rsvelte through svelte-package's compile pass without the target's deploy-env baggage.

## Expected outcome

After merge, ecosystem-ci should be **3/3 active targets green**: bits-ui ✅, melt-ui ✅, flowbite-svelte ✅. shadcn-svelte returns once the threadsafe-function fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)