### PR TITLE
test(svelte2tsx): support expected.error.json fixtures

### DIFF
--- a/docs/skip-remaining-clusters.md
+++ b/docs/skip-remaining-clusters.md
@@ -140,15 +140,20 @@ required — the skip is intentional on the upstream side.
 
 ---
 
-## 7. svelte2tsx error fixtures (2 fixtures)
+## 7. svelte2tsx error fixtures (✅ landed)
 
 `svelte2tsx/editing-mustache`, `svelte2tsx/unclosed-tag-containing-tag.v5`.
 
-These ship `expected.error.json` (not `expected.tsx`). Our svelte2tsx
-test harness currently only walks success fixtures. Porting error-fixture
-support means teaching `tests/common/svelte2tsx.rs` to compare the
-emitted error against the expected JSON. Low priority — these fixtures
-test rsvelte's *error* output rather than success codegen.
+These ship `expected.error.json` (not `expected.tsx`). The fixture
+runner in `tests/common/svelte2tsx.rs` now detects them, calls
+`svelte2tsx`, and verifies the surfaced error's `{ start, end }`
+positions match the expected JSON — mirroring upstream's Svelte 5
+comparison strategy (see
+`submodules/language-tools/packages/svelte2tsx/test/helpers.ts`).
+To align with upstream's `js_parse_error(err.pos, …)` semantics,
+`check_js_parse_error` was widened to also surface the OXC label
+offset and `parse_js_expression_strict` now reports a point span
+(`start == end`).
 
 ---
 

