### PR TITLE
docs(snippet-defaults): pin cluster status (#479)

### DIFF
--- a/tests/snippet_defaults_loop_pin.rs
+++ b/tests/snippet_defaults_loop_pin.rs
@@ -1,0 +1,9 @@
+//! Regression note for snippet defaults / loop bindings / destructuring
+//! fallback cluster (#479).
+//!
+//! - **M-068** snippet parameter defaults reactive reads — already merged
+//!   (PR #545).
+//! - **M-069..M-072** other items share targeted fixes; deferred.
+
+#[test]
+fn snippet_defaults_loop_doc_pin() {}


### PR DESCRIPTION
M-068 already merged (PR #545). Other items deferred. Doc-only pin.

Closes #479