### PR TITLE
feat(css): match upstream selector pruning + :where() composition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Use the `Agent` tool for substantial work — feature implementation, multi-file
 
 ## Test Status
 
-Source: `pnpm run compatibility-report` (generated 2026-05-26, Svelte commit `b65a3f3fc5e1`). Re-run `pnpm run test-and-update` to refresh. Skip lists live in `tests/compatibility_report.rs` and `tests/runtime.rs`; `tests/audit_skipped.rs` re-checks every skipped fixture after a Svelte bump. See [docs/skip-remaining-clusters.md](docs/skip-remaining-clusters.md) for a per-cluster breakdown of remaining skips with upstream commits, root causes, and a porting plan.
+Source: `pnpm run compatibility-report` (generated 2026-05-27, Svelte commit `b65a3f3fc5e1`). Re-run `pnpm run test-and-update` to refresh. Skip lists live in `tests/compatibility_report.rs` and `tests/runtime.rs`; `tests/audit_skipped.rs` re-checks every skipped fixture after a Svelte bump. See [docs/skip-remaining-clusters.md](docs/skip-remaining-clusters.md) for a per-cluster breakdown of remaining skips with upstream commits, root causes, and a porting plan.
 
 | Suite | Pass/Total | Notes |
 |-------|------------|-------|
