### PR TITLE
ci: weekly auto-update workflows for git submodules

### DIFF
--- a/.github/workflows/auto-update-submodules.yml
+++ b/.github/workflows/auto-update-submodules.yml
@@ -1,0 +1,146 @@
+name: auto-update-submodules
+
+# Weekly bump of the tooling submodules — everything EXCEPT svelte. The svelte
+# submodule is handled separately by `auto-update-svelte.yml` because bumping it
+# requires regenerating fixtures and fixing test regressions (the `upgrade-svelte`
+# skill), which CI cannot do unattended.
+#
+# One independent PR per submodule (a matrix job each). The gitlink is advanced
+# to the latest commit of the submodule's tracked ref (the `branch` from
+# .gitmodules, or the remote default branch when none is set). Each PR is
+# upserted onto a stable per-submodule branch, so a re-run force-updates the
+# existing PR instead of opening duplicates.
+#
+# SETUP:
+#   - Settings → Actions → General → Workflow permissions: enable "Allow GitHub
+#     Actions to create and approve pull requests" (required for the default
+#     GITHUB_TOKEN to open PRs).
+#   - PRs created with the default GITHUB_TOKEN do NOT trigger the `CI` workflow.
+#     To have CI run automatically on these PRs, add a repo secret `GH_PAT`
+#     (fine-grained PAT with `contents: write` + `pull-requests: write`); it is
+#     used for checkout/push/PR when present and falls back to GITHUB_TOKEN.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 5 * * 1' # Mondays 05:17 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Update ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Independent PRs — one failing submodule must not cancel the others.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: language-tools
+            path: submodules/language-tools
+          - name: typescript-go
+            path: submodules/typescript-go
+          - name: vite-plugin-svelte
+            path: submodules/vite-plugin-svelte
+    concurrency:
+      group: auto-update-submodules-${{ matrix.name }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Do not check the submodule contents out — we only rewrite the
+          # gitlink SHA in the index, which needs the superproject tree only.
+          submodules: false
+          token: ${{ secrets.GH_PAT || github.token }}
+
+      - name: Update ${{ matrix.name }} gitlink and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          SUB_NAME: ${{ matrix.name }}
+          SUB_PATH: ${{ matrix.path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Resolve this submodule's configured URL and tracked ref from
+          # .gitmodules (section names are inconsistent, so map by path).
+          section=$(git config -f .gitmodules --get-regexp '\.path$' \
+            | awk -v p="${SUB_PATH}" '$2 == p { sub(/\.path$/, "", $1); print $1 }')
+          if [ -z "${section}" ]; then
+            echo "::error::No .gitmodules entry found for path ${SUB_PATH}"
+            exit 1
+          fi
+          url=$(git config -f .gitmodules "${section}.url")
+          # Fetch over HTTPS so no SSH key is needed in CI.
+          url="${url/git@github.com:/https://github.com/}"
+          branch=$(git config -f .gitmodules "${section}.branch" 2>/dev/null || true)
+          if [ -n "${branch}" ]; then
+            ref="refs/heads/${branch}"
+          else
+            ref="HEAD" # remote default branch
+          fi
+          echo "Submodule ${SUB_NAME}: url=${url} ref=${ref}"
+
+          new=$(git ls-remote "${url}" "${ref}" | awk 'NR==1 {print $1}')
+          if [ -z "${new}" ]; then
+            echo "::error::git ls-remote ${url} ${ref} returned no SHA (private repo without GH_PAT?)"
+            exit 1
+          fi
+          cur=$(git ls-tree HEAD -- "${SUB_PATH}" | awk '{print $3}')
+          echo "current=${cur}"
+          echo "latest =${new}"
+
+          if [ "${new}" = "${cur}" ]; then
+            echo "${SUB_NAME} is already up to date; nothing to do."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          pr_branch="chore/update-${SUB_NAME}"
+          git checkout -B "${pr_branch}"
+
+          # Advance the gitlink to the new commit without checking the
+          # submodule out (mode 160000 = gitlink).
+          git update-index --cacheinfo "160000,${new},${SUB_PATH}"
+
+          short_new=${new:0:12}
+          short_cur=${cur:0:12}
+          title="chore(deps): update ${SUB_NAME} submodule to ${short_new}"
+          git commit -m "${title}"
+          git push --force origin "${pr_branch}"
+
+          # Build a compare link from the (https) submodule URL.
+          repo_url="${url%.git}"
+          {
+            echo "Weekly automated bump of the \`${SUB_PATH}\` submodule."
+            echo
+            echo "| | commit |"
+            echo "|---|---|"
+            echo "| from | \`${short_cur}\` |"
+            echo "| to | \`${short_new}\` |"
+            echo
+            echo "Tracked ref: \`${ref}\`"
+            echo
+            echo "[Compare upstream changes](${repo_url}/compare/${cur}...${new})"
+            echo
+            echo "---"
+            echo
+            echo "Opened by the \`auto-update-submodules\` workflow. Review the upstream"
+            echo "diff and merge once CI is green. A bump may surface new upstream test"
+            echo "fixtures (e.g. svelte2tsx) that need port work before CI passes."
+          } > pr-body.md
+
+          existing=$(gh pr list --head "${pr_branch}" --state open --json number --jq 'length')
+          if [ "${existing}" -eq 0 ]; then
+            gh pr create --base main --head "${pr_branch}" \
+              --title "${title}" --body-file pr-body.md
+          else
+            number=$(gh pr list --head "${pr_branch}" --state open --json number --jq '.[0].number')
+            gh pr edit "${number}" --title "${title}" --body-file pr-body.md
+            echo "Updated existing PR #${number} (force-pushed ${pr_branch})."
+          fi

--- a/.github/workflows/auto-update-svelte.yml
+++ b/.github/workflows/auto-update-svelte.yml
@@ -1,0 +1,182 @@
+name: auto-update-svelte
+
+# Weekly: when a newer stable svelte@X.Y.Z is published than the one pinned by
+# the submodules/svelte gitlink, open a STARTER PR that advances the gitlink to
+# the new tag and bumps the playground preview version strings.
+#
+# Unlike the tooling submodules (see auto-update-submodules.yml), a svelte bump
+# cannot be completed unattended: it needs regenerated fixtures and manual
+# regression fixes via the `upgrade-svelte` skill. CI on this PR will fail until
+# that work is done — the PR is just a ready-to-grab starting point.
+#
+# Complements `check-svelte-release.yml`, which files a tracking issue for the
+# same event. (If you prefer PRs only, that issue workflow can be retired.)
+#
+# SETUP:
+#   - Settings → Actions → General → Workflow permissions: enable "Allow GitHub
+#     Actions to create and approve pull requests" (required for the default
+#     GITHUB_TOKEN to open PRs).
+#   - PRs created with the default GITHUB_TOKEN do NOT trigger the `CI` workflow.
+#     Add a `GH_PAT` repo secret to have CI run automatically; it falls back to
+#     GITHUB_TOKEN when absent.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '37 5 * * 1' # Mondays 05:37 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-update-svelte
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Open Svelte upgrade PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: false
+          token: ${{ secrets.GH_PAT || github.token }}
+
+      - name: Read pinned Svelte version
+        id: current
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: |
+          set -euo pipefail
+          SHA=$(git ls-tree HEAD submodules/svelte | awk '{print $3}')
+          if [ -z "${SHA}" ]; then
+            echo "::error::Could not determine submodule SHA for submodules/svelte"
+            exit 1
+          fi
+          VERSION=$(gh api \
+            "repos/sveltejs/svelte/contents/packages/svelte/package.json?ref=${SHA}" \
+            --jq '.content' | base64 -d | jq -r '.version')
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+            echo "::error::Could not read svelte package version at ${SHA}"
+            exit 1
+          fi
+          echo "sha=${SHA}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Pinned svelte version: ${VERSION} (${SHA})"
+
+      - name: Fetch latest stable Svelte release
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: |
+          set -euo pipefail
+          gh api repos/sveltejs/svelte/releases \
+            --jq '[.[]
+                  | select(.tag_name | startswith("svelte@"))
+                  | select(.prerelease == false)
+                  | select(.draft == false)][0]' \
+            > latest.json
+          if [ ! -s latest.json ] || [ "$(jq -r '. // empty' latest.json)" = "" ]; then
+            echo "::error::No stable svelte@* release found on sveltejs/svelte"
+            exit 1
+          fi
+          TAG=$(jq -r '.tag_name' latest.json)
+          VERSION=${TAG#svelte@}
+          URL=$(jq -r '.html_url' latest.json)
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "url=${URL}" >> "${GITHUB_OUTPUT}"
+          echo "Latest stable svelte release: ${VERSION} (${URL})"
+
+      - name: Open upgrade PR if a newer release is available
+        if: steps.current.outputs.version != steps.latest.outputs.version
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          CURRENT_VERSION: ${{ steps.current.outputs.version }}
+          LATEST_VERSION: ${{ steps.latest.outputs.version }}
+          LATEST_TAG: ${{ steps.latest.outputs.tag }}
+          LATEST_URL: ${{ steps.latest.outputs.url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Only act when the pinned version is strictly older (version-aware).
+          NEWEST=$(printf '%s\n%s\n' "${CURRENT_VERSION}" "${LATEST_VERSION}" | sort -V | tail -n1)
+          if [ "${NEWEST}" = "${CURRENT_VERSION}" ]; then
+            echo "Pinned ${CURRENT_VERSION} >= latest ${LATEST_VERSION}; nothing to do."
+            exit 0
+          fi
+
+          # Resolve the new tag's commit (peel annotated tags to the commit).
+          svelte_url="https://github.com/sveltejs/svelte.git"
+          new=$(git ls-remote "${svelte_url}" "refs/tags/${LATEST_TAG}^{}" | awk 'NR==1 {print $1}')
+          if [ -z "${new}" ]; then
+            new=$(git ls-remote "${svelte_url}" "refs/tags/${LATEST_TAG}" | awk 'NR==1 {print $1}')
+          fi
+          if [ -z "${new}" ]; then
+            echo "::error::Could not resolve commit for ${LATEST_TAG}"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          pr_branch="chore/upgrade-svelte-${LATEST_VERSION}"
+          git checkout -B "${pr_branch}"
+
+          # Advance the svelte gitlink (mode 160000 = gitlink).
+          git update-index --cacheinfo "160000,${new},submodules/svelte"
+
+          # Bump the playground preview runtime + rsvelte shim version strings,
+          # mirroring scripts/dev/upgrade-svelte.sh steps [5]/[6].
+          preview="apps/playground/src/lib/preview.ts"
+          shim="apps/playground/rsvelte-shim/compiler.mjs"
+          if [ -f "${preview}" ]; then
+            sed -i "s|esm\.sh/svelte@[0-9.]*|esm.sh/svelte@${LATEST_VERSION}|g" "${preview}"
+            git add "${preview}"
+          fi
+          if [ -f "${shim}" ]; then
+            sed -i "s|export const VERSION = '[0-9.]*';|export const VERSION = '${LATEST_VERSION}';|g" "${shim}"
+            sed -i "s|sveltejs/svelte@[0-9.]*|sveltejs/svelte@${LATEST_VERSION}|g" "${shim}"
+            git add "${shim}"
+          fi
+
+          short_new=${new:0:12}
+          title="chore: upgrade Svelte submodule to ${LATEST_VERSION}"
+          git commit -m "${title}"
+          git push --force origin "${pr_branch}"
+
+          {
+            echo "Starter PR to upgrade the Svelte compatibility target."
+            echo
+            echo "- from: \`${CURRENT_VERSION}\`"
+            echo "- to: [\`${LATEST_VERSION}\`](${LATEST_URL}) (\`${short_new}\`)"
+            echo
+            echo "## ⚠️ Not mergeable as-is"
+            echo
+            echo "A svelte bump needs fixtures regenerated and any regressions"
+            echo "fixed. **CI will fail until that is done.** To finish:"
+            echo
+            echo "1. \`git fetch origin ${pr_branch} && git checkout ${pr_branch}\`"
+            echo "2. \`git submodule update --init --recursive submodules/svelte\`"
+            echo "3. Run the \`upgrade-svelte\` skill (or \`./scripts/dev/upgrade-svelte.sh ${LATEST_VERSION}\`)"
+            echo "   to rebuild the compiler, regenerate fixtures, fix regressions,"
+            echo "   refresh docs, and add a changeset."
+            echo "4. Push the fixes to this branch."
+            echo
+            echo "---"
+            echo
+            echo "Opened by the \`auto-update-svelte\` workflow."
+          } > pr-body.md
+
+          existing=$(gh pr list --head "${pr_branch}" --state open --json number --jq 'length')
+          if [ "${existing}" -eq 0 ]; then
+            gh pr create --base main --head "${pr_branch}" \
+              --title "${title}" --body-file pr-body.md
+          else
+            number=$(gh pr list --head "${pr_branch}" --state open --json number --jq '.[0].number')
+            gh pr edit "${number}" --title "${title}" --body-file pr-body.md
+            echo "Updated existing PR #${number}."
+          fi


### PR DESCRIPTION
## Summary

Adds two scheduled GitHub Actions (Mondays) that open PRs to keep the git submodules current, splitting **svelte** from the **tooling** submodules — per the existing repo convention that a svelte bump can't be completed unattended.

### `auto-update-submodules.yml` — tooling submodules (one PR each)
A matrix job per non-svelte submodule (`language-tools`, `typescript-go`, `vite-plugin-svelte`):
- Resolves the submodule's URL + tracked ref from `.gitmodules` (handles the inconsistent section names; rewrites `git@github.com:` → HTTPS so no SSH key is needed).
- `git ls-remote` → latest commit of the tracked ref (the `.gitmodules` `branch`, or the remote default branch).
- If the gitlink is behind, advances it with `git update-index --cacheinfo` (no submodule checkout needed) and **upserts an individual PR** on a stable `chore/update-<name>` branch.

### `auto-update-svelte.yml` — svelte starter PR
- Detects the latest stable `svelte@X.Y.Z` release (same logic as `check-svelte-release.yml`), resolves the tag's commit, bumps the `submodules/svelte` gitlink + the playground version strings, and opens a `chore/upgrade-svelte-<v>` PR.
- The PR body makes clear it is **not mergeable as-is**: fixtures must be regenerated and regressions fixed via the `upgrade-svelte` skill; CI fails until then. Complements `check-svelte-release.yml` (which files a tracking issue — that one can be retired if you prefer PRs only).

## Notes
- Both titled `chore:` so they don't trip the fix/feat changeset gate.
- Both use `secrets.GH_PAT || github.token`. **Setup required:** enable *Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"*. PRs opened by the default `GITHUB_TOKEN` won't trigger CI; add a `GH_PAT` secret to have CI run on the bump PRs automatically.

## Verified locally
- ✅ YAML parses
- ✅ `.gitmodules` section/url/ref derivation for all 4 submodules (incl. `submodule.submodules/typescript-go`)
- ✅ `git ls-remote` returns the expected latest SHAs (the `vite-plugin-svelte` fork is public; svelte tag-peel `^{}` works)
- ✅ `git update-index --cacheinfo` gitlink rewrite + commit produces a single-file submodule bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)