### PR TITLE
fix(playground): pkg/ import path needs four levels, not three

### DIFF
--- a/apps/playground/src/lib/compiler.ts
+++ b/apps/playground/src/lib/compiler.ts
@@ -1,6 +1,6 @@
-import type { ParseResultWasm, CompileResultWasm } from '../../../pkg/rsvelte_core';
+import type { ParseResultWasm, CompileResultWasm } from '../../../../pkg/rsvelte_core';
 
-let wasmModule: typeof import('../../../pkg/rsvelte_core') | null = null;
+let wasmModule: typeof import('../../../../pkg/rsvelte_core') | null = null;
 let initPromise: Promise<void> | null = null;
 
 export async function initCompiler(): Promise<void> {
@@ -8,7 +8,7 @@ export async function initCompiler(): Promise<void> {
 	if (initPromise) return initPromise;
 
 	initPromise = (async () => {
-		const wasm = await import('../../../pkg/rsvelte_core');
+		const wasm = await import('../../../../pkg/rsvelte_core');
 		await wasm.default();
 		wasmModule = wasm;
 	})();


### PR DESCRIPTION
## Summary

Deploy Docs failed on the post-merge run of #624 with:

```
[UNRESOLVED_IMPORT] Error: Could not resolve '../../../pkg/rsvelte_core' in src/lib/compiler.ts
```

Root cause: latent regression from PR #615. `apps/playground/src/lib/compiler.ts` is at depth 4 from the repo root (`apps/playground/src/lib/`), but the import uses three levels of `../`, resolving to `apps/pkg/` — which doesn't exist. The old `docs/src/lib/compiler.ts` was depth 3, so the same string worked.

Bumped to `'../../../../pkg/rsvelte_core'` (one more `../`).

## Why this didn't fail before

Deploy Docs is the only workflow that runs `pnpm run build` on the playground. It runs on `push` to `main`, not per-PR. PR #615's CI passed because:
- Its per-PR jobs only ran `pnpm install` + `pnpm run lint`.
- The post-merge Deploy Docs run for PR #615 happened earlier today before the rename, when the WASM file was still named `svelte_compiler_rust_bg.wasm` — and the import string `../../../pkg/svelte_compiler_rust` ALSO didn't resolve. But that failure must have been masked by an earlier failing step (the WASM build itself was already broken — see PR #624).

Now that PR #624 unblocked the upstream steps (`wasm-pack build`, `pnpm install`), this import error gets reached and surfaces.

## Test plan

- [x] `cd apps/playground && pnpm run build` succeeds — "Wrote site to 'build'"
- [ ] Deploy Docs workflow green on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)