### PR TITLE
bench: add fmt benchmarks and refresh the corpus benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,6 +1961,7 @@ dependencies = [
 name = "rsvelte_formatter"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "oxc_allocator",
  "oxc_ast",
  "oxc_formatter",

--- a/apps/playground/src/lib/types/benchmark.ts
+++ b/apps/playground/src/lib/types/benchmark.ts
@@ -38,5 +38,8 @@ export interface BenchmarkResults extends BenchmarkTaskResults {
 	testFilesCount: number;
 	parse: BenchmarkTaskResults;
 	svelte2tsx?: BenchmarkTaskResults;
+	// rsvelte_formatter vs prettier-plugin-svelte. Optional — older JSON
+	// snapshots predate the fmt task.
+	fmt?: BenchmarkTaskResults;
 	svelteCheck?: SvelteCheckBenchmarkTaskResults;
 }

--- a/apps/playground/src/routes/benchmark/+page.svelte
+++ b/apps/playground/src/routes/benchmark/+page.svelte
@@ -7,7 +7,7 @@
 
 	let { data }: { data: PageData } = $props();
 
-	type TaskId = 'full' | 'parse' | 'svelte2tsx' | 'svelte-check';
+	type TaskId = 'full' | 'parse' | 'svelte2tsx' | 'fmt' | 'svelte-check';
 
 	// `animationTime` is the elapsed wall-clock ms since the run started.
 	// Each bar across every task shows `min(animationTime, this.durationMs)`,
@@ -44,6 +44,8 @@
 		id: TaskId;
 		label: string;
 		sub: string;
+		// Name of the JavaScript tool this task is benchmarked against.
+		baseline: string;
 		data: BenchmarkTaskResults;
 		filesCount?: number;
 	};
@@ -52,15 +54,25 @@
 		if (!data.results) return [];
 		const r = data.results;
 		const list: TaskPanel[] = [
-			{ id: 'full', label: 'Full pipeline', sub: 'parse / analyze / codegen', data: r },
-			{ id: 'parse', label: 'Parser only', sub: 'phase 1, isolated', data: r.parse }
+			{ id: 'full', label: 'Full pipeline', sub: 'parse / analyze / codegen', baseline: 'svelte/compiler', data: r },
+			{ id: 'parse', label: 'Parser only', sub: 'phase 1, isolated', baseline: 'svelte/compiler', data: r.parse }
 		];
 		if (r.svelte2tsx) {
 			list.push({
 				id: 'svelte2tsx',
 				label: 'svelte2tsx',
 				sub: '.svelte / .tsx generation',
+				baseline: 'svelte2tsx',
 				data: r.svelte2tsx
+			});
+		}
+		if (r.fmt) {
+			list.push({
+				id: 'fmt',
+				label: 'fmt',
+				sub: 'formatter · .svelte sources',
+				baseline: 'prettier-svelte',
+				data: r.fmt
 			});
 		}
 		if (r.svelteCheck) {
@@ -68,6 +80,7 @@
 				id: 'svelte-check',
 				label: 'svelte-check',
 				sub: `CLI · ${r.svelteCheck.filesCount.toLocaleString('en-US')}-file workspace`,
+				baseline: 'svelte-check',
 				data: r.svelteCheck,
 				filesCount: r.svelteCheck.filesCount
 			});
@@ -238,7 +251,7 @@
 						</header>
 						<div class="bars">
 							{#each [
-								{ name: 'svelte/compiler', sub: 'JavaScript', dur: t.javascript.durationMs, tone: 'js' },
+								{ name: task.baseline, sub: 'JavaScript', dur: t.javascript.durationMs, tone: 'js' },
 								{ name: 'rsvelte / single', sub: 'no parallelism', dur: t.rustSingleThread.durationMs, tone: 'rs' },
 								{ name: 'rsvelte / multi', sub: 'rayon fan-out', dur: t.rustMultiThread.durationMs, tone: 'rm' }
 							] as bar (bar.name)}
@@ -278,11 +291,11 @@
 				<pre><code><span class="c-cmt"># 1. Build the Rust compiler in release mode</span>
 <span class="c-prompt">$</span> cargo build <span class="c-flag">--release</span>
 
-<span class="c-cmt"># 2. Run the corpus benchmark</span>
-<span class="c-prompt">$</span> node scripts/bench/run-benchmark.mjs <span class="c-op">&gt;</span> apps/playground/static/benchmark-results.json
+<span class="c-cmt"># 2. Run the corpus benchmark (compile / parse / svelte2tsx / fmt / svelte-check)</span>
+<span class="c-prompt">$</span> pnpm run generate-benchmark
 
 <span class="c-cmt"># 3. View the report locally</span>
-<span class="c-prompt">$</span> cd docs <span class="c-op">&amp;&amp;</span> pnpm dev</code></pre>
+<span class="c-prompt">$</span> pnpm run dev:docs</code></pre>
 			</figure>
 		</section>
 	{/if}

--- a/apps/playground/static/benchmark-results.json
+++ b/apps/playground/static/benchmark-results.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-30T00:04:15.554Z",
-  "commitSha": "fec3d95a",
+  "generatedAt": "2026-06-06T09:42:54.599Z",
+  "commitSha": "a412c14c",
   "runner": {
     "label": "local",
     "os": "darwin",
@@ -9,139 +9,172 @@
     "cpuModel": "Apple M1 Pro",
     "nodeVersion": "24.13.0",
     "v8Version": "13.6.233.17-node.37",
-    "loadAvg1min": 1.73779296875,
-    "warmupIterations": 1,
-    "benchmarkIterations": 3
+    "loadAvg1min": 1.833984375,
+    "warmupIterations": 3,
+    "benchmarkIterations": 10
   },
