### PR TITLE
fix(preprocess): decode base64-VLQ Source Map v3 mappings (#451 H-012)

### DIFF
--- a/src/compiler/preprocess/decode_sourcemap.rs
+++ b/src/compiler/preprocess/decode_sourcemap.rs
@@ -7,8 +7,10 @@ use super::types::{Processed, SimpleDecodedMap, SourceMapInput};
 /// Decode a source map from a Processed result.
 ///
 /// This handles:
-/// - JSON string maps (parses and decodes VLQ mappings)
-/// - Pre-decoded maps with string mappings (decodes VLQ)
+/// - JSON string maps with VLQ-encoded `mappings` (standard Source Map v3,
+///   e.g. anything produced by typical preprocessors)
+/// - JSON string maps with already-decoded `mappings: [[[...]]]`
+///   (rsvelte-internal pre-decoded form)
 /// - Already-decoded maps (returns as-is)
 ///
 /// Corresponds to `decode_map` in decode_sourcemap.js.
@@ -17,11 +19,128 @@ pub fn decode_map(processed: &Processed) -> Option<SimpleDecodedMap> {
 
     match map_input {
         SourceMapInput::Json(json_str) => {
-            // Parse JSON string to our decoded format
-            serde_json::from_str(json_str).ok()
+            // Try the rsvelte-internal pre-decoded form first.
+            if let Ok(decoded) = serde_json::from_str::<SimpleDecodedMap>(json_str) {
+                return Some(decoded);
+            }
+            // Fall back to the standard Source Map v3 spec, where `mappings` is
+            // a base64-VLQ-encoded string. Previously this branch silently
+            // returned `None`, so every standard preprocessor map was dropped
+            // (issue #451, H-012).
+            decode_vlq_sourcemap_json(json_str)
         }
         SourceMapInput::Decoded(decoded) => Some(decoded.clone()),
     }
+}
+
+/// Parse a standard Source Map v3 JSON document whose `mappings` field is a
+/// base64-VLQ-encoded string, decoding it into the array form
+/// `SimpleDecodedMap` uses.
+fn decode_vlq_sourcemap_json(json_str: &str) -> Option<SimpleDecodedMap> {
+    #[derive(serde::Deserialize)]
+    struct RawMap {
+        version: Option<u32>,
+        file: Option<String>,
+        #[serde(default)]
+        sources: Vec<Option<String>>,
+        #[serde(rename = "sourcesContent", default)]
+        sources_content: Option<Vec<Option<String>>>,
+        #[serde(default)]
+        names: Vec<String>,
+        mappings: String,
+        #[serde(rename = "sourceRoot")]
+        source_root: Option<String>,
+    }
+    let raw: RawMap = serde_json::from_str(json_str).ok()?;
+    Some(SimpleDecodedMap {
+        version: raw.version,
+        file: raw.file,
+        sources: raw
+            .sources
+            .into_iter()
+            .map(|s| s.unwrap_or_default())
+            .collect(),
+        sources_content: raw.sources_content,
+        names: raw.names,
+        mappings: decode_vlq_mappings(&raw.mappings),
+        source_root: raw.source_root,
+    })
+}
+
+/// Decode a Source Map v3 `mappings` field — `;`-separated lines, each a
+/// `,`-separated list of VLQ-encoded segments (relative to the running
+/// `[generatedCol, sourceIdx, sourceLine, sourceCol, nameIdx]` state).
+fn decode_vlq_mappings(s: &str) -> Vec<Vec<Vec<i64>>> {
+    let mut lines: Vec<Vec<Vec<i64>>> = Vec::new();
+    // Running state across segments: generated column resets each line; the
+    // other four fields persist across lines.
+    let mut last = [0i64; 5];
+    for line_str in s.split(';') {
+        let mut segments: Vec<Vec<i64>> = Vec::new();
+        last[0] = 0;
+        for seg_str in line_str.split(',') {
+            if seg_str.is_empty() {
+                continue;
+            }
+            let deltas = match decode_vlq_segment(seg_str) {
+                Some(d) => d,
+                None => continue,
+            };
+            let mut segment = Vec::with_capacity(deltas.len());
+            for (i, d) in deltas.into_iter().enumerate().take(5) {
+                last[i] += d;
+                segment.push(last[i]);
+            }
+            segments.push(segment);
+        }
+        lines.push(segments);
+    }
+    lines
+}
+
+/// Decode one VLQ-encoded segment (a base64 string) into its integer deltas.
+fn decode_vlq_segment(s: &str) -> Option<Vec<i64>> {
+    const B64: [i8; 128] = {
+        let mut t = [-1i8; 128];
+        let abc = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut i = 0;
+        while i < abc.len() {
+            t[abc[i] as usize] = i as i8;
+            i += 1;
+        }
+        t
+    };
+    let bytes = s.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let mut value: i64 = 0;
+        let mut shift = 0u32;
+        loop {
+            if i >= bytes.len() {
+                return None;
+            }
+            let b = bytes[i];
+            i += 1;
+            if b >= 128 {
+                return None;
+            }
+            let digit = B64[b as usize];
+            if digit < 0 {
+                return None;
+            }
+            let digit = digit as i64;
+            value |= (digit & 31) << shift;
+            shift += 5;
+            if digit & 32 == 0 {
+                break;
+            }
+        }
+        let neg = (value & 1) != 0;
+        let mag = value >> 1;
+        out.push(if neg { -mag } else { mag });
+    }
+    Some(out)
 }
 
 #[cfg(test)]

