### PR TITLE
fix(ecosystem-ci): apply the swap across pnpm 9/10/11 + verify rsvelte svelte-check

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -144,6 +144,11 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Required to comment on the PR below: GITHUB_TOKEN is a GitHub App token,
+      # and posting to a PR conversation needs `pull-requests: write` even though
+      # the API path is /issues/comments (`issues: write` alone yields
+      # "Resource not accessible by integration").
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -159,6 +164,9 @@ jobs:
 
       - name: Post summary to PR
         if: github.event_name == 'pull_request'
+        # Cosmetic: a comment-permission hiccup must never red the whole sweep —
+        # the verdict lives in the result-* artifacts and this job's log.
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/compat/ecosystem-ci/README.md
+++ b/compat/ecosystem-ci/README.md
@@ -56,7 +56,8 @@ See `targets/shadcn-svelte.json` for a worked example. Required fields:
 | `type` | `app` or `tool` — controls verification strategy |
 | `commands.install` | how to install deps |
 | `commands.test` and/or `commands.build` | what to run for verification (at least one required) |
-| `swap.strategy` | `vps-shim` (preferred when the target uses vite-plugin-svelte), `loader-hook` (require-hook fallback), or `pnpm-override` (already-forked targets). The runner stages a renamed copy of `submodules/vite-plugin-svelte/packages/vite-plugin-svelte` and uses three pnpm.overrides — `@sveltejs/vite-plugin-svelte`, `@rsvelte/vite-plugin-svelte-native`, and `@rsvelte/vite-plugin-svelte-native-<triple>` — so the target picks up the *local* NAPI binary, not the last npm-published one. |
+| `commands.check` | optional; a `svelte-check` invocation (Wave 2). When set, the runner also verifies the rsvelte `svelte-check` CLI: it runs the *same* command under the official `svelte-check` (baseline) and then under the rsvelte `@rsvelte/svelte-check` binary (swapped in alongside the compiler). Use flags both binaries accept (`--workspace`, `--output`, `--tsconfig`, `--ignore`, `--fail-on-warnings`, `--compiler-warnings`, `--diagnostic-sources`). Gated by the baseline like every other phase. |
+| `swap.strategy` | `vps-shim` (preferred when the target uses vite-plugin-svelte), `loader-hook` (require-hook fallback), or `pnpm-override` (already-forked targets). The runner stages a renamed copy of `submodules/vite-plugin-svelte/packages/vite-plugin-svelte` and injects pnpm `overrides` **into both `package.json` and `pnpm-workspace.yaml`** (each target pins a different pnpm major that reads overrides from a different place — see "pnpm version caveats" below) — `@sveltejs/vite-plugin-svelte`, `@rsvelte/vite-plugin-svelte-native`, and `@rsvelte/vite-plugin-svelte-native-<triple>` (plus `svelte-check` + `@rsvelte/svelte-check-<triple>` when `commands.check` is set) — so the target picks up the *local* rsvelte binaries, not the last npm-published ones. |
 | `subPath` | optional; if the verification target is a sub-package of a monorepo |
 | `timeoutMinutes` | per-phase timeout |
 | `tags` | free-form labels for grouping (`ui-library`, `sveltekit`, …) |
@@ -66,27 +67,57 @@ See `targets/shadcn-svelte.json` for a worked example. Required fields:
 
 1. Resolve the target JSON.
 2. Clone or fast-forward `compat/ecosystem-ci/checkout/<name>/` to the latest commit on `branch`.
