### PR TITLE
Harden arena reference storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "generate-fixtures:verbose": "node scripts/generate-fixtures.mjs --verbose",
     "test-results": "cargo run --release --bin test_reporter -- --output docs/static/test-results.json",
     "generate-benchmark": "node scripts/run-benchmark.mjs > docs/static/benchmark-results.json",
-    "compatibility-report": "RUST_TEST_THREADS=1 RUST_MIN_STACK=33554432 CARGO_PROFILE_RELEASE_LTO=off cargo test --release --lib --test compatibility_report generate_compatibility_report -- --nocapture",
+    "compatibility-report": "RUST_TEST_THREADS=1 RUST_MIN_STACK=33554432 CARGO_PROFILE_RELEASE_LTO=off cargo test --release --test compatibility_report generate_compatibility_report -- --nocapture",
     "list-categories": "cargo test --release --test compatibility_report list_test_categories -- --nocapture",
     "update-docs": "node scripts/update-docs.mjs",
     "test-and-update": "npm run compatibility-report && npm run update-docs",

--- a/src/ast/arena.rs
+++ b/src/ast/arena.rs
@@ -1,22 +1,23 @@
 //! Arena allocator for parse-phase AST nodes.
 //!
-//! Replaces individual `Box<JsNode>` heap allocations with contiguous `Vec`
-//! storage, referenced by `JsNodeId` indices. This gives:
+//! Replaces repeated AST ownership plumbing with arena-owned storage referenced
+//! by `JsNodeId` indices. This gives:
 //!
-//! - **Cache-friendly layout** (nodes are contiguous in memory)
 //! - **Zero-cost reads** (`arena.get_js_node(id)` is a single array index)
-//! - **Cheaper allocation** (Vec push vs global allocator)
+//! - **Stable shared references** (pushing more handles cannot move nodes)
 //!
 //! Follows the proven `JsArena` pattern from
 //! `src/compiler/phases/3_transform/js_ast/arena.rs`.
 //!
 //! # Safety
 //!
-//! The arena is single-threaded (not `Sync`) and append-only.
+//! The arena is single-threaded (not `Sync`) and append-only for safe APIs.
 //! `UnsafeCell` is safe because:
-//! - Allocation only appends (never moves existing elements)
-//! - Builders return owned values, not references into the Vec
-//! - `get_*` methods return references only when no allocation is in progress
+//! - Safe allocation stores nodes/slices behind `Box`, so `Vec` reallocation
+//!   cannot move values referenced by previously returned shared references
+//! - Builders return handles, not mutable references into arena storage
+//! - Mutable/destructive access is `unsafe` and requires callers to prove no
+//!   aliases exist
 
 use std::cell::UnsafeCell;
 
@@ -48,16 +49,29 @@ impl IdRange {
     }
 }
 
