### PR TITLE
fix(transform/server): strip TypeScript from final SSR output

### DIFF
--- a/src/compiler/phases/3_transform/mod.rs
+++ b/src/compiler/phases/3_transform/mod.rs
@@ -139,6 +139,24 @@ pub fn transform_component(
         }
         GenerateMode::Server => {
             let code = server::transform_server(analysis, ast, source, options)?;
+            // Template-expression interpolations in the SSR output are spliced
+            // straight from source positions, so for a TypeScript component
+            // (`<script lang="ts">`) bits of TS-only syntax — `as T` casts,
+            // `<T>` generics, `! ` non-null assertions, `: T` annotations on
+            // inline destructures — can leak into the emitted JS inside
+            // `$.escape(...)`, `$.stringify(...)`, `$.attr_style(...)`, etc.
+            // rolldown then rejects the result with
+            // `Type assertion expressions can only be used in TypeScript files`.
+            // Run the same TypeScript strip the analyzer uses over the final
+            // output to catch every leak in one pass, rather than threading
+            // a per-expression strip through every visitor source-slice site.
+            // Real-world surface: shadcn-svelte's `base-color-picker.svelte`
+            // → `style="--color: {map?.[mode.current as 'light' | 'dark']?.[…]}"`.
+            let code = if analysis.is_typescript {
+                crate::compiler::phases::phase2_analyze::types::strip_typescript(&code)
+            } else {
+                code
+            };
             if options.enable_sourcemap {
                 // Generate token-level mappings by matching tokens in the server
                 // output to tokens in the original source


### PR DESCRIPTION
## Summary

Template-expression interpolations in the server-side code generator are spliced straight from source byte positions, so for a TypeScript component (\`<script lang=\"ts\">\`) bits of TS-only syntax — \`as T\` casts, \`<T>\` generics, \`! \` non-null assertions, \`: T\` annotations on inline destructures — can leak into the emitted JS inside \`\$.escape(...)\`, \`\$.stringify(...)\`, \`\$.attr_style(...)\`, etc. rolldown then rejects the result with:

\`\`\`
Type assertion expressions can only be used in TypeScript files
\`\`\`

## Why a final-pass strip

The leak point isn't one specific visitor — it's the broad pattern of \`self.source[start..end]\` slicing across many template-emit sites. Threading a per-expression strip through every site is invasive and slow; running the same \`strip_typescript\` pass the analyzer already uses over the FULL server output once is one central edit, zero per-visitor churn.

## Verified locally

- \`cargo build --release --features napi --lib\` ✅
- \`cargo test --release --lib\` ✅ (1152 passed)
- Repro on shadcn-svelte's \`base-color-picker.svelte\` (\`style=\"--color: {map?.[mode.current as 'light' | 'dark']?.[...]}\"\`): SSR output now emits \`map?.[mode.current]?.[...]\` instead of leaking the TS cast.

## Remaining shadcn-svelte regressions

Several other bugs surface beneath this in the same smoke run, each its own follow-up PR:
- Scope-unaware derived-call rewrite: arrow-function/function parameters that happen to shadow a \`\$derived\` binding name also get \`()\` appended.
- Broken URL string in template literal: \`\"https:)\` truncation inside \`\$.escape(...)\` ternary.
- Unquoted hyphenated object keys in Svelte spread-attr emit: \`{ data-slot: '...' }\` should be \`{ 'data-slot': '...' }\`.
- IIFE-shaped function declarations in third-party precompiled \`.svelte\` modules (layerchart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)