### PR TITLE
fix(transform): make destructured-derived name counters call-local (flaky CI fix)

### DIFF
--- a/.changeset/fix-flaky-derived-array-counter.md
+++ b/.changeset/fix-flaky-derived-array-counter.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): make destructured-derived name counters call-local
+
+`expand_destructured_derived` in the server transform generated its `$$derived_array` / `$$d` helper names using function-level `static` `AtomicUsize` counters, reset with `store(0)` at the top of each call. Those statics are process-global and shared across threads, so concurrent compiles (e.g. a rayon-parallel consumer) raced — one compile's reset/increment clobbered another's, producing nondeterministic `$$derived_array_N` numbering in server output. The counters are now call-local `let` bindings, so each compile gets its own and server output is deterministic under parallel compilation.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -3095,10 +3095,13 @@ fn expand_destructured_derived(script: &str) -> String {
     // Counter for generating unique `$$derived_array` / `$$d` names across
     // the whole script. We don't try to be clever about scoping — there are
     // no nested destructured deriveds in the test corpus.
-    static DERIVED_ARRAY_COUNTER: AtomicUsize = AtomicUsize::new(0);
-    static D_COUNTER: AtomicUsize = AtomicUsize::new(0);
-    DERIVED_ARRAY_COUNTER.store(0, Ordering::Relaxed);
-    D_COUNTER.store(0, Ordering::Relaxed);
+    //
+    // These MUST be call-local, not `static`: the test runner (and any
+    // parallel consumer) compiles many components concurrently, and a shared
+    // global counter would race — one compile resetting/incrementing another's
+    // counter, producing nondeterministic `$$derived_array_N` numbering.
+    let derived_array_counter = AtomicUsize::new(0);
+    let d_counter = AtomicUsize::new(0);
 
     let mut result = String::with_capacity(script.len());
     let bytes = script.as_bytes();
@@ -3218,7 +3221,7 @@ fn expand_destructured_derived(script: &str) -> String {
         let base_expr = if !is_by && arg_is_ident {
             arg_expr.to_string()
         } else {
-            let n = D_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let n = d_counter.fetch_add(1, Ordering::Relaxed);
             let name = if n == 0 {
                 "$$d".to_string()
             } else {
@@ -3250,7 +3253,7 @@ fn expand_destructured_derived(script: &str) -> String {
             &base_expr,
             &mut inserts,
             &mut paths,
-            &DERIVED_ARRAY_COUNTER,
+            &derived_array_counter,
         );
 
         // Compose declarators in upstream order: inserts (already in DFS


### PR DESCRIPTION
## Why

`main`'s CI flakily failed on `runtime-runes/derived-destructured` with `server=MISMATCH`, while the same test passed on single-threaded local runs — a classic concurrency race.

## Root cause

`expand_destructured_derived` (server `transform_script.rs`) generated the `$$derived_array` / `$$d` helper names with **function-level `static` `AtomicUsize` counters**, resetting them via `store(0)` at the top of each call:

```rust
static DERIVED_ARRAY_COUNTER: AtomicUsize = AtomicUsize::new(0);
static D_COUNTER: AtomicUsize = AtomicUsize::new(0);
DERIVED_ARRAY_COUNTER.store(0, Ordering::Relaxed);
D_COUNTER.store(0, Ordering::Relaxed);
```

Those statics are process-global and shared across threads. The runtime test runner compiles fixtures in parallel (rayon), so concurrent compiles raced — one compile's `store(0)`/`fetch_add` clobbered another's, yielding nondeterministic `$$derived_array_N` numbering and the intermittent `server=MISMATCH`.

## Fix

Make both counters **call-local `let` bindings** so each compile gets its own independent counter.

## Verification

- 32-thread × 400-iter contention stress harness (interleaving decoy destructured-derived compiles): target output now deterministic (was divergent before the fix).
- `cargo test --release -p rsvelte_core --test runtime`: 19/19 pass (runtime-runes 992/992 server).
- `cargo fmt` + `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)