### PR TITLE
Reach 100% compiler compatibility on Svelte 5.56.1 (DeclarationTag cluster)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -2072,6 +2072,18 @@ pub struct ComponentClientTransformState<'a> {
     /// These are merged into the blocker detection in Fragment visitor.
     pub extra_blocker_indices: Vec<usize>,
 
+    /// Names referenced ONLY by shorthand style directives (`style:color` with no
+    /// `={...}` value), per the current fragment state. Upstream's
+    /// `StyleDirective.js` analyze visitor adds a shorthand directive's binding to
+    /// `metadata.expression.dependencies` (NOT `references`), and the client
+    /// `Memoizer.check_blockers` only walks `references`, so a shorthand-only
+    /// directive never contributes a `$$promises[N]` blocker to its
+    /// `$.template_effect`. The Rust blocker computation instead scans the literal
+    /// identifiers of update statements, so we record shorthand directive names here
+    /// and skip them during that scan unless the same name is also referenced by a
+    /// non-shorthand (blocker-contributing) construct in the same fragment.
+    pub style_shorthand_blocker_names: Vec<String>,
+
     /// Whether the fragment is standalone (single Component or RenderTag that
     /// doesn't need a template wrapper). Set by Fragment visitor and consumed by
     /// component/render-tag visitors to know if `$.next()` is needed after `$.async()`.
@@ -2228,6 +2240,7 @@ impl<'a> ComponentClientTransformState<'a> {
                 rustc_hash::FxHashMap::default(),
             )),
             extra_blocker_indices: Vec::new(),
+            style_shorthand_blocker_names: Vec::new(),
             is_standalone: false,
             const_blocker_map: Rc::new(std::cell::RefCell::new(rustc_hash::FxHashMap::default())),
             templates: Rc::new(std::cell::RefCell::new(rustc_hash::FxHashMap::default())),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
