### PR TITLE
chore(deps): bump all oxc crates to 187e1a5 (unified rev)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "phf",
  "proc-macro2 1.0.106",
@@ -1385,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1417,12 +1417,12 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 
 [[package]]
 name = "oxc_diagnostics"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter"
 version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1483,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_core"
 version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1517,7 +1517,7 @@ dependencies = [
 [[package]]
 name = "oxc_jsdoc"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1566,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "itertools 0.14.0",
  "memchr",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1614,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1626,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "cow-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,18 +24,18 @@ panic = "unwind"  # Criterion requires unwind for catching panics
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -54,7 +54,7 @@ oxc_syntax = "0.134"
 oxc_semantic = "0.134"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -16,6 +16,6 @@ oxc_allocator = "0.134"
 oxc_ast = "0.134"
 oxc_parser = "0.134"
 oxc_span = "0.134"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
 thiserror = "2.0"


### PR DESCRIPTION
Renovate opened #666 (`oxc_formatter`) and #667 (`oxc_formatter_core`) separately. Bumping only one oxc crate splits the git rev across the dependency graph and breaks AST type-unification under `[patch.crates-io]`, so this PR bumps **every** `oxc_*` crate + `oxc_formatter` + `oxc_formatter_core` to the same rev `187e1a5` in one shot. No API changes this time — build/clippy/formatter tests all pass locally.

Closes #666
Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)