### PR TITLE
feat(playground): rebrand site as the Svelte ecosystem in Rust

### DIFF
--- a/apps/playground/src/app.html
+++ b/apps/playground/src/app.html
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#0d0c09" media="(prefers-color-scheme: dark)" />
-		<title>Svelte Compiler Rust - Playground</title>
+		<title>rsvelte — the Svelte ecosystem, in Rust</title>
 		<script>
 			// Resolve theme before first paint to avoid a flash of the wrong palette.
 			// Order: explicit `?theme=…` query (used for shareable links and CI

--- a/apps/playground/src/lib/components/EcoCard.svelte
+++ b/apps/playground/src/lib/components/EcoCard.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+	import { type EcoComponent, statusLabel } from '$lib/ecosystem';
+
+	interface Props {
+		c: EcoComponent;
+		/** Compact cards drop the install row + blurb wraps tighter (home grid). */
+		compact?: boolean;
+	}
+
+	let { c, compact = false }: Props = $props();
+</script>
+
+<article class="card status-{c.status}" class:compact>
+	<header class="card-head">
+		<span class="badge">
+			<span class="dot"></span>
+			{statusLabel(c.status)}
+		</span>
+		{#if c.speedup}
+			<span class="speed" title="multi-threaded rsvelte vs. the official JS tool">
+				{c.speedup.x}×<span class="speed-of">faster</span>
+			</span>
+		{/if}
+	</header>
+
+	<h3 class="name">{c.name}</h3>
+
+	<p class="dropin">
+		{#if c.status === 'delegated'}
+			instead of
+		{:else}
+			drop-in for
+		{/if}
+		<a href={c.originalUrl} target="_blank" rel="noopener" class="orig">
+			{c.dropInFor}<span class="ext" aria-hidden="true">↗</span>
+		</a>
+		{#if c.routesTo}
+			<span class="routes">
+				→ <a href={c.routesTo.url} target="_blank" rel="noopener">{c.routesTo.label}</a>
+			</span>
+		{/if}
+	</p>
+
+	<p class="blurb">{c.blurb}</p>
+
+	<footer class="card-foot">
+		{#if c.note}
+			<span class="note">{c.note}</span>
+		{/if}
+		{#if !compact && (c.install || c.pkgUrl)}
+			<div class="actions">
+				{#if c.install}
+					<code class="install">{c.install}</code>
+				{/if}
+				{#if c.pkgUrl}
+					<a href={c.pkgUrl} target="_blank" rel="noopener" class="src">
+						source <span class="ext" aria-hidden="true">↗</span>
+					</a>
+				{/if}
+			</div>
+		{/if}
+	</footer>
+</article>
+
+<style>
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.7rem;
+		background: var(--bg);
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		padding: 1.25rem 1.35rem 1.35rem;
+		height: 100%;
+		transition: border-color 0.18s ease;
+	}
+
+	.card.status-shipped:hover {
+		border-color: color-mix(in srgb, var(--svelte) 45%, var(--rule));
+	}
+
+	.card-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.64rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--ink-soft);
+	}
+
+	.dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 999px;
+		background: var(--ink-faint);
+	}
+
+	.status-shipped .dot {
+		background: var(--ok);
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--ok) 18%, transparent);
+	}
+
+	.status-planned .dot {
+		background: var(--warn);
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--warn) 18%, transparent);
+	}
+
+	.status-delegated .dot {
+		background: var(--ink-faint);
+	}
+
+	.speed {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.3rem;
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		/* >=18.66px bold clears the WCAG large-text bar, so the Svelte-orange
+		   number stays AA-legible on the light card background. */
+		font-size: 1.25rem;
+		line-height: 1;
+		letter-spacing: -0.02em;
+		color: var(--svelte);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.speed-of {
+		font-family: 'Fira Mono', monospace;
+		font-weight: 500;
+		font-size: 0.6rem;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--ink-faint);
+	}
+
+	.name {
+		font-family: 'Fira Mono', monospace;
+		font-weight: 500;
+		font-size: 1.02rem;
+		letter-spacing: -0.01em;
+		color: var(--ink);
+		margin: 0;
+		word-break: break-word;
+	}
+
+	.dropin {
+		font-size: 0.84rem;
+		color: var(--ink-soft);
+		margin: 0;
+	}
+
+	.orig {
+		color: var(--svelte);
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.92em;
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+	}
+
+	.orig:hover {
+		color: var(--svelte-hover);
+	}
+
+	.ext {
+		font-size: 0.85em;
+		opacity: 0.6;
+		margin-left: 0.1em;
+		text-decoration: none;
+		display: inline-block;
+	}
+
+	.routes {
+		color: var(--ink-faint);
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.82em;
+	}
+
+	.routes a {
+		color: var(--rust);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+	}
+
+	.blurb {
+		font-size: 0.9rem;
+		line-height: 1.55;
+		color: var(--ink-soft);
+		margin: 0;
+		flex: 1;
+	}
+
+	.compact .blurb {
+		font-size: 0.86rem;
+	}
+
+	.card-foot {
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+		margin-top: 0.15rem;
+		padding-top: 0.8rem;
+		border-top: 1px solid var(--rule);
+	}
+
+	.note {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.68rem;
+		letter-spacing: 0.01em;
+		color: var(--ink-faint);
+		line-height: 1.4;
+	}
+
+	.actions {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.install {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.74rem;
+		color: var(--ink);
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 4px;
+		padding: 0.3rem 0.55rem;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 100%;
+	}
+
+	.src {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.74rem;
+		color: var(--ink-soft);
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		white-space: nowrap;
+		transition: color 0.18s ease;
+	}
+
+	.src:hover {
+		color: var(--ink);
+	}
+</style>

--- a/apps/playground/src/lib/components/SiteFooter.svelte
+++ b/apps/playground/src/lib/components/SiteFooter.svelte
@@ -14,7 +14,7 @@
 		<div class="meta">
 			<span>MIT licensed</span>
 			<span class="sep">·</span>
-			<span>Mirrors sveltejs/svelte@5.51.3</span>
+			<span>Mirrors sveltejs/svelte@5.56.0</span>
 			<span class="sep">·</span>
 			<a href="https://github.com/baseballyama/rsvelte" target="_blank" rel="noopener">
 				github.com/baseballyama/rsvelte

--- a/apps/playground/src/lib/components/SiteNav.svelte
+++ b/apps/playground/src/lib/components/SiteNav.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/state';
 	import { themeStore } from '$lib/theme.svelte';
 
-	type Active = 'home' | 'playground' | 'progress' | 'benchmark';
+	type Active = 'home' | 'ecosystem' | 'playground' | 'progress' | 'benchmark';
 
 	interface Props {
 		// Each page passes its own slug so the link gets the `active` style
@@ -34,10 +34,11 @@
 			</svg>
 		</span>
 		<span class="brand-text">rsvelte</span>
-		<span class="brand-tag">rust&nbsp;port</span>
+		<span class="brand-tag">svelte&nbsp;·&nbsp;in&nbsp;rust</span>
 	</a>
 
 	<div class="links">
+		<a href="{base}/ecosystem" class:active={isActive('ecosystem')}>Ecosystem</a>
 		<a href="{base}/playground" class:active={isActive('playground')}>Playground</a>
 		<a href="{base}/progress" class:active={isActive('progress')}>Compatibility</a>
 		<a href="{base}/benchmark" class:active={isActive('benchmark')}>Benchmark</a>
@@ -202,7 +203,10 @@
 			gap: 0.7rem;
 			font-size: 0.84rem;
 		}
-		.links a:nth-child(2) {
+		/* Keep the two primary destinations (Ecosystem, Playground) on phones;
+		   Compatibility + Benchmark are reachable from the home page. */
+		.links a:nth-child(3),
+		.links a:nth-child(4) {
 			display: none;
 		}
 	}

--- a/apps/playground/src/lib/ecosystem.ts
+++ b/apps/playground/src/lib/ecosystem.ts
@@ -1,0 +1,161 @@
+// Canonical inventory of the Svelte ecosystem ports.
+//
+// This is the single source of truth shared by the home page's ecosystem
+// section and the dedicated /ecosystem inventory page. When a wave lands or a
+// status changes, edit it here once.
+//
+// Status semantics:
+//   - 'shipped'    : published under @rsvelte, drop-in usable today
+//   - 'planned'    : on the roadmap but not yet usable (blocked / deferred)
+//   - 'delegated'  : intentionally NOT ported — the Rust path runs through the
+//                    wider OXC toolchain (oxlint / oxfmt / …) or stays in JS
+//
+// Speedups are multi-threaded rsvelte vs. the official JavaScript tool,
+// measured on the same corpus/machine — see /benchmark for the live numbers.
+
+export type EcoStatus = 'shipped' | 'planned' | 'delegated';
+
+export interface EcoComponent {
+	/** rsvelte package or tool name (e.g. `@rsvelte/compiler`). */
+	name: string;
+	/** The upstream tool this is a drop-in replacement for. */
+	dropInFor: string;
+	/** Link to the original library / docs. */
+	originalUrl: string;
+	/** Link to the rsvelte package source (optional). */
+	pkgUrl?: string;
+	/** npm install id, when published. */
+	install?: string;
+	status: EcoStatus;
+	/** Short, plain-language description of what it does. */
+	blurb: string;
+	/** Measured multi-thread speedup vs. the JS tool, when benchmarked. */
+	speedup?: { x: number; of: string };
+	/** Compatibility / status footnote (e.g. "100% of fixtures"). */
+	note?: string;
+	/** For delegated tools: where the Rust path actually lives. */
+	routesTo?: { label: string; url: string };
+}
+
+const STATUS_LABEL: Record<EcoStatus, string> = {
+	shipped: 'Shipped',
+	planned: 'Planned',
+	delegated: 'Delegated'
+};
+
+export const statusLabel = (s: EcoStatus): string => STATUS_LABEL[s];
+
+// ─── Ported / shipped ────────────────────────────────────────────────────────
+export const shipped: EcoComponent[] = [
+	{
+		name: '@rsvelte/compiler',
+		dropInFor: 'svelte/compiler',
+		originalUrl: 'https://svelte.dev/docs/svelte/svelte-compiler',
+		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/compiler',
+		install: 'npm i @rsvelte/compiler',
+		status: 'shipped',
+		blurb:
+			'The whole compile pipeline — parse, analyze, transform — for client, SSR and hydration. Output matches the official compiler across the in-scope test suite.',
+		speedup: { x: 17, of: 'full pipeline' },
+		note: 'Parser alone runs 145× · 99.8% of in-scope fixtures green'
+	},
+	{
+		name: '@rsvelte/svelte2tsx',
+		dropInFor: 'svelte2tsx',
+		originalUrl: 'https://github.com/sveltejs/language-tools/tree/master/packages/svelte2tsx',
+		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/svelte2tsx',
+		install: 'npm i @rsvelte/svelte2tsx',
+		status: 'shipped',
+		blurb:
+			'Turns a .svelte component into the TSX shadow file the TypeScript checker reads, with column-accurate source maps.',
+		speedup: { x: 22, of: 'svelte2tsx' },
+		note: 'Wave 1 · 100% of fixtures'
+	},
+	{
+		name: '@rsvelte/svelte-check',
+		dropInFor: 'svelte-check',
+		originalUrl: 'https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check',
+		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/svelte-check',
+		install: 'npm i -D @rsvelte/svelte-check',
+		status: 'shipped',
+		blurb:
+			'The project type-checker CLI. A Rust walker + overlay drives tsgo for the TypeScript half; diagnostics map back to .svelte positions. Watch + incremental cache included.',
+		speedup: { x: 144, of: 'svelte-check' },
+		note: 'Rust walker + tsgo backend · 500-file workspace'
+	},
+	{
+		name: '@rsvelte/vite-plugin-svelte',
+		dropInFor: '@sveltejs/vite-plugin-svelte',
+		originalUrl: 'https://github.com/sveltejs/vite-plugin-svelte',
+		pkgUrl: 'https://github.com/baseballyama/vite-plugin-svelte/tree/rsvelte',
+		install: 'npm i -D @rsvelte/vite-plugin-svelte',
+		status: 'shipped',
+		blurb:
+			'A fork of the Vite plugin whose every transform / HMR / preprocess call routes through the rsvelte compiler over NAPI. Your vite.config.js does not change.',
+		note: 'NAPI shim · public API matches upstream'
+	}
+];
+
+// ─── Planned / deferred ──────────────────────────────────────────────────────
+export const planned: EcoComponent[] = [
+	{
+		name: 'svelte-language-server',
+		dropInFor: 'svelte-language-server',
+		originalUrl: 'https://github.com/sveltejs/language-tools/tree/master/packages/language-server',
+		status: 'planned',
+		blurb:
+			'Editor hover / completion / rename. Deferred until tsgo ships a long-running tsserver-style daemon — sub-50 ms LSP latency needs it. CLI checking is already covered by svelte-check.',
+		note: 'Blocked on tsgo tsserver mode'
+	}
+];
+
+// ─── Delegated / out of scope ────────────────────────────────────────────────
+// These are intentionally NOT ported. The Rust path runs through the wider OXC
+// toolchain or stays in JS, so a rsvelte fork would only duplicate work.
+export const delegated: EcoComponent[] = [
+	{
+		name: 'eslint-plugin-svelte',
+		dropInFor: 'eslint-plugin-svelte',
+		originalUrl: 'https://github.com/sveltejs/eslint-plugin-svelte',
+		status: 'delegated',
+		blurb: 'Linting belongs in oxlint — rsvelte gives it a Svelte surface to call into.',
+		routesTo: { label: 'oxlint', url: 'https://oxc.rs/docs/guide/usage/linter.html' }
+	},
+	{
+		name: 'prettier-plugin-svelte',
+		dropInFor: 'prettier-plugin-svelte',
+		originalUrl: 'https://github.com/sveltejs/prettier-plugin-svelte',
+		status: 'delegated',
+		blurb: 'Formatting is a Rust-formatter job — oxfmt / dprint / biome, not a fork of Prettier.',
+		routesTo: { label: 'oxfmt', url: 'https://oxc.rs/' }
+	},
+	{
+		name: 'svelte-preprocess',
+		dropInFor: 'svelte-preprocess',
+		originalUrl: 'https://github.com/sveltejs/svelte-preprocess',
+		status: 'delegated',
+		blurb: 'A thin wrapper around sass / postcss / ts — all JS-heavy. Nothing to gain by porting the wrapper itself.'
+	},
+	{
+		name: 'mdsvex',
+		dropInFor: 'mdsvex',
+		originalUrl: 'https://github.com/pngwn/MDsveX',
+		status: 'delegated',
+		blurb: 'Built on the unified / remark markdown ecosystem, which is JS to the core.'
+	},
+	{
+		name: 'SvelteKit',
+		dropInFor: '@sveltejs/kit',
+		originalUrl: 'https://github.com/sveltejs/kit',
+		status: 'delegated',
+		blurb: 'A whole framework, deeply coupled to Vite / Rollup. Out of scope — specific hot paths may be revisited later.'
+	}
+];
+
+export const allComponents: EcoComponent[] = [...shipped, ...planned, ...delegated];
+
+export const counts = {
+	shipped: shipped.length,
+	planned: planned.length,
+	delegated: delegated.length
+};

--- a/apps/playground/src/routes/+page.svelte
+++ b/apps/playground/src/routes/+page.svelte
@@ -2,18 +2,27 @@
 	import { base } from '$app/paths';
 	import { onMount } from 'svelte';
 	import type { BenchmarkResults } from '$lib/types/benchmark';
+	import type { TestResults } from '$lib/types/test-results';
 	import SiteNav from '$lib/components/SiteNav.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
+	import EcoCard from '$lib/components/EcoCard.svelte';
+	import { shipped, counts } from '$lib/ecosystem';
 
 	let bench = $state<BenchmarkResults | null>(null);
+	let tests = $state<TestResults | null>(null);
 	let animated = $state(false);
 
 	onMount(async () => {
 		try {
-			const res = await fetch(`${base}/benchmark-results.json`);
-			if (res.ok) bench = await res.json();
+			const [b, t] = await Promise.all([
+				fetch(`${base}/benchmark-results.json`).then((r) => (r.ok ? r.json() : null)),
+				fetch(`${base}/test-results.json`).then((r) => (r.ok ? r.json() : null))
+			]);
+			bench = b;
+			tests = t;
 		} catch {
 			bench = null;
+			tests = null;
 		}
 		requestAnimationFrame(() => (animated = true));
 	});
@@ -33,14 +42,58 @@
 	const formatDate = (iso: string): string =>
 		new Date(iso).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 
-	const specs = [
-		{ n: 1202, label: 'runtime / legacy', sub: 'svelte 4 parity' },
-		{ n: 865, label: 'runtime / runes', sub: '$state / $derived / $effect' },
-		{ n: 324, label: 'validator + a11y', sub: 'warnings & errors' },
-		{ n: 245, label: 'svelte2tsx', sub: 'ecosystem / wave 1' },
-		{ n: 179, label: 'css', sub: ':global / scoping / keyframes' },
-		{ n: 144, label: 'compiler errors', sub: 'parse & semantic checks' }
+	// The four measured tools across the toolchain — each multi-threaded
+	// rsvelte vs. its official JavaScript counterpart on the same corpus.
+	const toolchain = $derived.by(() => {
+		if (!bench) return [];
+		const list = [
+			{ label: 'svelte/compiler', sub: 'full pipeline', x: bench.speedup.multiThreadVsJs },
+			{ label: 'parser', sub: 'phase 1, isolated', x: bench.parse.speedup.multiThreadVsJs }
+		];
+		if (bench.svelte2tsx) {
+			list.push({ label: 'svelte2tsx', sub: '.svelte → .tsx', x: bench.svelte2tsx.speedup.multiThreadVsJs });
+		}
+		if (bench.svelteCheck) {
+			list.push({ label: 'svelte-check', sub: 'project type-check', x: bench.svelteCheck.speedup.multiThreadVsJs });
+		}
+		return list;
+	});
+
+	const maxSpeedup = $derived(toolchain.reduce((m, t) => Math.max(m, t.x), 0));
+
+	const compat = $derived.by(() => {
+		if (!tests) return null;
+		const inScope = tests.summary.total - tests.summary.skipped;
+		return {
+			passed: tests.summary.passed,
+			inScope,
+			pct: tests.summary.percentage,
+			commit: tests.commit_sha
+		};
+	});
+
+	// Curated compatibility highlights — counts pulled live from the report.
+	const HIGHLIGHTS = [
+		{ id: 'runtime-legacy', label: 'runtime / legacy', sub: 'svelte 4 parity' },
+		{ id: 'runtime-runes', label: 'runtime / runes', sub: '$state / $derived / $effect' },
+		{ id: 'validator', label: 'validator + a11y', sub: 'warnings & errors' },
+		{ id: 'css', label: 'css', sub: ':global / scoping / keyframes' },
+		{ id: 'hydration', label: 'hydration', sub: 'resume server markup' },
+		{ id: 'compiler-errors', label: 'compiler errors', sub: 'parse & semantic checks' }
 	];
+
+	const specs = $derived(
+		HIGHLIGHTS.map((h) => {
+			const cat = tests?.categories.find((c) => c.id === h.id);
+			return {
+				label: h.label,
+				sub: h.sub,
+				passed: cat ? cat.passed : null,
+				total: cat ? cat.total - cat.skipped : null,
+				pct: cat ? cat.percentage : null
+			};
+		})
+	);
 
 	const why = [
 		{
@@ -55,17 +108,17 @@
 		},
 		{
 			n: '03',
-			h: 'Built for OXC.',
-			p: 'Conventions mirror oxc_ast so the compiler drops cleanly into the wider OXC toolchain when it lands.'
+			h: 'One stack, end to end.',
+			p: 'Compiler, svelte2tsx and svelte-check share the same Rust AST and OXC foundation — no JS hop between the tools in your build.'
 		}
 	];
 </script>
 
 <svelte:head>
-	<title>rsvelte · the Svelte compiler, in Rust</title>
+	<title>rsvelte · the Svelte ecosystem, in Rust</title>
 	<meta
 		name="description"
-		content="A Rust port of the Svelte 5 compiler. Same surface, identical output, parallelized by default."
+		content="A Rust port of the Svelte ecosystem — compiler, svelte2tsx, svelte-check and vite-plugin-svelte as drop-in replacements. Same surface, identical output, up to 145× faster."
 	/>
 </svelte:head>
 
@@ -73,23 +126,24 @@
 	<SiteNav active="home" />
 
 	<header class="hero">
-		<p class="eyebrow"><span class="rule"></span>Svelte 5 · written in Rust</p>
+		<p class="eyebrow"><span class="rule"></span>Svelte ecosystem · written in Rust</p>
 
 		<h1 class="title">
-			The Svelte compiler,<br />rewritten in <span class="ink-rust">Rust</span>.
+			The Svelte ecosystem,<br />rewritten in <span class="ink-rust">Rust</span>.
 		</h1>
 
 		<p class="lede">
-			A drop-in replacement for <code>svelte/compiler</code> — same surface, identical output,
-			parallelized by default.
+			Drop-in replacements for the tools you already run — the compiler, <code>svelte2tsx</code>,
+			<code>svelte-check</code>, the Vite plugin. Same surface, identical output, up to
+			<span class="ink-svelte">{bench ? Math.round(maxSpeedup) : 145}×</span> faster.
 		</p>
 
 		<div class="cta">
-			<a href="{base}/playground" class="btn btn-primary">
-				Open playground <span aria-hidden="true">→</span>
+			<a href="{base}/ecosystem" class="btn btn-primary">
+				Explore the ecosystem <span aria-hidden="true">→</span>
 			</a>
-			<a href="{base}/benchmark" class="btn btn-ghost">
-				View benchmark <span aria-hidden="true">→</span>
+			<a href="{base}/playground" class="btn btn-ghost">
+				Open playground <span aria-hidden="true">→</span>
 			</a>
 		</div>
 
@@ -101,24 +155,18 @@
 	<section class="perf" id="performance">
 		<div class="section-head">
 			<span class="num">01</span>
-			<h2>
-				{#if bench}
-					<span class="ink-svelte">{bench.speedup.multiThreadVsJs.toFixed(1)}×</span> faster than
-					<code>svelte/compiler</code>.
-				{:else}
-					Compilation, measured against <code>svelte/compiler</code>.
-				{/if}
-			</h2>
+			<h2>Fast across the <em>whole</em> toolchain.</h2>
 			<p class="lede">
-				The benchmark runs the full compile pipeline — parse, analyze, codegen — over the official
-				Svelte test corpus on the same machine.
+				Speed is the point. Every tool is benchmarked against its official
+				<code>svelte/*</code> counterpart — same machine, same corpus, full pipeline: parse,
+				analyze, codegen.
 			</p>
 		</div>
 
 		<div class="perf-grid">
 			<figure class="bars">
 				<figcaption>
-					<span class="bars-title">Compile (client)</span>
+					<span class="bars-title">Compile · full pipeline</span>
 					<span class="bars-sub"
 						>{bench ? `${bench.testFilesCount.toLocaleString('en-US')} .svelte files` : '—'}</span
 					>
@@ -131,24 +179,9 @@
 						bench.rustMultiThread.durationMs
 					)}
 					{@const rows = [
-						{
-							k: 'svelte/compiler',
-							tone: 'js',
-							sub: 'JavaScript',
-							dur: bench.javascript.durationMs
-						},
-						{
-							k: 'rsvelte / single',
-							tone: 'rs',
-							sub: 'no parallelism',
-							dur: bench.rustSingleThread.durationMs
-						},
-						{
-							k: 'rsvelte / multi',
-							tone: 'rm',
-							sub: 'rayon fan-out',
-							dur: bench.rustMultiThread.durationMs
-						}
+						{ k: 'svelte/compiler', tone: 'js', sub: 'JavaScript', dur: bench.javascript.durationMs },
+						{ k: 'rsvelte / single', tone: 'rs', sub: 'no parallelism', dur: bench.rustSingleThread.durationMs },
+						{ k: 'rsvelte / multi', tone: 'rm', sub: 'rayon fan-out', dur: bench.rustMultiThread.durationMs }
 					]}
 					<div class="bar-list">
 						{#each rows as r, i (r.k)}
@@ -159,10 +192,7 @@
 								</div>
 								<div class="bar-graph">
 									<span class="bar-track">
-										<span
-											class="bar-fill bar-{r.tone}"
-											style="--w: {(r.dur / max) * 100}%;"
-										></span>
+										<span class="bar-fill bar-{r.tone}" style="--w: {(r.dur / max) * 100}%;"></span>
 									</span>
 									<span class="bar-t">{formatDuration(r.dur)}</span>
 								</div>
@@ -186,49 +216,62 @@
 				</div>
 			</figure>
 
-			<aside class="stats">
-				<div class="stat stat-hero">
-					<span class="stat-k">Full pipeline · multi</span>
-					<span class="stat-n">
-						{bench ? bench.speedup.multiThreadVsJs.toFixed(1) : '—'}<span class="stat-x">×</span>
-					</span>
-					<span class="stat-s">rayon fan-out vs. <code>svelte/compiler</code></span>
-				</div>
-				<div class="stat">
-					<span class="stat-k">Parser only · multi</span>
-					<span class="stat-n">
-						{bench ? bench.parse.speedup.multiThreadVsJs.toFixed(0) : '—'}<span class="stat-x"
-							>×</span
-						>
-					</span>
-					<span class="stat-s">phase 1, isolated</span>
-				</div>
-				<div class="stat">
-					<span class="stat-k">Throughput</span>
-					<span class="stat-n">
-						{bench ? formatThroughput(bench.rustMultiThread.throughputFilesPerSec) : '—'}<span
-							class="stat-x">/s</span
-						>
-					</span>
-					<span class="stat-s">files compiled per second</span>
-				</div>
-				<a class="stat stat-link" href="{base}/benchmark">
-					<span class="stat-k">Full breakdown</span>
-					<span class="stat-go"
-						>parse · ssr · svelte2tsx <span aria-hidden="true">→</span></span
-					>
+			<aside class="toolchain">
+				<p class="toolchain-k">Multi-threaded vs. official JS</p>
+				{#if toolchain.length}
+					<ul class="toolchain-list">
+						{#each toolchain as t (t.label)}
+							<li class="toolchain-row">
+								<span class="tc-meta">
+									<span class="tc-name">{t.label}</span>
+									<span class="tc-sub">{t.sub}</span>
+								</span>
+								<span class="tc-x">{t.x.toFixed(t.x >= 50 ? 0 : 1)}<span class="x">×</span></span>
+							</li>
+						{/each}
+					</ul>
+				{:else}
+					<p class="toolchain-empty">—</p>
+				{/if}
+				<a class="toolchain-link" href="{base}/benchmark">
+					Full breakdown <span aria-hidden="true">→</span>
 				</a>
 			</aside>
 		</div>
 	</section>
 
-	<section class="dropin">
+	<section class="eco">
 		<div class="section-head">
 			<span class="num">02</span>
+			<h2>Not just a <em>compiler</em>.</h2>
+			<p class="lede">
+				rsvelte ports the hot path of every common Svelte workflow. {counts.shipped} drop-in
+				packages ship today, each a byte-for-byte replacement for its upstream tool.
+			</p>
+		</div>
+
+		<div class="eco-grid">
+			{#each shipped as c (c.name)}
+				<EcoCard {c} compact />
+			{/each}
+		</div>
+
+		<div class="eco-foot">
+			<a class="eco-link" href="{base}/ecosystem">
+				See the full inventory — shipped, planned &amp; delegated
+				<span aria-hidden="true">→</span>
+			</a>
+		</div>
+	</section>
+
+	<section class="dropin">
+		<div class="section-head">
+			<span class="num">03</span>
 			<h2>One import. <em>No flags.</em></h2>
 			<p class="lede">
-				No bundler plugin to wire, no compiler flag to flip. Same <code>compile()</code>,
-				<code>compileModule()</code>, <code>parse()</code>, <code>preprocess()</code>.
+				No bundler plugin to rewrite, no compiler flag to flip. The same
+				<code>compile()</code>, <code>parse()</code>, <code>preprocess()</code> — or swap the Vite
+				plugin and leave your <code>vite.config.js</code> untouched.
 			</p>
 		</div>
 
@@ -241,13 +284,49 @@
 		</figure>
 	</section>
 
+	<section class="compat">
+		<div class="section-head">
+			<span class="num">04</span>
+			<h2>Verified against the <em>official</em> suite.</h2>
+			<p class="lede">
+				{#if compat}
+					<span class="big-pct">{compat.passed.toLocaleString('en-US')} / {compat.inScope.toLocaleString('en-US')}</span>
+					in-scope fixtures from <code>sveltejs/svelte</code> — {compat.pct.toFixed(1)}%. Full
+					breakdown on the <a class="link" href="{base}/progress">compatibility page</a>.
+				{:else}
+					Every category of the official <code>sveltejs/svelte</code> suite, run locally. Full
+					breakdown on the <a class="link" href="{base}/progress">compatibility page</a>.
+				{/if}
+			</p>
+		</div>
+
+		<dl class="spec-list">
+			{#each specs as s, i (s.label)}
+				<div class="spec-row" style="--i: {i};">
+					<dt class="spec-k">{s.label}</dt>
+					<dd class="spec-v">
+						<span class="spec-n"
+							>{s.passed !== null ? s.passed.toLocaleString('en-US') : '—'}<span class="spec-n-sep"
+								>/</span
+							><span class="spec-n-tot">{s.total !== null ? s.total.toLocaleString('en-US') : '—'}</span></span
+						>
+						<span class="spec-s">{s.sub}</span>
+						<span class="spec-pct"
+							>{s.pct !== null ? Math.round(s.pct) : '—'}<span class="dim">%</span></span
+						>
+					</dd>
+				</div>
+			{/each}
+		</dl>
+	</section>
+
 	<section class="capi">
 		<div class="section-head">
-			<span class="num">03</span>
+			<span class="num">05</span>
 			<h2>Not just <em>Node.js</em>.</h2>
 			<p class="lede">
-				A stable C ABI ships alongside the NAPI build — one shared library, one header,
-				UTF-8 JSON in/out. Drive the same compiler from any language with a C FFI.
+				A stable C ABI ships alongside the NAPI build — one shared library, one header, UTF-8 JSON
+				in/out. Drive the same compiler from any language with a C FFI.
 			</p>
 		</div>
 
@@ -270,35 +349,10 @@
 		</p>
 	</section>
 
-	<section class="compat">
-		<div class="section-head">
-			<span class="num">04</span>
-			<h2>Every test, passing.</h2>
-			<p class="lede">
-				<span class="big-pct">3,341 / 3,341</span> in-scope fixtures from the official
-				<code>sveltejs/svelte</code> suite. Full breakdown on the
-				<a class="link" href="{base}/progress">compatibility page</a>.
-			</p>
-		</div>
-
-		<dl class="spec-list">
-			{#each specs as s, i (s.label)}
-				<div class="spec-row" style="--i: {i};">
-					<dt class="spec-k">{s.label}</dt>
-					<dd class="spec-v">
-						<span class="spec-n">{s.n.toLocaleString('en-US')}</span>
-						<span class="spec-s">{s.sub}</span>
-					</dd>
-					<span class="spec-pct">100<span class="dim">%</span></span>
-				</div>
-			{/each}
-		</dl>
-	</section>
-
 	<section class="why">
 		<div class="section-head">
-			<span class="num">05</span>
-			<h2>Why a port?</h2>
+			<span class="num">06</span>
+			<h2>Why it's fast.</h2>
 		</div>
 
 		<div class="why-list">
@@ -375,7 +429,7 @@
 
 	.lede {
 		font-size: clamp(1.05rem, 1.3vw, 1.2rem);
-		max-width: 52ch;
+		max-width: 54ch;
 		color: var(--ink-soft);
 		margin: 1.6rem 0 0;
 	}
@@ -465,6 +519,7 @@
 	}
 
 	.perf .section-head,
+	.eco .section-head,
 	.dropin .section-head,
 	.capi .section-head,
 	.compat .section-head,
@@ -506,7 +561,8 @@
 	}
 
 	.section-head h2 code,
-	.compat .lede code {
+	.compat .lede code,
+	.perf .lede code {
 		font-family: 'Fira Mono', monospace;
 		font-size: 0.78em;
 		font-weight: 500;
@@ -678,105 +734,153 @@
 		color: var(--ink-faint);
 	}
 
-	.stats {
-		display: flex;
-		flex-direction: column;
-		gap: 0.65rem;
-	}
-
-	.stat {
+	/* TOOLCHAIN SPEEDUP LIST */
+	.toolchain {
 		background: var(--bg);
 		border: 1px solid var(--rule);
 		border-radius: 6px;
-		padding: 1rem 1.2rem 1.15rem;
-		display: grid;
-		grid-template-areas: 'k k' 'n n' 's s';
-		gap: 0.1rem;
-	}
-
-	.stat.stat-hero {
-		border-color: var(--rust);
-		background: var(--bg);
-		box-shadow: 0 0 0 3px color-mix(in srgb, var(--rust) 8%, transparent);
-	}
-
-	.stat-k {
-		grid-area: k;
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.7rem;
-		letter-spacing: 0.06em;
-		text-transform: uppercase;
-		color: var(--ink-soft);
-	}
-
-	.stat-n {
-		grid-area: n;
-		font-family: 'Overpass', sans-serif;
-		font-weight: 800;
-		font-size: clamp(2rem, 3.6vw, 2.7rem);
-		line-height: 1;
-		letter-spacing: -0.035em;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
-		display: inline-flex;
-		align-items: baseline;
-		margin-top: 0.35rem;
-	}
-
-	.stat-hero .stat-n {
-		color: var(--rust);
-	}
-
-	.stat-x {
-		font-family: 'Fira Mono', monospace;
-		font-weight: 500;
-		font-size: 0.4em;
-		margin-left: 0.18em;
-		color: var(--ink-faint);
-		letter-spacing: 0.04em;
-	}
-
-	.stat-hero .stat-x {
-		color: var(--rust);
-		opacity: 0.75;
-	}
-
-	.stat-s {
-		grid-area: s;
-		font-size: 0.82rem;
-		color: var(--ink-soft);
-		margin-top: 0.4rem;
-	}
-
-	.stat-s code {
-		font-size: 0.92em;
-		color: var(--ink);
-	}
-
-	.stat-link {
+		padding: 1.1rem 1.25rem 1.25rem;
 		display: flex;
 		flex-direction: column;
-		gap: 0.45rem;
-		padding: 0.95rem 1.2rem 1rem;
+		gap: 0.2rem;
+	}
+
+	.toolchain-k {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.66rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--ink-faint);
+		margin: 0 0 0.5rem;
+	}
+
+	.toolchain-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.toolchain-row {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: 0.7rem 0;
+		border-bottom: 1px solid var(--rule);
+	}
+
+	.toolchain-row:first-child {
+		border-top: 1px solid var(--rule);
+	}
+
+	.tc-meta {
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+		min-width: 0;
+	}
+
+	.tc-name {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.8rem;
 		color: var(--ink);
-		transition: border-color 0.18s;
 	}
 
-	.stat-link:hover {
-		border-color: var(--ink);
+	.tc-sub {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.66rem;
+		color: var(--ink-faint);
 	}
 
-	.stat-go {
+	.tc-x {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: 1.45rem;
+		line-height: 1;
+		letter-spacing: -0.03em;
+		color: var(--svelte);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.tc-x .x {
+		font-family: 'Fira Mono', monospace;
+		font-weight: 500;
+		font-size: 0.42em;
+		margin-left: 0.1em;
+		color: var(--svelte);
+		opacity: 0.7;
+	}
+
+	.toolchain-empty {
+		font-family: 'Fira Mono', monospace;
+		color: var(--ink-faint);
+		padding: 1rem 0;
+	}
+
+	.toolchain-link {
+		margin-top: 0.9rem;
 		font-family: 'Fira Mono', monospace;
 		font-size: 0.78rem;
 		color: var(--ink-soft);
 		display: inline-flex;
 		align-items: center;
 		gap: 0.4rem;
+		transition: color 0.18s;
 	}
 
-	.stat-link:hover .stat-go {
+	.toolchain-link span {
+		transition: transform 0.18s;
+	}
+
+	.toolchain-link:hover {
 		color: var(--svelte);
+	}
+
+	.toolchain-link:hover span {
+		transform: translateX(3px);
+	}
+
+	/* ECOSYSTEM */
+	.eco {
+		max-width: 1080px;
+		margin: 0 auto;
+	}
+
+	.eco-grid {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: 0 clamp(1rem, 4vw, 2.5rem);
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+		gap: 1rem;
+	}
+
+	.eco-foot {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: 1.6rem clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
+	}
+
+	.eco-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-family: 'Overpass', sans-serif;
+		font-weight: 600;
+		font-size: 0.95rem;
+		color: var(--svelte);
+	}
+
+	.eco-link span {
+		transition: transform 0.18s;
+	}
+
+	.eco-link:hover {
+		color: var(--svelte-hover);
+	}
+
+	.eco-link:hover span {
+		transform: translateX(3px);
 	}
 
 	/* DROP-IN */
@@ -912,7 +1016,7 @@
 
 	.spec-row {
 		display: grid;
-		grid-template-columns: minmax(10rem, 14rem) 1fr auto;
+		grid-template-columns: minmax(10rem, 14rem) 1fr;
 		gap: 1.4rem;
 		align-items: baseline;
 		padding: 1rem 0;
@@ -949,6 +1053,17 @@
 		min-width: 0;
 	}
 
+	/* The percentage is the last child of the value <dd>; push it to the row's
+	   right edge so the layout matches the old 3-column grid. */
+	.spec-pct {
+		margin-left: auto;
+		padding-left: 0.85rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.82rem;
+		color: var(--ink);
+		font-variant-numeric: tabular-nums;
+	}
+
 	.spec-n {
 		font-family: 'Overpass', sans-serif;
 		font-weight: 700;
@@ -958,17 +1073,20 @@
 		letter-spacing: -0.015em;
 	}
 
+	.spec-n-sep {
+		color: var(--ink-faint);
+		margin: 0 0.18em;
+	}
+
+	.spec-n-tot {
+		color: var(--ink-soft);
+		font-size: 0.82em;
+	}
+
 	.spec-s {
 		font-family: 'Fira Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink-soft);
-	}
-
-	.spec-pct {
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.82rem;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
 	}
 
 	.spec-pct .dim {
@@ -1042,11 +1160,8 @@
 			grid-template-columns: 1fr;
 		}
 		.spec-row {
-			grid-template-columns: 1fr auto;
+			grid-template-columns: 1fr;
 			gap: 0.4rem 1rem;
-		}
-		.spec-v {
-			grid-column: 1 / -1;
 		}
 	}
 

--- a/apps/playground/src/routes/ecosystem/+page.svelte
+++ b/apps/playground/src/routes/ecosystem/+page.svelte
@@ -1,0 +1,361 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import SiteNav from '$lib/components/SiteNav.svelte';
+	import SiteFooter from '$lib/components/SiteFooter.svelte';
+	import EcoCard from '$lib/components/EcoCard.svelte';
+	import { shipped, planned, delegated, counts } from '$lib/ecosystem';
+</script>
+
+<svelte:head>
+	<title>Ecosystem · rsvelte</title>
+	<meta
+		name="description"
+		content="The Svelte ecosystem, ported to Rust — compiler, svelte2tsx, svelte-check and vite-plugin-svelte as drop-in replacements, with links to every upstream tool and what's delegated to OXC."
+	/>
+</svelte:head>
+
+<div class="page">
+	<SiteNav active="ecosystem" />
+
+	<header class="hero">
+		<p class="eyebrow"><span class="rule"></span>The ecosystem · in Rust</p>
+
+		<h1 class="title">
+			The Svelte ecosystem,<br />ported to <span class="ink-rust">Rust</span>.
+		</h1>
+
+		<p class="lede">
+			rsvelte is more than a compiler. Every tool on the hot path of a Svelte project gets a
+			Rust-native, <strong>drop-in</strong> replacement — same surface, identical behaviour, only
+			<span class="ink-svelte">faster</span>. Below is the full inventory: what's shipped, what's
+			planned, and what we deliberately hand to the wider
+			<a class="link" href="https://oxc.rs/" target="_blank" rel="noopener">OXC</a> toolchain.
+		</p>
+
+		<dl class="hero-meta">
+			<div>
+				<dt>Shipped</dt>
+				<dd><span class="big ok">{counts.shipped}</span> <span class="dim">drop-in packages</span></dd>
+			</div>
+			<div>
+				<dt>Planned</dt>
+				<dd><span class="big warn">{counts.planned}</span> <span class="dim">on the roadmap</span></dd>
+			</div>
+			<div>
+				<dt>Delegated</dt>
+				<dd>
+					<span class="big">{counts.delegated}</span> <span class="dim">routed to OXC / JS</span>
+				</dd>
+			</div>
+			<div>
+				<dt>Top speedup</dt>
+				<dd><span class="big ink-svelte">145×</span> <span class="dim">parser vs. JS</span></dd>
+			</div>
+		</dl>
+	</header>
+
+	<section class="group">
+		<div class="section-head">
+			<span class="num">01</span>
+			<h2><span class="ink-ok">Shipped</span> — usable today.</h2>
+			<p class="lede">
+				Published under the <code>@rsvelte</code> scope on npm. Swap the import (or add a
+				package-manager override) and the rest of your project is unchanged. Speedups are
+				multi-threaded rsvelte vs. the official JavaScript tool — see the
+				<a class="link" href="{base}/benchmark">benchmark</a>.
+			</p>
+		</div>
+		<div class="grid">
+			{#each shipped as c (c.name)}
+				<EcoCard {c} />
+			{/each}
+		</div>
+	</section>
+
+	<section class="group">
+		<div class="section-head">
+			<span class="num">02</span>
+			<h2><span class="ink-warn">Planned</span> — on the roadmap.</h2>
+			<p class="lede">
+				Not yet usable, and honest about why. CLI type-checking is already covered today by
+				<code>@rsvelte/svelte-check</code>.
+			</p>
+		</div>
+		<div class="grid">
+			{#each planned as c (c.name)}
+				<EcoCard {c} />
+			{/each}
+		</div>
+	</section>
+
+	<section class="group">
+		<div class="section-head">
+			<span class="num">03</span>
+			<h2>Delegated — <em>not</em> ported, on purpose.</h2>
+			<p class="lede">
+				These aren't gaps. Linting, formatting and bundling are themselves moving to Rust through
+				<a class="link" href="https://oxc.rs/" target="_blank" rel="noopener">OXC</a>; rsvelte's job
+				is to give those tools a Svelte surface to call into, not to fork them. Markdown and
+				wrapper tools stay in JS where their dependencies live.
+			</p>
+		</div>
+		<div class="grid">
+			{#each delegated as c (c.name)}
+				<EcoCard {c} />
+			{/each}
+		</div>
+	</section>
+
+	<section class="outro">
+		<p>
+			The plan in full — wave structure, acceptance criteria and risk registers — lives in
+			<a
+				class="link"
+				href="https://github.com/baseballyama/rsvelte/blob/main/docs/ecosystem-implementation-plan.md"
+				target="_blank"
+				rel="noopener">docs/ecosystem-implementation-plan.md</a
+			>.
+		</p>
+	</section>
+
+	<SiteFooter />
+</div>
+
+<style>
+	.page {
+		min-height: 100vh;
+	}
+
+	code {
+		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+	}
+
+	/* HERO */
+	.hero {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: clamp(3.5rem, 9vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
+	}
+
+	.eyebrow {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.7rem;
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.75rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--rust);
+		margin: 0 0 1.4rem;
+	}
+
+	.eyebrow .rule {
+		display: inline-block;
+		width: 24px;
+		height: 1px;
+		background: var(--rust);
+	}
+
+	.title {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: clamp(2.1rem, 5.4vw, 3.8rem);
+		line-height: 1.04;
+		letter-spacing: -0.03em;
+		color: var(--ink);
+		margin: 0;
+	}
+
+	.ink-rust {
+		color: var(--rust);
+		font-style: italic;
+		font-weight: 700;
+	}
+
+	.ink-svelte {
+		color: var(--svelte);
+		font-style: italic;
+	}
+
+	.lede {
+		font-size: clamp(1.02rem, 1.25vw, 1.16rem);
+		max-width: 60ch;
+		color: var(--ink-soft);
+		margin: 1.6rem 0 0;
+		line-height: 1.6;
+	}
+
+	.lede strong {
+		color: var(--ink);
+		font-weight: 700;
+	}
+
+	.lede code {
+		background: var(--paper);
+		color: var(--ink);
+		padding: 0.08em 0.4em;
+		border-radius: 3px;
+		font-size: 0.86em;
+		border: 1px solid var(--rule);
+	}
+
+	.link {
+		color: var(--svelte);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 3px;
+	}
+
+	.link:hover {
+		color: var(--svelte-hover);
+	}
+
+	.hero-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1.8rem 2.6rem;
+		margin-top: 2.2rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--rule);
+	}
+
+	.hero-meta > div {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.hero-meta dt {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.66rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--ink-faint);
+	}
+
+	.hero-meta dd {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		margin: 0;
+	}
+
+	.hero-meta .big {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 800;
+		font-size: 1.7rem;
+		line-height: 1;
+		letter-spacing: -0.03em;
+		color: var(--ink);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.hero-meta .big.ok {
+		color: var(--ok);
+	}
+	.hero-meta .big.warn {
+		color: var(--warn);
+	}
+	.hero-meta .big.ink-svelte {
+		color: var(--svelte);
+		font-style: normal;
+	}
+
+	.hero-meta .dim {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.76rem;
+		color: var(--ink-soft);
+	}
+
+	/* GROUPS */
+	.group {
+		max-width: 1080px;
+		margin: 0 auto;
+	}
+
+	.section-head {
+		max-width: 1080px;
+		padding: clamp(2.5rem, 6vh, 4rem) clamp(1rem, 4vw, 2.5rem) clamp(1.2rem, 3vh, 1.8rem);
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: 0.4rem 1.4rem;
+		align-items: baseline;
+	}
+
+	.section-head .num {
+		font-family: 'Fira Mono', monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.18em;
+		color: var(--rust);
+		grid-row: 1;
+		grid-column: 1;
+	}
+
+	.section-head h2 {
+		font-family: 'Overpass', sans-serif;
+		font-weight: 700;
+		font-size: clamp(1.5rem, 3vw, 2.3rem);
+		line-height: 1.1;
+		letter-spacing: -0.022em;
+		margin: 0;
+		color: var(--ink);
+		grid-row: 1;
+		grid-column: 2;
+	}
+
+	.section-head h2 em {
+		font-style: italic;
+		color: var(--svelte);
+		font-weight: 700;
+	}
+
+	.ink-ok {
+		color: var(--ok);
+	}
+	.ink-warn {
+		color: var(--warn);
+	}
+
+	.section-head .lede {
+		grid-row: 2;
+		grid-column: 2;
+		margin-top: 0.6rem;
+		max-width: 66ch;
+		font-size: clamp(0.96rem, 1.1vw, 1.06rem);
+	}
+
+	.section-head .lede code {
+		font-size: 0.86em;
+		padding: 0.06em 0.4em;
+		background: var(--paper);
+		border: 1px solid var(--rule);
+		border-radius: 3px;
+		color: var(--rust);
+	}
+
+	.grid {
+		padding: 0 clamp(1rem, 4vw, 2.5rem);
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+		gap: 1rem;
+	}
+
+	/* OUTRO */
+	.outro {
+		max-width: 1080px;
+		margin: 0 auto;
+		padding: clamp(3rem, 7vh, 5rem) clamp(1rem, 4vw, 2.5rem) clamp(4rem, 8vh, 6rem);
+	}
+
+	.outro p {
+		font-size: 0.95rem;
+		color: var(--ink-soft);
+		max-width: 64ch;
+	}
+
+	@media (max-width: 880px) {
+		.section-head {
+			grid-template-columns: auto 1fr;
+		}
+	}
+</style>

--- a/apps/playground/src/routes/playground/+page.svelte
+++ b/apps/playground/src/routes/playground/+page.svelte
@@ -147,7 +147,7 @@
 	<title>Playground · rsvelte</title>
 	<meta
 		name="description"
-		content="A live playground for the Rust port of the Svelte 5 compiler — edit a component and see the generated JS, CSS, AST and rendered preview."
+		content="A live playground for rsvelte, the Rust port of the Svelte ecosystem — edit a component and see the generated JS, CSS, AST and rendered preview."
 	/>
 </svelte:head>
 

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -16,7 +16,9 @@ export default defineConfig({
 	server: {
 		port: 5234,
 		fs: {
-			allow: ['..']
+			// `pkg/` (the wasm build) lives at the repo root, two levels above
+			// this app, so the dev server needs to serve from there.
+			allow: ['../..']
 		}
 	},
 	optimizeDeps: {


### PR DESCRIPTION
Rebrands the site from **"the Svelte compiler, in Rust"** to **"the Svelte ecosystem, in Rust"** and surfaces the full ecosystem-port inventory. Reuses the existing design system (Overpass / Fira Mono, CSS tokens, editorial layout) — no visual-language changes.

## What's new
- **New `/ecosystem` page** — the full "洗い出し": **Shipped** (`@rsvelte/compiler`, `svelte2tsx`, `svelte-check`, `vite-plugin-svelte`), **Planned** (`svelte-language-server`), **Delegated to OXC** (`eslint-plugin-svelte`→oxlint, `prettier-plugin-svelte`→oxfmt, `svelte-preprocess`, `mdsvex`, SvelteKit). Each card links its **upstream library** and, where shipped, the drop-in `@rsvelte` package + install command.
- **New `src/lib/ecosystem.ts`** — single source of truth, shared by the home grid and the inventory page via a new `EcoCard.svelte`.
- **Home** — hero leads with the ecosystem; §1 is now **toolchain-wide speed** (full 17×, parser 145×, svelte2tsx 22×, svelte-check 144×); §2 is the ecosystem grid. Compatibility is **live-driven and honest** (`3,253 / 3,259`, 99.8% — replaces the stale hardcoded `3,341/3,341 · all 100%`).
- **Nav** gains an Ecosystem link; **footer** mirrors `svelte@5.56.0`; titles/meta reframed.
- `vite` dev `fs.allow` widened to `../..` so the repo-root `pkg/` wasm resolves after the four-level import path (#626).

## Verification
- ✅ `pnpm build` passes; no Svelte warnings from new files; `oxlint` clean.
- ✅ All upstream library links return HTTP 200.
- ✅ Verified in light/dark/mobile; zero horizontal overflow (measured via CDP).
- ✅ Numbers cross-checked against `benchmark-results.json` / `test-results.json` via an adversarial multi-agent review; overclaims removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)