### PR TITLE
chore(release): changesets for 0.6.0 catch-up release

### DIFF
--- a/.changeset/release-compiler-catch-up.md
+++ b/.changeset/release-compiler-catch-up.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": minor
+---
+
+Bundle 71 compiler/AST correctness commits since 0.5.1 (Svelte target stays at 5.55.9). Highlights:
+
+- **async / blockers**: sync-statement grouping in the async-body transform (5.54.1), transitive `touch`-through-assignments in `compute_blocker_map` (5.55.1), `{#await await ...}` async-batching (5.55.9), `$derived(await ...)` nested-fn `$.save` lowering + then-arg shadowing (5.55.9), `has_more_blockers_than` IfBlock flattening guard and `@debug` blocker plumbing (5.55.3/5.55.6), `async-eager-derived` blocker reorder (5.53.12), `$inspect` after top-level await, `$$promises` threaded through head effects.
+- **`@const`**: per-const-tag blocker computation (5.55.3).
+- **CSS**: upstream-matching selector pruning + `:where()` composition.
+- **parse**: comments between attributes and in expressions, OXC-AST script-statement splitting, empty transition/in/out directive name rejection, attribute-shorthand bare-identifier rule, assignment-target preservation for for-of/for-in.
+- **analyze**: lexical-scope resolution of same-name rune declarations, `NewExpression` template-literal coercion.
+- **server**: SSR rune rewrite inside `{#if}` tests (5.55.4), multi-line declaration collapse in `extract_constant_vars`.
+- **napi**: upgrade napi-rs to v3 (compat-mode), RAII arena guard + zero-copy envelope offset/length validation.
+- **client**: whitespace-tolerant `$bindable` / `$props.id()`, call-only `<title>` memo binding, logical-assign proxy + store ops.
+
+Plus ~50 smaller correctness fixes from the review backlog.

--- a/.changeset/release-svelte-check-catch-up.md
+++ b/.changeset/release-svelte-check-catch-up.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+- Escape GitHub Actions command property values in `--output machine`/GH-format diagnostics.
+- Apply `warning_filter`, forward module-level warnings, and make machine output line-safe.
+- Rebuild against the bundled `@rsvelte/compiler` correctness work.

--- a/.changeset/release-svelte2tsx-catch-up.md
+++ b/.changeset/release-svelte2tsx-catch-up.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Pick up the bundled `@rsvelte/compiler` correctness work and support `expected.error.json` start/end-offset comparison in the svelte2tsx error fixtures.

--- a/.changeset/release-vps-catch-up.md
+++ b/.changeset/release-vps-catch-up.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+- `resolve_id` now preserves `?query` / `#hash` suffixes and handles bare `<script module>` HMR.
+- Rebuild against the bundled `@rsvelte/compiler` correctness work.


### PR DESCRIPTION
## Summary

Bundles the **102 commits** landed on `main` since the last release (`@rsvelte/compiler@0.5.1`, 2026-05-26) into changesets. The Svelte target is unchanged (still 5.55.9); these are all correctness ports/fixes plus the napi v3 upgrade.

Merging this PR triggers the **Release** workflow, which opens the automated **Version Packages** PR. Publishing happens when that second PR is merged.

### Resulting version bumps (`changeset status` verified)

| Package | Bump | New version |
|---|---|---|
| `@rsvelte/compiler` | minor | 0.5.1 → **0.6.0** |
| `@rsvelte/svelte2tsx` | patch | 0.1.4 → 0.1.5 |
| `@rsvelte/svelte-check` (+5 platform binaries, fixed group) | patch | 0.1.3 → 0.1.4 |
| `@rsvelte/vite-plugin-svelte-native` (+5 platform binaries, fixed group) | patch | 0.1.3 → 0.1.4 |

All 14 publishable packages covered: 4 leader packages declared in changesets, 10 platform-binary packages auto-bumped via the two `fixed` groups.

### Why compiler is minor

71 of the commits touch `src/compiler` / `src/ast`, including 21 `feat` commits that change emitted output (async batching / blocker computation, `@const` per-tag blockers, CSS selector pruning + `:where()` composition, parse fixes, analyze lexical scoping, SSR rune rewrite, napi-rs v3). No public API additions and no breaking changes, so minor per the repo's convention (0.5.0 likewise treated output-changing Svelte ports as minor).

## Test plan

- [x] `changeset status --verbose` confirms the bump plan above
- [ ] Release workflow runs on merge and opens the Version Packages PR