### PR TITLE
fix(preprocess): apply attribute-only diffs + honour Some({}) attribute clears (H-139, H-140)

### DIFF
--- a/src/compiler/preprocess/mod.rs
+++ b/src/compiler/preprocess/mod.rs
@@ -356,8 +356,15 @@ async fn process_tag(
                     deps.extend_from_slice(&processed.dependencies);
                 }
 
-                // Check if anything changed
-                if processed.map.is_none() && processed.code == content {
+                // Check if anything changed. An attribute-only change (same code,
+                // no map, but returned `attributes`) must still be treated as a
+                // real diff so the tag is re-emitted with the new attributes —
+                // otherwise the original tag with stale attributes is returned
+                // (H-139).
+                if processed.map.is_none()
+                    && processed.code == content
+                    && processed.attributes.is_none()
+                {
                     return Ok(MappedCode::from_source(&slice_source(
                         tag_with_content.to_string(),
                         tag_offset,
@@ -365,11 +372,14 @@ async fn process_tag(
                     )));
                 }
 
-                let generated_attributes = stringify_tag_attributes(&processed.attributes);
-                let final_attributes = if generated_attributes.is_empty() {
-                    attributes.to_string()
-                } else {
-                    generated_attributes
+                // `Some(attrs)` returned by the preprocessor replaces the original
+                // attributes — including `Some({})`, which intentionally clears
+                // them. Only `None` ("unchanged") falls back to the originals
+                // (H-140); previously an empty generated string also fell back,
+                // so a deliberate clear was impossible.
+                let final_attributes = match &processed.attributes {
+                    Some(_) => stringify_tag_attributes(&processed.attributes),
+                    None => attributes.to_string(),
                 };
 
                 Ok(processed_tag_to_code(

--- a/tests/preprocess_attributes.rs
+++ b/tests/preprocess_attributes.rs
@@ -1,0 +1,76 @@
+//! Issue #460: a preprocessor that returns changed `attributes` must have them
+//! applied even when the code is unchanged (H-139), and `Some({})` must clear
+//! the tag's attributes rather than fall back to the originals (H-140).
+
+use rustc_hash::FxHashMap;
+use std::future::Future;
+use svelte_compiler_rust::compiler::preprocess::preprocess;
+use svelte_compiler_rust::compiler::preprocess::types::{
+    AttributeValue, PreprocessError, PreprocessorFn, PreprocessorGroup, PreprocessorOptions,
+    PreprocessorResult, Processed,
+};
+
+fn ok<F>(f: F) -> PreprocessorResult
+where
+    F: Future<Output = Result<Option<Processed>, PreprocessError>> + Send + 'static,
+{
+    Box::pin(f)
+}
+
+fn run(source: &str, group: PreprocessorGroup) -> String {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    rt.block_on(preprocess(
+        source.to_string(),
+        vec![group],
+        Some("T.svelte".to_string()),
+    ))
+    .unwrap()
+    .code
+}
+
+const SRC: &str = "<script lang=\"ts\">let x = 1;</script>";
+
+/// H-139: changed attributes are applied even though the code is unchanged.
+#[test]
+fn attribute_only_change_is_applied() {
+    let group = PreprocessorGroup {
+        script: Some(Box::new(|opts: PreprocessorOptions| {
+            ok(async move {
+                let mut attrs = FxHashMap::default();
+                attrs.insert("foo".to_string(), AttributeValue::String("bar".to_string()));
+                Ok(Some(Processed {
+                    code: opts.content,
+                    attributes: Some(attrs),
+                    ..Default::default()
+                }))
+            })
+        }) as PreprocessorFn),
+        ..Default::default()
+    };
+    let out = run(SRC, group);
+    assert!(
+        out.contains("foo=\"bar\""),
+        "attribute change discarded: {out}"
+    );
+}
+
+/// H-140: `Some({})` clears the tag's attributes.
+#[test]
+fn empty_attributes_map_clears() {
+    let group = PreprocessorGroup {
+        script: Some(Box::new(|opts: PreprocessorOptions| {
+            ok(async move {
+                Ok(Some(Processed {
+                    code: opts.content,
+                    attributes: Some(FxHashMap::default()),
+                    ..Default::default()
+                }))
+            })
+        }) as PreprocessorFn),
+        ..Default::default()
+    };
+    let out = run(SRC, group);
+    assert!(!out.contains("lang"), "attributes not cleared: {out}");
+}


### PR DESCRIPTION
## Summary

Two preprocessor-pipeline fixes from issue #460:

- **H-139** — the "nothing changed" short-circuit only checked `code` and `map`, so a script/style preprocessor that returned the **same code with changed attributes** had its new attributes discarded — the original tag (stale attrs) was re-emitted. The check now also requires `processed.attributes.is_none()`.
- **H-140** — the final-attribute selection fell back to the original attributes whenever the generated attribute string was empty, so `attributes: Some({})` (an intentional clear) was indistinguishable from `None` (unchanged). It now matches on the `Option`: `Some(_)` — including the empty map — replaces the originals; only `None` keeps them.

> H-141 was already fixed (escaping); H-142 (sourcemap-index panic) was addressed in #504 (issue #451).

### Deferred (separate follow-ups on #460)

- **M-088** — empty-string attribute values parsed as boolean `true` instead of `""`.
- **M-089** — `sourcesContent` / `sourceRoot` dropped during `MappedCode::concat` (a sourcemap-quality follow-up tracked with the #451 cluster).

## Test plan

- [x] New `tests/preprocess_attributes.rs` — attribute-only change applied; `Some({})` clears attributes
- [x] `cargo test --test preprocess` — all 15 fixtures pass (no regression)
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)