### PR TITLE
fix(release): wait for registry propagation before changeset publish

### DIFF
--- a/scripts/release/publish-platform-binaries.mjs
+++ b/scripts/release/publish-platform-binaries.mjs
@@ -56,6 +56,38 @@ function isAlreadyPublished(name, version) {
 	return false;
 }
 
+// Block until the registry reflects a just-published version.
+//
+// Why: `changeset publish` runs immediately after this script and takes its
+// own `npm info` snapshot of every workspace package up front. If the registry
+// hasn't propagated a version we published here, changeset's snapshot shows it
+// as *not* published and it attempts a duplicate publish. npm answers that with
+// an E403 ("cannot publish over the previously published version"), and under
+// OIDC trusted publishing that error JSON carries no `summary` field — which
+// crashes changesets 2.31.0's `isAlreadyPublishedError(json.error.summary)`
+// (`undefined.includes(...)`), failing the whole release even though every
+// package actually published. Polling until the version is visible closes the
+// read-after-write gap so changeset reliably sees "already published" and skips
+// it (the benign "is not being published" warning) instead of racing.
+function waitUntilVisible(name, version, { timeoutMs = 90_000, intervalMs = 3_000 } = {}) {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (isAlreadyPublished(name, version)) {
+			return true;
+		}
+		if (Date.now() >= deadline) {
+			// Don't fail the release: the publish itself succeeded, this is only
+			// the propagation barrier. Worst case changeset races as before.
+			console.warn(
+				`[publish-platform] ${name}@${version} not visible after ${timeoutMs}ms — continuing anyway`,
+			);
+			return false;
+		}
+		// Synchronous sleep so the barrier stays in this sequential script.
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, intervalMs);
+	}
+}
+
 let failures = 0;
 for (const relDir of platformDirs) {
 	const absDir = resolve(repoRoot, relDir);
@@ -82,6 +114,14 @@ for (const relDir of platformDirs) {
 	if (result.status !== 0) {
 		console.error(`[publish-platform] FAILED: ${name}@${version} (exit ${result.status})`);
 		failures += 1;
+		continue;
+	}
+	// Wait for registry propagation before the next package / `changeset
+	// publish` so the duplicate-publish race can't crash changesets. Skipped
+	// for dry runs, which never touch the registry.
+	if (!dryRun) {
+		console.log(`[publish-platform] waiting for ${name}@${version} to be visible on the registry`);
+		waitUntilVisible(name, version);
 	}
 }
 


### PR DESCRIPTION
## What

Adds a registry-propagation barrier to `scripts/release/publish-platform-binaries.mjs`: after each `npm publish`, poll `npm view` until the version is visible (90s cap, non-fatal on timeout) before moving on / handing off to `changeset publish`.

## Why

The `Publish` job failed in [run 27059936393](https://github.com/baseballyama/rsvelte/actions/runs/27059936393/job/79871594617) with:

```
TypeError: Cannot read properties of undefined (reading 'includes')
    at isAlreadyPublishedError (@changesets/cli/.../changesets-cli.cjs.js:873:17)
```

The release stages two publishers back to back:

1. `publish-platform-binaries.mjs` publishes the POSIX platform packages via `npm publish` (preserves the +x bit, which `pnpm publish` strips).
2. `changeset publish` publishes everything else, skipping versions it sees as already on the registry.

changeset takes an `npm info` snapshot of every workspace package **up front**. In the failed run it ran ~1s after the custom script published `@rsvelte/fmt-linux-arm64-gnu@0.1.1`, before the registry had propagated — so changeset saw it as unpublished and attempted a duplicate publish. npm answered **E403** ("cannot publish over the previously published version"), and under OIDC trusted publishing that error JSON carries **no `summary` field**, crashing changesets 2.31.0:

```js
// changesets-cli.cjs.js
if (json.error.code === "E403" && isAlreadyPublishedError(json.error.summary)) // summary === undefined → undefined.includes(...) → TypeError
```

The whole release failed even though **every package actually published** (all `@rsvelte/fmt*` are live at 0.1.1). This is a flaky read-after-write race, not a packaging error.

## Fix

The barrier closes the read-after-write gap so changeset's upfront snapshot reliably sees "already published" and emits the benign `is not being published` warning instead of racing into the crash path. Timeout is non-fatal because the `npm publish` itself already succeeded — worst case it degrades to today's behavior.

## Testing

- `node --check` passes.
- `--dry-run` exercises the script end to end (all platform packages already on npm → skipped, no spurious publishes).
- The live barrier path only runs under CI OIDC, so it can't be exercised locally; logic is straightforward polling.

## Residual risk

CDN edge differences could in theory still serve stale metadata to changeset after `npm view` confirms. If that recurs, the fully-deterministic follow-up is a `pnpm patch` of `@changesets/cli` guarding `isAlreadyPublishedError(json.error.summary ?? "")`. Left out here to avoid dependency-patch maintenance cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)