### PR TITLE
ci(release): quote cancel-in-progress expression to fix YAML parse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,12 @@ concurrency:
   # in-flight publish — npm publish is per-package, so a mid-flight cancel
   # can leave us with versions bumped in package.json but never published
   # to the registry.
-  cancel-in-progress: ${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}
+  # The expression is quoted so the literal colon in the predicate
+  # string ('chore(release): version packages') doesn't confuse the
+  # YAML parser. GitHub Actions still evaluates `${{ }}` inside the
+  # string and `cancel-in-progress` accepts the resulting `'true'` /
+  # `'false'` literal.
+  cancel-in-progress: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
 
 jobs:
   # Per-platform svelte-check binary builds. Each job uploads its rsvelte


### PR DESCRIPTION
## Summary

Every push to `main` since the cancel-in-progress scoping change (#560) has triggered a release workflow run that fails immediately with:

> Invalid workflow file: .github/workflows/release.yml#L24
> You have an error in your yaml syntax on line 24

The literal colon inside the predicate string `'chore(release): version packages'` is being interpreted by GitHub's YAML parser as a mapping separator, so the file no longer round-trips. PR #596 made this visible because the broken workflow blocked the version-packages PR from opening.

## Fix

Wrap the `${{ … }}` template in double quotes. GitHub still evaluates the expression and `cancel-in-progress` accepts the resulting `'true'` / `'false'` literal, so the runtime behaviour is unchanged.

```diff
-  cancel-in-progress: ${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}
+  cancel-in-progress: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
```

## Test plan

- [x] Local `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` passes (it used to raise `ScannerError`)
- [ ] CI parses the file and the release workflow proceeds past the "Invalid workflow file" gate
- [ ] After merge, the version-packages PR for #596's changeset opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)