### PR TITLE
fix(diagnostics): apply warning_filter + forward module warnings + line-safe machine output (H-083, H-084, H-098)

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -679,6 +679,14 @@ pub fn compile(source: &str, options: CompileOptions) -> Result<CompileResult, C
                         frame,
                     }
                 })
+                // Apply the public `warning_filter` (keep the warning when the
+                // filter returns true, or when no filter is set) — H-083.
+                .filter(|w| {
+                    options
+                        .warning_filter
+                        .as_ref()
+                        .is_none_or(|filter| filter(w))
+                })
                 .collect()
         },
         metadata: CompileMetadata { runes: runes_mode },
@@ -941,6 +949,13 @@ pub fn compile_module(
                     end: end_pos,
                     frame,
                 }
+            })
+            // Apply the public `warning_filter` for module compilation too (H-083).
+            .filter(|w| {
+                options
+                    .warning_filter
+                    .as_ref()
+                    .is_none_or(|filter| filter(w))
             })
             .collect(),
         metadata: CompileMetadata { runes: true },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,10 @@ pub use compiler::print::{PrintError, PrintOptions, PrintResult, print};
 #[cfg(feature = "native")]
 pub use compiler::{
     CompileError, CompileOptions, CompileResult, ExperimentalOptions, GenerateMode,
-    ModuleCompileOptions, compile, compile_batch, compile_module,
+    ModuleCompileOptions, Warning, WarningFilterFn, compile, compile_batch, compile_module,
 };
 #[cfg(not(feature = "native"))]
 pub use compiler::{
     CompileError, CompileOptions, CompileResult, ExperimentalOptions, GenerateMode,
-    ModuleCompileOptions, compile, compile_module,
+    ModuleCompileOptions, Warning, WarningFilterFn, compile, compile_module,
 };

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -41,6 +41,47 @@ use crate::svelte2tsx::{
 };
 
 /// Compile a Svelte component.
+/// Serialise compiler warnings into the JSON shape the official
+/// `svelte/compiler` output uses (`code`, `message`, `filename`, `start`, `end`,
+/// `position`, `frame`).
+fn warnings_to_json(warnings: &[crate::compiler::Warning]) -> Vec<Value> {
+    warnings
+        .iter()
+        .map(|w| {
+            let mut map = serde_json::Map::new();
+            map.insert("code".to_string(), Value::String(w.code.clone()));
+            map.insert("message".to_string(), Value::String(w.message.clone()));
+            if let Some(ref filename) = w.filename {
+                map.insert("filename".to_string(), Value::String(filename.clone()));
+            }
+            if let Some(ref start) = w.start {
+                let mut s = serde_json::Map::new();
+                s.insert("line".to_string(), serde_json::json!(start.line));
+                s.insert("column".to_string(), serde_json::json!(start.column));
+                s.insert("character".to_string(), serde_json::json!(start.character));
+                map.insert("start".to_string(), Value::Object(s));
+            }
+            if let Some(ref end) = w.end {
+                let mut e = serde_json::Map::new();
+                e.insert("line".to_string(), serde_json::json!(end.line));
+                e.insert("column".to_string(), serde_json::json!(end.column));
+                e.insert("character".to_string(), serde_json::json!(end.character));
+                map.insert("end".to_string(), Value::Object(e));
+            }
+            if let (Some(start), Some(end)) = (&w.start, &w.end) {
+                map.insert(
+                    "position".to_string(),
+                    serde_json::json!([start.character, end.character]),
+                );
+            }
+            if let Some(ref frame) = w.frame {
+                map.insert("frame".to_string(), Value::String(frame.clone()));
+            }
+            Value::Object(map)
+        })
+        .collect()
+}
+
 ///
 /// Takes source code and an options object, returns a result object
 /// matching the official `svelte/compiler` output shape.
@@ -63,44 +104,7 @@ pub fn napi_compile(source: String, options: Option<NapiCompileOptions>) -> napi
                 })
             });
 
