### PR TITLE
perf(ci): cache cargo builds and trim capi submodule checkout

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -88,6 +88,9 @@ jobs:
         run: pnpm run generate-fixtures
         timeout-minutes: 15
 
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - name: Run criterion
         # `--save-baseline pr` saves results so a follow-up job (or the next
         # commit) can diff against this baseline with `--baseline pr`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
         with:
           components: clippy
 
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -205,6 +208,9 @@ jobs:
         run: pnpm run generate-fixtures
         timeout-minutes: 15
 
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - name: Run tests
         # `--all-features` would enable `napi`, which only links cleanly when
         # loaded from Node.js — `cargo test` would otherwise hit `rust-lld:
@@ -307,6 +313,9 @@ jobs:
         run: pnpm run generate-fixtures
         timeout-minutes: 15
 
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - name: Generate compatibility report
         run: pnpm run compatibility-report
         timeout-minutes: 30
@@ -384,6 +393,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build documentation
         run: cargo doc --no-deps

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,6 +62,9 @@ jobs:
           path: fixtures
           key: fixtures-v2-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
 
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -105,6 +105,14 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # `matrix.target` is the external repo under test, not a Rust target —
+      # every matrix leg builds the same host napi binding, so share one
+      # cache across them instead of fragmenting per target.
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: ecosystem
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release-capi.yml
+++ b/.github/workflows/release-capi.yml
@@ -63,6 +63,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.target }}
+
       # Resolve the release version from the trigger:
       #   - push of capi-vX.Y.Z → strip the `capi-v` prefix
       #   - workflow_dispatch   → use the `version` input

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.target }}
+
       - name: Build svelte-check
         shell: bash
         env:
@@ -166,6 +171,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.target }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -224,6 +234,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.target }}
+
       - name: Build rsvelte-fmt
         shell: bash
         env:
@@ -265,6 +280,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: wasm32-unknown-unknown
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0

--- a/.github/workflows/rsvelte-capi.yml
+++ b/.github/workflows/rsvelte-capi.yml
@@ -61,10 +61,29 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: true
+          submodules: false
+
+      # capi only needs the `svelte` submodule: rsvelte_core's build.rs
+      # reads submodules/svelte/packages/svelte/package.json to embed the
+      # version string in the disclose-version import. The other three
+      # submodules (language-tools, typescript-go, vite-plugin-svelte —
+      # ~534 MB combined) are never touched by the capi build/tests, and
+      # vite-plugin-svelte is an SSH-only remote. Shallow-init just svelte
+      # to keep the uploaded library's version accurate.
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+
+      # Without this every run recompiles the whole oxc_* dependency graph
+      # in release mode from scratch (the bulk of the build time). The
+      # cache is keyed per-OS and shared across this workflow's runs
+      # (incl. main pushes) so PR builds restore the prebuilt deps.
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: capi-${{ matrix.os }}
 
       # Build twice on purpose: the first run regenerates the header
       # into include/rsvelte.h (build script writes when env var unset),


### PR DESCRIPTION
## Why

CI was slow primarily because **no workflow used a Rust build cache** — every run recompiled the entire `oxc_*` dependency graph (the bulk of build time) from scratch in release mode. The `rsvelte_capi (C ABI)` workflow also checked out all four submodules (~790 MB) when its build/tests only need one.

## What

**1. Rust build cache (`Swatinem/rust-cache@v2.9.1`, SHA-pinned) on every cargo-compiling job:**

| Workflow | Jobs |
|---|---|
| ci.yml | clippy, test, compatibility-report, docs |
| coverage.yml | coverage |
| bench.yml | bench |
| deploy-docs.yml | build |
| ecosystem-ci.yml | run (shared cache — every leg builds the same host napi) |
| release.yml | svelte-check, vps-native, rsvelte-fmt, wasm (keyed per target) |
| release-capi.yml | build matrix (keyed per target) |
| rsvelte-capi.yml | capi matrix (shared per OS) |

Cache restores the prebuilt dependency graph so PR/push builds skip recompiling `oxc_*` etc. Keyed per-OS / per-target where matrices cross-compile; invalidates automatically on `Cargo.lock` + rustc changes.

**2. Trim `rsvelte_capi (C ABI)` checkout:** `submodules: true` → `false` + shallow init of only `submodules/svelte`. The build/tests only need svelte (build.rs reads its `package.json` for the version string); `language-tools` / `typescript-go` / `vite-plugin-svelte` (~534 MB combined, the last SSH-only) are never touched.

## Coverage unchanged

The C ABI language-binding smokes (Go/Python/Ruby/PHP/Java) stay on all 3 OS — `release-capi.yml` only builds, so this PR's matrix is the only place they run; concentrating them on Linux would let macOS/Windows bindings break silently.

## Expected impact

- First run (cold cache): faster from the submodule trim.
- Subsequent runs (warm cache): large reduction — dependency recompilation is eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)