### PR TITLE
chore(svelte): upgrade submodule to 5.53.5 + escape contenteditable bindings

### DIFF
--- a/.changeset/svelte-5-53-5.md
+++ b/.changeset/svelte-5-53-5.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Bump target Svelte to **5.53.5** and port upstream commit `0df5abcae` "Merge commit from fork — fix: escape `innerText` and `textContent` bindings of `contenteditable`". The server transform now HTML-escapes `bind:innerText` / `bind:textContent` expressions on contenteditable elements to prevent XSS via attacker-controlled content. `bind:innerHTML` keeps its raw expression because the user is explicitly opting into HTML.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ A single-threaded **100× speedup** over the JS compiler is one of this project'
 ## Compatibility
 
 <!-- svelte-target-version -->
-**Targeting Svelte `v5.53.4`** ([`96fd3ce76352`](https://github.com/sveltejs/svelte/commit/96fd3ce76352)) — automatically maintained by `pnpm run update-docs`.
+**Targeting Svelte `v5.53.5`** ([`ed14b499d6ea`](https://github.com/sveltejs/svelte/commit/ed14b499d6ea)) — automatically maintained by `pnpm run update-docs`.
 <!-- /svelte-target-version -->
 
 Current compatibility with the official Svelte compiler test suite:

--- a/docs/rsvelte-shim/compiler.mjs
+++ b/docs/rsvelte-shim/compiler.mjs
@@ -79,8 +79,8 @@ function logOnce() {
 
 // The upstream svelte version we mirror. vite-plugin-svelte does
 // `gte(VERSION, '5.36.0')` to decide whether async features are available.
-// rsvelte targets sveltejs/svelte@5.53.4, so report that.
-export const VERSION = '5.53.4';
+// rsvelte targets sveltejs/svelte@5.53.5, so report that.
+export const VERSION = '5.53.5';
 
 // The NAPI compile binding deserialises `options` via serde_json, which can't
 // represent JS functions. vite-plugin-svelte sets `options.cssHash = () => …`

--- a/docs/src/lib/preview.ts
+++ b/docs/src/lib/preview.ts
@@ -7,9 +7,9 @@
 
 const IMPORT_MAP = {
 	imports: {
-		svelte: 'https://esm.sh/svelte@5.53.4',
-		'svelte/internal/disclose-version': 'https://esm.sh/svelte@5.53.4/internal/disclose-version',
-		'svelte/internal/client': 'https://esm.sh/svelte@5.53.4/internal/client'
+		svelte: 'https://esm.sh/svelte@5.53.5',
+		'svelte/internal/disclose-version': 'https://esm.sh/svelte@5.53.5/internal/disclose-version',
+		'svelte/internal/client': 'https://esm.sh/svelte@5.53.5/internal/client'
 	}
 };
 

--- a/docs/static/test-results.json
+++ b/docs/static/test-results.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-05-25T05:33:46.423900+00:00",
-  "commit_sha": "96fd3ce76352",
+  "generated_at": "2026-05-25T05:49:35.872425+00:00",
+  "commit_sha": "ed14b499d6ea",
   "summary": {
-    "total": 3437,
-    "passed": 3343,
+    "total": 3442,
+    "passed": 3348,
     "failed": 0,
     "skipped": 94,
     "percentage": 100
@@ -12002,8 +12002,8 @@
     {
       "id": "server-side-rendering",
       "name": "SSR",
-      "total": 89,
-      "passed": 89,
+      "total": 94,
+      "passed": 94,
       "failed": 0,
       "skipped": 0,
       "percentage": 100,
@@ -12017,11 +12017,23 @@
           "status": "pass"
         },
         {
+          "name": "boundary-error-html-comment-overlap-escape",
+          "status": "pass"
+        },
+        {
           "name": "textarea-value",
           "status": "pass"
         },
         {
           "name": "select-value-implicit-value-complex",
+          "status": "pass"
+        },
+        {
+          "name": "boundary-error-html-comment-escape",
+          "status": "pass"
+        },
+        {
+          "name": "contenteditable-bindings-escaped",
           "status": "pass"
         },
         {
@@ -12097,6 +12109,10 @@
           "status": "pass"
         },
         {
+          "name": "boundary-error-html-comment-open-escape",
+          "status": "pass"
+        },
+        {
           "name": "invalid-nested-svelte-element",
           "status": "pass"
         },
@@ -12154,6 +12170,10 @@
         },
         {
           "name": "head-svelte-components-raw-content",
+          "status": "pass"
+        },
+        {
+          "name": "boundary-error-html-comment-close-bang-escape",
           "status": "pass"
         },
         {

--- a/src/compiler/phases/3_transform/server/visitors/element.rs
+++ b/src/compiler/phases/3_transform/server/visitors/element.rs
@@ -115,7 +115,13 @@ impl<'a> ServerCodeGenerator<'a> {
             None
         };
 
-        // Detect content-editable binding (bind:innerHTML, bind:textContent, bind:innerText)
+        // Detect content-editable binding (bind:innerHTML, bind:textContent, bind:innerText).
+        //
+        // Svelte 5.53.5 (upstream commit `0df5abcae`, "Merge commit from fork")
+        // started HTML-escaping `bind:innerText` / `bind:textContent` to
+        // prevent XSS via attacker-controlled content in contenteditable
+        // surfaces. `bind:innerHTML` keeps its raw expression because the
+        // user is explicitly opting into HTML.
         let content_editable_expr: Option<String> = element.attributes.iter().find_map(|attr| {
             if let Attribute::BindDirective(bind) = attr {
                 let bind_name = bind.name.as_str();
@@ -125,7 +131,11 @@ impl<'a> ServerCodeGenerator<'a> {
                     if expr_end > expr_start && expr_end <= self.source.len() {
                         let raw = self.source[expr_start..expr_end].trim().to_string();
                         let raw = self.transform_store_refs(&raw);
-                        return Some(raw);
+                        return if bind_name == "innerHTML" {
+                            Some(raw)
+                        } else {
+                            Some(format!("$.escape({})", raw))
+                        };
                     }
                 }
             }


### PR DESCRIPTION
Bump Svelte 5.53.4 → 5.53.5 and port the SSR XSS fix for contenteditable bindings (`bind:innerText` / `bind:textContent` now wrap in `$.escape(...)`). 3,400/3,400 in-scope passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)