### PR TITLE
fix(codegen): sanitise template-literal quasis for title + attr/style (H-160, H-161)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -14,6 +14,7 @@ use crate::compiler::phases::phase3_transform::js_ast::nodes::JsLiteral;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::{
     JsExpr, JsObjectMember, JsPattern, JsStatement, JsTemplateLiteral,
 };
+use crate::compiler::phases::phase3_transform::shared::template::sanitize_template_string;
 
 use super::utils::build_expression;
 
@@ -217,7 +218,7 @@ where
                 }
 
                 // Cannot fold - push the accumulated text as a quasi
-                quasis.push(b::quasi(&current_text, false));
+                quasis.push(b::quasi(sanitize_template_string(&current_text), false));
                 current_text.clear();
 
                 // Build the expression using full context-aware conversion
@@ -277,7 +278,7 @@ where
     }
 
     // Push the final text
-    quasis.push(b::quasi(&current_text, true));
+    quasis.push(b::quasi(sanitize_template_string(&current_text), true));
 
     // If no expressions remain (all were folded), return a simple string
     if expressions.is_empty() {
@@ -1201,7 +1202,7 @@ fn build_style_attribute_value_with_memoization(
                         }
 
                         // Push accumulated text as quasi
-                        quasis.push(b::quasi(&current_text, false));
+                        quasis.push(b::quasi(sanitize_template_string(&current_text), false));
                         current_text.clear();
 
                         // Convert and build the expression
@@ -1273,7 +1274,7 @@ fn build_style_attribute_value_with_memoization(
             }
 
             // Push final quasi
-            quasis.push(b::quasi(&current_text, true));
+            quasis.push(b::quasi(sanitize_template_string(&current_text), true));
 
             let value = JsExpr::TemplateLiteral(JsTemplateLiteral {
                 quasis,

--- a/src/compiler/phases/3_transform/client/visitors/title_element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/title_element.rs
@@ -14,6 +14,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::
 };
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::template::sanitize_template_string;
 
 /// An entry in the memoizer - represents either a sync or async memoized value.
 struct MemoEntry {
@@ -378,7 +379,12 @@ fn build_title_content(
     let template_quasis: Vec<_> = quasis
         .iter()
         .enumerate()
-        .map(|(i, text)| b::quasi(text.as_str(), i == quasis.len() - 1))
+        .map(|(i, text)| {
+            b::quasi(
+                sanitize_template_string(text.as_str()),
+                i == quasis.len() - 1,
+            )
+        })
         .collect();
     let value = b::template(template_quasis, expressions);
     (value, has_state, memo_entries)

--- a/tests/template_literal_sanitize.rs
+++ b/tests/template_literal_sanitize.rs
@@ -1,0 +1,53 @@
+//! Issue #455 H-160/H-161: generated template literals must escape backticks /
+//! `${` in user text. The multi-node `<title>` path and the mixed client
+//! attribute / style value paths now route through `sanitize_template_string`.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+/// H-160: a backtick in multi-node `<title>` text must be escaped in the
+/// generated template literal.
+#[test]
+fn title_text_backtick_is_escaped() {
+    let out =
+        client("<script>let x = 1;</script>\n<svelte:head><title>a`b {x}</title></svelte:head>");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains(r"a\`b"), "title backtick not escaped: {out}");
+}
+
+/// H-161: a backtick in a mixed attribute value must be escaped in the generated
+/// template literal. A prop keeps the value dynamic so it stays a template
+/// literal (a const would fold to a plain single-quoted string).
+#[test]
+fn attribute_value_backtick_is_escaped() {
+    let out = client("<script>export let x;</script>\n<div data-x=\"a`b {x}\"></div>");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains(r"a\`b"),
+        "attribute backtick not escaped: {out}"
+    );
+}
+
+/// H-161: a backtick in a mixed `style:` directive value must be escaped too.
+#[test]
+fn style_directive_value_backtick_is_escaped() {
+    let out = client("<script>export let x;</script>\n<div style:color=\"a`b {x}\"></div>");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains(r"a\`b"),
+        "style directive backtick not escaped: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the two Critical template-literal sanitisation gaps from issue #455:

- **H-160** — the multi-node `<title>` path built quasis with `b::quasi(text, …)` straight from user text, so a backtick or `${` in title text broke the generated JS.
- **H-161** — the mixed client attribute and `style:` directive value paths (`shared/element.rs`, 4 sites) did the same.

Both now route the text through the existing `sanitize_template_string` helper (escaping `\`, `` ` ``, `${`) before building the quasi, matching the shared template-chunk path.

### Deferred (separate follow-ups on #455)

- **H-091** — svelte2tsx mixed-attribute template literals don't escape backslashes (Windows paths like `C:\new` get embedded `\n`/`\t`).
- **H-092** — slot names / slot-prop keys interpolated without robust quoting.

Both live in the svelte2tsx template builder with their own escaping and need a separate change.

## Test plan

- [x] New `tests/template_literal_sanitize.rs` — backtick escaped in `<title>` text, in a dynamic attribute value, and in a `style:` directive value
- [x] `cargo test` — snapshot, ssr, runtime, hydration, validator, real_world, svelte2tsx all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)