-  "testFilesCount": 3812,
+  "testFilesCount": 3852,
   "javascript": {
-    "durationMs": 941.444583,
-    "throughputFilesPerSec": 4049.0965361473645,
-    "minMs": 856.3650419999999,
-    "maxMs": 961.5827079999999,
-    "meanMs": 919.7974443333333,
-    "stdDevMs": 45.60071833470983,
-    "samples": 3
+    "durationMs": 807.4865620000005,
+    "throughputFilesPerSec": 4770.358023617485,
+    "minMs": 798.7430000000004,
+    "maxMs": 870.8925420000005,
+    "meanMs": 815.7737540000002,
+    "stdDevMs": 20.602795993189357,
+    "samples": 10
   },
   "rustSingleThread": {
-    "durationMs": 407.2988,
-    "throughputFilesPerSec": 9359.2222712171,
-    "minMs": 404.6802,
-    "maxMs": 408.0335,
-    "meanMs": 406.67083333333335,
-    "stdDevMs": 1.4391923251910725,
-    "samples": 3
+    "durationMs": 436.5185,
+    "throughputFilesPerSec": 8824.368268469721,
+    "minMs": 433.6209,
+    "maxMs": 440.3388,
+    "meanMs": 436.4702899999999,
+    "stdDevMs": 1.760481966650039,
+    "samples": 10
   },
   "rustMultiThread": {
-    "durationMs": 55.0441,
-    "throughputFilesPerSec": 69253.56214380832,
-    "minMs": 53.9302,
-    "maxMs": 58.1003,
-    "meanMs": 55.69153333333333,
-    "stdDevMs": 1.762916323091433,
-    "samples": 3
+    "durationMs": 61.21665,
+    "throughputFilesPerSec": 62924.05742555334,
+    "minMs": 55.5363,
+    "maxMs": 65.9575,
+    "meanMs": 61.252469999999995,
+    "stdDevMs": 3.3141236672912493,
+    "samples": 10
   },
   "speedup": {
-    "singleThreadVsJs": 2.3114347083762583,
-    "multiThreadVsJs": 17.10346037086627
+    "singleThreadVsJs": 1.8498335397010677,
+    "multiThreadVsJs": 13.190636240303911
   },
   "parse": {
     "javascript": {
-      "durationMs": 220.84400000001187,
-      "throughputFilesPerSec": 17261.053051021514,
-      "minMs": 218.1868330000143,
-      "maxMs": 245.5561250000028,
-      "meanMs": 228.19565266667632,
-      "stdDevMs": 12.323544778015087,
-      "samples": 3
+      "durationMs": 210.87924999999814,
+      "throughputFilesPerSec": 18266.377559669974,
+      "minMs": 208.01033399999142,
+      "maxMs": 223.911334000004,
+      "meanMs": 212.43845419999852,
+      "stdDevMs": 4.73717712864939,
+      "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 9.1863,
-      "throughputFilesPerSec": 414965.764235873,
-      "minMs": 9.1315,
-      "maxMs": 9.2581,
-      "meanMs": 9.191966666666668,
-      "stdDevMs": 0.051839324412607406,
-      "samples": 3
+      "durationMs": 9.8636,
+      "throughputFilesPerSec": 390526.78535220405,
+      "minMs": 9.7915,
+      "maxMs": 10.0468,
+      "meanMs": 9.87299,
+      "stdDevMs": 0.07217667836635311,
+      "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 1.5223,
-      "throughputFilesPerSec": 2504105.6296393615,
-      "minMs": 1.4935,
-      "maxMs": 2.1989,
-      "meanMs": 1.7382333333333335,
-      "stdDevMs": 0.32595264823113324,
-      "samples": 3
+      "durationMs": 2.1901,
+      "throughputFilesPerSec": 1758823.7980000912,
+      "minMs": 1.4749,
+      "maxMs": 2.2582,
+      "meanMs": 2.1262800000000004,
+      "stdDevMs": 0.22075597296562552,
+      "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 24.040582171278086,
-      "multiThreadVsJs": 145.07258753203172
+      "singleThreadVsJs": 21.379541952228205,
+      "multiThreadVsJs": 96.28749828774856
     }
   },
   "svelte2tsx": {
     "javascript": {
-      "durationMs": 342.2046670000127,
-      "throughputFilesPerSec": 11139.532471659302,
-      "minMs": 335.9473750000179,
-      "maxMs": 369.1167499999865,
-      "meanMs": 349.08959733333904,
-      "stdDevMs": 14.389893646658239,
-      "samples": 3
+      "durationMs": 328.252353999982,
+      "throughputFilesPerSec": 11734.873956152074,
+      "minMs": 319.1319169999915,
+      "maxMs": 350.7194999999774,
+      "meanMs": 332.65422489999327,
+      "stdDevMs": 10.451484715093157,
+      "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 124.5595,
-      "throughputFilesPerSec": 30603.847960211788,
-      "minMs": 124.2971,
-      "maxMs": 125.3033,
-      "meanMs": 124.71996666666666,
-      "stdDevMs": 0.42616254593236225,
-      "samples": 3
+      "durationMs": 129.96634999999998,
+      "throughputFilesPerSec": 29638.44102723513,
+      "minMs": 129.1045,
+      "maxMs": 131.6651,
+      "meanMs": 130.13685,
+      "stdDevMs": 0.7791196150142766,
+      "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 15.6321,
-      "throughputFilesPerSec": 243857.1912922768,
-      "minMs": 15.6305,
-      "maxMs": 15.7155,
-      "meanMs": 15.659366666666665,
-      "stdDevMs": 0.03969763497013717,
-      "samples": 3
+      "durationMs": 17.23355,
+      "throughputFilesPerSec": 223517.4992964305,
+      "minMs": 16.302,
+      "maxMs": 19.3302,
+      "meanMs": 17.48205,
+      "stdDevMs": 1.046834452289377,
+      "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 2.74731888776057,
-      "multiThreadVsJs": 21.891151348827908
+      "singleThreadVsJs": 2.5256718681411154,
+      "multiThreadVsJs": 19.047285904528202
+    }
+  },
+  "fmt": {
+    "javascript": {
+      "durationMs": 3475.8962294999947,
+      "throughputFilesPerSec": 1108.2033943671868,
+      "minMs": 3437.191916999989,
+      "maxMs": 3524.942249999993,
+      "meanMs": 3476.7471040999953,
+      "stdDevMs": 24.811574163994912,
+      "samples": 10
+    },
+    "rustSingleThread": {
+      "durationMs": 98.15165,
+      "throughputFilesPerSec": 39245.39220685542,
+      "minMs": 97.6334,
+      "maxMs": 103.0321,
+      "meanMs": 98.7493,
+      "stdDevMs": 1.570382498628916,
+      "samples": 10
+    },
+    "rustMultiThread": {
+      "durationMs": 17.02035,
+      "throughputFilesPerSec": 226317.3201491156,
+      "minMs": 16.5043,
+      "maxMs": 18.1907,
+      "meanMs": 17.04873,
+      "stdDevMs": 0.4416377385369144,
+      "samples": 10
+    },
+    "speedup": {
+      "singleThreadVsJs": 35.41352824430353,
+      "multiThreadVsJs": 204.2200207105021
     }
   },
   "svelteCheck": {
     "javascript": {
-      "durationMs": 2052.480041,
-      "throughputFilesPerSec": 243.60772821761148,
-      "minMs": 2046.306333,
-      "maxMs": 2053.05325,
-      "meanMs": 2050.6132079999998,
-      "stdDevMs": 3.054398068211203,
-      "samples": 3
+      "durationMs": 2086.854187,
+      "throughputFilesPerSec": 239.59508197301759,
+      "minMs": 2079.782792,
+      "maxMs": 2208.875708,
+      "meanMs": 2097.9999040000002,
+      "stdDevMs": 37.10481598121199,
+      "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 48.491292,
-      "throughputFilesPerSec": 10311.129676643797,
-      "minMs": 48.302958,
-      "maxMs": 48.679042,
-      "meanMs": 48.49109733333333,
-      "stdDevMs": 0.1535357117748928,
-      "samples": 3
+      "durationMs": 50.613208,
+      "throughputFilesPerSec": 9878.844273218168,
+      "minMs": 49.241334,
+      "maxMs": 51.390416,
+      "meanMs": 50.6035292,
+      "stdDevMs": 0.6397536924313605,
+      "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 14.2205,
-      "throughputFilesPerSec": 35160.507717731445,
-      "minMs": 14.207167,
-      "maxMs": 15.181416,
-      "meanMs": 14.536361,
-      "stdDevMs": 0.4561552418428039,
-      "samples": 3
+      "durationMs": 14.345875,
+      "throughputFilesPerSec": 34853.2243589185,
+      "minMs": 14.212584,
+      "maxMs": 15.13675,
+      "meanMs": 14.452579200000002,
+      "stdDevMs": 0.2740787301954677,
+      "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 42.326775722948355,
-      "multiThreadVsJs": 144.3324806441405
+      "singleThreadVsJs": 41.23141506857261,
+      "multiThreadVsJs": 145.46719436771895
     },
     "filesCount": 500
   }

