### PR TITLE
fix(deps): unify all oxc_* + oxc_formatter to rev beb46d3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,19 +1348,8 @@ source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
- "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "rustc-hash",
-]
-
-[[package]]
-name = "oxc_allocator"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
-dependencies = [
- "allocator-api2",
- "hashbrown 0.17.1",
- "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_data_structures",
+ "oxc_estree",
  "rustc-hash",
  "serde",
 ]
@@ -1368,35 +1357,24 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "bitflags",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
  "oxc_diagnostics",
- "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_estree",
  "oxc_regular_expression",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
 version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
-dependencies = [
- "phf",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "oxc_ast_macros"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "phf",
  "proc-macro2 1.0.106",
@@ -1407,32 +1385,32 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
  "oxc_ast",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_codegen"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "bitflags",
  "cow-utils",
  "dragonbox_ecma",
  "itoa",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
  "oxc_ast",
- "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_data_structures",
  "oxc_index",
  "oxc_semantic",
  "oxc_sourcemap",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
  "rustc-hash",
 ]
 
@@ -1442,14 +1420,9 @@ version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 
 [[package]]
-name = "oxc_data_structures"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
-
-[[package]]
 name = "oxc_diagnostics"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1459,37 +1432,32 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
  "oxc_ast",
  "oxc_regular_expression",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_estree"
 version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
-
-[[package]]
-name = "oxc_estree"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
- "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_data_structures",
 ]
 
 [[package]]
 name = "oxc_formatter"
 version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1497,15 +1465,15 @@ dependencies = [
  "markdown",
  "natord",
  "nodejs-built-in-modules",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
  "oxc_ast",
  "oxc_diagnostics",
- "oxc_formatter_core 0.53.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_formatter_core",
  "oxc_jsdoc",
  "oxc_parser",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
  "phf",
  "rustc-hash",
  "smallvec",
@@ -1518,24 +1486,10 @@ version = "0.53.0"
 source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "cow-utils",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "rustc-hash",
- "unicode-width 0.2.2",
-]
-
-[[package]]
-name = "oxc_formatter_core"
-version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
-dependencies = [
- "cow-utils",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
+ "oxc_data_structures",
+ "oxc_span",
+ "oxc_syntax",
  "rustc-hash",
  "serde_json",
  "unicode-width 0.2.2",
@@ -1555,32 +1509,32 @@ dependencies = [
 [[package]]
 name = "oxc_jsdoc"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "oxc_ast",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_parser"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "bitflags",
  "cow-utils",
  "memchr",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
  "oxc_ast",
- "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_regular_expression",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
  "rustc-hash",
  "seq-macro",
 ]
@@ -1588,14 +1542,14 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "bitflags",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
+ "oxc_ast_macros",
  "oxc_diagnostics",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_str",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -1604,19 +1558,19 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 dependencies = [
  "itertools 0.14.0",
  "memchr",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
  "rustc-hash",
  "self_cell",
  "smallvec",
@@ -1642,23 +1596,10 @@ source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
-]
-
-[[package]]
-name = "oxc_span"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
-dependencies = [
- "compact_str",
- "oxc-miette",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_str",
  "serde",
 ]
 
@@ -1669,19 +1610,8 @@ source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
-]
-
-[[package]]
-name = "oxc_str"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
-dependencies = [
- "compact_str",
- "hashbrown 0.17.1",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
+ "oxc_estree",
  "serde",
 ]
 
