### PR TITLE
fix(client): bind memo param for call-only <title> (#476 partial)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/title_element.rs
+++ b/src/compiler/phases/3_transform/client/visitors/title_element.rs
@@ -62,7 +62,12 @@ pub fn title_element(node: &TitleElement, context: &mut ComponentContext) {
         b::assign(&context.arena, document_title, value),
     );
 
-    if has_state {
+    // Use the memoised `deferred_template_effect` form whenever the title has
+    // reactive state OR a memoised call/await value. Previously this branched on
+    // `has_state` alone, so a call-only title (`<title>{foo()}</title>`) fell
+    // through to the plain `$.effect` form below while its value still
+    // referenced the memo parameter `$0` — emitting an unbound `$0`. H-157.
+    if has_state || !memo_entries.is_empty() {
         // Separate memo entries into sync and async
         let sync_entries: Vec<&MemoEntry> = memo_entries.iter().filter(|e| !e.is_async).collect();
         let async_entries: Vec<&MemoEntry> = memo_entries.iter().filter(|e| e.is_async).collect();
@@ -86,7 +91,11 @@ pub fn title_element(node: &TitleElement, context: &mut ComponentContext) {
             b::array(
                 sync_entries
                     .iter()
-                    .map(|e| b::thunk(&context.arena, e.expression.clone()))
+                    // Explicit `() => expr` thunks — NOT `b::thunk` (which would
+                    // unthunk `() => foo()` to `foo`). Upstream keeps the thunk
+                    // in the `deferred_template_effect` deps array
+                    // (`[() => foo()]`). H-157.
+                    .map(|e| b::arrow(&context.arena, vec![], e.expression.clone()))
                     .collect(),
             )
         };

--- a/tests/title_call_only_memo.rs
+++ b/tests/title_call_only_memo.rs
@@ -1,0 +1,46 @@
+//! Regression test: a call-only `<title>` expression must bind its memo
+//! parameter (issue #476, H-157).
+//!
+//! Bug: `<svelte:head><title>{foo()}</title></svelte:head>` memoised `foo()` as
+//! `$0` but, because `has_state` was false, fell through to the plain
+//! `$.effect(() => { title = $0 ?? '' })` form — leaving `$0` unbound (undefined).
+//! It must use `$.deferred_template_effect(($0) => …, [() => foo()])` like upstream.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn call_only_title_binds_memo_param() {
+    let src = r#"<script>function foo() { return 'x'; }</script>
+<svelte:head><title>{foo()}</title></svelte:head>"#;
+    let out = compile_js(src);
+    assert!(
+        out.contains("deferred_template_effect"),
+        "call-only title should use deferred_template_effect, got:\n{out}"
+    );
+    // The memo parameter must be bound by the callback arrow.
+    assert!(
+        out.contains("($0)"),
+        "memo parameter $0 must be bound, got:\n{out}"
+    );
+    // And supplied as a thunk in the deps array.
+    assert!(
+        out.contains("() => foo()"),
+        "memoised call should be passed as a thunk, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Partial fix for the #476 title-element cluster. Addresses the **Critical H-157**.

## Fixed

- **H-157 (Critical)** — `<svelte:head><title>{foo()}</title></svelte:head>` memoised `foo()` as `$0` but, because `has_state` was false, fell through to the plain `$.effect(() => { $.document.title = $0 ?? '' })` form, emitting an **unbound `$0`** (undefined at runtime). The memoised `deferred_template_effect` path is now taken whenever there are memo entries (call/await) as well as for state, so the callback binds `($0)` and supplies the deps array — matching upstream `$.deferred_template_effect(($0) => …, [() => foo()])`. The deps now use explicit `() => expr` arrows (not `b::thunk`, which unthunked `() => foo()` to `foo`), so the array matches upstream exactly.

## Deferred (issue stays open)

- **H-158** — awaited calls *with arguments* are emitted eagerly (`build_async_thunk` returns the raw call when there are args); should wrap as `async () => fn(...)`.
- **H-159** — title expressions bypass the shared `build_expression` pipeline (so `has_state`/`has_call`/`has_await` + parameter naming can diverge from the shared chunk path).
- **M-096** — title effects are pushed to `state.after_update` rather than the fragment `state.update` blocker pipeline.
- **M-097** — title re-splits memoised values while keeping source-order parameter names.

These four want title lowering routed through the shared `build_expression` path — a larger refactor; deferred.

## Test plan

- [x] `tests/title_call_only_memo.rs` (call-only title binds `($0)` and emits `[() => foo()]`)
- [x] runtime-runes / runtime-legacy / hydration / compiler-snapshot suites pass
- [x] `cargo clippy --lib` clean for the touched file

Addresses H-157 of #476 (issue remains open for H-158, H-159, M-096, M-097).

🤖 Generated with [Claude Code](https://claude.com/claude-code)