### PR TITLE
fix(ci): bump Cargo.lock to bust stale rust-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sized-chunks"


### PR DESCRIPTION
## Summary

- Bump `siphasher` 1.0.2 → 1.0.3 in `Cargo.lock` as a no-op patch upgrade so the `Swatinem/rust-cache` key for the `Compatibility Report` and `Deploy Docs` jobs shifts and CI rebuilds from scratch.

## Why

Both the `Compatibility Report` CI job and the `Deploy Docs to GitHub Pages` workflow have been failing on `main` since 78352ac3 (and earlier for Deploy Docs) with two shapes that share one root cause — a corrupted cargo cache:

- Compatibility Report: `expected FxBuildHasher, found rustc_hash::FxBuildHasher` (two distinct compiled copies of rustc-hash 2.1.2 in the test crate's dependency graph).
- Deploy Docs: `undefined symbol: svelte_compiler_rust::svelte_check::runner::run` when relinking the `svelte_check` bin against a stale `libsvelte_compiler_rust` rlib.

The cache-key (`Cargo.lock` hash + rustc version) won't naturally invalidate, so this is the same surgical fix as the prior, dangling `de6c0568 fix(ci): bump Cargo.lock to bust stale Compatibility Report cargo cache` — bump a transitive patch dep so the lock file's hash changes.

## Test plan

- [ ] `Compatibility Report` CI job passes
- [ ] `Deploy Docs to GitHub Pages` workflow passes (only runs on push to main; will verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)