### PR TITLE
fix(client): reject non-identifier class-field names from rune scanner (#452 H-057)

### DIFF
--- a/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -908,6 +908,29 @@ pub(super) fn strip_field_quotes(name: &str) -> String {
 }
 
 /// Parse a state field definition.
+/// `true` when `name` (the text we extracted as the left-hand side of `= $state(...)`)
+/// is actually a valid class-field name shape: a plain identifier, a quoted
+/// string key (`"foo-bar"` / `'foo-bar'`), or a computed key (`[expr]`).
+/// Anything else — text carrying parens, braces, or whitespace, like the start
+/// of a method body — is rejected. (issue #452, H-057)
+fn is_valid_class_field_name(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let bytes = name.as_bytes();
+    let first = bytes[0];
+    let last = bytes[bytes.len() - 1];
+    if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+        return true;
+    }
+    if first == b'[' && last == b']' {
+        return true;
+    }
+    !name
+        .chars()
+        .any(|c| c.is_whitespace() || matches!(c, '(' | ')' | '{' | '}' | ';' | ','))
+}
+
 pub(super) fn parse_state_field(line: &str, rune_type: &str) -> Option<ClassStateField> {
     let trimmed = line.trim().trim_end_matches(';');
 
@@ -920,6 +943,15 @@ pub(super) fn parse_state_field(line: &str, rune_type: &str) -> Option<ClassStat
         .trim()
         .trim_start_matches('#')
         .to_string();
+
+    // Reject text that is clearly not a class-field name. Without this guard a
+    // method body like `m(){ let x = $state(0); return "}"; }` matches the rune
+    // pattern and gets parsed as a field named `m(){ let x` — the sanitiser
+    // would then emit `#m____let_x = $.state(0)` and a quoted accessor with the
+    // same shape, corrupting the class. (issue #452, H-057)
+    if !is_valid_class_field_name(&name) {
+        return None;
+    }
 
     // Find the rune call
     let rune_pattern = format!("{}(", rune_type);

--- a/tests/class_method_with_state_not_field.rs
+++ b/tests/class_method_with_state_not_field.rs
@@ -1,0 +1,83 @@
+//! Regression test: a class method whose body contains a rune call (or text
+//! shaped like `... = $state(...)`) must not be mis-parsed as a class field
+//! by the line-based class-rune scanner (issue #452, H-057).
+//!
+//! Bug: `parse_state_field` extracted the field name by `trimmed.find('=')` and
+//! ran the result through a *sanitiser*. For `class C { m(){ let x = $state(0); return "}"; } }`
+//! the first `=` lives inside the method body, so the scanner extracted
+//! `m(){ let x` as a name, then emitted a private backing
+//! `#m____let_x = $.state(0)` and a quoted accessor — corrupting the whole class.
+//! `parse_state_field` now rejects anything that doesn't look like a valid
+//! class-field name (plain identifier, quoted, or computed `[expr]`).
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn method_body_with_state_call_is_not_a_field() {
+    let out = client(r#"<script>class C { m(){ let x = $state(0); return "}"; } }</script>"#);
+    // No private backing for the method-name garbage, no quoted accessor.
+    assert!(
+        !out.contains("#m____let_x"),
+        "method body must not become a sanitised field, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\"m(){ let x\""),
+        "method body must not become a quoted accessor, got:\n{out}"
+    );
+    // The method is preserved verbatim (its function-local `$state(0)` is just
+    // the legacy `$state` call lowered to `0`, which is the expected behaviour
+    // for a non-runes mode function-scope rune call).
+    assert!(
+        out.contains("class C { m(){"),
+        "class body should survive, got:\n{out}"
+    );
+}
+
+#[test]
+fn normal_class_state_field_still_lowers() {
+    let out = client(r#"<script>class C { x = $state(0); }</script>"#);
+    assert!(out.contains("#x = $.state(0);"), "got:\n{out}");
+    assert!(out.contains("get x()"), "got:\n{out}");
+    assert!(out.contains("set x(value)"), "got:\n{out}");
+}
+
+#[test]
+fn h058_paren_in_string_already_lexical() {
+    // Pinned: rune-arg paren scan is JS-lexical-aware, so a `)` inside a string
+    // does not truncate.
+    let out = client(r#"<script>class C { x = $state(")"); }</script>"#);
+    assert!(out.contains("$.state(\")\")"), "got:\n{out}");
+}
+
+#[test]
+fn h059_new_class_with_args_does_not_double_parenthesise() {
+    // Pinned: `new class { … }(args)` keeps `(args)`, not `()`.
+    let out = client(
+        r#"<script>let x = new class { v = $state(0); constructor(a, b){} }(1, 2);</script>"#,
+    );
+    assert!(
+        out.contains("})(1, 2)"),
+        "user's original args must be preserved, got:\n{out}"
+    );
+    assert!(
+        !out.contains("})()(1, 2)"),
+        "must not double-parenthesise, got:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

`parse_state_field` extracted the field name with `trimmed.find('=')` and ran the result through a sanitiser. For a class method whose body contains `= \$state(...)` text:

\`\`\`svelte
class C { m(){ let x = \$state(0); return \"}\"; } }
\`\`\`

the first `=` lived inside the method body, so the scanner extracted `m(){ let x` as the name, sanitised it to `m____let_x`, and emitted a private backing field + quoted accessor — corrupting the whole class.

Add a validity guard: reject anything that isn't a plain identifier, a quoted string key, or a computed `[expr]` key. Method-shaped text is now ignored.

### Cluster status

| Finding | Status |
|---|---|
| **H-057** brace-scan + scanner accepts method text as field name | **fixed** in this PR |
| **H-058** rune-arg paren stops at `)` in strings | already fixed via `find_matching_paren_lexical` (class_transforms.rs:9-14) |
| **H-059** `new class {…}(args)` → `new (class{…})()(args)` | already fixed; the wrapper at class_transforms.rs:837-846 has an H-059 comment and only appends `()` when args are absent |

Closes #452

## Test plan

- [x] New `tests/class_method_with_state_not_field.rs` — 4 cases (H-057 method-with-state, normal field, H-058 paren-in-string, H-059 args preserved)
- [x] Full fixture suite — snapshot / ssr / runtime / compatibility_report / class_rune_lexical_scan — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)