@@ -1689,35 +1619,17 @@ dependencies = [
 name = "oxc_syntax"
 version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
-dependencies = [
- "bitflags",
- "cow-utils",
- "nonmax",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_index",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
- "phf",
- "unicode-id-start",
-]
-
-[[package]]
-name = "oxc_syntax"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "bitflags",
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
  "oxc_index",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_str",
  "phf",
  "serde",
  "unicode-id-start",
@@ -1996,7 +1908,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "notify",
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_codegen",
@@ -2004,8 +1916,8 @@ dependencies = [
  "oxc_formatter",
  "oxc_parser",
  "oxc_semantic",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
- "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
+ "oxc_syntax",
  "pretty_assertions",
  "rayon",
  "regex",
@@ -2031,7 +1943,7 @@ dependencies = [
  "anyhow",
  "clap",
  "oxc_formatter",
- "oxc_formatter_core 0.53.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_formatter_core",
  "rayon",
  "rsvelte_formatter",
  "walkdir",
@@ -2041,12 +1953,12 @@ dependencies = [
 name = "rsvelte_formatter"
 version = "0.1.0"
 dependencies = [
- "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_allocator",
  "oxc_ast",
  "oxc_formatter",
- "oxc_formatter_core 0.53.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_formatter_core",
  "oxc_parser",
- "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span",
  "rsvelte_core",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,12 +1344,23 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+dependencies = [
+ "allocator-api2",
+ "hashbrown 0.17.1",
+ "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
- "oxc_data_structures",
- "oxc_estree",
+ "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "rustc-hash",
  "serde",
 ]
@@ -1360,15 +1371,26 @@ version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "bitflags",
- "oxc_allocator",
- "oxc_ast_macros",
- "oxc_data_structures",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_diagnostics",
- "oxc_estree",
+ "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_regular_expression",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+]
+
+[[package]]
+name = "oxc_ast_macros"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+dependencies = [
+ "phf",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1387,10 +1409,10 @@ name = "oxc_ast_visit"
 version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
- "oxc_allocator",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_ast",
- "oxc_span",
- "oxc_syntax",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
 ]
 
 [[package]]
@@ -1402,17 +1424,22 @@ dependencies = [
  "cow-utils",
  "dragonbox_ecma",
  "itoa",
- "oxc_allocator",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_ast",
- "oxc_data_structures",
+ "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_index",
  "oxc_semantic",
  "oxc_sourcemap",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "rustc-hash",
 ]
+
+[[package]]
+name = "oxc_data_structures"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 
 [[package]]
 name = "oxc_data_structures"
@@ -1437,12 +1464,17 @@ dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
- "oxc_allocator",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_ast",
  "oxc_regular_expression",
- "oxc_span",
- "oxc_syntax",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
 ]
+
+[[package]]
+name = "oxc_estree"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
 
 [[package]]
 name = "oxc_estree"
@@ -1451,7 +1483,7 @@ source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835
 dependencies = [
  "dragonbox_ecma",
  "itoa",
- "oxc_data_structures",
+ "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
 ]
 
 [[package]]
@@ -1465,15 +1497,15 @@ dependencies = [
  "markdown",
  "natord",
  "nodejs-built-in-modules",
- "oxc_allocator",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_ast",
  "oxc_diagnostics",
- "oxc_formatter_core",
+ "oxc_formatter_core 0.53.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_jsdoc",
  "oxc_parser",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "phf",
  "rustc-hash",
  "smallvec",
@@ -1483,13 +1515,27 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_core"
 version = "0.53.0"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+dependencies = [
+ "cow-utils",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "rustc-hash",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "oxc_formatter_core"
+version = "0.53.0"
 source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "cow-utils",
- "oxc_allocator",
- "oxc_data_structures",
- "oxc_span",
- "oxc_syntax",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "rustc-hash",
  "serde_json",
  "unicode-width 0.2.2",
@@ -1512,7 +1558,7 @@ version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "oxc_ast",
- "oxc_span",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "rustc-hash",
 ]
 
@@ -1526,15 +1572,15 @@ dependencies = [
  "memchr",
  "num-bigint",
  "num-traits",
- "oxc_allocator",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_ast",
- "oxc_data_structures",
+ "oxc_data_structures 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_regular_expression",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "rustc-hash",
  "seq-macro",
 ]
@@ -1545,11 +1591,11 @@ version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "bitflags",
- "oxc_allocator",
- "oxc_ast_macros",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_diagnostics",
- "oxc_span",
- "oxc_str",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -1562,15 +1608,15 @@ source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835
 dependencies = [
  "itertools 0.14.0",
  "memchr",
- "oxc_allocator",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "rustc-hash",
  "self_cell",
  "smallvec",
@@ -1592,15 +1638,39 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+dependencies = [
+ "compact_str",
+ "oxc-miette",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+]
+
+[[package]]
+name = "oxc_span"
+version = "0.134.0"
 source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a#f6f0fbf5d9a565a46031166c835dbe56b875ac3a"
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc_allocator",
- "oxc_ast_macros",
- "oxc_estree",
- "oxc_str",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "serde",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+dependencies = [
+ "compact_str",
+ "hashbrown 0.17.1",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
 ]
 
 [[package]]
@@ -1610,9 +1680,27 @@ source = "git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
- "oxc_allocator",
- "oxc_estree",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "serde",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.134.0"
+source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "nonmax",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_index",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
+ "phf",
+ "unicode-id-start",
 ]
 
 [[package]]
@@ -1624,12 +1712,12 @@ dependencies = [
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
- "oxc_allocator",
- "oxc_ast_macros",
- "oxc_estree",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_ast_macros 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_estree 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_index",
- "oxc_span",
- "oxc_str",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_str 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "phf",
  "serde",
  "unicode-id-start",
@@ -1908,7 +1996,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "notify",
- "oxc_allocator",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_codegen",
@@ -1916,8 +2004,8 @@ dependencies = [
  "oxc_formatter",
  "oxc_parser",
  "oxc_semantic",
- "oxc_span",
- "oxc_syntax",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
+ "oxc_syntax 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "pretty_assertions",
  "rayon",
  "regex",
@@ -1943,7 +2031,7 @@ dependencies = [
  "anyhow",
  "clap",
  "oxc_formatter",
- "oxc_formatter_core",
+ "oxc_formatter_core 0.53.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
  "rayon",
  "rsvelte_formatter",
  "walkdir",
@@ -1953,12 +2041,12 @@ dependencies = [
 name = "rsvelte_formatter"
 version = "0.1.0"
 dependencies = [
- "oxc_allocator",
+ "oxc_allocator 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "oxc_ast",
  "oxc_formatter",
- "oxc_formatter_core",
+ "oxc_formatter_core 0.53.0 (git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28)",
  "oxc_parser",
- "oxc_span",
+ "oxc_span 0.134.0 (git+https://github.com/oxc-project/oxc?rev=f6f0fbf5d9a565a46031166c835dbe56b875ac3a)",
  "rsvelte_core",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,18 +24,18 @@ panic = "unwind"  # Criterion requires unwind for catching panics
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -54,7 +54,7 @@ oxc_syntax = "0.134"
 oxc_semantic = "0.134"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
 oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -16,6 +16,6 @@ oxc_allocator = "0.134"
 oxc_ast = "0.134"
 oxc_parser = "0.134"
 oxc_span = "0.134"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
 oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
 thiserror = "2.0"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -17,5 +17,5 @@ oxc_ast = "0.134"
 oxc_parser = "0.134"
 oxc_span = "0.134"
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "f6f0fbf5d9a565a46031166c835dbe56b875ac3a" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
 thiserror = "2.0"


### PR DESCRIPTION
Supersedes #640 and #641.

Renovate opened #640/#641 bumping only `oxc_formatter` / `oxc_formatter_core` to `beb46d3` while the rest of the `oxc_*` crates stayed pinned at `f6f0fbf` via `[patch.crates-io]`. That produced **two** copies of `oxc_allocator`/`oxc_ast`/etc. in the tree, so rsvelte's AST types no longer unified with `oxc_formatter`'s transitive deps — every compile-dependent CI job (Clippy, Test, Documentation, capi) failed.

This bumps **every** `oxc_*` and `oxc_formatter(_core)` git rev to a single commit (`beb46d3`) across all `Cargo.toml` files so the type-unification SPIKE holds. Local `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, and the formatter test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)