### PR TITLE
docs(formatter): add READMEs for rsvelte_formatter and rsvelte-fmt

### DIFF
--- a/crates/rsvelte_fmt/README.md
+++ b/crates/rsvelte_fmt/README.md
@@ -1,0 +1,140 @@
+# rsvelte-fmt
+
+Fast Svelte + JS/TS/CSS formatter — one CLI, written in Rust.
+
+`rsvelte-fmt` dispatches:
+
+- `.svelte` files to in-process [`rsvelte_formatter`](../rsvelte_formatter)
+- `.ts` / `.tsx` / `.js` / `.jsx` / `.cjs` / `.mjs` / `.json` / `.css`
+  files to a child `oxfmt` process
+
+Both pipelines run **in parallel** via `rayon::join`, so on a mixed
+project the in-process Svelte work overlaps with the `oxfmt` subprocess
+on every invocation. There are no Node calls and no Prettier doc-IR
+round-trip — just rsvelte parsing + `oxc_formatter`.
+
+## Status
+
+Functional v0. The Svelte path is tested end-to-end (6 integration
+tests). The `oxfmt` delegation path is exercised manually because
+`oxfmt` may not be present in every CI lane.
+
+## Install
+
+For now, build from source (the crate is not yet published):
+
+```bash
+cargo build --release -p rsvelte_fmt
+./target/release/rsvelte-fmt --help
+```
+
+You also need [`oxfmt`](https://oxc.rs/docs/guide/usage/formatter) on
+`$PATH` for non-`.svelte` files. Use `--oxfmt-bin PATH` to point at a
+specific binary.
+
+## Usage
+
+```
+rsvelte-fmt [OPTIONS] [PATH...]
+```
+
+### Write mode (default)
+
+```bash
+rsvelte-fmt src/
+```
+
+Walks `src/` recursively, formats every file in place. Skips
+`node_modules`, `target`, `dist`, `build`, and hidden directories.
+
+### Check mode
+
+```bash
+rsvelte-fmt --check src/
+```
+
+Reports which files would change, exits 1 if any. No writes.
+
+### Stdin mode (editor integration)
+
+```bash
+cat file.svelte | rsvelte-fmt --stdin --stdin-filepath file.svelte
+```
+
+Reads source on stdin, writes formatted output to stdout. The
+`--stdin-filepath` argument is used to dispatch to the right engine —
+the file does not need to exist on disk.
+
+This is the same shape Prettier and `oxfmt` use, so any editor
+integration that drives those (VS Code's Prettier extension, format-on-
+save hooks) can be pointed at `rsvelte-fmt` instead.
+
+## Options
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--write` | (implied for paths) | Write formatted output back |
+| `--check` | off | Exit 1 if any file would change |
+| `--stdin` | off | Read source on stdin |
+| `--stdin-filepath PATH` | — | Required with `--stdin` |
+| `--print-width N` | 80 | Maximum line width |
+| `--tab-width N` | 2 | Spaces per indent level |
+| `--use-tabs` | off | Indent with tabs |
+| `--oxfmt-bin PATH` | `oxfmt` | Subprocess binary for non-`.svelte` files |
+
+Options are forwarded to both halves of the dispatch so a mixed
+project formats consistently.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (write applied or check passed) |
+| 1 | `--check` found at least one file that would change |
+| 2 | Internal error (parse failure, `oxfmt` missing, IO error, …) |
+
+## Example
+
+```bash
+$ cat src/App.svelte
+<script>let count=1+2</script>
+<button on:click={() => count++}  class:active={count >0}>
+  { count + 1 }
+</button>
+
+$ rsvelte-fmt --check src/App.svelte
+would format src/App.svelte
+rsvelte-fmt: would reformat 1 / 1 files
+
+$ rsvelte-fmt src/App.svelte
+rsvelte-fmt: formatted 1 / 1 files
+
+$ cat src/App.svelte
+<script>
+  let count = 1 + 2;
+</script>
+<button on:click={() => count++} class:active={count > 0}>
+  {count + 1}
+</button>
+```
+
+## How it's different from `oxfmt + prettier-plugin-svelte`
+
+`oxfmt` currently delegates `.svelte` files to bundled
+`prettier-plugin-svelte`, which means every `.svelte` file pays:
+
+1. Node startup cost on the JS side
+2. Prettier's doc-IR round-trip
+3. Two parser passes (one in oxfmt for delegation, one in
+   prettier-plugin-svelte)
+
+`rsvelte-fmt` removes all three:
+
+- The Svelte parser is rsvelte (Rust, in-process).
+- The Svelte → output rewrite is straight `oxc_formatter` calls for JS
+  pieces plus a hand-rolled markup pass.
+- `oxfmt` is only invoked for the file types it natively supports.
+
+## License
+
+MIT

--- a/crates/rsvelte_formatter/README.md
+++ b/crates/rsvelte_formatter/README.md
@@ -1,0 +1,138 @@
+# rsvelte_formatter
+
+Fast Svelte 5 formatter built on top of the [rsvelte](../..) parser and
+[`oxc_formatter`](https://github.com/oxc-project/oxc/tree/main/crates/oxc_formatter).
+
+`rsvelte_formatter` is the library that powers [`rsvelte-fmt`](../rsvelte_fmt) —
+a Rust-native replacement for `prettier-plugin-svelte`. It formats `.svelte`
+source strings in-process, with zero subprocesses, zero Node, and JS/TS
+expression formatting handled by `oxc_formatter` so the JS half of a Svelte
+file matches what `oxfmt` produces for `.ts` / `.js`.
+
+## Status
+
+Functional and tested — **88 tests**, full hygiene (`cargo fmt`, `cargo
+clippy -- -D warnings`). Not yet shipped to crates.io; depended on by
+`rsvelte-fmt` via a workspace path.
+
+## What it formats
+
+| Surface | Status |
+|---|---|
+| `<script>` / `<script context="module">` body | Re-parsed with `oxc_parser`, formatted via `oxc_formatter::Formatter::build` |
+| Template-position `{expr}` interpolations | Formatted; whitespace inside braces collapsed |
+| Attribute values: `class={expr}`, `class="a{expr}b"` | Formatted inline |
+| Spread attribute: `{...obj.props}` | Formatted inline |
+| `{@html EXPR}`, `{@render EXPR}`, `{@debug ID, …}`, `{@attach EXPR}` | Formatted inline |
+| Directives: `bind:` / `class:` / `on:` / `transition:` / `in:` / `out:` / `animate:` / `use:` / `style:` | Expression formatted, modifiers preserved |
+| Block headers: `{#if}`, `{#each}`, `{#await}`, `{#key}`, `{#snippet}` | Test / iterable / promise / key formatted |
+| `<svelte:component this={X}>` / `<svelte:element this={X}>` | `this` rendered as first attribute |
+| Open-tag attribute spacing | Single space between attributes, normalized self-closing as ` />` |
+| Close-tag whitespace | `</div >` → `</div>` |
+| Attribute shorthand | `name={name}` → `{name}`, `bind:name={name}` → `bind:name`, `class:name={name}` → `class:name` |
+| Child indentation | Re-indented per nesting depth and `indent_style` / `indent_width` |
+| Block body indentation | Body of `{#if}` etc. indented one level deeper than the block |
+| Open-tag line wrapping | When the one-liner would overflow `line_width`, attributes break to one-per-line |
+| `<pre>` / `<textarea>` whitespace | Preserved verbatim |
+
+## What it does NOT (yet) format
+
+These are intentionally deferred — they need a pattern-formatting path
+(for destructuring-pattern formatting) or a CSS engine integration:
+
+| Surface | Why deferred |
+|---|---|
+| `{@const ident = expr}` | VariableDeclaration, not a bare expression — needs statement formatting |
+| `{#each iter as PATTERN}` context binding | Destructuring pattern |
+| `{#await … as PATTERN}` / `{:then PATTERN}` / `{:catch PATTERN}` | Destructuring patterns |
+| `{#snippet name(PARAM, …)}` parameter list | Destructuring patterns |
+| `let:item={PATTERN}` directive value | Destructuring pattern |
+| `<style>` body | CSS engine integration (see Roadmap) |
+| Text-content whitespace collapse | Behaviour decision pending (`<p>hello   world</p>`) |
+
+## Usage
+
+```rust
+use rsvelte_formatter::{format, FormatOptions, IndentStyle, JsFormatOptions, LineWidth};
+
+let source = r#"<script>let count=1+2</script>
+<button on:click={() => count++} class:active={count > 0}>
+  { count + 1 }
+</button>"#;
+
+let opts = FormatOptions {
+    js: JsFormatOptions {
+        indent_style: IndentStyle::Space,
+        line_width: LineWidth::try_from(80).unwrap(),
+        ..JsFormatOptions::new()
+    },
+};
+
+let formatted = format(source, &opts)?;
+```
+
+Output:
+
+```svelte
+<script>
+  let count = 1 + 2;
+</script>
+<button on:click={() => count++} class:active={count > 0}>
+  {count + 1}
+</button>
+```
+
+## Options
+
+`FormatOptions` is a thin wrapper around
+[`oxc_formatter::JsFormatOptions`](https://docs.rs/oxc_formatter/) so JS
+and Svelte share the same knobs:
+
+| Field | Default | Effect |
+|---|---|---|
+| `js.indent_style` | `Space` | Per indent level: `Space` or `Tab` |
+| `js.indent_width` | `2` | Spaces per indent level (ignored for tabs) |
+| `js.line_width` | `80` | Open-tag wrapping threshold |
+| `js.quote_style` | `Double` | String / attribute quote |
+| `js.semicolons` | `Always` | Semicolons in `<script>` bodies |
+| `js.trailing_commas` | `All` | Trailing commas in `<script>` bodies |
+| `js.arrow_parentheses` | `Always` | `(x) => x` vs `x => x` |
+| _everything else on `JsFormatOptions`_ | — | Used for `<script>` body and embedded expressions |
+
+`IndentStyle`, `IndentWidth`, and `LineWidth` are re-exported from
+the crate root.
+
+## Architecture (current implementation)
+
+The current implementation collects a list of source edits
+`(start, end, replacement)` from four passes, sorts them by descending
+start, and applies them in reverse order to the source string. Each pass
+owns a disjoint set of source spans:
+
+```
+lib.rs::format
+  ├─ script::format_script          (<script> bodies, oxc_formatter)
+  ├─ markup::collect_open_tag_edits (element open + close tags)
+  ├─ expression::collect_template_edits (template-position expressions, block headers, top-level @-tags)
+  └─ indent::collect_indent_edits   (whitespace-only Text nodes between siblings)
+```
+
+The passes are independent and compose because their spans don't
+overlap. A more principled Doc-IR-based formatter (using
+`oxc_formatter_core::Format`) is on the roadmap once the upstream
+builder helpers stabilize.
+
+## Roadmap
+
+- [ ] `<style>` body formatting (likely via `oxc_formatter`'s
+      `ExternalCallbacks::embedded_formatter` once the API stabilises,
+      or a small CSS engine integration)
+- [ ] Pattern formatting (destructuring inside `{#each as PATTERN}`,
+      `{#snippet name(PARAM)}`, `let:item={PATTERN}`)
+- [ ] `{@const}` statement formatting
+- [ ] Text-content whitespace collapse (`<p>hello   world</p>`)
+- [ ] User-extensible whitespace-sensitive element list
+
+## License
+
+MIT


### PR DESCRIPTION
> Stacked: #600 → #601 → #602 → #603 → #604 → #605 → #606 → **this PR**.

## Summary

User-facing documentation for the formatter library and CLI introduced in #600–#606.

### \`crates/rsvelte_formatter/README.md\`

- Status + test count (88)
- Capability table (what's formatted today)
- Deferred-features table (what's intentionally not formatted yet, with reasons)
- Programmatic usage example with output
- Full options reference covering \`FormatOptions\` + \`JsFormatOptions\`
- Architecture sketch of the edits-list strategy
- Roadmap

### \`crates/rsvelte_fmt/README.md\`

- Install + build
- Usage modes (write / check / stdin)
- Full CLI flag table
- Exit codes
- Worked example
- Comparison vs \`oxfmt + prettier-plugin-svelte\` showing why this is faster

## Test plan

- No code changes; nothing to test.
- Documentation reviewed for accuracy against current behavior (Phases 1–6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)