### PR TITLE
fix(fmt): don't re-indent multi-line template-literal interiors in attribute values (#698)

### DIFF
--- a/.changeset/fmt-multiline-template-attr-reindent.md
+++ b/.changeset/fmt-multiline-template-attr-reindent.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): don't re-indent multi-line template-literal interiors in attribute values (#698)
+
+A multi-line template literal passed as an **attribute value** (e.g. `text={` … `}`) had its interior lines re-indented to the markup nesting level on every format pass. Because template-literal whitespace is part of the runtime string, this both **mutated the string value** and was **non-idempotent** — every pass added another indent level so the formatter never reached a fixed point. This was a residual of the #692 multi-line attribute re-indentation fix.
+
+`reindent_continuation` in `rsvelte_formatter`'s open-tag rewriter now uses a template-literal-aware scanner (mirroring the `reindent_body` scanner added for #686): it tracks template-literal / `${ … }` nesting plus string and comment context, and leaves lines that begin inside template-literal quasi text verbatim. Code inside `${ … }` substitutions is still re-indented as ordinary code.

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -480,25 +480,194 @@ fn render_multi_line(
     out
 }
 
+/// One level of the scanner stack used by [`reindent_continuation`]. We only
+/// need to know whether a line begins inside template-literal *quasi* text
+/// (raw string content) versus ordinary code — the latter is re-indented, the
+/// former is left verbatim.
+enum AttrFrame {
+    /// Inside `` `…` `` quasi text (between backticks, outside `${}`).
+    Template,
+    /// Inside a `${ … }` substitution. The `u32` is the `{`-nesting depth
+    /// within the substitution, so the matching `}` is recognised.
+    Subst(u32),
+}
+
 /// Prefix every continuation line (every line after the first) of a rendered
 /// attribute value with `indent`, so a multi-line expression aligns under its
 /// attribute in the multi-line tag layout. The first line is left alone — the
 /// caller has already emitted the attribute indent before it. Empty lines are
 /// not indented (no trailing whitespace). See #692.
