### PR TITLE
fix(ssr): apply derived-read wrapping to {@html expr}

### DIFF
--- a/.changeset/ssr-html-tag-derived-reads.md
+++ b/.changeset/ssr-html-tag-derived-reads.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix(ssr): apply derived-read wrapping to `{@html expr}`
+
+On the server, `{@html expr}` skipped the dynamic-expression transforms that the
+regular `{expr}` tag runs — most importantly `wrap_derived_reads`. Since a
+`$derived` binding compiles to a getter function on the server, `{@html post.html}`
+where `post = $derived(...)` emitted `$.html(post.html)` (reading `.html` off a
+function, i.e. `undefined`) and rendered nothing. It now emits
+`$.html(post().html)`, matching the official compiler. Non-derived expressions
+and string literals are unaffected. This surfaced as empty article bodies when
+prerendering a SvelteKit site that does `{@html ...}` over a `$derived` value.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/html_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/html_tag.rs
@@ -14,6 +14,21 @@ impl<'a> ServerCodeGenerator<'a> {
 
         if end > start && end <= self.source.len() {
             let expr = self.source[start..end].trim().to_string();
+
+            // Apply the same dynamic-expression transforms as the regular
+            // `{expr}` (ExpressionTag) server path. Crucially this includes
+            // `wrap_derived_reads`: on the server, `$derived` bindings are getter
+            // functions, so `{@html post.html}` where `post` is `$derived(...)`
+            // must become `$.html(post().html)`. Without it the expression read
+            // `post.html` (a function's `.html`) is `undefined` and the tag
+            // renders empty. `{@html}` differs from `{expr}` only in that it is
+            // NOT HTML-escaped, so we skip the escape/constant-fold branch.
+            let expr = self.strip_ts_from_expr(&expr);
+            let expr = self.transform_store_refs(&expr);
+            let expr = self.transform_special_vars(&expr);
+            let expr = self.wrap_derived_reads(&expr);
+            let expr = Self::transform_rune_in_template_expr(&expr);
+
             // If the expression is a comma/sequence expression at the top level,
             // wrap it in parens so $.html((f = 0, '')) is a single-argument call.
             let expr = if has_top_level_comma(&expr) {

--- a/crates/rsvelte_core/tests/ssr_html_tag_derived.rs
+++ b/crates/rsvelte_core/tests/ssr_html_tag_derived.rs
@@ -1,0 +1,67 @@
+//! Regression tests for SSR `{@html expr}` expression handling.
+//!
+//! `{@html expr}` on the server must run the same dynamic-expression transforms
+//! as a regular `{expr}` tag — in particular `wrap_derived_reads`. On the
+//! server a `$derived` binding is a getter function, so `{@html post.html}`
+//! where `post = $derived(...)` must compile to `$.html(post().html)`. Without
+//! the transform it stayed `$.html(post.html)` (reading `.html` off a function),
+//! which renders empty.
+
+use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_ssr(source: &str) -> String {
+    let options = CompileOptions {
+        generate: GenerateMode::Server,
+        filename: Some("test.svelte".to_string()),
+        css: CssMode::External,
+        ..Default::default()
+    };
+    compile(source, options)
+        .expect("compilation should succeed")
+        .js
+        .code
+}
+
+#[test]
+fn html_tag_derived_member_calls_getter() {
+    let code = compile_ssr(
+        "<script>let { data } = $props(); const post = $derived(data.post);</script>\n{@html post.html}",
+    );
+    assert!(
+        code.contains("$.html(post().html)"),
+        "expected $.html(post().html) for a $derived binding, got:\n{}",
+        code
+    );
+}
+
+#[test]
+fn html_tag_derived_identifier_calls_getter() {
+    let code = compile_ssr(
+        "<script>let { data } = $props(); const html = $derived(data.html);</script>\n{@html html}",
+    );
+    assert!(
+        code.contains("$.html(html())"),
+        "expected $.html(html()) for a $derived binding, got:\n{}",
+        code
+    );
+}
+
+#[test]
+fn html_tag_plain_prop_unchanged() {
+    let code = compile_ssr("<script>let { post } = $props();</script>\n{@html post.html}");
+    assert!(
+        code.contains("$.html(post.html)"),
+        "non-derived prop should be left as-is, got:\n{}",
+        code
+    );
+}
+
+#[test]
+fn html_tag_string_literal_unchanged() {
+    let code = compile_ssr("{@html '<p>x</p>'}");
+    assert!(
+        code.contains("$.html("),
+        "string literal should render, got:\n{}",
+        code
+    );
+}


### PR DESCRIPTION
Fixes #622.

## Problem

In server/SSR mode, `{@html expr}` skipped the dynamic-expression transforms the regular `{expr}` (`ExpressionTag`) path runs — most importantly `wrap_derived_reads`. A `$derived` binding compiles to a getter function on the server, so `{@html post.html}` where `post = $derived(...)` emitted `$.html(post.html)` (reading `.html` off a function → `undefined`) and rendered nothing.

This caused **empty article bodies** when prerendering a SvelteKit site doing `{@html ...}` over a `$derived` value.

## Fix

`generate_html_tag` now runs the same transform chain as `generate_expression_tag`:
`strip_ts_from_expr` → `transform_store_refs` → `transform_special_vars` → `wrap_derived_reads` → `transform_rune_in_template_expr`.

`{@html}` differs from `{expr}` only in not being HTML-escaped, so the escape/constant-fold branch is intentionally skipped.

Verified output now matches the official compiler:
```js
// before: $$renderer.push(`${$.html(post.html)}`);
// after:  $$renderer.push(`${$.html(post().html)}`);
```

## Tests

`tests/ssr_html_tag_derived.rs` — derived member (`post().html`), derived identifier (`html()`), plain prop unchanged, string literal unchanged.

- `cargo test --test ssr_html_tag_derived` → 4 passed
- `cargo test --lib` → 1198 passed
- `ssr_attribute_escaping` / `ssr_component_css_props` / `ssr_component_spread_with_children` → all pass
- `cargo fmt` + `cargo clippy --lib --tests` clean

## Release

Changeset included (`patch` for `@rsvelte/compiler` and `@rsvelte/vite-plugin-svelte-native`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
