### PR TITLE
fix(effect): lower $effect.pending() to $.eager(() => $.pending()) (H-121)

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -2130,7 +2130,7 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         //   $effect.pre(fn)        -> $.user_pre_effect(fn)
         //   $effect.root(fn)       -> $.effect_root(fn)
         //   $effect.tracking()     -> $.effect_tracking()
-        //   $effect.pending()      -> $.eager($.pending)        (whole-call rewrite)
+        //   $effect.pending()      -> $.eager(() => $.pending())  (whole-call rewrite)
         //
         // The visitor's `scoped_vars` already tracks function/catch parameters
         // and let/const/var declarations, so `is_shadowed("$effect")` is the
@@ -2180,13 +2180,14 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
                             }
                             "pending" if expr.arguments.is_empty() => {
                                 // Whole-call rewrite: `$effect.pending()` becomes
-                                // `$.eager($.pending)`. The empty-arg call is
-                                // restructured into a different call shape, so we
-                                // replace the entire CallExpression span.
+                                // `$.eager(() => $.pending())`, matching upstream
+                                // (`$.eager` receives a thunk that calls
+                                // `$.pending()`). The entire CallExpression span is
+                                // replaced.
                                 self.add_replacement(
                                     expr.span.start,
                                     expr.span.end,
-                                    "$.eager($.pending)".to_string(),
+                                    "$.eager(() => $.pending())".to_string(),
                                 );
                                 return;
                             }

--- a/src/compiler/phases/3_transform/client/effect_rune_ast.rs
+++ b/src/compiler/phases/3_transform/client/effect_rune_ast.rs
@@ -17,7 +17,7 @@
 //! | `$effect.pre(fn)`     | `$.user_pre_effect(fn)`    |
 //! | `$effect.root(fn)`    | `$.effect_root(fn)`        |
 //! | `$effect.tracking()`  | `$.effect_tracking()`      |
-//! | `$effect.pending()`   | `$.eager($.pending)` (whole-call swap) |
+//! | `$effect.pending()`   | `$.eager(() => $.pending())` (whole-call swap) |
 
 use std::cell::RefCell;
 
@@ -121,13 +121,13 @@ impl<'a> Visit<'a> for EffectRuneCollector {
                     )),
                     "pending" => {
                         // Whole-call swap: `$effect.pending()` →
-                        // `$.eager($.pending)`. The original takes no
-                        // args; we discard the `()` and emit a fresh
-                        // call shape.
+                        // `$.eager(() => $.pending())`, matching upstream exactly
+                        // (`$.eager` receives a thunk that calls `$.pending()`).
+                        // The original takes no args; any are discarded.
                         self.replacements.push((
                             call.span.start,
                             call.span.end,
-                            "$.eager($.pending)".to_string(),
+                            "$.eager(() => $.pending())".to_string(),
                         ));
                     }
                     _ => {}
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn rewrites_effect_pending() {
         let out = apply_effect_rune_transforms_ast("let p = $effect.pending();", false).unwrap();
-        assert_eq!(out, "let p = $.eager($.pending);");
+        assert_eq!(out, "let p = $.eager(() => $.pending());");
     }
 
     #[test]

--- a/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -2619,22 +2619,22 @@ fn transform_rune_call(
         }
 
         "$effect.pending" => {
-            // $effect.pending() -> $.eager($.pending)
-            JsExpr::Call(JsCallExpression {
-                callee: context.arena.alloc_expr(JsExpr::Member(JsMemberExpression {
-                    object: context.arena.alloc_expr(JsExpr::Identifier("$".into())),
-                    property: JsMemberProperty::Identifier("eager".into()),
-                    computed: false,
-                    optional: false,
-                })),
-                arguments: vec![JsExpr::Member(JsMemberExpression {
-                    object: context.arena.alloc_expr(JsExpr::Identifier("$".into())),
-                    property: JsMemberProperty::Identifier("pending".into()),
-                    computed: false,
-                    optional: false,
-                })],
-                optional: false,
-            })
+            // $effect.pending() -> $.eager(() => $.pending())
+            // Mirror upstream exactly: `$.eager` receives a thunk that *calls*
+            // `$.pending()`, not a bare reference to `$.pending`. Any arguments
+            // are ignored, matching upstream (which performs no arity check).
+            use crate::compiler::phases::phase3_transform::js_ast::builders as b;
+            let pending_call = b::call(
+                &context.arena,
+                b::member_path(&context.arena, "$.pending"),
+                vec![],
+            );
+            let thunk = b::thunk(&context.arena, pending_call);
+            b::call(
+                &context.arena,
+                b::member_path(&context.arena, "$.eager"),
+                vec![thunk],
+            )
         }
 
         "$state.eager" => {

--- a/tests/effect_pending_lowering.rs
+++ b/tests/effect_pending_lowering.rs
@@ -1,0 +1,30 @@
+//! Issue #462 (H-121 lowering part): `$effect.pending()` must lower to
+//! `$.eager(() => $.pending())` — a thunk that *calls* `$.pending()` — matching
+//! upstream, not a bare `$.eager($.pending)` reference.
+
+use svelte_compiler_rust::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+
+fn client_async(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            experimental: ExperimentalOptions { r#async: true },
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn effect_pending_lowers_to_eager_thunk() {
+    let out = client_async("<script>const n = $effect.pending();</script>\n{n}");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        out.contains("$.eager(() => $.pending())"),
+        "wrong $effect.pending lowering: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

`$effect.pending()` was lowered to `$.eager($.pending)` — passing a bare reference to `$.pending` — across **all three** lowering paths:
- `effect_rune_ast.rs` (instance-script text rewrite),
- `ast_state_transform.rs` (instance-script AST-state rewrite),
- `expression_converter.rs` (template expression).

Upstream emits `$.eager(() => $.pending())`: `$.eager` receives a thunk that **calls** `$.pending()`. All three paths now produce the upstream shape.

### On the "validate arity" suggestion

H-121's suggested fix was to validate that `$effect.pending` takes no arguments. That is **intentionally not applied** — upstream's `CallExpression` analysis performs **no** argument check for `$effect.pending` (it just ignores extra arguments, see `phases/2-analyze/visitors/CallExpression.js`), so adding an error would diverge from upstream. The actual upstream divergence was the **lowering shape** (`$.eager($.pending)` vs `$.eager(() => $.pending())`), which is what this PR fixes.

### Deferred (separate follow-ups on #462)

- **H-122** — `effect_rune_ast` rewrites shadowed local `$effect` calls (no binding check).
- **H-123** — whole-call `$effect.pending(...)` replacement overlaps nested rune replacements.
- **M-079** — late `$effect` helper rewrites invalid arity shapes.
- **M-080** — text-based class-constructor effect fallback misses `.root` / `.tracking` / `.pending`.

These need the scope-resolved AST rewrite.

## Test plan

- [x] New `tests/effect_pending_lowering.rs` — instance-script `$effect.pending()` lowers to `$.eager(() => $.pending())`
- [x] `effect_rune_ast` unit tests updated and passing
- [x] `cargo test` — snapshot, ssr, runtime, validator, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)