### PR TITLE
chore(deps): unified oxc 0.134 bump (supersedes #402-#405, #410, #411, #610, #611)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,8 +1343,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1356,14 +1356,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "bitflags",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_data_structures",
- "oxc_diagnostics 0.133.0",
+ "oxc_diagnostics",
  "oxc_estree",
  "oxc_regular_expression",
  "oxc_span",
@@ -1373,8 +1373,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "phf",
  "proc-macro2 1.0.106",
@@ -1384,8 +1384,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1395,8 +1395,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1416,24 +1416,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
-
-[[package]]
-name = "oxc_diagnostics"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
-dependencies = [
- "cow-utils",
- "oxc-miette",
- "percent-encoding",
-]
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 
 [[package]]
 name = "oxc_diagnostics"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67daf165d8abff1577825a4303a5d0b61ae29c7b66c9e0e0e7f97f77705667ed"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1442,8 +1431,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1457,8 +1446,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1467,8 +1456,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.52.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.53.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1478,6 +1467,7 @@ dependencies = [
  "nodejs-built-in-modules",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_diagnostics",
  "oxc_formatter_core",
  "oxc_jsdoc",
  "oxc_parser",
@@ -1492,8 +1482,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter_core"
-version = "0.52.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.53.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1518,8 +1508,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_jsdoc"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1528,8 +1518,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1539,7 +1529,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",
- "oxc_diagnostics 0.133.0",
+ "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_regular_expression",
  "oxc_span",
@@ -1551,13 +1541,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "bitflags",
  "oxc_allocator",
  "oxc_ast_macros",
- "oxc_diagnostics 0.133.0",
+ "oxc_diagnostics",
  "oxc_span",
  "oxc_str",
  "phf",
@@ -1567,15 +1557,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "itertools 0.14.0",
  "memchr",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
- "oxc_diagnostics 0.133.0",
+ "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",
  "oxc_span",
@@ -1614,8 +1604,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1628,8 +1618,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1640,8 +1630,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.133.0"
-source = "git+https://github.com/oxc-project/oxc?rev=3d13e293e4e24c91eb2958df493245c85f7087bd#3d13e293e4e24c91eb2958df493245c85f7087bd"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1935,7 +1925,7 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_codegen",
- "oxc_diagnostics 0.134.0",
+ "oxc_diagnostics",
  "oxc_formatter",
  "oxc_parser",
  "oxc_semantic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,18 +24,18 @@ panic = "unwind"  # Criterion requires unwind for catching panics
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -44,17 +44,17 @@ smallvec = { version = "1.13", features = ["serde"] }
 rustc-hash = "2.0"
 
 # JavaScript parsing and code generation
-oxc_allocator = "0.133"
-oxc_parser = "0.133"
-oxc_ast = { version = "0.133", features = ["serialize"] }
-oxc_span = "0.133"
+oxc_allocator = "0.134"
+oxc_parser = "0.134"
+oxc_ast = { version = "0.134", features = ["serialize"] }
+oxc_span = "0.134"
 oxc_diagnostics = "0.134"
-oxc_codegen = "0.133"
-oxc_syntax = "0.133"
-oxc_semantic = "0.133"
+oxc_codegen = "0.134"
+oxc_syntax = "0.134"
+oxc_semantic = "0.134"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
 
 # Error handling
 thiserror = "2.0"
@@ -102,7 +102,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 getrandom = { version = "0.4", optional = true }
 lazy_static = "1.5.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
-oxc_ast_visit = "0.133"
+oxc_ast_visit = "0.134"
 
 # Better multi-threaded memory allocator (optional, Unix/Mac only)
 [target.'cfg(all(not(windows), not(target_arch = "wasm32")))'.dependencies]

--- a/crates/rsvelte_core/tests/oxc_formatter_probe.rs
+++ b/crates/rsvelte_core/tests/oxc_formatter_probe.rs
@@ -7,7 +7,7 @@
 //! Run: `cargo test --test oxc_formatter_probe -- --nocapture`
 
 use oxc_allocator::Allocator;
-use oxc_formatter::{Formatter, JsFormatOptions};
+use oxc_formatter::{JsFormatOptions, format_program};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
@@ -23,7 +23,15 @@ fn formats_unformatted_js() {
         parser_ret.errors
     );
 
-    let formatted = Formatter::new(&allocator, JsFormatOptions::new()).build(&parser_ret.program);
+    let formatted = format_program(
+        &allocator,
+        &parser_ret.program,
+        JsFormatOptions::new(),
+        None,
+    )
+    .print()
+    .expect("print")
+    .into_code();
 
     println!("--- input ---\n{source}\n--- output ---\n{formatted}");
 

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -12,10 +12,10 @@ crate-type = ["rlib"]
 
 [dependencies]
 rsvelte_core = { path = "../rsvelte_core", default-features = false, features = ["native"] }
-oxc_allocator = "0.133"
-oxc_ast = "0.133"
-oxc_parser = "0.133"
-oxc_span = "0.133"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "3d13e293e4e24c91eb2958df493245c85f7087bd" }
+oxc_allocator = "0.134"
+oxc_ast = "0.134"
+oxc_parser = "0.134"
+oxc_span = "0.134"
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
 thiserror = "2.0"

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::Allocator;
-use oxc_formatter::Formatter;
+use oxc_formatter::format_program;
 use oxc_parser::{ParseOptions as OxcParseOptions, Parser};
 use oxc_span::SourceType;
 use rsvelte_core::ast::js::Expression;
