### PR TITLE
fix(ts-strip): preserve parens around TS wrappers when precedence matters (#457 H-125)

### DIFF
--- a/src/compiler/phases/2_analyze/types.rs
+++ b/src/compiler/phases/2_analyze/types.rs
@@ -620,6 +620,64 @@ fn remove_keyword_from_source(
     }
 }
 
+/// Peel any `TSAsExpression` / `TSSatisfiesExpression` / `TSNonNullExpression`
+/// / `TSTypeAssertion` / `TSInstantiationExpression` layers and return the
+/// underlying expression. Used by the parenthesis-stripping path to decide
+/// whether the parens around a TS wrapper are safe to drop. (issue #457, H-125)
+fn peel_ts_wrappers<'a>(
+    mut expr: &'a oxc_ast::ast::Expression<'a>,
+) -> &'a oxc_ast::ast::Expression<'a> {
+    use oxc_ast::ast::Expression as E;
+    loop {
+        match expr {
+            E::TSAsExpression(inner) => expr = &inner.expression,
+            E::TSSatisfiesExpression(inner) => expr = &inner.expression,
+            E::TSNonNullExpression(inner) => expr = &inner.expression,
+            E::TSTypeAssertion(inner) => expr = &inner.expression,
+            E::TSInstantiationExpression(inner) => expr = &inner.expression,
+            _ => return expr,
+        }
+    }
+}
+
+/// `true` when `expr` is a "simple" expression form whose precedence is high
+/// enough that wrapping parens never matter — bare identifiers, literals,
+/// member / call / `new` expressions, parenthesised sub-expressions, etc.
+/// Returns `false` for unary / binary / logical / conditional / assignment /
+/// arrow / sequence expressions, where dropping the parens can silently change
+/// what the surrounding code means (e.g. `-n ** 2` is a JS syntax error,
+/// `a + b * c` reassociates a `+`). (issue #457, H-125)
+fn is_paren_safe_to_drop(expr: &oxc_ast::ast::Expression) -> bool {
+    use oxc_ast::ast::Expression as E;
+    matches!(
+        expr,
+        E::Identifier(_)
+            | E::BooleanLiteral(_)
+            | E::NullLiteral(_)
+            | E::NumericLiteral(_)
+            | E::StringLiteral(_)
+            | E::BigIntLiteral(_)
+            | E::RegExpLiteral(_)
+            | E::TemplateLiteral(_)
+            | E::TaggedTemplateExpression(_)
+            | E::ThisExpression(_)
+            | E::Super(_)
+            | E::ArrayExpression(_)
+            | E::ObjectExpression(_)
+            | E::FunctionExpression(_)
+            | E::ClassExpression(_)
+            | E::ParenthesizedExpression(_)
+            | E::CallExpression(_)
+            | E::NewExpression(_)
+            | E::ChainExpression(_)
+            | E::ComputedMemberExpression(_)
+            | E::StaticMemberExpression(_)
+            | E::PrivateFieldExpression(_)
+            | E::MetaProperty(_)
+            | E::ImportExpression(_)
+    )
+}
+
 /// Collect TS removals from an expression.
 fn collect_ts_removals_from_expression(
     expr: &oxc_ast::ast::Expression,
@@ -796,7 +854,13 @@ fn collect_ts_removals_from_expression(
             // the type annotation is stripped. Collapse them together so that
             // `((expr)?.filter(x) as T[])[0]` becomes `(expr)?.filter(x)[0]`,
             // matching esrap/astring output. We only drop the outer parens when
-            // the inner expression is one of the single-value TS wrappers.
+            // the inner expression is one of the single-value TS wrappers AND
+            // peeling the wrapper exposes a "simple" expression — one whose
+            // precedence never requires the surrounding parens. For a unary /
+            // binary / logical / conditional / etc. expression we keep the
+            // parens because removing them can silently change the meaning
+            // (e.g. `(-n as number) ** 2` → `-n ** 2` is a JS syntax error;
+            // `(a + b as T) * c` → `a + b * c` reassociates). (issue #457, H-125)
             let inner = &paren.expression;
             let is_ts_wrapper = matches!(
                 inner,
@@ -807,9 +871,12 @@ fn collect_ts_removals_from_expression(
                     | E::TSInstantiationExpression(_)
             );
             if is_ts_wrapper {
-                // Remove `(` and `)` surrounding the TS wrapper.
-                removals.push((paren.span.start, inner.span().start));
-                removals.push((inner.span().end, paren.span.end));
+                let unwrapped = peel_ts_wrappers(inner);
+                if is_paren_safe_to_drop(unwrapped) {
+                    // Remove `(` and `)` surrounding the TS wrapper.
+                    removals.push((paren.span.start, inner.span().start));
+                    removals.push((inner.span().end, paren.span.end));
+                }
             }
             collect_ts_removals_from_expression(inner, source, removals);
         }

--- a/tests/ts_strip_paren_precedence.rs
+++ b/tests/ts_strip_paren_precedence.rs
@@ -1,0 +1,64 @@
+//! Regression test: stripping `(X as T)` / `(X!)` parens must preserve
+//! precedence (issue #457, H-125).
+//!
+//! Bug: when a parenthesized expression wraps a TS-only wrapper (`as`,
+//! `satisfies`, `!`, `<T>`), the type-erasure pass dropped both layers
+//! unconditionally. `(-n as number) ** 2` → `-n ** 2` is a JS syntax error
+//! (unary cannot directly precede `**`); `(a + b as number) * c` →
+//! `a + b * c` silently reassociates. Now the parens are only dropped when
+//! peeling the TS wrapper exposes a "simple" expression (identifier, literal,
+//! member / call / `new`, etc.) — never a unary / binary / logical /
+//! conditional / sequence expression.
+
+use svelte_compiler_rust::{GenerateMode, compile_module, compiler::ModuleCompileOptions};
+
+fn compile_ts(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("x.svelte.ts".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn unary_in_exponentiation_keeps_parens() {
+    let out = compile_ts("export function f(n:number){ return (-n as number) ** 2; }");
+    assert!(out.contains("(-n) ** 2"), "got:\n{out}");
+}
+
+#[test]
+fn binary_in_multiplication_keeps_parens() {
+    let out = compile_ts(
+        "export function f(a:number,b:number,c:number){ return (a + b as number) * c; }",
+    );
+    assert!(out.contains("(a + b) * c"), "got:\n{out}");
+}
+
+#[test]
+fn simple_identifier_drops_parens() {
+    let out = compile_ts("export function f(x:number){ return (x as number); }");
+    assert!(out.contains("return x;"), "got:\n{out}");
+    assert!(
+        !out.contains("return (x"),
+        "must drop parens for simple id, got:\n{out}"
+    );
+}
+
+#[test]
+fn simple_call_drops_parens() {
+    let out = compile_ts("export function f(){ return (foo() as number); }");
+    assert!(out.contains("return foo();"), "got:\n{out}");
+}
+
+#[test]
+fn ts_non_null_unary_keeps_parens() {
+    let out = compile_ts("export function f(n:number){ return (-n!) ** 2; }");
+    assert!(out.contains("(-n) ** 2"), "got:\n{out}");
+}


### PR DESCRIPTION
## Summary

The type-erasure pass dropped both the outer parens *and* the TS-only wrapper (`as` / `satisfies` / `!` / `<T>`) unconditionally. With a unary or binary inside, the result was either a JS syntax error or silently changed meaning:

- `(-n as number) ** 2` → `-n ** 2` — invalid JS (unary cannot directly precede `**`)
- `(a + b as number) * c` → `a + b * c` — silent re-association

Add `peel_ts_wrappers` + `is_paren_safe_to_drop`: collapse parens only when peeling the TS wrapper exposes a "simple" expression form (identifier, literal, member / call / `new`, etc.). Unary, binary, logical, conditional, assignment, arrow, and sequence expressions all keep their wrapping parens.

### Cluster status

| Finding | Status |
|---|---|
| **M-024** destructured TS snippet-parameter defaults | already merged (PR #518) |
| **H-125** paren stripping breaks precedence | **fixed** in this PR |
| **H-124 / H-126 / M-081 / M-082** | concrete but each is on the same text-erasure layer; the issue itself suggests routing through OXC's `--erase-types` transformer (separate refactor). Not reproducing with practical inputs against the current scanners. Deferred. |

Closes #457

## Test plan

- [x] New `tests/ts_strip_paren_precedence.rs` — 5 cases (unary in `**`, binary in `*`, identifier drops, call drops, TS-non-null + unary)
- [x] Full fixture suite — snapshot / ssr / runtime / compatibility_report / module_compile_ts_strip — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)