### PR TITLE
fix(vps): resolve_id ?query/#hash + bare <script module> HMR (#470 partial)

### DIFF
--- a/src/vps/hmr.rs
+++ b/src/vps/hmr.rs
@@ -68,11 +68,11 @@ pub fn hmr_diff(prev: &str, curr: &str) -> HmrDiff {
     }
 }
 
-/// Lexically pull out the body of `<script>` (when `module=false`) or
-/// `<script context="module">` (when `module=true`). Returns `None`
-/// when the requested script tag is absent.
+/// Lexically pull out the body of `<script>` (when `module=false`) or the
+/// module script — both the Svelte 5 bare `<script module>` and the legacy
+/// `<script context="module">` (when `module=true`). Returns `None` when the
+/// requested script tag is absent.
 fn extract_script(source: &str, module: bool) -> Option<String> {
-    let needle = if module { "context=\"module\"" } else { "" };
     let bytes = source.as_bytes();
     let mut i = 0;
     while let Some(open) = source[i..].find("<script") {
@@ -84,9 +84,7 @@ fn extract_script(source: &str, module: bool) -> Option<String> {
             None => return None,
         };
         let tag_attrs = &source[after_open..close_attrs];
-        let is_module = tag_attrs.contains("context=\"module\"")
-            || tag_attrs.contains("context='module'")
-            || tag_attrs.contains("context=module");
+        let is_module = is_module_script_attrs(tag_attrs);
         let body_start = close_attrs + 1;
         // Find the closing `</script>`.
         let body_end = match source[body_start..].find("</script>") {
@@ -99,15 +97,43 @@ fn extract_script(source: &str, module: bool) -> Option<String> {
             return Some(source[body_start..body_end].to_string());
         }
         i = next_i;
-        if needle.is_empty() {
-            // Caller wanted instance-script; don't loop forever if we
-            // somehow stay at the same position.
-            if i <= abs_open {
-                break;
-            }
+        // Don't loop forever if we somehow stay at the same position.
+        if i <= abs_open {
+            break;
         }
     }
     None
+}
+
+/// Decide whether a `<script …>` opening tag's attribute text marks a module
+/// script. Recognises the legacy `context="module"` forms and the Svelte 5
+/// bare `module` attribute (H-094). The bare form is matched as a standalone
+/// token so it isn't confused with `module` appearing inside another
+/// attribute's quoted value.
+fn is_module_script_attrs(tag_attrs: &str) -> bool {
+    if tag_attrs.contains("context=\"module\"")
+        || tag_attrs.contains("context='module'")
+        || tag_attrs.contains("context=module")
+    {
+        return true;
+    }
+    let bytes = tag_attrs.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = tag_attrs[from..].find("module") {
+        let start = from + rel;
+        let end = start + "module".len();
+        let prev_ok = start == 0 || bytes[start - 1].is_ascii_whitespace();
+        let next_ok = end >= bytes.len()
+            || matches!(
+                bytes[end],
+                b' ' | b'\t' | b'\n' | b'\r' | b'=' | b'/' | b'>'
+            );
+        if prev_ok && next_ok {
+            return true;
+        }
+        from = end;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -157,5 +183,36 @@ mod tests {
         let d = hmr_diff(prev, curr);
         assert!(d.instance_changed);
         assert!(!d.module_changed);
+    }
+
+    #[test]
+    fn recognises_bare_module_attribute() {
+        // H-094: Svelte 5 `<script module>` must be classified as the module
+        // script, not the instance script.
+        assert!(is_module_script_attrs(" module"));
+        assert!(is_module_script_attrs(" lang=\"ts\" module"));
+        assert!(is_module_script_attrs(" module lang=\"ts\""));
+        assert!(is_module_script_attrs(" context=\"module\""));
+        // Not a module script:
+        assert!(!is_module_script_attrs(""));
+        assert!(!is_module_script_attrs(" lang=\"ts\""));
+        assert!(!is_module_script_attrs(" generics=\"T extends Module\""));
+    }
+
+    #[test]
+    fn bare_module_script_separated_from_instance() {
+        let src = "<script module>let A = 1;</script><script>let B = 1;</script><p />";
+        assert_eq!(extract_script(src, true).as_deref(), Some("let A = 1;"));
+        assert_eq!(extract_script(src, false).as_deref(), Some("let B = 1;"));
+    }
+
+    #[test]
+    fn bare_module_script_change_forces_full_reload() {
+        let prev = "<script module>let MOD = 1;</script><div>x</div>";
+        let curr = "<script module>let MOD = 2;</script><div>x</div>";
+        let d = hmr_diff(prev, curr);
+        assert_eq!(d.change, HmrChange::FullReload);
+        assert!(d.module_changed);
+        assert!(!d.instance_changed);
     }
 }

--- a/src/vps/resolver.rs
+++ b/src/vps/resolver.rs
@@ -29,18 +29,39 @@ pub struct ResolveResult {
 /// bare specifiers or anything that doesn't exist on disk; the JS shim
 /// falls back to Vite's resolver for those cases.
 pub fn resolve_id(opts: ResolveOptions<'_>) -> Option<ResolveResult> {
-    if !is_relative(opts.specifier) {
+    // Split off any `?query` / `#hash` suffix before touching the filesystem.
+    // Vite passes specifiers like `./Foo.svelte?raw` / `./styles.css?url`; the
+    // suffix is not part of the filename, so it must be stripped for the path
+    // lookup and re-appended to the resolved id. M-062.
+    let (bare, suffix) = split_query_hash(opts.specifier);
+    if !is_relative(bare) {
         return None;
     }
     let importer_dir = opts.importer.and_then(|p| p.parent())?;
-    let combined = combine(importer_dir, opts.specifier);
+    let combined = combine(importer_dir, bare);
     let normalised = normalise(&combined);
     if let Some(found) = first_existing(&normalised, &candidate_extensions()) {
         return Some(ResolveResult {
-            resolved: to_posix_string(&found),
+            resolved: format!("{}{}", to_posix_string(&found), suffix),
         });
     }
     None
+}
+
+/// Split `spec` into its path part and any trailing `?query` / `#hash`
+/// (returned verbatim, including the leading `?` / `#`). Whichever delimiter
+/// appears first begins the suffix.
+fn split_query_hash(spec: &str) -> (&str, &str) {
+    let cut = match (spec.find('?'), spec.find('#')) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    };
+    match cut {
+        Some(i) => (&spec[..i], &spec[i..]),
+        None => (spec, ""),
+    }
 }
 
 fn is_relative(spec: &str) -> bool {
@@ -152,6 +173,58 @@ mod tests {
         })
         .expect("implicit extension");
         assert!(r2.resolved.ends_with("/src/Foo.svelte"), "{}", r2.resolved);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn split_query_hash_cases() {
+        assert_eq!(split_query_hash("./a.svelte"), ("./a.svelte", ""));
+        assert_eq!(split_query_hash("./a.svelte?raw"), ("./a.svelte", "?raw"));
+        assert_eq!(split_query_hash("./a.svelte#frag"), ("./a.svelte", "#frag"));
+        // Whichever delimiter is first starts the suffix.
+        assert_eq!(split_query_hash("./a.svelte?x#y"), ("./a.svelte", "?x#y"));
+        assert_eq!(split_query_hash("./a.svelte#y?x"), ("./a.svelte", "#y?x"));
+    }
+
+    #[test]
+    fn resolves_relative_import_with_query_suffix() {
+        let tmp = std::env::temp_dir().join(format!("vps_resolver_q_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::File::create(tmp.join("src/Foo.svelte"))
+            .unwrap()
+            .write_all(b"<div />")
+            .unwrap();
+        let importer = tmp.join("src/App.svelte");
+        fs::File::create(&importer)
+            .unwrap()
+            .write_all(b"<div />")
+            .unwrap();
+
+        // `?raw` suffix: resolve the base file, keep the query on the result.
+        let r = resolve_id(ResolveOptions {
+            importer: Some(&importer),
+            specifier: "./Foo.svelte?raw",
+        })
+        .expect("relative .svelte?raw resolves");
+        assert!(
+            r.resolved.ends_with("/src/Foo.svelte?raw"),
+            "{}",
+            r.resolved
+        );
+
+        // Implicit extension + query.
+        let r2 = resolve_id(ResolveOptions {
+            importer: Some(&importer),
+            specifier: "./Foo?url",
+        })
+        .expect("implicit extension with query");
+        assert!(
+            r2.resolved.ends_with("/src/Foo.svelte?url"),
+            "{}",
+            r2.resolved
+        );
 
         let _ = fs::remove_dir_all(&tmp);
     }


### PR DESCRIPTION
Partial fix for the #470 svelte2tsx/VPS cluster. Addresses **M-062** and **H-094** — self-contained robustness bugs in the Vite-plugin layer.

## Fixed

- **M-062** — `resolve_id` combined the raw specifier with the importer dir, so `./Foo.svelte?raw` / `./styles.css?url` were treated as literal filenames and failed to resolve. The `?query` / `#hash` suffix is now split off before the filesystem lookup and re-appended to the resolved id.
- **H-094** — HMR script diffing recognised only the legacy `<script context="module">`, so Svelte 5's bare `<script module>` was misclassified as the instance script. Module detection now also matches a standalone `module` attribute (word-boundary aware).

## Deferred (issue stays open)

- **H-090** (nested top-level await detection), **H-093** (`<script generics>` whitespace/tuple-type fragility), **M-013** (opening-tag scanner not JS-comment/regex-aware), **M-014** (snippet hoist analysis ASCII-only) — these are the svelte2tsx transforms the issue itself recommends driving from the AST / OXC; larger refactors.
- **M-063** (overlay JSONC tokenizer), **M-064** (whole-file `lang="ts"` sniffing) — `svelte_check/overlay.rs`; warrant a proper JSONC tokenizer / per-script lang detection.
- **H-094 sub-note**: the raw `<script` scan can still match substrings inside template text/strings; robustly fixing that needs full tag parsing (deferred).

## Test plan

- [x] `resolver` unit tests: `split_query_hash` cases + `?raw`/`?url` relative resolution
- [x] `hmr` unit tests: bare-`module` recognition, instance/module separation, full-reload on bare-module change
- [x] `cargo clippy --lib` clean for touched files

Addresses M-062, H-094 of #470 (issue remains open for the deferred items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)