### PR TITLE
feat(capi): GitHub Releases pipeline + prebuilt-binary docs

### DIFF
--- a/.github/workflows/release-capi.yml
+++ b/.github/workflows/release-capi.yml
@@ -1,0 +1,243 @@
+name: Release rsvelte_capi
+
+# Cut a versioned release of the C ABI bindings.
+#
+#  - Tag the worktree as `capi-v<MAJOR.MINOR.PATCH>` (must match the
+#    `version` in `crates/rsvelte_capi/Cargo.toml`) and push the tag.
+#    The push event triggers this workflow; on success it creates a
+#    GitHub Release with the per-OS/arch archives attached.
+#  - `workflow_dispatch` lets you do a dry-run end-to-end without
+#    actually publishing — pick a "version" input (defaults to "test")
+#    and run; the build matrix produces artifacts you can inspect.
+#
+# The matrix mirrors the existing svelte-check / vps-native release
+# pipelines (.github/workflows/release.yml) so the toolchain quirks
+# are already known to work: aarch64-apple-darwin natively, intel mac
+# cross-compiled from arm64 runner, linux arm64 with the gcc cross-
+# linker, windows-msvc native.
+
+on:
+  push:
+    tags:
+      - 'capi-v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to use for the dry-run archive names (no Release is created)'
+        required: false
+        default: 'test'
+
+permissions:
+  contents: write   # gh release create / upload
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: build (${{ matrix.triple }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-latest,   target: aarch64-apple-darwin,       triple: darwin-arm64,    archive: tar.gz, lib: librsvelte_capi.dylib,  staticlib: librsvelte_capi.a }
+          - { os: macos-latest,   target: x86_64-apple-darwin,        triple: darwin-x64,      archive: tar.gz, lib: librsvelte_capi.dylib,  staticlib: librsvelte_capi.a }
+          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu,   triple: linux-x64-gnu,   archive: tar.gz, lib: librsvelte_capi.so,     staticlib: librsvelte_capi.a }
+          - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu,  triple: linux-arm64-gnu, archive: tar.gz, lib: librsvelte_capi.so,     staticlib: librsvelte_capi.a, apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc,     triple: win32-x64-msvc,  archive: zip,    lib: rsvelte_capi.dll,       staticlib: rsvelte_capi.lib, implib: rsvelte_capi.dll.lib }
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Install cross-compile linker
+        if: matrix.apt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: release-capi-${{ matrix.target }}
+
+      # Resolve the release version from the trigger:
+      #   - push of capi-vX.Y.Z → strip the `capi-v` prefix
+      #   - workflow_dispatch   → use the `version` input
+      - name: Resolve release version
+        id: ver
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/capi-v* ]]; then
+            version="${GITHUB_REF#refs/tags/capi-v}"
+          else
+            version="${{ github.event.inputs.version || 'test' }}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # On a real tag push, refuse to build if the crate version
+      # disagrees with the tag — otherwise the published archive would
+      # claim a version the actual binary doesn't carry.
+      - name: Verify Cargo.toml version matches tag
+        if: startsWith(github.ref, 'refs/tags/capi-v')
+        shell: bash
+        run: |
+          tag_ver="${GITHUB_REF#refs/tags/capi-v}"
+          crate_ver=$(grep -E '^version = ' crates/rsvelte_capi/Cargo.toml | head -1 | sed -E 's/version = "(.+)"/\1/')
+          if [[ "$tag_ver" != "$crate_ver" ]]; then
+            echo "::error::Tag is capi-v${tag_ver} but crates/rsvelte_capi/Cargo.toml has version = \"${crate_ver}\""
+            exit 1
+          fi
+
+      - name: Build cdylib + staticlib
+        shell: bash
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
+          RSVELTE_CAPI_CHECK_HEADER: '1'
+        run: cargo build --release -p rsvelte_capi --target ${{ matrix.target }}
+
+      - name: Stage archive contents
+        shell: bash
+        run: |
+          set -euo pipefail
+          ver="${{ steps.ver.outputs.version }}"
+          name="rsvelte_capi-${ver}-${{ matrix.triple }}"
+          stage="stage/${name}"
+          mkdir -p "${stage}/lib" "${stage}/include"
+          cp "target/${{ matrix.target }}/release/${{ matrix.lib }}" "${stage}/lib/"
+          if [[ -f "target/${{ matrix.target }}/release/${{ matrix.staticlib }}" ]]; then
+            cp "target/${{ matrix.target }}/release/${{ matrix.staticlib }}" "${stage}/lib/"
+          fi
+          # Windows MSVC also writes an import library next to the DLL.
+          if [[ -n "${{ matrix.implib || '' }}" && -f "target/${{ matrix.target }}/release/${{ matrix.implib }}" ]]; then
+            cp "target/${{ matrix.target }}/release/${{ matrix.implib }}" "${stage}/lib/"
+          fi
+          cp crates/rsvelte_capi/include/rsvelte.h "${stage}/include/"
+          cp crates/rsvelte_capi/README.md         "${stage}/README.md"
+          cp LICENSE                                "${stage}/LICENSE"
+          echo "${ver}" > "${stage}/VERSION"
+          echo "$(git rev-parse HEAD)" > "${stage}/COMMIT"
+          ls -lR "${stage}"
+
+      - name: Pack archive
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          ver="${{ steps.ver.outputs.version }}"
+          name="rsvelte_capi-${ver}-${{ matrix.triple }}"
+          cd stage
+          if [[ "${{ matrix.archive }}" == "zip" ]]; then
+            # Windows runners ship 7z and bsdtar; use the latter for portability.
+            tar -a -cf "../${name}.zip" "${name}"
+            archive="${name}.zip"
+          else
+            tar -czf "../${name}.tar.gz" "${name}"
+            archive="${name}.tar.gz"
+          fi
+          cd ..
+          # Per-archive SHA-256 for the release notes.
+          if command -v sha256sum >/dev/null; then
+            sha256sum "${archive}" > "${archive}.sha256"
+          else
+            shasum -a 256 "${archive}" > "${archive}.sha256"
+          fi
+          cat "${archive}.sha256"
+          echo "archive=${archive}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rsvelte_capi-${{ matrix.triple }}
+          path: |
+            ${{ steps.pack.outputs.archive }}
+            ${{ steps.pack.outputs.archive }}.sha256
+          if-no-files-found: error
+          retention-days: 14
+
+  release:
+    name: GitHub Release
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Only publish on a real tag push. workflow_dispatch leaves the
+    # artifacts attached to the workflow run for inspection without
+    # creating a Release.
+    if: startsWith(github.ref, 'refs/tags/capi-v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Inspect what was downloaded
+        run: ls -la artifacts/
+
+      - name: Build combined checksums file
+        run: |
+          set -euo pipefail
+          cd artifacts
+          : > SHA256SUMS
+          for f in *.tar.gz *.zip; do
+            [[ -e "$f" ]] || continue
+            shasum -a 256 "$f" >> SHA256SUMS
+          done
+          cat SHA256SUMS
+
+      - name: Compose release notes
+        id: notes
+        shell: bash
+        run: |
+          ver="${GITHUB_REF#refs/tags/capi-v}"
+          {
+            echo "## rsvelte_capi v${ver}"
+            echo
+            echo "C ABI bindings for the rsvelte Svelte compiler. One \`cdylib\` + one cbindgen-generated \`rsvelte.h\` lets any language with a C FFI drive the compiler — UTF-8 JSON in, UTF-8 JSON out."
+            echo
+            echo "### Download"
+            echo
+            echo "| Triple | Archive |"
+            echo "|---|---|"
+            for f in artifacts/*.tar.gz artifacts/*.zip; do
+              [[ -e "$f" ]] || continue
+              base="$(basename "$f")"
+              triple="$(basename "$f" | sed -E "s/^rsvelte_capi-${ver}-//; s/\.(tar\.gz|zip)$//")"
+              echo "| \`${triple}\` | [${base}](https://github.com/${{ github.repository }}/releases/download/capi-v${ver}/${base}) |"
+            done
+            echo
+            echo "### Verify"
+            echo
+            echo '```sh'
+            echo "curl -LO https://github.com/${{ github.repository }}/releases/download/capi-v${ver}/SHA256SUMS"
+            echo "shasum -a 256 -c SHA256SUMS"
+            echo '```'
+            echo
+            echo "### Documentation"
+            echo
+            echo "See [\`crates/rsvelte_capi/README.md\`](https://github.com/${{ github.repository }}/blob/capi-v${ver}/crates/rsvelte_capi/README.md) for the API, JSON envelope, memory ownership rules, and per-language quick-start."
+          } > release-notes.md
+          cat release-notes.md
+
+      - name: Create / update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ver="${GITHUB_REF#refs/tags/capi-v}"
+          tag="capi-v${ver}"
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            gh release edit "${tag}" --notes-file release-notes.md --title "rsvelte_capi v${ver}"
+          else
+            gh release create "${tag}" --title "rsvelte_capi v${ver}" --notes-file release-notes.md
+          fi
+          gh release upload "${tag}" artifacts/*.tar.gz artifacts/*.zip artifacts/*.sha256 artifacts/SHA256SUMS --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,10 +209,10 @@ dependencies = [
  "indexmap",
  "log",
  "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "quote 1.0.45",
  "serde",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
  "toml",
 ]

--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ The Rust API is the same surface OXC will eventually wire `oxlint` / `oxfmt` int
 
 A `cdylib` exposing a stable C ABI ships in [`crates/rsvelte_capi`](crates/rsvelte_capi). One shared library + one cbindgen-generated header (`rsvelte.h`) lets any language with a C FFI drive the same compiler — UTF-8 JSON in, UTF-8 JSON out, no per-language schema generation.
 
+**Download prebuilt binaries** from [GitHub Releases](https://github.com/baseballyama/rsvelte/releases) under the `capi-vX.Y.Z` tag scheme (`darwin-{arm64,x64}`, `linux-{x64,arm64}-gnu`, `win32-x64-msvc`; each archive ships the dylib + static archive + `rsvelte.h` + checksums):
+
+```bash
+VERSION=0.1.0 TRIPLE=darwin-arm64
+curl -L "https://github.com/baseballyama/rsvelte/releases/download/capi-v${VERSION}/rsvelte_capi-${VERSION}-${TRIPLE}.tar.gz" | tar -xz
+```
+
+Or build from source:
+
 ```bash
 cargo build -p rsvelte_capi --release
 # → target/release/librsvelte_capi.{dylib,so,a}, rsvelte_capi.dll

--- a/crates/rsvelte_capi/Cargo.toml
+++ b/crates/rsvelte_capi/Cargo.toml
@@ -3,8 +3,19 @@ name = "rsvelte_capi"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.90"
-description = "C ABI bindings for the rsvelte Svelte compiler"
+description = "C ABI bindings for the rsvelte Svelte 5 compiler — drive the compiler from C, Go, Python, Ruby, PHP, Zig, Java (JDK 22+ FFM), or any language with a C FFI"
 license = "MIT"
+repository = "https://github.com/baseballyama/rsvelte"
+homepage = "https://github.com/baseballyama/rsvelte/tree/main/crates/rsvelte_capi"
+documentation = "https://github.com/baseballyama/rsvelte/blob/main/crates/rsvelte_capi/README.md"
+readme = "README.md"
+keywords = ["svelte", "compiler", "ffi", "cdylib", "bindings"]
+categories = ["compilers", "external-ffi-bindings", "web-programming"]
+# Releases live on GitHub Releases (per-OS prebuilt cdylibs) — see the
+# Release rsvelte_capi workflow. crates.io publishing additionally
+# requires `svelte-compiler-rust` itself to be published; until then,
+# Rust callers should depend on this crate via a git path.
+publish = false
 
 [lib]
 # rlib is required so integration tests can `use rsvelte_capi::*`.

--- a/crates/rsvelte_capi/README.md
+++ b/crates/rsvelte_capi/README.md
@@ -25,9 +25,51 @@ The CI workflow (`.github/workflows/rsvelte-capi.yml`) runs the entire
 matrix on Linux, macOS, and Windows for every PR that touches the C ABI
 or the compiler.
 
-## Build
+## Install
+
+### Download prebuilt binaries (recommended)
+
+Tagged releases publish per-OS/arch archives to
+[GitHub Releases](https://github.com/baseballyama/rsvelte/releases)
+under the `capi-vX.Y.Z` tag scheme. Each archive contains the dynamic
+library, the static archive (where applicable), and `include/rsvelte.h`.
 
 ```bash
+# Pick the triple for your target:
+#   darwin-arm64, darwin-x64,
+#   linux-x64-gnu, linux-arm64-gnu,
+#   win32-x64-msvc
+VERSION=0.1.0
+TRIPLE=darwin-arm64
+
+curl -L -o rsvelte_capi.tar.gz \
+  "https://github.com/baseballyama/rsvelte/releases/download/capi-v${VERSION}/rsvelte_capi-${VERSION}-${TRIPLE}.tar.gz"
+tar -xzf rsvelte_capi.tar.gz
+
+# Layout after extraction:
+#   rsvelte_capi-<ver>-<triple>/
+#     ├── include/rsvelte.h
+#     ├── lib/librsvelte_capi.{dylib|so}        (Unix)
+#     ├── lib/rsvelte_capi.dll + .dll.lib       (Windows)
+#     ├── lib/librsvelte_capi.a                 (static archive)
+#     ├── README.md
+#     ├── LICENSE
+#     ├── VERSION
+#     └── COMMIT
+```
+
+A combined `SHA256SUMS` file is attached to every release. Verify with:
+
+```sh
+curl -LO "https://github.com/baseballyama/rsvelte/releases/download/capi-v${VERSION}/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS  # filters to whatever you have locally
+```
+
+### Build from source
+
+```bash
+git clone https://github.com/baseballyama/rsvelte
+cd rsvelte
 cargo build -p rsvelte_capi --release
 # Produces:
 #   target/release/librsvelte_capi.dylib   (macOS)
@@ -36,6 +78,17 @@ cargo build -p rsvelte_capi --release
 #   target/release/librsvelte_capi.a       (static archive)
 # Plus:
 #   crates/rsvelte_capi/include/rsvelte.h  (regenerated via cbindgen)
+```
+
+### Rust callers (`Cargo.toml`)
+
+`rsvelte_capi` itself is not yet published to crates.io (it depends
+on the unpublished `svelte-compiler-rust` core crate). Add it as a
+git dependency in the meantime:
+
+```toml
+[dependencies]
+rsvelte_capi = { git = "https://github.com/baseballyama/rsvelte", tag = "capi-v0.1.0" }
 ```
 
 ## API at a glance
@@ -139,3 +192,29 @@ message, before any downstream wrapper smoke even runs.
   ABI calls on every platform (Ruby Fiddle on AArch64, for instance).
 - **`#[unsafe(no_mangle)]` + edition 2024.** Requires `cbindgen >= 0.28`
   to parse correctly.
+
+## Cutting a release
+
+The C ABI uses its own tag scheme (`capi-vMAJOR.MINOR.PATCH`) and its
+own workflow ([`.github/workflows/release-capi.yml`](../../.github/workflows/release-capi.yml)),
+intentionally independent from the npm/changeset pipeline that ships
+`@rsvelte/compiler` et al.
+
+1. Bump `crates/rsvelte_capi/Cargo.toml`'s `version`.
+2. Open a PR, get it merged.
+3. From `main`, tag and push:
+
+   ```bash
+   git tag capi-v0.1.1
+   git push origin capi-v0.1.1
+   ```
+
+4. The release workflow builds the five-triple matrix, packages each
+   into `rsvelte_capi-<ver>-<triple>.tar.gz` (or `.zip` for Windows),
+   computes per-archive + combined SHA-256 sums, and creates the
+   GitHub Release with all archives attached. The workflow refuses to
+   build if the tag and `Cargo.toml` version disagree.
+
+`workflow_dispatch` (in the Actions tab) lets you run the matrix
+against any branch with a synthetic version label, producing
+inspectable artifacts without creating a Release.


### PR DESCRIPTION
## Summary

Follow-up to #297 — wires up actual distribution for the C ABI. Tags of the form `capi-vX.Y.Z` now trigger a release workflow that builds per-OS/arch archives and attaches them to a [GitHub Release](https://github.com/baseballyama/rsvelte/releases).

- **`.github/workflows/release-capi.yml`** — 5-triple build matrix + release job that creates / updates the Release.
- **`crates/rsvelte_capi/Cargo.toml`** — crates.io metadata polish; `publish = false` until the parent crate is published.
- **README + crates/rsvelte_capi/README** — "Download prebuilt binaries" sections, SHA-256 verification snippet, on-disk layout, and a "Cutting a release" walkthrough.

## What downstream users get

```bash
VERSION=0.1.0
TRIPLE=darwin-arm64   # or darwin-x64, linux-x64-gnu, linux-arm64-gnu, win32-x64-msvc

curl -L "https://github.com/baseballyama/rsvelte/releases/download/capi-v${VERSION}/rsvelte_capi-${VERSION}-${TRIPLE}.tar.gz" | tar -xz

# Archive layout:
#   rsvelte_capi-<ver>-<triple>/
#     ├── include/rsvelte.h
#     ├── lib/{librsvelte_capi.dylib|.so | rsvelte_capi.dll + .dll.lib}
#     ├── lib/{librsvelte_capi.a | rsvelte_capi.lib}    (static)
#     ├── README.md
#     ├── LICENSE
#     ├── VERSION
#     └── COMMIT
```

A combined `SHA256SUMS` is attached to every release for verification.

## How releases are cut

1. Bump `crates/rsvelte_capi/Cargo.toml`'s `version`, merge.
2. `git tag capi-v0.1.1 && git push origin capi-v0.1.1`.
3. Workflow builds the matrix, refuses to ship if the tag and Cargo.toml version disagree, then creates the Release with all archives + checksums + an auto-generated download table.

`workflow_dispatch` is enabled for dry-runs against any branch (no Release is created).

## Why not crates.io (yet)

`rsvelte_capi` path-depends on `svelte-compiler-rust`, which is not on crates.io. Publishing the child would require publishing the parent first (a separate decision: it's a long-term namespace + versioning commitment). For now:

- Non-Rust users: GitHub Releases (this PR).
- Rust users: git dep —

  ```toml
  [dependencies]
  rsvelte_capi = { git = "https://github.com/baseballyama/rsvelte", tag = "capi-v0.1.0" }
  ```

The crate's `publish = false` is an explicit gate so `cargo publish` can't fire accidentally before the parent is ready.

## Test plan

- [x] `cargo build -p rsvelte_capi --release` — clean
- [x] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Local packaging simulation: built `rsvelte_capi-0.1.0-darwin-arm64.tar.gz` with the expected layout (`include/`, `lib/`, `README.md`, `LICENSE`, `VERSION`, `COMMIT`), 40 MB, sha256 verified
- [ ] First real `capi-v…` tag push will exercise the full matrix end-to-end. The workflow uses the same `actions/upload-artifact@v4` + `gh release` machinery as the existing svelte-check / vps-native release pipeline, so the toolchain quirks are known to work.

## Out of scope

- crates.io publish (blocked on parent crate availability).
- Homebrew tap, apt repo, vcpkg manifest (each is a separate PR with its own maintenance footprint; GitHub Releases covers the universal install path first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)