### PR TITLE
fix(capi/release): set macOS dylib install_name to @rpath + bump 0.1.1

### DIFF
--- a/.github/workflows/release-capi.yml
+++ b/.github/workflows/release-capi.yml
@@ -103,6 +103,21 @@ jobs:
           RSVELTE_CAPI_CHECK_HEADER: '1'
         run: cargo build --release -p rsvelte_capi --target ${{ matrix.target }}
 
+      # On macOS, cargo defaults the dylib's LC_ID_DYLIB to the build's
+      # absolute path. Anything that links against the shipped dylib
+      # then asks dyld to load it from that nonexistent CI runner path
+      # (/Users/runner/work/...). Repoint to @rpath so downstream
+      # binaries find the dylib via their own LC_RPATH instead.
+      - name: Patch macOS install_name to @rpath
+        if: startsWith(matrix.target, 'aarch64-apple-darwin') || startsWith(matrix.target, 'x86_64-apple-darwin')
+        shell: bash
+        run: |
+          set -euo pipefail
+          dylib="target/${{ matrix.target }}/release/${{ matrix.lib }}"
+          install_name_tool -id "@rpath/${{ matrix.lib }}" "${dylib}"
+          echo "After patch:"
+          otool -D "${dylib}"
+
       - name: Stage archive contents
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ A `cdylib` exposing a stable C ABI ships in [`crates/rsvelte_capi`](crates/rsvel
 **Download prebuilt binaries** from [GitHub Releases](https://github.com/baseballyama/rsvelte/releases) under the `capi-vX.Y.Z` tag scheme (`darwin-{arm64,x64}`, `linux-{x64,arm64}-gnu`, `win32-x64-msvc`; each archive ships the dylib + static archive + `rsvelte.h` + checksums):
 
 ```bash
-VERSION=0.1.0 TRIPLE=darwin-arm64
+VERSION=0.1.1 TRIPLE=darwin-arm64
 curl -L "https://github.com/baseballyama/rsvelte/releases/download/capi-v${VERSION}/rsvelte_capi-${VERSION}-${TRIPLE}.tar.gz" | tar -xz
 ```
 

--- a/crates/rsvelte_capi/Cargo.toml
+++ b/crates/rsvelte_capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_capi"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.90"
 description = "C ABI bindings for the rsvelte Svelte 5 compiler — drive the compiler from C, Go, Python, Ruby, PHP, Zig, Java (JDK 22+ FFM), or any language with a C FFI"

--- a/crates/rsvelte_capi/README.md
+++ b/crates/rsvelte_capi/README.md
@@ -39,7 +39,7 @@ library, the static archive (where applicable), and `include/rsvelte.h`.
 #   darwin-arm64, darwin-x64,
 #   linux-x64-gnu, linux-arm64-gnu,
 #   win32-x64-msvc
-VERSION=0.1.0
+VERSION=0.1.1
 TRIPLE=darwin-arm64
 
 curl -L -o rsvelte_capi.tar.gz \
@@ -88,7 +88,7 @@ git dependency in the meantime:
 
 ```toml
 [dependencies]
-rsvelte_capi = { git = "https://github.com/baseballyama/rsvelte", tag = "capi-v0.1.0" }
+rsvelte_capi = { git = "https://github.com/baseballyama/rsvelte", tag = "capi-v0.1.1" }
 ```
 
 ## API at a glance


### PR DESCRIPTION
## Summary

The 0.1.0 darwin-arm64 / darwin-x64 archives we just published ship dylibs whose `LC_ID_DYLIB` still points at the CI runner's absolute build path:

```
/Users/runner/work/rsvelte/rsvelte/target/aarch64-apple-darwin/release/deps/librsvelte_capi.dylib
```

Anything that links against the shipped dylib then asks dyld to load it from that nonexistent CI path and aborts:

```
dyld[…]: Library not loaded: /Users/runner/work/rsvelte/rsvelte/target/…/librsvelte_capi.dylib
```

This PR patches the install_name to `@rpath/librsvelte_capi.dylib` right after the cargo build, so consumers' own `LC_RPATH` (e.g. `@executable_path/lib`) resolves it — the same convention every other macOS shared-library distribution follows.

Linux and Windows are unaffected (their SONAME / DLL-search-order resolution doesn't embed absolute build paths — verified the 0.1.0 linux .so has no CI runner string).

## Verified

Downloaded the 0.1.0 darwin-arm64 archive, ran the same `install_name_tool -id @rpath/librsvelte_capi.dylib` command this PR adds, then built and ran a small C smoke against it:

```
ver=0.1.0
len=418
{"ok":true,"result":{"js":{"code":"import 'svelte/internal/disclose-version';...
```

Without the patch: `dyld[]: Library not loaded`. With the patch: full envelope, no dyld error.

## Version bump

0.1.0 was already published, and the release workflow's `Verify Cargo.toml version matches tag` step refuses to ship if they disagree. So this hotfix lands as **0.1.1**. The 0.1.0 release will get a release-notes edit pointing at 0.1.1 as the recommended version (separate gh CLI step, outside this PR).

## Test plan

- [x] Locally reproduced the bug + verified the install_name_tool fix on the downloaded 0.1.0 dylib
- [x] cargo build still clean
- [ ] After merge: tag `capi-v0.1.1`, push, observe the release workflow upload patched dylibs; download → smoke against the 0.1.1 archive on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)