### PR TITLE
fix(parse): error on duplicate <svelte:options> (#449 H-113)

### DIFF
--- a/src/compiler/phases/1_parse/read/options.rs
+++ b/src/compiler/phases/1_parse/read/options.rs
@@ -185,6 +185,20 @@ impl Parser<'_> {
             }
         }
 
+        // Only one `<svelte:options>` element is allowed per component. Upstream
+        // surfaces `svelte_meta_duplicate` from the analyzer because it emits a
+        // SvelteOptions AST node; rsvelte stores the result in parser state
+        // without emitting a node, so the analyzer never sees it. Detect the
+        // duplicate here at the parser layer so the diagnostic still fires.
+        // (issue #449, H-113)
+        if self.svelte_options.is_some() {
+            return Err(ParseError::svelte(
+                "svelte_meta_duplicate",
+                "A component can only have one `<svelte:options>` element\nhttps://svelte.dev/e/svelte_meta_duplicate",
+                (start, start),
+            ));
+        }
+
         // Store the options
         self.svelte_options = Some(SvelteOptions {
             start: start as u32,

--- a/tests/svelte_options_validation.rs
+++ b/tests/svelte_options_validation.rs
@@ -1,0 +1,140 @@
+//! Regression test: `<svelte:options>` validation + public option enforcement
+//! (issue #449).
+//!
+//! Bug: duplicate `<svelte:options>` was silently accepted (the second one
+//! overwrote the first). Upstream errors with `svelte_meta_duplicate`. rsvelte
+//! never emitted a SvelteOptions AST node, so the analyzer-side check that
+//! upstream relies on (`A component can only have one <svelte:options> element`)
+//! never fired. Detect the duplicate at the parser layer where the option store
+//! happens.
+//!
+//! The other findings in the cluster (H-087 disclose_version, H-088 name, H-114
+//! runes={false}, H-115 customElement={null}) already work correctly; this test
+//! pins their behaviour so regressions surface.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn try_compile(src: &str, opts: CompileOptions) -> Result<String, String> {
+    match compile(src, opts) {
+        Ok(r) => Ok(r.js.code),
+        Err(e) => Err(format!("{e:?}")),
+    }
+}
+
+fn default_opts() -> CompileOptions {
+    CompileOptions {
+        filename: Some("T.svelte".to_string()),
+        generate: GenerateMode::Client,
+        dev: false,
+        css: CssMode::External,
+        runes: None,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn h113_duplicate_svelte_options_errors() {
+    let err = try_compile(
+        r#"<svelte:options runes/><svelte:options runes={false}/><p>x</p>"#,
+        default_opts(),
+    )
+    .expect_err("should error");
+    assert!(
+        err.contains("svelte_meta_duplicate"),
+        "expected `svelte_meta_duplicate`, got:\n{err}"
+    );
+}
+
+#[test]
+fn h113_single_svelte_options_compiles() {
+    try_compile(r#"<svelte:options runes/><p>x</p>"#, default_opts())
+        .expect("single options should compile");
+}
+
+#[test]
+fn h114_runes_false_disables_runes_mode() {
+    // Using $state in runes={false} mode must error.
+    let err = try_compile(
+        r#"<svelte:options runes={false}/><script>let x = $state(1);</script>{x}"#,
+        default_opts(),
+    )
+    .expect_err("should error");
+    assert!(
+        err.contains("rune_invalid_usage"),
+        "expected `rune_invalid_usage`, got:\n{err}"
+    );
+}
+
+#[test]
+fn h115_custom_element_null_does_not_enable_custom_element() {
+    let out = try_compile(
+        r#"<svelte:options customElement={null}/><p>x</p>"#,
+        default_opts(),
+    )
+    .expect("compile");
+    assert!(
+        !out.contains("customElements.define"),
+        "customElement={{null}} must not enable CE, got:\n{out}"
+    );
+}
+
+#[test]
+fn h088_name_option_overrides_export_name() {
+    let out = try_compile(
+        "<p>x</p>",
+        CompileOptions {
+            name: Some("Foo".to_string()),
+            ..default_opts()
+        },
+    )
+    .expect("compile");
+    assert!(
+        out.contains("export default function Foo("),
+        "name option should rename the export, got:\n{out}"
+    );
+}
+
+#[test]
+fn h087_disclose_version_false_drops_import() {
+    let out = try_compile(
+        "<p>x</p>",
+        CompileOptions {
+            disclose_version: false,
+            ..default_opts()
+        },
+    )
+    .expect("compile");
+    assert!(
+        !out.contains("svelte/internal/disclose-version"),
+        "disclose_version=false should drop the import, got:\n{out}"
+    );
+}
+
+#[test]
+fn h087_disclose_version_true_keeps_import() {
+    let out = try_compile(
+        "<p>x</p>",
+        CompileOptions {
+            disclose_version: true,
+            ..default_opts()
+        },
+    )
+    .expect("compile");
+    assert!(
+        out.contains("svelte/internal/disclose-version"),
+        "disclose_version=true should keep the import, got:\n{out}"
+    );
+}
+
+#[test]
+fn h116_namespace_svg_emits_from_svg() {
+    let out = try_compile(
+        r#"<svelte:options namespace="svg"/><circle cx="50" cy="50" r="40"/>"#,
+        default_opts(),
+    )
+    .expect("compile");
+    assert!(
+        out.contains("$.from_svg"),
+        "namespace=svg should classify root elements as SVG, got:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

Detect duplicate `<svelte:options>` in the parser and surface `svelte_meta_duplicate`, matching upstream. The store-into-parser-state approach previously let the second tag silently overwrite the first.

### Cluster status

| Finding | Status |
|---|---|
| **H-087** disclose_version ignored | already honoured (option flips the import) |
| **H-088** name option ignored | already applied (renames `export default function`) |
| **H-113** duplicate `<svelte:options>` | **fixed** in this PR |
| **H-114** `runes={false}` undone by auto-detect | already respected (`$state` errors as expected) |
| **H-115** `customElement={null}` enables CE | already off (no `customElements.define`) |
| **H-116** `namespace="svg"` not propagated | already classifies via `$.from_svg(...)` |

A regression test pins H-113 + all five "already-fixed" findings so future drift surfaces.

Closes #449

## Test plan

- [x] New `tests/svelte_options_validation.rs` — 8 cases (H-113 duplicate + single, H-114 runes-false, H-115 custom-element-null, H-088 name option, H-087 disclose_version on/off, H-116 namespace svg)
- [x] Full fixture suite — parser / errors / snapshot / validator / ssr / runtime / compatibility_report — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)