-3. `pnpm install` (or whatever `commands.install` says).
-4. **Baseline**: run `commands.build` and/or `commands.test` against the unmodified target. Save log + exit code under `.cache/<name>-baseline.{log,json}`.
-5. Build rsvelte NAPI via `.claude/skills/verify-svelte-compat/scripts/build-rsvelte.sh`, drop the `.node` into `checkout/<name>/.rsvelte/`.
-6. **Swap**: invoke the swap script that matches `swap.strategy`. This injects a `svelte/compiler` shim or a `pnpm.overrides` entry.
-7. **rsvelte run**: re-run the same commands. Save log + exit code under `.cache/<name>-rsvelte.{log,json}`.
-8. **Compare**: exit codes + log diff. Write final verdict to `results/<name>.json`:
+3. Ensure `pnpm-workspace.yaml` carries `dangerouslyAllowAllBuilds: true` (see "pnpm version caveats" below), then `pnpm install` (or whatever `commands.install` says).
+4. **Baseline**: run `commands.build`, `commands.test`, and/or `commands.check` against the unmodified target. Save log + exit code under `.cache/<name>-baseline-*.{log,json}`.
+5. Build rsvelte NAPI (`cargo build --release --features napi --lib`) and stage it into `apps/npm/vite-plugin-svelte-native-<triple>/`; for targets with `commands.check`, also build `svelte_check` and stage it into `apps/npm/svelte-check-<triple>/`.
+6. **Swap**: inject pnpm `overrides` into the target's `package.json` and `pnpm-workspace.yaml`, then remove `node_modules` + `pnpm-lock.yaml` and re-install so the overrides actually resolve (see "pnpm version caveats" below). A post-install sanity check confirms the rsvelte plugin really landed in `node_modules`.
+7. **rsvelte run**: re-run the same commands. Save log + exit code under `.cache/<name>-rsvelte-*.{log,json}`.
+8. **Verdict**: written to `results/<name>.json`. The rsvelte phases must all exit 0 (gated by the baseline):
 
    ```jsonc
    {
      "name": "shadcn-svelte",
-     "targetCommit": "abc123",
-     "rsvelteCommit": "def456",
-     "result": "pass" | "baseline-failure" | "regression",
-     "baseline": { "exitCode": 0, "durationSeconds": 145 },
-     "rsvelte":  { "exitCode": 0, "durationSeconds": 162 },
+     "targetSha": "abc123",
+     "rsvelteSha": "def456",
+     "result": "pass" | "baseline-failure" | "regression" | "rsvelte-install-failure" | "swap-failure" | "swap-noop",
+     "baseline": { "install": { "exitCode": 0, "durationMs": 145000 }, "build": { "exitCode": 0, "durationMs": 12000 } },
+     "rsvelte":  { "install": { "exitCode": 0, "durationMs": 8000 }, "build": { "exitCode": 0, "durationMs": 16000 } },
      "verifiedAt": "2026-05-25T12:34:56Z"
    }
    ```
 
 If baseline itself fails, the run is classified `baseline-failure` and does
-**not** count as a regression — the target is broken for everyone.
+**not** count as a regression — the target is broken for everyone. `swap-noop`
+means the override silently failed to take effect (the run would have verified
+official svelte, not rsvelte) — treated as a hard failure, never a green pass.
+
+### pnpm version caveats
+
+Each target pins its own pnpm via `package.json#packageManager` (corepack /
+pnpm's self-version-management honours it), so a single sweep runs a mix of
+pnpm majors — e.g. melt-ui pins `pnpm@9`, bits-ui `pnpm@10`, and flowbite-svelte
+(no pin) uses the ambient pnpm 11. Where pnpm reads its config changed across
+those majors, so the harness works around three things:
+
+- **Where `overrides` live moved.** pnpm 9 reads `package.json#pnpm.overrides`
+  and ignores overrides in `pnpm-workspace.yaml`; pnpm 11 ignores the
+  `package.json` `pnpm` field entirely and only reads `pnpm-workspace.yaml`;
+  pnpm 10 reads both. The swap therefore writes the overrides to **both** places
+  so it takes effect regardless of the target's pinned pnpm.
+- **Build-script approval (pnpm 10+).** pnpm 10+ aborts install with
+  `ERR_PNPM_IGNORED_BUILDS` when a dependency ships an unapproved build script.
+  Targets that keep their approvals in `package.json#pnpm.onlyBuiltDependencies`
+  (ignored by pnpm 11, e.g. flowbite-svelte) would break at baseline, so we set
+  `dangerouslyAllowAllBuilds: true` in `pnpm-workspace.yaml` to build native deps
+  (esbuild, sharp, …) during install. pnpm 9 builds everything anyway and just
+  ignores the key.
+- **Changing overrides doesn't invalidate an existing install.** A plain (or even
+  `--force`) reinstall reports "Already up to date" and keeps the baseline's
+  official packages, so the swap becomes a silent no-op. The runner therefore
+  deletes `node_modules` + `pnpm-lock.yaml` before the rsvelte install to force a
+  fresh resolution against the overrides; the warm pnpm store keeps that
+  re-resolution fast. A post-install sanity check (`swap-noop` result) fails the
+  run loudly if the rsvelte plugin still didn't land in `node_modules`.
 
 ## Adding a target
 

