### PR TITLE
fix(svelte2tsx): escape backslashes in mixed-attribute template literals (#455 partial)

### DIFF
--- a/src/svelte2tsx/template/mod.rs
+++ b/src/svelte2tsx/template/mod.rs
@@ -3306,8 +3306,15 @@ fn format_attribute_node(node: &AttributeNode, source: &str) -> Option<String> {
             for part in parts {
                 match part {
                     AttributeValuePart::Text(text) => {
-                        // Escape backtick characters in the text
-                        let escaped = text.raw.replace('`', "\\`").replace('$', "\\$");
+                        // Escape backslash first (so a Windows path like
+                        // `C:\new\test` doesn't turn `\n` / `\t` into control
+                        // characters inside the template literal), then backtick
+                        // and `$`. H-091.
+                        let escaped = text
+                            .raw
+                            .replace('\\', "\\\\")
+                            .replace('`', "\\`")
+                            .replace('$', "\\$");
                         value_parts.push(escaped);
                     }
                     AttributeValuePart::ExpressionTag(expr) => {
@@ -3377,7 +3384,13 @@ fn format_attribute_node_segments(node: &AttributeNode, source: &str) -> Option<
             for part in parts {
                 match part {
                     AttributeValuePart::Text(text) => {
-                        let escaped = text.raw.replace('`', "\\`").replace('$', "\\$");
+                        // Escape backslash first so `\n` / `\t` in raw text
+                        // (e.g. a Windows path) stay literal. H-091.
+                        let escaped = text
+                            .raw
+                            .replace('\\', "\\\\")
+                            .replace('`', "\\`")
+                            .replace('$', "\\$");
                         segs_push_lit(&mut out, &escaped);
                     }
                     AttributeValuePart::ExpressionTag(expr) => {
@@ -3482,7 +3495,13 @@ fn format_style_directive_segments(style: &StyleDirective, source: &str) -> Vec<
             for part in parts {
                 match part {
                     AttributeValuePart::Text(text) => {
-                        let escaped = text.raw.replace('`', "\\`").replace('$', "\\$");
+                        // Escape backslash first so `\n` / `\t` in raw text
+                        // (e.g. a Windows path) stay literal. H-091.
+                        let escaped = text
+                            .raw
+                            .replace('\\', "\\\\")
+                            .replace('`', "\\`")
+                            .replace('$', "\\$");
                         segs_push_lit(&mut out, &escaped);
                     }
                     AttributeValuePart::ExpressionTag(expr) => {
@@ -3541,7 +3560,13 @@ fn format_slot_prop_node(node: &AttributeNode, source: &str) -> Option<String> {
             for part in parts {
                 match part {
                     AttributeValuePart::Text(text) => {
-                        let escaped = text.raw.replace('`', "\\`").replace('$', "\\$");
+                        // Escape backslash first so `\n` / `\t` in raw text
+                        // (e.g. a Windows path) stay literal. H-091.
+                        let escaped = text
+                            .raw
+                            .replace('\\', "\\\\")
+                            .replace('`', "\\`")
+                            .replace('$', "\\$");
                         value_parts.push(escaped);
                     }
                     AttributeValuePart::ExpressionTag(expr) => {
@@ -3736,7 +3761,13 @@ fn format_style_directive(style: &StyleDirective, source: &str) -> String {
             for part in parts {
                 match part {
                     AttributeValuePart::Text(text) => {
-                        let escaped = text.raw.replace('`', "\\`").replace('$', "\\$");
+                        // Escape backslash first so `\n` / `\t` in raw text
+                        // (e.g. a Windows path) stay literal. H-091.
+                        let escaped = text
+                            .raw
+                            .replace('\\', "\\\\")
+                            .replace('`', "\\`")
+                            .replace('$', "\\$");
                         value_parts.push(escaped);
                     }
                     AttributeValuePart::ExpressionTag(expr) => {

--- a/tests/svelte2tsx_backslash_escape.rs
+++ b/tests/svelte2tsx_backslash_escape.rs
@@ -1,0 +1,34 @@
+//! Regression test: svelte2tsx mixed-attribute template literals must escape
+//! backslashes (issue #455, H-091). A Windows-style path in an attribute value
+//! would otherwise turn `\n` / `\t` into a newline / tab inside the generated
+//! template literal.
+
+use svelte_compiler_rust::svelte2tsx::{
+    Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion, svelte2tsx,
+};
+
+fn opts() -> Svelte2TsxOptions {
+    Svelte2TsxOptions {
+        filename: "T.svelte".to_string(),
+        is_ts_file: false,
+        mode: Svelte2TsxMode::Ts,
+        accessors: false,
+        namespace: Svelte2TsxNamespace::Html,
+        version: SvelteVersion::V5,
+        runes: None,
+        emit_jsdoc: false,
+        rewrite_external_imports: None,
+    }
+}
+
+#[test]
+fn backslash_in_mixed_attribute_is_escaped() {
+    // A mixed attribute (static text + expression) is emitted as a template
+    // literal; the static text contains backslashes that must be escaped.
+    let input = r#"<script>let x = 1;</script><div class="C:\temp\new{x}"></div>"#;
+    let out = svelte2tsx(input, opts()).expect("svelte2tsx").code;
+    assert!(
+        out.contains(r"C:\\temp\\new"),
+        "backslashes in attribute text were not escaped, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Partial fix for the #455 template-literal sanitisation cluster. Addresses **H-091**.

## Fixed

- **H-091** — the svelte2tsx mixed-attribute / style template-literal builders escaped only `` ` `` and `$` in static text chunks, so a Windows path in an attribute (`class="C:\new\test{x}"`) emitted a template literal where `\n` / `\t` became a newline / tab. All five text-chunk escape sites now escape `\` first.

## Status of the rest

- **H-160 / H-161 (Critical)** — already landed via merged PR **#515** (title + attr/style quasis now go through `sanitize_template_string`). Confirmed on `main`.
- **H-092** — slot names / slot-prop keys interpolated without robust escaping (`'{}': ''` / verbatim joins); a name with `'` or hyphens/spaces breaks. Deferred (needs proper key quoting/escaping in the slot-typing emit).

## Test plan

- [x] `tests/svelte2tsx_backslash_escape.rs` (Windows path in a mixed attribute → escaped `\\`)
- [x] svelte2tsx fixture suite passes
- [x] `cargo clippy --lib` clean for the touched file

Addresses H-091 of #455 (H-160/H-161 done via #515; H-092 deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)