### PR TITLE
ci: cancel in-progress runs on new commits

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,6 +11,10 @@ on:
       - '.github/workflows/bench.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/rsvelte-capi.yml
+++ b/.github/workflows/rsvelte-capi.yml
@@ -33,6 +33,10 @@ on:
       - '.github/workflows/rsvelte-capi.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary
- Add `concurrency` blocks to **CI**, **Coverage**, **Benchmark**, and **rsvelte_capi** so a newer push cancels the previous run on the same ref.
- Group key is `${{ github.workflow }}-${{ github.head_ref || github.ref }}` — for PRs this is the source branch, for `push` to `main` this is `refs/heads/main`. The naive `head_ref || run_id` pattern falls back to a unique `run_id` for push events, so main-branch pushes would never cancel, which is the exact case backing up today's queue.
- Workflows intentionally left alone:
  - **release** / **deploy-docs**: already have `cancel-in-progress: false` (must not be interrupted).
  - **ecosystem-ci** / **ecosystem-ci-poll**: already have appropriate concurrency groups.
  - **release-capi**: triggered on tag pushes only — does not accumulate.
  - **refresh-benchmark**: `workflow_dispatch` only.

## Test plan
- [ ] Push a follow-up commit to this branch and confirm the previous CI/Coverage/Benchmark/rsvelte_capi run is cancelled.
- [ ] Land two main commits in quick succession and confirm the older main run is cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)