-            let warnings: Vec<Value> = result
-                .warnings
-                .iter()
-                .map(|w| {
-                    // Build warning object with keys in the same order as official Svelte:
-                    // code, message, filename, start, end, position, frame
-                    let mut map = serde_json::Map::new();
-                    map.insert("code".to_string(), Value::String(w.code.clone()));
-                    map.insert("message".to_string(), Value::String(w.message.clone()));
-                    if let Some(ref filename) = w.filename {
-                        map.insert("filename".to_string(), Value::String(filename.clone()));
-                    }
-                    if let Some(ref start) = w.start {
-                        let mut s = serde_json::Map::new();
-                        s.insert("line".to_string(), serde_json::json!(start.line));
-                        s.insert("column".to_string(), serde_json::json!(start.column));
-                        s.insert("character".to_string(), serde_json::json!(start.character));
-                        map.insert("start".to_string(), Value::Object(s));
-                    }
-                    if let Some(ref end) = w.end {
-                        let mut e = serde_json::Map::new();
-                        e.insert("line".to_string(), serde_json::json!(end.line));
-                        e.insert("column".to_string(), serde_json::json!(end.column));
-                        e.insert("character".to_string(), serde_json::json!(end.character));
-                        map.insert("end".to_string(), Value::Object(e));
-                    }
-                    if let (Some(start), Some(end)) = (&w.start, &w.end) {
-                        map.insert(
-                            "position".to_string(),
-                            serde_json::json!([start.character, end.character]),
-                        );
-                    }
-                    if let Some(ref frame) = w.frame {
-                        map.insert("frame".to_string(), Value::String(frame.clone()));
-                    }
-                    Value::Object(map)
-                })
-                .collect();
+            let warnings: Vec<Value> = warnings_to_json(&result.warnings);
 
             let output = serde_json::json!({
                 "js": js_obj,
@@ -371,7 +375,8 @@ pub fn napi_compile_module(
             let output = serde_json::json!({
                 "js": js_obj,
                 "css": Value::Null,
-                "warnings": [],
+                // Forward module-compilation warnings instead of dropping them (H-084).
+                "warnings": warnings_to_json(&result.warnings),
                 "metadata": {
                     "runes": true,
                 },

--- a/src/svelte_check/writers.rs
+++ b/src/svelte_check/writers.rs
@@ -90,7 +90,14 @@ fn write_machine(
             .display()
             .to_string()
     };
-    let escaped = diag.message.replace('"', "\\\"");
+    // The machine format is line-oriented (one diagnostic per line), so a
+    // message carrying newlines must be encoded or it splits into several
+    // un-parseable lines (H-098). Escape quotes and CR/LF.
+    let escaped = diag
+        .message
+        .replace('"', "\\\"")
+        .replace('\r', "\\r")
+        .replace('\n', "\\n");
     let _ = writeln!(
         out,
         "{} {}:{}:{} \"{}\" {}",
@@ -244,5 +251,25 @@ mod tests {
     fn github_actions_escapes_special_chars() {
         let escaped = escape_workflow_command("100% match\nnext line\rthird");
         assert_eq!(escaped, "100%25 match%0Anext line%0Dthird");
+    }
+
+    #[test]
+    fn machine_output_is_single_line_for_multiline_message() {
+        // H-098: a diagnostic message with newlines must not split the
+        // line-oriented machine output into several un-parseable lines.
+        let ws = Path::new("/work");
+        let mut d = diag(DiagnosticSeverity::Error, "/work/A.svelte", 1, 1);
+        d.message = "line one\nline two\rthird".into();
+        let mut out = String::new();
+        write_diagnostic(&mut out, &d, ws, OutputFormat::Machine);
+        assert_eq!(
+            out.matches('\n').count(),
+            1,
+            "machine output split across lines: {out:?}"
+        );
+        assert!(
+            out.contains("line one\\nline two\\rthird"),
+            "newlines not encoded: {out:?}"
+        );
     }
 }

--- a/tests/warning_filter.rs
+++ b/tests/warning_filter.rs
@@ -1,0 +1,55 @@
+//! Issue #450 H-083: the public `warning_filter` option must actually be
+//! applied — a filter that returns false drops the warning.
+
+use std::sync::Arc;
+use svelte_compiler_rust::{CompileOptions, Warning, compile};
+
+fn warning_codes(
+    src: &str,
+    filter: Option<Arc<dyn Fn(&Warning) -> bool + Send + Sync>>,
+) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            warning_filter: filter,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .warnings
+    .into_iter()
+    .map(|w| w.code)
+    .collect()
+}
+
+// `<img>` without `alt` reliably produces an a11y warning.
+const SRC: &str = "<img src=\"x.png\">";
+
+#[test]
+fn warning_filter_none_keeps_warnings() {
+    let codes = warning_codes(SRC, None);
+    assert!(!codes.is_empty(), "expected at least one warning");
+}
+
+#[test]
+fn warning_filter_false_drops_all() {
+    let codes = warning_codes(SRC, Some(Arc::new(|_w: &Warning| false)));
+    assert!(
+        codes.is_empty(),
+        "warning_filter returning false should drop: {codes:?}"
+    );
+}
+
+#[test]
+fn warning_filter_can_drop_by_code() {
+    // Keep everything except a11y_* warnings.
+    let codes = warning_codes(
+        SRC,
+        Some(Arc::new(|w: &Warning| !w.code.starts_with("a11y"))),
+    );
+    assert!(
+        !codes.iter().any(|c| c.starts_with("a11y")),
+        "a11y warnings should have been filtered out: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Three diagnostic-pipeline fixes from issue #450:

- **H-083** — the public `warning_filter` option was defined but never invoked. Both the component and module warning-collection paths now keep a warning only when `warning_filter` returns `true` (or no filter is set). `Warning` and `WarningFilterFn` are also re-exported from the crate root so external callers can actually build a filter (the `CompileOptions.warning_filter` field referenced types that weren't public).
- **H-084** — the NAPI `compileModule` bridge hard-coded `"warnings": []`, discarding module-compilation warnings. Warning→JSON serialisation is factored into a `warnings_to_json` helper, and the module bridge now forwards `result.warnings` like the component bridge.
- **H-098** — the line-oriented machine writer only escaped `"`, so a diagnostic message containing a newline split into several un-parseable lines. CR/LF are now encoded as `\r` / `\n` (existing single-line goldens are unaffected since only quote-escaping applied to them).

### Deferred (separate follow-ups on #450)

- **H-085** — `.svelte.ts` module compilation swallows TS-strip errors (`let _ = phases::…`).
- **H-086** — `compile_module` catches transform errors and returns raw source with a header comment instead of propagating.

Both change failure behavior and risk surfacing previously-swallowed errors across the fixture suite, so they need their own evaluation.

## Test plan

- [x] New `tests/warning_filter.rs` — no filter keeps warnings; `false` drops all; code-based filter drops a11y only
- [x] New `svelte_check::writers` unit test — multi-line message stays one machine-output line with CR/LF encoded
- [x] `cargo test` — snapshot, ssr, runtime, validator, svelte_check_golden, real_world all pass
- [x] `cargo check --features napi` clean; `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)