### PR TITLE
fix(analyze): error on let/const + function name collision (#480 partial)

### DIFF
--- a/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/src/compiler/phases/2_analyze/scope_builder.rs
@@ -497,14 +497,31 @@ impl<'a> ScopeBuilder<'a> {
         // Also allow function redeclarations (TypeScript overloads declare the same
         // function name multiple times).
         if let Some(&existing_idx) = self.scopes[target_scope].declarations.get(&name) {
-            let existing_binding = &self.bindings[existing_idx];
-            // Only error if neither declaration is a var and neither is a function
-            // (function redeclarations are valid in JS/TS for overloads)
-            if existing_binding.declaration_kind != DeclarationKind::Var
+            let existing_kind = self.bindings[existing_idx].declaration_kind;
+            // Original rule: error when neither side is hoistable (`var`) or a
+            // function — function redeclarations stay valid for TS overloads.
+            let both_non_hoistable = existing_kind != DeclarationKind::Var
                 && declaration_kind != DeclarationKind::Var
-                && existing_binding.declaration_kind != DeclarationKind::Function
-                && declaration_kind != DeclarationKind::Function
-            {
+                && existing_kind != DeclarationKind::Function
+                && declaration_kind != DeclarationKind::Function;
+            // A block-lexical binding (`let` / `const` / `using`) cannot share
+            // its name with anything else in the same scope — including a
+            // function declaration (`let x; function x() {}`), which the
+            // function-redeclaration allowance above previously suppressed. L-002.
+            let is_block_lexical = |k: DeclarationKind| {
+                matches!(
+                    k,
+                    DeclarationKind::Let
+                        | DeclarationKind::Const
+                        | DeclarationKind::Using
+                        | DeclarationKind::AwaitUsing
+                )
+            };
+            let lexical_vs_function = (is_block_lexical(existing_kind)
+                && declaration_kind == DeclarationKind::Function)
+                || (existing_kind == DeclarationKind::Function
+                    && is_block_lexical(declaration_kind));
+            if both_non_hoistable || lexical_vs_function {
                 self.validation_errors
                     .push(errors::declaration_duplicate(&name));
             }

--- a/tests/duplicate_let_function.rs
+++ b/tests/duplicate_let_function.rs
@@ -1,0 +1,35 @@
+//! Regression test: a block-lexical binding colliding with a function
+//! declaration must error (issue #480, L-002). `let x; function x(){}` is a
+//! redeclaration error in JS/TS; the function-redeclaration allowance (kept for
+//! TS overloads) previously suppressed it.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn tc(src: &str) -> Result<(), String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .map(|_| ())
+    .map_err(|e| format!("{e:?}"))
+}
+
+#[test]
+fn let_then_function_errors() {
+    assert!(tc("<script>let x; function x(){}</script>").is_err());
+    assert!(tc("<script>const x = 1; function x(){}</script>").is_err());
+    assert!(tc("<script>function x(){} let x;</script>").is_err());
+}
+
+#[test]
+fn function_overloads_still_allowed() {
+    // Two function declarations (TS-overload-style) must NOT error.
+    assert!(tc("<script>function x(){} function x(){}</script>").is_ok());
+}


### PR DESCRIPTION
Partial fix for the #480 low-priority cluster. Addresses **L-002**.

## Fixed

- **L-002** — the duplicate-declaration check suppressed an error whenever either binding was a `var` or a `function` (the latter to keep TS function overloads valid), which also swallowed genuine errors like `let x; function x() {}` (a redeclaration error in JS/TS, confirmed via the official compiler → `js_parse_error`). A block-lexical binding (`let`/`const`/`using`) colliding with a function declaration now errors; `function`+`function` (overloads) and `var` redeclarations stay allowed.

## Status of the rest

- **L-001** → tracked at **#433** (arena soundness). **L-004** → **#470** (HMR script extraction). **L-006** → **#467** (print sourcemap). Not duplicated here.
- **L-003** (strict option-enum parsing) — NAPI-boundary; the official JS API doesn't hard-error on an unknown `generate` string in the same way, so this needs its own decision. Deferred.
- **L-005** (`<svelte:self>` dev metadata at offset 0) and **L-007** (`Root.end` ignores an options-only component) and **L-008** (self-closing script/style synthetic offsets) — dev-metadata / offset cosmetics; deferred.
- Note: `function x(){} function x(){}` (both with bodies) still isn't rejected — distinguishing it from valid TS overload signatures (no body) needs body-presence info in the scope builder; deferred.

## Test plan

- [x] `tests/duplicate_let_function.rs` (`let x; function x(){}` errors; `function x(){} function x(){}` overloads still allowed)
- [x] validator / compiler-errors / runtime-runes / runtime-legacy pass (no false positives)
- [x] `cargo clippy --lib` clean for the touched file

Addresses L-002 of #480 (issue remains open for the deferred / cross-referenced items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)