### PR TITLE
fix(fmt): preserve markup after a script block; fix self-closing close-tag panic (#669)

### DIFF
--- a/.changeset/fmt-self-closing-after-script.md
+++ b/.changeset/fmt-self-closing-after-script.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): preserve markup after a `<script>` block and stop the self-closing close-tag panic (#669)
+
+A self-closing / void element (`<span />`, `<path />`) after a leading
+`<script>` block was corrupted: the close-tag detector scanned backward for any
+`</` and matched the preceding `</script>`, emitting a bogus edit over the
+script-close plus the markup in between. One such element silently dropped the
+markup (exit 0); two or more siblings produced overlapping edits that panicked
+with a slice out-of-bounds.
+
+`find_close_tag_span` is now strict — the close tag must be the text immediately
+ending at the element (`<`, `/`, tag name, optional whitespace, `>`) — so
+self-closing/void elements yield no edit while genuine `</tag>` close tags still
+normalize. The Node CLI wrapper also now propagates native signal terminations
+(e.g. SIGABRT from a panic) as a non-zero exit instead of reporting exit 0.

--- a/apps/npm/fmt/bin/rsvelte-fmt.cjs
+++ b/apps/npm/fmt/bin/rsvelte-fmt.cjs
@@ -132,4 +132,15 @@ if (result.error) {
 	console.error(`[@rsvelte/fmt] Failed to exec ${binPath}: ${result.error.message}`);
 	process.exit(1);
 }
+
+// If the native binary was killed by a signal (e.g. SIGABRT from a Rust
+// panic), `result.status` is null and `result.signal` holds the signal
+// name. Returning `status ?? 0` here would mask the crash as a clean exit 0,
+// hiding panics and any partial/corrupt output from tooling and CI. Propagate
+// signal terminations as the conventional 128 + signal-number exit code.
+if (result.signal) {
+	const signum = require('node:os').constants.signals[result.signal];
+	console.error(`[@rsvelte/fmt] ${binPath} was terminated by ${result.signal}.`);
+	process.exit(typeof signum === 'number' ? 128 + signum : 1);
+}
 process.exit(result.status ?? 0);

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -209,29 +209,52 @@ fn push_close_tag(
     tag_name: &str,
     edits: &mut Vec<(u32, u32, String)>,
 ) {
-    let Some((start, end)) = find_close_tag_span(source, element_end) else {
+    let Some((start, end)) = find_close_tag_span(source, element_end, tag_name) else {
         return;
     };
     edits.push((start, end, format!("</{tag_name}>")));
 }
 
-fn find_close_tag_span(source: &str, element_end: u32) -> Option<(u32, u32)> {
+/// Locate the element's closing tag `</tagname ...>` that ends exactly at
+/// `element_end`. The close tag must be the text *immediately* ending at
+/// `element_end`: `<`, `/`, the tag name, optional whitespace, then `>`.
+///
+/// This is deliberately strict. Self-closing / void elements (`<span />`,
+/// `<br>`) have no close tag, so this returns `None` for them. An earlier
+/// version scanned backward for *any* `</`, which would happily match the
+/// `</` of a preceding `</script>` block or sibling element's close tag —
+/// producing a bogus edit that overwrote everything in between (see #669).
+fn find_close_tag_span(source: &str, element_end: u32, tag_name: &str) -> Option<(u32, u32)> {
     let bytes = source.as_bytes();
     let end = element_end as usize;
-    if end == 0 || bytes.get(end.checked_sub(1)?) != Some(&b'>') {
+    if end == 0 || end > bytes.len() || bytes[end - 1] != b'>' {
         return None;
     }
-    // Scan backward for "</".
-    let mut i = end.checked_sub(2)?;
-    loop {
-        if bytes.get(i) == Some(&b'<') && bytes.get(i + 1) == Some(&b'/') {
-            return Some((i as u32, end as u32));
-        }
-        if i == 0 {
-            return None;
-        }
-        i -= 1;
+
+    // Walk back over whitespace between the tag name and the closing `>`.
+    let mut i = end - 1; // at '>'
+    i = i.checked_sub(1)?;
+    while matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
+        i = i.checked_sub(1)?;
     }
+
+    // `bytes[i]` is now the last character of the tag name; match the name
+    // backward (case-insensitively, matching HTML close-tag semantics).
+    let name = tag_name.as_bytes();
+    let name_end = i + 1;
+    let name_start = name_end.checked_sub(name.len())?;
+    if !bytes[name_start..name_end].eq_ignore_ascii_case(name) {
+        return None;
+    }
+
+    // The tag name must be preceded by `</`.
+    let slash = name_start.checked_sub(1)?;
+    let lt = slash.checked_sub(1)?;
+    if bytes[slash] != b'/' || bytes[lt] != b'<' {
+        return None;
+    }
+
+    Some((lt as u32, end as u32))
 }
 
 /// Push one edit covering the element's open tag span (from `<` to the

--- a/crates/rsvelte_formatter/tests/markup_close_tag.rs
+++ b/crates/rsvelte_formatter/tests/markup_close_tag.rs
@@ -1,0 +1,74 @@
+//! Regression tests for close-tag span detection (#669).
+//!
+//! Self-closing / void elements have no close tag. An earlier version of
+//! `find_close_tag_span` scanned backward for *any* `</`, so a self-closing
+//! element after a `<script>`/`<style>` block matched the `</` of the
+//! preceding `</script>` and emitted a bogus edit that overwrote everything
+//! in between — silently dropping markup (one element) or panicking with a
+//! slice out-of-bounds (two or more siblings).
+
+use rsvelte_formatter::{FormatOptions, format};
+
+fn fmt(src: &str) -> String {
+    format(src, &FormatOptions::default()).expect("format ok")
+}
+
+#[test]
+fn single_self_closing_after_script_is_preserved() {
+    let src = "<script>\n  let x = 1;\n</script>\n\n<div><span /></div>\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("<div><span /></div>"),
+        "self-closing markup after a script must survive:\n{out}"
+    );
+    assert!(
+        !out.contains("</span>/div>"),
+        "must not emit mangled close fragment:\n{out}"
+    );
+}
+
+#[test]
+fn two_self_closing_siblings_after_script_do_not_panic() {
+    // Previously panicked with a slice out-of-bounds.
+    let src = "<script>\n  let x = 1;\n</script>\n\n<div><span /><span /></div>\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("<div><span /><span /></div>"),
+        "two self-closing siblings after a script must survive:\n{out}"
+    );
+}
+
+#[test]
+fn self_closing_svg_path_after_script_is_preserved() {
+    let src = "<script>\n  let x = 1;\n</script>\n\n<svg><path d=\"M0 0\" /></svg>\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("<svg><path d=\"M0 0\" /></svg>"),
+        "svg/path must survive:\n{out}"
+    );
+}
+
+#[test]
+fn normal_close_tag_whitespace_is_normalized() {
+    let out = fmt("<div >hello</div >\n");
+    assert!(
+        out.contains("<div>hello</div>"),
+        "close-tag whitespace should be normalized:\n{out}"
+    );
+}
+
+#[test]
+fn nested_same_name_close_tags_round_trip() {
+    let src = "<div><div>x</div></div>\n";
+    assert_eq!(fmt(src), src);
+}
+
+#[test]
+fn self_closing_inside_component_after_script_is_preserved() {
+    let src = "<script>\n  import Foo from \"./Foo.svelte\";\n</script>\n\n<Foo><span /></Foo>\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("<Foo><span /></Foo>"),
+        "self-closing child inside a component must survive:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #669.

## Root cause

The "offset desync after the inline `<script>` reformat" hypothesis in the issue turned out to be a red herring — the script body in the repro doesn't even change length. The actual bug is in the markup close-tag detection.

`push_close_tag` ran for **every** element, and `find_close_tag_span` scanned backward for *any* `</`. Self-closing / void elements (`<span />`, `<path />`, `<br>`) have no close tag, so the backward scan walked past the element and matched the `</` of the preceding **`</script>`** block (or a sibling's close tag), emitting a close-tag edit whose span covered `</script>…<div><span />` and replaced it with `</span>`.

- **1 self-closing element** → that one bogus edit silently dropped the markup (exit 0).
- **≥2 self-closing siblings** → two overlapping bogus edits (both starting at the `</script>` offset) collided in `String::replace_range`, panicking with the `range end index N out of range` slice OOB.

The same markup with no `<script>` formatted fine only because there was no earlier `</` to mis-match.

## Fix

`find_close_tag_span` is now strict: the close tag must be the text **immediately** ending at `element_end` — `<`, `/`, tag name (case-insensitive), optional whitespace, then `>`. Self-closing / void elements correctly yield `None` (no edit), while genuine `</tag>` / `</tag >` close tags still normalize as before.

Also addresses the CLI wrapper finding (#3 in the issue): a native SIGABRT left `spawnSync`'s `result.status` null, so `status ?? 0` reported **exit 0** and hid the crash. The wrapper now propagates signal terminations as `128 + signum` (e.g. 134 for SIGABRT).

## Verification

All four repros from the issue now round-trip correctly with exit 0:

```
<div><span /></div>
<svg><path d="M0 0" /></svg>
<div><span /><span /></div>
<g><path /><path /></g>
```

New regression suite `crates/rsvelte_formatter/tests/markup_close_tag.rs` (6 tests) plus the full existing `rsvelte_formatter` / `rsvelte_fmt` suites pass; `cargo clippy -D warnings` clean.

The two "related but separate" findings (inline `<style>` oxfmt 0.49 `--stdin` contract, inline-block config inheritance) have distinct root causes and are left for separate issues, as the reporter offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)