+#[derive(Clone)]
+struct ChildRange {
+    start: u32,
+    len: u32,
+    nodes: Box<[JsNode]>,
+}
+
 /// Arena that owns all `JsNode` instances for a single parse unit.
 ///
 /// Allocation takes `&self` (not `&mut self`) so that builder functions
 /// can nest calls without borrow-checker conflicts.
 pub struct ParseArena {
     /// All standalone JsNode instances (referenced by JsNodeId).
-    js_nodes: UnsafeCell<Vec<JsNode>>,
+    #[allow(clippy::vec_box)] // Box keeps node addresses stable across handle Vec growth.
+    js_nodes: UnsafeCell<Vec<Box<JsNode>>>,
     /// JsNode children for `Vec<JsNode>` fields (arguments, body, properties, etc.).
-    /// Referenced by IdRange.
-    js_children: UnsafeCell<Vec<JsNode>>,
+    /// `IdRange` stores logical offsets; each range owns one boxed slice so
+    /// returned child slices remain stable if this table grows.
+    js_children: UnsafeCell<Vec<ChildRange>>,
+    /// Maps each logical child start offset to the index in `js_children` that
+    /// owns that range. Non-start offsets are left as `u32::MAX`.
+    js_child_range_by_start: UnsafeCell<Vec<u32>>,
+    next_js_child_start: UnsafeCell<u32>,
     /// Bump arena reserved for subsequent migration phases (see
     /// `docs/bumpalo-migration-plan.md`). Currently unused — Phase 0 adds it
     /// to ParseArena without changing public APIs so that Phase 1+ have a
@@ -68,7 +82,7 @@ pub struct ParseArena {
 // ParseArena is explicitly NOT Sync - it's single-threaded only.
 // Send is fine since we can move it between threads.
 //
-// SAFETY: ParseArena owns its `UnsafeCell<Vec<JsNode>>` storage. Moving it
+// SAFETY: ParseArena owns its `UnsafeCell` storage. Moving it
 // between threads is sound because no shared references exist when ownership
 // transfers, and all internal mutation happens through `&self` methods that
 // are documented as single-threaded (UnsafeCell is `!Sync`, so the type
@@ -84,6 +98,8 @@ impl ParseArena {
         Self {
             js_nodes: UnsafeCell::new(Vec::new()),
             js_children: UnsafeCell::new(Vec::new()),
+            js_child_range_by_start: UnsafeCell::new(Vec::new()),
+            next_js_child_start: UnsafeCell::new(0),
             bump: Bump::new(),
         }
     }
@@ -102,15 +118,12 @@ impl ParseArena {
     #[inline(always)]
     pub fn alloc_js_node(&self, node: JsNode) -> JsNodeId {
         // SAFETY: ParseArena is `!Sync` (single-threaded). `UnsafeCell` is used
-        // so allocation can take `&self`. Append-only `Vec::push` never invalidates
-        // existing references because we do not return any reference here — only
-        // an owned `JsNodeId` index. No outstanding `&` or `&mut` to the Vec exist
-        // at this point because all `get_*` methods only borrow during a single
-        // call.
+        // so allocation can take `&self`. Values are stored behind `Box`, so
+        // growing the handle Vec cannot move nodes referenced by earlier reads.
         unsafe {
             let vec = &mut *self.js_nodes.get();
             let id = JsNodeId(vec.len() as u32);
-            vec.push(node);
+            vec.push(Box::new(node));
             id
         }
     }
@@ -118,14 +131,9 @@ impl ParseArena {
     /// Get a shared reference to a JsNode by handle.
     #[inline(always)]
     pub fn get_js_node(&self, id: JsNodeId) -> &JsNode {
-        // SAFETY: Single-threaded, append-only Vec — once an element is pushed
-        // its address remains stable for the Vec's lifetime, so the returned
-        // shared reference cannot be invalidated by subsequent `alloc_js_node`
-        // calls (push only grows; reallocation moves elements but `&self` borrow
-        // tied to the returned `&JsNode` prevents concurrent allocation per the
-        // borrow checker — the caller cannot call `alloc_js_node` while the
-        // returned reference is alive). Out-of-range IDs return a static fallback
-        // rather than panicking.
+        // SAFETY: Single-threaded read. The returned reference points into a
+        // `Box<JsNode>`, not into the handle Vec allocation, so later safe
+        // appends cannot invalidate it.
         unsafe {
             let vec = &*self.js_nodes.get();
             if (id.0 as usize) >= vec.len() {
@@ -138,55 +146,26 @@ impl ParseArena {
                 static NULL_NODE: JsNode = JsNode::Null;
                 return &NULL_NODE;
             }
-            &vec[id.0 as usize]
+            vec[id.0 as usize].as_ref()
         }
     }
 
     /// Get a mutable reference to a JsNode by handle.
+    ///
+    /// # Safety
+    /// The caller must ensure no shared or mutable references to the same node
+    /// are live for the duration of the returned borrow.
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
-    pub fn get_js_node_mut(&self, id: JsNodeId) -> &mut JsNode {
-        // SAFETY: Single-threaded. Caller is responsible for ensuring no other
-        // outstanding reference exists for the same `id` (the borrow checker
-        // cannot enforce this through `&self`, which is why this method uses
-        // `#[allow(clippy::mut_from_ref)]`). Used only by mutation passes that
-        // are aware of arena aliasing — see `crate::compiler::phases::phase2_analyze`.
+    pub unsafe fn get_js_node_mut(&self, id: JsNodeId) -> &mut JsNode {
+        // SAFETY: Enforced by the caller's contract above.
         unsafe {
             let vec = &mut *self.js_nodes.get();
-            &mut vec[id.0 as usize]
+            vec[id.0 as usize].as_mut()
         }
     }
 
     // -- JsNode children (for Vec<JsNode> fields) ----------------------------
-
-    /// Get the current child count (used to record IdRange start).
-    #[inline(always)]
-    pub fn js_children_count(&self) -> u32 {
-        // SAFETY: Single-threaded, immutable read of `Vec::len`. `len()` does not
-        // take a reference into the Vec, so no aliasing concern.
-        unsafe { (*self.js_children.get()).len() as u32 }
-    }
-
-    /// Allocate a JsNode child (for `Vec<JsNode>` fields like arguments, body).
-    #[inline(always)]
-    pub fn alloc_js_child(&self, node: JsNode) {
-        // SAFETY: Same as `alloc_js_node` — single-threaded append-only push,
-        // no reference returned to the caller.
-        unsafe {
-            let vec = &mut *self.js_children.get();
-            vec.push(node);
-        }
-    }
-
-    /// Build an IdRange from children allocated since `start`.
-    #[inline(always)]
-    pub fn children_range_since(&self, start: u32) -> IdRange {
-        let end = self.js_children_count();
-        IdRange {
-            start,
-            len: end - start,
-        }
-    }
 
     /// Get a slice of JsNode children by range.
     #[inline(always)]
@@ -194,41 +173,57 @@ impl ParseArena {
         if range.is_empty() {
             return &[];
         }
-        // SAFETY: Single-threaded read. Append-only Vec means `range.start`
-        // through `range.start + range.len` was valid at the time the IdRange
-        // was minted; subsequent `alloc_js_child` calls only extend past `end`.
-        // The borrow checker prevents concurrent allocation while this `&[JsNode]`
-        // borrow is alive (the borrow ties to `&self`).
+        // SAFETY: Single-threaded read. Matching ranges own boxed slices, so
+        // later safe allocation cannot move returned child slices.
         unsafe {
-            let vec = &*self.js_children.get();
-            let end = (range.start + range.len) as usize;
-            if end > vec.len() {
+            let ranges = &*self.js_children.get();
+            let by_start = &*self.js_child_range_by_start.get();
+            if let Some(&range_index) = by_start.get(range.start as usize)
+                && range_index != u32::MAX
+            {
+                let entry = &ranges[range_index as usize];
+                if entry.start == range.start && entry.len == range.len {
+                    return entry.nodes.as_ref();
+                }
+            }
+
+            #[cfg(debug_assertions)]
+            {
+                let child_count = *self.next_js_child_start.get();
                 #[cfg(debug_assertions)]
                 eprintln!(
                     "ARENA CHILDREN MISMATCH: range({},{}) but arena has {} children",
-                    range.start,
-                    range.len,
-                    vec.len()
+                    range.start, range.len, child_count
                 );
-                return &[];
             }
-            &vec[range.start as usize..end]
+            &[]
         }
     }
 
     /// Get a mutable slice of JsNode children by range.
+    ///
+    /// # Safety
+    /// The caller must ensure no shared or mutable references to the same child
+    /// range are live for the duration of the returned borrow.
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
-    pub fn get_js_children_mut(&self, range: IdRange) -> &mut [JsNode] {
+    pub unsafe fn get_js_children_mut(&self, range: IdRange) -> &mut [JsNode] {
         if range.is_empty() {
             return &mut [];
         }
-        // SAFETY: Single-threaded. Caller is responsible for non-aliasing —
-        // see notes on `get_js_node_mut`. Used by transform passes that
-        // mutate children in place.
+        // SAFETY: Enforced by the caller's contract above.
         unsafe {
-            let vec = &mut *self.js_children.get();
-            &mut vec[range.start as usize..(range.start + range.len) as usize]
+            let ranges = &mut *self.js_children.get();
+            let by_start = &*self.js_child_range_by_start.get();
+            let range_index = by_start
+                .get(range.start as usize)
+                .copied()
+                .filter(|idx| *idx != u32::MAX)
+                .expect("arena child range not found");
+            let entry = &mut ranges[range_index as usize];
+            assert_eq!(entry.start, range.start, "arena child range start mismatch");
+            assert_eq!(entry.len, range.len, "arena child range len mismatch");
+            entry.nodes.as_mut()
         }
     }
 
@@ -239,14 +234,35 @@ impl ParseArena {
         if nodes.is_empty() {
             return IdRange::empty();
         }
-        let start = self.js_children_count();
-        // SAFETY: Same as `alloc_js_child` — single-threaded append-only extend,
-        // no reference returned to the caller.
+        // SAFETY: Single-threaded counter update.
+        let start = unsafe {
+            let next = &mut *self.next_js_child_start.get();
+            let start = *next;
+            *next += nodes.len() as u32;
+            start
+        };
+        let len = nodes.len();
+        // SAFETY: Single-threaded append. Children are kept in a boxed slice, so
+        // returned slices remain stable even if the range table reallocates.
         unsafe {
-            let vec = &mut *self.js_children.get();
-            vec.extend(nodes);
+            let ranges = &mut *self.js_children.get();
+            let range_index = ranges.len() as u32;
+            ranges.push(ChildRange {
+                start,
+                len: len as u32,
+                nodes: nodes.into_boxed_slice(),
+            });
+            let by_start = &mut *self.js_child_range_by_start.get();
+            let required_len = start as usize + len;
+            if by_start.len() < required_len {
+                by_start.resize(required_len, u32::MAX);
+            }
+            by_start[start as usize] = range_index;
         }
-        self.children_range_since(start)
+        IdRange {
+            start,
+            len: len as u32,
+        }
     }
 }
 
@@ -258,9 +274,9 @@ impl Default for ParseArena {
 
 impl Clone for ParseArena {
     fn clone(&self) -> Self {
-        // SAFETY: Single-threaded `Clone` — we read both Vecs and clone their
-        // contents. No outstanding mutable borrow on `self` during clone (the
-        // `&self` parameter prevents concurrent mutation per the borrow checker).
+        // SAFETY: Single-threaded `Clone` — we read the arena tables and clone
+        // their contents. Callers must not clone while unsafe mutable/destructive
+        // arena operations are active.
         //
         // The `bump` field gets a fresh empty `Bump` on clone (Bump isn't
         // Clone). This matches the not-yet-used status — Phase 1+ will need
@@ -269,6 +285,10 @@ impl Clone for ParseArena {
             Self {
                 js_nodes: UnsafeCell::new((*self.js_nodes.get()).clone()),
                 js_children: UnsafeCell::new((*self.js_children.get()).clone()),
+                js_child_range_by_start: UnsafeCell::new(
+                    (*self.js_child_range_by_start.get()).clone(),
+                ),
+                next_js_child_start: UnsafeCell::new(*self.next_js_child_start.get()),
                 bump: Bump::new(),
             }
         }
@@ -282,9 +302,61 @@ impl std::fmt::Debug for ParseArena {
         unsafe {
             f.debug_struct("ParseArena")
                 .field("js_nodes_count", &(*self.js_nodes.get()).len())
-                .field("js_children_count", &(*self.js_children.get()).len())
+                .field("js_children_count", &*self.next_js_child_start.get())
                 .finish()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use compact_str::CompactString;
+
+    fn ident(name: &str) -> JsNode {
+        JsNode::Identifier {
+            start: 0,
+            end: 0,
+            loc: None,
+            name: CompactString::new(name),
+        }
+    }
+
+    #[test]
+    fn js_node_refs_survive_later_allocations() {
+        let arena = ParseArena::new();
+        let id = arena.alloc_js_node(ident("first"));
+        let node = arena.get_js_node(id);
+
+        for i in 0..10_000 {
+            arena.alloc_js_node(ident(&format!("n{i}")));
+        }
+
+        assert!(matches!(node, JsNode::Identifier { name, .. } if name == "first"));
+    }
+
+    #[test]
+    fn js_child_slices_survive_later_allocations() {
+        let arena = ParseArena::new();
+        let range = arena.alloc_js_children(vec![ident("first")]);
+        let children = arena.get_js_children(range);
+
+        for i in 0..10_000 {
+            arena.alloc_js_children(vec![ident(&format!("n{i}"))]);
+        }
+
+        assert!(matches!(&children[0], JsNode::Identifier { name, .. } if name == "first"));
+    }
+
+    #[test]
+    fn js_child_lookup_uses_start_index() {
+        let arena = ParseArena::new();
+        let ranges: Vec<_> = (0..10_000)
+            .map(|i| arena.alloc_js_children(vec![ident(&format!("n{i}"))]))
+            .collect();
+
+        let children = arena.get_js_children(ranges[9_999]);
+        assert!(matches!(&children[0], JsNode::Identifier { name, .. } if name == "n9999"));
     }
 }
 
@@ -303,10 +375,9 @@ thread_local! {
 /// Restoring (rather than clearing to `None`) is critical: nested
 /// callers — e.g. `JsNode::to_value` falling back to `DESER_ARENA` while
 /// a `compile()` already installed its own arena — would otherwise wipe
-/// the outer scope's pointer and leave the caller's later
-/// `resolve_js_node_for_serialize` calls reading from the wrong (or no)
-/// arena, surfacing as cross-talk between concurrent compilations on
-/// the same thread.
+/// the outer scope's pointer and leave later serialization reads without
+/// the correct arena, surfacing as cross-talk between compilations on the
+/// same thread.
 pub struct SerializeArenaGuard {
     prev: Option<*const ParseArena>,
 }
@@ -356,17 +427,22 @@ pub unsafe fn set_serialize_arena(arena: *const ParseArena) {
     });
 }
 
-/// Try to get the current serialize arena for allocation (used by deserialization).
-/// Returns None if no arena is set.
+/// Run `f` with the current serialize arena if one is installed.
 #[inline]
-pub fn try_get_serialize_arena() -> Option<&'static ParseArena> {
-    // SAFETY: The pointer is set only via `with_serialize_arena` (which scopes
-    // the pointer's validity to a single function call) or via the explicitly
-    // `unsafe` `set_serialize_arena` (whose contract is documented). The
-    // `'static` lifetime is fictional but bounded by the discipline that callers
-    // never retain the returned reference past `clear_serialize_arena()` /
-    // `with_serialize_arena` scope.
-    SERIALIZE_ARENA.with(|cell| cell.get().map(|ptr| unsafe { &*ptr }))
+pub fn try_with_current_serialize_arena<R>(f: impl FnOnce(&ParseArena) -> R) -> Option<R> {
+    SERIALIZE_ARENA.with(|cell| {
+        let ptr = cell.get()?;
+        // SAFETY: The returned reference is scoped to this closure call. The
+        // pointer is installed by `with_serialize_arena` or by the unsafe
+        // `set_serialize_arena` API, whose caller must keep the arena alive.
+        Some(f(unsafe { &*ptr }))
+    })
+}
+
+/// Run `f` with the current serialize arena. Panics if no arena is set.
+#[inline]
+pub fn with_current_serialize_arena<R>(f: impl FnOnce(&ParseArena) -> R) -> R {
+    try_with_current_serialize_arena(f).expect("serialize arena not set")
 }
 
 /// Clear the thread-local serialize arena.
@@ -380,33 +456,4 @@ pub fn clear_serialize_arena() {
 #[inline(always)]
 pub fn has_serialize_arena() -> bool {
     SERIALIZE_ARENA.with(|cell| cell.get().is_some())
-}
-
-/// Resolve a JsNodeId during serialization. Panics if no arena is set.
-#[inline(always)]
-pub fn resolve_js_node_for_serialize(id: JsNodeId) -> &'static JsNode {
-    // SAFETY: The thread-local pointer is dereferenced inside the closure
-    // passed to `SERIALIZE_ARENA.with`, which holds the cell read-only for the
-    // duration of the call. The transmute extends the borrow to `'static` —
-    // this is sound only because callers must invoke this function inside
-    // `with_serialize_arena` (or explicitly between `set_serialize_arena` and
-    // `clear_serialize_arena`), guaranteeing the arena outlives the returned
-    // reference. Misuse outside of that scope would dangle, but the public
-    // API contract documents this.
-    SERIALIZE_ARENA.with(|cell| unsafe {
-        let arena = &*cell.get().expect("serialize arena not set");
-        std::mem::transmute::<&JsNode, &'static JsNode>(arena.get_js_node(id))
-    })
-}
-
-/// Resolve an IdRange of JsNode children during serialization.
-#[inline(always)]
-pub fn resolve_js_children_for_serialize(range: IdRange) -> &'static [JsNode] {
-    // SAFETY: Same lifetime contract as `resolve_js_node_for_serialize` — the
-    // arena must outlive the returned slice, which is guaranteed when the
-    // caller is inside `with_serialize_arena`.
-    SERIALIZE_ARENA.with(|cell| unsafe {
-        let arena = &*cell.get().expect("serialize arena not set");
-        std::mem::transmute::<&[JsNode], &'static [JsNode]>(arena.get_js_children(range))
-    })
 }

--- a/src/ast/typed_expr.rs
+++ b/src/ast/typed_expr.rs
@@ -646,7 +646,9 @@ macro_rules! ser_loc {
 /// Helper: serialize a JsNodeId field by resolving through the arena.
 macro_rules! ser_node {
     ($map:ident, $key:expr, $id:expr) => {
-        $map.serialize_entry($key, crate::ast::arena::resolve_js_node_for_serialize(*$id))?
+        crate::ast::arena::with_current_serialize_arena(|arena| {
+            $map.serialize_entry($key, arena.get_js_node(*$id))
+        })?
     };
 }
 
@@ -654,9 +656,9 @@ macro_rules! ser_node {
 macro_rules! ser_opt_node {
     ($map:ident, $key:expr, $opt:expr) => {
         match $opt {
-            Some(id) => {
-                $map.serialize_entry($key, crate::ast::arena::resolve_js_node_for_serialize(*id))?
-            }
+            Some(id) => crate::ast::arena::with_current_serialize_arena(|arena| {
+                $map.serialize_entry($key, arena.get_js_node(*id))
+            })?,
             None => $map.serialize_entry($key, &Value::Null)?,
         }
     };
@@ -665,10 +667,9 @@ macro_rules! ser_opt_node {
 /// Helper: serialize an IdRange field as a JSON array by resolving children through the arena.
 macro_rules! ser_children {
     ($map:ident, $key:expr, $range:expr) => {
-        $map.serialize_entry(
-            $key,
-            &crate::ast::arena::resolve_js_children_for_serialize(*$range),
-        )?
+        crate::ast::arena::with_current_serialize_arena(|arena| {
+            $map.serialize_entry($key, arena.get_js_children(*$range))
+        })?
     };
 }
 
@@ -1961,9 +1962,8 @@ thread_local! {
 /// fallback DESER_ARENA (tests / standalone). The two `deser_alloc_*` helpers
 /// below are thin wrappers around this combinator.
 fn with_deser_arena<R>(f: impl FnOnce(&ParseArena) -> R) -> R {
-    use crate::ast::arena::try_get_serialize_arena;
-    if let Some(arena) = try_get_serialize_arena() {
-        f(arena)
+    if crate::ast::arena::has_serialize_arena() {
+        crate::ast::arena::with_current_serialize_arena(f)
     } else {
         DESER_ARENA.with(|a| f(&a.borrow()))
     }

--- a/src/compiler/phases/1_parse/read/expression.rs
+++ b/src/compiler/phases/1_parse/read/expression.rs
@@ -821,7 +821,7 @@ fn try_parse_arrow_function(
 
     // Parse params between ( and )
     let params_str = content[1..close_paren].trim();
-    let params_start = arena.js_children_count();
+    let mut params_nodes = Vec::new();
 
     if !params_str.is_empty() {
         for param in params_str.split(',') {
@@ -836,7 +836,7 @@ fn try_parse_arrow_function(
             if !p_bytes.iter().all(|&b| is_ident_continue_byte(b)) {
                 return None; // Has type annotations or defaults — too complex
             }
-            arena.alloc_js_child(JsNode::Identifier {
+            params_nodes.push(JsNode::Identifier {
                 start: 0, // Approximate — exact positions not critical for compilation
                 end: 0,
                 loc: None,
@@ -844,7 +844,7 @@ fn try_parse_arrow_function(
             });
         }
     }
-    let params = arena.children_range_since(params_start);
+    let params = arena.alloc_js_children(params_nodes);
 
     let total_end = offset + content.len();
     Some(Expression::from_node(JsNode::ArrowFunctionExpression {

--- a/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -197,7 +197,7 @@ pub fn unified_build_bind_this(
         ) {
             if let JsExpr::Member(member) = expr {
                 member.optional = true;
-                let mut inner = arena.take_expr(member.object);
+                let mut inner = unsafe { arena.take_expr(member.object) };
                 make_optional(arena, &mut inner);
                 member.object = arena.alloc_expr(inner);
             }

--- a/src/compiler/phases/3_transform/js_ast/arena.rs
+++ b/src/compiler/phases/3_transform/js_ast/arena.rs
@@ -1,12 +1,10 @@
 //! Arena allocator for JavaScript AST nodes.
 //!
-//! Instead of heap-allocating each sub-expression/sub-statement via `Box`,
-//! we store all expressions and statements in a contiguous `Vec` and reference
+//! We store all expressions and statements behind stable boxes and reference
 //! them by index (`ExprId` / `StmtId`).  This gives:
 //!
-//! - **Cache-friendly iteration** (nodes are contiguous in memory)
 //! - **Zero-cost reads** (`arena.get_expr(id)` is a single array index)
-//! - **Cheaper allocation** (push to a Vec vs. global allocator)
+//! - **Stable shared references** (pushing more handles cannot move nodes)
 //!
 //! The allocation methods (`alloc_expr`, `alloc_stmt`) take `&self` instead of
 //! `&mut self`, using `UnsafeCell` internally. This is critical because builder
@@ -17,14 +15,14 @@
 //!
 //! # Safety
 //!
-//! The arena is single-threaded (not `Sync`) and append-only for allocation.
+//! The arena is single-threaded (not `Sync`) and append-only for safe APIs.
 //! `UnsafeCell` is safe here because:
-//! - Allocation only appends (never moves existing elements, since we use
-//!   `reserve` to avoid reallocation)
-//! - No references into the Vec are held across allocation calls in the
-//!   builder API (builders return owned `JsExpr`/`JsStatement`, not references)
-//! - `get_expr`/`get_stmt` return references but are only called when no
-//!   allocation is in progress
+//! - Safe allocation stores nodes behind `Box`, so `Vec` reallocation cannot
+//!   move values referenced by previously returned shared references
+//! - Builders return handles or owned values, not mutable references into
+//!   arena storage
+//! - Mutable/destructive access is `unsafe` and requires callers to prove no
+//!   aliases exist
 
 use super::nodes::{JsExpr, JsStatement};
 use std::cell::UnsafeCell;
@@ -43,8 +41,10 @@ pub struct StmtId(pub u32);
 /// Allocation takes `&self` (not `&mut self`) so that builder functions
 /// can nest calls without borrow-checker conflicts.
 pub struct JsArena {
-    exprs: UnsafeCell<Vec<JsExpr>>,
-    stmts: UnsafeCell<Vec<JsStatement>>,
+    #[allow(clippy::vec_box)] // Box keeps expression addresses stable across handle Vec growth.
+    exprs: UnsafeCell<Vec<Box<JsExpr>>>,
+    #[allow(clippy::vec_box)] // Box keeps statement addresses stable across handle Vec growth.
+    stmts: UnsafeCell<Vec<Box<JsStatement>>>,
 }
 
 // JsArena is explicitly NOT Sync - it's single-threaded only.
@@ -67,12 +67,12 @@ impl JsArena {
     /// Takes `&self` (not `&mut self`) to allow nested builder calls.
     #[inline(always)]
     pub fn alloc_expr(&self, expr: JsExpr) -> ExprId {
-        // SAFETY: single-threaded, append-only, no outstanding references
-        // into the Vec during allocation (builders return owned values).
+        // SAFETY: single-threaded append. Values are stored behind `Box`, so
+        // growing the handle Vec cannot move expressions referenced earlier.
         unsafe {
             let vec = &mut *self.exprs.get();
             let id = ExprId(vec.len() as u32);
-            vec.push(expr);
+            vec.push(Box::new(expr));
             id
         }
     }
@@ -80,26 +80,25 @@ impl JsArena {
     /// Get a shared reference to an expression by handle.
     #[inline(always)]
     pub fn get_expr(&self, id: ExprId) -> &JsExpr {
-        // SAFETY: no mutation happens while shared references exist
-        // (alloc_expr only appends, doesn't touch existing elements)
+        // SAFETY: single-threaded read from stable boxed storage.
         unsafe {
             let vec = &*self.exprs.get();
-            &vec[id.0 as usize]
+            vec[id.0 as usize].as_ref()
         }
     }
 
     /// Get a mutable reference to an expression by handle.
     ///
-    /// # Safety note
-    /// Caller must ensure no other references to the same slot exist.
-    /// This is safe in our single-threaded builder context.
+    /// # Safety
+    /// The caller must ensure no shared or mutable references to the same
+    /// expression are live for the duration of the returned borrow.
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
-    pub fn get_expr_mut(&self, id: ExprId) -> &mut JsExpr {
-        // SAFETY: single-threaded, caller ensures no aliasing
+    pub unsafe fn get_expr_mut(&self, id: ExprId) -> &mut JsExpr {
+        // SAFETY: Enforced by the caller's contract above.
         unsafe {
             let vec = &mut *self.exprs.get();
-            &mut vec[id.0 as usize]
+            vec[id.0 as usize].as_mut()
         }
     }
 
@@ -107,15 +106,18 @@ impl JsArena {
     /// Useful when you need ownership (e.g., to transform an expression).
     ///
     /// Takes `&self` (not `&mut self`) because this is called from builder
-    /// functions that may be nested. Safe because the arena is single-threaded
-    /// and we only swap a single element (no reallocation).
+    /// functions that may be nested.
+    ///
+    /// # Safety
+    /// The caller must ensure no shared or mutable references to the same
+    /// expression are live while the slot is replaced.
     #[inline(always)]
-    pub fn take_expr(&self, id: ExprId) -> JsExpr {
-        // SAFETY: single-threaded, only modifies one existing element
+    pub unsafe fn take_expr(&self, id: ExprId) -> JsExpr {
+        // SAFETY: Enforced by the caller's contract above.
         unsafe {
             let vec = &mut *self.exprs.get();
             std::mem::replace(
-                &mut vec[id.0 as usize],
+                vec[id.0 as usize].as_mut(),
                 JsExpr::Literal(super::nodes::JsLiteral::Null),
             )
         }
@@ -132,7 +134,7 @@ impl JsArena {
         unsafe {
             let vec = &mut *self.stmts.get();
             let id = StmtId(vec.len() as u32);
-            vec.push(stmt);
+            vec.push(Box::new(stmt));
             id
         }
     }
@@ -143,30 +145,38 @@ impl JsArena {
         // SAFETY: same as get_expr
         unsafe {
             let vec = &*self.stmts.get();
-            &vec[id.0 as usize]
+            vec[id.0 as usize].as_ref()
         }
     }
 
     /// Get a mutable reference to a statement by handle.
+    ///
+    /// # Safety
+    /// The caller must ensure no shared or mutable references to the same
+    /// statement are live for the duration of the returned borrow.
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
-    pub fn get_stmt_mut(&self, id: StmtId) -> &mut JsStatement {
-        // SAFETY: single-threaded, caller ensures no aliasing
+    pub unsafe fn get_stmt_mut(&self, id: StmtId) -> &mut JsStatement {
+        // SAFETY: Enforced by the caller's contract above.
         unsafe {
             let vec = &mut *self.stmts.get();
-            &mut vec[id.0 as usize]
+            vec[id.0 as usize].as_mut()
         }
     }
 
     /// Take a statement out of the arena, replacing it with Empty.
     ///
     /// Takes `&self` for the same reasons as `take_expr`.
+    ///
+    /// # Safety
+    /// The caller must ensure no shared or mutable references to the same
+    /// statement are live while the slot is replaced.
     #[inline(always)]
-    pub fn take_stmt(&self, id: StmtId) -> JsStatement {
-        // SAFETY: single-threaded, only modifies one existing element
+    pub unsafe fn take_stmt(&self, id: StmtId) -> JsStatement {
+        // SAFETY: Enforced by the caller's contract above.
         unsafe {
             let vec = &mut *self.stmts.get();
-            std::mem::replace(&mut vec[id.0 as usize], JsStatement::Empty)
+            std::mem::replace(vec[id.0 as usize].as_mut(), JsStatement::Empty)
         }
     }
 }
@@ -175,8 +185,12 @@ impl JsArena {
     /// Clear all stored expressions and statements, keeping the allocated buffer
     /// for reuse. This is O(n) for dropping stored elements but the next compilation
     /// benefits from zero allocation (the Vec buffer is already sized).
-    pub fn reset(&self) {
-        // SAFETY: single-threaded, no outstanding references after a compilation
+    ///
+    /// # Safety
+    /// The caller must ensure no shared or mutable references into this arena
+    /// are live while the arena is cleared.
+    pub unsafe fn reset(&self) {
+        // SAFETY: Enforced by the caller's contract above.
         unsafe {
             (*self.exprs.get()).clear();
             (*self.stmts.get()).clear();
@@ -244,7 +258,7 @@ mod tests {
         let arena = JsArena::new();
         let id = arena.alloc_expr(JsExpr::Identifier(CompactString::new("bar")));
 
-        let taken = arena.take_expr(id);
+        let taken = unsafe { arena.take_expr(id) };
         match taken {
             JsExpr::Identifier(name) => assert_eq!(name.as_str(), "bar"),
             _ => panic!("expected identifier"),
@@ -261,7 +275,7 @@ mod tests {
         let arena = JsArena::new();
         let id = arena.alloc_stmt(JsStatement::Debugger);
 
-        let taken = arena.take_stmt(id);
+        let taken = unsafe { arena.take_stmt(id) };
         assert!(matches!(taken, JsStatement::Debugger));
         // After take, slot should contain Empty
         assert!(matches!(arena.get_stmt(id), JsStatement::Empty));
@@ -272,7 +286,7 @@ mod tests {
         let arena = JsArena::new();
         let id = arena.alloc_expr(JsExpr::Identifier(CompactString::new("x")));
 
-        *arena.get_expr_mut(id) = JsExpr::Identifier(CompactString::new("y"));
+        *unsafe { arena.get_expr_mut(id) } = JsExpr::Identifier(CompactString::new("y"));
 
         match arena.get_expr(id) {
             JsExpr::Identifier(name) => assert_eq!(name.as_str(), "y"),
@@ -296,6 +310,21 @@ mod tests {
             }
             _ => panic!("expected number"),
         }
+    }
+
+    #[test]
+    fn test_expr_refs_survive_later_allocations() {
+        let arena = JsArena::new();
+        let id = arena.alloc_expr(JsExpr::Identifier(CompactString::new("first")));
+        let expr = arena.get_expr(id);
+
+        for i in 0..10_000u32 {
+            arena.alloc_expr(JsExpr::Literal(super::super::nodes::JsLiteral::Number(
+                i as f64,
+            )));
+        }
+
+        assert!(matches!(expr, JsExpr::Identifier(name) if name.as_str() == "first"));
     }
 
     #[test]

--- a/src/compiler/phases/3_transform/js_ast/builders.rs
+++ b/src/compiler/phases/3_transform/js_ast/builders.rs
@@ -539,7 +539,7 @@ pub fn js_expr_has_await(arena: &JsArena, expr: &JsExpr) -> bool {
 /// Otherwise returns the original expression unchanged.
 pub fn strip_await(arena: &JsArena, expr: JsExpr) -> JsExpr {
     match expr {
-        JsExpr::Await(inner_id) => arena.take_expr(inner_id),
+        JsExpr::Await(inner_id) => unsafe { arena.take_expr(inner_id) },
         other => other,
     }
 }
@@ -599,19 +599,19 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         JsExpr::Await(inner_id) => {
             if is_tail {
                 // Tail position: leave as plain `await X`
-                let inner = arena.take_expr(inner_id);
+                let inner = unsafe { arena.take_expr(inner_id) };
                 let transformed = apply_save_recursive(arena, inner, true);
                 JsExpr::Await(arena.alloc_expr(transformed))
             } else {
                 // Non-tail position: wrap as `(await $.save(X))()`
-                let inner = arena.take_expr(inner_id);
+                let inner = unsafe { arena.take_expr(inner_id) };
                 save(arena, inner)
             }
         }
 
         JsExpr::Binary(bin) => {
-            let left = arena.take_expr(bin.left);
-            let right = arena.take_expr(bin.right);
+            let left = unsafe { arena.take_expr(bin.left) };
+            let right = unsafe { arena.take_expr(bin.right) };
             let left = apply_save_recursive(arena, left, false);
             let right = apply_save_recursive(arena, right, is_tail);
             JsExpr::Binary(JsBinaryExpression {
@@ -622,8 +622,8 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         }
 
         JsExpr::Logical(log) => {
-            let left = arena.take_expr(log.left);
-            let right = arena.take_expr(log.right);
+            let left = unsafe { arena.take_expr(log.left) };
+            let right = unsafe { arena.take_expr(log.right) };
             let left = apply_save_recursive(arena, left, false);
             let right = apply_save_recursive(arena, right, is_tail);
             JsExpr::Logical(JsLogicalExpression {
@@ -634,8 +634,8 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         }
 
         JsExpr::Assignment(assign) => {
-            let left = arena.take_expr(assign.left);
-            let right = arena.take_expr(assign.right);
+            let left = unsafe { arena.take_expr(assign.left) };
+            let right = unsafe { arena.take_expr(assign.right) };
             let left = apply_save_recursive(arena, left, false);
             let right = apply_save_recursive(arena, right, is_tail);
             JsExpr::Assignment(JsAssignmentExpression {
@@ -646,7 +646,7 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         }
 
         JsExpr::Call(call_expr) => {
-            let callee = arena.take_expr(call_expr.callee);
+            let callee = unsafe { arena.take_expr(call_expr.callee) };
             let callee = apply_save_recursive(arena, callee, false);
             let len = call_expr.arguments.len();
             let arguments: Vec<JsExpr> = call_expr
@@ -666,7 +666,7 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         }
 
         JsExpr::New(new_expr) => {
-            let callee = arena.take_expr(new_expr.callee);
+            let callee = unsafe { arena.take_expr(new_expr.callee) };
             let callee = apply_save_recursive(arena, callee, false);
             let len = new_expr.arguments.len();
             let arguments: Vec<JsExpr> = new_expr
@@ -701,9 +701,9 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         }
 
         JsExpr::Conditional(cond) => {
-            let test = arena.take_expr(cond.test);
-            let consequent = arena.take_expr(cond.consequent);
-            let alternate = arena.take_expr(cond.alternate);
+            let test = unsafe { arena.take_expr(cond.test) };
+            let consequent = unsafe { arena.take_expr(cond.consequent) };
+            let alternate = unsafe { arena.take_expr(cond.alternate) };
             let test = apply_save_recursive(arena, test, false);
             let consequent = apply_save_recursive(arena, consequent, is_tail);
             let alternate = apply_save_recursive(arena, alternate, is_tail);
@@ -716,11 +716,11 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
 
         JsExpr::Member(member) => {
             let object_is_tail = if member.computed { false } else { is_tail };
-            let object = arena.take_expr(member.object);
+            let object = unsafe { arena.take_expr(member.object) };
             let object = apply_save_recursive(arena, object, object_is_tail);
             let property = match member.property {
                 JsMemberProperty::Expression(e_id) => {
-                    let e = arena.take_expr(e_id);
+                    let e = unsafe { arena.take_expr(e_id) };
                     let transformed = apply_save_recursive(arena, e, is_tail);
                     JsMemberProperty::Expression(arena.alloc_expr(transformed))
                 }
@@ -766,7 +766,7 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         }
 
         JsExpr::TaggedTemplate(tt) => {
-            let tag = arena.take_expr(tt.tag);
+            let tag = unsafe { arena.take_expr(tt.tag) };
             let tag = apply_save_recursive(arena, tag, false);
             let len = tt.quasi.expressions.len();
             let expressions: Vec<JsExpr> = tt
@@ -800,13 +800,13 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
                         JsObjectMember::Property(p) => {
                             let key = match p.key {
                                 JsPropertyKey::Computed(e_id) => {
-                                    let e = arena.take_expr(e_id);
+                                    let e = unsafe { arena.take_expr(e_id) };
                                     let transformed = apply_save_recursive(arena, e, false);
                                     JsPropertyKey::Computed(arena.alloc_expr(transformed))
                                 }
                                 other => other,
                             };
-                            let value = arena.take_expr(p.value);
+                            let value = unsafe { arena.take_expr(p.value) };
                             let value = apply_save_recursive(arena, value, prop_is_tail);
                             JsObjectMember::Property(JsProperty {
                                 key,
@@ -818,7 +818,7 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
                             })
                         }
                         JsObjectMember::SpreadElement(e_id) => {
-                            let e = arena.take_expr(e_id);
+                            let e = unsafe { arena.take_expr(e_id) };
                             let transformed = apply_save_recursive(arena, e, prop_is_tail);
                             JsObjectMember::SpreadElement(arena.alloc_expr(transformed))
                         }
@@ -829,7 +829,7 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         }
 
         JsExpr::Unary(un) => {
-            let argument = arena.take_expr(un.argument);
+            let argument = unsafe { arena.take_expr(un.argument) };
             let argument = apply_save_recursive(arena, argument, false);
             JsExpr::Unary(JsUnaryExpression {
                 operator: un.operator,
@@ -839,7 +839,7 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         }
 
         JsExpr::Update(up) => {
-            let argument = arena.take_expr(up.argument);
+            let argument = unsafe { arena.take_expr(up.argument) };
             let argument = apply_save_recursive(arena, argument, false);
             JsExpr::Update(JsUpdateExpression {
                 operator: up.operator,
@@ -849,13 +849,13 @@ fn apply_save_recursive(arena: &JsArena, expr: JsExpr, is_tail: bool) -> JsExpr 
         }
 
         JsExpr::Spread(inner_id) => {
-            let inner = arena.take_expr(inner_id);
+            let inner = unsafe { arena.take_expr(inner_id) };
             let transformed = apply_save_recursive(arena, inner, is_tail);
             JsExpr::Spread(arena.alloc_expr(transformed))
         }
 
         JsExpr::Void(inner_id) => {
-            let inner = arena.take_expr(inner_id);
+            let inner = unsafe { arena.take_expr(inner_id) };
             let transformed = apply_save_recursive(arena, inner, false);
             JsExpr::Void(arena.alloc_expr(transformed))
         }


### PR DESCRIPTION
## Summary
- Store parse and transform arena nodes behind stable boxed allocations so safe shared references survive later handle-table growth.
- Convert mutable/destructive transform arena operations to `unsafe` and update the narrow internal call sites.
- Replace fabricated `'static` serialization resolver helpers with closure-scoped access to the active parse arena.
- Add regression tests that hold arena references/slices while forcing later allocations.

## Issue
Addresses #433.

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo test arena`
- `cargo test --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`