### PR TITLE
fix(svelte:component): wrap member-expression root in $.get for SSR/client (Svelte 5.55.6 e00944ffd)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -2711,8 +2711,25 @@ fn build_component_expression(
                 }
             }
             // Apply transforms to handle derived values (const B = $derived(A) -> $.get(B))
-            let id_expr = b::id(component_name);
-            super::utils::apply_transforms_to_expression(&id_expr, context)
+            //
+            // Svelte 5.55.6 (upstream commit `e00944ffd` "fix: correctly compile
+            // component member expressions for SSR") + the matching client
+            // change in `b.member_id(component_name)`: when the component name
+            // is a dotted path like `state.x.Y`, build the equivalent
+            // `MemberExpression` chain so transforms only apply to the root
+            // identifier (e.g. `$.get(state).x.Y`).
+            let parts: Vec<&str> = component_name.split('.').collect();
+            if parts.len() > 1 {
+                let base_expr = b::id(parts[0]);
+                let mut expr = super::utils::apply_transforms_to_expression(&base_expr, context);
+                for part in &parts[1..] {
+                    expr = b::member(&context.arena, expr, part.to_string());
+                }
+                expr
+            } else {
+                let id_expr = b::id(component_name);
+                super::utils::apply_transforms_to_expression(&id_expr, context)
+            }
         }
         ComponentNode::SvelteComponent(comp) => {
             // Use the `this` expression

--- a/tests/audit_skipped.rs
+++ b/tests/audit_skipped.rs
@@ -417,7 +417,6 @@ fn audit_skipped_fixtures() {
         ("runtime-runes", "async-dont-rebase-new-batch-4"),
         ("runtime-runes", "async-debug-awaited-expression"),
         ("runtime-runes", "async-state-updates-microtask-separated"),
-        ("runtime-runes", "dynamic-component-member"),
         ("runtime-runes", "async-await-block-2"),
         ("runtime-runes", "async-await"),
         ("runtime-runes", "async-duplicate-dependencies"),

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1062,9 +1062,9 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         // - Svelte 5.55.6 cluster: upstream commits `e00944ffd`/`89b6a939f`/
         //   `4c96b469f`/`69b4c9f56`. New async-* fixtures exercise the same
         //   sync-grouping/`Promise.all`-save follow-up tracked since 5.54.1.
-        //   `dynamic-component-member` exposes an additional rsvelte gap
-        //   (`<svelte:component this={state.x.Y}>` doesn't wrap `state` in
-        //   `$.get(...)` for SSR/client). Tracked as a follow-up port.
+        //   `dynamic-component-member` was unblocked by porting `e00944ffd`
+        //   (member-id wrapping for both SSR `Component` and the
+        //   client-side `$.component(node, () => ...)` thunk).
         ("runtime-runes", "async-flushsync-in-effect"),
         ("runtime-runes", "async-stale-derived-4"),
         ("runtime-runes", "async-eager-block"),
@@ -1075,7 +1075,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         ("runtime-runes", "async-dont-rebase-new-batch-4"),
         ("runtime-runes", "async-debug-awaited-expression"),
         ("runtime-runes", "async-state-updates-microtask-separated"),
-        ("runtime-runes", "dynamic-component-member"),
         // - Svelte 5.55.9 cluster: upstream commits `a5df6616e` "fix: avoid
         //   unnecessary stringify in server attributes" (inlines static
         //   string interpolations into the literal HTML push instead of

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -214,7 +214,6 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     "async-flushsync-in-effect",
     "async-stale-derived-4",
     "async-state-updates-microtask-separated",
-    "dynamic-component-member",
     // Svelte 5.55.9 cluster (upstream `a5df6616e` "fix: avoid unnecessary
     // stringify in server attributes"). The `<div title=...>` snapshot path
     // is handled; the runes fixtures below also hit code paths that aren't


### PR DESCRIPTION
## Summary

- Port the client-side half of upstream commit [`e00944ffd`](https://github.com/sveltejs/svelte/commit/e00944ffd) "fix: correctly compile component member expressions for SSR" (PR #18192) for `<svelte:component>` / dotted-named component usage.
- When the component name is a dotted path (e.g. `<platformIcons.currency.Icon />` where `platformIcons` is `$state`- or `$derived`-bound), `build_component_expression` now constructs a real `MemberExpression` chain — equivalent to upstream's `b.member_id(component_name)` — so the read transform that wraps state/derived bindings in `$.get(...)` is applied to **only the root identifier**, matching upstream output (`$.get(platformIcons).currency.Icon`).
- Server side already produced the correct output via `wrap_derived_reads`, so no server change is required.

## Test plan

- [x] `cargo test --release --test audit_skipped -- --nocapture` flips `runtime-runes/dynamic-component-member` from `client=FAIL server=OK` to NOW PASSING.
- [x] `cargo test --release --test runtime` — 19/19 pass (944/944 in `test_runtime_runes`, no regressions in `derived-destructured` or any other fixture).
- [x] `cargo test --release --test compiler_fixtures` — 17/17 pass.
- [x] `cargo test --release --test compatibility_report` — 16/16 pass; report totals 3447 → 3449 in-scope-run passing, 39 → 38 in-scope skipped.
- [x] `cargo fmt` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)