### PR TITLE
fix(ci): factor warning_filter test closure into type alias

### DIFF
--- a/tests/warning_filter.rs
+++ b/tests/warning_filter.rs
@@ -4,10 +4,9 @@
 use std::sync::Arc;
 use svelte_compiler_rust::{CompileOptions, Warning, compile};
 
-fn warning_codes(
-    src: &str,
-    filter: Option<Arc<dyn Fn(&Warning) -> bool + Send + Sync>>,
-) -> Vec<String> {
+type WarningFilter = Option<Arc<dyn Fn(&Warning) -> bool + Send + Sync>>;
+
+fn warning_codes(src: &str, filter: WarningFilter) -> Vec<String> {
     compile(
         src,
         CompileOptions {


### PR DESCRIPTION
## Summary

Rust 1.95's \`clippy::type_complexity\` now flags
\`Option<Arc<dyn Fn(&Warning) -> bool + Send + Sync>>\` in
\`tests/warning_filter.rs\`. Extract it to a \`WarningFilter\` type alias
to suppress the lint cleanly.

## Why

Main's \`Clippy\` CI is failing on every commit since \`#503\` landed:

\`\`\`
error: very complex type used. Consider factoring parts into \`type\` definitions
  --> tests/warning_filter.rs:9:13
   |
 9 |     filter: Option<Arc<dyn Fn(&Warning) -> bool + Send + Sync>>,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
\`\`\`

This blocks every other PR's CI from passing (Clippy is \`-D warnings\`).

## Test plan

- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)