### PR TITLE
chore(crate): rename svelte-compiler-rust → rsvelte_core

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -12,4 +12,4 @@ We have a quick list of common questions to get you started engaging with this p
 4. Once merged to `main`, the **Release** workflow opens (or updates) a "Version Packages" PR that bumps the version and updates `CHANGELOG.md`.
 5. Merging that PR triggers `wasm-pack build` and `pnpm publish` to the npm registry.
 
-See `npm/svelte-compiler-rust/README.md` for how the published artifact is assembled from `pkg/`.
+See `npm/rsvelte_core/README.md` for how the published artifact is assembled from `pkg/`.

--- a/.claude/sessions/ssr-ast-refactor-prompt.md
+++ b/.claude/sessions/ssr-ast-refactor-prompt.md
@@ -188,12 +188,12 @@ pub fn transform_server(analysis, ast, source, options) -> Result<String, Transf
 
 ## 環境
 
-- Docker コンテナ: `svelte-compiler-rust-dev`
-- ビルド: `docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && cargo build --release --features napi --lib && cp target/release/libsvelte_compiler_rust.so svelte/rsvelte.linux-arm64-gnu.node'`
-- テスト: `docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && cargo test --release --test runtime test_runtime_runes -- --nocapture'`
-- SSR 測定: `docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/bench/measure-ssr.mjs'`
-- Client 測定: `docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/precise-semantic-diff.mjs'`
-- 1ファイル SSR 差分: `docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/ssr-diff-one.mjs ".real-world-tests/<PATH>"'`
+- Docker コンテナ: `rsvelte_core-dev`
+- ビルド: `docker exec rsvelte_core-dev bash -c 'cd /workspace && cargo build --release --features napi --lib && cp target/release/librsvelte_core.so svelte/rsvelte.linux-arm64-gnu.node'`
+- テスト: `docker exec rsvelte_core-dev bash -c 'cd /workspace && cargo test --release --test runtime test_runtime_runes -- --nocapture'`
+- SSR 測定: `docker exec rsvelte_core-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/bench/measure-ssr.mjs'`
+- Client 測定: `docker exec rsvelte_core-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/precise-semantic-diff.mjs'`
+- 1ファイル SSR 差分: `docker exec rsvelte_core-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/ssr-diff-one.mjs ".real-world-tests/<PATH>"'`
 
 ## 現在の SSR 差分一覧 (30件)
 

--- a/.claude/sessions/ssr-fix-prompt.md
+++ b/.claude/sessions/ssr-fix-prompt.md
@@ -9,31 +9,31 @@
 
 ## 環境
 
-- 作業ディレクトリ: /Users/baseballyama/git/svelte-compiler-rust
-- Docker コンテナ: svelte-compiler-rust-dev で cargo コマンドを実行
+- 作業ディレクトリ: /Users/baseballyama/git/rsvelte_core
+- Docker コンテナ: rsvelte_core-dev で cargo コマンドを実行
 - NAPI バインディング: svelte/rsvelte.linux-arm64-gnu.node
 
 ## ビルドと測定コマンド
 
 ```bash
 # ビルド + NAPI コピー
-docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && cargo build --release --features napi --lib 2>&1 | tail -3 && cp target/release/libsvelte_compiler_rust.so svelte/rsvelte.linux-arm64-gnu.node'
+docker exec rsvelte_core-dev bash -c 'cd /workspace && cargo build --release --features napi --lib 2>&1 | tail -3 && cp target/release/librsvelte_core.so svelte/rsvelte.linux-arm64-gnu.node'
 
 # SSR 測定
-docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/bench/measure-ssr.mjs 2>&1'
+docker exec rsvelte_core-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/bench/measure-ssr.mjs 2>&1'
 
 # Client 測定（リグレッション確認用）
-docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/precise-semantic-diff.mjs 2>&1 | head -10'
+docker exec rsvelte_core-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/precise-semantic-diff.mjs 2>&1 | head -10'
 
 # SSR カテゴリ分類
-docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/categorize-ssr-diffs.mjs 2>&1'
+docker exec rsvelte_core-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/categorize-ssr-diffs.mjs 2>&1'
 
 # 1ファイルのSSR差分確認
-docker exec svelte-compiler-rust-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/ssr-diff-one.mjs <FILE_PATH> 2>&1'
+docker exec rsvelte_core-dev bash -c 'cd /workspace && LD_PRELOAD=/workspace/svelte/rsvelte.linux-arm64-gnu.node node scripts/diff/ssr-diff-one.mjs <FILE_PATH> 2>&1'
 # → /tmp/ssr_js.js と /tmp/ssr_rs.js に書き出される
 
 # テスト
-docker exec svelte-compiler-rust-dev cargo test --release --no-fail-fast 2>&1 | grep FAILED
+docker exec rsvelte_core-dev cargo test --release --no-fail-fast 2>&1 | grep FAILED
 ```
 
 ## SSR 141 件の差異カテゴリ
