### PR TITLE
fix(fmt): snippet param lists, open-tag comments, and template-literal re-indentation (#684, #685, #686)

### DIFF
--- a/.changeset/fmt-snippet-params-tag-comments-template-reindent.md
+++ b/.changeset/fmt-snippet-params-tag-comments-template-reindent.md
@@ -1,0 +1,33 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): snippet param lists, open-tag comments, and template-literal re-indentation (#684, #685, #686)
+
+Three formatter bugs found via a real-monorepo corpus pass:
+
+- **`{#snippet}` parameter lists (#684):** snippet parameters are ordinary
+  (TS) function parameters, but they were routed through the destructuring
+  pattern path (`let <pattern> = …`). Optional params (`x?: T`) errored
+  (`Optional declaration is not allowed here`, exit 2), default values
+  (`x: T = v`) errored (`Cannot assign to this expression`, exit 2), and a
+  typed default (`items: string[] = []`) silently leaked the internal
+  `__rsvelte_fmt_rhs__` sentinel into the output (exit 0, invalid Svelte).
+  Snippet params now format through a real function parameter list
+  (`function f(<param>) {}`), so optional markers, type annotations, and
+  default values all round-trip.
+
+- **Open-tag comments dropped (#685):** a `//` line comment (or `/* … */`)
+  placed between attributes inside an element's start tag was silently
+  deleted, because the open-tag rewrite rebuilt the tag from the attribute
+  list alone. Comments in the open tag are now collected and interleaved
+  with the attributes in source order; a line comment forces the multi-line
+  tag shape (it can't share a line with the closing `>`).
+
+- **Template-literal re-indentation (#686):** re-embedding the formatted
+  `<script>` re-indented every line — including the interior of multi-line
+  template literals, whose whitespace is part of the string value. That both
+  mutated the embedded string and made formatting non-idempotent (each pass
+  added another indent level). The re-embed step now skips lines that begin
+  inside template-literal quasi text, so the string value is preserved and
+  formatting is a fixed point.

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -156,7 +156,7 @@ fn collect_node_edits(
         TemplateNode::SnippetBlock(blk) => {
             push_bare_expression(source, &blk.expression, options, edits)?;
             for p in &blk.parameters {
-                push_pattern_at_span(source, p, options, edits)?;
+                push_param_at_span(source, p, options, edits)?;
             }
             collect_template_edits(source, &blk.body, options, edits)?;
         }
@@ -459,6 +459,130 @@ fn push_pattern_at_span(
     let formatted = format_pattern_source(slice, options)?;
     edits.push((start, end, formatted));
     Ok(())
+}
+
+/// Splice a `{#snippet}` parameter's source span with its formatted
+/// version. Snippet parameter lists are ordinary (TS) function parameter
+/// lists, so a parameter may carry an optional marker (`x?: T`), a type
+/// annotation, and/or a default value (`x: T = v`). The destructuring-only
+/// [`format_pattern_source`] path can't represent those — wrapping
+/// `x?: string` as `let x?: string = …` is a hard error and a typed default
+/// (`items: string[] = []`) leaks the internal sentinel into the output
+/// (#684). Route snippet params through [`format_param_source`] instead,
+/// which wraps them in a real function parameter list.
+fn push_param_at_span(
+    source: &str,
+    expr: &Expression,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
+        return Ok(());
+    };
+    let slice = source
+        .get(start as usize..end as usize)
+        .ok_or_else(|| FormatError::Parse("snippet parameter span out of bounds".into()))?
+        .trim();
+    if slice.is_empty() {
+        return Ok(());
+    }
+    let formatted = format_param_source(slice, options)?;
+    edits.push((start, end, formatted));
+    Ok(())
+}
+
+/// Format a single function parameter (as found in a `{#snippet}` header).
+///
+/// Wraps the parameter in a function declaration — `function f(<param>) {}` —
+/// so optional markers (`x?: T`), type annotations, and default values all
+/// parse and round-trip. The formatted parameter list is then sliced back
+/// out from between the parentheses.
+///
+/// As with [`format_pattern_source`], the JS formatter is forced onto a
+/// single line (`expand = Never`, max `line_width`) so a multi-line param
+/// can't land across the Svelte `{#snippet …}` block header.
+pub(crate) fn format_param_source(
+    param_source: &str,
+    options: &FormatOptions,
+) -> Result<String, FormatError> {
+    let allocator = Allocator::default();
+    let source_type = if options.typescript {
+        SourceType::ts()
+    } else {
+        SourceType::default()
+    };
+
+    let wrapped = format!("function __rsvelte_fmt_fn__({param_source}) {{}}");
+    let parser_ret = Parser::new(&allocator, &wrapped, source_type)
+        .with_options(formatter_parse_options())
+        .parse();
+    if !parser_ret.errors.is_empty() {
+        return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
+    }
+
+    let mut single_line = options.js.clone();
+    single_line.line_width =
+        oxc_formatter_core::LineWidth::try_from(u16::MAX).unwrap_or(single_line.line_width);
+    single_line.expand = oxc_formatter::Expand::Never;
+
+    let formatted = format_program(&allocator, &parser_ret.program, single_line, None)
+        .print()
+        .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
+        .into_code();
+
+    // Output shape: `function __rsvelte_fmt_fn__(<param>) {}`. Slice the
+    // text between the parameter-list parentheses back out.
+    let s = formatted.trim();
+    let candidate = extract_paren_group(s)
+        .map(str::trim)
+        .unwrap_or(param_source)
+        .to_string();
+
+    // A hard-wrapped multi-line parameter can't sit inside the Svelte
+    // `{#snippet …}` block header (re-read as a single line); fall back to
+    // the verbatim source for those.
+    if candidate.contains('\n') {
+        return Ok(param_source.trim().to_string());
+    }
+    Ok(candidate)
+}
+
+/// Return the text between the first top-level `(` and its matching `)`,
+/// skipping nested parens and string/template literals. Used to peel a
+/// formatted `function f(<params>) {}` back down to its parameter list.
+fn extract_paren_group(s: &str) -> Option<&str> {
+    let bytes = s.as_bytes();
+    let open = s.find('(')?;
+    let mut depth: usize = 0;
+    let mut i = open;
+    let mut in_str: Option<u8> = None;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if let Some(q) = in_str {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == q {
+                in_str = None;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\'' | b'"' | b'`' => in_str = Some(c),
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return s.get(open + 1..i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Format a destructuring pattern. Patterns like `{a, b = 1}`,

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -289,28 +289,46 @@ fn push_open_tag(
 
     let self_closing = is_self_closing(source, open_tag_end);
 
-    // Build the list of fully-rendered attribute strings once, so the
-    // one-line and multi-line shapes share the same content.
-    let mut rendered_attrs: Vec<String> = Vec::with_capacity(attributes.len() + 1);
+    // Build the list of fully-rendered open-tag items (attributes plus any
+    // comments interleaved between them), each tagged with its source
+    // position so the rendering order matches the source. Comments inside an
+    // element's open tag are owned by this rewrite, so they'd be silently
+    // dropped if we rebuilt the tag from the attribute list alone (#685).
+    let mut items: Vec<(u32, String)> = Vec::with_capacity(attributes.len() + 1);
 
     if let Some(expr) = this_expression
         && let Some(formatted) = format_expression_at(source, expr, options)?
     {
-        rendered_attrs.push(format!("this={{{formatted}}}"));
+        // `this={X}` is emitted first regardless of source position.
+        items.push((element_start, format!("this={{{formatted}}}")));
     }
 
     for attr in attributes {
-        rendered_attrs.push(render_attribute(attr, source, options)?);
+        let (attr_start, _) = attribute_span(attr);
+        items.push((attr_start, render_attribute(attr, source, options)?));
     }
+
+    let comments = collect_open_tag_comments(source, element_start, open_tag_end, attributes);
+    let has_line_comment = comments.iter().any(|c| c.is_line);
+    for c in comments {
+        items.push((c.start, c.text));
+    }
+
+    items.sort_by_key(|(start, _)| *start);
+    let rendered_attrs: Vec<String> = items.into_iter().map(|(_, text)| text).collect();
 
     let one_liner = render_one_line(tag_name, &rendered_attrs, self_closing);
 
     let leading_indent_width = indent_visual_width(depth, &options.js);
     let line_width = options.js.line_width.value() as usize;
 
-    let rendered = if rendered_attrs.is_empty()
-        || leading_indent_width + visual_width(&one_liner) <= line_width
-    {
+    // A `//` line comment can't share a line with the closing `>` (it would
+    // comment out the rest of the tag), so any line comment forces the
+    // multi-line shape.
+    let fits_one_line =
+        !has_line_comment && leading_indent_width + visual_width(&one_liner) <= line_width;
+
+    let rendered = if rendered_attrs.is_empty() || fits_one_line {
         one_liner
     } else {
         render_multi_line(tag_name, &rendered_attrs, self_closing, depth, &options.js)
@@ -318,6 +336,92 @@ fn push_open_tag(
 
     edits.push((element_start, open_tag_end, rendered));
     Ok(())
+}
+
+/// A comment found between attributes inside an element's open tag.
+struct OpenTagComment {
+    start: u32,
+    text: String,
+    is_line: bool,
+}
+
+/// Scan the open-tag region for `//` and `/* … */` comments that sit in the
+/// gaps between attributes (or before the first / after the last). These are
+/// not part of the attribute list, so they must be collected separately to
+/// avoid being dropped when the open tag is rewritten (#685).
+fn collect_open_tag_comments(
+    source: &str,
+    element_start: u32,
+    open_tag_end: u32,
+    attributes: &[Attribute],
+) -> Vec<OpenTagComment> {
+    let bytes = source.as_bytes();
+    let name_end = open_tag_name_end(source, element_start);
+    let end = (open_tag_end as usize).min(bytes.len());
+
+    // Attribute spans (sorted) so we can skip over them while scanning gaps.
+    let mut spans: Vec<(usize, usize)> = attributes
+        .iter()
+        .map(|a| {
+            let (s, e) = attribute_span(a);
+            (s as usize, e as usize)
+        })
+        .collect();
+    spans.sort_by_key(|s| s.0);
+
+    let mut comments = Vec::new();
+    let mut i = name_end;
+    let mut span_idx = 0;
+    while i < end {
+        // Skip past any attribute span covering `i`.
+        while span_idx < spans.len() && spans[span_idx].1 <= i {
+            span_idx += 1;
+        }
+        if span_idx < spans.len() && spans[span_idx].0 <= i {
+            i = spans[span_idx].1;
+            continue;
+        }
+
+        if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'/') {
+            let start = i;
+            i += 2;
+            while i < end && bytes[i] != b'\n' {
+                i += 1;
+            }
+            let text = source[start..i].trim_end().to_string();
+            comments.push(OpenTagComment {
+                start: start as u32,
+                text,
+                is_line: true,
+            });
+        } else if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            let start = i;
+            i += 2;
+            while i < end && !(bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/')) {
+                i += 1;
+            }
+            i = (i + 2).min(end);
+            comments.push(OpenTagComment {
+                start: start as u32,
+                text: source[start..i].to_string(),
+                is_line: false,
+            });
+        } else {
+            i += 1;
+        }
+    }
+    comments
+}
+
+/// Return the byte offset just past the `<tagname` opener (the first
+/// whitespace / `>` / `/` after the tag name).
+fn open_tag_name_end(source: &str, element_start: u32) -> usize {
+    let bytes = source.as_bytes();
+    let mut i = element_start as usize + 1;
+    while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r' | b'>' | b'/') {
+        i += 1;
+    }
+    i
 }
 
 fn render_one_line(tag_name: &str, attrs: &[String], self_closing: bool) -> String {
@@ -422,6 +526,24 @@ fn find_open_tag_end(source: &str, element_start: u32, attributes: &[Attribute])
     let bytes = source.as_bytes();
     let mut i = scan_from;
     while i < bytes.len() {
+        // Skip over comments so a `>` inside `// …` / `/* … */` (which can
+        // sit between the last attribute and the closing `>`) doesn't end
+        // the open tag prematurely (#685).
+        if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'/') {
+            i += 2;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            i += 2;
+            while i < bytes.len() && !(bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/')) {
+                i += 1;
+            }
+            i += 2;
+            continue;
+        }
         if bytes[i] == b'>' {
             return Some((i + 1) as u32);
         }

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -65,23 +65,197 @@ pub(crate) fn format_script(
     // oxc_formatter emits a trailing newline. Add one indent level to
     // every non-empty line so the body is nested under `<script>` using
     // the same indent unit (tab vs N-space) that the formatter used
-    // internally.
+    // internally. Lines that fall *inside* a multi-line template literal
+    // are skipped — their whitespace is part of the string value, so
+    // re-indenting them would both mutate the runtime string and make
+    // formatting non-idempotent (every pass adds another level) (#686).
     let unit = indent_unit(&options.js);
-    let body_indented = formatted
-        .trim_end()
-        .lines()
-        .map(|line| {
-            if line.is_empty() {
-                String::new()
-            } else {
-                format!("{unit}{line}")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let body_indented = reindent_body(formatted.trim_end(), &unit);
     let wrapped = format!("\n{body_indented}\n");
 
     Ok(Some((body_start as u32, body_end as u32, wrapped)))
+}
+
+/// One level of the scanner stack used by [`reindent_body`]. We only need
+/// to know whether a line begins inside template-literal *quasi* text (raw
+/// string content) versus ordinary code — the latter is re-indented, the
+/// former is left verbatim.
+enum Frame {
+    /// Inside `` `…` `` quasi text (between backticks, outside `${}`).
+    Template,
+    /// Inside a `${ … }` substitution. The `u32` is the `{`-nesting depth
+    /// within the substitution, so the matching `}` is recognised.
+    Subst(u32),
+}
+
+/// Add `unit` to the start of every line of `formatted`, **except** lines
+/// that begin inside multi-line template-literal quasi text. Such lines'
+/// leading whitespace is significant (part of the string value) and
+/// `oxc_formatter` preserves it verbatim, so re-indenting them would mutate
+/// the string and break idempotency.
+///
+/// The scanner tracks template-literal / `${}` nesting plus string and
+/// comment context so backticks, `${`, and braces inside strings or
+/// comments aren't misread.
+fn reindent_body(formatted: &str, unit: &str) -> String {
+    let chars: Vec<char> = formatted.chars().collect();
+    let n = chars.len();
+    let mut out = String::with_capacity(formatted.len() + 16);
+    let mut stack: Vec<Frame> = Vec::new();
+    let mut line_comment = false;
+    let mut block_comment = false;
+    let mut string: Option<char> = None;
+    let mut at_line_start = true;
+    let mut i = 0;
+
+    while i < n {
+        let c = chars[i];
+
+        if at_line_start {
+            let in_quasi = matches!(stack.last(), Some(Frame::Template));
+            if c != '\n' && !in_quasi {
+                out.push_str(unit);
+            }
+            at_line_start = false;
+        }
+
+        // Line comment: runs to end of line.
+        if line_comment {
+            out.push(c);
+            i += 1;
+            if c == '\n' {
+                line_comment = false;
+                at_line_start = true;
+            }
+            continue;
+        }
+
+        // Block comment: runs to `*/`. Interior lines are still re-indented
+        // (code context), matching `oxc_formatter`'s own re-alignment.
+        if block_comment {
+            if c == '*' && chars.get(i + 1) == Some(&'/') {
+                out.push('*');
+                out.push('/');
+                i += 2;
+                block_comment = false;
+                continue;
+            }
+            out.push(c);
+            i += 1;
+            if c == '\n' {
+                at_line_start = true;
+            }
+            continue;
+        }
+
+        // Regular string: consumes its own escapes; can't span lines in
+        // well-formed formatter output.
+        if let Some(q) = string {
+            out.push(c);
+            if c == '\\' {
+                if i + 1 < n {
+                    out.push(chars[i + 1]);
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+            i += 1;
+            if c == q {
+                string = None;
+            }
+            continue;
+        }
+
+        if matches!(stack.last(), Some(Frame::Template)) {
+            // Inside template-literal quasi text.
+            match c {
+                '`' => {
+                    stack.pop();
+                    out.push(c);
+                    i += 1;
+                }
+                '\\' => {
+                    out.push(c);
+                    if i + 1 < n {
+                        out.push(chars[i + 1]);
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                '$' if chars.get(i + 1) == Some(&'{') => {
+                    stack.push(Frame::Subst(0));
+                    out.push('$');
+                    out.push('{');
+                    i += 2;
+                }
+                '\n' => {
+                    out.push(c);
+                    at_line_start = true;
+                    i += 1;
+                }
+                _ => {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+        } else {
+            // Ordinary code context (top level or inside `${ … }`).
+            match c {
+                '`' => {
+                    stack.push(Frame::Template);
+                    out.push(c);
+                    i += 1;
+                }
+                '\'' | '"' => {
+                    string = Some(c);
+                    out.push(c);
+                    i += 1;
+                }
+                '/' if chars.get(i + 1) == Some(&'/') => {
+                    line_comment = true;
+                    out.push('/');
+                    out.push('/');
+                    i += 2;
+                }
+                '/' if chars.get(i + 1) == Some(&'*') => {
+                    block_comment = true;
+                    out.push('/');
+                    out.push('*');
+                    i += 2;
+                }
+                '{' => {
+                    if let Some(Frame::Subst(d)) = stack.last_mut() {
+                        *d += 1;
+                    }
+                    out.push(c);
+                    i += 1;
+                }
+                '}' => {
+                    if matches!(stack.last(), Some(Frame::Subst(0))) {
+                        stack.pop();
+                    } else if let Some(Frame::Subst(d)) = stack.last_mut() {
+                        *d -= 1;
+                    }
+                    out.push(c);
+                    i += 1;
+                }
+                '\n' => {
+                    out.push(c);
+                    at_line_start = true;
+                    i += 1;
+                }
+                _ => {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    out
 }
 
 /// Compute the byte range of the script BODY (between the opening tag's

--- a/crates/rsvelte_formatter/tests/markup_open_tag.rs
+++ b/crates/rsvelte_formatter/tests/markup_open_tag.rs
@@ -221,3 +221,36 @@ fn end_to_end_realistic_component() {
     );
     assert!(out.contains("{count}"), "{out}");
 }
+
+// ─── Comments inside the open tag are preserved (#685) ───────────────────
+
+#[test]
+fn line_comment_between_attributes_is_preserved() {
+    let out = fmt("<div\n  role=\"x\"\n  // important note\n  class=\"y\"\n></div>");
+    assert!(
+        out.contains("// important note"),
+        "line comment inside open tag was dropped:\n{out}"
+    );
+    assert!(out.contains("role=\"x\""), "{out}");
+    assert!(out.contains("class=\"y\""), "{out}");
+}
+
+#[test]
+fn line_comment_forces_multiline_open_tag() {
+    // A `//` comment can't share a line with the closing `>`, so even a
+    // short tag must render multi-line when one is present.
+    let out = fmt("<div\n  role=\"x\"\n  // note\n  class=\"y\"\n></div>");
+    assert!(
+        out.lines().any(|l| l.trim_start() == "// note"),
+        "expected line comment on its own line:\n{out}"
+    );
+}
+
+#[test]
+fn block_comment_between_attributes_is_preserved() {
+    let out = fmt("<div\n  role=\"x\"\n  /* note */\n  class=\"y\"\n></div>");
+    assert!(
+        out.contains("/* note */"),
+        "block comment inside open tag was dropped:\n{out}"
+    );
+}

--- a/crates/rsvelte_formatter/tests/markup_patterns.rs
+++ b/crates/rsvelte_formatter/tests/markup_patterns.rs
@@ -85,6 +85,58 @@ fn snippet_object_destructuring_parameter() {
     );
 }
 
+// ─── Snippet parameter lists are TS function parameters (#684) ───────────
+//
+// Optional (`?`), type-annotated, and default-valued params must round-trip
+// and never leak the internal `__rsvelte_fmt_rhs__` sentinel.
+
+fn fmt_ts(snippet: &str) -> String {
+    let src = format!("<script lang=\"ts\"></script>\n{snippet}\n");
+    format(&src, &FormatOptions::default()).expect("format ok")
+}
+
+#[test]
+fn snippet_optional_typed_parameter() {
+    let out = fmt_ts("{#snippet f(x?: string)}<p>{x}</p>{/snippet}");
+    assert!(
+        out.contains("{#snippet f(x?: string)}"),
+        "optional param dropped/garbled:\n{out}"
+    );
+}
+
+#[test]
+fn snippet_default_value_parameter() {
+    let out = fmt_ts("{#snippet f(x: number = 1)}<p>{x}</p>{/snippet}");
+    assert!(
+        out.contains("{#snippet f(x: number = 1)}"),
+        "default-value param dropped/garbled:\n{out}"
+    );
+}
+
+#[test]
+fn snippet_typed_default_does_not_leak_sentinel() {
+    let out = fmt_ts("{#snippet f(items: string[] = [])}<p>{items}</p>{/snippet}");
+    assert!(
+        !out.contains("__rsvelte_fmt_rhs__"),
+        "internal sentinel leaked into output:\n{out}"
+    );
+    assert!(
+        out.contains("{#snippet f(items: string[] = [])}"),
+        "typed default param garbled:\n{out}"
+    );
+}
+
+#[test]
+fn snippet_multiple_optional_parameters() {
+    let out = fmt_ts(
+        "{#snippet chip(label: string, subLabel?: string, icon?: number)}<p>{label}</p>{/snippet}",
+    );
+    assert!(
+        out.contains("{#snippet chip(label: string, subLabel?: string, icon?: number)}"),
+        "multi optional/typed params garbled:\n{out}"
+    );
+}
+
 #[test]
 fn snippet_multiple_parameters() {
     let out = fmt("{#snippet row({name},{ value })}<li>{name}</li>{/snippet}");

--- a/crates/rsvelte_formatter/tests/smoke.rs
+++ b/crates/rsvelte_formatter/tests/smoke.rs
@@ -52,3 +52,36 @@ fn formats_module_and_instance_independently() {
     );
     assert!(out.contains("<p>{x}</p>"), "markup not preserved:\n{out}");
 }
+
+#[test]
+fn template_literal_interior_is_not_reindented() {
+    // Re-embedding `<script>` must not re-indent the interior of a
+    // multi-line template literal — that whitespace is part of the string
+    // value, and re-indenting it both mutates the string and breaks
+    // idempotency (#686).
+    let source = concat!(
+        "<script lang=\"ts\">\n",
+        "  const html = `\n",
+        "    <div>\n",
+        "      hello\n",
+        "    </div>\n",
+        "  `;\n",
+        "</script>\n",
+        "\n",
+        "<p>{html}</p>\n",
+    );
+    let out = format(source, &FormatOptions::default()).expect("format ok");
+    println!("--- output ---\n{out}");
+    // Quasi lines keep their original indentation (4 / 6 spaces).
+    assert!(
+        out.contains("\n    <div>\n"),
+        "quasi line reindented:\n{out}"
+    );
+    assert!(
+        out.contains("\n      hello\n"),
+        "quasi line reindented:\n{out}"
+    );
+    // Idempotent: a second pass is a fixed point.
+    let out2 = format(&out, &FormatOptions::default()).expect("format ok");
+    assert_eq!(out, out2, "formatting is not idempotent");
+}


### PR DESCRIPTION
Fixes #684, #685, #686 — three `@rsvelte/fmt` bugs found via a real-monorepo corpus pass.

## #684 — `{#snippet}` parameter lists
Snippet parameters are ordinary (TS) function parameters, but they were routed through the destructuring-pattern path (`let <pattern> = …`):

- optional params (`x?: T`) → exit 2 (`Optional declaration is not allowed here`)
- default values (`x: T = v`) → exit 2 (`Cannot assign to this expression`)
- typed defaults (`items: string[] = []`) → exit 0 but **leaked the internal `__rsvelte_fmt_rhs__` sentinel** into the output (silent corruption)

Now formatted through a real function parameter list (`function f(<param>) {}`), so optional markers, type annotations, and default values all round-trip.

## #685 — Comments dropped from element open tags
A `//` (or `/* … */`) comment between attributes inside a start tag was silently deleted, because the open-tag rewrite rebuilt the tag from the attribute list alone. Comments are now collected and interleaved with attributes in source order; a `//` comment forces the multi-line tag shape, and `find_open_tag_end` skips comments so a `>` inside one can't terminate the tag early.

## #686 — Template-literal re-indentation (non-idempotent + string mutation)
Re-embedding the formatted `<script>` re-indented every line, including the interior of multi-line template literals — whose whitespace is part of the string value. That mutated the embedded string and made formatting non-idempotent (each pass added another indent level). The re-embed step now skips lines that begin inside template-literal quasi text, preserving the string value and making formatting a fixed point.

## Tests
- `markup_patterns.rs` — snippet optional / default / typed-default / multi-param (incl. a sentinel-leak guard)
- `markup_open_tag.rs` — line + block comments preserved, line comment forces multi-line
- `smoke.rs` — template-literal interior unchanged + idempotency assertion

All `rsvelte_formatter` / `rsvelte_fmt` tests pass; `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)