### PR TITLE
fix(parse): reject empty transition/in/out directive names (#473 partial)

### DIFF
--- a/src/compiler/phases/1_parse/state/element.rs
+++ b/src/compiler/phases/1_parse/state/element.rs
@@ -1774,19 +1774,29 @@ impl Parser<'_> {
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute>> {
         // Determine type and extract name with modifiers
-        let (transition_name, intro, outro, modifiers) =
+        let (directive_label, transition_name, intro, outro, modifiers) =
             if let Some(stripped) = full_name.strip_prefix("transition:") {
                 let (name, mods) = Self::extract_name_and_modifiers(stripped);
-                (name, true, true, mods)
+                ("transition:", name, true, true, mods)
             } else if let Some(stripped) = full_name.strip_prefix("in:") {
                 let (name, mods) = Self::extract_name_and_modifiers(stripped);
-                (name, true, false, mods)
+                ("in:", name, true, false, mods)
             } else if let Some(stripped) = full_name.strip_prefix("out:") {
                 let (name, mods) = Self::extract_name_and_modifiers(stripped);
-                (name, false, true, mods)
+                ("out:", name, false, true, mods)
             } else {
                 return Ok(None);
             };
+
+        // An empty name (`transition:`, `in:|global`, …) is a parse error —
+        // it would otherwise lower to an empty JS identifier. H-146 / M-040.
+        if transition_name.is_empty() {
+            return Err(crate::error::ParseError::svelte(
+                "directive_missing_name",
+                format!("`{directive_label}` name cannot be empty"),
+                (start, name_end),
+            ));
+        }
 
         let name_loc = self.create_name_loc_optional(name_start, name_end);
 

--- a/tests/directive_empty_name.rs
+++ b/tests/directive_empty_name.rs
@@ -1,0 +1,35 @@
+//! Regression test: an empty transition/in/out directive name is a parse error
+//! (issue #473, H-146 / M-040), matching `use:` / `animate:` which already
+//! rejected empty names. Previously it lowered to an empty JS identifier.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn try_compile(src: &str) -> Result<(), String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|_| ())
+    .map_err(|e| format!("{e:?}"))
+}
+
+#[test]
+fn empty_transition_name_errors() {
+    assert!(try_compile("<div transition:>x</div>").is_err());
+    assert!(try_compile("<div in:>x</div>").is_err());
+    assert!(try_compile("<div out:>x</div>").is_err());
+    // Empty name before a modifier is still empty.
+    assert!(try_compile("<div transition:|global>x</div>").is_err());
+}
+
+#[test]
+fn valid_transition_still_compiles() {
+    let src = r#"<script>import { fade } from 'x';</script><div transition:fade|global>x</div>"#;
+    assert!(try_compile(src).is_ok(), "valid transition should compile");
+}


### PR DESCRIPTION
Partial fix for the #473 directives cluster. Addresses **H-146 / M-040**, verified against the official compiler.

## Fixed

- **H-146 / M-040** — `parse_transition_directive` never checked for an empty name, so `transition:` / `in:` / `out:` (and `transition:|global`) lowered to an empty JS identifier. `use:` / `animate:` already rejected empty names; the transition parser now emits the same `directive_missing_name` parse error, matching upstream (Svelte errors `directive_missing_name` for all of these).

## Triage of the rest (verified against the official compiler)

- **H-144** — Svelte does **not** reject unknown transition modifiers (`transition:fade|bogus` compiles OK upstream), so "modifiers parsed but never validated" is largely a non-bug; only `global`/`local` are meaningful and phase-3 already special-cases `global`. No error change warranted.
- **H-145** — `use:foo|bar` also compiles OK upstream, so a pipe suffix isn't a hard error; the exact lowering semantics need more investigation before changing.
- **H-147 / M-039** (plain quoted directive values, e.g. `transition:fade="foo"` → `directive_invalid_value`) — REAL, but the plain-quoted handling differs across the use/animate/transition/class/style parsers; deferred so it can be fixed consistently in one pass.
- **H-143** (animate direct-child validation leaks through control-flow blocks — `each_block_stack` push/pop) — REAL, analyzer-stack change; deferred.
- **M-041** (delegated-event lowering vs documented runtime contract) and **M-091** (`$store` directive factory scanning) — deferred.

## Test plan

- [x] `tests/directive_empty_name.rs` (empty transition/in/out + empty-before-modifier; valid `transition:fade|global` still compiles)
- [x] parser-fixtures / compiler-errors / runtime-runes / runtime-legacy / compiler-snapshot pass
- [x] `cargo clippy --lib` clean for the touched file

Addresses H-146, M-040 of #473 (issue remains open; H-144 noted as largely a non-bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)