@@ -123,7 +123,7 @@ RS:     const flipOrdering = (ordering) => {
 
 - Client の 910/910 を壊さないこと。各変更後に `precise-semantic-diff.mjs` を実行
 - SSR パニック修正済み（`helpers.rs:1409` のスライスエラー）
-- `docker-dev.sh` ではなく直接 `docker exec svelte-compiler-rust-dev ...` を使う
+- `docker-dev.sh` ではなく直接 `docker exec rsvelte_core-dev ...` を使う
 - Docker コンテナは `aarch64` (ARM64)
 - コミットは頻繁に、各論理的な修正ごとに commit + push
 - `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings` をコミット前に

--- a/.claude/skills/full-code-review/SKILL.md
+++ b/.claude/skills/full-code-review/SKILL.md
@@ -835,7 +835,7 @@ NAPI 経由の挙動に影響する変更があれば、vitest も実行する:
 
 ```bash
 cargo build --release --features napi --lib
-cp target/release/libsvelte_compiler_rust.dylib svelte/rsvelte.darwin-arm64.node
+cp target/release/librsvelte_core.dylib svelte/rsvelte.darwin-arm64.node
 cd svelte
 USE_RSVELTE=true npx vitest run packages/svelte/tests/runtime-runes/test.ts packages/svelte/tests/runtime-legacy/test.ts
 ```

--- a/.claude/skills/perf-loop/SKILL.md
+++ b/.claude/skills/perf-loop/SKILL.md
@@ -368,7 +368,7 @@ ls ~/.cargo/registry/src/*/oxc_ast-*/src/
 
 ```bash
 cargo build --release --features napi --lib
-cp target/release/libsvelte_compiler_rust.dylib svelte/rsvelte.darwin-arm64.node
+cp target/release/librsvelte_core.dylib svelte/rsvelte.darwin-arm64.node
 cd svelte && USE_RSVELTE=true npx vitest run \
   packages/svelte/tests/runtime-runes/test.ts \
   packages/svelte/tests/runtime-legacy/test.ts

--- a/.claude/skills/upgrade-svelte/SKILL.md
+++ b/.claude/skills/upgrade-svelte/SKILL.md
@@ -229,7 +229,7 @@ All tests must pass.
 ```bash
 # Build NAPI binding
 cargo build --release --features napi --lib
-cp target/release/libsvelte_compiler_rust.dylib svelte/rsvelte.darwin-arm64.node
+cp target/release/librsvelte_core.dylib svelte/rsvelte.darwin-arm64.node
 
 # Run official Svelte test suite with rsvelte
 cd svelte
@@ -297,7 +297,7 @@ cargo test --release
 
 # NAPI build
 cargo build --release --features napi --lib
-cp target/release/libsvelte_compiler_rust.dylib svelte/rsvelte.darwin-arm64.node
+cp target/release/librsvelte_core.dylib svelte/rsvelte.darwin-arm64.node
 
 # Vitest
 cd svelte && USE_RSVELTE=true npx vitest run packages/svelte/tests/runtime-runes/test.ts packages/svelte/tests/runtime-legacy/test.ts

--- a/.claude/skills/verify-svelte-compat/scripts/build-rsvelte.sh
+++ b/.claude/skills/verify-svelte-compat/scripts/build-rsvelte.sh
@@ -28,7 +28,7 @@ cd "$ROOT"
 echo "[build-rsvelte] cargo build --release --features napi --lib"
 cargo build --release --features napi --lib
 
-SRC="target/release/libsvelte_compiler_rust.${EXT}"
+SRC="target/release/librsvelte_core.${EXT}"
 if [ ! -f "$SRC" ]; then
   echo "[build-rsvelte] ERROR: build output not found: $SRC" >&2
   exit 1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "svelte-compiler-rust",
+  "name": "rsvelte_core",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "dev",
   "workspaceFolder": "/workspace",

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -107,13 +107,13 @@ jobs:
         # apps/playground/rsvelte-shim/compiler.mjs loads
         # apps/npm/vite-plugin-svelte-native-<triple>/rsvelte.node at build time so
         # vite-plugin-svelte compiles every .svelte through rsvelte. Ubuntu CI
-        # is linux-x64-gnu; the cdylib is named libsvelte_compiler_rust.so.
+        # is linux-x64-gnu; the cdylib is named librsvelte_core.so.
         run: cargo build --release --features napi --lib
 
       - name: Stage NAPI binding
         run: |
           mkdir -p apps/npm/vite-plugin-svelte-native-linux-x64-gnu
-          cp target/release/libsvelte_compiler_rust.so \
+          cp target/release/librsvelte_core.so \
              apps/npm/vite-plugin-svelte-native-linux-x64-gnu/rsvelte.node
 
       - name: Setup pnpm cache for playground

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, dylib: libsvelte_compiler_rust.dylib }
-          - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, dylib: libsvelte_compiler_rust.dylib }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, dylib: libsvelte_compiler_rust.so }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, dylib: libsvelte_compiler_rust.so, apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, dylib: svelte_compiler_rust.dll }
+          - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, dylib: librsvelte_core.dylib }
+          - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, dylib: librsvelte_core.dylib }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, dylib: librsvelte_core.so }
+          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, dylib: librsvelte_core.so, apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, dylib: rsvelte_core.dll }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,9 +1892,60 @@ name = "rsvelte_capi"
 version = "0.1.1"
 dependencies = [
  "cbindgen",
+ "rsvelte_core",
  "serde",
  "serde_json",
- "svelte-compiler-rust",
+]
+
+[[package]]
+name = "rsvelte_core"
+version = "0.6.0"
+dependencies = [
+ "bumpalo",
+ "chrono",
+ "clap",
+ "compact_str",
+ "console_error_panic_hook",
+ "criterion",
+ "getrandom 0.4.2",
+ "glob",
+ "im",
+ "indexmap",
+ "insta",
+ "itoa",
+ "lazy_static",
+ "memchr",
+ "miette",
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "notify",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_codegen",
+ "oxc_diagnostics",
+ "oxc_formatter",
+ "oxc_parser",
+ "oxc_semantic",
+ "oxc_span",
+ "oxc_syntax",
+ "pretty_assertions",
+ "rayon",
+ "regex",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "similar 3.1.1",
+ "smallvec",
+ "sourcemap",
+ "string_wizard",
+ "test-generator",
+ "thiserror",
+ "tikv-jemallocator",
+ "tokio",
+ "walkdir",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1920,7 +1971,7 @@ dependencies = [
  "oxc_formatter_core",
  "oxc_parser",
  "oxc_span",
- "svelte-compiler-rust",
+ "rsvelte_core",
  "thiserror",
 ]
 
@@ -2169,57 +2220,6 @@ name = "supports-unicode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
-
-[[package]]
-name = "svelte-compiler-rust"
-version = "0.6.0"
-dependencies = [
- "bumpalo",
- "chrono",
- "clap",
- "compact_str",
- "console_error_panic_hook",
- "criterion",
- "getrandom 0.4.2",
- "glob",
- "im",
- "indexmap",
- "insta",
- "itoa",
- "lazy_static",
- "memchr",
- "miette",
- "napi",
- "napi-build",
- "napi-derive",
- "notify",
- "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_codegen",
- "oxc_diagnostics",
- "oxc_formatter",
- "oxc_parser",
- "oxc_semantic",
- "oxc_span",
- "oxc_syntax",
- "pretty_assertions",
- "rayon",
- "regex",
- "rustc-hash",
- "serde",
- "serde_json",
- "similar 3.1.1",
- "smallvec",
- "sourcemap",
- "string_wizard",
- "test-generator",
- "thiserror",
- "tikv-jemallocator",
- "tokio",
- "walkdir",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "syn"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Development environment for svelte-compiler-rust
+# Development environment for rsvelte_core
 FROM rust:1.96-bookworm
 
 # Install Node.js 22.x and pnpm

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Useful if you're building your own language tooling on top of the same surface `
 
 ```toml
 [dependencies]
-svelte-compiler-rust = { git = "https://github.com/baseballyama/rsvelte" }
+rsvelte_core = { git = "https://github.com/baseballyama/rsvelte" }
 ```
 
 ```rust

--- a/apps/npm/compiler/README.md
+++ b/apps/npm/compiler/README.md
@@ -2,7 +2,7 @@
 
 This directory is the **changesets version anchor** for the `@rsvelte/compiler` npm package. It contains no runtime code.
 
-The actual published artifact is built by `wasm-pack` into the repo-root `pkg/` directory. When `pnpm publish` runs against this workspace package, the `publishConfig.directory` field redirects it to pack and upload `pkg/`. Right before publish, `scripts/release/finalize-pkg.mjs` rewrites `pkg/package.json`'s `name` from the Cargo crate name (`svelte-compiler-rust`) to the scoped npm name (`@rsvelte/compiler`).
+The actual published artifact is built by `wasm-pack` into the repo-root `pkg/` directory. When `pnpm publish` runs against this workspace package, the `publishConfig.directory` field redirects it to pack and upload `pkg/`. Right before publish, `scripts/release/finalize-pkg.mjs` rewrites `pkg/package.json`'s `name` from the Cargo crate name (`rsvelte_core`) to the scoped npm name (`@rsvelte/compiler`).
 
 Why split it this way:
 

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -20,6 +20,6 @@ export default defineConfig({
 		}
 	},
 	optimizeDeps: {
-		exclude: ['svelte-compiler-rust']
+		exclude: ['rsvelte_core']
 	}
 });

--- a/crates/rsvelte_capi/Cargo.toml
+++ b/crates/rsvelte_capi/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["svelte", "compiler", "ffi", "cdylib", "bindings"]
 categories = ["compilers", "external-ffi-bindings", "web-programming"]
 # Releases live on GitHub Releases (per-OS prebuilt cdylibs) — see the
 # Release rsvelte_capi workflow. crates.io publishing additionally
-# requires `svelte-compiler-rust` itself to be published; until then,
+# requires `rsvelte_core` itself to be published; until then,
 # Rust callers should depend on this crate via a git path.
 publish = false
 
@@ -23,7 +23,7 @@ publish = false
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-svelte-compiler-rust = { path = "../rsvelte_core", default-features = false, features = ["native"] }
+rsvelte_core = { path = "../rsvelte_core", default-features = false, features = ["native"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 

--- a/crates/rsvelte_capi/README.md
+++ b/crates/rsvelte_capi/README.md
@@ -16,7 +16,7 @@ shared library + one header that **any** language with a C FFI can call
 | PHP (7.4+)        | built-in `FFI` extension                 | code shipped           | ✅      |
 | Java (JDK 22+)    | `java.lang.foreign` (FFM API)            | code shipped           | ✅      |
 | C++               | include `rsvelte.h` (extern "C" guarded) | covered by C smoke     | —       |
-| Rust              | depend on `svelte-compiler-rust` direct  | —                      | —       |
+| Rust              | depend on `rsvelte_core` direct  | —                      | —       |
 | Kotlin / Scala    | same as Java (FFM)                       | code shipped           | —       |
 | .NET (C# / F#)    | `[DllImport]` / `LibraryImport`          | applicable             | —       |
 | Swift             | bridging header                          | applicable             | —       |
@@ -83,7 +83,7 @@ cargo build -p rsvelte_capi --release
 ### Rust callers (`Cargo.toml`)
 
 `rsvelte_capi` itself is not yet published to crates.io (it depends
-on the unpublished `svelte-compiler-rust` core crate). Add it as a
+on the unpublished `rsvelte_core` core crate). Add it as a
 git dependency in the meantime:
 
 ```toml

--- a/crates/rsvelte_capi/include/rsvelte.h
+++ b/crates/rsvelte_capi/include/rsvelte.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Library version (matches the `svelte-compiler-rust` crate version).
+ * Library version (matches the `rsvelte_core` crate version).
  *
  * Returns a static, NUL-terminated UTF-8 string. The caller MUST NOT
  * free the returned pointer.

--- a/crates/rsvelte_capi/src/lib.rs
+++ b/crates/rsvelte_capi/src/lib.rs
@@ -28,12 +28,12 @@
 
 use std::os::raw::c_char;
 
-use serde::Deserialize;
-use serde_json::Value;
-use svelte_compiler_rust::compiler::{
+use rsvelte_core::compiler::{
     CompileOptions, CssMode, ExperimentalOptions, GenerateMode, ModuleCompileOptions, Namespace,
     compile as rust_compile, compile_module as rust_compile_module,
 };
+use serde::Deserialize;
+use serde_json::Value;
 
 /// Owned byte buffer crossing the FFI boundary.
 ///
@@ -67,7 +67,7 @@ impl RsvelteBuf {
     }
 }
 
-/// Library version (matches the `svelte-compiler-rust` crate version).
+/// Library version (matches the `rsvelte_core` crate version).
 ///
 /// Returns a static, NUL-terminated UTF-8 string. The caller MUST NOT
 /// free the returned pointer.
@@ -393,20 +393,20 @@ unsafe fn parse_compile_options(ptr: *const u8, len: usize) -> Result<CompileOpt
         && let Some(v) = compat.component_api
     {
         opts.compatibility.component_api = if v == 4 {
-            svelte_compiler_rust::compiler::ComponentApi::V4
+            rsvelte_core::compiler::ComponentApi::V4
         } else {
-            svelte_compiler_rust::compiler::ComponentApi::V5
+            rsvelte_core::compiler::ComponentApi::V5
         };
     }
     if let Some(hash_override) = raw.css_hash_override {
         opts.css_hash = Some(std::sync::Arc::new(
-            move |_: &svelte_compiler_rust::compiler::CssHashInput| hash_override.clone(),
+            move |_: &rsvelte_core::compiler::CssHashInput| hash_override.clone(),
         ));
     }
     if let Some(v) = raw.fragments.as_deref() {
         opts.fragments = match v {
-            "tree" => svelte_compiler_rust::compiler::FragmentMode::Tree,
-            _ => svelte_compiler_rust::compiler::FragmentMode::Html,
+            "tree" => rsvelte_core::compiler::FragmentMode::Tree,
+            _ => rsvelte_core::compiler::FragmentMode::Html,
         };
     }
     Ok(opts)
@@ -450,7 +450,7 @@ unsafe fn parse_module_options(ptr: *const u8, len: usize) -> Result<ModuleCompi
 
 // --- result encoding ------------------------------------------------------
 
-fn compile_result_to_json(result: &svelte_compiler_rust::compiler::CompileResult) -> Value {
+fn compile_result_to_json(result: &rsvelte_core::compiler::CompileResult) -> Value {
     let js_obj = serde_json::json!({
         "code": result.js.code,
         "map": result

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "svelte-compiler-rust"
+name = "rsvelte_core"
 version = "0.6.0"
 edition = "2024"
 rust-version = "1.90"

--- a/crates/rsvelte_core/benches/compiler.rs
+++ b/crates/rsvelte_core/benches/compiler.rs
@@ -10,10 +10,10 @@ use std::fs;
 use std::hint::black_box;
 use std::path::PathBuf;
 
-use svelte_compiler_rust::compiler::phases::phase1_parse::{ParseOptions, parse};
-use svelte_compiler_rust::compiler::phases::phase2_analyze::analyze_component;
-use svelte_compiler_rust::compiler::phases::phase3_transform::transform_component;
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse};
+use rsvelte_core::compiler::phases::phase2_analyze::analyze_component;
+use rsvelte_core::compiler::phases::phase3_transform::transform_component;
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 /// Get sample Svelte files for benchmarking.
 fn get_sample_files() -> Vec<(String, String)> {

--- a/crates/rsvelte_core/benches/parser.rs
+++ b/crates/rsvelte_core/benches/parser.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::hint::black_box;
 use std::path::PathBuf;
 
-use svelte_compiler_rust::{ParseOptions, parse, parse_parallel};
+use rsvelte_core::{ParseOptions, parse, parse_parallel};
 
 /// Get sample Svelte files for benchmarking.
 fn get_sample_files() -> Vec<(String, String)> {

--- a/crates/rsvelte_core/src/bin/benchmark_runner.rs
+++ b/crates/rsvelte_core/src/bin/benchmark_runner.rs
@@ -25,10 +25,10 @@ use std::time::Instant;
 #[cfg(feature = "native")]
 use rayon::prelude::*;
 
-use svelte_compiler_rust::svelte2tsx::{
+use rsvelte_core::svelte2tsx::{
     Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion, svelte2tsx,
 };
-use svelte_compiler_rust::{CompileOptions, GenerateMode, ParseOptions, compile, parse};
+use rsvelte_core::{CompileOptions, GenerateMode, ParseOptions, compile, parse};
 
 #[derive(Debug, Clone, PartialEq)]
 enum Task {
@@ -193,7 +193,7 @@ fn run_single_threaded(files: &[(String, String)], task: &Task) {
         Task::Parse => {
             // Reuse parser instance across files for reduced per-file overhead
             let dummy_source = "";
-            let mut parser = svelte_compiler_rust::compiler::phases::phase1_parse::Parser::new(
+            let mut parser = rsvelte_core::compiler::phases::phase1_parse::Parser::new(
                 dummy_source,
                 ParseOptions {
                     modern: true,
@@ -209,7 +209,7 @@ fn run_single_threaded(files: &[(String, String)], task: &Task) {
                 ..Default::default()
             };
             for (_path, content) in files {
-                let _ = svelte_compiler_rust::compiler::phases::phase1_parse::parse_reuse(
+                let _ = rsvelte_core::compiler::phases::phase1_parse::parse_reuse(
                     &mut parser,
                     content,
                     options,

--- a/crates/rsvelte_core/src/bin/compile_profile.rs
+++ b/crates/rsvelte_core/src/bin/compile_profile.rs
@@ -18,12 +18,12 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use svelte_compiler_rust::compiler::phases::phase1_parse::{
+use rsvelte_core::compiler::phases::phase1_parse::{
     ParseOptions, compute_line_offsets, ensure_script_parsed, parse, resolve_lazy_expressions,
 };
-use svelte_compiler_rust::compiler::phases::phase2_analyze::analyze_component;
-use svelte_compiler_rust::compiler::phases::phase3_transform::{profile, transform_component};
-use svelte_compiler_rust::{CompileOptions, GenerateMode};
+use rsvelte_core::compiler::phases::phase2_analyze::analyze_component;
+use rsvelte_core::compiler::phases::phase3_transform::{profile, transform_component};
+use rsvelte_core::{CompileOptions, GenerateMode};
 
 fn main() {
     let files = collect_files();
@@ -39,7 +39,7 @@ fn main() {
 
     // Warmup
     for (_, content) in files.iter().take(100) {
-        let _ = svelte_compiler_rust::compile(
+        let _ = rsvelte_core::compile(
             content,
             CompileOptions {
                 generate: GenerateMode::Client,
@@ -79,11 +79,9 @@ fn main() {
         if let Some(ref mut ast) = asts[i] {
             // SAFETY: `ast` is in `asts[i]` for the whole iteration; the
             // serialize arena pointer is cleared before this borrow ends.
-            unsafe {
-                svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
-            };
+            unsafe { rsvelte_core::ast::arena::set_serialize_arena(&ast.arena as *const _) };
             let _ = resolve_lazy_expressions(ast, content);
-            svelte_compiler_rust::ast::arena::clear_serialize_arena();
+            rsvelte_core::ast::arena::clear_serialize_arena();
         }
     }
     let resolve_lazy_time = start.elapsed();
@@ -94,16 +92,14 @@ fn main() {
         if let Some(ref mut ast) = asts[i] {
             let line_offsets = compute_line_offsets(content, false);
             // SAFETY: same lifetime invariant as 2a.
-            unsafe {
-                svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
-            };
+            unsafe { rsvelte_core::ast::arena::set_serialize_arena(&ast.arena as *const _) };
             if let Some(ref mut instance) = ast.instance {
                 ensure_script_parsed(&ast.arena, instance, content, &line_offsets);
             }
             if let Some(ref mut module) = ast.module {
                 ensure_script_parsed(&ast.arena, module, content, &line_offsets);
             }
-            svelte_compiler_rust::ast::arena::clear_serialize_arena();
+            rsvelte_core::ast::arena::clear_serialize_arena();
         }
     }
     let ensure_script_time = start.elapsed();
@@ -114,11 +110,9 @@ fn main() {
     for (i, (_, content)) in files.iter().enumerate() {
         if let Some(ref mut ast) = asts[i] {
             // SAFETY: same lifetime invariant as 2a.
-            unsafe {
-                svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
-            };
+            unsafe { rsvelte_core::ast::arena::set_serialize_arena(&ast.arena as *const _) };
             let analysis = analyze_component(ast, content, &compile_opts).ok();
-            svelte_compiler_rust::ast::arena::clear_serialize_arena();
+            rsvelte_core::ast::arena::clear_serialize_arena();
             analyses.push(analysis);
         } else {
             analyses.push(None);
@@ -138,11 +132,9 @@ fn main() {
             // loop iteration; the serialize arena pointer is cleared before
             // we move to the next iteration so the pointer never outlives
             // its referent.
-            unsafe {
-                svelte_compiler_rust::ast::arena::set_serialize_arena(&ast.arena as *const _)
-            };
+            unsafe { rsvelte_core::ast::arena::set_serialize_arena(&ast.arena as *const _) };
             let _ = transform_component(analysis, ast, content, &compile_opts);
-            svelte_compiler_rust::ast::arena::clear_serialize_arena();
+            rsvelte_core::ast::arena::clear_serialize_arena();
         }
     }
     let transform_time = start.elapsed();

--- a/crates/rsvelte_core/src/bin/min_parse_cost.rs
+++ b/crates/rsvelte_core/src/bin/min_parse_cost.rs
@@ -12,10 +12,8 @@
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, Parser, parse, parse_reuse};
 use std::time::Instant;
-use svelte_compiler_rust::compiler::phases::phase1_parse::{
-    ParseOptions, Parser, parse, parse_reuse,
-};
 
 fn main() {
     let options = ParseOptions {

--- a/crates/rsvelte_core/src/bin/oxc_call_counter.rs
+++ b/crates/rsvelte_core/src/bin/oxc_call_counter.rs
@@ -67,7 +67,7 @@ fn main() {
     println!();
 
     // Now measure parse time breakdown
-    use svelte_compiler_rust::compiler::phases::phase1_parse::{ParseOptions, parse};
+    use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse};
 
     // Warmup
     for _ in 0..3 {

--- a/crates/rsvelte_core/src/bin/parse_bottleneck.rs
+++ b/crates/rsvelte_core/src/bin/parse_bottleneck.rs
@@ -19,7 +19,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use svelte_compiler_rust::compiler::phases::phase1_parse::{ParseOptions, parse};
+use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse};
 
 fn main() {
     let files = collect_files();
@@ -124,7 +124,7 @@ fn main() {
 }
 
 fn bench_reuse(files: &[(String, String)], options: ParseOptions, label: &str) -> f64 {
-    use svelte_compiler_rust::compiler::phases::phase1_parse::{Parser, parse_reuse};
+    use rsvelte_core::compiler::phases::phase1_parse::{Parser, parse_reuse};
 
     let mut parser = Parser::new("", options);
 

--- a/crates/rsvelte_core/src/bin/parse_profile.rs
+++ b/crates/rsvelte_core/src/bin/parse_profile.rs
@@ -20,7 +20,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use svelte_compiler_rust::compiler::phases::phase1_parse::{ParseOptions, parse};
+use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse};
 
 fn main() {
     let large = create_large_file();

--- a/crates/rsvelte_core/src/bin/profiler.rs
+++ b/crates/rsvelte_core/src/bin/profiler.rs
@@ -35,10 +35,10 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use svelte_compiler_rust::compiler::phases::phase1_parse::{ParseOptions, parse};
-use svelte_compiler_rust::compiler::phases::phase2_analyze::analyze_component;
-use svelte_compiler_rust::compiler::phases::phase3_transform::transform_component;
-use svelte_compiler_rust::{CompileOptions, GenerateMode};
+use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse};
+use rsvelte_core::compiler::phases::phase2_analyze::analyze_component;
+use rsvelte_core::compiler::phases::phase3_transform::transform_component;
+use rsvelte_core::{CompileOptions, GenerateMode};
 
 #[derive(Debug, Clone)]
 struct Config {

--- a/crates/rsvelte_core/src/bin/samply_target.rs
+++ b/crates/rsvelte_core/src/bin/samply_target.rs
@@ -14,9 +14,9 @@
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse};
 use std::fs;
 use std::path::PathBuf;
-use svelte_compiler_rust::compiler::phases::phase1_parse::{ParseOptions, parse};
 
 fn main() {
     let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");

--- a/crates/rsvelte_core/src/bin/svelte_check.rs
+++ b/crates/rsvelte_core/src/bin/svelte_check.rs
@@ -22,7 +22,7 @@ use std::process::ExitCode;
 use std::collections::{HashMap, HashSet};
 
 use clap::Parser;
-use svelte_compiler_rust::svelte_check::{
+use rsvelte_core::svelte_check::{
     OutputFormat, RunOptions, run,
     runner::{DiagnosticSource, WarningOverride},
     watch::{WatchOptions, run_watch},
@@ -170,7 +170,7 @@ fn main() -> ExitCode {
 }
 
 fn print_run(
-    result: &svelte_compiler_rust::svelte_check::runner::RunResult,
+    result: &rsvelte_core::svelte_check::runner::RunResult,
     workspace: &Path,
     format: OutputFormat,
 ) {

--- a/crates/rsvelte_core/src/bin/test_reporter.rs
+++ b/crates/rsvelte_core/src/bin/test_reporter.rs
@@ -25,9 +25,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use chrono::Utc;
+use rsvelte_core::compiler::CssMode;
+use rsvelte_core::{CompileOptions, GenerateMode, ParseOptions, compile, parse};
 use serde::{Deserialize, Serialize};
-use svelte_compiler_rust::compiler::CssMode;
-use svelte_compiler_rust::{CompileOptions, GenerateMode, ParseOptions, compile, parse};
 use walkdir::WalkDir;
 
 // ============================================================================

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -27,7 +27,7 @@
 //! ## Usage
 //!
 //! ```rust,ignore
-//! use svelte_compiler_rust::{compile, CompileOptions, GenerateMode};
+//! use rsvelte_core::{compile, CompileOptions, GenerateMode};
 //!
 //! let source = "<h1>Hello World</h1>";
 //! let options = CompileOptions {
@@ -1283,7 +1283,7 @@ fn strip_ts_from_attribute_value(
 /// # Example
 ///
 /// ```rust,ignore
-/// use svelte_compiler_rust::{compile_batch, CompileOptions, GenerateMode};
+/// use rsvelte_core::{compile_batch, CompileOptions, GenerateMode};
 ///
 /// let sources = vec![
 ///     ("<h1>Hello</h1>", CompileOptions { generate: GenerateMode::Client, ..Default::default() }),

--- a/crates/rsvelte_core/src/compiler/print/mod.rs
+++ b/crates/rsvelte_core/src/compiler/print/mod.rs
@@ -10,7 +10,7 @@
 //! ## Usage
 //!
 //! ```rust,ignore
-//! use svelte_compiler_rust::compiler::print::print;
+//! use rsvelte_core::compiler::print::print;
 //!
 //! let ast = parse(source, options)?;
 //! let result = print(&ast, None)?;

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -1,4 +1,4 @@
-//! # svelte-compiler-rust
+//! # rsvelte_core
 //!
 //! A high-performance Rust implementation of the Svelte compiler.
 //!
@@ -10,7 +10,7 @@
 //! ## Usage
 //!
 //! ```rust,no_run
-//! use svelte_compiler_rust::{parse, ParseOptions};
+//! use rsvelte_core::{parse, ParseOptions};
 //!
 //! let source = r#"<h1>Hello, {name}!</h1>"#;
 //! let ast = parse(source, ParseOptions::default()).unwrap();

--- a/crates/rsvelte_core/src/main.rs
+++ b/crates/rsvelte_core/src/main.rs
@@ -17,13 +17,13 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use std::fs;
 use std::path::PathBuf;
 
-use svelte_compiler_rust::{ParseOptions, parse};
+use rsvelte_core::{ParseOptions, parse};
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() < 2 {
-        eprintln!("Usage: svelte-compiler-rust <file.svelte>");
+        eprintln!("Usage: rsvelte_core <file.svelte>");
         std::process::exit(1);
     }
 

--- a/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
@@ -193,7 +193,7 @@ impl Svelte2TsxError {
 /// # Example
 ///
 /// ```rust,ignore
-/// use svelte_compiler_rust::svelte2tsx::{svelte2tsx, Svelte2TsxOptions};
+/// use rsvelte_core::svelte2tsx::{svelte2tsx, Svelte2TsxOptions};
 ///
 /// let source = "<h1>Hello</h1>";
 /// let result = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap();

--- a/crates/rsvelte_core/tests/a11y_validator_fixes.rs
+++ b/crates/rsvelte_core/tests/a11y_validator_fixes.rs
@@ -2,7 +2,7 @@
 //! (H-077), dangerous `href` schemes match case-insensitively (H-081), and
 //! valid nested lists don't trip the `<li>`-in-`<li>` descendant rule (H-082).
 
-use svelte_compiler_rust::{CompileOptions, compile};
+use rsvelte_core::{CompileOptions, compile};
 
 fn warning_codes(src: &str) -> Vec<String> {
     match compile(

--- a/crates/rsvelte_core/tests/analyze_attribute_expression_no_arena.rs
+++ b/crates/rsvelte_core/tests/analyze_attribute_expression_no_arena.rs
@@ -13,7 +13,7 @@
 //! The fix is to use `Expression::as_json()` which falls back to a
 //! per-thread deserialization arena when no serialize arena is active.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn compile_client(src: &str) {
     compile(

--- a/crates/rsvelte_core/tests/aria_bare_attribute_warning.rs
+++ b/crates/rsvelte_core/tests/aria_bare_attribute_warning.rs
@@ -9,7 +9,7 @@
 //! `aria-checked` (tristate). Distinguish the bare-attribute case and route it
 //! through the per-type warning.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn warnings(src: &str) -> Vec<String> {
     compile(

--- a/crates/rsvelte_core/tests/async_body_stmt_edge_cases.rs
+++ b/crates/rsvelte_core/tests/async_body_stmt_edge_cases.rs
@@ -2,7 +2,7 @@
 //! orphan `else` continuation, regex-literal scanning, multi-declarator await
 //! splitting, post-await class hoisting, and nested-destructure leaf hoisting.
 
-use svelte_compiler_rust::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
 
 fn ssr_async(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/attribute_shorthand_validation.rs
+++ b/crates/rsvelte_core/tests/attribute_shorthand_validation.rs
@@ -3,7 +3,7 @@
 //! upstream; rsvelte previously accepted the whole expression text as the
 //! attribute name.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn try_compile(src: &str) -> Result<(), String> {
     compile(

--- a/crates/rsvelte_core/tests/audit_skipped.rs
+++ b/crates/rsvelte_core/tests/audit_skipped.rs
@@ -19,8 +19,8 @@ use std::fs;
 use common::{
     canonicalize_css, compare_js, ensure_fixtures_exist, load_fixture_output, svelte_path,
 };
-use svelte_compiler_rust::ast::arena::with_serialize_arena;
-use svelte_compiler_rust::{
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{
     CompileOptions, ExperimentalOptions, GenerateMode, ParseOptions, compile, compile_module,
     compiler::CssMode, convert_to_legacy, parse,
 };
@@ -313,7 +313,7 @@ fn audit_css(name: &str) -> Outcome {
 }
 
 fn audit_print(name: &str) -> Outcome {
-    use svelte_compiler_rust::compiler::print::print_with_source;
+    use rsvelte_core::compiler::print::print_with_source;
 
     let mut out = Outcome::default();
     let input_path = svelte_path()

--- a/crates/rsvelte_core/tests/bind_indeterminate_no_type.rs
+++ b/crates/rsvelte_core/tests/bind_indeterminate_no_type.rs
@@ -6,7 +6,7 @@
 //! `bind:checked` and `bind:files`; `indeterminate` / `group` are never
 //! type-checked, so binding them to a type-less input is accepted.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn try_compile(src: &str) -> Result<(), String> {
     compile(

--- a/crates/rsvelte_core/tests/bindable_whitespace.rs
+++ b/crates/rsvelte_core/tests/bindable_whitespace.rs
@@ -5,7 +5,7 @@
 //! `$bindable (0)` (valid JS) wasn't unwrapped and the rune call leaked into the
 //! generated `$.prop(...)` default.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_js(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/block_close_mismatch.rs
+++ b/crates/rsvelte_core/tests/block_close_mismatch.rs
@@ -10,8 +10,8 @@
 //! (erroring in strict mode on a mismatch), and `parse()` reports
 //! `block_unexpected_close` for a leftover `{/...}` at root.
 
-use svelte_compiler_rust::error::ParseError;
-use svelte_compiler_rust::{ParseOptions, parse};
+use rsvelte_core::error::ParseError;
+use rsvelte_core::{ParseOptions, parse};
 
 fn error_code(source: &str) -> String {
     match parse(source, ParseOptions::default()) {

--- a/crates/rsvelte_core/tests/block_head_parse_errors.rs
+++ b/crates/rsvelte_core/tests/block_head_parse_errors.rs
@@ -9,7 +9,7 @@
 //! complete expression surface as `expected_token`, an incomplete expression as
 //! `js_parse_error`.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn try_compile(src: &str) -> Result<(), (String, usize, usize)> {
     match compile(

--- a/crates/rsvelte_core/tests/class_method_with_state_not_field.rs
+++ b/crates/rsvelte_core/tests/class_method_with_state_not_field.rs
@@ -10,7 +10,7 @@
 //! `parse_state_field` now rejects anything that doesn't look like a valid
 //! class-field name (plain identifier, quoted, or computed `[expr]`).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/class_rune_lexical_scan.rs
+++ b/crates/rsvelte_core/tests/class_rune_lexical_scan.rs
@@ -3,7 +3,7 @@
 //! truncate the class body / argument (H-057, H-058), and `new class {}(args)`
 //! must keep the user's constructor arguments (H-059).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/client_transforms_pin.rs
+++ b/crates/rsvelte_core/tests/client_transforms_pin.rs
@@ -17,7 +17,7 @@
 //!   M-046..M-048** all share the AST-driven rewrite the issue itself
 //!   recommends as the fix; deferred to the coordinated effort.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/common/preprocess_fixtures.rs
+++ b/crates/rsvelte_core/tests/common/preprocess_fixtures.rs
@@ -3,11 +3,11 @@
 //! `tests/compatibility_report.rs` (the dashboard) hand-port each fixture's
 //! `_config.js` JS preprocessor into Rust closures here.
 
-use rustc_hash::FxHashMap;
-use svelte_compiler_rust::compiler::preprocess::types::{
+use rsvelte_core::compiler::preprocess::types::{
     AttributeValue, MarkupPreprocessorFn, MarkupPreprocessorOptions, PreprocessorFn,
     PreprocessorGroup, PreprocessorOptions, PreprocessorResult, Processed,
 };
+use rustc_hash::FxHashMap;
 
 /// Read a string attribute value, panicking if it isn't a `String`.
 pub fn attr_str<'a>(attrs: &'a FxHashMap<String, AttributeValue>, name: &str) -> Option<&'a str> {
@@ -22,7 +22,7 @@ where
     F: std::future::Future<
             Output = Result<
                 Option<Processed>,
-                svelte_compiler_rust::compiler::preprocess::types::PreprocessError,
+                rsvelte_core::compiler::preprocess::types::PreprocessError,
             >,
         > + Send
         + 'static,
@@ -108,7 +108,7 @@ pub fn build_preprocessors(name: &str) -> Option<Vec<PreprocessorGroup>> {
         "empty-sourcemap" => vec![PreprocessorGroup {
             style: Some(Box::new(|opts: PreprocessorOptions| {
                 ok(async move {
-                    use svelte_compiler_rust::compiler::preprocess::types::{
+                    use rsvelte_core::compiler::preprocess::types::{
                         SimpleDecodedMap, SourceMapInput,
                     };
                     Ok(Some(Processed {

--- a/crates/rsvelte_core/tests/common/svelte2tsx.rs
+++ b/crates/rsvelte_core/tests/common/svelte2tsx.rs
@@ -10,7 +10,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use svelte_compiler_rust::svelte2tsx::{
+use rsvelte_core::svelte2tsx::{
     RewriteExternalImportsOptions, Svelte2TsxError, Svelte2TsxMode, Svelte2TsxNamespace,
     Svelte2TsxOptions, SvelteVersion, svelte2tsx,
 };

--- a/crates/rsvelte_core/tests/compatibility_report.rs
+++ b/crates/rsvelte_core/tests/compatibility_report.rs
@@ -16,7 +16,7 @@ use common::{
     canonicalize_css, compare_js, ensure_fixtures_exist, fixtures_path, get_fixture_samples,
     get_svelte_test_samples, load_fixture_output, svelte_path, write_actual_output,
 };
-use svelte_compiler_rust::{
+use rsvelte_core::{
     CompileOptions, ExperimentalOptions, GenerateMode, ModuleCompileOptions, ParseOptions, compile,
     compile_module, compiler::CssMode, convert_to_legacy, parse,
 };
@@ -94,7 +94,7 @@ fn run_parser_tests(category: TestCategory, modern: bool) -> CategoryResult {
         match parse(&input, options) {
             Ok(ast) => {
                 let actual_json =
-                    svelte_compiler_rust::ast::arena::with_serialize_arena(&ast.arena, || {
+                    rsvelte_core::ast::arena::with_serialize_arena(&ast.arena, || {
                         if modern {
                             serde_json::to_string_pretty(&ast).unwrap_or_default()
                         } else {
@@ -1232,8 +1232,8 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
 /// `output.svelte`. Mirrors `tests/print.rs::test_print` so the
 /// compatibility-report stays in sync with the standalone test.
 fn run_print_tests() -> CategoryResult {
-    use svelte_compiler_rust::compiler::print::print_with_source;
-    use svelte_compiler_rust::{ParseOptions, parse};
+    use rsvelte_core::compiler::print::print_with_source;
+    use rsvelte_core::{ParseOptions, parse};
 
     let samples = get_svelte_test_samples("print");
     let mut result = CategoryResult::new("print");
@@ -1325,7 +1325,7 @@ fn normalize_print_output(s: &str) -> String {
 /// closures (see `tests/common/preprocess_fixtures.rs`). Mirrors
 /// `tests/preprocess.rs` so the compat dashboard stays in lock-step.
 fn run_preprocess_tests() -> CategoryResult {
-    use svelte_compiler_rust::compiler::preprocess::preprocess;
+    use rsvelte_core::compiler::preprocess::preprocess;
 
     let samples = get_svelte_test_samples("preprocess");
     let mut result = CategoryResult::new("preprocess");

--- a/crates/rsvelte_core/tests/compiler_errors.rs
+++ b/crates/rsvelte_core/tests/compiler_errors.rs
@@ -10,11 +10,11 @@ use std::path::{Path, PathBuf};
 
 // use rayon::prelude::*;  // Disabled for sequential execution
 use common::get_svelte_test_samples;
-use serde::Deserialize;
-use svelte_compiler_rust::{
+use rsvelte_core::{
     CompileOptions, ExperimentalOptions, GenerateMode, ModuleCompileOptions, compile,
     compile_module,
 };
+use serde::Deserialize;
 
 /// Get all compiler-errors test samples.
 fn get_compiler_error_samples() -> Vec<PathBuf> {

--- a/crates/rsvelte_core/tests/compiler_fixtures.rs
+++ b/crates/rsvelte_core/tests/compiler_fixtures.rs
@@ -13,7 +13,7 @@ use common::{
     write_actual_output,
 };
 use rayon::prelude::*;
-use svelte_compiler_rust::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
 
 /// Load input from Svelte test suite. Normalizes CRLF→LF so byte offsets
 /// in the compiled output match LF-authored fixtures on Windows runners.

--- a/crates/rsvelte_core/tests/component_bind_getter_setter.rs
+++ b/crates/rsvelte_core/tests/component_bind_getter_setter.rs
@@ -7,7 +7,7 @@
 //! (`bind_get_1`, …). A second binding therefore called an undeclared
 //! `bind_get_1` / `bind_set_1`.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_js(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/const_tag_multibyte.rs
+++ b/crates/rsvelte_core/tests/const_tag_multibyte.rs
@@ -2,7 +2,7 @@
 //! character indices, so a multi-byte character before the `=` doesn't corrupt
 //! (or panic on) the pattern/init slice.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn go(src: &str, mode: GenerateMode) -> String {
     compile(

--- a/crates/rsvelte_core/tests/const_tag_pattern_pin.rs
+++ b/crates/rsvelte_core/tests/const_tag_pattern_pin.rs
@@ -5,7 +5,7 @@
 //! plumbing has been hardened in adjacent passes). Pin the cases the issue
 //! cites so future drift surfaces.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/css.rs
+++ b/crates/rsvelte_core/tests/css.rs
@@ -14,7 +14,7 @@ use common::{
     canonicalize_css, ensure_fixtures_exist, get_fixture_samples, load_fixture_output, svelte_path,
     write_actual_output,
 };
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 /// Load input from Svelte test suite. Normalizes CRLF→LF so byte offsets
 /// in the compiled output match LF-authored fixtures on Windows runners.

--- a/crates/rsvelte_core/tests/css_nth_child_args.rs
+++ b/crates/rsvelte_core/tests/css_nth_child_args.rs
@@ -9,7 +9,7 @@
 //! latter had no match arm for `"Nth"` and silently returned an empty
 //! string. The emitted CSS therefore had `:nth-child()` (no argument).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_css(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/css_selector_list_split.rs
+++ b/crates/rsvelte_core/tests/css_selector_list_split.rs
@@ -7,7 +7,7 @@
 //! selectors. The official Svelte compiler treats `[data-x="a,b"]` as a single
 //! selector. The splitter now also tracks `[` / `]` depth and string quotes.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_css(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/css_svelte_boundary_scope.rs
+++ b/crates/rsvelte_core/tests/css_svelte_boundary_scope.rs
@@ -9,7 +9,7 @@
 //! scope class). The official Svelte compiler scopes straight through the
 //! boundary.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_css(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/derived_destructure_nested_default.rs
+++ b/crates/rsvelte_core/tests/derived_destructure_nested_default.rs
@@ -14,7 +14,7 @@
 //!    became `() => { width: 0, … }` — an arrow with a *block* body, not
 //!    one returning the object. Mirrors the same fix from #150 / #151.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn compile_client(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/derived_object_literal.rs
+++ b/crates/rsvelte_core/tests/derived_object_literal.rs
@@ -7,7 +7,7 @@
 //! fails. Wrap the body in parens (`() => ({ … })`) so the arrow returns the
 //! object expression.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn compile_client(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/directive_empty_name.rs
+++ b/crates/rsvelte_core/tests/directive_empty_name.rs
@@ -2,7 +2,7 @@
 //! (issue #473, H-146 / M-040), matching `use:` / `animate:` which already
 //! rejected empty names. Previously it lowered to an empty JS identifier.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn try_compile(src: &str) -> Result<(), String> {
     compile(

--- a/crates/rsvelte_core/tests/duplicate_let_function.rs
+++ b/crates/rsvelte_core/tests/duplicate_let_function.rs
@@ -3,7 +3,7 @@
 //! redeclaration error in JS/TS; the function-redeclaration allowance (kept for
 //! TS overloads) previously suppressed it.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn tc(src: &str) -> Result<(), String> {
     compile(

--- a/crates/rsvelte_core/tests/each_block_as_const.rs
+++ b/crates/rsvelte_core/tests/each_block_as_const.rs
@@ -6,8 +6,8 @@
 //! Svelte parses the iterable greedily so the alias separator is the LAST
 //! top-level ` as `. We mirror that with a right-most-` as ` scan.
 
-use svelte_compiler_rust::ast::arena::with_serialize_arena;
-use svelte_compiler_rust::{ParseOptions, convert_to_legacy, parse};
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{ParseOptions, convert_to_legacy, parse};
 
 /// Compile-time invariant: `serialize_to_json` produces a JSON tree where the
 /// each-block context (alias) is recognisable. We just check the rendered

--- a/crates/rsvelte_core/tests/each_object_rest_key_escape.rs
+++ b/crates/rsvelte_core/tests/each_object_rest_key_escape.rs
@@ -2,7 +2,7 @@
 //! must be JS-escaped — a string-literal key containing a quote would otherwise
 //! produce invalid JS in the `$.exclude_from_object(..., [...])` call.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/each_pattern_pin.rs
+++ b/crates/rsvelte_core/tests/each_pattern_pin.rs
@@ -7,7 +7,7 @@
 //! Pin the H-135 / H-136 cases that have working code paths so future drift
 //! in the each-block destructuring lowering surfaces.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/effect_pending_lowering.rs
+++ b/crates/rsvelte_core/tests/effect_pending_lowering.rs
@@ -2,7 +2,7 @@
 //! `$.eager(() => $.pending())` — a thunk that *calls* `$.pending()` — matching
 //! upstream, not a bare `$.eager($.pending)` reference.
 
-use svelte_compiler_rust::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
 
 fn client_async(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/effect_rune_pin.rs
+++ b/crates/rsvelte_core/tests/effect_rune_pin.rs
@@ -11,7 +11,7 @@
 //!   rejects user variables that start with `$` (the `dollar_prefix_invalid`
 //!   diagnostic fires before any rewrite can run).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/inline_js_statement_pin.rs
+++ b/crates/rsvelte_core/tests/inline_js_statement_pin.rs
@@ -7,7 +7,7 @@
 //! destructured catch parameter) are easy to regress when the converter is
 //! touched, so pin each one with a single targeted assertion.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/inline_js_statements.rs
+++ b/crates/rsvelte_core/tests/inline_js_statements.rs
@@ -1,7 +1,7 @@
 //! Issue #456: inline JS statement conversion must preserve `for...in` (vs
 //! `for...of`, H-110) and destructuring `catch` parameters (H-112).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/labeled_statement_preserved.rs
+++ b/crates/rsvelte_core/tests/labeled_statement_preserved.rs
@@ -2,7 +2,7 @@
 //! (issue #456, H-111). The converter previously returned only the body, so a
 //! surviving `break label;` / `continue label;` referenced a removed label.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_js(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/module_compile_error_propagation.rs
+++ b/crates/rsvelte_core/tests/module_compile_error_propagation.rs
@@ -12,7 +12,7 @@
 //!
 //! Both paths now use the same `?` propagation the component compile path uses.
 
-use svelte_compiler_rust::{GenerateMode, compile_module, compiler::ModuleCompileOptions};
+use rsvelte_core::{GenerateMode, compile_module, compiler::ModuleCompileOptions};
 
 fn opts(filename: &str) -> ModuleCompileOptions {
     ModuleCompileOptions {

--- a/crates/rsvelte_core/tests/module_compile_ts_strip.rs
+++ b/crates/rsvelte_core/tests/module_compile_ts_strip.rs
@@ -21,9 +21,9 @@
 //!    mutated (e.g. a form-model `isValid` stayed `false` even after the
 //!    form was filled in).
 
-use svelte_compiler_rust::GenerateMode;
-use svelte_compiler_rust::compile_module;
-use svelte_compiler_rust::compiler::ModuleCompileOptions;
+use rsvelte_core::GenerateMode;
+use rsvelte_core::compile_module;
+use rsvelte_core::compiler::ModuleCompileOptions;
 
 fn compile_mod(src: &str, generate: GenerateMode) -> String {
     let result = compile_module(

--- a/crates/rsvelte_core/tests/module_state_raw_reads.rs
+++ b/crates/rsvelte_core/tests/module_state_raw_reads.rs
@@ -10,9 +10,9 @@
 //! object instead of the underlying value — `currentProps[key]` returned
 //! undefined for every key.
 
-use svelte_compiler_rust::GenerateMode;
-use svelte_compiler_rust::compile_module;
-use svelte_compiler_rust::compiler::ModuleCompileOptions;
+use rsvelte_core::GenerateMode;
+use rsvelte_core::compile_module;
+use rsvelte_core::compiler::ModuleCompileOptions;
 
 fn compile_mod_client(src: &str) -> String {
     let result = compile_module(

--- a/crates/rsvelte_core/tests/options_immutable_deprecation.rs
+++ b/crates/rsvelte_core/tests/options_immutable_deprecation.rs
@@ -2,7 +2,7 @@
 //! `options_deprecated_immutable` warning (issue #481, M-061). The warning was
 //! defined but never emitted.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn warnings(src: &str) -> Vec<String> {
     let r = compile(

--- a/crates/rsvelte_core/tests/parser_fixtures.rs
+++ b/crates/rsvelte_core/tests/parser_fixtures.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 
 use common::get_svelte_test_samples;
 use rayon::prelude::*;
-use svelte_compiler_rust::ast::arena::with_serialize_arena;
-use svelte_compiler_rust::{ParseOptions, convert_to_legacy, parse};
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{ParseOptions, convert_to_legacy, parse};
 
 /// Get all parser test samples from the Svelte test suite.
 fn get_parser_samples(test_type: &str) -> Vec<PathBuf> {

--- a/crates/rsvelte_core/tests/parser_scanner_lexical.rs
+++ b/crates/rsvelte_core/tests/parser_scanner_lexical.rs
@@ -3,7 +3,7 @@
 //! expression must ignore braces / parens / ` as ` that appear inside string
 //! literals, template literals, and comments.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn client(src: &str) -> Result<String, String> {
     compile(

--- a/crates/rsvelte_core/tests/preprocess.rs
+++ b/crates/rsvelte_core/tests/preprocess.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 use common::get_svelte_test_samples;
 use common::preprocess_fixtures::{build_preprocessors, filename_for};
-use svelte_compiler_rust::compiler::preprocess::preprocess;
+use rsvelte_core::compiler::preprocess::preprocess;
 
 #[derive(Debug, Clone)]
 pub struct PreprocessFixture {

--- a/crates/rsvelte_core/tests/preprocess_attributes.rs
+++ b/crates/rsvelte_core/tests/preprocess_attributes.rs
@@ -2,13 +2,13 @@
 //! applied even when the code is unchanged (H-139), and `Some({})` must clear
 //! the tag's attributes rather than fall back to the originals (H-140).
 
-use rustc_hash::FxHashMap;
-use std::future::Future;
-use svelte_compiler_rust::compiler::preprocess::preprocess;
-use svelte_compiler_rust::compiler::preprocess::types::{
+use rsvelte_core::compiler::preprocess::preprocess;
+use rsvelte_core::compiler::preprocess::types::{
     AttributeValue, PreprocessError, PreprocessorFn, PreprocessorGroup, PreprocessorOptions,
     PreprocessorResult, Processed,
 };
+use rustc_hash::FxHashMap;
+use std::future::Future;
 
 fn ok<F>(f: F) -> PreprocessorResult
 where

--- a/crates/rsvelte_core/tests/preprocess_vlq_sourcemap.rs
+++ b/crates/rsvelte_core/tests/preprocess_vlq_sourcemap.rs
@@ -6,8 +6,8 @@
 //! preprocessor map (with mappings as `"AAAA,SAASA"` etc.) failed to deserialise
 //! and was silently dropped — `decode_map` returned `None`.
 
-use svelte_compiler_rust::compiler::preprocess::decode_sourcemap::decode_map;
-use svelte_compiler_rust::compiler::preprocess::types::{Processed, SourceMapInput};
+use rsvelte_core::compiler::preprocess::decode_sourcemap::decode_map;
+use rsvelte_core::compiler::preprocess::types::{Processed, SourceMapInput};
 
 fn vlq_processed(map_json: &str) -> Processed {
     Processed {

--- a/crates/rsvelte_core/tests/print.rs
+++ b/crates/rsvelte_core/tests/print.rs
@@ -8,8 +8,8 @@ use std::fs;
 use std::path::Path;
 
 use common::get_svelte_test_samples;
-use svelte_compiler_rust::compiler::print::print_with_source;
-use svelte_compiler_rust::{ParseOptions, parse};
+use rsvelte_core::compiler::print::print_with_source;
+use rsvelte_core::{ParseOptions, parse};
 
 /// A Print test fixture.
 #[allow(dead_code)]

--- a/crates/rsvelte_core/tests/print_await_pending_only.rs
+++ b/crates/rsvelte_core/tests/print_await_pending_only.rs
@@ -1,8 +1,8 @@
 //! Regression test: printing a pending-only `{#await}` block (no `:then` /
 //! `:catch`) must not emit a dangling `{:` (issue #467, H-052).
 
-use svelte_compiler_rust::compiler::print::print_with_source;
-use svelte_compiler_rust::{ParseOptions, parse};
+use rsvelte_core::compiler::print::print_with_source;
+use rsvelte_core::{ParseOptions, parse};
 
 fn print_roundtrip(src: &str) -> String {
     let ast = parse(

--- a/crates/rsvelte_core/tests/props_call_extra_space.rs
+++ b/crates/rsvelte_core/tests/props_call_extra_space.rs
@@ -10,7 +10,7 @@
 //! Fix: `canonicalize_props_call` normalises `= $props ()` → `= $props()`
 //! before the text matchers run, in both the client and server transforms.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn compile_code(src: &str, mode: GenerateMode) -> String {
     compile(

--- a/crates/rsvelte_core/tests/props_id_no_space.rs
+++ b/crates/rsvelte_core/tests/props_id_no_space.rs
@@ -2,7 +2,7 @@
 //! (`let id=$props.id()`) must be skipped, not survive alongside the generated
 //! `const id = $.props_id()` (issue #477, H-060).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_js(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/reactive_cycle_block_body.rs
+++ b/crates/rsvelte_core/tests/reactive_cycle_block_body.rs
@@ -8,7 +8,7 @@
 //! empty assignment sets and were dropped from the cycle graph — a cross
 //! assignment cycle was silently accepted and looped forever at runtime.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn compile_error_code(src: &str) -> Option<String> {
     match compile(

--- a/crates/rsvelte_core/tests/real_world.rs
+++ b/crates/rsvelte_core/tests/real_world.rs
@@ -15,8 +15,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use common::canonicalize_js;
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 use serde::Deserialize;
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
 
 /// Fixture directory path.
 fn fixtures_dir() -> PathBuf {

--- a/crates/rsvelte_core/tests/render_tag_multiline_args.rs
+++ b/crates/rsvelte_core/tests/render_tag_multiline_args.rs
@@ -16,7 +16,7 @@
 //! argument lost N characters off the end, and the first argument lost
 //! anywhere up to its full length (saturating at empty).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn compile_server(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/render_tag_placeholder_counter.rs
+++ b/crates/rsvelte_core/tests/render_tag_placeholder_counter.rs
@@ -4,7 +4,7 @@
 //! (`let $N = $.derived(...)`) share one `$N` namespace, so they must draw from
 //! a single counter — otherwise the `let $0` shadows the async param `$0`.
 
-use svelte_compiler_rust::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
 
 fn client_async(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -17,9 +17,7 @@ use common::{
     compare_js_with_debug as compare_js_debug, ensure_fixtures_exist, get_fixture_samples,
     load_fixture_output, svelte_path, write_actual_output,
 };
-use svelte_compiler_rust::{
-    CompileOptions, ExperimentalOptions, GenerateMode, compile, compiler::CssMode,
-};
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile, compiler::CssMode};
 
 /// Load input from Svelte test suite.
 fn load_input(category: &str, sample_name: &str) -> Option<String> {

--- a/crates/rsvelte_core/tests/scope_block_scoping.rs
+++ b/crates/rsvelte_core/tests/scope_block_scoping.rs
@@ -2,7 +2,7 @@
 //! enclosing function scope, and `try` / `finally` blocks and `switch` bodies
 //! get their own lexical scopes so `let`/`const` inside them don't leak.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn compile_client(src: &str) -> Result<String, String> {
     compile(

--- a/crates/rsvelte_core/tests/script_for_of_assignment_target.rs
+++ b/crates/rsvelte_core/tests/script_for_of_assignment_target.rs
@@ -5,7 +5,7 @@
 //! `JsNode::Null`, and the downstream converter then bailed out (`?` on a missing
 //! object), discarding the whole loop from the generated output.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_js(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/server_module_effect_strip.rs
+++ b/crates/rsvelte_core/tests/server_module_effect_strip.rs
@@ -3,7 +3,7 @@
 //! `$effect.pre(` / `$effect(` as raw byte patterns and rewrote them even inside
 //! string / template literals and comments, corrupting their contents.
 
-use svelte_compiler_rust::{GenerateMode, compile_module, compiler::ModuleCompileOptions};
+use rsvelte_core::{GenerateMode, compile_module, compiler::ModuleCompileOptions};
 
 fn server_module(src: &str) -> String {
     compile_module(

--- a/crates/rsvelte_core/tests/server_regex_literal_string_scanner.rs
+++ b/crates/rsvelte_core/tests/server_regex_literal_string_scanner.rs
@@ -8,7 +8,7 @@
 //! literal backslash-t in the emitted JS, which rolldown/oxc reject as
 //! `Invalid Unicode escape sequence`.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn compile_server(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/server_ts_type_guard.rs
+++ b/crates/rsvelte_core/tests/server_ts_type_guard.rs
@@ -20,7 +20,7 @@
 //! The fix teaches the pass to keep tracking when a line ends with a
 //! continuation operator (the arrow `=>`, binary operators, `.`, etc.).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn compile_server(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/snippet_default_transform.rs
+++ b/crates/rsvelte_core/tests/snippet_default_transform.rs
@@ -5,7 +5,7 @@
 //! `apply_transforms_to_expression`, so a default like `{#snippet foo(x = count)}`
 //! emitted the bare `count` instead of `$.get(count)` inside `$.fallback(...)`.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_js(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/snippet_param_destructuring.rs
+++ b/crates/rsvelte_core/tests/snippet_param_destructuring.rs
@@ -3,7 +3,7 @@
 //! object/array rest, and nested array patterns must match upstream Svelte's
 //! `extract_paths` output instead of the previous hand-rolled partial handling.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn cj(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/sourcemaps.rs
+++ b/crates/rsvelte_core/tests/sourcemaps.rs
@@ -12,7 +12,7 @@ use common::{
     compare_js, compare_sourcemaps, ensure_fixtures_exist, get_fixture_samples,
     load_fixture_output, svelte_path, write_actual_output,
 };
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 /// Load input from Svelte test suite. Normalizes CRLF→LF so byte offsets
 /// in the compiled output match LF-authored fixtures on Windows runners.

--- a/crates/rsvelte_core/tests/special_element_capture_events.rs
+++ b/crates/rsvelte_core/tests/special_element_capture_events.rs
@@ -3,7 +3,7 @@
 //! `lostpointercapture` end in "capture" but are real event names, not capture
 //! variants, so they must not be split into `gotpointer` + capture.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/ssr.rs
+++ b/crates/rsvelte_core/tests/ssr.rs
@@ -12,7 +12,7 @@ use common::{
     compare_js, ensure_fixtures_exist, get_fixture_samples, load_fixture_output, svelte_path,
     write_actual_output,
 };
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 /// Load input from Svelte test suite. Normalizes CRLF→LF so byte offsets
 /// in the compiled output match LF-authored fixtures on Windows runners.

--- a/crates/rsvelte_core/tests/ssr_attribute_escaping.rs
+++ b/crates/rsvelte_core/tests/ssr_attribute_escaping.rs
@@ -10,7 +10,7 @@
 //! `escape_html(data, /*is_attr*/ true)`) then `escape_js_string` (JS literal),
 //! so the output is valid JS and byte-identical to the official compiler.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn ssr(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/ssr_component_css_props.rs
+++ b/crates/rsvelte_core/tests/ssr_component_css_props.rs
@@ -3,7 +3,7 @@
 //! `$.store_get` and static text JS-escaped — rather than emitted from raw
 //! source.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn ssr(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/ssr_component_spread_with_children.rs
+++ b/crates/rsvelte_core/tests/ssr_component_spread_with_children.rs
@@ -8,7 +8,7 @@
 //! alongside the bindings). The component-spreads cases now route through
 //! `$.spread_props([…interleaved spreads/props…, { … }])`, matching upstream.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn ssr(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/store_member_mutate_binding_kind.rs
+++ b/crates/rsvelte_core/tests/store_member_mutate_binding_kind.rs
@@ -10,7 +10,7 @@
 //! `store()` for a prop, the bare name for plain / `$state` / reactive-import
 //! stores — matching `get_store()` in the official compiler.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/store_ref_multibyte.rs
+++ b/crates/rsvelte_core/tests/store_ref_multibyte.rs
@@ -3,7 +3,7 @@
 //! `$store` reference shifted the position. Verify a store ref after a
 //! multi-byte identifier is still detected and rewritten correctly.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/store_subscription_pin.rs
+++ b/crates/rsvelte_core/tests/store_subscription_pin.rs
@@ -11,7 +11,7 @@
 //! - **H-074..H-076 / M-049..M-051** all live downstream of the same
 //!   text-based scanner and share the AST refactor; deferred.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/strict_equals_member_after_call.rs
+++ b/crates/rsvelte_core/tests/strict_equals_member_after_call.rs
@@ -17,9 +17,9 @@
 //! and matched `(...)` / `[...]` groups in turn — so `$.get(items).length`
 //! is returned as a single operand.
 
-use svelte_compiler_rust::GenerateMode;
-use svelte_compiler_rust::compile_module;
-use svelte_compiler_rust::compiler::ModuleCompileOptions;
+use rsvelte_core::GenerateMode;
+use rsvelte_core::compile_module;
+use rsvelte_core::compiler::ModuleCompileOptions;
 
 fn compile_mod_client_dev(src: &str) -> String {
     let result = compile_module(

--- a/crates/rsvelte_core/tests/svelte2tsx_backslash_escape.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_backslash_escape.rs
@@ -3,7 +3,7 @@
 //! would otherwise turn `\n` / `\t` into a newline / tab inside the generated
 //! template literal.
 
-use svelte_compiler_rust::svelte2tsx::{
+use rsvelte_core::svelte2tsx::{
     Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion, svelte2tsx,
 };
 

--- a/crates/rsvelte_core/tests/svelte2tsx_slot_name_escape.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_slot_name_escape.rs
@@ -6,7 +6,7 @@
 //! interpolated the raw slot name without escaping. A slot whose `name`
 //! attribute carries `'` produced invalid JS such as `slots: {'foo'bar': {}}`.
 
-use svelte_compiler_rust::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
 
 fn run(src: &str) -> String {
     svelte2tsx(

--- a/crates/rsvelte_core/tests/svelte_check_golden.rs
+++ b/crates/rsvelte_core/tests/svelte_check_golden.rs
@@ -24,9 +24,9 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use svelte_compiler_rust::svelte_check::diagnostic::DiagnosticSeverity;
-use svelte_compiler_rust::svelte_check::tsgo::find_compiler;
-use svelte_compiler_rust::svelte_check::{RunOptions, run};
+use rsvelte_core::svelte_check::diagnostic::DiagnosticSeverity;
+use rsvelte_core::svelte_check::tsgo::find_compiler;
+use rsvelte_core::svelte_check::{RunOptions, run};
 
 fn fixture_root() -> Option<PathBuf> {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/rsvelte_core/tests/svelte_component_validation.rs
+++ b/crates/rsvelte_core/tests/svelte_component_validation.rs
@@ -8,7 +8,7 @@
 //! both compiled successfully while upstream errors with
 //! `svelte_component_missing_this` and `component_invalid_directive`.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn try_compile(src: &str) -> Result<(), String> {
     match compile(

--- a/crates/rsvelte_core/tests/svelte_ignore_pin.rs
+++ b/crates/rsvelte_core/tests/svelte_ignore_pin.rs
@@ -15,7 +15,7 @@
 //!   `pending_leading_comments` plumbing. The others would each need
 //!   targeted scope-tracking changes; deferred.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn warnings(src: &str) -> Vec<String> {
     compile(

--- a/crates/rsvelte_core/tests/svelte_ignore_routing.rs
+++ b/crates/rsvelte_core/tests/svelte_ignore_routing.rs
@@ -2,7 +2,7 @@
 //! `analysis.warnings.push(...)` bypassed the `svelte-ignore` stack. Routing
 //! them through `emit_warning` lets an in-scope `svelte-ignore` suppress them.
 
-use svelte_compiler_rust::{CompileOptions, compile};
+use rsvelte_core::{CompileOptions, compile};
 
 fn warning_codes(src: &str) -> Vec<String> {
     match compile(

--- a/crates/rsvelte_core/tests/svelte_options_public.rs
+++ b/crates/rsvelte_core/tests/svelte_options_public.rs
@@ -2,7 +2,7 @@
 //! explicit `runes={false}` (H-114), `customElement={null}` (H-115), the
 //! `disclose_version` option (H-087), and the `name` option (H-088).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn opts(name: Option<String>, disclose: bool) -> CompileOptions {
     CompileOptions {

--- a/crates/rsvelte_core/tests/svelte_options_validation.rs
+++ b/crates/rsvelte_core/tests/svelte_options_validation.rs
@@ -12,7 +12,7 @@
 //! runes={false}, H-115 customElement={null}) already work correctly; this test
 //! pins their behaviour so regressions surface.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn try_compile(src: &str, opts: CompileOptions) -> Result<String, String> {
     match compile(src, opts) {

--- a/crates/rsvelte_core/tests/switch_statement_codegen.rs
+++ b/crates/rsvelte_core/tests/switch_statement_codegen.rs
@@ -2,7 +2,7 @@
 //! reactive block) must be emitted as a real switch, not flattened into a block
 //! (issue #456, H-109).
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_js(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/template_literal_sanitize.rs
+++ b/crates/rsvelte_core/tests/template_literal_sanitize.rs
@@ -2,7 +2,7 @@
 //! `${` in user text. The multi-node `<title>` path and the mixed client
 //! attribute / style value paths now route through `sanitize_template_string`.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
 fn client(src: &str) -> String {
     compile(

--- a/crates/rsvelte_core/tests/title_call_only_memo.rs
+++ b/crates/rsvelte_core/tests/title_call_only_memo.rs
@@ -6,7 +6,7 @@
 //! `$.effect(() => { title = $0 ?? '' })` form — leaving `$0` unbound (undefined).
 //! It must use `$.deferred_template_effect(($0) => …, [() => foo()])` like upstream.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_js(src: &str) -> String {
     let result = compile(

--- a/crates/rsvelte_core/tests/ts_strip_paren_precedence.rs
+++ b/crates/rsvelte_core/tests/ts_strip_paren_precedence.rs
@@ -10,7 +10,7 @@
 //! member / call / `new`, etc.) — never a unary / binary / logical /
 //! conditional / sequence expression.
 
-use svelte_compiler_rust::{GenerateMode, compile_module, compiler::ModuleCompileOptions};
+use rsvelte_core::{GenerateMode, compile_module, compiler::ModuleCompileOptions};
 
 fn compile_ts(src: &str) -> String {
     compile_module(

--- a/crates/rsvelte_core/tests/validator.rs
+++ b/crates/rsvelte_core/tests/validator.rs
@@ -14,10 +14,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use common::get_svelte_test_samples;
+use rsvelte_core::{CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module};
 use serde::Deserialize;
-use svelte_compiler_rust::{
-    CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module,
-};
 
 /// Get all validator test samples.
 fn get_validator_samples() -> Vec<PathBuf> {

--- a/crates/rsvelte_core/tests/warning_filter.rs
+++ b/crates/rsvelte_core/tests/warning_filter.rs
@@ -1,8 +1,8 @@
 //! Issue #450 H-083: the public `warning_filter` option must actually be
 //! applied — a filter that returns false drops the warning.
 
+use rsvelte_core::{CompileOptions, Warning, compile};
 use std::sync::Arc;
-use svelte_compiler_rust::{CompileOptions, Warning, compile};
 
 type WarningFilter = Option<Arc<dyn Fn(&Warning) -> bool + Send + Sync>>;
 

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 crate-type = ["rlib"]
 
 [dependencies]
-svelte-compiler-rust = { path = "../rsvelte_core", default-features = false, features = ["native"] }
+rsvelte_core = { path = "../rsvelte_core", default-features = false, features = ["native"] }
 oxc_allocator = "0.133"
 oxc_ast = "0.133"
 oxc_parser = "0.133"

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -2,8 +2,8 @@ use oxc_allocator::Allocator;
 use oxc_formatter::Formatter;
 use oxc_parser::{ParseOptions as OxcParseOptions, Parser};
 use oxc_span::SourceType;
-use svelte_compiler_rust::ast::js::Expression;
-use svelte_compiler_rust::ast::template::{ExpressionTag, Fragment, TemplateNode};
+use rsvelte_core::ast::js::Expression;
+use rsvelte_core::ast::template::{ExpressionTag, Fragment, TemplateNode};
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;

--- a/crates/rsvelte_formatter/src/indent.rs
+++ b/crates/rsvelte_formatter/src/indent.rs
@@ -15,7 +15,7 @@
 //! (`{#if}` / `{#each}` / ...) add one indent level to their bodies.
 
 use oxc_formatter::JsFormatOptions;
-use svelte_compiler_rust::ast::template::{Fragment, TemplateNode};
+use rsvelte_core::ast::template::{Fragment, TemplateNode};
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -27,7 +27,7 @@ pub use options::{FormatOptions, StyleFormatter};
 pub use oxc_formatter::JsFormatOptions;
 pub use oxc_formatter_core::{IndentStyle, IndentWidth, LineWidth};
 
-use svelte_compiler_rust::{ParseOptions, parse};
+use rsvelte_core::{ParseOptions, parse};
 
 /// Format a Svelte source string.
 ///

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -26,8 +26,8 @@
 //! - Children fragments (recursed into separately by the caller)
 
 use oxc_formatter::JsFormatOptions;
-use svelte_compiler_rust::ast::js::Expression;
-use svelte_compiler_rust::ast::template::{
+use rsvelte_core::ast::js::Expression;
+use rsvelte_core::ast::template::{
     Attribute, AttributeNode, AttributeValue, AttributeValuePart, Fragment, SpreadAttribute,
     TemplateNode,
 };

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -2,7 +2,7 @@ use oxc_allocator::Allocator;
 use oxc_formatter::{Formatter, JsFormatOptions};
 use oxc_parser::{ParseOptions as OxcParseOptions, Parser};
 use oxc_span::SourceType;
-use svelte_compiler_rust::ast::template::Script;
+use rsvelte_core::ast::template::Script;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;

--- a/crates/rsvelte_formatter/src/style.rs
+++ b/crates/rsvelte_formatter/src/style.rs
@@ -9,7 +9,7 @@
 //!
 //! When no callback is set the style body is left verbatim.
 
-use svelte_compiler_rust::ast::css::StyleSheet;
+use rsvelte_core::ast::css::StyleSheet;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: svelte-compiler-rust-dev
+    container_name: rsvelte_core-dev
     volumes:
       # Mount source code
       - .:/workspace

--- a/docs/archive/ssr-remaining-diffs.md
+++ b/docs/archive/ssr-remaining-diffs.md
@@ -139,11 +139,11 @@ function foo() { ... }
 
 ## 環境
 
-- NAPI ビルド: `cargo build --release --features napi --lib && cp target/release/libsvelte_compiler_rust.dylib svelte/rsvelte.darwin-arm64.node`
+- NAPI ビルド: `cargo build --release --features napi --lib && cp target/release/librsvelte_core.dylib svelte/rsvelte.darwin-arm64.node`
 - SSR 測定: `node scripts/measure-ssr-batch.mjs` (結果は `/tmp/ssr_batch_result.txt`)
 - 個別差分: `node scripts/show-ssr-diff.mjs ".real-world-tests/<PATH>"`
 - テスト: `cargo test --release --test ssr test_ssr`
-- 注意: NAPI ビルド後のテストはキャッシュ衝突する。`find target/release -name "libsvelte_compiler_rust*" -delete && find target/release/.fingerprint -name "svelte-compiler-rust-*" -exec rm -rf {} +` でクリーン。
+- 注意: NAPI ビルド後のテストはキャッシュ衝突する。`find target/release -name "librsvelte_core*" -delete && find target/release/.fingerprint -name "rsvelte_core-*" -exec rm -rf {} +` でクリーン。
 
 ## 差分ファイル一覧 (27件)
 

--- a/docs/ecosystem-implementation-plan.md
+++ b/docs/ecosystem-implementation-plan.md
@@ -403,7 +403,7 @@ These bits land in Wave 1 and are reused by every later wave.
 
 ### NAPI binding strategy
 
-- Single crate (`svelte-compiler-rust`) keeps exporting all NAPI functions
+- Single crate (`rsvelte_core`) keeps exporting all NAPI functions
   rather than splitting per tool. Avoids double-loading the Rust runtime in
   consumer Node processes.
 - Async APIs (`preprocess`, future `hot_update_diff`) use

--- a/docs/perf-roadmap.md
+++ b/docs/perf-roadmap.md
@@ -258,7 +258,7 @@ cargo test --release
 pnpm run compatibility-report
 
 # Runtime tests (MUST run in Docker)
-docker exec svelte-compiler-rust-dev cargo test --release --test runtime
+docker exec rsvelte_core-dev cargo test --release --test runtime
 
 # Benchmark
 ./scripts/bench/bench.sh --quick
@@ -284,7 +284,7 @@ node --expose-gc scripts/dev/test-raw-transfer.mjs
 4. **JsNode::Raw fallback is critical** — ArrowFunctionExpression
    bodies store child nodes as `JsNode::Raw(Value)`. All pattern
    matching must handle Raw with JSON fallback.
-5. **Test in Docker** — `docker exec svelte-compiler-rust-dev cargo
+5. **Test in Docker** — `docker exec rsvelte_core-dev cargo
    test --release --test runtime`
 6. **Benchmark is noisy** — run 3 times, look at Rust absolute ms not
    the ratio (JS varies too)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "svelte-compiler-rust-monorepo",
+  "name": "rsvelte_core-monorepo",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/scripts/dev/build-vps-native-local.mjs
+++ b/scripts/dev/build-vps-native-local.mjs
@@ -18,19 +18,19 @@ let triple;
 let dylib;
 if (platform === 'darwin' && arch === 'arm64') {
 	triple = 'darwin-arm64';
-	dylib = 'libsvelte_compiler_rust.dylib';
+	dylib = 'librsvelte_core.dylib';
 } else if (platform === 'darwin' && arch === 'x64') {
 	triple = 'darwin-x64';
-	dylib = 'libsvelte_compiler_rust.dylib';
+	dylib = 'librsvelte_core.dylib';
 } else if (platform === 'linux' && arch === 'x64') {
 	triple = 'linux-x64-gnu';
-	dylib = 'libsvelte_compiler_rust.so';
+	dylib = 'librsvelte_core.so';
 } else if (platform === 'linux' && arch === 'arm64') {
 	triple = 'linux-arm64-gnu';
-	dylib = 'libsvelte_compiler_rust.so';
+	dylib = 'librsvelte_core.so';
 } else if (platform === 'win32' && arch === 'x64') {
 	triple = 'win32-x64-msvc';
-	dylib = 'svelte_compiler_rust.dll';
+	dylib = 'rsvelte_core.dll';
 } else {
 	console.error(`[build-vps-native] unsupported platform ${platform}/${arch}`);
 	process.exit(2);

--- a/scripts/dev/test-raw-transfer.mjs
+++ b/scripts/dev/test-raw-transfer.mjs
@@ -25,7 +25,7 @@ function loadBinding() {
 		repoRoot,
 		`apps/npm/vite-plugin-svelte-native-${triple()}/rsvelte.node`,
 	);
-	const cdylib = join(repoRoot, 'target/release/libsvelte_compiler_rust.dylib');
+	const cdylib = join(repoRoot, 'target/release/librsvelte_core.dylib');
 	for (const candidate of [cdylib, staged]) {
 		try {
 			return require(candidate);

--- a/scripts/dev/test-vps-shim.mjs
+++ b/scripts/dev/test-vps-shim.mjs
@@ -8,7 +8,7 @@
 // upstream pnpm workspace.
 //
 // Run: `node scripts/dev/test-vps-shim.mjs` (after `cargo build --release
-// --features napi --lib` and `cp target/release/libsvelte_compiler_rust.dylib
+// --features napi --lib` and `cp target/release/librsvelte_core.dylib
 // apps/npm/vite-plugin-svelte-native-<triple>/rsvelte.node`).
 
 import { createRequire } from 'node:module';

--- a/scripts/ecosystem/ecosystem-ci.mjs
+++ b/scripts/ecosystem/ecosystem-ci.mjs
@@ -222,7 +222,7 @@ function buildRsvelte(checkoutPath) {
 		{ stdio: 'inherit', cwd: ROOT },
 	);
 	if (r.status !== 0) throw new Error('cargo build failed');
-	const srcPath = path.join(ROOT, 'target', 'release', `libsvelte_compiler_rust.${ext}`);
+	const srcPath = path.join(ROOT, 'target', 'release', `librsvelte_core.${ext}`);
 	if (!fs.existsSync(srcPath)) throw new Error(`cargo output missing: ${srcPath}`);
 
 	// Stage A: drop a copy under checkout/<name>/.rsvelte/ for the loader-hook

--- a/scripts/release/finalize-pkg.mjs
+++ b/scripts/release/finalize-pkg.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // `wasm-pack build` writes `pkg/package.json` based on the Cargo crate name
-// (`svelte-compiler-rust`). We publish under the scoped npm name
+// (`rsvelte_core`). We publish under the scoped npm name
 // `@rsvelte/compiler`, so we overlay the npm-side metadata here after the
 // wasm build completes and before `pnpm publish` reads it.
 //

--- a/scripts/release/publish-all-local.sh
+++ b/scripts/release/publish-all-local.sh
@@ -275,9 +275,9 @@ sc_dest_for() {
 dylib_for() {
   local target="$1"
   case "$target" in
-    *-apple-darwin)    echo "libsvelte_compiler_rust.dylib" ;;
-    *-unknown-linux-*) echo "libsvelte_compiler_rust.so" ;;
-    *-pc-windows-msvc) echo "svelte_compiler_rust.dll" ;;
+    *-apple-darwin)    echo "librsvelte_core.dylib" ;;
+    *-unknown-linux-*) echo "librsvelte_core.so" ;;
+    *-pc-windows-msvc) echo "rsvelte_core.dll" ;;
   esac
 }
 

--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Sync the npm package version from `npm/svelte-compiler-rust/package.json`
+// Sync the npm package version from `npm/rsvelte_core/package.json`
 // (managed by changesets) into `Cargo.toml` and `Cargo.lock`.
 //
 // `wasm-pack build` derives `pkg/package.json` from `Cargo.toml`, so keeping
@@ -40,14 +40,14 @@ function patchCargoLock() {
 	const original = readFileSync(cargoLockPath, 'utf8');
 	// Each package entry in Cargo.lock looks like:
 	//   [[package]]
-	//   name = "svelte-compiler-rust"
+	//   name = "rsvelte_core"
 	//   version = "0.1.0"
 	// Match exactly the entry whose name is the crate we publish.
 	const re =
-		/(\[\[package\]\]\nname = "svelte-compiler-rust"\nversion = ")([^"]+)(")/;
+		/(\[\[package\]\]\nname = "rsvelte_core"\nversion = ")([^"]+)(")/;
 	const match = original.match(re);
 	if (!match) {
-		throw new Error('Failed to find svelte-compiler-rust entry in Cargo.lock');
+		throw new Error('Failed to find rsvelte_core entry in Cargo.lock');
 	}
 	if (match[2] === targetVersion) return;
 	writeFileSync(cargoLockPath, original.replace(re, `$1${targetVersion}$3`));


### PR DESCRIPTION
## Summary

The core crate's name predated the rsvelte project umbrella and stuck out next to its `rsvelte_capi` / `rsvelte_fmt` / `rsvelte_formatter` siblings. Rename to `rsvelte_core` so the workspace has a consistent naming scheme. Pure rename — no behavior or version changes.

## What changes

- **Cargo package name** `svelte-compiler-rust` → `rsvelte_core`, which also flips the lib name (`svelte_compiler_rust` → `rsvelte_core`) and the cdylib filenames:

  | Platform | Before | After |
  |---|---|---|
  | Linux | `libsvelte_compiler_rust.so` | `librsvelte_core.so` |
  | macOS | `libsvelte_compiler_rust.dylib` | `librsvelte_core.dylib` |
  | Windows | `svelte_compiler_rust.dll` | `rsvelte_core.dll` |

- **All ~140 `use svelte_compiler_rust::`** in tests, bins, benches, and a handful of in-crate identifiers
- **`crates/rsvelte_capi/Cargo.toml`** + **`crates/rsvelte_formatter/Cargo.toml`** — dependency entry name (path unchanged)
- **`Cargo.lock`** regenerated
- **CI workflows** (`release.yml`, `deploy-docs.yml`) — cdylib stage commands and per-target matrix entries
- **Release / dev / ecosystem scripts** that grep or `cp` the cdylib
- **`.claude/skills/*`** and **`.claude/sessions/*`** command snippets
- **Top-level docs**: `README.md`, `AGENTS.md` / `CLAUDE.md` (symlink), `CONTRIBUTING.md`, `apps/npm/compiler/README.md`, `docs/perf-roadmap.md`, archived docs

## What stays the same

- The published npm package is still **`@rsvelte/compiler`** — `scripts/release/finalize-pkg.mjs` overlays the npm-side identity on top of the wasm-pack output, so the Cargo rename just changes its source-side name (verified the script doesn't grep for the old name).
- The published Cargo crate version (0.6.0) and all dep versions.
- The verify-svelte-compat skill's `rsvelte.<triple>.node` staging path (only the dylib source filename changed; the staged target keeps its name so downstream consumers see no change).
- `npm/*/CHANGELOG.md` historical entries (deliberately left in past tense).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo build --workspace --tests` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `pnpm run test:envelope` passes
- [x] `pnpm run test:vps-shim` passes (9/9)
- [ ] CI green

Follow-up to the 6-PR repo reorganization (#612 #613 #614 #615 #618 #619). With this landed, the only naming inconsistency left would be choosing whether to also rename the `napi`/`wasm`/`svelte_check`/`svelte2tsx`/`vps` modules out of `rsvelte_core` into their own crates — that's a separate (much larger) design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)