### PR TITLE
fix(parse): require exact block close tags, reject stray closes (C-006)

### DIFF
--- a/src/compiler/phases/1_parse/state/fragment.rs
+++ b/src/compiler/phases/1_parse/state/fragment.rs
@@ -119,6 +119,22 @@ impl Parser<'_> {
             }
         }
 
+        // A stray block close tag at root (e.g. `{/if}`) has no matching open
+        // block. `parse_fragment` stops on `{/...}` without consuming it, so any
+        // leftover close marker here is an error in strict mode. (Comments
+        // `{/*`, `{//` are not close markers.)
+        if !self.options.loose
+            && self.match_str("{/")
+            && !self.match_str("{/*")
+            && !self.match_str("{//")
+        {
+            return Err(crate::error::ParseError::svelte(
+                "block_unexpected_close",
+                "Unexpected block closing tag",
+                (self.index, self.index + 1),
+            ));
+        }
+
         // Determine the end position of script/style tags
         let script_end = self
             .instance_script

--- a/src/compiler/phases/1_parse/state/tag.rs
+++ b/src/compiler/phases/1_parse/state/tag.rs
@@ -100,6 +100,45 @@ impl Parser<'_> {
         }
     }
 
+    /// Consume the matching `{/keyword}` close tag for the current block.
+    ///
+    /// Mirrors upstream `close()` in `state/tag.js`: the block keyword and the
+    /// trailing `}` are required (a mismatched keyword such as `{#if}` closed by
+    /// `{/each}` is a hard `expected_token` error in strict mode), while loose
+    /// mode tolerates a mismatch for best-effort recovery. Precondition:
+    /// `parse_fragment` has stopped on a `{/...}` close marker, so the parser is
+    /// positioned at the `{`.
+    ///
+    /// Returns `Ok(true)` when the matching close tag was consumed. Returns
+    /// `Ok(false)` when no matching close was consumed: at EOF (no close marker
+    /// present) or, in loose mode, when a `{/other}` marker does not match this
+    /// block — in which case the marker is left intact for an outer block to
+    /// consume (best-effort recovery).
+    fn expect_block_close(&mut self, keyword: &str) -> ParseResult<bool> {
+        // No close marker present (e.g. EOF): nothing to consume.
+        if !self.match_str("{/") {
+            return Ok(false);
+        }
+        let checkpoint = self.index;
+        self.advance_by(2); // consume '{/'
+
+        // Require the exact block keyword. `eat(keyword, true, false)` errors in
+        // strict mode on a mismatch and returns false (without erroring) in
+        // loose mode.
+        if !self.eat_required_strict(keyword)? {
+            // Loose mode only (strict mode errored above): the close marker
+            // belongs to an outer block. Backtrack so it is left intact.
+            self.index = checkpoint;
+            return Ok(false);
+        }
+
+        self.skip_whitespace();
+        // Require the closing `}` (in both strict and loose mode, matching
+        // upstream `parser.eat('}', true)`).
+        self.eat("}", true, true)?;
+        Ok(true)
+    }
+
     /// Parse {#if} block.
     pub fn parse_if_block(&mut self, start: usize) -> ParseResult<Option<TemplateNode>> {
         self.skip_whitespace();
@@ -126,14 +165,7 @@ impl Parser<'_> {
         let mut alternate = self.parse_if_alternate()?;
 
         // Handle closing {/if} if not already consumed
-        let mut found_closing = false;
-        if self.match_str("{/") {
-            self.advance_by(2);
-            self.eat_optional("if");
-            self.skip_whitespace();
-            self.eat_optional("}");
-            found_closing = true;
-        }
+        let found_closing = self.expect_block_close("if")?;
 
         // Pop from stack only if we found the closing tag
         // If we reached EOF without closing, leave on stack for error reporting
@@ -404,17 +436,11 @@ impl Parser<'_> {
                 }
             }
 
-            // Handle {/each}
-            if self.match_str("{/each}") {
-                self.advance_by(7);
-            } else if self.match_str("{/") {
-                self.advance_by(2);
-                self.eat_optional("each");
-                self.skip_whitespace();
-                self.eat_optional("}");
-            }
+            // Handle {/each}. A mismatched close (e.g. `{/if}`) errors in strict
+            // mode; in loose mode it is left for an outer block.
+            self.expect_block_close("each")?;
 
-            // Pop from stack
+            // Pop from stack (matched close, or EOF / loose-mode recovery).
             if !self.stack.is_empty() {
                 self.stack.pop();
             }
