### PR TITLE
fix(fmt): `.oxfmtrc` in inline blocks, full oxfmt file-set coverage, multi-line attr re-indent (#692, #693, #694)

### DIFF
--- a/.changeset/fmt-multiline-attr-reindent.md
+++ b/.changeset/fmt-multiline-attr-reindent.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): re-indent multi-line attribute expressions to the markup nesting level (#692)
+
+A multi-line expression inside an element attribute (a multi-line arrow handler, a `bind:` getter/setter pair, …) was not re-indented to its position in the markup tree: the delegated expression formatter emits at column 0, so continuation lines collapsed toward column 0–2 instead of aligning under the attribute. The output was valid and idempotent, but visually broken — and a large share of the structural churn when adopting rsvelte on a real component tree.
+
+Two changes in `rsvelte_formatter`'s open-tag rewriter:
+
+- A multi-line attribute value now forces the multi-line tag layout (each attribute on its own line). Previously a short-by-char-count value with embedded newlines was treated as fitting on one line.
+- In the multi-line layout, every continuation line of an attribute value is re-indented to the attribute column, so a multi-line `onclick={() => { … }}` / `bind:expanded={getter, setter}` aligns under the attribute and its closing `}}` sits at the attribute indent.

--- a/.changeset/fmt-oxfmtrc-and-dir-coverage.md
+++ b/.changeset/fmt-oxfmtrc-and-dir-coverage.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): honor `.oxfmtrc` in inline `<script>`/`<style>` and cover the full oxfmt file set on directories (#693, #694)
+
+Two formatter fixes for using `rsvelte-fmt` as a drop-in project formatter:
+
+- **#693 — inline blocks now respect the project `.oxfmtrc`.** Standalone files delegated to `oxfmt` already discovered the config, but inline `<script>` blocks (formatted in-process by `oxc_formatter`) and inline `<style>` blocks (staged in a temp dir, out of reach of oxfmt's own cwd discovery) were formatted with defaults — so e.g. `singleQuote: true` was ignored and every string in a component flipped to double quotes. `rsvelte-fmt` now resolves `.oxfmtrc.json` / `.oxfmtrc.jsonc` (upward from the working directory, or via a new `--config`/`-c` flag) and applies it to inline blocks: `singleQuote`, `semi`, `printWidth`, `tabWidth`, `useTabs`, `trailingComma`, `quoteProps`, `arrowParens`, `bracketSpacing`, `bracketSameLine`, and `endOfLine` now match standalone files. Explicit `--print-width` / `--tab-width` / `--use-tabs` flags still win.
+
+- **#694 — directories now cover the full oxfmt-supported set.** The walker hard-coded 9 extensions, silently skipping `.md` / `.yaml` / `.toml` / `.html` (and anything else oxfmt supports), so `rsvelte-fmt .` formatted strictly fewer files than `oxfmt .`. Directory inputs are now delegated whole to a single `oxfmt` invocation (with a `!**/*.svelte` exclude so the in-process Svelte pass keeps those, and `--no-error-on-unmatched-pattern` so a Svelte-only tree is a clean no-op). Coverage now matches `oxfmt .` and is `.gitignore`-aware, while the two passes still run in parallel.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "oxc_formatter_core",
  "rayon",
  "rsvelte_formatter",
+ "serde_json",
  "walkdir",
 ]
 

--- a/apps/npm/fmt/README.md
+++ b/apps/npm/fmt/README.md
@@ -1,9 +1,11 @@
 # @rsvelte/fmt
 
 A Rust-powered formatter for Svelte projects. `rsvelte-fmt` formats `.svelte`
