### PR TITLE
feat(formatter): rewrite element open tags with normalized attribute spacing

### DIFF
--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -3,9 +3,7 @@ use oxc_formatter::Formatter;
 use oxc_parser::{ParseOptions as OxcParseOptions, Parser};
 use oxc_span::SourceType;
 use svelte_compiler_rust::ast::js::Expression;
-use svelte_compiler_rust::ast::template::{
-    Attribute, AttributeValue, AttributeValuePart, ExpressionTag, Fragment, TemplateNode,
-};
+use svelte_compiler_rust::ast::template::{ExpressionTag, Fragment, TemplateNode};
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
@@ -81,20 +79,20 @@ fn collect_node_edits(
             // Statement-shaped tags (`{@const x = e}`, `{let x = e}`,
             // `{const x = e}`) — defer until statement formatting lands.
         }
+        // For every element type, attribute lists (and `this={X}` on
+        // `<svelte:component>` / `<svelte:element>`) are owned by the
+        // open-tag rewrite in `crate::markup`. Here we only recurse into
+        // the children.
         TemplateNode::RegularElement(elem) => {
-            collect_attribute_list_edits(source, &elem.attributes, options, edits)?;
             collect_template_edits(source, &elem.fragment, options, edits)?;
         }
         TemplateNode::Component(c) => {
-            collect_attribute_list_edits(source, &c.attributes, options, edits)?;
             collect_template_edits(source, &c.fragment, options, edits)?;
         }
         TemplateNode::TitleElement(t) => {
-            collect_attribute_list_edits(source, &t.attributes, options, edits)?;
             collect_template_edits(source, &t.fragment, options, edits)?;
         }
         TemplateNode::SlotElement(s) => {
-            collect_attribute_list_edits(source, &s.attributes, options, edits)?;
             collect_template_edits(source, &s.fragment, options, edits)?;
         }
         TemplateNode::SvelteHead(s)
@@ -105,17 +103,12 @@ fn collect_node_edits(
         | TemplateNode::SvelteOptions(s)
         | TemplateNode::SvelteSelf(s)
         | TemplateNode::SvelteWindow(s) => {
-            collect_attribute_list_edits(source, &s.attributes, options, edits)?;
             collect_template_edits(source, &s.fragment, options, edits)?;
         }
         TemplateNode::SvelteComponent(c) => {
-            collect_attribute_list_edits(source, &c.attributes, options, edits)?;
-            push_brace_wrapped_expression(source, &c.expression, options, edits)?;
             collect_template_edits(source, &c.fragment, options, edits)?;
         }
         TemplateNode::SvelteElement(e) => {
-            collect_attribute_list_edits(source, &e.attributes, options, edits)?;
-            push_brace_wrapped_expression(source, &e.tag, options, edits)?;
             collect_template_edits(source, &e.fragment, options, edits)?;
         }
         TemplateNode::IfBlock(blk) => {
@@ -158,98 +151,6 @@ fn collect_node_edits(
             collect_template_edits(source, &blk.body, options, edits)?;
         }
         TemplateNode::Text(_) | TemplateNode::Comment(_) => {}
-    }
-    Ok(())
-}
-
-fn collect_attribute_list_edits(
-    source: &str,
-    attributes: &[Attribute],
-    options: &FormatOptions,
-    edits: &mut Vec<(u32, u32, String)>,
-) -> Result<(), FormatError> {
-    for attr in attributes {
-        match attr {
-            Attribute::Attribute(node) => {
-                collect_attribute_value_edits(source, &node.value, options, edits)?;
-            }
-            Attribute::SpreadAttribute(spread) => {
-                push_spread_attribute(
-                    source,
-                    spread.start,
-                    spread.end,
-                    &spread.expression,
-                    options,
-                    edits,
-                )?;
-            }
-            Attribute::AttachTag(attach) => {
-                push_tag_form(
-                    source,
-                    attach.start,
-                    attach.end,
-                    "@attach",
-                    &attach.expression,
-                    options,
-                    edits,
-                )?;
-            }
-            Attribute::BindDirective(d) => {
-                push_brace_wrapped_expression(source, &d.expression, options, edits)?;
-            }
-            Attribute::ClassDirective(d) => {
-                push_brace_wrapped_expression(source, &d.expression, options, edits)?;
-            }
-            Attribute::OnDirective(d) => {
-                if let Some(expr) = &d.expression {
-                    push_brace_wrapped_expression(source, expr, options, edits)?;
-                }
-            }
-            Attribute::TransitionDirective(d) => {
-                if let Some(expr) = &d.expression {
-                    push_brace_wrapped_expression(source, expr, options, edits)?;
-                }
-            }
-            Attribute::AnimateDirective(d) => {
-                if let Some(expr) = &d.expression {
-                    push_brace_wrapped_expression(source, expr, options, edits)?;
-                }
-            }
-            Attribute::UseDirective(d) => {
-                if let Some(expr) = &d.expression {
-                    push_brace_wrapped_expression(source, expr, options, edits)?;
-                }
-            }
-            Attribute::StyleDirective(d) => {
-                collect_attribute_value_edits(source, &d.value, options, edits)?;
-            }
-            Attribute::LetDirective(_) => {
-                // `let:item={pattern}` — value side is a destructuring
-                // pattern. Defer until pattern formatting is in.
-            }
-        }
-    }
-    Ok(())
-}
-
-fn collect_attribute_value_edits(
-    source: &str,
-    value: &AttributeValue,
-    options: &FormatOptions,
-    edits: &mut Vec<(u32, u32, String)>,
-) -> Result<(), FormatError> {
-    match value {
-        AttributeValue::True(_) => {}
-        AttributeValue::Expression(tag) => {
-            push_expression_tag(source, tag, options, edits)?;
-        }
-        AttributeValue::Sequence(parts) => {
-            for part in parts {
-                if let AttributeValuePart::ExpressionTag(tag) = part {
-                    push_expression_tag(source, tag, options, edits)?;
-                }
-            }
-        }
     }
     Ok(())
 }
