### PR TITLE
fix(parse): JS-lexical-aware directive / each-header / each-key scanning (H-001, H-018, H-019)

### DIFF
--- a/src/compiler/phases/1_parse/parser.rs
+++ b/src/compiler/phases/1_parse/parser.rs
@@ -853,9 +853,10 @@ impl<'a> Parser<'a> {
     /// Returns the position of the closing `}` (or EOF if unbalanced).
     /// Does NOT advance past the closing brace - caller must do that.
     ///
-    /// Uses the JS-lexical-aware [`find_matching_bracket`] so that braces inside
-    /// strings, template literals, comments, and regex literals in a directive /
-    /// attribute expression are not miscounted (e.g. `on:click={() => x("}")}`).
+    /// Uses the JS-lexical-aware `utils::find_matching_bracket` so that braces
+    /// inside strings, template literals, comments, and regex literals in a
+    /// directive / attribute expression are not miscounted (e.g.
+    /// `on:click={() => x("}")}`).
     #[inline]
     pub fn scan_to_closing_brace(&mut self) -> usize {
         self.index = crate::compiler::phases::phase1_parse::utils::find_matching_bracket(

--- a/src/compiler/phases/1_parse/parser.rs
+++ b/src/compiler/phases/1_parse/parser.rs
@@ -849,29 +849,21 @@ impl<'a> Parser<'a> {
         self.skip_whitespace();
     }
 
-    /// Scan forward from the current position to find the matching closing brace,
-    /// tracking nested brace depth. Returns the position of the closing `}`.
-    /// Uses byte-level scanning for maximum speed.
+    /// Scan forward from the current position to find the matching closing brace.
+    /// Returns the position of the closing `}` (or EOF if unbalanced).
     /// Does NOT advance past the closing brace - caller must do that.
+    ///
+    /// Uses the JS-lexical-aware [`find_matching_bracket`] so that braces inside
+    /// strings, template literals, comments, and regex literals in a directive /
+    /// attribute expression are not miscounted (e.g. `on:click={() => x("}")}`).
     #[inline]
     pub fn scan_to_closing_brace(&mut self) -> usize {
-        let mut depth: u32 = 1;
-        while self.index < self.bytes.len() && depth > 0 {
-            match self.bytes[self.index] {
-                b'{' => {
-                    depth += 1;
-                    self.index += 1;
-                }
-                b'}' => {
-                    depth -= 1;
-                    if depth > 0 {
-                        self.index += 1;
-                    }
-                }
-                b if b < 0x80 => self.index += 1,
-                _ => self.advance(),
-            }
-        }
+        self.index = crate::compiler::phases::phase1_parse::utils::find_matching_bracket(
+            self.source,
+            self.index,
+            '{',
+        )
+        .unwrap_or(self.bytes.len());
         self.index
     }
 }

--- a/src/compiler/phases/1_parse/state/tag.rs
+++ b/src/compiler/phases/1_parse/state/tag.rs
@@ -265,6 +265,38 @@ impl Parser<'_> {
         }
     }
 
+    /// Skip a string or template literal whose opening quote byte (`'`, `"`, or
+    /// `` ` ``) is at `self.index`. Advances `self.index` past the closing quote.
+    /// Handles backslash escapes and, for template literals, balanced `${ … }`
+    /// interpolations so their braces aren't miscounted by header scanners.
+    fn skip_header_string(&mut self, quote: u8) {
+        self.index += 1; // consume the opening quote
+        while self.index < self.bytes.len() {
+            let c = self.bytes[self.index];
+            if c == b'\\' {
+                self.index += 2;
+                continue;
+            }
+            if quote == b'`' && c == b'$' && self.bytes.get(self.index + 1) == Some(&b'{') {
+                self.index += 2;
+                let mut brace_depth = 1u32;
+                while self.index < self.bytes.len() && brace_depth > 0 {
+                    match self.bytes[self.index] {
+                        b'{' => brace_depth += 1,
+                        b'}' => brace_depth -= 1,
+                        _ => {}
+                    }
+                    self.index += 1;
+                }
+                continue;
+            }
+            self.index += 1;
+            if c == quote {
+                break;
+            }
+        }
+    }
+
     /// Parse {#each} block.
     /// Syntax: {#each expression as context}...{:else}...{/each}
     /// Or: {#each expression as context, index}...{/each}
