### PR TITLE
docs: reflect the fmt benchmark across README, site, and package docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,18 +233,19 @@ The Rust API (`rsvelte_core::compile`) has no such restriction — `css_hash: Op
 
 ## Performance
 
-Per-task benchmark across 3,637 real `.svelte` files, 10 iterations (3 warmup), against the official `svelte/compiler`:
+Per-task benchmark across 3,852 real `.svelte` files, 10 iterations (3 warmup). Each task is measured against its JavaScript counterpart — `svelte/compiler` for the compiler phases, `svelte2tsx`, `svelte-check`, and `prettier-plugin-svelte` for `fmt`:
 
-| Task | JS (`svelte/compiler`) | Rust (single-threaded) | Rust (multi-threaded) | Multi vs JS |
+| Task | JS baseline | Rust (single-threaded) | Rust (multi-threaded) | Multi vs JS |
 |---|---:|---:|---:|---:|
-| **Full pipeline** — parse / analyze / codegen | 864.8 ms | 381.1 ms | 50.1 ms | **17.3×** |
-| **Parser only** — phase 1, isolated | 187.5 ms | 8.7 ms | 1.9 ms | **99.5×** |
-| **`svelte2tsx`** — `.svelte` → `.tsx` generation | 306.1 ms | 115.3 ms | 16.0 ms | **19.1×** |
-| **`svelte-check`** — CLI, 500-file workspace | 2,088.0 ms | 46.9 ms | 13.8 ms | **151.5×** |
+| **Full pipeline** — parse / analyze / codegen | 807.5 ms | 436.5 ms | 61.2 ms | **13.2×** |
+| **Parser only** — phase 1, isolated | 210.9 ms | 9.9 ms | 2.2 ms | **96.3×** |
+| **`svelte2tsx`** — `.svelte` → `.tsx` generation | 328.3 ms | 130.0 ms | 17.2 ms | **19.0×** |
+| **`fmt`** — formatter, `.svelte` sources | 3,475.9 ms | 98.2 ms | 17.0 ms | **204.2×** |
+| **`svelte-check`** — CLI, 500-file workspace | 2,086.9 ms | 50.6 ms | 14.3 ms | **145.5×** |
 
-> Apple M1 Pro · 10-core arm64 · 3,637 `.svelte` files · 10 iterations (3 warmup). Recorded 2026-05-24 at commit `da6b3c8`. Live numbers, charts, and reproduction steps live on the [benchmark page](https://baseballyama.github.io/rsvelte/benchmark) (or run `node scripts/bench/run-benchmark.mjs > apps/playground/static/benchmark-results.json` locally).
+> Apple M1 Pro · 10-core arm64 · 3,852 `.svelte` files · 10 iterations (3 warmup). Recorded 2026-06-06 on the latest `main`. Live numbers, charts, and reproduction steps live on the [benchmark page](https://baseballyama.github.io/rsvelte/benchmark) (or run `pnpm run generate-benchmark` locally).
 
-A single-threaded **100× speedup** over the JS compiler is one of this project's explicit goals — the parser is already at multi-threaded `99.5×` and `svelte-check` at `151.5×`, but the full pipeline is still climbing. Current numbers are a snapshot, not a ceiling.
+A single-threaded **100× speedup** over the JS compiler is one of this project's explicit goals — `fmt` already lands at multi-threaded `204.2×` (and `35.4×` single-threaded) against `prettier-plugin-svelte`, the parser at `96.3×`, and `svelte-check` at `145.5×`, while the full pipeline is still climbing. Current numbers are a snapshot, not a ceiling.
 
 ## Compatibility
 

--- a/apps/npm/fmt/README.md
+++ b/apps/npm/fmt/README.md
@@ -100,6 +100,11 @@ project. The Svelte parser is rsvelte (Rust, in-process) and the JS rewrite is
 straight `oxc_formatter` — no Node calls and no Prettier round-trip for the
 Svelte markup itself.
 
+Formatting 3,852 real `.svelte` files (Apple M1 Pro, 10 iterations / 3 warmup),
+the Svelte engine runs **35× faster single-threaded and 204× faster
+multi-threaded** than `prettier-plugin-svelte`. Live numbers and reproduction
+steps are on the [benchmark page](https://baseballyama.github.io/rsvelte/benchmark).
+
 ## License
 
 MIT

--- a/apps/playground/src/lib/ecosystem.ts
+++ b/apps/playground/src/lib/ecosystem.ts
@@ -56,8 +56,8 @@ export const shipped: EcoComponent[] = [
 		status: 'shipped',
 		blurb:
 			'The whole compile pipeline — parse, analyze, transform — for client, SSR and hydration. Output matches the official compiler across the in-scope test suite.',
-		speedup: { x: 17, of: 'full pipeline' },
-		note: 'Parser alone runs 145× · 99.8% of in-scope fixtures green'
+		speedup: { x: 13, of: 'full pipeline' },
+		note: 'Parser alone runs 96× · 99.8% of in-scope fixtures green'
 	},
 	{
 		name: '@rsvelte/svelte2tsx',
@@ -68,7 +68,7 @@ export const shipped: EcoComponent[] = [
 		status: 'shipped',
 		blurb:
 			'Turns a .svelte component into the TSX shadow file the TypeScript checker reads, with column-accurate source maps.',
-		speedup: { x: 22, of: 'svelte2tsx' },
+		speedup: { x: 19, of: 'svelte2tsx' },
 		note: 'Wave 1 · 100% of fixtures'
 	},
 	{
@@ -80,8 +80,20 @@ export const shipped: EcoComponent[] = [
 		status: 'shipped',
 		blurb:
 			'The project type-checker CLI. A Rust walker + overlay drives tsgo for the TypeScript half; diagnostics map back to .svelte positions. Watch + incremental cache included.',
-		speedup: { x: 144, of: 'svelte-check' },
+		speedup: { x: 145, of: 'svelte-check' },
 		note: 'Rust walker + tsgo backend · 500-file workspace'
+	},
+	{
+		name: '@rsvelte/fmt',
+		dropInFor: 'prettier-plugin-svelte',
+		originalUrl: 'https://github.com/sveltejs/prettier-plugin-svelte',
+		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/fmt',
+		install: 'npm i -D @rsvelte/fmt',
+		status: 'shipped',
+		blurb:
+			'A Rust-native formatter for .svelte files — in-process, with no Node startup and no Prettier doc-IR round-trip. Routes .js / .ts / .css to oxfmt, with both pipelines running in parallel.',
+		speedup: { x: 204, of: 'fmt' },
+		note: 'Built on oxc_formatter · vs prettier-plugin-svelte'
 	},
 	{
 		name: '@rsvelte/vite-plugin-svelte',
@@ -120,14 +132,6 @@ export const delegated: EcoComponent[] = [
 		status: 'delegated',
 		blurb: 'Linting belongs in oxlint — rsvelte gives it a Svelte surface to call into.',
 		routesTo: { label: 'oxlint', url: 'https://oxc.rs/docs/guide/usage/linter.html' }
-	},
-	{
-		name: 'prettier-plugin-svelte',
-		dropInFor: 'prettier-plugin-svelte',
-		originalUrl: 'https://github.com/sveltejs/prettier-plugin-svelte',
-		status: 'delegated',
-		blurb: 'Formatting is a Rust-formatter job — oxfmt / dprint / biome, not a fork of Prettier.',
-		routesTo: { label: 'oxfmt', url: 'https://oxc.rs/' }
 	},
 	{
 		name: 'svelte-preprocess',

--- a/apps/playground/src/routes/+page.svelte
+++ b/apps/playground/src/routes/+page.svelte
@@ -42,7 +42,7 @@
 	const formatDate = (iso: string): string =>
 		new Date(iso).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 
-	// The four measured tools across the toolchain — each multi-threaded
+	// The measured tools across the toolchain — each multi-threaded
 	// rsvelte vs. its official JavaScript counterpart on the same corpus.
 	const toolchain = $derived.by(() => {
 		if (!bench) return [];
@@ -52,6 +52,9 @@
 		];
 		if (bench.svelte2tsx) {
 			list.push({ label: 'svelte2tsx', sub: '.svelte → .tsx', x: bench.svelte2tsx.speedup.multiThreadVsJs });
+		}
+		if (bench.fmt) {
+			list.push({ label: 'fmt', sub: 'formatter vs prettier', x: bench.fmt.speedup.multiThreadVsJs });
 		}
 		if (bench.svelteCheck) {
 			list.push({ label: 'svelte-check', sub: 'project type-check', x: bench.svelteCheck.speedup.multiThreadVsJs });
@@ -109,7 +112,7 @@
 		{
 			n: '03',
 			h: 'One stack, end to end.',
-			p: 'Compiler, svelte2tsx and svelte-check share the same Rust AST and OXC foundation — no JS hop between the tools in your build.'
+			p: 'Compiler, svelte2tsx, svelte-check and fmt share the same Rust AST and OXC foundation — no JS hop between the tools in your build.'
 		}
 	];
 </script>
@@ -118,7 +121,7 @@
 	<title>rsvelte · the Svelte ecosystem, in Rust</title>
 	<meta
 		name="description"
-		content="A Rust port of the Svelte ecosystem — compiler, svelte2tsx, svelte-check and vite-plugin-svelte as drop-in replacements. Same surface, identical output, up to 145× faster."
+		content="A Rust port of the Svelte ecosystem — compiler, svelte2tsx, svelte-check, fmt and vite-plugin-svelte as drop-in replacements. Same surface, identical output, up to 204× faster."
 	/>
 </svelte:head>
 
@@ -136,8 +139,8 @@
 
 		<p class="lede">
 			Drop-in replacements for the tools you already run — the compiler, <code>svelte2tsx</code>,
-			<code>svelte-check</code>, the Vite plugin. Same surface, identical output, up to
-			<span class="ink-svelte">{bench ? Math.round(maxSpeedup) : 145}×</span> faster.
+			<code>svelte-check</code>, <code>fmt</code>, the Vite plugin. Same surface, identical output, up to
+			<span class="ink-svelte">{bench ? Math.round(maxSpeedup) : 204}×</span> faster.
 		</p>
 
 		<div class="cta">

--- a/apps/playground/src/routes/ecosystem/+page.svelte
+++ b/apps/playground/src/routes/ecosystem/+page.svelte
@@ -10,7 +10,7 @@
 	<title>Ecosystem · rsvelte</title>
 	<meta
 		name="description"
-		content="The Svelte ecosystem, ported to Rust — compiler, svelte2tsx, svelte-check and vite-plugin-svelte as drop-in replacements, with links to every upstream tool and what's delegated to OXC."
+		content="The Svelte ecosystem, ported to Rust — compiler, svelte2tsx, svelte-check, fmt and vite-plugin-svelte as drop-in replacements, with links to every upstream tool and what's delegated to OXC."
 	/>
 </svelte:head>
 
@@ -49,7 +49,7 @@
 			</div>
 			<div>
 				<dt>Top speedup</dt>
-				<dd><span class="big ink-svelte">145×</span> <span class="dim">parser vs. JS</span></dd>
+				<dd><span class="big ink-svelte">204×</span> <span class="dim">fmt vs. JS</span></dd>
 			</div>
 		</dl>
 	</header>

--- a/crates/rsvelte_fmt/README.md
+++ b/crates/rsvelte_fmt/README.md
@@ -162,6 +162,12 @@ $ cat src/App.svelte
 - `oxfmt` is invoked only for standalone non-`.svelte` files and for the CSS
   body of `<style>` blocks — never for the Svelte markup itself.
 
+Across 3,852 real `.svelte` files (Apple M1 Pro, 10 iterations / 3 warmup), the
+Svelte engine formats **35× faster single-threaded and 204× faster
+multi-threaded** than `prettier-plugin-svelte`. Benchmark the formatter locally
+with `cargo bench -p rsvelte_formatter --bench formatter`, or run the full
+JS-vs-Rust comparison with `pnpm run generate-benchmark`.
+
 ## License
 
 MIT

--- a/crates/rsvelte_formatter/README.md
+++ b/crates/rsvelte_formatter/README.md
@@ -24,6 +24,10 @@ Functional and tested — **105 tests**, full hygiene (`cargo fmt`,
 `cargo clippy -- -D warnings`). Not yet published to crates.io; consumed by
 `rsvelte-fmt` via a workspace path dependency.
 
+On 3,852 real `.svelte` files (Apple M1 Pro), `format` runs **35× faster
+single-threaded and 204× faster multi-threaded** than `prettier-plugin-svelte`.
+Micro-bench it with `cargo bench -p rsvelte_formatter --bench formatter`.
+
 ## What it formats
 
 | Surface | Notes |


### PR DESCRIPTION
Follow-up to #673 (fmt benchmarks). That PR added the `fmt` task and refreshed `benchmark-results.json`; this PR propagates the numbers to every user-facing surface that quotes benchmark/speedup figures, and refreshes the now-stale ones.

## README

- Performance table: add the **`fmt`** row (204.2× multi-thread vs `prettier-plugin-svelte`), refresh every figure to the latest measurement (3,852 files), relabel the JS column as "JS baseline" (it was never all `svelte/compiler`), and update the footnote + reproduce command (`pnpm run generate-benchmark`).
- Narrative: lead with fmt (`204.2×` multi / `35.4×` single) alongside parser/svelte-check.

## Playground site

- **Home** — add the `fmt` chip to the toolchain speedup list; list fmt in the lede / meta description / "one stack" architecture copy; bump the hardcoded fallback headline 145× → 204×.
- **Ecosystem** — add `@rsvelte/fmt` as a **shipped** drop-in for `prettier-plugin-svelte` (204×) and drop the superseded *delegated* `prettier-plugin-svelte` entry; refresh compiler / parser / svelte2tsx / svelte-check speedups; update the "Top speedup" stat to 204× fmt.

## Package / crate READMEs

- `@rsvelte/fmt`, `rsvelte_fmt`, `rsvelte_formatter` — add the concrete **35× single / 204× multi** numbers and how to reproduce (`cargo bench -p rsvelte_formatter --bench formatter` / `pnpm run generate-benchmark`).

## Notes

- Numbers match the `benchmark-results.json` merged in #673 (measured on an Apple M1 Pro). Main has since bumped oxc (#668); the figures are not expected to move materially, so this does not re-measure — say the word if you'd like a fresh run on the current oxc rev.
- `ecosystem.ts` counts shift accordingly: shipped 4 → 5, delegated 5 → 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)