### PR TITLE
ci: add daily check for new Svelte releases

### DIFF
--- a/.github/workflows/check-svelte-release.yml
+++ b/.github/workflows/check-svelte-release.yml
@@ -1,0 +1,125 @@
+name: check-svelte-release
+
+# Daily poll of sveltejs/svelte for new stable releases. When the latest
+# svelte@X.Y.Z release is newer than the version pinned by the
+# submodules/svelte gitlink, opens a tracking issue (idempotent — skips when
+# an issue with the same title already exists, open or closed).
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 6 * * *' # Daily at 06:23 UTC
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: check-svelte-release
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check for new Svelte release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: false
+
+      - name: Read pinned Svelte submodule version
+        id: current
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SHA=$(git ls-tree HEAD submodules/svelte | awk '{print $3}')
+          if [ -z "${SHA}" ]; then
+            echo "::error::Could not determine submodule SHA for submodules/svelte"
+            exit 1
+          fi
+          VERSION=$(gh api \
+            "repos/sveltejs/svelte/contents/packages/svelte/package.json?ref=${SHA}" \
+            --jq '.content' | base64 -d | jq -r '.version')
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+            echo "::error::Could not read svelte package version at ${SHA}"
+            exit 1
+          fi
+          echo "sha=${SHA}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Pinned svelte version: ${VERSION} (${SHA})"
+
+      - name: Fetch latest stable Svelte release
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api repos/sveltejs/svelte/releases \
+            --jq '[.[]
+                  | select(.tag_name | startswith("svelte@"))
+                  | select(.prerelease == false)
+                  | select(.draft == false)][0]' \
+            > latest.json
+          if [ ! -s latest.json ] || [ "$(jq -r '. // empty' latest.json)" = "" ]; then
+            echo "::error::No stable svelte@* release found on sveltejs/svelte"
+            exit 1
+          fi
+          TAG=$(jq -r '.tag_name' latest.json)
+          VERSION=${TAG#svelte@}
+          URL=$(jq -r '.html_url' latest.json)
+          PUBLISHED=$(jq -r '.published_at' latest.json)
+          jq -r '.body // ""' latest.json > release-body.md
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "url=${URL}" >> "${GITHUB_OUTPUT}"
+          echo "published=${PUBLISHED}" >> "${GITHUB_OUTPUT}"
+          echo "Latest stable svelte release: ${VERSION} (${URL})"
+
+      - name: Open issue if a newer release is available
+        if: steps.current.outputs.version != steps.latest.outputs.version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_VERSION: ${{ steps.current.outputs.version }}
+          LATEST_VERSION: ${{ steps.latest.outputs.version }}
+          LATEST_URL: ${{ steps.latest.outputs.url }}
+          PUBLISHED: ${{ steps.latest.outputs.published }}
+        run: |
+          set -euo pipefail
+
+          # Skip when the pinned version is already >= the latest stable release.
+          # `sort -V` is version-aware; if CURRENT sorts last, it is >= LATEST.
+          NEWEST=$(printf '%s\n%s\n' "${CURRENT_VERSION}" "${LATEST_VERSION}" | sort -V | tail -n1)
+          if [ "${NEWEST}" = "${CURRENT_VERSION}" ]; then
+            echo "Pinned ${CURRENT_VERSION} >= latest ${LATEST_VERSION}; nothing to do."
+            exit 0
+          fi
+
+          TITLE="Upgrade Svelte submodule to ${LATEST_VERSION}"
+
+          # Exact-title dedupe across open and closed issues.
+          EXISTING=$(gh issue list --state all --limit 200 \
+            --search "in:title \"Upgrade Svelte submodule to\"" \
+            --json title --jq '.[].title' \
+            | grep -Fxc "${TITLE}" || true)
+          if [ "${EXISTING:-0}" -gt 0 ]; then
+            echo "Issue '${TITLE}' already exists; skipping."
+            exit 0
+          fi
+
+          {
+            echo "A new Svelte release is available."
+            echo
+            echo "- Current pinned version: \`${CURRENT_VERSION}\`"
+            echo "- Latest release: [\`${LATEST_VERSION}\`](${LATEST_URL})"
+            echo "- Published: ${PUBLISHED}"
+            echo
+            echo "Run the \`upgrade-svelte\` skill (or follow its workflow) to bump the submodule, regenerate fixtures, and resolve any regressions."
+            echo
+            echo "---"
+            echo
+            echo "### Release notes"
+            echo
+            cat release-body.md
+          } > issue-body.md
+
+          gh issue create --title "${TITLE}" --body-file issue-body.md


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/check-svelte-release.yml` — a daily cron (06:23 UTC) that polls `sveltejs/svelte` for new stable `svelte@X.Y.Z` releases.
- Opens a tracking issue titled `Upgrade Svelte submodule to X.Y.Z` when the latest release is newer than the version pinned by the `submodules/svelte` gitlink. Body includes current/latest versions, publish date, a pointer to the `upgrade-svelte` skill, and the upstream release notes.
- Idempotent: skips when an issue with the exact same title already exists (open or closed).
- Resolves the request to "Svelteの新しいバージョンがリリースされていることを定期的に github actions で監視して新しいバージョンがあったら issue を作成する".

## Implementation notes
- Reads the pinned version from the submodule's `package.json` via `gh api …/contents/packages/svelte/package.json?ref=<gitlink-sha>` — no submodule checkout needed.
- Filters `releases` for `tag_name | startswith("svelte@")` and `prerelease == false && draft == false`, because `sveltejs/svelte` is a monorepo and `/releases/latest` is not guaranteed to return the `svelte` package.
- Uses `sort -V` semver comparison so being ahead of the latest stable does not spam an issue.

## Test plan
- [x] YAML parses.
- [x] Version-comparison shell logic verified locally (current<latest → create; current>=latest → skip).
- [ ] After merge, trigger via Actions → `check-svelte-release` → "Run workflow" to confirm it opens an issue for the pending `5.55.9` → `5.56.0` upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)