### PR TITLE
chore(ci): drop Swatinem/rust-cache from every workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -53,13 +53,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          # Don't share with the test job; a release build with bench-only
-          # features differs enough that mixing the caches hurts both.
-          shared-key: bench
-
       - name: Resolve Svelte submodule SHA
         id: svelte-sha
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
         with:
           components: clippy
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -97,9 +94,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Resolve Svelte submodule SHA
         id: svelte-sha
@@ -227,9 +221,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
       - name: Resolve Svelte submodule SHA
         id: svelte-sha
         shell: bash
@@ -346,9 +337,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build documentation
         run: cargo doc --no-deps

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
       - name: Resolve Svelte submodule SHA
         id: svelte-sha
         shell: bash

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
       - name: Resolve Svelte submodule SHA
         id: svelte-sha
         shell: bash

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -105,9 +105,6 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release-capi.yml
+++ b/.github/workflows/release-capi.yml
@@ -63,11 +63,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: release-capi-${{ matrix.target }}
-
       # Resolve the release version from the trigger:
       #   - push of capi-vX.Y.Z → strip the `capi-v` prefix
       #   - workflow_dispatch   → use the `version` input

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: svelte-check-${{ matrix.target }}
-
       - name: Build svelte-check
         shell: bash
         env:
@@ -115,11 +110,6 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: vps-native-${{ matrix.target }}
-
       - name: Build NAPI cdylib
         shell: bash
         env:
@@ -177,9 +167,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/rsvelte-capi.yml
+++ b/.github/workflows/rsvelte-capi.yml
@@ -66,9 +66,6 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
       # Build twice on purpose: the first run regenerates the header
       # into include/rsvelte.h (build script writes when env var unset),
       # the second run *verifies* the committed header is identical to


### PR DESCRIPTION
## Summary

Drop `Swatinem/rust-cache` from every workflow. The cache keeps getting poisoned and producing two recurring failure shapes:

- `Compatibility Report` (`cargo test --release --lib --test compatibility_report` with `CARGO_PROFILE_RELEASE_LTO=off`) hits `expected FxBuildHasher, found rustc_hash::FxBuildHasher` — two distinct compiled copies of rustc-hash 2.1.2 end up in the test crate's dependency graph.
- `Deploy Docs to GitHub Pages` hits `undefined symbol: svelte_compiler_rust::svelte_check::*` when relinking the \`svelte_check\` bin against a stale \`libsvelte_compiler_rust\` rlib.

Both come from a corrupted Swatinem/rust-cache state that the cache-key (Cargo.lock hash + rustc version) won't naturally invalidate. Lockfile-bump workarounds (e.g. PR #435) only buy time.

## Why

Each recurrence costs ~30 min of red CI and a hand-bump commit. Trading ~2-3 min of cold-build time per affected job for permanent reliability is worth it.

## Kept

The `actions/cache` entries keyed on the Svelte submodule SHA — \`fixtures-v2-...\` and \`svelte-build-v2-...\` — are content-addressed and immune to this failure mode. They stay.

## Test plan

- [ ] All workflows pass on this PR (cold builds, no cache restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)