### PR TITLE
fix(parse): preserve assignment-target left of for-of/for-in (#472 partial)

### DIFF
--- a/src/compiler/phases/1_parse/read/expression.rs
+++ b/src/compiler/phases/1_parse/read/expression.rs
@@ -6319,7 +6319,13 @@ fn convert_statement_for_program(
                 oxc_ast::ast::ForStatementLeft::VariableDeclaration(vd) => {
                     convert_variable_declaration_as_node(arena, vd, offset, line_offsets)
                 }
-                _ => JsNode::Null,
+                // Assignment-target left (`for (x of arr)`, `for ([a,b] of arr)`,
+                // `for (obj.p of arr)`): preserve it instead of dropping it to
+                // `Null` (which made the whole loop vanish downstream). H-127.
+                other => other
+                    .as_assignment_target()
+                    .map(|t| convert_assignment_target_for_program(arena, t, offset, line_offsets))
+                    .unwrap_or(JsNode::Null),
             };
 
             let right = expr_to_node(convert_expression_for_program(
@@ -6352,7 +6358,12 @@ fn convert_statement_for_program(
                 oxc_ast::ast::ForStatementLeft::VariableDeclaration(vd) => {
                     convert_variable_declaration_as_node(arena, vd, offset, line_offsets)
                 }
-                _ => JsNode::Null,
+                // Assignment-target left (`for (x in obj)`, `for (a.b in obj)`):
+                // preserve it instead of dropping it to `Null`. H-127.
+                other => other
+                    .as_assignment_target()
+                    .map(|t| convert_assignment_target_for_program(arena, t, offset, line_offsets))
+                    .unwrap_or(JsNode::Null),
             };
 
             let right = expr_to_node(convert_expression_for_program(

--- a/tests/script_for_of_assignment_target.rs
+++ b/tests/script_for_of_assignment_target.rs
@@ -1,0 +1,51 @@
+//! Regression test: `for (x of …)` / `for (x in …)` with an assignment-target
+//! left (not a `let`/`const` declaration) must not be dropped (issue #472, H-127).
+//!
+//! Bug: the script parser converted a non-`VariableDeclaration` for-of/in left to
+//! `JsNode::Null`, and the downstream converter then bailed out (`?` on a missing
+//! object), discarding the whole loop from the generated output.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn for_of_with_assignment_target_left_is_preserved() {
+    let src = r#"<script>
+let x;
+let out = [];
+for (x of [1, 2, 3]) { out.push(x); }
+</script>"#;
+    let out = compile_js(src);
+    assert!(
+        out.contains("for (x of"),
+        "for-of with assignment-target left was dropped, got:\n{out}"
+    );
+}
+
+#[test]
+fn for_in_with_assignment_target_left_is_preserved() {
+    let src = r#"<script>
+let k;
+let out = [];
+for (k in { a: 1 }) { out.push(k); }
+</script>"#;
+    let out = compile_js(src);
+    assert!(
+        out.contains("for (k in"),
+        "for-in with assignment-target left was dropped, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Partial fix for the #472 script-parser cluster. Addresses **H-127**.

## Fixed

- **H-127 (High)** — a non-`VariableDeclaration` for-of/for-in left (`for (x of arr)`, `for ([a,b] of arr)`, `for (k in obj)`) was converted to `JsNode::Null`, and the downstream converter then bailed out, **silently dropping the entire loop** from the output. The non-declaration arm now routes the left through `convert_assignment_target_for_program` (via OXC's `as_assignment_target`), so the loop is preserved with program-context offsets.

## Deferred (issue stays open)

- **H-128** (`export * from '…'` silently omitted) — needs a new `ExportAllDeclaration` variant in the typed AST + parser + converter + codegen.
- **H-129 / H-130** (program-level `switch`/`do-while` tests and computed property keys go through the wrapped-expression converter that applies a `-1` offset) — offset-convention correctness; should route through `convert_expression_for_program`, but touches several call sites and is sourcemap-sensitive.
- **M-083** (import/export attributes parsed but always emitted empty) — thread the attribute list through to codegen.
- **M-084** (`export default interface` → unstrippable null default export) — skip the wrapper so TS strip removes the whole statement.

## Test plan

- [x] `tests/script_for_of_assignment_target.rs` (for-of + for-in assignment-target left preserved)
- [x] `test_runtime_runes` / `test_runtime_legacy` / `test_compiler_snapshot_fixtures` / `test_compiler_errors` pass
- [x] `cargo clippy --lib` clean for the touched file

Addresses H-127 of #472 (issue remains open for the deferred items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)