### PR TITLE
ci: speedup combo (drop Build, label-gate Coverage+Bench, PR-skip macOS, cache Svelte build)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -79,8 +79,11 @@ jobs:
           path: |
             submodules/svelte/node_modules
             submodules/svelte/packages/svelte/node_modules
-            submodules/svelte/packages/svelte/dist
-          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+            submodules/svelte/packages/svelte/compiler/index.js
+            submodules/svelte/packages/svelte/types
+            submodules/svelte/packages/svelte/*.d.ts
+            submodules/svelte/packages/svelte/scripts/_bundle.js
+          key: svelte-build-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
 
       - name: Build Svelte compiler
         if: steps.svelte-build-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,7 +57,19 @@ jobs:
           path: fixtures
           key: fixtures-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
 
+      - name: Cache Svelte compiler build
+        # See the matching step in `.github/workflows/ci.yml`.
+        id: svelte-build-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            submodules/svelte/node_modules
+            submodules/svelte/packages/svelte/node_modules
+            submodules/svelte/packages/svelte/dist
+          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+
       - name: Build Svelte compiler
+        if: steps.svelte-build-cache.outputs.cache-hit != 'true'
         run: |
           cd submodules/svelte
           pnpm install --frozen-lockfile

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,7 @@
 name: Benchmark
 
 on:
-  pull_request:
+  push:
     branches: [main]
     paths:
       - 'src/**'
@@ -9,6 +9,11 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/bench.yml'
+  pull_request:
+    branches: [main]
+    # Default + `labeled` so adding the `bench` label triggers a run; the
+    # job's `if:` below skips unlabeled events.
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 concurrency:
@@ -23,6 +28,15 @@ jobs:
     name: Criterion benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Criterion takes ~25 minutes per run; not worth gating every PR on
+    # absolute throughput numbers that move slowly. Always run on push to
+    # `main` (and manual dispatch); on PRs run only when the PR is
+    # labeled `bench`.
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'bench'))
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,11 @@ jobs:
           path: |
             submodules/svelte/node_modules
             submodules/svelte/packages/svelte/node_modules
-            submodules/svelte/packages/svelte/dist
-          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+            submodules/svelte/packages/svelte/compiler/index.js
+            submodules/svelte/packages/svelte/types
+            submodules/svelte/packages/svelte/*.d.ts
+            submodules/svelte/packages/svelte/scripts/_bundle.js
+          key: svelte-build-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
 
       - name: Build Svelte compiler
         if: steps.svelte-build-cache.outputs.cache-hit != 'true'
@@ -249,8 +252,11 @@ jobs:
           path: |
             submodules/svelte/node_modules
             submodules/svelte/packages/svelte/node_modules
-            submodules/svelte/packages/svelte/dist
-          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+            submodules/svelte/packages/svelte/compiler/index.js
+            submodules/svelte/packages/svelte/types
+            submodules/svelte/packages/svelte/*.d.ts
+            submodules/svelte/packages/svelte/scripts/_bundle.js
+          key: svelte-build-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
 
       - name: Build Svelte compiler
         if: steps.svelte-build-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,38 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  # macOS is dropped from the PR matrix to keep PR feedback fast — it
+  # consistently runs ~2x slower than Linux for identical work and the
+  # platform-specific failure modes (PATH, line endings, dylib loading)
+  # are already covered by `rsvelte_capi` and the `Release` workflow.
+  # macOS still runs on every push to `main` and on demand via the
+  # `macos-ci` label, so regressions are caught before the next release.
+  set-test-matrix:
+    name: Set Test matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      os: ${{ steps.matrix.outputs.os }}
+    steps:
+      - id: matrix
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "push" \
+                || "${{ contains(github.event.pull_request.labels.*.name, 'macos-ci') }}" == "true" ]]; then
+            echo 'os=["ubuntu-latest","macos-latest"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'os=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Test
+    needs: set-test-matrix
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: ${{ fromJSON(needs.set-test-matrix.outputs.os) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,7 +121,24 @@ jobs:
           # from `_config.js`, so any cache pre-dating that change is stale.
           key: fixtures-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
 
+      - name: Cache Svelte compiler build
+        # The Svelte compiler is built identically across CI / Compatibility
+        # Report / Coverage / Bench / Deploy Docs. Cache `node_modules` +
+        # `packages/svelte/dist` keyed on the submodule SHA + pnpm-lock so
+        # cache-hit runs skip the ~1-2 minute `pnpm install && pnpm build`.
+        # Includes `node_modules/.bin/tsc`, which is referenced via
+        # `TSGO_BIN` below.
+        id: svelte-build-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            submodules/svelte/node_modules
+            submodules/svelte/packages/svelte/node_modules
+            submodules/svelte/packages/svelte/dist
+          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+
       - name: Build Svelte compiler
+        if: steps.svelte-build-cache.outputs.cache-hit != 'true'
         run: |
           cd submodules/svelte
           pnpm install --frozen-lockfile
@@ -200,7 +241,19 @@ jobs:
           # from `_config.js`, so any cache pre-dating that change is stale.
           key: fixtures-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
 
+      - name: Cache Svelte compiler build
+        # See the matching step in the `test` job above.
+        id: svelte-build-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            submodules/svelte/node_modules
+            submodules/svelte/packages/svelte/node_modules
+            submodules/svelte/packages/svelte/dist
+          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+
       - name: Build Svelte compiler
+        if: steps.svelte-build-cache.outputs.cache-hit != 'true'
         run: |
           cd submodules/svelte
           pnpm install --frozen-lockfile
@@ -269,23 +322,12 @@ jobs:
               });
             }
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release
-        run: cargo build --release
+  # `Build` (`cargo build --release` for the main crate) was removed —
+  # release-mode codegen is already exercised by `rsvelte_capi (C ABI)`
+  # (Linux/macOS/Windows release builds with the same crate's source) and
+  # by the `Release` workflow's `build-svelte-check` / `build-vps-native`
+  # matrices, so a standalone PR-time build only repeated work. To restore
+  # a pure release-mode smoke test add a `cargo check --release` step here.
 
   docs:
     name: Documentation

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Include the default events plus `labeled` so adding the `coverage`
+    # label to an existing PR (re-)triggers the workflow. The job's `if:`
+    # below short-circuits when the label isn't present, so unlabeled PRs
+    # cost nothing beyond GitHub's free event scheduling.
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -18,6 +24,15 @@ jobs:
     name: Code coverage
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Run unconditionally on push-to-main and manual dispatch. On PRs run
+    # only when the author opts in by labeling the PR `coverage` —
+    # llvm-cov instrumentation roughly doubles test runtime and the
+    # report is rarely actionable per-PR, so the default is to skip it.
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'coverage'))
     steps:
       - uses: actions/checkout@v4
         with:
@@ -53,7 +68,19 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - name: Cache Svelte compiler build
+        # See the matching step in `.github/workflows/ci.yml`.
+        id: svelte-build-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            submodules/svelte/node_modules
+            submodules/svelte/packages/svelte/node_modules
+            submodules/svelte/packages/svelte/dist
+          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+
       - name: Build Svelte compiler
+        if: steps.svelte-build-cache.outputs.cache-hit != 'true'
         run: |
           cd submodules/svelte
           pnpm install --frozen-lockfile

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -76,8 +76,11 @@ jobs:
           path: |
             submodules/svelte/node_modules
             submodules/svelte/packages/svelte/node_modules
-            submodules/svelte/packages/svelte/dist
-          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+            submodules/svelte/packages/svelte/compiler/index.js
+            submodules/svelte/packages/svelte/types
+            submodules/svelte/packages/svelte/*.d.ts
+            submodules/svelte/packages/svelte/scripts/_bundle.js
+          key: svelte-build-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
 
       - name: Build Svelte compiler
         if: steps.svelte-build-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -51,10 +51,22 @@ jobs:
           path: fixtures
           key: fixtures-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
 
+      - name: Cache Svelte compiler build
+        # See the matching step in `.github/workflows/ci.yml`.
+        id: svelte-build-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            submodules/svelte/node_modules
+            submodules/svelte/packages/svelte/node_modules
+            submodules/svelte/packages/svelte/dist
+          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+
       - name: Build Svelte compiler
         # `generate-fixtures` and `compatibility-report` both import directly
         # from the Svelte submodule; its workspace deps (acorn, magic-string,
         # …) must be installed first.
+        if: steps.svelte-build-cache.outputs.cache-hit != 'true'
         run: |
           cd submodules/svelte
           pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -59,8 +59,11 @@ jobs:
           path: |
             submodules/svelte/node_modules
             submodules/svelte/packages/svelte/node_modules
-            submodules/svelte/packages/svelte/dist
-          key: svelte-build-v1-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
+            submodules/svelte/packages/svelte/compiler/index.js
+            submodules/svelte/packages/svelte/types
+            submodules/svelte/packages/svelte/*.d.ts
+            submodules/svelte/packages/svelte/scripts/_bundle.js
+          key: svelte-build-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml') }}
 
       - name: Build Svelte compiler
         # `generate-fixtures` and `compatibility-report` both import directly


### PR DESCRIPTION
## Summary

PR-time CI on the recent `5051274` run was ~43 min wall-clock and ~90+ runner-minutes of compute. This PR applies five low-risk speedups identified in the recent CI review:

1. **Delete the standalone `Build` job** — `cargo build --release` for the main crate. `rsvelte_capi (C ABI)` (Linux/macOS/Windows release builds against the same `src/**`) and the `Release` workflow's per-target matrices already cover release-mode codegen on every PR / release. Estimated savings: ~6 min/PR.
2. **Gate `Coverage` on PRs behind the `coverage` label**. `cargo llvm-cov --workspace` adds ~11 min/PR with instrumentation and the per-PR report is rarely actionable. Push-to-`main` and `workflow_dispatch` still run unconditionally; PRs run only when labeled `coverage`. Estimated savings: ~11 min/PR.
3. **Drop `Test (macos-latest)` from the default PR matrix**. macOS is consistently ~2x slower than Linux (~4m30s vs ~2m30s) and platform-specific issues are already exercised by `rsvelte_capi (C ABI)` (release build + per-language smoke on `macos-latest`) and the `Release` matrices. macOS still runs on every push to `main` and can be opted in per-PR via the `macos-ci` label. Estimated savings: ~4 min/PR.
4. **Cache `submodules/svelte/{node_modules,packages/svelte/{node_modules,dist}}` across jobs**. CI / Compatibility Report / Coverage / Bench / Deploy Docs each ran `pnpm install --frozen-lockfile && pnpm build` against the same submodule SHA, paying ~1-2 minutes per job. Keyed on submodule SHA + pnpm-lock; the build step now runs only on cache miss. Estimated compute savings: ~5-10 min/PR.
5. **Gate `Bench` on PRs behind the `bench` label**. Criterion takes ~25 min per run and absolute throughput numbers move slowly; gating every PR on them isn't worth the wall-clock cost. `Bench` now runs unconditionally on push to `main` (so the `pr` baseline still lands somewhere) and on `workflow_dispatch`; on PRs only when labeled `bench`. Estimated savings: ~25 min/PR critical path when `paths:` would have triggered it.

Combined: PR critical path ~43 min → ~15-20 min on a cache-warm run.

## Test plan
- [ ] Watch this PR's CI run — `Build` is gone, `Test` runs only on Linux, `Coverage` / `Bench` are skipped (no `coverage` / `bench` label), `Compatibility Report` cache-hits the Svelte build after the first run lands on `main`.
- [ ] After merge, push something to `main` and confirm `Test (macos-latest)` and `Bench` run alongside `Test (ubuntu-latest)`.
- [ ] Label a PR `coverage` / `bench` and confirm those jobs run; remove the label and confirm they skip on the next sync.
- [ ] First `Compatibility Report` after merge will cache-miss the Svelte build (`svelte-build-v1-...`); subsequent runs on the same Svelte SHA should cache-hit and skip the install/build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)