@@ -625,15 +651,11 @@ impl Parser<'_> {
             }
         }
 
-        // Handle closing {/each}
-        if self.match_str("{/") {
-            self.advance_by(2);
-            self.eat_optional("each");
-            self.skip_whitespace();
-            self.eat_optional("}");
-        }
+        // Handle closing {/each}. A mismatched close (e.g. `{/if}`) errors in
+        // strict mode; in loose mode it is left for an outer block.
+        self.expect_block_close("each")?;
 
-        // Pop from stack
+        // Pop from stack (matched close, or EOF / loose-mode recovery).
         if !self.stack.is_empty() {
             self.stack.pop();
         }
@@ -976,13 +998,15 @@ impl Parser<'_> {
             }
         }
 
-        // Handle closing {/await}
-        if self.match_str("{/await}") {
-            self.advance_by(8);
-        }
+        // Handle closing {/await}. A mismatched close (e.g. `{#await}` closed by
+        // `{/if}`) errors in strict mode; in loose mode it is left for an outer
+        // block.
+        self.expect_block_close("await")?;
 
-        // Pop the stack
-        self.stack.pop();
+        // Pop the stack (matched close, or EOF / loose-mode recovery).
+        if !self.stack.is_empty() {
+            self.stack.pop();
+        }
 
         Ok(Some(TemplateNode::AwaitBlock(Box::new(AwaitBlock {
             start: start as u32,
@@ -1019,15 +1043,11 @@ impl Parser<'_> {
         // Parse body
         let fragment = self.parse_fragment()?;
 
-        // Handle closing {/key} if present (but NOT other closing tags like {/if})
-        if self.match_str("{/key") {
-            self.advance_by(2); // consume '{/'
-            self.eat_optional("key");
-            self.skip_whitespace();
-            self.eat_optional("}");
-        }
+        // Handle closing {/key}. A mismatched close (e.g. `{/if}`) errors in
+        // strict mode; in loose mode it is left for an outer block.
+        self.expect_block_close("key")?;
 
-        // Pop from stack
+        // Pop from stack (matched close, or EOF / loose-mode recovery).
         if !self.stack.is_empty() {
             self.stack.pop();
         }
@@ -1196,15 +1216,11 @@ impl Parser<'_> {
         // Parse body
         let body = self.parse_fragment()?;
 
-        // Handle closing {/snippet}
-        if self.match_str("{/") {
-            self.advance_by(2);
-            self.eat_optional("snippet");
-            self.skip_whitespace();
-            self.eat_optional("}");
-        }
+        // Handle closing {/snippet}. A mismatched close (e.g. `{/if}`) errors in
+        // strict mode; in loose mode it is left for an outer block.
+        self.expect_block_close("snippet")?;
 
-        // Pop from stack
+        // Pop from stack (matched close, or EOF / loose-mode recovery).
         if !self.stack.is_empty() {
             self.stack.pop();
         }

--- a/tests/block_close_mismatch.rs
+++ b/tests/block_close_mismatch.rs
@@ -1,0 +1,78 @@
+//! Regression tests for block close-tag handling (correctness review C-006).
+//!
+//! Bugs: rsvelte's block-close handlers consumed `{/` and then treated the
+//! keyword and `}` as optional, so a mismatched close (`{#if}` closed by
+//! `{/each}`) was silently accepted and the wrong block popped, and the
+//! `{#await}` handler popped its stack entry even when the keyword did not
+//! match. A stray `{/if}` at root was also accepted without error.
+//!
+//! Fix: a strict `expect_block_close(keyword)` requires the exact `{/keyword}`
+//! (erroring in strict mode on a mismatch), and `parse()` reports
+//! `block_unexpected_close` for a leftover `{/...}` at root.
+
+use svelte_compiler_rust::error::ParseError;
+use svelte_compiler_rust::{ParseOptions, parse};
+
+fn error_code(source: &str) -> String {
+    match parse(source, ParseOptions::default()) {
+        Ok(_) => panic!("expected a parse error for:\n{source}"),
+        Err(ParseError::SvelteError { code, .. }) => code,
+        Err(other) => panic!("expected a SvelteError, got {other:?} for:\n{source}"),
+    }
+}
+
+#[test]
+fn mismatched_if_close_is_an_error() {
+    // `{#if}` closed by `{/each}` must error rather than silently pop the
+    // if-block and parse `each}` as text.
+    assert_eq!(error_code("{#if ok}{/each}"), "expected_token");
+}
+
+#[test]
+fn mismatched_await_close_is_an_error() {
+    // `{#await}` closed by `{/if}` must error rather than pop the await stack
+    // entry unconditionally.
+    assert_eq!(error_code("{#await p}{/if}"), "expected_token");
+}
+
+#[test]
+fn mismatched_each_close_is_an_error() {
+    assert_eq!(error_code("{#each xs as x}{/if}"), "expected_token");
+}
+
+#[test]
+fn mismatched_key_close_is_an_error() {
+    assert_eq!(error_code("{#key k}{/each}"), "expected_token");
+}
+
+#[test]
+fn mismatched_snippet_close_is_an_error() {
+    assert_eq!(error_code("{#snippet foo()}{/if}"), "expected_token");
+}
+
+#[test]
+fn stray_block_close_at_root_is_an_error() {
+    assert_eq!(error_code("{/if}"), "block_unexpected_close");
+    assert_eq!(error_code("<p>hi</p>\n{/each}"), "block_unexpected_close");
+}
+
+#[test]
+fn matching_block_closes_still_parse() {
+    // Valid blocks must continue to parse without error.
+    for source in [
+        "{#if ok}<p>a</p>{/if}",
+        "{#if ok}<p>a</p>{:else}<p>b</p>{/if}",
+        "{#each xs as x}{x}{/each}",
+        "{#each xs as x, i (x.id)}{x}{/each}",
+        "{#key k}<p>a</p>{/key}",
+        "{#await p}<p>loading</p>{:then v}{v}{:catch e}{e}{/await}",
+        "{#snippet foo()}<p>a</p>{/snippet}",
+        // Whitespace inside the close tag is allowed: `{/if }`.
+        "{#if ok}<p>a</p>{/if }",
+    ] {
+        assert!(
+            parse(source, ParseOptions::default()).is_ok(),
+            "expected a clean parse for:\n{source}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the permissive block close-tag handling described in #436 (correctness review #431, finding C-006).

The per-block close handlers for `{#if}`, `{#each}`, `{#await}`, `{#key}`, and `{#snippet}` consumed `{/` and then treated the keyword and the trailing `}` as optional (`eat_optional`). As a result:
- A mismatched close was silently accepted: `{#if ok}{/each}` popped the if-block, failed to require `if`/`}`, and parsed the leftover `each}` as text.
- The `{#await}` handler popped its stack entry unconditionally even when `{/await}` did not match (e.g. `{#await p}{/if}`).
- A stray `{/if}` at root terminated parsing with no error.

## Fix
- New `expect_block_close(keyword)` helper in `state/tag.rs` mirrors upstream `close()` (`state/tag.js`): the exact `{/keyword}` is required (optional inner whitespace), a mismatch is a hard `expected_token` error in strict mode, and loose mode **backtracks** so the close marker is left intact for an outer block (best-effort recovery, matching upstream's pop-and-recurse).
- All five block-close handlers route through the helper instead of the permissive `eat_optional` path.
- `parse()` now reports `block_unexpected_close` for a leftover `{/...}` marker at root (comments `{/*`, `{//` excluded).

Stack pops are unchanged in behavior: a strict-mode mismatch now errors *before* any pop, so the only pops that remain happen on a matched close or on EOF/loose-mode recovery — satisfying acceptance item 4.

## Acceptance
- [x] Centralized block-close parsing in `expect_block_close(keyword)`.
- [x] Keyword and `}` are not optional in strict mode.
- [x] Root-level stray `{/...}` reports `block_unexpected_close`.
- [x] No block stack entry is popped on a strict-mode mismatch (it errors first); EOF / loose-mode recovery still pop as before.

## Test plan
- [x] New `tests/block_close_mismatch.rs` — mismatched `{/...}` for every block type errors with `expected_token`; stray root close errors with `block_unexpected_close`; valid blocks (incl. `{:else}`, keyed each, await/then/catch, `{/if }` with whitespace) still parse.
- [x] `cargo test --test parser_fixtures` — 17 passed (incl. loose-mode `loose-unclosed-block`)
- [x] `cargo test --test compiler_errors` — passed
- [x] `cargo test --test validator --test css --test print --test svelte2tsx_fixtures --test ssr` — passed
- [x] `cargo test --test runtime --test compatibility_report` — passed (full compatibility matrix unchanged)

Closes #436