### PR TITLE
fix(analyze): emit options_deprecated_immutable in runes mode (#481 partial)

### DIFF
--- a/src/compiler/phases/2_analyze/mod.rs
+++ b/src/compiler/phases/2_analyze/mod.rs
@@ -275,6 +275,15 @@ pub fn analyze_component(
     // (unless it's a custom element). This overrides any options passed by the user.
     // Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/index.js
     if analysis.runes {
+        // `<svelte:options immutable>` is deprecated in runes mode (it has no
+        // effect there). Mirror upstream's analyze-phase warning, which fires
+        // when the `immutable` option attribute is present and runes is on
+        // (2-analyze/index.js). M-061.
+        if ast.options.as_ref().is_some_and(|o| o.immutable.is_some()) {
+            analysis
+                .warnings
+                .push(warnings::options_deprecated_immutable());
+        }
         analysis.immutable = true;
         if analysis.custom_element.is_none() {
             analysis.accessors = false;

--- a/tests/options_immutable_deprecation.rs
+++ b/tests/options_immutable_deprecation.rs
@@ -1,0 +1,42 @@
+//! Regression test: `<svelte:options immutable>` in runes mode emits the
+//! `options_deprecated_immutable` warning (issue #481, M-061). The warning was
+//! defined but never emitted.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn warnings(src: &str) -> Vec<String> {
+    let r = compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    r.warnings.into_iter().map(|w| w.code).collect()
+}
+
+#[test]
+fn immutable_option_warns_in_runes_mode() {
+    let src = "<svelte:options immutable />\n<script>let x = $state(0);</script>{x}";
+    assert!(
+        warnings(src)
+            .iter()
+            .any(|c| c == "options_deprecated_immutable"),
+        "expected options_deprecated_immutable in runes mode"
+    );
+}
+
+#[test]
+fn immutable_option_silent_in_legacy_mode() {
+    let src = "<svelte:options immutable />\n<div>hi</div>";
+    assert!(
+        !warnings(src)
+            .iter()
+            .any(|c| c == "options_deprecated_immutable"),
+        "legacy mode must not warn (matches upstream)"
+    );
+}


### PR DESCRIPTION
Partial fix for the #481 misc cluster. Addresses **M-061**.

## Fixed

- **M-061** — the `options_deprecated_immutable` warning was defined but never emitted. Upstream warns (analyze phase) when `<svelte:options immutable>` is present and the component is in runes mode (where `immutable` has no effect). rsvelte now pushes the warning in the runes branch when the immutable option attribute was present; legacy mode stays silent (verified against the official compiler).

## Status of the rest

- **M-073** — already fixed (ticked in the issue).
- **M-031 / M-032** — async-blocker primitives (`calculate_blockers` placeholder / raw identifier over-collection); intricate async-pipeline work, deferred.
- **M-033** — `$props()` after-`await` first-substring matching; deferred.
- **M-034** — dynamic/self component child analysis not entering the `let:` slot-prop scope; deferred.
- **M-060** — warning-filename normalisation uses `strip_prefix` without a path-boundary check; deferred.
- **M-052..M-056** overlap the a11y cluster **#454**; **M-074..M-076** overlap the svelte-options cluster **#449**. Not duplicated here.
- Note: the `immutable: true` *compiler option* (vs the `<svelte:options>` attribute) is warned by upstream's `validate-options` regardless of runes; that's a separate emission point (option validation) left for follow-up.

## Test plan

- [x] `tests/options_immutable_deprecation.rs` (runes → warns; legacy → silent)
- [x] validator suite passes
- [x] `cargo clippy --lib` clean for the touched file

Addresses M-061 of #481 (issue remains open for the deferred items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)