### PR TITLE
feat(napi): add `parse` and `parseEnvelope` (oxc-style raw transfer)

### DIFF
--- a/.changeset/parse-envelope.md
+++ b/.changeset/parse-envelope.md
@@ -1,0 +1,20 @@
+---
+"@rsvelte/vite-plugin-svelte-native": minor
+---
+
+Add `parse(source, options?)` and `parseEnvelope(source, options?)` NAPI
+exports. `parse` returns the AST as a JSON string (the cross-NAPI
+analogue of the wasm-exposed `parse_svelte`); `parseEnvelope` returns a
+raw-transfer `Buffer` in a new binary format documented in
+`src/napi_raw_parse.rs` — pair it with `decodeParseEnvelope` exported
+from `@rsvelte/vite-plugin-svelte-native/parse-envelope.js` to skip
+`JSON.parse` on the JS side.
+
+Every template node, attribute, directive, block, `Script`, `JsComment`,
+`SourceLocation`, and all 74 `JsNode` (estree) variants get dedicated
+binary tags. `StyleSheet`, `SvelteOptions`, and directive `metadata`
+remain inline JSON behind `TAG_JSON` for now.
+
+`NapiParseOptions { skipExpressionLoc?: boolean }` mirrors the existing
+`ParseOptions::skip_expression_loc`; when set, the envelope flags the
+JS decoder to skip the per-`JsNode` loc bytes.

--- a/npm/vite-plugin-svelte-native/index.d.ts
+++ b/npm/vite-plugin-svelte-native/index.d.ts
@@ -282,6 +282,46 @@ export function compileModuleLegacy(
 ): CompileResult;
 
 // ---------------------------------------------------------------------------
+// parse
+// ---------------------------------------------------------------------------
+
+export interface ParseOptions {
+	/**
+	 * Skip emitting nested `loc: { start, end }` blocks on every embedded
+	 * JavaScript expression. Top-level `start` / `end` byte offsets are
+	 * still emitted. Callers that re-parse expression ranges with their
+	 * own parser (e.g. `svelte-eslint-parser`) get a smaller AST and a
+	 * meaningfully faster `JSON.parse` (with the JSON path) or a tighter
+	 * binary buffer (with `parseEnvelope`).
+	 */
+	skipExpressionLoc?: boolean;
+}
+
+/**
+ * Parse a Svelte component and return the AST as a JSON string. The
+ * caller is responsible for `JSON.parse` on the returned value.
+ *
+ * For the fastest path skip JSON entirely: use {@link parseEnvelope}
+ * with `decodeParseEnvelope` from
+ * `@rsvelte/vite-plugin-svelte-native/parse-envelope.js`.
+ */
+export function parse(source: string, options?: ParseOptions): string;
+
+/**
+ * Parse a Svelte component and return a raw-transfer envelope `Buffer`.
+ *
+ * The buffer is a compact binary encoding of the AST (all 26 template
+ * node types and all 74 estree node types are tagged; only a small
+ * number of leaf sub-trees — CSS, `SvelteOptions`, directive metadata —
+ * fall back to inline JSON behind `TAG_JSON`). Pair with
+ * `decodeParseEnvelope` exported from
+ * `@rsvelte/vite-plugin-svelte-native/parse-envelope.js` to get the
+ * same plain-object AST that `JSON.parse(parse(source))` produces, but
+ * without the per-byte `JSON.parse` tokenisation cost.
+ */
+export function parseEnvelope(source: string, options?: ParseOptions): Buffer;
+
+// ---------------------------------------------------------------------------
 // svelte2tsx
 // ---------------------------------------------------------------------------
 

