### PR TITLE
fix(svelte-check): put svelte2tsx shims in include so --tsgo resolves ambients

### DIFF
--- a/.changeset/svelte-check-tsgo-shim-include.md
+++ b/.changeset/svelte-check-tsgo-shim-include.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): put svelte2tsx shims in `include` so `--tsgo` resolves ambients
+
+The overlay tsconfig listed the svelte2tsx shim `.d.ts` files (which declare the
+ambient `svelteHTML` / `__sveltets_2_*` symbols the generated `.tsx` shadows
+rely on) only in `files`. `tsc` applies their `declare global` augmentations
+from there, but `tsgo` only does so when the shims are part of `include` —
+so `--tsgo` regressed every `.svelte` file with spurious "Cannot find name
+'svelteHTML' / '__sveltets_2_*'" errors. The shims now go in `include`, which
+both backends honour, so `svelte-check --tsgo` reports 0 errors on a clean
+SvelteKit project again.


### PR DESCRIPTION
Fixes #628.

## Problem

`svelte-check --tsgo` produced ~150 spurious `Cannot find name 'svelteHTML' / '__sveltets_2_*'` errors on a clean SvelteKit project; the tsc backend reported 0.

## Root cause

The overlay tsconfig listed the svelte2tsx shim `.d.ts` files (which declare those ambients via `declare global`) only in **`files`**. tsc applies `declare global` from `files`; **tsgo only does so when the shims are in `include`**. Bisected against the real overlay (same tsconfig, two backends): shims-in-`files` → tsc 0 / tsgo 150; shims-in-`include` → tsc 0 / tsgo 0.

## Fix

`write_overlay_tsconfig` now appends the shim paths to `include` instead of `files` (the user's own `files` entries stay in `files`). Both backends honour `include`, so this fixes tsgo without regressing tsc.

Verified end-to-end: built `svelte_check` with the fix and ran `--tsgo` against a real SvelteKit blog → **0 errors** (was 150).

## Tests

- New `overlay::tests::shims_go_in_include_not_files` asserts shim placement.
- `cargo test -p rsvelte_core --lib svelte_check` → 64 passed.
- `cargo fmt` / `cargo clippy -p rsvelte_core --lib` clean.

## Release

Changeset included (`patch` for `@rsvelte/svelte-check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