--- a/tests/preprocess_vlq_sourcemap.rs
+++ b/tests/preprocess_vlq_sourcemap.rs
@@ -1,0 +1,64 @@
+//! Regression test: `decode_map` must understand standard Source Map v3 JSON
+//! whose `mappings` field is a base64-VLQ-encoded string (issue #451, H-012).
+//!
+//! Bug: the previous decoder was a one-line `serde_json::from_str(json_str).ok()`
+//! into `SimpleDecodedMap`, whose `mappings` is `Vec<Vec<Vec<i64>>>`. A real
+//! preprocessor map (with mappings as `"AAAA,SAASA"` etc.) failed to deserialise
+//! and was silently dropped — `decode_map` returned `None`.
+
+use svelte_compiler_rust::compiler::preprocess::decode_sourcemap::decode_map;
+use svelte_compiler_rust::compiler::preprocess::types::{Processed, SourceMapInput};
+
+fn vlq_processed(map_json: &str) -> Processed {
+    Processed {
+        code: String::new(),
+        map: Some(SourceMapInput::Json(map_json.to_string())),
+        dependencies: vec![],
+        attributes: None,
+    }
+}
+
+#[test]
+fn decodes_standard_vlq_map_with_names() {
+    let m = r#"{"version":3,"sources":["input.svelte"],"names":["foo"],"mappings":"AAAA,SAASA,GAAG,CAAC"}"#;
+    let d = decode_map(&vlq_processed(m)).expect("VLQ map should decode");
+    assert_eq!(d.sources, vec!["input.svelte".to_string()]);
+    assert_eq!(d.names, vec!["foo".to_string()]);
+    // First segment of the first line is the origin `[0, 0, 0, 0]`.
+    assert_eq!(d.mappings[0][0], vec![0, 0, 0, 0]);
+    // VLQ-decoded deltas accumulate across segments — every segment after the
+    // first carries non-zero values.
+    assert!(d.mappings[0].len() >= 2);
+    assert!(d.mappings[0][1][0] > 0);
+}
+
+#[test]
+fn decodes_multiline_vlq_map() {
+    // Two lines: `AAAA;ACAA` → line 0: `[[0,0,0,0]]`; line 1 starts at col 0
+    // but with relative source offsets carried over (so [0, 0, 1, 0]).
+    let m = r#"{"version":3,"sources":["a.svelte"],"names":[],"mappings":"AAAA;ACAA"}"#;
+    let d = decode_map(&vlq_processed(m)).expect("VLQ map should decode");
+    assert_eq!(d.mappings.len(), 2);
+    assert_eq!(d.mappings[0][0], vec![0, 0, 0, 0]);
+    // Second line resets generated column to 0; source index advances by 1
+    // (the `C` in `ACAA` = +1).
+    assert_eq!(d.mappings[1][0][0], 0);
+    assert_eq!(d.mappings[1][0][1], 1);
+}
+
+#[test]
+fn already_decoded_form_still_works() {
+    // The rsvelte-internal form (mappings already as a nested array) is still
+    // accepted — the VLQ path is only a fallback.
+    let m = r#"{"version":3,"sources":["x"],"names":[],"mappings":[[[0,0,0,0]]]}"#;
+    let d = decode_map(&vlq_processed(m)).expect("array form should decode");
+    assert_eq!(d.mappings[0][0], vec![0, 0, 0, 0]);
+}
+
+#[test]
+fn empty_mappings_string_decodes_to_empty() {
+    let m = r#"{"version":3,"sources":[],"names":[],"mappings":""}"#;
+    let d = decode_map(&vlq_processed(m)).expect("empty VLQ map should decode");
+    // Empty string still produces one (empty) line.
+    assert_eq!(d.mappings, vec![vec![] as Vec<Vec<i64>>]);
+}


### PR DESCRIPTION
## Summary

`decode_map` was a one-line `serde_json::from_str(json_str).ok()` into `SimpleDecodedMap` whose `mappings` is `Vec<Vec<Vec<i64>>>`. Real preprocessor maps (mappings as the standard VLQ-encoded string `\"AAAA,SAASA,GAAG,CAAC\"`) failed to deserialise and were silently dropped.

Add a VLQ decoder fallback — try the rsvelte-internal pre-decoded form first, then decode the standard string form (base64-VLQ deltas accumulated across segments, generated column resetting per line, the other four fields persisting). Output matches `@jridgewell/sourcemap-codec`.

### Cluster status

| Finding | Status |
|---|---|
| **H-142** Critical panic (`replace_in_code.rs` out-of-range source/name index) | already fixed — segments are bounds-checked via `if let Some(&mapped) = …get(…)` |
| **H-012** standard VLQ mappings dropped | **fixed** in this PR |
| **H-013** `combine_sourcemaps` doesn't compose | deferred — needs a `@jridgewell/remapping`-equivalent walker |
| **H-014 / M-009** UTF-16 vs UTF-8 vs scalar column counts | deferred — coordinated column refactor |
| **M-010 / M-011** token cross-mapping, multi-source content | deferred — needs lexical-aware matching |

These all live downstream of the decoder. The project has no source-map fixtures yet (`Sourcemaps | 0/0` in the compatibility report), so the natural next step is the test infrastructure, then a coordinated quality pass.

Closes #451

## Test plan

- [x] New `tests/preprocess_vlq_sourcemap.rs` — 4 cases (standard VLQ, multi-line VLQ, already-decoded form, empty mappings)
- [x] Full fixture suite — preprocess / preprocess_attributes / snapshot / ssr / runtime / compatibility_report — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)