### PR TITLE
fix(bind): getter/setter helper names + bind:indeterminate validation (#468 partial)

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/bind_directive.rs
+++ b/src/compiler/phases/2_analyze/visitors/bind_directive.rs
@@ -622,8 +622,10 @@ fn validate_input_binding(
             }
         }
     } else {
-        // No type attribute - validate bindings that require specific types
-        // Default input type is "text", so checked, files, and indeterminate are invalid
+        // No type attribute (default `text`). Upstream only type-validates
+        // `checked` and `files` here — `indeterminate` / `group` are never
+        // type-checked, so binding them to a type-less input is accepted
+        // (matches `BindDirective.js`). H-036.
         if binding_name == "checked" {
             return Err(errors::bind_invalid_target(
                 binding_name,
@@ -635,13 +637,6 @@ fn validate_input_binding(
             return Err(errors::bind_invalid_target(
                 binding_name,
                 "`<input type=\"file\">`",
-            ));
-        }
-
-        if binding_name == "indeterminate" {
-            return Err(errors::bind_invalid_target(
-                binding_name,
-                "`<input type=\"checkbox\">`",
             ));
         }
     }

--- a/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1406,17 +1406,22 @@ fn process_bind_directive(
         let get = seq.expressions[0].clone();
         let set = seq.expressions[1].clone();
 
-        let get_id = b::id(context.state.memoizer.generate_id("bind_get"));
-        let set_id = b::id(context.state.memoizer.generate_id("bind_set"));
+        // The getter/setter helpers are declared AND called by the same
+        // conflict-resolved name. Previously the declarations hard-coded
+        // `bind_get`/`bind_set` while the calls used the unique generated id
+        // (`bind_get_1`, …), so a second getter/setter binding produced a call
+        // to an undeclared variable. H-044.
+        let get_name = context.state.memoizer.generate_id("bind_get");
+        let set_name = context.state.memoizer.generate_id("bind_set");
 
         context
             .state
             .init
-            .push(b::var_decl(&context.arena, "bind_get", Some(get)));
+            .push(b::var_decl(&context.arena, get_name.clone(), Some(get)));
         context
             .state
             .init
-            .push(b::var_decl(&context.arena, "bind_set", Some(set)));
+            .push(b::var_decl(&context.arena, set_name.clone(), Some(set)));
 
         // Add getter
         delayed_props.push(DelayedProp {
@@ -1425,7 +1430,7 @@ fn process_bind_directive(
                 bind.name.as_str(),
                 vec![b::return_value(
                     &context.arena,
-                    b::call(&context.arena, get_id.clone(), vec![]),
+                    b::call(&context.arena, b::id(get_name), vec![]),
                 )],
             ),
         });
@@ -1438,7 +1443,7 @@ fn process_bind_directive(
                 "$$value",
                 vec![b::stmt(
                     &context.arena,
-                    b::call(&context.arena, set_id, vec![b::id("$$value")]),
+                    b::call(&context.arena, b::id(set_name), vec![b::id("$$value")]),
                 )],
             ),
         });

--- a/tests/bind_indeterminate_no_type.rs
+++ b/tests/bind_indeterminate_no_type.rs
@@ -1,0 +1,51 @@
+//! Regression test: `bind:indeterminate` on a type-less `<input>` must compile
+//! (issue #468, H-036).
+//!
+//! Bug: rsvelte rejected `bind:indeterminate` with `bind_invalid_target` when the
+//! input had no `type` attribute. The official compiler only type-validates
+//! `bind:checked` and `bind:files`; `indeterminate` / `group` are never
+//! type-checked, so binding them to a type-less input is accepted.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn try_compile(src: &str) -> Result<(), String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .map(|_| ())
+    .map_err(|e| format!("{e:?}"))
+}
+
+#[test]
+fn bind_indeterminate_without_type_compiles() {
+    let src = r#"<script>let x = $state(false);</script><input bind:indeterminate={x} />"#;
+    assert!(
+        try_compile(src).is_ok(),
+        "bind:indeterminate on a type-less input should compile"
+    );
+}
+
+#[test]
+fn bind_indeterminate_with_text_type_compiles() {
+    let src =
+        r#"<script>let x = $state(false);</script><input type="text" bind:indeterminate={x} />"#;
+    assert!(try_compile(src).is_ok());
+}
+
+#[test]
+fn bind_checked_without_type_still_errors() {
+    // The genuine type constraint (`checked` requires a checkbox) must remain.
+    let src = r#"<script>let x = $state(false);</script><input bind:checked={x} />"#;
+    assert!(
+        try_compile(src).is_err(),
+        "bind:checked on a non-checkbox input should still be rejected"
+    );
+}

--- a/tests/component_bind_getter_setter.rs
+++ b/tests/component_bind_getter_setter.rs
@@ -1,0 +1,48 @@
+//! Regression test: a component with two getter/setter `bind:` pairs must
+//! declare each helper under the same conflict-resolved name it is called by
+//! (issue #468, H-044).
+//!
+//! Bug: the getter/setter helper declarations hard-coded `bind_get` / `bind_set`
+//! while the getter/setter bodies called the unique generated id
+//! (`bind_get_1`, …). A second binding therefore called an undeclared
+//! `bind_get_1` / `bind_set_1`.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn two_getter_setter_binds_declare_unique_names() {
+    let src = r#"<script>let x = $state(0); let y = $state(0);</script>
+<C bind:a={() => x, (v) => x = v} bind:b={() => y, (v) => y = v} />"#;
+    let out = compile_js(src);
+
+    // The second pair's helpers must be both declared and called under the
+    // suffixed name — not declared as `bind_get` while called as `bind_get_1`.
+    assert!(
+        out.contains("bind_get_1 ="),
+        "second getter helper should be declared as bind_get_1, got:\n{out}"
+    );
+    assert!(
+        out.contains("bind_get_1()"),
+        "second getter should be called as bind_get_1, got:\n{out}"
+    );
+    assert!(
+        out.contains("bind_set_1("),
+        "second setter helper should be declared/called as bind_set_1, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Partial fix for the #468 bind/component cluster. Addresses **H-044** and **H-036**, both verified against the official Svelte compiler.

## Fixed

- **H-044 (High)** — component getter/setter bindings declared their helpers under the hard-coded names `bind_get` / `bind_set` but the getter/setter bodies called the unique generated ids (`bind_get_1`, …). A component with **two** getter/setter `bind:` pairs called an *undeclared* `bind_get_1` / `bind_set_1` (broken JS). Declarations now use the generated name, matching Svelte (`bind_get`/`bind_set`, then `bind_get_1`/`bind_set_1`).
- **H-036 (Medium)** — `bind:indeterminate` on a type-less `<input>` was wrongly rejected with `bind_invalid_target`. Upstream only type-validates `bind:checked` (checkbox) and `bind:files` (file); `indeterminate` / `group` are never type-checked. Removed the spurious rejection; `checked` / `files` constraints preserved.

## Triage of the rest (verified vs the official compiler)

REAL, deferred (mostly shared/analyze+client blast radius or larger):
- **H-037** per-binding `bind:group` names, **H-045** component-bind full validation, **M-025** computed-literal keypath collapse, **M-026** group-value sequence deps, **H-066/H-067** spread/CSS-prop memoization for call/await, **H-068** style-directive multi-chunk metadata, **H-089** svelte2tsx `needs_instance` missing `BindDirective`, **M-028** truncated SVG element list, **M-030** `<svelte:body>` attribute validation, **M-038** directive async-blocker discovery (overlaps #469).

NOT bugs (rsvelte already matches Svelte):
- **M-027** dynamic `<select multiple>` validation runs only for non-`this` bindings (same as upstream).
- **M-029** `bind:focused` has no `omit_in_ssr` / valid-element constraints upstream either.

## Test plan

- [x] `tests/component_bind_getter_setter.rs` (H-044) and `tests/bind_indeterminate_no_type.rs` (H-036)
- [x] runtime-runes / compiler-snapshot / compiler-errors / validator suites pass
- [x] `cargo clippy --lib` clean for touched files

Addresses H-044, H-036 of #468 (issue remains open for the deferred items; M-027/M-029 confirmed not-bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)