### PR TITLE
fix(transform): local $derived in a class method with a default param no longer leaks into a private field (#648)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -4272,6 +4272,44 @@ fn line_ends_with_continuation(trimmed: &str) -> bool {
 }
 
 /// Count bracket depth change for a line (positive = more opens, negative = more closes).
+/// Update `depth` for the curly-brace nesting of a class member body as `line`
+/// is consumed. `{`/`}` that sit inside parentheses/brackets (e.g. a `{}`
+/// default-parameter value in `getTimeline(opts = {}) {`) or inside string /
+/// template literals are ignored, so an object-literal default parameter does
+/// not prematurely close the method block. Returns `true` if `depth` reached 0
+/// on this line (the member body closed). (issue #648)
+fn update_member_brace_depth(line: &str, depth: &mut i32) -> bool {
+    let mut paren: i32 = 0;
+    let mut in_str = false;
+    let mut str_ch = ' ';
+    let mut closed = false;
+    for ch in line.chars() {
+        if in_str {
+            if ch == str_ch {
+                in_str = false;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' | '`' => {
+                in_str = true;
+                str_ch = ch;
+            }
+            '(' | '[' => paren += 1,
+            ')' | ']' => paren -= 1,
+            '{' if paren == 0 => *depth += 1,
+            '}' if paren == 0 => {
+                *depth -= 1;
+                if *depth == 0 {
+                    closed = true;
+                }
+            }
+            _ => {}
+        }
+    }
+    closed
+}
+
 fn count_bracket_depth(line: &str) -> i32 {
     let mut depth: i32 = 0;
     let mut in_str = false;
@@ -4511,23 +4549,14 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
 
         if in_block {
             block_lines.push(line.to_string());
-            for c in trimmed.chars() {
-                match c {
-                    '{' => block_depth += 1,
-                    '}' => {
-                        block_depth -= 1;
-                        if block_depth == 0 {
-                            in_block = false;
-                            if block_is_arrow_fn {
-                                members.push(ClassMember::ArrowFn(block_lines.clone()));
-                            } else {
-                                members.push(ClassMember::Method(block_lines.clone()));
-                            }
-                            block_lines.clear();
-                        }
-                    }
-                    _ => {}
+            if update_member_brace_depth(trimmed, &mut block_depth) {
+                in_block = false;
+                if block_is_arrow_fn {
+                    members.push(ClassMember::ArrowFn(block_lines.clone()));
+                } else {
+                    members.push(ClassMember::Method(block_lines.clone()));
                 }
+                block_lines.clear();
             }
             continue;
         }
@@ -4554,19 +4583,10 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
             block_depth = 0;
             block_lines.clear();
             block_lines.push(line.to_string());
-            for c in trimmed.chars() {
-                match c {
-                    '{' => block_depth += 1,
-                    '}' => {
-                        block_depth -= 1;
-                        if block_depth == 0 {
-                            in_block = false;
-                            members.push(ClassMember::Method(block_lines.clone()));
-                            block_lines.clear();
-                        }
-                    }
-                    _ => {}
-                }
+            if update_member_brace_depth(trimmed, &mut block_depth) {
+                in_block = false;
+                members.push(ClassMember::Method(block_lines.clone()));
+                block_lines.clear();
             }
             continue;
         }
@@ -4584,25 +4604,30 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
             block_depth = 0;
             block_lines.clear();
             block_lines.push(line.to_string());
-            for c in trimmed.chars() {
-                match c {
-                    '{' => block_depth += 1,
-                    '}' => {
-                        block_depth -= 1;
-                        if block_depth == 0 {
-                            in_block = false;
-                            members.push(ClassMember::ArrowFn(block_lines.clone()));
-                            block_lines.clear();
-                        }
-                    }
-                    _ => {}
-                }
+            if update_member_brace_depth(trimmed, &mut block_depth) {
+                in_block = false;
+                members.push(ClassMember::ArrowFn(block_lines.clone()));
+                block_lines.clear();
             }
             continue;
         }
 
-        let is_method_start = (trimmed.contains('(') && trimmed.contains('{'))
-            && !trimmed.contains('=')
+        // A method signature is `name(params) {` — its first `(` comes before
+        // any `=` (a `=` only appears inside the parens as a default parameter,
+        // e.g. `getTimeline(opts = {}) {`). A class *field* (`x = …`, including
+        // arrow fields `x = () => {` already consumed by `is_arrow_fn_start`
+        // above) has its `=` *before* the `(`. The old guard `!contains('=')`
+        // was too broad: it false-negatived any method with a default param, so
+        // the scanner never entered the method block and mis-parsed a local
+        // `const x = $derived(…)` in the body as a private derived class field
+        // (`#const_x = $.derived(…)`), emitting invalid JS. Mirror the
+        // `constructor(` guard below: method iff `(` precedes the first `=`.
+        // (issue #648)
+        let is_method_start = trimmed.contains('(')
+            && trimmed.contains('{')
+            && trimmed
+                .find('=')
+                .is_none_or(|eq_pos| trimmed.find('(').is_some_and(|p| p < eq_pos))
             && !trimmed.starts_with("//")
             && !trimmed.starts_with("/*");
 
@@ -4612,19 +4637,10 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
             block_depth = 0;
             block_lines.clear();
             block_lines.push(line.to_string());
-            for c in trimmed.chars() {
-                match c {
-                    '{' => block_depth += 1,
-                    '}' => {
-                        block_depth -= 1;
-                        if block_depth == 0 {
-                            in_block = false;
-                            members.push(ClassMember::Method(block_lines.clone()));
-                            block_lines.clear();
-                        }
-                    }
-                    _ => {}
-                }
+            if update_member_brace_depth(trimmed, &mut block_depth) {
+                in_block = false;
+                members.push(ClassMember::Method(block_lines.clone()));
+                block_lines.clear();
             }
             continue;
         }

--- a/crates/rsvelte_core/tests/class_method_default_param_local_derived.rs
+++ b/crates/rsvelte_core/tests/class_method_default_param_local_derived.rs
@@ -1,0 +1,152 @@
+//! Regression test for baseballyama/rsvelte#648.
+//!
+//! A class method whose signature contains a `=` — most commonly a default
+//! parameter such as `getTimeline(opts = {}) {` — was not recognised as a
+//! method by the server class-field scanner (`transform_class_fields_server`).
+//! Two compounding bugs:
+//!
+//!   1. The `is_method_start` heuristic required `!trimmed.contains('=')`, so a
+//!      default-parameter method was never treated as a method start.
+//!   2. Even once recognised, the curly-brace depth counter naively counted the
+//!      `{}` of an object-literal default parameter (`opts = {}`), so the block
+//!      closed on the *signature* line before the body `{` ever opened.
+//!
+//! Either way the method body's local `const x = $derived(…)` was then parsed
+//! as a private derived *class field* and emitted as `#const_x = $.derived(…)`
+//! in statement position — invalid JS (`#name` is the private-in operator
+//! outside a class field), so the compiler's own output failed to parse with
+//! `Expected 'in' but found '='`.
+//!
+//! After the fix the local declaration is preserved verbatim and lowered as an
+//! ordinary local binding (`const x = $.derived(…)`, read via `x()` on the
+//! server / `$.get(x)` on the client).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_component(src: &str, mode: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("App.svelte".to_string()),
+            generate: mode,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn assert_no_private_local(out: &str) {
+    assert!(
+        !out.contains("#const_") && !out.contains("#let_"),
+        "local declaration leaked into a private class field:\n{out}"
+    );
+}
+
+const DEFAULT_PARAM: &str = r#"<script>
+class Service {
+  data = $state([]);
+  getTimeline(opts = {}) {
+    const auditTimeline = $derived.by(() => {
+      return this.data;
+    });
+    return auditTimeline;
+  }
+}
+</script>"#;
+
+#[test]
+fn default_param_method_server() {
+    let out = compile_component(DEFAULT_PARAM, GenerateMode::Server);
+    assert_no_private_local(&out);
+    // The local derived survives as a local binding, read via `name()` on the server.
+    assert!(
+        out.contains("const auditTimeline = $.derived("),
+        "expected local `const auditTimeline = $.derived(...)`. Got:\n{out}"
+    );
+    assert!(
+        out.contains("return auditTimeline()"),
+        "expected server read `return auditTimeline()`. Got:\n{out}"
+    );
+}
+
+#[test]
+fn default_param_method_client() {
+    let out = compile_component(DEFAULT_PARAM, GenerateMode::Client);
+    assert_no_private_local(&out);
+    assert!(
+        out.contains("const auditTimeline = $.derived("),
+        "expected local `const auditTimeline = $.derived(...)`. Got:\n{out}"
+    );
+    assert!(
+        out.contains("$.get(auditTimeline)"),
+        "expected client read `$.get(auditTimeline)`. Got:\n{out}"
+    );
+}
+
+#[test]
+fn destructuring_default_param_method_server() {
+    // A destructuring default whose default value is itself an object literal —
+    // exercises both the `=`-in-signature path and brace-skipping inside parens.
+    let src = r#"<script>
+class Service {
+  data = $state([]);
+  getTimeline({ limit = 10 } = {}) {
+    const view = $derived.by(() => this.data.slice(0, limit));
+    return view;
+  }
+}
+</script>"#;
+    let out = compile_component(src, GenerateMode::Server);
+    assert_no_private_local(&out);
+    assert!(
+        out.contains("const view = $.derived("),
+        "expected local `const view = $.derived(...)`. Got:\n{out}"
+    );
+}
+
+#[test]
+fn plain_method_still_works_server() {
+    // Guard: a method with no `=` in its signature must keep working.
+    let src = r#"<script>
+class Service {
+  data = $state([]);
+  getTimeline() {
+    const auditTimeline = $derived.by(() => this.data);
+    return auditTimeline;
+  }
+}
+</script>"#;
+    let out = compile_component(src, GenerateMode::Server);
+    assert_no_private_local(&out);
+    assert!(out.contains("const auditTimeline = $.derived("));
+}
+
+#[test]
+fn real_derived_field_with_default_param_method_server() {
+    // Guard: a genuine `$derived` *class field* must still be lowered to a
+    // private backing field + getter, even when a default-param method is
+    // present in the same class.
+    let src = r#"<script>
+class Service {
+  data = $state([]);
+  total = $derived(this.data.length);
+  getTimeline(opts = {}) {
+    const auditTimeline = $derived.by(() => this.data);
+    return auditTimeline;
+  }
+}
+</script>"#;
+    let out = compile_component(src, GenerateMode::Server);
+    // The local stays local…
+    assert!(
+        out.contains("const auditTimeline = $.derived("),
+        "local derived should stay local:\n{out}"
+    );
+    // …while the real field becomes a private backing field.
+    assert!(
+        out.contains("#total = $.derived("),
+        "real derived field should lower to a private backing field:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #648 — `@rsvelte/compiler` emitted a local `const x = $derived(…)` / `$derived.by(…)` declared inside a class method as an **invalid private class field** `#const_x = $.derived(…)`, so the compiler's own output failed to parse (`Expected 'in' but found '='`).

## Root cause

The symptom is produced by the **server** class-field scanner `transform_class_fields_server` (used by the SSR build of any component that carries a runed class). It only triggers when the method's signature contains a `=` — most commonly a **default parameter**, e.g. `getTimeline(opts = {}) {`. The minimal example in the issue (a bare `getTimeline()`) does not reproduce; the real failing modules have default-param / destructuring-default methods.

Two compounding bugs:

1. `is_method_start` required `!trimmed.contains('=')`, so a default-parameter method was never recognised as a method start.
2. Even once recognised, the curly-brace depth counter naively counted the `{}` of an object-literal default (`opts = {}`), so the "method" closed on the **signature** line before the body `{` ever opened.

Either way `in_block` stayed `false`, so the body's local `const x = $derived(…)` was scanned as a private derived **class field** and emitted as `#const_x = $.derived(…)` in statement position — invalid JS.

> Note: the `.svelte.ts` **module** path was already safe — it uses the guarded client scanner (`is_valid_class_field_name` rejects a `const x` name). This bug lives only in the server *component* class transform.

## Fix

- `is_method_start` now mirrors the existing `constructor(` guard: a line is a method iff its first `(` precedes the first `=` (a `=` inside the parens is a default parameter). `getTimeline(opts = {}) {` is a method; `data = $state(…)` / `x = () => {…}` stay fields.
- New `update_member_brace_depth` helper tracks paren/bracket nesting and string literals, counting `{`/`}` only at paren-depth 0. All four member-scanning loops (in-block continuation, constructor, arrow field, method) route through it, so an object-literal default parameter no longer prematurely closes the block. This also hardens the constructor path against the same shape.

### Before / after (SSR)

```js
// before — invalid
getTimeline(opts = {}) {
  #const_auditTimeline = $.derived(() => { return this.data; });
  get const auditTimeline() { ... }
  ...

// after — correct
getTimeline(opts = {}) {
  const auditTimeline = $.derived(() => { return this.data; });
  return auditTimeline();
}
```

## Tests

- New `tests/class_method_default_param_local_derived.rs`: default-param, destructuring-default, plain-method, and real-derived-field cases on both client and server (5 tests).
- Full suite green with no regressions: `compatibility_report` 16/16, `runtime` 19/19, whole `cargo test` exits 0. `cargo fmt` / `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
