### PR TITLE
fix(print): optional computed member + pending-only await (#467 partial)

### DIFF
--- a/src/compiler/print/helpers.rs
+++ b/src/compiler/print/helpers.rs
@@ -248,9 +248,11 @@ impl EstreeGenerator {
         }
 
         if computed {
-            if !optional {
-                self.output.push('[');
-            }
+            // Optional computed access prints as `obj?.[key]`: the `?.` above
+            // plus a full `[ … ]`. The opening bracket must always be emitted
+            // (previously it was skipped when `optional`, yielding the invalid
+            // `obj?.key]`). M-037.
+            self.output.push('[');
             if let Some(property) = node.get("property") {
                 self.generate_node(property);
             }
@@ -1343,6 +1345,25 @@ mod tests {
         assert_eq!(escape_html("hello"), "hello");
         assert_eq!(escape_html("a<b>c"), "a&lt;b&gt;c");
         assert_eq!(escape_html("a&b"), "a&amp;b");
+    }
+
+    #[test]
+    fn test_member_expression_optional_computed() {
+        // M-037: `obj?.[key]` must keep its opening bracket (was printing the
+        // invalid `obj?.key]`).
+        let member = |optional: bool, computed: bool| {
+            serde_json::json!({
+                "type": "MemberExpression",
+                "object": { "type": "Identifier", "name": "obj" },
+                "property": { "type": "Identifier", "name": "key" },
+                "optional": optional,
+                "computed": computed,
+            })
+        };
+        assert_eq!(estree_to_string(&member(true, true)), "obj?.[key]");
+        assert_eq!(estree_to_string(&member(false, true)), "obj[key]");
+        assert_eq!(estree_to_string(&member(true, false)), "obj?.key");
+        assert_eq!(estree_to_string(&member(false, false)), "obj.key");
     }
 
     #[test]

--- a/src/compiler/print/visitors.rs
+++ b/src/compiler/print/visitors.rs
@@ -904,7 +904,12 @@ fn visit_await_block(context: &mut Context, await_block: &crate::ast::AwaitBlock
         if let Some(ref pending) = await_block.pending {
             block(context, pending, false);
         }
-        context.write("{:");
+        // The `{:` only opens the next clause (`{:then}` / `{:catch}`). A
+        // pending-only `{#await expr}…{/await}` has neither, so emitting `{:`
+        // here produced an invalid dangling `{:{/await}`. H-052.
+        if await_block.then.is_some() || await_block.catch.is_some() {
+            context.write("{:");
+        }
     } else {
         context.write(" ");
     }

--- a/tests/print_await_pending_only.rs
+++ b/tests/print_await_pending_only.rs
@@ -1,0 +1,41 @@
+//! Regression test: printing a pending-only `{#await}` block (no `:then` /
+//! `:catch`) must not emit a dangling `{:` (issue #467, H-052).
+
+use svelte_compiler_rust::compiler::print::print_with_source;
+use svelte_compiler_rust::{ParseOptions, parse};
+
+fn print_roundtrip(src: &str) -> String {
+    let ast = parse(
+        src,
+        ParseOptions {
+            modern: true,
+            ..Default::default()
+        },
+    )
+    .expect("parse");
+    print_with_source(&ast, None, Some(src))
+        .expect("print")
+        .code
+}
+
+#[test]
+fn pending_only_await_has_no_dangling_separator() {
+    let src = "{#await promise}\n\t<p>waiting...</p>\n{/await}";
+    let out = print_roundtrip(src);
+    assert!(
+        !out.contains("{:"),
+        "pending-only await must not emit a `{{:` separator, got:\n{out}"
+    );
+    assert!(out.contains("{#await promise}"), "got:\n{out}");
+    assert!(out.contains("{/await}"), "got:\n{out}");
+    assert!(out.contains("<p>waiting...</p>"), "got:\n{out}");
+}
+
+#[test]
+fn full_await_still_prints_all_clauses() {
+    let src = "{#await promise}\n\tp\n{:then value}\n\tt\n{:catch error}\n\tc\n{/await}";
+    let out = print_roundtrip(src);
+    assert!(out.contains("{:then value}"), "got:\n{out}");
+    assert!(out.contains("{:catch error}"), "got:\n{out}");
+    assert!(out.contains("{/await}"), "got:\n{out}");
+}


### PR DESCRIPTION
Partial fix for the #467 Print cluster. Addresses **M-037** and **H-052** — both unambiguous round-trip defects verified by parse→print.

## Fixed

- **M-037** — the ESTree fallback printer emitted optional computed member access as the invalid `obj?.key]` (wrote `?.` but skipped the opening `[`, then still wrote `]`). The `[` is now always emitted for computed access → `obj?.[key]`.
- **H-052** — a pending-only `{#await expr}…{/await}` printed a dangling `{:{/await}` (the `{:` clause-opener was written unconditionally after the pending block). It is now emitted only when a `then`/`catch` clause follows.

## Deferred (issue stays open)

- **H-049** (no source → lossy JS formatter), **H-051** (whitespace collapse ignores `preserveWhitespace`), **H-050** (decoded `Text.data` re-emitted as active markup), **M-036** (standalone comments/trivia dropped) — these are larger, partly architectural (verbatim-source retention / whitespace-context tracking).
- **M-035** (attribute value forced into double quotes without escaping an embedded `"` from a single-quoted source) — narrow; the correct fix (escape vs. preserve original quote style) needs Svelte ground-truth confirmation first.
- **L-006** (sourcemap advertised but `get_source_map()` returns `None`) — API/doc cleanup.

## Test plan

- [x] `estree_to_string` unit test covering all four member-access combinations
- [x] New `tests/print_await_pending_only.rs` round-trip test
- [x] Full `print` suite passes

Addresses M-037, H-052 of #467 (issue remains open for the deferred items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)