### PR TITLE
fix(special-elements): shared capture-event check for special-element events (H-053)

### DIFF
--- a/src/compiler/phases/3_transform/client/types.rs
+++ b/src/compiler/phases/3_transform/client/types.rs
@@ -1639,8 +1639,12 @@ impl<'a> ComponentContext<'a> {
                         let mut event_name = &event_attr.name[2..];
                         let mut capture = false;
 
-                        // Check if this is a capture event (e.g., "clickcapture")
-                        if event_name.ends_with("capture") && event_name.len() > 7 {
+                        // Check if this is a capture event (e.g., "clickcapture").
+                        // Use the shared helper so `gotpointercapture` /
+                        // `lostpointercapture` are correctly excluded — they end
+                        // in "capture" but are real event names, not capture
+                        // variants (H-053).
+                        if crate::compiler::utils::is_capture_event(event_name) {
                             event_name = &event_name[..event_name.len() - 7];
                             capture = true;
                         }

--- a/tests/special_element_capture_events.rs
+++ b/tests/special_element_capture_events.rs
@@ -1,0 +1,41 @@
+//! Issue #453 H-053: event attributes on special elements must use the same
+//! capture-event detection as regular elements — `gotpointercapture` /
+//! `lostpointercapture` end in "capture" but are real event names, not capture
+//! variants, so they must not be split into `gotpointer` + capture.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn pointer_capture_events_are_not_split() {
+    let src = "<script>let h = () => {};</script>\n<svelte:window ongotpointercapture={h} onlostpointercapture={h} onclickcapture={h} />";
+    let out = client(src);
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    // Pointer-capture events keep their full name and are NOT marked capture.
+    assert!(
+        out.contains("$.event('gotpointercapture', $.window, h)"),
+        "gotpointercapture mis-split: {out}"
+    );
+    assert!(
+        out.contains("$.event('lostpointercapture', $.window, h)"),
+        "lostpointercapture mis-split: {out}"
+    );
+    // A genuine capture event is still detected (name stripped, capture=true).
+    assert!(
+        out.contains("$.event('click', $.window, h, true)"),
+        "clickcapture not treated as capture: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes H-053 from issue #453. Event attributes on special elements (`<svelte:window>`, `<svelte:body>`, `<svelte:document>`, …) re-implemented capture-event detection inline as `event_name.ends_with("capture") && len > 7`, missing the `gotpointercapture` / `lostpointercapture` exclusion that the shared `is_capture_event` helper (and the regular-element path) has.

As a result `<svelte:window ongotpointercapture={h} />` was emitted as the capture variant of a `gotpointer` event (`$.event('gotpointer', $.window, h, true)`) instead of the real `$.event('gotpointercapture', $.window, h)`. The special-element path now calls `crate::compiler::utils::is_capture_event`, agreeing with regular elements.

### Deferred (separate follow-ups on #453)

H-046, H-047, H-048, H-054, H-055, H-056 route special elements through the shared directive/attribute validators (`validate_component_attributes` / `validate_element_attributes` / `validate_directive_expression`). Those **add** new validation diagnostics, which can surface previously-accepted constructs as errors, so they need their own evaluation against the fixture suite.

## Test plan

- [x] New `tests/special_element_capture_events.rs` — `gotpointercapture` / `lostpointercapture` keep their full names; `clickcapture` is still treated as capture
- [x] `cargo test` — snapshot, ssr, runtime, validator, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)