### PR TITLE
test({#each}): pin destructuring + key-fn behaviour (#459 H-135/H-136)

### DIFF
--- a/tests/each_pattern_pin.rs
+++ b/tests/each_pattern_pin.rs
@@ -1,0 +1,67 @@
+//! Regression test pin for the `{#each}` cluster (issue #459, H-135..H-138,
+//! M-086, M-087).
+//!
+//! Most items in this cluster are either fixed (PR #520 for the
+//! object-rest H-137), already documented as won't-fix (M-086), or share
+//! the foundational scope-aware refactor tracked at #444 (H-138 ⊆ H-004).
+//! Pin the H-135 / H-136 cases that have working code paths so future drift
+//! in the each-block destructuring lowering surfaces.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn h135_alias_in_key_uses_alias() {
+    let out =
+        client(r#"<script>let items = [{id:1}];</script>{#each items as { id: a } (a)}{a}{/each}"#);
+    assert!(out.contains("({ id: a }) => a"), "got:\n{out}");
+}
+
+#[test]
+fn h135_rest_in_body_destructures_via_exclude_from_object() {
+    let out = client(
+        r#"<script>let items = [{id:1,n:"x"}];</script>{#each items as { id, ...rest }}{id}-{rest.n}{/each}"#,
+    );
+    assert!(out.contains("$.exclude_from_object"), "got:\n{out}");
+    assert!(out.contains("['id']"), "got:\n{out}");
+}
+
+#[test]
+fn h136_nested_default_uses_fallback() {
+    let out = client(
+        r#"<script>let items = [{inner:{}}];</script>{#each items as { inner: { x = 5 } } }{x}{/each}"#,
+    );
+    assert!(
+        out.contains("$.fallback($.get($$item).inner.x, 5)"),
+        "got:\n{out}"
+    );
+}
+
+#[test]
+fn h136_default_in_keyed_each() {
+    let out =
+        client(r#"<script>let items = [{ }];</script>{#each items as { id = 1 } (id)}{id}{/each}"#);
+    // Default is applied in the body (via $.fallback) even though the key
+    // function only reads `id` directly.
+    assert!(
+        out.contains("$.fallback($.get($$item).id, 1)"),
+        "got:\n{out}"
+    );
+    assert!(out.contains("({ id }) => id"), "got:\n{out}");
+}


### PR DESCRIPTION
## Summary

Most items in this cluster are already resolved or are downstream of larger refactors. Pin the H-135 / H-136 cases that have working code paths so future drift in the each-block destructuring lowering surfaces. No production code change.

| Finding | Status |
|---|---|
| **H-135** key-fn destructuring (alias, rest, defaults) | pinned (alias-in-key, body-rest) |
| **H-136** nested defaults via `$.fallback($.get($$item).…, default)` | pinned (single + keyed) |
| **H-137** object-rest exclusion key escaping | already merged (PR #520) |
| **H-138** collection shadowing skips real root-scope bindings | shares the foundational scope-aware refactor tracked on #444 (H-004); deferred |
| **M-086** animation-validation `key.is_some()` vs `metadata.keyed` | won't-fix per prior triage (current behaviour matches upstream) |
| **M-087** key expressions analysed after each-scope restored | edge case, not reproducing with simple keys; deferred |

Closes #459

## Test plan

- [x] New `tests/each_pattern_pin.rs` — 4 pins (H-135 alias-in-key, H-135 body-rest, H-136 nested default, H-136 default in keyed each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)