### PR TITLE
fix(transform): read prop-backed store source via getter in store mutate (C-014)

### DIFF
--- a/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
+++ b/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
@@ -49,6 +49,22 @@ const MAX_FIXED_POINT_ITERS: usize = 16;
 /// the bindings in `store_subs`. Returns `None` when there's
 /// nothing to rewrite or the source fails to parse.
 pub fn transform_store_member_mutate_ast(source: &str, store_subs: &[String]) -> Option<String> {
+    transform_store_member_mutate_ast_with_props(source, store_subs, &[])
+}
+
+/// Like [`transform_store_member_mutate_ast`], but `prop_store_names` lists the
+/// underlying store source names (without the `$` prefix) that are bound to a
+/// **prop**. For those, the first `$.store_mutate(...)` argument is the prop
+/// getter call (`store()`) rather than the bare name, matching the official
+/// compiler's `get_store()` (= `context.visit(b.id(name.slice(1)))`): reading a
+/// prop binding yields a getter call, so the store source must be read the same
+/// way. Without this a `$prop.x = …` mutation passed the subscription view
+/// instead of the prop's current value.
+pub fn transform_store_member_mutate_ast_with_props(
+    source: &str,
+    store_subs: &[String],
+    prop_store_names: &[String],
+) -> Option<String> {
     if store_subs.is_empty() {
         return None;
     }
@@ -62,7 +78,7 @@ pub fn transform_store_member_mutate_ast(source: &str, store_subs: &[String]) ->
     let mut current = source.to_string();
     let mut any_changed = false;
     for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, store_subs) {
+        match single_pass(&current, store_subs, prop_store_names) {
             Some(next) => {
                 current = next;
                 any_changed = true;
@@ -74,7 +90,7 @@ pub fn transform_store_member_mutate_ast(source: &str, store_subs: &[String]) ->
     if any_changed { Some(current) } else { None }
 }
 
-fn single_pass(source: &str, store_subs: &[String]) -> Option<String> {
+fn single_pass(source: &str, store_subs: &[String], prop_store_names: &[String]) -> Option<String> {
     MODULE_STORE_MEMBER_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
@@ -86,6 +102,7 @@ fn single_pass(source: &str, store_subs: &[String]) -> Option<String> {
         let mut collector = MemberMutateCollector {
             source,
             store_subs,
+            prop_store_names,
             replacements: Vec::new(),
         };
         collector.visit_program(&parser_ret.program);
@@ -125,6 +142,7 @@ fn single_pass(source: &str, store_subs: &[String]) -> Option<String> {
 struct MemberMutateCollector<'a> {
     source: &'a str,
     store_subs: &'a [String],
+    prop_store_names: &'a [String],
     replacements: Vec<(u32, u32, String)>,
 }
 
@@ -171,6 +189,14 @@ impl<'a> MemberMutateCollector<'a> {
         }
         let store_sub = root_name;
         let store_name = &root_name[1..];
+        // The store source is read like any other reference to its binding.
+        // For a prop binding that means the getter call `store()`; for plain /
+        // state / reactive-import stores the bare name is correct.
+        let store_access = if self.prop_store_names.iter().any(|n| n == store_name) {
+            format!("{}()", store_name)
+        } else {
+            store_name.to_string()
+        };
 
         let outer_text = &self.source[outer_span.start as usize..outer_span.end as usize];
         let rs = (root_span.start - outer_span.start) as usize;
@@ -185,7 +211,7 @@ impl<'a> MemberMutateCollector<'a> {
 
         let rewrite = format!(
             "$.store_mutate({}, {}, $.untrack({}))",
-            store_name, wrapped, store_sub
+            store_access, wrapped, store_sub
         );
         self.replacements
             .push((outer_span.start, outer_span.end, rewrite));
@@ -231,6 +257,22 @@ mod tests {
         assert_eq!(
             out,
             "$.store_mutate(store, ++$.untrack($store).prop, $.untrack($store));"
+        );
+    }
+
+    #[test]
+    fn prop_backed_store_uses_getter_for_source() {
+        // When the store source is a prop, the first `$.store_mutate(...)`
+        // argument is the prop getter call `store()`, not the bare name.
+        let out = transform_store_member_mutate_ast_with_props(
+            "$store.prop = 5;",
+            &ssv(&["$store"]),
+            &ssv(&["store"]),
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "$.store_mutate(store(), $.untrack($store).prop = 5, $.untrack($store));"
         );
     }
 

--- a/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
+++ b/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
@@ -48,18 +48,15 @@ const MAX_FIXED_POINT_ITERS: usize = 16;
 /// AST-based rewrite of `$store.prop = x` / `$store[i]++` etc. for
 /// the bindings in `store_subs`. Returns `None` when there's
 /// nothing to rewrite or the source fails to parse.
-pub fn transform_store_member_mutate_ast(source: &str, store_subs: &[String]) -> Option<String> {
-    transform_store_member_mutate_ast_with_props(source, store_subs, &[])
-}
-
-/// Like [`transform_store_member_mutate_ast`], but `prop_store_names` lists the
-/// underlying store source names (without the `$` prefix) that are bound to a
-/// **prop**. For those, the first `$.store_mutate(...)` argument is the prop
-/// getter call (`store()`) rather than the bare name, matching the official
-/// compiler's `get_store()` (= `context.visit(b.id(name.slice(1)))`): reading a
-/// prop binding yields a getter call, so the store source must be read the same
-/// way. Without this a `$prop.x = …` mutation passed the subscription view
-/// instead of the prop's current value.
+///
+/// `prop_store_names` lists the underlying store source names (without the
+/// `$` prefix) that are bound to a **prop**. For those, the first
+/// `$.store_mutate(...)` argument is the prop getter call (`store()`) rather
+/// than the bare name, matching the official compiler's `get_store()` (=
+/// `context.visit(b.id(name.slice(1)))`): reading a prop binding yields a
+/// getter call, so the store source must be read the same way. Without this
+/// a `$prop.x = …` mutation passed the subscription view instead of the
+/// prop's current value. Pass `&[]` for the non-prop case.
 pub fn transform_store_member_mutate_ast_with_props(
     source: &str,
     store_subs: &[String],
@@ -240,6 +237,11 @@ mod tests {
 
     fn ssv(names: &[&str]) -> Vec<String> {
         names.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Test helper: the non-prop case (no prop-backed store sources).
+    fn transform_store_member_mutate_ast(source: &str, store_subs: &[String]) -> Option<String> {
+        transform_store_member_mutate_ast_with_props(source, store_subs, &[])
     }
 
     #[test]

--- a/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -66,7 +66,7 @@ pub(super) fn transform_store_assignments_client(
     // name (other binding kinds keep the bare name).
     for store_sub in store_sub_vars {
         let store_name = store_sub[1..].to_string();
-        let prop_store_names: Vec<String> = if prop_vars.iter().any(|p| *p == store_name) {
+        let prop_store_names: Vec<String> = if prop_vars.contains(&store_name) {
             vec![store_name]
         } else {
             Vec::new()

--- a/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -58,15 +58,20 @@ pub(super) fn transform_store_assignments_client(
     );
     let mut result = after_assigns.unwrap_or_else(|| stage1.to_string());
 
-    // Member-expression mutations (`$store.prop = …`, `$store[0]++`,
-    // etc.) are still handled per-store via the dedicated AST helper
-    // — the prefix-form `$.store_mutate(store, $.untrack($store)…)`
-    // is the same shape regardless of how the underlying store is
-    // bound (regular / prop / state-var), so no caller-side
-    // store_access plumbing is needed.
+    // Member-expression mutations (`$store.prop = …`, `$store[0]++`, etc.)
+    // are handled per-store via the dedicated AST helper. The first
+    // `$.store_mutate(...)` argument is the store *source* read the same way
+    // any reference to its binding would be: a prop binding reads as the getter
+    // call `store()`, so prop-backed stores need that form rather than the bare
+    // name (other binding kinds keep the bare name).
     for store_sub in store_sub_vars {
-        let store_name = &store_sub[1..];
-        result = transform_store_member_mutations(&result, store_sub, store_name);
+        let store_name = store_sub[1..].to_string();
+        let prop_store_names: Vec<String> = if prop_vars.iter().any(|p| *p == store_name) {
+            vec![store_name]
+        } else {
+            Vec::new()
+        };
+        result = transform_store_member_mutations(&result, store_sub, &prop_store_names);
     }
 
     result
@@ -492,11 +497,12 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
 pub(super) fn transform_store_member_mutations(
     line: &str,
     store_sub: &str,
-    _store_name: &str,
+    prop_store_names: &[String],
 ) -> String {
-    super::store_member_mutate_ast::transform_store_member_mutate_ast(
+    super::store_member_mutate_ast::transform_store_member_mutate_ast_with_props(
         line,
         std::slice::from_ref(&store_sub.to_string()),
+        prop_store_names,
     )
     .unwrap_or_else(|| line.to_string())
 }

--- a/tests/store_member_mutate_binding_kind.rs
+++ b/tests/store_member_mutate_binding_kind.rs
@@ -1,0 +1,64 @@
+//! Regression tests for legacy store member mutations across binding kinds
+//! (correctness review C-014).
+//!
+//! Bug: `$store.x = …` rewrote the subscription identifier but always passed
+//! the bare store name as the first `$.store_mutate(...)` argument. For a store
+//! sourced from a **prop**, the official compiler reads the source via the prop
+//! getter (`store()`), so the bare name passed a stale / wrong reference.
+//!
+//! Fix: the store source is now read like any other reference to its binding —
+//! `store()` for a prop, the bare name for plain / `$state` / reactive-import
+//! stores — matching `get_store()` in the official compiler.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn plain_store_member_mutate_uses_bare_name() {
+    let src = "<script>\nimport { writable } from 'svelte/store';\nconst obj = writable({ a: 1 });\nfunction f() { $obj.a = 2; }\n</script>";
+    let out = client(src);
+    assert!(
+        out.contains("$.store_mutate(obj, $.untrack($obj).a = 2, $.untrack($obj))"),
+        "plain store should mutate via the bare name:\n{out}"
+    );
+}
+
+#[test]
+fn prop_store_member_mutate_uses_getter() {
+    // The store source is a prop, so its current value is read via the getter
+    // `obj()` — matching the official compiler's `$.store_mutate(obj(), …)`.
+    let src = "<script>\nexport let obj;\nfunction f() { $obj.a = 2; }\n</script>";
+    let out = client(src);
+    assert!(
+        out.contains("$.store_mutate(obj(), $.untrack($obj).a = 2, $.untrack($obj))"),
+        "prop store should mutate via the getter `obj()`:\n{out}"
+    );
+    assert!(
+        !out.contains("$.store_mutate(obj, "),
+        "prop store must not pass the bare name:\n{out}"
+    );
+}
+
+#[test]
+fn state_store_member_mutate_uses_bare_name() {
+    let src = "<script>\nimport { writable } from 'svelte/store';\nlet obj = $state(writable({ a: 1 }));\nfunction f() { $obj.a = 2; }\n</script>";
+    let out = client(src);
+    assert!(
+        out.contains("$.store_mutate(obj, $.untrack($obj).a = 2, $.untrack($obj))"),
+        "state-held store should mutate via the bare name:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes the store member-mutation bug described in #440 (correctness review #431, finding C-014).

Legacy store member mutations (`$store.x = …`) always passed the **bare** store name as the first `$.store_mutate(...)` argument, regardless of binding kind. I compared rsvelte vs the official compiler across binding kinds; the divergence is the **prop** case:

| Store source | rsvelte (before) | official compiler |
|---|---|---|
| plain (`const s = writable(…)`) | `$.store_mutate(obj, …)` ✓ | `$.store_mutate(obj, …)` |
| **prop** (`export let obj`) | `$.store_mutate(obj, …)` ❌ | `$.store_mutate(obj(), …)` |
| `$state(writable(…))` | `$.store_mutate(obj, …)` ✓ | `$.store_mutate(obj, …)` |
| reactive import | `$.store_mutate(obj, …)` ✓ | `$.store_mutate(obj, …)` |

## Fix
The store source is read like any other reference to its binding — `store()` for a prop (the `$.prop` getter call), the bare name for plain / `$state` / reactive-import stores — matching the official compiler's `get_store()` (`context.visit(b.id(name.slice(1)))`). The text-transform layer already knows the prop names (`prop_vars`); a new `transform_store_member_mutate_ast_with_props` threads them to the rewrite, and the prop-backed source emits `store()`.

Verified byte-identical to the official compiler for the plain / prop / state cases.

## Acceptance
- [x] Prop-backed store member mutation now reads the source via the getter and matches the official compiler; plain / state remain bare and unchanged.

> Note: the issue suggested adding fixtures `store-member-mutate-{prop,state,reactive-import}`. Parser/compiler fixtures are generated from the upstream Svelte test suite (each needs an `output.json` from the real compiler), so these regressions live as Rust tests instead.

## Test plan
- [x] New `tests/store_member_mutate_binding_kind.rs` — plain/prop/state assert the exact `$.store_mutate(...)` source argument.
- [x] New unit test `prop_backed_store_uses_getter_for_source` in `store_member_mutate_ast.rs`.
- [x] `cargo test --test compatibility_report --test runtime` — passed (full compatibility matrix unchanged).

Closes #440