### PR TITLE
fix(ci): repair release / docs / coverage / ecosystem after PR6+PR7

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -101,7 +101,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build WASM
-        run: wasm-pack build --target web --no-default-features --features wasm
+        run: wasm-pack build crates/rsvelte_core --out-dir ../../pkg --target web --no-default-features --features wasm
 
       - name: Build NAPI cdylib
         # apps/playground/rsvelte-shim/compiler.mjs loads

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ rsvelte_core = { git = "https://github.com/baseballyama/rsvelte" }
 ```
 
 ```rust
-use svelte_compiler_rust::{compile, CompileOptions};
+use rsvelte_core::{compile, CompileOptions};
 
 let source = r#"<h1>Hello, {name}!</h1>"#;
 let result = compile(source, CompileOptions::default()).unwrap();
@@ -202,7 +202,7 @@ If your build relies on any of these, the value won't take effect. Use the worka
 
 Everything else (`generate`, `css`, `dev`, `hmr`, `sourcemap`, `runes`, `compatibility`, `experimental.async`, `preserveComments`, `preserveWhitespace`, `customElement`, `accessors`, `namespace`, `immutable`, `modernAst`, `discloseVersion`, `outputFilename`, `cssOutputFilename`, …) matches upstream exactly. The full list of accepted fields is mirrored in [`apps/npm/vite-plugin-svelte-native/index.d.ts`](apps/npm/vite-plugin-svelte-native/index.d.ts).
 
-The Rust API (`svelte_compiler_rust::compile`) has no such restriction — `css_hash: Option<CssHashFn>` and `warning_filter: Option<WarningFilterFn>` work as real `Arc<dyn Fn>` closures.
+The Rust API (`rsvelte_core::compile`) has no such restriction — `css_hash: Option<CssHashFn>` and `warning_filter: Option<WarningFilterFn>` work as real `Arc<dyn Fn>` closures.
 
 ## Performance
 

