### PR TITLE
fix(codegen): preserve for...in + destructuring catch params in inline JS (H-110, H-112)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -3733,12 +3733,13 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                 .unwrap_or_else(|| JsBlockStatement { body: Vec::new() });
             let handler = obj.get("handler").and_then(|h| {
                 let h_obj = h.as_object()?;
+                // Route the catch parameter through the full pattern converter so
+                // destructuring catch params (`catch ({ message }) {}`) are
+                // preserved, not just bare identifiers (H-112).
                 let param = h_obj
                     .get("param")
-                    .and_then(|p| p.as_object())
-                    .and_then(|p| p.get("name"))
-                    .and_then(|n| n.as_str())
-                    .map(|n| JsPattern::Identifier(n.into()));
+                    .filter(|p| !p.is_null())
+                    .and_then(|p| convert_param_pattern(p, context));
                 let body = h_obj
                     .get("body")
                     .and_then(|b| b.as_object())
@@ -3962,23 +3963,16 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             }
 
             let is_await = obj.get("await").and_then(|a| a.as_bool()).unwrap_or(false);
-            if is_for_of {
-                Some(JsStatement::ForOf(JsForOfStatement {
-                    left,
-                    right,
-                    body,
-                    is_await,
-                }))
-            } else {
-                // For-in uses the same JsForOfStatement with a different codegen
-                // path. Since we don't have a ForIn variant, emit as raw block for now.
-                Some(JsStatement::ForOf(JsForOfStatement {
-                    left,
-                    right,
-                    body,
-                    is_await: false,
-                }))
-            }
+            // `for...in` and `for...of` share `JsForOfStatement`; the `is_for_in`
+            // flag drives codegen to emit ` in ` vs ` of ` (H-110). `for await`
+            // only applies to `for...of`.
+            Some(JsStatement::ForOf(JsForOfStatement {
+                left,
+                right,
+                body,
+                is_await: is_for_of && is_await,
+                is_for_in: !is_for_of,
+            }))
         }
         "WhileStatement" => {
             let test = obj

--- a/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -1841,6 +1841,7 @@ fn apply_transforms_to_statement_with_shadowed(
                 right: transformed_right,
                 body: transformed_body,
                 is_await: for_of.is_await,
+                is_for_in: for_of.is_for_in,
             })
         }
 

--- a/src/compiler/phases/3_transform/js_ast/builders.rs
+++ b/src/compiler/phases/3_transform/js_ast/builders.rs
@@ -1303,6 +1303,7 @@ pub fn for_of(
         right: arena.alloc_expr(right),
         body: arena.alloc_stmt(body),
         is_await,
+        is_for_in: false,
     })
 }
 

--- a/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -670,7 +670,8 @@ impl<'a> JsCodegen<'a> {
             }
             JsForOfLeft::Pattern(pattern) => self.emit_pattern(pattern),
         }
-        self.output.push_str(" of ");
+        self.output
+            .push_str(if for_of.is_for_in { " in " } else { " of " });
         self.emit_expression(self.arena.get_expr(for_of.right));
         self.output.push_str(") ");
         self.emit_statement_as_block(self.arena.get_stmt(for_of.body));

--- a/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -223,13 +223,16 @@ pub enum JsForInit {
     Expression(ExprId),
 }
 
-/// For-of statement.
+/// For-of statement. Also represents `for...in` when `is_for_in` is set (the
+/// two share a structure; codegen emits ` in ` vs ` of ` accordingly).
 #[derive(Debug, Clone)]
 pub struct JsForOfStatement {
     pub left: JsForOfLeft,
     pub right: ExprId,
     pub body: StmtId,
     pub is_await: bool,
+    /// `true` for `for (… in …)`, `false` for `for (… of …)`.
+    pub is_for_in: bool,
 }
 
 /// Left side of for-of statement.

--- a/tests/inline_js_statements.rs
+++ b/tests/inline_js_statements.rs
@@ -1,0 +1,46 @@
+//! Issue #456: inline JS statement conversion must preserve `for...in` (vs
+//! `for...of`, H-110) and destructuring `catch` parameters (H-112).
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+/// H-110: a `for...in` loop in inline JS must be emitted as `for...in`, not
+/// `for...of`.
+#[test]
+fn for_in_is_not_emitted_as_for_of() {
+    let out = client(
+        "<script>let obj = {};</script>\n<button onclick={() => { for (const k in obj) { console.log(k); } }}>x</button>",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("for (const k in obj)"),
+        "for-in emitted as for-of: {out}"
+    );
+    assert!(!out.contains("for (const k of obj)"), "{out}");
+}
+
+/// H-112: a destructuring `catch` parameter must be preserved.
+#[test]
+fn destructuring_catch_param_is_preserved() {
+    let out = client(
+        "<script>let f = () => {};</script>\n<button onclick={() => { try { f(); } catch ({ message }) { console.log(message); } }}>x</button>",
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("catch ({ message })"),
+        "destructuring catch param dropped: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Two inline-JS statement-conversion fixes from issue #456:

- **H-110 (Critical)** — `for...in` was converted into `JsForOfStatement` and codegen unconditionally printed ` of `, so `for (const k in obj)` was emitted as `for (const k of obj)` — different runtime semantics (keys vs values). Added an `is_for_in` flag to `JsForOfStatement`, set from the ESTree node type, and codegen emits ` in ` vs ` of ` accordingly. All construction sites updated.
- **H-112** — the `catch` parameter converter only read a direct `.name`, so a destructuring param like `catch ({ message }) {}` came through as `None`. It now routes through `convert_param_pattern`, preserving object/array patterns.

### Deferred (separate follow-ups on #456)

- **H-109 (Critical)** — `switch` is flattened into a plain `Block`; needs a real `JsStatement::Switch` variant (discriminant + cases + default) plus codegen.
- **H-111 (Critical)** — labeled statements drop the label while labeled `break`/`continue` survive → `ReferenceError`. A `JsStatement::Labeled` variant exists but the converter discards the label.

Both are larger AST + converter + codegen additions.

## Test plan

- [x] New `tests/inline_js_statements.rs` — `for...in` stays `for...in`; destructuring catch param preserved
- [x] `cargo test` — snapshot, ssr, runtime, validator, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)