@@ -366,7 +366,10 @@ pub(crate) fn format_expression_source(
         return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
     }
 
-    let formatted = Formatter::new(&allocator, options.js.clone()).build(&parser_ret.program);
+    let formatted = format_program(&allocator, &parser_ret.program, options.js.clone(), None)
+        .print()
+        .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
+        .into_code();
 
     let s = formatted.trim_end().trim_end_matches(';').trim_end();
     Ok(strip_outer_parens(s).trim().to_string())
@@ -432,7 +435,10 @@ pub(crate) fn format_pattern_source(
         oxc_formatter_core::LineWidth::try_from(u16::MAX).unwrap_or(single_line.line_width);
     single_line.expand = oxc_formatter_core::Expand::Never;
 
-    let formatted = Formatter::new(&allocator, single_line).build(&parser_ret.program);
+    let formatted = format_program(&allocator, &parser_ret.program, single_line, None)
+        .print()
+        .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
+        .into_code();
 
     // Output shape: `let <pattern> = __rsvelte_fmt_rhs__;\n`. Strip the
     // leading `let ` and the trailing ` = __rsvelte_fmt_rhs__;` so we

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::Allocator;
-use oxc_formatter::{Formatter, JsFormatOptions};
+use oxc_formatter::{JsFormatOptions, format_program};
 use oxc_parser::{ParseOptions as OxcParseOptions, Parser};
 use oxc_span::SourceType;
 use rsvelte_core::ast::template::Script;
@@ -57,7 +57,10 @@ pub(crate) fn format_script(
         return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
     }
 
-    let formatted = Formatter::new(&allocator, options.js.clone()).build(&parser_ret.program);
+    let formatted = format_program(&allocator, &parser_ret.program, options.js.clone(), None)
+        .print()
+        .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
+        .into_code();
 
     // oxc_formatter emits a trailing newline. Add one indent level to
     // every non-empty line so the body is nested under `<script>` using


### PR DESCRIPTION
## What

Bump **all** oxc crates and `oxc_formatter`/`oxc_formatter_core` to **0.134** (git rev `f6f0fbf`) in a single change.

## Why a unified bump (not the individual Renovate PRs)

`Cargo.toml` uses `[patch.crates-io]` to redirect every `oxc_*` crate to one git rev so rsvelte's AST types unify with `oxc_formatter`'s transitive deps (the "two `Program<'a>` types" guard). The individual Renovate PRs (#402, #403, #404, #405, #410, #411, #610, #611) each bump only a subset of oxc crates, which leaves the dependency graph with both 0.133 and 0.134 copies → type-unification breaks → `Test` / `capi` / `Clippy` / `Compatibility Report` all fail. They can only pass when every oxc crate moves together, which is what this PR does. Those 8 PRs are superseded and will be closed.

## Changes

- `Cargo.toml` `[patch.crates-io]`: rev `3d13e293` → `f6f0fbf` (0.134)
- `rsvelte_core` / `rsvelte_formatter`: oxc version requirements `0.133` → `0.134`
- `rsvelte_fmt` / `rsvelte_formatter` / `rsvelte_core`: `oxc_formatter` rev bump
- **oxc_formatter 0.134 API**: `Formatter::new(..).build(&program)` was removed; replaced with `format_program(alloc, &program, opts, None).print()?.into_code()` at all call sites (`script.rs`, `expression.rs`, `oxc_formatter_probe.rs`)

## Verification

- `cargo build` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --check`: clean
- Full `cargo test -p rsvelte_core` at CI's `RUST_MIN_STACK=32MB`: equivalent results to 0.133 (verified by reverting deps to 0.133 in place — the two produce **identical** test outcomes, confirming oxc has no behavioral effect here)
- Compatibility report: 16/16 report sub-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)