### PR TITLE
chore(release): add changeset for Svelte 5.55.9 follow-up fixes

### DIFF
--- a/.changeset/svelte-5-55-9-stringify-omittance.md
+++ b/.changeset/svelte-5-55-9-stringify-omittance.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix: port Svelte 5.55.9 follow-ups — `nullish-coallescence-omittance` SSR
+stringify omittance (upstream `a5df6616e`) and `Percentage` keyframe
+double-print (upstream `ca3f35bf7`). Class / style / innerHTML SSR paths
+and the head-element SSR / `css-keyframes-percent` print path are still
+tracked as follow-ups in the per-suite skip lists.


### PR DESCRIPTION
Triggers a patch release covering the Svelte 5.55.9 follow-up ports landed in #376:

* SSR `nullish-coallescence-omittance` — known-literal attribute interpolations are now inlined into the surrounding template-literal text, `null`/`undefined` are dropped, and `typeof X` / no-expression template literals skip `\$.stringify(...)`. Mirrors upstream commit `a5df6616e`.
* CSS `Percentage` keyframe double-print — drops the no-longer-needed `%` doubling. Mirrors upstream commit `ca3f35bf7`.

Bumps:
- `@rsvelte/compiler`: patch (0.5.0 → 0.5.1)
- `@rsvelte/svelte-check`: patch (0.1.2 → 0.1.3)
- `@rsvelte/vite-plugin-svelte-native`: patch (0.1.2 → 0.1.3)
- `@rsvelte/svelte2tsx`: patch (0.1.4 → 0.1.5) — auto via `updateInternalDependencies` on the compiler bump

Merging this PR will land the changeset on `main` and the `Release` workflow's `changesets/action` step will (re-)open a "Version Packages" PR with the actual version bumps + CHANGELOG entries. Merging that follow-up PR triggers the publish + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)