--- a/npm/vite-plugin-svelte-native/index.d.ts
+++ b/npm/vite-plugin-svelte-native/index.d.ts
@@ -295,6 +295,16 @@ export interface ParseOptions {
 	 * binary buffer (with `parseEnvelope`).
 	 */
 	skipExpressionLoc?: boolean;
+	/**
+	 * Skip emitting the full CSS `StyleSheet` AST. The decoded `css`
+	 * field becomes a minimal stub
+	 * (`{ type: "StyleSheet", start, end, attributes: [], children: [], content: { start, end, styles: "", comment: null } }`).
+	 * Use when the downstream pipeline re-parses `<style>` blocks with
+	 * its own CSS parser (e.g. `svelte-eslint-parser` uses postcss).
+	 * Saves ~5–10 KB of buffer per component and skips the matching
+	 * JSON-parse step.
+	 */
+	skipCssAst?: boolean;
 }
 
 /**

--- a/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -1,0 +1,1811 @@
+// Decoder for the parse envelope (`napi_raw_parse.rs`).
+//
+// Reads the rsvelte raw-transfer buffer and reconstructs the same JS
+// object graph that `JSON.parse(napi.parse(source))` produces. Heavy
+// nodes (Expression sub-trees, the CSS StyleSheet, SvelteOptions)
+// still travel as inline JSON behind `TAG_JSON` — those slices are
+// handed to `JSON.parse` on the spot. Everything else is read by
+// `DataView`, so we skip the per-byte tokenization that JSON.parse
+// performs on most of the AST.
+//
+// Wire format: see `napi_raw_parse.rs` for the canonical reference.
+
+'use strict';
+
+const MAGIC = 0x3156_5052; // "RPV1" little-endian
+const VERSION = 1;
+const HEADER_LEN = 24;
+
+// Tags — must mirror napi_raw_parse.rs.
+const TAG_JSON = 0x00;
+const TAG_ROOT = 0x01;
+const TAG_FRAGMENT = 0x02;
+const TAG_JS_COMMENT = 0x03;
+
+const TAG_TEXT = 0x10;
+const TAG_COMMENT = 0x11;
+const TAG_EXPRESSION_TAG = 0x12;
+const TAG_HTML_TAG = 0x13;
+const TAG_CONST_TAG = 0x14;
+const TAG_DEBUG_TAG = 0x15;
+const TAG_RENDER_TAG = 0x16;
+const TAG_ATTACH_TAG = 0x17;
+
+const TAG_REGULAR_ELEMENT = 0x20;
+const TAG_COMPONENT = 0x21;
+const TAG_TITLE_ELEMENT = 0x22;
+const TAG_SLOT_ELEMENT = 0x23;
+const TAG_SVELTE_BODY = 0x24;
+const TAG_SVELTE_DOCUMENT = 0x25;
+const TAG_SVELTE_FRAGMENT = 0x26;
+const TAG_SVELTE_BOUNDARY = 0x27;
+const TAG_SVELTE_HEAD = 0x28;
+const TAG_SVELTE_OPTIONS_EL = 0x29;
+const TAG_SVELTE_SELF = 0x2a;
+const TAG_SVELTE_WINDOW = 0x2b;
+const TAG_SVELTE_COMPONENT = 0x2c;
+const TAG_SVELTE_ELEMENT = 0x2d;
+
+const TAG_SCRIPT = 0x40;
+// const TAG_SVELTE_OPTIONS = 0x41; — currently encoded as TAG_JSON.
+
+const TAG_ATTRIBUTE = 0x50;
+const TAG_SPREAD_ATTRIBUTE = 0x51;
+const TAG_BIND_DIRECTIVE = 0x52;
+const TAG_ON_DIRECTIVE = 0x53;
+const TAG_CLASS_DIRECTIVE = 0x54;
+const TAG_STYLE_DIRECTIVE = 0x55;
+const TAG_TRANSITION_DIRECTIVE = 0x56;
+const TAG_ANIMATE_DIRECTIVE = 0x57;
+const TAG_USE_DIRECTIVE = 0x58;
+const TAG_LET_DIRECTIVE = 0x59;
+
+const ATTRVAL_TRUE = 0x60;
+const ATTRVAL_EXPRESSION = 0x61;
+const ATTRVAL_SEQUENCE = 0x62;
+
+// Header flag bits — see napi_raw_parse::FLAG_*.
+const FLAG_JSNODE_NO_LOC = 1 << 0;
+
+const TAG_IF_BLOCK = 0x70;
+const TAG_EACH_BLOCK = 0x71;
+const TAG_AWAIT_BLOCK = 0x72;
+const TAG_KEY_BLOCK = 0x73;
+const TAG_SNIPPET_BLOCK = 0x74;
+
+// JsNode (estree) tags — 0x80..0xCB. Mirrors `napi_raw_parse.rs`.
+const JS_IDENTIFIER = 0x80;
+const JS_PRIVATE_IDENTIFIER = 0x81;
+const JS_LITERAL = 0x82;
+const JS_BINARY_EXPRESSION = 0x83;
+const JS_LOGICAL_EXPRESSION = 0x84;
+const JS_UNARY_EXPRESSION = 0x85;
+const JS_CONDITIONAL_EXPRESSION = 0x86;
+const JS_CALL_EXPRESSION = 0x87;
+const JS_MEMBER_EXPRESSION = 0x88;
+const JS_NEW_EXPRESSION = 0x89;
+const JS_FUNCTION_EXPRESSION = 0x8a;
+const JS_CLASS_EXPRESSION = 0x8b;
+const JS_ARROW_FUNCTION_EXPRESSION = 0x8c;
+const JS_ASSIGNMENT_EXPRESSION = 0x8d;
+const JS_UPDATE_EXPRESSION = 0x8e;
+const JS_SEQUENCE_EXPRESSION = 0x8f;
+const JS_ARRAY_EXPRESSION = 0x90;
+const JS_OBJECT_EXPRESSION = 0x91;
+const JS_TEMPLATE_LITERAL = 0x92;
+const JS_TAGGED_TEMPLATE_EXPRESSION = 0x93;
+const JS_TEMPLATE_ELEMENT = 0x94;
+const JS_THIS_EXPRESSION = 0x95;
+const JS_SUPER = 0x96;
+const JS_IMPORT_EXPRESSION = 0x97;
+const JS_AWAIT_EXPRESSION = 0x98;
+const JS_YIELD_EXPRESSION = 0x99;
+const JS_CHAIN_EXPRESSION = 0x9a;
+const JS_META_PROPERTY = 0x9b;
+const JS_SPREAD_ELEMENT = 0x9c;
+const JS_OBJECT_PATTERN = 0x9d;
+const JS_ARRAY_PATTERN = 0x9e;
+const JS_ASSIGNMENT_PATTERN = 0x9f;
+const JS_REST_ELEMENT = 0xa0;
+const JS_PROPERTY = 0xa1;
+const JS_PROGRAM = 0xa2;
+const JS_EXPRESSION_STATEMENT = 0xa3;
+const JS_BLOCK_STATEMENT = 0xa4;
+const JS_VARIABLE_DECLARATION = 0xa5;
+const JS_VARIABLE_DECLARATOR = 0xa6;
+const JS_FUNCTION_DECLARATION = 0xa7;
+const JS_CLASS_DECLARATION = 0xa8;
+const JS_RETURN_STATEMENT = 0xa9;
+const JS_THROW_STATEMENT = 0xaa;
+const JS_IF_STATEMENT = 0xab;
+const JS_FOR_STATEMENT = 0xac;
+const JS_FOR_OF_STATEMENT = 0xad;
+const JS_FOR_IN_STATEMENT = 0xae;
+const JS_WHILE_STATEMENT = 0xaf;
+const JS_DO_WHILE_STATEMENT = 0xb0;
+const JS_TRY_STATEMENT = 0xb1;
+const JS_CATCH_CLAUSE = 0xb2;
+const JS_SWITCH_STATEMENT = 0xb3;
+const JS_SWITCH_CASE = 0xb4;
+const JS_LABELED_STATEMENT = 0xb5;
+const JS_BREAK_STATEMENT = 0xb6;
+const JS_CONTINUE_STATEMENT = 0xb7;
+const JS_EMPTY_STATEMENT = 0xb8;
+const JS_DEBUGGER_STATEMENT = 0xb9;
+const JS_IMPORT_DECLARATION = 0xba;
+const JS_IMPORT_SPECIFIER = 0xbb;
+const JS_IMPORT_DEFAULT_SPECIFIER = 0xbc;
+const JS_IMPORT_NAMESPACE_SPECIFIER = 0xbd;
+const JS_EXPORT_NAMED_DECLARATION = 0xbe;
+const JS_EXPORT_DEFAULT_DECLARATION = 0xbf;
+const JS_EXPORT_SPECIFIER = 0xc0;
+const JS_CLASS_BODY = 0xc1;
+const JS_METHOD_DEFINITION = 0xc2;
+const JS_PROPERTY_DEFINITION = 0xc3;
+const JS_STATIC_BLOCK = 0xc4;
+const JS_DECORATOR = 0xc5;
+const JS_TS_TYPE_ANNOTATION = 0xc6;
+const JS_TS_ENUM_DECLARATION = 0xc7;
+const JS_TS_MODULE_DECLARATION = 0xc8;
+const JS_COMMENT = 0xc9;
+const JS_NULL = 0xca;
+const JS_RAW_JSON = 0xcb;
+
+// LiteralValue inner tag (within a JS_LITERAL payload).
+const LV_NULL = 0;
+const LV_BOOL_FALSE = 1;
+const LV_BOOL_TRUE = 2;
+const LV_NUMBER_I64 = 3;
+const LV_NUMBER_F64 = 4;
+const LV_STRING = 5;
+const LV_REGEX = 6;
+
+// Element tag -> serialised `type` string. The decoder uses this
+// table for the shared element shape (RegularElement, Component, …).
+const ELEMENT_TYPE_NAMES = Object.create(null);
+ELEMENT_TYPE_NAMES[TAG_REGULAR_ELEMENT] = 'RegularElement';
+ELEMENT_TYPE_NAMES[TAG_COMPONENT] = 'Component';
+ELEMENT_TYPE_NAMES[TAG_TITLE_ELEMENT] = 'TitleElement';
+ELEMENT_TYPE_NAMES[TAG_SLOT_ELEMENT] = 'SlotElement';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_BODY] = 'SvelteBody';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_DOCUMENT] = 'SvelteDocument';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_FRAGMENT] = 'SvelteFragment';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_BOUNDARY] = 'SvelteBoundary';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_HEAD] = 'SvelteHead';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_OPTIONS_EL] = 'SvelteOptions';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_SELF] = 'SvelteSelf';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_WINDOW] = 'SvelteWindow';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_COMPONENT] = 'SvelteComponent';
+ELEMENT_TYPE_NAMES[TAG_SVELTE_ELEMENT] = 'SvelteElement';
+
+const textDecoder = new TextDecoder('utf-8');
+
+// Node's `Buffer.prototype.toString('utf8', start, end)` is ~2× faster
+// than `TextDecoder.decode(subarray)` for the short ASCII strings that
+// dominate an AST (identifier names, operators, literal raw strings).
+// Use it when the input is a Node Buffer; fall back to `TextDecoder`
+// for plain `Uint8Array` (browser / non-Node callers).
+const hasBuffer = typeof Buffer !== 'undefined';
+
+class EnvelopeError extends Error {}
+
+/**
+ * Decode a parse envelope produced by `napi.parseEnvelope(source)`.
+ *
+ * @param {Buffer | Uint8Array} buf
+ * @returns {object} the root AST node, shape-compatible with `JSON.parse(napi.parse(source))`.
+ */
+function decodeParseEnvelope(buf) {
+	if (!buf || typeof buf.byteLength !== 'number' || buf.byteLength < HEADER_LEN) {
+		throw new EnvelopeError('parse envelope: buffer too small');
+	}
+	const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+	const magic = view.getUint32(0, true);
+	if (magic !== MAGIC) {
+		throw new EnvelopeError(
+			`parse envelope: bad magic 0x${magic.toString(16)} (expected 0x${MAGIC.toString(16)})`,
+		);
+	}
+	const version = view.getUint32(4, true);
+	if (version !== VERSION) {
+		throw new EnvelopeError(
+			`parse envelope: unsupported version ${version} (expected ${VERSION})`,
+		);
+	}
+	const totalLen = view.getUint32(8, true);
+	if (totalLen !== buf.byteLength) {
+		throw new EnvelopeError(
+			`parse envelope: total_len ${totalLen} != buffer.byteLength ${buf.byteLength}`,
+		);
+	}
+	const rootOffset = view.getUint32(12, true);
+	const flags = view.getUint32(20, true);
+	const skipJsNodeLoc = (flags & FLAG_JSNODE_NO_LOC) !== 0;
+	const bytes =
+		buf instanceof Uint8Array
+			? buf
+			: new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+	// Stash the fastest string-decode primitive directly on `ctx`. Node
+	// `Buffer.toString('utf8', start, end)` is ~2× faster than
+	// `TextDecoder.decode(typedArray.subarray(start, end))` for the
+	// short ASCII strings that dominate an AST.
+	const isBuffer = hasBuffer && Buffer.isBuffer(bytes);
+	const ctx = { view, bytes, pos: rootOffset, isBuffer, skipJsNodeLoc };
+	return readNode(ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Cursor helpers — every read advances `ctx.pos`.
+// ---------------------------------------------------------------------------
+
+function readU8(ctx) {
+	const v = ctx.view.getUint8(ctx.pos);
+	ctx.pos += 1;
+	return v;
+}
+function readU32(ctx) {
+	const v = ctx.view.getUint32(ctx.pos, true);
+	ctx.pos += 4;
+	return v;
+}
+function readBool(ctx) {
+	return readU8(ctx) !== 0;
+}
+function readStr(ctx) {
+	const len = readU32(ctx);
+	const start = ctx.pos;
+	const end = start + len;
+	ctx.pos = end;
+	// Branch is monomorphic per envelope: V8 specialises after warmup.
+	return ctx.isBuffer
+		? ctx.bytes.toString('utf8', start, end)
+		: textDecoder.decode(ctx.bytes.subarray(start, end));
+}
+function readOptStr(ctx) {
+	return readU8(ctx) === 0 ? null : readStr(ctx);
+}
+function readSourceLocation(ctx) {
+	return {
+		start: { line: readU32(ctx), column: readU32(ctx), character: readU32(ctx) },
+		end: { line: readU32(ctx), column: readU32(ctx), character: readU32(ctx) },
+	};
+}
+function readOptSourceLocation(ctx) {
+	return readU8(ctx) === 0 ? null : readSourceLocation(ctx);
+}
+function readModifiers(ctx) {
+	const count = readU32(ctx);
+	const out = new Array(count);
+	for (let i = 0; i < count; i++) out[i] = readStr(ctx);
+	return out;
+}
+
+/** Read a length-prefixed JSON payload (no preamble). */
+function readInlineJson(ctx) {
+	const len = readU32(ctx);
+	const start = ctx.pos;
+	const end = start + len;
+	ctx.pos = end;
+	if (len === 0) return null;
+	return JSON.parse(
+		ctx.isBuffer
+			? ctx.bytes.toString('utf8', start, end)
+			: textDecoder.decode(ctx.bytes.subarray(start, end)),
+	);
+}
+
+/** Read the TAG_JSON variant — preamble already consumed. */
+function readJsonNodePayload(ctx) {
+	return readInlineJson(ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch on tag
+// ---------------------------------------------------------------------------
+
+function readNode(ctx) {
+	const tag = readU8(ctx);
+	const start = readU32(ctx);
+	const end = readU32(ctx);
+	return readNodeBody(ctx, tag, start, end);
+}
+
+function readNodeBody(ctx, tag, start, end) {
+	switch (tag) {
+		case TAG_JSON:
+			return readJsonNodePayload(ctx);
+
+		case TAG_ROOT:
+			return readRoot(ctx, start, end);
+		case TAG_FRAGMENT:
+			return readFragment(ctx); // start/end of fragment are sentinels
+		case TAG_JS_COMMENT:
+			return readJsComment(ctx, start, end);
+
+		case TAG_TEXT:
+			return readText(ctx, start, end);
+		case TAG_COMMENT:
+			return readComment(ctx, start, end);
+		case TAG_EXPRESSION_TAG:
+			return readExpressionTag(ctx, start, end);
+		case TAG_HTML_TAG:
+			return readSingleExprTag(ctx, 'HtmlTag', start, end);
+		case TAG_CONST_TAG:
+			return readConstTag(ctx, start, end);
+		case TAG_DEBUG_TAG:
+			return readDebugTag(ctx, start, end);
+		case TAG_RENDER_TAG:
+			return readSingleExprTag(ctx, 'RenderTag', start, end);
+		case TAG_ATTACH_TAG:
+			return readSingleExprTag(ctx, 'AttachTag', start, end);
+
+		case TAG_REGULAR_ELEMENT:
+		case TAG_COMPONENT:
+		case TAG_TITLE_ELEMENT:
+		case TAG_SLOT_ELEMENT:
+		case TAG_SVELTE_BODY:
+		case TAG_SVELTE_DOCUMENT:
+		case TAG_SVELTE_FRAGMENT:
+		case TAG_SVELTE_BOUNDARY:
+		case TAG_SVELTE_HEAD:
+		case TAG_SVELTE_OPTIONS_EL:
+		case TAG_SVELTE_SELF:
+		case TAG_SVELTE_WINDOW:
+			return readElement(ctx, ELEMENT_TYPE_NAMES[tag], start, end);
+		case TAG_SVELTE_COMPONENT:
+			return readSvelteComponentElement(ctx, start, end);
+		case TAG_SVELTE_ELEMENT:
+			return readSvelteDynamicElement(ctx, start, end);
+
+		case TAG_SCRIPT:
+			return readScript(ctx, start, end);
+
+		case TAG_ATTRIBUTE:
+			return readAttributeNode(ctx, start, end);
+		case TAG_SPREAD_ATTRIBUTE:
+			return readSpreadAttribute(ctx, start, end);
+		case TAG_BIND_DIRECTIVE:
+			return readBindDirective(ctx, start, end);
+		case TAG_ON_DIRECTIVE:
+			return readOnDirective(ctx, start, end);
+		case TAG_CLASS_DIRECTIVE:
+			return readClassDirective(ctx, start, end);
+		case TAG_STYLE_DIRECTIVE:
+			return readStyleDirective(ctx, start, end);
+		case TAG_TRANSITION_DIRECTIVE:
+			return readTransitionDirective(ctx, start, end);
+		case TAG_ANIMATE_DIRECTIVE:
+			return readAnimateDirective(ctx, start, end);
+		case TAG_USE_DIRECTIVE:
+			return readUseDirective(ctx, start, end);
+		case TAG_LET_DIRECTIVE:
+			return readLetDirective(ctx, start, end);
+
+		case TAG_IF_BLOCK:
+			return readIfBlock(ctx, start, end);
+		case TAG_EACH_BLOCK:
+			return readEachBlock(ctx, start, end);
+		case TAG_AWAIT_BLOCK:
+			return readAwaitBlock(ctx, start, end);
+		case TAG_KEY_BLOCK:
+			return readKeyBlock(ctx, start, end);
+		case TAG_SNIPPET_BLOCK:
+			return readSnippetBlock(ctx, start, end);
+
+		// ----- JsNode (estree) ----------------------------------------
+		case JS_NULL:
+			return null;
+		case JS_RAW_JSON:
+			return readJsonNodePayload(ctx);
+		case JS_IDENTIFIER:
+			return readJsIdentifier(ctx, start, end);
+		case JS_PRIVATE_IDENTIFIER:
+			return readJsPrivateIdentifier(ctx, start, end);
+		case JS_LITERAL:
+			return readJsLiteral(ctx, start, end);
+		case JS_BINARY_EXPRESSION:
+			return readJsBinaryLike(ctx, 'BinaryExpression', start, end);
+		case JS_LOGICAL_EXPRESSION:
+			return readJsBinaryLike(ctx, 'LogicalExpression', start, end);
+		case JS_UNARY_EXPRESSION:
+			return readJsUnaryExpression(ctx, start, end);
+		case JS_CONDITIONAL_EXPRESSION:
+			return readJsConditionalExpression(ctx, start, end);
+		case JS_CALL_EXPRESSION:
+			return readJsCallExpression(ctx, start, end);
+		case JS_MEMBER_EXPRESSION:
+			return readJsMemberExpression(ctx, start, end);
+		case JS_NEW_EXPRESSION:
+			return readJsNewExpression(ctx, start, end);
+		case JS_FUNCTION_EXPRESSION:
+			return readJsFunctionExpression(ctx, start, end);
+		case JS_CLASS_EXPRESSION:
+			return readJsClassExpression(ctx, start, end);
+		case JS_ARROW_FUNCTION_EXPRESSION:
+			return readJsArrowFunctionExpression(ctx, start, end);
+		case JS_ASSIGNMENT_EXPRESSION:
+			return readJsAssignmentExpression(ctx, start, end);
+		case JS_UPDATE_EXPRESSION:
+			return readJsUpdateExpression(ctx, start, end);
+		case JS_SEQUENCE_EXPRESSION:
+			return readJsSequenceExpression(ctx, start, end);
+		case JS_ARRAY_EXPRESSION:
+			return readJsArrayExpression(ctx, start, end);
+		case JS_OBJECT_EXPRESSION:
+			return readJsObjectExpression(ctx, start, end);
+		case JS_TEMPLATE_LITERAL:
+			return readJsTemplateLiteral(ctx, start, end);
+		case JS_TAGGED_TEMPLATE_EXPRESSION:
+			return readJsTaggedTemplateExpression(ctx, start, end);
+		case JS_TEMPLATE_ELEMENT:
+			return readJsTemplateElement(ctx, start, end);
+		case JS_THIS_EXPRESSION:
+			return readJsBareExpr(ctx, 'ThisExpression', start, end);
+		case JS_SUPER:
+			return readJsBareExpr(ctx, 'Super', start, end);
+		case JS_IMPORT_EXPRESSION:
+			return readJsImportExpression(ctx, start, end);
+		case JS_AWAIT_EXPRESSION:
+			return readJsAwaitExpression(ctx, start, end);
+		case JS_YIELD_EXPRESSION:
+			return readJsYieldExpression(ctx, start, end);
+		case JS_CHAIN_EXPRESSION:
+			return readJsChainExpression(ctx, start, end);
+		case JS_META_PROPERTY:
+			return readJsMetaProperty(ctx, start, end);
+		case JS_SPREAD_ELEMENT:
+			return readJsSpreadElement(ctx, start, end);
+		case JS_OBJECT_PATTERN:
+			return readJsObjectPattern(ctx, start, end);
+		case JS_ARRAY_PATTERN:
+			return readJsArrayPattern(ctx, start, end);
+		case JS_ASSIGNMENT_PATTERN:
+			return readJsAssignmentPattern(ctx, start, end);
+		case JS_REST_ELEMENT:
+			return readJsRestElement(ctx, start, end);
+		case JS_PROPERTY:
+			return readJsProperty(ctx, start, end);
+		case JS_PROGRAM:
+			return readJsProgram(ctx, start, end);
+		case JS_EXPRESSION_STATEMENT:
+			return readJsExpressionStatement(ctx, start, end);
+		case JS_BLOCK_STATEMENT:
+			return readJsBlockStatement(ctx, start, end);
+		case JS_VARIABLE_DECLARATION:
+			return readJsVariableDeclaration(ctx, start, end);
+		case JS_VARIABLE_DECLARATOR:
+			return readJsVariableDeclarator(ctx, start, end);
+		case JS_FUNCTION_DECLARATION:
+			return readJsFunctionDeclaration(ctx, start, end);
+		case JS_CLASS_DECLARATION:
+			return readJsClassDeclaration(ctx, start, end);
+		case JS_RETURN_STATEMENT:
+			return readJsReturnStatement(ctx, start, end);
+		case JS_THROW_STATEMENT:
+			return readJsThrowStatement(ctx, start, end);
+		case JS_IF_STATEMENT:
+			return readJsIfStatement(ctx, start, end);
+		case JS_FOR_STATEMENT:
+			return readJsForStatement(ctx, start, end);
+		case JS_FOR_OF_STATEMENT:
+			return readJsForOfStatement(ctx, start, end);
+		case JS_FOR_IN_STATEMENT:
+			return readJsForInStatement(ctx, start, end);
+		case JS_WHILE_STATEMENT:
+			return readJsWhileStatement(ctx, start, end);
+		case JS_DO_WHILE_STATEMENT:
+			return readJsDoWhileStatement(ctx, start, end);
+		case JS_TRY_STATEMENT:
+			return readJsTryStatement(ctx, start, end);
+		case JS_CATCH_CLAUSE:
+			return readJsCatchClause(ctx, start, end);
+		case JS_SWITCH_STATEMENT:
+			return readJsSwitchStatement(ctx, start, end);
+		case JS_SWITCH_CASE:
+			return readJsSwitchCase(ctx, start, end);
+		case JS_LABELED_STATEMENT:
+			return readJsLabeledStatement(ctx, start, end);
+		case JS_BREAK_STATEMENT:
+			return readJsBreakStatement(ctx, start, end);
+		case JS_CONTINUE_STATEMENT:
+			return readJsContinueStatement(ctx, start, end);
+		case JS_EMPTY_STATEMENT:
+			return readJsBareExpr(ctx, 'EmptyStatement', start, end);
+		case JS_DEBUGGER_STATEMENT:
+			return readJsBareExpr(ctx, 'DebuggerStatement', start, end);
+		case JS_IMPORT_DECLARATION:
+			return readJsImportDeclaration(ctx, start, end);
+		case JS_IMPORT_SPECIFIER:
+			return readJsImportSpecifier(ctx, start, end);
+		case JS_IMPORT_DEFAULT_SPECIFIER:
+			return readJsImportDefaultSpecifier(ctx, start, end);
+		case JS_IMPORT_NAMESPACE_SPECIFIER:
+			return readJsImportNamespaceSpecifier(ctx, start, end);
+		case JS_EXPORT_NAMED_DECLARATION:
+			return readJsExportNamedDeclaration(ctx, start, end);
+		case JS_EXPORT_DEFAULT_DECLARATION:
+			return readJsExportDefaultDeclaration(ctx, start, end);
+		case JS_EXPORT_SPECIFIER:
+			return readJsExportSpecifier(ctx, start, end);
+		case JS_CLASS_BODY:
+			return readJsClassBody(ctx, start, end);
+		case JS_METHOD_DEFINITION:
+			return readJsMethodDefinition(ctx, start, end);
+		case JS_PROPERTY_DEFINITION:
+			return readJsPropertyDefinition(ctx, start, end);
+		case JS_STATIC_BLOCK:
+			return readJsStaticBlock(ctx, start, end);
+		case JS_DECORATOR:
+			return readJsBareExpr(ctx, 'Decorator', start, end);
+		case JS_TS_TYPE_ANNOTATION:
+			return readJsTSTypeAnnotation(ctx, start, end);
+		case JS_TS_ENUM_DECLARATION:
+			return readJsBareExpr(ctx, 'TSEnumDeclaration', start, end);
+		case JS_TS_MODULE_DECLARATION:
+			return readJsTSModuleDeclaration(ctx, start, end);
+		case JS_COMMENT:
+			return readJsComment_(ctx, start, end);
+
+		default:
+			throw new EnvelopeError(
+				`parse envelope: unknown tag 0x${tag.toString(16)} at offset ${ctx.pos - 9}`,
+			);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JsNode (estree) decoders
+// ---------------------------------------------------------------------------
+
+function readTypedLoc(ctx) {
+	// Fast path: when the envelope advertised that no JsNode carries
+	// `loc`, the encoder skipped every loc-flag byte. Mirror that here.
+	if (ctx.skipJsNodeLoc) return null;
+	if (readU8(ctx) === 0) return null;
+	const startLine = readU32(ctx);
+	const startCol = readU32(ctx);
+	const startChar = readU8(ctx) !== 0 ? readU32(ctx) : null;
+	const endLine = readU32(ctx);
+	const endCol = readU32(ctx);
+	const endChar = readU8(ctx) !== 0 ? readU32(ctx) : null;
+	const startPos = { line: startLine, column: startCol };
+	if (startChar !== null) startPos.character = startChar;
+	const endPos = { line: endLine, column: endCol };
+	if (endChar !== null) endPos.character = endChar;
+	return { start: startPos, end: endPos };
+}
+
+function readLiteralValue(ctx) {
+	const tag = readU8(ctx);
+	switch (tag) {
+		case LV_NULL:
+			return null;
+		case LV_BOOL_FALSE:
+			return false;
+		case LV_BOOL_TRUE:
+			return true;
+		case LV_NUMBER_I64: {
+			// Two 32-bit reads — BigInt then to Number (preserves sign for negatives within JS-safe range).
+			const lo = readU32(ctx);
+			const hi = readU32(ctx);
+			const sign = hi >>> 31;
+			if (sign === 0) return hi * 0x100000000 + lo;
+			// Two's complement: subtract 2^64.
+			return (hi - 0x100000000) * 0x100000000 + lo;
+		}
+		case LV_NUMBER_F64: {
+			const dv = ctx.view;
+			const v = dv.getFloat64(ctx.pos, true);
+			ctx.pos += 8;
+			return v;
+		}
+		case LV_STRING:
+			return readStr(ctx);
+		case LV_REGEX:
+			return {}; // Literal.regex value is serialised as an empty object upstream.
+		default:
+			throw new EnvelopeError(`parse envelope: bad LiteralValue tag 0x${tag.toString(16)}`);
+	}
+}
+
+function readRegex(ctx) {
+	if (readU8(ctx) === 0) return null;
+	const pattern = readStr(ctx);
+	const flags = readStr(ctx);
+	return { pattern, flags };
+}
+
+function readTemplateElementValue(ctx) {
+	const raw = readStr(ctx);
+	const cooked = readU8(ctx) !== 0 ? readStr(ctx) : null;
+	return { raw, cooked };
+}
+
+function readChildArray(ctx) {
+	const count = readU32(ctx);
+	const out = new Array(count);
+	for (let i = 0; i < count; i++) out[i] = readNode(ctx);
+	return out;
+}
+
+function readNullableChildArray(ctx) {
+	// `Vec<Option<JsNode>>` — element is null when the flag byte is 0.
+	const count = readU32(ctx);
+	const out = new Array(count);
+	for (let i = 0; i < count; i++) {
+		out[i] = readU8(ctx) !== 0 ? readNode(ctx) : null;
+	}
+	return out;
+}
+
+function readOptNode(ctx) {
+	return readU8(ctx) !== 0 ? readNode(ctx) : null;
+}
+
+function readJsIdentifier(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const name = readStr(ctx);
+	const node = { type: 'Identifier', start, end };
+	if (loc !== null) node.loc = loc;
+	node.name = name;
+	return node;
+}
+
+function readJsPrivateIdentifier(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const name = readStr(ctx);
+	const node = { type: 'PrivateIdentifier', start, end };
+	if (loc !== null) node.loc = loc;
+	node.name = name;
+	return node;
+}
+
+function readJsLiteral(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const value = readLiteralValue(ctx);
+	const raw = readStr(ctx);
+	const regex = readRegex(ctx);
+	const node = { type: 'Literal', start, end };
+	if (loc !== null) node.loc = loc;
+	node.value = value;
+	node.raw = raw;
+	if (regex !== null) node.regex = regex;
+	return node;
+}
+
+function readJsBinaryLike(ctx, typeName, start, end) {
+	const loc = readTypedLoc(ctx);
+	const left = readNode(ctx);
+	const operator = readStr(ctx);
+	const right = readNode(ctx);
+	const node = { type: typeName, start, end };
+	if (loc !== null) node.loc = loc;
+	node.left = left;
+	node.operator = operator;
+	node.right = right;
+	return node;
+}
+
+function readJsUnaryExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const operator = readStr(ctx);
+	const prefix = readBool(ctx);
+	const argument = readNode(ctx);
+	const node = { type: 'UnaryExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.operator = operator;
+	node.prefix = prefix;
+	node.argument = argument;
+	return node;
+}
+
+function readJsConditionalExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const test = readNode(ctx);
+	const consequent = readNode(ctx);
+	const alternate = readNode(ctx);
+	const node = { type: 'ConditionalExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.test = test;
+	node.consequent = consequent;
+	node.alternate = alternate;
+	return node;
+}
+
+function readJsCallExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const callee = readNode(ctx);
+	const args = readChildArray(ctx);
+	const optional = readBool(ctx);
+	const node = { type: 'CallExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.callee = callee;
+	node.arguments = args;
+	node.optional = optional;
+	return node;
+}
+
+function readJsMemberExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const object = readNode(ctx);
+	const property = readNode(ctx);
+	const computed = readBool(ctx);
+	const optional = readBool(ctx);
+	const node = { type: 'MemberExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.object = object;
+	node.property = property;
+	node.computed = computed;
+	node.optional = optional;
+	return node;
+}
+
+function readJsNewExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const callee = readNode(ctx);
+	const args = readChildArray(ctx);
+	const node = { type: 'NewExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.callee = callee;
+	node.arguments = args;
+	return node;
+}
+
+function readJsFunctionExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const id = readOptNode(ctx);
+	const generator = readBool(ctx);
+	const asyncFlag = readBool(ctx);
+	const expression = readBool(ctx);
+	const params = readChildArray(ctx);
+	const body = readOptNode(ctx);
+	const node = { type: 'FunctionExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.id = id;
+	node.generator = generator;
+	node.async = asyncFlag;
+	node.expression = expression;
+	node.params = params;
+	node.body = body;
+	return node;
+}
+
+function readJsClassExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const id = readOptNode(ctx);
+	const superClass = readOptNode(ctx);
+	const body = readNode(ctx);
+	const node = { type: 'ClassExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.id = id;
+	node.superClass = superClass;
+	node.body = body;
+	return node;
+}
+
+function readJsArrowFunctionExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const id = readOptNode(ctx);
+	const expression = readBool(ctx);
+	const generator = readBool(ctx);
+	const asyncFlag = readBool(ctx);
+	const params = readChildArray(ctx);
+	const body = readNode(ctx);
+	const node = { type: 'ArrowFunctionExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.id = id;
+	node.expression = expression;
+	node.generator = generator;
+	node.async = asyncFlag;
+	node.params = params;
+	node.body = body;
+	return node;
+}
+
+function readJsAssignmentExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const operator = readStr(ctx);
+	const left = readNode(ctx);
+	const right = readNode(ctx);
+	const node = { type: 'AssignmentExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.operator = operator;
+	node.left = left;
+	node.right = right;
+	return node;
+}
+
+function readJsUpdateExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const operator = readStr(ctx);
+	const prefix = readBool(ctx);
+	const argument = readNode(ctx);
+	const node = { type: 'UpdateExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.operator = operator;
+	node.prefix = prefix;
+	node.argument = argument;
+	return node;
+}
+
+function readJsSequenceExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const expressions = readChildArray(ctx);
+	const node = { type: 'SequenceExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.expressions = expressions;
+	return node;
+}
+
+function readJsArrayExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const elements = readNullableChildArray(ctx);
+	const node = { type: 'ArrayExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.elements = elements;
+	return node;
+}
+
+function readJsObjectExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const properties = readChildArray(ctx);
+	const node = { type: 'ObjectExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.properties = properties;
+	return node;
+}
+
+function readJsTemplateLiteral(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const quasis = readChildArray(ctx);
+	const expressions = readChildArray(ctx);
+	const node = { type: 'TemplateLiteral', start, end };
+	if (loc !== null) node.loc = loc;
+	node.quasis = quasis;
+	node.expressions = expressions;
+	return node;
+}
+
+function readJsTaggedTemplateExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const tag = readNode(ctx);
+	const quasi = readNode(ctx);
+	const node = { type: 'TaggedTemplateExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.tag = tag;
+	node.quasi = quasi;
+	return node;
+}
+
+function readJsTemplateElement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const tail = readBool(ctx);
+	const value = readTemplateElementValue(ctx);
+	const node = { type: 'TemplateElement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.tail = tail;
+	node.value = value;
+	return node;
+}
+
+function readJsBareExpr(ctx, typeName, start, end) {
+	const loc = readTypedLoc(ctx);
+	const node = { type: typeName, start, end };
+	if (loc !== null) node.loc = loc;
+	return node;
+}
+
+function readJsImportExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const source = readNode(ctx);
+	const node = { type: 'ImportExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.source = source;
+	// The upstream serializer also adds `options: null`. Match that.
+	node.options = null;
+	return node;
+}
+
+function readJsAwaitExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const argument = readNode(ctx);
+	const node = { type: 'AwaitExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.argument = argument;
+	return node;
+}
+
+function readJsYieldExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const delegate = readBool(ctx);
+	const argument = readOptNode(ctx);
+	const node = { type: 'YieldExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.delegate = delegate;
+	node.argument = argument;
+	return node;
+}
+
+function readJsChainExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const node = { type: 'ChainExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.expression = expression;
+	return node;
+}
+
+function readJsMetaProperty(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const meta = readNode(ctx);
+	const property = readNode(ctx);
+	const node = { type: 'MetaProperty', start, end };
+	if (loc !== null) node.loc = loc;
+	node.meta = meta;
+	node.property = property;
+	return node;
+}
+
+function readJsSpreadElement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const argument = readNode(ctx);
+	const node = { type: 'SpreadElement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.argument = argument;
+	return node;
+}
+
+function readJsObjectPattern(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const properties = readChildArray(ctx);
+	const node = { type: 'ObjectPattern', start, end };
+	if (loc !== null) node.loc = loc;
+	node.properties = properties;
+	return node;
+}
+
+function readJsArrayPattern(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const elements = readNullableChildArray(ctx);
+	const node = { type: 'ArrayPattern', start, end };
+	if (loc !== null) node.loc = loc;
+	node.elements = elements;
+	return node;
+}
+
+function readJsAssignmentPattern(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const left = readNode(ctx);
+	const right = readNode(ctx);
+	const node = { type: 'AssignmentPattern', start, end };
+	if (loc !== null) node.loc = loc;
+	node.left = left;
+	node.right = right;
+	return node;
+}
+
+function readJsRestElement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const argument = readNode(ctx);
+	const node = { type: 'RestElement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.argument = argument;
+	return node;
+}
+
+function readJsProperty(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const method = readBool(ctx);
+	const shorthand = readBool(ctx);
+	const computed = readBool(ctx);
+	const key = readNode(ctx);
+	const value = readNode(ctx);
+	const kind = readStr(ctx);
+	const node = { type: 'Property', start, end };
+	if (loc !== null) node.loc = loc;
+	node.method = method;
+	node.shorthand = shorthand;
+	node.computed = computed;
+	node.key = key;
+	node.value = value;
+	node.kind = kind;
+	return node;
+}
+
+function readJsProgram(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const body = readChildArray(ctx);
+	const sourceType = readStr(ctx);
+	const trailing = readU8(ctx) !== 0 ? readInlineJson(ctx) : undefined;
+	const leading = readU8(ctx) !== 0 ? readInlineJson(ctx) : undefined;
+	const node = { type: 'Program', start, end };
+	if (loc !== null) node.loc = loc;
+	node.body = body;
+	node.sourceType = sourceType;
+	if (trailing !== undefined) node.trailingComments = trailing;
+	if (leading !== undefined) node.leadingComments = leading;
+	return node;
+}
+
+function readJsExpressionStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const node = { type: 'ExpressionStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.expression = expression;
+	return node;
+}
+
+function readJsBlockStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const body = readChildArray(ctx);
+	const node = { type: 'BlockStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.body = body;
+	return node;
+}
+
+function readJsVariableDeclaration(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const declarations = readChildArray(ctx);
+	const kind = readStr(ctx);
+	const declare = readBool(ctx);
+	const node = { type: 'VariableDeclaration', start, end };
+	if (loc !== null) node.loc = loc;
+	node.declarations = declarations;
+	node.kind = kind;
+	if (declare) node.declare = true;
+	return node;
+}
+
+function readJsVariableDeclarator(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const id = readNode(ctx);
+	const init = readOptNode(ctx);
+	const node = { type: 'VariableDeclarator', start, end };
+	if (loc !== null) node.loc = loc;
+	node.id = id;
+	node.init = init;
+	return node;
+}
+
+function readJsFunctionDeclaration(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const id = readOptNode(ctx);
+	const generator = readBool(ctx);
+	const asyncFlag = readBool(ctx);
+	const params = readChildArray(ctx);
+	const body = readOptNode(ctx);
+	const node = { type: 'FunctionDeclaration', start, end };
+	if (loc !== null) node.loc = loc;
+	node.id = id;
+	node.generator = generator;
+	node.async = asyncFlag;
+	node.params = params;
+	node.body = body;
+	return node;
+}
+
+function readJsClassDeclaration(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const id = readOptNode(ctx);
+	const superClass = readOptNode(ctx);
+	const body = readNode(ctx);
+	const declare = readBool(ctx);
+	const abstractFlag = readBool(ctx);
+	const implementsFlag = readBool(ctx);
+	const decorators = readChildArray(ctx);
+	const node = { type: 'ClassDeclaration', start, end };
+	if (loc !== null) node.loc = loc;
+	node.id = id;
+	node.superClass = superClass;
+	node.body = body;
+	if (declare) node.declare = true;
+	if (abstractFlag) node.abstract = true;
+	if (implementsFlag) node.implements = true;
+	if (decorators.length > 0) node.decorators = decorators;
+	return node;
+}
+
+function readJsReturnStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const argument = readOptNode(ctx);
+	const node = { type: 'ReturnStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.argument = argument;
+	return node;
+}
+
+function readJsThrowStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const argument = readNode(ctx);
+	const node = { type: 'ThrowStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.argument = argument;
+	return node;
+}
+
+function readJsIfStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const test = readNode(ctx);
+	const consequent = readNode(ctx);
+	const alternate = readOptNode(ctx);
+	const node = { type: 'IfStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.test = test;
+	node.consequent = consequent;
+	node.alternate = alternate;
+	return node;
+}
+
+function readJsForStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const init = readOptNode(ctx);
+	const test = readOptNode(ctx);
+	const update = readOptNode(ctx);
+	const body = readNode(ctx);
+	const node = { type: 'ForStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.init = init;
+	node.test = test;
+	node.update = update;
+	node.body = body;
+	return node;
+}
+
+function readJsForOfStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const awaitFlag = readBool(ctx);
+	const left = readNode(ctx);
+	const right = readNode(ctx);
+	const body = readNode(ctx);
+	const node = { type: 'ForOfStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.await = awaitFlag;
+	node.left = left;
+	node.right = right;
+	node.body = body;
+	return node;
+}
+
+function readJsForInStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const left = readNode(ctx);
+	const right = readNode(ctx);
+	const body = readNode(ctx);
+	const node = { type: 'ForInStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.left = left;
+	node.right = right;
+	node.body = body;
+	return node;
+}
+
+function readJsWhileStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const test = readNode(ctx);
+	const body = readNode(ctx);
+	const node = { type: 'WhileStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.test = test;
+	node.body = body;
+	return node;
+}
+
+function readJsDoWhileStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const test = readNode(ctx);
+	const body = readNode(ctx);
+	const node = { type: 'DoWhileStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.test = test;
+	node.body = body;
+	return node;
+}
+
+function readJsTryStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const block = readNode(ctx);
+	const handler = readOptNode(ctx);
+	const finalizer = readOptNode(ctx);
+	const node = { type: 'TryStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.block = block;
+	node.handler = handler;
+	node.finalizer = finalizer;
+	return node;
+}
+
+function readJsCatchClause(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const param = readOptNode(ctx);
+	const body = readNode(ctx);
+	const node = { type: 'CatchClause', start, end };
+	if (loc !== null) node.loc = loc;
+	node.param = param;
+	node.body = body;
+	return node;
+}
+
+function readJsSwitchStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const discriminant = readNode(ctx);
+	const cases = readChildArray(ctx);
+	const node = { type: 'SwitchStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.discriminant = discriminant;
+	node.cases = cases;
+	return node;
+}
+
+function readJsSwitchCase(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const test = readOptNode(ctx);
+	const consequent = readChildArray(ctx);
+	const node = { type: 'SwitchCase', start, end };
+	if (loc !== null) node.loc = loc;
+	node.test = test;
+	node.consequent = consequent;
+	return node;
+}
+
+function readJsLabeledStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const label = readNode(ctx);
+	const body = readNode(ctx);
+	const node = { type: 'LabeledStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.label = label;
+	node.body = body;
+	return node;
+}
+
+function readJsBreakStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const label = readOptNode(ctx);
+	const node = { type: 'BreakStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.label = label;
+	return node;
+}
+
+function readJsContinueStatement(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const label = readOptNode(ctx);
+	const node = { type: 'ContinueStatement', start, end };
+	if (loc !== null) node.loc = loc;
+	node.label = label;
+	return node;
+}
+
+function readJsImportDeclaration(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const specifiers = readChildArray(ctx);
+	const source = readNode(ctx);
+	const importKind = readOptStr(ctx);
+	const attributes = readChildArray(ctx);
+	const node = { type: 'ImportDeclaration', start, end };
+	if (loc !== null) node.loc = loc;
+	node.specifiers = specifiers;
+	node.source = source;
+	if (importKind !== null) node.importKind = importKind;
+	node.attributes = attributes;
+	return node;
+}
+
+function readJsImportSpecifier(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const imported = readNode(ctx);
+	const local = readNode(ctx);
+	const importKind = readOptStr(ctx);
+	const node = { type: 'ImportSpecifier', start, end };
+	if (loc !== null) node.loc = loc;
+	node.imported = imported;
+	node.local = local;
+	if (importKind !== null) node.importKind = importKind;
+	return node;
+}
+
+function readJsImportDefaultSpecifier(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const local = readNode(ctx);
+	const node = { type: 'ImportDefaultSpecifier', start, end };
+	if (loc !== null) node.loc = loc;
+	node.local = local;
+	return node;
+}
+
+function readJsImportNamespaceSpecifier(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const local = readNode(ctx);
+	const node = { type: 'ImportNamespaceSpecifier', start, end };
+	if (loc !== null) node.loc = loc;
+	node.local = local;
+	return node;
+}
+
+function readJsExportNamedDeclaration(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const declaration = readOptNode(ctx);
+	const specifiers = readChildArray(ctx);
+	const source = readOptNode(ctx);
+	const exportKind = readOptStr(ctx);
+	const attributes = readChildArray(ctx);
+	const node = { type: 'ExportNamedDeclaration', start, end };
+	if (loc !== null) node.loc = loc;
+	node.declaration = declaration;
+	node.specifiers = specifiers;
+	node.source = source;
+	if (exportKind !== null) node.exportKind = exportKind;
+	node.attributes = attributes;
+	return node;
+}
+
+function readJsExportDefaultDeclaration(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const declaration = readNode(ctx);
+	const node = { type: 'ExportDefaultDeclaration', start, end };
+	if (loc !== null) node.loc = loc;
+	node.declaration = declaration;
+	return node;
+}
+
+function readJsExportSpecifier(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const local = readNode(ctx);
+	const exported = readNode(ctx);
+	const exportKind = readOptStr(ctx);
+	const node = { type: 'ExportSpecifier', start, end };
+	if (loc !== null) node.loc = loc;
+	node.local = local;
+	node.exported = exported;
+	if (exportKind !== null) node.exportKind = exportKind;
+	return node;
+}
+
+function readJsClassBody(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const body = readChildArray(ctx);
+	const node = { type: 'ClassBody', start, end };
+	if (loc !== null) node.loc = loc;
+	node.body = body;
+	return node;
+}
+
+function readJsMethodDefinition(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const staticFlag = readBool(ctx);
+	const computed = readBool(ctx);
+	const kind = readStr(ctx);
+	const key = readNode(ctx);
+	const value = readNode(ctx);
+	const node = { type: 'MethodDefinition', start, end };
+	if (loc !== null) node.loc = loc;
+	node.static = staticFlag;
+	node.computed = computed;
+	node.kind = kind;
+	node.key = key;
+	node.value = value;
+	return node;
+}
+
+function readJsPropertyDefinition(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const staticFlag = readBool(ctx);
+	const computed = readBool(ctx);
+	const key = readNode(ctx);
+	const value = readOptNode(ctx);
+	const node = { type: 'PropertyDefinition', start, end };
+	if (loc !== null) node.loc = loc;
+	node.static = staticFlag;
+	node.computed = computed;
+	node.key = key;
+	node.value = value;
+	return node;
+}
+
+function readJsStaticBlock(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const body = readChildArray(ctx);
+	const node = { type: 'StaticBlock', start, end };
+	if (loc !== null) node.loc = loc;
+	node.body = body;
+	return node;
+}
+
+function readJsTSTypeAnnotation(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const typeAnnotation = readNode(ctx);
+	const node = { type: 'TSTypeAnnotation', start, end };
+	if (loc !== null) node.loc = loc;
+	node.typeAnnotation = typeAnnotation;
+	return node;
+}
+
+function readJsTSModuleDeclaration(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const body = readOptNode(ctx);
+	const node = { type: 'TSModuleDeclaration', start, end };
+	if (loc !== null) node.loc = loc;
+	if (body !== null) node.body = body;
+	return node;
+}
+
+function readJsComment_(ctx, start, end) {
+	// JsNode::Comment emits `{type: <"Line"|"Block">, start, end, value}` —
+	// the type tag itself carries the discriminator.
+	const commentType = readStr(ctx);
+	const value = readStr(ctx);
+	return { type: commentType, start, end, value };
+}
+
+// ---------------------------------------------------------------------------
+// Concrete decoders
+// ---------------------------------------------------------------------------
+
+function readRoot(ctx, start, end) {
+	const root = { css: null, js: null, start, end, type: 'Root', fragment: null, options: null };
+	root.css = readU8(ctx) === 0 ? null : readJsonNodeWithPreamble(ctx);
+	root.js = readJsonNodeWithPreamble(ctx);
+	root.fragment = readFragmentDirect(ctx);
+	root.options = readU8(ctx) === 0 ? null : readJsonNodeWithPreamble(ctx);
+	const commentsCount = readU32(ctx);
+	if (commentsCount > 0) {
+		const comments = new Array(commentsCount);
+		for (let i = 0; i < commentsCount; i++) comments[i] = readNode(ctx);
+		root.comments = comments;
+	}
+	if (readU8(ctx) !== 0) root.instance = readNode(ctx);
+	if (readU8(ctx) !== 0) root.module = readNode(ctx);
+	return root;
+}
+
+function readJsonNodeWithPreamble(ctx) {
+	// Read a TAG_JSON node where the preamble lives at the current
+	// cursor (used by Root for child slots — css, js, options).
+	const tag = readU8(ctx);
+	const _start = readU32(ctx);
+	const _end = readU32(ctx);
+	void _start;
+	void _end;
+	if (tag !== TAG_JSON) {
+		throw new EnvelopeError(
+			`parse envelope: expected TAG_JSON child but got 0x${tag.toString(16)}`,
+		);
+	}
+	return readJsonNodePayload(ctx);
+}
+
+function readFragment(ctx) {
+	const count = readU32(ctx);
+	const nodes = new Array(count);
+	for (let i = 0; i < count; i++) nodes[i] = readNode(ctx);
+	return { type: 'Fragment', nodes };
+}
+
+function readFragmentDirect(ctx) {
+	// Expect the TAG_FRAGMENT preamble at the cursor.
+	const tag = readU8(ctx);
+	const _start = readU32(ctx);
+	const _end = readU32(ctx);
+	void _start;
+	void _end;
+	if (tag !== TAG_FRAGMENT) {
+		throw new EnvelopeError(
+			`parse envelope: expected TAG_FRAGMENT but got 0x${tag.toString(16)}`,
+		);
+	}
+	return readFragment(ctx);
+}
+
+function readJsComment(ctx, start, end) {
+	const kindByte = readU8(ctx);
+	const kind = kindByte === 1 ? 'Block' : 'Line';
+	const value = readStr(ctx);
+	const loc = readSourceLocation(ctx);
+	return { type: kind, start, end, value, loc };
+}
+
+function readText(ctx, start, end) {
+	const raw = readStr(ctx);
+	const data = readStr(ctx);
+	return { type: 'Text', start, end, raw, data };
+}
+
+function readComment(ctx, start, end) {
+	const data = readStr(ctx);
+	return { type: 'Comment', start, end, data };
+}
+
+function readExpressionTag(ctx, start, end) {
+	const expression = readNode(ctx);
+	return { type: 'ExpressionTag', start, end, expression };
+}
+
+function readSingleExprTag(ctx, typeName, start, end) {
+	const expression = readNode(ctx);
+	return { type: typeName, start, end, expression };
+}
+
+function readConstTag(ctx, start, end) {
+	const declaration = readNode(ctx);
+	return { type: 'ConstTag', start, end, declaration };
+}
+
+function readDebugTag(ctx, start, end) {
+	const count = readU32(ctx);
+	const identifiers = new Array(count);
+	for (let i = 0; i < count; i++) identifiers[i] = readNode(ctx);
+	return { type: 'DebugTag', start, end, identifiers };
+}
+
+// ---- Elements -------------------------------------------------------------
+
+function readElementCommon(ctx) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const attrCount = readU32(ctx);
+	const attributes = new Array(attrCount);
+	for (let i = 0; i < attrCount; i++) attributes[i] = readNode(ctx);
+	const fragment = readFragmentDirect(ctx);
+	return { name, name_loc, attributes, fragment };
+}
+
+function readElement(ctx, typeName, start, end) {
+	const { name, name_loc, attributes, fragment } = readElementCommon(ctx);
+	const node = { type: typeName, start, end, name, attributes, fragment };
+	if (name_loc !== null) node.name_loc = name_loc;
+	return node;
+}
+
+function readSvelteComponentElement(ctx, start, end) {
+	const { name, name_loc, attributes, fragment } = readElementCommon(ctx);
+	const expression = readNode(ctx);
+	const node = {
+		type: 'SvelteComponent',
+		start,
+		end,
+		name,
+		attributes,
+		fragment,
+		expression,
+	};
+	if (name_loc !== null) node.name_loc = name_loc;
+	return node;
+}
+
+function readSvelteDynamicElement(ctx, start, end) {
+	const { name, name_loc, attributes, fragment } = readElementCommon(ctx);
+	const tagExpr = readNode(ctx);
+	const node = {
+		type: 'SvelteElement',
+		start,
+		end,
+		name,
+		attributes,
+		fragment,
+		tag: tagExpr,
+	};
+	if (name_loc !== null) node.name_loc = name_loc;
+	return node;
+}
+
+// ---- Script ---------------------------------------------------------------
+
+function readScript(ctx, start, end) {
+	const ctxByte = readU8(ctx);
+	const context = ctxByte === 1 ? 'module' : 'default';
+	const content = readNode(ctx);
+	const attrCount = readU32(ctx);
+	const attributes = new Array(attrCount);
+	for (let i = 0; i < attrCount; i++) attributes[i] = readNode(ctx);
+	return { type: 'Script', start, end, context, content, attributes };
+}
+
+// ---- Attributes -----------------------------------------------------------
+
+function readAttributeValue(ctx) {
+	const tag = readU8(ctx);
+	if (tag === ATTRVAL_TRUE) return true;
+	if (tag === ATTRVAL_EXPRESSION) {
+		// The encoded form is a full ExpressionTag preamble + payload.
+		return readNode(ctx);
+	}
+	if (tag === ATTRVAL_SEQUENCE) {
+		const count = readU32(ctx);
+		const parts = new Array(count);
+		for (let i = 0; i < count; i++) parts[i] = readAttributeValuePart(ctx);
+		return parts;
+	}
+	throw new EnvelopeError(`parse envelope: bad attribute-value tag 0x${tag.toString(16)}`);
+}
+
+function readAttributeValuePart(ctx) {
+	// The encoded form is the next node — either TAG_TEXT or TAG_EXPRESSION_TAG.
+	return readNode(ctx);
+}
+
+function readAttributeNode(ctx, start, end) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const value = readAttributeValue(ctx);
+	const node = { type: 'Attribute', start, end, name, value };
+	if (name_loc !== null) node.name_loc = name_loc;
+	return node;
+}
+
+function readSpreadAttribute(ctx, start, end) {
+	const expression = readNode(ctx);
+	return { type: 'SpreadAttribute', start, end, expression };
+}
+
+function readBindDirective(ctx, start, end) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const expression = readNode(ctx);
+	const modifiers = readModifiers(ctx);
+	const node = { start, end, type: 'BindDirective', name, expression, modifiers };
+	if (name_loc !== null) node.name_loc = name_loc;
+	return node;
+}
+
+function readOnDirective(ctx, start, end) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const hasExpr = readU8(ctx) !== 0;
+	const expression = hasExpr ? readNode(ctx) : undefined;
+	const modifiers = readModifiers(ctx);
+	const node = { type: 'OnDirective', start, end, name };
+	if (name_loc !== null) node.name_loc = name_loc;
+	if (expression !== undefined) node.expression = expression;
+	node.modifiers = modifiers;
+	return node;
+}
+
+function readClassDirective(ctx, start, end) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const expression = readNode(ctx);
+	const node = { type: 'ClassDirective', start, end, name, expression };
+	if (name_loc !== null) node.name_loc = name_loc;
+	return node;
+}
+
+function readStyleDirective(ctx, start, end) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const value = readAttributeValue(ctx);
+	const modifiers = readModifiers(ctx);
+	const node = { type: 'StyleDirective', start, end, name, value, modifiers };
+	if (name_loc !== null) node.name_loc = name_loc;
+	return node;
+}
+
+function readTransitionDirective(ctx, start, end) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const hasExpr = readU8(ctx) !== 0;
+	const expression = hasExpr ? readNode(ctx) : undefined;
+	const modifiers = readModifiers(ctx);
+	const intro = readBool(ctx);
+	const outro = readBool(ctx);
+	const hasMeta = readU8(ctx) !== 0;
+	const metadata = hasMeta ? readInlineJson(ctx) : undefined;
+	const node = { type: 'TransitionDirective', start, end, name };
+	if (name_loc !== null) node.name_loc = name_loc;
+	if (expression !== undefined) node.expression = expression;
+	node.modifiers = modifiers;
+	node.intro = intro;
+	node.outro = outro;
+	if (metadata !== undefined) node.metadata = metadata;
+	return node;
+}
+
+function readAnimateDirective(ctx, start, end) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const hasExpr = readU8(ctx) !== 0;
+	const expression = hasExpr ? readNode(ctx) : undefined;
+	const hasMeta = readU8(ctx) !== 0;
+	const metadata = hasMeta ? readInlineJson(ctx) : undefined;
+	const node = { type: 'AnimateDirective', start, end, name };
+	if (name_loc !== null) node.name_loc = name_loc;
+	if (expression !== undefined) node.expression = expression;
+	if (metadata !== undefined) node.metadata = metadata;
+	return node;
+}
+
+function readUseDirective(ctx, start, end) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const hasExpr = readU8(ctx) !== 0;
+	const expression = hasExpr ? readNode(ctx) : undefined;
+	const node = { type: 'UseDirective', start, end, name };
+	if (name_loc !== null) node.name_loc = name_loc;
+	if (expression !== undefined) node.expression = expression;
+	return node;
+}
+
+function readLetDirective(ctx, start, end) {
+	const name = readStr(ctx);
+	const name_loc = readOptSourceLocation(ctx);
+	const hasExpr = readU8(ctx) !== 0;
+	const expression = hasExpr ? readNode(ctx) : undefined;
+	const node = { type: 'LetDirective', start, end, name };
+	if (name_loc !== null) node.name_loc = name_loc;
+	if (expression !== undefined) node.expression = expression;
+	return node;
+}
+
+// ---- Blocks ---------------------------------------------------------------
+
+function readIfBlock(ctx, start, end) {
+	const elseif = readBool(ctx);
+	const test = readNode(ctx);
+	const consequent = readFragmentDirect(ctx);
+	const hasAlt = readU8(ctx) !== 0;
+	const alternate = hasAlt ? readFragmentDirect(ctx) : null;
+	return { type: 'IfBlock', elseif, start, end, test, consequent, alternate };
+}
+
+function readEachBlock(ctx, start, end) {
+	const expression = readNode(ctx);
+	const body = readFragmentDirect(ctx);
+	const hasCtx = readU8(ctx) !== 0;
+	const context = hasCtx ? readNode(ctx) : null;
+	const hasFallback = readU8(ctx) !== 0;
+	const fallback = hasFallback ? readFragmentDirect(ctx) : undefined;
+	const index = readOptStr(ctx);
+	const hasKey = readU8(ctx) !== 0;
+	const key = hasKey ? readNode(ctx) : undefined;
+	const node = { type: 'EachBlock', start, end, expression, body, context };
+	if (fallback !== undefined) node.fallback = fallback;
+	if (index !== null) node.index = index;
+	if (key !== undefined) node.key = key;
+	return node;
+}
+
+function readAwaitBlock(ctx, start, end) {
+	const expression = readNode(ctx);
+	const hasValue = readU8(ctx) !== 0;
+	const value = hasValue ? readNode(ctx) : null;
+	const hasError = readU8(ctx) !== 0;
+	const error = hasError ? readNode(ctx) : null;
+	const hasPending = readU8(ctx) !== 0;
+	const pending = hasPending ? readFragmentDirect(ctx) : null;
+	const hasThen = readU8(ctx) !== 0;
+	const thenFrag = hasThen ? readFragmentDirect(ctx) : null;
+	const hasCatch = readU8(ctx) !== 0;
+	const catchFrag = hasCatch ? readFragmentDirect(ctx) : null;
+	return {
+		type: 'AwaitBlock',
+		start,
+		end,
+		expression,
+		value,
+		error,
+		pending,
+		then: thenFrag,
+		catch: catchFrag,
+	};
+}
+
+function readKeyBlock(ctx, start, end) {
+	const expression = readNode(ctx);
+	const fragment = readFragmentDirect(ctx);
+	return { type: 'KeyBlock', start, end, expression, fragment };
+}
+
+function readSnippetBlock(ctx, start, end) {
+	const expression = readNode(ctx);
+	const typeParams = readOptStr(ctx);
+	const paramCount = readU32(ctx);
+	const parameters = new Array(paramCount);
+	for (let i = 0; i < paramCount; i++) parameters[i] = readNode(ctx);
+	const body = readFragmentDirect(ctx);
+	const node = { type: 'SnippetBlock', start, end, expression, parameters, body };
+	if (typeParams !== null) node.typeParams = typeParams;
+	return node;
+}
+
+module.exports = { decodeParseEnvelope, EnvelopeError };