@@ -338,31 +239,6 @@ fn push_debug_tag(
     }
     let joined = parts.join(", ");
     edits.push((tag_start, tag_end, format!("{{@debug {joined}}}")));
-    Ok(())
-}
-
-/// Replace `{...EXPR}` (spread-attribute full span) with the formatted
-/// expression body prefixed by `...`.
-fn push_spread_attribute(
-    source: &str,
-    attr_start: u32,
-    attr_end: u32,
-    expr: &Expression,
-    options: &FormatOptions,
-    edits: &mut Vec<(u32, u32, String)>,
-) -> Result<(), FormatError> {
-    let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
-        return Ok(());
-    };
-    let slice = source
-        .get(start as usize..end as usize)
-        .ok_or_else(|| FormatError::Parse("spread expression span out of bounds".into()))?
-        .trim();
-    if slice.is_empty() {
-        return Ok(());
-    }
-    let formatted = format_expression_source(slice, options)?;
-    edits.push((attr_start, attr_end, format!("{{...{formatted}}}")));
     Ok(())
 }
 

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod error;
 mod expression;
+mod markup;
 mod options;
 mod script;
 
@@ -44,6 +45,10 @@ pub fn format(source: &str, options: &FormatOptions) -> Result<String, FormatErr
         }
     }
 