+///
+/// Lines that begin *inside* multi-line template-literal quasi text are left
+/// verbatim — their leading whitespace is part of the runtime string value, so
+/// re-indenting them would both mutate the string and make formatting
+/// non-idempotent (every pass would add another level) (#698). The scanner
+/// tracks template-literal / `${}` nesting plus string and comment context so
+/// backticks, `${`, and braces inside strings or comments aren't misread.
 fn reindent_continuation(rendered: &str, indent: &str) -> String {
     if !rendered.contains('\n') {
         return rendered.to_string();
     }
+    let chars: Vec<char> = rendered.chars().collect();
+    let n = chars.len();
     let mut out = String::with_capacity(rendered.len() + indent.len() * 2);
-    for (i, line) in rendered.split('\n').enumerate() {
-        if i > 0 {
-            out.push('\n');
-            if !line.is_empty() {
+    let mut stack: Vec<AttrFrame> = Vec::new();
+    let mut line_comment = false;
+    let mut block_comment = false;
+    let mut string: Option<char> = None;
+    // The first line is emitted without an indent prefix (the caller already
+    // wrote the attribute indent before it), so we start past the line-start
+    // handling for line 0.
+    let mut at_line_start = false;
+    let mut i = 0;
+
+    while i < n {
+        let c = chars[i];
+
+        if at_line_start {
+            let in_quasi = matches!(stack.last(), Some(AttrFrame::Template));
+            if c != '\n' && !in_quasi {
                 out.push_str(indent);
             }
+            at_line_start = false;
         }
-        out.push_str(line);
+
+        // Line comment: runs to end of line.
+        if line_comment {
+            out.push(c);
+            i += 1;
+            if c == '\n' {
+                line_comment = false;
+                at_line_start = true;
+            }
+            continue;
+        }
+
+        // Block comment: runs to `*/`. Interior lines are still re-indented
+        // (code context), matching the expression formatter's own alignment.
+        if block_comment {
+            if c == '*' && chars.get(i + 1) == Some(&'/') {
+                out.push('*');
+                out.push('/');
+                i += 2;
+                block_comment = false;
+                continue;
+            }
+            out.push(c);
+            i += 1;
+            if c == '\n' {
+                at_line_start = true;
+            }
+            continue;
+        }
+
+        // Regular string: consumes its own escapes; can't span lines in
+        // well-formed formatter output.
+        if let Some(q) = string {
+            out.push(c);
+            if c == '\\' {
+                if i + 1 < n {
+                    out.push(chars[i + 1]);
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+            i += 1;
+            if c == q {
+                string = None;
+            }
+            continue;
+        }
+
+        if matches!(stack.last(), Some(AttrFrame::Template)) {
+            // Inside template-literal quasi text.
+            match c {
+                '`' => {
+                    stack.pop();
+                    out.push(c);
+                    i += 1;
+                }
+                '\\' => {
+                    out.push(c);
+                    if i + 1 < n {
+                        out.push(chars[i + 1]);
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                '$' if chars.get(i + 1) == Some(&'{') => {
+                    stack.push(AttrFrame::Subst(0));
+                    out.push('$');
+                    out.push('{');
+                    i += 2;
+                }
+                '\n' => {
+                    out.push(c);
+                    at_line_start = true;
+                    i += 1;
+                }
+                _ => {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+        } else {
+            // Ordinary code context (top level or inside `${ … }`).
+            match c {
+                '`' => {
+                    stack.push(AttrFrame::Template);
+                    out.push(c);
+                    i += 1;
+                }
+                '\'' | '"' => {
+                    string = Some(c);
+                    out.push(c);
+                    i += 1;
+                }
+                '/' if chars.get(i + 1) == Some(&'/') => {
+                    line_comment = true;
+                    out.push('/');
+                    out.push('/');
+                    i += 2;
+                }
+                '/' if chars.get(i + 1) == Some(&'*') => {
+                    block_comment = true;
+                    out.push('/');
+                    out.push('*');
+                    i += 2;
+                }
+                '{' => {
+                    if let Some(AttrFrame::Subst(d)) = stack.last_mut() {
+                        *d += 1;
+                    }
+                    out.push(c);
+                    i += 1;
+                }
+                '}' => {
+                    if matches!(stack.last(), Some(AttrFrame::Subst(0))) {
+                        stack.pop();
+                    } else if let Some(AttrFrame::Subst(d)) = stack.last_mut() {
+                        *d -= 1;
+                    }
+                    out.push(c);
+                    i += 1;
+                }
+                '\n' => {
+                    out.push(c);
+                    at_line_start = true;
+                    i += 1;
+                }
+                _ => {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+        }
     }
+
     out
 }
 

--- a/crates/rsvelte_formatter/tests/markup_open_tag.rs
+++ b/crates/rsvelte_formatter/tests/markup_open_tag.rs
@@ -299,3 +299,40 @@ fn multiline_attr_idempotent() {
     let twice = fmt(&once);
     assert_eq!(once, twice, "re-indentation should be idempotent");
 }
+
+// ─── Multi-line template literals in attribute values (#698) ──────────────
+
+#[test]
+fn multiline_template_literal_attr_interior_not_reindented() {
+    // The interior lines of a template literal are part of the runtime string
+    // value, so they must NOT be re-indented to the markup column (#698).
+    let src = "<div>\n  <Comp text={`\n    line1\n    line2\n  `} />\n</div>\n";
+    let out = fmt(src);
+    // The quasi lines keep their original column — not pushed to the attribute
+    // indent. Look for the exact interior, un-prefixed.
+    assert!(
+        out.contains("\n    line1\n    line2\n"),
+        "template-literal interior was re-indented:\n{out}"
+    );
+}
+
+#[test]
+fn multiline_template_literal_attr_idempotent() {
+    // The whole point of #698: formatting must reach a fixed point and must not
+    // mutate the literal's content on repeated passes.
+    let src = "<div>\n  <Comp text={`\n    line1\n    line2\n  `} />\n</div>\n";
+    let once = fmt(src);
+    let twice = fmt(&once);
+    assert_eq!(once, twice, "template-literal attr must be idempotent");
+}
+
+#[test]
+fn template_literal_substitution_in_attr_is_reindented() {
+    // Code inside `${ … }` is ordinary code context: if a substitution spans
+    // lines its continuation should still align under the attribute, while the
+    // surrounding quasi text stays verbatim.
+    let src = "<div>\n  <Comp text={`a\n${\nfoo()}\nb`} />\n</div>\n";
+    let once = fmt(src);
+    let twice = fmt(&once);
+    assert_eq!(once, twice, "substitution re-indent must be idempotent");
+}


### PR DESCRIPTION
Fixes #698.

## Problem

A multi-line template literal passed as an **attribute value** had its interior lines re-indented to the markup nesting level on **every** format pass:

```svelte
<div>
  <Comp text={`
    line1
    line2
  `} />
</div>
```

Because template-literal whitespace is part of the runtime string, this both **mutated the string value** and was **non-idempotent** — each pass added another indent level to `line1` / `line2`, so the formatter never reached a fixed point. It was a residual of the #692 fix that started re-indenting multi-line attribute expressions to the markup level (same root cause as #686, in the attribute context).

## Fix

`reindent_continuation` in `rsvelte_formatter`'s open-tag rewriter previously prefixed *every* continuation line with the attribute indent. It now uses a template-literal-aware scanner — the same approach as the `reindent_body` scanner added for #686:

- Tracks template-literal / `${ … }` nesting plus string and comment context so backticks, `${`, and braces inside strings/comments aren't misread.
- Lines that begin inside template-literal **quasi text** are left verbatim (their leading whitespace is significant).
- Code inside `${ … }` substitutions is still re-indented as ordinary code.

The result is idempotent and preserves the literal's content exactly, while keeping the #692 behavior for multi-line arrow handlers / `bind:` getter-setter pairs.

## Tests

Added to `crates/rsvelte_formatter/tests/markup_open_tag.rs`:

- `multiline_template_literal_attr_interior_not_reindented` — interior stays at its original column.
- `multiline_template_literal_attr_idempotent` — repeated passes reach a fixed point (the core of #698).
- `template_literal_substitution_in_attr_is_reindented` — `${ … }` code path stays idempotent.

Full `rsvelte_formatter` suite, `cargo fmt`, and `cargo clippy -D warnings` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)