@@ -287,6 +319,33 @@ impl Parser<'_> {
         let mut depth: i32 = 0;
         while self.index < self.bytes.len() {
             let b = self.bytes[self.index];
+
+            // Skip string / template literals and comments so a ` as `, brace,
+            // or bracket inside them isn't treated as structure (H-018). e.g.
+            // `{#each " as ".split(x) as item}` must split at the second ` as `.
+            match b {
+                b'\'' | b'"' | b'`' => {
+                    self.skip_header_string(b);
+                    continue;
+                }
+                b'/' if self.bytes.get(self.index + 1) == Some(&b'/') => {
+                    while self.index < self.bytes.len() && self.bytes[self.index] != b'\n' {
+                        self.index += 1;
+                    }
+                    continue;
+                }
+                b'/' if self.bytes.get(self.index + 1) == Some(&b'*') => {
+                    self.index += 2;
+                    while self.index + 1 < self.bytes.len()
+                        && !(self.bytes[self.index] == b'*' && self.bytes[self.index + 1] == b'/')
+                    {
+                        self.index += 1;
+                    }
+                    self.index = (self.index + 2).min(self.bytes.len());
+                    continue;
+                }
+                _ => {}
+            }
 
             // Track brace depth
             match b {
@@ -602,18 +661,11 @@ impl Parser<'_> {
         if self.eat_optional("(") {
             self.skip_whitespace();
             let key_start = self.index;
-            let mut key_depth = 1;
-            while !self.is_eof() && key_depth > 0 {
-                let c = self.current_char();
-                if c == '(' {
-                    key_depth += 1;
-                } else if c == ')' {
-                    key_depth -= 1;
-                }
-                if key_depth > 0 {
-                    self.advance();
-                }
-            }
+            // Find the matching ')' with JS-lexical awareness so a `)` inside a
+            // string / comment / regex in the key expression (e.g.
+            // `{#each items as item (item.name + ")")}`) doesn't close it early.
+            self.index =
+                find_matching_bracket(self.source, key_start, '(').unwrap_or(self.bytes.len());
             let key_content = self.source[key_start..self.index].trim();
             // Use opening_token = '(' for key expressions (corresponds to Svelte's read_expression(parser, '('))
             key = Some(self.parse_js_expression_internal(key_content, key_start, false, '('));

--- a/tests/parser_scanner_lexical.rs
+++ b/tests/parser_scanner_lexical.rs
@@ -1,0 +1,66 @@
+//! JS-lexical-aware scanning in the parser (issue #445, H-001/H-018/H-019):
+//! directive expressions, the `{#each}` ` as ` split, and the `{#each}` key
+//! expression must ignore braces / parens / ` as ` that appear inside string
+//! literals, template literals, and comments.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> Result<String, String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .map_err(|e| format!("{e:?}"))
+}
+
+/// H-001: a `}` inside a string in a directive expression must not terminate
+/// the directive early (`scan_to_closing_brace` is now JS-lexical-aware).
+#[test]
+fn on_directive_brace_in_string_literal() {
+    let out = client(r#"<button on:click={() => go("}")}>x</button>"#);
+    assert!(out.is_ok(), "{out:?}");
+    assert!(
+        out.unwrap().contains(r#"go("}")"#),
+        "handler truncated at brace"
+    );
+}
+
+/// H-001: same for the shorthand `onclick={...}` attribute path.
+#[test]
+fn onclick_attr_brace_in_string_literal() {
+    let out = client(r#"<button onclick={() => go("}")}>x</button>"#);
+    assert!(out.is_ok(), "{out:?}");
+    assert!(
+        out.unwrap().contains(r#"go("}")"#),
+        "handler truncated at brace"
+    );
+}
+
+/// H-018: a ` as ` inside a comment after the real alias separator must not be
+/// mistaken for the separator (the header scan now skips strings/comments).
+#[test]
+fn each_as_split_ignores_comment() {
+    let out = client(r#"{#each items as item /* x as y */}{item}{/each}"#);
+    assert!(
+        out.is_ok(),
+        "each header mis-split on comment ` as `: {out:?}"
+    );
+    assert!(out.unwrap().contains("item"), "each alias lost");
+}
+
+/// H-019: a `)` inside a string in the `{#each}` key expression must not close
+/// the key early (the key scan now uses the JS-aware bracket matcher).
+#[test]
+fn each_key_paren_in_string_literal() {
+    let out = client(r#"{#each items as item (item.name + ")")}{item}{/each}"#);
+    assert!(
+        out.is_ok(),
+        "each key truncated at `)` inside string: {out:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses the three JS-lexical-aware scanning findings from issue #445 — the ones the issue's "Suggested fix" frames as "replace … expression scan with the existing JS-aware `find_matching_bracket`":

- **H-001** — `Parser::scan_to_closing_brace` (used by all 15 directive / attribute expression readers in `state/element.rs`) counted raw `{`/`}` bytes and truncated at a brace inside a string, template literal, comment, or regex. It now delegates to `find_matching_bracket`, so `on:click={() => go("}")}` and `onclick={() => go("}")}` keep the `}` inside the string.
- **H-018** — the `{#each}` ` as ` header scan now skips string / template literals and `//` / `/*` comments (new `skip_header_string` helper), so an ` as ` inside them is never mistaken for the alias separator.
- **H-019** — the `{#each}` key-expression scan now uses `find_matching_bracket('(')` instead of raw paren-depth counting, so a `)` inside a string in the key (`(item.name + ")")`) no longer closes it early.

### Deferred (separate follow-ups on #445)

- **H-002** — propagating swallowed block/directive parse errors (changes acceptance + adds diagnostics broadly).
- **H-003** — JS-mode `parse_expression` falling back to TS.
- **H-016** — whole-source TS-mode detection flipping `self.ts` globally.
- **H-017** — unknown-block diagnostic + `{@attach}` lowering (feature work).

These change parser acceptance/diagnostic behavior or add a feature, so they need their own focused evaluation against the fixture suite rather than being bundled with the low-risk scanning fixes.

## Test plan

- [x] New `tests/parser_scanner_lexical.rs` — 4 tests (on:directive brace-in-string, onclick brace-in-string, each ` as ` ignores comment, each key paren-in-string)
- [x] `cargo test` — parser, snapshot, ssr, runtime, css, validator, print, svelte2tsx, compiler_errors, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)