--- a/crates/rsvelte_core/benches/compiler.rs
+++ b/crates/rsvelte_core/benches/compiler.rs
@@ -30,7 +30,10 @@ fn get_sample_files() -> Vec<(String, String)> {
 
     for entry in fs::read_dir(&samples_dir).unwrap() {
         let entry = entry.unwrap();
-        let input_path = entry.path().join("input.svelte");
+        // Runtime-runes samples name their root component `main.svelte`, not
+        // `input.svelte` (which is the parser/snapshot convention) — looking
+        // for the wrong name here previously yielded a single real sample.
+        let input_path = entry.path().join("main.svelte");
 
         if input_path.exists() {
             let name = entry.file_name().to_str().unwrap().to_string();

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -11,6 +11,14 @@ publish = false
 name = "rsvelte-fmt"
 path = "src/main.rs"
 
+# Benchmark driver invoked by `scripts/bench/run-benchmark.mjs` for the `fmt`
+# task. Lives here (not in `rsvelte_core`'s `benchmark_runner`) because the
+# formatter sits in `rsvelte_formatter`, which depends on `rsvelte_core` —
+# the reverse dependency would be a cycle.
+[[bin]]
+name = "fmt_benchmark_runner"
+path = "src/bin/fmt_benchmark_runner.rs"
+
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }

--- a/crates/rsvelte_fmt/src/bin/fmt_benchmark_runner.rs
+++ b/crates/rsvelte_fmt/src/bin/fmt_benchmark_runner.rs
@@ -1,0 +1,228 @@
+//! Benchmark runner for the `fmt` task.
+//!
+//! Mirrors `rsvelte_core`'s `benchmark_runner` (same CLI surface and JSON
+//! output) but formats `.svelte` sources with [`rsvelte_formatter::format`]
+//! instead of compiling them. It is a separate binary in `rsvelte_fmt`
+//! because the formatter depends on `rsvelte_core`, so the compiler crate
+//! cannot depend on the formatter without a cycle.
+//!
+//! Invoked by `scripts/bench/run-benchmark.mjs` under the `bench` profile —
+//! the workspace `release` profile sets `panic = "abort"`, which would defeat
+//! the `catch_unwind` guard below; `profile.bench` keeps release's
+//! optimisation flags but uses `panic = "unwind"`:
+//!
+//! ```text
+//! cargo run --profile=bench --bin fmt_benchmark_runner -- \
+//!     --mode single|multi --files <list> --iterations N --warmup N
+//! ```
+//!
+//! Output (stdout): `{"times": [<ms>, ...]}`.
+
+use std::env;
+use std::fs;
+use std::io::{self, BufRead};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use rayon::prelude::*;
+use rsvelte_formatter::{FormatOptions, format};
+
+/// Count of inputs the formatter panicked on across the whole run. A
+/// benchmark over thousands of files must not be aborted by a single edge
+/// case that makes the formatter panic, so each call is wrapped in
+/// `catch_unwind` and failures are tallied here and reported once on stderr
+/// rather than crashing the process. The current corpus formats panic-free;
+/// this is a guard against regressions and out-of-corpus inputs.
+static PANIC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug)]
+struct Config {
+    mode: String,
+    files_path: String,
+    iterations: usize,
+    warmup: usize,
+}
+
+fn parse_args() -> Result<Config, String> {
+    let args: Vec<String> = env::args().collect();
+    let mut mode = String::from("single");
+    let mut files_path = String::new();
+    let mut iterations = 5;
+    let mut warmup = 2;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--mode" => {
+                i += 1;
+                if i < args.len() {
+                    mode = args[i].clone();
+                }
+            }
+            // Accepted and ignored: this runner only has one task. Keeping
+            // the flag means `run-benchmark.mjs` can pass `--task fmt`
+            // uniformly alongside the compiler runner.
+            "--task" => {
+                i += 1;
+            }
+            "--files" => {
+                i += 1;
+                if i < args.len() {
+                    files_path = args[i].clone();
+                }
+            }
+            "--iterations" => {
+                i += 1;
+                if i < args.len() {
+                    match args[i].parse() {
+                        Ok(n) => iterations = n,
+                        Err(_) => eprintln!(
+                            "warning: invalid --iterations value '{}', using default {}",
+                            args[i], iterations
+                        ),
+                    }
+                }
+            }
+            "--warmup" => {
+                i += 1;
+                if i < args.len() {
+                    match args[i].parse() {
+                        Ok(n) => warmup = n,
+                        Err(_) => eprintln!(
+                            "warning: invalid --warmup value '{}', using default {}",
+                            args[i], warmup
+                        ),
+                    }
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    if files_path.is_empty() {
+        return Err("--files argument is required".to_string());
+    }
+
+    Ok(Config {
+        mode,
+        files_path,
+        iterations,
+        warmup,
+    })
+}
+
+fn load_files(files_path: &str) -> io::Result<Vec<(String, String)>> {
+    let file = fs::File::open(files_path)?;
+    let reader = io::BufReader::new(file);
+    let mut files = Vec::new();
+
+    for line in reader.lines() {
+        let path = line?;
+        if path.is_empty() {
+            continue;
+        }
+        if let Ok(content) = fs::read_to_string(&path) {
+            files.push((path, content));
+        }
+    }
+
+    Ok(files)
+}
+
+fn format_file(source: &str, options: &FormatOptions) {
+    // Ignore parse/format errors — some corpus inputs intentionally contain
+    // syntax the formatter can't round-trip; the benchmark only times work,
+    // not correctness (the compatibility report covers correctness).
+    //
+    // `catch_unwind` guards against the formatter panicking on an edge case:
+    // the whole point of a benchmark is to time the corpus, not to assert
+    // robustness, so a single bad file is tallied and skipped rather than
+    // aborting the run. `AssertUnwindSafe` is needed because `FormatOptions`
+    // holds an `Option<Arc<dyn Fn>>` (None here) which isn't `RefUnwindSafe`.
+    let result = catch_unwind(AssertUnwindSafe(|| format(source, options)));
+    if result.is_err() {
+        PANIC_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn run_single_threaded(files: &[(String, String)], options: &FormatOptions) {
+    for (_path, content) in files {
+        format_file(content, options);
+    }
+}
+
+fn run_multi_threaded(files: &[(String, String)], options: &FormatOptions) {
+    files.par_iter().for_each(|(_path, content)| {
+        format_file(content, options);
+    });
+}
+
+fn main() {
+    let config = match parse_args() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let files = match load_files(&config.files_path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error loading files: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    eprintln!(
+        "Loaded {} files, mode: {}, task: fmt, iterations: {}, warmup: {}",
+        files.len(),
+        config.mode,
+        config.iterations,
+        config.warmup
+    );
+
+    // Swallow the per-panic backtrace spam from `catch_unwind`; we report a
+    // single aggregate count at the end instead.
+    std::panic::set_hook(Box::new(|_| {}));
+
+    let options = FormatOptions::default();
+    let is_multi = config.mode == "multi";
+
+    // Warmup
+    for _ in 0..config.warmup {
+        if is_multi {
+            run_multi_threaded(&files, &options);
+        } else {
+            run_single_threaded(&files, &options);
+        }
+    }
+
+    // Benchmark
+    let mut times = Vec::with_capacity(config.iterations);
+    for _ in 0..config.iterations {
+        let start = Instant::now();
+        if is_multi {
+            run_multi_threaded(&files, &options);
+        } else {
+            run_single_threaded(&files, &options);
+        }
+        times.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    let panics = PANIC_COUNT.load(Ordering::Relaxed);
+    if panics > 0 {
+        // Per-iteration count: PANIC_COUNT accumulates across every warmup +
+        // measured pass, so divide back out to report distinct bad files.
+        let passes = config.warmup + config.iterations;
+        eprintln!(
+            "note: formatter panicked on ~{} file(s) (skipped, not counted as work)",
+            panics / passes.max(1)
+        );
+    }
+
+    let times_json: Vec<String> = times.iter().map(|t| format!("{:.4}", t)).collect();
+    println!("{{\"times\": [{}]}}", times_json.join(", "));
+}

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -19,3 +19,10 @@ oxc_span = "0.134"
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
 oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "d727b6b10c690ef8b401572687fcb23589ac688e" }
 thiserror = "2.0"
+
+[dev-dependencies]
+criterion = { version = "0.8", features = ["html_reports"] }
+
+[[bench]]
+name = "formatter"
+harness = false

--- a/crates/rsvelte_formatter/benches/formatter.rs
+++ b/crates/rsvelte_formatter/benches/formatter.rs
@@ -1,0 +1,128 @@
+//! Formatter benchmarks.
+//!
+//! Measures the throughput of the Svelte formatter (`rsvelte_formatter::format`)
+//! on real Svelte test inputs plus a couple of synthetic stress files. The
+//! formatter parses each `.svelte` source, formats every `<script>` /
+//! `<style>` body and the markup, and reassembles the output — so these
+//! numbers cover the full format pipeline, not just the JS pass.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::fs;
+use std::hint::black_box;
+use std::path::PathBuf;
+
+use rsvelte_formatter::{FormatOptions, format};
+
+/// Collect representative Svelte sources for benchmarking.
+///
+/// Pulls inputs from the `runtime-runes` and `runtime-legacy` sample
+/// directories (the most script-heavy corpora, which exercise the JS
+/// formatting path the hardest), sorts by size, and keeps a small / medium
+/// / large spread so the report shows how the formatter scales with input
+/// size rather than drowning in hundreds of tiny fixtures.
+fn get_sample_files() -> Vec<(String, String)> {
+    let tests_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("submodules/svelte/packages/svelte/tests");
+
+    let sample_dirs = ["runtime-runes/samples", "runtime-legacy/samples"];
+
+    let mut files = Vec::new();
+    for sub in sample_dirs {
+        let dir = tests_dir.join(sub);
+        if !dir.exists() {
+            continue;
+        }
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            // Runtime samples name their root component `main.svelte` (unlike
+            // the parser/snapshot corpora, which use `input.svelte`).
+            let input_path = entry.path().join("main.svelte");
+            if !input_path.exists() {
+                continue;
+            }
+            if let Ok(content) = fs::read_to_string(&input_path) {
+                // Skip trivial files — they only measure fixed overhead.
+                if content.len() <= 80 {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().into_owned();
+                files.push((name, content));
+            }
+        }
+    }
+
+    files.sort_by_key(|(_, content)| content.len());
+
+    // Small / medium / large spread.
+    let mut selected = Vec::new();
+    if files.len() >= 3 {
+        selected.push(files[0].clone());
+        selected.push(files[files.len() / 2].clone());
+        selected.push(files[files.len() - 1].clone());
+    } else {
+        selected = files;
+    }
+    selected
+}
+
+/// A script-heavy synthetic component, to baseline the JS-formatting hot path.
+fn create_script_heavy_file() -> (String, String) {
+    let mut src = String::from("<script>\n    let count = $state(0);\n");
+    for i in 0..60 {
+        src.push_str(&format!(
+            "    function handler_{i}(event){{const a={i};const b=a*2;let total=a+b;if(total>{i}){{count=total;}}else{{count=a;}}return count;}}\n"
+        ));
+    }
+    src.push_str("</script>\n\n");
+    for i in 0..30 {
+        src.push_str(&format!(
+            "<button onclick={{handler_{i}}}>Item {i}: {{count}}</button>\n"
+        ));
+    }
+    ("synthetic-script-heavy".to_string(), src)
+}
+
+/// A markup-heavy synthetic component, to baseline the indent / open-tag /
+/// template-expression passes.
+fn create_markup_heavy_file() -> (String, String) {
+    let mut src = String::from("<script>\n  let count = $state(0);\n</script>\n\n");
+    for i in 0..80 {
+        src.push_str(&format!(
+            "<div class=\"item-{i}\" data-index={{ {i} }} aria-label=\"row {i}\"><span>Item {i}: {{count + {i}}}</span>{{#if count > {i}}}<strong>on</strong>{{:else}}<em>off</em>{{/if}}</div>\n"
+        ));
+    }
+    ("synthetic-markup-heavy".to_string(), src)
+}
+
+fn all_inputs() -> Vec<(String, String)> {
+    let mut files = get_sample_files();
+    files.push(create_script_heavy_file());
+    files.push(create_markup_heavy_file());
+    files
+}
+
+fn bench_format(c: &mut Criterion) {
+    let files = all_inputs();
+    if files.is_empty() {
+        eprintln!("No sample files found for formatter benchmarking");
+        return;
+    }
+
+    let mut group = c.benchmark_group("format");
+
+    for (name, content) in &files {
+        group.throughput(Throughput::Bytes(content.len() as u64));
+        group.bench_with_input(BenchmarkId::new("svelte", name), content, |b, source| {
+            let options = FormatOptions::default();
+            b.iter(|| format(black_box(source), &options));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_format);
+criterion_main!(benches);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",
-    "oxfmt": "^0.53.0"
+    "oxfmt": "^0.53.0",
+    "prettier": "^3.8.3",
+    "prettier-plugin-svelte": "^4.1.0",
+    "svelte": "^5.56.2"
   },
   "packageManager": "pnpm@11.5.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,16 @@ importers:
         version: 2.31.0
       oxfmt:
         specifier: ^0.53.0
-        version: 0.53.0
+        version: 0.53.0(svelte@5.56.2)
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
+      prettier-plugin-svelte:
+        specifier: ^4.1.0
+        version: 4.1.0(prettier@3.8.3)(svelte@5.56.2)
+      svelte:
+        specifier: ^5.56.2
+        version: 5.56.2
 
   apps/npm/compiler:
     publishDirectory: ../../../pkg
@@ -22,7 +31,7 @@ importers:
     dependencies:
       oxfmt:
         specifier: '*'
-        version: 0.53.0
+        version: 0.53.0(svelte@5.56.2)
     optionalDependencies:
       '@rsvelte/fmt-darwin-arm64':
         specifier: workspace:^
@@ -182,6 +191,22 @@ packages:
       '@types/node':
         optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -322,8 +347,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sveltejs/acorn-typescript@1.0.10':
+    resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -339,9 +380,17 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -354,6 +403,10 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -361,6 +414,9 @@ packages:
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
+
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -370,10 +426,21 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esrap@2.2.11:
+    resolution: {integrity: sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -436,6 +503,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -458,12 +528,18 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -539,9 +615,21 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  prettier-plugin-svelte@4.1.0:
+    resolution: {integrity: sha512-YZkhA2Q9oOerFFG9tq+2f98WYT7Z2JgrybJrAyrB78jpsH9i/DdgplXemehuFPgsldetFNCcR/yCcYlDjPy94Q==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^5.0.0
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
     hasBin: true
 
   quansync@0.2.11:
@@ -603,6 +691,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  svelte@5.56.2:
+    resolution: {integrity: sha512-1lDf8TLqpxyAt3xgybfytWPJQbaUD6TiDgpiCLH0BKrKEwzecB9pjuNVnEJMpzH018xUzo6oxheK2HT0oa2RoQ==}
+    engines: {node: '>=18'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -623,6 +715,9 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
 
@@ -776,6 +871,25 @@ snapshots:
       chardet: 2.1.1
       iconv-lite: 0.7.2
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -861,7 +975,17 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.53.0':
     optional: true
 
+  '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
+  '@types/estree@1.0.9': {}
+
   '@types/node@12.20.55': {}
+
+  '@types/trusted-types@2.0.7': {}
+
+  acorn@8.16.0: {}
 
   ansi-colors@4.1.3: {}
 
@@ -873,7 +997,11 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.1: {}
+
   array-union@2.1.0: {}
+
+  axobject-query@4.1.0: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -885,6 +1013,8 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  clsx@2.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -892,6 +1022,8 @@ snapshots:
       which: 2.0.2
 
   detect-indent@6.1.0: {}
+
+  devalue@5.8.1: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -902,7 +1034,13 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  esm-env@1.2.2: {}
+
   esprima@4.0.1: {}
+
+  esrap@2.2.11:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   extendable-error@0.1.7: {}
 
@@ -970,6 +1108,10 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -991,11 +1133,17 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  locate-character@3.0.0: {}
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
 
   lodash.startcase@4.4.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   merge2@1.4.1: {}
 
@@ -1008,7 +1156,7 @@ snapshots:
 
   outdent@0.5.0: {}
 
-  oxfmt@0.53.0:
+  oxfmt@0.53.0(svelte@5.56.2):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -1031,6 +1179,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.53.0
       '@oxfmt/binding-win32-ia32-msvc': 0.53.0
       '@oxfmt/binding-win32-x64-msvc': 0.53.0
+      svelte: 5.56.2
 
   p-filter@2.1.0:
     dependencies:
@@ -1064,7 +1213,14 @@ snapshots:
 
   pify@4.0.1: {}
 
+  prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.2):
+    dependencies:
+      prettier: 3.8.3
+      svelte: 5.56.2
+
   prettier@2.8.8: {}
+
+  prettier@3.8.3: {}
 
   quansync@0.2.11: {}
 
@@ -1112,6 +1268,27 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  svelte@5.56.2:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.8.1
+      esm-env: 1.2.2
+      esrap: 2.2.11
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
   term-size@2.2.1: {}
 
   tinypool@2.1.0: {}
@@ -1125,3 +1302,5 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  zimmerframe@1.1.4: {}

--- a/scripts/bench/bench.sh
+++ b/scripts/bench/bench.sh
@@ -55,10 +55,18 @@ const fmtMs = (v) => v.toFixed(0) + 'ms';
 console.log('=== Benchmark Results (' + r.testFilesCount + ' files) ===');
 console.log('');
 
-for (const task of ['compile-client', 'compile-server', 'parse', 'svelte2tsx']) {
-    const d = r[task];
-    if (!d) continue;
-    console.log(d.taskLabel + ':');
+// compile-client lives at the top level of the JSON for backwards
+// compat; every other task is a nested sibling keyed by name.
+const tasks = [
+    ['Compile (Client)', r],
+    ['Parse', r.parse],
+    ['svelte2tsx', r.svelte2tsx],
+    ['fmt', r.fmt],
+    ['svelte-check', r.svelteCheck],
+];
+for (const [label, d] of tasks) {
+    if (!d || !d.javascript) continue;
+    console.log(label + ':');
     console.log('  JavaScript:           ' + fmtMs(d.javascript.durationMs));
     console.log('  Rust (single-thread): ' + fmtMs(d.rustSingleThread.durationMs) + '  (' + fmt(d.speedup.singleThreadVsJs) + 'x)');
     console.log('  Rust (multi-thread):  ' + fmtMs(d.rustMultiThread.durationMs) + '  (' + fmt(d.speedup.multiThreadVsJs) + 'x)');
@@ -72,6 +80,7 @@ run_criterion() {
     log "Running Criterion benchmarks..."
     cargo bench --bench compiler 2>&1
     cargo bench --bench parser 2>&1
+    cargo bench -p rsvelte_formatter --bench formatter 2>&1
     ok "Criterion benchmarks complete. See target/criterion/ for HTML reports."
 }
 
@@ -139,10 +148,16 @@ console.log('');
 console.log('Task               | JS       | Rust     | Speedup');
 console.log('-------------------|----------|----------|--------');
 
-for (const task of ['compile-client', 'compile-server', 'parse', 'svelte2tsx']) {
-    const d = r[task];
-    if (!d) continue;
-    const label = d.taskLabel.padEnd(18);
+const tasks = [
+    ['Compile (Client)', r],
+    ['Parse', r.parse],
+    ['svelte2tsx', r.svelte2tsx],
+    ['fmt', r.fmt],
+    ['svelte-check', r.svelteCheck],
+];
+for (const [taskLabel, d] of tasks) {
+    if (!d || !d.javascript) continue;
+    const label = taskLabel.padEnd(18);
     const js = fmtMs(d.javascript.durationMs).padStart(8);
     const rs = fmtMs(d.rustSingleThread.durationMs).padStart(8);
     const sp = (fmt(d.speedup.singleThreadVsJs) + 'x').padStart(7);

--- a/scripts/bench/run-benchmark.mjs
+++ b/scripts/bench/run-benchmark.mjs
@@ -108,6 +108,24 @@ const { svelte2tsx: upstreamSvelte2tsx } = await import(
 	'../../submodules/language-tools/packages/svelte2tsx/index.mjs'
 );
 
+// Prettier + prettier-plugin-svelte are the JS baseline for the `fmt` task.
+// Both are plain npm devDependencies (see root package.json), so a normal
+// `pnpm install` makes them resolvable — unlike svelte/compiler and
+// language-tools above, there is nothing to build first. prettier-plugin-
+// svelte also peer-depends on `svelte`, which is likewise a devDependency.
+let prettier;
+let prettierPluginSvelte;
+try {
+	const prettierMod = await import('prettier');
+	prettier = prettierMod.default ?? prettierMod;
+	prettierPluginSvelte = await import('prettier-plugin-svelte');
+} catch (err) {
+	console.error(
+		'[run-benchmark] prettier / prettier-plugin-svelte not found — run `pnpm install`.',
+	);
+	throw err;
+}
+
 // Test directories containing Svelte files
 const TEST_CATEGORIES = [
 	'parser-modern/samples',
@@ -229,9 +247,15 @@ function benchmarkJavaScript(files, iterations, task) {
 }
 
 /**
- * Benchmark Rust compiler using the benchmark binary
+ * Benchmark Rust compiler using the benchmark binary.
+ *
+ * `binName` selects which Cargo binary drives the task. Compiler tasks
+ * (compile-client / parse / svelte2tsx) use `benchmark_runner` in
+ * `rsvelte_core`; the `fmt` task uses `fmt_benchmark_runner` in
+ * `rsvelte_fmt` (the formatter can't live in the compiler crate without a
+ * dependency cycle). Both share the same CLI + JSON-output contract.
  */
-async function benchmarkRust(files, singleThread, task) {
+async function benchmarkRust(files, singleThread, task, binName = 'benchmark_runner') {
 	const mode = singleThread ? 'single' : 'multi';
 
 	// Create a temp file with all file paths
@@ -239,12 +263,21 @@ async function benchmarkRust(files, singleThread, task) {
 	const tempFile = join(__dirname, '../../.benchmark-files.txt');
 	writeFileSync(tempFile, fileList);
 
+	// `profile.release` sets `panic = "abort"`, so a formatter panic on a
+	// malformed corpus file would kill the whole run. The fmt runner relies
+	// on `catch_unwind` to skip such files, which only works under a profile
+	// with `panic = "unwind"` — that's exactly what `profile.bench` is for
+	// (it inherits release's optimisation flags, so the timings stay
+	// representative). Compiler tasks don't panic on this corpus, so they
+	// keep the faster-to-link release profile.
+	const profileFlag = binName === 'fmt_benchmark_runner' ? '--profile=bench' : '--release';
+
 	return new Promise((resolve, reject) => {
 		const args = [
 			'run',
-			'--release',
+			profileFlag,
 			'--bin',
-			'benchmark_runner',
+			binName,
 			'--',
 			'--mode',
 			mode,
@@ -436,6 +469,88 @@ function asTaskResults(taskResult) {
 	return { javascript, rustSingleThread, rustMultiThread, speedup };
 }
 
+// ── fmt task ────────────────────────────────────────────────────────────────
+//
+// The `fmt` task pits prettier + prettier-plugin-svelte (the canonical JS
+// Svelte formatter) against rsvelte_formatter over the shared per-file
+// corpus. It needs its own runner because prettier 3's `format()` is async,
+// whereas the compiler tasks above call synchronous APIs. The Rust side is
+// driven by the `fmt_benchmark_runner` binary in `rsvelte_fmt`.
+
+async function benchmarkPrettier(files, iterations) {
+	const opts = (filepath) => ({
+		parser: 'svelte',
+		plugins: [prettierPluginSvelte],
+		filepath,
+	});
+
+	// Warmup
+	for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+		for (const file of files) {
+			try {
+				await prettier.format(file.content, opts(file.path));
+			} catch {
+				// Ignore formatting errors — some fixtures aren't valid Svelte.
+			}
+		}
+	}
+
+	const times = [];
+	for (let i = 0; i < iterations; i++) {
+		const start = performance.now();
+		for (const file of files) {
+			try {
+				await prettier.format(file.content, opts(file.path));
+			} catch {
+				// Ignore formatting errors for benchmark
+			}
+		}
+		times.push(performance.now() - start);
+	}
+	return times;
+}
+
+async function runFmtTask(files) {
+	console.error('\n=== fmt ===');
+
+	console.error('  Benchmarking JavaScript (prettier-plugin-svelte)...');
+	const jsTimes = await benchmarkPrettier(files, BENCHMARK_ITERATIONS);
+	const jsStats = calculateStats(jsTimes, files.length);
+	console.error(
+		`    ${jsStats.durationMs.toFixed(2)}ms (${jsStats.throughputFilesPerSec.toFixed(0)} files/sec)`,
+	);
+
+	console.error('  Benchmarking Rust (single-threaded)...');
+	const rustSingleTimes = await benchmarkRust(files, true, 'fmt', 'fmt_benchmark_runner');
+	const rustSingleStats = calculateStats(rustSingleTimes, files.length);
+	console.error(
+		`    ${rustSingleStats.durationMs.toFixed(2)}ms (${rustSingleStats.throughputFilesPerSec.toFixed(0)} files/sec)`,
+	);
+
+	console.error('  Benchmarking Rust (multi-threaded)...');
+	const rustMultiTimes = await benchmarkRust(files, false, 'fmt', 'fmt_benchmark_runner');
+	const rustMultiStats = calculateStats(rustMultiTimes, files.length);
+	console.error(
+		`    ${rustMultiStats.durationMs.toFixed(2)}ms (${rustMultiStats.throughputFilesPerSec.toFixed(0)} files/sec)`,
+	);
+
+	const speedupSingle = jsStats.durationMs / rustSingleStats.durationMs;
+	const speedupMulti = jsStats.durationMs / rustMultiStats.durationMs;
+	console.error(`  Speedup: single=${speedupSingle.toFixed(1)}x, multi=${speedupMulti.toFixed(1)}x`);
+
+	return {
+		task: 'fmt',
+		taskLabel: 'fmt',
+		javascript: { ...jsStats },
+		rustSingleThread: { ...rustSingleStats },
+		rustMultiThread: { ...rustMultiStats },
+		speedup: {
+			singleThreadVsJs: speedupSingle,
+			multiThreadVsJs: speedupMulti,
+		},
+	};
+}
+
 // ── svelte-check task ──────────────────────────────────────────────────────
 //
 // Unlike the other tasks, svelte-check is a project-wise CLI, not a per-file
@@ -568,11 +683,12 @@ async function main() {
 	const compileClient = await runBenchmarkTask(files, 'compile-client');
 	const parse = await runBenchmarkTask(files, 'parse');
 	const svelte2tsx = await runBenchmarkTask(files, 'svelte2tsx');
+	const fmt = await runFmtTask(files);
 	const svelteCheck = await runSvelteCheckTask();
 
 	// Output combined JSON. Compile-client lives at the top level for
 	// backward compatibility with the existing benchmark page; parse,
-	// svelte2tsx and svelte-check are nested siblings so the page can
+	// svelte2tsx, fmt and svelte-check are nested siblings so the page can
 	// render each as its own section.
 	const output = {
 		generatedAt: new Date().toISOString(),
@@ -582,6 +698,7 @@ async function main() {
 		...asTaskResults(compileClient),
 		parse: asTaskResults(parse),
 		svelte2tsx: asTaskResults(svelte2tsx),
+		fmt: asTaskResults(fmt),
 		svelteCheck: { ...svelteCheck, filesCount: SVELTE_CHECK_FILES },
 	};
 


### PR DESCRIPTION
## Why

The benchmark harness had no coverage of the formatter (`rsvelte_formatter` / `rsvelte_fmt`), and a few of the existing benches had quietly rotted. This adds fmt benchmarking on both axes and brings the rest up to date, then re-measures on the latest `main`.

## fmt benchmarks (both forms)

- **Criterion micro-bench** — `crates/rsvelte_formatter/benches/formatter.rs` times `rsvelte_formatter::format` over a small/medium/large spread of real runtime samples plus script- and markup-heavy synthetic files.
- **JS-vs-Rust task** — a `fmt` task in `scripts/bench/run-benchmark.mjs` compares **prettier + prettier-plugin-svelte** against a new `fmt_benchmark_runner` binary in `rsvelte_fmt`. (The formatter depends on `rsvelte_core`, so the runner can't live in the compiler crate without a dependency cycle.) It runs under `profile.bench` (`panic=unwind`) and wraps each format in `catch_unwind`, so a formatter panic on an edge case is skipped + tallied rather than aborting the whole run — defensive only; the current corpus formats panic-free.
- **Playground** `/benchmark` page renders the fmt panel and now labels each task's JS baseline correctly (`svelte/compiler`, `svelte2tsx`, `svelte-check`, `prettier-svelte`) instead of hardcoding "svelte/compiler".

## Existing-bench fixes

- `compiler.rs` / the new `formatter.rs` sample loaders look for `main.svelte` in the runtime-runes corpus (the runtime convention) instead of `input.svelte` — previously only **one** real sample was ever picked up.
- `bench.sh` summary printers read the actual JSON shape (`r['compile-client']` / `d.taskLabel` no longer exist, so the summary printed nothing/`undefined`); added fmt + the formatter criterion bench.
- Refreshed the page's reproduce commands to the current scripts.

## Results

Refreshed `apps/playground/static/benchmark-results.json` on an Apple M1 Pro (10c), 3,852-file corpus, warmup 3 / 10 iterations, against the latest `main`:

| Task | JS baseline | rsvelte 1-thread | rsvelte multi |
|---|---|---|---|
| Compile (client) | 808 ms | 437 ms (1.8×) | 61 ms (13.2×) |
| Parse | 211 ms | 9.9 ms (21.4×) | 2.2 ms (96.3×) |
| svelte2tsx | 328 ms | 130 ms (2.5×) | 17 ms (19.0×) |
| **fmt** | **3,476 ms** | **98 ms (35.4×)** | **17 ms (204.2×)** |
| svelte-check | 2,087 ms | 51 ms (41.2×) | 14 ms (145.5×) |

## Validation

- `cargo fmt` / `clippy` clean
- Both Criterion benches execute (real small/medium/large spread + synthetics)
- Full JS-vs-Rust run is green; **0 formatter panics** on the current corpus

> Note: adds `prettier`, `prettier-plugin-svelte`, and `svelte` as root devDependencies (the JS fmt baseline + its peer dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)