### PR TITLE
fix(options): enforce runes={false} / customElement={null} / disclose_version / name (H-114, H-115, H-087, H-088)

### DIFF
--- a/src/compiler/phases/1_parse/read/options.rs
+++ b/src/compiler/phases/1_parse/read/options.rs
@@ -176,7 +176,9 @@ impl Parser<'_> {
                         css = Some(CssOption::Injected);
                     }
                     "customElement" => {
-                        custom_element = Some(parse_custom_element_option(attr_node)?);
+                        // `parse_custom_element_option` returns `None` for
+                        // `customElement={null}` so the pipeline stays off (H-115).
+                        custom_element = parse_custom_element_option(attr_node)?;
                     }
                     _ => {}
                 }
@@ -289,42 +291,38 @@ fn get_boolean_value(attr: &crate::ast::template::AttributeNode) -> ParseResult<
 /// - `customElement={null}` - disable custom element (for backwards compat)
 fn parse_custom_element_option(
     attr: &crate::ast::template::AttributeNode,
-) -> ParseResult<CustomElementOptions> {
+) -> ParseResult<Option<CustomElementOptions>> {
     match &attr.value {
         AttributeValue::Sequence(parts) => {
             // Check if this is a text value
             if let Some(AttributeValuePart::Text(text)) = parts.first() {
                 let tag = text.data.to_string();
                 validate_tag_name(&tag, attr)?;
-                return Ok(CustomElementOptions {
+                return Ok(Some(CustomElementOptions {
                     tag: Some(tag.into()),
                     shadow: None,
                     props: None,
                     extend: None,
-                });
+                }));
             }
 
             // Expression value
             if let Some(AttributeValuePart::ExpressionTag(expr)) = parts.first() {
                 let expr_json = expr.expression.as_json();
 
-                // Check for null value (backwards compat - disable custom element)
+                // Check for null value (backwards compat - disable custom element).
+                // Return None so the custom-element pipeline stays off (H-115); a
+                // `Some(default)` here would (wrongly) enable it.
                 if expr_json.get("type") == Some(&JsonValue::String("Literal".to_string()))
                     && let Some(JsonValue::Null) = expr_json.get("value")
                 {
-                    // customElement={null} - skip
-                    return Ok(CustomElementOptions {
-                        tag: None,
-                        shadow: None,
-                        props: None,
-                        extend: None,
-                    });
+                    return Ok(None);
                 }
 
                 // Object expression: customElement={{tag: "...", ...}}
                 if expr_json.get("type") == Some(&JsonValue::String("ObjectExpression".to_string()))
                 {
-                    return parse_custom_element_object(expr_json, attr);
+                    return parse_custom_element_object(expr_json, attr).map(Some);
                 }
             }
         }
@@ -338,22 +336,17 @@ fn parse_custom_element_option(
         AttributeValue::Expression(expr) => {
             let expr_json = expr.expression.as_json();
 
-            // Check for null value (backwards compat - disable custom element)
+            // Check for null value (backwards compat - disable custom element).
+            // Return None so the pipeline stays off (H-115).
             if expr_json.get("type") == Some(&JsonValue::String("Literal".to_string()))
                 && let Some(JsonValue::Null) = expr_json.get("value")
             {
-                // customElement={null} - skip
-                return Ok(CustomElementOptions {
-                    tag: None,
-                    shadow: None,
-                    props: None,
-                    extend: None,
-                });
+                return Ok(None);
             }
 
             // Object expression: customElement={{tag: "...", ...}}
             if expr_json.get("type") == Some(&JsonValue::String("ObjectExpression".to_string())) {
-                return parse_custom_element_object(expr_json, attr);
+                return parse_custom_element_object(expr_json, attr).map(Some);
             }
         }
     }

--- a/src/compiler/phases/2_analyze/mod.rs
+++ b/src/compiler/phases/2_analyze/mod.rs
@@ -110,6 +110,10 @@ pub fn analyze_component(
     if let Some(ref svelte_options) = ast.options {
         if let Some(runes) = svelte_options.runes {
             analysis.runes = runes;
+            // Record that runes mode was set explicitly so the later
+            // auto-detection passes (extract_scripts / create_scopes) don't
+            // flip an explicit `<svelte:options runes={false} />` back on (H-114).
+            analysis.runes_explicitly_set = Some(runes);
         }
         // Handle <svelte:options accessors />
         if let Some(accessors) = svelte_options.accessors {
@@ -185,10 +189,12 @@ pub fn analyze_component(
     // 1. Auto-detecting runes mode (await or rune references imply runes)
     // 2. Marking the component as needing async function wrapper
     //
-    // When runes mode is already explicitly set (options.runes == Some(true) or
-    // <svelte:options runes />), we only need to detect await expressions, not
-    // rune references. This avoids expensive JSON walks for rune detection.
-    let needs_rune_detection = options.runes.is_none() && !analysis.runes;
+    // When runes mode is already explicitly set (options.runes == Some(true/false)
+    // or <svelte:options runes={…} />), we only need to detect await expressions,
+    // not rune references. Use `runes_explicitly_set` (which now also captures
+    // `<svelte:options runes={false} />`) rather than `options.runes` so an
+    // explicit `runes={false}` isn't undone by auto-detection (H-114).
+    let needs_rune_detection = analysis.runes_explicitly_set.is_none() && !analysis.runes;
 
     // We collect store subscription names to exclude them from rune detection.
     // Store auto-subscriptions ($store) look like rune references (dollar prefix)

--- a/src/compiler/phases/2_analyze/types.rs
+++ b/src/compiler/phases/2_analyze/types.rs
@@ -1490,10 +1490,12 @@ pub struct ComponentAnalysis {
 impl ComponentAnalysis {
     /// Create a new component analysis.
     pub fn new(source: &str, options: &CompileOptions) -> Self {
+        // The explicit `name` option wins; otherwise derive from the filename
+        // (H-088). Previously `options.name` was accepted but ignored.
         let name = options
-            .filename
-            .as_ref()
-            .map(|f| derive_component_name(f))
+            .name
+            .clone()
+            .or_else(|| options.filename.as_ref().map(|f| derive_component_name(f)))
             .unwrap_or_else(|| "Component".to_string());
 
         // If runes is explicitly set in options, use that; otherwise default to false

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -1626,11 +1626,14 @@ fn transform_client_with_visitors(
         }));
     }
 
-    // Add disclose-version import (always first)
-    body.push(JsStatement::Import(JsImportDeclaration {
-        specifiers: vec![],
-        source: "svelte/internal/disclose-version".into(),
-    }));
+    // Add disclose-version import (first), unless the public `disclose_version`
+    // option opts out of it (H-087). Defaults to true.
+    if options.disclose_version {
+        body.push(JsStatement::Import(JsImportDeclaration {
+            specifiers: vec![],
+            source: "svelte/internal/disclose-version".into(),
+        }));
+    }
 
     // Add feature flag imports
     if !analysis.runes {

--- a/tests/svelte_options_public.rs
+++ b/tests/svelte_options_public.rs
@@ -1,0 +1,77 @@
+//! Issue #449: public/`<svelte:options>` options must actually be enforced —
+//! explicit `runes={false}` (H-114), `customElement={null}` (H-115), the
+//! `disclose_version` option (H-087), and the `name` option (H-088).
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn opts(name: Option<String>, disclose: bool) -> CompileOptions {
+    CompileOptions {
+        filename: Some("T.svelte".into()),
+        generate: GenerateMode::Client,
+        dev: false,
+        name,
+        disclose_version: disclose,
+        ..Default::default()
+    }
+}
+
+/// H-114: `<svelte:options runes={false} />` must keep runes mode off, so a
+/// `$state` rune is rejected rather than silently re-enabling runes via
+/// auto-detection.
+#[test]
+fn explicit_runes_false_is_not_undone_by_autodetection() {
+    let src = "<svelte:options runes={false} />\n<script>let count = $state(0);</script>\n{count}";
+    let err = compile(src, opts(None, true)).err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("rune_invalid_usage"),
+        "runes={{false}} was undone by auto-detection: {msg}"
+    );
+}
+
+/// H-115: `customElement={null}` must NOT enable the custom-element pipeline,
+/// so no `options_missing_custom_element` warning is produced.
+#[test]
+fn custom_element_null_does_not_enable_pipeline() {
+    let src = "<svelte:options customElement={null} />\n<script>let x = 0;</script>\n{x}";
+    let result = compile(src, opts(None, true)).expect("should compile");
+    assert!(
+        !result
+            .warnings
+            .iter()
+            .any(|w| w.code == "options_missing_custom_element"),
+        "customElement={{null}} wrongly enabled the custom-element pipeline"
+    );
+    assert!(
+        !result.js.code.contains("customElement"),
+        "{}",
+        result.js.code
+    );
+}
+
+/// H-087: `disclose_version: false` must omit the disclose-version import.
+#[test]
+fn disclose_version_false_omits_import() {
+    let src = "<script>let x = 0;</script>\n{x}";
+    let with = compile(src, opts(None, true)).unwrap().js.code;
+    let without = compile(src, opts(None, false)).unwrap().js.code;
+    assert!(with.contains("svelte/internal/disclose-version"));
+    assert!(
+        !without.contains("svelte/internal/disclose-version"),
+        "disclose_version=false still emitted the import: {without}"
+    );
+}
+
+/// H-088: the public `name` option overrides the filename-derived component name.
+#[test]
+fn name_option_overrides_filename() {
+    let src = "<script>let x = 0;</script>\n{x}";
+    let code = compile(src, opts(Some("MyComp".into()), true))
+        .unwrap()
+        .js
+        .code;
+    assert!(
+        code.contains("function MyComp("),
+        "name option not applied: {code}"
+    );
+}


### PR DESCRIPTION
## Summary

Enforces four public/`<svelte:options>` options that were accepted but not honoured (issue #449):

- **H-114** — an explicit `<svelte:options runes={false} />` was undone by rune auto-detection. The svelte:options `runes={…}` value is now recorded in `runes_explicitly_set`, and the rune-detection gate (`needs_rune_detection`) keys off `runes_explicitly_set` instead of only the compile-level `options.runes`. So a `$state` used under `runes={false}` is correctly rejected (`rune_invalid_usage`) rather than silently switching the component to runes mode.
- **H-115** — `customElement={null}` returned `Some(default)`, enabling the custom-element pipeline. `parse_custom_element_option` now returns `None` for null, so the pipeline stays off and no `options_missing_custom_element` warning fires.
- **H-087** — the `svelte/internal/disclose-version` import was emitted unconditionally; it's now gated on the public `disclose_version` option (default `true`, so default output is unchanged).
- **H-088** — the public `name` option was accepted but ignored; it now overrides the filename-derived component name when seeding `ComponentAnalysis`.

### Deferred (separate follow-ups on #449)

- **H-113** — emit a `SvelteOptions` AST node from the parser so the analyzer can surface `<svelte:options>` duplicate / placement errors (currently the tag is consumed into parser state with no node).
- **H-116** — plumb the `namespace` option through to regular-element metadata and the client initial namespace.

Both span parser + analyzer + codegen and need their own change.

## Test plan

- [x] New `tests/svelte_options_public.rs` — `runes={false}` rejects `$state`; `customElement={null}` no warning / no CE output; `disclose_version:false` omits the import; `name` overrides the function name
- [x] `cargo test` — snapshot, ssr, runtime, css, validator, print, parser, svelte2tsx, compiler_errors, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)