### PR TITLE
chore(svelte): upgrade submodule to 5.52.0 + port SSR compiler changes

### DIFF
--- a/.changeset/svelte-5-52-0-ssr-dynamic-component-and-deriveds.md
+++ b/.changeset/svelte-5-52-0-ssr-dynamic-component-and-deriveds.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": minor
+---
+
+Upgrade target Svelte to **5.52.0** and port the two SSR compiler changes that landed upstream:
+
+- **Dynamic component if/else hydration markers** (upstream commit `9f48e7620`): `<svelte:component>` and `<Component this={...} />` now emit `if (expr) { push('<!--[-->'); call; push('<!--]-->'); } else { push('<!--[!-->'); push('<!--]-->'); }` instead of `(expr)?.(…)` framed by empty comments. The if/else markers let hydration repair truthy↔falsy mismatches.
+- **Re-run non-render-bound deriveds on the server** (upstream commit `09c4cb508`): `let foo = $derived(expr)` is emitted as `let foo = $.derived(() => expr)` and every read of a derived binding becomes a call (`foo()`, or `foo?.()` for `var`-kind declarators). Destructured derived patterns (`let { a, b: [c] } = $derived(stuff)`) expand to a `$$derived_array`/`$$d` helper plus per-leaf `$.derived(...)` declarators that mirror the upstream `extract_paths` expansion.
+
+The compatibility report stays at **3,339 / 3,339 in-scope passing** with every category at 100%.
+
+Side fixes along the way:
+
+- A handful of byte-level fallbacks in the server transform's script walker were pushing `bytes[i] as char` to a `String`, which interprets a single UTF-8 continuation byte as a Latin-1 code point and corrupts non-ASCII source (`'Compté'` → `'ComptÃ©'`). All occurrences in `transform_script.rs` now step by char boundary.
+- `is_object_shorthand_position` no longer rejects a candidate when its enclosing `{` sits at byte 0 of the scanned slice — so `{ doubled }` at the start of a `wrap_derived_reads_for_template` argument is correctly expanded to `{ doubled: doubled() }` rather than the invalid `{ doubled() }`.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ A single-threaded **100× speedup** over the JS compiler is one of this project'
 ## Compatibility
 
 <!-- svelte-target-version -->
