### PR TITLE
ci(release): scope cancel-in-progress to version-packages merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,14 @@ permissions:
 
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: false
+  # Only the "Version Packages" merge (the publish run) cancels older queued
+  # runs. This kills any in-flight regular-commit run that is about to
+  # re-open the version PR on stale state (the race that produced #554).
+  # Regular pushes keep cancel-in-progress: false so they never abort an
+  # in-flight publish — npm publish is per-package, so a mid-flight cancel
+  # can leave us with versions bumped in package.json but never published
+  # to the registry.
+  cancel-in-progress: ${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}
 
 jobs:
   # Per-platform svelte-check binary builds. Each job uploads its rsvelte


### PR DESCRIPTION
## Summary

- Fixes the duplicate "Version Packages" PR race that produced #554.
- Publish-trigger runs (commit `chore(release): version packages`) now cancel older in-flight runs in the `release-main` concurrency group; regular pushes keep `cancel-in-progress: false` so they never abort a publish.

## Why

Timeline that produced #554 (2026-05-29 UTC):

| time | event |
|---|---|
| 16:47:35 | #552 (pnpm bump) merged → release.yml run starts on tree where changesets still exist |
| 16:47:43 | #553 (Version Packages) merged |
| 16:47:50 | #553's publish run starts → fails |
| 16:57:26 | #552's run finally finishes — changesets/action force-pushes the same version-bump to `changeset-release/main` |
| 16:57:28 | #553 is already closed, so a new PR (#554) is opened with duplicate content |

Root cause: `cancel-in-progress: false` let the stale #552-run survive past #553's merge, then it re-opened the version PR on its outdated view of main.

## Why not just `cancel-in-progress: true`

`true` everywhere would let a regular push abort an in-flight publish. `changeset publish` walks packages one by one, so a mid-flight cancel can leave us with versions bumped in `package.json` but never pushed to npm — much worse than a duplicate PR.

Scoping `cancel-in-progress` to publish runs only:
- Publish run starts → cancels any stale regular-commit run (kills the #554 race).
- Regular push during a publish → does **not** cancel the publish.
- Regular push during another regular run → does not cancel (conservative; worst case is one redundant version-PR refresh, never a duplicate PR).

## Test plan

- [ ] Land this, then merge a no-op changeset + a follow-up regular commit back-to-back and confirm only one Version Packages PR is open.
- [ ] Confirm a regular push during an active publish run does not cancel the publish (visually inspect Actions tab on next release cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)