### PR TITLE
fix(render): unify {@render} $N placeholder counter (H-099)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/render_tag.rs
+++ b/src/compiler/phases/3_transform/client/visitors/render_tag.rs
@@ -61,6 +61,13 @@ pub fn render_tag(node: &RenderTag, context: &mut ComponentContext) -> JsStateme
     let mut any_has_await = false;
 
     let mut derived_decls: Vec<JsStatement> = Vec::new();
+    // Async placeholders (callback params `$0`, `$1`, …) and memoised-call
+    // placeholders (`let $0 = $.derived(…)`) share one `$N` namespace inside the
+    // generated render block, so they must draw from a SINGLE counter. Two
+    // independent counters (one per kind) would both start at 0 and emit a
+    // duplicate `$0` when a render tag has both an awaited arg and a call arg —
+    // the `let $0` would shadow the async callback param `$0` (H-099).
+    let mut placeholder_index: usize = 0;
     let args: Vec<JsExpr> = raw_args
         .iter()
         .enumerate()
@@ -78,8 +85,9 @@ pub fn render_tag(node: &RenderTag, context: &mut ComponentContext) -> JsStateme
 
             if arg_has_await {
                 any_has_await = true;
-                // Generate async value id like $0, $1, etc.
-                let id_name = format!("${}", async_values.len());
+                // Generate async value id like $0, $1, etc. (shared counter)
+                let id_name = format!("${}", placeholder_index);
+                placeholder_index += 1;
                 // Strip the top-level await since $.async handles the awaiting
                 let stripped = b::strip_await(&context.arena, built);
                 // If the stripped expression still contains awaits, use async thunk
@@ -103,10 +111,11 @@ pub fn render_tag(node: &RenderTag, context: &mut ComponentContext) -> JsStateme
                 // If the argument expression has a call, we need to memoize it with $.derived()
                 let has_call_from_expr = render_tag_has_call(arg);
                 if template_metadata.has_call() || has_call_from_expr {
-                    // Use literal `$0`, `$1`, etc. as the identifier. Each derived
-                    // decl is wrapped in its own block scope, so these names do not
-                    // need to be globally unique across render tags.
-                    let id_name = format!("${}", derived_decls.len());
+                    // Draw from the same `$N` counter as async placeholders so a
+                    // memoised-call arg never collides with an async callback
+                    // param in the same render block (H-099).
+                    let id_name = format!("${}", placeholder_index);
+                    placeholder_index += 1;
                     derived_decls.push(b::let_decl(
                         &context.arena,
                         &id_name,

--- a/tests/render_tag_placeholder_counter.rs
+++ b/tests/render_tag_placeholder_counter.rs
@@ -1,0 +1,39 @@
+//! Issue #446 H-099: a `{@render}` tag with both an awaited argument and a
+//! memoised-call argument must not emit two `$0` placeholders. The async
+//! placeholder (a callback param) and the memoised-call placeholder
+//! (`let $N = $.derived(...)`) share one `$N` namespace, so they must draw from
+//! a single counter — otherwise the `let $0` shadows the async param `$0`.
+
+use svelte_compiler_rust::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+
+fn client_async(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            experimental: ExperimentalOptions { r#async: true },
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn render_tag_async_and_call_args_use_distinct_placeholders() {
+    let src = "<script>\nlet foo;\nfunction bar() { return 1; }\nasync function x() { return 2; }\n</script>\n{@render foo(await x(), bar())}";
+    let out = client_async(src);
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    // async arg -> callback param `$0`; memoised-call arg -> `let $1 = $.derived`.
+    assert!(out.contains("$0"), "missing async placeholder: {out}");
+    assert!(
+        out.contains("let $1 = $.derived"),
+        "memoised-call placeholder did not advance past the async `$0`: {out}"
+    );
+    assert!(
+        !out.contains("let $0 = $.derived"),
+        "memoised-call placeholder collided with async `$0`: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the Critical placeholder-collision finding (H-099) from issue #446.

A `{@render}` tag derived async-value placeholder ids from `async_values.len()` and memoised-call placeholder ids from `derived_decls.len()` — two independent counters sharing the same `$0`/`$1`/… namespace within the generated render block. When one render tag had **both** an awaited argument and a call argument, both started at `0`:

```js
$.async($$anchor, void 0, [x], ($$anchor, $0) => {
  let $0 = $.derived(bar);          // ← shadows the async param `$0`
  foo($$anchor, () => $.get($0), () => $.get($0));  // both read the derived
});
```

Both placeholder kinds now draw from a single `placeholder_index`, so the memoised call gets `$1`:

```js
$.async($$anchor, void 0, [x], ($$anchor, $0) => {
  let $1 = $.derived(bar);
  foo($$anchor, () => $.get($0), () => $.get($1));
});
```

### Deferred (separate follow-up on #446)

The destructured snippet-parameter defects **H-100..H-103** (object-pattern alias binding, per-element & whole-parameter defaults, object-rest exclusion, array assignment/rest/nested patterns) are **not** in this PR. Upstream lowers these uniformly via `extract_paths`; rsvelte's client snippet visitor works on the `serde_json` AST while the existing `extract_paths_walk` lives in the server transform on a different representation. Doing it right needs a JSON-AST `extract_paths` port shared with the destructuring infrastructure, which is too large to land safely alongside this isolated counter fix. Tracking on #446.

## Test plan

- [x] New `tests/render_tag_placeholder_counter.rs` — asserts the async param `$0` and memoised-call `let $1 = $.derived` are distinct (no `let $0 = $.derived`)
- [x] `cargo test` — snapshot, ssr, runtime, validator, svelte2tsx all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)