### PR TITLE
feat(analyze): treat NewExpression as not-provably-defined for template-literal coercion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ pbcopy
 # entry, `changesets/action` includes them in the "Version Packages" PR
 # (~70 MB per run, baked into git history forever).
 artifacts/
+
+# Claude scheduled task lock (runtime artifact)
+.claude/scheduled_tasks.lock

--- a/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -772,8 +772,14 @@ fn is_expression_defined(node: &Value) -> bool {
         | "ObjectExpression"
         | "ArrowFunctionExpression"
         | "FunctionExpression"
-        | "TemplateLiteral"
-        | "NewExpression" => true,
+        | "TemplateLiteral" => true,
+        // `new SomeClass(...)` always returns an object at runtime, but its
+        // toString / valueOf are user-controlled, so upstream's scope.evaluate
+        // returns `is_string: false` and the template-literal `${...}`
+        // coercion adds `?? ''` for safety (Svelte 5.53.3 `f67d03df5`).
+        // Mirror that here by treating NewExpression as NOT provably-defined
+        // for `is_expression_defined`'s consumers.
+        "NewExpression" => false,
         "AssignmentExpression" => node
             .get("right")
             .map(is_expression_defined)
@@ -1121,8 +1127,12 @@ fn is_expression_defined_typed(node: &JsNode, arena: &crate::ast::arena::ParseAr
         | JsNode::ObjectExpression { .. }
         | JsNode::ArrowFunctionExpression { .. }
         | JsNode::FunctionExpression { .. }
-        | JsNode::TemplateLiteral { .. }
-        | JsNode::NewExpression { .. } => true,
+        | JsNode::TemplateLiteral { .. } => true,
+        // See the JSON variant above — Svelte 5.53.3 `f67d03df5` treats
+        // `new SomeClass()` as not-provably-string, so we report it as
+        // not-provably-defined for the template-literal coercion path that
+        // consumes this signal via `binding.initial_is_defined`.
+        JsNode::NewExpression { .. } => false,
         JsNode::AssignmentExpression { right, .. } => {
             is_expression_defined_typed(arena.get_js_node(*right), arena)
         }

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1102,7 +1102,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
             "inline-style-directive-string-variable-kebab-case",
         ),
         ("runtime-runes", "derived-name-shadowed"),
-        ("runtime-runes", "set-text-stable-coercion"),
         ("runtime-runes", "async-boundary-nav-race"),
         ("runtime-runes", "async-if-else"),
         // - HtmlTag is_controlled cluster (Svelte 5.53.8, upstream commit

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -168,12 +168,6 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // of the outer `function foo()` — needs the upstream scopes.set(node.id)
     // fix on the rsvelte ScopeBuilder. Tracked as a follow-up port.
     "derived-name-shadowed",
-    // Svelte 5.53.3 `f67d03df5`: template-literal `set_text` should wrap
-    // non-provably-string values with `?? ''` to coerce. rsvelte's
-    // `is_expression_defined` treats `new Widget()` as defined; upstream's
-    // `scope.evaluate` distinguishes "defined" from "is_string" and only
-    // skips `?? ''` when both are true. Tracked as follow-up port.
-    "set-text-stable-coercion",
     // Async boundary / async-if-else fixtures added in Svelte 5.53.4 that
     // exercise async-blocker plumbing rsvelte doesn't yet emit. Also
     // skipped in compatibility_report.


### PR DESCRIPTION
## Summary

Upstream commit `f67d03df5` "fix: make string coercion consistent to toString" (Svelte 5.53.3) switched the internal `set_text` helper from `value + ''` to a template literal so coercion uses `toString()` instead of `valueOf()`. To stay null-safe inside the template literal, the compiler adds `?? ''` to interpolations whose value isn't a provably-defined string — including `const value = new Widget()` cases where the user's class could have any `toString()`.

rsvelte previously treated `NewExpression` as guaranteed-defined, which set `binding.initial_is_defined = true` for `const value = new Widget()` and caused the template-chunk emitter to skip the `?? ''` wrapping.

Drop `NewExpression` from the "defined" set in both phase-2 helpers (`is_expression_defined` / `is_expression_defined_typed`). Other kinds (ArrayExpression / ObjectExpression / ArrowFunctionExpression / TemplateLiteral / ...) keep their previous semantics — they're syntactically-known string-coercible values.

Unblocks 1 fixture: `runtime-runes/set-text-stable-coercion`.

Also cleans up an accidentally-tracked `.claude/scheduled_tasks.lock` (runtime lock file, no longer committed; gitignored).

## Test plan

- [x] cargo test --release --test runtime — 19/19 pass
- [x] cargo test --release --lib --test ssr — 16/16 pass
- [x] cargo test --release --lib --test compiler_fixtures — 17/17 pass
- [x] cargo clippy --release --tests -- -D warnings — clean
- [x] cargo fmt --check — clean

Compatibility report: **skipped 132 → 131** (in-scope **56 → 55**). All in-scope-run fixtures continue to pass.