### PR TITLE
fix(client): transform reactive reads in snippet defaults (#479 partial)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
+++ b/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
@@ -600,10 +600,14 @@ fn build_fallback_args(
     context: &mut ComponentContext,
 ) -> Vec<JsExpr> {
     use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::convert_expression;
+    use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::apply_transforms_to_expression;
 
     if is_simple_expression_json(default_value) {
-        // Simple default: $.fallback(arg?.(), default)
+        // Simple default: $.fallback(arg?.(), default). Apply reactive-read
+        // transforms so a default like `x = count` becomes `$.get(count)`
+        // (the default expression was previously emitted untransformed). M-068.
         let default_expr = convert_expression(&Expression::Value(default_value.clone()), context);
+        let default_expr = apply_transforms_to_expression(&default_expr, context);
         vec![default_expr]
     } else {
         // Complex default - check for the unthunk optimization:
@@ -625,9 +629,11 @@ fn build_fallback_args(
             );
             vec![callee_expr, JsExpr::Literal(JsLiteral::Boolean(true))]
         } else {
-            // General case: thunk the expression
+            // General case: thunk the (transformed) expression so reactive reads
+            // inside a complex default (`x = a + b`) are wrapped. M-068.
             let default_expr =
                 convert_expression(&Expression::Value(default_value.clone()), context);
+            let default_expr = apply_transforms_to_expression(&default_expr, context);
             vec![
                 b::thunk(&context.arena, default_expr),
                 JsExpr::Literal(JsLiteral::Boolean(true)),

--- a/tests/snippet_default_transform.rs
+++ b/tests/snippet_default_transform.rs
@@ -1,0 +1,39 @@
+//! Regression test: a snippet parameter default that reads reactive state must
+//! be transformed (issue #479, M-068).
+//!
+//! Bug: `build_fallback_args` ran `convert_expression` but not
+//! `apply_transforms_to_expression`, so a default like `{#snippet foo(x = count)}`
+//! emitted the bare `count` instead of `$.get(count)` inside `$.fallback(...)`.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn snippet_default_wraps_reactive_read() {
+    // `count` is reassigned, so it stays reactive ($.state) rather than being
+    // demoted to a plain `let`; its read in the default must be `$.get(count)`.
+    let src = r#"<script>let count = $state(5);</script>
+<button onclick={() => count++}>{count}</button>
+{#snippet foo(x = count)}{x}{/snippet}
+{@render foo()}"#;
+    let out = compile_js(src);
+    assert!(
+        out.contains("$.fallback($$arg0?.(), $.get(count))"),
+        "snippet default should wrap the reactive read as $.get(count), got:\n{out}"
+    );
+}


### PR DESCRIPTION
Partial fix for the #479 snippet-defaults / destructuring cluster. Addresses **M-068**.

## Fixed

- **M-068** — `build_fallback_args` converted a snippet parameter default with `convert_expression` but never `apply_transforms_to_expression`, so a default reading reactive state (`{#snippet foo(x = count)}`) emitted the bare `count` inside `$.fallback(...)` instead of `$.get(count)`. The simple and general-thunk paths now apply the reactive-read transforms (matching the title cluster's pipeline). Verified vs upstream: `$.fallback($$arg0?.(), $.get(count))`.

## Status of the rest

- **M-069** — already fixed (uses `b::optional_call`); ticked in the issue.
- **M-070** — bound-component true snippets miss dev-only snippet guards (server build); deferred.
- **M-071** — destructured loop bindings (`{#each items as {a, b}}`) don't suppress outer transforms (only `id.name` collected, not patterns); needs pattern-walking to collect bound names. Deferred.
- **M-072** — destructuring-assignment fallback emits `JsExpr::Raw(pattern_to_string(...))` with `/* computed */` / `/* default */` placeholders; needs a real `ObjectPattern`/`ArrayPattern` LHS AST. Deferred.

## Test plan

- [x] `tests/snippet_default_transform.rs` (`x = count` default → `$.get(count)`)
- [x] runtime-runes / runtime-legacy / compiler-snapshot suites pass
- [x] `cargo clippy --lib` clean for the touched file

Addresses M-068 of #479 (issue remains open for M-070, M-071, M-072).

🤖 Generated with [Claude Code](https://claude.com/claude-code)