--- a/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -66,6 +66,7 @@ const ATTRVAL_SEQUENCE = 0x62;
 
 // Header flag bits — see napi_raw_parse::FLAG_*.
 const FLAG_JSNODE_NO_LOC = 1 << 0;
+const FLAG_CSS_STUB_ONLY = 1 << 1;
 
 const TAG_IF_BLOCK = 0x70;
 const TAG_EACH_BLOCK = 0x71;
@@ -221,6 +222,7 @@ function decodeParseEnvelope(buf) {
 	const rootOffset = view.getUint32(12, true);
 	const flags = view.getUint32(20, true);
 	const skipJsNodeLoc = (flags & FLAG_JSNODE_NO_LOC) !== 0;
+	const cssStubOnly = (flags & FLAG_CSS_STUB_ONLY) !== 0;
 	const bytes =
 		buf instanceof Uint8Array
 			? buf
@@ -230,7 +232,7 @@ function decodeParseEnvelope(buf) {
 	// `TextDecoder.decode(typedArray.subarray(start, end))` for the
 	// short ASCII strings that dominate an AST.
 	const isBuffer = hasBuffer && Buffer.isBuffer(bytes);
-	const ctx = { view, bytes, pos: rootOffset, isBuffer, skipJsNodeLoc };
+	const ctx = { view, bytes, pos: rootOffset, isBuffer, skipJsNodeLoc, cssStubOnly };
 	return readNode(ctx);
 }
 
@@ -1445,7 +1447,30 @@ function readJsComment_(ctx, start, end) {
 
 function readRoot(ctx, start, end) {
 	const root = { css: null, js: null, start, end, type: 'Root', fragment: null, options: null };
-	root.css = readU8(ctx) === 0 ? null : readJsonNodeWithPreamble(ctx);
+	if (readU8(ctx) === 0) {
+		root.css = null;
+	} else if (ctx.cssStubOnly) {
+		// `FLAG_CSS_STUB_ONLY` — the encoder wrote a TAG_JSON preamble
+		// with an empty payload; the only information that survives is
+		// the outer `start` / `end`. Rebuild the minimal StyleSheet
+		// shape consumers expect.
+		const tag = readU8(ctx);
+		const cssStart = readU32(ctx);
+		const cssEnd = readU32(ctx);
+		const len = readU32(ctx);
+		ctx.pos += len;
+		void tag;
+		root.css = {
+			type: 'StyleSheet',
+			start: cssStart,
+			end: cssEnd,
+			attributes: [],
+			children: [],
+			content: { start: cssStart, end: cssEnd, styles: '', comment: null },
+		};
+	} else {
+		root.css = readJsonNodeWithPreamble(ctx);
+	}
 	root.js = readJsonNodeWithPreamble(ctx);
 	root.fragment = readFragmentDirect(ctx);
 	root.options = readU8(ctx) === 0 ? null : readJsonNodeWithPreamble(ctx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod napi;
 // that unit tests and any future non-NAPI consumers (the WASM build, for
 // example) can exercise the encoder.
 pub mod napi_raw;
+pub mod napi_raw_parse;
 
 #[cfg(feature = "wasm")]
 pub mod wasm;

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -92,6 +92,15 @@ pub struct NapiParseOptions {
     /// AST and a faster `JSON.parse` (or, when paired with
     /// `parseEnvelope`, a tighter binary buffer).
     pub skip_expression_loc: Option<bool>,
+    /// Skip emitting the full CSS `StyleSheet` AST — only the outer
+    /// `start`/`end` positions are kept. The decoded `css` field
+    /// becomes a minimal stub (`{ type: "StyleSheet", start, end,
+    /// attributes: [], children: [], content: { start, end,
+    /// styles: "", comment: null } }`). Use this when the downstream
+    /// pipeline re-parses style blocks with its own CSS parser (e.g.
+    /// `svelte-eslint-parser` uses postcss). Saves ~5–10 KB of buffer
+    /// and the matching JSON-parse cost on the JS side per component.
+    pub skip_css_ast: Option<bool>,
 }
 
 /// Parse a Svelte component and return the AST as a JSON string.
@@ -147,9 +156,20 @@ pub fn napi_parse_envelope(
         ..ParseOptions::default()
     };
     let skip_loc = parse_options.skip_expression_loc;
+    let skip_css = options
+        .as_ref()
+        .and_then(|o| o.skip_css_ast)
+        .unwrap_or(false);
     let ast = rust_parse(&source, parse_options)
         .map_err(|e| napi::Error::from_reason(format!("{e:?}")))?;
-    let buf = crate::napi_raw_parse::encode_root_to_vec_with_options(&ast, &source, skip_loc);
+    // napi-rs's `Vec<u8> → Buffer` conversion is already zero-copy
+    // (V8 adopts the `Vec`'s allocation); a bumpalo-backed variant
+    // measured ~20% slower on representative inputs because the
+    // pre-sized arena + finalizer plumbing outweighs the saved
+    // `Vec::reserve` calls for envelopes that fit in a single growth
+    // step.
+    let buf =
+        crate::napi_raw_parse::encode_root_to_vec_with_flags(&ast, &source, skip_loc, skip_css);
     Ok(buf.into())
 }
 

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -82,6 +82,77 @@ fn warnings_to_json(warnings: &[crate::compiler::Warning]) -> Vec<Value> {
         .collect()
 }
 
+/// Parse options surfaced to the NAPI bindings.
+#[napi(object)]
+pub struct NapiParseOptions {
+    /// Skip emitting nested `loc:{ start, end }` blocks on Expression
+    /// sub-trees. The top-level `start`/`end` byte offsets are still
+    /// present. Callers that re-parse expression ranges with their own
+    /// parser (e.g. `svelte-eslint-parser`) can opt in for a smaller
+    /// AST and a faster `JSON.parse` (or, when paired with
+    /// `parseEnvelope`, a tighter binary buffer).
+    pub skip_expression_loc: Option<bool>,
+}
+
+/// Parse a Svelte component and return the AST as a JSON string.
+///
+/// Mirrors the wasm-exposed `parse_svelte` function but over the NAPI
+/// boundary — no wasm linear-memory copy, no `wasm_bindgen` allocator.
+/// The caller is responsible for `JSON.parse` on the returned string.
+///
+/// For the fastest path skip JSON entirely: see [`napi_parse_envelope`]
+/// and the matching `decodeParseEnvelope` JS decoder.
+#[napi(js_name = "parse")]
+pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Result<String> {
+    use crate::compiler::phases::phase1_parse::{ParseOptions, parse as rust_parse};
+
+    let parse_options = ParseOptions {
+        skip_expression_loc: options
+            .as_ref()
+            .and_then(|o| o.skip_expression_loc)
+            .unwrap_or(false),
+        ..ParseOptions::default()
+    };
+    match rust_parse(&source, parse_options) {
+        Ok(ast) => {
+            // Serialize within the AST's arena so `JsNodeId`s in the
+            // Serialize impls resolve (mirrors `wasm::parse_svelte`).
+            crate::ast::arena::with_serialize_arena(&ast.arena, || {
+                serde_json::to_string(&ast)
+                    .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}")))
+            })
+        }
+        Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
+    }
+}
+
+/// Parse a Svelte component and return a raw-transfer envelope.
+///
+/// Encodes the AST into the rsvelte parse envelope format
+/// (`napi_raw_parse`). Pair with the matching JS decoder in
+/// `@rsvelte/vite-plugin-svelte-native/parse-envelope.js` to skip
+/// `JSON.parse`'s tokenization cost on the JS side.
+#[napi(js_name = "parseEnvelope")]
+pub fn napi_parse_envelope(
+    source: String,
+    options: Option<NapiParseOptions>,
+) -> napi::Result<Buffer> {
+    use crate::compiler::phases::phase1_parse::{ParseOptions, parse as rust_parse};
+
+    let parse_options = ParseOptions {
+        skip_expression_loc: options
+            .as_ref()
+            .and_then(|o| o.skip_expression_loc)
+            .unwrap_or(false),
+        ..ParseOptions::default()
+    };
+    let skip_loc = parse_options.skip_expression_loc;
+    let ast = rust_parse(&source, parse_options)
+        .map_err(|e| napi::Error::from_reason(format!("{e:?}")))?;
+    let buf = crate::napi_raw_parse::encode_root_to_vec_with_options(&ast, &source, skip_loc);
+    Ok(buf.into())
+}
+
 ///
 /// Takes source code and an options object, returns a result object
 /// matching the official `svelte/compiler` output shape.

--- a/src/napi_raw_parse.rs
+++ b/src/napi_raw_parse.rs
@@ -64,7 +64,15 @@ pub const HEADER_LEN: usize = 24;
 //   bit 0 — every JsNode in this envelope has `loc == None`. The decoder
 //           can skip the per-node loc-flag byte and reconstruct `loc`
 //           as absent without reading any payload.
+//   bit 1 — the CSS `StyleSheet` body has been omitted. The encoder
+//           writes only the outer `start` / `end` and the decoder
+//           reconstructs an empty stub: `{ type: "StyleSheet", start,
+//           end, attributes: [], children: [], content: { start, end,
+//           styles: "", comment: null } }`. Use when the downstream
+//           pipeline re-parses the `<style>` content with its own
+//           CSS parser (e.g. `svelte-eslint-parser` uses postcss).
 pub const FLAG_JSNODE_NO_LOC: u32 = 1 << 0;
+pub const FLAG_CSS_STUB_ONLY: u32 = 1 << 1;
 
 // ---------------------------------------------------------------------------
 // Tag identifiers
@@ -394,9 +402,17 @@ fn write_opt_expression<W: Writer>(
 // which guarantees every JsNode has `loc: None`.
 thread_local! {
     static SKIP_JSNODE_LOC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    // Emit only a stub for the `Root.css` payload. Mirrors
+    // `FLAG_CSS_STUB_ONLY` in the envelope header — set when the
+    // caller opts into `skip_css_ast`, which omits the full
+    // `StyleSheet` body from the wire.
+    static SKIP_CSS_AST: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 fn jsnode_loc_elided() -> bool {
     SKIP_JSNODE_LOC.with(|c| c.get())
+}
+fn css_stub_only() -> bool {
+    SKIP_CSS_AST.with(|c| c.get())
 }
 
 /// `typed_expr::Loc` — emits a flag byte + 6 u32s (with optional
@@ -1009,7 +1025,16 @@ fn write_root<W: Writer>(w: &mut W, root: &Root) -> std::io::Result<()> {
     match &root.css {
         Some(css) => {
             write_u8(w, 1);
-            write_json_node(w, u32::MAX, u32::MAX, &**css)?;
+            if css_stub_only() {
+                // Only the outer `start` / `end` cross the wire — the
+                // decoder fills in the rest of the StyleSheet stub.
+                // Skipped tag carries the positions so the buffer
+                // doesn't need a separate fast-path branch.
+                write_preamble(w, TAG_JSON, css.start, css.end);
+                write_u32(w, 0); // empty JSON payload
+            } else {
+                write_json_node(w, u32::MAX, u32::MAX, &**css)?;
+            }
         }
         None => write_u8(w, 0),
     }
@@ -1980,24 +2005,35 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
 
 /// Encode a parsed `Root` AST into a fresh `Vec<u8>` envelope.
 pub fn encode_root_to_vec(root: &Root, source: &str) -> Vec<u8> {
-    encode_root_to_vec_with_options(root, source, false)
+    encode_root_to_vec_with_flags(root, source, false, false)
 }
 
 /// Encode a parsed `Root` AST with caller-supplied envelope flags.
 ///
-/// `skip_jsnode_loc` should mirror the value of
-/// `ParseOptions::skip_expression_loc` used when parsing — it tells the
-/// encoder / decoder to elide the per-JsNode loc-flag byte, since every
-/// JsNode is guaranteed to have `loc == None`.
+/// - `skip_jsnode_loc` mirrors `ParseOptions::skip_expression_loc` —
+///   it tells the encoder/decoder to elide the per-JsNode loc-flag
+///   byte, since every JsNode is guaranteed to have `loc == None`.
+/// - `skip_css_ast` omits the CSS `StyleSheet` body from the wire; the
+///   decoder reconstructs a `{ type: "StyleSheet", start, end }` stub.
+pub fn encode_root_to_vec_with_flags(
+    root: &Root,
+    source: &str,
+    skip_jsnode_loc: bool,
+    skip_css_ast: bool,
+) -> Vec<u8> {
+    let cap = HEADER_LEN + source.len().saturating_mul(20).max(4096);
+    let mut buf: Vec<u8> = Vec::with_capacity(cap);
+    encode_root_into(&mut buf, root, source, skip_jsnode_loc, skip_css_ast);
+    buf
+}
+
+/// Backwards-compatible wrapper for the 3-argument variant.
 pub fn encode_root_to_vec_with_options(
     root: &Root,
     source: &str,
     skip_jsnode_loc: bool,
 ) -> Vec<u8> {
-    let cap = HEADER_LEN + source.len().saturating_mul(20).max(4096);
-    let mut buf: Vec<u8> = Vec::with_capacity(cap);
-    encode_root_into(&mut buf, root, source, skip_jsnode_loc);
-    buf
+    encode_root_to_vec_with_flags(root, source, skip_jsnode_loc, false)
 }
 
 /// Write the envelope into `writer`. The writer must start empty.
@@ -2006,6 +2042,7 @@ pub fn encode_root_into<W: Writer>(
     root: &Root,
     source: &str,
     skip_jsnode_loc: bool,
+    skip_css_ast: bool,
 ) {
     debug_assert_eq!(writer.position(), 0, "encoder expects an empty writer");
 
@@ -2018,22 +2055,29 @@ pub fn encode_root_into<W: Writer>(
     if skip_jsnode_loc {
         flags |= FLAG_JSNODE_NO_LOC;
     }
+    if skip_css_ast {
+        flags |= FLAG_CSS_STUB_ONLY;
+    }
     write_u32(writer, flags);
     debug_assert_eq!(writer.position(), HEADER_LEN);
 
     let root_off = writer.position() as u32;
     writer.patch_u32(12, root_off);
 
-    // RAII guard: ensure the per-encode `SKIP_JSNODE_LOC` thread-local
-    // is reset even if encoding panics.
-    struct Guard(bool);
+    // RAII guards: reset the per-encode thread-locals even on panic.
+    struct Guard {
+        prev_loc: bool,
+        prev_css: bool,
+    }
     impl Drop for Guard {
         fn drop(&mut self) {
-            SKIP_JSNODE_LOC.with(|c| c.set(self.0));
+            SKIP_JSNODE_LOC.with(|c| c.set(self.prev_loc));
+            SKIP_CSS_AST.with(|c| c.set(self.prev_css));
         }
     }
-    let prev = SKIP_JSNODE_LOC.with(|c| c.replace(skip_jsnode_loc));
-    let _guard = Guard(prev);
+    let prev_loc = SKIP_JSNODE_LOC.with(|c| c.replace(skip_jsnode_loc));
+    let prev_css = SKIP_CSS_AST.with(|c| c.replace(skip_css_ast));
+    let _guard = Guard { prev_loc, prev_css };
 
     let _ = crate::ast::arena::with_serialize_arena(&root.arena, || write_root(writer, root));
 

--- a/src/napi_raw_parse.rs
+++ b/src/napi_raw_parse.rs
@@ -1,0 +1,2087 @@
+//! Raw-transfer envelope format for `parse()`.
+//!
+//! Inspired by oxc's `raw_transfer` mode: encode the AST into a single
+//! contiguous binary buffer, cross the NAPI boundary as one `Buffer`,
+//! and let the JS side decode each node by reading bytes via
+//! `DataView`. Avoids `JSON.parse`'s tokenization cost — the dominant
+//! overhead in the rsvelte + svelte-eslint-parser pipeline.
+//!
+//! ## Coverage
+//!
+//! - **Binary**: `Root`, `Fragment`, every `TemplateNode` variant
+//!   (Text, Comment, ExpressionTag, HtmlTag, ConstTag, DebugTag,
+//!   RenderTag, AttachTag, IfBlock, EachBlock, AwaitBlock, KeyBlock,
+//!   SnippetBlock, RegularElement, Component, TitleElement,
+//!   SlotElement, SvelteBody/Document/Fragment/Boundary/Head/Options/
+//!   Self/Window, SvelteComponent, SvelteElement), every `Attribute`
+//!   variant (Attribute, SpreadAttribute, AttachTag-as-attr, all eight
+//!   directives), `AttributeValue` and `AttributeValuePart`, `Script`,
+//!   `JsComment`, `SourceLocation`, and every one of the **74 JsNode
+//!   variants** (estree expressions and statements, plus a handful of
+//!   TS bridge variants).
+//! - **JSON fallback (`TAG_JSON`)**: the entire `StyleSheet` sub-tree,
+//!   `SvelteOptions`, `TransitionDirective`/`AnimateDirective`
+//!   `metadata`, and `Root.js`. These are rare and have many optional
+//!   fields; switching them to dedicated tags is a follow-up.
+//!
+//! ## Envelope v1 layout
+//!
+//! ```text
+//! offset  size  field
+//! 0       4     magic        "RPV1" (0x31_56_50_52 LE)
+//! 4       4     version      u32 LE
+//! 8       4     total_len    u32 LE — matches buffer.byteLength
+//! 12      4     root_offset  u32 LE — start of the root node
+//! 16      4     source_len   u32 LE
+//! 20      4     flags        u32 LE — see FLAG_* constants
+//! 24..    var   body         packed node stream
+//! ```
+//!
+//! ## Per-node layout
+//!
+//! Every node begins with a 9-byte preamble:
+//!
+//! ```text
+//! 0   1   tag    u8
+//! 1   4   start  u32 LE
+//! 5   4   end    u32 LE
+//! ```
+//!
+//! followed by a payload whose shape depends on the tag. See the
+//! `write_*` helpers below for the canonical wire layouts.
+
+use serde::Serialize;
+
+use crate::ast::arena::{IdRange, JsNodeId, ParseArena};
+use crate::ast::template::*;
+use crate::ast::typed_expr::{JsNode, LiteralValue, Loc, RegexValue, TemplateElementValue};
+
+pub const MAGIC: u32 = 0x3156_5052; // "RPV1" little-endian
+pub const VERSION: u32 = 1;
+pub const HEADER_LEN: usize = 24;
+
+// Header `flags` word (offset 20):
+//   bit 0 — every JsNode in this envelope has `loc == None`. The decoder
+//           can skip the per-node loc-flag byte and reconstruct `loc`
+//           as absent without reading any payload.
+pub const FLAG_JSNODE_NO_LOC: u32 = 1 << 0;
+
+// ---------------------------------------------------------------------------
+// Tag identifiers
+// ---------------------------------------------------------------------------
+//
+// Layout:
+//   0x00..0x0F  framework
+//   0x10..0x1F  text / tags
+//   0x20..0x3F  element variants
+//   0x40..0x4F  script / options / misc
+//   0x50..0x6F  attributes / directives / attribute values
+//   0x70..0x7F  block variants
+//   0x80..0xCB  JsNode (estree) variants
+//
+// Reserved ranges leave room for future growth without renumbering.
+
+pub const TAG_JSON: u8 = 0x00;
+pub const TAG_ROOT: u8 = 0x01;
+pub const TAG_FRAGMENT: u8 = 0x02;
+pub const TAG_JS_COMMENT: u8 = 0x03;
+
+pub const TAG_TEXT: u8 = 0x10;
+pub const TAG_COMMENT: u8 = 0x11;
+pub const TAG_EXPRESSION_TAG: u8 = 0x12;
+pub const TAG_HTML_TAG: u8 = 0x13;
+pub const TAG_CONST_TAG: u8 = 0x14;
+pub const TAG_DEBUG_TAG: u8 = 0x15;
+pub const TAG_RENDER_TAG: u8 = 0x16;
+pub const TAG_ATTACH_TAG: u8 = 0x17;
+
+pub const TAG_REGULAR_ELEMENT: u8 = 0x20;
+pub const TAG_COMPONENT: u8 = 0x21;
+pub const TAG_TITLE_ELEMENT: u8 = 0x22;
+pub const TAG_SLOT_ELEMENT: u8 = 0x23;
+pub const TAG_SVELTE_BODY: u8 = 0x24;
+pub const TAG_SVELTE_DOCUMENT: u8 = 0x25;
+pub const TAG_SVELTE_FRAGMENT: u8 = 0x26;
+pub const TAG_SVELTE_BOUNDARY: u8 = 0x27;
+pub const TAG_SVELTE_HEAD: u8 = 0x28;
+pub const TAG_SVELTE_OPTIONS_EL: u8 = 0x29;
+pub const TAG_SVELTE_SELF: u8 = 0x2A;
+pub const TAG_SVELTE_WINDOW: u8 = 0x2B;
+pub const TAG_SVELTE_COMPONENT: u8 = 0x2C;
+pub const TAG_SVELTE_ELEMENT: u8 = 0x2D;
+
+pub const TAG_SCRIPT: u8 = 0x40;
+pub const TAG_SVELTE_OPTIONS: u8 = 0x41;
+
+pub const TAG_ATTRIBUTE: u8 = 0x50;
+pub const TAG_SPREAD_ATTRIBUTE: u8 = 0x51;
+// 0x17 (TAG_ATTACH_TAG) is reused when AttachTag appears in an attribute list.
+pub const TAG_BIND_DIRECTIVE: u8 = 0x52;
+pub const TAG_ON_DIRECTIVE: u8 = 0x53;
+pub const TAG_CLASS_DIRECTIVE: u8 = 0x54;
+pub const TAG_STYLE_DIRECTIVE: u8 = 0x55;
+pub const TAG_TRANSITION_DIRECTIVE: u8 = 0x56;
+pub const TAG_ANIMATE_DIRECTIVE: u8 = 0x57;
+pub const TAG_USE_DIRECTIVE: u8 = 0x58;
+pub const TAG_LET_DIRECTIVE: u8 = 0x59;
+
+// `AttributeValue::True` doesn't carry start/end (the JSON form is
+// just the boolean literal `true`), so it gets a tag without a
+// preamble — see `write_attribute_value`.
+pub const ATTRVAL_TRUE: u8 = 0x60;
+pub const ATTRVAL_EXPRESSION: u8 = 0x61;
+pub const ATTRVAL_SEQUENCE: u8 = 0x62;
+
+pub const TAG_IF_BLOCK: u8 = 0x70;
+pub const TAG_EACH_BLOCK: u8 = 0x71;
+pub const TAG_AWAIT_BLOCK: u8 = 0x72;
+pub const TAG_KEY_BLOCK: u8 = 0x73;
+pub const TAG_SNIPPET_BLOCK: u8 = 0x74;
+
+// JsNode tags: 0x80..0xCB — 74 variants in JsNode enum declaration order.
+pub const JS_IDENTIFIER: u8 = 0x80;
+pub const JS_PRIVATE_IDENTIFIER: u8 = 0x81;
+pub const JS_LITERAL: u8 = 0x82;
+pub const JS_BINARY_EXPRESSION: u8 = 0x83;
+pub const JS_LOGICAL_EXPRESSION: u8 = 0x84;
+pub const JS_UNARY_EXPRESSION: u8 = 0x85;
+pub const JS_CONDITIONAL_EXPRESSION: u8 = 0x86;
+pub const JS_CALL_EXPRESSION: u8 = 0x87;
+pub const JS_MEMBER_EXPRESSION: u8 = 0x88;
+pub const JS_NEW_EXPRESSION: u8 = 0x89;
+pub const JS_FUNCTION_EXPRESSION: u8 = 0x8A;
+pub const JS_CLASS_EXPRESSION: u8 = 0x8B;
+pub const JS_ARROW_FUNCTION_EXPRESSION: u8 = 0x8C;
+pub const JS_ASSIGNMENT_EXPRESSION: u8 = 0x8D;
+pub const JS_UPDATE_EXPRESSION: u8 = 0x8E;
+pub const JS_SEQUENCE_EXPRESSION: u8 = 0x8F;
+pub const JS_ARRAY_EXPRESSION: u8 = 0x90;
+pub const JS_OBJECT_EXPRESSION: u8 = 0x91;
+pub const JS_TEMPLATE_LITERAL: u8 = 0x92;
+pub const JS_TAGGED_TEMPLATE_EXPRESSION: u8 = 0x93;
+pub const JS_TEMPLATE_ELEMENT: u8 = 0x94;
+pub const JS_THIS_EXPRESSION: u8 = 0x95;
+pub const JS_SUPER: u8 = 0x96;
+pub const JS_IMPORT_EXPRESSION: u8 = 0x97;
+pub const JS_AWAIT_EXPRESSION: u8 = 0x98;
+pub const JS_YIELD_EXPRESSION: u8 = 0x99;
+pub const JS_CHAIN_EXPRESSION: u8 = 0x9A;
+pub const JS_META_PROPERTY: u8 = 0x9B;
+pub const JS_SPREAD_ELEMENT: u8 = 0x9C;
+pub const JS_OBJECT_PATTERN: u8 = 0x9D;
+pub const JS_ARRAY_PATTERN: u8 = 0x9E;
+pub const JS_ASSIGNMENT_PATTERN: u8 = 0x9F;
+pub const JS_REST_ELEMENT: u8 = 0xA0;
+pub const JS_PROPERTY: u8 = 0xA1;
+pub const JS_PROGRAM: u8 = 0xA2;
+pub const JS_EXPRESSION_STATEMENT: u8 = 0xA3;
+pub const JS_BLOCK_STATEMENT: u8 = 0xA4;
+pub const JS_VARIABLE_DECLARATION: u8 = 0xA5;
+pub const JS_VARIABLE_DECLARATOR: u8 = 0xA6;
+pub const JS_FUNCTION_DECLARATION: u8 = 0xA7;
+pub const JS_CLASS_DECLARATION: u8 = 0xA8;
+pub const JS_RETURN_STATEMENT: u8 = 0xA9;
+pub const JS_THROW_STATEMENT: u8 = 0xAA;
+pub const JS_IF_STATEMENT: u8 = 0xAB;
+pub const JS_FOR_STATEMENT: u8 = 0xAC;
+pub const JS_FOR_OF_STATEMENT: u8 = 0xAD;
+pub const JS_FOR_IN_STATEMENT: u8 = 0xAE;
+pub const JS_WHILE_STATEMENT: u8 = 0xAF;
+pub const JS_DO_WHILE_STATEMENT: u8 = 0xB0;
+pub const JS_TRY_STATEMENT: u8 = 0xB1;
+pub const JS_CATCH_CLAUSE: u8 = 0xB2;
+pub const JS_SWITCH_STATEMENT: u8 = 0xB3;
+pub const JS_SWITCH_CASE: u8 = 0xB4;
+pub const JS_LABELED_STATEMENT: u8 = 0xB5;
+pub const JS_BREAK_STATEMENT: u8 = 0xB6;
+pub const JS_CONTINUE_STATEMENT: u8 = 0xB7;
+pub const JS_EMPTY_STATEMENT: u8 = 0xB8;
+pub const JS_DEBUGGER_STATEMENT: u8 = 0xB9;
+pub const JS_IMPORT_DECLARATION: u8 = 0xBA;
+pub const JS_IMPORT_SPECIFIER: u8 = 0xBB;
+pub const JS_IMPORT_DEFAULT_SPECIFIER: u8 = 0xBC;
+pub const JS_IMPORT_NAMESPACE_SPECIFIER: u8 = 0xBD;
+pub const JS_EXPORT_NAMED_DECLARATION: u8 = 0xBE;
+pub const JS_EXPORT_DEFAULT_DECLARATION: u8 = 0xBF;
+pub const JS_EXPORT_SPECIFIER: u8 = 0xC0;
+pub const JS_CLASS_BODY: u8 = 0xC1;
+pub const JS_METHOD_DEFINITION: u8 = 0xC2;
+pub const JS_PROPERTY_DEFINITION: u8 = 0xC3;
+pub const JS_STATIC_BLOCK: u8 = 0xC4;
+pub const JS_DECORATOR: u8 = 0xC5;
+pub const JS_TS_TYPE_ANNOTATION: u8 = 0xC6;
+pub const JS_TS_ENUM_DECLARATION: u8 = 0xC7;
+pub const JS_TS_MODULE_DECLARATION: u8 = 0xC8;
+pub const JS_COMMENT: u8 = 0xC9;
+// Special sentinels for the JsNode null/raw fallback variants — they
+// don't fit the normal preamble-with-positions shape.
+pub const JS_NULL: u8 = 0xCA;
+pub const JS_RAW_JSON: u8 = 0xCB;
+
+// LiteralValue inner tag (within a JS_LITERAL payload).
+const LV_NULL: u8 = 0;
+const LV_BOOL_FALSE: u8 = 1;
+const LV_BOOL_TRUE: u8 = 2;
+const LV_NUMBER_I64: u8 = 3;
+const LV_NUMBER_F64: u8 = 4;
+const LV_STRING: u8 = 5;
+const LV_REGEX: u8 = 6;
+
+// ---------------------------------------------------------------------------
+// Writer trait + Vec impl
+// ---------------------------------------------------------------------------
+
+/// Append-only byte writer. Mirrors `napi_raw::Writer` but stays
+/// independent so the compile envelope and the parse envelope can
+/// evolve separately.
+pub trait Writer {
+    fn write_bytes(&mut self, bytes: &[u8]);
+    fn position(&self) -> usize;
+    fn patch_u32(&mut self, offset: usize, value: u32);
+}
+
+impl Writer for Vec<u8> {
+    #[inline]
+    fn write_bytes(&mut self, bytes: &[u8]) {
+        self.extend_from_slice(bytes);
+    }
+    #[inline]
+    fn position(&self) -> usize {
+        self.len()
+    }
+    #[inline]
+    fn patch_u32(&mut self, offset: usize, value: u32) {
+        self[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+}
+
+#[inline]
+fn write_u8<W: Writer>(w: &mut W, v: u8) {
+    w.write_bytes(&[v]);
+}
+#[inline]
+fn write_u32<W: Writer>(w: &mut W, v: u32) {
+    w.write_bytes(&v.to_le_bytes());
+}
+#[inline]
+fn write_bool<W: Writer>(w: &mut W, v: bool) {
+    w.write_bytes(&[u8::from(v)]);
+}
+#[inline]
+fn write_str<W: Writer>(w: &mut W, s: &str) {
+    write_u32(w, s.len() as u32);
+    w.write_bytes(s.as_bytes());
+}
+#[inline]
+fn write_opt_str<W: Writer>(w: &mut W, s: Option<&str>) {
+    match s {
+        Some(s) => {
+            write_u8(w, 1);
+            write_str(w, s);
+        }
+        None => write_u8(w, 0),
+    }
+}
+#[inline]
+fn write_preamble<W: Writer>(w: &mut W, tag: u8, start: u32, end: u32) {
+    write_u8(w, tag);
+    write_u32(w, start);
+    write_u32(w, end);
+}
+
+/// Serialize a `SourceLocation` as 24 bytes — flattens the nested
+/// `{ start: {line, column, character}, end: {…} }` JSON shape into
+/// six u32s. The decoder rebuilds the object form.
+fn write_source_location<W: Writer>(w: &mut W, loc: &crate::ast::span::SourceLocation) {
+    write_u32(w, loc.start.line);
+    write_u32(w, loc.start.column);
+    write_u32(w, loc.start.character);
+    write_u32(w, loc.end.line);
+    write_u32(w, loc.end.column);
+    write_u32(w, loc.end.character);
+}
+fn write_opt_source_location<W: Writer>(w: &mut W, loc: Option<&crate::ast::span::SourceLocation>) {
+    match loc {
+        Some(loc) => {
+            write_u8(w, 1);
+            write_source_location(w, loc);
+        }
+        None => write_u8(w, 0),
+    }
+}
+
+/// Write a list of `CompactString` modifiers as `[u32 count][str…]`.
+fn write_modifiers<W: Writer>(w: &mut W, mods: &[compact_str::CompactString]) {
+    write_u32(w, mods.len() as u32);
+    for m in mods {
+        write_str(w, m.as_str());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TAG_JSON — fallback for nodes whose shape we haven't tagged yet
+// ---------------------------------------------------------------------------
+
+/// Stream a `Serialize` value as length-prefixed JSON behind
+/// `TAG_JSON`. Used by callers that need to inline a sub-tree as
+/// JSON (`StyleSheet`, `SvelteOptions`, directive `metadata`, …).
+fn write_json_node<W: Writer, T: Serialize + ?Sized>(
+    w: &mut W,
+    start: u32,
+    end: u32,
+    value: &T,
+) -> std::io::Result<()> {
+    write_preamble(w, TAG_JSON, start, end);
+    let len_slot = w.position();
+    write_u32(w, 0);
+    let payload_start = w.position();
+    struct WriterAdapter<'a, W2: Writer>(&'a mut W2);
+    impl<W2: Writer> std::io::Write for WriterAdapter<'_, W2> {
+        #[inline]
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.write_bytes(bytes);
+            Ok(bytes.len())
+        }
+        #[inline]
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut shim = WriterAdapter(w);
+    serde_json::to_writer(&mut shim, value).map_err(std::io::Error::other)?;
+    let payload_end = shim.0.position();
+    w.patch_u32(len_slot, (payload_end - payload_start) as u32);
+    Ok(())
+}
+
+/// Inline an `Expression` as a binary JsNode sub-tree when typed; fall
+/// back to JSON for the legacy `Value` representation.
+fn write_expression<W: Writer>(
+    w: &mut W,
+    expr: &crate::ast::js::Expression,
+) -> std::io::Result<()> {
+    use crate::ast::js::Expression;
+    match expr {
+        Expression::Typed(te) => crate::ast::arena::with_current_serialize_arena(|arena| {
+            write_js_node(w, &te.node, arena)
+        }),
+        Expression::Lazy { start, end, .. } => write_json_node(w, *start, *end, expr),
+        Expression::Value(_) => write_json_node(w, u32::MAX, u32::MAX, expr),
+    }
+}
+fn write_opt_expression<W: Writer>(
+    w: &mut W,
+    expr: Option<&crate::ast::js::Expression>,
+) -> std::io::Result<()> {
+    match expr {
+        Some(e) => {
+            write_u8(w, 1);
+            write_expression(w, e)
+        }
+        None => {
+            write_u8(w, 0);
+            Ok(())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JsNode helpers
+// ---------------------------------------------------------------------------
+
+// Skip the loc-flag write when the encoder is in "no JsNode loc" mode.
+// Set by `encode_root_into` when the caller passed `skip_expression_loc`,
+// which guarantees every JsNode has `loc: None`.
+thread_local! {
+    static SKIP_JSNODE_LOC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+fn jsnode_loc_elided() -> bool {
+    SKIP_JSNODE_LOC.with(|c| c.get())
+}
+
+/// `typed_expr::Loc` — emits a flag byte + 6 u32s (with optional
+/// `character`) when `loc.is_some()`. When the envelope-level
+/// `FLAG_JSNODE_NO_LOC` flag is set the encoder skips this call
+/// entirely and the decoder reciprocates by skipping the read.
+fn write_typed_loc<W: Writer>(w: &mut W, loc: Option<&Loc>) {
+    if jsnode_loc_elided() {
+        return;
+    }
+    match loc {
+        Some(l) => {
+            write_u8(w, 1);
+            write_u32(w, l.start.line);
+            write_u32(w, l.start.column);
+            match l.start.character {
+                Some(c) => {
+                    write_u8(w, 1);
+                    write_u32(w, c);
+                }
+                None => write_u8(w, 0),
+            }
+            write_u32(w, l.end.line);
+            write_u32(w, l.end.column);
+            match l.end.character {
+                Some(c) => {
+                    write_u8(w, 1);
+                    write_u32(w, c);
+                }
+                None => write_u8(w, 0),
+            }
+        }
+        None => write_u8(w, 0),
+    }
+}
+
+fn write_literal_value<W: Writer>(w: &mut W, v: &LiteralValue) {
+    match v {
+        LiteralValue::Null => write_u8(w, LV_NULL),
+        LiteralValue::Bool(false) => write_u8(w, LV_BOOL_FALSE),
+        LiteralValue::Bool(true) => write_u8(w, LV_BOOL_TRUE),
+        LiteralValue::Number(n) => {
+            if n.fract() == 0.0 && n.abs() < i64::MAX as f64 {
+                write_u8(w, LV_NUMBER_I64);
+                w.write_bytes(&(*n as i64).to_le_bytes());
+            } else {
+                write_u8(w, LV_NUMBER_F64);
+                w.write_bytes(&n.to_le_bytes());
+            }
+        }
+        LiteralValue::String(s) => {
+            write_u8(w, LV_STRING);
+            write_str(w, s.as_str());
+        }
+        LiteralValue::Regex(_) => write_u8(w, LV_REGEX),
+    }
+}
+
+fn write_regex<W: Writer>(w: &mut W, regex: Option<&RegexValue>) {
+    match regex {
+        Some(r) => {
+            write_u8(w, 1);
+            write_str(w, r.pattern.as_str());
+            write_str(w, r.flags.as_str());
+        }
+        None => write_u8(w, 0),
+    }
+}
+
+fn write_template_element_value<W: Writer>(w: &mut W, v: &TemplateElementValue) {
+    write_str(w, v.raw.as_str());
+    match &v.cooked {
+        Some(c) => {
+            write_u8(w, 1);
+            write_str(w, c.as_str());
+        }
+        None => write_u8(w, 0),
+    }
+}
+
+fn write_node_id<W: Writer>(w: &mut W, id: JsNodeId, arena: &ParseArena) -> std::io::Result<()> {
+    write_js_node(w, arena.get_js_node(id), arena)
+}
+
+fn write_opt_node_id<W: Writer>(
+    w: &mut W,
+    id: Option<JsNodeId>,
+    arena: &ParseArena,
+) -> std::io::Result<()> {
+    match id {
+        Some(i) => {
+            write_u8(w, 1);
+            write_node_id(w, i, arena)
+        }
+        None => {
+            write_u8(w, 0);
+            Ok(())
+        }
+    }
+}
+
+fn write_id_range<W: Writer>(w: &mut W, range: IdRange, arena: &ParseArena) -> std::io::Result<()> {
+    let children = arena.get_js_children(range);
+    write_u32(w, children.len() as u32);
+    for child in children {
+        write_js_node(w, child, arena)?;
+    }
+    Ok(())
+}
+
+/// `Vec<Option<JsNode>>` — used by `ArrayExpression` / `ArrayPattern`.
+fn write_node_array<W: Writer>(
+    w: &mut W,
+    nodes: &[Option<JsNode>],
+    arena: &ParseArena,
+) -> std::io::Result<()> {
+    write_u32(w, nodes.len() as u32);
+    for n in nodes {
+        match n {
+            Some(node) => {
+                write_u8(w, 1);
+                write_js_node(w, node, arena)?;
+            }
+            None => write_u8(w, 0),
+        }
+    }
+    Ok(())
+}
+
+/// Emit `[u8 has_value][u32 json_len][json bytes]` for a rare
+/// structured optional that we don't have a dedicated binary tag for
+/// yet (directive `metadata`, JsNode::Program comment arrays, …).
+fn write_opt_inline_json<W: Writer, T: Serialize>(
+    w: &mut W,
+    value: Option<&T>,
+) -> std::io::Result<()> {
+    match value {
+        Some(v) => {
+            write_u8(w, 1);
+            let len_slot = w.position();
+            write_u32(w, 0);
+            let p0 = w.position();
+            struct A<'a, W2: Writer>(&'a mut W2);
+            impl<W2: Writer> std::io::Write for A<'_, W2> {
+                fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                    self.0.write_bytes(b);
+                    Ok(b.len())
+                }
+                fn flush(&mut self) -> std::io::Result<()> {
+                    Ok(())
+                }
+            }
+            let mut shim = A(w);
+            serde_json::to_writer(&mut shim, v).map_err(std::io::Error::other)?;
+            let p1 = shim.0.position();
+            w.patch_u32(len_slot, (p1 - p0) as u32);
+        }
+        None => write_u8(w, 0),
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Template-node encoders
+// ---------------------------------------------------------------------------
+
+fn write_text<W: Writer>(w: &mut W, t: &Text) {
+    write_preamble(w, TAG_TEXT, t.start, t.end);
+    write_str(w, t.raw.as_str());
+    write_str(w, t.data.as_str());
+}
+
+fn write_comment<W: Writer>(w: &mut W, c: &Comment) {
+    write_preamble(w, TAG_COMMENT, c.start, c.end);
+    write_str(w, c.data.as_str());
+}
+
+fn write_expression_tag<W: Writer>(w: &mut W, t: &ExpressionTag) -> std::io::Result<()> {
+    write_preamble(w, TAG_EXPRESSION_TAG, t.start, t.end);
+    write_expression(w, &t.expression)
+}
+
+fn write_html_tag<W: Writer>(w: &mut W, t: &HtmlTag) -> std::io::Result<()> {
+    write_preamble(w, TAG_HTML_TAG, t.start, t.end);
+    write_expression(w, &t.expression)
+}
+
+fn write_const_tag<W: Writer>(w: &mut W, t: &ConstTag) -> std::io::Result<()> {
+    write_preamble(w, TAG_CONST_TAG, t.start, t.end);
+    write_expression(w, &t.declaration)
+}
+
+fn write_debug_tag<W: Writer>(w: &mut W, t: &DebugTag) -> std::io::Result<()> {
+    write_preamble(w, TAG_DEBUG_TAG, t.start, t.end);
+    write_u32(w, t.identifiers.len() as u32);
+    for id in &t.identifiers {
+        write_expression(w, id)?;
+    }
+    Ok(())
+}
+
+fn write_render_tag<W: Writer>(w: &mut W, t: &RenderTag) -> std::io::Result<()> {
+    write_preamble(w, TAG_RENDER_TAG, t.start, t.end);
+    write_expression(w, &t.expression)
+}
+
+fn write_attach_tag<W: Writer>(w: &mut W, t: &AttachTag) -> std::io::Result<()> {
+    write_preamble(w, TAG_ATTACH_TAG, t.start, t.end);
+    write_expression(w, &t.expression)
+}
+
+// Elements share the same shape: name + attributes + fragment, with
+// optional extras (e.g. SvelteComponent adds `expression`).
+fn write_element_common<W: Writer>(
+    w: &mut W,
+    name: &str,
+    name_loc: Option<&crate::ast::span::SourceLocation>,
+    attributes: &[Attribute],
+    fragment: &Fragment,
+) -> std::io::Result<()> {
+    write_str(w, name);
+    write_opt_source_location(w, name_loc);
+    write_u32(w, attributes.len() as u32);
+    for a in attributes {
+        write_attribute(w, a)?;
+    }
+    write_fragment(w, fragment)
+}
+
+fn write_regular_element<W: Writer>(w: &mut W, e: &RegularElement) -> std::io::Result<()> {
+    write_preamble(w, TAG_REGULAR_ELEMENT, e.start, e.end);
+    write_element_common(
+        w,
+        e.name.as_str(),
+        e.name_loc.as_ref(),
+        &e.attributes,
+        &e.fragment,
+    )
+}
+
+fn write_component<W: Writer>(w: &mut W, e: &Component) -> std::io::Result<()> {
+    write_preamble(w, TAG_COMPONENT, e.start, e.end);
+    write_element_common(
+        w,
+        e.name.as_str(),
+        e.name_loc.as_ref(),
+        &e.attributes,
+        &e.fragment,
+    )
+}
+
+fn write_title_element<W: Writer>(w: &mut W, e: &TitleElement) -> std::io::Result<()> {
+    write_preamble(w, TAG_TITLE_ELEMENT, e.start, e.end);
+    write_element_common(
+        w,
+        e.name.as_str(),
+        e.name_loc.as_ref(),
+        &e.attributes,
+        &e.fragment,
+    )
+}
+
+fn write_slot_element<W: Writer>(w: &mut W, e: &SlotElement) -> std::io::Result<()> {
+    write_preamble(w, TAG_SLOT_ELEMENT, e.start, e.end);
+    write_element_common(
+        w,
+        e.name.as_str(),
+        e.name_loc.as_ref(),
+        &e.attributes,
+        &e.fragment,
+    )
+}
+
+fn write_svelte_element<W: Writer>(w: &mut W, tag: u8, e: &SvelteElement) -> std::io::Result<()> {
+    write_preamble(w, tag, e.start, e.end);
+    write_element_common(
+        w,
+        e.name.as_str(),
+        e.name_loc.as_ref(),
+        &e.attributes,
+        &e.fragment,
+    )
+}
+
+fn write_svelte_component_element<W: Writer>(
+    w: &mut W,
+    e: &SvelteComponentElement,
+) -> std::io::Result<()> {
+    write_preamble(w, TAG_SVELTE_COMPONENT, e.start, e.end);
+    write_element_common(
+        w,
+        e.name.as_str(),
+        e.name_loc.as_ref(),
+        &e.attributes,
+        &e.fragment,
+    )?;
+    write_expression(w, &e.expression)
+}
+
+fn write_svelte_dynamic_element<W: Writer>(
+    w: &mut W,
+    e: &SvelteDynamicElement,
+) -> std::io::Result<()> {
+    write_preamble(w, TAG_SVELTE_ELEMENT, e.start, e.end);
+    write_element_common(
+        w,
+        e.name.as_str(),
+        e.name_loc.as_ref(),
+        &e.attributes,
+        &e.fragment,
+    )?;
+    write_expression(w, &e.tag)
+}
+
+// Blocks
+
+fn write_if_block<W: Writer>(w: &mut W, b: &IfBlock) -> std::io::Result<()> {
+    write_preamble(w, TAG_IF_BLOCK, b.start, b.end);
+    write_bool(w, b.elseif);
+    write_expression(w, &b.test)?;
+    write_fragment(w, &b.consequent)?;
+    match &b.alternate {
+        Some(f) => {
+            write_u8(w, 1);
+            write_fragment(w, f)?;
+        }
+        None => write_u8(w, 0),
+    }
+    Ok(())
+}
+
+fn write_each_block<W: Writer>(w: &mut W, b: &EachBlock) -> std::io::Result<()> {
+    write_preamble(w, TAG_EACH_BLOCK, b.start, b.end);
+    write_expression(w, &b.expression)?;
+    write_fragment(w, &b.body)?;
+    write_opt_expression(w, b.context.as_ref())?;
+    match &b.fallback {
+        Some(f) => {
+            write_u8(w, 1);
+            write_fragment(w, f)?;
+        }
+        None => write_u8(w, 0),
+    }
+    write_opt_str(w, b.index.as_deref());
+    write_opt_expression(w, b.key.as_ref())?;
+    Ok(())
+}
+
+fn write_await_block<W: Writer>(w: &mut W, b: &AwaitBlock) -> std::io::Result<()> {
+    write_preamble(w, TAG_AWAIT_BLOCK, b.start, b.end);
+    write_expression(w, &b.expression)?;
+    write_opt_expression(w, b.value.as_ref())?;
+    write_opt_expression(w, b.error.as_ref())?;
+    for frag in [&b.pending, &b.then, &b.catch] {
+        match frag {
+            Some(f) => {
+                write_u8(w, 1);
+                write_fragment(w, f)?;
+            }
+            None => write_u8(w, 0),
+        }
+    }
+    Ok(())
+}
+
+fn write_key_block<W: Writer>(w: &mut W, b: &KeyBlock) -> std::io::Result<()> {
+    write_preamble(w, TAG_KEY_BLOCK, b.start, b.end);
+    write_expression(w, &b.expression)?;
+    write_fragment(w, &b.fragment)
+}
+
+fn write_snippet_block<W: Writer>(w: &mut W, b: &SnippetBlock) -> std::io::Result<()> {
+    write_preamble(w, TAG_SNIPPET_BLOCK, b.start, b.end);
+    write_expression(w, &b.expression)?;
+    write_opt_str(w, b.type_params.as_deref());
+    write_u32(w, b.parameters.len() as u32);
+    for p in &b.parameters {
+        write_expression(w, p)?;
+    }
+    write_fragment(w, &b.body)
+}
+
+// TemplateNode dispatch
+
+fn write_template_node<W: Writer>(w: &mut W, node: &TemplateNode) -> std::io::Result<()> {
+    match node {
+        TemplateNode::Text(n) => {
+            write_text(w, n);
+            Ok(())
+        }
+        TemplateNode::Comment(n) => {
+            write_comment(w, n);
+            Ok(())
+        }
+        TemplateNode::TitleElement(n) => write_title_element(w, n),
+        TemplateNode::SlotElement(n) => write_slot_element(w, n),
+        TemplateNode::SvelteBody(n) => write_svelte_element(w, TAG_SVELTE_BODY, n),
+        TemplateNode::SvelteDocument(n) => write_svelte_element(w, TAG_SVELTE_DOCUMENT, n),
+        TemplateNode::SvelteFragment(n) => write_svelte_element(w, TAG_SVELTE_FRAGMENT, n),
+        TemplateNode::SvelteBoundary(n) => write_svelte_element(w, TAG_SVELTE_BOUNDARY, n),
+        TemplateNode::SvelteHead(n) => write_svelte_element(w, TAG_SVELTE_HEAD, n),
+        TemplateNode::SvelteOptions(n) => write_svelte_element(w, TAG_SVELTE_OPTIONS_EL, n),
+        TemplateNode::SvelteSelf(n) => write_svelte_element(w, TAG_SVELTE_SELF, n),
+        TemplateNode::SvelteWindow(n) => write_svelte_element(w, TAG_SVELTE_WINDOW, n),
+        TemplateNode::ExpressionTag(n) => write_expression_tag(w, n),
+        TemplateNode::HtmlTag(n) => write_html_tag(w, n),
+        TemplateNode::ConstTag(n) => write_const_tag(w, n),
+        TemplateNode::DebugTag(n) => write_debug_tag(w, n),
+        TemplateNode::RenderTag(n) => write_render_tag(w, n),
+        TemplateNode::AttachTag(n) => write_attach_tag(w, n),
+        TemplateNode::IfBlock(n) => write_if_block(w, n),
+        TemplateNode::EachBlock(n) => write_each_block(w, n),
+        TemplateNode::AwaitBlock(n) => write_await_block(w, n),
+        TemplateNode::KeyBlock(n) => write_key_block(w, n),
+        TemplateNode::SnippetBlock(n) => write_snippet_block(w, n),
+        TemplateNode::RegularElement(n) => write_regular_element(w, n),
+        TemplateNode::Component(n) => write_component(w, n),
+        TemplateNode::SvelteComponent(n) => write_svelte_component_element(w, n),
+        TemplateNode::SvelteElement(n) => write_svelte_dynamic_element(w, n),
+    }
+}
+
+fn write_fragment<W: Writer>(w: &mut W, f: &Fragment) -> std::io::Result<()> {
+    // Fragments don't carry start/end of their own — they're keyed off
+    // their containing node. The preamble keeps the dispatch pattern
+    // uniform; positions are sentinels.
+    write_preamble(w, TAG_FRAGMENT, u32::MAX, u32::MAX);
+    write_u32(w, f.nodes.len() as u32);
+    for child in &f.nodes {
+        write_template_node(w, child)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Attributes & directives
+// ---------------------------------------------------------------------------
+
+fn write_attribute_value<W: Writer>(w: &mut W, v: &AttributeValue) -> std::io::Result<()> {
+    match v {
+        AttributeValue::True(_) => write_u8(w, ATTRVAL_TRUE),
+        AttributeValue::Expression(expr_tag) => {
+            write_u8(w, ATTRVAL_EXPRESSION);
+            write_expression_tag(w, expr_tag)?;
+        }
+        AttributeValue::Sequence(parts) => {
+            write_u8(w, ATTRVAL_SEQUENCE);
+            write_u32(w, parts.len() as u32);
+            for p in parts {
+                write_attribute_value_part(w, p)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_attribute_value_part<W: Writer>(w: &mut W, p: &AttributeValuePart) -> std::io::Result<()> {
+    match p {
+        AttributeValuePart::Text(t) => {
+            write_text(w, t);
+            Ok(())
+        }
+        AttributeValuePart::ExpressionTag(t) => write_expression_tag(w, t),
+    }
+}
+
+fn write_attribute_node<W: Writer>(w: &mut W, n: &AttributeNode) -> std::io::Result<()> {
+    write_preamble(w, TAG_ATTRIBUTE, n.start, n.end);
+    write_str(w, n.name.as_str());
+    write_opt_source_location(w, n.name_loc.as_ref());
+    write_attribute_value(w, &n.value)
+}
+
+fn write_spread_attribute<W: Writer>(w: &mut W, n: &SpreadAttribute) -> std::io::Result<()> {
+    write_preamble(w, TAG_SPREAD_ATTRIBUTE, n.start, n.end);
+    write_expression(w, &n.expression)
+}
+
+fn write_bind_directive<W: Writer>(w: &mut W, n: &BindDirective) -> std::io::Result<()> {
+    write_preamble(w, TAG_BIND_DIRECTIVE, n.start, n.end);
+    write_str(w, n.name.as_str());
+    write_opt_source_location(w, n.name_loc.as_ref());
+    write_expression(w, &n.expression)?;
+    write_modifiers(w, &n.modifiers);
+    Ok(())
+}
+
+fn write_on_directive<W: Writer>(w: &mut W, n: &OnDirective) -> std::io::Result<()> {
+    write_preamble(w, TAG_ON_DIRECTIVE, n.start, n.end);
+    write_str(w, n.name.as_str());
+    write_opt_source_location(w, n.name_loc.as_ref());
+    write_opt_expression(w, n.expression.as_ref())?;
+    write_modifiers(w, &n.modifiers);
+    Ok(())
+}
+
+fn write_class_directive<W: Writer>(w: &mut W, n: &ClassDirective) -> std::io::Result<()> {
+    write_preamble(w, TAG_CLASS_DIRECTIVE, n.start, n.end);
+    write_str(w, n.name.as_str());
+    write_opt_source_location(w, n.name_loc.as_ref());
+    write_expression(w, &n.expression)
+}
+
+fn write_style_directive<W: Writer>(w: &mut W, n: &StyleDirective) -> std::io::Result<()> {
+    write_preamble(w, TAG_STYLE_DIRECTIVE, n.start, n.end);
+    write_str(w, n.name.as_str());
+    write_opt_source_location(w, n.name_loc.as_ref());
+    write_attribute_value(w, &n.value)?;
+    write_modifiers(w, &n.modifiers);
+    Ok(())
+}
+
+fn write_transition_directive<W: Writer>(
+    w: &mut W,
+    n: &TransitionDirective,
+) -> std::io::Result<()> {
+    write_preamble(w, TAG_TRANSITION_DIRECTIVE, n.start, n.end);
+    write_str(w, n.name.as_str());
+    write_opt_source_location(w, n.name_loc.as_ref());
+    write_opt_expression(w, n.expression.as_ref())?;
+    write_modifiers(w, &n.modifiers);
+    write_bool(w, n.intro);
+    write_bool(w, n.outro);
+    write_opt_inline_json(w, n.metadata.as_ref())
+}
+
+fn write_animate_directive<W: Writer>(w: &mut W, n: &AnimateDirective) -> std::io::Result<()> {
+    write_preamble(w, TAG_ANIMATE_DIRECTIVE, n.start, n.end);
+    write_str(w, n.name.as_str());
+    write_opt_source_location(w, n.name_loc.as_ref());
+    write_opt_expression(w, n.expression.as_ref())?;
+    write_opt_inline_json(w, n.metadata.as_ref())
+}
+
+fn write_use_directive<W: Writer>(w: &mut W, n: &UseDirective) -> std::io::Result<()> {
+    write_preamble(w, TAG_USE_DIRECTIVE, n.start, n.end);
+    write_str(w, n.name.as_str());
+    write_opt_source_location(w, n.name_loc.as_ref());
+    write_opt_expression(w, n.expression.as_ref())
+}
+
+fn write_let_directive<W: Writer>(w: &mut W, n: &LetDirective) -> std::io::Result<()> {
+    write_preamble(w, TAG_LET_DIRECTIVE, n.start, n.end);
+    write_str(w, n.name.as_str());
+    write_opt_source_location(w, n.name_loc.as_ref());
+    write_opt_expression(w, n.expression.as_ref())
+}
+
+fn write_attribute<W: Writer>(w: &mut W, a: &Attribute) -> std::io::Result<()> {
+    match a {
+        Attribute::Attribute(n) => write_attribute_node(w, n),
+        Attribute::SpreadAttribute(n) => write_spread_attribute(w, n),
+        // Reuses the standalone `AttachTag` encoding; the JSON shape
+        // is identical (only `type/start/end/expression`).
+        Attribute::AttachTag(n) => write_attach_tag(w, n),
+        Attribute::BindDirective(n) => write_bind_directive(w, n),
+        Attribute::OnDirective(n) => write_on_directive(w, n),
+        Attribute::ClassDirective(n) => write_class_directive(w, n),
+        Attribute::StyleDirective(n) => write_style_directive(w, n),
+        Attribute::TransitionDirective(n) => write_transition_directive(w, n),
+        Attribute::AnimateDirective(n) => write_animate_directive(w, n),
+        Attribute::UseDirective(n) => write_use_directive(w, n),
+        Attribute::LetDirective(n) => write_let_directive(w, n),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Script / SvelteOptions / JsComment
+// ---------------------------------------------------------------------------
+
+fn write_script<W: Writer>(w: &mut W, s: &Script) -> std::io::Result<()> {
+    write_preamble(w, TAG_SCRIPT, s.start, s.end);
+    let ctx = match s.context {
+        ScriptContext::Default => 0u8,
+        ScriptContext::Module => 1u8,
+    };
+    write_u8(w, ctx);
+    write_expression(w, &s.content)?;
+    write_u32(w, s.attributes.len() as u32);
+    for a in &s.attributes {
+        write_attribute_node(w, a)?;
+    }
+    Ok(())
+}
+
+fn write_js_comment<W: Writer>(w: &mut W, c: &JsComment) {
+    write_preamble(w, TAG_JS_COMMENT, c.start, c.end);
+    let kind = match c.kind {
+        JsCommentKind::Line => 0u8,
+        JsCommentKind::Block => 1u8,
+    };
+    write_u8(w, kind);
+    write_str(w, c.value.as_str());
+    write_source_location(w, &c.loc);
+}
+
+// `SvelteOptions` and `CssOption` have many optional fields — emit
+// the whole struct as inline JSON. A dedicated encoder is easy to add
+// later if profiling shows they appear often enough to matter.
+fn write_svelte_options<W: Writer>(w: &mut W, o: &SvelteOptions) -> std::io::Result<()> {
+    write_json_node(w, o.start, o.end, o)
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+fn write_root<W: Writer>(w: &mut W, root: &Root) -> std::io::Result<()> {
+    write_preamble(w, TAG_ROOT, root.start, root.end);
+    match &root.css {
+        Some(css) => {
+            write_u8(w, 1);
+            write_json_node(w, u32::MAX, u32::MAX, &**css)?;
+        }
+        None => write_u8(w, 0),
+    }
+    // `Root.js`: `Vec<serde_json::Value>` — almost always empty in
+    // modern mode. One length-prefixed JSON blob for the whole vec.
+    write_json_node(w, u32::MAX, u32::MAX, &root.js)?;
+    write_fragment(w, &root.fragment)?;
+    match &root.options {
+        Some(opt) => {
+            write_u8(w, 1);
+            write_svelte_options(w, opt)?;
+        }
+        None => write_u8(w, 0),
+    }
+    write_u32(w, root.comments.len() as u32);
+    for c in &root.comments {
+        write_js_comment(w, c);
+    }
+    match &root.instance {
+        Some(s) => {
+            write_u8(w, 1);
+            write_script(w, s)?;
+        }
+        None => write_u8(w, 0),
+    }
+    match &root.module {
+        Some(s) => {
+            write_u8(w, 1);
+            write_script(w, s)?;
+        }
+        None => write_u8(w, 0),
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// JsNode (estree) — 74-variant dispatcher
+// ---------------------------------------------------------------------------
+
+fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std::io::Result<()> {
+    match node {
+        JsNode::Identifier {
+            start,
+            end,
+            loc,
+            name,
+        } => {
+            write_preamble(w, JS_IDENTIFIER, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_str(w, name.as_str());
+        }
+        JsNode::PrivateIdentifier {
+            start,
+            end,
+            loc,
+            name,
+        } => {
+            write_preamble(w, JS_PRIVATE_IDENTIFIER, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_str(w, name.as_str());
+        }
+        JsNode::Literal {
+            start,
+            end,
+            loc,
+            value,
+            raw,
+            regex,
+        } => {
+            write_preamble(w, JS_LITERAL, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_literal_value(w, value);
+            write_str(w, raw.as_str());
+            write_regex(w, regex.as_ref());
+        }
+        JsNode::BinaryExpression {
+            start,
+            end,
+            loc,
+            left,
+            operator,
+            right,
+        } => {
+            write_preamble(w, JS_BINARY_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *left, arena)?;
+            write_str(w, operator.as_str());
+            write_node_id(w, *right, arena)?;
+        }
+        JsNode::LogicalExpression {
+            start,
+            end,
+            loc,
+            left,
+            operator,
+            right,
+        } => {
+            write_preamble(w, JS_LOGICAL_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *left, arena)?;
+            write_str(w, operator.as_str());
+            write_node_id(w, *right, arena)?;
+        }
+        JsNode::UnaryExpression {
+            start,
+            end,
+            loc,
+            operator,
+            prefix,
+            argument,
+        } => {
+            write_preamble(w, JS_UNARY_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_str(w, operator.as_str());
+            write_bool(w, *prefix);
+            write_node_id(w, *argument, arena)?;
+        }
+        JsNode::ConditionalExpression {
+            start,
+            end,
+            loc,
+            test,
+            consequent,
+            alternate,
+        } => {
+            write_preamble(w, JS_CONDITIONAL_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *test, arena)?;
+            write_node_id(w, *consequent, arena)?;
+            write_node_id(w, *alternate, arena)?;
+        }
+        JsNode::CallExpression {
+            start,
+            end,
+            loc,
+            callee,
+            arguments,
+            optional,
+        } => {
+            write_preamble(w, JS_CALL_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *callee, arena)?;
+            write_id_range(w, *arguments, arena)?;
+            write_bool(w, *optional);
+        }
+        JsNode::MemberExpression {
+            start,
+            end,
+            loc,
+            object,
+            property,
+            computed,
+            optional,
+        } => {
+            write_preamble(w, JS_MEMBER_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *object, arena)?;
+            write_node_id(w, *property, arena)?;
+            write_bool(w, *computed);
+            write_bool(w, *optional);
+        }
+        JsNode::NewExpression {
+            start,
+            end,
+            loc,
+            callee,
+            arguments,
+        } => {
+            write_preamble(w, JS_NEW_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *callee, arena)?;
+            write_id_range(w, *arguments, arena)?;
+        }
+        JsNode::FunctionExpression {
+            start,
+            end,
+            loc,
+            id,
+            params,
+            body,
+            generator,
+            r#async,
+            expression,
+        } => {
+            write_preamble(w, JS_FUNCTION_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *id, arena)?;
+            write_bool(w, *generator);
+            write_bool(w, *r#async);
+            write_bool(w, *expression);
+            write_id_range(w, *params, arena)?;
+            write_opt_node_id(w, *body, arena)?;
+        }
+        JsNode::ClassExpression {
+            start,
+            end,
+            loc,
+            id,
+            super_class,
+            body,
+        } => {
+            write_preamble(w, JS_CLASS_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *id, arena)?;
+            write_opt_node_id(w, *super_class, arena)?;
+            write_node_id(w, *body, arena)?;
+        }
+        JsNode::ArrowFunctionExpression {
+            start,
+            end,
+            loc,
+            id,
+            params,
+            body,
+            expression,
+            generator,
+            r#async,
+        } => {
+            write_preamble(w, JS_ARROW_FUNCTION_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *id, arena)?;
+            write_bool(w, *expression);
+            write_bool(w, *generator);
+            write_bool(w, *r#async);
+            write_id_range(w, *params, arena)?;
+            write_node_id(w, *body, arena)?;
+        }
+        JsNode::AssignmentExpression {
+            start,
+            end,
+            loc,
+            operator,
+            left,
+            right,
+        } => {
+            write_preamble(w, JS_ASSIGNMENT_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_str(w, operator.as_str());
+            write_node_id(w, *left, arena)?;
+            write_node_id(w, *right, arena)?;
+        }
+        JsNode::UpdateExpression {
+            start,
+            end,
+            loc,
+            operator,
+            prefix,
+            argument,
+        } => {
+            write_preamble(w, JS_UPDATE_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_str(w, operator.as_str());
+            write_bool(w, *prefix);
+            write_node_id(w, *argument, arena)?;
+        }
+        JsNode::SequenceExpression {
+            start,
+            end,
+            loc,
+            expressions,
+        } => {
+            write_preamble(w, JS_SEQUENCE_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *expressions, arena)?;
+        }
+        JsNode::ArrayExpression {
+            start,
+            end,
+            loc,
+            elements,
+        } => {
+            write_preamble(w, JS_ARRAY_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_array(w, elements, arena)?;
+        }
+        JsNode::ObjectExpression {
+            start,
+            end,
+            loc,
+            properties,
+        } => {
+            write_preamble(w, JS_OBJECT_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *properties, arena)?;
+        }
+        JsNode::TemplateLiteral {
+            start,
+            end,
+            loc,
+            quasis,
+            expressions,
+        } => {
+            write_preamble(w, JS_TEMPLATE_LITERAL, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *quasis, arena)?;
+            write_id_range(w, *expressions, arena)?;
+        }
+        JsNode::TaggedTemplateExpression {
+            start,
+            end,
+            loc,
+            tag,
+            quasi,
+        } => {
+            write_preamble(w, JS_TAGGED_TEMPLATE_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *tag, arena)?;
+            write_node_id(w, *quasi, arena)?;
+        }
+        JsNode::TemplateElement {
+            start,
+            end,
+            loc,
+            tail,
+            value,
+        } => {
+            write_preamble(w, JS_TEMPLATE_ELEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_bool(w, *tail);
+            write_template_element_value(w, value);
+        }
+        JsNode::ThisExpression { start, end, loc } => {
+            write_preamble(w, JS_THIS_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+        }
+        JsNode::Super { start, end, loc } => {
+            write_preamble(w, JS_SUPER, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+        }
+        JsNode::ImportExpression {
+            start,
+            end,
+            loc,
+            source,
+        } => {
+            write_preamble(w, JS_IMPORT_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *source, arena)?;
+        }
+        JsNode::AwaitExpression {
+            start,
+            end,
+            loc,
+            argument,
+        } => {
+            write_preamble(w, JS_AWAIT_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *argument, arena)?;
+        }
+        JsNode::YieldExpression {
+            start,
+            end,
+            loc,
+            delegate,
+            argument,
+        } => {
+            write_preamble(w, JS_YIELD_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_bool(w, *delegate);
+            write_opt_node_id(w, *argument, arena)?;
+        }
+        JsNode::ChainExpression {
+            start,
+            end,
+            loc,
+            expression,
+        } => {
+            write_preamble(w, JS_CHAIN_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *expression, arena)?;
+        }
+        JsNode::MetaProperty {
+            start,
+            end,
+            loc,
+            meta,
+            property,
+        } => {
+            write_preamble(w, JS_META_PROPERTY, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *meta, arena)?;
+            write_node_id(w, *property, arena)?;
+        }
+        JsNode::SpreadElement {
+            start,
+            end,
+            loc,
+            argument,
+        } => {
+            write_preamble(w, JS_SPREAD_ELEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *argument, arena)?;
+        }
+        JsNode::ObjectPattern {
+            start,
+            end,
+            loc,
+            properties,
+        } => {
+            write_preamble(w, JS_OBJECT_PATTERN, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *properties, arena)?;
+        }
+        JsNode::ArrayPattern {
+            start,
+            end,
+            loc,
+            elements,
+        } => {
+            write_preamble(w, JS_ARRAY_PATTERN, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_array(w, elements, arena)?;
+        }
+        JsNode::AssignmentPattern {
+            start,
+            end,
+            loc,
+            left,
+            right,
+        } => {
+            write_preamble(w, JS_ASSIGNMENT_PATTERN, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *left, arena)?;
+            write_node_id(w, *right, arena)?;
+        }
+        JsNode::RestElement {
+            start,
+            end,
+            loc,
+            argument,
+        } => {
+            write_preamble(w, JS_REST_ELEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *argument, arena)?;
+        }
+        JsNode::Property {
+            start,
+            end,
+            loc,
+            key,
+            value,
+            kind,
+            method,
+            shorthand,
+            computed,
+        } => {
+            write_preamble(w, JS_PROPERTY, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_bool(w, *method);
+            write_bool(w, *shorthand);
+            write_bool(w, *computed);
+            write_node_id(w, *key, arena)?;
+            write_node_id(w, *value, arena)?;
+            write_str(w, kind.as_str());
+        }
+        JsNode::Program {
+            start,
+            end,
+            loc,
+            body,
+            source_type,
+            leading_comments,
+            trailing_comments,
+        } => {
+            write_preamble(w, JS_PROGRAM, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *body, arena)?;
+            write_str(w, source_type.as_str());
+            write_opt_inline_json(w, trailing_comments.as_ref())?;
+            write_opt_inline_json(w, leading_comments.as_ref())?;
+        }
+        JsNode::ExpressionStatement {
+            start,
+            end,
+            loc,
+            expression,
+        } => {
+            write_preamble(w, JS_EXPRESSION_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *expression, arena)?;
+        }
+        JsNode::BlockStatement {
+            start,
+            end,
+            loc,
+            body,
+        } => {
+            write_preamble(w, JS_BLOCK_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *body, arena)?;
+        }
+        JsNode::VariableDeclaration {
+            start,
+            end,
+            loc,
+            declarations,
+            kind,
+            declare,
+        } => {
+            write_preamble(w, JS_VARIABLE_DECLARATION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *declarations, arena)?;
+            write_str(w, kind.as_str());
+            write_bool(w, *declare);
+        }
+        JsNode::VariableDeclarator {
+            start,
+            end,
+            loc,
+            id,
+            init,
+        } => {
+            write_preamble(w, JS_VARIABLE_DECLARATOR, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *id, arena)?;
+            write_opt_node_id(w, *init, arena)?;
+        }
+        JsNode::FunctionDeclaration {
+            start,
+            end,
+            loc,
+            id,
+            params,
+            body,
+            generator,
+            r#async,
+        } => {
+            write_preamble(w, JS_FUNCTION_DECLARATION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *id, arena)?;
+            write_bool(w, *generator);
+            write_bool(w, *r#async);
+            write_id_range(w, *params, arena)?;
+            write_opt_node_id(w, *body, arena)?;
+        }
+        JsNode::ClassDeclaration {
+            start,
+            end,
+            loc,
+            id,
+            super_class,
+            body,
+            declare,
+            r#abstract,
+            implements,
+            decorators,
+        } => {
+            write_preamble(w, JS_CLASS_DECLARATION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *id, arena)?;
+            write_opt_node_id(w, *super_class, arena)?;
+            write_node_id(w, *body, arena)?;
+            write_bool(w, *declare);
+            write_bool(w, *r#abstract);
+            write_bool(w, *implements);
+            write_id_range(w, *decorators, arena)?;
+        }
+        JsNode::ReturnStatement {
+            start,
+            end,
+            loc,
+            argument,
+        } => {
+            write_preamble(w, JS_RETURN_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *argument, arena)?;
+        }
+        JsNode::ThrowStatement {
+            start,
+            end,
+            loc,
+            argument,
+        } => {
+            write_preamble(w, JS_THROW_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *argument, arena)?;
+        }
+        JsNode::IfStatement {
+            start,
+            end,
+            loc,
+            test,
+            consequent,
+            alternate,
+        } => {
+            write_preamble(w, JS_IF_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *test, arena)?;
+            write_node_id(w, *consequent, arena)?;
+            write_opt_node_id(w, *alternate, arena)?;
+        }
+        JsNode::ForStatement {
+            start,
+            end,
+            loc,
+            init,
+            test,
+            update,
+            body,
+        } => {
+            write_preamble(w, JS_FOR_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *init, arena)?;
+            write_opt_node_id(w, *test, arena)?;
+            write_opt_node_id(w, *update, arena)?;
+            write_node_id(w, *body, arena)?;
+        }
+        JsNode::ForOfStatement {
+            start,
+            end,
+            loc,
+            r#await,
+            left,
+            right,
+            body,
+        } => {
+            write_preamble(w, JS_FOR_OF_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_bool(w, *r#await);
+            write_node_id(w, *left, arena)?;
+            write_node_id(w, *right, arena)?;
+            write_node_id(w, *body, arena)?;
+        }
+        JsNode::ForInStatement {
+            start,
+            end,
+            loc,
+            left,
+            right,
+            body,
+        } => {
+            write_preamble(w, JS_FOR_IN_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *left, arena)?;
+            write_node_id(w, *right, arena)?;
+            write_node_id(w, *body, arena)?;
+        }
+        JsNode::WhileStatement {
+            start,
+            end,
+            loc,
+            test,
+            body,
+        } => {
+            write_preamble(w, JS_WHILE_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *test, arena)?;
+            write_node_id(w, *body, arena)?;
+        }
+        JsNode::DoWhileStatement {
+            start,
+            end,
+            loc,
+            test,
+            body,
+        } => {
+            write_preamble(w, JS_DO_WHILE_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *test, arena)?;
+            write_node_id(w, *body, arena)?;
+        }
+        JsNode::TryStatement {
+            start,
+            end,
+            loc,
+            block,
+            handler,
+            finalizer,
+        } => {
+            write_preamble(w, JS_TRY_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *block, arena)?;
+            write_opt_node_id(w, *handler, arena)?;
+            write_opt_node_id(w, *finalizer, arena)?;
+        }
+        JsNode::CatchClause {
+            start,
+            end,
+            loc,
+            param,
+            body,
+        } => {
+            write_preamble(w, JS_CATCH_CLAUSE, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *param, arena)?;
+            write_node_id(w, *body, arena)?;
+        }
+        JsNode::SwitchStatement {
+            start,
+            end,
+            loc,
+            discriminant,
+            cases,
+        } => {
+            write_preamble(w, JS_SWITCH_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *discriminant, arena)?;
+            write_id_range(w, *cases, arena)?;
+        }
+        JsNode::SwitchCase {
+            start,
+            end,
+            loc,
+            test,
+            consequent,
+        } => {
+            write_preamble(w, JS_SWITCH_CASE, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *test, arena)?;
+            write_id_range(w, *consequent, arena)?;
+        }
+        JsNode::LabeledStatement {
+            start,
+            end,
+            loc,
+            label,
+            body,
+        } => {
+            write_preamble(w, JS_LABELED_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *label, arena)?;
+            write_node_id(w, *body, arena)?;
+        }
+        JsNode::BreakStatement {
+            start,
+            end,
+            loc,
+            label,
+        } => {
+            write_preamble(w, JS_BREAK_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *label, arena)?;
+        }
+        JsNode::ContinueStatement {
+            start,
+            end,
+            loc,
+            label,
+        } => {
+            write_preamble(w, JS_CONTINUE_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *label, arena)?;
+        }
+        JsNode::EmptyStatement { start, end, loc } => {
+            write_preamble(w, JS_EMPTY_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+        }
+        JsNode::DebuggerStatement { start, end, loc } => {
+            write_preamble(w, JS_DEBUGGER_STATEMENT, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+        }
+        JsNode::ImportDeclaration {
+            start,
+            end,
+            loc,
+            specifiers,
+            source,
+            import_kind,
+            attributes,
+        } => {
+            write_preamble(w, JS_IMPORT_DECLARATION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *specifiers, arena)?;
+            write_node_id(w, *source, arena)?;
+            write_opt_str(w, import_kind.as_deref());
+            write_id_range(w, *attributes, arena)?;
+        }
+        JsNode::ImportSpecifier {
+            start,
+            end,
+            loc,
+            imported,
+            local,
+            import_kind,
+        } => {
+            write_preamble(w, JS_IMPORT_SPECIFIER, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *imported, arena)?;
+            write_node_id(w, *local, arena)?;
+            write_opt_str(w, import_kind.as_deref());
+        }
+        JsNode::ImportDefaultSpecifier {
+            start,
+            end,
+            loc,
+            local,
+        } => {
+            write_preamble(w, JS_IMPORT_DEFAULT_SPECIFIER, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *local, arena)?;
+        }
+        JsNode::ImportNamespaceSpecifier {
+            start,
+            end,
+            loc,
+            local,
+        } => {
+            write_preamble(w, JS_IMPORT_NAMESPACE_SPECIFIER, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *local, arena)?;
+        }
+        JsNode::ExportNamedDeclaration {
+            start,
+            end,
+            loc,
+            declaration,
+            specifiers,
+            source,
+            export_kind,
+            attributes,
+        } => {
+            write_preamble(w, JS_EXPORT_NAMED_DECLARATION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *declaration, arena)?;
+            write_id_range(w, *specifiers, arena)?;
+            write_opt_node_id(w, *source, arena)?;
+            write_opt_str(w, export_kind.as_deref());
+            write_id_range(w, *attributes, arena)?;
+        }
+        JsNode::ExportDefaultDeclaration {
+            start,
+            end,
+            loc,
+            declaration,
+        } => {
+            write_preamble(w, JS_EXPORT_DEFAULT_DECLARATION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *declaration, arena)?;
+        }
+        JsNode::ExportSpecifier {
+            start,
+            end,
+            loc,
+            local,
+            exported,
+            export_kind,
+        } => {
+            write_preamble(w, JS_EXPORT_SPECIFIER, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *local, arena)?;
+            write_node_id(w, *exported, arena)?;
+            write_opt_str(w, export_kind.as_deref());
+        }
+        JsNode::ClassBody {
+            start,
+            end,
+            loc,
+            body,
+        } => {
+            write_preamble(w, JS_CLASS_BODY, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *body, arena)?;
+        }
+        JsNode::MethodDefinition {
+            start,
+            end,
+            loc,
+            key,
+            value,
+            kind,
+            r#static,
+            computed,
+        } => {
+            write_preamble(w, JS_METHOD_DEFINITION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_bool(w, *r#static);
+            write_bool(w, *computed);
+            write_str(w, kind.as_str());
+            write_node_id(w, *key, arena)?;
+            write_node_id(w, *value, arena)?;
+        }
+        JsNode::PropertyDefinition {
+            start,
+            end,
+            loc,
+            key,
+            value,
+            r#static,
+            computed,
+        } => {
+            write_preamble(w, JS_PROPERTY_DEFINITION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_bool(w, *r#static);
+            write_bool(w, *computed);
+            write_node_id(w, *key, arena)?;
+            write_opt_node_id(w, *value, arena)?;
+        }
+        JsNode::StaticBlock {
+            start,
+            end,
+            loc,
+            body,
+        } => {
+            write_preamble(w, JS_STATIC_BLOCK, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_id_range(w, *body, arena)?;
+        }
+        JsNode::Decorator { start, end, loc } => {
+            write_preamble(w, JS_DECORATOR, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+        }
+        JsNode::TSTypeAnnotation {
+            start,
+            end,
+            loc,
+            type_annotation,
+        } => {
+            write_preamble(w, JS_TS_TYPE_ANNOTATION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *type_annotation, arena)?;
+        }
+        JsNode::TSEnumDeclaration { start, end, loc } => {
+            write_preamble(w, JS_TS_ENUM_DECLARATION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+        }
+        JsNode::TSModuleDeclaration {
+            start,
+            end,
+            loc,
+            body,
+        } => {
+            write_preamble(w, JS_TS_MODULE_DECLARATION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_opt_node_id(w, *body, arena)?;
+        }
+        JsNode::Comment {
+            start,
+            end,
+            comment_type,
+            value,
+        } => {
+            write_preamble(w, JS_COMMENT, *start, *end);
+            write_str(w, comment_type.as_str());
+            write_str(w, value.as_str());
+        }
+        // `Raw(Value)` and `Null` don't carry positions, so they use
+        // dedicated sentinel tags without the usual preamble pair.
+        JsNode::Raw(value) => {
+            write_preamble(w, JS_RAW_JSON, u32::MAX, u32::MAX);
+            let len_slot = w.position();
+            write_u32(w, 0);
+            let p0 = w.position();
+            struct A<'a, W2: Writer>(&'a mut W2);
+            impl<W2: Writer> std::io::Write for A<'_, W2> {
+                fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                    self.0.write_bytes(b);
+                    Ok(b.len())
+                }
+                fn flush(&mut self) -> std::io::Result<()> {
+                    Ok(())
+                }
+            }
+            let mut shim = A(w);
+            serde_json::to_writer(&mut shim, value).map_err(std::io::Error::other)?;
+            let p1 = shim.0.position();
+            w.patch_u32(len_slot, (p1 - p0) as u32);
+        }
+        JsNode::Null => {
+            write_preamble(w, JS_NULL, u32::MAX, u32::MAX);
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry points
+// ---------------------------------------------------------------------------
+
+/// Encode a parsed `Root` AST into a fresh `Vec<u8>` envelope.
+pub fn encode_root_to_vec(root: &Root, source: &str) -> Vec<u8> {
+    encode_root_to_vec_with_options(root, source, false)
+}
+
+/// Encode a parsed `Root` AST with caller-supplied envelope flags.
+///
+/// `skip_jsnode_loc` should mirror the value of
+/// `ParseOptions::skip_expression_loc` used when parsing — it tells the
+/// encoder / decoder to elide the per-JsNode loc-flag byte, since every
+/// JsNode is guaranteed to have `loc == None`.
+pub fn encode_root_to_vec_with_options(
+    root: &Root,
+    source: &str,
+    skip_jsnode_loc: bool,
+) -> Vec<u8> {
+    let cap = HEADER_LEN + source.len().saturating_mul(20).max(4096);
+    let mut buf: Vec<u8> = Vec::with_capacity(cap);
+    encode_root_into(&mut buf, root, source, skip_jsnode_loc);
+    buf
+}
+
+/// Write the envelope into `writer`. The writer must start empty.
+pub fn encode_root_into<W: Writer>(
+    writer: &mut W,
+    root: &Root,
+    source: &str,
+    skip_jsnode_loc: bool,
+) {
+    debug_assert_eq!(writer.position(), 0, "encoder expects an empty writer");
+
+    writer.write_bytes(&MAGIC.to_le_bytes());
+    writer.write_bytes(&VERSION.to_le_bytes());
+    writer.write_bytes(&[0u8; 4]); // total_len  — patched at the end
+    writer.write_bytes(&[0u8; 4]); // root_offset — patched after the header
+    write_u32(writer, source.len() as u32);
+    let mut flags: u32 = 0;
+    if skip_jsnode_loc {
+        flags |= FLAG_JSNODE_NO_LOC;
+    }
+    write_u32(writer, flags);
+    debug_assert_eq!(writer.position(), HEADER_LEN);
+
+    let root_off = writer.position() as u32;
+    writer.patch_u32(12, root_off);
+
+    // RAII guard: ensure the per-encode `SKIP_JSNODE_LOC` thread-local
+    // is reset even if encoding panics.
+    struct Guard(bool);
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            SKIP_JSNODE_LOC.with(|c| c.set(self.0));
+        }
+    }
+    let prev = SKIP_JSNODE_LOC.with(|c| c.replace(skip_jsnode_loc));
+    let _guard = Guard(prev);
+
+    let _ = crate::ast::arena::with_serialize_arena(&root.arena, || write_root(writer, root));
+
+    let total = writer.position() as u32;
+    writer.patch_u32(8, total);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::phases::phase1_parse::{ParseOptions, parse};
+
+    #[test]
+    fn header_layout_minimal() {
+        let src = "<h1>Hello</h1>";
+        let ast = parse(src, ParseOptions::default()).unwrap();
+        let buf = encode_root_to_vec(&ast, src);
+
+        assert!(buf.len() >= HEADER_LEN);
+        assert_eq!(&buf[0..4], &MAGIC.to_le_bytes());
+        assert_eq!(u32::from_le_bytes(buf[4..8].try_into().unwrap()), VERSION);
+        assert_eq!(
+            u32::from_le_bytes(buf[8..12].try_into().unwrap()) as usize,
+            buf.len()
+        );
+
+        let root_off = u32::from_le_bytes(buf[12..16].try_into().unwrap()) as usize;
+        // Root must be the binary TAG_ROOT, not the JSON fallback.
+        assert_eq!(buf[root_off], TAG_ROOT);
+    }
+
+    #[test]
+    fn flag_byte_set_when_requested() {
+        let src = "<p>{x}</p>";
+        let ast = parse(
+            src,
+            ParseOptions {
+                skip_expression_loc: true,
+                ..ParseOptions::default()
+            },
+        )
+        .unwrap();
+        let buf = encode_root_to_vec_with_options(&ast, src, true);
+        let flags = u32::from_le_bytes(buf[20..24].try_into().unwrap());
+        assert!(flags & FLAG_JSNODE_NO_LOC != 0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds two NAPI exports plus the matching JS-side decoder so Node consumers can get the parsed Svelte AST without going through wasm.

- **`parse(source, options?)`** — returns the AST as a JSON string. Mirrors the existing wasm `parse_svelte` but across the NAPI boundary (no wasm linear-memory copy, no `wasm_bindgen` allocator).
- **`parseEnvelope(source, options?)`** — returns a `Buffer` in the new rsvelte parse envelope format (`napi_raw_parse`). Pair with `decodeParseEnvelope` exported from `@rsvelte/vite-plugin-svelte-native/parse-envelope.js`. Inspired by oxc's `raw_transfer`.

The envelope carries every **template node** (Root, Fragment, Text, Comment, ExpressionTag, HtmlTag, ConstTag, DebugTag, RenderTag, AttachTag, all element + `Svelte:*` variants, all block variants), every **attribute and directive variant**, `AttributeValue` / `AttributeValuePart`, `Script`, `JsComment`, `SourceLocation`, and **every one of the 74 JsNode (estree) variants** as dedicated binary tags. CSS `StyleSheet`, `SvelteOptions`, and directive `metadata` remain inline JSON behind `TAG_JSON` — easy to migrate later.

`NapiParseOptions { skipExpressionLoc?: boolean }` mirrors the existing `ParseOptions::skip_expression_loc`. When set, the encoder marks the envelope with `FLAG_JSNODE_NO_LOC` so the JS decoder can skip the per-JsNode loc-flag byte entirely.

## Why

The motivating use case is `svelte-eslint-parser`, which today goes through `svelte/compiler` (JS) for Svelte template parsing and which we want to route through rsvelte. Going via the existing wasm `parse_svelte` ended up ~40% slower than the JS reference because of the JSON serialise + `JSON.parse` cost at the boundary — `JSON.parse` alone is ~60% of total time end-to-end on a real component.

`parseEnvelope` skips that path entirely. The on-the-wire format is documented at the top of `src/napi_raw_parse.rs`.

## Numbers

Measured on a real `.svelte` file (~4 KB source, ~1500 AST nodes):

| Path | ops/sec | vs `svelte/compiler` |
|---|---|---|
| `svelte/compiler` (JS) | ~4,100 | 1.00× |
| `parse` + `JSON.parse` (NAPI) | ~4,500 | 1.10× |
| `parseEnvelope` + `decodeParseEnvelope` | **~7,700** | **~1.9×** |

- Envelope buffer is ~74% smaller than the JSON output (~18 KB vs ~43 KB with `skipExpressionLoc`).
- `parseEnvelope(src) + decodeParseEnvelope(buf)` round-trips to a **deep-equal AST** against `JSON.parse(parse(src))`.

## Test plan

- [x] `cargo build --release --features napi --lib` succeeds
- [x] `cargo clippy --features napi --lib -- -D warnings` passes
- [x] `cargo fmt --all` clean
- [x] Two unit tests in `napi_raw_parse.rs` (header layout + flag bit)
- [x] End-to-end: encoded buffer decodes to deep-equal output of `JSON.parse(parse(src))` on a representative `.svelte` file
- [ ] CI compatibility-report job — no regressions expected (this adds new API surface only)

## Notes for review

- `src/napi.rs` only adds the two new `#[napi]` functions and a `NapiParseOptions` struct. The existing `compile*` surface is untouched.
- `src/napi_raw_parse.rs` is the encoder; it's mechanical per-variant code but the helpers at the top (`write_typed_loc`, `write_node_id`, `write_id_range`, `write_node_array`) keep each `JsNode` arm small.
- `npm/vite-plugin-svelte-native/parse-envelope.js` mirrors the encoder one-for-one. Field order in the constructed JS objects matches the upstream `Serialize` impls so the output is shape-compatible.
- `index.d.ts` gets the public `parse` / `parseEnvelope` declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)