### PR TITLE
feat(formatter): preserve whitespace inside &lt;pre&gt; and &lt;textarea&gt;

### DIFF
--- a/crates/rsvelte_formatter/src/indent.rs
+++ b/crates/rsvelte_formatter/src/indent.rs
@@ -75,6 +75,14 @@ fn recurse_into_children(
     let next_depth = enclosing_depth + 1;
     match node {
         TemplateNode::RegularElement(elem) => {
+            // `<pre>` and `<textarea>` preserve whitespace; don't recurse
+            // so no Text edits are pushed for their subtree. Open and
+            // close tags of the element itself are still normalized by
+            // `markup.rs` and expressions inside are still formatted by
+            // `expression.rs`.
+            if is_whitespace_preserving(elem.name.as_str()) {
+                return Ok(());
+            }
             collect_indent_edits(source, &elem.fragment, next_depth, options, edits)?;
         }
         TemplateNode::Component(c) => {
@@ -163,6 +171,13 @@ fn is_indent_provoking(node: &TemplateNode) -> bool {
 
 fn is_whitespace_only(s: &str) -> bool {
     !s.is_empty() && s.chars().all(|c| c.is_whitespace())
+}
+
+/// Elements whose interior whitespace is meaningful and must survive
+/// verbatim. Matches prettier-plugin-svelte's `whitespaceSensitive`
+/// list for the common cases.
+fn is_whitespace_preserving(tag_name: &str) -> bool {
+    matches!(tag_name, "pre" | "textarea")
 }
 
 fn indent_for_level(level: usize, opts: &JsFormatOptions) -> String {

--- a/crates/rsvelte_formatter/tests/markup_preserve_ws.rs
+++ b/crates/rsvelte_formatter/tests/markup_preserve_ws.rs
@@ -1,0 +1,72 @@
+//! Phase 6 coverage: whitespace inside `<pre>` and `<textarea>` is
+//! preserved verbatim. The element's own open / close tags are still
+//! normalized; only the body whitespace is left alone.
+
+use rsvelte_formatter::{FormatOptions, format};
+
+fn fmt(src: &str) -> String {
+    format(src, &FormatOptions::default()).expect("format ok")
+}
+
+#[test]
+fn pre_preserves_inner_whitespace() {
+    // Use lines that don't contain `{` — Svelte would otherwise parse
+    // it as a template expression. `<pre>` doesn't change that.
+    let src = "<pre>\n  some\n    indented\n      text\n</pre>";
+    let out = fmt(src);
+    assert!(
+        out.contains("\n  some\n    indented\n      text\n"),
+        "expected pre body verbatim:\n{out}"
+    );
+}
+
+#[test]
+fn pre_open_tag_still_normalized() {
+    let out = fmt("<pre  class=\"a\"  >x</pre>");
+    assert!(
+        out.starts_with("<pre class=\"a\">"),
+        "expected open tag normalized:\n{out}"
+    );
+}
+
+#[test]
+fn textarea_preserves_inner_whitespace() {
+    let src = "<textarea>\n  line1\n     line2\n</textarea>";
+    let out = fmt(src);
+    assert!(
+        out.contains("\n  line1\n     line2\n"),
+        "expected textarea body verbatim:\n{out}"
+    );
+}
+
+#[test]
+fn pre_with_child_element_preserves_outer_whitespace() {
+    // `<pre><code>x</code></pre>` — the whitespace-only Text inside is
+    // preserved; `<code>`'s open tag is still normalized.
+    let src = "<pre>\n  <code  class=\"x\">y</code>\n</pre>";
+    let out = fmt(src);
+    assert!(
+        out.contains("\n  <code class=\"x\">y</code>\n"),
+        "expected pre's inner whitespace preserved and code normalized:\n{out}"
+    );
+}
+
+#[test]
+fn nested_pre_inside_div_preserves() {
+    let src = "<div>\n<pre>\n  raw stuff\n</pre>\n</div>";
+    let out = fmt(src);
+    // The outer <div> still normalizes the whitespace around <pre>
+    // (depth 1 indent), but <pre>'s body is verbatim.
+    assert!(
+        out.contains("\n  <pre>\n  raw stuff\n</pre>\n"),
+        "expected outer indent + inner pre verbatim:\n{out}"
+    );
+}
+
+#[test]
+fn non_pre_element_still_reindents() {
+    // Sanity: this is the regression marker — Phase 6 should not have
+    // broken regular indentation.
+    let out = fmt("<div>\n<p>x</p>\n</div>");
+    assert_eq!(out, "<div>\n  <p>x</p>\n</div>");
+}


### PR DESCRIPTION
> Stacked: #600 → #601 → #602 → #603 → #604 → #605 → **this PR**.

## Summary

\`indent.rs\` now stops recursing into \`<pre>\` and \`<textarea>\` subtrees, so the whitespace-only Text nodes inside survive verbatim. The element's own open and close tags are still normalized (by \`markup.rs\`), and embedded \`{expr}\` interpolations inside the preserved body are still formatted (by \`expression.rs\`) — only the ambient whitespace is left alone.

This matches prettier-plugin-svelte's \`whitespaceSensitive\` behavior for the common cases. Other whitespace-sensitive elements (e.g. user-declared via Prettier's \`whitespaceSensitivity\` option) can be added later if there's demand.

## Example

Input:

\`\`\`svelte
<pre  class=\"a\"  >
  some
    indented
      text
</pre>
\`\`\`

Output:

\`\`\`svelte
<pre class=\"a\">
  some
    indented
      text
</pre>
\`\`\`

Open tag is normalized, body whitespace is preserved.

## Tests

6 new tests in \`tests/markup_preserve_ws.rs\` covering pre body verbatim, pre open-tag still normalized, textarea body verbatim, pre with a child element (outer ws preserved, child tag normalized), pre nested inside a normalizing div (outer indent applied, inner verbatim), and a regression marker that regular elements still re-indent.

Total crate tests: **88** (was 82).

## Test plan

- [x] \`cargo test -p rsvelte_formatter\`: 88 / 88 passing
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [ ] CI (gated on chain merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)