### PR TITLE
fix(transform): lower $props() written with non-standard whitespace (C-008)

### DIFF
--- a/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1654,6 +1654,10 @@ pub(super) fn transform_props_destructuring(
     read_only_props: &[(String, String)],
     dev: bool,
 ) -> Option<String> {
+    // Canonicalise spacing in the `$props()` call (`= $props ()` → `= $props()`)
+    // so the byte matchers below recognise whitespace variants. The AST detector
+    // that gates this helper already confirmed it is a `$props()` rune call.
+    let line = crate::compiler::phases::phase3_transform::utils::canonicalize_props_call(line);
     let trimmed = line.trim();
 
     // Determine the original declaration keyword (let or const) to preserve it

--- a/src/compiler/phases/3_transform/client/state.rs
+++ b/src/compiler/phases/3_transform/client/state.rs
@@ -265,7 +265,11 @@ fn collect_read_only_props(script_content: &str) -> Vec<String> {
     let mut props = Vec::new();
 
     for line in script_content.lines() {
-        let trimmed = line.trim();
+        // Canonicalise spacing in the `$props()` call so `let { x } = $props ()`
+        // is recognised the same as `= $props()`.
+        let trimmed =
+            crate::compiler::phases::phase3_transform::utils::canonicalize_props_call(line.trim());
+        let trimmed = trimmed.as_ref();
 
         // Match patterns like: let { prop1, prop2 } = $props()
         if memmem::find(trimmed.as_bytes(), b"$props()").is_some()

--- a/src/compiler/phases/3_transform/server/build.rs
+++ b/src/compiler/phases/3_transform/server/build.rs
@@ -935,6 +935,15 @@ impl<'a> ServerCodeGenerator<'a> {
             } else {
                 raw_script
             };
+            // Canonicalise `$props ()` → `$props()` so every downstream byte
+            // matcher (props detection here, destructure lowering in helpers.rs,
+            // `$props()` → `$$props` in transform_script) recognises the call
+            // regardless of user spacing.
+            let raw_script =
+                crate::compiler::phases::phase3_transform::utils::canonicalize_props_call(
+                    &raw_script,
+                )
+                .into_owned();
             let raw_script = remove_effect_blocks(&raw_script, self.use_async, self.dev);
             let has_bindable_props = self.analysis.is_some_and(|a| {
                 a.root.bindings.iter().any(|b| {

--- a/src/compiler/phases/3_transform/utils.rs
+++ b/src/compiler/phases/3_transform/utils.rs
@@ -1054,9 +1054,49 @@ pub fn determine_namespace_for_children(node: &RegularElement, _namespace: &str)
     }
 }
 
+/// Canonicalises a `$props()` rune assignment written with non-standard
+/// whitespace — `= $props ()`, `=$props()`, `= $props( )` — to the exact
+/// `= $props()` form expected by the text-level props matchers in both the
+/// client and server transforms.
+///
+/// The AST-level `$props()` detector accepts any spacing, so without this
+/// normalisation a spaced `$props ()` call is detected but never lowered and
+/// survives into the generated output as a reference to the undefined global
+/// `$props`. `$props` is a compiler rune (not a user value when unshadowed),
+/// so collapsing the call whitespace is always semantics-preserving.
+pub(crate) fn canonicalize_props_call(s: &str) -> Cow<'_, str> {
+    static REGEX_PROPS_ASSIGN: std::sync::LazyLock<regex::Regex> =
+        std::sync::LazyLock::new(|| regex::Regex::new(r"=\s*\$props\s*\(\s*\)").unwrap());
+    // `$$` is the regex-crate escape for a literal `$` in the replacement
+    // string (a bare `$props` would be read as a capture-group reference).
+    REGEX_PROPS_ASSIGN.replace_all(s, "= $$props()")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonicalize_props_call_collapses_whitespace() {
+        assert_eq!(
+            canonicalize_props_call("let p = $props ()"),
+            "let p = $props()"
+        );
+        assert_eq!(
+            canonicalize_props_call("let p =$props()"),
+            "let p = $props()"
+        );
+        assert_eq!(
+            canonicalize_props_call("let { x } = $props( )"),
+            "let { x } = $props()"
+        );
+        // Unrelated `=` and defaults are untouched.
+        assert_eq!(
+            canonicalize_props_call("let { x = 1 } = $props()"),
+            "let { x = 1 } = $props()"
+        );
+        assert_eq!(canonicalize_props_call("let y = 5"), "let y = 5");
+    }
 
     #[test]
     fn test_clean_nodes_empty() {

--- a/tests/props_call_extra_space.rs
+++ b/tests/props_call_extra_space.rs
@@ -1,0 +1,96 @@
+//! Regression tests for `$props()` written with non-standard whitespace
+//! (correctness review C-008).
+//!
+//! Bug: the AST-level `$props()` detector accepts any spacing, but the
+//! text-level lowering only matched the exact bytes `= $props()` /
+//! `$props()`. A spaced `$props ()` call was therefore detected but never
+//! lowered, so the raw `$props ()` survived into the generated client/SSR
+//! output as a reference to the undefined global `$props`.
+//!
+//! Fix: `canonicalize_props_call` normalises `= $props ()` → `= $props()`
+//! before the text matchers run, in both the client and server transforms.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn compile_code(src: &str, mode: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: mode,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile must not panic")
+    .js
+    .code
+}
+
+/// The spaced form must produce exactly the same output as the no-space form.
+fn assert_spacing_equivalent(no_space: &str, spaced: &str, mode: GenerateMode) {
+    let expected = compile_code(no_space, mode);
+    let actual = compile_code(spaced, mode);
+    assert_eq!(
+        actual, expected,
+        "spaced `$props ()` should compile identically to `$props()` ({mode:?})\n\
+         --- spaced ---\n{actual}\n--- no-space ---\n{expected}"
+    );
+    // The raw rune name must never survive into output.
+    assert!(
+        !actual.contains("$props ("),
+        "raw `$props (` leaked into output ({mode:?}):\n{actual}"
+    );
+    assert!(
+        !actual.contains("= $props()") && !actual.contains("$props()"),
+        "raw `$props()` call should be lowered away ({mode:?}):\n{actual}"
+    );
+}
+
+const DESTRUCTURE_NO_SPACE: &str = r#"<script>
+    let { x } = $props();
+</script>
+<p>{x}</p>"#;
+
+const DESTRUCTURE_SPACED: &str = r#"<script>
+    let { x } = $props ();
+</script>
+<p>{x}</p>"#;
+
+const IDENTIFIER_NO_SPACE: &str = r#"<script>
+    let props = $props();
+</script>
+<p>{props.x}</p>"#;
+
+const IDENTIFIER_SPACED: &str = r#"<script>
+    let props = $props ();
+</script>
+<p>{props.x}</p>"#;
+
+#[test]
+fn destructure_props_extra_space_client() {
+    assert_spacing_equivalent(
+        DESTRUCTURE_NO_SPACE,
+        DESTRUCTURE_SPACED,
+        GenerateMode::Client,
+    );
+}
+
+#[test]
+fn destructure_props_extra_space_server() {
+    assert_spacing_equivalent(
+        DESTRUCTURE_NO_SPACE,
+        DESTRUCTURE_SPACED,
+        GenerateMode::Server,
+    );
+}
+
+#[test]
+fn identifier_props_extra_space_client() {
+    assert_spacing_equivalent(IDENTIFIER_NO_SPACE, IDENTIFIER_SPACED, GenerateMode::Client);
+}
+
+#[test]
+fn identifier_props_extra_space_server() {
+    assert_spacing_equivalent(IDENTIFIER_NO_SPACE, IDENTIFIER_SPACED, GenerateMode::Server);
+}


### PR DESCRIPTION
## Summary
Fixes the `$props()` whitespace bug described in #438 (correctness review #431, finding C-008).

The AST-level `$props()` detector (`ast_state_transform.rs`) accepts any spacing, but the text-level lowering only matched the exact bytes `= $props()` / `$props()`. A spaced `$props ()` call was detected but never lowered, so the raw `$props ()` survived into the generated client/SSR output as a reference to the undefined global `$props`.

## Fix
New shared `canonicalize_props_call` helper (`3_transform/utils.rs`) normalises `= $props ()` / `=$props()` / `= $props( )` → canonical `= $props()` before the byte matchers run. All matchers route through it:
- Client: `transform_props_destructuring` (identifier + destructure forms) and `collect_read_only_props`.
- Server: `raw_script` in `build.rs` — covering props detection, the destructure lowering in `helpers.rs`, and the `$props()` → `$$props` rewrite in `transform_script.rs`.

`$props` is a compiler rune (not a user value when unshadowed), so collapsing the call whitespace is semantics-preserving. Defaults and unrelated `=` are untouched (the regex only matches `=\s*\$props\s*\(\s*\)`).

## Acceptance
- [x] `props-call-extra-space` regression test (identifier + destructure forms) verifies the generated client **and** SSR output for the spaced form is byte-identical to the no-space form.
- [x] Normalised the `= $props()` / `$props()` text matchers via the shared canonicaliser rather than leaving exact-byte matches.

## Test plan
- [x] New `tests/props_call_extra_space.rs` — 4 tests (identifier/destructure × client/server), each asserting spaced ≡ no-space and that no raw `$props (` / `$props()` survives.
- [x] Unit test for `canonicalize_props_call` (collapses whitespace, leaves defaults/unrelated `=` alone).
- [x] `cargo test --test compatibility_report --test ssr --test runtime` — passed (full compatibility matrix unchanged).

Closes #438