### PR TITLE
fix(stores): byte-index store-subscription reference positions (M-005)

### DIFF
--- a/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -634,6 +634,10 @@ fn collect_dollar_identifiers_from_js_with_context(
     // Simple regex-like scanning for $xxx identifiers
     // We look for $ followed by valid identifier characters
     let chars: Vec<char> = js.chars().collect();
+    // Byte offset of each character, so a `StoreRef.position` (consumed
+    // downstream as a byte index into the source) stays correct when multi-byte
+    // characters precede the reference (M-005).
+    let char_byte_offsets: Vec<usize> = js.char_indices().map(|(b, _)| b).collect();
     let len = chars.len();
     let mut i = 0;
     let mut in_string: Option<char> = None; // track if inside a string literal
@@ -779,7 +783,11 @@ fn collect_dollar_identifiers_from_js_with_context(
                     {
                         refs.push(StoreRef {
                             name: ident,
-                            position: base_offset + ident_start,
+                            position: base_offset
+                                + char_byte_offsets
+                                    .get(ident_start)
+                                    .copied()
+                                    .unwrap_or(js.len()),
                             in_module,
                         });
                     }

--- a/tests/store_ref_multibyte.rs
+++ b/tests/store_ref_multibyte.rs
@@ -1,0 +1,37 @@
+//! Issue #461 M-005: store-subscription detection computed character indices
+//! but stored them as byte positions, so a multi-byte character before a
+//! `$store` reference shifted the position. Verify a store ref after a
+//! multi-byte identifier is still detected and rewritten correctly.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn store_ref_after_multibyte_identifier() {
+    let src = "<script>\nimport { writable } from 'svelte/store';\nconst café = 1;\nconst s = writable(0);\n$: total = $s + café;\n</script>\n{total}";
+    let out = client(src);
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    // The store read is rewritten through $.store_get and the multi-byte
+    // identifier is preserved untouched.
+    assert!(
+        out.contains("$.store_get(s, '$s'"),
+        "store ref not detected: {out}"
+    );
+    assert!(
+        out.contains("café"),
+        "multi-byte identifier corrupted: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes M-005 from issue #461. The `$xxx` store-reference scanner iterated a `Vec<char>` and stored the **character** index as `StoreRef.position`, but `position` is consumed downstream as a **byte** offset into the source (to peek at the character after the reference and to rewrite the read). A multi-byte character before a `$store` reference shifted every later position.

The scanner now precomputes a character-index → byte-offset table once and stores the byte offset, so positions stay correct regardless of multi-byte characters.

### Deferred (separate follow-ups on #461)

These need a real post-TS-strip AST walk with string/comment/regex skipping:
- **H-074** — runes-mode store member updates miss chained computed member targets.
- **H-075** — legacy statement-wide parameter filtering drops unrelated store reads.
- **H-076** — store detection scans raw TypeScript before type-strip.
- **M-049** — legacy store read/call rewriting can mutate inert string/template/regex/comment text.
- **M-050** — store refs in snippet parameter defaults not collected.
- **M-051** — `$derived` import disambiguation is substring/line based.

## Test plan

- [x] New `tests/store_ref_multibyte.rs` — a store ref after a multi-byte identifier (`café`) is still detected (`$.store_get(s, '$s', …)`) and the identifier is preserved
- [x] `cargo test` — snapshot, ssr, runtime, validator, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)