### PR TITLE
fix(client): logical-assign proxy + store ops + prop/export scanners (#465 partial)

### DIFF
--- a/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -2525,10 +2525,38 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
                             rhs_trimmed.to_string()
                         };
 
-                        let replacement = format!(
-                            "$.set({}, {}({}) {} {})",
-                            name, getter, name, op_str, rhs_str
+                        // Non-coercive logical compound operators (`||=`, `&&=`,
+                        // `??=`) can store the RHS value as-is, so — like a plain
+                        // `=` — the assigned value must be proxied when proxiable.
+                        // Coercive operators (`+=`, `*=`, …) always coerce to a
+                        // primitive, so never proxy. Mirrors upstream's
+                        // `is_non_coercive_operator` gate on `should_proxy` in
+                        // AssignmentExpression.js / build_assignment_value.
+                        let is_logical = matches!(
+                            op,
+                            AssignmentOperator::LogicalOr
+                                | AssignmentOperator::LogicalAnd
+                                | AssignmentOperator::LogicalNullish
                         );
+                        let is_raw = self.raw_state_vars.contains(name);
+                        let is_derived = self.derived_vars.contains(name);
+                        let needs_proxy = is_logical
+                            && self.is_runes
+                            && !is_raw
+                            && !is_derived
+                            && should_proxy_ast(&expr.right, self.non_proxy_vars);
+
+                        let replacement = if needs_proxy {
+                            format!(
+                                "$.set({}, {}({}) {} {}, true)",
+                                name, getter, name, op_str, rhs_str
+                            )
+                        } else {
+                            format!(
+                                "$.set({}, {}({}) {} {})",
+                                name, getter, name, op_str, rhs_str
+                            )
+                        };
                         self.add_replacement(full_start, full_end, replacement);
                     }
                     _ => unreachable!(),
