### PR TITLE
ci: decouple Version Packages PR from binary builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,52 @@ concurrency:
   cancel-in-progress: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
 
 jobs:
+  # Fast path: open / refresh the "Version Packages" PR. The version cycle
+  # never stages binaries (changeset version only bumps package.json/CHANGELOG
+  # and mirrors the version into Cargo.toml/Cargo.lock as text), so this job
+  # has NO dependency on the binary build matrix. Decoupling it means a flaky
+  # crates.io download in one build leg can no longer block the version PR
+  # from being created — the failure that produced run 27058363504.
+  #
+  # Runs on every push to main EXCEPT the "Version Packages" merge itself —
+  # that commit consumes the changesets and triggers the `publish` job below.
+  version-pr:
+    name: Version PR
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history so changesets can read the merge base when computing
+          # which packages need releasing.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # No `publish` input on purpose — this job ONLY ever opens/refreshes the
+      # version PR. When there are no changesets it is a no-op. Publishing is
+      # handled by the `publish` job once the version PR is merged.
+      - name: Create or refresh Release Pull Request
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          # changeset version (bump versions, write CHANGELOG)
+          # + sync-version.mjs (mirror the bump into Cargo.toml/Cargo.lock)
+          version: pnpm run version-packages
+          commit: 'chore(release): version packages'
+          title: 'chore(release): version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Per-platform svelte-check binary builds. Each job uploads its rsvelte
   # `svelte-check` artifact; the `release` job below downloads them all and
   # stages them into the corresponding `apps/npm/svelte-check-<triple>/` package
@@ -37,6 +83,9 @@ jobs:
   # CI minutes for not having to detect publish vs. version-PR up front.
   build-svelte-check:
     name: Build svelte-check (${{ matrix.triple }})
+    # Only the publish path needs binaries staged; gate every build leg to the
+    # "Version Packages" merge commit so regular pushes skip them entirely.
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
     strategy:
       fail-fast: false
       matrix:
@@ -92,6 +141,7 @@ jobs:
   # it for the release job to stage into the matching platform package.
   build-vps-native:
     name: Build vps-native (${{ matrix.triple }})
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
     strategy:
       fail-fast: false
       matrix:
@@ -148,6 +198,7 @@ jobs:
   # `[[bin]] name = "rsvelte-fmt"`), so no underscore rename is needed.
   build-rsvelte-fmt:
     name: Build rsvelte-fmt (${{ matrix.triple }})
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
     strategy:
       fail-fast: false
       matrix:
@@ -194,8 +245,12 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  release:
-    name: Release
+  publish:
+    name: Publish
+    # Publish only runs on the "Version Packages" merge commit, once the
+    # version PR (opened by `version-pr` above) has been merged and the
+    # changesets consumed. This is the only path that needs staged binaries.
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
     runs-on: ubuntu-latest
     needs: [build-svelte-check, build-vps-native, build-rsvelte-fmt]
     timeout-minutes: 30
@@ -258,19 +313,18 @@ jobs:
       # on npmjs.com pointing at this repo + workflow. No NPM_TOKEN is set
       # on purpose — writing an empty token to ~/.npmrc silently disables
       # the OIDC fallback.
-      - name: Create Release Pull Request or Publish
+      - name: Publish
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          # When the "Version Packages" PR is merged, this script runs:
+          # On the "Version Packages" merge there are no changesets left, so
+          # changesets/action takes the publish path and runs this script:
           # sync-version.mjs (version → Cargo.toml / Cargo.lock),
           # wasm-pack build (regenerates pkg/ with the new version),
           # finalize-pkg.mjs (rewrites pkg/package.json to @rsvelte/compiler),
           # changeset publish (pnpm publish all workspace packages).
+          # No `version` input here — version bumping happens in the separate
+          # `version-pr` job, decoupled from the binary builds this job needs.
           publish: pnpm run release
-          # When changesets exist on main, open/refresh a PR that runs:
-          # changeset version (bump versions, write CHANGELOG)
-          # + sync-version.mjs (mirror the bump into Cargo.toml/Cargo.lock)
-          version: pnpm run version-packages
           commit: 'chore(release): version packages'
           title: 'chore(release): version packages'
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "phf",
  "proc-macro2 1.0.106",
@@ -1385,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1417,12 +1417,12 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 
 [[package]]
 name = "oxc_diagnostics"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter"
 version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1483,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_core"
 version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1517,7 +1517,7 @@ dependencies = [
 [[package]]
 name = "oxc_jsdoc"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1566,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "itertools 0.14.0",
  "memchr",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1614,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1626,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=d727b6b10c690ef8b401572687fcb23589ac688e#d727b6b10c690ef8b401572687fcb23589ac688e"
+source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
 dependencies = [
  "bitflags",
  "cow-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,18 +24,18 @@ panic = "unwind"  # Criterion requires unwind for catching panics
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -54,7 +54,7 @@ oxc_syntax = "0.134"
 oxc_semantic = "0.134"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -16,6 +16,6 @@ oxc_allocator = "0.134"
 oxc_ast = "0.134"
 oxc_parser = "0.134"
 oxc_span = "0.134"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
 thiserror = "2.0"


### PR DESCRIPTION
## Why

The release job that runs `changesets/action` was gated behind `needs: [build-svelte-check, build-vps-native, build-rsvelte-fmt]`. A single flaky build leg — e.g. a transient `download of se/rd/serde failed` on darwin-x64 in [run 27058363504](https://github.com/baseballyama/rsvelte/actions/runs/27058363504) — skipped the `release` job entirely (`- Release in 0s`), so the **"Version Packages" PR was never created or refreshed** even though changesets existed on `main`.

## What

Split `release.yml` into three jobs:

| Job | Runs on | Build deps | Role |
|---|---|---|---|
| **version-pr** (new) | every main push except the version-packages merge | **none** | open/refresh the Version Packages PR |
| **build-\*** ×3 | version-packages merge commit only | — | stage publish binaries |
| **publish** (renamed from `release`) | version-packages merge commit only | all build-\* | `changeset publish` |

`version-pr` runs on Node + pnpm alone — `sync-version.mjs` only rewrites `Cargo.toml`/`Cargo.lock` as text, no cargo/Rust needed. A flaky binary build can no longer block the version PR. Regular pushes now also skip the 15 build legs entirely, cutting CI time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)