### PR TITLE
chore(release): changeset for next CI publish

### DIFF
--- a/.changeset/release-2026-05-25.md
+++ b/.changeset/release-2026-05-25.md
@@ -1,0 +1,21 @@
+---
+'@rsvelte/compiler': patch
+'@rsvelte/svelte-check': patch
+'@rsvelte/svelte2tsx': patch
+'@rsvelte/vite-plugin-svelte-native': patch
+---
+
+Roll up everything that has landed on `main` since `0.3.1` / `0.1.1`.
+
+- compiler: track upstream Svelte `5.51.4` → `5.51.5`.
+- vite-plugin-svelte-native: NAPI bindings now disable jemalloc's
+  `initial-exec` TLS model so the dylib is safe to `dlopen` from Node on
+  glibc hosts.
+- svelte-check / svelte2tsx: republish to pick up the routine dependency
+  refresh (`serde_json` 1.0.150, `rustc-hash` 2.1.2).
+- Release workflow now publishes via npm OIDC trusted publishing (no
+  `NPM_TOKEN`), Node 22, and `npm publish --provenance` for every
+  platform sub-package — every tarball ships with provenance attestation.
+- Docs: README rewritten around the OXC integration goal, with per-task
+  benchmark breakdown (parser / svelte2tsx / svelte-check) mirroring
+  the live `/benchmark` page.


### PR DESCRIPTION
Adds a single changeset so the next \`Release\` workflow run on \`main\` opens a \"Version Packages\" PR. Merging that PR triggers the actual npm publish (via OIDC trusted publishing, as set up in #294).

Patch-bumps all 4 publishable packages:

- \`@rsvelte/compiler\` 0.3.1 → 0.3.2
- \`@rsvelte/svelte-check\` 0.1.1 → 0.1.2 (+ 5 platform sub-packages)
- \`@rsvelte/svelte2tsx\` 0.1.1 → 0.1.2
- \`@rsvelte/vite-plugin-svelte-native\` 0.1.1 → 0.1.2 (+ 5 platform sub-packages)

Rolling up everything that has landed since the previous release (4e18768):

- Compiler tracks Svelte \`5.51.4\` → \`5.51.5\` (#288, #289).
- NAPI binding disables jemalloc \`initial-exec\` TLS for \`dlopen\` safety (#305).
- Routine dep refresh: \`serde_json\` 1.0.150 (#286), \`rustc-hash\` 2.1.2 (#285), \`pnpm\` 10.33.4 (#293), \`oxfmt\` 0.51.0 (#292).
- Release pipeline migrated to npm OIDC trusted publishing + \`--provenance\` (#294).
- README rewritten around OXC integration goal + per-task benchmark table (#287, #290).

## Heads-up

\`@rsvelte/svelte2tsx\` and \`@rsvelte/vite-plugin-svelte-native\` (plus their 5+5 platform sub-packages) were last published under the classic NPM_TOKEN flow. Trusted Publishing config on npmjs.com is required per-package before the next publish; if missing, the publish step will 404 and the failed package name will appear directly in the workflow logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)