### PR TITLE
chore(audit): drop async-eager-block from skip lists

### DIFF
--- a/tests/audit_skipped.rs
+++ b/tests/audit_skipped.rs
@@ -387,7 +387,6 @@ fn audit_skipped_fixtures() {
         ("runtime-runes", "async-overlap-multiple-6"),
         ("runtime-runes", "async-overlap-multiple-7"),
         ("runtime-runes", "async-derived-const-blocker"),
-        ("runtime-runes", "async-eager-block"),
         ("runtime-runes", "async-dont-rebase-new-batch-1"),
         ("runtime-runes", "async-dont-rebase-new-batch-3"),
         ("runtime-runes", "async-dont-rebase-new-batch-4"),

--- a/tests/compatibility_report.rs
+++ b/tests/compatibility_report.rs
@@ -1038,7 +1038,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         //   `dynamic-component-member` exposes an additional rsvelte gap
         //   (`<svelte:component this={state.x.Y}>` doesn't wrap `state` in
         //   `$.get(...)` for SSR/client). Tracked as a follow-up port.
-        ("runtime-runes", "async-eager-block"),
         ("runtime-runes", "async-dont-rebase-new-batch-1"),
         ("runtime-runes", "async-dont-rebase-new-batch-3"),
         ("runtime-runes", "async-dont-rebase-new-batch-4"),

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -194,7 +194,6 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     "async-dont-rebase-new-batch-1",
     "async-dont-rebase-new-batch-3",
     "async-dont-rebase-new-batch-4",
-    "async-eager-block",
     "async-state-updates-microtask-separated",
     // Svelte 5.55.9 cluster (upstream `a5df6616e` "fix: avoid unnecessary
     // stringify in server attributes"). The `<div title=...>` snapshot path


### PR DESCRIPTION
Following PR #511 (\`$.save\` parent-walk predicate), \`runtime-runes/async-eager-block\` now passes. Remove it from skip lists.

\`cargo test --release --test audit_skipped -- --nocapture\` on post-#511 main reports it as NOW PASSING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)