### PR TITLE
chore(release): changeset for @rsvelte/compiler 0.7.0 (Svelte 5.56.1, 100%)

### DIFF
--- a/.changeset/svelte-5-56-1-100-percent.md
+++ b/.changeset/svelte-5-56-1-100-percent.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/compiler": minor
+---
+
+Upgrade the Svelte compatibility target to **5.56.1** and reach **100% in-scope
+test compatibility (3515/3515)**.
+
+The 5.56.1 bump was entirely DeclarationTag bug-fixes (upstream #18330 / #18348 /
+#18350 / #18352 / #18353); all of them are ported:
+
+- loose `{let x = a / }` → empty-name declarator (#18353)
+- unterminated declaration tag (`{let x = a /`) now reports `unexpected_eof` (#18350)
+- `type`-identifier-vs-type-alias disambiguation + interior-comment attachment,
+  so `{type instanceof Foo}` / `{type in foo}` parse as expression tags (#18330)
+- multi-declarator parsing + leading-whitespace + client comma-rejoin +
+  server cross-tag derived access + division-after-string (#18348 / #18353)
+- the `state_referenced_locally` warning for DeclarationTag (#18348)
+- async-derived component-prop getter + server `$.async_derived` unthunk (#18352)
+
+Also lands the remaining 5.56.0 async-declaration-tag clusters:
+
+- element-nested `{const}` / `{let}` block-scope wrap + constant-folding of the
+  shadowed binding (`declaration-tags`)
+- `metadata.promises_id` lowering for `{let x = $state(await …)}` on both client
+  and server (`async-declaration-tag`, `async-declaration-tag-2`)
+- shorthand `style:x` directive after a top-level `await` no longer over-emits
+  `$$promises` blockers (`async-style-after-await`)


### PR DESCRIPTION
## What

Adds a changeset bumping **`@rsvelte/compiler` 0.6.1 → 0.7.0 (minor)**.

The compiler work itself already landed via #655 (Svelte 5.56.1 target, **100% in-scope compatibility — 3515/3515**). This PR only carries the release metadata so the Release workflow can open the "Version Packages" PR.

## Why minor

Matches the 0.6.0 precedent: a Svelte-target bump (now → **5.56.1**) plus a batch of compiler correctness fixes is released as a minor.

## Changeset summary

- DeclarationTag bug-fixes ported (upstream #18330 / #18348 / #18350 / #18352 / #18353)
- Remaining 5.56.0 async-declaration-tag clusters: element-nested `{const}`/`{let}` block-scope wrap, `metadata.promises_id` lowering for `{let x = $state(await …)}`, shorthand `style:x` blocker fix

`@rsvelte/svelte2tsx` is bumped at patch automatically via `updateInternalDependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)