### PR TITLE
ci: auto-follow new oxfmt npm releases

### DIFF
--- a/.github/workflows/auto-update-oxfmt.yml
+++ b/.github/workflows/auto-update-oxfmt.yml
@@ -1,0 +1,181 @@
+name: auto-update-oxfmt
+
+# Auto-follow new `oxfmt` npm releases. `oxfmt` is the engine rsvelte delegates
+# inline `<style>` CSS (and standalone md/yaml/toml/html) to, pinned with a
+# caret range in the workspace package.json files. When a newer version is
+# published on npm than the one pinned, this opens a PR that bumps every caret
+# pin and refreshes the pnpm lockfile.
+#
+# Unlike the svelte bump (auto-update-svelte.yml), an oxfmt bump is mechanical
+# and the PR is intended to be mergeable once CI is green. An oxfmt change can
+# alter inline `<style>` CSS output, so CI (formatter + compatibility report) is
+# the gate — review the diff if it surfaces fixture changes.
+#
+# A minimum release-age gate (RELEASE_AGE_MIN_HOURS) skips versions published
+# very recently, mirroring the stability window used for oxfmt elsewhere, so a
+# just-published (and potentially yanked) release isn't chased immediately.
+#
+# SETUP:
+#   - Settings → Actions → General → Workflow permissions: enable "Allow GitHub
+#     Actions to create and approve pull requests" (required for the default
+#     GITHUB_TOKEN to open PRs).
+#   - PRs created with the default GITHUB_TOKEN do NOT trigger the `CI` workflow.
+#     Add a `GH_PAT` repo secret (fine-grained PAT with `contents: write` +
+#     `pull-requests: write`) to have CI run automatically; it falls back to
+#     GITHUB_TOKEN when absent.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '47 5 * * *' # Daily at 05:47 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-update-oxfmt
+  cancel-in-progress: false
+
+env:
+  # Skip a release published less than this many hours ago (stability window).
+  RELEASE_AGE_MIN_HOURS: '24'
+
+jobs:
+  update:
+    name: Open oxfmt upgrade PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: false
+          token: ${{ secrets.GH_PAT || github.token }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Read currently pinned oxfmt version
+        id: current
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The caret range in the root package.json devDependencies is the
+          # source of truth (apps/* mirror it). Strip a leading ^ / ~.
+          RANGE=$(jq -r '.devDependencies.oxfmt // .dependencies.oxfmt // empty' package.json)
+          if [ -z "${RANGE}" ]; then
+            echo "::error::Could not read oxfmt version range from package.json"
+            exit 1
+          fi
+          VERSION=${RANGE#[\^~]}
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Pinned oxfmt version: ${VERSION} (range: ${RANGE})"
+
+      - name: Fetch latest oxfmt release from npm
+        id: latest
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://registry.npmjs.org/oxfmt > meta.json
+          VERSION=$(jq -r '."dist-tags".latest' meta.json)
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+            echo "::error::Could not read oxfmt dist-tags.latest from npm"
+            exit 1
+          fi
+          PUBLISHED=$(jq -r --arg v "${VERSION}" '.time[$v] // empty' meta.json)
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "published=${PUBLISHED}" >> "${GITHUB_OUTPUT}"
+          echo "Latest oxfmt on npm: ${VERSION} (published ${PUBLISHED})"
+
+      - name: Open upgrade PR if a newer release is available
+        if: steps.current.outputs.version != steps.latest.outputs.version
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          CURRENT_VERSION: ${{ steps.current.outputs.version }}
+          LATEST_VERSION: ${{ steps.latest.outputs.version }}
+          PUBLISHED: ${{ steps.latest.outputs.published }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Only act when the pinned version is strictly older (version-aware).
+          NEWEST=$(printf '%s\n%s\n' "${CURRENT_VERSION}" "${LATEST_VERSION}" | sort -V | tail -n1)
+          if [ "${NEWEST}" = "${CURRENT_VERSION}" ]; then
+            echo "Pinned ${CURRENT_VERSION} >= latest ${LATEST_VERSION}; nothing to do."
+            exit 0
+          fi
+
+          # Stability window: skip a release that is younger than the gate.
+          if [ -n "${PUBLISHED}" ]; then
+            now=$(date -u +%s)
+            pub=$(date -u -d "${PUBLISHED}" +%s 2>/dev/null || echo 0)
+            if [ "${pub}" -gt 0 ]; then
+              age_h=$(( (now - pub) / 3600 ))
+              if [ "${age_h}" -lt "${RELEASE_AGE_MIN_HOURS}" ]; then
+                echo "oxfmt ${LATEST_VERSION} is only ${age_h}h old (< ${RELEASE_AGE_MIN_HOURS}h gate); waiting."
+                exit 0
+              fi
+            fi
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          pr_branch="chore/update-oxfmt-${LATEST_VERSION}"
+          git checkout -B "${pr_branch}"
+
+          # Bump every caret/tilde-pinned oxfmt range across the workspace.
+          # The `"oxfmt": "*"` peer entry in apps/npm/fmt is intentionally left
+          # untouched (it accepts any installed oxfmt).
+          mapfile -t files < <(grep -rl '"oxfmt": *"[\^~][0-9]' --include=package.json . | grep -v node_modules || true)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::No caret/tilde-pinned oxfmt entries found to bump"
+            exit 1
+          fi
+          for f in "${files[@]}"; do
+            sed -i -E "s|(\"oxfmt\": *\")[\^~][0-9][0-9.]*(\")|\1^${LATEST_VERSION}\2|g" "${f}"
+            git add "${f}"
+            echo "Bumped ${f}"
+          done
+
+          # Refresh the lockfile so CI's --frozen-lockfile install succeeds.
+          pnpm install --lockfile-only
+          git add pnpm-lock.yaml
+
+          title="chore(deps): update oxfmt to ${LATEST_VERSION}"
+          git commit -m "${title}"
+          git push --force origin "${pr_branch}"
+
+          {
+            echo "Automated bump of the \`oxfmt\` npm dependency."
+            echo
+            echo "| | version |"
+            echo "|---|---|"
+            echo "| from | \`${CURRENT_VERSION}\` |"
+            echo "| to | \`${LATEST_VERSION}\` |"
+            echo
+            echo "Published: ${PUBLISHED}"
+            echo
+            echo "\`oxfmt\` is the engine rsvelte delegates inline \`<style>\` CSS"
+            echo "(and standalone md/yaml/toml/html) to. A version bump can change"
+            echo "CSS formatting output, so **review CI** — the formatter and"
+            echo "compatibility-report jobs gate this PR. Merge once green."
+            echo
+            echo "---"
+            echo
+            echo "Opened by the \`auto-update-oxfmt\` workflow."
+          } > pr-body.md
+
+          existing=$(gh pr list --head "${pr_branch}" --state open --json number --jq 'length')
+          if [ "${existing}" -eq 0 ]; then
+            gh pr create --base main --head "${pr_branch}" \
+              --title "${title}" --body-file pr-body.md
+          else
+            number=$(gh pr list --head "${pr_branch}" --state open --json number --jq '.[0].number')
+            gh pr edit "${number}" --title "${title}" --body-file pr-body.md
+            echo "Updated existing PR #${number} (force-pushed ${pr_branch})."
+          fi


### PR DESCRIPTION
Adds an `auto-update-oxfmt` GitHub Actions workflow that automatically follows new [`oxfmt`](https://www.npmjs.com/package/oxfmt) releases — the engine rsvelte delegates inline `<style>` CSS (and standalone md/yaml/toml/html) to.

## What it does

- **Daily poll** (`05:47 UTC`, plus manual `workflow_dispatch`) of the npm registry for the latest `oxfmt` version.
- Compares it (version-aware) against the caret pin in the workspace `package.json` files.
- When a newer version is available, opens/updates a PR that:
  - bumps every caret/tilde-pinned `oxfmt` range (`package.json`, `apps/playground/package.json`); the `"oxfmt": "*"` peer entry in `apps/npm/fmt` is intentionally left untouched,
  - refreshes `pnpm-lock.yaml` via `pnpm install --lockfile-only`.
- A **24h stability-window gate** skips a just-published (potentially-yanked) release.

Mirrors the existing `auto-update-svelte` / `auto-update-submodules` workflows (same pinned action SHAs, `GH_PAT` fallback, upsert-onto-stable-branch behavior). Unlike a svelte bump, an oxfmt bump is mechanical, so the generated PR is meant to be **mergeable once CI is green** — and since an oxfmt change can alter inline `<style>` CSS output, the formatter + compatibility-report jobs are the gate.

## Validation

Locally verified against the current tree:
- YAML parses.
- `jq` reads the current pin (`^0.53.0`).
- `grep`/`sed` bump logic targets exactly `package.json` + `apps/playground/package.json` and leaves the `apps/npm/fmt` `"*"` peer untouched.

Current pin (`^0.53.0`) already matches npm latest (`0.53.0`), so the workflow is a no-op until the next oxfmt release.

> [!NOTE]
> Needs **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** enabled (same prerequisite as the existing auto-update workflows). Add a `GH_PAT` secret if you want CI to run automatically on the generated PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)