### PR TITLE
fix(client): preserve labels on labeled statements (#456 partial)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -4135,7 +4135,23 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                 .unwrap_or_else(|| context.arena.alloc_stmt(JsStatement::Empty));
             Some(JsStatement::DoWhile(JsDoWhileStatement { test, body }))
         }
-        "LabeledStatement" => obj.get("body").and_then(|b| convert_statement(b, context)),
+        "LabeledStatement" => {
+            // Preserve the label, not just the body — otherwise a surviving
+            // `break label;` / `continue label;` references a label that no
+            // longer exists (ReferenceError at runtime). H-111.
+            let label = obj
+                .get("label")
+                .and_then(|l| l.get("name"))
+                .and_then(|n| n.as_str())?;
+            let body = obj
+                .get("body")
+                .and_then(|b| convert_statement(b, context))?;
+            let body_id = context.arena.alloc_stmt(body);
+            Some(JsStatement::Labeled(JsLabeledStatement {
+                label: label.into(),
+                body: body_id,
+            }))
+        }
         "BreakStatement" => {
             let label = obj
                 .get("label")

--- a/tests/labeled_statement_preserved.rs
+++ b/tests/labeled_statement_preserved.rs
@@ -1,0 +1,37 @@
+//! Regression test: a labeled statement in a converted body must keep its label
+//! (issue #456, H-111). The converter previously returned only the body, so a
+//! surviving `break label;` / `continue label;` referenced a removed label.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn label_is_preserved_with_labeled_continue() {
+    let src = r#"<script>let y = $state(0);</script>
+<button onclick={() => { outer: for (let i = 0; i < 3; i++) { for (let j = 0; j < 3; j++) { if (j === 1) continue outer; y = i; } } }}>b</button>"#;
+    let out = compile_js(src);
+    assert!(
+        out.contains("outer:"),
+        "label declaration dropped, got:\n{out}"
+    );
+    assert!(
+        out.contains("continue outer"),
+        "labeled continue missing, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Partial fix for the #456 inline-JS-statement cluster. Addresses **H-111**.

## Fixed

- **H-111 (Critical)** — the inline-statement converter returned only the *body* of a `LabeledStatement`, dropping the label. A surviving `break label;` / `continue label;` then referenced a removed label → ReferenceError at runtime. The converter now builds a `JsStatement::Labeled` (the variant and its codegen already existed) from the label + converted body. Verified: `outer:` is preserved alongside `continue outer`.

## Status of the rest

- **H-110** (`for...in` emitted as `for...of`) — already fixed: the converter sets `is_for_in` and codegen emits ` in `. Verified.
- **H-112** (catch params only preserve identifiers) — works: `catch ({ message })` preserves the destructured param. Verified.
- **H-109 (Critical)** — `switch` is still flattened into a `Block` (loses `case` matching). Fixing it needs a new `JsStatement::Switch` variant (discriminant + cases) plus converter + codegen that matches upstream's esrap formatting (indentation + blank line between cases). No fixture currently validates it, so it needs a careful dedicated implementation. **Deferred.**

## Test plan

- [x] `tests/labeled_statement_preserved.rs` (label + labeled `continue` preserved)
- [x] runtime-runes / runtime-legacy / compiler-snapshot suites pass
- [x] `cargo clippy --lib` clean for the changed arm

Addresses H-111 of #456 (H-110/H-112 already work; H-109 deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)