### PR TITLE
fix(each): escape object-rest exclusion keys in {#each} context patterns (H-137)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -54,6 +54,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::
 };
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::shared::template::escape_js_string;
 use rustc_hash::FxHashMap;
 use std::cell::Cell;
 use std::rc::Rc;
@@ -1293,7 +1294,7 @@ fn _extract_destructured_paths(
                                         && !computed
                                         && let Some(name) = key.get("name").and_then(|n| n.as_str())
                                     {
-                                        excluded_keys.push(format!("'{}'", name));
+                                        excluded_keys.push(format!("'{}'", escape_js_string(name)));
                                     } else if key_type == Some("Literal") {
                                         // Match official compiler: b.literal(String(p.key.value))
                                         if let Some(val) = key.get("value") {
@@ -1320,7 +1321,8 @@ fn _extract_destructured_paths(
                                                 serde_json::Value::Bool(b) => b.to_string(),
                                                 _ => format!("{}", val),
                                             };
-                                            excluded_keys.push(format!("'{}'", val_str));
+                                            excluded_keys
+                                                .push(format!("'{}'", escape_js_string(&val_str)));
                                         }
                                     } else if computed {
                                         // Match official compiler: b.call('String', p.key)

--- a/tests/each_object_rest_key_escape.rs
+++ b/tests/each_object_rest_key_escape.rs
@@ -1,0 +1,29 @@
+//! Issue #459 H-137: object-rest exclusion keys in `{#each}` context patterns
+//! must be JS-escaped — a string-literal key containing a quote would otherwise
+//! produce invalid JS in the `$.exclude_from_object(..., [...])` call.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn object_rest_exclusion_key_with_quote_is_escaped() {
+    let out = client("{#each items as { \"a'b\": v, ...rest }}{v}{rest}{/each}");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains(r"['a\'b']"),
+        "object-rest exclusion key not escaped: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the contained part of H-137 from issue #459. Object-rest exclusion keys for `{#each items as { key, ...rest }}` were emitted via `format!("'{}'", value)` with no escaping, so a string-literal key containing a quote — `{#each items as { "a'b": v, ...rest }}` — produced the invalid `$.exclude_from_object($$item, ['a'b'])`. Identifier and literal keys now run through `escape_js_string`, yielding `['a\'b']`.

### Deferred (separate follow-ups on #459)

These share the destructuring-pattern-conversion area / the H-004 root-scope issue and need a shared pattern converter:
- **H-135** — key-function param conversion drops rest / computed / literal / default keys.
- **H-136** — nested defaults in context destructuring lose the fallback expression.
- **H-138** — collection shadowing skips real root-scope bindings (underlying cause is H-004).
- the computed-key `apply_transforms_to_expression` part of H-137.
- **M-087** — key expressions analysed after the each-scope is restored.

**M-086 is intentionally not changed:** upstream's animation validation keys off `parent.key` (existence) — `key.is_some()` already matches it. Switching to `metadata.keyed` (which is false for `{#each x as i, i (i)}`) would diverge from upstream.

## Test plan

- [x] New `tests/each_object_rest_key_escape.rs` — string-literal exclusion key with a quote is escaped
- [x] `cargo test` — snapshot, ssr, runtime, validator, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)