### PR TITLE
fix(fmt): shorthand attrs, TypeScript template expressions, and oxfmt `--stdin` (#679, #680, #682)

### DIFF
--- a/.changeset/fmt-shorthand-and-oxfmt-stdin.md
+++ b/.changeset/fmt-shorthand-and-oxfmt-stdin.md
@@ -1,0 +1,22 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): preserve `{name}` shorthand attributes and drop the unsupported `oxfmt --stdin` flag (#679, #680)
+
+Two formatter bugs that together blocked formatting most real `.svelte` files:
+
+- **Shorthand attribute corruption (#679):** a `{name}` shorthand attribute's
+  `ExpressionTag` spans only the identifier (matching upstream `start: id.start,
+  end: id.end`), with no surrounding braces. The formatter unconditionally
+  sliced one byte off each end of the span, so `{width}` was silently rewritten
+  to `width={idt}` and the 1-char `{x}` to `x={}` — undefined-identifier
+  references emitted with exit 0. Brace-stripping now only happens when braces
+  are actually present at the span boundaries, so `{name}` round-trips verbatim.
+
+- **`oxfmt --stdin` rejected (#680):** inline `<style>` blocks were delegated to
+  `oxfmt --stdin --stdin-filepath inline.css`, but oxfmt 0.49.0+ has no
+  `--stdin` flag and exits non-zero (`--stdin is not expected in this context`),
+  failing every file with a `<style>` block (exit 2). oxfmt reads stdin
+  implicitly given `--stdin-filepath`, so the `--stdin` flag is dropped from both
+  oxfmt invocations.

--- a/.changeset/fmt-shorthand-and-oxfmt-stdin.md
+++ b/.changeset/fmt-shorthand-and-oxfmt-stdin.md
@@ -2,9 +2,9 @@
 "@rsvelte/fmt": patch
 ---
 
-fix(fmt): preserve `{name}` shorthand attributes and drop the unsupported `oxfmt --stdin` flag (#679, #680)
+fix(fmt): preserve `{name}` shorthand attributes, parse template expressions as TypeScript, and drop the unsupported `oxfmt --stdin` flag (#679, #680, #682)
 
-Two formatter bugs that together blocked formatting most real `.svelte` files:
+Three formatter bugs that together blocked formatting most real `.svelte` files:
 
 - **Shorthand attribute corruption (#679):** a `{name}` shorthand attribute's
   `ExpressionTag` spans only the identifier (matching upstream `start: id.start,
@@ -20,3 +20,14 @@ Two formatter bugs that together blocked formatting most real `.svelte` files:
   failing every file with a `<style>` block (exit 2). oxfmt reads stdin
   implicitly given `--stdin-filepath`, so the `--stdin` flag is dropped from both
   oxfmt invocations.
+
+- **Template expressions parsed as JS, not TS (#682):** mustache `{…}`,
+  attribute, and directive expressions were always parsed as plain JavaScript,
+  even in a `<script lang="ts">` component. TS-only syntax (`as` / `satisfies` /
+  non-null `!` / `as const` / type-arg casts) errored with TS8016 (exit 2) and a
+  generic call `fn<T>(a)` silently miscompiled to the comparison `fn < T > a`.
+  Template source is now parsed in the same dialect as the `<script>` body. For
+  directive values the parser narrows a cast down to its inner identifier (so
+  `bind:value={value as string}` was collapsing to `bind:value`, dropping the
+  cast), so directive values are now sliced from the brace source rather than
+  the bare AST node.

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -196,6 +196,8 @@ fn build_format_options(cli: &Cli) -> FormatOptions {
             ..JsFormatOptions::new()
         },
         style_formatter: Some(make_oxfmt_style_formatter(cli.oxfmt_bin.clone())),
+        // `format` derives this per-document from `<script lang="ts">`.
+        typescript: false,
     }
 }
 

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -199,8 +199,8 @@ fn build_format_options(cli: &Cli) -> FormatOptions {
     }
 }
 
-/// Build the callback that runs `oxfmt --stdin --stdin-filepath
-/// inline.<lang>` for every `<style>` body inside a `.svelte` file.
+/// Build the callback that runs `oxfmt --stdin-filepath inline.<lang>`
+/// for every `<style>` body inside a `.svelte` file.
 /// This way CSS / SCSS / Less inside Svelte components are formatted
 /// by the same engine that handles standalone `.css` files.
 fn make_oxfmt_style_formatter(oxfmt: PathBuf) -> rsvelte_formatter::StyleFormatter {
@@ -212,8 +212,10 @@ fn make_oxfmt_style_formatter(oxfmt: PathBuf) -> rsvelte_formatter::StyleFormatt
             _ => "css",
         };
         let filename = format!("inline.{ext}");
+        // oxfmt reads stdin implicitly when `--stdin-filepath` is given with no
+        // path arguments. It has no `--stdin` flag and errors if one is passed
+        // (#680), so feed the body on stdin and pass only `--stdin-filepath`.
         let mut child = oxfmt_command(&oxfmt)
-            .arg("--stdin")
             .arg("--stdin-filepath")
             .arg(&filename)
             .stdin(Stdio::piped())
@@ -273,7 +275,8 @@ fn run_stdin(cli: &Cli, options: &FormatOptions) -> Result<ExitCode> {
 
 fn oxfmt_stdin(oxfmt: &Path, path: &Path, source: &str, check: bool) -> Result<ExitCode> {
     let mut cmd = oxfmt_command(oxfmt);
-    cmd.arg("--stdin");
+    // oxfmt reads stdin implicitly given `--stdin-filepath`; passing `--stdin`
+    // is rejected (#680).
     cmd.arg("--stdin-filepath").arg(path);
     if check {
         cmd.arg("--check");

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -346,6 +346,64 @@ fn enclosing_braces_span(source: &str, expr_start: u32, expr_end: u32) -> Option
     Some((lbrace as u32, (rbrace + 1) as u32))
 }
 
+/// Format a directive value `{ EXPR }` by slicing the full brace interior
+/// from the source, where `value_end` is the offset just past the closing
+/// `}` (the directive node's `end`).
+///
+/// Unlike [`crate::markup::format_expression_at`], this works from source
+/// text rather than the AST expression node. The parser narrows a TS cast
+/// (`{value as string}`) down to its inner identifier (`value`), so the bare
+/// node span would silently drop `as string` — turning `bind:value={value as
+/// string}` into `bind:value` and `class:x={v as T}` into `class:x={v}`
+/// (#682). Slicing `{` … `}` from the source keeps the cast verbatim, then
+/// re-parses/formats it (as TypeScript when `options.typescript`).
+///
+/// Falls back to `None` (caller uses the bare-node path) when the value
+/// braces can't be located, so non-`{expr}` values stay on the old path.
+pub(crate) fn format_directive_value(
+    source: &str,
+    expr: &Expression,
+    value_end: u32,
+    options: &FormatOptions,
+) -> Result<Option<String>, FormatError> {
+    let Some(expr_start) = expr.start() else {
+        return Ok(None);
+    };
+    let bytes = source.as_bytes();
+
+    // Closing brace: the directive node ends just past it.
+    let end = value_end as usize;
+    if end == 0 || bytes.get(end - 1) != Some(&b'}') {
+        return Ok(None);
+    }
+    let close = end - 1;
+
+    // Opening brace: whitespace-only back-scan from the expression start.
+    let mut open = None;
+    let mut i = expr_start as usize;
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b' ' | b'\t' | b'\n' | b'\r' => continue,
+            b'{' => {
+                open = Some(i);
+                break;
+            }
+            _ => break,
+        }
+    }
+    let Some(open) = open else { return Ok(None) };
+    if open >= close {
+        return Ok(None);
+    }
+
+    let inner = source.get(open + 1..close).unwrap_or("").trim();
+    if inner.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(format_expression_source(inner, options)?))
+}
+
 // ─── Expression formatter ───────────────────────────────────────────────
 
 /// Format a single JS expression source. Wraps in parens to force
@@ -356,7 +414,11 @@ pub(crate) fn format_expression_source(
     options: &FormatOptions,
 ) -> Result<String, FormatError> {
     let allocator = Allocator::default();
-    let source_type = SourceType::default();
+    let source_type = if options.typescript {
+        SourceType::ts()
+    } else {
+        SourceType::default()
+    };
 
     let wrapped = format!("({expr_source});");
     let parser_ret = Parser::new(&allocator, &wrapped, source_type)
@@ -415,7 +477,11 @@ pub(crate) fn format_pattern_source(
 ) -> Result<String, FormatError> {
     const SENTINEL: &str = "__rsvelte_fmt_rhs__";
     let allocator = Allocator::default();
-    let source_type = SourceType::default();
+    let source_type = if options.typescript {
+        SourceType::ts()
+    } else {
+        SourceType::default()
+    };
 
     let wrapped = format!("let {pattern_source} = {SENTINEL};");
     let parser_ret = Parser::new(&allocator, &wrapped, source_type)

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -38,6 +38,27 @@ pub fn format(source: &str, options: &FormatOptions) -> Result<String, FormatErr
 
     let mut edits: Vec<(u32, u32, String)> = Vec::new();
 
+    // A component is TypeScript if either `<script>` block declares
+    // `lang="ts"`. Template `{expr}` / attribute / pattern source must then
+    // be parsed in the same dialect as the script body, so `{value as
+    // string}` and friends round-trip instead of erroring as JS (#682).
+    // Thread the flag via a per-document clone — the shared `&FormatOptions`
+    // is never mutated, so parallel `format()` calls stay independent.
+    let typescript = [root.instance.as_deref(), root.module.as_deref()]
+        .into_iter()
+        .flatten()
+        .any(|script| script.is_typescript);
+    let ts_options;
+    let options = if typescript && !options.typescript {
+        ts_options = FormatOptions {
+            typescript: true,
+            ..options.clone()
+        };
+        &ts_options
+    } else {
+        options
+    };
+
     for script in [root.instance.as_deref(), root.module.as_deref()]
         .into_iter()
         .flatten()

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -466,7 +466,7 @@ fn render_attribute(
             Ok(format!("{{@attach {inner}}}"))
         }
         Attribute::BindDirective(d) => {
-            let inner = format_expression_at(source, &d.expression, options)?.unwrap_or_default();
+            let inner = render_directive_value(source, &d.expression, d.end, options)?;
             let modifiers = render_modifiers(&d.modifiers);
             if inner == d.name.as_str() && modifiers.is_empty() {
                 Ok(format!("bind:{}", d.name))
@@ -475,7 +475,7 @@ fn render_attribute(
             }
         }
         Attribute::ClassDirective(d) => {
-            let inner = format_expression_at(source, &d.expression, options)?.unwrap_or_default();
+            let inner = render_directive_value(source, &d.expression, d.end, options)?;
             if inner == d.name.as_str() {
                 Ok(format!("class:{}", d.name))
             } else {
@@ -485,7 +485,7 @@ fn render_attribute(
         Attribute::OnDirective(d) => {
             let modifiers = render_modifiers(&d.modifiers);
             if let Some(expr) = &d.expression {
-                let inner = format_expression_at(source, expr, options)?.unwrap_or_default();
+                let inner = render_directive_value(source, expr, d.end, options)?;
                 Ok(format!("on:{}{modifiers}={{{inner}}}", d.name))
             } else {
                 Ok(format!("on:{}{modifiers}", d.name))
@@ -501,7 +501,7 @@ fn render_attribute(
             };
             let modifiers = render_modifiers(&d.modifiers);
             if let Some(expr) = &d.expression {
-                let inner = format_expression_at(source, expr, options)?.unwrap_or_default();
+                let inner = render_directive_value(source, expr, d.end, options)?;
                 Ok(format!("{prefix}:{}{modifiers}={{{inner}}}", d.name))
             } else {
                 Ok(format!("{prefix}:{}{modifiers}", d.name))
@@ -509,7 +509,7 @@ fn render_attribute(
         }
         Attribute::AnimateDirective(d) => {
             if let Some(expr) = &d.expression {
-                let inner = format_expression_at(source, expr, options)?.unwrap_or_default();
+                let inner = render_directive_value(source, expr, d.end, options)?;
                 Ok(format!("animate:{}={{{inner}}}", d.name))
             } else {
                 Ok(format!("animate:{}", d.name))
@@ -517,7 +517,7 @@ fn render_attribute(
         }
         Attribute::UseDirective(d) => {
             if let Some(expr) = &d.expression {
-                let inner = format_expression_at(source, expr, options)?.unwrap_or_default();
+                let inner = render_directive_value(source, expr, d.end, options)?;
                 Ok(format!("use:{}={{{inner}}}", d.name))
             } else {
                 Ok(format!("use:{}", d.name))
@@ -675,6 +675,24 @@ fn render_modifiers<S: AsRef<str>>(modifiers: &[S]) -> String {
 
 /// Slice the expression's source span, trim it, and format. Returns
 /// `None` if the span is missing or empty.
+/// Format a directive's `{ EXPR }` value. Prefers the source-brace slice
+/// ([`crate::expression::format_directive_value`]) so a TS cast the parser
+/// narrows away — `bind:value={value as string}` → bare `value` node — is
+/// preserved verbatim (#682), and falls back to the bare-node formatter when
+/// the value braces can't be located. `value_end` is the directive node's
+/// `end` (just past the closing `}`).
+fn render_directive_value(
+    source: &str,
+    expr: &Expression,
+    value_end: u32,
+    options: &FormatOptions,
+) -> Result<String, FormatError> {
+    if let Some(s) = crate::expression::format_directive_value(source, expr, value_end, options)? {
+        return Ok(s);
+    }
+    Ok(format_expression_at(source, expr, options)?.unwrap_or_default())
+}
+
 fn format_expression_at(
     source: &str,
     expr: &Expression,

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -28,8 +28,8 @@
 use oxc_formatter::JsFormatOptions;
 use rsvelte_core::ast::js::Expression;
 use rsvelte_core::ast::template::{
-    Attribute, AttributeNode, AttributeValue, AttributeValuePart, Fragment, SpreadAttribute,
-    TemplateNode,
+    Attribute, AttributeNode, AttributeValue, AttributeValuePart, ExpressionTag, Fragment,
+    SpreadAttribute, TemplateNode,
 };
 
 use crate::error::FormatError;
@@ -553,6 +553,26 @@ fn render_attribute(
     }
 }
 
+/// Return the source text of an `ExpressionTag`'s inner expression, without
+/// the surrounding `{`/`}`.
+///
+/// A regular `name={expr}` attribute's `ExpressionTag` spans the braces, so we
+/// strip one byte from each end. But the attribute shorthand `{name}` is
+/// parsed (matching upstream `start: id.start, end: id.end`) so its
+/// `ExpressionTag` spans only the identifier — there are no braces to strip.
+/// Blindly slicing `start+1..end-1` there dropped the first and last character
+/// of the identifier, silently rewriting `{width}` to `width={idt}` (#679). So
+/// only peel braces when they're actually present at the span boundaries.
+fn expression_tag_inner<'a>(tag: &ExpressionTag, source: &'a str) -> &'a str {
+    let (start, end) = (tag.start as usize, tag.end as usize);
+    let bytes = source.as_bytes();
+    if bytes.get(start) == Some(&b'{') && end > start + 1 && bytes.get(end - 1) == Some(&b'}') {
+        source.get(start + 1..end - 1).unwrap_or("")
+    } else {
+        source.get(start..end).unwrap_or("")
+    }
+}
+
 fn render_attribute_node(
     node: &AttributeNode,
     source: &str,
@@ -561,10 +581,7 @@ fn render_attribute_node(
     match &node.value {
         AttributeValue::True(_) => Ok(node.name.to_string()),
         AttributeValue::Expression(tag) => {
-            let inner_src = source
-                .get(tag.start as usize + 1..tag.end as usize - 1)
-                .unwrap_or("")
-                .trim();
+            let inner_src = expression_tag_inner(tag, source).trim();
             if inner_src.is_empty() {
                 return Ok(format!("{}={{}}", node.name));
             }
@@ -591,10 +608,7 @@ fn render_attribute_value_for_directive(
     match value {
         AttributeValue::True(_) => Ok(String::new()),
         AttributeValue::Expression(tag) => {
-            let inner_src = source
-                .get(tag.start as usize + 1..tag.end as usize - 1)
-                .unwrap_or("")
-                .trim();
+            let inner_src = expression_tag_inner(tag, source).trim();
             if inner_src.is_empty() {
                 return Ok("{}".to_string());
             }

--- a/crates/rsvelte_formatter/src/options.rs
+++ b/crates/rsvelte_formatter/src/options.rs
@@ -18,7 +18,7 @@ pub struct FormatOptions {
     /// attribute says (e.g. `"scss"`, `"less"`, `"postcss"`).
     ///
     /// When `None` (the default), `<style>` content survives verbatim.
-    /// The `rsvelte-fmt` CLI wires this up to spawn `oxfmt --stdin`, so
+    /// The `rsvelte-fmt` CLI wires this up to spawn `oxfmt`, so
     /// CSS / SCSS / Less formatting happens through the same engine
     /// `oxfmt` uses for standalone `.css` files.
     ///

--- a/crates/rsvelte_formatter/src/options.rs
+++ b/crates/rsvelte_formatter/src/options.rs
@@ -25,6 +25,14 @@ pub struct FormatOptions {
     /// The callback must be `Send + Sync` so the same `FormatOptions`
     /// can drive parallel file formatting via `rayon`.
     pub style_formatter: Option<StyleFormatter>,
+
+    /// Whether template `{expr}` / attribute / pattern source should be
+    /// parsed as TypeScript. [`crate::format`] sets this per-document from
+    /// the component's `<script lang="ts">` declaration, so a `{value as
+    /// string}` mustache parses with the same dialect as the `<script>`
+    /// body (#682). Callers normally leave it at its `false` default; it is
+    /// not a user-facing knob.
+    pub typescript: bool,
 }
 
 /// Callback used to format the body of a `<style>` block. See
@@ -36,6 +44,7 @@ impl FormatOptions {
         Self {
             js: JsFormatOptions::new(),
             style_formatter: None,
+            typescript: false,
         }
     }
 
@@ -60,6 +69,7 @@ impl std::fmt::Debug for FormatOptions {
                 "style_formatter",
                 &self.style_formatter.as_ref().map(|_| "<callback>"),
             )
+            .field("typescript", &self.typescript)
             .finish()
     }
 }

--- a/crates/rsvelte_formatter/src/style.rs
+++ b/crates/rsvelte_formatter/src/style.rs
@@ -3,9 +3,9 @@
 //! `rsvelte_formatter` doesn't ship its own CSS engine. Instead it
 //! exposes a callback on [`crate::FormatOptions::style_formatter`] that
 //! receives the body and the lang (`css` / `scss` / `less` / ...). The
-//! `rsvelte-fmt` CLI wires this up to spawn `oxfmt --stdin
-//! --stdin-filepath style.<lang>`, so CSS formatting goes through the
-//! same engine `oxfmt` uses for standalone files.
+//! `rsvelte-fmt` CLI wires this up to spawn
+//! `oxfmt --stdin-filepath style.<lang>`, so CSS formatting goes through
+//! the same engine `oxfmt` uses for standalone files.
 //!
 //! When no callback is set the style body is left verbatim.
 

--- a/crates/rsvelte_formatter/tests/markup_open_tag.rs
+++ b/crates/rsvelte_formatter/tests/markup_open_tag.rs
@@ -70,6 +70,36 @@ fn attribute_shorthand_collapses() {
 }
 
 #[test]
+fn shorthand_attribute_is_preserved_verbatim() {
+    // Regression for #679: a `{name}` shorthand's ExpressionTag spans only the
+    // identifier (no braces), so the formatter must not strip a byte from each
+    // end — `{width}` was being rewritten to `width={idt}` (silent data loss).
+    for (src, expect) in [
+        ("<div {width}></div>", "<div {width}>"),
+        ("<div {height}></div>", "<div {height}>"),
+        ("<input {value} />", "<input {value} />"),
+        (
+            "<div {disabled} {hidden}></div>",
+            "<div {disabled} {hidden}>",
+        ),
+    ] {
+        let out = fmt(src);
+        assert!(
+            out.contains(expect),
+            "expected `{expect}` from `{src}`:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn single_char_shorthand_attribute_is_preserved() {
+    // The 1-char case `{x}` previously sliced to an empty range (`1..0`) and
+    // emitted `x={}` (#679).
+    let out = fmt("<div {x}></div>");
+    assert!(out.contains("<div {x}>"), "expected `<div {{x}}>`:\n{out}");
+}
+
+#[test]
 fn attribute_no_shorthand_when_names_differ() {
     let out = fmt("<div id={otherId}></div>");
     assert!(

--- a/crates/rsvelte_formatter/tests/typescript.rs
+++ b/crates/rsvelte_formatter/tests/typescript.rs
@@ -1,0 +1,125 @@
+//! Regression coverage for #682 — template `{expr}` / attribute / directive
+//! source in a `<script lang="ts">` component must be parsed and formatted as
+//! TypeScript, the same dialect as the `<script>` body. Before the fix, every
+//! template expression was parsed as plain JS: TS-only syntax (`as`,
+//! `satisfies`, non-null `!`, `as const`, type-arg casts) errored with TS8016
+//! (exit 2), and a generic call `fn<T>(a)` silently miscompiled to the
+//! comparison `fn < T > a`.
+
+use rsvelte_formatter::{FormatOptions, format};
+
+const TS: &str = "<script lang=\"ts\"></script>";
+
+fn fmt_ts(markup: &str) -> String {
+    let src = format!("{TS}{markup}");
+    format(&src, &FormatOptions::default()).expect("format ok")
+}
+
+// ─── Mustache / template expressions ─────────────────────────────────────
+
+#[test]
+fn mustache_ts_casts_round_trip() {
+    for (markup, expect) in [
+        ("<p>{value as string}</p>", "{value as string}"),
+        (
+            "<p>{value satisfies string}</p>",
+            "{value satisfies string}",
+        ),
+        ("<p>{value!}</p>", "{value!}"),
+        ("<p>{x as const}</p>", "{x as const}"),
+        ("<p>{arr as string[]}</p>", "{arr as string[]}"),
+        ("<p>{(x as string).length}</p>", "{(x as string).length}"),
+    ] {
+        let out = fmt_ts(markup);
+        assert!(
+            out.contains(expect),
+            "expected `{expect}` from `{markup}`:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn mustache_generic_call_is_not_a_comparison() {
+    // In JS mode this parsed as `fn < string > (a)`; TS mode keeps the
+    // generic call intact.
+    let out = fmt_ts("<p>{fn<string>(a)}</p>");
+    assert!(
+        out.contains("{fn<string>(a)}"),
+        "expected generic call kept:\n{out}"
+    );
+    assert!(
+        !out.contains("<string >"),
+        "must not become a comparison:\n{out}"
+    );
+}
+
+// ─── Attribute values ────────────────────────────────────────────────────
+
+#[test]
+fn attribute_value_ts_cast_round_trips() {
+    let out = fmt_ts("<Comp prop={value as string} />");
+    assert!(out.contains("prop={value as string}"), "{out}");
+}
+
+// ─── Directive values ────────────────────────────────────────────────────
+//
+// Directives are the subtle case: the parser narrows a TS cast down to its
+// inner identifier, so the formatter must slice the brace interior from the
+// source rather than the bare AST node — otherwise `bind:value={value as
+// string}` collapsed to `bind:value` (silent data loss).
+
+#[test]
+fn directive_values_preserve_ts_casts() {
+    for (markup, expect) in [
+        (
+            "<input bind:value={value as string} />",
+            "bind:value={value as string}",
+        ),
+        (
+            "<div class:x={value as string}></div>",
+            "class:x={value as string}",
+        ),
+        (
+            "<button on:click={handler as any}>x</button>",
+            "on:click={handler as any}",
+        ),
+        (
+            "<div use:action={value as string}></div>",
+            "use:action={value as string}",
+        ),
+    ] {
+        let out = fmt_ts(markup);
+        assert!(
+            out.contains(expect),
+            "expected `{expect}` from `{markup}`:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn directive_shorthand_collapse_still_applies_without_a_cast() {
+    // The TS path must not break the `bind:value={value}` → `bind:value`
+    // collapse, nor turn `bind:value={other}` into a shorthand.
+    assert!(fmt_ts("<input bind:value={value} />").contains("bind:value />"));
+    assert!(fmt_ts("<div class:active={active}></div>").contains("class:active>"));
+    assert!(fmt_ts("<input bind:value={other} />").contains("bind:value={other}"));
+}
+
+#[test]
+fn transition_object_param_unaffected_by_ts_path() {
+    let out = fmt_ts("<div in:fade out:slide={ {duration: 200} }></div>");
+    assert!(out.contains("out:slide={{ duration: 200 }}"), "{out}");
+}
+
+// ─── A plain (non-TS) component still rejects TS-only syntax ──────────────
+
+#[test]
+fn non_ts_component_does_not_parse_ts_syntax() {
+    // No `<script lang="ts">`, so `as` is not valid — the formatter surfaces
+    // the parse error rather than silently producing wrong output.
+    let res = format("<p>{value as string}</p>", &FormatOptions::default());
+    assert!(
+        res.is_err(),
+        "expected a parse error for `as` in a JS component"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes three `@rsvelte/fmt` bugs (all reported today against 0.1.1) that together blocked formatting most real `.svelte` files.

### #679 — Shorthand attribute `{name}` silently corrupted (data loss, exit 0)

A `{name}` shorthand attribute's `ExpressionTag` spans **only the identifier** (matching upstream `start: id.start, end: id.end`) — no surrounding braces, unlike a regular `name={expr}` whose tag spans the braces. The formatter unconditionally sliced one byte off each end (`start+1..end-1`):

| input | was | now |
|---|---|---|
| `{width}` | `width={idt}` ❌ | `{width}` ✅ |
| `{height}` | `height={eigh}` ❌ | `{height}` ✅ |
| `{x}` | `x={}` ❌ | `{x}` ✅ |

A new `expression_tag_inner` helper only peels braces when they are actually present at the span boundaries.

### #680 — Inline `<style>` delegates to `oxfmt --stdin`, which oxfmt rejects (exit 2)

oxfmt 0.49.0+ has no `--stdin` flag (it reads stdin implicitly given `--stdin-filepath`) and exits non-zero with `` `--stdin` is not expected in this context ``, failing every file with a `<style>` block. The `--stdin` flag is dropped from both oxfmt invocations.

### #682 — Template expressions parsed as JS, not TS

Mustache `{…}`, attribute, and directive expressions were always parsed as plain JavaScript, even in a `<script lang="ts">` component. TS-only syntax (`as` / `satisfies` / non-null `!` / `as const` / type-arg casts) errored with TS8016 (exit 2); a generic call `fn<T>(a)` silently miscompiled to `fn < T > a` (exit 0).

- `FormatOptions::typescript` is set per-document by `format()` from the `<script lang="ts">` declaration (via a per-document clone — the shared `&FormatOptions` that drives parallel formatting is never mutated). Expression/pattern source parses with `SourceType::ts()` when set.
- **Directive values were the subtle case:** the parser narrows a TS cast down to its inner identifier (`value as string` → `value`), so the bare AST-node span dropped the cast — `bind:value={value as string}` collapsed to `bind:value` (silent data loss). Directive values are now sliced from the brace source using the directive node's `end`, with a fallback to the bare-node path.

## Verification

Reproduced every issue case on the pre-fix binary, confirmed fixed after (oxfmt 0.53.0 locally — same `--stdin` rejection as 0.49.0):

```
<div {width} {height}></div>             →  <div {width} {height}></div>
<div {x}></div>                          →  <div {x}></div>
<style> a { color: red; } </style>       →  exit 0 (was exit 2)
<p>{value as string}</p>          (ts)   →  <p>{value as string}</p>     (was TS8016)
<p>{fn<string>(a)}</p>            (ts)   →  <p>{fn<string>(a)}</p>       (was fn < string > a)
<input bind:value={value as string} /> (ts) → unchanged (was bind:value, cast dropped)
<div in:fade out:slide={ {duration:200} }></div> → out:slide={{ duration: 200 }} (unchanged)
```

Controls unchanged: `{...props}`, `class={foo}`, `bind:value`, `class:active`, `width={someExpr + 1}`, `bind:value={value}` → `bind:value`, `bind:value={other}`.

## Tests

- `markup_open_tag.rs`: shorthand-input regression tests (existing tests only covered the `name={name}` → `{name}` collapse direction).
- New `typescript.rs` suite: mustache / attribute / directive TS casts, the generic-call case, the still-applies shorthand collapse, and that a non-TS component still rejects TS-only syntax.
- Full `rsvelte_formatter` + `rsvelte_fmt` suites pass; `cargo fmt` + `clippy --all-targets --all-features -D warnings` clean.

Closes #679
Closes #680
Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)