@@ -123,7 +123,7 @@ Source: `pnpm run compatibility-report` (generated 2026-05-26, Svelte commit `b6
 | Parser Legacy | 82/83 | 1 skipped (`javascript-comments` — OXC drops standalone comments that acorn surfaces) |
 | Compiler Errors | 144/144 | |
 | Compiler Snapshot | 20/20 | |
-| CSS | 180/181 | 1 skipped (`css-prune-edge-cases` — Svelte 5.53.7) |
+| CSS | 181/181 | Deep descendant-chain pruning + `:where(...)` inner scoping ported (Svelte 5.53.7 `0965028d3`). |
 | Validator | 324/325 | 1 skipped (`error-mode-warn` — opted out via `_config.js`) |
 | SSR | 97/97 | HtmlTag SSR class-hash inlining + synthetic `<option value>` ported (Svelte 5.53.6, 5.55.9). |
 | Hydration | 78/78 | HtmlTag `is_controlled` cluster ported (Svelte 5.53.8 `0206a2019`) |
@@ -136,7 +136,7 @@ Source: `pnpm run compatibility-report` (generated 2026-05-26, Svelte commit `b6
 | svelte2tsx | 245/247 | Wave 1 of the ecosystem port. 2 skipped (`expected.error.json` error fixtures). Driven by `tests/common/svelte2tsx.rs` |
 | Migrate | 0/76 | **Out of scope** — rsvelte is a Svelte 5 compiler port, not a Svelte 4 → 5 migration tool |
 
-**Compatibility report total: 3427/3427 in-scope-run passing — every executed fixture in every in-scope category passes. 49 in-scope fixtures remain skipped (see [docs/skip-remaining-clusters.md](docs/skip-remaining-clusters.md)); the 76 `migrate` fixtures are intentionally out of scope.**
+**Compatibility report total: 3428/3428 in-scope-run passing — every executed fixture in every in-scope category passes. 48 in-scope fixtures remain skipped (see [docs/skip-remaining-clusters.md](docs/skip-remaining-clusters.md)); the 76 `migrate` fixtures are intentionally out of scope.**
 
 ### Ports landed for skip-reduction (Svelte 5.53.0+)
 
@@ -147,6 +147,7 @@ Source: `pnpm run compatibility-report` (generated 2026-05-26, Svelte commit `b6
 - **SSR attribute `$.stringify` elide** (Svelte 5.55.9 `a5df6616e`, partial) — `eval_attr_expr_json` handles `ConditionalExpression` and string-concat `BinaryExpression`. Class, style-directive, and class-attribute (no-directive) emission paths route through it; the no-class-directive path also falls back to a static `class="..."` attribute when every interpolation inlines. Unblocked `attribute-dynamic-multiple`, `globals-not-overwritten-by-bindings`, `attribute-parts`, `head-raw-elements-content`, `innerhtml-interpolated-literal`. Multi-line `let` extraction remains pending.
 - **ASI-aware side-effect import detection** (Svelte 5.55.2 cluster) — `extract_imports` in `src/compiler/phases/3_transform/{client/mod.rs,server/helpers.rs}` now recognises `import "module"` / `import 'module'` (no `from`, no `;`) as a complete one-line side-effect import via `is_complete_side_effect_import`. Previously the line-by-line splitter only treated an import as complete when it contained `;` or matched `... from "…"`, so the side-effect form merged into the next statement (e.g. `let count = 1;`), breaking legacy `$.mutable_source` lowering. Unblocked `flush-sync-each-block`.
 - **Comments in element openers and `Root.comments`** (Svelte 5.53.0 `92e2fc120`) — `parse_attribute` in `1_parse/state/element.rs` consumes `// …` / `/* … */` between attributes and pushes a `JsComment` onto `Root.comments`. The JS parser pipeline (`parse_expression` / `parse_program`) also forwards every OXC-discovered comment via a per-thread sink. Legacy AST surfaces the same data as `_comments`. Unblocked `parser-modern/comment-in-tag`, `parser-modern/parens`, `parser-legacy/script-comment-only`.
+- **CSS prune-edge-cases / `:where()` composition** (Svelte 5.53.7 `0965028d3`) — `is_descendant_selector_unused` walks chains of arbitrary depth (was 2-link only), so `main > article > div > section > span` is now pruned as unused when the DOM doesn't satisfy the chain. `format_simple_selector_with_scope` and the relative-selector loop now also treat standalone `:where(...)` like `:is(...)`, recursing into the inner SelectorList so `ul :where(li)` emits `ul.svelte-xxx :where(li:where(.svelte-xxx))` instead of `:where(.svelte-xxx):where(li)`. Unblocked `css/css-prune-edge-cases`.
 
 ### Ecosystem port (`docs/ecosystem-implementation-plan.md`)
 

--- a/docs/skip-remaining-clusters.md
+++ b/docs/skip-remaining-clusters.md
@@ -87,21 +87,21 @@ parser comments — on `Root.comments` (modern AST) and `_comments`
 
 ---
 
-## 4. CSS prune-edge-cases (1 fixture, **CSS pruning**)
+## 4. CSS prune-edge-cases ✅ landed
 
-`css/css-prune-edge-cases`. Upstream commit `0965028d3` "perf: optimize
-CSS selector pruning" (Svelte 5.53.7).
+Was `css/css-prune-edge-cases`. Upstream commit `0965028d3` "perf:
+optimize CSS selector pruning" (Svelte 5.53.7). Both divergences are now
+fixed in `src/compiler/phases/3_transform/css.rs`:
 
-Two known divergences:
-
-1. A deep `main > article > div > section > span` chain that upstream
-   prunes as unused stays in our CSS output.
-2. `:where(li:where(.hash))` is emitted as `:where(.hash):where(li)` —
-   the selector composition order doesn't match upstream.
-
-Fix lives in `src/compiler/phases/3_transform/.../css` selector pruning
-and composition. Walking the fixture's tests with `--release` is fast
-(under 1s), so iterate locally before pushing.
+1. `is_descendant_selector_unused` walks arbitrary-depth combinator
+   chains (descendant + child) instead of only 2 links, so deep chains
+   like `main > article > div > section > span` are pruned when the DOM
+   doesn't satisfy them.
+2. `format_simple_selector_with_scope` + the relative-selector emission
+   loop now treat standalone `:where(...)` like `:is(...)`, recursing
+   into the inner SelectorList so `ul :where(li)` becomes
+   `ul.svelte-xxx :where(li:where(.svelte-xxx))` instead of
+   `:where(.svelte-xxx):where(li)`.
 
 ---
 

--- a/src/compiler/phases/3_transform/css.rs
+++ b/src/compiler/phases/3_transform/css.rs
@@ -2463,117 +2463,148 @@ fn is_descendant_selector_unused(rel_selectors: &[Value], ctx: &CssContext) -> b
         return false;
     }
 
-    // Only handle simple two-selector case for now (parent > child or parent child)
-    if rel_selectors.len() != 2 {
-        return false;
+    // For a chain like `a > b > c > d`, every relative selector must contribute
+    // a usable constraint (TypeSelector or :not()-like universal pseudo). Bail
+    // out as soon as we encounter a link we can't reason about, so we stay
+    // conservative (e.g. compound selectors like `a.foo b` are already pruned
+    // by the simple-selector pass when `.foo` isn't used).
+    let owned_tags: Vec<Option<String>> =
+        rel_selectors.iter().map(get_type_selector_name).collect();
+    for (i, rel) in rel_selectors.iter().enumerate() {
+        if owned_tags[i].is_none() && !is_universal_pseudo_selector(rel) {
+            return false;
+        }
     }
 
-    // Get the parent element type (first selector)
-    let parent_tag = get_type_selector_name(&rel_selectors[0]);
-    if parent_tag.is_none() {
-        return false;
-    }
-    let parent_tag = parent_tag.unwrap();
-
-    // Get the child element type (second selector)
-    // If the child is just a pseudo-class like :not(.foo), it implicitly matches any element
-    let child_tag = get_type_selector_name(&rel_selectors[1]);
-
-    // Check if the second selector is a pure pseudo-class (like :not())
-    // that matches any element type
-    let is_universal_pseudo = if child_tag.is_none() {
-        // Check if it's a :not() pseudo-class without a type selector
-        is_universal_pseudo_selector(&rel_selectors[1])
-    } else {
-        false
-    };
-
-    // If no child type and not a universal pseudo, we can't determine usage
-    if child_tag.is_none() && !is_universal_pseudo {
-        return false;
-    }
-
-    // Get the combinator between parent and child
-    let combinator = rel_selectors[1]
-        .get("combinator")
-        .and_then(|c| c.get("name"))
-        .and_then(|n| n.as_str())
-        .unwrap_or(" ");
-
-    // Find all elements that match the parent
-    let parent_indices: Vec<usize> = ctx
+    // Pick start: every element whose tag matches the first link. When the
+    // first link is a universal pseudo (`:not(...)`-shaped), accept any tag.
+    let first_tag = owned_tags[0].as_deref();
+    let first_universal = matches!(first_tag, Some("*") | None);
+    let start_indices: Vec<usize> = ctx
         .dom_structure
         .elements
         .iter()
         .enumerate()
-        .filter(|(_, el)| el.tag_name == parent_tag)
+        .filter(|(_, el)| {
+            if first_universal {
+                true
+            } else {
+                first_tag.is_some_and(|t| t == el.tag_name)
+            }
+        })
         .map(|(i, _)| i)
         .collect();
 
-    if parent_indices.is_empty() {
-        // Parent element doesn't exist - will be caught by simple selector check
+    if start_indices.is_empty() {
+        // No element matches the first link — the simple-selector pass already
+        // marks this as unused; don't double-flag here.
         return false;
     }
 
-    // Check based on combinator type
-    for parent_idx in &parent_indices {
-        let parent_el = &ctx.dom_structure.elements[*parent_idx];
-
-        // If the parent has opaque content (render tags, slots, components),
-        // it could have any element as a descendant at runtime - be conservative
-        if parent_el.has_opaque_content {
-            return false;
+    // Walk every (combinator, tag) link from idx=1 onward, gathering the
+    // candidate descendants at each step. If any opaque ancestor is hit, bail.
+    fn walk(
+        ctx: &CssContext,
+        current: &[usize],
+        chain: &[(&str, &str)], // (combinator, "" for universal)
+        idx: usize,
+    ) -> Option<bool> {
+        if idx == chain.len() {
+            return Some(true);
         }
-
-        // Also check ancestors: if any ancestor has opaque content,
-        // the parent itself could receive unknown descendants via render tags
-        if has_opaque_ancestor(ctx, *parent_idx) {
-            return false;
-        }
-
-        if is_universal_pseudo {
-            // Universal pseudo (like :not()) matches any element
-            // Check if parent has any children at all
-            if combinator == ">" {
-                // Child combinator: only direct children
-                if has_any_direct_child(ctx, *parent_idx) {
-                    return false; // Found a potential match
-                }
-            } else {
-                // Descendant combinator: any descendant
-                if has_any_descendant(ctx, *parent_idx) {
-                    return false; // Found a potential match
-                }
+        let (combinator, tag) = chain[idx];
+        let mut next: Vec<usize> = Vec::new();
+        for &cur in current {
+            // Opaque content makes the chain unverifiable from this anchor.
+            if ctx.dom_structure.elements[cur].has_opaque_content {
+                return None;
             }
-        } else if let Some(ref child_tag) = child_tag {
-            // Universal selector (*) matches any element
-            let is_universal = child_tag == "*";
+            if has_opaque_ancestor(ctx, cur) {
+                return None;
+            }
+            collect_chain_candidates(ctx, cur, combinator, tag, &mut next);
+        }
+        if next.is_empty() {
+            return Some(false);
+        }
+        // Deduplicate to bound the recursion.
+        next.sort_unstable();
+        next.dedup();
+        walk(ctx, &next, chain, idx + 1)
+    }
 
-            if is_universal {
-                // * matches any element
-                if combinator == ">" {
-                    if has_any_direct_child(ctx, *parent_idx) {
-                        return false;
-                    }
-                } else if has_any_descendant(ctx, *parent_idx) {
-                    return false;
-                }
-            } else if combinator == ">" {
-                // Child combinator: only direct children
-                if has_direct_child_with_tag(ctx, *parent_idx, child_tag) {
-                    return false; // Found a valid parent > child relationship
-                }
-            } else {
-                // Descendant combinator: any descendant
-                if has_descendant_with_tag(ctx, *parent_idx, child_tag) {
-                    return false; // Found a valid parent child relationship
-                }
+    // Pre-compute the (combinator, tag) chain for idx>=1 in owned form.
+    let owned_chain: Vec<(&str, &str)> = (1..rel_selectors.len())
+        .map(|i| {
+            let combinator = rel_selectors[i]
+                .get("combinator")
+                .and_then(|c| c.get("name"))
+                .and_then(|n| n.as_str())
+                .unwrap_or(" ");
+            let tag = match owned_tags[i].as_deref() {
+                Some("*") | None => "*",
+                Some(t) => t,
+            };
+            (combinator, tag)
+        })
+        .collect();
+
+    match walk(ctx, &start_indices, &owned_chain, 0) {
+        Some(true) => false, // chain matches → not unused
+        Some(false) => true, // chain cannot match → unused
+        None => false,       // opaque element → stay conservative
+    }
+}
+
+/// Push every element under `parent_idx` that satisfies the next chain link
+/// (`combinator` + `tag`, with `tag == "*"` meaning universal).
+fn collect_chain_candidates(
+    ctx: &CssContext,
+    parent_idx: usize,
+    combinator: &str,
+    tag: &str,
+    out: &mut Vec<usize>,
+) {
+    let universal = tag == "*";
+    let total_elements = ctx.dom_structure.elements.len();
+    // Snapshot the child indices so we can recurse without re-borrowing
+    // `ctx.dom_structure.elements` later in the loop.
+    let children: Vec<usize> = ctx.dom_structure.elements[parent_idx].children_idx.to_vec();
+    let parent_tag_is_selectedcontent =
+        ctx.dom_structure.elements[parent_idx].tag_name == "selectedcontent";
+
+    let consider = |out: &mut Vec<usize>, child_idx: usize| {
+        if child_idx >= total_elements {
+            return;
+        }
+        let child = &ctx.dom_structure.elements[child_idx];
+        if universal || child.tag_name == tag {
+            out.push(child_idx);
+        }
+    };
+
+    if combinator == ">" {
+        for child_idx in &children {
+            consider(out, *child_idx);
+        }
+        if parent_tag_is_selectedcontent {
+            for option_idx in find_option_elements_for_selectedcontent(ctx, parent_idx) {
+                collect_chain_candidates(ctx, option_idx, combinator, tag, out);
+            }
+        }
+    } else {
+        // Descendant combinator (including the implicit " ").
+        for &child_idx in &children {
+            consider(out, child_idx);
+            // Recurse into grandchildren.
+            collect_chain_candidates(ctx, child_idx, combinator, tag, out);
+        }
+        if parent_tag_is_selectedcontent {
+            for option_idx in find_option_elements_for_selectedcontent(ctx, parent_idx) {
+                collect_chain_candidates(ctx, option_idx, combinator, tag, out);
             }
         }
     }
-
-    // No valid relationship found
-    true
 }
 
 /// Get the type selector name from a relative selector
@@ -2590,101 +2621,6 @@ fn get_type_selector_name(rel_selector: &Value) -> Option<String> {
                 }
             })
         })
-}
-
-/// Check if an element has a direct child with the given tag name
-fn has_direct_child_with_tag(ctx: &CssContext, parent_idx: usize, tag_name: &str) -> bool {
-    let element = &ctx.dom_structure.elements[parent_idx];
-
-    for &child_idx in &element.children_idx {
-        if child_idx < ctx.dom_structure.elements.len() {
-            let child = &ctx.dom_structure.elements[child_idx];
-            if child.tag_name == tag_name {
-                return true;
-            }
-        }
-    }
-
-    // Special handling for <selectedcontent>: also check <option> descendants in parent <select>
-    if element.tag_name == "selectedcontent" {
-        for option_idx in find_option_elements_for_selectedcontent(ctx, parent_idx) {
-            if has_direct_child_with_tag(ctx, option_idx, tag_name) {
-                return true;
-            }
-        }
-    }
-
-    false
-}
-
-/// Check if an element has a descendant with the given tag name
-fn has_descendant_with_tag(ctx: &CssContext, parent_idx: usize, tag_name: &str) -> bool {
-    let element = &ctx.dom_structure.elements[parent_idx];
-
-    for &child_idx in &element.children_idx {
-        if child_idx < ctx.dom_structure.elements.len() {
-            let child = &ctx.dom_structure.elements[child_idx];
-            if child.tag_name == tag_name {
-                return true;
-            }
-            // Recursively check descendants
-            if has_descendant_with_tag(ctx, child_idx, tag_name) {
-                return true;
-            }
-        }
-    }
-
-    // Special handling for <selectedcontent>: also check <option> descendants in parent <select>
-    if element.tag_name == "selectedcontent" {
-        for option_idx in find_option_elements_for_selectedcontent(ctx, parent_idx) {
-            if has_descendant_with_tag(ctx, option_idx, tag_name) {
-                return true;
-            }
-        }
-    }
-
-    false
-}
-
-/// Check if an element has any direct children (elements, not text nodes)
-fn has_any_direct_child(ctx: &CssContext, parent_idx: usize) -> bool {
-    let element = &ctx.dom_structure.elements[parent_idx];
-    if !element.children_idx.is_empty() {
-        return true;
-    }
-
-    // Special handling for <selectedcontent>
-    if element.tag_name == "selectedcontent" {
-        for option_idx in find_option_elements_for_selectedcontent(ctx, parent_idx) {
-            if has_any_direct_child(ctx, option_idx) {
-                return true;
-            }
-        }
-    }
-
-    false
-}
-
-/// Check if an element has any descendants (elements, not text nodes)
-fn has_any_descendant(ctx: &CssContext, parent_idx: usize) -> bool {
-    let element = &ctx.dom_structure.elements[parent_idx];
-
-    for &child_idx in &element.children_idx {
-        if child_idx < ctx.dom_structure.elements.len() {
-            return true;
-        }
-    }
-
-    // Special handling for <selectedcontent>
-    if element.tag_name == "selectedcontent" {
-        for option_idx in find_option_elements_for_selectedcontent(ctx, parent_idx) {
-            if has_any_descendant(ctx, option_idx) {
-                return true;
-            }
-        }
-    }
-
-    false
 }
 
 /// Check if any ancestor of the given element has opaque content
@@ -5160,14 +5096,27 @@ fn transform_complex_selector(
                     // - For other pseudo-classes like :has, :not, :hover, etc., prepend the scoping class
                     // Also skip if we have a NestingSelector - it inherits scoping from parent
                     if needs_scoping && last_non_pseudo_idx.is_none() && !has_nesting_selector {
-                        // Check if first selector is one that should not have scoping added before it
+                        // Check if first selector is one that should not have scoping added before it.
+                        // Mirrors upstream Svelte's "skip standalone :is/:where/& selectors" branch
+                        // which only triggers when `relative_selector.selectors.length === 1`, plus
+                        // the unconditional :root / :host exemptions and the :is internal-scoping
+                        // case which rsvelte already collapses here.
                         let first_is_global_like = selectors.first().is_some_and(|s| {
                             if s.get("type").and_then(|t| t.as_str()) == Some("PseudoClassSelector")
                             {
                                 let name = s.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                                // Only :root, :host should NOT have scoping added before them
-                                // :is handles scoping internally via its arguments
-                                name == "is" || name == "host" || name == "root"
+                                if name == "host" || name == "root" {
+                                    return true;
+                                }
+                                if name == "is" {
+                                    return true;
+                                }
+                                // Standalone :where(...) handles scoping internally
+                                // (mirrors upstream `continue` for length===1 + :where)
+                                if name == "where" && selectors.len() == 1 {
+                                    return true;
+                                }
+                                false
                             } else {
                                 false
                             }
@@ -5418,10 +5367,14 @@ fn format_simple_selector_with_scope(
         "PseudoClassSelector" => {
             let name = sel.get("name").and_then(|n| n.as_str()).unwrap_or("");
 
-            // Handle :is(), :not(), :has() - these take selector lists as arguments
-            // and need to scope their inner selectors
+            // Handle :is(), :not(), :has(), :where() - these take selector lists as
+            // arguments and need to scope their inner selectors. Mirrors upstream
+            // Svelte's `PseudoClassSelector` visitor which calls `context.next()`
+            // for is/where/has/not so the inner SelectorList gets scoped.
             if let Some(args) = sel.get("args") {
-                if (name == "is" || name == "not" || name == "has") && !selector.is_empty() {
+                if (name == "is" || name == "not" || name == "has" || name == "where")
+                    && !selector.is_empty()
+                {
                     // Transform the inner selector list with appropriate scoping
                     // Per the official Svelte compiler, inner selectors inherit the
                     // specificity state from the outer context. When the outer selector

--- a/tests/audit_skipped.rs
+++ b/tests/audit_skipped.rs
@@ -426,7 +426,7 @@ fn audit_skipped_fixtures() {
 
     let parser_legacy_skipped = &["javascript-comments", "script-comment-only"];
     let parser_modern_skipped = &["comment-in-tag", "parens"];
-    let css_skipped = &["css-prune-edge-cases"];
+    let css_skipped: &[&str] = &[];
     let print_skipped = &["css-keyframes-percent"];
 
     let mut now_passing: Vec<(String, String)> = Vec::new();

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -374,15 +374,12 @@ fn run_css_tests() -> CategoryResult {
     let mut result = CategoryResult::new("css");
 
     // CSS samples that exercise pruning/scoping edge cases rsvelte doesn't
-    // fully match upstream on yet.
-    //
-    // - `css-prune-edge-cases` (Svelte 5.53.7, upstream `0965028d3`
-    //   "perf: optimize CSS selector pruning"): a deep
-    //   `main > article > div > section > span` chain that upstream prunes
-    //   as unused stays in our output, and `:where(li:where(.hash))` is
-    //   emitted as `:where(.hash):where(li)` (selector composition order).
-    //   Tracked as a follow-up port.
-    let skip_css: &[&str] = &["css-prune-edge-cases"];
+    // fully match upstream on yet. Empty for now — the previous
+    // `css-prune-edge-cases` skip (Svelte 5.53.7, upstream `0965028d3`)
+    // was lifted once the deep descendant-chain prune walker became
+    // generalised and `:where(...)` started scoping its inner selector list
+    // like `:is()`/`:has()`/`:not()`.
+    let skip_css: &[&str] = &[];
 
     for sample_dir in &samples {
         let name = sample_dir

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -69,14 +69,7 @@ struct TestResult {
 /// doesn't yet match. Mirrors the corresponding entries in
 /// `tests/compatibility_report.rs` so `test_css` stops blocking unrelated work;
 /// remove an entry as soon as the upstream behaviour is matched.
-const CSS_SKIP_NAMES: &[&str] = &[
-    // Svelte 5.53.7 (upstream `0965028d3` "perf: optimize CSS selector
-    // pruning"): a deep `main > article > div > section > span` chain that
-    // upstream prunes as unused stays in rsvelte's output, and
-    // `:where(li:where(.hash))` is emitted as `:where(.hash):where(li)`
-    // (selector composition order). Tracked as a follow-up port.
-    "css-prune-edge-cases",
-];
+const CSS_SKIP_NAMES: &[&str] = &[];
 
 /// Run a single CSS test with timeout.
 fn run_css_test(fixture: &CssFixture) -> TestResult {


### PR DESCRIPTION
## Summary

Lands [cluster 4 from `docs/skip-remaining-clusters.md`](docs/skip-remaining-clusters.md) — Svelte 5.53.7 upstream commit `0965028d3` ("perf: optimize CSS selector pruning"). Unblocks the `css/css-prune-edge-cases` fixture (now passing) and clears the last CSS skip, so CSS goes from 180/181 to 181/181.

The upstream commit is mostly a perf refactor, but it ships a new fixture that catches two semantic divergences in rsvelte's CSS pruner / scoper:

1. **Deep descendant-chain pruning.** `is_descendant_selector_unused` in `src/compiler/phases/3_transform/css.rs` was hard-coded to chains of exactly two relative selectors. The fixture's `main > article > div > section > span { color: red; }` (5 links, DOM only has `main > article > section > div > span`) couldn't be pruned. The walk now handles arbitrary-depth chains of `>` / descendant combinators: collect every element matching the first link, then for each subsequent link gather candidate descendants and bail when no candidates remain or any opaque ancestor (render tag / slot / component) is hit.

2. **`:where()` inner scoping.** `format_simple_selector_with_scope` only recursed into `:is()` / `:not()` / `:has()` args, so `:where(li)` was treated as an opaque pseudo and the scope modifier was prepended *outside* (`:where(.svelte-xxx):where(li)`). Upstream's `PseudoClassSelector` visitor handles `is/where/has/not` identically (`context.next()` recurses), and the standalone `:is`/`:where` skip branch is length-1 only. rsvelte now adds `where` to the recursion list and treats standalone single-`:where` relative selectors like `:is`, so `ul :where(li)` becomes `ul.svelte-xxx :where(li:where(.svelte-xxx))`.

## Regression coverage

- `cargo test --release --test css` — 16/16 (all CSS pruning fixtures, including the previously-skipped `css-prune-edge-cases`)
- `cargo test --release --test compiler_fixtures` — 17/17
- `cargo test --release --test runtime` — 19/19 (runtime-runes / -legacy / -browser / hydration)
- `cargo test --release --test ssr --test parser_fixtures --test validator --test compiler_errors --test print` — all pass
- `cargo test --release --test audit_skipped` — confirms `css/css-prune-edge-cases` no longer in the "STILL FAILING" list
- `pnpm run compatibility-report` — every category in the JSON now reports 100% passed for its in-scope run; CSS jumps from 180/181 to 181/181
- `cargo clippy --release --lib --tests --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

## Test plan

- [x] `cargo test --release --test css`
- [x] `cargo test --release --test compiler_fixtures`
- [x] `cargo test --release --test runtime`
- [x] `cargo test --release --test audit_skipped`
- [x] `pnpm run compatibility-report` + `pnpm run update-docs`
- [x] `cargo clippy --release -- -D warnings`
- [x] `cargo fmt --check`