@@ -3855,9 +3883,11 @@ mod tests {
 
     #[test]
     fn test_compound_nullish() {
+        // Non-coercive logical operators proxy the assigned value (`, true`),
+        // matching upstream `is_non_coercive_operator` + `should_proxy`.
         assert_eq!(
             transform("count ??= fallback", &["count"]),
-            "$.set(count, $.get(count) ?? fallback)"
+            "$.set(count, $.get(count) ?? fallback, true)"
         );
     }
 
@@ -3866,7 +3896,41 @@ mod tests {
         // When the RHS is also a state var, it should get $.get() wrapping
         assert_eq!(
             transform("count ??= fallback", &["count", "fallback"]),
-            "$.set(count, $.get(count) ?? $.get(fallback))"
+            "$.set(count, $.get(count) ?? $.get(fallback), true)"
+        );
+    }
+
+    #[test]
+    fn test_compound_logical_or_proxies() {
+        assert_eq!(
+            transform("count ||= other", &["count"]),
+            "$.set(count, $.get(count) || other, true)"
+        );
+    }
+
+    #[test]
+    fn test_compound_logical_and_proxies() {
+        assert_eq!(
+            transform("count &&= other", &["count"]),
+            "$.set(count, $.get(count) && other, true)"
+        );
+    }
+
+    #[test]
+    fn test_compound_addition_does_not_proxy() {
+        // Coercive operators always produce a primitive — no proxy flag.
+        assert_eq!(
+            transform("count += other", &["count"]),
+            "$.set(count, $.get(count) + other)"
+        );
+    }
+
+    #[test]
+    fn test_compound_nullish_literal_rhs_no_proxy() {
+        // A primitive literal RHS is never proxied even for logical operators.
+        assert_eq!(
+            transform("count ??= 5", &["count"]),
+            "$.set(count, $.get(count) ?? 5)"
         );
     }
 

--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -2076,6 +2076,22 @@ fn is_complete_side_effect_import(trimmed: &str) -> bool {
     after_import[i..].trim().is_empty()
 }
 
+/// True when `trimmed` begins an `export { ... }` specifier statement,
+/// tolerating any whitespace between `export` and `{` — including none, since
+/// `export{a}` is valid JavaScript (M-021). Guards against matching longer
+/// identifiers (`exporter`) or other export forms (`export default`,
+/// `export function`, `export const`).
+fn starts_export_specifier(trimmed: &str) -> bool {
+    let Some(rest) = trimmed.strip_prefix("export") else {
+        return false;
+    };
+    match rest.chars().next() {
+        Some('{') => true,
+        Some(c) if c.is_whitespace() => rest.trim_start().starts_with('{'),
+        _ => false,
+    }
+}
+
 /// Clean up an import statement after TypeScript stripping.
 /// Removes empty specifier slots (trailing commas, double commas) that result from
 /// type-only specifier removal. Normalizes `import { A,  , C,  } from 'x'` to
@@ -3950,7 +3966,7 @@ fn transform_instance_script_for_visitors(
         // not ES module export syntax. `export { a, b as c }` statements are only
         // used by the analysis phase to mark bindings as BindableProp/exports.
         // The actual declarations (let a, let b) remain and get transformed to $.prop() calls.
-        if first_line_trimmed.starts_with("export {") {
+        if starts_export_specifier(first_line_trimmed) {
             return;
         }
 
@@ -4316,7 +4332,7 @@ fn transform_instance_script_for_visitors(
         }
 
         // Skip export { ... } statements (will be handled via $$exports object)
-        if trimmed.starts_with("export {") {
+        if starts_export_specifier(trimmed) {
             in_export_block = !trimmed.contains('}');
             line_idx += 1;
             continue;
@@ -5085,6 +5101,22 @@ fn transform_local_assignment(line: &str, var_name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_starts_export_specifier() {
+        // M-021: recognise `export { ... }` regardless of whitespace before `{`.
+        assert!(starts_export_specifier("export { a, b }"));
+        assert!(starts_export_specifier("export {a}"));
+        assert!(starts_export_specifier("export{a}"));
+        assert!(starts_export_specifier("export  {a}"));
+        assert!(starts_export_specifier("export\t{ a }"));
+        // Must not match other export forms or longer identifiers.
+        assert!(!starts_export_specifier("export default x"));
+        assert!(!starts_export_specifier("export function f() {}"));
+        assert!(!starts_export_specifier("export const x = 1"));
+        assert!(!starts_export_specifier("exporter({a})"));
+        assert!(!starts_export_specifier("let x = 1"));
+    }
 
     // Tests for comma-separated variable declarations on client side.
     // These verify that destructured patterns ($state, $derived, $props) produce

--- a/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1574,16 +1574,35 @@ pub(super) fn make_lazy_prop_arg(value: &str) -> String {
     }
 }
 
-/// Split declarators by comma, handling nested braces, brackets, and parens.
+/// Split declarators by comma, handling nested braces, brackets, parens, and
+/// string / template literals.
 ///
-/// For example: "a, b = {x: 1}, c" -> ["a", "b = {x: 1}", "c"]
+/// For example: `a, b = {x: 1}, c` -> `["a", "b = {x: 1}", "c"]`, and a comma
+/// inside a string default (`a = "x,y", b`) does not split the list.
 pub(super) fn split_declarators(s: &str) -> Vec<&str> {
     let mut result = Vec::new();
     let mut depth: usize = 0;
     let mut start = 0;
+    // Track the open quote of the current string/template literal so commas and
+    // brackets inside it are ignored. `${}` interpolation inside a template is
+    // not descended into — a top-level comma there can't terminate a `$props()`
+    // declarator anyway.
+    let mut string_char: Option<char> = None;
+    let mut escaped = false;
 
     for (i, c) in s.char_indices() {
+        if let Some(quote) = string_char {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == quote {
+                string_char = None;
+            }
+            continue;
+        }
         match c {
+            '"' | '\'' | '`' => string_char = Some(c),
             '{' | '[' | '(' => depth += 1,
             '}' | ']' | ')' => depth = depth.saturating_sub(1),
             ',' if depth == 0 => {
@@ -2742,4 +2761,44 @@ pub(super) fn split_top_level_args(s: &str) -> Vec<String> {
     }
 
     parts
+}
+
+#[cfg(test)]
+mod split_declarators_tests {
+    use super::split_declarators;
+
+    #[test]
+    fn splits_top_level_commas() {
+        assert_eq!(split_declarators("a, b, c"), vec!["a", " b", " c"]);
+    }
+
+    #[test]
+    fn ignores_commas_inside_brackets() {
+        assert_eq!(
+            split_declarators("a, b = {x: 1, y: 2}, c"),
+            vec!["a", " b = {x: 1, y: 2}", " c"]
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_strings() {
+        // M-045: a comma inside a string default must not split the list.
+        assert_eq!(
+            split_declarators(r#"a = "x,y", b"#),
+            vec![r#"a = "x,y""#, " b"]
+        );
+        assert_eq!(split_declarators("a = 'x,y', b"), vec!["a = 'x,y'", " b"]);
+        assert_eq!(
+            split_declarators("a = `x,${y},z`, b"),
+            vec!["a = `x,${y},z`", " b"]
+        );
+    }
+
+    #[test]
+    fn honours_escaped_quote_in_string() {
+        assert_eq!(
+            split_declarators(r#"a = "x\",y", b"#),
+            vec![r#"a = "x\",y""#, " b"]
+        );
+    }
 }

--- a/src/compiler/phases/3_transform/client/store_assign_ast.rs
+++ b/src/compiler/phases/3_transform/client/store_assign_ast.rs
@@ -14,6 +14,9 @@
 //! | `$count &&= expr`| `$.store_set(<access>, $count() && expr)`    |
 //! | `$count \|\|= expr`| `$.store_set(<access>, $count() \|\| expr)` |
 //!
+//! The bitwise / shift compound operators (`**= <<= >>= >>>= &= \|= ^=`) lower
+//! the same way and were previously dropped (H-026).
+//!
 //! `<access>` follows the same three-way classification used by
 //! `store_update_ast` (prop getter / reactive-state read / plain
 //! identifier).
@@ -46,6 +49,33 @@ thread_local! {
 }
 
 const MAX_FIXED_POINT_ITERS: usize = 16;
+
+/// Map a compound assignment operator to the binary operator it expands to for
+/// `$.store_set(access, $sub() <op> rhs)` lowering. Returns `None` only for the
+/// plain `=` operator, which the caller handles separately. Covers the full set
+/// (`+ - * / % ** << >> >>> | ^ & || && ??`) so bitwise / shift store
+/// compound-assignments are no longer dropped (matches upstream).
+fn compound_store_op(op: AssignmentOperator) -> Option<&'static str> {
+    use AssignmentOperator::*;
+    Some(match op {
+        Addition => "+",
+        Subtraction => "-",
+        Multiplication => "*",
+        Division => "/",
+        Remainder => "%",
+        Exponential => "**",
+        ShiftLeft => "<<",
+        ShiftRight => ">>",
+        ShiftRightZeroFill => ">>>",
+        BitwiseOR => "|",
+        BitwiseXOR => "^",
+        BitwiseAnd => "&",
+        LogicalOr => "||",
+        LogicalAnd => "&&",
+        LogicalNullish => "??",
+        Assign => return None,
+    })
+}
 
 /// AST-based rewrite of `$count = expr` / `$count <op>= expr` for
 /// the bindings listed in `store_sub_vars`. The underlying
@@ -190,62 +220,20 @@ impl<'a, 'ast> Visit<'ast> for StoreAssignCollector<'a> {
         let rhs_span = expr.right.span();
         let rhs_text = &self.source[rhs_span.start as usize..rhs_span.end as usize];
 
-        let rewrite = match expr.operator {
-            AssignmentOperator::Assign => {
-                format!("$.store_set({}, {})", store_access, rhs_text)
-            }
-            AssignmentOperator::Addition => {
-                format!(
-                    "$.store_set({}, {}() + {})",
-                    store_access, store_sub, rhs_text
-                )
-            }
-            AssignmentOperator::Subtraction => {
-                format!(
-                    "$.store_set({}, {}() - {})",
-                    store_access, store_sub, rhs_text
-                )
-            }
-            AssignmentOperator::Multiplication => {
-                format!(
-                    "$.store_set({}, {}() * {})",
-                    store_access, store_sub, rhs_text
-                )
-            }
-            AssignmentOperator::Division => {
-                format!(
-                    "$.store_set({}, {}() / {})",
-                    store_access, store_sub, rhs_text
-                )
-            }
-            AssignmentOperator::Remainder => {
-                format!(
-                    "$.store_set({}, {}() % {})",
-                    store_access, store_sub, rhs_text
-                )
-            }
-            AssignmentOperator::LogicalNullish => {
-                format!(
-                    "$.store_set({}, {}() ?? {})",
-                    store_access, store_sub, rhs_text
-                )
-            }
-            AssignmentOperator::LogicalAnd => {
-                format!(
-                    "$.store_set({}, {}() && {})",
-                    store_access, store_sub, rhs_text
-                )
-            }
-            AssignmentOperator::LogicalOr => {
-                format!(
-                    "$.store_set({}, {}() || {})",
-                    store_access, store_sub, rhs_text
-                )
-            }
-            // Other operators (**=, <<=, >>=, >>>=, &=, |=, ^=) are
-            // not in the text version's allowlist — leave them
-            // untouched and the existing text path (if any) handles.
-            _ => return,
+        let rewrite = if expr.operator == AssignmentOperator::Assign {
+            format!("$.store_set({}, {})", store_access, rhs_text)
+        } else {
+            // Every compound operator lowers to `$.store_set(access, $sub() <op> rhs)`.
+            // (RHS grouping for lower-precedence expressions is a separate, broader
+            // fix — the shared parens helper is precedence-incomplete and also
+            // affects the state path; see H-025 deferral.)
+            let Some(op_str) = compound_store_op(expr.operator) else {
+                return;
+            };
+            format!(
+                "$.store_set({}, {}() {} {})",
+                store_access, store_sub, op_str, rhs_text
+            )
         };
 
         self.replacements
@@ -348,6 +336,23 @@ mod tests {
         let out =
             transform_store_assign_ast("$count ||= 5;", &ssv(&["$count"]), &[], &[], &[]).unwrap();
         assert_eq!(out, "$.store_set(count, $count() || 5);");
+    }
+
+    #[test]
+    fn compound_bitwise_and_shift_ops() {
+        // H-026: bitwise / shift compound operators were previously dropped.
+        for (src, expected) in [
+            ("$count &= 3;", "$.store_set(count, $count() & 3);"),
+            ("$count |= 3;", "$.store_set(count, $count() | 3);"),
+            ("$count ^= 3;", "$.store_set(count, $count() ^ 3);"),
+            ("$count <<= 2;", "$.store_set(count, $count() << 2);"),
+            ("$count >>= 2;", "$.store_set(count, $count() >> 2);"),
+            ("$count >>>= 2;", "$.store_set(count, $count() >>> 2);"),
+            ("$count **= 2;", "$.store_set(count, $count() ** 2);"),
+        ] {
+            let out = transform_store_assign_ast(src, &ssv(&["$count"]), &[], &[], &[]).unwrap();
+            assert_eq!(out, expected, "for {src}");
+        }
     }
 
     #[test]
@@ -482,18 +487,6 @@ mod tests {
     fn no_op_without_prefix_dollar() {
         assert!(
             transform_store_assign_ast("let x = 1;", &ssv(&["$count"]), &[], &[], &[]).is_none()
-        );
-    }
-
-    #[test]
-    fn leaves_unsupported_operator_alone() {
-        // `**=`, `<<=`, `>>=`, `>>>=`, `&=`, `|=`, `^=` not in the
-        // text version's allowlist either.
-        assert!(
-            transform_store_assign_ast("$count **= 2;", &ssv(&["$count"]), &[], &[], &[]).is_none()
-        );
-        assert!(
-            transform_store_assign_ast("$count &= 7;", &ssv(&["$count"]), &[], &[], &[]).is_none()
         );
     }
 }


### PR DESCRIPTION
Partial fix for the #465 client-transform cluster. Addresses **H-024, H-026, M-045, M-021**. Each fix was verified against the official Svelte compiler's output (the project's parity target).

## Fixed

- **H-024 (Critical)** — `count ??= x` / `||=` / `&&=` on runes `$state` now emit the proxy flag (`$.set(count, count() ?? x, true)`), matching upstream's `is_non_coercive_operator` gate on `should_proxy`. Coercive ops (`+=`, …) remain unproxied.
  - *Note:* the issue's framing — that `??=` is wrongly lowered to an unconditional setter — is **not** itself a divergence: upstream's `build_assignment_value` also rewrites `x ??= y` to the always-writing `$.set(x, x() ?? y)` by design. The real divergence was the missing proxy flag.
- **H-026** — legacy store compound-assignments no longer drop the bitwise/shift operators (`**= <<= >>= >>>= &= |= ^=`); `store_assign_ast.rs` now covers the full operator set.
- **M-045** — `split_declarators` is now string/template-aware, so a comma inside a `$props()` default string (`let { a = "x,y", b } = $props()`) no longer splits the declarator list mid-string.
- **M-021** — `export { ... }` stripping now tolerates any whitespace (incl. none) between `export` and `{`, so the valid `export{a}` form no longer leaks into the output.

## Deferred (issue stays open)

These remaining sub-findings need broader / riskier changes and are left for follow-ups:

- **H-025** (store RHS grouping) — entangled with the precedence-incomplete shared `needs_compound_assignment_parens` helper, which also drives the state path; a correct fix must make it operator-precedence-aware.
- **H-027** (import scanner swallows code after `import x from 'y' // c`) — needs a string-literal-aware scan (`//` legitimately appears in `from 'http://…'`).
- **H-028** (`customElement.props` / `extend` not emitted) — needs AST + analyzer plumbing to parse/serialize `extend` and the `props` object.
- **M-020, M-022, M-023, M-042, M-043, M-044, M-047, M-048** — text-scanner robustness items that each span overlapping transform paths; safest done individually with per-path verification.
- **M-046** (prop-name escaping) — the prop name is emitted into single-quoted strings at ~20 sites across several functions; a correct fix should thread one escaped value through all of them rather than patching sites piecemeal.

## Test plan

- [x] New/updated unit tests: `ast_state_transform` (proxy flag), `store_assign_ast` (bitwise/shift), `split_declarators_tests` (M-045), `starts_export_specifier` (M-021)
- [x] `test_runtime_runes`, `test_runtime_legacy`, `test_hydration` codegen suites pass
- [x] `test_compiler_snapshot_fixtures` passes
- [x] `cargo clippy --lib` clean for touched files

Addresses H-024, H-026, M-045, M-021 of #465 (issue remains open for the deferred items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)