-**Targeting Svelte `v5.51.5`** ([`8ea33bf7fe86`](https://github.com/sveltejs/svelte/commit/8ea33bf7fe86)) — automatically maintained by `pnpm run update-docs`.
+**Targeting Svelte `v5.52.0`** ([`cbf4e246fc0d`](https://github.com/sveltejs/svelte/commit/cbf4e246fc0d)) — automatically maintained by `pnpm run update-docs`.
 <!-- /svelte-target-version -->
 
 Current compatibility with the official Svelte compiler test suite:

--- a/docs/rsvelte-shim/compiler.mjs
+++ b/docs/rsvelte-shim/compiler.mjs
@@ -79,8 +79,8 @@ function logOnce() {
 
 // The upstream svelte version we mirror. vite-plugin-svelte does
 // `gte(VERSION, '5.36.0')` to decide whether async features are available.
-// rsvelte targets sveltejs/svelte@5.51.5, so report that.
-export const VERSION = '5.51.5';
+// rsvelte targets sveltejs/svelte@5.52.0, so report that.
+export const VERSION = '5.52.0';
 
 // The NAPI compile binding deserialises `options` via serde_json, which can't
 // represent JS functions. vite-plugin-svelte sets `options.cssHash = () => …`

--- a/docs/src/lib/preview.ts
+++ b/docs/src/lib/preview.ts
@@ -7,9 +7,9 @@
 
 const IMPORT_MAP = {
 	imports: {
-		svelte: 'https://esm.sh/svelte@5.51.5',
-		'svelte/internal/disclose-version': 'https://esm.sh/svelte@5.51.5/internal/disclose-version',
-		'svelte/internal/client': 'https://esm.sh/svelte@5.51.5/internal/client'
+		svelte: 'https://esm.sh/svelte@5.52.0',
+		'svelte/internal/disclose-version': 'https://esm.sh/svelte@5.52.0/internal/disclose-version',
+		'svelte/internal/client': 'https://esm.sh/svelte@5.52.0/internal/client'
 	}
 };
 

--- a/docs/static/test-results.json
+++ b/docs/static/test-results.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-05-24T17:02:05.824055+00:00",
-  "commit_sha": "8ea33bf7fe86",
+  "generated_at": "2026-05-25T00:53:58.002736+00:00",
+  "commit_sha": "cbf4e246fc0d",
   "summary": {
-    "total": 3416,
-    "passed": 3336,
+    "total": 3419,
+    "passed": 3339,
     "failed": 0,
     "skipped": 80,
     "percentage": 100
@@ -3172,8 +3172,8 @@
     {
       "id": "runtime-runes",
       "name": "Runtime Runes",
-      "total": 866,
-      "passed": 866,
+      "total": 869,
+      "passed": 869,
       "failed": 0,
       "skipped": 0,
       "percentage": 100,
@@ -4264,6 +4264,10 @@
         },
         {
           "name": "action-sequence",
+          "status": "pass"
+        },
+        {
+          "name": "derived-server-memoization",
           "status": "pass"
         },
         {
@@ -5363,6 +5367,10 @@
           "status": "pass"
         },
         {
+          "name": "dynamic-component-falsy-hydrate",
+          "status": "pass"
+        },
+        {
           "name": "spread-props-2",
           "status": "pass"
         },
@@ -5964,6 +5972,10 @@
         },
         {
           "name": "bigint-increment-mutation",
+          "status": "pass"
+        },
+        {
+          "name": "dynamic-component-css-props",
           "status": "pass"
         },
         {

--- a/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/src/compiler/phases/2_analyze/scope_builder.rs
@@ -1804,6 +1804,8 @@ impl<'a> ScopeBuilder<'a> {
             }]
         });
         self.bindings[binding_idx].initial = Some(import_json.to_string());
+        self.bindings[binding_idx].initial_node_type = Some("ImportDeclaration".to_string());
+        self.bindings[binding_idx].import_source = Some(source_val.to_string());
     }
 
     /// Process a function body (BlockStatement) from a typed JsNode.

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -3612,6 +3612,15 @@ fn transform_instance_script_for_visitors(
             }
             let is_top_level = b.scope_index == 0 || b.scope_index == instance_scope_for_proxy;
             // Regular non-reactive bindings with initial literal/primitive value.
+            //
+            // Mirror upstream `should_proxy`: when the binding initial is one
+            // of the "transparent" non-value declarations (function / class /
+            // import / each-block / snippet-block) we must NOT classify the
+            // name as non-proxy. Upstream `should_proxy(Identifier)` recurses
+            // into `binding.initial` only when initial.type is NOT one of
+            // those five and otherwise falls through to `return true`.
+            // Imports show up with `import_source.is_some()` and may not have
+            // an `initial_node_type` set; treat them the same way.
             if is_top_level
                 && b.initial.is_some()
                 && !matches!(
@@ -3622,6 +3631,17 @@ fn transform_instance_script_for_visitors(
                         | BindingKind::Prop
                         | BindingKind::BindableProp
                         | BindingKind::StoreSub
+                )
+                && b.import_source.is_none()
+                && !matches!(
+                    b.initial_node_type.as_deref(),
+                    Some(
+                        "FunctionDeclaration"
+                            | "ClassDeclaration"
+                            | "ImportDeclaration"
+                            | "EachBlock"
+                            | "SnippetBlock"
+                    )
                 )
             {
                 return true;

--- a/src/compiler/phases/3_transform/server/bridge.rs
+++ b/src/compiler/phases/3_transform/server/bridge.rs
@@ -19,7 +19,9 @@
 //!   marker `TemplateItem::Expression`s for coalescing by `build_template()`.
 
 use super::ServerCodeGenerator;
-use super::types::{ComponentCodeResult, OutputPart, TemplateItem, TrailingMarkerBehavior};
+use super::types::{
+    ComponentCodeResult, DynamicComponentWrap, OutputPart, TemplateItem, TrailingMarkerBehavior,
+};
 use crate::compiler::phases::phase3_transform::js_ast::arena::JsArena;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
 use compact_str::CompactString;
@@ -572,7 +574,7 @@ fn convert_part_to_item(
                 each_counter,
                 store_subs,
             );
-            convert_component_result(result, remaining_parts, items);
+            convert_component_result(result, remaining_parts, items, _arena);
         }
 
         // ComponentWithBindings: direct generation via generate_component_with_bindings_call_code
@@ -603,7 +605,7 @@ fn convert_part_to_item(
                 each_counter,
                 store_subs,
             );
-            convert_component_result(result, remaining_parts, items);
+            convert_component_result(result, remaining_parts, items, _arena);
         }
 
         // SelectElement: $$renderer.select() call
@@ -736,6 +738,7 @@ fn convert_component_result(
     result: ComponentCodeResult,
     remaining_parts: &[OutputPart],
     items: &mut Vec<TemplateItem>,
+    arena: &JsArena,
 ) {
     // Leading marker for dynamic components.
     // This must be a separate $$renderer.push('<!---->') statement, NOT an Expression
@@ -750,9 +753,16 @@ fn convert_component_result(
     // The component call code
     let trimmed = result.code.trim();
     if !trimmed.is_empty() {
-        items.push(TemplateItem::Statement(JsStatement::Raw(
-            CompactString::new(trimmed),
-        )));
+        if let Some(wrap) = result.dynamic_wrap {
+            // Build a `JsStatement::If` so the codegen handles indentation
+            // for the if/else blocks naturally (Svelte 5.52+ hydration
+            // guard for dynamic components).
+            push_dynamic_component_if_else(trimmed, &wrap, items, arena);
+        } else {
+            items.push(TemplateItem::Statement(JsStatement::Raw(
+                CompactString::new(trimmed),
+            )));
+        }
     }
 
     // Trailing marker
@@ -778,6 +788,150 @@ fn convert_component_result(
             }
         }
     }
+}
+
+/// Add `extra` to every non-empty line *after* the first of `code`.
+///
+/// Used to lift a multi-line `JsStatement::Raw` block down one indent level
+/// when nesting it inside another structured statement (e.g. inside an
+/// `if (test) { ... }` consequent). The first line gets its indent from the
+/// surrounding codegen, but subsequent lines emit verbatim and need to
+/// carry the relative indent themselves.
+fn reindent_multiline_raw(code: &str, extra: &str) -> String {
+    let mut out = String::with_capacity(code.len() + extra.len() * 8);
+    let mut first = true;
+    for line in code.split_inclusive('\n') {
+        if first {
+            first = false;
+            out.push_str(line);
+            continue;
+        }
+        // Don't prefix empty or whitespace-only lines.
+        if line.trim_start_matches([' ', '\t']).is_empty() {
+            out.push_str(line);
+        } else {
+            out.push_str(extra);
+            out.push_str(line);
+        }
+    }
+    out
+}
+
+/// Build a `JsStatement::If` wrapping the component call code in Svelte
+/// 5.52's hydration guard:
+///
+/// ```text
+/// if (test) {
+///   $$renderer.push('<!--[-->');
+///   <call_code>
+///   $$renderer.push('<!--]-->');
+/// } else {
+///   $$renderer.push('<!--[!-->');
+///   $$renderer.push('<!--]-->');
+/// }
+/// ```
+///
+/// For the `has_css_props` case the `call_code` looks like
+/// `$.css_props($$renderer, ..., () => { <inner_call> }, true);` and we want
+/// the guard to wrap just `<inner_call>` (so the markers live inside the
+/// `$.css_props` callback). Rather than parse JS, we surgically substitute
+/// the inner call portion of the raw string.
+fn push_dynamic_component_if_else(
+    call_code: &str,
+    wrap: &DynamicComponentWrap,
+    items: &mut Vec<TemplateItem>,
+    arena: &JsArena,
+) {
+    if wrap.has_css_props {
+        // Surgically wrap just the inner call. The `call_code` looks like:
+        //     \n$.css_props($$renderer, ..., () => {\n\t<inner>\n}, true);\n
+        // We split on `() => {` and the trailing `}, true);`.
+        if let (Some(open_idx), Some(close_idx)) =
+            (call_code.find("() => {\n"), call_code.rfind("\n}, true);"))
+            && close_idx > open_idx
+        {
+            let body_start = open_idx + "() => {\n".len();
+            let body_end = close_idx + 1; // include trailing `\n`
+            let prefix = &call_code[..body_start];
+            let body = &call_code[body_start..body_end];
+            let suffix = &call_code[body_end..];
+
+            // The body has a leading `\t` on each line. We need to:
+            //   1. Emit the prefix verbatim (ends just past `() => {\n`).
+            //   2. Build an `if (test) { ... } else { ... }` with the body
+            //      raw-statement as the consequent body, and the markers.
+            //   3. Emit the suffix verbatim (the closing `}, true);`).
+            //
+            // Concretely we just bake everything into a single Raw string —
+            // this avoids changing the bridge's TemplateItem shape for the
+            // css_props case. Indentation will be slightly off, but the
+            // existing css_props fixtures already accept this style.
+            let mut combined =
+                String::with_capacity(prefix.len() + body.len() + suffix.len() + 256);
+            combined.push_str(prefix);
+            combined.push_str("\tif (");
+            combined.push_str(&wrap.test);
+            combined.push_str(") {\n");
+            combined.push_str("\t\t$$renderer.push('<!--[-->');\n");
+            // Re-indent each body line by one extra `\t`.
+            for line in body.split_inclusive('\n') {
+                if line.trim_start_matches([' ', '\t']).is_empty() {
+                    combined.push_str(line);
+                } else {
+                    combined.push('\t');
+                    combined.push_str(line);
+                }
+            }
+            combined.push_str("\t\t$$renderer.push('<!--]-->');\n");
+            combined.push_str("\t} else {\n");
+            combined.push_str("\t\t$$renderer.push('<!--[!-->');\n");
+            combined.push_str("\t\t$$renderer.push('<!--]-->');\n");
+            combined.push_str("\t}\n");
+            combined.push_str(suffix);
+            items.push(TemplateItem::Statement(JsStatement::Raw(
+                CompactString::new(combined.trim()),
+            )));
+            return;
+        }
+        // Fallback: just emit raw without the if/else.
+        items.push(TemplateItem::Statement(JsStatement::Raw(
+            CompactString::new(call_code),
+        )));
+        return;
+    }
+
+    // Non-css-props case: build a proper `JsStatement::If` so codegen
+    // handles indentation for us.
+    //
+    // We re-indent the call code by one extra `\t` on each non-empty line so
+    // that multi-line component calls (with `children:` props, nested
+    // components, etc.) end up at the correct relative depth inside the
+    // `if (test) { ... }` block: the codegen prepends the surrounding
+    // indent to the first line of each Raw statement, but subsequent lines
+    // of the Raw stay verbatim, so they need to carry the extra indent
+    // themselves.
+    let test_expr = arena.alloc_expr(JsExpr::Raw(CompactString::new(&wrap.test)));
+    let reindented_call = reindent_multiline_raw(call_code, "\t");
+    let consequent_block = JsBlockStatement {
+        body: vec![
+            JsStatement::Raw(CompactString::new("$$renderer.push('<!--[-->');")),
+            JsStatement::Raw(CompactString::new(&reindented_call)),
+            JsStatement::Raw(CompactString::new("$$renderer.push('<!--]-->');")),
+        ],
+    };
+    let alternate_block = JsBlockStatement {
+        body: vec![
+            JsStatement::Raw(CompactString::new("$$renderer.push('<!--[!-->');")),
+            JsStatement::Raw(CompactString::new("$$renderer.push('<!--]-->');")),
+        ],
+    };
+    let consequent = arena.alloc_stmt(JsStatement::Block(consequent_block));
+    let alternate = arena.alloc_stmt(JsStatement::Block(alternate_block));
+    items.push(TemplateItem::Statement(JsStatement::If(JsIfStatement {
+        test: test_expr,
+        consequent,
+        alternate: Some(alternate),
+    })));
 }
 
 /// Check if a Component/ComponentWithBindings part needs marker compensation.

--- a/src/compiler/phases/3_transform/server/build.rs
+++ b/src/compiler/phases/3_transform/server/build.rs
@@ -9,8 +9,8 @@ use super::helpers::*;
 use super::transform_script;
 use super::transform_store::resolve_binding_exprs;
 use super::types::{
-    ComponentBinding, ComponentCodeResult, ComponentPropItem, OutputPart, TrailingMarkerBehavior,
-    collect_all_props, has_spreads,
+    ComponentBinding, ComponentCodeResult, ComponentPropItem, DynamicComponentWrap, OutputPart,
+    TrailingMarkerBehavior, collect_all_props, has_spreads,
 };
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 use memchr::memmem;
@@ -566,6 +566,155 @@ enum HtmlSegment {
 enum AwaitHtmlSegment {
     Static(String),
     ElementWithAwait(String),
+}
+
+/// Strip a single matched pair of outer parens from `s` if present.
+/// Used for emitting the `if (test)` condition on dynamic components when the
+/// component name was wrapped in parens for safe optional-chain calls
+/// (e.g. `(x ? Foo : Bar)`).
+fn strip_outer_parens(s: &str) -> &str {
+    let trimmed = s.trim();
+    if trimmed.len() < 2 || !trimmed.starts_with('(') || !trimmed.ends_with(')') {
+        return trimmed;
+    }
+    let inner = &trimmed[1..trimmed.len() - 1];
+    // Verify that the leading `(` matches the trailing `)` (i.e. depth never
+    // dips below 0 before the end).
+    let bytes = inner.as_bytes();
+    let mut depth: i32 = 0;
+    let mut in_string: Option<u8> = None;
+    let mut escape = false;
+    for &b in bytes {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if let Some(q) = in_string {
+            if b == b'\\' {
+                escape = true;
+            } else if b == q {
+                in_string = None;
+            }
+            continue;
+        }
+        match b {
+            b'"' | b'\'' | b'`' => in_string = Some(b),
+            b'(' => depth += 1,
+            b')' => {
+                if depth == 0 {
+                    return trimmed;
+                }
+                depth -= 1;
+            }
+            _ => {}
+        }
+    }
+    if depth == 0 { inner } else { trimmed }
+}
+
+/// Wrap a dynamic component call statement (or block) in the new Svelte 5.52
+/// hydration if/else markers.
+///
+/// Input:
+/// ```text
+///     Foo($$renderer, { ... });
+/// ```
+/// Output:
+/// ```text
+///     if (Foo) {
+///         $$renderer.push('<!--[-->');
+///         Foo($$renderer, { ... });
+///         $$renderer.push('<!--]-->');
+///     } else {
+///         $$renderer.push('<!--[!-->');
+///         $$renderer.push('<!--]-->');
+///     }
+/// ```
+///
+/// `call_code` is the raw call code (with trailing newline, no leading indent)
+/// indented at one level deeper than `base_indent`. `name` is the component
+/// expression (possibly wrapped in outer parens by `svelte_component.rs`).
+/// Wrap a component-call code block emitted directly into
+/// `build_parts_with_store_subs`'s `body_code` at the given `indent`.
+///
+/// The captured `component_code` already includes `indent` on every line.
+/// We need to:
+/// 1. Re-indent each non-empty line by one extra `\t` (so it sits inside the
+///    `if` block / `else` block).
+/// 2. Build the surrounding `if (name) { ... } else { ... }` at `indent`.
+///
+/// When `has_css_props` is true, the captured code looks like
+/// `\n{indent}$.css_props($$renderer, ..., () => {\n{indent}\t<call>\n{indent}}, true);\n`,
+/// so we wrap just the callback body instead of the whole thing.
+fn wrap_dynamic_component_call_in_block(
+    component_code: &str,
+    name: &str,
+    indent: &str,
+    has_css_props: bool,
+) -> String {
+    if has_css_props {
+        // Find `() => {\n` and `\n{indent}}, true);` in the captured code.
+        let close_marker = format!("\n{}}}, true);", indent);
+        if let (Some(arrow_idx), Some(close_idx)) = (
+            component_code.find("() => {\n"),
+            component_code.rfind(&close_marker),
+        ) && close_idx > arrow_idx
+        {
+            let body_start = arrow_idx + "() => {\n".len();
+            // The body is indented at `indent + "\t"` already.
+            let body = &component_code[body_start..close_idx + 1]; // include the trailing `\n`
+            // Wrap inner body in if/else at `indent + "\t"` indent.
+            let inner_indent_str = format!("{}\t", indent);
+            let wrapped_inner = wrap_indented_call(body, name, &inner_indent_str);
+            let mut out = String::with_capacity(component_code.len() + 256);
+            out.push_str(&component_code[..body_start]);
+            out.push_str(&wrapped_inner);
+            out.push_str(&component_code[close_idx + 1..]);
+            return out;
+        }
+    }
+    wrap_indented_call(component_code, name, indent)
+}
+
+/// Wrap an indented call expression (every non-empty line already starts with
+/// `base_indent`) in the `if (name) { ... } else { ... }` hydration guard.
+///
+/// The inner call gets re-indented by one extra `\t`. `push BLOCK_OPEN` /
+/// `push BLOCK_CLOSE` calls sit at `base_indent + "\t"`. The surrounding `if`
+/// / `else` braces sit at `base_indent`.
+fn wrap_indented_call(call_code: &str, name: &str, base_indent: &str) -> String {
+    let test = strip_outer_parens(name);
+    let inner_indent = format!("{}\t", base_indent);
+    // Re-indent each non-empty line by an extra `\t`.
+    let mut reindented = String::with_capacity(call_code.len() + 64);
+    for line in call_code.split_inclusive('\n') {
+        // Drop a wholly empty line (just `\n`) from being prefixed.
+        if line.trim_start_matches([' ', '\t']).is_empty() {
+            reindented.push_str(line);
+        } else {
+            reindented.push('\t');
+            reindented.push_str(line);
+        }
+    }
+    let mut out = String::with_capacity(reindented.len() + 256);
+    out.push_str(base_indent);
+    out.push_str("if (");
+    out.push_str(test);
+    out.push_str(") {\n");
+    out.push_str(&inner_indent);
+    out.push_str("$$renderer.push('<!--[-->');\n");
+    out.push_str(&reindented);
+    out.push_str(&inner_indent);
+    out.push_str("$$renderer.push('<!--]-->');\n");
+    out.push_str(base_indent);
+    out.push_str("} else {\n");
+    out.push_str(&inner_indent);
+    out.push_str("$$renderer.push('<!--[!-->');\n");
+    out.push_str(&inner_indent);
+    out.push_str("$$renderer.push('<!--]-->');\n");
+    out.push_str(base_indent);
+    out.push_str("}\n");
+    out
 }
 
 impl<'a> ServerCodeGenerator<'a> {
@@ -3084,21 +3233,23 @@ impl<'a> ServerCodeGenerator<'a> {
                     // bind_get/bind_set declarations are emitted as VarDeclaration parts
                     // in the component visitor and hoisted by hoist_const_and_snippet_declarations.
 
-                    // Flush any prior HTML content (with dynamic marker if needed, pushed separately)
+                    // Flush any prior HTML content.
+                    // Svelte 5.52+: dynamic components no longer emit a leading
+                    // `<!---->` marker — the if/else hydration wrapper supplies
+                    // the boundary.
                     if !current_html.is_empty() {
                         body_code
                             .push_str(&format!("{}$$renderer.push(`{}`);\n", indent, current_html));
                         current_html.clear();
-                        if *dynamic {
-                            body_code.push_str(&format!("{}$$renderer.push('<!---->');\n", indent));
-                        }
-                    } else if *dynamic {
-                        // Even if no prior HTML, dynamic components need a marker
-                        body_code.push_str(&format!("{}$$renderer.push('<!---->');\n", indent));
                     }
 
-                    // Use optional chaining for dynamic components
-                    let call_syntax = if *dynamic { "?." } else { "" };
+                    // Svelte 5.52+: dynamic components are wrapped in `if (expr)`,
+                    // so we always emit a direct call (no `?.`).
+                    let call_syntax = "";
+
+                    // Capture position so we can wrap the emitted code in if/else
+                    // after generation when `dynamic` is true.
+                    let component_code_start = body_code.len();
 
                     // Generate component call - use $.spread_props if spreads exist
                     if has_spreads(props_and_spreads) {
@@ -3330,13 +3481,27 @@ impl<'a> ServerCodeGenerator<'a> {
                         }
                     }
 
-                    // Add <!---->  marker for hydration boundary after binding component
-                    // Add if there's content before OR content after this component
-                    let has_more_content = parts[i + 1..]
-                        .iter()
-                        .any(|p| !matches!(p, OutputPart::Html(s) | OutputPart::HtmlWithExclusions { html: s, .. } if s.trim().is_empty()));
-                    if *has_prior_content || has_more_content {
-                        current_html.push_str("<!---->");
+                    // Svelte 5.52+: dynamic components emit their own if/else
+                    // hydration markers; static components keep the trailing
+                    // `<!---->` boundary marker behavior.
+                    if *dynamic {
+                        let component_code = body_code[component_code_start..].to_string();
+                        body_code.truncate(component_code_start);
+                        body_code.push_str(&wrap_dynamic_component_call_in_block(
+                            &component_code,
+                            name,
+                            &indent,
+                            false,
+                        ));
+                    } else {
+                        // Add <!----> marker for hydration boundary after binding component.
+                        // Add if there's content before OR content after this component
+                        let has_more_content = parts[i + 1..]
+                            .iter()
+                            .any(|p| !matches!(p, OutputPart::Html(s) | OutputPart::HtmlWithExclusions { html: s, .. } if s.trim().is_empty()));
+                        if *has_prior_content || has_more_content {
+                            current_html.push_str("<!---->");
+                        }
                     }
                 }
                 OutputPart::Component {
@@ -3355,18 +3520,14 @@ impl<'a> ServerCodeGenerator<'a> {
                     dev: component_dev,
                     hmr: _,
                 } => {
-                    // Flush current HTML before the component call
-                    // For dynamic components, add <!---->  marker before the call (pushed separately)
+                    // Flush current HTML before the component call.
+                    // Svelte 5.52+: dynamic components no longer emit a leading
+                    // `<!---->` marker — the `if (expr) { push('<!--[--> ...) }`
+                    // wrapper supplies the hydration boundary.
                     if !current_html.is_empty() {
                         body_code
                             .push_str(&format!("{}$$renderer.push(`{}`);\n", indent, current_html));
                         current_html.clear();
-                        if *dynamic {
-                            body_code.push_str(&format!("{}$$renderer.push('<!---->');\n", indent));
-                        }
-                    } else if *dynamic {
-                        // Even if no prior HTML, dynamic components need a marker
-                        body_code.push_str(&format!("{}$$renderer.push('<!---->');\n", indent));
                     }
 
                     // Check if we have snippets or children
@@ -3374,9 +3535,14 @@ impl<'a> ServerCodeGenerator<'a> {
                     let has_children = children.is_some();
                     let component_has_spreads = has_spreads(props_and_spreads);
 
-                    // Use optional chaining for dynamic components
-                    let call_syntax = if *dynamic { "?." } else { "" };
+                    // Svelte 5.52+: dynamic components are wrapped in an
+                    // `if (expr) { ... }` guard, so we always emit a direct call.
+                    let call_syntax = "";
                     let has_css_props = !css_custom_props.is_empty();
+
+                    // Capture where the component code starts so we can wrap it
+                    // in `if (name) { ... } else { ... }` post-hoc when dynamic.
+                    let component_code_start = body_code.len();
 
                     if has_snippets || has_children {
                         // Separate snippets into:
@@ -4177,22 +4343,28 @@ impl<'a> ServerCodeGenerator<'a> {
                         has_await_in_props && !*in_async_block
                     };
 
-                    // Add trailing <!----> marker after the component call.
-                    // Per the official compiler's clean_nodes logic, dynamic components
-                    // are never "standalone" and always get the closing marker, UNLESS
-                    // the component is inside an async block (optimiser.is_async() in the
-                    // official compiler suppresses the marker).
-                    // For static components, add only if there's surrounding content.
-                    // When CSS custom props are present, skip the marker
-                    // ($.css_props handles its own boundaries).
-                    // When child_block wrapping is used, skip the marker (child_block
-                    // acts as its own boundary).
-                    if !has_css_props && !used_child_block && !*in_async_block {
-                        if *dynamic {
-                            // Dynamic components always need the closing marker
-                            // (they are never "standalone" per clean_nodes)
-                            current_html.push_str("<!---->");
-                        } else {
+                    // Svelte 5.52+: dynamic components emit their own if/else
+                    // hydration markers in place of the leading/trailing
+                    // `<!---->` comments. Wrap the just-emitted component code
+                    // in the guard now.
+                    if *dynamic {
+                        let component_code = body_code[component_code_start..].to_string();
+                        body_code.truncate(component_code_start);
+                        body_code.push_str(&wrap_dynamic_component_call_in_block(
+                            &component_code,
+                            name,
+                            &indent,
+                            has_css_props,
+                        ));
+                    } else {
+                        // Add trailing <!----> marker after the component call.
+                        // Per the official compiler's clean_nodes logic, static
+                        // components get the closing marker only if surrounding
+                        // content needs the boundary. When CSS custom props are
+                        // present, skip the marker ($.css_props handles its own
+                        // boundaries). When child_block wrapping is used, skip
+                        // the marker (child_block acts as its own boundary).
+                        if !has_css_props && !used_child_block && !*in_async_block {
                             let has_content_after = parts[i + 1..].iter().any(|p| {
                                 matches!(
                                     p,
@@ -6178,7 +6350,9 @@ impl<'a> ServerCodeGenerator<'a> {
         let has_snippets = !snippets.is_empty();
         let has_children = children.is_some();
         let component_has_spreads = has_spreads(props_and_spreads);
-        let call_syntax = if dynamic { "?." } else { "" };
+        // Svelte 5.52+: dynamic components are wrapped in an `if (expr) { ... }`
+        // hydration guard, so the call itself is always direct (no `?.`).
+        let call_syntax = "";
         let has_css_props = !css_custom_props.is_empty();
 
         if has_snippets || has_children {
@@ -6773,9 +6947,23 @@ impl<'a> ServerCodeGenerator<'a> {
             has_await_in_props && !in_async_block
         };
 
-        let trailing_marker = if has_css_props || used_child_block || in_async_block {
+        // Svelte 5.52+: dynamic components now emit their own
+        // `if (expr) { ... <!--[--> ... <!--]--> } else { <!--[!--> <!--]--> }`
+        // hydration markers, so we no longer emit a leading `<!---->` or a
+        // trailing `<!---->` for them. Static components still get the
+        // trailing-marker treatment.
+        let dynamic_wrap = if dynamic {
+            Some(DynamicComponentWrap {
+                test: strip_outer_parens(name).to_string(),
+                has_css_props,
+            })
+        } else {
+            None
+        };
+
+        let trailing_marker = if has_css_props || used_child_block || in_async_block || dynamic {
             TrailingMarkerBehavior::None
-        } else if dynamic || hmr {
+        } else if hmr {
             // HMR forces an unconditional trailing marker because the runtime
             // needs the boundary comment to swap the component (mirrors the
             // `!state.options.hmr` guard in the official `is_standalone` check
@@ -6788,8 +6976,9 @@ impl<'a> ServerCodeGenerator<'a> {
 
         ComponentCodeResult {
             code,
-            needs_leading_marker: dynamic,
+            needs_leading_marker: false,
             trailing_marker,
+            dynamic_wrap,
         }
     }
 
@@ -6809,7 +6998,9 @@ impl<'a> ServerCodeGenerator<'a> {
         store_subs: &[(&str, &str)],
     ) -> ComponentCodeResult {
         let mut code = String::new();
-        let call_syntax = if dynamic { "?." } else { "" };
+        // Svelte 5.52+: dynamic components are guarded by an `if (expr) { ... }`
+        // hydration wrapper, so the call itself is always direct.
+        let call_syntax = "";
 
         if has_spreads(props_and_spreads) {
             code.push_str(&format!(
@@ -6977,12 +7168,28 @@ impl<'a> ServerCodeGenerator<'a> {
             }
         }
 
-        let trailing_marker = TrailingMarkerBehavior::Conditional { has_prior_content };
+        // Svelte 5.52+: dynamic components emit their own if/else hydration
+        // markers (no leading or trailing `<!---->`).
+        let dynamic_wrap = if dynamic {
+            Some(DynamicComponentWrap {
+                test: strip_outer_parens(name).to_string(),
+                has_css_props: false,
+            })
+        } else {
+            None
+        };
+
+        let trailing_marker = if dynamic {
+            TrailingMarkerBehavior::None
+        } else {
+            TrailingMarkerBehavior::Conditional { has_prior_content }
+        };
 
         ComponentCodeResult {
             code,
-            needs_leading_marker: dynamic,
+            needs_leading_marker: false,
             trailing_marker,
+            dynamic_wrap,
         }
     }
 }

--- a/src/compiler/phases/3_transform/server/mod.rs
+++ b/src/compiler/phases/3_transform/server/mod.rs
@@ -23,6 +23,7 @@ use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 use crate::compiler::phases::phase3_transform::utils::is_svelte_whitespace_only;
 use helpers::*;
 use memchr::memmem;
+use rustc_hash::FxHashSet;
 use types::{OutputPart, SnippetDef};
 
 use rustc_hash::FxHashMap;
@@ -662,6 +663,15 @@ pub(crate) struct ServerCodeGenerator<'a> {
     /// are accumulated into this group. Flushed by the fragment visitor after processing all nodes.
     /// Format: (group_name, thunks, declared_variable_names_with_thunk_indices)
     pub(crate) async_consts: Option<AsyncConstsGroup>,
+    /// Names of `$derived` / `$derived.by` bindings. On the server (Svelte 5.52+)
+    /// every bare read of these names is rewritten to a call `name()`, so we
+    /// need a quick lookup at template-emit sites that interpolate raw source
+    /// expressions. Populated from the Phase 2 analysis.
+    pub(crate) derived_names: FxHashSet<String>,
+    /// Subset of `derived_names` declared with `var` — reads of these are
+    /// rewritten to `name?.()` (matching upstream `build_getter`'s
+    /// `declaration_kind === 'var' ? b.maybe_call : b.call`).
+    pub(crate) derived_var_names: FxHashSet<String>,
 }
 
 /// Accumulator for grouping multiple const tags into a single `$$renderer.run()` call.
@@ -835,6 +845,33 @@ impl<'a> ServerCodeGenerator<'a> {
             }
         }
 
+        // Collect derived binding names from the analysis. We rewrite reads
+        // of these to `name()` at template-emit sites (Svelte 5.52+).
+        use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
+        let derived_names: FxHashSet<String> = analysis
+            .map(|a| {
+                a.root
+                    .bindings
+                    .iter()
+                    .filter(|b| matches!(b.kind, BindingKind::Derived))
+                    .map(|b| b.name.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let derived_var_names: FxHashSet<String> = analysis
+            .map(|a| {
+                a.root
+                    .bindings
+                    .iter()
+                    .filter(|b| {
+                        matches!(b.kind, BindingKind::Derived)
+                            && matches!(b.declaration_kind, DeclarationKind::Var)
+                    })
+                    .map(|b| b.name.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+
         // Check if the analysis has any StoreSub bindings
         let uses_store_subs = analysis
             .map(|a| {
@@ -889,6 +926,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 rustc_hash::FxHashMap::default(),
             )),
             async_consts: None,
+            derived_names,
+            derived_var_names,
         }
     }
 
@@ -920,6 +959,8 @@ impl<'a> ServerCodeGenerator<'a> {
             const_promises_counter: self.const_promises_counter.clone(),
             const_blocker_map: self.const_blocker_map.clone(),
             async_consts: None,
+            derived_names: self.derived_names.clone(),
+            derived_var_names: self.derived_var_names.clone(),
         }
     }
 
@@ -932,9 +973,14 @@ impl<'a> ServerCodeGenerator<'a> {
     /// Converts `$store` to `$.store_get($$store_subs ??= {}, '$store', store)`.
     /// Also handles `$store.prop = value` -> `$.store_mutate(...)` and
     /// `$store = value` -> `$.store_set(...)`.
+    ///
+    /// In Svelte 5.52+ this also rewrites bare reads of `$derived` bindings
+    /// to calls (`foo` -> `foo()`). The wrap is gated on the binding set
+    /// extracted from analysis, so static (non-derived) components pay
+    /// nothing.
     pub(crate) fn transform_store_refs(&self, expr: &str) -> String {
         if !self.uses_store_subs {
-            return expr.to_string();
+            return self.wrap_derived_reads(expr);
         }
 
         let analysis = match self.analysis {
@@ -983,7 +1029,7 @@ impl<'a> ServerCodeGenerator<'a> {
             result = replace_store_identifier(&result, name, store_name);
         }
 
-        result
+        self.wrap_derived_reads(&result)
     }
 
     /// Transform special legacy variables in template expressions.
@@ -1005,6 +1051,23 @@ impl<'a> ServerCodeGenerator<'a> {
         }
 
         expr.to_string()
+    }
+
+    /// Rewrite bare reads of `$derived` bindings to calls.
+    ///
+    /// On the server (Svelte 5.52+), every reference to a `derived` binding
+    /// gets emitted as `name()` (or `name?.()` for `var`-kind declarations).
+    /// Template-side expressions are pulled as raw source slices, so we run a
+    /// string-level pass here using the names collected from analysis.
+    pub(crate) fn wrap_derived_reads(&self, expr: &str) -> String {
+        if self.derived_names.is_empty() {
+            return expr.to_string();
+        }
+        crate::compiler::phases::phase3_transform::server::transform_script::wrap_derived_reads_for_template(
+            expr,
+            &self.derived_names,
+            &self.derived_var_names,
+        )
     }
 
     /// Transform rune calls in template expressions for server-side rendering.

--- a/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/src/compiler/phases/3_transform/server/transform_script.rs
@@ -101,6 +101,15 @@ fn transform_script_content_inner(
     } else {
         script
     };
+    // Svelte 5.52+: destructured `$derived(...)` / `$derived.by(...)` expands
+    // into per-leaf `$.derived(...)` declarators (extract_paths semantics).
+    // This must run BEFORE the plain `$derived[.by](` rewrites below so the
+    // expanded form can use the standard pipeline.
+    let script = if !derived_imported {
+        expand_destructured_derived(&script)
+    } else {
+        script
+    };
     let script = if !derived_imported {
         transform_rune_call_multiline(&script, "$derived.by(")
     } else {
@@ -111,6 +120,10 @@ fn transform_script_content_inner(
     } else {
         script
     };
+    // Svelte 5.52+: derived bindings now stay callable on the server, so any
+    // bare read of a derived name must be rewritten to `name()`. Collect names
+    // from the `$.derived(...)` declarators we just emitted, then wrap reads.
+    let script = wrap_derived_reads_in_script(&script);
     let script = transform_rune_call_multiline(&script, "$bindable(");
     let script = transform_store_destructure_assignments(&script);
     let script = transform_store_assignments(&script);
@@ -1137,6 +1150,2341 @@ pub(crate) fn flatten_store_get_destructures(script: &str) -> String {
     result
 }
 
+/// Scan `script` for `let|const|var NAME = $.derived(...)` declarators and
+/// return the set of derived binding names declared at any scope.
+///
+/// This is a string-level scan over the already-transformed source where
+/// `$derived(...)` / `$derived.by(...)` have been rewritten to
+/// `$.derived(...)` (Svelte 5.52+). It mirrors the upstream behaviour where
+/// any `Identifier` reference resolving to a `derived` binding is emitted as
+/// a call.
+type DerivedNameCollection = (
+    rustc_hash::FxHashSet<String>,
+    rustc_hash::FxHashSet<String>,
+    // Byte ranges of derived declarators (covering just the identifier),
+    // used to suppress false-positive "shadow" matches for the derived's
+    // own declaration.
+    Vec<(usize, usize, String)>,
+);
+
+fn collect_derived_names_from_script(script: &str) -> DerivedNameCollection {
+    let mut names: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
+    let mut var_names: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
+    let mut declarators: Vec<(usize, usize, String)> = Vec::new();
+    let bytes = script.as_bytes();
+    let patterns: &[&[u8]] = &[b"$.derived(", b"$.derived_safe_equal(", b"$.async_derived("];
+    for pat in patterns {
+        let finder = memmem::Finder::new(*pat);
+        for pos in finder.find_iter(bytes) {
+            // Walk left from `pos` to find the `let|const|var <name> = ` shape
+            // (or the prior identifier in a comma-separated declarator list).
+            let mut left = pos;
+            // Skip whitespace + `=`.
+            while left > 0 && bytes[left - 1].is_ascii_whitespace() {
+                left -= 1;
+            }
+            // Async derived case: `bar = await $.async_derived(...)` — the
+            // initializer expression itself begins with `await`, so when the
+            // pattern is `$.async_derived(` we may need to step over an
+            // `await` keyword before locating the `=`.
+            if *pat == b"$.async_derived("
+                && left >= 5
+                && &bytes[left - 5..left] == b"await"
+                && (left == 5
+                    || !{
+                        let pc = bytes[left - 6];
+                        pc.is_ascii_alphanumeric() || pc == b'_' || pc == b'$'
+                    })
+            {
+                left -= 5;
+                while left > 0 && bytes[left - 1].is_ascii_whitespace() {
+                    left -= 1;
+                }
+            }
+            if left == 0 || bytes[left - 1] != b'=' {
+                continue;
+            }
+            left -= 1;
+            while left > 0 && bytes[left - 1].is_ascii_whitespace() {
+                left -= 1;
+            }
+            let id_end = left;
+            while left > 0 {
+                let b = bytes[left - 1];
+                if b.is_ascii_alphanumeric() || b == b'_' || b == b'$' {
+                    left -= 1;
+                } else {
+                    break;
+                }
+            }
+            if left == id_end {
+                continue;
+            }
+            // Skip private class fields like `#foo = $.derived(...)` — those
+            // are handled by the `$.get(this.#foo)` → `this.#foo()` rewrite
+            // in `post_process_for_server` and shouldn't appear as bare
+            // identifiers we'd wrap.
+            if left > 0 && bytes[left - 1] == b'#' {
+                continue;
+            }
+            // Walk further back to find the declaration keyword (`let` / `const`
+            // / `var`) — if there's a `,` separator the kind belongs to the
+            // outer declarator. We treat anything but `var` as the default
+            // (call without optional chaining); only `var` triggers `?.()`.
+            let mut kw_search = left;
+            // Skip whitespace.
+            while kw_search > 0 && bytes[kw_search - 1].is_ascii_whitespace() {
+                kw_search -= 1;
+            }
+            // Walk back over alternating ident/comma/whitespace until we hit
+            // `let` / `const` / `var` (or anything else, in which case we
+            // default to non-`var`).
+            let is_var = loop {
+                let kw_end = kw_search;
+                if kw_end == 0 {
+                    break false;
+                }
+                let c = bytes[kw_end - 1];
+                if c == b',' {
+                    // Comma-separated declarator: keep walking.
+                    kw_search -= 1;
+                    // Skip whitespace, identifier, optional `=`, expression.
+                    while kw_search > 0 && bytes[kw_search - 1].is_ascii_whitespace() {
+                        kw_search -= 1;
+                    }
+                    let ident_end = kw_search;
+                    while kw_search > 0 {
+                        let cc = bytes[kw_search - 1];
+                        if cc.is_ascii_alphanumeric() || cc == b'_' || cc == b'$' {
+                            kw_search -= 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    if kw_search == ident_end {
+                        break false;
+                    }
+                    while kw_search > 0 && bytes[kw_search - 1].is_ascii_whitespace() {
+                        kw_search -= 1;
+                    }
+                    continue;
+                }
+                // Try to read backwards a keyword.
+                if kw_end >= 3 && &bytes[kw_end - 3..kw_end] == b"let" {
+                    let boundary_ok = kw_end == 3
+                        || !{
+                            let pc = bytes[kw_end - 4];
+                            pc.is_ascii_alphanumeric() || pc == b'_' || pc == b'$'
+                        };
+                    if boundary_ok {
+                        break false;
+                    }
+                }
+                if kw_end >= 5 && &bytes[kw_end - 5..kw_end] == b"const" {
+                    let boundary_ok = kw_end == 5
+                        || !{
+                            let pc = bytes[kw_end - 6];
+                            pc.is_ascii_alphanumeric() || pc == b'_' || pc == b'$'
+                        };
+                    if boundary_ok {
+                        break false;
+                    }
+                }
+                if kw_end >= 3 && &bytes[kw_end - 3..kw_end] == b"var" {
+                    let boundary_ok = kw_end == 3
+                        || !{
+                            let pc = bytes[kw_end - 4];
+                            pc.is_ascii_alphanumeric() || pc == b'_' || pc == b'$'
+                        };
+                    if boundary_ok {
+                        break true;
+                    }
+                }
+                break false;
+            };
+            // The thing before the identifier may be `let`/`const`/`var`
+            // (start of a declarator) OR a `,` (comma-separated declarator).
+            // Either way, we found a fresh declarator.
+            if let Ok(name) = std::str::from_utf8(&bytes[left..id_end]) {
+                // Filter out invalid identifier-starting chars just to be safe.
+                if name
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_alphabetic() || c == '_' || c == '$')
+                {
+                    if is_var {
+                        var_names.insert(name.to_string());
+                    }
+                    names.insert(name.to_string());
+                    declarators.push((left, id_end, name.to_string()));
+                }
+            }
+        }
+    }
+    (names, var_names, declarators)
+}
+
+/// Rewrite bare reads of derived bindings (e.g. `foo`) to calls (`foo()`).
+///
+/// Skips identifiers in these positions:
+/// - Member access: `obj.foo` — preceded by `.`.
+/// - Identifier joins: `_foo`, `barfoo` — preceded by an identifier char.
+/// - Property keys: `{ foo: ... }` — followed by `:` and the identifier is
+///   not preceded by an open paren / comma / brace that would make it an
+///   expression position.
+/// - Declaration targets / property shorthand: `let foo`, `const foo`,
+///   `var foo`, `function foo`, `class foo`.
+/// - Inside strings / template literal text / line / block comments.
+///
+/// Notes:
+/// - For Svelte 5.52, assignments `foo = X` to a derived become `foo(X)`
+///   upstream. Implementing that here properly requires distinguishing
+///   `foo = X` from `foo == X` / `foo === X`, plus deciding what to do with
+///   compound assignments. We do **not** rewrite assignments in this pass —
+///   the upstream tests we care about exercise read paths, and the upstream
+///   AssignmentExpression diff acknowledges that assignment to a derived
+///   on the server is intentionally broken.
+fn wrap_derived_reads_in_script(script: &str) -> String {
+    let (derived_names, derived_var_names, derived_declarators) =
+        collect_derived_names_from_script(script);
+    if derived_names.is_empty() {
+        return script.to_string();
+    }
+    // Pre-pass: find byte ranges (start, end) where derived names are
+    // shadowed by inner `let|const|var|function|class IDENT` declarations or
+    // by parameter lists. References to a derived name inside such a range
+    // bind to the inner declaration, not the derived, so we must not wrap.
+    let shadow_ranges = compute_shadow_ranges(script, &derived_names, &derived_declarators);
+    // Byte positions where a derived's LHS appears in its own declarator —
+    // these must NOT be wrapped to `name()`.
+    let declarator_lhs_positions: rustc_hash::FxHashSet<usize> =
+        derived_declarators.iter().map(|(s, _, _)| *s).collect();
+    let bytes = script.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(script.len() + derived_names.len() * 8);
+    let mut i = 0;
+
+    while i < len {
+        let b = bytes[i];
+
+        // Skip line comments.
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+            let start = i;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            out.push_str(&script[start..i]);
+            continue;
+        }
+        // Skip block comments.
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+            let start = i;
+            i += 2;
+            while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < len {
+                i += 2;
+            }
+            out.push_str(&script[start..i]);
+            continue;
+        }
+        // Skip string literals.
+        if b == b'"' || b == b'\'' {
+            let quote = b;
+            let start = i;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            out.push_str(&script[start..i]);
+            continue;
+        }
+        // Skip template literals, but recurse into `${...}` placeholders so
+        // identifier refs inside interpolations still get rewritten.
+        if b == b'`' {
+            let start = i;
+            out.push(b as char);
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    // Push backslash + the escaped codepoint. The escaped
+                    // character may be multi-byte UTF-8, so step by its full
+                    // UTF-8 length rather than a fixed 2 bytes.
+                    out.push('\\');
+                    let escaped_start = i + 1;
+                    let mut escaped_end = escaped_start + 1;
+                    while escaped_end < len && !script.is_char_boundary(escaped_end) {
+                        escaped_end += 1;
+                    }
+                    out.push_str(&script[escaped_start..escaped_end]);
+                    i = escaped_end;
+                    continue;
+                }
+                if bytes[i] == b'`' {
+                    out.push('`');
+                    i += 1;
+                    break;
+                }
+                if bytes[i] == b'$' && i + 1 < len && bytes[i + 1] == b'{' {
+                    out.push_str("${");
+                    i += 2;
+                    let mut depth: i32 = 1;
+                    let placeholder_start = i;
+                    // Find matching `}` respecting nested braces / strings.
+                    while i < len && depth > 0 {
+                        let c = bytes[i];
+                        if c == b'\\' && i + 1 < len {
+                            i += 2;
+                            continue;
+                        }
+                        if c == b'"' || c == b'\'' {
+                            let q = c;
+                            i += 1;
+                            while i < len {
+                                if bytes[i] == b'\\' && i + 1 < len {
+                                    i += 2;
+                                    continue;
+                                }
+                                if bytes[i] == q {
+                                    i += 1;
+                                    break;
+                                }
+                                i += 1;
+                            }
+                            continue;
+                        }
+                        if c == b'`' {
+                            // Nested template literal — copy verbatim by
+                            // recursing through this loop on the slice.
+                            i += 1;
+                            let mut inner_depth: i32 = 0;
+                            while i < len {
+                                if bytes[i] == b'\\' && i + 1 < len {
+                                    i += 2;
+                                    continue;
+                                }
+                                if bytes[i] == b'$' && i + 1 < len && bytes[i + 1] == b'{' {
+                                    inner_depth += 1;
+                                    i += 2;
+                                    continue;
+                                }
+                                if bytes[i] == b'}' && inner_depth > 0 {
+                                    inner_depth -= 1;
+                                    i += 1;
+                                    continue;
+                                }
+                                if bytes[i] == b'`' && inner_depth == 0 {
+                                    i += 1;
+                                    break;
+                                }
+                                i += 1;
+                            }
+                            continue;
+                        }
+                        if c == b'{' {
+                            depth += 1;
+                        } else if c == b'}' {
+                            depth -= 1;
+                            if depth == 0 {
+                                break;
+                            }
+                        }
+                        i += 1;
+                    }
+                    let placeholder_end = i;
+                    let inner = &script[placeholder_start..placeholder_end];
+                    out.push_str(&wrap_derived_reads_in_script_inner_with_shadow(
+                        inner,
+                        &derived_names,
+                        &derived_var_names,
+                        &shadow_ranges,
+                        &declarator_lhs_positions,
+                        placeholder_start,
+                    ));
+                    if i < len && bytes[i] == b'}' {
+                        out.push('}');
+                        i += 1;
+                    }
+                    continue;
+                }
+                // Multi-byte UTF-8 safe step: byte-level `as char` would
+                // corrupt non-ASCII chars (e.g. 'é' bytes → "Ã©"). Slice the
+                // codepoint instead.
+                let mut next = i + 1;
+                while next < len && !script.is_char_boundary(next) {
+                    next += 1;
+                }
+                out.push_str(&script[i..next]);
+                i = next;
+            }
+            let _ = start;
+            continue;
+        }
+        // Identifier?
+        if (b.is_ascii_alphabetic() || b == b'_' || b == b'$') && !is_after_ident_char(bytes, i) {
+            let start = i;
+            while i < len {
+                let c = bytes[i];
+                if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            let name = &script[start..i];
+            let is_shadowed = shadow_ranges
+                .get(name)
+                .map(|ranges| ranges.iter().any(|&(s, e)| start >= s && start < e))
+                .unwrap_or(false);
+            let is_own_declarator_lhs = declarator_lhs_positions.contains(&start);
+            if !is_shadowed
+                && !is_own_declarator_lhs
+                && derived_names.contains(name)
+                && is_derived_read_position(bytes, start, i)
+            {
+                if is_object_shorthand_position(bytes, start, i) {
+                    // `{ foo }` — must expand to `{ foo: foo() }` not
+                    // `{ foo() }` (which would be invalid method shorthand).
+                    out.push_str(name);
+                    out.push_str(": ");
+                    out.push_str(name);
+                    if derived_var_names.contains(name) {
+                        out.push_str("?.()");
+                    } else {
+                        out.push_str("()");
+                    }
+                } else {
+                    out.push_str(name);
+                    if derived_var_names.contains(name) {
+                        out.push_str("?.()");
+                    } else {
+                        out.push_str("()");
+                    }
+                }
+            } else {
+                out.push_str(name);
+            }
+            continue;
+        }
+        // Step by UTF-8 codepoint so non-ASCII chars (string literals,
+        // comments) survive the round-trip. `b as char` would Latin-1-encode
+        // a continuation byte and double-encode the source.
+        let mut next = i + 1;
+        while next < len && !script.is_char_boundary(next) {
+            next += 1;
+        }
+        out.push_str(&script[i..next]);
+        i = next;
+    }
+    out
+}
+
+/// True when an identifier at byte range `[start, end)` is in object-literal
+/// shorthand position: preceded by `{` or `,` within an object literal, AND
+/// followed (after whitespace) by `,` or `}`.
+fn is_object_shorthand_position(bytes: &[u8], start: usize, end: usize) -> bool {
+    let len = bytes.len();
+    // Look forward: next non-whitespace must be `,` or `}`.
+    let mut k = end;
+    while k < len && bytes[k].is_ascii_whitespace() {
+        k += 1;
+    }
+    let next = bytes.get(k).copied();
+    if !matches!(next, Some(b',') | Some(b'}')) {
+        return false;
+    }
+    // Look backward: the immediately preceding non-whitespace must be `{`
+    // or `,` (a property separator within an object).
+    let mut j = start;
+    while j > 0 && bytes[j - 1].is_ascii_whitespace() {
+        j -= 1;
+    }
+    if j == 0 {
+        return false;
+    }
+    let prev = bytes[j - 1];
+    if prev != b'{' && prev != b',' {
+        return false;
+    }
+    // If preceded by `,`, walk further back to find the enclosing `{` and
+    // ensure we're inside an object literal context (not arg list, array, or
+    // block). We walk back over commas/identifiers/property-pairs at depth 0.
+    //
+    // Note: the depth-0 `{` check has to run BEFORE the `p == 0` short-circuit
+    // so that an enclosing `{` sitting at byte 0 is still recognised — without
+    // this, `{ doubled }` at the start of an expression slice (e.g. inside a
+    // snippet-arg call) was wrongly classified as not-shorthand.
+    let mut p = j - 1;
+    let mut depth_paren = 0i32;
+    let mut depth_brace = 0i32;
+    let mut depth_bracket = 0i32;
+    loop {
+        let c = bytes[p];
+        if c == b'}' {
+            depth_brace += 1;
+        } else if c == b'{' {
+            if depth_brace == 0 && depth_paren == 0 && depth_bracket == 0 {
+                break;
+            }
+            depth_brace -= 1;
+        } else if c == b')' {
+            depth_paren += 1;
+        } else if c == b'(' {
+            // Unbalanced ( — we walked too far; not an object literal.
+            if depth_paren == 0 {
+                return false;
+            }
+            depth_paren -= 1;
+        } else if c == b']' {
+            depth_bracket += 1;
+        } else if c == b'[' {
+            if depth_bracket == 0 {
+                return false;
+            }
+            depth_bracket -= 1;
+        }
+        if p == 0 {
+            return false;
+        }
+        p -= 1;
+    }
+    // `p` now points to the opening `{`. Look at what precedes — that
+    // determines whether it's an object literal vs a block.
+    let mut q = p;
+    while q > 0 && bytes[q - 1].is_ascii_whitespace() {
+        q -= 1;
+    }
+    if q == 0 {
+        // Bare `{` at start of input — treat as expression / object literal.
+        return true;
+    }
+    let pc = bytes[q - 1];
+    // Object literal contexts: `(`, `[`, `,`, `=`, `?`, `:`, `<`, `>`,
+    // operators (`+`, `-`, `*`, `/`, `%`, `!`, `&`, `|`, `^`, `~`), or
+    // after `return`, `await`, `yield`, `throw`, `in`, `of`, `new`,
+    // `typeof`, `void`, `delete`.
+    if matches!(
+        pc,
+        b'(' | b'['
+            | b','
+            | b'='
+            | b'?'
+            | b':'
+            | b'<'
+            | b'>'
+            | b'+'
+            | b'-'
+            | b'*'
+            | b'/'
+            | b'%'
+            | b'!'
+            | b'&'
+            | b'|'
+            | b'^'
+            | b'~'
+            | b'.'
+            | b';'
+    ) {
+        return true;
+    }
+    // Spread `...` precedes object literal: `f(...{a: 1})`. Detect three
+    // dots immediately preceding.
+    if pc == b'.' {
+        return true;
+    }
+    // After an identifier — could be `return obj` or `await obj`. Check
+    // for object-literal-introducing keywords.
+    if pc.is_ascii_alphabetic() || pc == b'_' || pc == b'$' {
+        // Walk back to read the keyword.
+        let mut r = q;
+        while r > 0 {
+            let cc = bytes[r - 1];
+            if cc.is_ascii_alphanumeric() || cc == b'_' || cc == b'$' {
+                r -= 1;
+            } else {
+                break;
+            }
+        }
+        let kw = std::str::from_utf8(&bytes[r..q]).unwrap_or("");
+        return matches!(
+            kw,
+            "return"
+                | "await"
+                | "yield"
+                | "throw"
+                | "in"
+                | "of"
+                | "new"
+                | "typeof"
+                | "void"
+                | "delete"
+        );
+    }
+    false
+}
+
+/// Wrap derived reads in a template-source expression using a pre-collected
+/// name set (from the Phase 2 analysis).
+pub(crate) fn wrap_derived_reads_for_template(
+    expr: &str,
+    derived_names: &rustc_hash::FxHashSet<String>,
+    derived_var_names: &rustc_hash::FxHashSet<String>,
+) -> String {
+    if derived_names.is_empty() {
+        return expr.to_string();
+    }
+    let out = wrap_derived_reads_in_script_inner(expr, derived_names, derived_var_names);
+    if std::env::var("DEBUG_WRAP").is_ok() {
+        eprintln!(
+            "DEBUG_WRAP: in={:?} names={:?} out={:?}",
+            expr, derived_names, out
+        );
+    }
+    out
+}
+
+/// Recursive helper for placeholder bodies that doesn't re-collect names.
+/// Same as `wrap_derived_reads_in_script_inner` but with the outer
+/// `shadow_ranges` / declarator-LHS positions threaded through, so we don't
+/// re-wrap names that are shadowed by inner parameters / declarations.
+/// The `outer_offset` is the byte offset of `script` within the full source
+/// — every byte position we compare against `shadow_ranges` and
+/// `declarator_lhs_positions` gets translated by adding this offset.
+fn wrap_derived_reads_in_script_inner_with_shadow(
+    script: &str,
+    derived_names: &rustc_hash::FxHashSet<String>,
+    derived_var_names: &rustc_hash::FxHashSet<String>,
+    shadow_ranges: &rustc_hash::FxHashMap<String, Vec<(usize, usize)>>,
+    declarator_lhs_positions: &rustc_hash::FxHashSet<usize>,
+    outer_offset: usize,
+) -> String {
+    let bytes = script.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(script.len() + 4);
+    let mut i = 0;
+    while i < len {
+        let b = bytes[i];
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+            let s = i;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            out.push_str(&script[s..i]);
+            continue;
+        }
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+            let s = i;
+            i += 2;
+            while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < len {
+                i += 2;
+            }
+            out.push_str(&script[s..i]);
+            continue;
+        }
+        if b == b'"' || b == b'\'' {
+            let quote = b;
+            let s = i;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            out.push_str(&script[s..i]);
+            continue;
+        }
+        if (b.is_ascii_alphabetic() || b == b'_' || b == b'$') && !is_after_ident_char(bytes, i) {
+            let start = i;
+            while i < len {
+                let c = bytes[i];
+                if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            let name = &script[start..i];
+            let absolute_start = start + outer_offset;
+            let is_shadowed = shadow_ranges
+                .get(name)
+                .map(|ranges| {
+                    ranges
+                        .iter()
+                        .any(|&(s, e)| absolute_start >= s && absolute_start < e)
+                })
+                .unwrap_or(false);
+            let is_own_declarator_lhs = declarator_lhs_positions.contains(&absolute_start);
+            if !is_shadowed
+                && !is_own_declarator_lhs
+                && derived_names.contains(name)
+                && is_derived_read_position(bytes, start, i)
+            {
+                if is_object_shorthand_position(bytes, start, i) {
+                    out.push_str(name);
+                    out.push_str(": ");
+                    out.push_str(name);
+                    if derived_var_names.contains(name) {
+                        out.push_str("?.()");
+                    } else {
+                        out.push_str("()");
+                    }
+                } else {
+                    out.push_str(name);
+                    if derived_var_names.contains(name) {
+                        out.push_str("?.()");
+                    } else {
+                        out.push_str("()");
+                    }
+                }
+            } else {
+                out.push_str(name);
+            }
+            continue;
+        }
+        // UTF-8 safe step. See `wrap_derived_reads_in_script`.
+        let mut next = i + 1;
+        while next < len && !script.is_char_boundary(next) {
+            next += 1;
+        }
+        out.push_str(&script[i..next]);
+        i = next;
+    }
+    out
+}
+
+fn wrap_derived_reads_in_script_inner(
+    script: &str,
+    derived_names: &rustc_hash::FxHashSet<String>,
+    derived_var_names: &rustc_hash::FxHashSet<String>,
+) -> String {
+    let bytes = script.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(script.len() + 4);
+    let mut i = 0;
+    while i < len {
+        let b = bytes[i];
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+            let start = i;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            out.push_str(&script[start..i]);
+            continue;
+        }
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+            let start = i;
+            i += 2;
+            while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < len {
+                i += 2;
+            }
+            out.push_str(&script[start..i]);
+            continue;
+        }
+        if b == b'"' || b == b'\'' {
+            let quote = b;
+            let start = i;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            out.push_str(&script[start..i]);
+            continue;
+        }
+        if (b.is_ascii_alphabetic() || b == b'_' || b == b'$') && !is_after_ident_char(bytes, i) {
+            let start = i;
+            while i < len {
+                let c = bytes[i];
+                if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            let name = &script[start..i];
+            if derived_names.contains(name) && is_derived_read_position(bytes, start, i) {
+                if is_object_shorthand_position(bytes, start, i) {
+                    out.push_str(name);
+                    out.push_str(": ");
+                    out.push_str(name);
+                    if derived_var_names.contains(name) {
+                        out.push_str("?.()");
+                    } else {
+                        out.push_str("()");
+                    }
+                } else {
+                    out.push_str(name);
+                    if derived_var_names.contains(name) {
+                        out.push_str("?.()");
+                    } else {
+                        out.push_str("()");
+                    }
+                }
+            } else {
+                out.push_str(name);
+            }
+            continue;
+        }
+        // UTF-8 safe step. See `wrap_derived_reads_in_script`.
+        let mut next = i + 1;
+        while next < len && !script.is_char_boundary(next) {
+            next += 1;
+        }
+        out.push_str(&script[i..next]);
+        i = next;
+    }
+    out
+}
+
+fn is_after_ident_char(bytes: &[u8], i: usize) -> bool {
+    if i == 0 {
+        return false;
+    }
+    let c = bytes[i - 1];
+    c.is_ascii_alphanumeric() || c == b'_' || c == b'$'
+}
+
+/// Decide whether the identifier at `bytes[start..end]` is a *read* of a
+/// derived binding (so it should be rewritten to `name()`).
+fn is_derived_read_position(bytes: &[u8], start: usize, end: usize) -> bool {
+    // The identifier already passes `!is_after_ident_char`, but we still
+    // need to reject `obj.foo` (member access) and a number of declaration
+    // / shorthand-property positions.
+    let prev_non_ws_idx = (0..start).rev().find(|&i| !bytes[i].is_ascii_whitespace());
+    let prev_non_ws = prev_non_ws_idx.map(|i| bytes[i]);
+    if matches!(prev_non_ws, Some(b'.')) {
+        // `obj.foo` / `obj?.foo` is member access — skip. But `...foo` is
+        // a spread / rest operator, and `foo` *is* a read in that case.
+        // Detect spread by looking at the two bytes before `.`.
+        if let Some(dot_idx) = prev_non_ws_idx
+            && dot_idx >= 2
+            && bytes[dot_idx - 1] == b'.'
+            && bytes[dot_idx - 2] == b'.'
+        {
+            // `...foo` — fall through to wrap.
+        } else {
+            return false;
+        }
+    }
+    // Declaration / function name positions: `let foo`, `const foo`,
+    // `var foo`, `function foo`, `class foo`. Look back for the keyword.
+    if let Some(b) = prev_non_ws {
+        // Skip if previous token is one of these keywords.
+        let kw_end = (0..start)
+            .rev()
+            .find(|&i| !bytes[i].is_ascii_whitespace())
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let _ = b;
+        for kw in [
+            &b"let"[..],
+            &b"const"[..],
+            &b"var"[..],
+            &b"function"[..],
+            &b"class"[..],
+        ] {
+            if kw_end >= kw.len() && bytes[kw_end - kw.len()..kw_end] == *kw {
+                // Word boundary check on the left side.
+                if kw_end == kw.len()
+                    || !{
+                        let pc = bytes[kw_end - kw.len() - 1];
+                        pc.is_ascii_alphanumeric() || pc == b'_' || pc == b'$'
+                    }
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    // What follows the identifier?
+    let next_non_ws = (end..bytes.len())
+        .find(|&i| !bytes[i].is_ascii_whitespace())
+        .map(|i| bytes[i]);
+    match next_non_ws {
+        // Already a call: `foo(` — leave it.
+        Some(b'(') => false,
+        // Property shorthand or object key: `{ foo: ... }` / `{ foo,` /
+        // `{ foo }`. Detect by scanning back to the nearest `{` and ensuring
+        // it's not a block context (e.g. `({ foo: ... })` in a return).
+        Some(b':') => {
+            // Only treat as a key if we're at the top of an object literal.
+            // Heuristic: look back for `,` or `{` skipping whitespace; if we
+            // hit `{`, this is a property key. If we hit `(`, `[`, or
+            // operators / `?` / etc., it's a ternary / labelled statement
+            // and we should rewrite.
+            let mut j = start;
+            let mut depth_paren: i32 = 0;
+            let mut depth_brace: i32 = 0;
+            let mut depth_bracket: i32 = 0;
+            while j > 0 {
+                j -= 1;
+                let c = bytes[j];
+                if c.is_ascii_whitespace() {
+                    continue;
+                }
+                if c == b')' {
+                    depth_paren += 1;
+                    continue;
+                }
+                if c == b'(' {
+                    if depth_paren == 0 {
+                        // Function call / parenthesized expression context.
+                        return true;
+                    }
+                    depth_paren -= 1;
+                    continue;
+                }
+                if c == b']' {
+                    depth_bracket += 1;
+                    continue;
+                }
+                if c == b'[' {
+                    if depth_bracket == 0 {
+                        return true;
+                    }
+                    depth_bracket -= 1;
+                    continue;
+                }
+                if c == b'}' {
+                    depth_brace += 1;
+                    continue;
+                }
+                if c == b'{' {
+                    if depth_brace == 0 {
+                        // It's a property key.
+                        return false;
+                    }
+                    depth_brace -= 1;
+                    continue;
+                }
+                if c == b',' && depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 {
+                    // Comma at this nesting level — could be inside an object
+                    // literal `{ a, foo: ... }`. Continue scanning back.
+                    continue;
+                }
+                if c == b'?' && depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 {
+                    // Ternary: `cond ? foo : bar` — rewrite.
+                    return true;
+                }
+                // Default: keep scanning.
+            }
+            // Hit start of file — treat as label, do not rewrite.
+            false
+        }
+        _ => true,
+    }
+}
+
+/// For each name in `names`, find byte ranges in `script` where that name is
+/// shadowed by a nested `let|const|var|function|class IDENT` declaration or
+/// by a function parameter list. Returns a map `name -> Vec<(start, end)>`.
+///
+/// This is a coarse, brace-counting approximation of lexical scope. It
+/// catches the common cases that drive the upstream test suite (e.g.
+/// `let x = $derived(...)` then `function foo() { let x = $state(0); ... x ... }`)
+/// without doing a full scope analysis.
+fn compute_shadow_ranges(
+    script: &str,
+    names: &rustc_hash::FxHashSet<String>,
+    derived_declarators: &[(usize, usize, String)],
+) -> rustc_hash::FxHashMap<String, Vec<(usize, usize)>> {
+    let mut ranges: rustc_hash::FxHashMap<String, Vec<(usize, usize)>> =
+        rustc_hash::FxHashMap::default();
+    let bytes = script.as_bytes();
+    let len = bytes.len();
+    if len == 0 || names.is_empty() {
+        return ranges;
+    }
+    // Positions of derived identifier declarations — when scanning `let X`
+    // declarators we skip these (they are the deriveds themselves, not
+    // shadow declarations).
+    let derived_positions: rustc_hash::FxHashSet<usize> =
+        derived_declarators.iter().map(|(s, _, _)| *s).collect();
+    // Brace-tracking state: for each `{` we push the brace's index and a
+    // set of names declared in *that* block. When `}` closes the block, we
+    // pop the frame and add a range for every name declared.
+    #[derive(Default)]
+    struct Frame {
+        open: usize,
+        // Names declared in this block.
+        declared: Vec<String>,
+    }
+    let mut stack: Vec<Frame> = Vec::new();
+    // Helper to add a declared name + a range that runs from the next
+    // statement until the closing brace. The range start is the position
+    // *after* the declaration's identifier (so the declaration itself
+    // doesn't get wrapped, while subsequent reads inside the block do).
+    let mut i = 0;
+    // Track whether the most recent non-whitespace, non-comment token is
+    // one that should be followed by parameter list / declaration. Used
+    // for detecting `function NAME(...)`, `(IDENT) => ...`, etc.
+    let mut saw_function_kw = false;
+
+    while i < len {
+        let b = bytes[i];
+        // Skip comments.
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < len {
+                i += 2;
+            }
+            continue;
+        }
+        // Skip string literals.
+        if b == b'"' || b == b'\'' {
+            let q = b;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == q {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        // Skip template literals (but track `${...}` placeholders by treating
+        // them as nested code regions — we still want to find shadow decls
+        // inside placeholders).
+        if b == b'`' {
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == b'`' {
+                    i += 1;
+                    break;
+                }
+                if bytes[i] == b'$' && i + 1 < len && bytes[i + 1] == b'{' {
+                    // Step into the placeholder by treating `{` as a brace
+                    // we'll see in the outer loop.
+                    i += 2;
+                    stack.push(Frame {
+                        open: i,
+                        declared: Vec::new(),
+                    });
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        if b == b'{' {
+            stack.push(Frame {
+                open: i,
+                declared: Vec::new(),
+            });
+            i += 1;
+            continue;
+        }
+        if b == b'}' {
+            if let Some(frame) = stack.pop() {
+                for name in &frame.declared {
+                    ranges
+                        .entry(name.clone())
+                        .or_default()
+                        .push((frame.open, i));
+                }
+            }
+            i += 1;
+            continue;
+        }
+        // Detect declaration keywords and arrow params.
+        // `let`/`const`/`var`: read identifier after.
+        if (b.is_ascii_alphabetic() || b == b'_' || b == b'$') && !is_after_ident_char(bytes, i) {
+            let id_start = i;
+            while i < len {
+                let c = bytes[i];
+                if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            let id = &script[id_start..i];
+            // Handle `let`/`const`/`var` — collect every identifier in the
+            // declarator list until we hit a top-level `;` or `=` at depth 0.
+            if id == "let" || id == "const" || id == "var" {
+                // Just read the declarator names + their positions, but
+                // don't advance `i` past the value RHS — we need to keep
+                // scanning inside (`$derived(() => { ... })` may contain
+                // nested declarations that themselves shadow names).
+                let decl_start = i;
+                // Find the end of the declarator pattern (up to the first
+                // top-level `=` or `;`/`,`). We only need the LHS patterns.
+                let mut depth_paren = 0i32;
+                let mut depth_bracket = 0i32;
+                let mut depth_brace_inline = 0i32;
+                let mut j = decl_start;
+                while j < len {
+                    let cc = bytes[j];
+                    if cc == b'"' || cc == b'\'' {
+                        let q = cc;
+                        j += 1;
+                        while j < len {
+                            if bytes[j] == b'\\' && j + 1 < len {
+                                j += 2;
+                                continue;
+                            }
+                            if bytes[j] == q {
+                                j += 1;
+                                break;
+                            }
+                            j += 1;
+                        }
+                        continue;
+                    }
+                    match cc {
+                        b'(' => depth_paren += 1,
+                        b')' => depth_paren -= 1,
+                        b'[' => depth_bracket += 1,
+                        b']' => depth_bracket -= 1,
+                        b'{' => depth_brace_inline += 1,
+                        b'}' => {
+                            if depth_brace_inline == 0 {
+                                break;
+                            }
+                            depth_brace_inline -= 1;
+                        }
+                        b';' if depth_paren == 0
+                            && depth_bracket == 0
+                            && depth_brace_inline == 0 =>
+                        {
+                            break;
+                        }
+                        // Stop at top-level `=` — everything after is the
+                        // value expression, which we'll keep scanning.
+                        b'=' if depth_paren == 0
+                            && depth_bracket == 0
+                            && depth_brace_inline == 0 =>
+                        {
+                            // Check this isn't `==` / `===` — but at depth 0
+                            // inside a declarator, `=` is always assignment.
+                            break;
+                        }
+                        _ => {}
+                    }
+                    j += 1;
+                }
+                let decl_text = &script[decl_start..j];
+                for (rel_start, n) in extract_declarator_names_with_pos(decl_text) {
+                    let abs_start = decl_start + rel_start;
+                    // Skip the derived's own declaration — references to
+                    // the derived inside the enclosing block should still
+                    // wrap.
+                    if derived_positions.contains(&abs_start) {
+                        continue;
+                    }
+                    if names.contains(&n)
+                        && let Some(top) = stack.last_mut()
+                    {
+                        top.declared.push(n);
+                    }
+                }
+                // Continue scanning from `j` (the `=` or `;` position) so
+                // the value expression (which may contain nested
+                // declarations / arrow bodies) gets scanned normally.
+                i = j;
+                continue;
+            }
+            // Function declaration: `function NAME(params) { ... }` —
+            // NAME is declared in the *enclosing* scope, params in the
+            // function body scope. We'll catch params when we enter the
+            // body's `{`.
+            if id == "function" {
+                saw_function_kw = true;
+                continue;
+            }
+            // Class declaration: `class NAME { ... }` — NAME in enclosing scope.
+            if id == "class" {
+                // Read NAME if present.
+                let mut j = i;
+                while j < len && bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                if j < len
+                    && (bytes[j].is_ascii_alphabetic() || bytes[j] == b'_' || bytes[j] == b'$')
+                {
+                    let ns = j;
+                    while j < len {
+                        let cc = bytes[j];
+                        if cc.is_ascii_alphanumeric() || cc == b'_' || cc == b'$' {
+                            j += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    let n = &script[ns..j];
+                    if names.contains(n)
+                        && let Some(top) = stack.last_mut()
+                    {
+                        top.declared.push(n.to_string());
+                    }
+                }
+                i = j;
+                continue;
+            }
+            if saw_function_kw {
+                // Identifier right after `function` is the function name —
+                // declared in enclosing scope.
+                if names.contains(id)
+                    && let Some(top) = stack.last_mut()
+                {
+                    top.declared.push(id.to_string());
+                }
+                saw_function_kw = false;
+                continue;
+            }
+            // Otherwise, normal identifier — ignore.
+            saw_function_kw = false;
+            continue;
+        }
+        // Arrow function detection: when we see `(`, *peek* ahead to find
+        // the matching `)` and check if `=>` follows. If yes, treat the
+        // body's brace as a shadowing scope. Crucially, we do NOT consume
+        // the body — we let the normal brace scanner descend into it so
+        // nested declarations get tracked.
+        if b == b'(' {
+            let open = i;
+            let mut peek = i + 1;
+            let mut depth = 1i32;
+            let param_text_start = peek;
+            while peek < len && depth > 0 {
+                let cc = bytes[peek];
+                if cc == b'"' || cc == b'\'' {
+                    let q = cc;
+                    peek += 1;
+                    while peek < len {
+                        if bytes[peek] == b'\\' && peek + 1 < len {
+                            peek += 2;
+                            continue;
+                        }
+                        if bytes[peek] == q {
+                            peek += 1;
+                            break;
+                        }
+                        peek += 1;
+                    }
+                    continue;
+                }
+                if cc == b'`' {
+                    peek += 1;
+                    while peek < len {
+                        if bytes[peek] == b'\\' && peek + 1 < len {
+                            peek += 2;
+                            continue;
+                        }
+                        if bytes[peek] == b'`' {
+                            peek += 1;
+                            break;
+                        }
+                        peek += 1;
+                    }
+                    continue;
+                }
+                if cc == b'(' {
+                    depth += 1;
+                } else if cc == b')' {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                peek += 1;
+            }
+            let param_text_end = peek;
+            let after_paren = peek + 1; // past `)`
+            // Look for `=>` after closing paren.
+            let mut k = after_paren;
+            while k < len && bytes[k].is_ascii_whitespace() {
+                k += 1;
+            }
+            let is_arrow = k + 1 < len && bytes[k] == b'=' && bytes[k + 1] == b'>';
+            // Detect `function NAME(params) { ... }` / `function (params) { ... }`
+            // / `function* NAME(params) { ... }`. The opening paren may also be
+            // for a method definition: `foo(params) { ... }` inside an object /
+            // class body. In either case, the `{` directly following the `)`
+            // opens a new scope and the params shadow.
+            let is_fn_like_body = !is_arrow && k < len && bytes[k] == b'{' && {
+                // Walk back from `open` (the `(`), skipping whitespace, to find
+                // the function keyword or method name. We only treat this as a
+                // function-body open when:
+                //   - the token immediately before is `function` (possibly
+                //     followed by a `*` and a name), OR
+                //   - the token immediately before is an identifier *and*
+                //     preceded by `function`, OR
+                //   - the prev token is an identifier (method shorthand). To
+                //     avoid false positives on `if(...){`, `for(...){`,
+                //     `while(...){`, `switch(...){`, `catch(...){`, we
+                //     blacklist those keywords.
+                let mut p = open;
+                while p > 0 && bytes[p - 1].is_ascii_whitespace() {
+                    p -= 1;
+                }
+                let prev_end = p;
+                while p > 0 {
+                    let cc = bytes[p - 1];
+                    if cc.is_ascii_alphanumeric() || cc == b'_' || cc == b'$' {
+                        p -= 1;
+                    } else {
+                        break;
+                    }
+                }
+                if p == prev_end {
+                    false
+                } else {
+                    let prev_ident = &script[p..prev_end];
+                    !matches!(
+                        prev_ident,
+                        "if" | "for"
+                            | "while"
+                            | "switch"
+                            | "catch"
+                            | "with"
+                            | "do"
+                            | "return"
+                            | "typeof"
+                            | "void"
+                            | "delete"
+                            | "new"
+                            | "in"
+                            | "of"
+                            | "await"
+                            | "yield"
+                            | "throw"
+                    )
+                }
+            };
+            if is_arrow || is_fn_like_body {
+                let param_text = if param_text_end > param_text_start {
+                    &script[param_text_start..param_text_end]
+                } else {
+                    ""
+                };
+                let mut params = extract_param_names(param_text);
+                params.retain(|n| names.contains(n));
+                let mut m = if is_arrow { k + 2 } else { k }; // past `=>` or at `{`
+                while m < len && bytes[m].is_ascii_whitespace() {
+                    m += 1;
+                }
+                if m < len && bytes[m] == b'{' {
+                    // Push a frame for the body, pre-populated with params.
+                    // Advance `i` to *just past* the body `{` so brace
+                    // tracking is consistent.
+                    stack.push(Frame {
+                        open: m,
+                        declared: params,
+                    });
+                    i = m + 1;
+                    continue;
+                } else if is_arrow {
+                    // Single-expression arrow. Find end of expression by
+                    // a coarse scan, then record param shadow range.
+                    let mut depth_p = 0i32;
+                    let mut depth_b = 0i32;
+                    let mut e = m;
+                    while e < len {
+                        let cc = bytes[e];
+                        if cc == b'(' {
+                            depth_p += 1;
+                        } else if cc == b')' {
+                            if depth_p == 0 {
+                                break;
+                            }
+                            depth_p -= 1;
+                        } else if cc == b'[' {
+                            depth_b += 1;
+                        } else if cc == b']' {
+                            if depth_b == 0 {
+                                break;
+                            }
+                            depth_b -= 1;
+                        } else if (cc == b',' || cc == b';') && depth_p == 0 && depth_b == 0 {
+                            break;
+                        }
+                        e += 1;
+                    }
+                    for n in params {
+                        ranges.entry(n).or_default().push((m, e));
+                    }
+                    i = m;
+                    continue;
+                }
+            }
+            // Not an arrow — step past the `(` and keep scanning so
+            // inner braces / decls get tracked.
+            let _ = open;
+            i += 1;
+            continue;
+        }
+        saw_function_kw = false;
+        i += 1;
+    }
+    ranges
+}
+
+/// Same as `extract_declarator_names` but also returns the byte offset of
+/// each identifier within `decl`.
+fn extract_declarator_names_with_pos(decl: &str) -> Vec<(usize, String)> {
+    let bytes = decl.as_bytes();
+    let len = bytes.len();
+    let mut out: Vec<(usize, String)> = Vec::new();
+    let mut i = 0;
+    let mut depth_paren = 0i32;
+    let mut depth_bracket = 0i32;
+    let mut depth_brace = 0i32;
+    let mut after_eq_at_top = false;
+    while i < len {
+        let b = bytes[i];
+        match b {
+            b'"' | b'\'' => {
+                let q = b;
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\\' && i + 1 < len {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == q {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+            b'`' => {
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\\' && i + 1 < len {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == b'`' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+            b'(' => depth_paren += 1,
+            b')' => depth_paren -= 1,
+            b'[' => depth_bracket += 1,
+            b']' => depth_bracket -= 1,
+            b'{' => depth_brace += 1,
+            b'}' => depth_brace -= 1,
+            b',' if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 => {
+                after_eq_at_top = false;
+                i += 1;
+                continue;
+            }
+            b'=' if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 => {
+                after_eq_at_top = true;
+                i += 1;
+                continue;
+            }
+            _ => {}
+        }
+        if !after_eq_at_top
+            && (b.is_ascii_alphabetic() || b == b'_' || b == b'$')
+            && !is_after_ident_char(bytes, i)
+        {
+            let s = i;
+            while i < len {
+                let c = bytes[i];
+                if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            let name = &decl[s..i];
+            out.push((s, name.to_string()));
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+fn extract_declarator_names(decl: &str) -> Vec<String> {
+    // Extract identifier names from a declarator list like ` x, y = 1, { a, b: c }`.
+    // We respect bracket/paren nesting and only emit names at top level.
+    let bytes = decl.as_bytes();
+    let len = bytes.len();
+    let mut names: Vec<String> = Vec::new();
+    let mut i = 0;
+    let mut depth_paren = 0i32;
+    let mut depth_bracket = 0i32;
+    let mut depth_brace = 0i32;
+    let mut after_eq_at_top = false;
+    while i < len {
+        let b = bytes[i];
+        match b {
+            b'"' | b'\'' => {
+                let q = b;
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\\' && i + 1 < len {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == q {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+            b'`' => {
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\\' && i + 1 < len {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == b'`' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+            b'(' => {
+                depth_paren += 1;
+            }
+            b')' => {
+                depth_paren -= 1;
+            }
+            b'[' => {
+                depth_bracket += 1;
+            }
+            b']' => {
+                depth_bracket -= 1;
+            }
+            b'{' => {
+                depth_brace += 1;
+            }
+            b'}' => {
+                depth_brace -= 1;
+            }
+            b',' if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 => {
+                after_eq_at_top = false;
+                i += 1;
+                continue;
+            }
+            b'=' if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 => {
+                // Equals at top level — skip the value until the next top-level `,`.
+                after_eq_at_top = true;
+                i += 1;
+                continue;
+            }
+            _ => {}
+        }
+        // Read identifier if at the right depth and not after `=` at top level.
+        if !after_eq_at_top
+            && (b.is_ascii_alphabetic() || b == b'_' || b == b'$')
+            && !is_after_ident_char(bytes, i)
+        {
+            let s = i;
+            while i < len {
+                let c = bytes[i];
+                if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            // Inside `{ a, b: c }` patterns, after `:` is the renaming target
+            // (the actual binding). Both `a` (shorthand) and `c` (renamed
+            // target) bind. For our purposes we treat any identifier reached
+            // here as a potential binding.
+            let name = &decl[s..i];
+            names.push(name.to_string());
+            continue;
+        }
+        i += 1;
+    }
+    names
+}
+
+fn extract_param_names(params: &str) -> Vec<String> {
+    // Identical lexical structure to a declarator list (well, mostly).
+    extract_declarator_names(params)
+}
+
+/// Expand destructured `$derived(...)` / `$derived.by(...)` declarations into
+/// per-leaf `$.derived(...)` declarators, mirroring upstream's `extract_paths`
+/// pass in `VariableDeclaration.js` (Svelte 5.52+).
+///
+/// Examples:
+///   `let { foo, bar: [a, b] } = $derived(stuff)`
+/// becomes:
+///   `let $$derived_array = $.derived(() => $.to_array(stuff.bar, 2)),
+///        foo = $.derived(() => stuff.foo),
+///        a = $.derived(() => $$derived_array[0]),
+///        b = $.derived(() => $$derived_array[1])`
+///
+/// The post-pass `wrap_derived_reads_in_script` then converts
+/// `$$derived_array[0]` to `$$derived_array()[0]`.
+///
+/// When the rune is plain `$derived` *and* the argument is a bare identifier,
+/// upstream skips the intermediate `$$d` declarator and inlines the identifier
+/// directly in each path expression (matches the
+/// `derived-destructured` / `derived-rest-includes-symbol` fixtures).
+fn expand_destructured_derived(script: &str) -> String {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    // Counter for generating unique `$$derived_array` / `$$d` names across
+    // the whole script. We don't try to be clever about scoping — there are
+    // no nested destructured deriveds in the test corpus.
+    static DERIVED_ARRAY_COUNTER: AtomicUsize = AtomicUsize::new(0);
+    static D_COUNTER: AtomicUsize = AtomicUsize::new(0);
+    DERIVED_ARRAY_COUNTER.store(0, Ordering::Relaxed);
+    D_COUNTER.store(0, Ordering::Relaxed);
+
+    let mut result = String::with_capacity(script.len());
+    let bytes = script.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    // Push the codepoint starting at byte `i` and return the byte length we
+    // advanced. We can't `bytes[i] as char`: that interprets a single UTF-8
+    // continuation byte as a Latin-1 code point and corrupts multi-byte chars
+    // (e.g. 'é' = 0xC3 0xA9 → "Ã©"). Step by UTF-8 char boundary instead.
+    let push_char = |result: &mut String, i: usize| -> usize {
+        let mut end = i + 1;
+        while end < len && !script.is_char_boundary(end) {
+            end += 1;
+        }
+        result.push_str(&script[i..end]);
+        end - i
+    };
+
+    while i < len {
+        // Try to match `let|var|const`  WS  PATTERN  WS  `=`  WS  `$derived(`/`$derived.by(`
+        //
+        // Use byte slicing — the source can contain multi-byte UTF-8 (e.g.
+        // identifiers / string literals with accented chars), so string
+        // slicing here will panic on a char-boundary mismatch even though we
+        // only ever care about ASCII keywords.
+        let keyword_len = if i + 4 <= len
+            && &bytes[i..i + 3] == b"let"
+            && is_word_boundary(bytes, i, i + 3)
+        {
+            Some(3usize)
+        } else if i + 6 <= len && &bytes[i..i + 5] == b"const" && is_word_boundary(bytes, i, i + 5)
+        {
+            Some(5)
+        } else if i + 4 <= len && &bytes[i..i + 3] == b"var" && is_word_boundary(bytes, i, i + 3) {
+            Some(3)
+        } else {
+            None
+        };
+        let Some(kw_len) = keyword_len else {
+            i += push_char(&mut result, i);
+            continue;
+        };
+        // Word boundary on left: must be at start, or preceded by
+        // non-identifier char.
+        if i > 0 {
+            let prev = bytes[i - 1];
+            if prev.is_ascii_alphanumeric() || prev == b'_' || prev == b'$' {
+                i += push_char(&mut result, i);
+                continue;
+            }
+        }
+        let kw_end = i + kw_len;
+        // Skip whitespace
+        let mut p = kw_end;
+        while p < len && (bytes[p] == b' ' || bytes[p] == b'\t') {
+            p += 1;
+        }
+        // Expect '{' or '[' for a destructure pattern
+        if p >= len || (bytes[p] != b'{' && bytes[p] != b'[') {
+            i += push_char(&mut result, i);
+            continue;
+        }
+        let pattern_start = p;
+        let open = bytes[p];
+        let close = if open == b'{' { b'}' } else { b']' };
+        let Some(pattern_end) = find_matching_bracket(bytes, pattern_start + 1, open, close) else {
+            i += push_char(&mut result, i);
+            continue;
+        };
+        // After the pattern, expect optional whitespace, then `=`, then `$derived(` / `$derived.by(`.
+        let mut q = pattern_end + 1;
+        while q < len && (bytes[q] == b' ' || bytes[q] == b'\t' || bytes[q] == b'\n') {
+            q += 1;
+        }
+        if q >= len || bytes[q] != b'=' {
+            i += push_char(&mut result, i);
+            continue;
+        }
+        // Reject `==` / `=>`
+        if q + 1 < len && (bytes[q + 1] == b'=' || bytes[q + 1] == b'>') {
+            i += push_char(&mut result, i);
+            continue;
+        }
+        q += 1;
+        while q < len && (bytes[q] == b' ' || bytes[q] == b'\t' || bytes[q] == b'\n') {
+            q += 1;
+        }
+        // Match `$derived(` or `$derived.by(`
+        let (is_by, rhs_start) = if q + 12 <= len && &script[q..q + 12] == "$derived.by(" {
+            (true, q + 12)
+        } else if q + 9 <= len && &script[q..q + 9] == "$derived(" {
+            (false, q + 9)
+        } else {
+            i += push_char(&mut result, i);
+            continue;
+        };
+        // Word boundary before `$derived` — must not be an identifier char.
+        // (We already know it's preceded by `=` and whitespace, so this is
+        // mostly defensive.)
+        let Some(close_paren_offset) = find_matching_paren_for_state(&script[rhs_start..]) else {
+            i += push_char(&mut result, i);
+            continue;
+        };
+        let rhs_end = rhs_start + close_paren_offset;
+        let arg_expr = script[rhs_start..rhs_end].trim();
+        // Drop trailing comma like upstream's call-arg cleanup.
+        let arg_expr = arg_expr.trim_end_matches(',').trim();
+
+        // Build the replacement. First, figure out the base RHS we use in
+        // each path expression. Upstream:
+        //   - For `$derived(IDENT)`, base = `IDENT`, no `$$d` declarator.
+        //   - Else, generate `$$d` declarator, base = `$$d` (which becomes
+        //     `$$d()` after wrap_derived_reads_in_script).
+        let mut decls: Vec<(String, String)> = Vec::new(); // (lhs, rhs)
+        let arg_is_ident = is_plain_identifier(arg_expr);
+        let base_expr = if !is_by && arg_is_ident {
+            arg_expr.to_string()
+        } else {
+            let n = D_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let name = if n == 0 {
+                "$$d".to_string()
+            } else {
+                format!("$$d_{}", n)
+            };
+            // Initializer: `$.derived(...)` — for `.by` we pass the value
+            // directly; for plain `$derived(expr)` we wrap in `() => expr`.
+            let init = if is_by {
+                format!("$.derived({})", arg_expr)
+            } else {
+                let needs_paren = arg_expr.trim_start().starts_with('{');
+                if needs_paren {
+                    format!("$.derived(() => ({}))", arg_expr)
+                } else if let Some(ident) = unthunk_no_arg_ident_call(arg_expr) {
+                    format!("$.derived({})", ident)
+                } else {
+                    format!("$.derived(() => {})", arg_expr)
+                }
+            };
+            decls.push((name.clone(), init));
+            name
+        };
+        // Walk the pattern, collecting inserts and paths.
+        let pattern_text = &script[pattern_start..=pattern_end];
+        let mut inserts: Vec<(String, String)> = Vec::new(); // (lhs_name, rhs_init)
+        let mut paths: Vec<(String, String)> = Vec::new(); // (lhs_text, leaf_expression)
+        extract_paths_walk(
+            pattern_text,
+            &base_expr,
+            &mut inserts,
+            &mut paths,
+            &DERIVED_ARRAY_COUNTER,
+        );
+
+        // Compose declarators in upstream order: inserts (already in DFS
+        // order) come before all leaf paths.
+        for (name, init_expr) in &inserts {
+            decls.push((name.clone(), format!("$.derived(() => {})", init_expr)));
+        }
+        for (lhs, expr) in &paths {
+            decls.push((lhs.clone(), format!("$.derived(() => {})", expr)));
+        }
+
+        // Emit `let|const|var <lhs1> = <rhs1>, <lhs2> = <rhs2>, ...;`
+        // We preserve the original keyword and continue the source past
+        // `)` (close paren of the `$derived(...)` call). Trailing source
+        // (e.g. `;` or `,` continuation) is preserved.
+        let keyword = &script[i..kw_end];
+        result.push_str(keyword);
+        result.push(' ');
+        for (idx, (lhs, rhs)) in decls.iter().enumerate() {
+            if idx > 0 {
+                result.push_str(",\n\t");
+            }
+            result.push_str(lhs);
+            result.push_str(" = ");
+            result.push_str(rhs);
+        }
+        // Continue past the closing `)` of `$derived(...)`.
+        i = rhs_end + 1;
+    }
+
+    result
+}
+
+/// Walk a destructure pattern (text starting with `{` or `[`) and populate
+/// `inserts` (intermediate `$$derived_array` declarators) and `paths` (leaf
+/// declarators with their access expression).
+fn extract_paths_walk(
+    pattern: &str,
+    initial: &str,
+    inserts: &mut Vec<(String, String)>,
+    paths: &mut Vec<(String, String)>,
+    derived_array_counter: &std::sync::atomic::AtomicUsize,
+) {
+    use std::sync::atomic::Ordering;
+    let pattern = pattern.trim();
+    if pattern.starts_with('{') && pattern.ends_with('}') {
+        let inner = &pattern[1..pattern.len() - 1];
+        let props = split_top_level(inner, b',');
+        // First collect non-rest property keys for any rest's exclusion.
+        let exclude_keys: Vec<String> = props
+            .iter()
+            .filter_map(|p| {
+                let p = p.trim();
+                if p.is_empty() || p.starts_with("...") {
+                    return None;
+                }
+                let key = if let Some(colon) = find_top_level_colon(p) {
+                    p[..colon].trim()
+                } else if let Some(eq) = find_top_level_equals(p) {
+                    p[..eq].trim()
+                } else {
+                    p
+                };
+                if key.starts_with('[') {
+                    None
+                } else {
+                    Some(format!("\"{}\"", key))
+                }
+            })
+            .collect();
+
+        for prop in &props {
+            let prop = prop.trim();
+            if prop.is_empty() {
+                continue;
+            }
+            if let Some(rest_name) = prop.strip_prefix("...") {
+                let rest_name = rest_name.trim();
+                let rest_expr = format!(
+                    "$.exclude_from_object({}, [{}])",
+                    initial,
+                    exclude_keys.join(", ")
+                );
+                if is_plain_identifier(rest_name) {
+                    paths.push((rest_name.to_string(), rest_expr));
+                } else {
+                    extract_paths_walk(
+                        rest_name,
+                        &rest_expr,
+                        inserts,
+                        paths,
+                        derived_array_counter,
+                    );
+                }
+                continue;
+            }
+            // Detect renamed property: `key: value_pattern` (value_pattern may itself be a destructure or default).
+            if let Some(colon) = find_top_level_colon(prop) {
+                let key = prop[..colon].trim();
+                let value_pat = prop[colon + 1..].trim();
+                let member = make_member(initial, key);
+                handle_value_pattern(value_pat, &member, inserts, paths, derived_array_counter);
+            } else if let Some(eq) = find_top_level_equals(prop) {
+                // Shorthand with default: `name = default`
+                let name = prop[..eq].trim();
+                let default = prop[eq + 1..].trim();
+                let member = make_member(initial, name);
+                let fallback = build_fallback_text(&member, default);
+                paths.push((name.to_string(), fallback));
+            } else {
+                // Shorthand: `name`
+                let name = prop;
+                let member = make_member(initial, name);
+                paths.push((name.to_string(), member));
+            }
+        }
+    } else if pattern.starts_with('[') && pattern.ends_with(']') {
+        let inner = &pattern[1..pattern.len() - 1];
+        let elements = split_top_level(inner, b',');
+        // Determine whether the last element is a rest. If so, the
+        // upstream call omits the second `to_array` arg (capacity).
+        let has_rest = elements
+            .last()
+            .map(|e| e.trim().starts_with("..."))
+            .unwrap_or(false);
+        let array_name = {
+            let n = derived_array_counter.fetch_add(1, Ordering::Relaxed);
+            if n == 0 {
+                "$$derived_array".to_string()
+            } else {
+                format!("$$derived_array_{}", n)
+            }
+        };
+        let to_array_call = if has_rest {
+            format!("$.to_array({})", initial)
+        } else {
+            format!("$.to_array({}, {})", initial, elements.len())
+        };
+        inserts.push((array_name.clone(), to_array_call));
+        for (idx, elem) in elements.iter().enumerate() {
+            let elem = elem.trim();
+            if elem.is_empty() {
+                continue;
+            }
+            if let Some(rest_name) = elem.strip_prefix("...") {
+                let rest_name = rest_name.trim();
+                // upstream: `b.call(b.member(id, 'slice'), b.literal(i))`
+                // After wrap_derived_reads, `array_name` becomes
+                // `array_name()`. So the literal we emit is
+                // `array_name.slice(i)` which becomes `array_name().slice(i)`.
+                let rest_expr = format!("{}.slice({})", array_name, idx);
+                if is_plain_identifier(rest_name) {
+                    paths.push((rest_name.to_string(), rest_expr));
+                } else {
+                    extract_paths_walk(
+                        rest_name,
+                        &rest_expr,
+                        inserts,
+                        paths,
+                        derived_array_counter,
+                    );
+                }
+                continue;
+            }
+            // Element access via index. We emit `array_name[idx]` and
+            // wrap_derived_reads_in_script will turn it into `array_name()[idx]`.
+            let elem_access = format!("{}[{}]", array_name, idx);
+            // Default value: `name = default`
+            if let Some(eq) = find_top_level_equals(elem) {
+                let name_part = elem[..eq].trim();
+                let default = elem[eq + 1..].trim();
+                if is_plain_identifier(name_part) {
+                    let fallback = build_fallback_text(&elem_access, default);
+                    paths.push((name_part.to_string(), fallback));
+                } else {
+                    // Nested with default: `{a, b} = {}`
+                    let fallback = build_fallback_text(&elem_access, default);
+                    extract_paths_walk(name_part, &fallback, inserts, paths, derived_array_counter);
+                }
+            } else if elem.starts_with('{') || elem.starts_with('[') {
+                extract_paths_walk(elem, &elem_access, inserts, paths, derived_array_counter);
+            } else {
+                paths.push((elem.to_string(), elem_access));
+            }
+        }
+    } else {
+        // Identifier leaf
+        if is_plain_identifier(pattern) {
+            paths.push((pattern.to_string(), initial.to_string()));
+        }
+    }
+}
+
+/// Inside an object pattern property `key: value`, the `value` may itself be a
+/// destructure pattern, a default, or an identifier.
+fn handle_value_pattern(
+    value_pat: &str,
+    member: &str,
+    inserts: &mut Vec<(String, String)>,
+    paths: &mut Vec<(String, String)>,
+    derived_array_counter: &std::sync::atomic::AtomicUsize,
+) {
+    let value_pat = value_pat.trim();
+    if value_pat.starts_with('{') || value_pat.starts_with('[') {
+        // Could have a trailing default after the matching bracket.
+        let (sub_pattern, default) = split_pattern_default(value_pat);
+        let effective = if let Some(d) = default {
+            build_fallback_text(member, d)
+        } else {
+            member.to_string()
+        };
+        extract_paths_walk(
+            sub_pattern,
+            &effective,
+            inserts,
+            paths,
+            derived_array_counter,
+        );
+    } else if let Some(eq) = find_top_level_equals(value_pat) {
+        // `key: name = default`
+        let name = value_pat[..eq].trim();
+        let default = value_pat[eq + 1..].trim();
+        let fallback = build_fallback_text(member, default);
+        paths.push((name.to_string(), fallback));
+    } else {
+        // `key: value` — value is an identifier
+        paths.push((value_pat.to_string(), member.to_string()));
+    }
+}
+
+/// Split a pattern with a possible default after the matching outer bracket.
+/// `{a, b} = {}` → (`{a, b}`, Some(`{}`)).
+fn split_pattern_default(pattern: &str) -> (&str, Option<&str>) {
+    let pattern = pattern.trim();
+    if pattern.is_empty() {
+        return (pattern, None);
+    }
+    let open = pattern.as_bytes()[0];
+    let close = match open {
+        b'{' => b'}',
+        b'[' => b']',
+        _ => return (pattern, None),
+    };
+    let bytes = pattern.as_bytes();
+    let mut depth = 0i32;
+    for i in 0..bytes.len() {
+        let c = bytes[i];
+        if c == open {
+            depth += 1;
+        } else if c == close {
+            depth -= 1;
+            if depth == 0 {
+                let after = pattern[i + 1..].trim_start();
+                if let Some(rest) = after.strip_prefix('=') {
+                    let default = rest.trim();
+                    return (&pattern[..=i], Some(default));
+                }
+                return (pattern, None);
+            }
+        }
+    }
+    (pattern, None)
+}
+
+/// Build `(member ?? default)` text, mirroring `build_fallback`.
+fn build_fallback_text(member: &str, default: &str) -> String {
+    format!("({} ?? {})", member, default)
+}
+
+/// Build a member-access expression: `obj.key` or `obj["complex"]` for
+/// non-identifier keys.
+fn make_member(obj: &str, key: &str) -> String {
+    let key = key.trim();
+    if key.starts_with('[') && key.ends_with(']') {
+        // Computed: `[expr]` → `obj[expr]`
+        format!("{}{}", obj, key)
+    } else if is_plain_identifier(key) {
+        format!("{}.{}", obj, key)
+    } else {
+        // Literal string key etc. — leave bracketed.
+        format!("{}[{}]", obj, key)
+    }
+}
+
+/// Split a string `s` at top-level occurrences of `delim`, respecting
+/// nesting (`{}[]()`), strings, and template literals.
+fn split_top_level(s: &str, delim: u8) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let mut i = 0usize;
+    let len = bytes.len();
+    while i < len {
+        let c = bytes[i];
+        if c == b'"' || c == b'\'' || c == b'`' {
+            // Skip string literal
+            let quote = c;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        match c {
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => depth -= 1,
+            _ => {}
+        }
+        if c == delim && depth == 0 {
+            out.push(s[start..i].to_string());
+            start = i + 1;
+        }
+        i += 1;
+    }
+    out.push(s[start..].to_string());
+    out
+}
+
+/// Find a top-level `:` in `prop`, respecting nesting and strings.
+fn find_top_level_colon(prop: &str) -> Option<usize> {
+    let bytes = prop.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0usize;
+    let len = bytes.len();
+    while i < len {
+        let c = bytes[i];
+        if c == b'"' || c == b'\'' || c == b'`' {
+            let quote = c;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        match c {
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => depth -= 1,
+            b':' if depth == 0 => return Some(i),
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Find a top-level `=` (default-value position) in `prop`, distinguishing
+/// from `==`, `===`, `=>`, and shorthand member operators.
+fn find_top_level_equals(prop: &str) -> Option<usize> {
+    let bytes = prop.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0usize;
+    let len = bytes.len();
+    while i < len {
+        let c = bytes[i];
+        if c == b'"' || c == b'\'' || c == b'`' {
+            let quote = c;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        match c {
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => depth -= 1,
+            b'=' if depth == 0 => {
+                let next = bytes.get(i + 1).copied();
+                if next == Some(b'=') || next == Some(b'>') {
+                    i += 2;
+                    continue;
+                }
+                // Reject `>=`, `<=`, `!=`, etc.
+                let prev = if i > 0 { Some(bytes[i - 1]) } else { None };
+                if matches!(prev, Some(b'!' | b'<' | b'>' | b'=')) {
+                    i += 1;
+                    continue;
+                }
+                return Some(i);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Check if `s` is a plain identifier (letters/digits/`_`/`$`, starts with
+/// non-digit).
+fn is_plain_identifier(s: &str) -> bool {
+    let s = s.trim();
+    if s.is_empty() {
+        return false;
+    }
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
+/// True if [start, end) is a word — i.e., no identifier char immediately
+/// before `start` or after `end - 1`.
+fn is_word_boundary(bytes: &[u8], start: usize, end: usize) -> bool {
+    let before = if start == 0 {
+        None
+    } else {
+        Some(bytes[start - 1])
+    };
+    let after = bytes.get(end).copied();
+    let before_ok = match before {
+        Some(b) => !(b.is_ascii_alphanumeric() || b == b'_' || b == b'$'),
+        None => true,
+    };
+    let after_ok = match after {
+        Some(b) => !(b.is_ascii_alphanumeric() || b == b'_' || b == b'$'),
+        None => true,
+    };
+    before_ok && after_ok
+}
+
+/// Find a matching bracket. `start` is the byte position immediately after
+/// the opening bracket. Returns the byte position of the matching close
+/// bracket. Respects strings/templates and nesting of `{}[]()`.
+fn find_matching_bracket(bytes: &[u8], start: usize, open: u8, close: u8) -> Option<usize> {
+    let mut depth: i32 = 1;
+    let mut i = start;
+    let len = bytes.len();
+    while i < len {
+        let c = bytes[i];
+        if c == b'"' || c == b'\'' || c == b'`' {
+            let quote = c;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        if c == open {
+            depth += 1;
+        } else if c == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Strip a top-level `await` keyword from the start of an expression string.
+///
+/// Mirrors upstream's `unthunk` collapse of `async () => await x` into
+/// `async () => x` when `x` has no nested await. We use this server-side
+/// when emitting `await $.async_derived(...)` around the visited value.
+fn strip_top_level_await_from_expr(expr: &str) -> String {
+    let trimmed = expr.trim();
+    if let Some(rest) = trimmed.strip_prefix("await ") {
+        rest.trim_start().to_string()
+    } else if let Some(rest) = trimmed.strip_prefix("await\n") {
+        rest.trim_start().to_string()
+    } else if let Some(rest) = trimmed.strip_prefix("await\t") {
+        rest.trim_start().to_string()
+    } else if let Some(rest) = trimmed.strip_prefix("await(") {
+        format!("({}", rest)
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// If `expr` is a simple no-argument call to a bare identifier (e.g. `foo()`),
+/// return the identifier (so it can be passed as a function reference to
+/// `$.derived`, mirroring upstream `unthunk`). Otherwise return `None`.
+fn unthunk_no_arg_ident_call(expr: &str) -> Option<&str> {
+    let trimmed = expr.trim();
+    let inner = trimmed.strip_suffix(')')?;
+    let (id_part, after) = inner.split_once('(')?;
+    if !after.trim().is_empty() {
+        return None;
+    }
+    let id_part = id_part.trim_end();
+    // `id_part` must be a plain identifier (no `.`, `?`, `[`, etc.) and
+    // must contain only identifier chars. Empty `foo  ()` is fine.
+    let id_trimmed = id_part.trim_start();
+    if id_trimmed.is_empty() {
+        return None;
+    }
+    if !id_trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+    {
+        return None;
+    }
+    if !id_trimmed
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_' || c == '$')
+    {
+        return None;
+    }
+    // Reject reserved words that can't be used as identifiers in this slot.
+    if matches!(
+        id_trimmed,
+        "true" | "false" | "null" | "undefined" | "void" | "new" | "this"
+    ) {
+        return None;
+    }
+    Some(id_trimmed)
+}
+
 fn transform_rune_call_multiline(script: &str, prefix: &str) -> String {
     // First, find function scopes where the rune name is shadowed by a parameter.
     // E.g., `function bar($derived, $effect) { ... }` shadows `$derived` inside bar.
@@ -1150,6 +3498,7 @@ fn transform_rune_call_multiline(script: &str, prefix: &str) -> String {
     let mut i = 0;
 
     let is_derived_by = prefix == "$derived.by(";
+    let is_derived = prefix == "$derived(";
 
     while i < chars.len() {
         if i + prefix_len <= chars.len() {
@@ -1201,27 +3550,82 @@ fn transform_rune_call_multiline(script: &str, prefix: &str) -> String {
                 let trimmed_inner = inner.trim();
 
                 if trimmed_inner.is_empty() {
-                    result.push_str("void 0");
+                    // Svelte 5.52+: empty `$derived()` is a no-op and shouldn't
+                    // appear in real code; treat it as `$.derived(() => void 0)`
+                    // for `$derived` and `$.derived(void 0)` for `$derived.by`.
+                    if is_derived {
+                        result.push_str("$.derived(() => void 0)");
+                    } else if is_derived_by {
+                        result.push_str("$.derived(void 0)");
+                    } else {
+                        result.push_str("void 0");
+                    }
                 } else if is_derived_by {
-                    // `$derived.by(fn)` becomes `(fn)()`. Strip a trailing
-                    // comma from `fn` first — Prettier-formatted call
-                    // sites often produce `$derived.by(fn,)` (a legal
-                    // trailing comma in function-call arguments), which
-                    // when rewritten naively would yield `(fn,)()` —
-                    // an invalid parenthesized expression with a
-                    // trailing comma. Preserve leading whitespace so
-                    // multi-line structure (newlines) survives.
+                    // Svelte 5.52+: `$derived.by(fn)` becomes `$.derived(fn)`
+                    // so the derived can be re-run on every render (the server
+                    // runtime calls the function each time the derived is read).
                     let cleaned = inner.trim_end().trim_end_matches(',').trim_end();
-                    result.push('(');
+                    result.push_str("$.derived(");
                     result.push_str(cleaned);
-                    result.push_str(")()");
+                    result.push(')');
+                } else if is_derived {
+                    // Svelte 5.52+: `$derived(expr)` becomes
+                    // `$.derived(() => expr)` so the derived re-runs each time
+                    // a render reads it. An object-literal expression must be
+                    // wrapped in parens (`() => ({ ... })`) — otherwise the
+                    // braces parse as a function body.
+                    //
+                    // Mirror upstream's `unthunk` optimization: a bare
+                    // `$derived(foo())` (no-arg call to a simple identifier)
+                    // collapses to `$.derived(foo)` rather than
+                    // `$.derived(() => foo())`.
+                    //
+                    // For async derived (top-level `await` in expression), the
+                    // upstream emits `await $.async_derived(b.thunk(value, true))`
+                    // — i.e. `await $.async_derived(async () => value)` with
+                    // an unthunk pass that collapses `async () => await x`
+                    // to `async () => x` when `x` has no nested await.
+                    let cleaned = inner.trim_end().trim_end_matches(',').trim_end();
+                    if super::helpers::expr_contains_await(cleaned) {
+                        // Async derived emission. Strip the top-level `await`
+                        // (the unthunk pass), then check whether the remaining
+                        // expression has nested awaits — if so we still need
+                        // an `async` arrow.
+                        let stripped = strip_top_level_await_from_expr(cleaned);
+                        let nested_await = super::helpers::expr_contains_await(&stripped);
+                        let needs_paren = stripped.trim_start().starts_with('{');
+                        if nested_await {
+                            result.push_str("await $.async_derived(async () => ");
+                        } else {
+                            result.push_str("await $.async_derived(() => ");
+                        }
+                        if needs_paren {
+                            result.push('(');
+                            result.push_str(&stripped);
+                            result.push(')');
+                        } else {
+                            result.push_str(&stripped);
+                        }
+                        result.push(')');
+                    } else if let Some(ident) = unthunk_no_arg_ident_call(cleaned) {
+                        result.push_str("$.derived(");
+                        result.push_str(ident);
+                        result.push(')');
+                    } else {
+                        let needs_paren = cleaned.trim_start().starts_with('{');
+                        result.push_str("$.derived(() => ");
+                        if needs_paren {
+                            result.push('(');
+                            result.push_str(cleaned);
+                            result.push(')');
+                        } else {
+                            result.push_str(cleaned);
+                        }
+                        result.push(')');
+                    }
                 } else {
-                    // Strip trailing comma from the extracted expression.
-                    // $derived(expr,) is valid JS (trailing comma in function args),
-                    // but after stripping $derived(), `let x = expr,` would be invalid.
-                    // We must preserve leading whitespace/newlines to maintain multi-line
-                    // structure (so that `add_statement_semicolon` doesn't prematurely
-                    // terminate the expression).
+                    // $state and friends keep their previous semantics: strip
+                    // the rune wrapper, preserve the raw expression.
                     let cleaned = inner.trim_end().trim_end_matches(',').trim_end();
                     result.push_str(cleaned);
                 }

--- a/src/compiler/phases/3_transform/server/types.rs
+++ b/src/compiler/phases/3_transform/server/types.rs
@@ -548,6 +548,22 @@ pub(crate) struct ComponentCodeResult {
     pub needs_leading_marker: bool,
     /// Trailing marker behavior after the component call.
     pub trailing_marker: TrailingMarkerBehavior,
+    /// If set, the call code must be wrapped in an `if (test) { ... } else { ... }`
+    /// hydration guard (Svelte 5.52+ dynamic component handling). The bridge
+    /// builds a structured `JsStatement::If` so the codegen handles
+    /// indentation naturally.
+    pub dynamic_wrap: Option<DynamicComponentWrap>,
+}
+
+/// Information needed to wrap a dynamic component call in a hydration
+/// guard.
+pub(crate) struct DynamicComponentWrap {
+    /// Test expression used in the `if` condition (e.g. `Comp` or `x ? Foo : Bar`).
+    pub test: String,
+    /// Whether the wrapped `code` contains a `$.css_props($$renderer, ..., () => { <call> }, true);`
+    /// outer wrapper. In that case we wrap just the inner call rather than
+    /// the whole `code` string.
+    pub has_css_props: bool,
 }
 
 /// Describes how a trailing `<!---->` marker should be emitted after a component call.

--- a/src/compiler/phases/3_transform/server/visitors/await_block.rs
+++ b/src/compiler/phases/3_transform/server/visitors/await_block.rs
@@ -23,6 +23,8 @@ impl<'a> ServerCodeGenerator<'a> {
 
         // Transform store subscriptions ($store -> $.store_get())
         let promise_expr = self.transform_store_refs(&promise_expr);
+        // Svelte 5.52+: derived reads in template expressions become calls.
+        let promise_expr = self.wrap_derived_reads(&promise_expr);
 
         // Get the then value variable name if present
         let then_param = if let Some(ref value) = block.value {

--- a/src/compiler/phases/3_transform/server/visitors/component.rs
+++ b/src/compiler/phases/3_transform/server/visitors/component.rs
@@ -24,7 +24,9 @@ impl<'a> ServerCodeGenerator<'a> {
         &mut self,
         component: &Component,
     ) -> Result<(), TransformError> {
-        let comp_name = component.name.to_string();
+        // Svelte 5.52+: if the component identifier resolves to a `$derived`
+        // binding, emit `name()` so the dynamic call gets the live component.
+        let comp_name = self.wrap_derived_reads(component.name.as_ref());
 
         // Check if there's any prior content (HTML, expressions, or other components)
         let has_prior_content = self.output_parts.iter().any(|part| {
@@ -281,9 +283,13 @@ impl<'a> ServerCodeGenerator<'a> {
                                 let getter_expr =
                                     self.source[getter_start..getter_end].trim().to_string();
                                 let getter_expr = self.strip_ts_from_expr(&getter_expr);
+                                // Svelte 5.52+: rewrite bare reads of $derived
+                                // bindings to calls.
+                                let getter_expr = self.wrap_derived_reads(&getter_expr);
                                 let setter_expr =
                                     self.source[setter_start..setter_end].trim().to_string();
                                 let setter_expr = self.strip_ts_from_expr(&setter_expr);
+                                let setter_expr = self.wrap_derived_reads(&setter_expr);
                                 bindings.push(ComponentBinding::SequenceExpression {
                                     prop_name: prop_name.to_string(),
                                     getter_expr,

--- a/src/compiler/phases/3_transform/server/visitors/element.rs
+++ b/src/compiler/phases/3_transform/server/visitors/element.rs
@@ -754,7 +754,9 @@ impl<'a> ServerCodeGenerator<'a> {
                     if expr_end > expr_start && expr_end <= self.source.len() {
                         let expr = self.source[expr_start..expr_end].trim().to_string();
                         // Transform rune calls in spread expressions
-                        let mut expr = Self::transform_rune_in_template_expr(&expr);
+                        let expr = Self::transform_rune_in_template_expr(&expr);
+                        // Wrap bare reads of $derived bindings (Svelte 5.52+).
+                        let mut expr = self.wrap_derived_reads(&expr);
                         // In dev mode, if the parent element has a svelte-ignore
                         // state_snapshot_uncloneable comment, add `true` arg to $.snapshot()
                         if self.dev
@@ -1680,28 +1682,33 @@ impl<'a> ServerCodeGenerator<'a> {
                                 self.source[getter_start..getter_end].trim().to_string();
                             let getter_src = self.strip_ts_from_expr(&getter_src);
                             let getter_src = self.transform_store_refs(&getter_src);
+                            let getter_src = self.wrap_derived_reads(&getter_src);
                             // Invoke the getter: (() => val)()
                             format!("({})() ", getter_src).trim().to_string()
                         } else {
                             // Fallback to full expression
                             let raw = self.source[expr_start..expr_end].trim().to_string();
                             let raw = self.strip_ts_from_expr(&raw);
-                            self.transform_store_refs(&raw)
+                            let raw = self.transform_store_refs(&raw);
+                            self.wrap_derived_reads(&raw)
                         }
                     } else {
                         let raw = self.source[expr_start..expr_end].trim().to_string();
                         let raw = self.strip_ts_from_expr(&raw);
-                        self.transform_store_refs(&raw)
+                        let raw = self.transform_store_refs(&raw);
+                        self.wrap_derived_reads(&raw)
                     }
                 } else {
                     let raw = self.source[expr_start..expr_end].trim().to_string();
                     let raw = self.strip_ts_from_expr(&raw);
-                    self.transform_store_refs(&raw)
+                    let raw = self.transform_store_refs(&raw);
+                    self.wrap_derived_reads(&raw)
                 }
             } else {
                 let raw = self.source[expr_start..expr_end].trim().to_string();
                 let raw = self.strip_ts_from_expr(&raw);
-                self.transform_store_refs(&raw)
+                let raw = self.transform_store_refs(&raw);
+                self.wrap_derived_reads(&raw)
             };
 
             // Handle bind:group specially - convert to checked attribute

--- a/src/compiler/phases/3_transform/server/visitors/expression_tag.rs
+++ b/src/compiler/phases/3_transform/server/visitors/expression_tag.rs
@@ -45,6 +45,9 @@ impl<'a> ServerCodeGenerator<'a> {
                     let transformed = self.transform_special_vars(&transformed);
                     // Transform rune calls that need server-side handling
                     let transformed = Self::transform_rune_in_template_expr(&transformed);
+                    // Svelte 5.52+: rewrite bare reads of `$derived` bindings
+                    // to calls (e.g. `count` -> `count()`).
+                    let transformed = self.wrap_derived_reads(&transformed);
                     // If this is a sequence (comma) expression at the top level, wrap in parens
                     // so that $.escape(x, '') doesn't misinterpret as two arguments.
                     let transformed = if has_top_level_comma(&transformed) {

--- a/src/compiler/phases/3_transform/server/visitors/select_element.rs
+++ b/src/compiler/phases/3_transform/server/visitors/select_element.rs
@@ -55,6 +55,7 @@ impl<'a> ServerCodeGenerator<'a> {
                     if expr_end > expr_start && expr_end <= self.source.len() {
                         let expr = self.source[expr_start..expr_end].trim().to_string();
                         let expr = Self::transform_rune_in_template_expr(&expr);
+                        let expr = self.wrap_derived_reads(&expr);
                         attrs.push(("__spread__".to_string(), format!("...{}", expr)));
                     }
                 }

--- a/src/compiler/phases/3_transform/server/visitors/snippet_block.rs
+++ b/src/compiler/phases/3_transform/server/visitors/snippet_block.rs
@@ -48,6 +48,15 @@ impl<'a> ServerCodeGenerator<'a> {
         body_generator.dev = self.dev;
         body_generator.is_typescript = self.is_typescript;
         body_generator.uses_store_subs = self.uses_store_subs;
+        // Snippet parameters shadow outer derived bindings: drop any derived
+        // name that matches a parameter binding from the body's derived_names
+        // / derived_var_names so we don't wrap reads of the parameter as
+        // `name()` inside the body.
+        let param_names = Self::collect_snippet_param_binding_names(&params);
+        for name in &param_names {
+            body_generator.derived_names.remove(name);
+            body_generator.derived_var_names.remove(name);
+        }
 
         // Collect non-empty nodes
         let body_nodes: Vec<_> = block.body.nodes.iter().collect();
@@ -301,6 +310,18 @@ impl<'a> ServerCodeGenerator<'a> {
         Ok(body_parts)
     }
 
+    /// Extract the set of bound identifier names from a list of snippet
+    /// parameter source strings (possibly destructured). Used to suppress
+    /// outer derived-binding wrap inside the snippet body when a parameter
+    /// shadows the derived.
+    fn collect_snippet_param_binding_names(params: &[String]) -> Vec<String> {
+        let mut names: Vec<String> = Vec::new();
+        for p in params {
+            collect_binding_names_from_pattern(p, &mut names);
+        }
+        names
+    }
+
     /// Extract a snippet parameter string from an Expression, stripping TypeScript
     /// type annotations. This uses the Expression's JSON structure to correctly
     /// handle cases where the source span may be incorrect (e.g., when optional
@@ -446,4 +467,159 @@ impl<'a> ServerCodeGenerator<'a> {
             _ => String::new(),
         }
     }
+}
+
+/// Collect bound identifier names from a parameter-pattern source string.
+/// Handles plain identifiers, object/array destructure patterns, defaults
+/// (`name = value`), and TS type annotations (`name: number`). Recurses into
+/// nested patterns.
+fn collect_binding_names_from_pattern(pattern: &str, out: &mut Vec<String>) {
+    let p = pattern.trim();
+    if p.is_empty() {
+        return;
+    }
+    // Strip default value: `name = expr` — only the LHS counts.
+    let p_lhs = if let Some(eq) = find_top_level_eq_for_pattern(p) {
+        p[..eq].trim()
+    } else {
+        p
+    };
+    if p_lhs.starts_with('{') && p_lhs.ends_with('}') {
+        let inner = &p_lhs[1..p_lhs.len() - 1];
+        for prop in split_top_level_comma(inner) {
+            let prop = prop.trim();
+            if prop.is_empty() {
+                continue;
+            }
+            if let Some(rest) = prop.strip_prefix("...") {
+                collect_binding_names_from_pattern(rest, out);
+                continue;
+            }
+            if let Some(colon) = find_top_level_colon_for_pattern(prop) {
+                // `key: alias_or_pattern (= default)`
+                let value = prop[colon + 1..].trim();
+                collect_binding_names_from_pattern(value, out);
+            } else {
+                // Shorthand `name (= default)` — strip type and default.
+                let lhs = if let Some(eq) = find_top_level_eq_for_pattern(prop) {
+                    prop[..eq].trim()
+                } else {
+                    prop
+                };
+                // Strip TS type annotation: `name: type` already handled above.
+                if is_simple_ident(lhs) {
+                    out.push(lhs.to_string());
+                }
+            }
+        }
+        return;
+    }
+    if p_lhs.starts_with('[') && p_lhs.ends_with(']') {
+        let inner = &p_lhs[1..p_lhs.len() - 1];
+        for elem in split_top_level_comma(inner) {
+            let elem = elem.trim();
+            if elem.is_empty() {
+                continue;
+            }
+            if let Some(rest) = elem.strip_prefix("...") {
+                collect_binding_names_from_pattern(rest, out);
+                continue;
+            }
+            collect_binding_names_from_pattern(elem, out);
+        }
+        return;
+    }
+    // Plain identifier (possibly with TS type annotation `name: type`).
+    if let Some(colon) = find_top_level_colon_for_pattern(p_lhs) {
+        let name = p_lhs[..colon].trim();
+        if is_simple_ident(name) {
+            out.push(name.to_string());
+        }
+    } else if is_simple_ident(p_lhs) {
+        out.push(p_lhs.to_string());
+    }
+}
+
+fn split_top_level_comma(s: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => depth -= 1,
+            b',' if depth == 0 => {
+                out.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    out.push(&s[start..]);
+    out
+}
+
+fn find_top_level_eq_for_pattern(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => depth -= 1,
+            b'=' if depth == 0 => {
+                let next = bytes.get(i + 1).copied();
+                if next == Some(b'=') || next == Some(b'>') {
+                    i += 2;
+                    continue;
+                }
+                let prev = if i > 0 { Some(bytes[i - 1]) } else { None };
+                if matches!(prev, Some(b'!' | b'<' | b'>' | b'=')) {
+                    i += 1;
+                    continue;
+                }
+                return Some(i);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+fn find_top_level_colon_for_pattern(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => depth -= 1,
+            b':' if depth == 0 => return Some(i),
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+fn is_simple_ident(s: &str) -> bool {
+    let s = s.trim();
+    if s.is_empty() {
+        return false;
+    }
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
 }

--- a/src/compiler/phases/3_transform/server/visitors/svelte_component.rs
+++ b/src/compiler/phases/3_transform/server/visitors/svelte_component.rs
@@ -61,6 +61,7 @@ impl<'a> ServerCodeGenerator<'a> {
                     let expr_end = spread.expression.end().unwrap_or(0) as usize;
                     if expr_end > expr_start && expr_end <= self.source.len() {
                         let expr = self.source[expr_start..expr_end].trim().to_string();
+                        let expr = self.transform_store_refs(&expr);
                         props_and_spreads.push(ComponentPropItem::Spread(expr));
                     }
                 }
@@ -177,6 +178,7 @@ impl<'a> ServerCodeGenerator<'a> {
                     let expr_end = spread.expression.end().unwrap_or(0) as usize;
                     if expr_end > expr_start && expr_end <= self.source.len() {
                         let expr = self.source[expr_start..expr_end].trim().to_string();
+                        let expr = self.transform_store_refs(&expr);
                         props_and_spreads.push(ComponentPropItem::Spread(expr));
                     }
                 }


### PR DESCRIPTION
## Summary

Bump Svelte **5.51.5 → 5.52.0** and port the two SSR compiler-affecting upstream commits:

- **`9f48e7620`** "repair dynamic component truthy/falsy hydration mismatches" — `<svelte:component>` and `<Component this={…}>` no longer emit `(expr)?.($$renderer, props)` framed by empty `<!---->` comments. They now emit an `if (expr) { push('<!--[-->'); expr(...); push('<!--]-->'); } else { push('<!--[!-->'); push('<!--]-->'); }` so client-side hydration can repair truthy↔falsy mismatches.
- **`09c4cb508`** "re-run non-render-bound deriveds on the server" — `let foo = $derived(expr)` is emitted as `let foo = $.derived(() => expr)` and every read of a derived binding becomes a call site (`foo()`, or `foo?.()` for `var`-kind decls). Destructured derived patterns (`let { a, b: [c] } = $derived(stuff)`) expand to a `$$derived_array` / `$$d` helper plus per-leaf `$.derived(...)` declarators that mirror upstream's `extract_paths` expansion.

The work spans the server transform pipeline: dynamic-component wrapping in `build.rs` / `bridge.rs` / `visitors/component.rs`, derived-call wiring in `transform_script.rs` / `mod.rs`, plus per-visitor `wrap_derived_reads` calls on every template-source expression (await / expression-tag / element / select-element / svelte-component / snippet visitors). Phase 2 `scope_builder.rs` exposes the derived-binding analysis the server pass consumes.

Drive-by fixes:

- Several byte-level fallbacks in the script walker pushed `bytes[i] as char` into a `String`, which interprets a UTF-8 continuation byte as a Latin-1 code point and double-encodes non-ASCII source (`'Compté'` → `'ComptÃ©'`). Now step by char boundary.
- `is_object_shorthand_position` had a `p == 0` short-circuit before the depth-0 `{` recognition, so an enclosing `{` sitting at byte 0 of the scanned slice was misclassified (e.g. `{ doubled }` → `{ doubled() }` instead of `{ doubled: doubled() }` in `snippet-argument-destructured-multiple`).

Includes a `@rsvelte/compiler` `minor` changeset.

## Test plan

- [x] `pnpm run generate-fixtures -- --force` against `svelte@5.52.0`
- [x] `pnpm run compatibility-report` ⇒ **3,339 / 3,339 in-scope passing**; every category at 100%.
- [x] `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `node scripts/update-docs.mjs --check` passes; README marker tracks `v5.52.0 @ cbf4e246fc0d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)