-files in-process with the rsvelte formatter and delegates every other file
-(`.ts` / `.tsx` / `.js` / `.jsx` / `.cjs` / `.mjs` / `.json` / `.css`) — and the
-`<style>` CSS body of each Svelte component — to [`oxfmt`](https://oxc.rs/docs/guide/usage/formatter).
+files in-process with the rsvelte formatter and delegates every other file — and
+the `<script>` / `<style>` bodies of each Svelte component — to
+[`oxfmt`](https://oxc.rs/docs/guide/usage/formatter). On a directory it covers
+the full oxfmt-supported set (`.ts` / `.js` / `.css` / `.json`, plus `.md` /
+`.yaml` / `.toml` / `.html`, …), so it formats the same files `oxfmt .` would.
 Both pipelines run in parallel, so a mixed project formats in a single pass with
 no Node startup cost on the Svelte side and no Prettier doc-IR round-trip.
 
@@ -67,8 +69,21 @@ Add it to your `package.json`:
 }
 ```
 
-Directory inputs are walked recursively, skipping `node_modules`, `target`,
-`dist`, `build`, and hidden directories.
+Directory inputs hand every non-`.svelte` file to `oxfmt` (which respects
+`.gitignore` / `.prettierignore` and skips `node_modules`), while `.svelte`
+files are walked in-process, skipping `node_modules`, `target`, `dist`,
+`build`, and hidden directories.
+
+## Configuration (`.oxfmtrc`)
+
+`rsvelte-fmt` reads the project's [`oxfmt` config](https://oxc.rs/docs/guide/usage/formatter)
+(`.oxfmtrc.json` / `.oxfmtrc.jsonc`, discovered upward from the working
+directory, or `--config <path>`). Standalone files already pick it up via
+`oxfmt`; the inline `<script>` and `<style>` blocks inside `.svelte` files now
+honor it too, so settings like `singleQuote`, `semi`, `printWidth`,
+`trailingComma`, `quoteProps`, `arrowParens`, `bracketSpacing`, and `endOfLine`
+apply consistently across standalone files and embedded blocks. Explicit
+`--print-width` / `--tab-width` / `--use-tabs` flags override the config.
 
 ## CLI flags
 
@@ -78,9 +93,10 @@ Directory inputs are walked recursively, skipping `node_modules`, `target`,
 | `--check` | off | Exit 1 if any file would change; no writes |
 | `--stdin` | off | Read source on stdin, write result to stdout |
 | `--stdin-filepath PATH` | — | Filename used to pick the engine (required with `--stdin`) |
-| `--print-width N` | 80 | Maximum line width before breaking |
-| `--tab-width N` | 2 | Spaces per indent level |
-| `--use-tabs` | off | Indent with tabs |
+| `--print-width N` | `.oxfmtrc` / 80 | Maximum line width before breaking |
+| `--tab-width N` | `.oxfmtrc` / 2 | Spaces per indent level |
+| `--use-tabs` | `.oxfmtrc` / off | Indent with tabs |
+| `--config PATH`, `-c` | discovered | `.oxfmtrc` to apply to inline `<script>` / `<style>` blocks |
 | `--oxfmt-bin PATH` | resolved / `oxfmt` | Override the oxfmt binary used for non-`.svelte` files |
 
 Run `rsvelte-fmt --help` for the authoritative list.

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -27,3 +27,4 @@ clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"
 anyhow = "1.0"
+serde_json = "1.0"

--- a/crates/rsvelte_fmt/README.md
+++ b/crates/rsvelte_fmt/README.md
@@ -11,9 +11,13 @@ Fast Svelte + JS/TS/CSS formatter — one CLI, written in Rust.
 
 - `.svelte` files → in-process [`rsvelte_formatter`](../rsvelte_formatter).
   CSS inside `<style>` blocks is sent to `oxfmt` through a callback, so it
-  matches what `oxfmt` produces for standalone `.css`.
-- `.ts` / `.tsx` / `.js` / `.jsx` / `.cjs` / `.mjs` / `.json` / `.css`
-  files → a child `oxfmt` process.
+  matches what `oxfmt` produces for standalone `.css`. Inline `<script>` /
+  `<style>` blocks honor the project `.oxfmtrc` (discovered upward from cwd, or
+  `--config`), so quote style / print width / etc. match standalone files.
+- Every non-`.svelte` path → a single child `oxfmt` process. Directories are
+  delegated whole (with a `!**/*.svelte` exclude), so coverage matches
+  `oxfmt .` — the full supported set (`.ts` / `.js` / `.css` / `.json`, plus
+  `.md` / `.yaml` / `.toml` / `.html`, …), `.gitignore`-aware.
 
 Both pipelines run **in parallel** via `rayon::join`, so on a mixed project the
 in-process Svelte work overlaps with the `oxfmt` subprocess on every invocation.
@@ -22,9 +26,10 @@ There are no Node calls and no Prettier doc-IR round-trip — just rsvelte parsi
 
 ## Status
 
-Functional v0. The Svelte path is tested end-to-end (6 CLI integration
-tests, plus 105 tests in `rsvelte_formatter`). The `oxfmt` delegation path
-is exercised manually because `oxfmt` may not be present in every CI lane.
+Functional v0. The Svelte path is tested end-to-end (CLI integration tests,
+plus the tests in `rsvelte_formatter`). The `oxfmt` delegation path is
+exercised with a fake `oxfmt` in tests and against real `oxfmt` in the
+ecosystem-ci lane.
 
 ## Install
 
@@ -103,9 +108,10 @@ save hooks) can be pointed at `rsvelte-fmt` instead.
 | `--check` | off | Exit 1 if any file would change |
 | `--stdin` | off | Read source on stdin |
 | `--stdin-filepath PATH` | — | Required with `--stdin` |
-| `--print-width N` | 80 | Maximum line width |
-| `--tab-width N` | 2 | Spaces per indent level |
-| `--use-tabs` | off | Indent with tabs |
+| `--print-width N` | `.oxfmtrc` / 80 | Maximum line width |
+| `--tab-width N` | `.oxfmtrc` / 2 | Spaces per indent level |
+| `--use-tabs` | `.oxfmtrc` / off | Indent with tabs |
+| `--config PATH`, `-c` | discovered | `.oxfmtrc` applied to inline `<script>` / `<style>` |
 | `--oxfmt-bin PATH` | `oxfmt` | Subprocess binary for non-`.svelte` files |
 
 Options are forwarded to both halves of the dispatch so a mixed

--- a/crates/rsvelte_fmt/src/config.rs
+++ b/crates/rsvelte_fmt/src/config.rs
@@ -1,0 +1,346 @@
+//! Resolve the project's oxfmt config (`.oxfmtrc.json` / `.oxfmtrc.jsonc`) and
+//! apply it to the inline `<script>` / `<style>` formatting paths.
+//!
+//! Standalone files delegated to `oxfmt` already discover `.oxfmtrc` from the
+//! working directory, but inline `<script>` blocks are formatted in-process by
+//! `oxc_formatter` (which knows nothing about `.oxfmtrc`) and inline `<style>`
+//! blocks are staged into a temp dir (where `oxfmt`'s own discovery can't find
+//! the project config). Both end up formatted with defaults — e.g. ignoring
+//! `singleQuote: true` and flipping every string to double quotes. See #693.
+//!
+//! We mirror oxfmt's behavior: search upward from the working directory for the
+//! nearest config file (the same place oxfmt looks for `--stdin-filepath`),
+//! parse the keys `oxc_formatter` can honor, and layer them onto the JS options
+//! used for inline `<script>`. The resolved path is also handed to every child
+//! `oxfmt` invocation via `-c` so inline `<style>` blocks use it too.
+
+use std::path::{Path, PathBuf};
+
+use oxc_formatter::{
+    ArrowParentheses, JsFormatOptions, QuoteProperties, QuoteStyle, Semicolons, TrailingCommas,
+};
+use oxc_formatter_core::LineEnding;
+
+/// Config file names oxfmt recognises, in the order it prefers them.
+const CONFIG_NAMES: &[&str] = &[".oxfmtrc.json", ".oxfmtrc.jsonc"];
+
+/// The subset of `.oxfmtrc` keys that affect JS/TS formatting and that
+/// `oxc_formatter` can honor. Every field is `Option` so an absent key leaves
+/// the corresponding `JsFormatOptions` value untouched.
+#[derive(Debug, Default, Clone)]
+pub struct OxfmtConfig {
+    /// Path the config was read from. Passed to child `oxfmt` invocations via
+    /// `-c` so inline `<style>` blocks (staged in a temp dir, out of reach of
+    /// oxfmt's own cwd-based discovery) pick up the same settings.
+    pub path: Option<PathBuf>,
+    pub single_quote: Option<bool>,
+    pub semi: Option<bool>,
+    pub trailing_comma: Option<TrailingCommas>,
+    pub quote_props: Option<QuoteProperties>,
+    pub arrow_parens: Option<ArrowParentheses>,
+    pub bracket_spacing: Option<bool>,
+    pub bracket_same_line: Option<bool>,
+    pub print_width: Option<u16>,
+    pub tab_width: Option<u8>,
+    pub use_tabs: Option<bool>,
+    pub end_of_line: Option<LineEnding>,
+}
+
+impl OxfmtConfig {
+    /// Resolve the config: an explicit `--config` path if given, else the
+    /// nearest config file searching upward from `start` (the working
+    /// directory). Returns an empty config (everything `None`) when no file is
+    /// found, so callers can apply it unconditionally.
+    pub fn resolve(explicit: Option<&Path>, start: &Path) -> Self {
+        let path = match explicit {
+            Some(p) => Some(p.to_path_buf()),
+            None => find_upward(start),
+        };
+        let Some(path) = path else {
+            return Self::default();
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(src) => {
+                let mut cfg = parse(&src);
+                cfg.path = Some(path);
+                cfg
+            }
+            Err(e) => {
+                eprintln!(
+                    "rsvelte-fmt: warning: could not read config {}: {e}",
+                    path.display()
+                );
+                Self::default()
+            }
+        }
+    }
+
+    /// Layer the config's JS-affecting keys onto `js`. Indent / line-width are
+    /// resolved by the caller (they share precedence with CLI flags), so this
+    /// only touches quote style, semicolons, trailing commas, etc.
+    pub fn apply_js(&self, js: &mut JsFormatOptions) {
+        if let Some(v) = self.single_quote {
+            js.quote_style = if v {
+                QuoteStyle::Single
+            } else {
+                QuoteStyle::Double
+            };
+        }
+        if let Some(v) = self.semi {
+            js.semicolons = if v {
+                Semicolons::Always
+            } else {
+                Semicolons::AsNeeded
+            };
+        }
+        if let Some(v) = self.trailing_comma {
+            js.trailing_commas = v;
+        }
+        if let Some(v) = self.quote_props {
+            js.quote_properties = v;
+        }
+        if let Some(v) = self.arrow_parens {
+            js.arrow_parentheses = v;
+        }
+        if let Some(v) = self.bracket_spacing {
+            js.bracket_spacing = v.into();
+        }
+        if let Some(v) = self.bracket_same_line {
+            js.bracket_same_line = v.into();
+        }
+        if let Some(v) = self.end_of_line {
+            js.line_ending = v;
+        }
+    }
+}
+
+/// Search `start` and each ancestor directory for the first recognised config
+/// file. `start` may be a file or a directory; only directory components are
+/// inspected.
+fn find_upward(start: &Path) -> Option<PathBuf> {
+    let mut dir: Option<&Path> = if start.is_dir() {
+        Some(start)
+    } else {
+        start.parent()
+    };
+    while let Some(d) = dir {
+        for name in CONFIG_NAMES {
+            let candidate = d.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+/// Parse an `.oxfmtrc` document (JSON or JSONC) into an [`OxfmtConfig`].
+/// Unknown keys, unparsable values, and unsupported config dialects (`.ts` /
+/// `.js`, etc.) are ignored — a best-effort mapping is strictly better than
+/// silently formatting inline blocks with defaults.
+fn parse(src: &str) -> OxfmtConfig {
+    let stripped = strip_jsonc(src);
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&stripped) else {
+        return OxfmtConfig::default();
+    };
+    let serde_json::Value::Object(map) = value else {
+        return OxfmtConfig::default();
+    };
+
+    let mut cfg = OxfmtConfig::default();
+    let as_bool = |k: &str| map.get(k).and_then(serde_json::Value::as_bool);
+    let as_str = |k: &str| map.get(k).and_then(serde_json::Value::as_str);
+    let as_u64 = |k: &str| map.get(k).and_then(serde_json::Value::as_u64);
+
+    cfg.single_quote = as_bool("singleQuote");
+    cfg.semi = as_bool("semi");
+    cfg.bracket_spacing = as_bool("bracketSpacing");
+    cfg.bracket_same_line = as_bool("bracketSameLine");
+    cfg.use_tabs = as_bool("useTabs");
+
+    cfg.trailing_comma = as_str("trailingComma").and_then(|s| match s {
+        "all" => Some(TrailingCommas::All),
+        "es5" => Some(TrailingCommas::Es5),
+        "none" => Some(TrailingCommas::None),
+        _ => None,
+    });
+    cfg.quote_props = as_str("quoteProps").and_then(|s| match s {
+        "as-needed" => Some(QuoteProperties::AsNeeded),
+        "consistent" => Some(QuoteProperties::Consistent),
+        "preserve" => Some(QuoteProperties::Preserve),
+        _ => None,
+    });
+    cfg.arrow_parens = as_str("arrowParens").and_then(|s| match s {
+        "always" => Some(ArrowParentheses::Always),
+        "avoid" => Some(ArrowParentheses::AsNeeded),
+        _ => None,
+    });
+    cfg.end_of_line = as_str("endOfLine").and_then(|s| match s {
+        "lf" => Some(LineEnding::Lf),
+        "crlf" => Some(LineEnding::Crlf),
+        "cr" => Some(LineEnding::Cr),
+        // "auto" depends on the source; leave it to the formatter default.
+        _ => None,
+    });
+
+    cfg.print_width = as_u64("printWidth").and_then(|n| u16::try_from(n).ok());
+    cfg.tab_width = as_u64("tabWidth").and_then(|n| u8::try_from(n).ok());
+
+    cfg
+}
+
+/// Strip `//` and `/* */` comments and trailing commas from a JSONC document,
+/// leaving byte positions otherwise intact so `serde_json` can parse it. String
+/// contents (including `//` or `/*` *inside* a string) are preserved verbatim.
+///
+/// Works on bytes: every byte the comment markers / commas key off is ASCII, and
+/// UTF-8 multi-byte sequences never contain an ASCII byte, so non-ASCII string
+/// contents (e.g. `ignorePatterns`) survive intact and the output stays valid
+/// UTF-8.
+fn strip_jsonc(src: &str) -> String {
+    let bytes = src.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(src.len());
+    let mut i = 0;
+    let mut in_string = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_string {
+            out.push(b);
+            if b == b'\\' && i + 1 < bytes.len() {
+                // Preserve the escaped character as-is.
+                out.push(bytes[i + 1]);
+                i += 2;
+                continue;
+            }
+            if b == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'"' => {
+                in_string = true;
+                out.push(b'"');
+                i += 1;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                // Line comment — skip to end of line (keep the newline).
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                // Block comment — skip to the closing `*/`.
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i += 2;
+            }
+            _ => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    // `out` is `src` with whole ASCII comment regions removed, so it remains
+    // valid UTF-8.
+    let stripped = String::from_utf8(out).unwrap_or_default();
+    strip_trailing_commas(&stripped)
+}
+
+/// Remove trailing commas (a comma whose next non-whitespace character is `}`
+/// or `]`), which JSONC allows but `serde_json` rejects. Skips string contents.
+fn strip_trailing_commas(src: &str) -> String {
+    let bytes = src.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(src.len());
+    let mut in_string = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_string {
+            out.push(b);
+            if b == b'\\' && i + 1 < bytes.len() {
+                out.push(bytes[i + 1]);
+                i += 2;
+                continue;
+            }
+            if b == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if b == b'"' {
+            in_string = true;
+            out.push(b'"');
+            i += 1;
+            continue;
+        }
+        if b == b',' {
+            // Look ahead past whitespace for a closing bracket.
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < bytes.len() && (bytes[j] == b'}' || bytes[j] == b']') {
+                // Drop the comma; whitespace is re-emitted by the outer loop.
+                i += 1;
+                continue;
+            }
+        }
+        out.push(b);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_json() {
+        let cfg = parse(r#"{ "singleQuote": true, "printWidth": 100 }"#);
+        assert_eq!(cfg.single_quote, Some(true));
+        assert_eq!(cfg.print_width, Some(100));
+    }
+
+    #[test]
+    fn parses_jsonc_with_comments_and_trailing_commas() {
+        let cfg = parse(
+            r#"{
+            // quotes
+            "singleQuote": true,
+            "semi": false, /* no semicolons */
+            "trailingComma": "es5",
+        }"#,
+        );
+        assert_eq!(cfg.single_quote, Some(true));
+        assert_eq!(cfg.semi, Some(false));
+        assert!(matches!(cfg.trailing_comma, Some(TrailingCommas::Es5)));
+    }
+
+    #[test]
+    fn keeps_comment_markers_inside_strings() {
+        // A `//` or `/*` inside a string value must survive untouched.
+        let cfg = parse(r#"{ "ignorePatterns": ["a//b", "c/*d"], "singleQuote": true }"#);
+        assert_eq!(cfg.single_quote, Some(true));
+    }
+
+    #[test]
+    fn unknown_and_unparsable_keys_are_ignored() {
+        let cfg = parse(r#"{ "totallyUnknown": 1, "singleQuote": "notabool" }"#);
+        assert_eq!(cfg.single_quote, None);
+    }
+
+    #[test]
+    fn empty_on_garbage() {
+        let cfg = parse("not json at all");
+        assert_eq!(cfg.single_quote, None);
+        assert_eq!(cfg.print_width, None);
+    }
+}

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -15,13 +15,18 @@ use oxc_formatter_core::{IndentStyle, IndentWidth, LineWidth};
 use rayon::prelude::*;
 use rsvelte_formatter::{FormatOptions, format};
 
+mod config;
+use config::OxfmtConfig;
+
 /// rsvelte-fmt: fast Svelte + JS/TS/CSS formatter.
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
 struct Cli {
-    /// Files or directories to format. Directories are walked recursively
-    /// for `.svelte`, `.ts`, `.tsx`, `.js`, `.jsx`, `.cjs`, `.mjs`,
-    /// `.css`, and `.json` files.
+    /// Files or directories to format. `.svelte` files are formatted in
+    /// process; every other path is delegated to `oxfmt`, so directories cover
+    /// the full oxfmt-supported set (`.ts`/`.js`/`.css`/`.json` and also
+    /// `.md`/`.yaml`/`.toml`/`.html`, etc.) — the same files `oxfmt .` would
+    /// format. See #694.
     paths: Vec<PathBuf>,
 
     /// Write formatted output back to source files. Default when paths
@@ -44,17 +49,28 @@ struct Cli {
     #[arg(long, value_name = "PATH")]
     stdin_filepath: Option<PathBuf>,
 
-    /// Maximum line width before the formatter tries to break.
-    #[arg(long, value_name = "N", default_value_t = 80)]
-    print_width: u16,
+    /// Maximum line width before the formatter tries to break. Overrides
+    /// `printWidth` from `.oxfmtrc`; defaults to 80 when neither is set.
+    #[arg(long, value_name = "N")]
+    print_width: Option<u16>,
 
-    /// Number of spaces per indent level. Ignored when `--use-tabs`.
-    #[arg(long, value_name = "N", default_value_t = 2)]
-    tab_width: u8,
+    /// Number of spaces per indent level. Ignored when `--use-tabs`. Overrides
+    /// `tabWidth` from `.oxfmtrc`; defaults to 2 when neither is set.
+    #[arg(long, value_name = "N")]
+    tab_width: Option<u8>,
 
-    /// Indent with tabs instead of spaces.
+    /// Indent with tabs instead of spaces. When omitted, `useTabs` from
+    /// `.oxfmtrc` applies (if any), else spaces.
     #[arg(long)]
     use_tabs: bool,
+
+    /// Path to an `.oxfmtrc` config file. When omitted, the nearest
+    /// `.oxfmtrc.json` / `.oxfmtrc.jsonc` is discovered upward from the working
+    /// directory (matching oxfmt). The resolved config drives inline
+    /// `<script>` / `<style>` formatting so embedded blocks match standalone
+    /// files (quote style, print width, …).
+    #[arg(short = 'c', long, value_name = "PATH")]
+    config: Option<PathBuf>,
 
     /// Path to the `oxfmt` binary. Defaults to `oxfmt` on `$PATH`.
     #[arg(long, value_name = "PATH", default_value = "oxfmt")]
@@ -92,9 +108,10 @@ fn oxfmt_command(oxfmt: &Path) -> Command {
     }
 }
 
-/// File extensions that get delegated to `oxfmt`. Kept narrow on purpose
-/// so we don't accidentally feed binary files into the formatter.
-const OXFMT_EXTS: &[&str] = &["ts", "tsx", "js", "jsx", "cjs", "mjs", "json", "css"];
+/// oxfmt exclude pattern that keeps `.svelte` files out of the delegated pass —
+/// those are handled in-process by `rsvelte_formatter`. Applies to directory
+/// walks and to any explicitly-passed `.svelte` path.
+const OXFMT_EXCLUDE_SVELTE: &str = "!**/*.svelte";
 
 fn main() -> ExitCode {
     match run() {
@@ -108,10 +125,25 @@ fn main() -> ExitCode {
 
 fn run() -> Result<ExitCode> {
     let cli = Cli::parse();
-    let options = build_format_options(&cli);
+
+    // Resolve the project's `.oxfmtrc` once. Standalone files delegated to
+    // `oxfmt` discover it themselves; we resolve it here so inline `<script>`
+    // (formatted in-process) and inline `<style>` (staged in a temp dir) honor
+    // the same settings. Discovery starts from `--stdin-filepath`'s directory
+    // in stdin mode, else the working directory — matching oxfmt.
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let config_start = cli
+        .stdin_filepath
+        .as_deref()
+        .filter(|_| cli.stdin)
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| cwd.clone());
+    let cfg = OxfmtConfig::resolve(cli.config.as_deref(), &config_start);
+
+    let options = build_format_options(&cli, &cfg);
 
     if cli.stdin {
-        return run_stdin(&cli, &options);
+        return run_stdin(&cli, &options, &cfg);
     }
 
     if cli.paths.is_empty() {
@@ -120,15 +152,15 @@ fn run() -> Result<ExitCode> {
         ));
     }
 
-    let (svelte, others) = partition_files(&cli.paths)?;
+    let (svelte, oxfmt_paths) = partition_files(&cli.paths)?;
 
     let mode = if cli.check { Mode::Check } else { Mode::Write };
 
     // Run both pipelines in parallel — oxfmt subprocess will overlap
     // with the in-process Svelte formatter.
     let (svelte_result, oxfmt_result) = rayon::join(
-        || run_svelte_files(&svelte, &options, &cli.oxfmt_bin, mode),
-        || run_oxfmt(&others, &cli.oxfmt_bin, mode),
+        || run_svelte_files(&svelte, &options, &cli.oxfmt_bin, &cfg, mode),
+        || run_oxfmt(&oxfmt_paths, &cli.oxfmt_bin, mode),
     );
 
     let svelte_status = svelte_result?;
@@ -179,23 +211,39 @@ fn combine(a: PipelineStatus, b: PipelineStatus, mode: Mode) -> ExitCode {
     }
 }
 
-fn build_format_options(cli: &Cli) -> FormatOptions {
-    let indent_style = if cli.use_tabs {
+/// Build the [`FormatOptions`] for the in-process Svelte formatter, layering
+/// the resolved `.oxfmtrc` under any explicit CLI flags. Precedence for the
+/// keys that exist in both places (`--print-width`/`--tab-width`/`--use-tabs`):
+/// CLI flag > `.oxfmtrc` > built-in default. Keys with no CLI equivalent
+/// (`singleQuote`, `semi`, `trailingComma`, …) come straight from `.oxfmtrc`.
+fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> FormatOptions {
+    let use_tabs = cli.use_tabs || cfg.use_tabs.unwrap_or(false);
+    let indent_style = if use_tabs {
         IndentStyle::Tab
     } else {
         IndentStyle::Space
     };
-    let indent_width = IndentWidth::try_from(cli.tab_width).unwrap_or(IndentWidth::default());
-    let line_width = LineWidth::try_from(cli.print_width).unwrap_or(LineWidth::default());
+    let tab_width = cli.tab_width.or(cfg.tab_width).unwrap_or(2);
+    let print_width = cli.print_width.or(cfg.print_width).unwrap_or(80);
+    let indent_width = IndentWidth::try_from(tab_width).unwrap_or(IndentWidth::default());
+    let line_width = LineWidth::try_from(print_width).unwrap_or(LineWidth::default());
+
+    let mut js = JsFormatOptions {
+        indent_style,
+        indent_width,
+        line_width,
+        ..JsFormatOptions::new()
+    };
+    // Layer the remaining `.oxfmtrc` JS keys (quotes, semicolons, …) so inline
+    // `<script>` blocks match standalone files. See #693.
+    cfg.apply_js(&mut js);
 
     FormatOptions {
-        js: JsFormatOptions {
-            indent_style,
-            indent_width,
-            line_width,
-            ..JsFormatOptions::new()
-        },
-        style_formatter: Some(make_oxfmt_style_formatter(cli.oxfmt_bin.clone())),
+        js,
+        style_formatter: Some(make_oxfmt_style_formatter(
+            cli.oxfmt_bin.clone(),
+            cfg.path.clone(),
+        )),
         // `format` derives this per-document from `<script lang="ts">`.
         typescript: false,
     }
@@ -205,13 +253,24 @@ fn build_format_options(cli: &Cli) -> FormatOptions {
 /// for every `<style>` body inside a `.svelte` file.
 /// This way CSS / SCSS / Less inside Svelte components are formatted
 /// by the same engine that handles standalone `.css` files.
-fn make_oxfmt_style_formatter(oxfmt: PathBuf) -> rsvelte_formatter::StyleFormatter {
+fn make_oxfmt_style_formatter(
+    oxfmt: PathBuf,
+    config: Option<PathBuf>,
+) -> rsvelte_formatter::StyleFormatter {
     Arc::new(move |body: &str, lang: &str| -> Result<String, String> {
         let filename = format!("inline.{}", oxfmt_ext(lang));
         // oxfmt reads stdin implicitly when `--stdin-filepath` is given with no
         // path arguments. It has no `--stdin` flag and errors if one is passed
         // (#680), so feed the body on stdin and pass only `--stdin-filepath`.
-        let mut child = oxfmt_command(&oxfmt)
+        let mut cmd = oxfmt_command(&oxfmt);
+        // Force the resolved project config so inline `<style>` settings match
+        // standalone files even though oxfmt's own cwd discovery would apply
+        // here too — explicit is harmless and keeps the path consistent with
+        // the temp-dir batch path. See #693.
+        if let Some(c) = &config {
+            cmd.arg("-c").arg(c);
+        }
+        let mut child = cmd
             .arg("--stdin-filepath")
             .arg(&filename)
             .stdin(Stdio::piped())
@@ -238,7 +297,7 @@ fn make_oxfmt_style_formatter(oxfmt: PathBuf) -> rsvelte_formatter::StyleFormatt
 
 // ─── stdin path ─────────────────────────────────────────────────────────
 
-fn run_stdin(cli: &Cli, options: &FormatOptions) -> Result<ExitCode> {
+fn run_stdin(cli: &Cli, options: &FormatOptions, cfg: &OxfmtConfig) -> Result<ExitCode> {
     let filepath = cli
         .stdin_filepath
         .as_ref()
@@ -265,14 +324,31 @@ fn run_stdin(cli: &Cli, options: &FormatOptions) -> Result<ExitCode> {
         Ok(ExitCode::SUCCESS)
     } else {
         // Pass through to oxfmt via stdin.
-        oxfmt_stdin(&cli.oxfmt_bin, filepath, &source, cli.check)
+        oxfmt_stdin(
+            &cli.oxfmt_bin,
+            cfg.path.as_deref(),
+            filepath,
+            &source,
+            cli.check,
+        )
     }
 }
 
-fn oxfmt_stdin(oxfmt: &Path, path: &Path, source: &str, check: bool) -> Result<ExitCode> {
+fn oxfmt_stdin(
+    oxfmt: &Path,
+    config: Option<&Path>,
+    path: &Path,
+    source: &str,
+    check: bool,
+) -> Result<ExitCode> {
     let mut cmd = oxfmt_command(oxfmt);
     // oxfmt reads stdin implicitly given `--stdin-filepath`; passing `--stdin`
-    // is rejected (#680).
+    // is rejected (#680). Forward an explicit `--config` when the user set one
+    // so stdin formatting matches the rest of the project; otherwise oxfmt
+    // discovers `.oxfmtrc` from cwd on its own.
+    if let Some(c) = config {
+        cmd.arg("-c").arg(c);
+    }
     cmd.arg("--stdin-filepath").arg(path);
     if check {
         cmd.arg("--check");
@@ -295,28 +371,42 @@ fn oxfmt_stdin(oxfmt: &Path, path: &Path, source: &str, check: bool) -> Result<E
 
 // ─── file walking ───────────────────────────────────────────────────────
 
+/// Split the user's inputs into the in-process Svelte pass and the delegated
+/// `oxfmt` pass.
+///
+/// `.svelte` files are enumerated for the in-process formatter by walking every
+/// directory input (plus any explicit `.svelte` file arguments). Everything else
+/// is handed to `oxfmt`: directory inputs go through verbatim so `oxfmt` walks
+/// them with its full supported extension set (`.md`/`.yaml`/`.toml`/`.html`,
+/// …) — the same coverage as `oxfmt .` — while a `!**/*.svelte` exclude (added
+/// in [`run_oxfmt`]) keeps the Svelte files for us. Non-`.svelte` file
+/// arguments are passed straight through. See #694.
 fn partition_files(roots: &[PathBuf]) -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
     let mut svelte = Vec::new();
-    let mut others = Vec::new();
+    let mut oxfmt_paths = Vec::new();
     for root in roots {
-        for entry in walkdir::WalkDir::new(root)
-            .follow_links(false)
-            .into_iter()
-            .filter_entry(|e| !is_hidden(e.path()) && !is_ignored_dir(e.path()))
-        {
-            let entry = entry.context("walking input tree")?;
-            if !entry.file_type().is_file() {
-                continue;
+        let meta = std::fs::metadata(root)
+            .with_context(|| format!("reading {} — no such file or directory", root.display()))?;
+        if meta.is_dir() {
+            // Enumerate `.svelte` files ourselves; oxfmt walks the rest.
+            for entry in walkdir::WalkDir::new(root)
+                .follow_links(false)
+                .into_iter()
+                .filter_entry(|e| !is_hidden(e.path()) && !is_ignored_dir(e.path()))
+            {
+                let entry = entry.context("walking input tree")?;
+                if entry.file_type().is_file() && is_svelte(entry.path()) {
+                    svelte.push(entry.into_path());
+                }
             }
-            let path = entry.into_path();
-            match path.extension().and_then(OsStr::to_str) {
-                Some(SVELTE_EXT) => svelte.push(path),
-                Some(ext) if OXFMT_EXTS.contains(&ext) => others.push(path),
-                _ => {}
-            }
+            oxfmt_paths.push(root.clone());
+        } else if is_svelte(root) {
+            svelte.push(root.clone());
+        } else {
+            oxfmt_paths.push(root.clone());
         }
     }
-    Ok((svelte, others))
+    Ok((svelte, oxfmt_paths))
 }
 
 fn is_hidden(p: &Path) -> bool {
@@ -374,6 +464,7 @@ fn run_svelte_files(
     files: &[PathBuf],
     options: &FormatOptions,
     oxfmt: &Path,
+    cfg: &OxfmtConfig,
     mode: Mode,
 ) -> Result<PipelineStatus> {
     // ── Pass 1: format in parallel, collecting <style> bodies ──
@@ -395,8 +486,8 @@ fn run_svelte_files(
     }
 
     // ── Batch: one oxfmt call for every <style> body ──
-    let formatted_css =
-        batch_format_styles(oxfmt, &slot_css).context("formatting <style> blocks via oxfmt")?;
+    let formatted_css = batch_format_styles(oxfmt, cfg.path.as_deref(), &slot_css)
+        .context("formatting <style> blocks via oxfmt")?;
 
     // file_idx → (local_idx → formatted css)
     let mut per_file: Vec<Vec<String>> = vec![Vec::new(); pass1.len()];
@@ -486,7 +577,11 @@ fn format_collecting(path: &Path, options: &FormatOptions) -> Pass1 {
 /// Format every collected `<style>` body in a single `oxfmt` invocation by
 /// staging each into a temp file and running `oxfmt <files...>` (in-place),
 /// then reading them back. Returns the formatted CSS in input order.
-fn batch_format_styles(oxfmt: &Path, styles: &[(&str, &str)]) -> Result<Vec<String>> {
+fn batch_format_styles(
+    oxfmt: &Path,
+    config: Option<&Path>,
+    styles: &[(&str, &str)],
+) -> Result<Vec<String>> {
     if styles.is_empty() {
         return Ok(Vec::new());
     }
@@ -506,7 +601,15 @@ fn batch_format_styles(oxfmt: &Path, styles: &[(&str, &str)]) -> Result<Vec<Stri
         })
         .collect::<Result<_>>()?;
 
-    let out = oxfmt_command(oxfmt)
+    let mut cmd = oxfmt_command(oxfmt);
+    // The temp files live in the system temp dir, where oxfmt's own upward
+    // config discovery can't reach the project's `.oxfmtrc`. Force it so inline
+    // `<style>` blocks are formatted with the same settings as standalone CSS.
+    // See #693.
+    if let Some(c) = config {
+        cmd.arg("-c").arg(c);
+    }
+    let out = cmd
         .args(&paths)
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
@@ -562,8 +665,17 @@ fn apply_output(path: &Path, source: &str, formatted: &str, mode: Mode) -> Resul
 
 // ─── oxfmt delegation ───────────────────────────────────────────────────
 
-fn run_oxfmt(files: &[PathBuf], oxfmt: &Path, mode: Mode) -> Result<PipelineStatus> {
-    if files.is_empty() {
+/// Delegate every non-`.svelte` path to a single `oxfmt` invocation.
+///
+/// `paths` are the user's directory / file inputs verbatim; a `!**/*.svelte`
+/// exclude keeps Svelte files for the in-process pass, and
+/// `--no-error-on-unmatched-pattern` makes a tree with only `.svelte` files a
+/// clean no-op rather than an error. oxfmt's informational summary
+/// ("Finished … on N files", "Format issues found in above N files") goes to
+/// stdout; we capture it to recover file counts for our own summary, then
+/// forward it. Warnings/errors on stderr stay inherited.
+fn run_oxfmt(paths: &[PathBuf], oxfmt: &Path, mode: Mode) -> Result<PipelineStatus> {
+    if paths.is_empty() {
         return Ok(PipelineStatus::default());
     }
 
@@ -574,16 +686,67 @@ fn run_oxfmt(files: &[PathBuf], oxfmt: &Path, mode: Mode) -> Result<PipelineStat
             cmd.arg("--check");
         }
     }
-    cmd.args(files);
-    cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    cmd.arg("--no-error-on-unmatched-pattern");
+    cmd.arg(OXFMT_EXCLUDE_SVELTE);
+    cmd.args(paths);
+    cmd.stdout(Stdio::piped()).stderr(Stdio::inherit());
 
-    let status = cmd
-        .status()
+    let out = cmd
+        .output()
         .with_context(|| format!("failed to run `{}` — is oxfmt installed?", oxfmt.display()))?;
 
+    // Forward oxfmt's captured stdout (its own summary / check listing).
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    print!("{stdout}");
+    let _ = io::stdout().flush();
+
+    let (files_total, issues) = parse_oxfmt_counts(&stdout);
+    let code = out.status.code();
+    let (files_changed, had_errors) = match mode {
+        // Check: exit 1 = "would reformat" (not an error); exit >1 = real error.
+        Mode::Check => (issues, code.is_none_or(|c| c > 1)),
+        // Write: oxfmt formats in place; any non-zero exit is a real error.
+        Mode::Write => (0, !out.status.success()),
+    };
+
     Ok(PipelineStatus {
-        files_total: files.len(),
-        files_changed: if status.success() { 0 } else { files.len() },
-        had_errors: status.code().is_none_or(|c| c > 1),
+        files_total,
+        files_changed,
+        had_errors,
     })
+}
+
+/// Recover `(files_total, issue_count)` from oxfmt's stdout summary. Best-effort
+/// — counts default to 0 when the expected lines are absent so reporting can
+/// never fail the run.
+fn parse_oxfmt_counts(stdout: &str) -> (usize, usize) {
+    // "Finished in 70ms on 3 files using 10 threads."
+    let total = stdout
+        .lines()
+        .find_map(|l| count_before_word(l, "Finished", "files"))
+        .unwrap_or(0);
+    // "Format issues found in above 2 files. Run without `--check` to fix."
+    let issues = stdout
+        .lines()
+        .find_map(|l| count_before_word(l, "Format issues found", "files"))
+        .unwrap_or(0);
+    (total, issues)
+}
+
+/// In a line that starts with (contains) `marker`, return the integer that
+/// immediately precedes the token `word` (e.g. the `N` in "… N files …").
+fn count_before_word(line: &str, marker: &str, word: &str) -> Option<usize> {
+    if !line.contains(marker) {
+        return None;
+    }
+    let mut prev: Option<&str> = None;
+    for tok in line.split_whitespace() {
+        // Trailing punctuation: oxfmt prints "… 2 files." (with a period) in the
+        // check summary but "… 3 files using …" elsewhere.
+        if tok.trim_end_matches(|c: char| !c.is_alphanumeric()) == word {
+            return prev.and_then(|p| p.parse::<usize>().ok());
+        }
+        prev = Some(tok);
+    }
+    None
 }

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -119,12 +119,20 @@ fn no_paths_errors_helpfully() {
 fn batched_style_delegation_maps_each_block_to_its_file() {
     let dir = tempdir();
 
-    // Fake oxfmt: prepend `/*FMT*/` to every file path it receives (in place).
+    // Fake oxfmt: prepend `/*FMT*/` to every real *file* it receives (in
+    // place). Skips flags (`--…`) and exclude globs (`!…`) and silently ignores
+    // directory arguments — so it tolerates the directory-delegation args
+    // (`--no-error-on-unmatched-pattern !**/*.svelte <dir>`) the non-`.svelte`
+    // pass now passes, while still exercising the temp-file `<style>` batch.
     let fake = dir.join("fake-oxfmt.cjs");
     std::fs::write(
         &fake,
         r#"const fs = require('node:fs');
 for (const p of process.argv.slice(2)) {
+  if (p.startsWith('-') || p.startsWith('!')) continue;
+  let st;
+  try { st = fs.statSync(p); } catch { continue; }
+  if (!st.isFile()) continue;
   fs.writeFileSync(p, '/*FMT*/' + fs.readFileSync(p, 'utf8'));
 }
 "#,
@@ -178,6 +186,115 @@ for (const p of process.argv.slice(2)) {
     assert!(
         !out1.contains("RSVELTE_FMT_STYLE"),
         "placeholder leaked:\n{out1}"
+    );
+}
+
+/// #693: inline `<script>` formatting must honor the project `.oxfmtrc`.
+/// The script body is formatted in-process (no `oxfmt` needed), so a config
+/// with `singleQuote: true` should keep the string single-quoted instead of
+/// flipping it to oxc_formatter's double-quote default.
+#[test]
+fn inline_script_respects_oxfmtrc_single_quote() {
+    let dir = tempdir();
+    let cfg = dir.join(".oxfmtrc.json");
+    std::fs::write(&cfg, r#"{ "singleQuote": true }"#).unwrap();
+
+    let (stdout, _stderr, code) = run_stdin(
+        "<script>const x = \"hello\"</script>\n<p>{x}</p>\n",
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            "x.svelte",
+            "--config",
+            cfg.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("const x = 'hello';"),
+        "expected single quotes from .oxfmtrc:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("\"hello\""),
+        "string should not be double-quoted:\n{stdout}"
+    );
+}
+
+/// Without a config, the in-process default is oxc_formatter's double quotes —
+/// confirms the config layer is what flips quote style, not something else.
+#[test]
+fn inline_script_defaults_to_double_quote_without_config() {
+    let (stdout, _stderr, code) = run_stdin(
+        "<script>const x = 'hello'</script>\n",
+        &["--stdin", "--stdin-filepath", "x.svelte"],
+    );
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("const x = \"hello\";"),
+        "expected double-quote default:\n{stdout}"
+    );
+}
+
+/// #694: a directory input is delegated to a single `oxfmt` invocation that
+/// covers the full supported set (not a hard-coded extension list), with
+/// `.svelte` excluded for the in-process pass. We stand in a fake `oxfmt` that
+/// logs the exact argv it received so we can assert the delegation contract:
+/// the directory is passed through, `.svelte` is excluded, and unmatched
+/// patterns don't error.
+#[test]
+fn directory_delegates_full_set_to_oxfmt_with_svelte_excluded() {
+    let dir = tempdir();
+
+    // Fake oxfmt: append its received argv (one per line) to $FAKE_OXFMT_LOG.
+    let fake = dir.join("fake-oxfmt.cjs");
+    std::fs::write(
+        &fake,
+        r#"const fs = require('node:fs');
+fs.appendFileSync(process.env.FAKE_OXFMT_LOG, process.argv.slice(2).join('\n') + '\n');
+"#,
+    )
+    .unwrap();
+
+    let log = dir.join("argv.log");
+    std::fs::write(&log, "").unwrap();
+    // A `.svelte` file (in-process) plus a non-`.svelte` file so the dir isn't
+    // svelte-only.
+    std::fs::write(dir.join("a.svelte"), "<p>{x}</p>\n").unwrap();
+    std::fs::write(dir.join("readme.md"), "# x\n").unwrap();
+
+    let status = Command::new(bin())
+        .args([
+            dir.to_str().unwrap(),
+            "--write",
+            "--oxfmt-bin",
+            fake.to_str().unwrap(),
+        ])
+        .env("FAKE_OXFMT_LOG", log.to_str().unwrap())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "exit code: {:?}", status.code());
+
+    let argv = std::fs::read_to_string(&log).unwrap();
+    let args: Vec<&str> = argv.lines().collect();
+    assert!(
+        args.contains(&"!**/*.svelte"),
+        "oxfmt should be told to exclude .svelte; argv:\n{argv}"
+    );
+    assert!(
+        args.contains(&"--no-error-on-unmatched-pattern"),
+        "oxfmt should not error on unmatched patterns; argv:\n{argv}"
+    );
+    assert!(
+        args.contains(&dir.to_str().unwrap()),
+        "the directory itself should be delegated to oxfmt; argv:\n{argv}"
+    );
+    // We must NOT enumerate individual non-svelte files — the directory is
+    // handed off whole so oxfmt's own walker decides coverage.
+    assert!(
+        !args.iter().any(|a| a.ends_with("readme.md")),
+        "individual files should not be enumerated; argv:\n{argv}"
     );
 }
 

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -322,11 +322,20 @@ fn push_open_tag(
     let leading_indent_width = indent_visual_width(depth, &options.js);
     let line_width = options.js.line_width.value() as usize;
 
+    // A multi-line attribute value (e.g. a multi-line arrow handler or a
+    // `bind:` getter/setter pair) can't sit on a single tag line — its
+    // continuation lines would collapse toward column 0 instead of aligning
+    // under the attribute. Force the multi-line shape so each attribute lands
+    // on its own line and its continuation lines are re-indented to the
+    // attribute column (#692).
+    let any_multiline_attr = rendered_attrs.iter().any(|a| a.contains('\n'));
+
     // A `//` line comment can't share a line with the closing `>` (it would
     // comment out the rest of the tag), so any line comment forces the
     // multi-line shape.
-    let fits_one_line =
-        !has_line_comment && leading_indent_width + visual_width(&one_liner) <= line_width;
+    let fits_one_line = !has_line_comment
+        && !any_multiline_attr
+        && leading_indent_width + visual_width(&one_liner) <= line_width;
 
     let rendered = if rendered_attrs.is_empty() || fits_one_line {
         one_liner
@@ -455,7 +464,11 @@ fn render_multi_line(
     for a in attrs {
         out.push('\n');
         out.push_str(&inner_indent);
-        out.push_str(a);
+        // A multi-line attribute value (arrow handler, `bind:` getter/setter,
+        // …) is formatted at column 0 by the delegated expression formatter;
+        // re-indent its continuation lines to the attribute column so they
+        // align under the attribute instead of collapsing to column 0 (#692).
+        out.push_str(&reindent_continuation(a, &inner_indent));
     }
     out.push('\n');
     out.push_str(&outer_indent);
@@ -463,6 +476,28 @@ fn render_multi_line(
         out.push_str("/>");
     } else {
         out.push('>');
+    }
+    out
+}
+
+/// Prefix every continuation line (every line after the first) of a rendered
+/// attribute value with `indent`, so a multi-line expression aligns under its
+/// attribute in the multi-line tag layout. The first line is left alone — the
+/// caller has already emitted the attribute indent before it. Empty lines are
+/// not indented (no trailing whitespace). See #692.
+fn reindent_continuation(rendered: &str, indent: &str) -> String {
+    if !rendered.contains('\n') {
+        return rendered.to_string();
+    }
+    let mut out = String::with_capacity(rendered.len() + indent.len() * 2);
+    for (i, line) in rendered.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+            if !line.is_empty() {
+                out.push_str(indent);
+            }
+        }
+        out.push_str(line);
     }
     out
 }

--- a/crates/rsvelte_formatter/tests/markup_open_tag.rs
+++ b/crates/rsvelte_formatter/tests/markup_open_tag.rs
@@ -254,3 +254,48 @@ fn block_comment_between_attributes_is_preserved() {
         "block comment inside open tag was dropped:\n{out}"
     );
 }
+
+// ─── Multi-line attribute values (#692) ──────────────────────────────────
+
+#[test]
+fn multiline_attr_expression_reindented_to_attribute_column() {
+    // A multi-line arrow handler must force the multi-line tag layout and have
+    // its continuation lines aligned under the attribute, not collapsed to
+    // column 0 (#692).
+    let src = "<div>\n  <div>\n    <button\n      onclick={() => {\n        foo();\n        bar();\n      }}\n    >x</button>\n  </div>\n</div>\n";
+    let out = fmt(src);
+    let expected = "    <button\n      onclick={() => {\n        foo();\n        bar();\n      }}\n    >x</button>";
+    assert!(
+        out.contains(expected),
+        "multi-line attr not re-indented to nesting level:\n{out}"
+    );
+}
+
+#[test]
+fn multiline_attr_forces_multiline_tag_even_when_short() {
+    // The one-liner would "fit" by char count, but a newline in the value means
+    // it can't actually be one line — force the multi-line shape.
+    let src = "<button onclick={() => {\n  a();\n  b();\n}}>x</button>\n";
+    let out = fmt(src);
+    // The attribute lands on its own line under `<button`.
+    assert!(
+        out.contains("<button\n  onclick={() => {"),
+        "expected multi-line tag layout:\n{out}"
+    );
+    // Closing brace of the handler aligns under the attribute (2 spaces), and
+    // the body one JS level deeper (4 spaces).
+    assert!(out.contains("\n    a();\n"), "body not re-indented:\n{out}");
+    assert!(
+        out.contains("\n  }}\n"),
+        "closing brace not aligned:\n{out}"
+    );
+}
+
+#[test]
+fn multiline_attr_idempotent() {
+    let src =
+        "<div>\n  <button\n    onclick={() => {\n      foo();\n    }}\n  >x</button>\n</div>\n";
+    let once = fmt(src);
+    let twice = fmt(&once);
+    assert_eq!(once, twice, "re-indentation should be idempotent");
+}


### PR DESCRIPTION
Closes #692. Closes #693. Closes #694.

Three formatter fixes that all ship in `@rsvelte/fmt`, for using `rsvelte-fmt` as a drop-in project formatter.

## #693 — inline `<script>`/`<style>` now respect the project `.oxfmtrc`

Standalone files delegated to `oxfmt` already discovered the config, but inline `<script>` blocks are formatted **in-process** by `oxc_formatter` (which knows nothing about `.oxfmtrc`) and inline `<style>` blocks are staged into a **temp dir** (out of reach of oxfmt's cwd discovery). So both were formatted with defaults — `singleQuote: true` was ignored and every component string flipped to double quotes (~49% of changed lines when adopting rsvelte in a single-quote project).

Now `rsvelte-fmt` resolves `.oxfmtrc.json` / `.oxfmtrc.jsonc` (upward from cwd, or `--config`/`-c`) and applies it: inline `<script>` ← mapped onto `JsFormatOptions` (`singleQuote`, `semi`, `printWidth`, `tabWidth`, `useTabs`, `trailingComma`, `quoteProps`, `arrowParens`, `bracketSpacing`, `bracketSameLine`, `endOfLine`); inline `<style>` ← config path passed to the child `oxfmt` via `-c`. Explicit `--print-width`/`--tab-width`/`--use-tabs` still win. JSON + JSONC parsed; unsupported config dialects / garbage degrade to defaults.

## #694 — directories now cover the full oxfmt-supported set

The walker hard-coded 9 extensions, silently skipping `.md`/`.yaml`/`.toml`/`.html` (and anything else oxfmt supports), so `rsvelte-fmt .` formatted strictly fewer files than `oxfmt .`. Directories are now delegated **whole** to a single `oxfmt` invocation with a `!**/*.svelte` exclude (Svelte files stay in-process) and `--no-error-on-unmatched-pattern` (a Svelte-only tree is a clean no-op). Coverage matches `oxfmt .` and is `.gitignore`-aware; the two passes still run in parallel.

## #692 — multi-line attribute expressions re-indented to the markup nesting level

A multi-line attribute value (arrow handler, `bind:` getter/setter, …) wasn't re-indented to its place in the tree — continuation lines collapsed toward column 0–2 instead of aligning under the attribute. The open-tag rewriter now forces the multi-line tag layout when any attribute value contains a newline, and re-indents each continuation line to the attribute column. Idempotent.

Before / after (`onclick`, nested two levels):

```svelte
<!-- before -->
    <button onclick={() => {
  foo();
}}>x</button>

<!-- after -->
    <button
      onclick={() => {
        foo();
      }}
    >x</button>
```

## Tests

- JSONC config parser unit tests (comments, trailing commas, markers inside strings, garbage).
- CLI tests: inline `<script>` honors `--config` `singleQuote` (and defaults to double quotes without it); directory delegation passes `!**/*.svelte` + `--no-error-on-unmatched-pattern` + the directory itself and does not enumerate individual non-svelte files; existing `<style>` batch test updated to tolerate the new args.
- Formatter tests: multi-line attr re-indented to nesting level, forces multi-line layout when short, idempotent.
- Verified end-to-end against real `oxfmt` 0.53.0 for every issue's reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)