### PR TITLE
feat(compiler): port HtmlTag is_controlled + partial SSR $.stringify elide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,10 +125,10 @@ Source: `pnpm run compatibility-report` (generated 2026-05-26, Svelte commit `b6
 | Compiler Snapshot | 20/20 | |
 | CSS | 180/181 | 1 skipped (`css-prune-edge-cases` — Svelte 5.53.7) |
 | Validator | 324/325 | 1 skipped (`error-mode-warn` — opted out via `_config.js`) |
-| SSR | 95/97 | 2 skipped (`head-raw-elements-content` SSR class-hash inlining; `select-option-store-implicit-value` synthetic `<option value>` SSR — Svelte 5.53.6 / 5.55.9) |
+| SSR | 97/97 | HtmlTag SSR class-hash inlining + synthetic `<option value>` ported (Svelte 5.53.6, 5.55.9). |
 | Hydration | 78/78 | HtmlTag `is_controlled` cluster ported (Svelte 5.53.8 `0206a2019`) |
-| Runtime Legacy | 1202/1205 | 3 skipped — `flush-sync-each-block` (no-semicolon import + legacy `$.mutable_source`), `inline-style-directive-string-variable-kebab-case` (multi-line const extraction), `innerhtml-interpolated-literal` (innerHTML codegen path) |
-| Runtime Runes | 931/979 | 48 skipped — async-blocker / `@const` clusters (Svelte 5.53.0–5.55.9). HtmlTag `is_controlled` cluster ported. |
+| Runtime Legacy | 1203/1205 | 2 skipped — `flush-sync-each-block` (no-semicolon import + legacy `$.mutable_source`), `inline-style-directive-string-variable-kebab-case` (multi-line const extraction) |
+| Runtime Runes | 934/979 | 45 skipped — async-blocker / `@const` clusters (Svelte 5.54.1–5.55.9). HtmlTag `is_controlled` + derived-update-server + derived-dep-set-while-rendering + attribute-parts ported. |
 | Runtime Browser | 32/32 | |
 | Print | 41/42 | 1 skipped (`css-keyframes-percent` — Svelte 5.55.8) |
 | Preprocess | 19/19 | Each fixture's `_config.js` JS preprocessor hand-ported in `tests/common/preprocess_fixtures.rs` |
@@ -136,12 +136,15 @@ Source: `pnpm run compatibility-report` (generated 2026-05-26, Svelte commit `b6
 | svelte2tsx | 245/247 | Wave 1 of the ecosystem port. 2 skipped (`expected.error.json` error fixtures). Driven by `tests/common/svelte2tsx.rs` |
 | Migrate | 0/76 | **Out of scope** — rsvelte is a Svelte 5 compiler port, not a Svelte 4 → 5 migration tool |
 
-**Compatibility report total: 3414/3414 in-scope-run passing — every executed fixture in every in-scope category passes. 62 in-scope fixtures remain skipped (codegen clusters tracked in the table above); the 76 `migrate` fixtures are intentionally out of scope.**
+**Compatibility report total: 3420/3420 in-scope-run passing — every executed fixture in every in-scope category passes. 56 in-scope fixtures remain skipped (codegen clusters tracked in the table above); the 76 `migrate` fixtures are intentionally out of scope.**
 
 ### Ports landed for skip-reduction (Svelte 5.53.0+)
 
 - **HtmlTag `is_controlled`** (Svelte 5.53.8 `0206a2019`) — fragment / html_tag visitor branches in `src/compiler/phases/3_transform/client/visitors/{html_tag.rs,shared/fragment.rs}`. Unblocked 11 fixtures across runtime-runes, runtime-legacy, hydration.
-- **SSR attribute `$.stringify` elide** (Svelte 5.55.9 `a5df6616e`, partial) — `eval_attr_expr_json` now handles `ConditionalExpression` and string-concat `BinaryExpression`. Class and style-directive emission paths (`element.rs`) now route through it so provably-string ternaries/concat skip the wrapper and known constants inline. Style-directive/innerHTML/multi-line const paths still pending.
+- **`$.update_derived` helpers on derived `++` / `--`** (Svelte 5.53.2 `6aa7b9c64`) — `transform_script.rs::rewrite_derived_update_expressions` rewrites `count()++`/`++count()` shape into `$.update_derived(count)` / `$.update_derived_pre(count)` after the bare-read wrap pass. Unblocked `derived-update-server`.
+- **`<option>` synthetic-value via `transform_store_refs`** (Svelte 5.53.6 `e3d277b00`) — `select_element.rs` now routes the synthetic value expression through `transform_store_refs` so `$label` becomes `$.store_get(...)`. Unblocked `select-option-store-implicit-value`.
+- **Bare-derived `$derived(visible)` collapse** (Svelte 5.55.5 `b771df3`) — `transform_script.rs::unthunk_bare_derived_arg` rewrites `$.derived(() => visible())` back to `$.derived(visible)` when the inner is a known derived. Unblocked `derived-dep-set-while-rendering`.
+- **SSR attribute `$.stringify` elide** (Svelte 5.55.9 `a5df6616e`, partial) — `eval_attr_expr_json` handles `ConditionalExpression` and string-concat `BinaryExpression`. Class, style-directive, and class-attribute (no-directive) emission paths route through it; the no-class-directive path also falls back to a static `class="..."` attribute when every interpolation inlines. Unblocked `attribute-dynamic-multiple`, `globals-not-overwritten-by-bindings`, `attribute-parts`, `head-raw-elements-content`, `innerhtml-interpolated-literal`. Multi-line `let` extraction remains pending.
 
 ### Ecosystem port (`docs/ecosystem-implementation-plan.md`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,28 +115,33 @@ Use the `Agent` tool for substantial work — feature implementation, multi-file
 
 ## Test Status
 
-Source: `pnpm run compatibility-report` (generated 2026-05-22, Svelte commit `04c0368aa8d8`). Re-run `pnpm run test-and-update` to refresh.
+Source: `pnpm run compatibility-report` (generated 2026-05-26, Svelte commit `b65a3f3fc5e1`). Re-run `pnpm run test-and-update` to refresh. Skip lists live in `tests/compatibility_report.rs` and `tests/runtime.rs`; `tests/audit_skipped.rs` re-checks every skipped fixture after a Svelte bump.
 
 | Suite | Pass/Total | Notes |
 |-------|------------|-------|
-| Parser Modern | 22/22 | |
-| Parser Legacy | 82/83 | 1 skipped (`javascript-comments` — OXC vs acorn comment attachment) |
+| Parser Modern | 22/24 | 2 skipped (`comment-in-tag`, `parens` — comments-in-tags Svelte 5.53.0) |
+| Parser Legacy | 81/83 | 2 skipped (`javascript-comments` OXC vs acorn comment attachment; `script-comment-only` same cluster) |
 | Compiler Errors | 144/144 | |
 | Compiler Snapshot | 20/20 | |
-| CSS | 179/179 | |
-| Validator | 324/325 | 1 skipped (`error-mode-warn`) |
-| SSR | 82/82 | |
-| Hydration | 77/77 | |
-| Runtime Legacy | 1202/1202 | |
-| Runtime Runes | 865/865 | |
-| Runtime Browser | 31/31 | |
-| Print | 40/40 | |
+| CSS | 180/181 | 1 skipped (`css-prune-edge-cases` — Svelte 5.53.7) |
+| Validator | 324/325 | 1 skipped (`error-mode-warn` — opted out via `_config.js`) |
+| SSR | 95/97 | 2 skipped (`head-raw-elements-content` SSR class-hash inlining; `select-option-store-implicit-value` synthetic `<option value>` SSR — Svelte 5.53.6 / 5.55.9) |
+| Hydration | 78/78 | HtmlTag `is_controlled` cluster ported (Svelte 5.53.8 `0206a2019`) |
+| Runtime Legacy | 1202/1205 | 3 skipped — `flush-sync-each-block` (no-semicolon import + legacy `$.mutable_source`), `inline-style-directive-string-variable-kebab-case` (multi-line const extraction), `innerhtml-interpolated-literal` (innerHTML codegen path) |
+| Runtime Runes | 931/979 | 48 skipped — async-blocker / `@const` clusters (Svelte 5.53.0–5.55.9). HtmlTag `is_controlled` cluster ported. |
+| Runtime Browser | 32/32 | |
+| Print | 41/42 | 1 skipped (`css-keyframes-percent` — Svelte 5.55.8) |
 | Preprocess | 19/19 | Each fixture's `_config.js` JS preprocessor hand-ported in `tests/common/preprocess_fixtures.rs` |
 | Sourcemaps | 0/0 | No fixtures yet |
-| svelte2tsx | 245/245 | Wave 1 of the ecosystem port. 2 skipped (`expected.error.json` error fixtures). Driven by `tests/common/svelte2tsx.rs` |
+| svelte2tsx | 245/247 | Wave 1 of the ecosystem port. 2 skipped (`expected.error.json` error fixtures). Driven by `tests/common/svelte2tsx.rs` |
 | Migrate | 0/76 | **Out of scope** — rsvelte is a Svelte 5 compiler port, not a Svelte 4 → 5 migration tool |
 
-**Compatibility report total: 3332/3332 in-scope passing — every in-scope category at 100%. The 76 `migrate` fixtures are intentionally out of scope and do not count against the total.**
+**Compatibility report total: 3414/3414 in-scope-run passing — every executed fixture in every in-scope category passes. 62 in-scope fixtures remain skipped (codegen clusters tracked in the table above); the 76 `migrate` fixtures are intentionally out of scope.**
+
+### Ports landed for skip-reduction (Svelte 5.53.0+)
+
+- **HtmlTag `is_controlled`** (Svelte 5.53.8 `0206a2019`) — fragment / html_tag visitor branches in `src/compiler/phases/3_transform/client/visitors/{html_tag.rs,shared/fragment.rs}`. Unblocked 11 fixtures across runtime-runes, runtime-legacy, hydration.
+- **SSR attribute `$.stringify` elide** (Svelte 5.55.9 `a5df6616e`, partial) — `eval_attr_expr_json` now handles `ConditionalExpression` and string-concat `BinaryExpression`. Class and style-directive emission paths (`element.rs`) now route through it so provably-string ternaries/concat skip the wrapper and known constants inline. Style-directive/innerHTML/multi-line const paths still pending.
 
 ### Ecosystem port (`docs/ecosystem-implementation-plan.md`)
 

--- a/docs/static/test-results.json
+++ b/docs/static/test-results.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-05-26T05:10:41.966865+00:00",
+  "generated_at": "2026-05-26T08:24:50.868442+00:00",
   "commit_sha": "b65a3f3fc5e1",
   "summary": {
     "total": 3552,
-    "passed": 3414,
+    "passed": 3420,
     "failed": 0,
-    "skipped": 138,
+    "skipped": 132,
     "percentage": 100
   },
   "categories": [
@@ -3193,9 +3193,9 @@
       "id": "runtime-runes",
       "name": "Runtime Runes",
       "total": 979,
-      "passed": 931,
+      "passed": 934,
       "failed": 0,
-      "skipped": 48,
+      "skipped": 45,
       "percentage": 100,
       "tests": [
         {
@@ -3507,8 +3507,7 @@
         },
         {
           "name": "attribute-parts",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "async-if-hydration",
@@ -3685,8 +3684,7 @@
         },
         {
           "name": "derived-update-server",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "each-updates-5",
@@ -4450,8 +4448,7 @@
         },
         {
           "name": "derived-dep-set-while-rendering",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "async-fork-snippet-dev",
@@ -7168,9 +7165,9 @@
       "id": "runtime-legacy",
       "name": "Runtime Legacy",
       "total": 1205,
-      "passed": 1202,
+      "passed": 1203,
       "failed": 0,
-      "skipped": 3,
+      "skipped": 2,
       "percentage": 100,
       "tests": [
         {
@@ -11037,8 +11034,7 @@
         },
         {
           "name": "innerhtml-interpolated-literal",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "instrumentation-script-destructuring",
@@ -12464,9 +12460,9 @@
       "id": "server-side-rendering",
       "name": "SSR",
       "total": 97,
-      "passed": 95,
+      "passed": 97,
       "failed": 0,
-      "skipped": 2,
+      "skipped": 0,
       "percentage": 100,
       "tests": [
         {
@@ -12611,8 +12607,7 @@
         },
         {
           "name": "select-option-store-implicit-value",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "component-yield",
@@ -12676,8 +12671,7 @@
         },
         {
           "name": "head-raw-elements-content",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "component-binding",

--- a/docs/static/test-results.json
+++ b/docs/static/test-results.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-05-25T11:48:04.055446+00:00",
+  "generated_at": "2026-05-26T05:10:41.966865+00:00",
   "commit_sha": "b65a3f3fc5e1",
   "summary": {
     "total": 3552,
-    "passed": 3389,
+    "passed": 3414,
     "failed": 0,
-    "skipped": 163,
+    "skipped": 138,
     "percentage": 100
   },
   "categories": [
@@ -467,15 +467,14 @@
       "id": "snapshot",
       "name": "Compiler Snapshot",
       "total": 20,
-      "passed": 19,
+      "passed": 20,
       "failed": 0,
-      "skipped": 1,
+      "skipped": 0,
       "percentage": 100,
       "tests": [
         {
           "name": "nullish-coallescence-omittance",
-          "status": "skip",
-          "skip_reason": "SSR static-attr inlining (Svelte 5.55.9) not yet ported"
+          "status": "pass"
         },
         {
           "name": "class-state-field-constructor-assignment",
@@ -3194,9 +3193,9 @@
       "id": "runtime-runes",
       "name": "Runtime Runes",
       "total": 979,
-      "passed": 927,
+      "passed": 931,
       "failed": 0,
-      "skipped": 52,
+      "skipped": 48,
       "percentage": 100,
       "tests": [
         {
@@ -3933,8 +3932,7 @@
         },
         {
           "name": "html-tag-contenteditable",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "async-each",
@@ -4415,8 +4413,7 @@
         },
         {
           "name": "await-html-hydration",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "inspect-multiple",
@@ -6264,8 +6261,7 @@
         },
         {
           "name": "event-global-hydration-error-cleanup",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "event-on-2",
@@ -6821,8 +6817,7 @@
         },
         {
           "name": "async-html-tag",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "snippet-prop-implicit",
@@ -7173,9 +7168,9 @@
       "id": "runtime-legacy",
       "name": "Runtime Legacy",
       "total": 1205,
-      "passed": 1186,
+      "passed": 1202,
       "failed": 0,
-      "skipped": 19,
+      "skipped": 3,
       "percentage": 100,
       "tests": [
         {
@@ -7240,8 +7235,7 @@
         },
         {
           "name": "const-tag-each-arrow",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "component-events",
@@ -8085,8 +8079,7 @@
         },
         {
           "name": "const-tag-each-duplicated-variable2",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "module-context-export-referenced-in-template",
@@ -8370,13 +8363,11 @@
         },
         {
           "name": "globals-not-overwritten-by-bindings",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "const-tag-each-duplicated-variable3",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "reactive-update-expression",
@@ -8528,8 +8519,7 @@
         },
         {
           "name": "const-tag-each-function",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "const-tag-each-destructure-computed-in-computed",
@@ -8653,8 +8643,7 @@
         },
         {
           "name": "attribute-dynamic-multiple",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "spread-element-multiple",
@@ -9162,8 +9151,7 @@
         },
         {
           "name": "svg-html-tag3",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "const-tag-if-else",
@@ -9175,8 +9163,7 @@
         },
         {
           "name": "svg-html-tag4",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "binding-input-text-deep-computed",
@@ -9548,8 +9535,7 @@
         },
         {
           "name": "raw-mustaches-preserved",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "svg-html-tag2",
@@ -9846,8 +9832,7 @@
         },
         {
           "name": "attribute-url",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "select-props",
@@ -9931,8 +9916,7 @@
         },
         {
           "name": "head-title-static-dynamic-element",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "semicolon-hoisting",
@@ -10632,8 +10616,7 @@
         },
         {
           "name": "await-block-func-function",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "binding-input-group-each-5",
@@ -10833,8 +10816,7 @@
         },
         {
           "name": "raw-svg",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "component-slot-let-scope",
@@ -10954,8 +10936,7 @@
         },
         {
           "name": "const-tag-each-const",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "immutable-nested",
@@ -11437,8 +11418,7 @@
         },
         {
           "name": "ignore-unchanged-raw",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "if-block-expression",
@@ -11478,8 +11458,7 @@
         },
         {
           "name": "raw-anchor-first-last-child",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "store-auto-subscribe-in-reactive-declaration-2",
@@ -12162,9 +12141,9 @@
       "id": "hydration",
       "name": "Hydration",
       "total": 78,
-      "passed": 75,
+      "passed": 78,
       "failed": 0,
-      "skipped": 3,
+      "skipped": 0,
       "percentage": 100,
       "tests": [
         {
@@ -12281,8 +12260,7 @@
         },
         {
           "name": "raw-repair",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "each-block-more-nodes-on-client",
@@ -12342,8 +12320,7 @@
         },
         {
           "name": "raw-empty",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "each-block-arg-clash",
@@ -12391,8 +12368,7 @@
         },
         {
           "name": "raw-svg",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "custom-element-with-settable-only-property",
@@ -12986,9 +12962,9 @@
       "id": "print",
       "name": "Print",
       "total": 42,
-      "passed": 40,
+      "passed": 41,
       "failed": 0,
-      "skipped": 2,
+      "skipped": 1,
       "percentage": 100,
       "tests": [
         {
@@ -13074,8 +13050,7 @@
         },
         {
           "name": "style",
-          "status": "skip",
-          "skip_reason": "CSS print re-formatter (Svelte 5.55.8) not yet ported"
+          "status": "pass"
         },
         {
           "name": "expression-tag",

--- a/src/compiler/phases/3_transform/client/types.rs
+++ b/src/compiler/phases/3_transform/client/types.rs
@@ -1926,6 +1926,15 @@ pub struct ComponentClientTransformState<'a> {
     /// This flag is set in fragment.rs process_children and checked in each_block.rs.
     pub is_controlled_each: bool,
 
+    /// Flag indicating if the current HtmlTag should be treated as "controlled".
+    /// Set when `{@html ...}` is the only child of an element (Svelte 5.53.8
+    /// upstream commit `0206a2019`); the visitor then skips the wrapper
+    /// comment anchor and emits `$.html(parent, thunk, true, ...)` so the
+    /// runtime can use the parent's namespace and clean up
+    /// externally-added DOM nodes (e.g. contenteditable input). Set in
+    /// shared/fragment.rs process_children and read in html_tag.rs.
+    pub is_controlled_html: bool,
+
     /// Local snippets for child processing (used when processing element children).
     /// In the JS version, this is `child_state.snippets`.
     /// When snippets are defined inside elements, they go here instead of init.
@@ -2155,6 +2164,7 @@ impl<'a> ComponentClientTransformState<'a> {
             in_event_attribute_handler: false,
             event_handler_arrow_body_level: 0,
             is_controlled_each: false,
+            is_controlled_html: false,
             snippets: Vec::new(),
             template_nesting_level: 0,
             in_control_flow_block: false,

--- a/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -173,6 +173,7 @@ pub fn fragment(
         in_event_attribute_handler: false,
         event_handler_arrow_body_level: 0,
         is_controlled_each: false,
+        is_controlled_html: false,
         snippets: Vec::new(),
         // Root fragment starts at level 0; non-root fragments (e.g., inside {#if}/{#each})
         // start at level 1 so that snippets inside blocks are not hoisted to the root.

--- a/src/compiler/phases/3_transform/client/visitors/html_tag.rs
+++ b/src/compiler/phases/3_transform/client/visitors/html_tag.rs
@@ -31,12 +31,11 @@ use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
 pub fn html_tag(node: &HtmlTag, context: &mut ComponentContext) -> JsStatement {
     // Svelte 5.53.8 (upstream commit `0206a2019` "fix: clean up
     // externally-added DOM nodes in {@html} on re-render") added an
-    // `is_controlled` flag — when the {@html} sits directly inside a
-    // contenteditable element the parent owns the namespace and the wrapper
-    // anchor comment is skipped. rsvelte doesn't surface
-    // `metadata.is_controlled` from analysis yet, so treat every {@html} as
-    // non-controlled (the common case) and always emit the anchor comment.
-    let is_controlled = false;
+    // `is_controlled` flag — when the {@html} is the only child of an
+    // element the parent owns the namespace and the wrapper anchor comment
+    // is skipped. fragment.rs::process_children sets
+    // `state.is_controlled_html` before visiting; we read it here.
+    let is_controlled = context.state.is_controlled_html;
 
     // Push comment anchor to template
     if !is_controlled {

--- a/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
@@ -496,6 +496,32 @@ pub fn process_children<F>(
                         }
                         context.state.node = saved_node;
                     }
+                } else if let TemplateNode::HtmlTag(html_tag) = node
+                    && nodes.len() == 1
+                    && is_element
+                    && !html_tag.metadata.expression.is_async()
+                {
+                    // Svelte 5.53.8 (upstream `0206a2019`): when `{@html ...}` is
+                    // the only child of an element AND the expression is NOT async,
+                    // set is_controlled so the visitor emits
+                    // `$.html(parent, thunk, true, ...)` without a wrapper comment
+                    // anchor. The visitor uses the parent node directly, so
+                    // there's no flush_node call. Async expressions keep the
+                    // wrapper because $.async() needs to skip sibling nodes up to
+                    // the wrapper.
+                    let saved = context.state.is_controlled_html;
+                    context.state.is_controlled_html = true;
+                    let result = context.visit_node(node, None);
+                    context.state.is_controlled_html = saved;
+                    match result {
+                        crate::compiler::phases::phase3_transform::client::types::TransformResult::Statement(stmt) => {
+                            context.state.init.push(stmt);
+                        }
+                        crate::compiler::phases::phase3_transform::client::types::TransformResult::Block(block) => {
+                            context.state.init.push(JsStatement::Block(block));
+                        }
+                        _ => {}
+                    }
                 } else {
                     // Get node name for identifier
                     let name = if let TemplateNode::RegularElement(elem) = node {

--- a/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/src/compiler/phases/3_transform/server/transform_script.rs
@@ -124,6 +124,12 @@ fn transform_script_content_inner(
     // bare read of a derived name must be rewritten to `name()`. Collect names
     // from the `$.derived(...)` declarators we just emitted, then wrap reads.
     let script = wrap_derived_reads_in_script(&script);
+    // Svelte 5.53.2 (upstream `6aa7b9c64` "fix: update expressions on server
+    // deriveds"): `name++` / `--name` etc. on a derived must use
+    // `$.update_derived(name)` / `$.update_derived_pre(name)` helpers. After
+    // `wrap_derived_reads_in_script` the source looks like `name()++`; this
+    // pass rewrites those wrappers to the proper helpers.
+    let script = rewrite_derived_update_expressions(&script);
     let script = transform_rune_call_multiline(&script, "$bindable(");
     let script = transform_store_destructure_assignments(&script);
     let script = transform_store_assignments(&script);
@@ -1748,6 +1754,154 @@ pub(crate) fn wrap_derived_reads_for_template(
             "DEBUG_WRAP: in={:?} names={:?} out={:?}",
             expr, derived_names, out
         );
+    }
+    out
+}
+
+/// Rewrite postfix/prefix update expressions on derived bindings.
+///
+/// Svelte 5.53.2 (upstream commit `6aa7b9c64` "fix: update expressions on
+/// server deriveds") routes `name++`/`name--`/`++name`/`--name` through new
+/// `$.update_derived(name)` / `$.update_derived_pre(name)` helpers when
+/// `name` resolves to a derived binding. By the time this pass runs,
+/// `wrap_derived_reads_in_script` has already rewritten reads of `count` to
+/// `count()`, so the input we see is `count()++`. We scan for that exact
+/// shape (any name in `derived_names` immediately followed by `()` and a
+/// `++`/`--`, or preceded by `++`/`--`) and substitute the helper call.
+///
+/// We deliberately do NOT walk strings / comments / regex literals here:
+/// the input has already been transformed by `wrap_derived_reads_in_script`
+/// which never inserts `name()` inside those regions, so the additional
+/// patterns can only appear in real code.
+fn rewrite_derived_update_expressions(script: &str) -> String {
+    let (derived_names, _, _) = collect_derived_names_from_script(script);
+    if derived_names.is_empty() {
+        return script.to_string();
+    }
+    let bytes = script.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(script.len());
+    let mut i = 0;
+    while i < len {
+        let b = bytes[i];
+        // Skip line / block comments and string / template literals — we
+        // only need to track them to avoid splicing inside them. The
+        // wrapping pass already left these untouched, but a derived
+        // declarator that happens to appear inside a template-string body
+        // would still hit our scan otherwise.
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+            let s = i;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            out.push_str(&script[s..i]);
+            continue;
+        }
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+            let s = i;
+            i += 2;
+            while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < len {
+                i += 2;
+            }
+            out.push_str(&script[s..i]);
+            continue;
+        }
+        if b == b'"' || b == b'\'' || b == b'`' {
+            let quote = b;
+            let s = i;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            out.push_str(&script[s..i]);
+            continue;
+        }
+        // Prefix `++name()` / `--name()` — check before consuming the
+        // operator. The trailing `()` is what `wrap_derived_reads_in_script`
+        // inserts; we strip it back off when emitting the helper call.
+        if (b == b'+' || b == b'-')
+            && i + 1 < len
+            && bytes[i + 1] == b
+            && i + 2 < len
+            && (bytes[i + 2].is_ascii_alphabetic() || bytes[i + 2] == b'_' || bytes[i + 2] == b'$')
+        {
+            let op = b;
+            let name_start = i + 2;
+            let mut name_end = name_start;
+            while name_end < len {
+                let c = bytes[name_end];
+                if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+                    name_end += 1;
+                } else {
+                    break;
+                }
+            }
+            let name = &script[name_start..name_end];
+            if derived_names.contains(name)
+                && name_end + 1 < len
+                && bytes[name_end] == b'('
+                && bytes[name_end + 1] == b')'
+            {
+                out.push_str("$.update_derived_pre(");
+                out.push_str(name);
+                if op == b'-' {
+                    out.push_str(", -1");
+                }
+                out.push(')');
+                i = name_end + 2;
+                continue;
+            }
+        }
+        // Identifier — look for postfix `name()++` / `name()--`.
+        if (b.is_ascii_alphabetic() || b == b'_' || b == b'$') && !is_after_ident_char(bytes, i) {
+            let name_start = i;
+            while i < len {
+                let c = bytes[i];
+                if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            let name = &script[name_start..i];
+            if derived_names.contains(name)
+                && i + 3 < len
+                && bytes[i] == b'('
+                && bytes[i + 1] == b')'
+                && (bytes[i + 2] == b'+' || bytes[i + 2] == b'-')
+                && bytes[i + 3] == bytes[i + 2]
+            {
+                let op = bytes[i + 2];
+                out.push_str("$.update_derived(");
+                out.push_str(name);
+                if op == b'-' {
+                    out.push_str(", -1");
+                }
+                out.push(')');
+                i += 4;
+                continue;
+            }
+            out.push_str(name);
+            continue;
+        }
+        // UTF-8 safe step.
+        let mut next = i + 1;
+        while next < len && !script.is_char_boundary(next) {
+            next += 1;
+        }
+        out.push_str(&script[i..next]);
+        i = next;
     }
     out
 }

--- a/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/src/compiler/phases/3_transform/server/transform_script.rs
@@ -130,6 +130,13 @@ fn transform_script_content_inner(
     // `wrap_derived_reads_in_script` the source looks like `name()++`; this
     // pass rewrites those wrappers to the proper helpers.
     let script = rewrite_derived_update_expressions(&script);
+    // Svelte 5.55.5 (upstream `b771df3`): `$derived(<bare_derived>)` should
+    // emit `$.derived(<bare_derived>)` directly (no thunk), because the
+    // server runtime treats a derived passed in this slot as a re-callable
+    // dependency. After `wrap_derived_reads_in_script` the bare ident gets
+    // wrapped to `<name>()`, leaving us with `$.derived(() => <name>())` —
+    // collapse that pattern back to `$.derived(<name>)`.
+    let script = unthunk_bare_derived_arg(&script);
     let script = transform_rune_call_multiline(&script, "$bindable(");
     let script = transform_store_destructure_assignments(&script);
     let script = transform_store_assignments(&script);
@@ -1898,6 +1905,64 @@ fn rewrite_derived_update_expressions(script: &str) -> String {
         // UTF-8 safe step.
         let mut next = i + 1;
         while next < len && !script.is_char_boundary(next) {
+            next += 1;
+        }
+        out.push_str(&script[i..next]);
+        i = next;
+    }
+    out
+}
+
+/// Collapse `$.derived(() => NAME())` to `$.derived(NAME)` when `NAME` is a
+/// derived binding. Mirrors Svelte 5.55.5 upstream `b771df3` "correctly
+/// calculate `@const` blockers" — the bare-identifier argument is passed
+/// directly so the runtime can wire up the dependency without an extra
+/// thunk hop.
+fn unthunk_bare_derived_arg(script: &str) -> String {
+    let (derived_names, _, _) = collect_derived_names_from_script(script);
+    if derived_names.is_empty() {
+        return script.to_string();
+    }
+    let bytes = script.as_bytes();
+    let needle = b"$.derived(() => ";
+    let mut out = String::with_capacity(script.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + needle.len() <= bytes.len() && &bytes[i..i + needle.len()] == needle {
+            // After the prefix `$.derived(() => ` we expect `NAME()` followed
+            // by `)`. Read an identifier.
+            let start = i + needle.len();
+            let mut j = start;
+            if j < bytes.len()
+                && (bytes[j].is_ascii_alphabetic() || bytes[j] == b'_' || bytes[j] == b'$')
+            {
+                while j < bytes.len() {
+                    let c = bytes[j];
+                    if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+                        j += 1;
+                    } else {
+                        break;
+                    }
+                }
+                let name = &script[start..j];
+                // Match the exact tail `()` then `)` — anything else is a
+                // genuine thunk body and must be left alone.
+                if derived_names.contains(name)
+                    && j + 2 < bytes.len()
+                    && bytes[j] == b'('
+                    && bytes[j + 1] == b')'
+                    && bytes[j + 2] == b')'
+                {
+                    out.push_str("$.derived(");
+                    out.push_str(name);
+                    out.push(')');
+                    i = j + 3;
+                    continue;
+                }
+            }
+        }
+        let mut next = i + 1;
+        while next < bytes.len() && !script.is_char_boundary(next) {
             next += 1;
         }
         out.push_str(&script[i..next]);

--- a/src/compiler/phases/3_transform/server/visitors/element.rs
+++ b/src/compiler/phases/3_transform/server/visitors/element.rs
@@ -174,24 +174,56 @@ impl<'a> ServerCodeGenerator<'a> {
                             .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)));
                         if has_expr {
                             // Mixed text + expression: class="block {expr}"
+                            //
+                            // Upstream `scope.evaluate` (Svelte 5.55.9 `a5df6616e`)
+                            // drops the `$.stringify` wrapper when the chunk is
+                            // known-string, inlines known-constants directly, and
+                            // omits `null`/`undefined`. Mirror that here so
+                            // `class='{cond ? "a" : "b"}'` emits `${cond ? "a" : "b"}`.
                             let mut tmpl = String::new();
+                            let mut has_remaining_expr = false;
                             for part in parts {
                                 match part {
                                     AttributeValuePart::Text(text) => {
                                         tmpl.push_str(&text.data);
                                     }
                                     AttributeValuePart::ExpressionTag(expr_tag) => {
-                                        let es = expr_tag.expression.start().unwrap_or(0) as usize;
-                                        let ee = expr_tag.expression.end().unwrap_or(0) as usize;
-                                        if ee > es && ee <= self.source.len() {
-                                            let expr = self.source[es..ee].trim().to_string();
-                                            let expr = self.transform_store_refs(&expr);
-                                            tmpl.push_str(&format!("${{$.stringify({})}}", expr));
+                                        let eval = self
+                                            .evaluate_attribute_expression(&expr_tag.expression);
+                                        match eval {
+                                            AttrExprEval::InlineLiteral(s) => tmpl.push_str(&s),
+                                            AttrExprEval::Empty => {}
+                                            AttrExprEval::StringNoWrap | AttrExprEval::Wrap => {
+                                                has_remaining_expr = true;
+                                                let es = expr_tag.expression.start().unwrap_or(0)
+                                                    as usize;
+                                                let ee =
+                                                    expr_tag.expression.end().unwrap_or(0) as usize;
+                                                if ee > es && ee <= self.source.len() {
+                                                    let expr =
+                                                        self.source[es..ee].trim().to_string();
+                                                    let expr = self.transform_store_refs(&expr);
+                                                    if matches!(eval, AttrExprEval::StringNoWrap) {
+                                                        tmpl.push_str(&format!("${{{}}}", expr));
+                                                    } else {
+                                                        tmpl.push_str(&format!(
+                                                            "${{$.stringify({})}}",
+                                                            expr
+                                                        ));
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
                             }
-                            base_class = Some(format!("__TMPL__:{}", tmpl));
+                            if has_remaining_expr {
+                                base_class = Some(format!("__TMPL__:{}", tmpl));
+                            } else {
+                                // All expressions were inlined to constants — fall
+                                // through to the static-string base_class path.
+                                base_class = Some(tmpl);
+                            }
                         } else {
                             base_class = self.extract_attribute_text_value(node);
                         }
@@ -2244,16 +2276,32 @@ impl<'a> ServerCodeGenerator<'a> {
                             }
                         }
                         AttributeValuePart::ExpressionTag(expr_tag) => {
-                            // Add accumulated text
-                            template_parts.push(current_text.clone());
-                            current_text.clear();
+                            // Svelte 5.55.9 (upstream `a5df6616e`): inline
+                            // known-constants, drop `$.stringify` wrapper for
+                            // provably-string chunks, and omit null/undefined.
+                            let eval = self.evaluate_attribute_expression(&expr_tag.expression);
+                            match eval {
+                                AttrExprEval::InlineLiteral(s) => current_text.push_str(&s),
+                                AttrExprEval::Empty => {}
+                                AttrExprEval::StringNoWrap | AttrExprEval::Wrap => {
+                                    // Add accumulated text
+                                    template_parts.push(current_text.clone());
+                                    current_text.clear();
 
-                            // Add expression wrapped in $.stringify()
-                            let expr_start = expr_tag.expression.start().unwrap_or(0) as usize;
-                            let expr_end = expr_tag.expression.end().unwrap_or(0) as usize;
-                            if expr_end > expr_start && expr_end <= self.source.len() {
-                                let expr = self.source[expr_start..expr_end].trim().to_string();
-                                template_parts.push(format!("${{$.stringify({})}}", expr));
+                                    let expr_start =
+                                        expr_tag.expression.start().unwrap_or(0) as usize;
+                                    let expr_end = expr_tag.expression.end().unwrap_or(0) as usize;
+                                    if expr_end > expr_start && expr_end <= self.source.len() {
+                                        let expr =
+                                            self.source[expr_start..expr_end].trim().to_string();
+                                        if matches!(eval, AttrExprEval::StringNoWrap) {
+                                            template_parts.push(format!("${{{}}}", expr));
+                                        } else {
+                                            template_parts
+                                                .push(format!("${{$.stringify({})}}", expr));
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -2325,6 +2373,13 @@ impl<'a> ServerCodeGenerator<'a> {
         let Some(ty) = obj.get("type").and_then(|t| t.as_str()) else {
             return AttrExprEval::Wrap;
         };
+        if std::env::var("DEBUG_EVAL").is_ok() {
+            eprintln!(
+                "[eval_attr_expr_json] type={} obj_keys={:?}",
+                ty,
+                obj.keys().collect::<Vec<_>>()
+            );
+        }
         match ty {
             "Literal" => match obj.get("value") {
                 Some(Value::String(s)) => AttrExprEval::InlineLiteral(s.clone()),
@@ -2385,7 +2440,57 @@ impl<'a> ServerCodeGenerator<'a> {
                     AttrExprEval::Wrap
                 }
             }
+            // Upstream `scope.evaluate` (Svelte 5.55.9 `a5df6616e`) treats a
+            // ternary as provably-string when BOTH branches are provably-string,
+            // so the wrapping `$.stringify(...)` can be elided.
+            "ConditionalExpression" => {
+                let Some(consequent) = obj.get("consequent") else {
+                    return AttrExprEval::Wrap;
+                };
+                let Some(alternate) = obj.get("alternate") else {
+                    return AttrExprEval::Wrap;
+                };
+                if Self::eval_is_string_or_inline(&self.eval_attr_expr_json(consequent))
+                    && Self::eval_is_string_or_inline(&self.eval_attr_expr_json(alternate))
+                {
+                    AttrExprEval::StringNoWrap
+                } else {
+                    AttrExprEval::Wrap
+                }
+            }
+            // String concatenation `a + b` where both operands are provably-string
+            // is itself provably-string.
+            "BinaryExpression" => {
+                let operator = obj.get("operator").and_then(|o| o.as_str()).unwrap_or("");
+                if operator != "+" {
+                    return AttrExprEval::Wrap;
+                }
+                let Some(left) = obj.get("left") else {
+                    return AttrExprEval::Wrap;
+                };
+                let Some(right) = obj.get("right") else {
+                    return AttrExprEval::Wrap;
+                };
+                if Self::eval_is_string_or_inline(&self.eval_attr_expr_json(left))
+                    && Self::eval_is_string_or_inline(&self.eval_attr_expr_json(right))
+                {
+                    AttrExprEval::StringNoWrap
+                } else {
+                    AttrExprEval::Wrap
+                }
+            }
             _ => AttrExprEval::Wrap,
+        }
+    }
+
+    /// Helper for `eval_attr_expr_json`: whether a sub-expression's evaluation
+    /// proves it returns a (non-nullish) string.
+    fn eval_is_string_or_inline(eval: &AttrExprEval) -> bool {
+        match eval {
+            AttrExprEval::InlineLiteral(_) | AttrExprEval::StringNoWrap => true,
+            // `Empty` corresponds to `null`/`undefined` — these are NOT strings,
+            // so a ternary with an `undefined` branch is not provably-string.
+            AttrExprEval::Empty | AttrExprEval::Wrap => false,
         }
     }
 
@@ -2603,8 +2708,13 @@ impl<'a> ServerCodeGenerator<'a> {
                         .iter()
                         .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)));
                     if has_expr {
-                        // Generate a template literal: `text${$.stringify(expr)}text`
-                        let mut template = String::from("`");
+                        // Svelte 5.55.9 (upstream `a5df6616e`): inline known
+                        // constants, elide `$.stringify` for provably-string
+                        // expressions, omit null/undefined. When all
+                        // expressions collapse to inline literals, emit a
+                        // plain string instead of a template literal.
+                        let mut template = String::new();
+                        let mut has_remaining_expr = false;
                         for part in parts {
                             match part {
                                 AttributeValuePart::Text(text) => {
@@ -2617,22 +2727,44 @@ impl<'a> ServerCodeGenerator<'a> {
                                     );
                                 }
                                 AttributeValuePart::ExpressionTag(expr_tag) => {
-                                    let expr_start =
-                                        expr_tag.expression.start().unwrap_or(0) as usize;
-                                    let expr_end = expr_tag.expression.end().unwrap_or(0) as usize;
-                                    if expr_end > expr_start && expr_end <= self.source.len() {
-                                        let expr_src = self.source[expr_start..expr_end].trim();
-                                        let transformed = self.transform_store_refs(expr_src);
-                                        template.push_str(&format!(
-                                            "${{$.stringify({})}}",
-                                            transformed
-                                        ));
+                                    let eval =
+                                        self.evaluate_attribute_expression(&expr_tag.expression);
+                                    match eval {
+                                        AttrExprEval::InlineLiteral(s) => template.push_str(&s),
+                                        AttrExprEval::Empty => {}
+                                        AttrExprEval::StringNoWrap | AttrExprEval::Wrap => {
+                                            has_remaining_expr = true;
+                                            let expr_start =
+                                                expr_tag.expression.start().unwrap_or(0) as usize;
+                                            let expr_end =
+                                                expr_tag.expression.end().unwrap_or(0) as usize;
+                                            if expr_end > expr_start
+                                                && expr_end <= self.source.len()
+                                            {
+                                                let expr_src =
+                                                    self.source[expr_start..expr_end].trim();
+                                                let transformed =
+                                                    self.transform_store_refs(expr_src);
+                                                if matches!(eval, AttrExprEval::StringNoWrap) {
+                                                    template
+                                                        .push_str(&format!("${{{}}}", transformed));
+                                                } else {
+                                                    template.push_str(&format!(
+                                                        "${{$.stringify({})}}",
+                                                        transformed
+                                                    ));
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
-                        template.push('`');
-                        template
+                        if has_remaining_expr {
+                            format!("`{}`", template)
+                        } else {
+                            format!("'{}'", template)
+                        }
                     } else {
                         // Static text value only
                         let mut text_val = String::new();

--- a/src/compiler/phases/3_transform/server/visitors/element.rs
+++ b/src/compiler/phases/3_transform/server/visitors/element.rs
@@ -2238,6 +2238,7 @@ impl<'a> ServerCodeGenerator<'a> {
                 let mut template_parts = Vec::new();
                 let mut current_text = String::new();
                 let mut is_first_part = true;
+                let mut has_remaining_expr = false;
 
                 for part in parts {
                     match part {
@@ -2284,6 +2285,7 @@ impl<'a> ServerCodeGenerator<'a> {
                                 AttrExprEval::InlineLiteral(s) => current_text.push_str(&s),
                                 AttrExprEval::Empty => {}
                                 AttrExprEval::StringNoWrap | AttrExprEval::Wrap => {
+                                    has_remaining_expr = true;
                                     // Add accumulated text
                                     template_parts.push(current_text.clone());
                                     current_text.clear();
@@ -2313,6 +2315,35 @@ impl<'a> ServerCodeGenerator<'a> {
                 }
 
                 let template_content = template_parts.join("");
+
+                if !has_remaining_expr {
+                    // All expressions were inlined to constants — emit as a
+                    // plain string attribute, optionally with CSS hash. This
+                    // is the equivalent of the all-static-text branch above.
+                    let normalized: String =
+                        template_content
+                            .split_whitespace()
+                            .fold(String::new(), |mut acc, word| {
+                                if !acc.is_empty() {
+                                    acc.push(' ');
+                                }
+                                acc.push_str(word);
+                                acc
+                            });
+                    let final_value = if let Some(hash) = css_hash {
+                        if normalized.is_empty() {
+                            hash.to_string()
+                        } else {
+                            format!("{} {}", normalized, hash)
+                        }
+                    } else {
+                        normalized
+                    };
+                    if final_value.is_empty() {
+                        return Ok(None);
+                    }
+                    return Ok(Some(format!(" {}=\"{}\"", name, final_value)));
+                }
 
                 // Build $.attr_class() call
                 if let Some(hash) = css_hash {

--- a/src/compiler/phases/3_transform/server/visitors/select_element.rs
+++ b/src/compiler/phases/3_transform/server/visitors/select_element.rs
@@ -553,11 +553,16 @@ impl<'a> ServerCodeGenerator<'a> {
 
         // Check if we have a synthetic_value_node - if so, pass the value directly
         if let Some(synthetic_value_node) = &element.metadata.synthetic_value_node {
-            // Get expression source directly
+            // Get expression source. Svelte 5.53.6 (upstream `e3d277b00`):
+            // `<option>` synthetic value is visited through
+            // `context.visit(...)` so store refs (e.g. `$label`) get rewritten
+            // via `$.store_get(...)`. Mirror that here by routing the
+            // expression through `transform_store_refs`.
             let expr_start = synthetic_value_node.expression.start().unwrap_or(0) as usize;
             let expr_end = synthetic_value_node.expression.end().unwrap_or(0) as usize;
             let expr_source = if expr_end > expr_start && expr_end <= self.source.len() {
-                self.source[expr_start..expr_end].trim().to_string()
+                let raw = self.source[expr_start..expr_end].trim().to_string();
+                self.transform_store_refs(&raw)
             } else {
                 "undefined".to_string()
             };

--- a/tests/audit_skipped.rs
+++ b/tests/audit_skipped.rs
@@ -1,0 +1,537 @@
+//! Audit: for every fixture currently in the skip lists, run the same
+//! compile-and-compare logic the compatibility report uses and report which
+//! fixtures now pass. Run after every Svelte submodule bump to spot
+//! "previously-broken but now passing" fixtures so the skip lists don't
+//! accumulate dead entries.
+//!
+//! Run: `cargo test --release --test audit_skipped -- --nocapture`
+//!
+//! When this prints `NOW PASSING (N fixtures)` with N > 0, remove the listed
+//! fixtures from `tests/compatibility_report.rs::runtime_skip_tests` and from
+//! the matching `RUNTIME_*_SKIP_NAMES` / `HYDRATION_SKIP_NAMES` arrays in
+//! `tests/runtime.rs` (or from the per-category `skip_*` arrays for parser /
+//! css / print / svelte2tsx).
+
+mod common;
+
+use std::fs;
+
+use common::{
+    canonicalize_css, compare_js, ensure_fixtures_exist, load_fixture_output, svelte_path,
+};
+use svelte_compiler_rust::ast::arena::with_serialize_arena;
+use svelte_compiler_rust::{
+    CompileOptions, ExperimentalOptions, GenerateMode, ParseOptions, compile, compile_module,
+    compiler::CssMode, convert_to_legacy, parse,
+};
+
+fn parser_normalize_json(json: &str) -> serde_json::Value {
+    let mut value: serde_json::Value =
+        serde_json::from_str(json).unwrap_or(serde_json::Value::Null);
+    remove_internal_fields(&mut value);
+    value
+}
+
+fn remove_internal_fields(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.remove("metadata");
+            fn remove_character_from_loc(loc: &mut serde_json::Value) {
+                if let serde_json::Value::Object(loc_map) = loc {
+                    if let Some(serde_json::Value::Object(start)) = loc_map.get_mut("start") {
+                        start.remove("character");
+                    }
+                    if let Some(serde_json::Value::Object(end)) = loc_map.get_mut("end") {
+                        end.remove("character");
+                    }
+                }
+            }
+            if let Some(loc) = map.get_mut("loc") {
+                remove_character_from_loc(loc);
+            }
+            if let Some(name_loc) = map.get_mut("name_loc") {
+                remove_character_from_loc(name_loc);
+            }
+            for (_, v) in map.iter_mut() {
+                remove_internal_fields(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                remove_internal_fields(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[derive(Debug, Default)]
+struct Outcome {
+    client_pass: Option<bool>,
+    server_pass: Option<bool>,
+    error: Option<String>,
+}
+
+impl Outcome {
+    fn passed(&self) -> bool {
+        self.error.is_none() && self.client_pass.unwrap_or(true) && self.server_pass.unwrap_or(true)
+    }
+
+    fn summary(&self) -> String {
+        if let Some(e) = &self.error {
+            return format!("ERROR: {}", e);
+        }
+        let mut parts = Vec::new();
+        if let Some(c) = self.client_pass {
+            parts.push(format!("client={}", if c { "OK" } else { "FAIL" }));
+        }
+        if let Some(s) = self.server_pass {
+            parts.push(format!("server={}", if s { "OK" } else { "FAIL" }));
+        }
+        if parts.is_empty() {
+            return "no-expected-output".to_string();
+        }
+        parts.join(" ")
+    }
+}
+
+fn audit_runtime(category: &str, name: &str) -> Outcome {
+    let mut out = Outcome::default();
+
+    let input_path = svelte_path()
+        .join("packages/svelte/tests")
+        .join(category)
+        .join("samples")
+        .join(name)
+        .join("main.svelte");
+
+    let Ok(input) = fs::read_to_string(&input_path) else {
+        out.error = Some(format!("input not found: {:?}", input_path));
+        return out;
+    };
+
+    let config_path = svelte_path()
+        .join("packages/svelte/tests")
+        .join(category)
+        .join("samples")
+        .join(name)
+        .join("_config.js");
+
+    let mut config_has_async = false;
+    let mut config_has_hmr = false;
+    if let Ok(config) = fs::read_to_string(&config_path) {
+        let without_skip = config
+            .replace("skip_no_async", "")
+            .replace("skip_async", "");
+        config_has_async = without_skip.contains("async: true");
+        config_has_hmr = config.contains("hmr: true");
+    }
+
+    let expected_client = load_fixture_output(category, name, "client.js");
+    let expected_server = load_fixture_output(category, name, "server.js");
+    if expected_client.is_none() && expected_server.is_none() {
+        out.error = Some("no expected client/server output".to_string());
+        return out;
+    }
+
+    let is_runtime_runes = category == "runtime-runes";
+    let use_async = is_runtime_runes || config_has_async;
+
+    let is_legacy = category == "runtime-legacy";
+    let use_accessors = if is_legacy {
+        fs::read_to_string(&config_path)
+            .map(|c| !c.contains("accessors: false") && !c.contains("accessors:false"))
+            .unwrap_or(true)
+    } else {
+        false
+    };
+
+    if let Some(expected) = &expected_client {
+        let options = CompileOptions {
+            generate: GenerateMode::Client,
+            filename: Some("main.svelte".to_string()),
+            css: CssMode::External,
+            experimental: ExperimentalOptions { r#async: use_async },
+            hmr: config_has_hmr,
+            accessors: use_accessors,
+            ..Default::default()
+        };
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| compile(&input, options))) {
+            Ok(Ok(result)) => out.client_pass = Some(compare_js(&result.js.code, expected)),
+            Ok(Err(e)) => {
+                out.error = Some(format!("client compile error: {}", e));
+                out.client_pass = Some(false);
+            }
+            Err(_) => {
+                out.error = Some("client compile panic".to_string());
+                out.client_pass = Some(false);
+            }
+        }
+    }
+
+    if let Some(expected) = &expected_server {
+        let options = CompileOptions {
+            generate: GenerateMode::Server,
+            filename: Some("main.svelte".to_string()),
+            css: CssMode::External,
+            experimental: ExperimentalOptions { r#async: use_async },
+            hmr: config_has_hmr,
+            ..Default::default()
+        };
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| compile(&input, options))) {
+            Ok(Ok(result)) => out.server_pass = Some(compare_js(&result.js.code, expected)),
+            Ok(Err(e)) => {
+                if out.error.is_none() {
+                    out.error = Some(format!("server compile error: {}", e));
+                }
+                out.server_pass = Some(false);
+            }
+            Err(_) => {
+                if out.error.is_none() {
+                    out.error = Some("server compile panic".to_string());
+                }
+                out.server_pass = Some(false);
+            }
+        }
+    }
+
+    out
+}
+
+fn audit_parser(name: &str, modern: bool) -> Outcome {
+    let mut out = Outcome::default();
+    let category = if modern {
+        "parser-modern"
+    } else {
+        "parser-legacy"
+    };
+    let input_path = svelte_path()
+        .join("packages/svelte/tests")
+        .join(category)
+        .join("samples")
+        .join(name)
+        .join("input.svelte");
+    let output_path = svelte_path()
+        .join("packages/svelte/tests")
+        .join(category)
+        .join("samples")
+        .join(name)
+        .join("output.json");
+
+    let Ok(input) = fs::read_to_string(&input_path) else {
+        out.error = Some("input not found".to_string());
+        return out;
+    };
+    let Ok(expected) = fs::read_to_string(&output_path) else {
+        out.error = Some("output.json not found".to_string());
+        return out;
+    };
+
+    let loose = name.contains("loose");
+    let opts = ParseOptions {
+        modern: true,
+        loose,
+        ..Default::default()
+    };
+
+    let parse_result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| parse(&input, opts)));
+    match parse_result {
+        Ok(Ok(ast)) => {
+            let actual_json = if modern {
+                with_serialize_arena(&ast.arena, || serde_json::to_string_pretty(&ast).unwrap())
+            } else {
+                let legacy_ast = convert_to_legacy(&input, ast);
+                serde_json::to_string_pretty(&legacy_ast).unwrap()
+            };
+            let a = parser_normalize_json(&actual_json);
+            let b = parser_normalize_json(&expected);
+            out.client_pass = Some(a == b);
+        }
+        Ok(Err(e)) => {
+            out.error = Some(format!("parse error: {}", e));
+            out.client_pass = Some(false);
+        }
+        Err(_) => {
+            out.error = Some("parse panic".to_string());
+            out.client_pass = Some(false);
+        }
+    }
+    out
+}
+
+fn audit_css(name: &str) -> Outcome {
+    let mut out = Outcome::default();
+    let input_path = svelte_path()
+        .join("packages/svelte/tests/css/samples")
+        .join(name)
+        .join("input.svelte");
+    let Ok(input) = fs::read_to_string(&input_path) else {
+        out.error = Some("input not found".to_string());
+        return out;
+    };
+    let expected = load_fixture_output("css", name, "css.css");
+    let Some(expected) = expected else {
+        out.error = Some("no expected css".to_string());
+        return out;
+    };
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let input_clone = input.clone();
+    std::thread::spawn(move || {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let opts = CompileOptions {
+                generate: GenerateMode::Client,
+                filename: Some("input.svelte".to_string()),
+                css: CssMode::External,
+                ..Default::default()
+            };
+            compile(&input_clone, opts)
+        }));
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok(Ok(Ok(result))) => {
+            let actual = result.css.map(|c| c.code).unwrap_or_default();
+            out.client_pass = Some(canonicalize_css(&actual) == canonicalize_css(&expected));
+        }
+        Ok(Ok(Err(e))) => {
+            out.error = Some(format!("compile error: {}", e));
+            out.client_pass = Some(false);
+        }
+        Ok(Err(_)) => {
+            out.error = Some("panic".to_string());
+            out.client_pass = Some(false);
+        }
+        Err(_) => {
+            out.error = Some("timed out after 10s".to_string());
+            out.client_pass = Some(false);
+        }
+    }
+    out
+}
+
+fn audit_print(name: &str) -> Outcome {
+    use svelte_compiler_rust::compiler::print::print_with_source;
+
+    let mut out = Outcome::default();
+    let input_path = svelte_path()
+        .join("packages/svelte/tests/print/samples")
+        .join(name)
+        .join("input.svelte");
+    let expected_path = svelte_path()
+        .join("packages/svelte/tests/print/samples")
+        .join(name)
+        .join("output.svelte");
+    let Ok(input) = fs::read_to_string(&input_path) else {
+        out.error = Some("input not found".to_string());
+        return out;
+    };
+    let Ok(expected) = fs::read_to_string(&expected_path) else {
+        out.error = Some("output.svelte not found".to_string());
+        return out;
+    };
+
+    let parse_opts = ParseOptions {
+        modern: true,
+        ..Default::default()
+    };
+    let parse_result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| parse(&input, parse_opts)));
+    match parse_result {
+        Ok(Ok(ast)) => match print_with_source(&ast, None, Some(&input)) {
+            Ok(actual) => {
+                let normalize = |s: &str| {
+                    let trimmed: Vec<String> =
+                        s.lines().map(|l| l.trim_end().to_string()).collect();
+                    let mut out = trimmed.join("\n");
+                    if !out.ends_with('\n') {
+                        out.push('\n');
+                    }
+                    out
+                };
+                out.client_pass = Some(normalize(&actual.code) == normalize(&expected));
+            }
+            Err(e) => {
+                out.error = Some(format!("print error: {:?}", e));
+                out.client_pass = Some(false);
+            }
+        },
+        Ok(Err(e)) => {
+            out.error = Some(format!("parse error: {}", e));
+            out.client_pass = Some(false);
+        }
+        Err(_) => {
+            out.error = Some("panic".to_string());
+            out.client_pass = Some(false);
+        }
+    }
+    out
+}
+
+#[test]
+fn audit_skipped_fixtures() {
+    let _ = compile_module;
+    ensure_fixtures_exist();
+
+    // Names lifted from the skip lists in tests/compatibility_report.rs and
+    // tests/runtime.rs (excluding the always-out-of-scope migrate / svelte2tsx
+    // error fixtures / validator's _config.js opt-out).
+    let runtime_skipped: &[(&str, &str)] = &[
+        ("runtime-runes", "async-derived-title-update"),
+        ("runtime-runes", "async-eager-derived"),
+        ("runtime-runes", "async-inspect-build"),
+        ("runtime-runes", "async-derived-indirect"),
+        ("runtime-runes", "async-if-hydration"),
+        ("runtime-runes", "async-derived-with-effect-and-boundary"),
+        ("runtime-runes", "async-binding-after-await"),
+        ("runtime-runes", "async-transform-empty-statements"),
+        ("runtime-runes", "async-later-sync-overlaps"),
+        ("runtime-runes", "async-style-after-await"),
+        ("runtime-runes", "async-overlap-multiple-1"),
+        ("runtime-runes", "async-overlap-multiple-2"),
+        ("runtime-runes", "async-overlap-multiple-3"),
+        ("runtime-runes", "async-overlap-multiple-4"),
+        ("runtime-runes", "async-overlap-multiple-5"),
+        ("runtime-runes", "async-overlap-multiple-6"),
+        ("runtime-runes", "async-overlap-multiple-7"),
+        ("runtime-runes", "async-if-block-unskip"),
+        ("runtime-legacy", "flush-sync-each-block"),
+        ("runtime-runes", "async-const"),
+        ("runtime-runes", "async-const-wait"),
+        ("runtime-runes", "async-derived-const-blocker"),
+        ("runtime-runes", "async-reactivity-loss-no-false-positive-1"),
+        ("runtime-runes", "async-reactivity-loss-no-false-positive-2"),
+        ("runtime-runes", "async-reactivity-loss-no-false-positive-3"),
+        ("runtime-runes", "async-reactivity-loss-async-after-sync"),
+        ("runtime-runes", "async-effect-pending-eager"),
+        ("runtime-runes", "async-context-after-await-const"),
+        ("runtime-runes", "derived-dep-set-while-rendering"),
+        ("runtime-runes", "async-flushsync-in-effect"),
+        ("runtime-runes", "async-stale-derived-4"),
+        ("runtime-runes", "async-eager-block"),
+        ("runtime-runes", "async-eager-each-block"),
+        ("runtime-runes", "async-dont-rebase-new-batch-1"),
+        ("runtime-runes", "async-dont-rebase-new-batch-2"),
+        ("runtime-runes", "async-dont-rebase-new-batch-3"),
+        ("runtime-runes", "async-dont-rebase-new-batch-4"),
+        ("runtime-runes", "async-debug-awaited-expression"),
+        ("runtime-runes", "async-state-updates-microtask-separated"),
+        ("runtime-runes", "dynamic-component-member"),
+        ("runtime-runes", "attribute-parts"),
+        ("runtime-runes", "async-await-block-2"),
+        ("runtime-runes", "async-await"),
+        ("runtime-runes", "async-duplicate-dependencies"),
+        ("runtime-legacy", "globals-not-overwritten-by-bindings"),
+        ("runtime-legacy", "attribute-dynamic-multiple"),
+        ("runtime-legacy", "attribute-url"),
+        ("runtime-legacy", "head-title-static-dynamic-element"),
+        (
+            "runtime-legacy",
+            "inline-style-directive-string-variable-kebab-case",
+        ),
+        ("runtime-legacy", "innerhtml-interpolated-literal"),
+        ("server-side-rendering", "head-raw-elements-content"),
+        ("runtime-runes", "derived-name-shadowed"),
+        ("runtime-runes", "derived-update-server"),
+        ("runtime-runes", "set-text-stable-coercion"),
+        ("runtime-runes", "async-boundary-nav-race"),
+        ("runtime-runes", "async-if-else"),
+        ("runtime-legacy", "const-tag-each-arrow"),
+        ("runtime-legacy", "const-tag-each-duplicated-variable2"),
+        ("runtime-legacy", "const-tag-each-duplicated-variable3"),
+        ("runtime-legacy", "const-tag-each-function"),
+        ("runtime-legacy", "const-tag-each-const"),
+        ("runtime-legacy", "await-block-func-function"),
+        ("runtime-runes", "html-tag-contenteditable"),
+        ("runtime-runes", "await-html-hydration"),
+        ("runtime-runes", "event-global-hydration-error-cleanup"),
+        ("runtime-runes", "async-html-tag"),
+        ("runtime-legacy", "svg-html-tag3"),
+        ("runtime-legacy", "svg-html-tag4"),
+        ("runtime-legacy", "raw-mustaches-preserved"),
+        ("runtime-legacy", "raw-svg"),
+        ("runtime-legacy", "ignore-unchanged-raw"),
+        ("runtime-legacy", "raw-anchor-first-last-child"),
+        ("hydration", "raw-repair"),
+        ("hydration", "raw-empty"),
+        ("hydration", "raw-svg"),
+        (
+            "server-side-rendering",
+            "select-option-store-implicit-value",
+        ),
+    ];
+
+    let parser_legacy_skipped = &["javascript-comments", "script-comment-only"];
+    let parser_modern_skipped = &["comment-in-tag", "parens"];
+    let css_skipped = &["css-prune-edge-cases"];
+    let print_skipped = &["css-keyframes-percent", "style"];
+
+    let mut now_passing: Vec<(String, String)> = Vec::new();
+    let mut still_failing: Vec<(String, String, String)> = Vec::new();
+
+    for (cat, name) in runtime_skipped {
+        let outcome = audit_runtime(cat, name);
+        if outcome.passed() {
+            now_passing.push((cat.to_string(), name.to_string()));
+        } else {
+            still_failing.push((cat.to_string(), name.to_string(), outcome.summary()));
+        }
+    }
+    for name in parser_legacy_skipped {
+        let outcome = audit_parser(name, false);
+        if outcome.passed() {
+            now_passing.push(("parser-legacy".to_string(), name.to_string()));
+        } else {
+            still_failing.push((
+                "parser-legacy".to_string(),
+                name.to_string(),
+                outcome.summary(),
+            ));
+        }
+    }
+    for name in parser_modern_skipped {
+        let outcome = audit_parser(name, true);
+        if outcome.passed() {
+            now_passing.push(("parser-modern".to_string(), name.to_string()));
+        } else {
+            still_failing.push((
+                "parser-modern".to_string(),
+                name.to_string(),
+                outcome.summary(),
+            ));
+        }
+    }
+    for name in css_skipped {
+        let outcome = audit_css(name);
+        if outcome.passed() {
+            now_passing.push(("css".to_string(), name.to_string()));
+        } else {
+            still_failing.push(("css".to_string(), name.to_string(), outcome.summary()));
+        }
+    }
+    for name in print_skipped {
+        let outcome = audit_print(name);
+        if outcome.passed() {
+            now_passing.push(("print".to_string(), name.to_string()));
+        } else {
+            still_failing.push(("print".to_string(), name.to_string(), outcome.summary()));
+        }
+    }
+
+    println!(
+        "\n=== SKIP AUDIT: NOW PASSING ({} fixtures) ===",
+        now_passing.len()
+    );
+    for (cat, name) in &now_passing {
+        println!("  PASS  {}/{}", cat, name);
+    }
+    println!(
+        "\n=== SKIP AUDIT: STILL FAILING ({} fixtures) ===",
+        still_failing.len()
+    );
+    for (cat, name, why) in &still_failing {
+        println!("  FAIL  {}/{}  ({})", cat, name, why);
+    }
+}

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1094,7 +1094,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         //   rsvelte still emits the `$.stringify` form for the former and
         //   the un-grouped sync-statement form for the latter. Tracked as
         //   follow-up ports.
-        ("runtime-runes", "attribute-parts"),
         ("runtime-runes", "async-await-block-2"),
         ("runtime-runes", "async-await"),
         ("runtime-runes", "async-duplicate-dependencies"),
@@ -1102,7 +1101,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
             "runtime-legacy",
             "inline-style-directive-string-variable-kebab-case",
         ),
-        ("server-side-rendering", "head-raw-elements-content"),
         ("runtime-runes", "derived-name-shadowed"),
         ("runtime-runes", "set-text-stable-coercion"),
         ("runtime-runes", "async-boundary-nav-race"),

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1099,10 +1099,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         ("runtime-runes", "async-await-block-2"),
         ("runtime-runes", "async-await"),
         ("runtime-runes", "async-duplicate-dependencies"),
-        ("runtime-legacy", "globals-not-overwritten-by-bindings"),
-        ("runtime-legacy", "attribute-dynamic-multiple"),
-        ("runtime-legacy", "attribute-url"),
-        ("runtime-legacy", "head-title-static-dynamic-element"),
         (
             "runtime-legacy",
             "inline-style-directive-string-variable-kebab-case",
@@ -1114,35 +1110,13 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         ("runtime-runes", "set-text-stable-coercion"),
         ("runtime-runes", "async-boundary-nav-race"),
         ("runtime-runes", "async-if-else"),
-        ("runtime-legacy", "const-tag-each-arrow"),
-        ("runtime-legacy", "const-tag-each-duplicated-variable2"),
-        ("runtime-legacy", "const-tag-each-duplicated-variable3"),
-        ("runtime-legacy", "const-tag-each-function"),
-        ("runtime-legacy", "const-tag-each-const"),
-        ("runtime-legacy", "await-block-func-function"),
         // - HtmlTag is_controlled cluster (Svelte 5.53.8, upstream commit
-        //   `0206a2019` "fix: clean up externally-added DOM nodes in {@html}
-        //   on re-render"): when `{@html ...}` is the ONLY child of an
-        //   element, the parent fragment marks `metadata.is_controlled = true`
-        //   and the visitor skips the wrapper comment + uses the parent node
-        //   directly (`$.html(svg, ...)` instead of `$.html(node_1, ...)`).
-        //   rsvelte's analysis doesn't surface `is_controlled` yet so the
-        //   HtmlTag visitor always takes the non-controlled path, which is
-        //   correct for the common case but mismatches the new fixtures
-        //   below. Tracked as a follow-up port.
-        ("runtime-runes", "html-tag-contenteditable"),
-        ("runtime-runes", "await-html-hydration"),
-        ("runtime-runes", "event-global-hydration-error-cleanup"),
-        ("runtime-runes", "async-html-tag"),
-        ("runtime-legacy", "svg-html-tag3"),
-        ("runtime-legacy", "svg-html-tag4"),
-        ("runtime-legacy", "raw-mustaches-preserved"),
-        ("runtime-legacy", "raw-svg"),
-        ("runtime-legacy", "ignore-unchanged-raw"),
-        ("runtime-legacy", "raw-anchor-first-last-child"),
-        ("hydration", "raw-repair"),
-        ("hydration", "raw-empty"),
-        ("hydration", "raw-svg"),
+        //   `0206a2019`) is now ported in `client/visitors/shared/fragment.rs`
+        //   + `client/visitors/html_tag.rs` — all 13 fixtures (runtime-runes,
+        //   runtime-legacy, hydration) now pass. `head-raw-elements-content`
+        //   above survives as the only remaining HtmlTag-adjacent skip and
+        //   actually belongs to the SSR `$.stringify` elide cluster, not
+        //   is_controlled.
         // - `select-option-store-implicit-value` (server-side-rendering,
         //   Svelte 5.53.6): upstream commit `e3d277b00` "fix: visit synthetic
         //   value node during ssr" wraps the synthetic `value` expression
@@ -1356,7 +1330,7 @@ fn run_print_tests() -> CategoryResult {
     // doesn't re-format the bodies of selectors / `@keyframes` blocks the
     // way upstream does (multi-line block normalisation, percentage handling).
     // Tracked as a follow-up port.
-    let skip_print: &[&str] = &["css-keyframes-percent", "style"];
+    let skip_print: &[&str] = &["css-keyframes-percent"];
 
     for sample_dir in &samples {
         let name = sample_dir

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1117,16 +1117,9 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         //   actually belongs to the SSR `$.stringify` elide cluster, not
         //   is_controlled.
         // - `select-option-store-implicit-value` (server-side-rendering,
-        //   Svelte 5.53.6): upstream commit `e3d277b00` "fix: visit synthetic
-        //   value node during ssr" wraps the synthetic `value` expression
-        //   computed for `<option>` inside `<select>` in `context.visit(...)`
-        //   so store refs (`$label` → `$.store_get(...)`) get rewritten.
-        //   rsvelte's SSR transform doesn't route the synthetic value node
-        //   through `transform_store_refs` yet — tracked as a follow-up port.
-        (
-            "server-side-rendering",
-            "select-option-store-implicit-value",
-        ),
+        //   Svelte 5.53.6, upstream `e3d277b00`): now ported in
+        //   `select_element.rs` — synthetic `<option>` value goes through
+        //   `transform_store_refs`.
     ];
 
     for sample_dir in &samples {

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1068,7 +1068,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         //   `wrap_derived_reads` re-wraps `visible` to `visible()` inside the
         //   thunk, producing `$.derived(() => visible())`. Tracked as a
         //   follow-up.
-        ("runtime-runes", "derived-dep-set-while-rendering"),
         // - Svelte 5.55.6 cluster: upstream commits `e00944ffd`/`89b6a939f`/
         //   `4c96b469f`/`69b4c9f56`. New async-* fixtures exercise the same
         //   sync-grouping/`Promise.all`-save follow-up tracked since 5.54.1.

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1102,7 +1102,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
             "runtime-legacy",
             "inline-style-directive-string-variable-kebab-case",
         ),
-        ("runtime-legacy", "innerhtml-interpolated-literal"),
         ("server-side-rendering", "head-raw-elements-content"),
         ("runtime-runes", "derived-name-shadowed"),
         ("runtime-runes", "set-text-stable-coercion"),

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1106,7 +1106,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         ("runtime-legacy", "innerhtml-interpolated-literal"),
         ("server-side-rendering", "head-raw-elements-content"),
         ("runtime-runes", "derived-name-shadowed"),
-        ("runtime-runes", "derived-update-server"),
         ("runtime-runes", "set-text-stable-coercion"),
         ("runtime-runes", "async-boundary-nav-race"),
         ("runtime-runes", "async-if-else"),

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -264,10 +264,10 @@ const RUNTIME_LEGACY_SKIP_NAMES: &[&str] = &[
     //   - inline-style-directive-string-variable-kebab-case relies on
     //     extracting a multi-line `let url = "..."` declaration as a constant;
     //     `extract_constant_vars` only handles single-line declarations.
-    //   - innerhtml-interpolated-literal hits the innerHTML codegen path,
-    //     which still emits `$.stringify` unconditionally.
+    //   - inline-style-directive-string-variable-kebab-case relies on a
+    //     multi-line `let url = "..."` declaration which
+    //     `extract_constant_vars` doesn't handle.
     "inline-style-directive-string-variable-kebab-case",
-    "innerhtml-interpolated-literal",
 ];
 
 /// hydration fixtures still failing. All HtmlTag is_controlled fixtures now pass

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -165,10 +165,6 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // Shadowing of a `$derived` name by an inner declaration — same upstream
     // class as the above; previously latent, now surfaced. Awaiting investigation.
     "derived-name-shadowed",
-    // `$derived` with postfix/prefix update operators — SSR output diverges
-    // from the official compiler. Added in Svelte 5.53.2; also skipped in
-    // compatibility_report. Awaiting investigation.
-    "derived-update-server",
     // Svelte 5.53.3 `f67d03df5`: template-literal `set_text` should wrap
     // non-provably-string values with `?? ''` to coerce. rsvelte's
     // `is_expression_defined` treats `new Widget()` as defined; upstream's

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -162,8 +162,11 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // the official compiler structurally, but the live comparison harness
     // diverges. Last 3 main CI runs failed this same fixture.
     "async-derived-title-update",
-    // Shadowing of a `$derived` name by an inner declaration — same upstream
-    // class as the above; previously latent, now surfaced. Awaiting investigation.
+    // Shadowing of a `$derived` name by an inner declaration (Svelte 5.53.1
+    // upstream `0c7f81514`). rsvelte's FunctionDeclaration scope handling
+    // associates the inner `const foo = $derived(...)` with template lookups
+    // of the outer `function foo()` — needs the upstream scopes.set(node.id)
+    // fix on the rsvelte ScopeBuilder. Tracked as a follow-up port.
     "derived-name-shadowed",
     // Svelte 5.53.3 `f67d03df5`: template-literal `set_text` should wrap
     // non-provably-string values with `?? ''` to coerce. rsvelte's

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -243,7 +243,6 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // is handled; the runes fixtures below also hit code paths that aren't
     // ported yet (attribute parts, async-await codegen). Mirrors the
     // entries in `tests/compatibility_report.rs`.
-    "attribute-parts",
     "async-await-block-2",
     "async-await",
     "async-duplicate-dependencies",

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -169,24 +169,17 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // from the official compiler. Added in Svelte 5.53.2; also skipped in
     // compatibility_report. Awaiting investigation.
     "derived-update-server",
-    // Template-literal `set_text` interpolation expects `?? ''` coercion;
-    // rsvelte's client transform doesn't emit it yet. Added in Svelte 5.53.3;
-    // also skipped in compatibility_report.
+    // Svelte 5.53.3 `f67d03df5`: template-literal `set_text` should wrap
+    // non-provably-string values with `?? ''` to coerce. rsvelte's
+    // `is_expression_defined` treats `new Widget()` as defined; upstream's
+    // `scope.evaluate` distinguishes "defined" from "is_string" and only
+    // skips `?? ''` when both are true. Tracked as follow-up port.
     "set-text-stable-coercion",
     // Async boundary / async-if-else fixtures added in Svelte 5.53.4 that
     // exercise async-blocker plumbing rsvelte doesn't yet emit. Also
     // skipped in compatibility_report.
     "async-boundary-nav-race",
     "async-if-else",
-    // HtmlTag `is_controlled` cluster (Svelte 5.53.8 upstream `0206a2019`).
-    // When `{@html ...}` is the only child of an element, the parent
-    // fragment marks `metadata.is_controlled = true` and the visitor uses
-    // the parent node directly. rsvelte's analysis doesn't surface
-    // `is_controlled`; also skipped in compatibility_report.
-    "html-tag-contenteditable",
-    "await-html-hydration",
-    "event-global-hydration-error-cleanup",
-    "async-html-tag",
     // async-eager-derived (Svelte 5.53.12, upstream `965f2a0ac` "fix:
     // eagerly load deriveds when async work is started"): expected
     // compiled output now threads `eager` promises through `$.derived(...)`
@@ -260,44 +253,30 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     "async-duplicate-dependencies",
 ];
 
-/// runtime-legacy fixtures that diverged after the Svelte 5.53.4 scope fix
-/// (commit `3a289797b` "fix: handle default parameters scope leaks"). The
-/// upstream change uses separate scopes for function declarations and their
-/// bodies, which shifts the names emitted by `const-tag` / `await`-block
-/// client codegen. rsvelte's transform doesn't yet mirror the new scope
-/// model; tracked as a follow-up port.
+/// runtime-legacy fixtures still failing on the rsvelte port. Each cluster is
+/// labelled with the upstream commit responsible. Remove an entry once the
+/// underlying port lands.
 const RUNTIME_LEGACY_SKIP_NAMES: &[&str] = &[
-    "await-block-func-function",
-    "const-tag-each-arrow",
-    "const-tag-each-const",
-    "const-tag-each-duplicated-variable2",
-    "const-tag-each-duplicated-variable3",
-    "const-tag-each-function",
-    // HtmlTag `is_controlled` cluster (Svelte 5.53.8 upstream `0206a2019`),
-    // legacy half. See RUNTIME_RUNES_SKIP_NAMES for the wider context.
-    "svg-html-tag3",
-    "svg-html-tag4",
-    "raw-mustaches-preserved",
-    "raw-svg",
-    "ignore-unchanged-raw",
-    "raw-anchor-first-last-child",
-    // flush-sync-each-block (Svelte 5.55.2): also skipped in compatibility_report.
+    // flush-sync-each-block (Svelte 5.55.2): two combined failures —
+    //   1) client: `import "./Inner.svelte"` (no semicolon) merges into the
+    //      following `let count = 1` because the script raw-emission path
+    //      strips line breaks.
+    //   2) server: legacy `let count` is not lowered to `$.mutable_source(...)`.
     "flush-sync-each-block",
     // Svelte 5.55.9 cluster (upstream `a5df6616e` "fix: avoid unnecessary
-    // stringify in server attributes"): static and known-string-defined
-    // attribute interpolations now skip `$.stringify(...)`. The
-    // `<div title=...>` case is handled, but class/style/style-directive/
-    // innerHTML paths still emit the wrapper. Mirrors the entries in
-    // `tests/compatibility_report.rs`; remove as those paths are ported.
-    "attribute-dynamic-multiple",
-    "globals-not-overwritten-by-bindings",
+    // stringify in server attributes"): two paths remain.
+    //   - inline-style-directive-string-variable-kebab-case relies on
+    //     extracting a multi-line `let url = "..."` declaration as a constant;
+    //     `extract_constant_vars` only handles single-line declarations.
+    //   - innerhtml-interpolated-literal hits the innerHTML codegen path,
+    //     which still emits `$.stringify` unconditionally.
     "inline-style-directive-string-variable-kebab-case",
     "innerhtml-interpolated-literal",
 ];
 
-/// hydration fixtures that diverge after the Svelte 5.53.8 HtmlTag `is_controlled`
-/// upstream change. See RUNTIME_RUNES_SKIP_NAMES for context.
-const HYDRATION_SKIP_NAMES: &[&str] = &["raw-repair", "raw-empty", "raw-svg"];
+/// hydration fixtures still failing. All HtmlTag is_controlled fixtures now pass
+/// post-port (Svelte 5.53.8 upstream `0206a2019`).
+const HYDRATION_SKIP_NAMES: &[&str] = &[];
 
 /// Run a single runtime fixture test.
 fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestResult {

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -225,9 +225,6 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     "async-reactivity-loss-no-false-positive-1",
     "async-reactivity-loss-no-false-positive-2",
     "async-reactivity-loss-no-false-positive-3",
-    // derived-dep-set-while-rendering (Svelte 5.55.5): also skipped in
-    // compatibility_report.
-    "derived-dep-set-while-rendering",
     // 5.55.6 async-codegen cluster: same gap as the previous async batches,
     // skipped in compatibility_report.
     "async-debug-awaited-expression",

--- a/tests/ssr.rs
+++ b/tests/ssr.rs
@@ -81,15 +81,7 @@ struct TestResult {
 /// yet implement. Mirrors the corresponding entries in `tests/compatibility_report.rs`
 /// so `test_ssr` stops blocking unrelated work; remove an entry as soon as the
 /// upstream behaviour is matched.
-const SSR_SKIP_NAMES: &[&str] = &[
-    // Svelte 5.55.9 cluster (upstream `a5df6616e` "fix: avoid unnecessary
-    // stringify in server attributes"): static interpolated literals are now
-    // inlined directly into `$$renderer.push(...)` instead of going through
-    // `$.head` + `$.stringify(...)`. Mirrors the entry in
-    // `tests/compatibility_report.rs`; remove once the head-element SSR path
-    // applies the same constant-folding.
-    "head-raw-elements-content",
-];
+const SSR_SKIP_NAMES: &[&str] = &[];
 
 /// Run a single SSR fixture test.
 fn run_ssr_fixture_test(fixture: &SsrFixture) -> TestResult {

--- a/tests/ssr.rs
+++ b/tests/ssr.rs
@@ -82,11 +82,6 @@ struct TestResult {
 /// so `test_ssr` stops blocking unrelated work; remove an entry as soon as the
 /// upstream behaviour is matched.
 const SSR_SKIP_NAMES: &[&str] = &[
-    // Svelte 5.53.6 (upstream `e3d277b00`): `<option>` synthetic `value` is
-    // visited through `context.visit(...)`, so store refs get rewritten via
-    // `$.store_get(...)`. rsvelte's SSR transform doesn't yet route the
-    // synthetic value node through `transform_store_refs`.
-    "select-option-store-implicit-value",
     // Svelte 5.55.9 cluster (upstream `a5df6616e` "fix: avoid unnecessary
     // stringify in server attributes"): static interpolated literals are now
     // inlined directly into `$$renderer.push(...)` instead of going through


### PR DESCRIPTION
## Summary

Reduces skipped fixtures **162 → 132** (in-scope **75 → 56**) by porting six Svelte 5.53.0–5.55.9 upstream changes and cleaning up dead skip entries. Every executed in-scope fixture passes (**3420/3420**).

### Ports landed

| Cluster | Upstream | Fixtures unblocked |
|---|---|---|
| **HtmlTag `is_controlled`** | 5.53.8 `0206a2019` | 11 (runtime-runes/legacy/hydration) |
| **`$.update_derived` for `++`/`--` on derived** | 5.53.2 `6aa7b9c64` | 1 (derived-update-server) |
| **`<option>` synthetic value via `transform_store_refs`** | 5.53.6 `e3d277b00` | 1 (select-option-store-implicit-value) |
| **Bare-derived `$derived(visible)` collapse** | 5.55.5 `b771df3` | 1 (derived-dep-set-while-rendering) |
| **SSR attribute `$.stringify` elide (partial)** | 5.55.9 `a5df6616e` | 5 (attribute-dynamic-multiple, globals-not-overwritten-by-bindings, attribute-parts, head-raw-elements-content, innerhtml-interpolated-literal) |
| **Dead-skip cleanup** | — | 11 (const-tag-each-*, await-block-func-function, attribute-url, head-title-static-dynamic-element, await-html-hydration, async-html-tag, print style) |

Also adds `tests/audit_skipped.rs`, a sweep that re-runs every fixture in the skip lists and reports "NOW PASSING" / "STILL FAILING" so future Svelte bumps surface dead entries automatically.

### What's still skipped (56 in-scope)

The remaining clusters all need deeper async-transform / scope-analysis work that doesn't fit this PR:

- **async-blocker / @const blocker cluster** (~45 fixtures, runtime-runes) — `$$promises` eager ordering, sync-statement grouping, `Promise.all` save, `@const` context reset across Svelte 5.54.1–5.55.9.
- `derived-name-shadowed` — `FunctionDeclaration` id-in-outer-scope binding (5.53.1 `0c7f81514`).
- `set-text-stable-coercion` — distinguish "provably string" vs "provably defined" in `is_expression_defined` (5.53.3 `f67d03df5`).
- `flush-sync-each-block` — two combined issues: instance-script raw-emission strips newlines around no-semicolon imports, and legacy `let` is not lowered to `$.mutable_source(...)`.
- `inline-style-directive-string-variable-kebab-case` — multi-line `let url = "..."` extraction in `extract_constant_vars`.
- Comments-in-tags (5.53.0), CSS prune edge cases (5.53.7), `@keyframes` percentage printer (5.55.8), `javascript-comments` (long-standing OXC vs acorn limitation).

## Test plan

- [x] `cargo test --release --test runtime` — 19/19 pass
- [x] `cargo test --release --test ssr` — pass
- [x] `cargo clippy --release --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --release --test audit_skipped -- --nocapture` — 30 "NOW PASSING", 53 "STILL FAILING" (all in remaining clusters above)
- [x] `pnpm run compatibility-report` — 100% on every in-scope category (3420/3420)