### PR TITLE
fix(a11y): braille ARIA attrs + case-insensitive href scheme + nested-list rule (H-077, H-081, H-082)

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -313,6 +313,18 @@ fn get_disallowed_descendant(
     }
 }
 
+/// Whether a disallowed-children rule is `direct` (the child auto-closes its
+/// *immediate* parent) rather than `descendant` in the official
+/// `autoclosing_children` table. `direct` rules must only be checked against the
+/// direct parent — not every ancestor — otherwise a valid nested list like
+/// `<ul><li><ul><li>` falsely reports `<li>` as a descendant of `<li>` (H-082).
+fn is_direct_only_disallowed(ancestor_tag: &str) -> bool {
+    matches!(
+        ancestor_tag,
+        "li" | "thead" | "tbody" | "tfoot" | "tr" | "td" | "th"
+    )
+}
+
 /// Check if a tag is valid with an ancestor.
 /// Returns an error message if invalid, or None if valid.
 fn is_tag_valid_with_ancestor(child_tag: &str, ancestors: &[String]) -> Option<String> {
@@ -871,6 +883,14 @@ pub fn visit(
             if let Some(disallowed) = get_disallowed_descendant(ancestor_name, &element.name)
                 && disallowed.contains(&element.name.as_str())
             {
+                // `direct`-only rules (e.g. `li`) apply only to the immediate
+                // parent, not every ancestor — `element_ancestors` is ordered
+                // outermost-first, so the direct parent is the last entry (H-082).
+                let is_direct_parent = i + 1 == context.element_ancestors.len();
+                if is_direct_only_disallowed(ancestor_name) && !is_direct_parent {
+                    continue;
+                }
+
                 let message = format!(
                     "`<{}>` cannot be a descendant of `<{}>`",
                     element.name, ancestor_name

--- a/src/compiler/phases/2_analyze/visitors/shared/a11y/constants.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/a11y/constants.rs
@@ -22,6 +22,8 @@ pub const ARIA_ATTRIBUTES: &[&str] = &[
     "activedescendant",
     "atomic",
     "autocomplete",
+    "braillelabel",
+    "brailleroledescription",
     "busy",
     "checked",
     "colcount",

--- a/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
@@ -21,8 +21,11 @@ use std::sync::LazyLock;
 
 // Regex patterns
 static REGEX_HEADING_TAGS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^h[1-6]$").unwrap());
+// Mirrors upstream `regex_js_prefix = /^\W*javascript:/i`: case-insensitive and
+// tolerant of leading non-word characters (whitespace / control chars), so
+// `JavaScript:` and ` javascript:` are caught too (H-081).
 static REGEX_JS_PREFIX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(javascript|data|vbscript):").unwrap());
+    LazyLock::new(|| Regex::new(r"(?i)^\W*javascript:").unwrap());
 static REGEX_NOT_WHITESPACE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\S").unwrap());
 static REGEX_REDUNDANT_IMG_ALT: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)\b(image|picture|photo)\b").unwrap());

--- a/tests/a11y_validator_fixes.rs
+++ b/tests/a11y_validator_fixes.rs
@@ -1,0 +1,62 @@
+//! Issue #454 a11y/ARIA validator fixes: braille ARIA attributes are known
+//! (H-077), dangerous `href` schemes match case-insensitively (H-081), and
+//! valid nested lists don't trip the `<li>`-in-`<li>` descendant rule (H-082).
+
+use svelte_compiler_rust::{CompileOptions, compile};
+
+fn warning_codes(src: &str) -> Vec<String> {
+    match compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            ..Default::default()
+        },
+    ) {
+        Ok(r) => r.warnings.into_iter().map(|w| w.code).collect(),
+        Err(e) => vec![format!("COMPILE_ERROR: {e:?}")],
+    }
+}
+
+/// H-077: `aria-braillelabel` / `aria-brailleroledescription` are valid ARIA
+/// attributes and must not be flagged unknown.
+#[test]
+fn braille_aria_attributes_are_known() {
+    let codes =
+        warning_codes("<div aria-braillelabel=\"x\" aria-brailleroledescription=\"y\"></div>");
+    assert!(
+        !codes.iter().any(|c| c.contains("unknown_aria")),
+        "braille ARIA attrs flagged unknown: {codes:?}"
+    );
+}
+
+/// H-081: a `javascript:` href is flagged regardless of case.
+#[test]
+fn dangerous_href_scheme_is_case_insensitive() {
+    assert!(
+        warning_codes("<a href=\"JavaScript:void(0)\">x</a>")
+            .iter()
+            .any(|c| c == "a11y_invalid_attribute"),
+        "mixed-case JavaScript: href not flagged"
+    );
+    // The canonical lowercase form is still flagged (no regression).
+    assert!(
+        warning_codes("<a href=\"javascript:void(0)\">x</a>")
+            .iter()
+            .any(|c| c == "a11y_invalid_attribute"),
+    );
+}
+
+/// H-082: a `<li>` inside a nested `<ul>` is valid and must not report
+/// `<li>` cannot be a descendant of `<li>`.
+#[test]
+fn nested_list_is_not_a_descendant_violation() {
+    let codes = warning_codes("<ul><li><ul><li>x</li></ul></li></ul>");
+    assert!(
+        !codes.iter().any(|c| c.contains("COMPILE_ERROR")),
+        "{codes:?}"
+    );
+    assert!(
+        !codes.iter().any(|c| c.contains("invalid_placement")),
+        "nested list falsely reported as descendant violation: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Three a11y/ARIA validator fixes from issue #454:

- **H-077** — `ARIA_ATTRIBUTES` ended at `valuetext` and omitted `braillelabel` / `brailleroledescription`, so `aria-braillelabel` was wrongly flagged as an unknown ARIA attribute. Both are now in the registry.
- **H-081** — dangerous `href` scheme detection used `^(javascript|data|vbscript):` (case-sensitive, byte-zero anchored, and broader than upstream). Aligned with upstream's `regex_js_prefix = /^\W*javascript:/i`, so `JavaScript:` and leading-whitespace forms are caught. `data:` / `vbscript:` are dropped to match upstream (no fixture used them; the only scheme fixture is lowercase `javascript:`, still flagged).
- **H-082** — the disallowed-descendant walk applied `li`'s rule to *every* ancestor, so a valid `<ul><li><ul><li>` falsely reported `<li>` cannot be a descendant of `<li>`. Per upstream's `autoclosing_children`, `li` (and the table rules `tr`/`td`/`th`/`thead`/`tbody`/`tfoot`) are `direct` rules — now only checked against the immediate parent, not all ancestors.

### Deferred (separate follow-ups on #454)

- **H-078** — bare ARIA attribute (`aria-hidden`) becomes the literal string `"true"`.
- **H-079** — `<input>` without `type` should default to the `text` role; case-fold the type.
- **H-080** — `role="button link"` token validation passes but downstream role-semantic checks receive the un-split raw string.

These change warning emission more broadly and need their own fixture evaluation.

## Test plan

- [x] New `tests/a11y_validator_fixes.rs` — braille attrs not flagged; mixed-case `JavaScript:` flagged (lowercase still flagged); nested list not a descendant violation
- [x] `cargo test` — validator, snapshot, ssr, runtime, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)