### PR TITLE
fix(@const): byte-index the {@const} assignment splitters (H-131)

### DIFF
--- a/src/compiler/phases/1_parse/state/tag.rs
+++ b/src/compiler/phases/1_parse/state/tag.rs
@@ -1529,43 +1529,51 @@ impl Parser<'_> {
 
                 // Simple check: if there's a comma at top level (outside parentheses/brackets),
                 // and not part of a single assignment, it's invalid
-                let mut depth = 0;
+                // Scan bytes (not a `Vec<char>`): `first_equals` is later used as
+                // a byte index to slice `trimmed`, so a character index would
+                // corrupt a `{@const}` whose LHS has a multi-byte character
+                // (H-131). Every token examined here is ASCII.
+                let mut depth = 0i32;
                 let mut in_string = false;
-                let mut string_char = '\0';
-                let chars: Vec<char> = trimmed.chars().collect();
-                let mut first_equals = None;
+                let mut string_char = 0u8;
+                let bytes = trimmed.as_bytes();
+                let mut first_equals: Option<usize> = None;
 
-                for (i, &c) in chars.iter().enumerate() {
+                let mut i = 0;
+                while i < bytes.len() {
+                    let c = bytes[i];
                     if in_string {
-                        if c == string_char && (i == 0 || chars[i - 1] != '\\') {
+                        if c == string_char && (i == 0 || bytes[i - 1] != b'\\') {
                             in_string = false;
                         }
+                        i += 1;
                         continue;
                     }
 
-                    if c == '"' || c == '\'' || c == '`' {
+                    if c == b'"' || c == b'\'' || c == b'`' {
                         in_string = true;
                         string_char = c;
+                        i += 1;
                         continue;
                     }
 
-                    if c == '(' || c == '[' || c == '{' {
+                    if c == b'(' || c == b'[' || c == b'{' {
                         depth += 1;
-                    } else if c == ')' || c == ']' || c == '}' {
+                    } else if c == b')' || c == b']' || c == b'}' {
                         depth -= 1;
-                    } else if c == '=' && first_equals.is_none() && depth == 0 {
+                    } else if c == b'=' && first_equals.is_none() && depth == 0 {
                         // Check it's not ==, ===, !=, !==, <=, >=, =>
-                        if i + 1 < chars.len()
-                            && chars[i + 1] != '='
-                            && chars[i + 1] != '>'
-                            && (i == 0
-                                || (chars[i - 1] != '!'
-                                    && chars[i - 1] != '<'
-                                    && chars[i - 1] != '>'))
+                        let next = bytes.get(i + 1).copied().unwrap_or(0);
+                        let prev = if i > 0 { bytes[i - 1] } else { 0 };
+                        if next != b'='
+                            && next != b'>'
+                            && prev != b'!'
+                            && prev != b'<'
+                            && prev != b'>'
                         {
                             first_equals = Some(i);
                         }
-                    } else if c == ',' && depth == 0 {
+                    } else if c == b',' && depth == 0 {
                         // Found top-level comma after the first assignment - this is a sequence expression
                         if first_equals.is_some() {
                             return Err(crate::error::ParseError::svelte(
@@ -1575,6 +1583,7 @@ impl Parser<'_> {
                             ));
                         }
                     }
+                    i += 1;
                 }
 
                 // Build a proper VariableDeclaration node, matching the official

--- a/src/compiler/phases/3_transform/server/visitors/const_tag.rs
+++ b/src/compiler/phases/3_transform/server/visitors/const_tag.rs
@@ -452,24 +452,30 @@ impl<'a> ServerCodeGenerator<'a> {
 /// Find the index of the assignment `=` in a const tag declaration.
 /// Skips past destructuring patterns (handles `{a, b} = expr` and `[a, b] = expr`).
 fn find_assignment_eq(decl: &str) -> Option<usize> {
-    let chars: Vec<char> = decl.chars().collect();
+    // Scan bytes (not chars) and return a BYTE index: the result is used to slice
+    // the UTF-8 string, so a `Vec<char>` index would corrupt a `{@const}` whose
+    // LHS contains a multi-byte character (H-131). All tokens matched here
+    // (`{[(}])`, `=`, `!`, `<`, `>`) are ASCII, so byte scanning is exact.
+    let bytes = decl.as_bytes();
     let mut depth = 0i32;
-    for (i, &c) in chars.iter().enumerate() {
-        match c {
-            '{' | '[' | '(' => depth += 1,
-            '}' | ']' | ')' => depth -= 1,
-            '=' if depth == 0 => {
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => depth -= 1,
+            b'=' if depth == 0 => {
                 // Make sure it's not `==` or `=>`
-                let next = chars.get(i + 1).copied().unwrap_or('\0');
-                if next != '=' && next != '>' {
-                    let prev = if i > 0 { chars[i - 1] } else { '\0' };
-                    if prev != '!' && prev != '<' && prev != '>' {
+                let next = bytes.get(i + 1).copied().unwrap_or(0);
+                if next != b'=' && next != b'>' {
+                    let prev = if i > 0 { bytes[i - 1] } else { 0 };
+                    if prev != b'!' && prev != b'<' && prev != b'>' {
                         return Some(i);
                     }
                 }
             }
             _ => {}
         }
+        i += 1;
     }
     None
 }

--- a/tests/const_tag_multibyte.rs
+++ b/tests/const_tag_multibyte.rs
@@ -1,0 +1,43 @@
+//! Issue #458 H-131: `{@const}` `=` splitters must use byte indices, not
+//! character indices, so a multi-byte character before the `=` doesn't corrupt
+//! (or panic on) the pattern/init slice.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn go(src: &str, mode: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: mode,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+// No space around `=` so the multi-byte `é` sits immediately before `=`: a
+// character index would land mid-`é` (a non-char-boundary byte) and panic.
+const SRC: &str = "{#if true}{@const café='x'}{café}{/if}";
+
+#[test]
+fn multibyte_const_lhs_client() {
+    let out = go(SRC, GenerateMode::Client);
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("café"),
+        "multi-byte const identifier lost: {out}"
+    );
+}
+
+#[test]
+fn multibyte_const_lhs_server() {
+    let out = go(SRC, GenerateMode::Server);
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("café='x'"),
+        "multi-byte const mis-split: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the Critical char-vs-byte index bug (H-131) in `{@const}` handling. The `=` splitters scanned a `Vec<char>` and returned a **character** index, which was then used to **byte-slice** the UTF-8 string. A `{@const}` whose LHS contained a multi-byte character produced a wrong pattern/init split — or panicked outright when the character index landed on a non-char-boundary byte (e.g. `{@const café='x'}`, where `é` sits right before `=`).

Both splitters now scan bytes and return byte indices:
- the parser's first-`=` scan in `state/tag.rs`;
- the server's `find_assignment_eq` in `const_tag.rs`.

Every token they examine (`{[(}])`, `=`, `!`, `<`, `>`, quotes, `,`) is ASCII, so byte scanning is exact.

### Deferred (separate follow-ups on #458)

The analysis-side items need dependency-graph / scope changes:
- **H-132** — walk `declaration.id` in `analyze_const_tag` so pattern defaults / computed keys participate in the dependency graph.
- **H-133** — declare object-rest leaf bindings in scope analysis.
- **H-134** — SSR async destructuring wrongly declares property keys / default deps as `let`s.
- **M-085** — async destructured blockers registered under the generated temp, not the destructured names.

## Test plan

- [x] New `tests/const_tag_multibyte.rs` — `{@const café='x'}` (multi-byte char immediately before `=`) compiles in both client and server modes with the identifier intact
- [x] `cargo test` — snapshot, ssr, runtime, parser, validator, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)