### PR TITLE
fix(client): emit real switch statements (#456 — completes the cluster)

### DIFF
--- a/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -4155,22 +4155,40 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
             Some(JsStatement::Continue(label))
         }
         "SwitchStatement" => {
-            let mut stmts = Vec::new();
-            if let Some(cases) = obj.get("cases").and_then(|c| c.as_array()) {
-                for case in cases {
-                    if let Some(case_obj) = case.as_object()
-                        && let Some(consequent) =
-                            case_obj.get("consequent").and_then(|c| c.as_array())
-                    {
-                        for s in consequent {
+            // Build a real switch (discriminant + cases), not a flat block —
+            // flattening dropped the discriminant and merged every case body,
+            // destroying the `case` matching. H-109.
+            let discriminant = {
+                let d = obj.get("discriminant")?;
+                let expr = convert_json_value(d, context);
+                context.arena.alloc_expr(expr)
+            };
+            let mut cases = Vec::new();
+            if let Some(cs) = obj.get("cases").and_then(|c| c.as_array()) {
+                for case in cs {
+                    let Some(case_obj) = case.as_object() else {
+                        continue;
+                    };
+                    // `test` is `null` for the `default:` clause.
+                    let test = case_obj.get("test").filter(|t| !t.is_null()).map(|t| {
+                        let expr = convert_json_value(t, context);
+                        context.arena.alloc_expr(expr)
+                    });
+                    let mut consequent = Vec::new();
+                    if let Some(stmts) = case_obj.get("consequent").and_then(|c| c.as_array()) {
+                        for s in stmts {
                             if let Some(converted) = convert_statement(s, context) {
-                                stmts.push(converted);
+                                consequent.push(converted);
                             }
                         }
                     }
+                    cases.push(JsSwitchCase { test, consequent });
                 }
             }
-            Some(JsStatement::Block(JsBlockStatement { body: stmts }))
+            Some(JsStatement::Switch(JsSwitchStatement {
+                discriminant,
+                cases,
+            }))
         }
         "FunctionDeclaration" => {
             let id: Option<CompactString> = obj

--- a/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -324,6 +324,7 @@ impl<'a> JsCodegen<'a> {
             JsStatement::ForOf(for_of) => self.emit_for_of_statement(for_of),
             JsStatement::While(while_stmt) => self.emit_while_statement(while_stmt),
             JsStatement::DoWhile(do_while) => self.emit_do_while_statement(do_while),
+            JsStatement::Switch(sw) => self.emit_switch_statement(sw),
             JsStatement::Block(block) => self.emit_block_statement(block),
             JsStatement::Empty => self.needs_semicolon = true,
             JsStatement::Debugger => {
@@ -701,6 +702,49 @@ impl<'a> JsCodegen<'a> {
         self.indent_level -= 1;
         self.indent();
         self.output.push('}');
+    }
+
+    fn emit_switch_statement(&mut self, sw: &JsSwitchStatement) {
+        self.output.push_str("switch (");
+        self.emit_expression(self.arena.get_expr(sw.discriminant));
+        self.output.push_str(") {");
+        // Cases sit one level in; their bodies a further level in. A `newline()`
+        // before each case is a plain line break for the first case (after `{`)
+        // and a blank-line separator for the rest (the previous non-empty case
+        // body ends in a newline), matching esrap's blank line between cases.
+        self.indent_level += 1;
+        for case in &sw.cases {
+            self.newline();
+            self.indent();
+            match &case.test {
+                Some(test) => {
+                    self.output.push_str("case ");
+                    self.emit_expression(self.arena.get_expr(*test));
+                    self.output.push(':');
+                }
+                None => self.output.push_str("default:"),
+            }
+            if !case.consequent.is_empty() {
+                self.indent_level += 1;
+                self.newline();
+                // Emit each statement tightly (no inter-statement blank lines —
+                // unlike `emit_body`, which adds them between differing top-level
+                // statement types; esrap keeps a case body compact).
+                for stmt in &case.consequent {
+                    self.emit_statement(stmt);
+                }
+                self.indent_level -= 1;
+            }
+        }
+        self.indent_level -= 1;
+        // A non-empty final case body already ends in a newline; an empty final
+        // case (or no cases) does not, so add one before the closing brace.
+        if !self.output.ends_with('\n') {
+            self.newline();
+        }
+        self.indent();
+        self.output.push('}');
+        self.needs_semicolon = false;
     }
 
     fn emit_block_inline(&mut self, block: &JsBlockStatement) {
@@ -1693,6 +1737,7 @@ impl<'a> JsCodegen<'a> {
             | JsStatement::While(_)
             | JsStatement::DoWhile(_)
             | JsStatement::Try(_)
+            | JsStatement::Switch(_)
             | JsStatement::ExportDefault(_) => true,
             // Block is multiline if it has any statements
             JsStatement::Block(block) => !block.body.is_empty(),
@@ -2054,6 +2099,7 @@ fn stmt_type_name(stmt: &JsStatement) -> &'static str {
         JsStatement::ForOf(_) => "ForOfStatement",
         JsStatement::While(_) => "WhileStatement",
         JsStatement::DoWhile(_) => "DoWhileStatement",
+        JsStatement::Switch(_) => "SwitchStatement",
         JsStatement::Block(_) => "BlockStatement",
         JsStatement::Empty => "EmptyStatement",
         JsStatement::Debugger => "DebuggerStatement",

--- a/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -61,6 +61,8 @@ pub enum JsStatement {
     While(JsWhileStatement),
     /// Do-while statement
     DoWhile(JsDoWhileStatement),
+    /// Switch statement
+    Switch(JsSwitchStatement),
     /// Block statement
     Block(JsBlockStatement),
     /// Empty statement
@@ -295,6 +297,21 @@ pub struct JsTryStatement {
     pub block: JsBlockStatement,
     pub handler: Option<JsCatchClause>,
     pub finalizer: Option<JsBlockStatement>,
+}
+
+/// Switch statement.
+#[derive(Debug, Clone)]
+pub struct JsSwitchStatement {
+    pub discriminant: ExprId,
+    pub cases: Vec<JsSwitchCase>,
+}
+
+/// A single `case` / `default` clause of a switch statement.
+#[derive(Debug, Clone)]
+pub struct JsSwitchCase {
+    /// The case test expression, or `None` for the `default:` clause.
+    pub test: Option<ExprId>,
+    pub consequent: Vec<JsStatement>,
 }
 
 /// Catch clause.

--- a/tests/switch_statement_codegen.rs
+++ b/tests/switch_statement_codegen.rs
@@ -1,0 +1,45 @@
+//! Regression test: a `switch` statement in a converted body (event handler /
+//! reactive block) must be emitted as a real switch, not flattened into a block
+//! (issue #456, H-109).
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn switch_in_handler_is_preserved() {
+    let src = r#"<script>let x = $state(0), y = $state(0);</script>
+<button onclick={() => { switch (x) { case 1: y = 1; break; default: y = 2; } }}>b</button>"#;
+    let out = compile_js(src);
+    assert!(
+        out.contains("switch (x) {"),
+        "switch not emitted, got:\n{out}"
+    );
+    assert!(out.contains("case 1:"), "case label lost, got:\n{out}");
+    assert!(out.contains("default:"), "default label lost, got:\n{out}");
+    // The reactive assignments inside the cases are still transformed.
+    assert!(
+        out.contains("$.set(y, 1)") && out.contains("$.set(y, 2)"),
+        "got:\n{out}"
+    );
+    // No blank line inside a case body (between `$.set(y, 1);` and `break;`).
+    assert!(
+        !out.contains("$.set(y, 1);\n\n"),
+        "unexpected blank line inside case body, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Completes the #456 inline-JS-statement cluster. Addresses **H-109** (the last open finding).

## Fixed

- **H-109 (Critical)** — a `switch` in a converted body (event handler / reactive block) was flattened into a `JsStatement::Block`, dropping the discriminant and merging every case consequent (destroyed `case` matching → wrong runtime behaviour). Added a `JsStatement::Switch` variant (`JsSwitchStatement` + `JsSwitchCase`), built it in the converter (discriminant + per-case test/consequent, `null` test = `default`), and emit it with esrap-matching formatting (cases at +1, bodies at +2, blank line between cases, compact case body). Verified against upstream's exact output.

## Cluster status (#456 now complete)

- **H-109** — fixed here.
- **H-110** (for-in vs for-of) — already fixed (`is_for_in` flag + codegen).
- **H-111** (labeled statements) — fixed in #549.
- **H-112** (catch destructure params) — already works.

With this + #549 merged, **#456 can be closed**.

## Test plan

- [x] `tests/switch_statement_codegen.rs` (switch preserved, cases/default kept, reactive assigns transformed, compact case body)
- [x] runtime-runes / runtime-legacy / hydration / compiler-snapshot suites pass
- [x] `cargo clippy --lib` clean

Addresses H-109 of #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)