--- a/compat/ecosystem-ci/targets/bits-ui.json
+++ b/compat/ecosystem-ci/targets/bits-ui.json
@@ -9,10 +9,11 @@
   },
   "commands": {
     "install": "pnpm install --no-frozen-lockfile",
-    "build": "pnpm -F bits-ui build"
+    "build": "pnpm -F bits-ui build",
+    "check": "pnpm -F bits-ui check"
   },
   "timeoutMinutes": 30,
-  "tags": ["ui-library", "headless"],
+  "tags": ["ui-library", "headless", "svelte-check"],
   "allowList": {
     "expectedBaselineFailures": []
   }

--- a/scripts/ecosystem/ecosystem-ci.mjs
+++ b/scripts/ecosystem/ecosystem-ci.mjs
@@ -246,6 +246,161 @@ function buildRsvelte(checkoutPath) {
 	return { nodeName, bindingPath: stageAPath, triple };
 }
 
+// Build the rsvelte `svelte-check` CLI binary and stage it into the matching
+// apps/npm/svelte-check-<triple>/ package, mirroring buildRsvelte's stage B for
+// the NAPI binding. Used by the svelte-check swap so pnpm picks up the local
+// rsvelte at HEAD, not the last npm-published version. The cargo invocation
+// mirrors the release workflow's `build-svelte-check` job.
+function buildSvelteCheck(triple) {
+	const ext = process.platform === 'win32' ? '.exe' : '';
+	log(`building rsvelte svelte-check binary (triple=${triple})`);
+	// No `--features napi`: the napi feature links against node's runtime, which a
+	// standalone binary can't satisfy (linker error). Mirrors release.yml's
+	// `build-svelte-check` job. This means rsvelte_core compiles a second time
+	// under the default feature set (buildRsvelte built it with `napi`), which is
+	// an acceptable one-off cost for the (single, opt-in) svelte-check target.
+	const r = spawnSync('cargo', ['build', '--release', '--bin', 'svelte_check'], {
+		stdio: 'inherit',
+		cwd: ROOT,
+	});
+	if (r.status !== 0) throw new Error('cargo build --bin svelte_check failed');
+	const srcPath = path.join(ROOT, 'target', 'release', `svelte_check${ext}`);
+	if (!fs.existsSync(srcPath)) throw new Error(`cargo output missing: ${srcPath}`);
+	const platformPkg = path.join(ROOT, 'apps', 'npm', `svelte-check-${triple}`);
+	if (!fs.existsSync(platformPkg)) {
+		throw new Error(`platform npm package missing: ${platformPkg}`);
+	}
+	// cargo names the binary after the bin's `name` field (`svelte_check`); the
+	// user-facing package ships it as `svelte-check` (see release.yml).
+	const destPath = path.join(platformPkg, `svelte-check${ext}`);
+	fs.copyFileSync(srcPath, destPath);
+	if (ext !== '.exe') fs.chmodSync(destPath, 0o755);
+	log(`staged svelte-check -> ${path.relative(ROOT, destPath)}`);
+}
+
+// pnpm 11 no longer reads the `pnpm` field from package.json (overrides,
+// onlyBuiltDependencies, supportedArchitectures, ... were all moved to
+// pnpm-workspace.yaml). Merge a small, controlled set of top-level keys into the
+// target's pnpm-workspace.yaml (creating it if absent) without a YAML dependency:
+//
+//   - dangerouslyAllowAllBuilds: true   — build native deps (esbuild, ...) during
+//     install instead of failing with ERR_PNPM_IGNORED_BUILDS. Targets that keep
+//     `pnpm.onlyBuiltDependencies` in package.json (e.g. flowbite-svelte) rely on
+//     this since pnpm 11 silently ignores that field.
+//   - overrides: { name: spec, ... }    — the swap. In pnpm 10 this used to be
+//     injected into package.json#pnpm.overrides; pnpm 11 ignores it there, so the
+//     swap was silently a no-op (the matrix verified official svelte, not rsvelte).
+//
+// The merge preserves existing content (packages, catalog, the target's own
+// overrides). Our override keys are namespaced (@sveltejs/..., @rsvelte/...,
+// svelte-check) and don't collide with a target's overrides in practice.
+function mergeWorkspaceYaml(
+	checkoutPath,
+	{ dangerouslyAllowAllBuilds = false, overrides = null } = {},
+) {
+	let wsPath = null;
+	for (const f of ['pnpm-workspace.yaml', 'pnpm-workspace.yml']) {
+		const p = path.join(checkoutPath, f);
+		if (fs.existsSync(p)) {
+			wsPath = p;
+			break;
+		}
+	}
+	if (!wsPath) wsPath = path.join(checkoutPath, 'pnpm-workspace.yaml');
+	let content = fs.existsSync(wsPath) ? fs.readFileSync(wsPath, 'utf8') : '';
+	if (content && !content.endsWith('\n')) content += '\n';
+
+	if (dangerouslyAllowAllBuilds && !/^dangerouslyAllowAllBuilds:/m.test(content)) {
+		content += 'dangerouslyAllowAllBuilds: true\n';
+	}
+
+	if (overrides && Object.keys(overrides).length > 0) {
+		const entryLines = Object.entries(overrides).map(
+			([k, v]) => `  '${k}': '${v}'`,
+		);
+		if (/^overrides:/m.test(content)) {
+			// Insert our entries right after the existing `overrides:` line.
+			content = content.replace(
+				/^(overrides:[^\n]*\n)/m,
+				(_m, head) => head + entryLines.join('\n') + '\n',
+			);
+		} else {
+			content += 'overrides:\n' + entryLines.join('\n') + '\n';
+		}
+	}
+
+	fs.writeFileSync(wsPath, content);
+	return wsPath;
+}
+
+// Remove a top-level YAML key and its indented block (or inline value) from
+// `content`. Used to drop a target's build-approval lists so they don't clash
+// with `dangerouslyAllowAllBuilds`.
+function removeYamlTopLevelKey(content, key) {
+	const lines = content.split('\n');
+	const out = [];
+	let skipping = false;
+	for (const line of lines) {
+		if (skipping) {
+			// Keep skipping the key's indented children; stop at the next
+			// top-level (non-indented) line or a blank line.
+			if (/^\s/.test(line) && line.trim() !== '') continue;
+			skipping = false;
+		}
+		if (new RegExp(`^${key}\\s*:`).test(line)) {
+			skipping = true;
+			continue;
+		}
+		out.push(line);
+	}
+	return out.join('\n');
+}
+
+// Make `pnpm install` build every dependency's install/postinstall script for
+// both the baseline and rsvelte runs, the way each target's own CI does.
+//
+// pnpm 10+ aborts with ERR_PNPM_IGNORED_BUILDS when a dependency ships an
+// unapproved build script, and `dangerouslyAllowAllBuilds: true` (set in
+// pnpm-workspace.yaml) lifts that. But it conflicts with a target's own
+// `onlyBuiltDependencies` / `neverBuiltDependencies` lists
+// (ERR_PNPM_CONFIG_CONFLICT_BUILT_DEPENDENCIES), so we strip those from both
+// package.json#pnpm (where pnpm 9/10 read them) and pnpm-workspace.yaml (pnpm
+// 11) first. pnpm 9 builds everything by default and ignores the workspace key.
+function prepareBuildApproval(checkoutPath) {
+	const pkgPath = path.join(checkoutPath, 'package.json');
+	if (fs.existsSync(pkgPath)) {
+		const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+		if (pkg.pnpm) {
+			delete pkg.pnpm.onlyBuiltDependencies;
+			delete pkg.pnpm.neverBuiltDependencies;
+			fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+		}
+	}
+	for (const f of ['pnpm-workspace.yaml', 'pnpm-workspace.yml']) {
+		const p = path.join(checkoutPath, f);
+		if (!fs.existsSync(p)) continue;
+		let content = fs.readFileSync(p, 'utf8');
+		content = removeYamlTopLevelKey(content, 'onlyBuiltDependencies');
+		content = removeYamlTopLevelKey(content, 'neverBuiltDependencies');
+		fs.writeFileSync(p, content);
+	}
+	return mergeWorkspaceYaml(checkoutPath, { dangerouslyAllowAllBuilds: true });
+}
+
+// Guard against a silent swap no-op: after the rsvelte install, confirm the
+// rsvelte vite-plugin-svelte NAPI wrapper actually landed in the target's
+// node_modules. It only gets installed when the `@sveltejs/vite-plugin-svelte`
+// override resolved to our staged fork (which depends on it). If the override
+// were ignored — as it was under pnpm 11 with the old package.json injection —
+// the official plugin (no rsvelte dep) is installed and this returns false.
+function assertVpsSwapApplied(checkoutPath) {
+	const pnpmDir = path.join(checkoutPath, 'node_modules', '.pnpm');
+	if (!fs.existsSync(pnpmDir)) return false;
+	return fs
+		.readdirSync(pnpmDir)
+		.some((e) => e.startsWith('@rsvelte+vite-plugin-svelte-native@'));
+}
+
 function applySwap(target, checkoutPath, bindingPath, triple) {
 	const strategy = target.swap?.strategy ?? 'loader-hook';
 
@@ -291,21 +446,46 @@ function applySwap(target, checkoutPath, bindingPath, triple) {
 		const stagedPkgPath = path.join(forkStage, 'package.json');
 		const stagedPkg = JSON.parse(fs.readFileSync(stagedPkgPath, 'utf8'));
 		stagedPkg.name = '@sveltejs/vite-plugin-svelte';
+		// Marker so assertVpsSwapApplied / debugging can tell our fork apart from
+		// the official plugin once pnpm has installed it.
+		stagedPkg._rsvelteShim = true;
 		fs.writeFileSync(stagedPkgPath, JSON.stringify(stagedPkg, null, 2) + '\n');
 
+		// All file: refs use plain paths (each staged/local package's name matches
+		// the override key).
+		const overrides = {
+			'@sveltejs/vite-plugin-svelte': `file:${forkStage}`,
+			'@rsvelte/vite-plugin-svelte-native': `file:${path.join(ROOT, 'apps', 'npm', 'vite-plugin-svelte-native')}`,
+			[`@rsvelte/vite-plugin-svelte-native-${triple}`]: `file:${path.join(ROOT, 'apps', 'npm', `vite-plugin-svelte-native-${triple}`)}`,
+		};
+		// Targets that also verify svelte-check get the rsvelte svelte-check CLI
+		// swapped in too (loader wrapper + platform binary, same two-package shape
+		// as the NAPI native packages). Only injected when commands.check is set so
+		// a target's own svelte-check usage isn't disturbed otherwise.
+		if (target.commands?.check) {
+			overrides['svelte-check'] = `file:${path.join(ROOT, 'apps', 'npm', 'svelte-check')}`;
+			overrides[`@rsvelte/svelte-check-${triple}`] =
+				`file:${path.join(ROOT, 'apps', 'npm', `svelte-check-${triple}`)}`;
+		}
+
+		// Write the overrides to BOTH places because each target pins its own pnpm
+		// (via package.json#packageManager / corepack), and where pnpm looks for
+		// overrides changed across majors:
+		//   - pnpm 9  reads package.json#pnpm.overrides; it ignores overrides in
+		//             pnpm-workspace.yaml (added in pnpm 10).
+		//   - pnpm 11 ignores the package.json `pnpm` field entirely; overrides
+		//             must be in pnpm-workspace.yaml.
+		//   - pnpm 10 reads pnpm-workspace.yaml (and warns about package.json#pnpm).
+		// e.g. melt-ui pins pnpm@9, flowbite-svelte uses the ambient pnpm 11.
 		const pkgPath = path.join(checkoutPath, 'package.json');
 		const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 		pkg.pnpm = pkg.pnpm ?? {};
-		pkg.pnpm.overrides = pkg.pnpm.overrides ?? {};
-		// All three overrides use plain file: refs (package.json#name matches
-		// the override key in each case).
-		pkg.pnpm.overrides['@sveltejs/vite-plugin-svelte'] = `file:${forkStage}`;
-		pkg.pnpm.overrides['@rsvelte/vite-plugin-svelte-native'] =
-			`file:${path.join(ROOT, 'apps', 'npm', 'vite-plugin-svelte-native')}`;
-		pkg.pnpm.overrides[`@rsvelte/vite-plugin-svelte-native-${triple}`] =
-			`file:${path.join(ROOT, 'apps', 'npm', `vite-plugin-svelte-native-${triple}`)}`;
+		pkg.pnpm.overrides = { ...(pkg.pnpm.overrides ?? {}), ...overrides };
 		fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
-		log(`vps-shim: staged fork -> ${path.relative(ROOT, forkStage)} and injected 3 pnpm.overrides`);
+		const wsPath = mergeWorkspaceYaml(checkoutPath, { overrides });
+		log(
+			`vps-shim: staged fork -> ${path.relative(ROOT, forkStage)} and injected ${Object.keys(overrides).length} overrides into package.json + ${path.relative(ROOT, wsPath)}`,
+		);
 		return { strategy, env: {}, needsReinstall: true };
 	}
 
@@ -328,7 +508,10 @@ function applySwap(target, checkoutPath, bindingPath, triple) {
 
 function restoreTarget(target) {
 	const dest = path.join(CHECKOUT_DIR, target.name);
-	for (const f of ['package.json', 'pnpm-lock.yaml']) {
+	// pnpm-workspace.yaml: restores the target's own file when it ships one; a
+	// no-op for the untracked sentinel we drop for non-monorepo targets (that
+	// gets recreated/cleaned on the next run).
+	for (const f of ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml']) {
 		spawnSync('git', ['checkout', '--', f], { cwd: dest, stdio: 'ignore' });
 	}
 	fs.rmSync(path.join(dest, '.rsvelte'), { recursive: true, force: true });
@@ -355,6 +538,13 @@ async function runTarget(name) {
 	log(`=== ${target.name} (${target.type}, swap=${target.swap?.strategy ?? 'loader-hook'}) ===`);
 
 	const { sha: targetSha } = cloneOrUpdate(target);
+	const checkoutPath = path.join(CHECKOUT_DIR, target.name);
+
+	// Allow all dependency build scripts for both baseline and rsvelte installs —
+	// matches what each target's own CI does, and keeps pnpm 10+ from aborting
+	// with ERR_PNPM_IGNORED_BUILDS on targets whose build approvals live in the
+	// (pnpm-11-ignored) package.json#pnpm.onlyBuiltDependencies, e.g. flowbite.
+	prepareBuildApproval(checkoutPath);
 
 	const baseline = {};
 	baseline.install = runPhase(
@@ -386,7 +576,21 @@ async function runTarget(name) {
 			target.timeoutMinutes,
 		);
 	}
-	const baselineFailed = ['install', 'build', 'test'].some(
+	// svelte-check verification (Wave 2). Gated by the baseline: if the official
+	// svelte-check already reports problems on this target, that's the target's
+	// issue, not a rsvelte regression — classify as baseline-failure and skip the
+	// rsvelte run. We only proceed to compare rsvelte's svelte-check on a target
+	// the official one passes cleanly.
+	if (target.commands.check) {
+		baseline.check = runPhase(
+			target,
+			'baseline-check',
+			target.commands.check,
+			{},
+			target.timeoutMinutes,
+		);
+	}
+	const baselineFailed = ['install', 'build', 'test', 'check'].some(
 		(k) => baseline[k] && baseline[k].exitCode !== 0,
 	);
 	if (baselineFailed) {
@@ -394,9 +598,10 @@ async function runTarget(name) {
 		return 'baseline-failure';
 	}
 
-	// Build rsvelte NAPI and stage it under the target's .rsvelte/
-	const checkoutPath = path.join(CHECKOUT_DIR, target.name);
+	// Build rsvelte NAPI (and the svelte-check binary when this target verifies
+	// it) and stage them under the target's .rsvelte/ + apps/npm.
 	const { bindingPath, triple } = buildRsvelte(checkoutPath);
+	if (target.commands.check) buildSvelteCheck(triple);
 
 	let swap;
 	try {
@@ -413,6 +618,17 @@ async function runTarget(name) {
 
 	const rsvelte = {};
 	if (swap.needsReinstall) {
+		// Force a fresh resolution so the swap overrides actually apply. pnpm 11
+		// does NOT invalidate an existing install when pnpm-workspace.yaml
+		// `overrides` change (even `--force` reports "Already up to date"), so a
+		// plain reinstall keeps the baseline's official packages and the swap is a
+		// silent no-op. Removing node_modules + the lockfile makes pnpm re-resolve
+		// against the overrides; the warm store keeps it fast.
+		fs.rmSync(path.join(checkoutPath, 'node_modules'), {
+			recursive: true,
+			force: true,
+		});
+		fs.rmSync(path.join(checkoutPath, 'pnpm-lock.yaml'), { force: true });
 		rsvelte.install = runPhase(
 			target,
 			'rsvelte-install',
@@ -429,6 +645,21 @@ async function runTarget(name) {
 			});
 			restoreTarget(target);
 			return 'rsvelte-install-failure';
+		}
+		// Fail loudly instead of silently verifying official svelte: if the
+		// override didn't take, the rsvelte plugin never got installed and any
+		// "pass" below would be meaningless.
+		if (swap.strategy === 'vps-shim' && !assertVpsSwapApplied(checkoutPath)) {
+			writeResult(target, targetSha, {
+				result: 'swap-noop',
+				baseline,
+				rsvelte,
+				swap: { strategy: swap.strategy },
+				error:
+					'rsvelte vite-plugin-svelte NAPI wrapper not found in node_modules after install — the override did not take effect (the run would have verified official svelte, not rsvelte)',
+			});
+			restoreTarget(target);
+			return 'swap-noop';
 		}
 	}
 	if (target.commands.build) {
@@ -449,8 +680,17 @@ async function runTarget(name) {
 			target.timeoutMinutes,
 		);
 	}
+	if (target.commands.check) {
+		rsvelte.check = runPhase(
+			target,
+			'rsvelte-check',
+			target.commands.check,
+			swap.env,
+			target.timeoutMinutes,
+		);
+	}
 
-	const rsvelteFailed = ['build', 'test'].some(
+	const rsvelteFailed = ['build', 'test', 'check'].some(
 		(k) => rsvelte[k] && rsvelte[k].exitCode !== 0,
 	);
 	const result = rsvelteFailed ? 'regression' : 'pass';
@@ -479,6 +719,8 @@ function exitCodeForResult(result) {
 			return 4;
 		case 'swap-failure':
 			return 5;
+		case 'swap-noop':
+			return 6;
 		default:
 			return 1;
 	}


### PR DESCRIPTION
## What & why

The nightly `ecosystem-ci` sweep ([run #282](https://github.com/baseballyama/rsvelte/actions/runs/26739588933), issue #632) failed with `flowbite-svelte` → `baseline-failure`. Triaging it surfaced two problems, one of which was masking that **the swap had silently stopped verifying rsvelte at all** on newer pnpm.

### 1. `flowbite-svelte` baseline install aborted (the reported failure)

flowbite (no `packageManager` pin → uses the ambient **pnpm 11**) keeps its build-script approvals in `package.json#pnpm.onlyBuiltDependencies`. pnpm 11 no longer reads the `pnpm` field from `package.json`, so esbuild's build script was never approved and install aborted with `ERR_PNPM_IGNORED_BUILDS`.

### 2. The swap was a silent no-op on pnpm 10/11 (latent, more serious)

The swap injected its `pnpm.overrides` into `package.json`. pnpm 11 ignores that field entirely, and changing overrides doesn't even invalidate an existing install — so the rsvelte install kept the **official** `@sveltejs/vite-plugin-svelte` and any "pass" was verifying upstream svelte, not rsvelte. melt-ui happened to still be real (it pins pnpm 9, which still reads `package.json` overrides), but flowbite/bits-ui ran on pnpm 11/10 where the override was dropped.

Each target pins its own pnpm via `packageManager` (melt-ui `pnpm@9`, bits-ui `pnpm@10`, flowbite ambient `pnpm 11`), and **where pnpm reads `overrides` changed across majors**, so there's no single location that works everywhere.

## Fix (`scripts/ecosystem/ecosystem-ci.mjs`)

- **Write `overrides` to BOTH `package.json#pnpm.overrides` and `pnpm-workspace.yaml`** so the swap applies regardless of the target's pinned pnpm (9 / 10 / 11).
- **`dangerouslyAllowAllBuilds: true`** in `pnpm-workspace.yaml` (+ strip the target's `onlyBuiltDependencies`/`neverBuiltDependencies`, which would otherwise conflict) so native deps (esbuild, sharp, …) build during install the way each target's own CI does.
- **Force a fresh resolution before the rsvelte install** (remove `node_modules` + `pnpm-lock.yaml`) — pnpm doesn't invalidate an install when only `pnpm-workspace.yaml` overrides change, even with `--force`. The warm store keeps it fast.
- **`swap-noop` guard**: after the rsvelte install, assert the rsvelte NAPI wrapper actually landed in `node_modules`; if not, fail the run loudly instead of reporting a meaningless green.

## New: verify rsvelte `svelte-check` (Wave 2)

Added an optional `commands.check` phase: the runner runs it under the official `svelte-check` (baseline) and then under the rsvelte `@rsvelte/svelte-check` CLI (built from `--bin svelte_check`, staged + swapped in via two more overrides), gated by the baseline like every other phase. Enabled conservatively on **bits-ui**, whose `svelte-check` is clean (921 files, 0 errors, 0 warnings).

> Known divergence (warnings only, doesn't affect the errors-only gate): rsvelte `svelte-check` doesn't yet apply a `compilerOptions.warningFilter` from `svelte.config.js`, so it reports the 92 `state_referenced_locally` warnings bits-ui filters out. Both exit 0.

## Verification (local, end-to-end)

| target | pnpm | result |
|---|---|---|
| melt-ui | 9 | ✅ pass (real swap) |
| bits-ui | 10 | ✅ pass (real swap + svelte-check) |
| flowbite-svelte | 10 & 11 | ✅ pass (real swap) — the reported failure is fixed |

Confirmed the rsvelte fork (`@sveltejs/vite-plugin-svelte@file:…` + `@rsvelte/vite-plugin-svelte-native`) is genuinely installed in each, not the official plugin.

Closes #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
