### PR TITLE
fix(svelte-ignore): route direct warning pushes through emit_warning (H-118)

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/expression_statement.rs
+++ b/src/compiler/phases/2_analyze/visitors/expression_statement.rs
@@ -107,11 +107,13 @@ pub fn visit(node: &Value, context: &mut VisitorContext) -> Result<(), AnalysisE
                                                 });
 
                                             if is_default_import {
-                                                // Emit the warning
-                                                context
-                                                    .analysis
-                                                    .warnings
-                                                    .push(warnings::legacy_component_creation());
+                                                // Route through emit_warning so a
+                                                // `svelte-ignore` in scope can suppress
+                                                // it (H-118); a direct push bypasses
+                                                // the ignore stack.
+                                                context.emit_warning(
+                                                    warnings::legacy_component_creation(),
+                                                );
                                             }
                                         }
                                     }
@@ -242,10 +244,9 @@ fn check_legacy_component_creation(expression: &Value, context: &mut VisitorCont
                 });
 
             if is_default_import {
-                context
-                    .analysis
-                    .warnings
-                    .push(warnings::legacy_component_creation());
+                // Route through emit_warning so a `svelte-ignore` in scope can
+                // suppress it (H-118).
+                context.emit_warning(warnings::legacy_component_creation());
             }
         }
     }

--- a/src/compiler/phases/2_analyze/visitors/identifier.rs
+++ b/src/compiler/phases/2_analyze/visitors/identifier.rs
@@ -450,10 +450,9 @@ fn visit_identifier_inner(
         let binding = &context.analysis.root.bindings[binding_idx];
         // Check if binding is in module scope (scope_index == 0) and is reassigned
         if binding.scope_index == 0 && binding.reassigned {
-            context
-                .analysis
-                .warnings
-                .push(warnings::reactive_declaration_module_script_dependency());
+            // Route through emit_warning so a `svelte-ignore` in scope can
+            // suppress it (H-118); a direct push bypasses the ignore stack.
+            context.emit_warning(warnings::reactive_declaration_module_script_dependency());
         }
     }
 

--- a/tests/svelte_ignore_routing.rs
+++ b/tests/svelte_ignore_routing.rs
@@ -1,0 +1,38 @@
+//! Issue #463 H-118: analysis warnings emitted via a direct
+//! `analysis.warnings.push(...)` bypassed the `svelte-ignore` stack. Routing
+//! them through `emit_warning` lets an in-scope `svelte-ignore` suppress them.
+
+use svelte_compiler_rust::{CompileOptions, compile};
+
+fn warning_codes(src: &str) -> Vec<String> {
+    match compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            ..Default::default()
+        },
+    ) {
+        Ok(r) => r.warnings.into_iter().map(|w| w.code).collect(),
+        Err(e) => vec![format!("COMPILE_ERROR: {e:?}")],
+    }
+}
+
+const CODE: &str = "reactive_declaration_module_script_dependency";
+
+#[test]
+fn module_script_reactive_warning_is_emitted_without_ignore() {
+    let src = "<script module>\nlet count = 0;\n</script>\n<script>\n$: doubled = count * 2;\ncount = count + 1;\n</script>\n{doubled}";
+    assert!(
+        warning_codes(src).iter().any(|c| c == CODE),
+        "expected the warning without an ignore"
+    );
+}
+
+#[test]
+fn module_script_reactive_warning_is_suppressed_by_svelte_ignore() {
+    let src = "<script module>\nlet count = 0;\n</script>\n<script>\n// svelte-ignore reactive_declaration_module_script_dependency\n$: doubled = count * 2;\ncount = count + 1;\n</script>\n{doubled}";
+    assert!(
+        !warning_codes(src).iter().any(|c| c == CODE),
+        "svelte-ignore should suppress the directly-pushed warning (H-118)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes H-118 from issue #463. Several analysis warnings were emitted via a direct `analysis.warnings.push(...)`, which bypasses the `svelte-ignore` stack — so an in-scope `svelte-ignore` could not suppress them. These now go through `context.emit_warning(...)` (which is `if !is_ignored(code) { push }` — equivalent to a push when nothing is ignored, and correctly suppressed when a matching `svelte-ignore` is in scope):

- `reactive_declaration_module_script_dependency` (`identifier.rs`)
- `legacy_component_creation` (`expression_statement.rs`, two sites)

### M-058 / M-077 — won't fix (matches upstream)

The legacy ignore-code mapping `module-script-reactive-declaration` → `reactive_declaration_module_script` mirrors upstream's `utils/extract_svelte_ignore.js` **exactly**. The issue suggests remapping it to `reactive_declaration_module_script_dependency`, but that would diverge from upstream (which maps to `reactive_declaration_module_script`). Left unchanged.

### Deferred (separate follow-ups on #463)

- **H-117** — HTML `svelte-ignore` before `<script>`.
- **H-119** — script path uses `extract_svelte_ignore` (no diagnostics).
- **H-120** — stale `pending_leading_comments` suppressing later CSS warnings.
- **M-059** — invalid `svelte-ignore` diagnostics dropped before text.
- **M-078** — `<svelte:self>` ignore lists not persisted.

These are broader warning routing/scoping changes.

## Test plan

- [x] New `tests/svelte_ignore_routing.rs` — `reactive_declaration_module_script_dependency` is emitted normally, and suppressed by an in-scope `// svelte-ignore`
- [x] `cargo test` — validator, snapshot, ssr, runtime, real_world all pass
- [x] `cargo fmt --check` clean; no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)