### PR TITLE
fix(analyze): push block scope for inner BlockStatements in track path

### DIFF
--- a/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/src/compiler/phases/2_analyze/scope_builder.rs
@@ -3754,10 +3754,23 @@ impl<'a> ScopeBuilder<'a> {
                 }
             }
             "BlockStatement" => {
+                // Push a new lexical scope. Without this, `let`/`const`
+                // inside if/else branches and other free blocks collapse
+                // into the parent function scope and trigger spurious
+                // `declaration_duplicate` validation errors when two
+                // branches each declare a same-named local (real-world
+                // case: svelte-sonner's toast-state.svelte.js — three
+                // `const message` declarations in if/else if branches of
+                // a `.then()` callback). Function-body BlockStatements
+                // are iterated directly by their owning function handler,
+                // so this only affects inner blocks where lexical
+                // block-scoping actually applies.
                 if let Some(body) = obj.get("body").and_then(|b| b.as_array()) {
+                    let old_scope = self.push_scope();
                     for stmt in body {
                         self.track_json_statement_updates(stmt);
                     }
+                    self.pop_scope(old_scope);
                 }
             }
             "ForStatement" | "WhileStatement" | "DoWhileStatement" => {


### PR DESCRIPTION
## Summary

\`track_json_statement_updates\` was iterating BlockStatement bodies without pushing a lexical scope. \`let\`/\`const\` declarations inside inner blocks (if/else branches, free blocks, etc.) therefore collapsed into the enclosing function scope and triggered spurious \`declaration_duplicate\` validation errors whenever two sibling branches each declared a same-named local.

## Background

Surfaced by [ecosystem-ci](https://github.com/baseballyama/rsvelte/actions/workflows/ecosystem-ci.yml) on shadcn-svelte. Its docs build pulls in **svelte-sonner**, whose \`toast-state.svelte.js\` has three \`const message\` declarations in sibling \`if/else if\` branches of a \`.then()\` callback:

\`\`\`js
p.then((response) => {
  if (...) {
    const message = constructPromiseErrorMessage(response);
    ...
  } else if (data.success !== undefined) {
    const message = typeof data.success === 'function' ? data.success(response) : data.success;
    ...
  }
}).catch((error) => {
  if (data.error !== undefined) {
    const message = typeof data.error === 'function' ? data.error(error) : data.error;
    ...
  }
});
\`\`\`

All valid JS, but \`compileModule\` rejected with:

\`\`\`
Analysis(ValidationWithCode { code: "declaration_duplicate", message: "\`message\` has already been declared" })
\`\`\`

## Fix

In \`track_json_statement_updates\`, BlockStatement now pushes a fresh scope before iterating its statements, then pops on exit. Function-body BlockStatements are iterated directly by their owning ArrowFunction/Function handlers (which already push their own function scope), so this only affects **inner** blocks where lexical block-scoping actually applies.

## Verified locally

- \`cargo build --release --features napi --lib\` ✅
- \`cargo test --release --lib\` ✅ (1152 passed)
- Minimal repro: \`r.compileModule(svelte-sonner-toast-state.svelte.js)\` now returns 7720 bytes of output with three \`const message\` declarations preserved (vs the previous Analysis error).
- Compat report needs \`pnpm run generate-fixtures\` to run locally; relying on CI to confirm no fixture regression.

## Follow-up

This is one of the parser/analyzer regressions blocking shadcn-svelte's ecosystem-ci target. After this lands, I'll re-run shadcn-svelte locally and tackle the remaining ones (TS-cast-in-template, etc.) — they're documented in shadcn-svelte's \`disabledReason\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)