### PR TITLE
fix(client): whitespace-tolerant $bindable / $props.id() (#477 partial)

### DIFF
--- a/src/compiler/phases/3_transform/client/mod.rs
+++ b/src/compiler/phases/3_transform/client/mod.rs
@@ -4358,12 +4358,18 @@ fn transform_instance_script_for_visitors(
             continue;
         }
 
-        // Skip $props.id() declarations - they will be added as const declarations in the component body
-        if (memmem::find(trimmed.as_bytes(), b"= $props.id()").is_some()
-            || memmem::find(trimmed.as_bytes(), b"= $.props_id()").is_some())
-            && (trimmed.starts_with("let ")
-                || trimmed.starts_with("const ")
-                || trimmed.starts_with("var "))
+        // Skip $props.id() declarations - they will be added as const declarations
+        // in the component body. Match on the initializer being exactly
+        // `$props.id()` / `$.props_id()` (whitespace-tolerant) rather than the
+        // literal `= $props.id()` substring, so `let id=$props.id()` (no spaces)
+        // is also skipped instead of surviving alongside the generated const. H-060.
+        if (trimmed.starts_with("let ")
+            || trimmed.starts_with("const ")
+            || trimmed.starts_with("var "))
+            && trimmed
+                .find('=')
+                .map(|eq| trimmed[eq + 1..].trim().trim_end_matches(';').trim())
+                .is_some_and(|rhs| rhs == "$props.id()" || rhs == "$.props_id()")
         {
             line_idx += 1;
             continue;

--- a/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1574,6 +1574,16 @@ pub(super) fn make_lazy_prop_arg(value: &str) -> String {
     }
 }
 
+/// If `s` is a `$bindable( … )` call, return the inner argument text (the raw
+/// slice between the parentheses, untrimmed). Tolerates whitespace between the
+/// `$bindable` rune and the opening `(` (`$bindable (x)`), which upstream's
+/// AST-based unwrap handles but a `starts_with("$bindable(")` text check
+/// missed. Returns `None` when `s` is not a `$bindable(...)` wrapper. H-061.
+fn strip_bindable_wrapper(s: &str) -> Option<&str> {
+    let rest = s.strip_prefix("$bindable")?.trim_start();
+    rest.strip_prefix('(')?.strip_suffix(')')
+}
+
 /// Split declarators by comma, handling nested braces, brackets, parens, and
 /// string / template literals.
 ///
@@ -1818,10 +1828,11 @@ pub(super) fn transform_props_destructuring(
 
             // Strip $bindable() wrapper: $bindable(value) -> value
             // Reference: VariableDeclaration.js - unwrap_bindable()
-            let was_bindable =
-                raw_default_value.starts_with("$bindable(") && raw_default_value.ends_with(')');
-            let default_value = if was_bindable {
-                let inner = &raw_default_value[10..raw_default_value.len() - 1];
+            // Tolerate whitespace between the rune and the `(` (`$bindable (x)`
+            // is valid JS that upstream's AST handles). H-061.
+            let bindable_inner = strip_bindable_wrapper(raw_default_value);
+            let was_bindable = bindable_inner.is_some();
+            let default_value = if let Some(inner) = bindable_inner {
                 if inner.is_empty() {
                     // $bindable() with no args - no default value
                     // Check if this binding is actually a prop source.

--- a/tests/bindable_whitespace.rs
+++ b/tests/bindable_whitespace.rs
@@ -1,0 +1,46 @@
+//! Regression test: `$bindable (default)` with whitespace before the `(` must
+//! be unwrapped like `$bindable(default)` (issue #477, H-061).
+//!
+//! Bug: the prop transform required `starts_with("$bindable(")`, so
+//! `$bindable (0)` (valid JS) wasn't unwrapped and the rune call leaked into the
+//! generated `$.prop(...)` default.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn bindable_with_space_is_unwrapped() {
+    let src = r#"<script>let { v = $bindable (0) } = $props();</script>{v}"#;
+    let out = compile_js(src);
+    assert!(
+        !out.contains("$bindable"),
+        "$bindable (x) wrapper should be stripped, got:\n{out}"
+    );
+    assert!(
+        out.contains("$.prop($$props, 'v', 11, 0)"),
+        "default value should be unwrapped to 0, got:\n{out}"
+    );
+}
+
+#[test]
+fn bindable_without_space_still_works() {
+    let src = r#"<script>let { v = $bindable(0) } = $props();</script>{v}"#;
+    let out = compile_js(src);
+    assert!(!out.contains("$bindable"), "got:\n{out}");
+    assert!(out.contains("$.prop($$props, 'v', 11, 0)"), "got:\n{out}");
+}

--- a/tests/props_id_no_space.rs
+++ b/tests/props_id_no_space.rs
@@ -1,0 +1,38 @@
+//! Regression test: a `$props.id()` declaration with no spaces around `=`
+//! (`let id=$props.id()`) must be skipped, not survive alongside the generated
+//! `const id = $.props_id()` (issue #477, H-060).
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn props_id_without_spaces_is_not_duplicated() {
+    let src = r#"<script>let id=$props.id();</script>{id}"#;
+    let out = compile_js(src);
+    // The raw `$props.id()` declaration must be removed (replaced by the
+    // generated `$.props_id()` const) — not left in place.
+    assert!(
+        !out.contains("$props.id()"),
+        "raw $props.id() declaration survived, got:\n{out}"
+    );
+    assert_eq!(
+        out.matches("$.props_id()").count(),
+        1,
+        "expected exactly one generated props_id declaration, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Partial fix for the #477 reactive/props/bindable text-scanner cluster. Addresses **H-060** and **H-061**, verified against the official compiler.

## Fixed

- **H-061** — `$bindable (value)` (whitespace between the rune and `(`) wasn't unwrapped (the transform required `starts_with("$bindable(")`), so the rune call leaked into the generated `$.prop(...)` default. A `strip_bindable_wrapper` helper now tolerates the whitespace, matching upstream's AST unwrap.
- **H-060** — `let id=$props.id()` (no spaces around `=`) wasn't skipped, so the original declaration survived alongside the generated `const id = $.props_id()` (duplicate `id`). The skip now matches the initializer being exactly `$props.id()` / `$.props_id()` (whitespace-tolerant), not the literal `= $props.id()` substring.

## Deferred (issue stays open)

- **H-064 (Critical)** — `find_assignment_position` tracks brackets only, so a regex literal containing `=` can be mis-split as an assignment; needs string/regex-aware scanning.
- **H-062** — member update expressions (`prop.count++`) excluded from the bindable-prop mutation wrapper.
- **H-063** — nested assignment detection is whitespace-sensitive (`format!("{}{}", var, op)` with surrounding spaces).
- **H-065** — reactive mutator helpers rewrite shadowed locals by identifier text only (miss params / destructured locals — needs scope info).

These want the rewrites driven from the AST + scope (the issue's suggested fix) and/or shared JS-lexical scanning state; larger, deferred.

## Test plan

- [x] `tests/bindable_whitespace.rs` (`$bindable (0)` and `$bindable(0)` both unwrap to `0`)
- [x] `tests/props_id_no_space.rs` (`let id=$props.id()` not duplicated)
- [x] runtime-runes / compiler-snapshot suites pass
- [x] `cargo clippy --lib` clean for touched files

Addresses H-060, H-061 of #477 (issue remains open for H-062, H-063, H-064, H-065).

🤖 Generated with [Claude Code](https://claude.com/claude-code)