### PR TITLE
chore(deps): bump all oxc crates to d727b6b (unified rev)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "phf",
  "proc-macro2 1.0.106",
@@ -1385,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1405,7 +1405,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",
- "oxc_index",
+ "oxc_index 5.0.0",
  "oxc_semantic",
  "oxc_sourcemap",
  "oxc_span",
@@ -1417,12 +1417,12 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 
 [[package]]
 name = "oxc_diagnostics"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter"
 version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1483,13 +1483,12 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_core"
 version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
  "oxc_data_structures",
  "oxc_span",
- "oxc_syntax",
  "rustc-hash",
  "serde_json",
  "unicode-width 0.2.2",
@@ -1501,15 +1500,24 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
 dependencies = [
- "nonmax",
  "rayon",
+ "serde",
+]
+
+[[package]]
+name = "oxc_index"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
+dependencies = [
+ "nonmax",
  "serde",
 ]
 
 [[package]]
 name = "oxc_jsdoc"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1519,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1542,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1558,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "itertools 0.14.0",
  "memchr",
@@ -1567,7 +1575,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_diagnostics",
  "oxc_ecmascript",
- "oxc_index",
+ "oxc_index 5.0.0",
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
@@ -1592,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1606,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1618,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=beb46d31faa27278abfae34ae99b5e016688ed28#beb46d31faa27278abfae34ae99b5e016688ed28"
+source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1627,7 +1635,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_estree",
- "oxc_index",
+ "oxc_index 5.0.0",
  "oxc_span",
  "oxc_str",
  "phf",
@@ -2175,7 +2183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3baeb89e3c96ae464a728a07da81b22f912312330afbe845f4b9c681f7796a33"
 dependencies = [
  "memchr",
- "oxc_index",
+ "oxc_index 4.1.0",
  "oxc_sourcemap",
  "regex",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,18 +24,18 @@ panic = "unwind"  # Criterion requires unwind for catching panics
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -54,7 +54,7 @@ oxc_syntax = "0.134"
 oxc_semantic = "0.134"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -16,6 +16,6 @@ oxc_allocator = "0.134"
 oxc_ast = "0.134"
 oxc_parser = "0.134"
 oxc_span = "0.134"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "beb46d31faa27278abfae34ae99b5e016688ed28" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
 thiserror = "2.0"

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -433,7 +433,7 @@ pub(crate) fn format_pattern_source(
     let mut single_line = options.js.clone();
     single_line.line_width =
         oxc_formatter_core::LineWidth::try_from(u16::MAX).unwrap_or(single_line.line_width);
-    single_line.expand = oxc_formatter_core::Expand::Never;
+    single_line.expand = oxc_formatter::Expand::Never;
 
     let formatted = format_program(&allocator, &parser_ret.program, single_line, None)
         .print()


### PR DESCRIPTION
Renovate opened #650 (`oxc_formatter`) and #651 (`oxc_formatter_core`) separately, but bumping only one oxc crate splits the git rev across the dependency graph and breaks AST type-unification under `[patch.crates-io]`. This PR bumps **every** `oxc_*` crate + `oxc_formatter` + `oxc_formatter_core` to the same rev `d727b6b` in one shot.

The new rev moved `Expand` out of `oxc_formatter_core` into `oxc_formatter` (it's the type of the `JsFormatOptions.expand` field), so the single use site in `rsvelte_formatter` is updated accordingly.

Verified locally: `cargo build --workspace`, `cargo clippy --all-targets --all-features -D warnings`, and the formatter test suites all pass.

Closes #650
Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)