### PR TITLE
feat(napi): upgrade napi-rs to v3 with compat-mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -459,13 +459,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
-dependencies = [
- "quote 1.0.45",
- "syn 2.0.117",
-]
+checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 
 [[package]]
 name = "data-encoding"
@@ -568,10 +564,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -585,8 +640,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -971,9 +1031,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link",
@@ -1056,15 +1116,17 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.16.17"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
+checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
 dependencies = [
  "bitflags",
  "ctor",
- "napi-derive",
+ "futures",
+ "napi-build",
  "napi-sys",
- "once_cell",
+ "nohash-hasher",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tokio",
@@ -1078,12 +1140,12 @@ checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "2.16.13"
+version = "3.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbe2585d8ac223f7d34f13701434b9d5f4eb9c332cccce8dee57ea18ab8ab0c"
+checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
 dependencies = [
- "cfg-if",
  "convert_case",
+ "ctor",
  "napi-derive-backend",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -1092,27 +1154,31 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.75"
+version = "5.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1639aaa9eeb76e91c6ae66da8ce3e89e921cd3885e99ec85f4abacae72fc91bf"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
 dependencies = [
  "convert_case",
- "once_cell",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
- "regex",
  "semver",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "napi-sys"
-version = "2.4.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
 dependencies = [
  "libloading",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nonmax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,8 +93,8 @@ clap = { version = "4.5", features = ["derive"] }
 chrono = "0.4"
 
 # N-API support (optional)
-napi = { version = "2", default-features = false, features = ["napi9", "serde-json", "async", "tokio_rt"], optional = true }
-napi-derive = { version = "2", optional = true }
+napi = { version = "3", default-features = false, features = ["napi9", "serde-json", "async", "tokio_rt", "compat-mode"], optional = true }
+napi-derive = { version = "3", optional = true }
 
 # WASM support (optional)
 wasm-bindgen = { version = "0.2", optional = true }

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -3,6 +3,14 @@
 //! This module provides Node.js native addon bindings via napi-rs,
 //! allowing the Rust Svelte compiler to be used from JavaScript/TypeScript.
 
+// napi 3 moved the legacy `JsBuffer` / `JsObject` / `Env::execute_tokio_future`
+// / `Env::create_buffer_with_borrowed_data` surface behind the `compat-mode`
+// feature and emits deprecation warnings against the new `Buffer` / `Object` /
+// `Env::spawn_future` / `BufferSlice::from_external` replacements. Suppress
+// those here — the surface is fully covered by `compat-mode` and migrating to
+// the new API surface is out of scope for the dep bump.
+#![allow(deprecated)]
+
 // Jemalloc is installed here (rather than at the lib root) so that the
 // rlib doesn't carry a `#[global_allocator]` symbol — which collides with
 // the cdylib's copy on Linux + fat LTO when a downstream bin links against
@@ -563,8 +571,9 @@ mod preprocess_bridge {
         PreprocessError, PreprocessorFn, PreprocessorGroup, PreprocessorOptions,
         PreprocessorResult, Processed, SimpleDecodedMap, SourceMapInput,
     };
+    use napi::Status;
     use napi::bindgen_prelude::{FromNapiValue, Object, Promise};
-    use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
+    use napi::threadsafe_function::ThreadsafeFunction;
     use rustc_hash::FxHashMap;
     use serde_json::Value;
 
@@ -584,12 +593,12 @@ mod preprocess_bridge {
     // matters in practice the moment any user preprocessor in the chain
     // happens to be synchronous (e.g. an inline `vitePreprocess`-style
     // markup filter that just returns `{ code }` without an `async`).
-    pub(super) enum MaybePromise<T: FromNapiValue> {
+    pub(super) enum MaybePromise<T: FromNapiValue + 'static> {
         Promise(Promise<T>),
         Value(T),
     }
 
-    impl<T: FromNapiValue> FromNapiValue for MaybePromise<T> {
+    impl<T: FromNapiValue + 'static> FromNapiValue for MaybePromise<T> {
         unsafe fn from_napi_value(
             env: napi::sys::napi_env,
             napi_val: napi::sys::napi_value,
@@ -611,10 +620,20 @@ mod preprocess_bridge {
 
     // Fatal strategy: the user-supplied JS callback receives the options
     // object as its sole argument — matching the upstream Svelte
-    // preprocessor contract `(opts) => Processed | undefined`. Using
-    // CalleeHandled would inject an `err` as the first argument, breaking
-    // every preprocessor that destructures `{ content, filename }`.
-    pub(super) type Tsfn = ThreadsafeFunction<Value, ErrorStrategy::Fatal>;
+    // preprocessor contract `(opts) => Processed | undefined`. The
+    // `CalleeHandled = false` const generic suppresses the legacy
+    // err-as-first-arg shape that would otherwise break every preprocessor
+    // that destructures `{ content, filename }`.
+    pub(super) type Tsfn = ThreadsafeFunction<
+        Value,
+        MaybePromise<Option<Value>>,
+        Value,
+        Status,
+        false,
+        false,
+        0,
+    >;
+    pub(super) type ArcTsfn = std::sync::Arc<Tsfn>;
 
     pub(super) struct Extracted {
         pub name: Option<String>,
@@ -628,10 +647,10 @@ mod preprocess_bridge {
             .into_iter()
             .map(|obj| {
                 Ok(Extracted {
-                    name: obj.get::<_, String>("name")?,
-                    markup: obj.get::<_, Tsfn>("markup")?,
-                    script: obj.get::<_, Tsfn>("script")?,
-                    style: obj.get::<_, Tsfn>("style")?,
+                    name: obj.get::<String>("name")?,
+                    markup: obj.get::<Tsfn>("markup")?,
+                    script: obj.get::<Tsfn>("script")?,
+                    style: obj.get::<Tsfn>("style")?,
                 })
             })
             .collect()
@@ -642,17 +661,19 @@ mod preprocess_bridge {
             .into_iter()
             .map(|g| PreprocessorGroup {
                 name: g.name,
-                markup: g.markup.map(make_markup_bridge),
-                script: g.script.map(|t| make_tag_bridge(t, "script")),
-                style: g.style.map(|t| make_tag_bridge(t, "style")),
+                markup: g.markup.map(|t| make_markup_bridge(ArcTsfn::new(t))),
+                script: g
+                    .script
+                    .map(|t| make_tag_bridge(ArcTsfn::new(t), "script")),
+                style: g.style.map(|t| make_tag_bridge(ArcTsfn::new(t), "style")),
             })
             .collect()
     }
 
-    fn make_markup_bridge(tsfn: Tsfn) -> MarkupPreprocessorFn {
+    fn make_markup_bridge(tsfn: ArcTsfn) -> MarkupPreprocessorFn {
         Box::new(
             move |opts: MarkupPreprocessorOptions| -> PreprocessorResult {
-                let tsfn = tsfn.clone();
+                let tsfn = ArcTsfn::clone(&tsfn);
                 Box::pin(async move {
                     let arg = serde_json::json!({
                         "content": opts.content,
@@ -665,9 +686,9 @@ mod preprocess_bridge {
         )
     }
 
-    fn make_tag_bridge(tsfn: Tsfn, _kind: &'static str) -> PreprocessorFn {
+    fn make_tag_bridge(tsfn: ArcTsfn, _kind: &'static str) -> PreprocessorFn {
         Box::new(move |opts: PreprocessorOptions| -> PreprocessorResult {
-            let tsfn = tsfn.clone();
+            let tsfn = ArcTsfn::clone(&tsfn);
             Box::pin(async move {
                 let arg = serde_json::json!({
                     "content": opts.content,
@@ -690,7 +711,7 @@ mod preprocess_bridge {
         // `napi_fatal_error`, surfacing as `threadsafe_function.rs:749 Failed
         // to convert return value … Failed to call then method`). The outer
         // `Option` collapses `undefined`/`null` to `None` on both paths.
-        match tsfn.call_async::<MaybePromise<Option<Value>>>(arg).await {
+        match tsfn.call_async(arg).await {
             Ok(MaybePromise::Promise(promise)) => match promise.await {
                 Ok(Some(v)) => Ok(v),
                 Ok(None) => Ok(Value::Null),
@@ -1129,7 +1150,7 @@ pub fn napi_compile_envelope_zero_copy(
             ptr,
             len,
             bump_ptr,
-            |bump_ptr: *mut bumpalo::Bump, _env| {
+            |_env, bump_ptr: *mut bumpalo::Bump| {
                 // SAFETY: `bump_ptr` is the same pointer we leaked above,
                 // never aliased, and the finalizer fires at most once.
                 let _bump: Box<bumpalo::Bump> = Box::from_raw(bump_ptr);
@@ -1172,7 +1193,7 @@ pub fn napi_compile_module_envelope_zero_copy(
             ptr,
             len,
             bump_ptr,
-            |bump_ptr: *mut bumpalo::Bump, _env| {
+            |_env, bump_ptr: *mut bumpalo::Bump| {
                 // SAFETY: same pointer as Box::into_raw above, fired once.
                 let _bump: Box<bumpalo::Bump> = Box::from_raw(bump_ptr);
             },

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -624,15 +624,8 @@ mod preprocess_bridge {
     // `CalleeHandled = false` const generic suppresses the legacy
     // err-as-first-arg shape that would otherwise break every preprocessor
     // that destructures `{ content, filename }`.
-    pub(super) type Tsfn = ThreadsafeFunction<
-        Value,
-        MaybePromise<Option<Value>>,
-        Value,
-        Status,
-        false,
-        false,
-        0,
-    >;
+    pub(super) type Tsfn =
+        ThreadsafeFunction<Value, MaybePromise<Option<Value>>, Value, Status, false, false, 0>;
     pub(super) type ArcTsfn = std::sync::Arc<Tsfn>;
 
     pub(super) struct Extracted {
@@ -662,9 +655,7 @@ mod preprocess_bridge {
             .map(|g| PreprocessorGroup {
                 name: g.name,
                 markup: g.markup.map(|t| make_markup_bridge(ArcTsfn::new(t))),
-                script: g
-                    .script
-                    .map(|t| make_tag_bridge(ArcTsfn::new(t), "script")),
+                script: g.script.map(|t| make_tag_bridge(ArcTsfn::new(t), "script")),
                 style: g.style.map(|t| make_tag_bridge(ArcTsfn::new(t), "style")),
             })
             .collect()


### PR DESCRIPTION
## Summary

Bump \`napi\` / \`napi-derive\` from v2 to v3 with the \`compat-mode\` feature so the existing N-API surface keeps working unchanged. The cdylib build, JS-visible bindings, and Wave 3 vite-plugin-svelte NAPI shim are all unaffected.

### What changed

- \`Cargo.toml\`: \`napi = "3"\` with \`compat-mode\` added to the feature list; \`napi-derive = "3"\`.
- \`src/napi.rs\`:
  - \`#![allow(deprecated)]\` since the v3 \`compat-mode\` surface intentionally exposes deprecated shims to the \`Buffer\` / \`Object\` / \`spawn_future\` / \`BufferSlice::from_external\` replacements.
  - \`Object::get\` is now \`get::<V>\` (one generic) instead of \`get::<_, V>\` (two generics).
  - \`MaybePromise<T>\` now requires \`T: 'static\` because \`Promise<T>\` does.
  - \`ThreadsafeFunction\` lost \`Clone\`, so the per-group function handles in \`preprocess_bridge\` are wrapped in \`Arc<Tsfn>\` and the bridges \`Arc::clone\` the handle.
  - \`ThreadsafeFunction\` no longer exposes \`ErrorStrategy::Fatal\`; reproduce the same "callee does not handle the error" contract via the explicit \`CalleeHandled = false\` const generic on the full 7-parameter type alias, threading \`Return = MaybePromise<Option<Value>>\` so \`call_async(arg).await\` returns the typed shape directly (and dropping the now-unsupported turbofish on the call site).
  - \`Env::create_buffer_with_borrowed_data\`'s finalizer closure now takes \`(Env, Hint)\` instead of \`(Hint, Env)\`; updated both call sites in \`compileEnvelopeZeroCopy\` / \`compileModuleEnvelopeZeroCopy\`.

Supersedes #396, #398.

## Test plan

- [x] \`cargo build --lib --features napi\` — clean.
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean.
- [x] \`cargo test --release\` — 43 suites, 0 failures (compatibility report still green).
- [x] Built the cdylib (\`cargo build --release --features napi --lib\`) and re-ran the end-to-end Wave 3 surface: \`pnpm run test:vps\` → \`9 passed, 0 failed\` (shim) + \`6 passed, 0 failed\` (fixture). The preprocess bridge, hmrDiff, resolveId, compile/compileModule envelopes, and source-map round-trip all pass on real napi v3.
- [ ] CI confirms the matrix builds (\`capi\` on ubuntu/macos/windows and the napi cdylib targets in release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)