+    // Open-tag rewrites first — they own the entire `<tag ...>` span
+    // including its attribute list. The expression pass below must skip
+    // anything inside an element opener so the two passes don't overlap.
+    markup::collect_open_tag_edits(source, &root.fragment, options, &mut edits)?;
     expression::collect_template_edits(source, &root.fragment, options, &mut edits)?;
 
     // Apply edits from the back so earlier offsets remain valid.

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -1,0 +1,526 @@
+//! Open-tag attribute normalization.
+//!
+//! Rewrites every element's open tag (`<tag attr1 attr2 ...>` or `... />`)
+//! with one normalized form per element. The rewrite includes the
+//! attribute list, so attribute-level expressions are formatted inline
+//! and the separate "edit per attribute expression" path in
+//! [`crate::expression`] is bypassed for everything inside an element's
+//! open tag.
+//!
+//! What this module owns:
+//! - Element open tags for every variant in [`TemplateNode`] that has
+//!   attributes (`RegularElement`, `Component`, `SvelteComponent`,
+//!   `SvelteElement`, `SlotElement`, `TitleElement`, plus the
+//!   `Svelte*` special-element family).
+//! - Attribute rendering (one space between attrs, normalized
+//!   self-closing as ` />`, shorthand for `name={name}` and
+//!   `bind:name={name}` / `class:name={name}`).
+//! - `this={X}` expressions on `<svelte:component>` and
+//!   `<svelte:element>` — they live in the open tag.
+//!
+//! What it does NOT own (those edits still come from
+//! [`crate::expression`]):
+//! - Template-position `{expr}`, `{@html ...}`, `{@render ...}`,
+//!   `{@debug ...}`, `{@attach ...}` standalone tags
+//! - Block headers (`{#if EXPR}`, `{#each ...}`, ...)
+//! - Children fragments (recursed into separately by the caller)
+
+use svelte_compiler_rust::ast::js::Expression;
+use svelte_compiler_rust::ast::template::{
+    Attribute, AttributeNode, AttributeValue, AttributeValuePart, Fragment, SpreadAttribute,
+    TemplateNode,
+};
+
+use crate::error::FormatError;
+use crate::expression::format_expression_source;
+use crate::options::FormatOptions;
+
+/// Walk a `Fragment` recursively and append open-tag rewrite edits for
+/// every element with attributes.
+pub(crate) fn collect_open_tag_edits(
+    source: &str,
+    fragment: &Fragment,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    for node in &fragment.nodes {
+        collect_node_open_tag_edits(source, node, options, edits)?;
+    }
+    Ok(())
+}
+
+fn collect_node_open_tag_edits(
+    source: &str,
+    node: &TemplateNode,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    match node {
+        TemplateNode::RegularElement(elem) => {
+            push_open_tag(
+                source,
+                elem.start,
+                elem.name.as_str(),
+                &elem.attributes,
+                None,
+                options,
+                edits,
+            )?;
+            collect_open_tag_edits(source, &elem.fragment, options, edits)?;
+        }
+        TemplateNode::Component(c) => {
+            push_open_tag(
+                source,
+                c.start,
+                c.name.as_str(),
+                &c.attributes,
+                None,
+                options,
+                edits,
+            )?;
+            collect_open_tag_edits(source, &c.fragment, options, edits)?;
+        }
+        TemplateNode::TitleElement(t) => {
+            push_open_tag(
+                source,
+                t.start,
+                t.name.as_str(),
+                &t.attributes,
+                None,
+                options,
+                edits,
+            )?;
+            collect_open_tag_edits(source, &t.fragment, options, edits)?;
+        }
+        TemplateNode::SlotElement(s) => {
+            push_open_tag(
+                source,
+                s.start,
+                s.name.as_str(),
+                &s.attributes,
+                None,
+                options,
+                edits,
+            )?;
+            collect_open_tag_edits(source, &s.fragment, options, edits)?;
+        }
+        TemplateNode::SvelteHead(s)
+        | TemplateNode::SvelteBody(s)
+        | TemplateNode::SvelteDocument(s)
+        | TemplateNode::SvelteFragment(s)
+        | TemplateNode::SvelteBoundary(s)
+        | TemplateNode::SvelteOptions(s)
+        | TemplateNode::SvelteSelf(s)
+        | TemplateNode::SvelteWindow(s) => {
+            push_open_tag(
+                source,
+                s.start,
+                s.name.as_str(),
+                &s.attributes,
+                None,
+                options,
+                edits,
+            )?;
+            collect_open_tag_edits(source, &s.fragment, options, edits)?;
+        }
+        TemplateNode::SvelteComponent(c) => {
+            push_open_tag(
+                source,
+                c.start,
+                c.name.as_str(),
+                &c.attributes,
+                Some(&c.expression),
+                options,
+                edits,
+            )?;
+            collect_open_tag_edits(source, &c.fragment, options, edits)?;
+        }
+        TemplateNode::SvelteElement(e) => {
+            push_open_tag(
+                source,
+                e.start,
+                e.name.as_str(),
+                &e.attributes,
+                Some(&e.tag),
+                options,
+                edits,
+            )?;
+            collect_open_tag_edits(source, &e.fragment, options, edits)?;
+        }
+        // Blocks have child fragments but no attributes themselves.
+        TemplateNode::IfBlock(blk) => {
+            collect_open_tag_edits(source, &blk.consequent, options, edits)?;
+            if let Some(alt) = &blk.alternate {
+                collect_open_tag_edits(source, alt, options, edits)?;
+            }
+        }
+        TemplateNode::EachBlock(blk) => {
+            collect_open_tag_edits(source, &blk.body, options, edits)?;
+            if let Some(fb) = &blk.fallback {
+                collect_open_tag_edits(source, fb, options, edits)?;
+            }
+        }
+        TemplateNode::AwaitBlock(blk) => {
+            if let Some(frag) = &blk.pending {
+                collect_open_tag_edits(source, frag, options, edits)?;
+            }
+            if let Some(frag) = &blk.then {
+                collect_open_tag_edits(source, frag, options, edits)?;
+            }
+            if let Some(frag) = &blk.catch {
+                collect_open_tag_edits(source, frag, options, edits)?;
+            }
+        }
+        TemplateNode::KeyBlock(blk) => {
+            collect_open_tag_edits(source, &blk.fragment, options, edits)?;
+        }
+        TemplateNode::SnippetBlock(blk) => {
+            collect_open_tag_edits(source, &blk.body, options, edits)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Push one edit covering the element's open tag span (from `<` to the
+/// `>` that closes the opener, inclusive). `this_expression` is the
+/// reactive `this={X}` expression carried by `<svelte:component>` and
+/// `<svelte:element>` — emitted as the first attribute when present so
+/// the rendering is independent of where the parser placed it in the
+/// source.
+fn push_open_tag(
+    source: &str,
+    element_start: u32,
+    tag_name: &str,
+    attributes: &[Attribute],
+    this_expression: Option<&Expression>,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    let Some(open_tag_end) = find_open_tag_end(source, element_start, attributes) else {
+        return Ok(());
+    };
+
+    let self_closing = is_self_closing(source, open_tag_end);
+
+    let mut rendered = String::with_capacity(tag_name.len() + 16);
+    rendered.push('<');
+    rendered.push_str(tag_name);
+
+    if let Some(expr) = this_expression
+        && let Some(formatted) = format_expression_at(source, expr, options)?
+    {
+        rendered.push(' ');
+        rendered.push_str("this={");
+        rendered.push_str(&formatted);
+        rendered.push('}');
+    }
+
+    for attr in attributes {
+        rendered.push(' ');
+        rendered.push_str(&render_attribute(attr, source, options)?);
+    }
+
+    if self_closing {
+        rendered.push_str(" />");
+    } else {
+        rendered.push('>');
+    }
+
+    edits.push((element_start, open_tag_end, rendered));
+    Ok(())
+}
+
+// ─── source-scan helpers ────────────────────────────────────────────────
+
+fn attribute_span(attr: &Attribute) -> (u32, u32) {
+    match attr {
+        Attribute::Attribute(n) => (n.start, n.end),
+        Attribute::SpreadAttribute(s) => (s.start, s.end),
+        Attribute::AttachTag(a) => (a.start, a.end),
+        Attribute::BindDirective(d) => (d.start, d.end),
+        Attribute::OnDirective(d) => (d.start, d.end),
+        Attribute::ClassDirective(d) => (d.start, d.end),
+        Attribute::StyleDirective(d) => (d.start, d.end),
+        Attribute::TransitionDirective(d) => (d.start, d.end),
+        Attribute::AnimateDirective(d) => (d.start, d.end),
+        Attribute::UseDirective(d) => (d.start, d.end),
+        Attribute::LetDirective(d) => (d.start, d.end),
+    }
+}
+
+/// Scan forward from after the last attribute (or just past `<tagname`
+/// when there are none) and return the position **after** the `>` that
+/// closes the opener.
+fn find_open_tag_end(source: &str, element_start: u32, attributes: &[Attribute]) -> Option<u32> {
+    let scan_from = if let Some(last) = attributes.last() {
+        attribute_span(last).1 as usize
+    } else {
+        // Skip the leading `<` and consume tag-name chars.
+        let bytes = source.as_bytes();
+        let mut i = element_start as usize + 1;
+        while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r' | b'>' | b'/') {
+            i += 1;
+        }
+        i
+    };
+
+    let bytes = source.as_bytes();
+    let mut i = scan_from;
+    while i < bytes.len() {
+        if bytes[i] == b'>' {
+            return Some((i + 1) as u32);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn is_self_closing(source: &str, open_tag_end: u32) -> bool {
+    let bytes = source.as_bytes();
+    if open_tag_end < 2 {
+        return false;
+    }
+    let mut i = open_tag_end as usize - 2;
+    loop {
+        match bytes[i] {
+            b' ' | b'\t' | b'\n' | b'\r' => {
+                if i == 0 {
+                    return false;
+                }
+                i -= 1;
+            }
+            b'/' => return true,
+            _ => return false,
+        }
+    }
+}
+
+// ─── attribute rendering ────────────────────────────────────────────────
+
+fn render_attribute(
+    attr: &Attribute,
+    source: &str,
+    options: &FormatOptions,
+) -> Result<String, FormatError> {
+    match attr {
+        Attribute::Attribute(node) => render_attribute_node(node, source, options),
+        Attribute::SpreadAttribute(spread) => render_spread(spread, source, options),
+        Attribute::AttachTag(attach) => {
+            let inner =
+                format_expression_at(source, &attach.expression, options)?.unwrap_or_default();
+            Ok(format!("{{@attach {inner}}}"))
+        }
+        Attribute::BindDirective(d) => {
+            let inner = format_expression_at(source, &d.expression, options)?.unwrap_or_default();
+            let modifiers = render_modifiers(&d.modifiers);
+            if inner == d.name.as_str() && modifiers.is_empty() {
+                Ok(format!("bind:{}", d.name))
+            } else {
+                Ok(format!("bind:{}{modifiers}={{{inner}}}", d.name))
+            }
+        }
+        Attribute::ClassDirective(d) => {
+            let inner = format_expression_at(source, &d.expression, options)?.unwrap_or_default();
+            if inner == d.name.as_str() {
+                Ok(format!("class:{}", d.name))
+            } else {
+                Ok(format!("class:{}={{{inner}}}", d.name))
+            }
+        }
+        Attribute::OnDirective(d) => {
+            let modifiers = render_modifiers(&d.modifiers);
+            if let Some(expr) = &d.expression {
+                let inner = format_expression_at(source, expr, options)?.unwrap_or_default();
+                Ok(format!("on:{}{modifiers}={{{inner}}}", d.name))
+            } else {
+                Ok(format!("on:{}{modifiers}", d.name))
+            }
+        }
+        Attribute::TransitionDirective(d) => {
+            let prefix = if d.intro && d.outro {
+                "transition"
+            } else if d.intro {
+                "in"
+            } else {
+                "out"
+            };
+            let modifiers = render_modifiers(&d.modifiers);
+            if let Some(expr) = &d.expression {
+                let inner = format_expression_at(source, expr, options)?.unwrap_or_default();
+                Ok(format!("{prefix}:{}{modifiers}={{{inner}}}", d.name))
+            } else {
+                Ok(format!("{prefix}:{}{modifiers}", d.name))
+            }
+        }
+        Attribute::AnimateDirective(d) => {
+            if let Some(expr) = &d.expression {
+                let inner = format_expression_at(source, expr, options)?.unwrap_or_default();
+                Ok(format!("animate:{}={{{inner}}}", d.name))
+            } else {
+                Ok(format!("animate:{}", d.name))
+            }
+        }
+        Attribute::UseDirective(d) => {
+            if let Some(expr) = &d.expression {
+                let inner = format_expression_at(source, expr, options)?.unwrap_or_default();
+                Ok(format!("use:{}={{{inner}}}", d.name))
+            } else {
+                Ok(format!("use:{}", d.name))
+            }
+        }
+        Attribute::StyleDirective(d) => {
+            let modifiers = render_modifiers(&d.modifiers);
+            let value = render_attribute_value_for_directive(&d.value, source, options)?;
+            if value.is_empty() {
+                Ok(format!("style:{}{modifiers}", d.name))
+            } else {
+                Ok(format!("style:{}{modifiers}={value}", d.name))
+            }
+        }
+        Attribute::LetDirective(d) => {
+            // `let:item` shorthand or `let:item={pattern}`.
+            // Pattern formatting is deferred — emit the raw source slice
+            // for the expression to avoid garbling destructuring.
+            if let Some(expr) = &d.expression {
+                let (Some(s), Some(e)) = (expr.start(), expr.end()) else {
+                    return Ok(format!("let:{}", d.name));
+                };
+                let raw = source.get(s as usize..e as usize).unwrap_or("").trim();
+                if raw.is_empty() || raw == d.name.as_str() {
+                    Ok(format!("let:{}", d.name))
+                } else {
+                    Ok(format!("let:{}={{{raw}}}", d.name))
+                }
+            } else {
+                Ok(format!("let:{}", d.name))
+            }
+        }
+    }
+}
+
+fn render_attribute_node(
+    node: &AttributeNode,
+    source: &str,
+    options: &FormatOptions,
+) -> Result<String, FormatError> {
+    match &node.value {
+        AttributeValue::True(_) => Ok(node.name.to_string()),
+        AttributeValue::Expression(tag) => {
+            let inner_src = source
+                .get(tag.start as usize + 1..tag.end as usize - 1)
+                .unwrap_or("")
+                .trim();
+            if inner_src.is_empty() {
+                return Ok(format!("{}={{}}", node.name));
+            }
+            let formatted = format_expression_source(inner_src, options)?;
+            // Svelte attribute shorthand: `name={name}` → `{name}`.
+            if formatted == node.name.as_str() {
+                Ok(format!("{{{formatted}}}"))
+            } else {
+                Ok(format!("{}={{{formatted}}}", node.name))
+            }
+        }
+        AttributeValue::Sequence(parts) => {
+            let body = render_attribute_value_sequence(parts, source, options)?;
+            Ok(format!("{}=\"{}\"", node.name, body))
+        }
+    }
+}
+
+fn render_attribute_value_for_directive(
+    value: &AttributeValue,
+    source: &str,
+    options: &FormatOptions,
+) -> Result<String, FormatError> {
+    match value {
+        AttributeValue::True(_) => Ok(String::new()),
+        AttributeValue::Expression(tag) => {
+            let inner_src = source
+                .get(tag.start as usize + 1..tag.end as usize - 1)
+                .unwrap_or("")
+                .trim();
+            if inner_src.is_empty() {
+                return Ok("{}".to_string());
+            }
+            let formatted = format_expression_source(inner_src, options)?;
+            Ok(format!("{{{formatted}}}"))
+        }
+        AttributeValue::Sequence(parts) => {
+            let body = render_attribute_value_sequence(parts, source, options)?;
+            Ok(format!("\"{body}\""))
+        }
+    }
+}
+
+fn render_attribute_value_sequence(
+    parts: &[AttributeValuePart],
+    source: &str,
+    options: &FormatOptions,
+) -> Result<String, FormatError> {
+    let mut out = String::new();
+    for part in parts {
+        match part {
+            AttributeValuePart::Text(t) => {
+                out.push_str(t.data.as_str());
+            }
+            AttributeValuePart::ExpressionTag(tag) => {
+                let inner_src = source
+                    .get(tag.start as usize + 1..tag.end as usize - 1)
+                    .unwrap_or("")
+                    .trim();
+                if inner_src.is_empty() {
+                    out.push_str("{}");
+                } else {
+                    let formatted = format_expression_source(inner_src, options)?;
+                    out.push('{');
+                    out.push_str(&formatted);
+                    out.push('}');
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn render_spread(
+    spread: &SpreadAttribute,
+    source: &str,
+    options: &FormatOptions,
+) -> Result<String, FormatError> {
+    let inner = format_expression_at(source, &spread.expression, options)?.unwrap_or_default();
+    Ok(format!("{{...{inner}}}"))
+}
+
+fn render_modifiers<S: AsRef<str>>(modifiers: &[S]) -> String {
+    if modifiers.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    for m in modifiers {
+        out.push('|');
+        out.push_str(m.as_ref());
+    }
+    out
+}
+
+/// Slice the expression's source span, trim it, and format. Returns
+/// `None` if the span is missing or empty.
+fn format_expression_at(
+    source: &str,
+    expr: &Expression,
+    options: &FormatOptions,
+) -> Result<Option<String>, FormatError> {
+    let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
+        return Ok(None);
+    };
+    let raw = source
+        .get(start as usize..end as usize)
+        .unwrap_or("")
+        .trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(format_expression_source(raw, options)?))
+}

--- a/crates/rsvelte_formatter/tests/markup_open_tag.rs
+++ b/crates/rsvelte_formatter/tests/markup_open_tag.rs
@@ -1,0 +1,193 @@
+//! Open-tag normalization: attribute spacing, self-closing form,
+//! `this={X}` rendering on `<svelte:component>` / `<svelte:element>`,
+//! and shorthand expansion.
+
+use rsvelte_formatter::{FormatOptions, format};
+
+fn fmt(src: &str) -> String {
+    format(src, &FormatOptions::default()).expect("format ok")
+}
+
+// ─── Whitespace normalization ────────────────────────────────────────────
+
+#[test]
+fn collapses_multiple_spaces_between_attributes() {
+    let out = fmt("<div  class=\"a\"   id=\"b\">  </div>");
+    assert!(
+        out.starts_with("<div class=\"a\" id=\"b\">"),
+        "expected single-space between attrs:\n{out}"
+    );
+}
+
+#[test]
+fn collapses_attribute_newlines_to_single_space() {
+    let out = fmt("<div\n  class=\"a\"\n  id=\"b\"\n></div>");
+    assert!(
+        out.starts_with("<div class=\"a\" id=\"b\">"),
+        "expected attributes on one line:\n{out}"
+    );
+}
+
+#[test]
+fn no_attributes_open_tag_stays_minimal() {
+    let out = fmt("<div  ></div>");
+    assert!(
+        out.starts_with("<div>"),
+        "expected `<div>` (trim trailing ws):\n{out}"
+    );
+}
+
+// ─── Self-closing form ───────────────────────────────────────────────────
+
+#[test]
+fn self_closing_normalized_to_space_slash() {
+    let out = fmt("<br/>");
+    assert!(out.contains("<br />"), "expected `<br />`:\n{out}");
+}
+
+#[test]
+fn self_closing_with_attributes() {
+    let out = fmt("<input  type=\"text\"  value={ foo }/>");
+    assert!(
+        out.contains("<input type=\"text\" value={foo} />"),
+        "expected normalized self-closing input:\n{out}"
+    );
+}
+
+#[test]
+fn closing_tag_not_treated_as_self_closing() {
+    let out = fmt("<div  class=\"a\"></div>");
+    assert!(out.contains("<div class=\"a\">"), "{out}");
+    assert!(!out.contains("/>"), "{out}");
+}
+
+// ─── Shorthand ───────────────────────────────────────────────────────────
+
+#[test]
+fn attribute_shorthand_collapses() {
+    let out = fmt("<div id={id}></div>");
+    assert!(out.contains("<div {id}>"), "expected shorthand:\n{out}");
+}
+
+#[test]
+fn attribute_no_shorthand_when_names_differ() {
+    let out = fmt("<div id={otherId}></div>");
+    assert!(
+        out.contains("<div id={otherId}>"),
+        "expected non-shorthand:\n{out}"
+    );
+}
+
+#[test]
+fn bind_directive_shorthand() {
+    let out = fmt("<input bind:value={value}/>");
+    assert!(
+        out.contains("<input bind:value />"),
+        "expected bind shorthand:\n{out}"
+    );
+}
+
+#[test]
+fn class_directive_shorthand() {
+    let out = fmt("<div class:active={active}></div>");
+    assert!(
+        out.contains("<div class:active>"),
+        "expected class shorthand:\n{out}"
+    );
+}
+
+// ─── Spread and tag-form attributes ──────────────────────────────────────
+
+#[test]
+fn spread_attribute_renders_in_open_tag() {
+    let out = fmt("<div  {...rest}  class=\"x\"></div>");
+    assert!(
+        out.starts_with("<div {...rest} class=\"x\">"),
+        "expected spread in open tag:\n{out}"
+    );
+}
+
+#[test]
+fn attach_attribute_renders_in_open_tag() {
+    let out = fmt("<div  {@attach effect}  class=\"x\"></div>");
+    assert!(
+        out.starts_with("<div {@attach effect} class=\"x\">"),
+        "expected @attach attribute in open tag:\n{out}"
+    );
+}
+
+// ─── Modifiers ───────────────────────────────────────────────────────────
+
+#[test]
+fn on_directive_preserves_modifiers() {
+    let out = fmt("<button on:click|preventDefault|stopPropagation={fn}></button>");
+    assert!(
+        out.contains("on:click|preventDefault|stopPropagation={fn}"),
+        "expected modifiers preserved:\n{out}"
+    );
+}
+
+#[test]
+fn transition_in_out_keyword() {
+    let out = fmt("<div in:fade  out:slide={ {duration: 200} }></div>");
+    assert!(out.contains("in:fade"), "{out}");
+    assert!(out.contains("out:slide={{ duration: 200 }}"), "{out}");
+}
+
+// ─── svelte:component / svelte:element this={X} ─────────────────────────
+
+#[test]
+fn svelte_component_this_renders_in_open_tag() {
+    let out = fmt("<svelte:component  this={ MyComp }  prop={ value } />");
+    assert!(
+        out.contains("<svelte:component this={MyComp} prop={value} />"),
+        "expected this attr in open tag:\n{out}"
+    );
+}
+
+#[test]
+fn svelte_element_tag_renders_in_open_tag() {
+    let out = fmt("<svelte:element  this={ tag }></svelte:element>");
+    assert!(
+        out.contains("<svelte:element this={tag}>"),
+        "expected this attr in open tag:\n{out}"
+    );
+}
+
+// ─── Component tags ──────────────────────────────────────────────────────
+
+#[test]
+fn component_open_tag_normalizes_attrs() {
+    let out = fmt("<MyComponent  name=\"x\"  value={ foo+1 } />");
+    assert!(
+        out.contains("<MyComponent name=\"x\" value={foo + 1} />"),
+        "expected component open tag normalized:\n{out}"
+    );
+}
+
+// ─── Title element ───────────────────────────────────────────────────────
+
+#[test]
+fn title_element_normalizes() {
+    let out = fmt("<title  >My Page</title>");
+    assert!(out.contains("<title>"), "{out}");
+}
+
+// ─── Combined ────────────────────────────────────────────────────────────
+
+#[test]
+fn end_to_end_realistic_component() {
+    let src = "<script>let count=0</script>\n\
+               <button  on:click={() =>count++}  class:active={count >0}  disabled={count > 10}>\n\
+                 {count}\n\
+               </button>";
+    let out = fmt(src);
+    assert!(out.contains("let count = 0;"), "{out}");
+    assert!(
+        out.contains(
+            "<button on:click={() => count++} class:active={count > 0} disabled={count > 10}>"
+        ),
+        "expected normalized open tag:\n{out}"
+    );
+    assert!(out.contains("{count}"), "{out}");
+}


### PR DESCRIPTION
> Stacked: #600 → #601 → #602 → **this PR**. CI doesn't run until each PR is retargeted at \`main\` (which happens automatically when the previous PR in the chain merges).

## Summary

The first piece of real markup formatting. Every element opener is rebuilt from the AST and spliced over the source span. The result is one consistently-spaced open tag per element, with attribute values' JS expressions formatted inline.

## What changes

For every element variant that carries attributes — \`RegularElement\`, \`Component\`, \`TitleElement\`, \`SlotElement\`, the \`Svelte*\` special-element family, plus \`<svelte:component>\` and \`<svelte:element>\` which also own the \`this={X}\` expression — the opener is rendered from scratch:

- One space between every attribute (collapses tabs, multiple spaces, newlines)
- Self-closing form normalized to \` />\` (with a single leading space)
- Attribute order preserved (rendered in AST order, mirroring source order)
- Attribute values' JS expressions formatted via the existing \`format_expression_source\` helper
- Svelte shorthand applied where round-trip-equivalent:
  - \`name={name}\` → \`{name}\`
  - \`bind:name={name}\` → \`bind:name\`
  - \`class:name={name}\` → \`class:name\`
- Directive modifiers preserved (\`on:click|preventDefault\`, etc.)
- \`transition:fade\` / \`in:fade\` / \`out:fade\` keyword preserved based on \`intro\` / \`outro\` flags
- \`<svelte:component this={X}>\` and \`<svelte:element this={X}>\` render \`this={X}\` as the first attribute, independent of where it appears in the source

## Why a single edit per opener (and not per attribute)

The expression pass in \`expression.rs\` previously pushed one edit per attribute-level expression. Those edits live inside the open-tag span that this module now owns, so they would overlap. To keep the splice math trivial:

- \`markup::collect_open_tag_edits\` runs **first** in \`lib.rs::format\`
- It pushes one edit per element opener, covering the whole opener
- \`expression::collect_template_edits\` no longer walks attribute lists or pushes \`this={X}\` edits — those branches were removed and the recursion now only descends into children fragments

The edits-list strategy is unchanged: all edits are applied in reverse-order at the end, so a per-opener rewrite composes with the expression/block/tag/script edits that target spans outside the opener.

## Examples

Input:

\`\`\`svelte
<div  class=\"a\"   id=\"b\"></div>
<input  type=\"text\"  value={ foo }/>
<button class:active={active} on:click|preventDefault={handler}>x</button>
<svelte:component  this={ MyComp }  prop={ value } />
\`\`\`

Output:

\`\`\`svelte
<div class=\"a\" id=\"b\"></div>
<input type=\"text\" value={foo} />
<button class:active on:click|preventDefault={handler}>x</button>
<svelte:component this={MyComp} prop={value} />
\`\`\`

## Skipped (still deferred to a pattern-formatting pass)

- \`let:item={pattern}\` — value rendered as raw source slice to avoid garbling destructuring. The directive itself is still normalized.

## Tests

19 new tests in \`tests/markup_open_tag.rs\` covering whitespace collapse, self-closing form, shorthand expansion, spread / \`@attach\` in open tags, directive modifiers, \`transition:\` / \`in:\` / \`out:\` keyword swap, \`<svelte:component>\` / \`<svelte:element>\` \`this\`, and a realistic combined fixture. Total crate tests: **57** (was 38).

## Test plan

- [x] \`cargo test -p rsvelte_formatter\`: 57 / 57 passing
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [ ] CI (gated on #602 merging into main first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)