### PR TITLE
feat(formatter): format expressions in attributes, directives, blocks, tags

### DIFF
--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -2,7 +2,10 @@ use oxc_allocator::Allocator;
 use oxc_formatter::Formatter;
 use oxc_parser::{ParseOptions as OxcParseOptions, Parser};
 use oxc_span::SourceType;
-use svelte_compiler_rust::ast::template::{ExpressionTag, Fragment, TemplateNode};
+use svelte_compiler_rust::ast::js::Expression;
+use svelte_compiler_rust::ast::template::{
+    Attribute, AttributeValue, AttributeValuePart, ExpressionTag, Fragment, TemplateNode,
+};
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
@@ -14,71 +17,254 @@ fn formatter_parse_options() -> OxcParseOptions {
     }
 }
 
-/// Walk a `Fragment` recursively and append `(start, end, replacement)`
-/// edits for every `{expression}` tag whose body can be formatted.
-pub(crate) fn collect_expression_tag_edits(
+/// Walk a `Fragment` recursively, appending `(start, end, replacement)`
+/// edits for every JS expression we can safely format.
+pub(crate) fn collect_template_edits(
     source: &str,
     fragment: &Fragment,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<(), FormatError> {
     for node in &fragment.nodes {
-        match node {
-            TemplateNode::ExpressionTag(tag) => {
-                if let Some((start, end, formatted)) = format_expression_tag(source, tag, options)?
-                {
-                    edits.push((start, end, formatted));
+        collect_node_edits(source, node, options, edits)?;
+    }
+    Ok(())
+}
+
+fn collect_node_edits(
+    source: &str,
+    node: &TemplateNode,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    match node {
+        TemplateNode::ExpressionTag(tag) => {
+            push_expression_tag(source, tag, options, edits)?;
+        }
+        TemplateNode::HtmlTag(tag) => {
+            push_tag_form(
+                source,
+                tag.start,
+                tag.end,
+                "@html",
+                &tag.expression,
+                options,
+                edits,
+            )?;
+        }
+        TemplateNode::RenderTag(tag) => {
+            push_tag_form(
+                source,
+                tag.start,
+                tag.end,
+                "@render",
+                &tag.expression,
+                options,
+                edits,
+            )?;
+        }
+        TemplateNode::AttachTag(tag) => {
+            push_tag_form(
+                source,
+                tag.start,
+                tag.end,
+                "@attach",
+                &tag.expression,
+                options,
+                edits,
+            )?;
+        }
+        TemplateNode::DebugTag(tag) => {
+            push_debug_tag(source, tag.start, tag.end, &tag.identifiers, options, edits)?;
+        }
+        TemplateNode::ConstTag(_) | TemplateNode::DeclarationTag(_) => {
+            // Statement-shaped tags (`{@const x = e}`, `{let x = e}`,
+            // `{const x = e}`) — defer until statement formatting lands.
+        }
+        TemplateNode::RegularElement(elem) => {
+            collect_attribute_list_edits(source, &elem.attributes, options, edits)?;
+            collect_template_edits(source, &elem.fragment, options, edits)?;
+        }
+        TemplateNode::Component(c) => {
+            collect_attribute_list_edits(source, &c.attributes, options, edits)?;
+            collect_template_edits(source, &c.fragment, options, edits)?;
+        }
+        TemplateNode::TitleElement(t) => {
+            collect_attribute_list_edits(source, &t.attributes, options, edits)?;
+            collect_template_edits(source, &t.fragment, options, edits)?;
+        }
+        TemplateNode::SlotElement(s) => {
+            collect_attribute_list_edits(source, &s.attributes, options, edits)?;
+            collect_template_edits(source, &s.fragment, options, edits)?;
+        }
+        TemplateNode::SvelteHead(s)
+        | TemplateNode::SvelteBody(s)
+        | TemplateNode::SvelteDocument(s)
+        | TemplateNode::SvelteFragment(s)
+        | TemplateNode::SvelteBoundary(s)
+        | TemplateNode::SvelteOptions(s)
+        | TemplateNode::SvelteSelf(s)
+        | TemplateNode::SvelteWindow(s) => {
+            collect_attribute_list_edits(source, &s.attributes, options, edits)?;
+            collect_template_edits(source, &s.fragment, options, edits)?;
+        }
+        TemplateNode::SvelteComponent(c) => {
+            collect_attribute_list_edits(source, &c.attributes, options, edits)?;
+            push_brace_wrapped_expression(source, &c.expression, options, edits)?;
+            collect_template_edits(source, &c.fragment, options, edits)?;
+        }
+        TemplateNode::SvelteElement(e) => {
+            collect_attribute_list_edits(source, &e.attributes, options, edits)?;
+            push_brace_wrapped_expression(source, &e.tag, options, edits)?;
+            collect_template_edits(source, &e.fragment, options, edits)?;
+        }
+        TemplateNode::IfBlock(blk) => {
+            push_bare_expression(source, &blk.test, options, edits)?;
+            collect_template_edits(source, &blk.consequent, options, edits)?;
+            if let Some(alt) = &blk.alternate {
+                collect_template_edits(source, alt, options, edits)?;
+            }
+        }
+        TemplateNode::EachBlock(blk) => {
+            push_bare_expression(source, &blk.expression, options, edits)?;
+            if let Some(key) = &blk.key {
+                push_brace_wrapped_expression(source, key, options, edits)?;
+            }
+            // `context` is a destructuring pattern — defer.
+            collect_template_edits(source, &blk.body, options, edits)?;
+            if let Some(fb) = &blk.fallback {
+                collect_template_edits(source, fb, options, edits)?;
+            }
+        }
+        TemplateNode::AwaitBlock(blk) => {
+            push_bare_expression(source, &blk.expression, options, edits)?;
+            // `value` / `error` are patterns — defer.
+            if let Some(frag) = &blk.pending {
+                collect_template_edits(source, frag, options, edits)?;
+            }
+            if let Some(frag) = &blk.then {
+                collect_template_edits(source, frag, options, edits)?;
+            }
+            if let Some(frag) = &blk.catch {
+                collect_template_edits(source, frag, options, edits)?;
+            }
+        }
+        TemplateNode::KeyBlock(blk) => {
+            push_bare_expression(source, &blk.expression, options, edits)?;
+            collect_template_edits(source, &blk.fragment, options, edits)?;
+        }
+        TemplateNode::SnippetBlock(blk) => {
+            push_bare_expression(source, &blk.expression, options, edits)?;
+            collect_template_edits(source, &blk.body, options, edits)?;
+        }
+        TemplateNode::Text(_) | TemplateNode::Comment(_) => {}
+    }
+    Ok(())
+}
+
+fn collect_attribute_list_edits(
+    source: &str,
+    attributes: &[Attribute],
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    for attr in attributes {
+        match attr {
+            Attribute::Attribute(node) => {
+                collect_attribute_value_edits(source, &node.value, options, edits)?;
+            }
+            Attribute::SpreadAttribute(spread) => {
+                push_spread_attribute(
+                    source,
+                    spread.start,
+                    spread.end,
+                    &spread.expression,
+                    options,
+                    edits,
+                )?;
+            }
+            Attribute::AttachTag(attach) => {
+                push_tag_form(
+                    source,
+                    attach.start,
+                    attach.end,
+                    "@attach",
+                    &attach.expression,
+                    options,
+                    edits,
+                )?;
+            }
+            Attribute::BindDirective(d) => {
+                push_brace_wrapped_expression(source, &d.expression, options, edits)?;
+            }
+            Attribute::ClassDirective(d) => {
+                push_brace_wrapped_expression(source, &d.expression, options, edits)?;
+            }
+            Attribute::OnDirective(d) => {
+                if let Some(expr) = &d.expression {
+                    push_brace_wrapped_expression(source, expr, options, edits)?;
                 }
             }
-            TemplateNode::RegularElement(elem) => {
-                collect_expression_tag_edits(source, &elem.fragment, options, edits)?;
-            }
-            TemplateNode::Component(c) => {
-                collect_expression_tag_edits(source, &c.fragment, options, edits)?;
-            }
-            TemplateNode::TitleElement(t) => {
-                collect_expression_tag_edits(source, &t.fragment, options, edits)?;
-            }
-            TemplateNode::IfBlock(blk) => {
-                collect_expression_tag_edits(source, &blk.consequent, options, edits)?;
-                if let Some(alt) = &blk.alternate {
-                    collect_expression_tag_edits(source, alt, options, edits)?;
+            Attribute::TransitionDirective(d) => {
+                if let Some(expr) = &d.expression {
+                    push_brace_wrapped_expression(source, expr, options, edits)?;
                 }
             }
-            TemplateNode::EachBlock(blk) => {
-                collect_expression_tag_edits(source, &blk.body, options, edits)?;
-                if let Some(fb) = &blk.fallback {
-                    collect_expression_tag_edits(source, fb, options, edits)?;
+            Attribute::AnimateDirective(d) => {
+                if let Some(expr) = &d.expression {
+                    push_brace_wrapped_expression(source, expr, options, edits)?;
                 }
             }
-            TemplateNode::AwaitBlock(blk) => {
-                if let Some(frag) = &blk.pending {
-                    collect_expression_tag_edits(source, frag, options, edits)?;
-                }
-                if let Some(frag) = &blk.then {
-                    collect_expression_tag_edits(source, frag, options, edits)?;
-                }
-                if let Some(frag) = &blk.catch {
-                    collect_expression_tag_edits(source, frag, options, edits)?;
+            Attribute::UseDirective(d) => {
+                if let Some(expr) = &d.expression {
+                    push_brace_wrapped_expression(source, expr, options, edits)?;
                 }
             }
-            TemplateNode::KeyBlock(blk) => {
-                collect_expression_tag_edits(source, &blk.fragment, options, edits)?;
+            Attribute::StyleDirective(d) => {
+                collect_attribute_value_edits(source, &d.value, options, edits)?;
             }
-            TemplateNode::SnippetBlock(blk) => {
-                collect_expression_tag_edits(source, &blk.body, options, edits)?;
+            Attribute::LetDirective(_) => {
+                // `let:item={pattern}` — value side is a destructuring
+                // pattern. Defer until pattern formatting is in.
             }
-            _ => {}
         }
     }
     Ok(())
 }
 
-fn format_expression_tag(
+fn collect_attribute_value_edits(
+    source: &str,
+    value: &AttributeValue,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    match value {
+        AttributeValue::True(_) => {}
+        AttributeValue::Expression(tag) => {
+            push_expression_tag(source, tag, options, edits)?;
+        }
+        AttributeValue::Sequence(parts) => {
+            for part in parts {
+                if let AttributeValuePart::ExpressionTag(tag) = part {
+                    push_expression_tag(source, tag, options, edits)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ─── Splice strategies ──────────────────────────────────────────────────
+
+/// Replace `{...}` (template-position or attribute-value `ExpressionTag`)
+/// with the formatted expression body wrapped in braces. Collapses any
+/// whitespace inside the braces.
+fn push_expression_tag(
     source: &str,
     tag: &ExpressionTag,
     options: &FormatOptions,
-) -> Result<Option<(u32, u32, String)>, FormatError> {
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
     let outer = source
         .get(tag.start as usize..tag.end as usize)
         .ok_or_else(|| FormatError::Parse("expression tag span out of bounds".into()))?;
@@ -89,12 +275,192 @@ fn format_expression_tag(
         .trim();
 
     if inner.is_empty() {
-        return Ok(None);
+        return Ok(());
     }
 
     let formatted = format_expression_source(inner, options)?;
-    Ok(Some((tag.start, tag.end, format!("{{{formatted}}}"))))
+    edits.push((tag.start, tag.end, format!("{{{formatted}}}")));
+    Ok(())
 }
+
+/// Replace `{@<keyword> EXPR}` (full tag span) with the formatted expression
+/// body and a single space after the keyword.
+fn push_tag_form(
+    source: &str,
+    tag_start: u32,
+    tag_end: u32,
+    keyword: &str,
+    expr: &Expression,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
+        return Ok(());
+    };
+    let slice = source
+        .get(start as usize..end as usize)
+        .ok_or_else(|| FormatError::Parse("tag expression span out of bounds".into()))?
+        .trim();
+    if slice.is_empty() {
+        return Ok(());
+    }
+    let formatted = format_expression_source(slice, options)?;
+    edits.push((tag_start, tag_end, format!("{{{keyword} {formatted}}}")));
+    Ok(())
+}
+
+/// Replace `{@debug a, b, c}` with each identifier formatted, joined by
+/// a comma + single space.
+fn push_debug_tag(
+    source: &str,
+    tag_start: u32,
+    tag_end: u32,
+    identifiers: &[Expression],
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    let mut parts = Vec::with_capacity(identifiers.len());
+    for id in identifiers {
+        let (Some(start), Some(end)) = (id.start(), id.end()) else {
+            continue;
+        };
+        let slice = source
+            .get(start as usize..end as usize)
+            .ok_or_else(|| FormatError::Parse("debug identifier span out of bounds".into()))?
+            .trim();
+        if slice.is_empty() {
+            continue;
+        }
+        parts.push(format_expression_source(slice, options)?);
+    }
+    if parts.is_empty() {
+        return Ok(());
+    }
+    let joined = parts.join(", ");
+    edits.push((tag_start, tag_end, format!("{{@debug {joined}}}")));
+    Ok(())
+}
+
+/// Replace `{...EXPR}` (spread-attribute full span) with the formatted
+/// expression body prefixed by `...`.
+fn push_spread_attribute(
+    source: &str,
+    attr_start: u32,
+    attr_end: u32,
+    expr: &Expression,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
+        return Ok(());
+    };
+    let slice = source
+        .get(start as usize..end as usize)
+        .ok_or_else(|| FormatError::Parse("spread expression span out of bounds".into()))?
+        .trim();
+    if slice.is_empty() {
+        return Ok(());
+    }
+    let formatted = format_expression_source(slice, options)?;
+    edits.push((attr_start, attr_end, format!("{{...{formatted}}}")));
+    Ok(())
+}
+
+/// Splice over an expression's enclosing `{ ... }` if the source has
+/// `{ <ws> EXPR <ws> }` around the AST expression span (directive values,
+/// `this={X}` etc.). If no such enclosure is detectable, splice just the
+/// bare expression span (block headers like `{#if EXPR}` fall into this
+/// branch — the `{#if ` keyword stops the back-scan).
+fn push_brace_wrapped_expression(
+    source: &str,
+    expr: &Expression,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
+        return Ok(());
+    };
+    let slice = source
+        .get(start as usize..end as usize)
+        .ok_or_else(|| FormatError::Parse("expression span out of bounds".into()))?
+        .trim();
+    if slice.is_empty() {
+        return Ok(());
+    }
+    let formatted = format_expression_source(slice, options)?;
+
+    if let Some((brace_start, brace_end)) = enclosing_braces_span(source, start, end) {
+        edits.push((brace_start, brace_end, format!("{{{formatted}}}")));
+    } else {
+        edits.push((start, end, formatted));
+    }
+    Ok(())
+}
+
+/// Splice just the bare expression span — preserves whatever surrounds it
+/// in the source. Used for block-header expressions (`{#if EXPR}`,
+/// `{#each EXPR as ...}`, etc.) where the `{` is followed by a Svelte
+/// keyword (`#if` / `#each` / ...) rather than the expression itself.
+fn push_bare_expression(
+    source: &str,
+    expr: &Expression,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
+        return Ok(());
+    };
+    let slice = source
+        .get(start as usize..end as usize)
+        .ok_or_else(|| FormatError::Parse("expression span out of bounds".into()))?
+        .trim();
+    if slice.is_empty() {
+        return Ok(());
+    }
+    let formatted = format_expression_source(slice, options)?;
+    edits.push((start, end, formatted));
+    Ok(())
+}
+
+/// If the AST expression at `[expr_start, expr_end)` is enclosed by `{`
+/// and `}` (only whitespace between brace and expression), return the
+/// span covering the braces inclusive. Otherwise return `None`.
+fn enclosing_braces_span(source: &str, expr_start: u32, expr_end: u32) -> Option<(u32, u32)> {
+    let bytes = source.as_bytes();
+
+    let mut lbrace = None;
+    let mut i = expr_start as usize;
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b' ' | b'\t' | b'\n' | b'\r' => continue,
+            b'{' => {
+                lbrace = Some(i);
+                break;
+            }
+            _ => return None,
+        }
+    }
+    let lbrace = lbrace?;
+
+    let mut rbrace = None;
+    let mut j = expr_end as usize;
+    while j < bytes.len() {
+        match bytes[j] {
+            b' ' | b'\t' | b'\n' | b'\r' => j += 1,
+            b'}' => {
+                rbrace = Some(j);
+                break;
+            }
+            _ => return None,
+        }
+    }
+    let rbrace = rbrace?;
+
+    Some((lbrace as u32, (rbrace + 1) as u32))
+}
+
+// ─── Expression formatter ───────────────────────────────────────────────
 
 /// Format a single JS expression source. Wraps in parens to force
 /// expression context (so object literals like `{a:1}` aren't parsed as
@@ -116,8 +482,6 @@ pub(crate) fn format_expression_source(
 
     let formatted = Formatter::new(&allocator, options.js.clone()).build(&parser_ret.program);
 
-    // Output shape: "(<formatted>);\n" — strip trailing whitespace, the
-    // statement-terminator semicolon, then the wrapper parens we added.
     let s = formatted.trim_end().trim_end_matches(';').trim_end();
     Ok(strip_outer_parens(s).trim().to_string())
 }
@@ -130,9 +494,6 @@ fn strip_outer_parens(s: &str) -> &str {
     if outer_parens_match(inner) { inner } else { s }
 }
 
-/// Returns true if the outer `(` and `)` we just stripped were a matching
-/// pair (i.e. they aren't part of two unrelated sub-expressions like
-/// `(a) + (b)`).
 fn outer_parens_match(inner: &str) -> bool {
     let mut depth: i32 = 0;
     for c in inner.chars() {

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -44,7 +44,7 @@ pub fn format(source: &str, options: &FormatOptions) -> Result<String, FormatErr
         }
     }
 
-    expression::collect_expression_tag_edits(source, &root.fragment, options, &mut edits)?;
+    expression::collect_template_edits(source, &root.fragment, options, &mut edits)?;
 
     // Apply edits from the back so earlier offsets remain valid.
     edits.sort_by_key(|(start, _, _)| std::cmp::Reverse(*start));

--- a/crates/rsvelte_formatter/tests/markup_expressions.rs
+++ b/crates/rsvelte_formatter/tests/markup_expressions.rs
@@ -1,0 +1,246 @@
+//! Phase 1 coverage: format every JS expression that can appear inside
+//! an attribute value, a directive value, a Svelte block header, or a
+//! standalone tag (`@html` / `@render` / `@debug` / `@attach`). Markup,
+//! whitespace, attribute order, etc. all stay verbatim.
+
+use rsvelte_formatter::{FormatOptions, format};
+
+fn fmt(src: &str) -> String {
+    format(src, &FormatOptions::default()).expect("format ok")
+}
+
+// ─── Attribute values ────────────────────────────────────────────────────
+
+#[test]
+fn attr_expression_value() {
+    let out = fmt("<div class={ foo +1 }></div>");
+    assert!(
+        out.contains("class={foo + 1}"),
+        "expected attribute expr formatted:\n{out}"
+    );
+}
+
+#[test]
+fn attr_sequence_with_interp() {
+    let out = fmt("<div class=\"a{ foo +1 }b\"></div>");
+    assert!(
+        out.contains("class=\"a{foo + 1}b\""),
+        "expected interp inside attribute sequence formatted:\n{out}"
+    );
+}
+
+#[test]
+fn attr_boolean_stays_verbatim() {
+    let out = fmt("<input disabled />");
+    assert_eq!(out, "<input disabled />");
+}
+
+// ─── Spread attribute ────────────────────────────────────────────────────
+
+#[test]
+fn spread_attribute_expression() {
+    let out = fmt("<div {...obj . props}></div>");
+    assert!(
+        out.contains("{...obj.props}"),
+        "expected spread expr formatted:\n{out}"
+    );
+}
+
+// ─── Directives ──────────────────────────────────────────────────────────
+
+#[test]
+fn bind_directive_expression() {
+    let out = fmt("<input bind:value={ foo .bar }/>");
+    assert!(
+        out.contains("bind:value={foo.bar}"),
+        "expected bind expr formatted:\n{out}"
+    );
+}
+
+#[test]
+fn class_directive_expression() {
+    let out = fmt("<div class:active={ a&&b }></div>");
+    assert!(
+        out.contains("class:active={a && b}"),
+        "expected class directive expr formatted:\n{out}"
+    );
+}
+
+#[test]
+fn on_directive_with_handler() {
+    let out = fmt("<button on:click={() =>count++}>x</button>");
+    assert!(
+        out.contains("on:click={() => count++}"),
+        "expected on directive expr formatted:\n{out}"
+    );
+}
+
+#[test]
+fn on_directive_without_handler() {
+    let out = fmt("<button on:click>x</button>");
+    assert_eq!(out, "<button on:click>x</button>");
+}
+
+#[test]
+fn use_directive_with_argument() {
+    let out = fmt("<div use:action={ {a:1} }></div>");
+    assert!(
+        out.contains("use:action={{ a: 1 }}"),
+        "expected use directive expr formatted:\n{out}"
+    );
+}
+
+#[test]
+fn transition_directive_with_argument() {
+    let out = fmt("<div transition:fade={ { duration : 200 } }></div>");
+    assert!(
+        out.contains("transition:fade={{ duration: 200 }}"),
+        "expected transition directive expr formatted:\n{out}"
+    );
+}
+
+#[test]
+fn style_directive_value() {
+    let out = fmt("<div style:color={ active?'red':'blue' }></div>");
+    assert!(
+        out.contains("style:color={active ? \"red\" : \"blue\"}"),
+        "expected style directive value formatted:\n{out}"
+    );
+}
+
+// ─── Block headers ───────────────────────────────────────────────────────
+
+#[test]
+fn if_block_test() {
+    let out = fmt("{#if foo +1}<p>x</p>{/if}");
+    assert!(
+        out.contains("{#if foo + 1}"),
+        "expected if test formatted:\n{out}"
+    );
+}
+
+#[test]
+fn if_else_block_both_branches() {
+    let out = fmt("{#if a&&b}<p>{ x +1 }</p>{:else}<p>{ y +2 }</p>{/if}");
+    assert!(out.contains("{#if a && b}"), "{out}");
+    assert!(out.contains("{x + 1}"), "{out}");
+    assert!(out.contains("{y + 2}"), "{out}");
+}
+
+#[test]
+fn each_block_iterable_and_key() {
+    let out = fmt("{#each items.map(x=>x) as item (item.id)}<li>{ item.name }</li>{/each}");
+    assert!(
+        out.contains("{#each items.map((x) => x)"),
+        "expected each iterable formatted:\n{out}"
+    );
+    assert!(
+        out.contains("(item.id)"),
+        "expected each key formatted:\n{out}"
+    );
+    assert!(
+        out.contains("{item.name}"),
+        "expected each body interp formatted:\n{out}"
+    );
+}
+
+#[test]
+fn await_block_promise() {
+    let out = fmt("{#await fetch( url )}<p>loading</p>{:then data}<p>{ data.value }</p>{/await}");
+    assert!(
+        out.contains("{#await fetch(url)}"),
+        "expected await promise formatted:\n{out}"
+    );
+    assert!(
+        out.contains("{data.value}"),
+        "expected then-body interp formatted:\n{out}"
+    );
+}
+
+#[test]
+fn key_block_expression() {
+    let out = fmt("{#key value+1}<p>x</p>{/key}");
+    assert!(
+        out.contains("{#key value + 1}"),
+        "expected key expr formatted:\n{out}"
+    );
+}
+
+// ─── Tags ────────────────────────────────────────────────────────────────
+
+#[test]
+fn html_tag() {
+    let out = fmt("{@html  raw +'x' }");
+    assert!(
+        out.contains("{@html raw + \"x\"}"),
+        "expected @html expr formatted:\n{out}"
+    );
+}
+
+#[test]
+fn render_tag() {
+    let out = fmt("{@render foo (a , b )}");
+    assert!(
+        out.contains("{@render foo(a, b)}"),
+        "expected @render expr formatted:\n{out}"
+    );
+}
+
+#[test]
+fn debug_tag_multiple_identifiers() {
+    let out = fmt("{@debug a, b, c}");
+    assert!(
+        out.contains("{@debug a, b, c}"),
+        "expected @debug identifiers formatted (no-op):\n{out}"
+    );
+}
+
+#[test]
+fn attach_tag_as_attribute() {
+    let out = fmt("<div {@attach  effect (x ) }></div>");
+    assert!(
+        out.contains("{@attach effect(x)}"),
+        "expected @attach expr formatted:\n{out}"
+    );
+}
+
+// ─── svelte:component / svelte:element ───────────────────────────────────
+
+#[test]
+fn svelte_component_this() {
+    let out = fmt("<svelte:component this={ Comp ||Fallback } />");
+    assert!(
+        out.contains("this={Comp || Fallback}"),
+        "expected svelte:component this expr formatted:\n{out}"
+    );
+}
+
+#[test]
+fn svelte_element_this() {
+    let out = fmt("<svelte:element this={ tagName ||'div' }></svelte:element>");
+    assert!(
+        out.contains("this={tagName || \"div\"}"),
+        "expected svelte:element this expr formatted:\n{out}"
+    );
+}
+
+// ─── End-to-end mixed sanity ─────────────────────────────────────────────
+
+#[test]
+fn end_to_end_mix() {
+    let src = "<script>let count=1+2</script>\n\
+               <button on:click={() =>count++} class:active={count >5}>\n\
+                 { count +3 }\n\
+               </button>\n\
+               {#each Array.from({length:count}) as item}<li>{ item }</li>{/each}";
+    let out = fmt(src);
+    assert!(out.contains("let count = 1 + 2"), "script:\n{out}");
+    assert!(out.contains("on:click={() => count++}"), "on:\n{out}");
+    assert!(out.contains("class:active={count > 5}"), "class:\n{out}");
+    assert!(out.contains("{count + 3}"), "interp:\n{out}");
+    assert!(
+        out.contains("{#each Array.from({ length: count })"),
+        "each:\n{out}"
+    );
+    assert!(out.contains("{item}"), "each-body:\n{out}");
+}


### PR DESCRIPTION
> Replaces #601 (auto-closed when its base branch \`spike/oxc-formatter\` was deleted on #600 merge).

## Summary

Expands the expression-formatting pass from \"only \`<script>\` bodies and template-position \`{...}\` interpolations\" (#600) to **every JS expression that appears anywhere in markup**.

## What's now formatted

- **Attribute values**: \`class={foo+1}\`, \`class=\"a{foo+1}b\"\`
- **Spread attributes**: \`{...obj.props}\`
- **Directives**: \`bind:\`, \`class:\`, \`on:\`, \`transition:\`, \`in:\`, \`out:\`, \`animate:\`, \`use:\`, \`style:\`, \`{@attach EXPR}\` as attribute
- **Block headers**: \`{#if EXPR}\`, \`{#each ITER as ... (KEY)}\`, \`{#await EXPR}\`, \`{#key EXPR}\`, \`{#snippet NAME(...)}\`
- **Top-level tags**: \`{@html EXPR}\`, \`{@render EXPR}\`, \`{@debug ID, ID, ...}\`, \`{@attach EXPR}\`
- **Special elements**: \`<svelte:component this={X}/>\`, \`<svelte:element this={X}/>\`

Three splice strategies (full-tag / brace-wrapped / bare-span) chosen per node type — details in the original PR description.

## Tests

23 tests in \`tests/markup_expressions.rs\`. Total: **38** (was 15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)