### PR TITLE
fix(napi): probe is_promise before typed Promise conversion in await_tsfn

### DIFF
--- a/ecosystem-ci/targets/shadcn-svelte.json
+++ b/ecosystem-ci/targets/shadcn-svelte.json
@@ -17,5 +17,5 @@
     "expectedBaselineFailures": []
   },
   "disabled": true,
-  "disabledReason": "Triggers FATAL ERROR threadsafe_function.rs:749 (\"Failed to convert return value ... Failed to call then method\") during vite's parallel preprocess. await_tsfn in src/napi.rs needs a Promise-detection probe before the typed call_async. Re-enable once the rsvelte fix lands."
+  "disabledReason": "Surfaces multiple parser-side rsvelte regressions on shadcn-svelte/docs (verified locally after the napi await_tsfn fix): (1) private class method call with default-object arg `this.#config({})` in svelte.ts modules → `Unexpected token`; (2) destructured param with `= {}` default in svelte.ts → `Unexpected token`; (3) compile_module duplicate-declaration check rejects `message` shadowing in svelte-sonner's toast-state.svelte.js; (4) TS type assertions inside Svelte template expressions (`{mode.current as 'light' | 'dark'}`) are flagged `Type assertion expressions can only be used in TypeScript files`. Each is its own parser fix; re-enable as they land."
 }

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -595,8 +595,7 @@ mod preprocess_bridge {
             napi_val: napi::sys::napi_value,
         ) -> napi::Result<Self> {
             let mut is_promise = false;
-            let status =
-                unsafe { napi::sys::napi_is_promise(env, napi_val, &mut is_promise) };
+            let status = unsafe { napi::sys::napi_is_promise(env, napi_val, &mut is_promise) };
             if status != napi::sys::Status::napi_ok {
                 return Err(napi::Error::from_status(napi::Status::from(status)));
             }
@@ -691,10 +690,7 @@ mod preprocess_bridge {
         // `napi_fatal_error`, surfacing as `threadsafe_function.rs:749 Failed
         // to convert return value … Failed to call then method`). The outer
         // `Option` collapses `undefined`/`null` to `None` on both paths.
-        match tsfn
-            .call_async::<MaybePromise<Option<Value>>>(arg)
-            .await
-        {
+        match tsfn.call_async::<MaybePromise<Option<Value>>>(arg).await {
             Ok(MaybePromise::Promise(promise)) => match promise.await {
                 Ok(Some(v)) => Ok(v),
                 Ok(None) => Ok(Value::Null),

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -563,10 +563,52 @@ mod preprocess_bridge {
         PreprocessError, PreprocessorFn, PreprocessorGroup, PreprocessorOptions,
         PreprocessorResult, Processed, SimpleDecodedMap, SourceMapInput,
     };
-    use napi::bindgen_prelude::{Object, Promise};
+    use napi::bindgen_prelude::{FromNapiValue, Object, Promise};
     use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
     use rustc_hash::FxHashMap;
     use serde_json::Value;
+
+    // Either a Promise<T> or a plain T from a threadsafe_function return.
+    //
+    // We can't use napi-rs's `Either<Promise<T>, T>` here because
+    // `Promise::validate` doesn't fail on non-Promise input — it
+    // substitutes a *rejected* Promise. Either then unconditionally picks
+    // variant A and calls `Promise::from_napi_value` on the original
+    // non-Promise value, which crashes inside `napi_call_function(then)`
+    // with `Failed to call then method` and triggers the FATAL ERROR at
+    // threadsafe_function.rs:749 — aborting the whole Node process.
+    //
+    // Probe `napi_is_promise` directly *before* the typed conversion
+    // and dispatch from there. The Svelte preprocessor contract allows
+    // sync `Processed` returns alongside `Promise<Processed>`, so this
+    // matters in practice the moment any user preprocessor in the chain
+    // happens to be synchronous (e.g. an inline `vitePreprocess`-style
+    // markup filter that just returns `{ code }` without an `async`).
+    pub(super) enum MaybePromise<T: FromNapiValue> {
+        Promise(Promise<T>),
+        Value(T),
+    }
+
+    impl<T: FromNapiValue> FromNapiValue for MaybePromise<T> {
+        unsafe fn from_napi_value(
+            env: napi::sys::napi_env,
+            napi_val: napi::sys::napi_value,
+        ) -> napi::Result<Self> {
+            let mut is_promise = false;
+            let status =
+                unsafe { napi::sys::napi_is_promise(env, napi_val, &mut is_promise) };
+            if status != napi::sys::Status::napi_ok {
+                return Err(napi::Error::from_status(napi::Status::from(status)));
+            }
+            if is_promise {
+                let p = unsafe { Promise::<T>::from_napi_value(env, napi_val)? };
+                Ok(MaybePromise::Promise(p))
+            } else {
+                let v = unsafe { T::from_napi_value(env, napi_val)? };
+                Ok(MaybePromise::Value(v))
+            }
+        }
+    }
 
     // Fatal strategy: the user-supplied JS callback receives the options
     // object as its sole argument — matching the upstream Svelte
@@ -643,29 +685,24 @@ mod preprocess_bridge {
     async fn await_tsfn(tsfn: &Tsfn, arg: Value) -> Result<Value, PreprocessError> {
         // The upstream Svelte preprocessor contract allows the callback to
         // return `Processed | Promise<Processed> | undefined | null`,
-        // sync or async. The outer `Option<Promise<…>>` handles the case
-        // where the JS callback returns `undefined`/`null` directly (sync
-        // no-op); the inner `Option<Value>` handles the case where an
-        // async callback resolves to `undefined`/`null` (async no-op).
-        // Sync object returns fall through to the raw `Value` path.
+        // sync or async. `MaybePromise<Option<Value>>` probes `napi_is_promise`
+        // *before* the typed conversion, so we never let napi-rs call
+        // `.then()` on a non-Promise value (which would abort the process via
+        // `napi_fatal_error`, surfacing as `threadsafe_function.rs:749 Failed
+        // to convert return value … Failed to call then method`). The outer
+        // `Option` collapses `undefined`/`null` to `None` on both paths.
         match tsfn
-            .call_async::<Option<Promise<Option<Value>>>>(arg.clone())
+            .call_async::<MaybePromise<Option<Value>>>(arg)
             .await
         {
-            Ok(Some(promise)) => match promise.await {
+            Ok(MaybePromise::Promise(promise)) => match promise.await {
                 Ok(Some(v)) => Ok(v),
                 Ok(None) => Ok(Value::Null),
                 Err(e) => Err(PreprocessError::Other(format!("{e}"))),
             },
-            Ok(None) => Ok(Value::Null),
-            Err(_) => {
-                // Not a Promise — accept a sync object/undefined return.
-                match tsfn.call_async::<Option<Value>>(arg).await {
-                    Ok(Some(v)) => Ok(v),
-                    Ok(None) => Ok(Value::Null),
-                    Err(e) => Err(PreprocessError::Other(format!("{e}"))),
-                }
-            }
+            Ok(MaybePromise::Value(Some(v))) => Ok(v),
+            Ok(MaybePromise::Value(None)) => Ok(Value::Null),
+            Err(e) => Err(PreprocessError::Other(format!("{e}"))),
         }
     }
 


### PR DESCRIPTION
## Summary

\`await_tsfn\` in the preprocess bridge was using a two-stage
\`call_async::<Option<Promise<Option<Value>>>>\` → fallback
\`call_async::<Option<Value>>\` to handle both async and sync
preprocessor returns. The fallback never reached.

napi-rs's \`Promise<T>::from_napi_value\` calls \`napi_call_function(napi_val, "then", ...)\` unconditionally. When the JS callback returns a non-Promise, the "then" property doesn't exist, the call fails, and the inner converter returns Err — which the ThreadsafeFunction handler at \`threadsafe_function.rs:749\` **escalates to \`napi_fatal_error\`, aborting the entire Node process** before the fallback can run.

\`Promise::validate\` does check is-promise, but on failure it **substitutes a rejected Promise** rather than returning Err — so any \`Either<Promise, _>\` path also picks variant A and falls into the broken \`from_napi_value\`.

Fix: define a \`MaybePromise<T>\` enum whose \`FromNapiValue\` impl probes \`napi_is_promise\` directly **before** the typed conversion, and only materializes a \`Promise<T>\` when the value really is a promise. Otherwise convert as plain T. The Svelte preprocessor contract allows sync \`Processed\` returns alongside \`Promise<Processed>\`, so this matters in practice the moment any preprocessor in the chain is synchronous.

## Background

Surfaced by [ecosystem-ci](https://github.com/baseballyama/rsvelte/actions/workflows/ecosystem-ci.yml) on shadcn-svelte: the docs build was crashing with

\`\`\`
FATAL ERROR: threadsafe_function.rs:749
Failed to convert return value ... Failed to call then method
\`\`\`

## Verified locally

\`node scripts/ecosystem-ci.mjs run shadcn-svelte\` on this branch:

- ✅ baseline build: pass (405s)
- ✅ NAPI build with the fix
- ✅ rsvelte build no longer FATAL-aborts at the threadsafe boundary
- ❌ rsvelte build now fails 28s in with a separate class of parser-side regressions (TS type assertions in templates, private-method-call-with-default-arg, etc.) — documented in the shadcn-svelte target's \`disabledReason\` for follow-up

ecosystem-ci on main stays 3/3 active green (bits-ui, melt-ui, flowbite-svelte). shadcn-svelte re-enables once the parser fixes land.

## Test plan

- [x] \`cargo build --release --features napi --lib\` ✅
- [x] \`cargo clippy --all-targets --all-features --release -- -D warnings\` ✅
- [x] Local smoke on shadcn-svelte: no FATAL ERROR, progresses past the threadsafe boundary
- [ ] CI standard checks
- [ ] Re-enable shadcn-svelte target in a follow-up after the parser fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)