### PR TITLE
chore(audit): drop 11 now-passing fixtures from skip lists

### DIFF
--- a/tests/audit_skipped.rs
+++ b/tests/audit_skipped.rs
@@ -382,12 +382,7 @@ fn audit_skipped_fixtures() {
     // execute as regular runs in the compatibility report rather than being
     // skipped — so they don't need to appear here.
     let runtime_skipped: &[(&str, &str)] = &[
-        ("runtime-runes", "async-inspect-build"),
         ("runtime-runes", "async-derived-indirect"),
-        ("runtime-runes", "async-if-hydration"),
-        ("runtime-runes", "async-derived-with-effect-and-boundary"),
-        ("runtime-runes", "async-binding-after-await"),
-        ("runtime-runes", "async-transform-empty-statements"),
         ("runtime-runes", "async-later-sync-overlaps"),
         ("runtime-runes", "async-style-after-await"),
         ("runtime-runes", "async-overlap-multiple-1"),
@@ -398,8 +393,6 @@ fn audit_skipped_fixtures() {
         ("runtime-runes", "async-overlap-multiple-6"),
         ("runtime-runes", "async-overlap-multiple-7"),
         ("runtime-runes", "async-if-block-unskip"),
-        ("runtime-runes", "async-const"),
-        ("runtime-runes", "async-const-wait"),
         ("runtime-runes", "async-derived-const-blocker"),
         ("runtime-runes", "async-reactivity-loss-no-false-positive-1"),
         ("runtime-runes", "async-reactivity-loss-no-false-positive-2"),
@@ -408,7 +401,6 @@ fn audit_skipped_fixtures() {
         ("runtime-runes", "async-flushsync-in-effect"),
         ("runtime-runes", "async-stale-derived-4"),
         ("runtime-runes", "async-eager-block"),
-        ("runtime-runes", "async-eager-each-block"),
         ("runtime-runes", "async-dont-rebase-new-batch-1"),
         ("runtime-runes", "async-dont-rebase-new-batch-2"),
         ("runtime-runes", "async-dont-rebase-new-batch-3"),
@@ -423,8 +415,8 @@ fn audit_skipped_fixtures() {
         ("runtime-runes", "async-if-else"),
     ];
 
-    let parser_legacy_skipped = &["javascript-comments", "script-comment-only"];
-    let parser_modern_skipped = &["comment-in-tag", "parens"];
+    let parser_legacy_skipped = &["javascript-comments"];
+    let parser_modern_skipped: &[&str] = &[];
     let css_skipped: &[&str] = &[];
     let print_skipped = &["css-keyframes-percent"];
 

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1070,7 +1070,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         ("runtime-runes", "async-flushsync-in-effect"),
         ("runtime-runes", "async-stale-derived-4"),
         ("runtime-runes", "async-eager-block"),
-        ("runtime-runes", "async-eager-each-block"),
         ("runtime-runes", "async-dont-rebase-new-batch-1"),
         ("runtime-runes", "async-dont-rebase-new-batch-2"),
         ("runtime-runes", "async-dont-rebase-new-batch-3"),

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -206,7 +206,6 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     "async-dont-rebase-new-batch-3",
     "async-dont-rebase-new-batch-4",
     "async-eager-block",
-    "async-eager-each-block",
     "async-flushsync-in-effect",
     "async-stale-derived-4",
     "async-state-updates-microtask-separated",


### PR DESCRIPTION
## Summary

Following PR #507 (\`feat(server): rewrite SSR runes in {#if} test\`, Svelte 5.55.4 \`273f1a85a\`), the following fixtures now pass and are removed from \`tests/{audit_skipped,runtime,compatibility_report}.rs\`:

- runtime-runes/async-inspect-build
- runtime-runes/async-if-hydration
- runtime-runes/async-derived-with-effect-and-boundary
- runtime-runes/async-binding-after-await
- runtime-runes/async-transform-empty-statements
- runtime-runes/async-const
- runtime-runes/async-const-wait
- runtime-runes/async-eager-each-block
- parser-legacy/script-comment-only
- parser-modern/comment-in-tag
- parser-modern/parens

The 3 parser entries were left over from the comments-in-tags port (already landed; see \`docs/skip-remaining-clusters.md\` §3) — the audit list just hadn't been cleared.

## Test plan

- [x] \`cargo test --release --test audit_skipped -- --nocapture\` on commit \`b68037df\` (post-#507) shows 11 NOW PASSING and 33 STILL FAILING
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)