### PR TITLE
fix(parse): attribute shorthand must be a bare identifier (#475 partial)

### DIFF
--- a/src/compiler/phases/1_parse/state/element.rs
+++ b/src/compiler/phases/1_parse/state/element.rs
@@ -1135,6 +1135,20 @@ impl Parser<'_> {
             // Create the attribute name from the expression (shorthand)
             let name = expr_content.trim().to_string();
 
+            // Attribute shorthand must be a bare identifier (`{foo}`). Upstream
+            // reads a single identifier and then expects `}`, so `{a.b}`,
+            // `{a + b}`, `{a()}` are `expected_token` errors at the first
+            // non-identifier character (not valid attribute names). H-153.
+            if !self.options.loose
+                && let Some(bad) = shorthand_first_invalid_offset(&name)
+            {
+                let leading_ws = expr_content.len() - expr_content.trim_start().len();
+                return Err(crate::error::ParseError::expected_token(
+                    "}",
+                    expr_start + leading_ws + bad,
+                ));
+            }
+
             // Check for reserved words in shorthand attributes
             // In the official Svelte, read_identifier() checks is_reserved(name)
             // Reference: svelte/packages/svelte/src/compiler/phases/1-parse/index.js L248
@@ -2495,4 +2509,20 @@ fn is_identifier_continue(c: char) -> bool {
 /// Check if a character is valid in a component name (after the first char).
 fn is_component_name_char(c: char) -> bool {
     is_identifier_continue(c) || c == '.'
+}
+
+/// Returns the byte offset within `name` of the first character that prevents
+/// it from being a bare JS identifier — the attribute-shorthand grammar accepts
+/// only a single identifier (`{foo}`), so `{a.b}` / `{a + b}` / `{a()}` are
+/// rejected at the offending character. Returns `None` when `name` is a valid
+/// identifier. An empty `name` returns `Some(0)`. H-153.
+fn shorthand_first_invalid_offset(name: &str) -> Option<usize> {
+    let mut iter = name.char_indices();
+    match iter.next() {
+        None => Some(0),
+        Some((_, c)) if !is_identifier_start(c) => Some(0),
+        _ => iter
+            .find(|(_, c)| !is_identifier_continue(*c))
+            .map(|(i, _)| i),
+    }
 }

--- a/tests/attribute_shorthand_validation.rs
+++ b/tests/attribute_shorthand_validation.rs
@@ -1,0 +1,37 @@
+//! Regression test: attribute shorthand `{…}` must be a bare identifier
+//! (issue #475, H-153). `{a.b}`, `{a + b}`, `{a()}` are `expected_token` errors
+//! upstream; rsvelte previously accepted the whole expression text as the
+//! attribute name.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn try_compile(src: &str) -> Result<(), String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|_| ())
+    .map_err(|e| format!("{e:?}"))
+}
+
+#[test]
+fn non_identifier_shorthand_is_rejected() {
+    assert!(try_compile("<div {a.b}></div>").is_err());
+    assert!(try_compile("<div {a + b}></div>").is_err());
+    assert!(try_compile("<div {a()}></div>").is_err());
+}
+
+#[test]
+fn bare_identifier_shorthand_compiles() {
+    let src = r#"<script>let foo = 1;</script><div {foo}></div>"#;
+    assert!(
+        try_compile(src).is_ok(),
+        "valid {{foo}} shorthand should compile"
+    );
+}


### PR DESCRIPTION
Partial fix for the #475 attribute-shorthand / expression-fast-path cluster. Addresses **H-153**.

## Fixed

- **H-153 (High)** — `{ … }` attribute shorthand used the whole trimmed expression text as the attribute name (only rejecting reserved words), so `{a.b}`, `{a + b}`, `{a()}` were accepted as attribute names. Upstream reads a single identifier then expects `}`, erroring `expected_token` at the first non-identifier char. The shorthand now validates that the content is a bare identifier and emits the same `expected_token` ("Expected token }") error. `$`/`_`-prefixed names and reserved-word / loose-mode handling are unchanged.

## Deferred (issue stays open)

- **H-154** — attribute spread / shorthand brace scanners aren't JS-aware (a `}` inside a string in `{...obj}` could misterminate); needs `find_matching_bracket`-style string-aware scanning.
- **H-155 / H-156** — the script-expression fast path special-cases only `true`/`false`/`null` (so other reserved words slip through) and parses `import.meta` / `new.target` as ordinary member expressions instead of `MetaProperty`. Safest fix is to make the fast path *bail out* to the full OXC parser for these shapes; needs care to keep the fast-path performance win.
- **M-095** (Low) — fast-path arrow-function params have zero spans (sourcemap cosmetic).

## Test plan

- [x] `tests/attribute_shorthand_validation.rs` (`{a.b}`/`{a + b}`/`{a()}` rejected; `{foo}` compiles)
- [x] parser-fixtures / compiler-errors / runtime-runes / runtime-legacy / compiler-snapshot pass
- [x] `cargo clippy --lib` clean for the touched file

Addresses H-153 of #475 (issue remains open for the deferred items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)