### PR TITLE
chore(audit): drop 33 stale entries from audit_skipped tracking list

### DIFF
--- a/tests/audit_skipped.rs
+++ b/tests/audit_skipped.rs
@@ -407,7 +407,6 @@ fn audit_skipped_fixtures() {
         ("runtime-runes", "async-reactivity-loss-async-after-sync"),
         ("runtime-runes", "async-effect-pending-eager"),
         ("runtime-runes", "async-context-after-await-const"),
-        ("runtime-runes", "derived-dep-set-while-rendering"),
         ("runtime-runes", "async-flushsync-in-effect"),
         ("runtime-runes", "async-stale-derived-4"),
         ("runtime-runes", "async-eager-block"),
@@ -419,54 +418,17 @@ fn audit_skipped_fixtures() {
         ("runtime-runes", "async-debug-awaited-expression"),
         ("runtime-runes", "async-state-updates-microtask-separated"),
         ("runtime-runes", "dynamic-component-member"),
-        ("runtime-runes", "attribute-parts"),
         ("runtime-runes", "async-await-block-2"),
         ("runtime-runes", "async-await"),
         ("runtime-runes", "async-duplicate-dependencies"),
-        ("runtime-legacy", "globals-not-overwritten-by-bindings"),
-        ("runtime-legacy", "attribute-dynamic-multiple"),
-        ("runtime-legacy", "attribute-url"),
-        ("runtime-legacy", "head-title-static-dynamic-element"),
-        (
-            "runtime-legacy",
-            "inline-style-directive-string-variable-kebab-case",
-        ),
-        ("runtime-legacy", "innerhtml-interpolated-literal"),
-        ("server-side-rendering", "head-raw-elements-content"),
-        ("runtime-runes", "derived-name-shadowed"),
-        ("runtime-runes", "derived-update-server"),
-        ("runtime-runes", "set-text-stable-coercion"),
         ("runtime-runes", "async-boundary-nav-race"),
         ("runtime-runes", "async-if-else"),
-        ("runtime-legacy", "const-tag-each-arrow"),
-        ("runtime-legacy", "const-tag-each-duplicated-variable2"),
-        ("runtime-legacy", "const-tag-each-duplicated-variable3"),
-        ("runtime-legacy", "const-tag-each-function"),
-        ("runtime-legacy", "const-tag-each-const"),
-        ("runtime-legacy", "await-block-func-function"),
-        ("runtime-runes", "html-tag-contenteditable"),
-        ("runtime-runes", "await-html-hydration"),
-        ("runtime-runes", "event-global-hydration-error-cleanup"),
-        ("runtime-runes", "async-html-tag"),
-        ("runtime-legacy", "svg-html-tag3"),
-        ("runtime-legacy", "svg-html-tag4"),
-        ("runtime-legacy", "raw-mustaches-preserved"),
-        ("runtime-legacy", "raw-svg"),
-        ("runtime-legacy", "ignore-unchanged-raw"),
-        ("runtime-legacy", "raw-anchor-first-last-child"),
-        ("hydration", "raw-repair"),
-        ("hydration", "raw-empty"),
-        ("hydration", "raw-svg"),
-        (
-            "server-side-rendering",
-            "select-option-store-implicit-value",
-        ),
     ];
 
     let parser_legacy_skipped = &["javascript-comments", "script-comment-only"];
     let parser_modern_skipped = &["comment-in-tag", "parens"];
     let css_skipped = &["css-prune-edge-cases"];
-    let print_skipped = &["css-keyframes-percent", "style"];
+    let print_skipped = &["css-keyframes-percent"];
 
     let mut now_passing: Vec<(String, String)> = Vec::new();
     let mut still_failing: Vec<(String, String, String)> = Vec::new();


### PR DESCRIPTION
## Summary

`cargo test --release --test audit_skipped -- --nocapture` on main shows 33 fixtures that the audit driver tracks as expected-skipped, but that are already passing. These are leftovers from prior skip-reduction PRs (HtmlTag \`is_controlled\`, \`derived-update-server\`, \`derived-name-shadowed\`, \`attribute-parts\`, \`set-text-stable-coercion\`, \`select-option-store-implicit-value\`, \`head-raw-elements-content\`, etc.) — the actual \`compatibility_report\` / \`runtime\` / \`ssr\` skip lists were trimmed when those ports landed, but the audit driver's own tracking list in \`tests/audit_skipped.rs\` was not.

This PR drops the 33 stale entries so the audit driver mirrors the real skip surface again. No effect on the compatibility-report skip count (53 → 53) — these were already passing, just falsely reported as \"NOW PASSING\" on every audit run.

## Dropped entries

```
runtime-runes: derived-dep-set-while-rendering, attribute-parts, derived-name-shadowed,
               derived-update-server, set-text-stable-coercion, html-tag-contenteditable,
               await-html-hydration, event-global-hydration-error-cleanup, async-html-tag
runtime-legacy: globals-not-overwritten-by-bindings, attribute-dynamic-multiple,
               attribute-url, head-title-static-dynamic-element,
               inline-style-directive-string-variable-kebab-case,
               innerhtml-interpolated-literal, const-tag-each-arrow,
               const-tag-each-duplicated-variable2, const-tag-each-duplicated-variable3,
               const-tag-each-function, const-tag-each-const, await-block-func-function,
               svg-html-tag3, svg-html-tag4, raw-mustaches-preserved, raw-svg,
               ignore-unchanged-raw, raw-anchor-first-last-child
hydration:     raw-repair, raw-empty, raw-svg
server-side-rendering: head-raw-elements-content, select-option-store-implicit-value
print:         style
```

After this change, audit output should be clean — NOW PASSING is empty, and STILL FAILING matches the in-scope skipped fixtures from \`tests/compatibility_report.rs\` exactly.

## Test plan

- [x] \`cargo check --release --test audit_skipped\` — clean.
- [ ] CI \`Compatibility Report\` job continues to pass (it does not consult the audit driver list).
- [ ] CI \`audit_skipped\` job (run nightly / on demand) now reports NOW PASSING = 0 instead of 33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)