### PR TITLE
fix(a11y): warn on bare ARIA attributes per upstream type rules (#454 H-078)

### DIFF
--- a/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
+++ b/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
@@ -113,10 +113,19 @@ pub fn check_element(node: &RegularElement, ancestor_names: &[String]) -> Vec<w:
                     warnings.push(w::a11y_hidden(&node.name));
                 }
 
-                // aria-proptypes validation
+                // aria-proptypes validation. A *bare* ARIA attribute (no value)
+                // must NOT be silently accepted as `true` for boolean / tristate
+                // / number / token / id properties — upstream reports a
+                // type-specific `a11y_incorrect_aria_attribute_type` warning
+                // because the attribute presence alone is not a valid value.
+                // (issue #454, H-078)
                 let value = get_static_value(attribute);
+                let is_bare = matches!(
+                    attribute,
+                    AttributeNode::Attribute(a) if matches!(a.value, AttributeValue::True(_))
+                );
                 if let Some(schema) = ARIA_PROPERTY_DEFINITIONS.get(name.as_str()) {
-                    validate_aria_attribute_value(&mut warnings, &name, schema, value);
+                    validate_aria_attribute_value(&mut warnings, &name, schema, value, is_bare);
                 }
 
                 // aria-activedescendant-has-tabindex
@@ -1051,19 +1060,62 @@ fn validate_aria_attribute_value(
     name: &str,
     schema: &AriaPropertyDefinition,
     value: Option<&str>,
+    is_bare: bool,
 ) {
-    // If value is None (dynamic), skip validation
+    // A bare ARIA attribute (no value) is *not* a valid value for any
+    // typed property — upstream emits the type-specific
+    // `a11y_incorrect_aria_attribute_type[_<kind>]` warning. (#454, H-078)
+    if is_bare {
+        match schema.property_type {
+            AriaPropertyType::Boolean => {
+                warnings.push(w::a11y_incorrect_aria_attribute_type_boolean(name));
+            }
+            AriaPropertyType::Tristate => {
+                warnings.push(w::a11y_incorrect_aria_attribute_type_tristate(name));
+            }
+            AriaPropertyType::Integer => {
+                warnings.push(w::a11y_incorrect_aria_attribute_type_integer(name));
+            }
+            AriaPropertyType::Number => {
+                warnings.push(w::a11y_incorrect_aria_attribute_type(name, "number"));
+            }
+            AriaPropertyType::Id | AriaPropertyType::String => {
+                warnings.push(w::a11y_incorrect_aria_attribute_type(
+                    name,
+                    "non-empty string",
+                ));
+            }
+            AriaPropertyType::IdList => {
+                warnings.push(w::a11y_incorrect_aria_attribute_type_idlist(name));
+            }
+            AriaPropertyType::Token => {
+                if let Some(valid_values) = schema.values {
+                    let values_list: Vec<String> =
+                        valid_values.iter().map(|v| format!("\"{}\"", v)).collect();
+                    warnings.push(w::a11y_incorrect_aria_attribute_type_token(
+                        name,
+                        &values_list.join(", "),
+                    ));
+                }
+            }
+            AriaPropertyType::TokenList => {
+                if let Some(valid_values) = schema.values {
+                    let values_list: Vec<String> =
+                        valid_values.iter().map(|v| format!("\"{}\"", v)).collect();
+                    warnings.push(w::a11y_incorrect_aria_attribute_type_tokenlist(
+                        name,
+                        &values_list.join(", "),
+                    ));
+                }
+            }
+        }
+        return;
+    }
+
+    // If value is None (dynamic, e.g. `aria-hidden={x}`), skip validation.
     let value = match value {
         None => return,
-        Some(v) => {
-            // If it was a boolean attribute (true), treat as empty string
-            if v == "true" && matches!(schema.property_type, AriaPropertyType::Boolean) {
-                // For aria-props, "true" (the string) is valid for boolean
-                // The issue is when attribute is present with no value or wrong value
-                return;
-            }
-            v
-        }
+        Some(v) => v,
     };
 
     match schema.property_type {

--- a/tests/aria_bare_attribute_warning.rs
+++ b/tests/aria_bare_attribute_warning.rs
@@ -1,0 +1,79 @@
+//! Regression test: a *bare* ARIA attribute (no value) must surface a
+//! type-specific `a11y_incorrect_aria_attribute_type[_<kind>]` warning, not be
+//! silently accepted as `true` (issue #454, H-078).
+//!
+//! Bug: `get_static_value` returned `Some("true")` for `AttributeValue::True`,
+//! and the boolean branch of `validate_aria_attribute_value` short-circuited
+//! `"true"` as valid — so `<div aria-hidden>` compiled with zero warnings while
+//! upstream emits `a11y_incorrect_aria_attribute_type_boolean`. Likewise
+//! `aria-checked` (tristate). Distinguish the bare-attribute case and route it
+//! through the per-type warning.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn warnings(src: &str) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .iter()
+    .map(|w| w.code.clone())
+    .collect()
+}
+
+#[test]
+fn bare_aria_hidden_emits_boolean_type_warning() {
+    let w = warnings(r#"<div aria-hidden>x</div>"#);
+    assert!(
+        w.contains(&"a11y_incorrect_aria_attribute_type_boolean".to_string()),
+        "got: {w:?}"
+    );
+}
+
+#[test]
+fn bare_aria_checked_emits_tristate_type_warning() {
+    let w = warnings(r#"<div role="checkbox" tabindex="0" aria-checked>x</div>"#);
+    assert!(
+        w.contains(&"a11y_incorrect_aria_attribute_type_tristate".to_string()),
+        "got: {w:?}"
+    );
+}
+
+#[test]
+fn explicit_true_is_accepted() {
+    let w = warnings(r#"<div aria-hidden="true">x</div>"#);
+    assert!(
+        !w.iter()
+            .any(|c| c.starts_with("a11y_incorrect_aria_attribute_type")),
+        "got: {w:?}"
+    );
+}
+
+#[test]
+fn explicit_false_is_accepted() {
+    let w = warnings(r#"<div aria-hidden="false">x</div>"#);
+    assert!(
+        !w.iter()
+            .any(|c| c.starts_with("a11y_incorrect_aria_attribute_type")),
+        "got: {w:?}"
+    );
+}
+
+#[test]
+fn dynamic_value_is_skipped() {
+    let w = warnings(r#"<script>let x = $state(true);</script><div aria-hidden={x}>x</div>"#);
+    assert!(
+        !w.iter()
+            .any(|c| c.starts_with("a11y_incorrect_aria_attribute_type")),
+        "got: {w:?}"
+    );
+}


### PR DESCRIPTION
## Summary

`get_static_value` returned `Some(\"true\")` for `AttributeValue::True` (a bare ARIA attribute, e.g. `<div aria-hidden>`), and the boolean branch of `validate_aria_attribute_value` short-circuited `\"true\"` as valid — so bare ARIA attributes compiled with zero warnings while upstream emits a type-specific `a11y_incorrect_aria_attribute_type[_<kind>]` warning.

Thread an `is_bare` flag into the validator and emit the matching warning per property type: `_boolean` for `aria-hidden`, `_tristate` for `aria-checked`, `_integer` / `_idlist` / `_token` / `_tokenlist`, plus the generic `non-empty string` / `number` warning for the rest.

### Cluster status

| Finding | Status |
|---|---|
| **H-077** braille ARIA attrs missing | already merged (PR #514) |
| **H-078** bare ARIA mis-accepted | **fixed** in this PR |
| **H-079** `<input>` without `type` losing text default | deferred — needs its own classifier refactor |
| **H-080** `role="<token> <token>"` validated per-token but consumed as one | deferred — needs the downstream role lookup refactor |
| **H-081** dangerous `href` case-sensitive | already merged (PR #514) |
| **H-082** list-nesting rule | already merged (PR #514) |

Closes #454

## Test plan

- [x] New `tests/aria_bare_attribute_warning.rs` — 5 cases (bare boolean, bare tristate, explicit true, explicit false, dynamic)
- [x] Full fixture suite — validator / errors / snapshot / a11y_validator_fixes / ssr / runtime / compatibility_report — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)