### PR TITLE
fix(ssr): normalise component CSS custom-prop values like ordinary attrs (H-108)

### DIFF
--- a/src/compiler/phases/3_transform/server/visitors/component.rs
+++ b/src/compiler/phases/3_transform/server/visitors/component.rs
@@ -64,12 +64,18 @@ impl<'a> ServerCodeGenerator<'a> {
                     let name = node.name.as_str();
                     // CSS custom properties (e.g., --color="red") are handled separately
                     if name.starts_with("--") {
+                        // CSS custom-prop values must be normalised exactly like
+                        // ordinary component attribute values (H-108): store refs
+                        // routed through `transform_store_refs`, and static text
+                        // JS-escaped via `escape_js_string`.
                         let value = match &node.value {
                             AttributeValue::Expression(expr_tag) => {
                                 let expr_start = expr_tag.expression.start().unwrap_or(0) as usize;
                                 let expr_end = expr_tag.expression.end().unwrap_or(0) as usize;
                                 if expr_end > expr_start && expr_end <= self.source.len() {
-                                    self.source[expr_start..expr_end].trim().to_string()
+                                    self.transform_store_refs(
+                                        self.source[expr_start..expr_end].trim(),
+                                    )
                                 } else {
                                     "''".to_string()
                                 }
@@ -94,10 +100,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                             if expr_end > expr_start
                                                 && expr_end <= self.source.len()
                                             {
-                                                value_str.push_str("${$.stringify(");
-                                                value_str.push_str(
+                                                let transformed = self.transform_store_refs(
                                                     self.source[expr_start..expr_end].trim(),
                                                 );
+                                                value_str.push_str("${$.stringify(");
+                                                value_str.push_str(&transformed);
                                                 value_str.push_str(")}");
                                             }
                                         }
@@ -106,7 +113,7 @@ impl<'a> ServerCodeGenerator<'a> {
                                 if has_expression {
                                     format!("`{}`", value_str)
                                 } else {
-                                    format!("'{}'", value_str)
+                                    format!("'{}'", escape_js_string(&value_str))
                                 }
                             }
                             AttributeValue::True(_) => "true".to_string(),

--- a/tests/ssr_component_css_props.rs
+++ b/tests/ssr_component_css_props.rs
@@ -1,0 +1,42 @@
+//! Issue #448 H-108: a component's CSS custom-prop (`--foo=...`) values must be
+//! normalised like ordinary component attributes — store refs routed through
+//! `$.store_get` and static text JS-escaped — rather than emitted from raw
+//! source.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn ssr(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Server,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn css_custom_prop_store_ref_is_transformed() {
+    let src = "<script>\nimport { writable } from 'svelte/store';\nimport Child from './Child.svelte';\nconst theme = writable('red');\n</script>\n<Child --color={$theme} />";
+    let out = ssr(src);
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("'--color': $.store_get("),
+        "store ref in CSS custom prop not transformed: {out}"
+    );
+}
+
+#[test]
+fn css_custom_prop_text_value_is_escaped() {
+    let src = "<script>\nimport Child from './Child.svelte';\n</script>\n<Child --label=\"a'b\" />";
+    let out = ssr(src);
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("'--label': 'a\\'b'"),
+        "single quote in CSS custom prop text value not escaped: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes H-108 from issue #448. A component's CSS custom-prop values (`--foo={...}` / `--foo="..."`) were emitted from raw source, unlike ordinary component attribute values:

- store refs were **not** routed through `transform_store_refs`, so `<Child --color={$theme} />` emitted raw `$theme` instead of `$.store_get($$store_subs ??= {}, '$theme', theme)`;
- static text values were wrapped in `'...'` **without** `escape_js_string`, so `<Child --label="a'b" />` produced the invalid `'--label': 'a'b'`.

The CSS custom-prop branch in `server/visitors/component.rs` now applies `transform_store_refs` to expression values (and template-literal interpolations) and `escape_js_string` to static text, mirroring the ordinary attribute path.

### Deferred (separate follow-ups on #448)

- **H-104..H-106 (Critical)** — `collect_all_props` returns `Vec::new()` for spreads, dropping them when true `{#snippet}` blocks / named-slot-only children / bound components are present. Needs the spread-as-positional-arg reimplementation.
- **H-107** — component CSS custom props only emitted for the simplest call shape / dropped for bound components.
- **H-038** — SSR `bind:group` value extraction emits invalid JS / ignores expression chunks.
- **H-071** — class/style directive name escaping (`quote_prop_name` has the same gap; near-zero real exposure, changing output risks snapshot churn).
- **H-072 / H-073** — `<select>`/`<option>`/`<textarea>` CSS-hash gating and class-composition divergence from the regular-element path.

These need the spread reimplementation or the class-composition unification and are each their own change.

## Test plan

- [x] New `tests/ssr_component_css_props.rs` — store ref transformed to `$.store_get`; text value `'` escaped
- [x] `cargo test` — ssr, runtime, snapshot, validator, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)