### PR TITLE
fix(parse): error on malformed block/directive head expressions (#445 H-002)

### DIFF
--- a/src/compiler/phases/1_parse/read/expression.rs
+++ b/src/compiler/phases/1_parse/read/expression.rs
@@ -1634,6 +1634,50 @@ pub fn check_js_parse_error_with_pos(content: &str) -> Option<(String, usize)> {
     js_result.or(ts_result)
 }
 
+/// For an *invalid* expression string, determine whether the failure is caused
+/// by **trailing tokens after an otherwise-complete expression** (e.g. `a b c`)
+/// rather than an incomplete / malformed expression (e.g. `a +`).
+///
+/// Returns `Some(offset)` — the byte offset (within `content`) of the first
+/// trailing non-whitespace character — when a complete leading expression is
+/// followed by more input. Returns `None` when the expression itself is
+/// incomplete or otherwise invalid.
+///
+/// This mirrors upstream Svelte's `read_expression` + `eat(close, true)` flow:
+/// acorn parses one maximal expression, and any leftover surfaces as
+/// `expected_token` while a broken expression surfaces as `js_parse_error`.
+pub fn trailing_token_offset(content: &str) -> Option<usize> {
+    // Wrap in parens so a *complete* leading expression is consumed greedily and
+    // the first error label lands on the first leftover token. (Parsing the bare
+    // string as a program is unreliable: OXC's statement-level error recovery
+    // folds trailing tokens into one recovered node, hiding the boundary.)
+    let mut wrapped = String::with_capacity(content.len() + 2);
+    wrapped.push('(');
+    wrapped.push_str(content);
+    wrapped.push(')');
+
+    let probe = |source_type: SourceType| -> Option<usize> {
+        with_oxc_allocator(|allocator| {
+            let result = OxcParser::new(allocator, &wrapped, source_type).parse();
+            let first_error = result.errors.first()?;
+            let label = first_error.labels.as_ref()?.first()?;
+            // Map the label's *start* back into `content` (strip the leading `(`).
+            let start = label.offset();
+            if start == 0 {
+                return None;
+            }
+            let content_pos = start - 1;
+            // A trailing-token error has leftover input *before* the synthetic
+            // closing `)`; an incomplete expression errors at/after the end.
+            if content_pos >= content.len() {
+                return None;
+            }
+            Some(content_pos)
+        })
+    };
+    probe(SourceType::ts()).or_else(|| probe(SourceType::mjs()))
+}
+
 /// Create an identifier for invalid expressions
 fn create_invalid_identifier(start: usize, end: usize, _line_offsets: &[usize]) -> Expression {
     // Note: Similar to get_loose_identifier, invalid identifiers don't include 'loc'

--- a/src/compiler/phases/1_parse/state/element.rs
+++ b/src/compiler/phases/1_parse/state/element.rs
@@ -1033,7 +1033,8 @@ impl Parser<'_> {
                 }
                 let expr_content = &self.source[expr_start..self.index];
                 self.advance(); // consume '}'
-                let expression = self.parse_js_expression(expr_content.trim(), expr_start);
+                let expression =
+                    self.parse_head_expression(expr_content.trim(), expr_start, false, '}')?;
                 return Ok(Some(crate::ast::Attribute::SpreadAttribute(
                     crate::ast::template::SpreadAttribute {
                         start: start as u32,
@@ -1300,7 +1301,7 @@ impl Parser<'_> {
                         self.advance();
                     }
                     (
-                        Some(self.parse_js_expression(expr_content, expr_start)),
+                        Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
                         self.index,
                     )
                 } else {
@@ -1319,7 +1320,7 @@ impl Parser<'_> {
                 let expr_content = &self.source[expr_start..self.index];
                 self.advance(); // consume '}'
                 (
-                    Some(self.parse_js_expression(expr_content, expr_start)),
+                    Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
                     self.index,
                 )
             } else {
@@ -1383,7 +1384,7 @@ impl Parser<'_> {
                         self.advance();
                     }
                     (
-                        self.parse_js_expression(expr_content, expr_start),
+                        self.parse_head_expression(expr_content, expr_start, false, '}')?,
                         self.index,
                     )
                 } else {
@@ -1411,7 +1412,7 @@ impl Parser<'_> {
                 let expr_content = &self.source[expr_start..self.index];
                 self.advance(); // consume '}'
                 (
-                    self.parse_js_expression(expr_content, expr_start),
+                    self.parse_head_expression(expr_content, expr_start, false, '}')?,
                     self.index,
                 )
             } else {
@@ -1493,7 +1494,7 @@ impl Parser<'_> {
                         self.advance();
                     }
                     (
-                        Some(self.parse_js_expression(expr_content, expr_start)),
+                        Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
                         self.index,
                     )
                 } else {
@@ -1514,7 +1515,7 @@ impl Parser<'_> {
                 let expr_content = &self.source[expr_start..expr_end];
                 self.advance(); // consume '}'
                 (
-                    Some(self.parse_js_expression(expr_content, expr_start)),
+                    Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
                     self.index,
                 )
             } else {
@@ -1577,7 +1578,7 @@ impl Parser<'_> {
                 if quote.is_some() {
                     self.advance(); // consume closing quote
                 }
-                self.parse_js_expression(expr_content, expr_start)
+                self.parse_head_expression(expr_content, expr_start, false, '}')?
             } else {
                 if quote.is_some() {
                     self.index -= 1; // revert quote consumption
@@ -1645,7 +1646,7 @@ impl Parser<'_> {
                 AttributeValue::Expression(ExpressionTag {
                     start: (expr_start - 1) as u32, // include the '{'
                     end: self.index as u32,
-                    expression: self.parse_js_expression(expr_content, expr_start),
+                    expression: self.parse_head_expression(expr_content, expr_start, false, '}')?,
                     metadata: Default::default(),
                 })
             } else if self.eat_optional("\"") || self.eat_optional("'") {
@@ -1832,7 +1833,7 @@ impl Parser<'_> {
                         self.advance();
                     }
                     (
-                        Some(self.parse_js_expression(expr_content, expr_start)),
+                        Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
                         self.index,
                     )
                 } else {
@@ -1851,7 +1852,7 @@ impl Parser<'_> {
                 let expr_content = &self.source[expr_start..self.index];
                 self.advance(); // consume '}'
                 (
-                    Some(self.parse_js_expression(expr_content, expr_start)),
+                    Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
                     self.index,
                 )
             } else {
@@ -1921,7 +1922,7 @@ impl Parser<'_> {
                 if quote.is_some() {
                     self.advance(); // consume closing quote
                 }
-                Some(self.parse_js_expression(expr_content, expr_start))
+                Some(self.parse_head_expression(expr_content, expr_start, false, '}')?)
             } else {
                 if quote.is_some() {
                     self.index -= 1; // revert quote consumption
@@ -1975,7 +1976,7 @@ impl Parser<'_> {
                 if quote.is_some() {
                     self.advance(); // consume closing quote
                 }
-                Some(self.parse_js_expression(expr_content, expr_start))
+                Some(self.parse_head_expression(expr_content, expr_start, false, '}')?)
             } else {
                 if quote.is_some() {
                     self.index -= 1; // revert quote consumption
@@ -2011,7 +2012,7 @@ impl Parser<'_> {
         let expr_content = &self.source[expr_start..expr_end];
         self.advance(); // consume closing '}'
 
-        let expression = self.parse_js_expression(expr_content.trim(), expr_start);
+        let expression = self.parse_head_expression(expr_content.trim(), expr_start, false, '}')?;
 
         Ok(Some(crate::ast::Attribute::AttachTag(
             crate::ast::template::AttachTag {

--- a/src/compiler/phases/1_parse/state/tag.rs
+++ b/src/compiler/phases/1_parse/state/tag.rs
@@ -151,7 +151,7 @@ impl Parser<'_> {
         let expr_content = &self.source[expr_start..self.index];
         self.advance(); // consume '}'
 
-        let test = self.parse_js_expression(expr_content.trim(), expr_start);
+        let test = self.parse_head_expression(expr_content.trim(), expr_start, false, '}')?;
 
         // Push block to stack
         self.stack.push(StackEntry::IfBlock {
@@ -232,7 +232,8 @@ impl Parser<'_> {
             let alt_expr_content = &self.source[alt_expr_start..self.index];
             self.advance(); // consume '}'
 
-            let alt_test = self.parse_js_expression(alt_expr_content.trim(), alt_expr_start);
+            let alt_test =
+                self.parse_head_expression(alt_expr_content.trim(), alt_expr_start, false, '}')?;
             let alt_consequent = self.parse_fragment()?;
 
             // Recursively check for another else/else-if
@@ -385,7 +386,7 @@ impl Parser<'_> {
         let expr_content = &self.source[expr_start..expr_end].trim();
         // Use disallow_loose = true to prevent patterns like `as { y = z }` from being parsed as expressions
         // (corresponds to Svelte's read_expression(parser, undefined, true))
-        let expression = self.parse_js_expression_internal(expr_content, expr_start, true, '{');
+        let expression = self.parse_head_expression(expr_content, expr_start, true, '}')?;
 
         if !found_as {
             // No "as" found - check for ", identifier" index syntax
@@ -668,7 +669,7 @@ impl Parser<'_> {
                 find_matching_bracket(self.source, key_start, '(').unwrap_or(self.bytes.len());
             let key_content = self.source[key_start..self.index].trim();
             // Use opening_token = '(' for key expressions (corresponds to Svelte's read_expression(parser, '('))
-            key = Some(self.parse_js_expression_internal(key_content, key_start, false, '('));
+            key = Some(self.parse_head_expression(key_content, key_start, false, ')')?);
             self.eat_optional(")"); // consume closing paren
         }
 
@@ -1085,7 +1086,7 @@ impl Parser<'_> {
         let expr_content = &self.source[expr_start..self.index];
         self.advance(); // consume '}'
 
-        let expression = self.parse_js_expression(expr_content.trim(), expr_start);
+        let expression = self.parse_head_expression(expr_content.trim(), expr_start, false, '}')?;
 
         // Push block to stack
         self.stack.push(StackEntry::KeyBlock {
@@ -1455,7 +1456,8 @@ impl Parser<'_> {
                 let expr_content = &self.source[expr_start..self.index];
                 self.advance(); // consume '}'
 
-                let expression = self.parse_js_expression(expr_content.trim(), expr_start);
+                let expression =
+                    self.parse_head_expression(expr_content.trim(), expr_start, false, '}')?;
 
                 Ok(Some(TemplateNode::HtmlTag(Box::new(HtmlTag {
                     start: start as u32,
@@ -1887,6 +1889,77 @@ impl Parser<'_> {
     /// and `opening_token = '{'`.
     pub fn parse_js_expression(&self, content: &str, offset: usize) -> Expression {
         self.parse_js_expression_internal(content, offset, false, '{')
+    }
+
+    /// Parse a block / directive head expression that, in strict (non-loose)
+    /// mode, must be a single complete JS expression terminated by `close_char`
+    /// (`'}'` or `')'`). Mirrors upstream Svelte, which parses one expression
+    /// with acorn and then `eat(close_char, true)`:
+    ///
+    /// - trailing tokens *after* a complete expression (`{#if a b c}`) surface
+    ///   as `expected_token`,
+    /// - an incomplete / invalid expression (`{#if a +}`) surfaces as
+    ///   `js_parse_error`.
+    ///
+    /// In loose / editor mode this stays lenient (placeholder identifier),
+    /// matching the previous swallowing behaviour of `parse_js_expression`.
+    /// (issue #445, H-002)
+    pub fn parse_head_expression(
+        &self,
+        content: &str,
+        offset: usize,
+        disallow_loose: bool,
+        close_char: char,
+    ) -> crate::error::ParseResult<Expression> {
+        let leading_ws = content.len() - content.trim_start().len();
+        let trimmed = content.trim();
+        let trimmed_offset = offset + leading_ws;
+        let opening_token = if close_char == ')' { '(' } else { '{' };
+
+        match super::super::read::expression::parse_expression(
+            &self.arena,
+            trimmed,
+            trimmed_offset,
+            self.expression_line_offsets(),
+            self.source,
+            self.options.loose,
+            disallow_loose,
+            opening_token,
+            self.ts,
+        ) {
+            Ok(expr) => Ok(expr),
+            Err((msg, _)) => {
+                // Loose / editor mode: stay lenient with a placeholder, matching
+                // the previous `unwrap_or_else` swallow.
+                if self.options.loose {
+                    return Ok(super::super::read::expression::create_empty_identifier(
+                        "",
+                        trimmed_offset,
+                        trimmed_offset + trimmed.len(),
+                    ));
+                }
+                // Strict mode: classify the failure the way upstream does. A
+                // complete leading expression followed by leftover input is an
+                // `expected_token` (missing `close_char`); anything else is a
+                // `js_parse_error` at the point acorn/OXC stopped.
+                if let Some(pos) = super::super::read::expression::trailing_token_offset(trimmed) {
+                    return Err(crate::error::ParseError::expected_token(
+                        &close_char.to_string(),
+                        trimmed_offset + pos,
+                    ));
+                }
+                let abs_pos =
+                    super::super::read::expression::check_js_parse_error_with_pos(trimmed)
+                        .map_or(trimmed_offset + trimmed.len(), |(_, pos)| {
+                            trimmed_offset + pos
+                        });
+                Err(crate::error::ParseError::svelte(
+                    "js_parse_error",
+                    msg,
+                    (abs_pos, abs_pos),
+                ))
+            }
+        }
     }
 }
 

--- a/tests/block_head_parse_errors.rs
+++ b/tests/block_head_parse_errors.rs
@@ -1,0 +1,103 @@
+//! Regression test: malformed block / directive head expressions must surface a
+//! parse error instead of being silently swallowed (issue #445, H-002).
+//!
+//! Bug: control-flow block heads (`{#if}`, `{#each}`, `{#key}`, `{@html}`) and
+//! directive value expressions routed their JS through `parse_js_expression`,
+//! whose `unwrap_or_else` returned an empty identifier on failure — so
+//! `{#if a b c}` compiled to broken output rather than erroring. Upstream Svelte
+//! parses one expression and then `eat(close, true)`: trailing tokens after a
+//! complete expression surface as `expected_token`, an incomplete expression as
+//! `js_parse_error`.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn try_compile(src: &str) -> Result<(), (String, usize, usize)> {
+    match compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let s = format!("{e:?}");
+            // Extract the svelte error code from the Debug repr.
+            let code = s
+                .split("code: \"")
+                .nth(1)
+                .and_then(|t| t.split('"').next())
+                .unwrap_or("")
+                .to_string();
+            Err((code, 0, 0))
+        }
+    }
+}
+
+#[track_caller]
+fn assert_expected_token(src: &str) {
+    match try_compile(src) {
+        Ok(()) => panic!("expected a parse error for {src:?}, but it compiled"),
+        Err((code, _, _)) => assert_eq!(
+            code, "expected_token",
+            "for {src:?} expected `expected_token`, got `{code}`"
+        ),
+    }
+}
+
+#[track_caller]
+fn assert_compiles(src: &str) {
+    if let Err((code, _, _)) = try_compile(src) {
+        panic!("expected {src:?} to compile, got error `{code}`");
+    }
+}
+
+#[test]
+fn block_heads_reject_trailing_tokens() {
+    assert_expected_token(r#"{#if a b c}x{/if}"#);
+    assert_expected_token(r#"{#if x}a{:else if a b c}b{/if}"#);
+    assert_expected_token(r#"{#each a b c as x}y{/each}"#);
+    assert_expected_token(r#"{#each items as item (a b)}x{/each}"#);
+    assert_expected_token(r#"{#key a b c}x{/key}"#);
+    assert_expected_token(r#"{@html a b c}"#);
+}
+
+#[test]
+fn block_heads_report_js_parse_error_for_incomplete() {
+    // An incomplete expression (no trailing token) is a `js_parse_error`, not
+    // `expected_token`.
+    match try_compile(r#"{#if a +}x{/if}"#) {
+        Ok(()) => panic!("expected a parse error"),
+        Err((code, _, _)) => assert_eq!(code, "js_parse_error"),
+    }
+}
+
+#[test]
+fn directive_heads_reject_trailing_tokens() {
+    assert_expected_token(r#"<input bind:value={a b c}>"#);
+    assert_expected_token(r#"<div use:foo={a b c}>x</div>"#);
+    assert_expected_token(r#"<div class:x={a b c}>y</div>"#);
+    assert_expected_token(r#"<div transition:fade={a b c}>y</div>"#);
+    assert_expected_token(r#"<div {...a b c}>x</div>"#);
+}
+
+#[test]
+fn valid_heads_still_compile() {
+    assert_compiles(r#"{#if a && b}x{/if}"#);
+    assert_compiles(r#"{#each items as x}y{/each}"#);
+    assert_compiles(r#"{#each items as item (item.id)}x{/each}"#);
+    assert_compiles(r#"{#key a}x{/key}"#);
+    assert_compiles(r#"{@html foo}"#);
+    assert_compiles(r#"<div {...obj}>x</div>"#);
+}
+
+#[test]
+fn script_raw_attributes_are_not_interpolated() {
+    // `<script>` attributes (generics/lang/...) are raw strings — a `{...}`
+    // inside must NOT be parsed as an expression interpolation.
+    assert_compiles(r#"<script generics="T extends { yes: boolean }">let x=1</script>{x}"#);
+}


### PR DESCRIPTION
## Summary

Addresses **H-002** from #445: malformed block / directive head expressions were silently swallowed (compiled to broken output) instead of producing a parse error.

`parse_js_expression`'s `unwrap_or_else` returned an empty identifier on failure, so `{#if a b c}`, `{#each a b c as x}`, `{#each items as item (a b)}`, `{@html a b c}`, `<div use:foo={a b c}>` etc. compiled instead of erroring (upstream rejects all of them).

### Fix

New `parse_head_expression` mirrors upstream Svelte's `read_expression` + `eat(close, true)`:
- a **complete** leading expression followed by leftover input → `expected_token` (at the trailing token),
- an **incomplete / invalid** expression → `js_parse_error`.

A new `trailing_token_offset` helper finds the trailing-token boundary (wrap-in-parens probe, mapping the first OXC error label start back into the source). Loose / editor mode stays lenient (placeholder identifier), preserving language-server behaviour.

Routed through it:
- block heads: `{#if}`, `{:else if}`, `{#each}` iterable + key, `{#key}`, `{@html}`
- directive values: `bind:` / `use:` / `class:` / `transition:` / `animate:` / `on:` / `let:`
- `{...spread}` and `{@attach}`

Error codes **and positions** now match upstream exactly (verified case-by-case against the official compiler).

### Deliberately out of scope (documented on the issue)

The general non-directive attribute-value reader (`title={a b c}`, Svelte-5 `onclick={a b c}`, quoted `"a{expr}b"` interpolation) is left swallowing. It is shared with `<script>` / `<style>` raw attributes — `<script generics="T extends { yes: boolean }">` must NOT interpolate the `{...}`. Propagating errors there needs the element's raw-text context threaded into the attribute reader (upstream's `read_static_attribute` distinction), a separate refactor.

### Other #445 findings

Assessed previously and unchanged here: H-001/H-019 (string/comment-aware brace/paren scan) not reproduced; H-018 (`{#each}` ` as ` split) masked by last-`as`-wins; H-003/H-016 (JS↔TS fallback) separate concern; H-017 (`{@attach}` is emitted; unknown blocks).

Closes #445

## Test plan

- [x] New `tests/block_head_parse_errors.rs` (block heads + directives error with `expected_token`; incomplete → `js_parse_error`; valid heads compile; `<script generics>` not interpolated)
- [x] Full fixture suite — parser / errors / snapshot / css / validator / ssr / print / svelte2tsx / runtime / compatibility_report — **3467 fixtures, zero regressions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)