### PR TITLE
feat(server): collapse multi-line declarations in extract_constant_vars

### DIFF
--- a/src/compiler/phases/3_transform/server/helpers.rs
+++ b/src/compiler/phases/3_transform/server/helpers.rs
@@ -1416,6 +1416,131 @@ pub(crate) fn transform_props_spread_ex(
     result
 }
 
+/// Collapse multi-line declarations / function calls into single logical lines.
+///
+/// `extract_constant_vars` walks the script line by line, but
+/// `let url =\n   "https://..."` is one logical statement split across two
+/// physical lines. We scan the script while tracking bracket / paren / brace
+/// / string depth — when a newline appears at depth > 0 (or directly after
+/// an open-paren / `=` with no value yet) we replace it with a single space
+/// so the next pass sees a complete declaration. Lines inside strings /
+/// template literals are left untouched.
+fn join_continuation_lines(script: &str) -> String {
+    let bytes = script.as_bytes();
+    let mut out = String::with_capacity(script.len());
+    let mut depth_paren: i32 = 0;
+    let mut depth_brace: i32 = 0;
+    let mut depth_bracket: i32 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // Line / block comments — copy as-is.
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            let s = i;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            out.push_str(&script[s..i]);
+            continue;
+        }
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            let s = i;
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < bytes.len() {
+                i += 2;
+            }
+            out.push_str(&script[s..i]);
+            continue;
+        }
+        // String / template literals — copy verbatim. Newlines inside
+        // template literals are legal and must not be collapsed.
+        if b == b'"' || b == b'\'' || b == b'`' {
+            let quote = b;
+            let s = i;
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            out.push_str(&script[s..i]);
+            continue;
+        }
+        if b == b'(' {
+            depth_paren += 1;
+        } else if b == b')' {
+            depth_paren -= 1;
+        } else if b == b'{' {
+            depth_brace += 1;
+        } else if b == b'}' {
+            depth_brace -= 1;
+        } else if b == b'[' {
+            depth_bracket += 1;
+        } else if b == b']' {
+            depth_bracket -= 1;
+        }
+        if b == b'\n' {
+            // Look back over already-emitted output (skipping trailing
+            // spaces / tabs) to see if the previous non-whitespace character
+            // is one that suggests the statement continues onto the next
+            // line — `=`, `+`, `-`, `,`, `(`, `[`, `{`, `?`, `:`, `&`, `|`,
+            // `!` (only as part of `!=`), `<`, `>`, `*`, `/`, `%`, `^`, `~`,
+            // a backtick, etc. The most common case we care about is `=`,
+            // but covering operators avoids surprises with hand-formatted
+            // declarations like `const x = a +\n  b`.
+            let prev = out
+                .as_bytes()
+                .iter()
+                .rposition(|c| !c.is_ascii_whitespace())
+                .map(|p| out.as_bytes()[p]);
+            let in_expr = depth_paren > 0 || depth_bracket > 0 || depth_brace > 0;
+            let after_continuation_op = matches!(
+                prev,
+                Some(
+                    b'=' | b'+'
+                        | b'-'
+                        | b','
+                        | b'?'
+                        | b':'
+                        | b'&'
+                        | b'|'
+                        | b'<'
+                        | b'>'
+                        | b'*'
+                        | b'/'
+                        | b'%'
+                        | b'^'
+                        | b'~'
+                        | b'('
+                        | b'['
+                        | b'{'
+                )
+            );
+            if in_expr || after_continuation_op {
+                out.push(' ');
+                i += 1;
+                continue;
+            }
+        }
+        let mut next = i + 1;
+        while next < bytes.len() && !script.is_char_boundary(next) {
+            next += 1;
+        }
+        out.push_str(&script[i..next]);
+        i = next;
+    }
+    out
+}
+
 /// Extract constant variable bindings from script content.
 /// Try to parse a value as a constant literal and insert into the constants map.
 /// Returns true if the value was successfully inserted.
@@ -1688,8 +1813,14 @@ pub(crate) fn extract_constant_vars(script: &str, full_source: &str) -> FxHashMa
     // Collect unresolved expressions for a second pass
     let mut unresolved: Vec<(String, String, bool)> = Vec::new(); // (name, expr, is_const)
 
+    // Join physical lines into "logical lines" (statements). A declaration
+    // like `let url =\n  "https://..."` spans two physical lines but is one
+    // statement — collapsing it lets the rest of this function recognise it
+    // as `let url = "https://..."`.
+    let logical_script = join_continuation_lines(script);
+
     // First pass: extract constants from non-rune declarations
-    for line in script.lines() {
+    for line in logical_script.lines() {
         let trimmed = line.trim();
 
         // Skip lines with $state, $derived, or $props - these are reactive and

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1097,10 +1097,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         ("runtime-runes", "async-await-block-2"),
         ("runtime-runes", "async-await"),
         ("runtime-runes", "async-duplicate-dependencies"),
-        (
-            "runtime-legacy",
-            "inline-style-directive-string-variable-kebab-case",
-        ),
         ("runtime-runes", "derived-name-shadowed"),
         ("runtime-runes", "set-text-stable-coercion"),
         ("runtime-runes", "async-boundary-nav-race"),

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -258,15 +258,6 @@ const RUNTIME_LEGACY_SKIP_NAMES: &[&str] = &[
     //      strips line breaks.
     //   2) server: legacy `let count` is not lowered to `$.mutable_source(...)`.
     "flush-sync-each-block",
-    // Svelte 5.55.9 cluster (upstream `a5df6616e` "fix: avoid unnecessary
-    // stringify in server attributes"): two paths remain.
-    //   - inline-style-directive-string-variable-kebab-case relies on
-    //     extracting a multi-line `let url = "..."` declaration as a constant;
-    //     `extract_constant_vars` only handles single-line declarations.
-    //   - inline-style-directive-string-variable-kebab-case relies on a
-    //     multi-line `let url = "..."` declaration which
-    //     `extract_constant_vars` doesn't handle.
-    "inline-style-directive-string-variable-kebab-case",
 ];
 
 /// hydration fixtures still failing. All HtmlTag is_controlled fixtures now pass


### PR DESCRIPTION
## Summary

Extends the SSR `$.stringify` elide cluster (Svelte 5.55.9 `a5df6616e`) to fixtures whose `let`/`const` declarations split a single statement across multiple physical lines:

```svelte
<script>
    let url =
        "https://raw.githubusercontent.com/sveltejs/branding/master/svelte-vertical.png";
    let alpha = 1;
</script>

<div style:background-image="url({url})" style:--css-variable="rgba(0, 0, 0, {alpha})" />
```

`extract_constant_vars` walks the script line by line, so it never saw `let url = "..."` as one statement before. New pass `join_continuation_lines` collapses newlines either inside open `()` / `[]` / `{}` or directly after a continuation operator (`=`, `+`, `-`, ... ) on the prior line. Strings and comments are copied verbatim so template literal interiors and JSDoc blocks aren't touched.

Result: `style:background-image="url({url})"` inlines to `'url(https://...)'` and the SSR output matches upstream byte-for-byte.

Unblocks 1 fixture: `runtime-legacy/inline-style-directive-string-variable-kebab-case`.

Compatibility report: **skipped 132 → 131** (in-scope **56 → 55**). All in-scope-run fixtures continue to pass.

## Test plan

- [x] cargo test --release --test runtime — 19/19 pass
- [x] cargo test --release --test ssr — pass
- [x] cargo clippy --release --tests -- -D warnings — clean
- [x] cargo fmt --check — clean