### PR TITLE
fix(napi): RAII-guard zero-copy envelope arena against leak on error (H-015)

### DIFF
--- a/src/napi.rs
+++ b/src/napi.rs
@@ -1130,6 +1130,23 @@ pub fn napi_compile_envelope_zero_copy(
         crate::napi_raw::estimate_size(&result),
     ));
     let bump_ptr: *mut bumpalo::Bump = Box::into_raw(bump);
+
+    // RAII guard: if we return early (e.g. `create_buffer_with_borrowed_data`
+    // errors) or unwind before ownership is handed to V8's finalizer, free the
+    // leaked arena instead of abandoning it (H-015). On success we disarm it so
+    // only the finalizer frees the arena.
+    struct BumpGuard(*mut bumpalo::Bump);
+    impl Drop for BumpGuard {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                // SAFETY: the pointer came from `Box::into_raw`, has not been
+                // handed to the finalizer, and is not aliased.
+                unsafe { drop(Box::from_raw(self.0)) };
+            }
+        }
+    }
+    let mut guard = BumpGuard(bump_ptr);
+
     // SAFETY: bump_ptr is freshly leaked from Box::into_raw and not
     // aliased; we re-acquire ownership via Box::from_raw inside the
     // finalizer below.
@@ -1154,6 +1171,9 @@ pub fn napi_compile_envelope_zero_copy(
             },
         )?
     };
+    // The finalizer now owns the arena; disarm the guard so it doesn't
+    // double-free.
+    guard.0 = std::ptr::null_mut();
     Ok(js_buf_value.into_raw())
 }
 


### PR DESCRIPTION
## Summary

Fixes the Critical arena leak (H-015) in `napi_compile_envelope_zero_copy`. The function leaked its bump arena via `Box::into_raw`, then called `env.create_buffer_with_borrowed_data(...)?`. If that NAPI call failed (or anything unwound) **before** the finalizer took ownership, the `?` returned early and the raw pointer was abandoned — a permanent arena leak with no RAII guard.

The leaked pointer is now held by a `BumpGuard` that frees it on drop (covering both the early `?` return and a panic). On success the guard is disarmed (its pointer nulled) so only V8's finalizer frees the arena — no double free.

### Deferred (separate follow-up on #464)

- **M-012** — the raw-envelope encoder uses unchecked `usize as u32` casts; making them checked (`u32::try_from` + propagate) requires the encoder to return a `Result` (a wider refactor) and is only reachable for >4 GB output. The JS-side decoder offset/length validation lives in `npm/` and is a separate change.

## Test plan

- [x] `cargo check --features napi` and default `cargo build` both clean
- [x] `cargo fmt --check` clean; no new clippy warnings (napi feature)

> This is a memory-safety fix on the NAPI boundary; it can't be unit-tested without injecting a NAPI buffer-creation failure from the JS runtime. Verified by compile + review: the guard frees on early return/unwind and is disarmed only after ownership transfers to the finalizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)