### PR TITLE
fix(css): selector-list split + <svelte:boundary> scoping (#466 partial)

### DIFF
--- a/src/compiler/phases/1_parse/read/style.rs
+++ b/src/compiler/phases/1_parse/read/style.rs
@@ -1045,16 +1045,28 @@ impl<'a> CssParser<'a> {
         base_offset: usize,
     ) -> Vec<(&'b str, usize)> {
         let mut result = Vec::new();
-        let mut depth = 0;
+        let mut depth = 0; // `(` … `)` nesting (`:is(.a, .b)` etc.)
+        let mut bracket_depth = 0; // `[` … `]` nesting (attribute selectors)
         let mut last_start = 0;
         let mut in_comment = false;
+        let mut string_char: Option<u8> = None; // open quote of the current string
 
         let bytes = text.as_bytes();
         let mut i = 0;
         while i < bytes.len() {
-            // Handle escaped characters
+            // Handle escaped characters (also handles `\"` inside a string).
             if bytes[i] == b'\\' && i + 1 < bytes.len() {
                 i += 2; // Skip backslash and next char
+                continue;
+            }
+
+            // Inside a string only the matching close-quote ends it — commas,
+            // brackets and `/*` are literal content (e.g. `[x=",("]`).
+            if let Some(quote) = string_char {
+                if bytes[i] == quote {
+                    string_char = None;
+                }
+                i += 1;
                 continue;
             }
 
@@ -1074,15 +1086,18 @@ impl<'a> CssParser<'a> {
                 continue;
             }
 
-            let c = bytes[i] as char;
-            if c == '(' {
-                depth += 1;
-            } else if c == ')' {
-                depth -= 1;
-            } else if c == ',' && depth == 0 {
-                let selector = &text[last_start..i];
-                result.push((selector, base_offset + last_start));
-                last_start = i + 1;
+            match bytes[i] {
+                b'"' | b'\'' => string_char = Some(bytes[i]),
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                b'[' => bracket_depth += 1,
+                b']' => bracket_depth -= 1,
+                b',' if depth == 0 && bracket_depth == 0 => {
+                    let selector = &text[last_start..i];
+                    result.push((selector, base_offset + last_start));
+                    last_start = i + 1;
+                }
+                _ => {}
             }
             i += 1;
         }

--- a/src/compiler/phases/2_analyze/css_scoping.rs
+++ b/src/compiler/phases/2_analyze/css_scoping.rs
@@ -1205,6 +1205,9 @@ fn collect_render_sites_in_node(
         TemplateNode::SvelteHead(head) => {
             collect_render_sites_in_fragment(&head.fragment, ancestors, map);
         }
+        TemplateNode::SvelteBoundary(boundary) => {
+            collect_render_sites_in_fragment(&boundary.fragment, ancestors, map);
+        }
         TemplateNode::SlotElement(slot) => {
             collect_render_sites_in_fragment(&slot.fragment, ancestors, map);
         }
@@ -1444,6 +1447,11 @@ fn process_node_scoping(
         }
         TemplateNode::SvelteHead(head) => {
             for child in &mut head.fragment.nodes {
+                process_node_scoping(child, css_selectors, ancestors, snippet_ancestors);
+            }
+        }
+        TemplateNode::SvelteBoundary(boundary) => {
+            for child in &mut boundary.fragment.nodes {
                 process_node_scoping(child, css_selectors, ancestors, snippet_ancestors);
             }
         }
@@ -2187,6 +2195,9 @@ fn apply_scoping_marks(fragment: &mut Fragment, elements_to_scope: &FxHashSet<(u
             TemplateNode::SvelteHead(head) => {
                 apply_scoping_marks(&mut head.fragment, elements_to_scope);
             }
+            TemplateNode::SvelteBoundary(boundary) => {
+                apply_scoping_marks(&mut boundary.fragment, elements_to_scope);
+            }
             TemplateNode::SlotElement(slot) => {
                 apply_scoping_marks(&mut slot.fragment, elements_to_scope);
             }
@@ -2348,6 +2359,15 @@ fn recurse_sibling_processing(
             TemplateNode::SvelteHead(head) => {
                 process_sibling_selectors(
                     &mut head.fragment,
+                    css_selectors,
+                    sibling_selectors,
+                    ancestors,
+                    snippet_ancestors,
+                );
+            }
+            TemplateNode::SvelteBoundary(boundary) => {
+                process_sibling_selectors(
+                    &mut boundary.fragment,
                     css_selectors,
                     sibling_selectors,
                     ancestors,
@@ -2749,6 +2769,14 @@ fn propagate_ancestor_scoping(
             TemplateNode::SvelteHead(head) => {
                 propagate_ancestor_scoping(
                     &mut head.fragment,
+                    css_selectors,
+                    ancestors,
+                    snippet_ancestors,
+                );
+            }
+            TemplateNode::SvelteBoundary(boundary) => {
+                propagate_ancestor_scoping(
+                    &mut boundary.fragment,
                     css_selectors,
                     ancestors,
                     snippet_ancestors,

--- a/tests/css_selector_list_split.rs
+++ b/tests/css_selector_list_split.rs
@@ -1,0 +1,55 @@
+//! Regression test for CSS selector-list splitting that is not string- /
+//! bracket-aware (issue #466, H-021).
+//!
+//! Bug: `split_by_comma_respecting_parens` tracked only `(` / `)` and `/* */`,
+//! so a comma inside an attribute selector value (`[data-x="a,b"]`) or inside
+//! `[...]` brackets split the selector list mid-selector, producing two broken
+//! selectors. The official Svelte compiler treats `[data-x="a,b"]` as a single
+//! selector. The splitter now also tracks `[` / `]` depth and string quotes.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_css(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.css.map(|c| c.code).unwrap_or_default()
+}
+
+#[test]
+fn comma_inside_attribute_value_does_not_split() {
+    let src = r#"<div data-x="a,b"></div>
+<style>
+[data-x="a,b"] { color: red }
+</style>"#;
+    let out = compile_css(src);
+    // The whole attribute selector survives as one scoped selector; a broken
+    // split would have produced a bare `[data-x="a` fragment (unterminated).
+    assert!(
+        out.contains(r#"[data-x="a,b"].svelte-"#),
+        "the attribute value comma must not split the selector, got:\n{out}"
+    );
+}
+
+#[test]
+fn comma_inside_attribute_value_in_selector_list() {
+    let src = r#"<a data-x="a,b"></a>
+<style>
+a, [data-x="a,b"] { color: red }
+</style>"#;
+    let out = compile_css(src);
+    // Both selectors survive and are scoped; the inner comma is not a separator.
+    assert!(out.contains(r#"[data-x="a,b"]"#), "got:\n{out}");
+    assert!(
+        out.matches("color: red").count() == 1,
+        "the two real selectors should share one rule body, got:\n{out}"
+    );
+}

--- a/tests/css_svelte_boundary_scope.rs
+++ b/tests/css_svelte_boundary_scope.rs
@@ -1,0 +1,55 @@
+//! Regression test: CSS scoping must traverse `<svelte:boundary>` like any
+//! other transparent wrapper (issue #466, H-023).
+//!
+//! Bug: `<svelte:boundary>` was handled only by `mark_all_elements_scoped_node`
+//! and was missing from `process_node_scoping`, the sibling-combinator pass,
+//! `apply_scoping_marks`, `propagate_ancestor_scoping`, and the render-site
+//! collector. Elements inside a boundary were therefore never visited, so their
+//! matching CSS rules were wrongly pruned as unused (and the elements lacked the
+//! scope class). The official Svelte compiler scopes straight through the
+//! boundary.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_css(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.css.map(|c| c.code).unwrap_or_default()
+}
+
+#[test]
+fn class_inside_boundary_is_scoped() {
+    let src = r#"<svelte:boundary><div class="a">x</div></svelte:boundary>
+<style>.a { color: red }</style>"#;
+    let out = compile_css(src);
+    // The rule must survive (not pruned) and be scoped.
+    assert!(
+        out.contains(".a.svelte-"),
+        "`.a` inside <svelte:boundary> should be scoped, got:\n{out}"
+    );
+}
+
+#[test]
+fn descendant_through_boundary_is_scoped() {
+    let src = r#"<div class="p"><svelte:boundary><span class="c">x</span></svelte:boundary></div>
+<style>.p .c { color: red }</style>"#;
+    let out = compile_css(src);
+    assert!(
+        out.contains(".p.svelte-") && out.contains(".c"),
+        "descendant selector through <svelte:boundary> should be scoped, got:\n{out}"
+    );
+    // The rule must not be dropped as unused.
+    assert!(
+        out.contains("color: red"),
+        "rule wrongly pruned, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Partial fix for the #466 CSS cluster. Addresses **H-021** and **H-023**, both verified against the official Svelte compiler's CSS output.

## Fixed

- **H-021** — the selector-list splitter (`split_by_comma_respecting_parens`) tracked only `()` and `/* */`, so a comma inside an attribute value (`[data-x="a,b"]`) or `[...]` split one selector into two broken fragments. It now tracks `[ ]` depth and string quotes too. Verified: Svelte keeps `[data-x="a,b"]` as one scoped selector.
- **H-023** — CSS scoping traversal skipped `<svelte:boundary>` everywhere except `mark_all_elements_scoped_node`, so elements inside a boundary were never scoped and their rules were pruned as "unused". `<svelte:boundary>` is now a transparent recurse at every traversal site (mirroring `<svelte:head>` / `Component`). Verified: Svelte scopes `.a` inside a boundary and supports descendant selectors through it.

## Triage results for the rest

- **M-018 (attribute-selector CSS-unescape)** — **NOT A BUG.** Upstream's `attribute_matches` compares the *raw, non-unescaped* selector value; Svelte prunes `[data-x="a\,b"]` as unused too. rsvelte already matches this exactly. No change needed.
- **H-020 (CSS emission re-extracts `<style>` via raw `memmem` rescan)** — REAL but deferred: a fake `</style>` inside an earlier `<script>` string makes `extract_css_content` return the wrong range (→ empty CSS). Fix needs the parsed `StyleSheet` byte range threaded into the transform entry. Medium, transform-entry blast radius.
- **H-022 (keyframe rewriting scans raw text)** — REAL but deferred: a global text scan rewrites keyframe names inside comments, strings, and substring property names (`--my-animation: spin`, `foo-animation: spin`). Fix needs the rewrite driven from `Declaration` AST nodes gated on `property == animation`/`animation-name`.
- **M-019 (nested at-rules stored as empty blocks)** — REAL only when a nested at-rule contains nested *selectors* (declarations-only nested `@media` already round-trips via raw copy). Fix is a parser + transform recursion; large, deferred.

## Test plan

- [x] New `tests/css_selector_list_split.rs` and `tests/css_svelte_boundary_scope.rs`
- [x] Full CSS suite (`tests/css.rs`) passes
- [x] `test_runtime_runes` / `test_runtime_legacy` / `test_hydration` / `test_ssr` / `test_compiler_snapshot_fixtures` pass (scoping also drives element scope-classes in the JS output)
- [x] `cargo clippy --lib` clean for touched files

Addresses H-021, H-023 of #466 (issue remains open for H-020, H-022, M-019; M-018 confirmed not-a-bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)