### PR TITLE
docs: refresh test-results.json after recent skip-reduction merges

### DIFF
--- a/docs/static/test-results.json
+++ b/docs/static/test-results.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-05-26T08:24:50.868442+00:00",
+  "generated_at": "2026-05-26T18:22:49.388902+00:00",
   "commit_sha": "b65a3f3fc5e1",
   "summary": {
     "total": 3552,
-    "passed": 3420,
+    "passed": 3423,
     "failed": 0,
-    "skipped": 132,
+    "skipped": 129,
     "percentage": 100
   },
   "categories": [
@@ -3193,9 +3193,9 @@
       "id": "runtime-runes",
       "name": "Runtime Runes",
       "total": 979,
-      "passed": 934,
+      "passed": 936,
       "failed": 0,
-      "skipped": 45,
+      "skipped": 43,
       "percentage": 100,
       "tests": [
         {
@@ -4514,8 +4514,7 @@
         },
         {
           "name": "set-text-stable-coercion",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "legacy-runes-ambiguous",
@@ -6695,8 +6694,7 @@
         },
         {
           "name": "derived-name-shadowed",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "error-boundary-7",
@@ -7165,9 +7163,9 @@
       "id": "runtime-legacy",
       "name": "Runtime Legacy",
       "total": 1205,
-      "passed": 1203,
+      "passed": 1204,
       "failed": 0,
-      "skipped": 2,
+      "skipped": 1,
       "percentage": 100,
       "tests": [
         {
@@ -10973,8 +10971,7 @@
         },
         {
           "name": "inline-style-directive-string-variable-kebab-case",
-          "status": "skip",
-          "skip_reason": "Async-derived $$promises blockers not yet threaded through template effects (introduced in Svelte 5.53.0)"
+          "status": "pass"
         },
         {
           "name": "component-slot-let-c",


### PR DESCRIPTION
Regenerated `docs/static/test-results.json` so the dashboard reflects the current state after PRs #408, #409, #412.

Compatibility report: **skipped 132 → 129** (in-scope **56 → 53**). Every executed in-scope fixture passes (3423/3423).