### PR TITLE
fix(napi): RAII arena guard + envelope offset/length validation (#464)

### DIFF
--- a/npm/vite-plugin-svelte-native/envelope.js
+++ b/npm/vite-plugin-svelte-native/envelope.js
@@ -26,6 +26,27 @@ const WARN_HAS_END = 1 << 2;
 const WARN_HAS_FRAME = 1 << 3;
 
 /**
+ * Validate that the byte window `[off, off + len)` lies fully inside a
+ * buffer of `bufLen` bytes. The encoder writes offsets/lengths as u32s
+ * the decoder otherwise trusts blindly — `buf.toString` / `subarray`
+ * silently *clamp* an out-of-range window, so a malformed envelope would
+ * decode to truncated data instead of failing loudly. Throw instead (M-012).
+ *
+ * @param {number} bufLen
+ * @param {number} off
+ * @param {number} len
+ * @param {string} label
+ */
+function assertWindow(bufLen, off, len, label) {
+	if (off < 0 || len < 0 || off + len > bufLen) {
+		throw new Error(
+			`[rsvelte] envelope ${label} out of bounds ` +
+				`(offset ${off} + length ${len} exceeds buffer of ${bufLen} bytes)`,
+		);
+	}
+}
+
+/**
  * Decode an envelope produced by `compileEnvelope` / `compileModuleEnvelope`.
  *
  * @param {Buffer|Uint8Array} buf
@@ -71,9 +92,23 @@ function decodeEnvelope(buf) {
 	const cssMapLen = view.getUint32(44, true);
 	const warningsOff = view.getUint32(48, true);
 	const warningsCount = view.getUint32(52, true);
+	const warningsLen = view.getUint32(56, true);
 
 	const hasCss = (flags & FLAG_HAS_CSS) !== 0;
 	const runes = (flags & FLAG_RUNES) !== 0;
+
+	// Validate every field window up front so a malformed envelope throws
+	// at decode time rather than silently truncating on first lazy read.
+	// A zero offset marks an absent optional field (the header alone fills
+	// the first HEADER_LEN bytes, so real data never starts at offset 0).
+	const len = buf.byteLength;
+	assertWindow(len, jsCodeOff, jsCodeLen, 'js.code');
+	if (jsMapOff !== 0) assertWindow(len, jsMapOff, jsMapLen, 'js.map');
+	if (hasCss) {
+		assertWindow(len, cssCodeOff, cssCodeLen, 'css.code');
+		if (cssMapOff !== 0) assertWindow(len, cssMapOff, cssMapLen, 'css.map');
+	}
+	if (warningsCount > 0) assertWindow(len, warningsOff, warningsLen, 'warnings');
 
 	// `buf.toString('utf8', start, end)` is the V8 fast path for
 	// Buffer→string and is consistently faster than wrapping in a
@@ -109,7 +144,7 @@ function decodeEnvelope(buf) {
 		configurable: true,
 		get() {
 			if (warningsCache === null) {
-				warningsCache = decodeWarnings(buf, view, warningsOff, warningsCount, slice);
+				warningsCache = decodeWarnings(buf, view, warningsOff, warningsLen, warningsCount, slice);
 			}
 			return warningsCache;
 		},
@@ -186,29 +221,50 @@ function makeCodeMapObject(buf, slice, codeOff, codeLen, mapOff, mapLen) {
 	return obj;
 }
 
-function decodeWarnings(buf, view, off, count, slice) {
+function decodeWarnings(buf, view, off, regionLen, count, slice) {
+	// Every record field is bounds-checked against the warnings region
+	// (already validated to lie inside the buffer by the caller) so a
+	// corrupt internal length throws rather than reading adjacent bytes
+	// or overrunning the buffer.
+	const end = off + regionLen;
+	const need = (p, n, what) => {
+		if (p < off || p + n > end) {
+			throw new Error(
+				`[rsvelte] truncated warning ${what} at offset ${p} ` +
+					`(needs ${n} bytes, region ends at ${end})`,
+			);
+		}
+	};
 	const out = new Array(count);
 	let p = off;
 	for (let i = 0; i < count; i++) {
+		need(p, 4, 'code length');
 		const codeLen = view.getUint32(p, true);
 		p += 4;
+		need(p, codeLen, 'code');
 		const code = slice(p, codeLen);
 		p += codeLen;
+		need(p, 4, 'message length');
 		const msgLen = view.getUint32(p, true);
 		p += 4;
+		need(p, msgLen, 'message');
 		const message = slice(p, msgLen);
 		p += msgLen;
+		need(p, 1, 'flags');
 		const flags = view.getUint8(p);
 		p += 1;
 
 		const w = { code, message };
 		if (flags & WARN_HAS_FILENAME) {
+			need(p, 4, 'filename length');
 			const len = view.getUint32(p, true);
 			p += 4;
+			need(p, len, 'filename');
 			w.filename = slice(p, len);
 			p += len;
 		}
 		if (flags & WARN_HAS_START) {
+			need(p, 12, 'start position');
 			w.start = {
 				line: view.getUint32(p, true),
 				column: view.getUint32(p + 4, true),
@@ -217,6 +273,7 @@ function decodeWarnings(buf, view, off, count, slice) {
 			p += 12;
 		}
 		if (flags & WARN_HAS_END) {
+			need(p, 12, 'end position');
 			w.end = {
 				line: view.getUint32(p, true),
 				column: view.getUint32(p + 4, true),
@@ -228,8 +285,10 @@ function decodeWarnings(buf, view, off, count, slice) {
 			w.position = [w.start.character, w.end.character];
 		}
 		if (flags & WARN_HAS_FRAME) {
+			need(p, 4, 'frame length');
 			const len = view.getUint32(p, true);
 			p += 4;
+			need(p, len, 'frame');
 			w.frame = slice(p, len);
 			p += len;
 		}
@@ -298,12 +357,22 @@ function decodeBatch(buf) {
 	}
 	const count = view.getUint32(12, true);
 
+	// The entry table must fit inside the buffer before we index into it.
+	const tableEnd = BATCH_HEADER_LEN + count * BATCH_ENTRY_LEN;
+	if (tableEnd > buf.byteLength) {
+		throw new Error(
+			`[rsvelte] batch entry table (${count} entries) exceeds buffer ` +
+				`(needs ${tableEnd} bytes, buffer is ${buf.byteLength})`,
+		);
+	}
+
 	const out = new Array(count);
 	for (let i = 0; i < count; i++) {
 		const entryOff = BATCH_HEADER_LEN + i * BATCH_ENTRY_LEN;
 		const status = view.getUint32(entryOff, true);
 		const payloadOff = view.getUint32(entryOff + 4, true);
 		const payloadLen = view.getUint32(entryOff + 8, true);
+		assertWindow(buf.byteLength, payloadOff, payloadLen, `batch entry ${i}`);
 		// Subarray gives a zero-copy view into the same underlying
 		// ArrayBuffer; `decodeEnvelope` walks it without further allocation.
 		const slice = buf.subarray

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "stage-svelte-check": "node scripts/stage-svelte-check-binaries.mjs",
     "stage-vps-native": "node scripts/stage-vps-binaries.mjs",
     "publish-platform-binaries": "node scripts/publish-platform-binaries.mjs",
+    "test:envelope": "node scripts/test-envelope-validation.mjs",
     "test:vps-shim": "node scripts/test-vps-shim.mjs",
     "test:vps-fixture": "node scripts/test-vps-vite-fixture.mjs",
     "test:vps": "node scripts/test-vps-shim.mjs && node scripts/test-vps-vite-fixture.mjs",

--- a/scripts/test-envelope-validation.mjs
+++ b/scripts/test-envelope-validation.mjs
@@ -1,0 +1,225 @@
+// Regression test for the envelope decoder's bounds validation (M-012).
+//
+// Hand-crafts valid and deliberately-corrupted envelopes (no NAPI
+// binding required) and asserts that `decodeEnvelope` / `decodeBatch`
+// throw on out-of-range offsets/lengths instead of silently truncating.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const { decodeEnvelope, decodeBatch } = await import(
+	`file://${join(repoRoot, 'npm/vite-plugin-svelte-native/envelope.js')}`
+).then((m) => m.default ?? m);
+
+const MAGIC = 0x31565352;
+const VERSION = 1;
+const HEADER_LEN = 60;
+const BATCH_MAGIC = 0x42565352;
+const BATCH_VERSION = 1;
+const BATCH_HEADER_LEN = 16;
+const BATCH_ENTRY_LEN = 12;
+
+let failures = 0;
+function ok(label) {
+	console.log(`  ✓ ${label}`);
+}
+function fail(label, detail) {
+	failures++;
+	console.error(`  ✗ ${label}${detail ? ` — ${detail}` : ''}`);
+}
+function expectThrow(label, fn, matcher) {
+	let threw = null;
+	try {
+		fn();
+	} catch (e) {
+		threw = e;
+	}
+	if (!threw) return fail(label, 'expected a throw, got none');
+	if (matcher && !matcher.test(threw.message)) {
+		return fail(label, `message ${JSON.stringify(threw.message)} !~ ${matcher}`);
+	}
+	ok(label);
+}
+function expectNoThrow(label, fn) {
+	try {
+		const v = fn();
+		ok(label);
+		return v;
+	} catch (e) {
+		fail(label, e.message);
+		return null;
+	}
+}
+function assertEq(label, a, b) {
+	if (a === b) ok(label);
+	else fail(label, `${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+}
+
+// --- builders --------------------------------------------------------------
+
+// Build a v1 envelope. `over` lets a test scribble raw header values
+// over the (otherwise-correct) ones to simulate corruption.
+function buildEnvelope({ jsCode = '', jsMap = null, warnings = [] } = {}, over = {}) {
+	const jsCodeBytes = Buffer.from(jsCode, 'utf8');
+	const jsMapBytes = jsMap == null ? null : Buffer.from(jsMap, 'utf8');
+	const warnBytes = Buffer.concat(warnings.map(encodeWarning));
+
+	const jsCodeOff = HEADER_LEN;
+	const jsMapOff = jsMapBytes ? jsCodeOff + jsCodeBytes.length : 0;
+	const warningsOff = jsCodeOff + jsCodeBytes.length + (jsMapBytes ? jsMapBytes.length : 0);
+	const total = warningsOff + warnBytes.length;
+
+	const buf = Buffer.alloc(total);
+	buf.writeUInt32LE(MAGIC, 0);
+	buf.writeUInt32LE(VERSION, 4);
+	buf.writeUInt32LE(total, 8);
+	buf.writeUInt32LE(0, 12); // flags — no css
+	buf.writeUInt32LE(jsCodeOff, 16);
+	buf.writeUInt32LE(jsCodeBytes.length, 20);
+	buf.writeUInt32LE(jsMapOff, 24);
+	buf.writeUInt32LE(jsMapBytes ? jsMapBytes.length : 0, 28);
+	buf.writeUInt32LE(warningsOff, 48);
+	buf.writeUInt32LE(warnings.length, 52);
+	buf.writeUInt32LE(warnBytes.length, 56);
+
+	jsCodeBytes.copy(buf, jsCodeOff);
+	if (jsMapBytes) jsMapBytes.copy(buf, jsMapOff);
+	warnBytes.copy(buf, warningsOff);
+
+	for (const [offset, value] of Object.entries(over)) {
+		buf.writeUInt32LE(value >>> 0, Number(offset));
+	}
+	return buf;
+}
+
+function encodeWarning(w) {
+	const code = Buffer.from(w.code ?? '', 'utf8');
+	const msg = Buffer.from(w.message ?? '', 'utf8');
+	const parts = [u32(code.length), code, u32(msg.length), msg, Buffer.from([0])];
+	return Buffer.concat(parts);
+}
+function u32(n) {
+	const b = Buffer.alloc(4);
+	b.writeUInt32LE(n >>> 0, 0);
+	return b;
+}
+
+function buildBatch(payloads, over = {}) {
+	const count = payloads.length;
+	const tableLen = count * BATCH_ENTRY_LEN;
+	const body = Buffer.concat(payloads.map((p) => p.buf));
+	const total = BATCH_HEADER_LEN + tableLen + body.length;
+	const buf = Buffer.alloc(total);
+	buf.writeUInt32LE(BATCH_MAGIC, 0);
+	buf.writeUInt32LE(BATCH_VERSION, 4);
+	buf.writeUInt32LE(total, 8);
+	buf.writeUInt32LE(count, 12);
+	let payloadOff = BATCH_HEADER_LEN + tableLen;
+	for (let i = 0; i < count; i++) {
+		const entryOff = BATCH_HEADER_LEN + i * BATCH_ENTRY_LEN;
+		buf.writeUInt32LE(payloads[i].status, entryOff);
+		buf.writeUInt32LE(payloadOff, entryOff + 4);
+		buf.writeUInt32LE(payloads[i].buf.length, entryOff + 8);
+		payloads[i].buf.copy(buf, payloadOff);
+		payloadOff += payloads[i].buf.length;
+	}
+	for (const [offset, value] of Object.entries(over)) {
+		buf.writeUInt32LE(value >>> 0, Number(offset));
+	}
+	return buf;
+}
+
+// --- tests -----------------------------------------------------------------
+
+console.log('=== envelope decoder bounds validation (M-012) ===\n');
+
+console.log('valid envelopes still decode:');
+const good = expectNoThrow('js.code-only envelope decodes', () =>
+	decodeEnvelope(buildEnvelope({ jsCode: 'let x = 1;' })),
+);
+if (good) assertEq('js.code round-trips', good.js.code, 'let x = 1;');
+
+const withWarn = expectNoThrow('envelope with one warning decodes', () =>
+	decodeEnvelope(buildEnvelope({ jsCode: 'x', warnings: [{ code: 'a11y_x', message: 'bad' }] })),
+);
+if (withWarn) {
+	assertEq('warnings length', withWarn.warnings.length, 1);
+	assertEq('warning code', withWarn.warnings[0].code, 'a11y_x');
+}
+
+console.log('\nmalformed envelopes throw:');
+// jsCodeLen far beyond the buffer (offset 20).
+expectThrow(
+	'oversized js.code length throws',
+	() => decodeEnvelope(buildEnvelope({ jsCode: 'x' }, { 20: 0xffffff })),
+	/js\.code out of bounds/,
+);
+// jsMapOff points past the end (offset 24) with a non-zero len (offset 28).
+expectThrow(
+	'js.map offset past buffer throws',
+	() => decodeEnvelope(buildEnvelope({ jsCode: 'x' }, { 24: 0xffffff, 28: 4 })),
+	/js\.map out of bounds/,
+);
+// warnings region length too large (offset 56), warnings touched lazily.
+expectThrow(
+	'oversized warnings region throws on read',
+	() => {
+		const r = decodeEnvelope(
+			buildEnvelope({ jsCode: 'x', warnings: [{ code: 'c', message: 'm' }] }, { 56: 0xffffff }),
+		);
+		void r.warnings;
+	},
+	/warnings out of bounds/,
+);
+// warnings region is the right size, but an internal code length is corrupt.
+expectThrow(
+	'corrupt warning code length throws on read',
+	() => {
+		const buf = buildEnvelope({ jsCode: 'x', warnings: [{ code: 'c', message: 'm' }] });
+		// The first warning's code-length u32 sits at warningsOff (read it back).
+		const warningsOff = buf.readUInt32LE(48);
+		buf.writeUInt32LE(0xffff, warningsOff); // claim a 64KB code field
+		void decodeEnvelope(buf).warnings;
+	},
+	/truncated warning/,
+);
+// too small to even hold a header.
+expectThrow(
+	'sub-header buffer throws',
+	() => decodeEnvelope(Buffer.alloc(HEADER_LEN - 1)),
+	/too small/,
+);
+
+console.log('\nbatch envelopes:');
+const okPayload = { status: 0, buf: buildEnvelope({ jsCode: 'let a = 1;' }) };
+const errPayload = { status: 1, buf: Buffer.from('parse error', 'utf8') };
+const batch = expectNoThrow('valid mixed batch decodes', () =>
+	decodeBatch(buildBatch([okPayload, errPayload])),
+);
+if (batch) {
+	assertEq('batch length', batch.length, 2);
+	assertEq('batch[0] ok', batch[0] instanceof Error, false);
+	assertEq('batch[1] err', batch[1] instanceof Error, true);
+}
+// Corrupt entry-0 payload length (entry table starts at 16; len field at +8).
+expectThrow(
+	'batch payload past buffer throws',
+	() => decodeBatch(buildBatch([okPayload, errPayload], { [BATCH_HEADER_LEN + 8]: 0xffffff })),
+	/batch entry 0 out of bounds/,
+);
+// Corrupt entry count (offset 12) so the entry table overruns the buffer.
+expectThrow(
+	'batch entry table overrun throws',
+	() => decodeBatch(buildBatch([okPayload], { 12: 0xffff })),
+	/batch entry table/,
+);
+
+console.log('');
+if (failures) {
+	console.error(`❌ ${failures} assertion(s) failed`);
+	process.exit(1);
+} else {
+	console.log('✅ all envelope-validation assertions passed');
+}

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -1062,6 +1062,22 @@ fn position_to_napi(p: crate::compiler::Position) -> NapiPosition {
 // same envelope: the buffer becomes a view into arena memory rather
 // than an owned `Vec<u8>`.
 
+/// Reject an envelope whose total size would overflow the `u32` header
+/// offsets (only reachable for more than 4 GiB of generated output).
+/// Surfaces the overflow as a `napi::Error` instead of letting `encode_*`
+/// silently truncate the offsets and hand the JS decoder a corrupt
+/// buffer (M-012).
+#[inline]
+fn ensure_envelope_size(size: usize) -> napi::Result<()> {
+    crate::napi_raw::check_envelope_size(size).map_err(|size| {
+        napi::Error::from_reason(format!(
+            "rsvelte: compiled output is {size} bytes, exceeding the \
+             {max}-byte envelope limit (header offsets are u32)",
+            max = crate::napi_raw::MAX_ENVELOPE_SIZE
+        ))
+    })
+}
+
 /// `compile()` returning a single packed envelope buffer.
 /// See `crate::napi_raw` for the byte-level format.
 #[napi(js_name = "compileEnvelope")]
@@ -1071,7 +1087,10 @@ pub fn napi_compile_envelope(
 ) -> napi::Result<Buffer> {
     let opts = options_to_compile(options);
     match rust_compile(&source, opts) {
-        Ok(result) => Ok(Buffer::from(crate::napi_raw::encode_to_vec(&result))),
+        Ok(result) => {
+            ensure_envelope_size(crate::napi_raw::estimate_size(&result))?;
+            Ok(Buffer::from(crate::napi_raw::encode_to_vec(&result)))
+        }
         Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
     }
 }
@@ -1126,9 +1145,9 @@ pub fn napi_compile_envelope_zero_copy(
         Ok(r) => r,
         Err(e) => return Err(napi::Error::from_reason(format!("{e:?}"))),
     };
-    let bump = Box::new(bumpalo::Bump::with_capacity(
-        crate::napi_raw::estimate_size(&result),
-    ));
+    let size = crate::napi_raw::estimate_size(&result);
+    ensure_envelope_size(size)?;
+    let bump = Box::new(bumpalo::Bump::with_capacity(size));
     let bump_ptr: *mut bumpalo::Bump = Box::into_raw(bump);
 
     // RAII guard: if we return early (e.g. `create_buffer_with_borrowed_data`
@@ -1196,9 +1215,9 @@ pub fn napi_compile_module_envelope_zero_copy(
         metadata: crate::compiler::CompileMetadata { runes: true },
         ast: None,
     };
-    let bump = Box::new(bumpalo::Bump::with_capacity(
-        crate::napi_raw::estimate_size(&cr),
-    ));
+    let size = crate::napi_raw::estimate_size(&cr);
+    ensure_envelope_size(size)?;
+    let bump = Box::new(bumpalo::Bump::with_capacity(size));
     let bump_ptr: *mut bumpalo::Bump = Box::into_raw(bump);
     let bump_ref: &bumpalo::Bump = unsafe { &*bump_ptr };
     let slice = crate::napi_raw::encode_into_bump(bump_ref, &cr);
@@ -1240,6 +1259,7 @@ pub fn napi_compile_module_envelope(
                 metadata: crate::compiler::CompileMetadata { runes: true },
                 ast: None,
             };
+            ensure_envelope_size(crate::napi_raw::estimate_size(&cr))?;
             Ok(Buffer::from(crate::napi_raw::encode_to_vec(&cr)))
         }
         Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
@@ -1311,6 +1331,7 @@ pub fn napi_compile_batch(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer
         })
         .collect();
 
+    ensure_envelope_size(crate::napi_raw::estimate_batch_size(&entries))?;
     Ok(Buffer::from(crate::napi_raw::encode_batch_to_vec(&entries)))
 }
 
@@ -1352,6 +1373,7 @@ impl Task for CompileEnvelopeTask {
         // small and we only pay it once per call.
         let result = rust_compile(&self.source, self.options.clone())
             .map_err(|e| napi::Error::from_reason(format!("{e:?}")))?;
+        ensure_envelope_size(crate::napi_raw::estimate_size(&result))?;
         Ok(crate::napi_raw::encode_to_vec(&result))
     }
 
@@ -1406,6 +1428,7 @@ impl Task for CompileBatchTask {
                 Err(_) => crate::napi_raw::BatchEntry::Err(e.as_deref().unwrap_or("unknown error")),
             })
             .collect();
+        ensure_envelope_size(crate::napi_raw::estimate_batch_size(&entries))?;
         Ok(crate::napi_raw::encode_batch_to_vec(&entries))
     }
 

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -1130,6 +1130,23 @@ pub fn napi_compile_envelope_zero_copy(
         crate::napi_raw::estimate_size(&result),
     ));
     let bump_ptr: *mut bumpalo::Bump = Box::into_raw(bump);
+
+    // RAII guard: if we return early (e.g. `create_buffer_with_borrowed_data`
+    // errors) or unwind before ownership is handed to V8's finalizer, free the
+    // leaked arena instead of abandoning it (H-015). On success we disarm it so
+    // only the finalizer frees the arena.
+    struct BumpGuard(*mut bumpalo::Bump);
+    impl Drop for BumpGuard {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                // SAFETY: the pointer came from `Box::into_raw`, has not been
+                // handed to the finalizer, and is not aliased.
+                unsafe { drop(Box::from_raw(self.0)) };
+            }
+        }
+    }
+    let mut guard = BumpGuard(bump_ptr);
+
     // SAFETY: bump_ptr is freshly leaked from Box::into_raw and not
     // aliased; we re-acquire ownership via Box::from_raw inside the
     // finalizer below.
@@ -1154,6 +1171,9 @@ pub fn napi_compile_envelope_zero_copy(
             },
         )?
     };
+    // The finalizer now owns the arena; disarm the guard so it doesn't
+    // double-free.
+    guard.0 = std::ptr::null_mut();
     Ok(js_buf_value.into_raw())
 }
 

--- a/src/napi_raw.rs
+++ b/src/napi_raw.rs
@@ -75,6 +75,29 @@ const WARN_HAS_START: u8 = 1 << 1;
 const WARN_HAS_END: u8 = 1 << 2;
 const WARN_HAS_FRAME: u8 = 1 << 3;
 
+/// Largest envelope that can address its own fields. Every header
+/// offset/length is a `u32` (little-endian), so an envelope whose total
+/// size exceeds this can't encode its own offsets without truncating
+/// them — the JS decoder would then read garbage. Only reachable for
+/// more than 4 GiB of generated output. Callers at the NAPI boundary
+/// must reject oversized results via [`check_envelope_size`] rather than
+/// letting the internal `usize as u32` casts silently wrap (M-012).
+pub const MAX_ENVELOPE_SIZE: usize = u32::MAX as usize;
+
+/// Returns `Err(size)` when an envelope of `size` bytes would overflow
+/// the `u32` header fields. Call this at the NAPI boundary before any
+/// `encode_*`; once it returns `Ok`, every offset/length in the
+/// envelope is `<= size <= u32::MAX` and so every internal `as u32`
+/// cast in [`encode_into`] is lossless.
+#[inline]
+pub fn check_envelope_size(size: usize) -> Result<(), usize> {
+    if size > MAX_ENVELOPE_SIZE {
+        Err(size)
+    } else {
+        Ok(())
+    }
+}
+
 /// Trait abstracting over the backing buffer. Step 2 implements this
 /// for `Vec<u8>`; Step 3 implements it for a bumpalo arena handle.
 pub trait Writer {
@@ -684,5 +707,16 @@ mod tests {
         assert_eq!(buf.len(), BATCH_HEADER_LEN);
         let read_u32 = |o: usize| u32::from_le_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]);
         assert_eq!(read_u32(12), 0, "empty batch count is 0");
+    }
+
+    #[test]
+    fn size_guard_accepts_in_range_and_rejects_overflow() {
+        assert!(check_envelope_size(0).is_ok());
+        assert!(check_envelope_size(HEADER_LEN).is_ok());
+        assert!(check_envelope_size(MAX_ENVELOPE_SIZE).is_ok());
+        assert_eq!(
+            check_envelope_size(MAX_ENVELOPE_SIZE + 1),
+            Err(MAX_ENVELOPE_SIZE + 1)
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #464 — NAPI envelope safety cluster (H-015, M-012).

- **H-015** (prior commit) — RAII-guard the zero-copy bump arena so it's freed if `create_buffer_with_borrowed_data` fails before the V8 finalizer takes ownership (no leak, no double-free).
- **M-012** (this commit) — make the raw envelope robust against malformed buffers and oversized output:
  - **Rust**: add `napi_raw::check_envelope_size` / `MAX_ENVELOPE_SIZE` and gate every envelope entry point (sync, zero-copy, module, batch, async) on it. Output larger than the `u32` offset range (>4 GiB) now returns a `napi::Error` instead of silently wrapping the header offsets. Once the guard passes, every offset/length is `<= total <= u32::MAX`, so the internal `as u32` casts in `encode_into` are provably lossless.
  - **JS**: `decodeEnvelope` validates every field window (js/css code+map, warnings region) against the buffer length up front; `decodeWarnings` bounds-checks each record field against the warnings region; `decodeBatch` validates the entry table and every payload window. All throw a descriptive error instead of returning silently-truncated data (Node's `Buffer.toString` / `subarray` otherwise clamp out-of-range windows).

## Test plan

- [x] `cargo check --features napi --lib`
- [x] `cargo test --lib napi_raw` (8 passed, incl. new `size_guard_accepts_in_range_and_rejects_overflow`)
- [x] `cargo clippy --all-targets --all-features` clean for touched files (`src/napi.rs`, `src/napi_raw.rs`)
- [x] `pnpm test:envelope` — new `scripts/test-envelope-validation.mjs` hand-crafts valid + corrupted v1/batch envelopes and asserts the decoder throws on out-of-range offsets/lengths and still decodes valid ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)