--- a/src/compiler/phases/1_parse/read/expression.rs
+++ b/src/compiler/phases/1_parse/read/expression.rs
@@ -1430,7 +1430,7 @@ pub fn parse_expression(
 
     // Check for parse errors and return them when not in loose mode
     if (!loose || disallow_loose)
-        && let Some(error_msg) = check_js_parse_error(content)
+        && let Some((error_msg, _)) = check_js_parse_error_with_pos(content)
     {
         return Err((error_msg, offset));
     }
@@ -1559,7 +1559,7 @@ pub fn parse_expression_with_end(
 
     // Check for parse errors and return them when not in loose mode
     if (!loose || disallow_loose)
-        && let Some(error_msg) = check_js_parse_error(content)
+        && let Some((error_msg, _)) = check_js_parse_error_with_pos(content)
     {
         return Err((error_msg, offset));
     }
@@ -1568,49 +1568,65 @@ pub fn parse_expression_with_end(
     Ok(create_invalid_identifier(offset, end, line_offsets))
 }
 
-/// Check if JavaScript expression has parse errors. Returns Some(error_message) if there is an error.
-pub fn check_js_parse_error(content: &str) -> Option<String> {
+/// Check if a JavaScript expression has parse errors, returning the failure
+/// position alongside the message.
+///
+/// Returns `Some((message, pos_in_content))` on parse failure. `pos_in_content`
+/// is the 0-based byte offset *within `content`* where the failure occurs (so
+/// callers can add their own absolute-offset base) — mirroring upstream
+/// Svelte's `js_parse_error(err.pos, ...)` semantics where `err.pos` is the
+/// acorn-reported position. When OXC doesn't surface a position (e.g. the
+/// synthetic "Assigning to rvalue" case) this falls back to 0 so the caller
+/// still gets a deterministic span.
+///
+/// `content` is wrapped in `(...)` before being handed to OXC, so we subtract
+/// one from OXC's reported `offset + len` (the right-edge of the labeled span)
+/// to land back in the unwrapped expression's coordinate space — and clamp
+/// the result to `[0, content.len()]`. Acorn reports `err.pos` at the point
+/// where it stopped consuming tokens, which corresponds to the *end* of the
+/// problematic region, not its start.
+pub fn check_js_parse_error_with_pos(content: &str) -> Option<(String, usize)> {
     let mut wrapped = String::with_capacity(content.len() + 2);
     wrapped.push('(');
     wrapped.push_str(content);
     wrapped.push(')');
 
+    let probe = |source_type: SourceType| -> Option<(String, usize)> {
+        with_oxc_allocator(|allocator| {
+            let parser = OxcParser::new(allocator, &wrapped, source_type);
+            let result = parser.parse();
+            if let Some(first_error) = result.errors.first() {
+                let pos = first_error
+                    .labels
+                    .as_ref()
+                    .and_then(|labels| labels.first())
+                    .map(|label| label.offset() + label.len())
+                    .map(|wrapped_end| {
+                        // Strip the leading `(` we added and clamp.
+                        wrapped_end.saturating_sub(1).min(content.len())
+                    })
+                    .unwrap_or(0);
+                return Some((first_error.message.to_string(), pos));
+            }
+            // Check for invalid assignment targets that OXC doesn't report as errors
+            if let Some(oxc_ast::ast::Statement::ExpressionStatement(expr_stmt)) =
+                result.program.body.first()
+                && is_invalid_assignment_expression(&expr_stmt.expression)
+            {
+                return Some(("Assigning to rvalue".to_string(), 0));
+            }
+            None
+        })
+    };
+
     // Try TypeScript first
-    let ts_result = with_oxc_allocator(|allocator| {
-        let parser = OxcParser::new(allocator, &wrapped, SourceType::ts());
-        let result = parser.parse();
-        if let Some(first_error) = result.errors.first() {
-            return Some(first_error.message.to_string());
-        }
-        // Check for invalid assignment targets that OXC doesn't report as errors
-        if let Some(oxc_ast::ast::Statement::ExpressionStatement(expr_stmt)) =
-            result.program.body.first()
-            && is_invalid_assignment_expression(&expr_stmt.expression)
-        {
-            return Some("Assigning to rvalue".to_string());
-        }
-        None
-    });
+    let ts_result = probe(SourceType::ts());
 
     // No TS errors means valid
     ts_result.as_ref()?;
 
     // Try JavaScript
-    let js_result = with_oxc_allocator(|allocator| {
-        let parser = OxcParser::new(allocator, &wrapped, SourceType::mjs());
-        let result = parser.parse();
-        if let Some(first_error) = result.errors.first() {
-            return Some(first_error.message.to_string());
-        }
-        // Check for invalid assignment targets that OXC doesn't report as errors
-        if let Some(oxc_ast::ast::Statement::ExpressionStatement(expr_stmt)) =
-            result.program.body.first()
-            && is_invalid_assignment_expression(&expr_stmt.expression)
-        {
-            return Some("Assigning to rvalue".to_string());
-        }
-        None
-    });
+    let js_result = probe(SourceType::mjs());
 
     // No JS errors means valid
     js_result.as_ref()?;

--- a/src/compiler/phases/1_parse/state/tag.rs
+++ b/src/compiler/phases/1_parse/state/tag.rs
@@ -1778,10 +1778,11 @@ impl Parser<'_> {
         // Adjust offset for leading whitespace that gets trimmed
         let leading_ws = content.len() - content.trim_start().len();
         let trimmed = content.trim();
+        let trimmed_offset = offset + leading_ws;
         super::super::expression::parse_expression(
             &self.arena,
             trimmed,
-            offset + leading_ws,
+            trimmed_offset,
             self.expression_line_offsets(),
             self.source,
             self.options.loose,
@@ -1789,8 +1790,17 @@ impl Parser<'_> {
             '{',
             self.ts,
         )
-        .map_err(|(msg, pos)| {
-            crate::error::ParseError::svelte("js_parse_error", msg, (pos, pos + trimmed.len()))
+        .map_err(|(msg, _)| {
+            // Recover the precise failure position from OXC's labeled span,
+            // mirroring upstream Svelte's `js_parse_error(err.pos, ...)` —
+            // a *point* error at the byte where acorn stopped consuming
+            // input. svelte2tsx's `expected.error.json` fixtures rely on
+            // this character-accurate location.
+            let abs_pos = super::super::read::expression::check_js_parse_error_with_pos(trimmed)
+                .map_or(trimmed_offset, |(_, content_pos)| {
+                    trimmed_offset + content_pos
+                });
+            crate::error::ParseError::svelte("js_parse_error", msg, (abs_pos, abs_pos))
         })
     }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -118,6 +118,24 @@ impl ParseError {
             span,
         }
     }
+
+    /// Return the `(start, end)` byte-offset span associated with this error.
+    ///
+    /// Every variant carries a `span` field (the `#[label]` source range used
+    /// by miette); this accessor exposes it without exhaustive matching.
+    pub fn span(&self) -> (usize, usize) {
+        match self {
+            ParseError::UnexpectedEof { span }
+            | ParseError::UnexpectedToken { span, .. }
+            | ParseError::UnclosedElement { span, .. }
+            | ParseError::UnclosedBlock { span, .. }
+            | ParseError::InvalidAttribute { span }
+            | ParseError::InvalidExpression { span, .. }
+            | ParseError::Generic { span, .. }
+            | ParseError::SvelteError { span, .. }
+            | ParseError::TypeScriptInvalidFeature { span, .. } => *span,
+        }
+    }
 }
 
 /// Result type for parse operations.

--- a/src/svelte2tsx/svelte2tsx.rs
+++ b/src/svelte2tsx/svelte2tsx.rs
@@ -155,6 +155,20 @@ impl From<crate::error::ParseError> for Svelte2TsxError {
     }
 }
 
+impl Svelte2TsxError {
+    /// Return the `(start, end)` byte-offset span if the error has one.
+    ///
+    /// Currently only `Svelte2TsxError::Parse` carries position info — the
+    /// `Template` / `Script` / `Other` variants are message-only so this
+    /// returns `None` for them.
+    pub fn span(&self) -> Option<(usize, usize)> {
+        match self {
+            Svelte2TsxError::Parse(e) => Some(e.span()),
+            _ => None,
+        }
+    }
+}
+
 // =============================================================================
 // Main entry point
 // =============================================================================

--- a/tests/audit_skipped.rs
+++ b/tests/audit_skipped.rs
@@ -376,8 +376,11 @@ fn audit_skipped_fixtures() {
     ensure_fixtures_exist();
 
     // Names lifted from the skip lists in tests/compatibility_report.rs and
-    // tests/runtime.rs (excluding the always-out-of-scope migrate / svelte2tsx
-    // error fixtures / validator's _config.js opt-out).
+    // tests/runtime.rs (excluding the always-out-of-scope migrate fixtures
+    // and validator's `_config.js` opt-out). svelte2tsx `expected.error.json`
+    // fixtures are now driven by `tests/common/svelte2tsx.rs` directly — they
+    // execute as regular runs in the compatibility report rather than being
+    // skipped — so they don't need to appear here.
     let runtime_skipped: &[(&str, &str)] = &[
         ("runtime-runes", "async-derived-title-update"),
         ("runtime-runes", "async-eager-derived"),

--- a/tests/common/svelte2tsx.rs
+++ b/tests/common/svelte2tsx.rs
@@ -11,8 +11,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use svelte_compiler_rust::svelte2tsx::{
-    RewriteExternalImportsOptions, Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions,
-    SvelteVersion, svelte2tsx,
+    RewriteExternalImportsOptions, Svelte2TsxError, Svelte2TsxMode, Svelte2TsxNamespace,
+    Svelte2TsxOptions, SvelteVersion, svelte2tsx,
 };
 
 use super::{CategoryResult, SampleResult, TestStatus};
@@ -638,6 +638,90 @@ pub fn first_diff_snippet(actual: &str, expected: &str, context_lines: usize) ->
 }
 
 // =========================================================================
+// Error-fixture support (`expected.error.json`)
+// =========================================================================
+//
+// Upstream `language-tools` validates these fixtures by JSON-stringifying
+// the thrown `Error` (via `JSON.stringify(err)`), then — for Svelte 5+ —
+// only diffing the `{ start, end }` pair. We mirror that strategy: convert
+// the error's byte-offset span into `{ line, column, character }` and
+// compare it to the expected JSON's `start` / `end` objects.
+//
+// See `submodules/language-tools/packages/svelte2tsx/test/helpers.ts`
+// (`sample.has('expected.error.json')` branch in `test_samples`).
+
+/// Convert a byte offset into a `{ line, column, character }` object
+/// matching the shape upstream's `locate-character` emits.
+///
+/// Mirrors `magic-string`'s locator: `line` is the 1-based line number,
+/// `column` is the 0-based column within that line, and `character` is the
+/// 0-based byte offset into the source. For ASCII (which both currently
+/// covered fixtures are) `column` equals the byte distance from the line
+/// start, which is what upstream produces too.
+fn offset_to_position(source: &str, offset: usize) -> serde_json::Value {
+    let bytes = source.as_bytes();
+    let clamped = offset.min(bytes.len());
+    let mut line: u32 = 1;
+    let mut line_start: usize = 0;
+    for (i, &b) in bytes.iter().enumerate().take(clamped) {
+        if b == b'\n' {
+            line += 1;
+            line_start = i + 1;
+        }
+    }
+    let column = clamped - line_start;
+    serde_json::json!({
+        "line": line,
+        "column": column,
+        "character": clamped,
+    })
+}
+
+/// Compare the rsvelte error against the upstream `expected.error.json`
+/// fixture. Returns `None` on success, `Some(diff)` describing the
+/// mismatch otherwise.
+///
+/// Following upstream's Svelte 5 path we only diff the `start` and `end`
+/// position objects — `code` / `message` / `frame` drift across Svelte
+/// versions and aren't part of the contract.
+fn compare_error_to_expected(
+    source: &str,
+    error: &Svelte2TsxError,
+    expected: &serde_json::Value,
+) -> Option<String> {
+    let (start, end) = match error.span() {
+        Some(span) => span,
+        None => {
+            return Some(format!(
+                "error has no span: {} (variant: {:?})",
+                error, error
+            ));
+        }
+    };
+    let actual_start = offset_to_position(source, start);
+    let actual_end = offset_to_position(source, end);
+    let expected_start = expected
+        .get("start")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let expected_end = expected
+        .get("end")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+
+    if actual_start == expected_start && actual_end == expected_end {
+        return None;
+    }
+    Some(format!(
+        "error span mismatch:\n  expected start: {}\n  actual   start: {}\n  expected end:   {}\n  actual   end:   {}",
+        serde_json::to_string(&expected_start).unwrap_or_default(),
+        serde_json::to_string(&actual_start).unwrap_or_default(),
+        serde_json::to_string(&expected_end).unwrap_or_default(),
+        serde_json::to_string(&actual_end).unwrap_or_default(),
+    ))
+}
+
+// =========================================================================
 // Public runner — used by both the standalone test and the dashboard.
 // =========================================================================
 
@@ -674,14 +758,97 @@ pub fn iter_svelte2tsx_outcomes() -> Option<Vec<FixtureOutcome>> {
             continue;
         }
 
-        // Error fixtures expect a parse failure — out of scope for the
-        // svelte2tsx success path.
-        if sample_dir.join("expected.error.json").exists() {
-            outcomes.push(FixtureOutcome {
-                name: sample_name,
-                status: TestStatus::Skipped,
-                message: Some("expected.error.json (error fixture)".into()),
-            });
+        // Error fixtures expect a parse failure. Mirror upstream's
+        // Svelte 5 strategy: run svelte2tsx, assert it throws, and verify
+        // the error's `{ start, end }` positions match the JSON fixture.
+        // See `compare_error_to_expected` above for the comparison details.
+        let error_path = sample_dir.join("expected.error.json");
+        if error_path.exists() {
+            let input_path = match find_svelte_file(&sample_dir) {
+                Some(p) => p,
+                None => {
+                    outcomes.push(FixtureOutcome {
+                        name: sample_name,
+                        status: TestStatus::Skipped,
+                        message: Some("no .svelte input file".into()),
+                    });
+                    continue;
+                }
+            };
+            let svelte_filename = input_path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
+            let input = match fs::read_to_string(&input_path) {
+                Ok(s) => s,
+                Err(_) => {
+                    outcomes.push(FixtureOutcome {
+                        name: sample_name,
+                        status: TestStatus::Skipped,
+                        message: Some("input.svelte unreadable".into()),
+                    });
+                    continue;
+                }
+            };
+            let expected_json: serde_json::Value = match fs::read_to_string(&error_path)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+            {
+                Some(v) => v,
+                None => {
+                    outcomes.push(FixtureOutcome {
+                        name: sample_name,
+                        status: TestStatus::Skipped,
+                        message: Some("expected.error.json unreadable".into()),
+                    });
+                    continue;
+                }
+            };
+
+            let options = build_options(&sample_name, &sample_dir, &svelte_filename);
+            let input_clone = input.clone();
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                svelte2tsx(&input_clone, options)
+            }));
+
+            match result {
+                Ok(Ok(_)) => {
+                    outcomes.push(FixtureOutcome {
+                        name: sample_name,
+                        status: TestStatus::Failed,
+                        message: Some(
+                            "expected svelte2tsx to throw an error but it succeeded".into(),
+                        ),
+                    });
+                }
+                Ok(Err(e)) => match compare_error_to_expected(&input, &e, &expected_json) {
+                    None => outcomes.push(FixtureOutcome {
+                        name: sample_name,
+                        status: TestStatus::Passed,
+                        message: None,
+                    }),
+                    Some(diff) => outcomes.push(FixtureOutcome {
+                        name: sample_name,
+                        status: TestStatus::Failed,
+                        message: Some(diff),
+                    }),
+                },
+                Err(panic_info) => {
+                    let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                        s.to_string()
+                    } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                        s.clone()
+                    } else {
+                        "unknown panic".to_string()
+                    };
+                    outcomes.push(FixtureOutcome {
+                        name: sample_name,
+                        status: TestStatus::Error,
+                        message: Some(format!("PANIC: {}", msg)),
+                    });
+                }
+            }
             continue;
         }
 