@@ -302,6 +302,19 @@ pub fn const_tag(node: &ConstTag, context: &mut ComponentContext) {
 /// Extract all identifier names from a destructuring pattern JSON.
 ///
 /// Handles ObjectPattern, ArrayPattern, RestElement, and AssignmentPattern.
+/// Public wrapper: extract all declared identifier names from a declarator
+/// `id` pattern JSON (Identifier / ObjectPattern / ArrayPattern). Used by the
+/// DeclarationTag async destructure lowering.
+pub(crate) fn extract_pattern_identifiers(pattern: &serde_json::Value) -> Vec<String> {
+    extract_identifiers_from_pattern(pattern)
+}
+
+/// Public wrapper: render a declarator `id` pattern JSON back to source-like
+/// text (fallback when the raw source span is unavailable).
+pub(crate) fn render_pattern_text(pattern: &serde_json::Value) -> String {
+    render_pattern_as_string(pattern)
+}
+
 fn extract_identifiers_from_pattern(pattern: &serde_json::Value) -> Vec<String> {
     let mut identifiers = Vec::new();
     collect_identifiers(pattern, &mut identifiers);
@@ -608,6 +621,25 @@ pub(crate) fn add_const_declaration(
     let has_blockers = !blockers.is_empty();
 
     if has_await || context.state.async_consts.is_some() || has_blockers {
+        // A `{const x = $derived(await …)}` async declaration is REACTIVE: reads
+        // of `x` must wrap in `$.get(x)` (and an object-shorthand `{ x }`
+        // expands to `{ x: $.get(x) }`). Detect the derived shape from the
+        // lowered RHS (`$.derived(...)` / `$.async_derived(...)`) so we can
+        // register the same `$.get` read transform that the ConstTag
+        // (`{@const}`) path registers in `create_derived`. Plain async bindings
+        // (`{const n = await …}` / cross-const `{const a = b + 1}` /
+        // destructured `{const { x } = await …}`) are NOT reactive and read
+        // bare, so they do NOT get this transform.
+        let is_reactive_derived = {
+            let code = crate::compiler::phases::phase3_transform::js_ast::codegen::generate_expr(
+                &expression,
+                &context.arena,
+            );
+            code.contains("$.derived(")
+                || code.contains("$.derived_safe_equal(")
+                || code.contains("$.async_derived(")
+        };
+
         // Async case: need to handle async consts
         let async_consts = context.state.async_consts.get_or_insert_with(|| {
             let id_name = context.state.memoizer.generate_id("promises");
@@ -676,6 +708,23 @@ pub(crate) fn add_const_declaration(
             .const_blocker_map
             .borrow_mut()
             .insert(id_name.to_string(), blocker_expr);
+
+        if is_reactive_derived {
+            context.state.transform.insert(
+                id_name.to_string(),
+                IdentifierTransform {
+                    read: Some(get_value),
+                    read_source: None,
+                    assign: None,
+                    mutate: None,
+                    update: None,
+                    skip_proxy: false,
+                    is_defined: false,
+                    is_reactive: true,
+                    replacement_id: None,
+                },
+            );
+        }
     } else {
         // Simple case: just add const declaration
         context
@@ -692,6 +741,141 @@ pub(crate) fn add_const_declaration(
                 b::svelte_call(&context.arena, "get", vec![b::id(id_name)]),
             ));
         }
+    }
+}
+
+/// Async-declaration lowering for a DESTRUCTURED / multi-binding declaration
+/// tag (`{const { length, 0: first } = await '01234'}`). Mirrors upstream's
+/// `build_async_declaration_parts` + `add_async_declaration`: emit one bare
+/// `let <name>;` per declared identifier, push the deferred assignment thunk
+/// (whose LHS is the WHOLE pattern) into the shared `async_consts` `$.run([…])`
+/// group, and register the SAME `promises[idx]` blocker for EVERY declared
+/// name in `const_blocker_map`. `lhs_pattern` is the RAW pattern text (so a
+/// binding whose name collides with a `$derived` is not wrapped on the
+/// assignment target). `rhs` is the lowered initializer (e.g.
+/// `await '01234'`). `init_refs` are identifiers referenced by `rhs` for
+/// cross-group blocker lookup.
+pub(crate) fn add_async_declaration_multi(
+    context: &mut ComponentContext,
+    declared_names: &[String],
+    lhs_pattern: &str,
+    rhs: JsExpr,
+    metadata: &crate::ast::template::ExpressionMetadata,
+    init_refs: &[String],
+) {
+    let has_await = metadata.has_await();
+
+    // Collect cross-group blockers (same logic as add_const_declaration).
+    let blockers = {
+        let const_blocker_map = context.state.const_blocker_map.borrow();
+        let top_level_blocker_map = context.state.blocker_map.borrow();
+        let current_async_consts_id =
+            context
+                .state
+                .async_consts
+                .as_ref()
+                .and_then(|ac| match &ac.id {
+                    JsExpr::Identifier(name) => Some(name.clone()),
+                    _ => None,
+                });
+
+        let mut blocker_list: Vec<JsExpr> = Vec::new();
+        let mut seen_ptrs: Vec<*const JsExpr> = Vec::new();
+        let mut seen_top_level: Vec<usize> = Vec::new();
+
+        for name in init_refs {
+            if let Some(blocker_expr) = const_blocker_map.get(name) {
+                let ptr = blocker_expr as *const JsExpr;
+                if seen_ptrs.contains(&ptr) {
+                    continue;
+                }
+                let should_include = match blocker_expr {
+                    JsExpr::Member(member_expr) => match context.arena.get_expr(member_expr.object)
+                    {
+                        JsExpr::Identifier(obj_name) => {
+                            current_async_consts_id.as_deref() != Some(obj_name.as_str())
+                        }
+                        _ => true,
+                    },
+                    _ => true,
+                };
+                if should_include {
+                    seen_ptrs.push(ptr);
+                    blocker_list.push(blocker_expr.clone());
+                }
+            } else if let Some(&idx) = top_level_blocker_map.get(name) {
+                if seen_top_level.contains(&idx) {
+                    continue;
+                }
+                seen_top_level.push(idx);
+                let blocker_expr =
+                    b::member_computed(&context.arena, b::id("$$promises"), b::number(idx as f64));
+                blocker_list.push(blocker_expr);
+            }
+        }
+        blocker_list
+    };
+
+    // Open / reuse the async_consts group.
+    let async_consts = context.state.async_consts.get_or_insert_with(|| {
+        let id_name = context.state.memoizer.generate_id("promises");
+        AsyncConsts {
+            id: b::id(&id_name),
+            thunks: Vec::new(),
+        }
+    });
+
+    // One bare `let <name>;` per declared identifier.
+    for name in declared_names {
+        context
+            .state
+            .consts
+            .push(b::let_decl(&context.arena, name, None));
+    }
+
+    // Blocker-wait thunks before the assignment thunk.
+    if blockers.len() == 1 {
+        let blocker_promise = b::member(
+            &context.arena,
+            blockers.into_iter().next().unwrap(),
+            "promise",
+        );
+        async_consts
+            .thunks
+            .push(b::thunk(&context.arena, blocker_promise));
+    } else if blockers.len() > 1 {
+        async_consts.thunks.push(b::thunk(
+            &context.arena,
+            b::svelte_call(&context.arena, "wait", vec![b::array(blockers)]),
+        ));
+    }
+
+    // Assignment with the WHOLE pattern as the LHS: `({ length, 0: first } = rhs)`.
+    let assignment = b::assign(&context.arena, JsExpr::Raw(lhs_pattern.into()), rhs);
+    if has_await {
+        async_consts
+            .thunks
+            .push(b::async_arrow(&context.arena, vec![], assignment));
+    } else {
+        async_consts
+            .thunks
+            .push(b::thunk(&context.arena, assignment));
+    }
+
+    // Register the SAME blocker for every declared name.
+    let thunk_index = async_consts.thunks.len() - 1;
+    let async_consts_id = async_consts.id.clone();
+    for name in declared_names {
+        let blocker_expr = b::member_computed(
+            &context.arena,
+            async_consts_id.clone(),
+            b::number(thunk_index as f64),
+        );
+        context
+            .state
+            .const_blocker_map
+            .borrow_mut()
+            .insert(name.clone(), blocker_expr);
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
@@ -528,7 +528,7 @@ fn create_derived(context: &ComponentContext, expression: JsExpr, is_async: bool
 /// When the expression has async dependencies (awaits or blockers from other async
 /// const declarations), this creates an async run group with wait thunks and registers
 /// the resulting binding's blocker for future const tags.
-fn add_const_declaration(
+pub(crate) fn add_const_declaration(
     context: &mut ComponentContext,
     id_name: &str,
     expression: JsExpr,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
@@ -18,7 +18,7 @@
 
 use crate::ast::template::DeclarationTag;
 use crate::compiler::phases::phase3_transform::client::types::*;
-use crate::compiler::phases::phase3_transform::js_ast::nodes::JsStatement;
+use crate::compiler::phases::phase3_transform::js_ast::nodes::{JsExpr, JsStatement};
 
 /// Visit a declaration tag.
 ///
@@ -68,6 +68,19 @@ pub fn declaration_tag(node: &DeclarationTag, context: &mut ComponentContext) {
         return;
     }
 
+    // Async path (Svelte 5.56.0 #18282 `add_async_declaration`): when the
+    // declaration's initializer is awaited or depends on an async binding,
+    // lower it to a bare `let name;` plus an assignment thunk collected into
+    // `state.async_consts` (emitted as `var promises_N = $.run([...])`), with
+    // blocker-wait thunks for cross-group dependencies. The rune-rewrite
+    // pipeline above already produced the exact lowered RHS (e.g.
+    // `$.state($.proxy(await id))` / `await $.async_derived(() => …)`); we just
+    // restructure it. Reuses `add_const_declaration`, which is upstream's
+    // `add_async_declaration` for the single-binding case.
+    if try_emit_async_declaration(node, trimmed, context).is_some() {
+        return;
+    }
+
     // A multi-declarator declaration tag (`{let a = …, b = …}`) is lowered by
     // the instance-script transform into separate `let`/`const` statements
     // (`let a = …;\nlet b = …;`). Upstream keeps it as one comma-separated
@@ -82,6 +95,102 @@ pub fn declaration_tag(node: &DeclarationTag, context: &mut ComponentContext) {
     };
 
     context.state.consts.push(JsStatement::Raw(raw.into()));
+}
+
+/// Try to emit a `{let x = …}` / `{const x = …}` declaration tag via the
+/// async-declaration lowering (`add_const_declaration` = upstream's
+/// `add_async_declaration`). Returns `Some(())` when handled (the declaration
+/// is a single simple-identifier declarator whose initializer is awaited or
+/// blocked by an async binding), otherwise `None` so the caller falls back to
+/// the synchronous text path.
+fn try_emit_async_declaration(
+    node: &DeclarationTag,
+    lowered: &str,
+    context: &mut ComponentContext,
+) -> Option<()> {
+    let decl_json = node.declaration.as_json();
+    let decls = decl_json.get("declarations")?.as_array()?;
+    // Only the single simple-identifier declarator shape is handled here;
+    // multi-declarator / destructuring async tags fall back to the sync path.
+    if decls.len() != 1 {
+        return None;
+    }
+    let d = decls[0].as_object()?;
+    let id = d.get("id")?;
+    if id.get("type")?.as_str()? != "Identifier" {
+        return None;
+    }
+    let name = id.get("name")?.as_str()?;
+    let init = d.get("init").filter(|i| !i.is_null())?;
+
+    // Identifiers referenced by the initializer, for async-blocker lookup.
+    let mut init_refs: Vec<String> = Vec::new();
+    collect_init_identifiers(init, &mut init_refs);
+
+    let has_await = node.metadata.expression.has_await();
+    let has_blocker = {
+        let bm = context.state.blocker_map.borrow();
+        let cbm = context.state.const_blocker_map.borrow();
+        init_refs
+            .iter()
+            .any(|r| bm.contains_key(r) || cbm.contains_key(r))
+    };
+    // Purely synchronous declarations stay on the text path (which preserves
+    // the user's `let`/`const` keyword verbatim).
+    if !has_await && !has_blocker {
+        return None;
+    }
+
+    // Extract the lowered RHS from `<kind> <name> = <RHS>;`. The first ` = ` is
+    // the declarator assignment (arrow `=>` and the RHS body never produce a
+    // bare ` = ` before it for these shapes).
+    let eq = lowered.find(" = ")?;
+    let rhs = lowered[eq + 3..]
+        .trim_end()
+        .trim_end_matches(';')
+        .trim()
+        .to_string();
+    if rhs.is_empty() {
+        return None;
+    }
+
+    super::const_tag::add_const_declaration(
+        context,
+        name,
+        JsExpr::Raw(rhs.into()),
+        &node.metadata.expression,
+        &init_refs,
+    );
+    Some(())
+}
+
+/// Recursively collect identifier names referenced anywhere in a JSON
+/// expression (over-collecting member-property names is harmless — they won't
+/// match a blocker-map entry).
+fn collect_init_identifiers(value: &serde_json::Value, out: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.get("type").and_then(|t| t.as_str()) == Some("Identifier")
+                && let Some(n) = map.get("name").and_then(|n| n.as_str())
+            {
+                let n = n.to_string();
+                if !out.contains(&n) {
+                    out.push(n);
+                }
+            }
+            for (k, v) in map {
+                if k != "type" {
+                    collect_init_identifiers(v, out);
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr {
+                collect_init_identifiers(v, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Whether a declaration body has a top-level comma (a multi-declarator

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
@@ -47,6 +47,35 @@ pub fn declaration_tag(node: &DeclarationTag, context: &mut ComponentContext) {
         return;
     }
 
+    // Mark the current (and any ancestor) each-block `index` binding as USED when
+    // a declarator initializer references it. Reads of the each index inside a
+    // DeclarationTag init (`{const i = $derived(await index)}`) go through the
+    // instance-script rune pipeline, NOT the template transform tracker, so the
+    // each-block visitor would otherwise omit the `index` callback parameter.
+    // Mirrors how the ConstTag (`{@const}`) path marks index usage via
+    // `build_expression`'s transform tracker.
+    {
+        let decl_json = node.declaration.as_json();
+        if let Some(decls) = decl_json.get("declarations").and_then(|d| d.as_array()) {
+            let mut refs: Vec<String> = Vec::new();
+            for d in decls {
+                if let Some(init) = d.get("init").filter(|i| !i.is_null()) {
+                    collect_init_identifiers(init, &mut refs);
+                }
+            }
+            if let Some(ref idx_name) = context.state.each_index_name
+                && refs.iter().any(|r| r == idx_name)
+            {
+                context.state.each_index_used.set(true);
+            }
+            for (anc_name, anc_used) in &context.state.ancestor_each_index_names {
+                if refs.iter().any(|r| r == anc_name) {
+                    anc_used.set(true);
+                }
+            }
+        }
+    }
+
     // Ensure the statement ends with `;` so the rune-rewriting pipeline (which
     // expects script-like input) can parse and re-emit it cleanly.
     let mut script_input = String::with_capacity(body.len() + 2);
@@ -110,17 +139,23 @@ fn try_emit_async_declaration(
 ) -> Option<()> {
     let decl_json = node.declaration.as_json();
     let decls = decl_json.get("declarations")?.as_array()?;
-    // Only the single simple-identifier declarator shape is handled here;
-    // multi-declarator / destructuring async tags fall back to the sync path.
+    // Only single-declarator tags are async-lowered here; genuine
+    // multi-declarator (`{let a = …, b = …}`) tags fall back to the sync /
+    // rejoin path. Destructuring patterns (`{const { x, y } = …}`) ARE handled
+    // (one declarator with an ObjectPattern / ArrayPattern id).
     if decls.len() != 1 {
         return None;
     }
     let d = decls[0].as_object()?;
     let id = d.get("id")?;
-    if id.get("type")?.as_str()? != "Identifier" {
+    let id_type = id.get("type")?.as_str()?;
+    let is_pattern = matches!(
+        id_type,
+        "ObjectPattern" | "ObjectExpression" | "ArrayPattern" | "ArrayExpression"
+    );
+    if id_type != "Identifier" && !is_pattern {
         return None;
     }
-    let name = id.get("name")?.as_str()?;
     let init = d.get("init").filter(|i| !i.is_null())?;
 
     // Identifiers referenced by the initializer, for async-blocker lookup.
@@ -135,25 +170,68 @@ fn try_emit_async_declaration(
             .iter()
             .any(|r| bm.contains_key(r) || cbm.contains_key(r))
     };
-    // Purely synchronous declarations stay on the text path (which preserves
-    // the user's `let`/`const` keyword verbatim).
-    if !has_await && !has_blocker {
+    // Route through the async-declaration lowering when the initializer awaits,
+    // depends on an async binding, OR an async group is already open in this
+    // fragment (`async_consts.is_some()`). The last clause mirrors upstream's
+    // `mark_async_declaration` condition (`has_await || async_consts ||
+    // blockers.length > 0`): once any tag opens a `$.run` group, every later
+    // declaration in the same block joins it, so a cross-const dep like
+    // `{const after_async = number + 1}` becomes a sequential thunk in the same
+    // group instead of a sync `const` that reads `number` before its thunk has
+    // assigned it. Purely synchronous declarations (no open group) stay on the
+    // text path, which preserves the user's `let`/`const` keyword verbatim.
+    if !has_await && !has_blocker && context.state.async_consts.is_none() {
         return None;
     }
 
-    // Extract the lowered RHS from `<kind> <name> = <RHS>;`. The first ` = ` is
-    // the declarator assignment (arrow `=>` and the RHS body never produce a
-    // bare ` = ` before it for these shapes).
-    let eq = lowered.find(" = ")?;
-    let rhs = lowered[eq + 3..]
-        .trim_end()
-        .trim_end_matches(';')
-        .trim()
-        .to_string();
+    // Extract the lowered RHS robustly: split at the FIRST top-level `=` that is
+    // not part of `==`/`===`/`=>`/`<=`/`>=`/`!=`, so non-canonical spacing in
+    // the source (`after_async =number + 1`) round-trips correctly. The
+    // declarator id (lhs) preceding it may be a multi-token pattern.
+    let rhs = {
+        let body = lowered.trim_end().trim_end_matches(';').trim();
+        let eq = find_top_level_assignment_eq(body)?;
+        body[eq + 1..].trim().to_string()
+    };
     if rhs.is_empty() {
         return None;
     }
 
+    if is_pattern {
+        // Destructuring: emit `let <name>;` per declared id + one assignment
+        // thunk whose LHS is the WHOLE raw pattern (so a binding named like a
+        // `$derived` is not call-wrapped on the assignment target). The raw
+        // pattern comes from the declarator `id` source span.
+        let declared_names = super::const_tag::extract_pattern_identifiers(id);
+        if declared_names.is_empty() {
+            return None;
+        }
+        let src = &context.state.analysis.source;
+        let lhs_pattern = id
+            .get("start")
+            .and_then(|v| v.as_u64())
+            .zip(id.get("end").and_then(|v| v.as_u64()))
+            .and_then(|(st, en)| {
+                let (st, en) = (st as usize, en as usize);
+                if st < en && en <= src.len() {
+                    Some(src[st..en].trim().to_string())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| super::const_tag::render_pattern_text(id));
+        super::const_tag::add_async_declaration_multi(
+            context,
+            &declared_names,
+            &lhs_pattern,
+            JsExpr::Raw(rhs.into()),
+            &node.metadata.expression,
+            &init_refs,
+        );
+        return Some(());
+    }
+
+    let name = id.get("name")?.as_str()?;
     super::const_tag::add_const_declaration(
         context,
         name,
@@ -162,6 +240,37 @@ fn try_emit_async_declaration(
         &init_refs,
     );
     Some(())
+}
+
+/// Find the byte index of the first top-level assignment `=` in `s`, skipping
+/// `==`/`===`/`=>`/`<=`/`>=`/`!=` and any `=` nested inside (), [], {}.
+fn find_top_level_assignment_eq(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth: i32 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b'=' if depth == 0 => {
+                let prev = if i > 0 { bytes[i - 1] } else { 0 };
+                let next = if i + 1 < bytes.len() { bytes[i + 1] } else { 0 };
+                // Skip ==, ===, =>, <=, >=, !=
+                if next == b'=' || next == b'>' {
+                    i += 1;
+                    continue;
+                }
+                if prev == b'=' || prev == b'<' || prev == b'>' || prev == b'!' {
+                    i += 1;
+                    continue;
+                }
+                return Some(i);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Recursively collect identifier names referenced anywhere in a JSON

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -195,6 +195,7 @@ pub fn fragment(
         blocker_map: context.state.blocker_map.clone(),
         blocker_map_primary_names: context.state.blocker_map_primary_names.clone(),
         extra_blocker_indices: Vec::new(),
+        style_shorthand_blocker_names: Vec::new(),
         is_standalone: false,
         const_blocker_map: context.state.const_blocker_map.clone(),
         needs_mutation_validation: context.state.needs_mutation_validation.clone(),
@@ -520,6 +521,25 @@ pub fn fragment(
                 // name already found in `state.update` is a no-op.
                 for memo_expr in state.memoizer.all_expressions() {
                     collect_ids_from_expr_props(&memo_expr, &context.arena, &mut all_names);
+                }
+
+                // Exclude names that are referenced ONLY by shorthand `style:x`
+                // directives. Upstream's `StyleDirective.js` analyze visitor adds a
+                // shorthand directive's binding to `metadata.expression.dependencies`
+                // (not `references`), and the client `Memoizer.check_blockers` only
+                // walks `references`, so a shorthand-only `$.set_style` never emits a
+                // `$$promises[N]` blocker on its `$.template_effect`. `build_set_style`
+                // records such names in `style_shorthand_blocker_names` only when ALL
+                // of that element's style directives are shorthand (if any is a normal
+                // `style:x={expr}`, upstream merges its references and the whole
+                // set_style blocks, so the name is not recorded).
+                if !state.style_shorthand_blocker_names.is_empty() {
+                    all_names.retain(|n| {
+                        !state
+                            .style_shorthand_blocker_names
+                            .iter()
+                            .any(|s| s.as_str() == n.as_str())
+                    });
                 }
 
                 // Collect instance-level blocker indices from blocker_map.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -628,13 +628,33 @@ pub fn fragment(
                 // Use pointer identity to deduplicate (same source pointer = same expression).
                 let mut const_blocker_exprs: Vec<JsExpr> = Vec::new();
                 let mut seen_ptrs: Vec<*const JsExpr> = Vec::new();
+                // Also dedup by VALUE: a destructured async declaration
+                // (`{const { length, 0: first } = await …}`) registers the
+                // SAME `promises[N]` slot for EVERY declared name, but each name
+                // is a separate `const_blocker_map` entry (distinct storage =
+                // distinct pointer). Upstream shares ONE blocker Expression for
+                // the whole pattern (`Memoizer.#blockers = new Set<Expression>`
+                // keyed on identity), so the pattern contributes a SINGLE array
+                // entry. Mirror that by also collapsing structurally-equal
+                // blocker expressions.
+                let mut seen_values: rustc_hash::FxHashSet<String> =
+                    rustc_hash::FxHashSet::default();
                 for name in &all_names {
                     if let Some(blocker_expr) = const_map.get(name.as_str()) {
                         let ptr = blocker_expr as *const JsExpr;
-                        if !seen_ptrs.contains(&ptr) {
-                            seen_ptrs.push(ptr);
-                            const_blocker_exprs.push(blocker_expr.clone());
+                        if seen_ptrs.contains(&ptr) {
+                            continue;
                         }
+                        let value_key =
+                            crate::compiler::phases::phase3_transform::js_ast::codegen::generate_expr(
+                                blocker_expr,
+                                &context.arena,
+                            );
+                        if !seen_values.insert(value_key) {
+                            continue;
+                        }
+                        seen_ptrs.push(ptr);
+                        const_blocker_exprs.push(blocker_expr.clone());
                     }
                 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/if_block.rs
@@ -154,6 +154,15 @@ pub fn if_block(node: &IfBlock, context: &mut ComponentContext) {
         .get_all_blockers_for_expr(&expression, &context.arena);
     let has_blockers = !blocker_exprs.is_empty();
 
+    // Scope `const_blocker_map` to this if-block. The map is name-keyed and
+    // shared (Rc<RefCell>), so a block-local async declaration like
+    // `{let name = $state(await …)}` inside a branch would otherwise overwrite
+    // an outer same-named binding's blocker (e.g. a root `{let name}`),
+    // corrupting the outer fragment's `template_effect` blockers. We snapshot it
+    // here (the branches still SEE outer entries + add their own, visible to
+    // their own nested elements) and restore the snapshot before returning.
+    let saved_const_blocker_map = context.state.const_blocker_map.borrow().clone();
+
     // Collect all flattened if/elseif branches (flattening is suppressed when
     // an else-if's test has blockers not in the outer's set — see
     // `collect_branch_blocker_strings`).
@@ -368,6 +377,10 @@ pub fn if_block(node: &IfBlock, context: &mut ComponentContext) {
     } else {
         context.state.init.push(b::block(statements));
     }
+
+    // Restore the outer `const_blocker_map`, dropping this if-block's
+    // branch-local blocker registrations so they don't leak to the parent.
+    *context.state.const_blocker_map.borrow_mut() = saved_const_blocker_map;
 }
 
 /// Visit a fragment and return its block statement.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -27,7 +27,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::fragmen
     TextOrExpr, is_static_element, process_children,
 };
 use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::{
-    build_template_chunk, expression_has_reactive_state,
+    build_render_statement_with_memoizer, build_template_chunk, expression_has_reactive_state,
 };
 use crate::compiler::phases::phase3_transform::client::visitors::transition_directive::transition_directive;
 use crate::compiler::phases::phase3_transform::client::visitors::use_directive::use_directive;
@@ -1313,16 +1313,69 @@ pub fn visit_regular_element(
         block_body.extend(child_init);
         block_body.extend(element_state_init);
 
-        // Add template_effect for update statements
+        // Add template_effect for update statements. If any update reads an
+        // async-blocked binding (e.g. a nested `{const g = $derived(await …)}`
+        // registers `g` → `promises_N[i]` in const_blocker_map), emit the
+        // blockers as the template_effect's 4th argument via
+        // `build_render_statement_with_memoizer` (which also collapses a single
+        // update into the `() => stmt` form). Mirrors `fragment.rs`.
         if !child_update.is_empty() {
-            block_body.push(b::stmt(
-                &context.arena,
-                b::call(
+            let block_blockers: Option<JsExpr> = {
+                let mut names: Vec<compact_str::CompactString> = Vec::new();
+                for stmt in &child_update {
+                    crate::compiler::phases::phase3_transform::client::visitors::fragment::collect_identifiers_from_statement(
+                        stmt,
+                        &context.arena,
+                        &mut names,
+                    );
+                }
+                let bm = context.state.blocker_map.borrow();
+                let cbm = context.state.const_blocker_map.borrow();
+                let mut exprs: Vec<JsExpr> = Vec::new();
+                let mut seen: rustc_hash::FxHashSet<compact_str::CompactString> =
+                    rustc_hash::FxHashSet::default();
+                for name in &names {
+                    if !seen.insert(name.clone()) {
+                        continue;
+                    }
+                    if let Some(blocker) = cbm.get(name.as_str()) {
+                        exprs.push(blocker.clone());
+                    } else if let Some(&idx) = bm.get(name.as_str()) {
+                        exprs.push(b::member_computed(
+                            &context.arena,
+                            b::id("$$promises"),
+                            b::number(idx as f64),
+                        ));
+                    }
+                }
+                if exprs.is_empty() {
+                    None
+                } else {
+                    Some(b::array(exprs))
+                }
+            };
+            if block_blockers.is_some() {
+                block_body.push(b::stmt(
                     &context.arena,
-                    b::member_path(&context.arena, "$.template_effect"),
-                    vec![b::arrow_block(vec![], child_update)],
-                ),
-            ));
+                    build_render_statement_with_memoizer(
+                        &context.arena,
+                        child_update,
+                        vec![],
+                        None,
+                        None,
+                        block_blockers,
+                    ),
+                ));
+            } else {
+                block_body.push(b::stmt(
+                    &context.arena,
+                    b::call(
+                        &context.arena,
+                        b::member_path(&context.arena, "$.template_effect"),
+                        vec![b::arrow_block(vec![], child_update)],
+                    ),
+                ));
+            }
         }
 
         block_body.extend(child_after_update);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -833,6 +833,23 @@ pub fn visit_regular_element(
         .iter()
         .any(|n| matches!(n, TemplateNode::SnippetBlock(_)));
 
+    // `has_declarations` mirrors upstream `RegularElement.js`:
+    //   const has_declarations = !node.fragment.metadata.transparent;
+    // An element fragment starts transparent and is downgraded to
+    // non-transparent ONLY when it directly contains a `DeclarationTag`
+    // (the new `{const x = …}` / `{let x = …}` syntax — NOT legacy `{@const}`
+    // ConstTag), per the parser's `pop()` rule
+    // (`phases/1-parse/index.js`). When set, the element's children get their
+    // own `consts` scope and are wrapped in a `{ … }` block so a nested
+    // `{const}` can shadow an outer binding of the same name. Computing it
+    // directly off the DeclarationTag presence avoids depending on the
+    // `transparent` metadata being threaded through analysis.
+    let has_declarations = node
+        .fragment
+        .nodes
+        .iter()
+        .any(|n| matches!(n, TemplateNode::DeclarationTag(_)));
+
     // Always create a separate child state for processing children.
     // This matches the JS implementation which always creates:
     //   const child_state = { ...state, init: [], update: [], after_update: [], snippets: [] };
@@ -841,6 +858,44 @@ pub fn visit_regular_element(
     let saved_child_update = std::mem::take(&mut context.state.update);
     let saved_child_after_update = std::mem::take(&mut context.state.after_update);
     let saved_child_snippets = std::mem::take(&mut context.state.snippets);
+    // When the fragment introduces declarations, children get their own
+    // `consts` buffer (upstream `consts: has_declarations ? [] : state.consts`).
+    // We always take the parent consts aside while visiting children, then
+    // either fold the child consts into the element block (has_declarations) or
+    // bubble them back up to the parent (transparent fragment).
+    let saved_child_consts = std::mem::take(&mut context.state.consts);
+
+    // When this element introduces declarations, switch `state.scope` to the
+    // element's Phase-2 child scope (keyed by `element.start` in
+    // `template_scope_map`) for the duration of child processing. `get_binding`
+    // is scope-aware (it consults `self.scope` first, then walks parents), so a
+    // nested `{const doubled}` then resolves to the block-local binding instead
+    // of an outer same-named `$derived`, and `scope.evaluate` can constant-fold
+    // it. Only done for `has_declarations` to keep resolution unchanged for the
+    // overwhelmingly common transparent element. Mirrors upstream's per-element
+    // `child_state.scope` (the fragment walker carries the fragment's scope).
+    let saved_scope = context.state.scope;
+    let saved_transform = context.state.transform.clone();
+    if has_declarations
+        && let Some(child_scope) = context
+            .state
+            .scope_root
+            .template_scope_map
+            .get(&node.start)
+            .and_then(|idx| context.state.scope_root.all_scopes.get(*idx))
+    {
+        // The child scope's declarations are exactly this element's
+        // DeclarationTag bindings. Drop any same-named instance-level
+        // `transform` entry (e.g. an outer `$derived` that maps the name to
+        // `$.get(name)`) so the block-local binding wins: `get_binding`
+        // resolves to the const and `get_literal_value` can constant-fold it
+        // instead of `convert_expression` emitting `$.get(...)`.
+        let decl_names: Vec<String> = child_scope.declarations.keys().cloned().collect();
+        context.state.scope = child_scope;
+        for n in &decl_names {
+            context.state.transform.remove(n);
+        }
+    }
 
     // Propagate preserve_whitespace to child processing so that `pre`/`textarea`
     // whitespace is preserved for ExpressionTag/Text content within nested elements.
@@ -1167,17 +1222,33 @@ pub fn visit_regular_element(
     let child_init = std::mem::take(&mut context.state.init);
     let child_update = std::mem::take(&mut context.state.update);
     let child_after_update = std::mem::take(&mut context.state.after_update);
+    let child_consts = std::mem::take(&mut context.state.consts);
 
     // Restore the parent state
     context.state.init = saved_child_init;
     context.state.update = saved_child_update;
     context.state.after_update = saved_child_after_update;
     context.state.snippets = saved_child_snippets;
+    context.state.consts = saved_child_consts;
+    context.state.scope = saved_scope;
+    context.state.transform = saved_transform;
+    // For a transparent fragment (no DeclarationTag), child consts (e.g. legacy
+    // `{@const}` that bubbled up from a nested transparent element) flow back to
+    // the parent scope. When `has_declarations`, they are instead emitted inside
+    // the element block below, so they are not pushed here.
+    if !has_declarations {
+        context.state.consts.extend(child_consts.iter().cloned());
+    }
 
-    if has_snippet_blocks {
-        // Wrap children in `{...}` to avoid declaration conflicts
+    if has_snippet_blocks || has_declarations {
+        // Wrap children in `{...}` to avoid declaration conflicts.
+        // Upstream block order: snippets, consts, init, element_state.init,
+        // render(update), after_update, element_state.after_update.
         let mut block_body = Vec::new();
         block_body.extend(child_snippets);
+        if has_declarations {
+            block_body.extend(child_consts);
+        }
         block_body.extend(child_init);
         block_body.extend(element_state_init);
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -864,6 +864,16 @@ pub fn visit_regular_element(
     // either fold the child consts into the element block (has_declarations) or
     // bubble them back up to the parent (transparent fragment).
     let saved_child_consts = std::mem::take(&mut context.state.consts);
+    // When the fragment introduces declarations, the child also gets a fresh
+    // `async_consts` group (upstream `async_consts: has_declarations ? undefined`)
+    // so a nested `{const = $derived(await …)}` / `{let = $state(await …)}`
+    // emits its own `var promises_N = $.run([…])` inside the element block,
+    // rather than leaking its thunk into the enclosing block's group.
+    let saved_async_consts = if has_declarations {
+        context.state.async_consts.take()
+    } else {
+        None
+    };
 
     // When this element introduces declarations, switch `state.scope` to the
     // element's Phase-2 child scope (keyed by `element.start` in
@@ -890,9 +900,29 @@ pub fn visit_regular_element(
         // `$.get(name)`) so the block-local binding wins: `get_binding`
         // resolves to the const and `get_literal_value` can constant-fold it
         // instead of `convert_expression` emitting `$.get(...)`.
-        let decl_names: Vec<String> = child_scope.declarations.keys().cloned().collect();
+        //
+        // ONLY for non-reactive (literal/plain `const`) declarations — those
+        // shadow an outer reactive binding. A block-local reactive declaration
+        // (`{let x = $state(…)}` / `{const y = $derived(…)}`) needs to KEEP its
+        // own `$.get` transform, so it is left in place.
+        use crate::compiler::phases::phase2_analyze::scope::BindingKind;
+        let removable_names: Vec<String> = child_scope
+            .declarations
+            .iter()
+            .filter(|entry| {
+                let idx = *entry.1;
+                match context.state.scope_root.bindings.get(idx) {
+                    Some(b) => !matches!(
+                        b.kind,
+                        BindingKind::State | BindingKind::RawState | BindingKind::Derived
+                    ),
+                    None => true,
+                }
+            })
+            .map(|entry| entry.0.clone())
+            .collect();
         context.state.scope = child_scope;
-        for n in &decl_names {
+        for n in &removable_names {
             context.state.transform.remove(n);
         }
     }
@@ -1223,6 +1253,31 @@ pub fn visit_regular_element(
     let child_update = std::mem::take(&mut context.state.update);
     let child_after_update = std::mem::take(&mut context.state.after_update);
     let child_consts = std::mem::take(&mut context.state.consts);
+    // Take the child's async_consts group (if any) and build its
+    // `var promises_N = $.run([…thunks])` declaration, mirroring
+    // `fragment.rs`. Emitted into the block after the consts, before init.
+    let child_async_consts_stmt = if has_declarations {
+        context.state.async_consts.take().and_then(|ac| {
+            if ac.thunks.is_empty() {
+                return None;
+            }
+            let id_name = match &ac.id {
+                JsExpr::Identifier(name) => name.clone(),
+                _ => "promises".into(),
+            };
+            Some(b::var_decl(
+                &context.arena,
+                id_name,
+                Some(b::call(
+                    &context.arena,
+                    b::member_path(&context.arena, "$.run"),
+                    vec![b::array(ac.thunks)],
+                )),
+            ))
+        })
+    } else {
+        None
+    };
 
     // Restore the parent state
     context.state.init = saved_child_init;
@@ -1232,6 +1287,9 @@ pub fn visit_regular_element(
     context.state.consts = saved_child_consts;
     context.state.scope = saved_scope;
     context.state.transform = saved_transform;
+    if has_declarations {
+        context.state.async_consts = saved_async_consts;
+    }
     // For a transparent fragment (no DeclarationTag), child consts (e.g. legacy
     // `{@const}` that bubbled up from a nested transparent element) flow back to
     // the parent scope. When `has_declarations`, they are instead emitted inside
@@ -1248,6 +1306,9 @@ pub fn visit_regular_element(
         block_body.extend(child_snippets);
         if has_declarations {
             block_body.extend(child_consts);
+            if let Some(stmt) = child_async_consts_stmt {
+                block_body.push(stmt);
+            }
         }
         block_body.extend(child_init);
         block_body.extend(element_state_init);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -1055,6 +1055,29 @@ pub fn build_set_style(
             prev = b::id(&id);
             previous_id = Some(id);
         }
+
+        // Upstream `StyleDirective.js` (analyze) adds a SHORTHAND directive's
+        // binding to `metadata.expression.dependencies` rather than `references`,
+        // and the client `Memoizer.check_blockers` only walks `references`. As a
+        // result a `$.set_style` whose directives are ALL shorthand never
+        // contributes a `$$promises[N]` blocker to its `$.template_effect`. Record
+        // the shorthand directive names so the Rust blocker scan (which works off
+        // the literal update-statement identifiers) can exclude them. If ANY
+        // directive in this set is non-shorthand, upstream merges its references
+        // into the shared metadata and the whole `set_style` blocks, so we record
+        // nothing.
+        if has_state
+            && style_directives
+                .iter()
+                .all(|d| matches!(&d.value, AttributeValue::True(true)))
+        {
+            for d in style_directives {
+                let name = d.name.to_string();
+                if !context.state.style_shorthand_blocker_names.contains(&name) {
+                    context.state.style_shorthand_blocker_names.push(name);
+                }
+            }
+        }
     }
 
     // Build the $.set_style call

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3932,6 +3932,27 @@ fn is_expression_defined_json(json_value: &serde_json::Value, context: &Componen
                     if matches!(binding.kind, BindingKind::EachIndex) {
                         return true;
                     }
+                    // A template-scoped DeclarationTag / ConstTag binding
+                    // (`{const after_async = number + 1}`) is defined when its
+                    // initializer is a statically-non-nullish shape. Upstream's
+                    // `is_defined` walks `binding.initial`; mirror that with the
+                    // recorded `initial_node_type` so e.g. `after_async`
+                    // (BinaryExpression) reads bare while `number`
+                    // (AwaitExpression) keeps `?? ''`.
+                    if matches!(binding.kind, BindingKind::Template)
+                        && binding.initial_is_defined
+                        && let Some(ref ity) = binding.initial_node_type
+                        && matches!(
+                            ity.as_str(),
+                            "BinaryExpression"
+                                | "UpdateExpression"
+                                | "ArrayExpression"
+                                | "ObjectExpression"
+                                | "TemplateLiteral"
+                        )
+                    {
+                        return true;
+                    }
                     // For Normal const bindings with defined initial value
                     if matches!(binding.kind, BindingKind::Normal)
                         && !binding.reassigned

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3514,6 +3514,33 @@ pub(crate) fn get_literal_value(
                     "false" => Some(Some("false".to_string())),
                     "null" | "undefined" => Some(None),
                     _ => {
+                        // Check for a JSON `Literal` node form (from binding.initial,
+                        // e.g. a `{const x = 'nested'}` DeclarationTag whose initial is
+                        // stored as `{"type":"Literal",...,"value":"nested","raw":"'nested'"}`).
+                        // Mirrors upstream `scope.evaluate()` returning the literal value.
+                        if init.contains("\"type\":\"Literal\"")
+                            && let Ok(parsed) = serde_json::from_str::<serde_json::Value>(init)
+                            && parsed.get("type").and_then(|t| t.as_str()) == Some("Literal")
+                        {
+                            return match parsed.get("value") {
+                                Some(v) if v.is_string() => {
+                                    Some(Some(v.as_str().unwrap().to_string()))
+                                }
+                                Some(v) if v.is_f64() || v.is_i64() || v.is_u64() => {
+                                    let n = v.as_f64().unwrap();
+                                    if n.fract() == 0.0 {
+                                        Some(Some(format!("{}", n as i64)))
+                                    } else {
+                                        Some(Some(n.to_string()))
+                                    }
+                                }
+                                Some(v) if v.is_boolean() => {
+                                    Some(Some(v.as_bool().unwrap().to_string()))
+                                }
+                                Some(v) if v.is_null() => Some(None),
+                                _ => None,
+                            };
+                        }
                         // Check for TemplateLiteral JSON format (from binding.initial)
                         // Template literals without expressions are known compile-time values
                         if init.contains("\"type\":\"TemplateLiteral\"")

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/svelte_boundary.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/svelte_boundary.rs
@@ -80,20 +80,25 @@ pub fn svelte_boundary(node: &SvelteElement, context: &mut ComponentContext) {
 
     let use_async = context.state.options.experimental_async;
 
-    // In async mode, check if there are const tags (needed to decide snippet hoisting)
+    // In async mode, check if there are const tags OR declaration tags (needed to
+    // decide snippet hoisting). Mirrors upstream SvelteBoundary.js which tracks
+    // both `has_const` (ConstTag, `{@const}`) and `has_declaration` (DeclarationTag,
+    // `{const x = …}` / `{let x = …}`) and keeps non-special snippets inside the
+    // boundary callback when either is present (so the snippet can reference them).
     let has_const = use_async
-        && node
-            .fragment
-            .nodes
-            .iter()
-            .any(|n| matches!(n, TemplateNode::ConstTag(_)));
+        && node.fragment.nodes.iter().any(|n| {
+            matches!(
+                n,
+                TemplateNode::ConstTag(_) | TemplateNode::DeclarationTag(_)
+            )
+        });
 
     // Process fragment children
     for child in &node.fragment.nodes {
         match child {
-            TemplateNode::ConstTag(_) => {
-                // In async mode, const tags live inside the boundary content
-                // In non-async mode, they are also processed inline
+            TemplateNode::ConstTag(_) | TemplateNode::DeclarationTag(_) => {
+                // In async mode, const / declaration tags live inside the boundary
+                // content. In non-async mode, they are also processed inline.
                 content_nodes.push(child.clone());
             }
             TemplateNode::SnippetBlock(snippet) => {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/build.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/build.rs
@@ -2657,10 +2657,16 @@ impl<'a> ServerCodeGenerator<'a> {
                     hoisted.push(part.clone());
                     in_hoisted_region = true;
                 }
-                OutputPart::RawStatement(s) if s.starts_with("let ") || s.starts_with("var ") => {
-                    // Hoist `let` and `var` declarations (from async const tags) alongside
-                    // ConstDeclaration and SnippetFunction to match the official
-                    // compiler's state.init ordering.
+                OutputPart::RawStatement(s)
+                    if s.starts_with("let ")
+                        || s.starts_with("var ")
+                        || s.starts_with("const ") =>
+                {
+                    // Hoist `let` / `var` / `const` declarations (from async const
+                    // tags and DeclarationTags `{let x = …}` / `{const x = …}`)
+                    // alongside ConstDeclaration and SnippetFunction to match the
+                    // official compiler's state.init ordering (declarations sit at
+                    // the top of the enclosing block before any rendered HTML).
                     hoisted.push(part.clone());
                     in_hoisted_region = true;
                 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
@@ -1518,6 +1518,31 @@ impl<'a> ServerCodeGenerator<'a> {
         let mut prev_text_ends_with_ws = false;
 
         for (i, node) in nodes.iter().enumerate() {
+            // Flush accumulated root-level async consts before processing a
+            // non-hoisted, non-whitespace node. The root fragment runs directly
+            // on `self` (no child generator), so unlike if/each/snippet bodies
+            // it has no other flush site — without this, a root-level
+            // `{let name = $state(await …)}` seeds `self.async_consts` but its
+            // `var promises = $$renderer.run([…])` is never emitted. Mirrors
+            // `fragment.rs` / `if_block.rs` flush discipline. `flush_async_consts`
+            // is a no-op when the group is None/empty, so this never disturbs the
+            // instance-script `$$promises` group (a separate Raw statement) nor
+            // any fixture without a root async declaration. Whitespace-only text
+            // is skipped so two consecutive declarations separated by template
+            // whitespace still group into one `$$renderer.run`.
+            let is_root_hoisted = matches!(
+                node,
+                TemplateNode::ConstTag(_)
+                    | TemplateNode::SnippetBlock(_)
+                    | TemplateNode::DeclarationTag(_)
+            ) || (matches!(node, TemplateNode::Comment(_))
+                && !self.preserve_comments);
+            let is_ws_only_text =
+                matches!(node, TemplateNode::Text(t) if is_svelte_whitespace_only(&t.data));
+            if !is_root_hoisted && !is_ws_only_text {
+                self.flush_async_consts();
+            }
+
             // Skip whitespace-only text at root level (unless preserveWhitespace is set)
             if !self.preserve_whitespace
                 && let TemplateNode::Text(text) = node
@@ -1796,6 +1821,8 @@ impl<'a> ServerCodeGenerator<'a> {
 
             self.generate_node(node, true)?;
         }
+        // Emit any trailing root-level async-const group (no-op when None/empty).
+        self.flush_async_consts();
         Ok(())
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/const_tag.rs
@@ -486,9 +486,37 @@ impl<'a> ServerCodeGenerator<'a> {
             let rhs = after_kw[eq_idx + 1..].trim().to_string();
             let init_refs = extract_identifiers_from_expr(&rhs);
             let blockers = self.compute_decl_tag_blockers(&init_refs);
-            if has_await || !blockers.is_empty() {
+            // Route through the async-declaration lowering when the initializer
+            // awaits, has a cross-group blocker, OR an async group is already
+            // open in this fragment (`self.async_consts.is_some()`). The last
+            // clause mirrors upstream's `mark_async_declaration` condition
+            // (`has_await || context.state.async_consts || blockers.length > 0`):
+            // once any tag opens a `$$renderer.run` group, every later
+            // declaration in the same block joins it, so a cross-const dep like
+            // `{const after_async = number + 1}` becomes a sequential thunk in
+            // the same group rather than a sync `const` that reads `number`
+            // before its thunk has assigned it. Mirrors the equivalent gate in
+            // `generate_const_tag` (the ConstTag / `{@const}` twin).
+            if has_await || !blockers.is_empty() || self.async_consts.is_some() {
                 let declared_names = extract_declared_names(&lhs);
-                self.emit_async_decl_tag(&declared_names, &lhs, &rhs, has_await, &blockers);
+                // For a destructuring LHS, take the pattern text from the RAW
+                // source (the declarator `id` span) so a binding whose name
+                // collides with a component-wide `$derived` (`length`) is NOT
+                // rewritten to `length()` inside the assignment TARGET. Reads in
+                // the RHS / template still go through the derived-wrap; only the
+                // assignment target must stay un-wrapped.
+                let lhs_for_assign = if lhs.starts_with('{') || lhs.starts_with('[') {
+                    self.raw_declarator_id(tag).unwrap_or_else(|| lhs.clone())
+                } else {
+                    lhs.clone()
+                };
+                self.emit_async_decl_tag(
+                    &declared_names,
+                    &lhs_for_assign,
+                    &rhs,
+                    has_await,
+                    &blockers,
+                );
                 return Ok(());
             }
         }
@@ -533,6 +561,25 @@ impl<'a> ServerCodeGenerator<'a> {
             }
         }
         Ok(())
+    }
+
+    /// Return the RAW source text of a single-declarator DeclarationTag's `id`
+    /// pattern (e.g. `{ length, 0: first }`). Used as the assignment-target text
+    /// for a destructured async declaration so the un-rewritten pattern is used
+    /// (no derived-call wrapping leaks into the assignment LHS).
+    fn raw_declarator_id(&self, tag: &DeclarationTag) -> Option<String> {
+        let decl_json = tag.declaration.as_json();
+        let decls = decl_json.get("declarations").and_then(|d| d.as_array())?;
+        if decls.len() != 1 {
+            return None;
+        }
+        let id = decls[0].get("id")?;
+        let start = id.get("start").and_then(|v| v.as_u64())? as usize;
+        let end = id.get("end").and_then(|v| v.as_u64())? as usize;
+        if start >= end || end > self.source.len() {
+            return None;
+        }
+        Some(self.source[start..end].trim().to_string())
     }
 
     /// Compute the cross-group async blockers for a DeclarationTag whose
@@ -678,6 +725,26 @@ impl<'a> ServerCodeGenerator<'a> {
             self.const_blocker_map
                 .borrow_mut()
                 .insert(name.clone(), blocker_expr);
+        }
+
+        // A DeclarationTag whose initializer is NOT a `$derived` declares a
+        // PLAIN (non-reactive) binding — e.g. the destructured
+        // `{const { length, 0: first } = await '01234'}`. If such a binding's
+        // name collides with a component-wide `$derived` of the same name
+        // declared in a sibling/nested scope (here the snippet's
+        // `{const length = $derived(await number)}`), the flat `derived_names`
+        // set would wrongly wrap this scope's plain read as `length()`. Shadow
+        // the derived name in THIS generator's `derived_names` so subsequent
+        // reads at this scope stay plain. Nested snippet bodies build a fresh
+        // `ServerCodeGenerator` (re-seeding `derived_names` from analysis), so
+        // their own derived reads are unaffected.
+        let is_derived = extract_async_derived_thunk_body(rhs).is_some()
+            || rhs.contains("$.derived(")
+            || rhs.contains("$.derived_safe_equal(");
+        if !is_derived {
+            for name in declared_names {
+                self.derived_names.remove(name);
+            }
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/const_tag.rs
@@ -466,6 +466,42 @@ impl<'a> ServerCodeGenerator<'a> {
             format!("{};", trimmed)
         };
         self.output_parts.push(OutputPart::RawStatement(stmt));
+
+        // Populate `constant_vars` for foldable literal declarators so reads of
+        // the binding constant-fold to the literal in template expressions
+        // (mirrors `generate_const_tag` + upstream `scope.evaluate`). Reactive
+        // initializers (`$state(…)` / `$derived(…)`) don't fold, so they're
+        // left out and continue to read via their runtime form.
+        let decl_json = tag.declaration.as_json();
+        if let Some(decls) = decl_json.get("declarations").and_then(|d| d.as_array()) {
+            for d in decls {
+                let (Some(id), Some(init)) = (d.get("id"), d.get("init")) else {
+                    continue;
+                };
+                if init.is_null() || id.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+                    continue;
+                }
+                let Some(name) = id.get("name").and_then(|n| n.as_str()) else {
+                    continue;
+                };
+                let (Some(s), Some(e)) = (
+                    init.get("start").and_then(|v| v.as_u64()),
+                    init.get("end").and_then(|v| v.as_u64()),
+                ) else {
+                    continue;
+                };
+                let (s, e) = (s as usize, e as usize);
+                if s >= e || e > self.source.len() {
+                    continue;
+                }
+                let rhs = self.source[s..e].trim();
+                if let Some(folded) =
+                    super::super::helpers::try_evaluate_with_constants(rhs, &self.constant_vars)
+                {
+                    self.constant_vars.insert(name.to_string(), folded);
+                }
+            }
+        }
         Ok(())
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/const_tag.rs
@@ -465,6 +465,36 @@ impl<'a> ServerCodeGenerator<'a> {
         } else {
             format!("{};", trimmed)
         };
+
+        // Decide sync vs async from the LOWERED declaration. An awaited or
+        // blocked initializer (`{let x = $state(await …)}` /
+        // `{const y = $derived(await …)}` / `{let z = $state(awaited_binding)}`)
+        // is lowered to a bare `let name;` plus an assignment thunk collected
+        // into `self.async_consts` (emitted `var promises_N =
+        // $$renderer.run([…])`), with blocker-wait thunks — mirroring the
+        // ConstTag async path (`generate_const_tag`).
+        let has_await = tag.metadata.expression.has_await();
+        let body_no_semi = stmt.trim_end().trim_end_matches(';').trim();
+        let after_kw = body_no_semi
+            .strip_prefix("let ")
+            .or_else(|| body_no_semi.strip_prefix("const "))
+            .or_else(|| body_no_semi.strip_prefix("var "))
+            .unwrap_or(body_no_semi)
+            .trim();
+        if let Some(eq_idx) = find_assignment_eq(after_kw) {
+            let lhs = after_kw[..eq_idx].trim().to_string();
+            let rhs = after_kw[eq_idx + 1..].trim().to_string();
+            let init_refs = extract_identifiers_from_expr(&rhs);
+            let blockers = self.compute_decl_tag_blockers(&init_refs);
+            if has_await || !blockers.is_empty() {
+                let declared_names = extract_declared_names(&lhs);
+                self.emit_async_decl_tag(&declared_names, &lhs, &rhs, has_await, &blockers);
+                return Ok(());
+            }
+        }
+
+        // Synchronous path: emit the rewritten declaration verbatim (preserving
+        // the user's `let`/`const` keyword).
         self.output_parts.push(OutputPart::RawStatement(stmt));
 
         // Populate `constant_vars` for foldable literal declarators so reads of
@@ -503,6 +533,136 @@ impl<'a> ServerCodeGenerator<'a> {
             }
         }
         Ok(())
+    }
+
+    /// Compute the cross-group async blockers for a DeclarationTag whose
+    /// initializer references `init_refs`. Mirrors the blocker computation in
+    /// `generate_const_tag`: a referenced binding registered in
+    /// `const_blocker_map` (a different async_consts group) or in the
+    /// instance-level `top_level_blocker_map` (`$$promises[N]`) contributes a
+    /// wait expression. Blockers within the current group are skipped (they are
+    /// ordered implicitly by sequential `$$renderer.run` execution).
+    fn compute_decl_tag_blockers(&self, init_refs: &[String]) -> Vec<String> {
+        let current_group_name = self.async_consts.as_ref().map(|g| g.name.clone());
+        let const_blocker_map = self.const_blocker_map.borrow();
+        let mut blist: Vec<String> = Vec::new();
+        for name in init_refs {
+            if let Some(blocker_expr) = const_blocker_map.get(name) {
+                if let Some(ref group_name) = current_group_name
+                    && blocker_expr.starts_with(&format!("{}[", group_name))
+                {
+                    continue;
+                }
+                if !blist.contains(blocker_expr) {
+                    blist.push(blocker_expr.clone());
+                }
+            } else if let Some(&idx) = self.top_level_blocker_map.get(name) {
+                let blocker_expr = format!("$$promises[{}]", idx);
+                if !blist.contains(&blocker_expr) {
+                    blist.push(blocker_expr);
+                }
+            }
+        }
+        blist
+    }
+
+    /// Emit a DeclarationTag through the async-declaration lowering: a bare
+    /// `let name;` for each declared binding, blocker-wait thunk(s), and the
+    /// deferred assignment thunk, all collected into `self.async_consts` (which
+    /// `flush_async_consts` renders as `var promises_N = $$renderer.run([…])`).
+    /// Registers each binding's blocker in `const_blocker_map` so downstream
+    /// reactive reads wrap in `$$renderer.async([promises_N[i]], …)`. Mirrors
+    /// the async branch of `generate_const_tag`.
+    fn emit_async_decl_tag(
+        &mut self,
+        declared_names: &[String],
+        lhs: &str,
+        rhs: &str,
+        has_await: bool,
+        blockers: &[String],
+    ) {
+        if self.async_consts.is_none() {
+            let group_name = self.generate_promises_name();
+            self.async_consts = Some(super::super::AsyncConstsGroup {
+                name: group_name,
+                thunks: Vec::new(),
+                declared_vars: Vec::new(),
+            });
+        }
+
+        for name in declared_names {
+            self.output_parts
+                .push(OutputPart::RawStatement(format!("let {};", name)));
+        }
+
+        let group = self.async_consts.as_mut().unwrap();
+
+        if blockers.len() == 1 {
+            group.thunks.push((format!("() => {}", blockers[0]), false));
+        } else if blockers.len() > 1 {
+            group.thunks.push((
+                format!("() => Promise.all([{}])", blockers.join(", ")),
+                false,
+            ));
+        }
+
+        let is_destructuring = lhs.starts_with('{') || lhs.starts_with('[');
+        // Re-indent multiline rhs so inner lines align with the thunk body.
+        let normalize_rhs = |rhs: &str| -> String {
+            if !rhs.contains('\n') {
+                return rhs.to_string();
+            }
+            let lines: Vec<&str> = rhs.lines().collect();
+            if lines.len() <= 1 {
+                return rhs.to_string();
+            }
+            let min_indent = lines[1..]
+                .iter()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| l.len() - l.trim_start().len())
+                .min()
+                .unwrap_or(0);
+            let mut result = lines[0].to_string();
+            for line in &lines[1..] {
+                result.push('\n');
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let stripped = if min_indent <= line.len() {
+                    &line[min_indent..]
+                } else {
+                    line.trim()
+                };
+                result.push_str("\t\t");
+                result.push_str(stripped);
+            }
+            result
+        };
+
+        let thunk_code = if has_await {
+            let save_wrapped = super::super::helpers::transform_await_to_save(rhs);
+            let save_wrapped = normalize_rhs(&save_wrapped);
+            if is_destructuring {
+                format!("async () => ({} = {})", lhs, save_wrapped)
+            } else {
+                format!("async () => {} = {}", lhs, save_wrapped)
+            }
+        } else if is_destructuring {
+            format!("() => ({} = {})", lhs, normalize_rhs(rhs))
+        } else {
+            format!("() => {} = {}", lhs, normalize_rhs(rhs))
+        };
+        let thunk_index = group.thunks.len();
+        group.thunks.push((thunk_code, has_await));
+
+        let group_name = group.name.clone();
+        for name in declared_names {
+            group.declared_vars.push((name.clone(), thunk_index));
+            let blocker_expr = format!("{}[{}]", group_name, thunk_index);
+            self.const_blocker_map
+                .borrow_mut()
+                .insert(name.clone(), blocker_expr);
+        }
     }
 
     /// Flush accumulated async const tags into a single `$$renderer.run([...])` call.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/const_tag.rs
@@ -640,7 +640,23 @@ impl<'a> ServerCodeGenerator<'a> {
         };
 
         let thunk_code = if has_await {
-            let save_wrapped = super::super::helpers::transform_await_to_save(rhs);
+            let save_wrapped = if let Some(inner_body) = extract_async_derived_thunk_body(rhs) {
+                // RHS is the lowered async-derived shape
+                // `await $.async_derived(() => X)`. Upstream keeps the OUTER
+                // `await $.async_derived(...)` untouched and save-wraps the
+                // INNER thunk body (re-adding the inner `await` the rune
+                // pipeline stripped):
+                //   `await $.async_derived(async () => (await $.save(X))())`.
+                let saved_body = super::super::helpers::transform_await_to_save(&format!(
+                    "await {}",
+                    inner_body
+                ));
+                format!("await $.async_derived(async () => {})", saved_body)
+            } else {
+                // `$state(await …)` etc. — the single outer await is the save
+                // target: `(await $.save(id))()`.
+                super::super::helpers::transform_await_to_save(rhs)
+            };
             let save_wrapped = normalize_rhs(&save_wrapped);
             if is_destructuring {
                 format!("async () => ({} = {})", lhs, save_wrapped)
@@ -747,6 +763,65 @@ fn find_assignment_eq(decl: &str) -> Option<usize> {
     None
 }
 
+/// If `rhs` is the lowered async-derived shape `await $.async_derived(<thunk>)`,
+/// return the thunk body `X` (the expression the inner arrow returns), with the
+/// rune pipeline's stripped inner `await` already removed. Handles the arrow
+/// shapes the server rune pipeline can emit:
+///   `await $.async_derived(() => X)`       -> Some("X")
+///   `await $.async_derived(async () => X)` -> Some("X")
+/// Uses bracket-matched extraction of the `$.async_derived(` argument so an
+/// inner body that itself ends in `)` is handled correctly.
+fn extract_async_derived_thunk_body(rhs: &str) -> Option<String> {
+    let t = rhs.trim();
+    const PREFIX: &str = "await $.async_derived(";
+    let after = t.strip_prefix(PREFIX)?;
+    // The remaining text after PREFIX is `<thunk>)` — find the closing paren
+    // that matches the `(` of `$.async_derived(`. We scan `after` with depth 1.
+    let bytes = after.as_bytes();
+    let mut depth = 1i32;
+    let mut i = 0;
+    let mut in_str: Option<u8> = None;
+    let mut close_idx = None;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if let Some(q) = in_str {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == q {
+                in_str = None;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\'' | b'"' | b'`' => in_str = Some(c),
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    close_idx = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    let close = close_idx?;
+    // Anything after the matched close paren means this is not a clean
+    // `await $.async_derived(<thunk>)` (e.g. trailing operators) — bail.
+    if !after[close + 1..].trim().is_empty() {
+        return None;
+    }
+    let inner = after[..close].trim();
+    inner
+        .strip_prefix("async () =>")
+        .or_else(|| inner.strip_prefix("() =>"))
+        .map(|body| body.trim().to_string())
+}
+
 /// Extract declared variable names from a destructuring pattern or simple identifier.
 /// Returns a list of identifier names declared by the LHS of a const tag declaration.
 fn extract_declared_names(lhs: &str) -> Vec<String> {
@@ -775,25 +850,69 @@ fn extract_identifiers_from_expr(expr: &str) -> Vec<String> {
     let chars: Vec<char> = expr.chars().collect();
     let len = chars.len();
     let mut i = 0;
-    let mut in_string = false;
-    let mut string_char = ' ';
 
     while i < len {
         let c = chars[i];
 
-        // String tracking
-        if c == '\'' || c == '"' || c == '`' {
-            if !in_string {
-                in_string = true;
-                string_char = c;
-            } else if c == string_char && (i == 0 || chars[i - 1] != '\\') {
-                in_string = false;
-            }
+        // Template literal: skip the literal text but recurse into `${ … }`
+        // interpolations so a `${name}` dependency is detected (mirrors
+        // upstream, where the interpolation expression is a real reference).
+        if c == '`' {
             i += 1;
+            while i < len {
+                let tc = chars[i];
+                if tc == '\\' {
+                    i += 2;
+                    continue;
+                }
+                if tc == '`' {
+                    i += 1;
+                    break;
+                }
+                if tc == '$' && i + 1 < len && chars[i + 1] == '{' {
+                    // Capture the balanced-brace interpolation body.
+                    let mut depth = 1i32;
+                    let inner_start = i + 2;
+                    let mut j = inner_start;
+                    while j < len && depth > 0 {
+                        match chars[j] {
+                            '{' => depth += 1,
+                            '}' => depth -= 1,
+                            _ => {}
+                        }
+                        if depth == 0 {
+                            break;
+                        }
+                        j += 1;
+                    }
+                    let inner: String = chars[inner_start..j].iter().collect();
+                    for id in extract_identifiers_from_expr(&inner) {
+                        idents.push(id);
+                    }
+                    i = if j < len { j + 1 } else { j };
+                    continue;
+                }
+                i += 1;
+            }
             continue;
         }
-        if in_string {
+
+        // Single/double quoted string: skip entirely.
+        if c == '\'' || c == '"' {
+            let quote = c;
             i += 1;
+            while i < len {
+                let sc = chars[i];
+                if sc == '\\' {
+                    i += 2;
+                    continue;
+                }
+                if sc == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
             continue;
         }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/each_block.rs
@@ -152,7 +152,9 @@ impl<'a> ServerCodeGenerator<'a> {
             let mut prev_hoisted = false;
             while first_visible < end_idx {
                 match body_nodes[first_visible] {
-                    TemplateNode::ConstTag(_) | TemplateNode::SnippetBlock(_) => {
+                    TemplateNode::ConstTag(_)
+                    | TemplateNode::DeclarationTag(_)
+                    | TemplateNode::SnippetBlock(_) => {
                         first_visible += 1;
                         prev_hoisted = true;
                     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/element.rs
@@ -89,8 +89,39 @@ impl<'a> ServerCodeGenerator<'a> {
         // `{const doubled = 'nested'}` must not leak its fold to an outer
         // same-named binding once the block closes.
         let saved_constants = self.constant_vars.clone();
+        // Set the parent's pending async_consts group aside so a nested
+        // `{const g = $derived(await …)}` / `{let l = $state(await …)}` emits
+        // its own `var promises_N = $$renderer.run([…])` INSIDE this element
+        // block (mirrors upstream `RegularElement.js`
+        // `async_consts: has_declarations ? undefined` and the client
+        // `regular_element.rs` has_declarations path).
+        let saved_async_consts = self.async_consts.take();
+        // Snapshot the const_blocker_map keys present BEFORE this element so we
+        // can prune only the block-local bindings it adds. The parent entries
+        // are kept intact while generating the body so a cross-group blocker
+        // lookup (e.g. greeting2 -> name -> promises_1[0]) still resolves.
+        let cbm_keys_before: rustc_hash::FxHashSet<String> =
+            self.const_blocker_map.borrow().keys().cloned().collect();
         self.generate_element_inner(element)?;
+        // Flush the element's own pending async_consts INTO the captured body
+        // (emits `var promises_N = …` + ConstBlockerMetadata). The build-time
+        // hoist moves the `var promises_N` to the top of the `{ }` block.
+        self.flush_async_consts();
         self.constant_vars = saved_constants;
+        self.async_consts = saved_async_consts;
+        // Remove only the block-local keys this element added; keep the parent
+        // map otherwise untouched (scoped restore, NOT a blanket save/restore).
+        {
+            let mut cbm = self.const_blocker_map.borrow_mut();
+            let added: Vec<String> = cbm
+                .keys()
+                .filter(|k| !cbm_keys_before.contains(*k))
+                .cloned()
+                .collect();
+            for k in added {
+                cbm.remove(&k);
+            }
+        }
         let body = std::mem::replace(&mut self.output_parts, saved);
         self.output_parts.push(OutputPart::BlockScope { body });
         Ok(())

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/element.rs
@@ -68,6 +68,35 @@ impl<'a> ServerCodeGenerator<'a> {
         &mut self,
         element: &RegularElement,
     ) -> Result<(), TransformError> {
+        // An element whose direct fragment contains a `DeclarationTag`
+        // (`{const x=…}` / `{let x=…}` — NOT legacy `{@const}`) is
+        // non-transparent: its children get their own scope and are wrapped in
+        // a `{ … }` block so a nested declaration can shadow an outer binding.
+        // Mirrors the client `regular_element.rs` `has_declarations` path and
+        // upstream `RegularElement.js`. We capture the element's generated
+        // output parts into a sub-body and wrap them in `OutputPart::BlockScope`
+        // (which renders `{ <body> }` and hoists const declarations to the top).
+        let has_declarations = element
+            .fragment
+            .nodes
+            .iter()
+            .any(|n| matches!(n, TemplateNode::DeclarationTag(_)));
+        if !has_declarations {
+            return self.generate_element_inner(element);
+        }
+        let saved = std::mem::take(&mut self.output_parts);
+        // Scope the block-local constant folds to this element: a nested
+        // `{const doubled = 'nested'}` must not leak its fold to an outer
+        // same-named binding once the block closes.
+        let saved_constants = self.constant_vars.clone();
+        self.generate_element_inner(element)?;
+        self.constant_vars = saved_constants;
+        let body = std::mem::replace(&mut self.output_parts, saved);
+        self.output_parts.push(OutputPart::BlockScope { body });
+        Ok(())
+    }
+
+    fn generate_element_inner(&mut self, element: &RegularElement) -> Result<(), TransformError> {
         // Lowercase element names in HTML namespace for XHTML compatibility
         // Reference: RegularElement.js L18: `const name = context.state.namespace === 'html' ? node.name.toLowerCase() : node.name;`
         let name_owned: String = if !element.metadata.svg && !element.metadata.mathml {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/fragment.rs
@@ -235,6 +235,7 @@ impl<'a> ServerCodeGenerator<'a> {
             for n in meaningful_nodes.iter().take(idx) {
                 let n_hoisted = matches!(n, TemplateNode::ConstTag(_))
                     || matches!(n, TemplateNode::SnippetBlock(_))
+                    || matches!(n, TemplateNode::DeclarationTag(_))
                     || matches!(n, TemplateNode::DebugTag(_))
                     || (matches!(n, TemplateNode::Comment(_)) && !self.preserve_comments);
                 if !n_hoisted {
@@ -297,6 +298,7 @@ impl<'a> ServerCodeGenerator<'a> {
                 matches!(node, TemplateNode::Comment(_)) && !self.preserve_comments;
             let is_hoisted = is_const_tag
                 || matches!(node, TemplateNode::SnippetBlock(_))
+                || matches!(node, TemplateNode::DeclarationTag(_))
                 || is_transparent_comment;
             // Flush accumulated async consts before processing non-const content.
             // Also skip SnippetBlock and transparent comments since those are hoisted/stripped.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/fragment.rs
@@ -185,7 +185,9 @@ impl<'a> ServerCodeGenerator<'a> {
             let mut prev_was_hoisted = false;
             while first_visible < end_idx {
                 match nodes[first_visible] {
-                    TemplateNode::ConstTag(_) | TemplateNode::SnippetBlock(_) => {
+                    TemplateNode::ConstTag(_)
+                    | TemplateNode::DeclarationTag(_)
+                    | TemplateNode::SnippetBlock(_) => {
                         first_visible += 1;
                         prev_was_hoisted = true;
                     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/if_block.rs
@@ -74,6 +74,20 @@ impl<'a> ServerCodeGenerator<'a> {
         // pass here.
         let test_expr = Self::transform_rune_in_template_expr(&test_expr);
 
+        // Snapshot the const_blocker_map entries present BEFORE this if-block
+        // so we can undo any SHADOW the branch introduces. The shared
+        // `const_blocker_map` is name-keyed; a block-local
+        // `{let name = $state(await …)}` registers `name -> promises_N[i]`,
+        // overwriting an OUTER same-named binding's blocker. After both
+        // branches are generated we re-assert the original value for every
+        // pre-existing key so the outer read (e.g. the root `{name}`) still
+        // resolves to the outer blocker. Keys the branch newly introduces
+        // (block-local consts consumed at the build root) are LEFT IN PLACE —
+        // a blanket remove would regress fixtures whose if-block `{@const}` /
+        // `$derived` consts are wrapped at the build wrapper level.
+        let cbm_before: rustc_hash::FxHashMap<String, String> =
+            self.const_blocker_map.borrow().clone();
+
         // Generate consequent body parts
         let consequent_body = self.generate_if_branch_body(&block.consequent, None)?;
 
@@ -88,6 +102,16 @@ impl<'a> ServerCodeGenerator<'a> {
         } else {
             None
         };
+
+        // Undo shadows: restore the ORIGINAL value for every key that existed
+        // before this if-block (fires AFTER both branches so nested
+        // `collect_blocker_identity_set` reads still saw the live entries).
+        {
+            let mut cbm = self.const_blocker_map.borrow_mut();
+            for (k, v) in &cbm_before {
+                cbm.insert(k.clone(), v.clone());
+            }
+        }
 
         self.output_parts.push(OutputPart::IfBlock {
             test_expr,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/if_block.rs
@@ -357,7 +357,8 @@ impl<'a> ServerCodeGenerator<'a> {
             }
 
             let is_hoisted = matches!(node, TemplateNode::ConstTag(_))
-                || matches!(node, TemplateNode::SnippetBlock(_));
+                || matches!(node, TemplateNode::SnippetBlock(_))
+                || matches!(node, TemplateNode::DeclarationTag(_));
             // Flush accumulated async consts before processing non-const content
             if !is_hoisted {
                 body_generator.flush_async_consts();

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -172,26 +172,12 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // lowering, etc.).
 
     // Svelte 5.56.0 #18282 (`59d3a36f8` "feat: allow declarations in the
-    // template") follow-ups: the synchronous DeclarationTag (`{let x = …}` /
-    // `{const x = …}`) lands in this PR, but two paths are pending and
-    // tracked as separate ports. See `AGENTS.md` Test Status notes.
-    //
-    // 1. `declaration-tags` — nested `{const}` inside an element needs a
-    //    block-scope `{ … }` wrap so its identifier doesn't leak into the
-    //    outer fragment. The fragment-walker reorganisation required for
-    //    this is non-trivial; ConstTag has the same gap with the same
-    //    output today.
-    // 2. `async-declaration-tag` / `async-declaration-tag-2` — the
-    //    `metadata.promises_id` async-blocker lowering path
-    //    (`add_async_declaration` in upstream's DeclarationTag.js) is not
-    //    yet ported. Synchronous declaration tags pass.
-    // `declaration-tags` — CLIENT output now fully matches (element-nested
-    // `{const}`/`{let}` block-scope wrap + child-scope binding resolution +
-    // `scope.evaluate` constant-folding all ported in
-    // `client/visitors/regular_element.rs` + `shared/utils.rs::get_literal_value`).
-    // Still SERVER-side pending: the string renderer does not yet block-scope
-    // element-nested declarations (`{ … }` wrap) or fold their literal reads.
-    "declaration-tags",
+    // template") follow-up: `async-declaration-tag` / `async-declaration-tag-2`
+    // need the `metadata.promises_id` async-blocker lowering path
+    // (`add_async_declaration` in upstream's DeclarationTag.js) for
+    // `{let x = $state(await …)}`, which is not yet ported. The synchronous
+    // DeclarationTag path — including element-nested block-scoping + constant
+    // folding (client + server) — is complete (`declaration-tags` passes).
     "async-declaration-tag",
     "async-declaration-tag-2",
     // Svelte 5.56.0 #18309 (`e705369de` "fix: propagate async @const

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -172,23 +172,15 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // lowering, etc.).
 
     // Svelte 5.56.0 #18282 (`59d3a36f8` "feat: allow declarations in the
-    // template") follow-up: `async-declaration-tag` / `async-declaration-tag-2`
-    // need the `metadata.promises_id` async-blocker lowering path
-    // (`add_async_declaration` in upstream's DeclarationTag.js) for
-    // `{let x = $state(await …)}`, which is not yet ported. The synchronous
-    // DeclarationTag path — including element-nested block-scoping + constant
-    // folding (client + server) — is complete (`declaration-tags` passes).
-    // `async-declaration-tag{,-2}` — `{let x = $state(await …)}` /
-    // `{const y = $derived(await …)}` async-declaration lowering. The client
-    // foundation is in place (`declaration_tag.rs` routes awaited/blocked
-    // declarations through `add_const_declaration` → `$.run([…])`), so the root
-    // and if-block groups already match upstream. Still pending for a full pass:
-    // element-block `async_consts` reset + `$.run` emission (so a nested
-    // `{const z = $derived(await …)}` gets its own `promises_N`),
-    // `const_blocker_map` scoping across blocks (so a shadowed `name` doesn't
-    // overwrite an outer binding's blocker), the matching server lowering, and
-    // the gnarly `-2` (svelte:boundary + snippet + destructured await + each).
-    "async-declaration-tag",
+    // template"). `async-declaration-tag` (`{let x = $state(await …)}` /
+    // `{const y = $derived(await …)}`) now FULLY passes on both client and
+    // server — the async-declaration lowering (`add_async_declaration` in
+    // upstream's DeclarationTag.js) is ported: root-fragment `$$renderer.run`
+    // flush, cross-block `const_blocker_map` shadow scoping, the
+    // `await $.async_derived(async () => (await $.save(X))())` save-wrap shape,
+    // and element-block `async_consts` reset + cross-group blocker. Only
+    // `async-declaration-tag-2` (svelte:boundary + snippet + destructured await
+    // + each) remains pending.
     "async-declaration-tag-2",
     // Svelte 5.56.0 #18309 (`e705369de` "fix: propagate async @const
     // blockers through closure references"): rsvelte's per-template_effect

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -185,6 +185,12 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     //    `metadata.promises_id` async-blocker lowering path
     //    (`add_async_declaration` in upstream's DeclarationTag.js) is not
     //    yet ported. Synchronous declaration tags pass.
+    // `declaration-tags` — CLIENT output now fully matches (element-nested
+    // `{const}`/`{let}` block-scope wrap + child-scope binding resolution +
+    // `scope.evaluate` constant-folding all ported in
+    // `client/visitors/regular_element.rs` + `shared/utils.rs::get_literal_value`).
+    // Still SERVER-side pending: the string renderer does not yet block-scope
+    // element-nested declarations (`{ … }` wrap) or fold their literal reads.
     "declaration-tags",
     "async-declaration-tag",
     "async-declaration-tag-2",

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -178,6 +178,16 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // `{let x = $state(await …)}`, which is not yet ported. The synchronous
     // DeclarationTag path — including element-nested block-scoping + constant
     // folding (client + server) — is complete (`declaration-tags` passes).
+    // `async-declaration-tag{,-2}` — `{let x = $state(await …)}` /
+    // `{const y = $derived(await …)}` async-declaration lowering. The client
+    // foundation is in place (`declaration_tag.rs` routes awaited/blocked
+    // declarations through `add_const_declaration` → `$.run([…])`), so the root
+    // and if-block groups already match upstream. Still pending for a full pass:
+    // element-block `async_consts` reset + `$.run` emission (so a nested
+    // `{const z = $derived(await …)}` gets its own `promises_N`),
+    // `const_blocker_map` scoping across blocks (so a shadowed `name` doesn't
+    // overwrite an outer binding's blocker), the matching server lowering, and
+    // the gnarly `-2` (svelte:boundary + snippet + destructured await + each).
     "async-declaration-tag",
     "async-declaration-tag-2",
     // Svelte 5.56.0 #18309 (`e705369de` "fix: propagate async @const

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -180,8 +180,12 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // `await $.async_derived(async () => (await $.save(X))())` save-wrap shape,
     // and element-block `async_consts` reset + cross-group blocker. Only
     // `async-declaration-tag-2` (svelte:boundary + snippet + destructured await
-    // + each) remains pending.
-    "async-declaration-tag-2",
+    // + each) now ALSO fully passes — the boundary keeps non-special snippets
+    // inside the `$.boundary(...)` callback when the fragment has DeclarationTags
+    // (`has_const || has_declaration`), the cross-const / destructured-await
+    // declaration tags route into the shared `$.run([…])` async group, the
+    // awaited `$derived` reads register the `$.get` transform, and the each
+    // collection + index param + per-binding blocker dedup all match upstream.
     // Svelte 5.56.0 #18309 (`e705369de` "fix: propagate async @const
     // blockers through closure references"): rsvelte's per-template_effect
     // blocker scanner does not yet propagate awaited `@const` blockers


### PR DESCRIPTION
## Summary

Completes the Svelte 5.56.1 follow-up by fixing every remaining failing fixture. The full compatibility report is now **3515/3515 (100%, 0 failures)** — every in-scope category at 100%, including `runtime-runes` 996/996.

This branch resolves the 4 `runtime-runes` failures that remained after the 5.56.1 submodule bump, all in the new template **DeclarationTag** (`{const x = …}` / `{let x = …}`, Svelte 5.56.0 #18282) cluster:

| Fixture | What was needed |
|---|---|
| `async-style-after-await` | shorthand `style:x` directives must not contribute async `$$promises` blockers (they go to `dependencies`, not `references`) |
| `declaration-tags` | element-nested `{const}`/`{let}` block-scoping + child-scope binding resolution + `scope.evaluate` constant-folding (client **and** server) |
| `async-declaration-tag` | `{let x = $state(await …)}` / `{const y = $derived(await …)}` async-declaration lowering — bare `let` + assignment thunk into `$.run([…])` / `$$renderer.run([…])` with blocker-wait thunks (client **and** server) |
| `async-declaration-tag-2` | the above + `<svelte:boundary>` + `{#snippet}` + **destructured** awaited declarations + `{#each}` + nested awaited `$derived` |

## Verification

Full compatibility report (Svelte 5.56.1):

```
parser-modern 26/26 · parser-legacy 82/82 · snapshot 29/29 · css 181/181
validator 332/332 · compiler-errors 145/145 · runtime-runes 996/996
runtime-legacy 1206/1206 · runtime-browser 32/32 · hydration 80/80
server-side-rendering 97/97 · print 43/43 · preprocess 19/19 · svelte2tsx 247/247
migrate: out of scope (skipped)

Passed: 3515 (100.0%)  Failed: 0
```

Each change was verified against the full report with no regressions; `generate_const_tag` (the `{@const}` path) is untouched throughout.

## Notes

The two async-declaration fixtures' server lowering and `async-declaration-tag-2` were designed + implemented with a multi-agent workflow (parallel cluster investigation, then worktree-isolated implementation), and **independently re-verified on a clean tree** before each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)