--- a/apps/npm/svelte2tsx/index.js
+++ b/apps/npm/svelte2tsx/index.js
@@ -20,7 +20,7 @@ let initPromise;
 async function ensureReady() {
 	if (!initPromise) {
 		initPromise = (async () => {
-			const wasmPath = require.resolve('@rsvelte/compiler/svelte_compiler_rust_bg.wasm');
+			const wasmPath = require.resolve('@rsvelte/compiler/rsvelte_core_bg.wasm');
 			const bytes = await readFile(wasmPath);
 			await initWasm({ module_or_path: bytes });
 		})();

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -7,7 +7,7 @@
 		"dev": "node --import ./rsvelte-shim/loader-register.mjs ./node_modules/vite/bin/vite.js dev",
 		"build": "node --import ./rsvelte-shim/loader-register.mjs ./node_modules/vite/bin/vite.js build",
 		"preview": "node --import ./rsvelte-shim/loader-register.mjs ./node_modules/vite/bin/vite.js preview",
-		"build:wasm": "cd ../.. && wasm-pack build --target web --no-default-features --features wasm",
+		"build:wasm": "cd ../.. && wasm-pack build crates/rsvelte_core --out-dir ../../pkg --target web --no-default-features --features wasm",
 		"lint": "oxlint src/**/*.ts --deny-warnings",
 		"format": "oxfmt",
 		"format:check": "oxfmt --check",

--- a/apps/playground/rsvelte-shim/compiler.mjs
+++ b/apps/playground/rsvelte-shim/compiler.mjs
@@ -48,11 +48,12 @@ if (!triple) {
 	);
 }
 
-// The repo layout keeps prebuilt `.node` artifacts in `<repo>/npm/<pkg>-<triple>/`.
-// `apps/playground/rsvelte-shim/` is two levels under the repo root.
-const repoRoot = join(here, '..', '..');
-const nodePath = join(repoRoot, 'npm', `vite-plugin-svelte-native-${triple}`, 'rsvelte.node');
-const envelopePath = join(repoRoot, 'npm', 'vite-plugin-svelte-native', 'envelope.js');
+// The repo layout keeps prebuilt `.node` artifacts in
+// `<repo>/apps/npm/<pkg>-<triple>/`. `apps/playground/rsvelte-shim/` is
+// three levels under the repo root.
+const repoRoot = join(here, '..', '..', '..');
+const nodePath = join(repoRoot, 'apps', 'npm', `vite-plugin-svelte-native-${triple}`, 'rsvelte.node');
+const envelopePath = join(repoRoot, 'apps', 'npm', 'vite-plugin-svelte-native', 'envelope.js');
 
 let binding;
 try {

--- a/apps/playground/src/lib/compiler.ts
+++ b/apps/playground/src/lib/compiler.ts
@@ -1,6 +1,6 @@
-import type { ParseResultWasm, CompileResultWasm } from '../../../pkg/svelte_compiler_rust';
+import type { ParseResultWasm, CompileResultWasm } from '../../../pkg/rsvelte_core';
 
-let wasmModule: typeof import('../../../pkg/svelte_compiler_rust') | null = null;
+let wasmModule: typeof import('../../../pkg/rsvelte_core') | null = null;
 let initPromise: Promise<void> | null = null;
 
 export async function initCompiler(): Promise<void> {
@@ -8,7 +8,7 @@ export async function initCompiler(): Promise<void> {
 	if (initPromise) return initPromise;
 
 	initPromise = (async () => {
-		const wasm = await import('../../../pkg/svelte_compiler_rust');
+		const wasm = await import('../../../pkg/rsvelte_core');
 		await wasm.default();
 		wasmModule = wasm;
 	})();

--- a/crates/rsvelte_core/tests/ssr_html_tag_derived.rs
+++ b/crates/rsvelte_core/tests/ssr_html_tag_derived.rs
@@ -7,7 +7,7 @@
 //! the transform it stayed `$.html(post.html)` (reading `.html` off a function),
 //! which renders empty.
 
-use svelte_compiler_rust::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_ssr(source: &str) -> String {
     let options = CompileOptions {

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -8,22 +8,10 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 fn bin() -> PathBuf {
-    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    p.pop();
-    p.pop();
-    p.push("target");
-    p.push(if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    });
-    p.push("rsvelte-fmt");
-    assert!(
-        p.exists(),
-        "rsvelte-fmt binary not built at {}",
-        p.display()
-    );
-    p
+    // Cargo sets CARGO_BIN_EXE_<bin-name> for integration tests so the test
+    // doesn't have to guess where the binary lives — important under
+    // cargo-llvm-cov, which uses target/llvm-cov-target/ instead of target/.
+    PathBuf::from(env!("CARGO_BIN_EXE_rsvelte-fmt"))
 }
 
 fn run_stdin(stdin: &str, args: &[&str]) -> (String, String, i32) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:wasm": "wasm-pack build --target web --release -- --features wasm --no-default-features",
+    "build:wasm": "wasm-pack build crates/rsvelte_core --out-dir ../../pkg --target web --release -- --features wasm --no-default-features",
     "build:wasm:clean": "cargo clean && pnpm run build:wasm",
     "clean:cache": "rm -rf apps/playground/node_modules/.vite",
     "dev": "pnpm run build:wasm && pnpm run clean:cache && cd apps/playground && pnpm run dev",

--- a/scripts/ecosystem/ecosystem-ci.mjs
+++ b/scripts/ecosystem/ecosystem-ci.mjs
@@ -236,7 +236,7 @@ function buildRsvelte(checkoutPath) {
 	// so the vps-shim swap can point pnpm at our local rsvelte rather than the
 	// last npm-published version. Without this, ecosystem-ci would verify
 	// whatever version was published to npm, not the rsvelte at HEAD.
-	const platformPkg = path.join(ROOT, 'npm', `vite-plugin-svelte-native-${triple}`);
+	const platformPkg = path.join(ROOT, 'apps', 'npm', `vite-plugin-svelte-native-${triple}`);
 	if (!fs.existsSync(platformPkg)) {
 		throw new Error(`platform npm package missing: ${platformPkg}`);
 	}
@@ -301,9 +301,9 @@ function applySwap(target, checkoutPath, bindingPath, triple) {
 		// the override key in each case).
 		pkg.pnpm.overrides['@sveltejs/vite-plugin-svelte'] = `file:${forkStage}`;
 		pkg.pnpm.overrides['@rsvelte/vite-plugin-svelte-native'] =
-			`file:${path.join(ROOT, 'npm', 'vite-plugin-svelte-native')}`;
+			`file:${path.join(ROOT, 'apps', 'npm', 'vite-plugin-svelte-native')}`;
 		pkg.pnpm.overrides[`@rsvelte/vite-plugin-svelte-native-${triple}`] =
-			`file:${path.join(ROOT, 'npm', `vite-plugin-svelte-native-${triple}`)}`;
+			`file:${path.join(ROOT, 'apps', 'npm', `vite-plugin-svelte-native-${triple}`)}`;
 		fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
 		log(`vps-shim: staged fork -> ${path.relative(ROOT, forkStage)} and injected 3 pnpm.overrides`);
 		return { strategy, env: {}, needsReinstall: true };

--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
-// Sync the npm package version from `npm/rsvelte_core/package.json`
-// (managed by changesets) into `Cargo.toml` and `Cargo.lock`.
+// Sync the npm package version from `apps/npm/compiler/package.json`
+// (managed by changesets) into `crates/rsvelte_core/Cargo.toml` and the
+// repo-root `Cargo.lock`.
 //
-// `wasm-pack build` derives `pkg/package.json` from `Cargo.toml`, so keeping
-// these aligned is what makes "bump the workspace package.json via changesets,
-// then publish the freshly built pkg/" produce a coherent npm release.
+// `wasm-pack build` derives `pkg/package.json` from the rsvelte_core
+// crate's Cargo.toml, so keeping these aligned is what makes "bump the
+// workspace package.json via changesets, then publish the freshly built
+// pkg/" produce a coherent npm release.
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -13,7 +15,7 @@ import { dirname, resolve } from 'node:path';
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../..');
 const npmPkgPath = resolve(repoRoot, 'apps/npm/compiler/package.json');
-const cargoTomlPath = resolve(repoRoot, 'Cargo.toml');
+const cargoTomlPath = resolve(repoRoot, 'crates/rsvelte_core/Cargo.toml');
 const cargoLockPath = resolve(repoRoot, 'Cargo.lock');
 
 const targetVersion = JSON.parse(readFileSync(npmPkgPath, 'utf8')).version;


### PR DESCRIPTION
## Summary

Post-merge CI workflows hit five regressions that the per-PR CI didn't catch (because each broken workflow only runs on push-to-main, or runs on a schedule). Pure path / config fixes — no behavior change.

### 1. `wasm-pack build` → not a package
`wasm-pack` errored with "missing field `package`" — the repo root is a virtual workspace after PR6 #619. Updated all 3 invocations to `wasm-pack build crates/rsvelte_core --out-dir ../../pkg ...` so the build still lands in repo-root `pkg/`:
- `package.json` `build:wasm`
- `apps/playground/package.json` `build:wasm`
- `.github/workflows/deploy-docs.yml`

### 2. `sync-version.mjs` → no `[package].version` in root
`scripts/release/sync-version.mjs` read `[package].version` from root `Cargo.toml`. Point it at `crates/rsvelte_core/Cargo.toml` and update the docstring.

### 3. Coverage workflow → `rsvelte-fmt` binary not where expected
`crates/rsvelte_fmt/tests/cli.rs` looked for the binary at `target/{debug,release}/rsvelte-fmt`, but `cargo llvm-cov` builds into `target/llvm-cov-target/debug/`. Use the `CARGO_BIN_EXE_rsvelte-fmt` env var cargo sets for integration tests (works under both plain `cargo test` and `cargo llvm-cov`).

### 4. ecosystem-ci → "platform npm package missing: .../npm/vite-plugin-svelte-native-linux-x64-gnu" (issues #620 #617)
PR5's bulk perl rewrite only matched the literal substring `npm/vite-plugin-svelte-native`, not the segmented `path.join(ROOT, 'npm', ...)` form used by:
- `scripts/ecosystem/ecosystem-ci.mjs` (3 sites)
- `apps/playground/rsvelte-shim/compiler.mjs` (2 sites)

Insert the `'apps'` segment so paths resolve. Also fix the playground shim's `repoRoot = join(here, '..', '..')` — it climbed two levels from `apps/playground/rsvelte-shim/` to `apps/`, not the repo root. Bump to `'..', '..', '..'`.

### 5. PR7 rename missed three WASM-filename consumers
After `svelte_compiler_rust` → `rsvelte_core`, `wasm-pack` writes `rsvelte_core_bg.wasm` (etc.) instead of the old filenames. Update the three remaining consumers:
- `apps/playground/src/lib/compiler.ts` (3 imports)
- `apps/npm/svelte2tsx/index.js` (`require.resolve` for the bg.wasm)
- `README.md` (two `use svelte_compiler_rust::...` examples)

## Test plan

- [x] `pnpm run build:wasm` succeeds; `pkg/` contains `rsvelte_core*.{wasm,js,d.ts}`
- [x] `cargo build --workspace --tests` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p rsvelte_fmt --tests` — all 6 tests pass
- [x] `pnpm run test:envelope` passes
- [x] `pnpm run test:vps-shim` — 9/9 pass
- [ ] CI green (specifically Coverage + Release on main + ecosystem-ci on schedule)

Closes #620, #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)