### PR DESCRIPTION
## Summary

- Teaches `tests/common/svelte2tsx.rs` to handle the two upstream svelte2tsx fixtures that ship `expected.error.json` instead of `expectedv2.ts` (`editing-mustache` and `unclosed-tag-containing-tag.v5`). The runner now invokes `svelte2tsx`, asserts it returns an error, and compares the error's `{ start, end }` line/column/character objects against the fixture — mirroring upstream's Svelte 5 strategy in `language-tools/packages/svelte2tsx/test/helpers.ts`.
- Surfaces OXC's labeled-span position from `check_js_parse_error` so the mustache error path can emit a point span (`start == end`) at the byte where parsing stopped, matching upstream's `js_parse_error(err.pos, ...)` semantics. The loose-mode path keeps the original offset to preserve identifier-synthesis behaviour for `parser-legacy/loose-invalid-expression`.
- `svelte2tsx` jumps from 245/247 to **247/247** (cluster 7 from `docs/skip-remaining-clusters.md` resolved). Overall in-scope total: 3423 → 3425.

## Test plan

- [x] `cargo test --release --test svelte2tsx_fixtures` — 247/247, including both newly-supported error fixtures (`PASS: editing-mustache`, `PASS: unclosed-tag-containing-tag.v5`)
- [x] `cargo test --release --test parser_fixtures --test compiler_fixtures --test runtime --test css --test compiler_errors --test validator --test ssr --test print --test preprocess --test audit_skipped` — all green (no regressions in adjacent suites)
- [x] `cargo clippy --release --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `pnpm run compatibility-report` + `pnpm run update-docs` — refreshed `docs/static/test-results.json` (skip count 129 → 127)

🤖 Generated with [Claude Code](https://claude.com/claude-code)