### PR TITLE
fix(analyze): validate svelte:component this + directives (#453 H-046/H-047)

### DIFF
--- a/src/compiler/phases/2_analyze/errors.rs
+++ b/src/compiler/phases/2_analyze/errors.rs
@@ -274,6 +274,14 @@ pub fn svelte_element_duplicate_this() -> AnalysisError {
     )
 }
 
+/// `<svelte:component>` must have a `this` attribute (issue #453, H-046)
+pub fn svelte_component_missing_this() -> AnalysisError {
+    error(
+        "svelte_component_missing_this",
+        "`<svelte:component>` must have a 'this' attribute",
+    )
+}
+
 /// A component can only have one `<%name%>` element
 pub fn svelte_meta_duplicate(name: &str) -> AnalysisError {
     error(

--- a/src/compiler/phases/2_analyze/visitors/svelte_component.rs
+++ b/src/compiler/phases/2_analyze/visitors/svelte_component.rs
@@ -4,7 +4,7 @@
 //!
 //! Corresponds to Svelte's `2-analyze/visitors/SvelteComponent.js`.
 
-use super::super::{AnalysisError, warnings};
+use super::super::{AnalysisError, errors, warnings};
 use super::VisitorContext;
 use super::shared::fragment;
 use super::shared::utils::validate_assignment_node;
@@ -20,6 +20,14 @@ pub fn visit(
     // In runes mode, <svelte:component> is deprecated because components are dynamic by default
     if context.analysis.runes {
         context.emit_warning(warnings::svelte_component_deprecated());
+    }
+
+    // `<svelte:component>` must have a `this` attribute — when missing, the
+    // parser leaves `component.expression` as a JSON-null expression with no
+    // node type. Mirror upstream's `svelte_component_missing_this` instead of
+    // silently accepting it. (issue #453, H-046)
+    if component.expression.node_type().is_none() {
+        return Err(errors::svelte_component_missing_this());
     }
 
     // svelte:component requires a `this` expression
@@ -62,7 +70,17 @@ pub fn visit(
                 // Walk attribute value expressions
                 super::attribute::visit_attribute_value_expressions(&mut a.value, context)?;
             }
-            _ => {}
+            Attribute::AttachTag(_) | Attribute::LetDirective(_) => {
+                // Allowed on components (matches the shared component validator)
+            }
+            _ => {
+                // `transition:` / `animate:` / `use:` / `class:` / `style:` are
+                // not valid on `<svelte:component>` — mirror the shared
+                // `validate_component_attributes` path so they raise
+                // `component_invalid_directive` instead of being silently
+                // accepted. (issue #453, H-047)
+                return Err(errors::component_invalid_directive());
+            }
         }
     }
 

--- a/tests/svelte_component_validation.rs
+++ b/tests/svelte_component_validation.rs
@@ -1,0 +1,105 @@
+//! Regression test: `<svelte:component>` analyzer must mirror the shared
+//! component-attribute validation (issue #453, H-046 / H-047).
+//!
+//! Bug: the parser left `component.expression` as a JSON-null expression when
+//! the `this` attribute was missing, and the analyzer's attribute match had a
+//! catch-all `_ => {}` that silently accepted every directive type. As a result
+//! `<svelte:component foo="bar"/>` and `<svelte:component this={X} animate:foo/>`
+//! both compiled successfully while upstream errors with
+//! `svelte_component_missing_this` and `component_invalid_directive`.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn try_compile(src: &str) -> Result<(), String> {
+    match compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let s = format!("{e:?}");
+            let code = s
+                .split("code: \"")
+                .nth(1)
+                .and_then(|t| t.split('"').next())
+                .unwrap_or("")
+                .to_string();
+            Err(code)
+        }
+    }
+}
+
+#[test]
+fn h046_missing_this_errors() {
+    let err = try_compile(r#"<svelte:component foo="bar"/>"#).expect_err("should error");
+    assert_eq!(err, "svelte_component_missing_this", "got `{err}`");
+}
+
+#[test]
+fn h046_valid_this_compiles() {
+    try_compile(r#"<script>let X;</script><svelte:component this={X}/>"#).expect("should compile");
+}
+
+#[test]
+fn h047_animate_directive_errors() {
+    let err = try_compile(r#"<script>let X;</script><svelte:component this={X} animate:foo/>"#)
+        .expect_err("should error");
+    assert_eq!(err, "component_invalid_directive", "got `{err}`");
+}
+
+#[test]
+fn h047_transition_directive_errors() {
+    let err = try_compile(r#"<script>let X;</script><svelte:component this={X} transition:fade/>"#)
+        .expect_err("should error");
+    assert_eq!(err, "component_invalid_directive", "got `{err}`");
+}
+
+#[test]
+fn h047_use_directive_errors() {
+    let err = try_compile(
+        r#"<script>let X; function f(){return v=>{}}</script><svelte:component this={X} use:f/>"#,
+    )
+    .expect_err("should error");
+    assert_eq!(err, "component_invalid_directive", "got `{err}`");
+}
+
+#[test]
+fn h047_bind_directive_still_works() {
+    try_compile(
+        r#"<script>let X; let v = $state("");</script><svelte:component this={X} bind:value={v}/>"#,
+    )
+    .expect("bind on svelte:component should compile");
+}
+
+#[test]
+fn h053_special_element_event_capture_excludes_pointercapture() {
+    // Pinned: the special-element event-attribute path uses the shared
+    // `is_capture_event` helper which excludes `gotpointercapture` /
+    // `lostpointercapture`, so those names are treated as regular event names.
+    // The compile must not error / strip the `capture` suffix.
+    let out = compile(
+        r#"<svelte:window ongotpointercapture={() => {}} onlostpointercapture={() => {}}/>"#,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    assert!(
+        out.contains("gotpointercapture") && out.contains("lostpointercapture"),
+        "got:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

The `<svelte:component>` analyzer silently accepted two malformed shapes upstream rejects:

| Finding | Bug | Fix |
|---|---|---|
| **H-046** | missing `this` attribute compiled successfully | error with `svelte_component_missing_this` |
| **H-047** | `animate:` / `transition:` / `use:` / `class:` / `style:` directives accepted via `_ => {}` catch-all | mirror shared `validate_component_attributes` → error with `component_invalid_directive` |

`AttachTag` and `LetDirective` are still allowed (matches the shared validator).

### Cluster status

| Finding | Status |
|---|---|
| **H-046 / H-047** | **fixed** in this PR |
| **H-053** special-element event-attr `gotpointercapture` / `lostpointercapture` mishandling | already fixed — routes through `is_capture_event` (client/types.rs:1643) |
| **H-048, H-054, H-055, H-056** | concrete but each needs its own visitor + phase-3 plumbing change; deferred to keep this PR focused on the `<svelte:component>` core |

Closes #453

## Test plan

- [x] New `tests/svelte_component_validation.rs` — 7 cases (H-046 missing/valid, H-047 animate/transition/use/bind, H-053 pin)
- [x] Full fixture suite — parser / errors / snapshot / validator / ssr / runtime / compatibility_report — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)