### PR TITLE
perf(fmt): stage inline `<style>` blocks to a dir, not N explicit oxfmt paths (#707)

### DIFF
--- a/.changeset/fmt-style-dir-mode.md
+++ b/.changeset/fmt-style-dir-mode.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/fmt": patch
+---
+
+perf(fmt): hand inline `<style>` blocks to oxfmt as a directory, not N explicit paths (#707)
+
+On a cold run (cache miss — first run, or CI without a persisted cache) the batched inline-`<style>` pass staged every extracted CSS body into a temp dir and invoked `oxfmt s0.css s1.css … sN.css` with one explicit path per block. A multi-hundred-entry argv defeats oxfmt's parallel directory walk (and at scale risks `ARG_MAX`), making the cold path slower than it needs to be.
+
+`rsvelte-fmt` now passes the staging directory itself (`oxfmt <dir>`) and reads the results back by their known `s{i}` names. The staging dir holds only our files and is cleared before each batch, so the walk formats exactly the set we read back. Output is byte-identical — same `oxfmt`, same forced `-c` config — and warm runs are unchanged (still served from the `<style>` cache). The two oxfmt subprocesses (non-`.svelte` delegation and the CSS batch) already overlap via `rayon::join`.

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -660,9 +660,15 @@ fn format_styles_cached(
 }
 
 /// Format every collected `<style>` body in a single `oxfmt` invocation by
-/// staging each into a temp file and running `oxfmt <files...>` (in-place),
+/// staging each into a temp directory and running `oxfmt <dir>` (in-place),
 /// then reading them back. Returns the formatted CSS in input order plus
 /// whether oxfmt exited successfully (so callers can decide whether to cache).
+///
+/// The styles are handed to oxfmt as a single **directory** argument rather
+/// than N explicit file paths: oxfmt parallelizes its directory walk, and on
+/// large trees a multi-thousand-entry argv can also be slower (or hit
+/// `ARG_MAX`). The staging dir holds only our `s{i}.{ext}` files, so the walk
+/// formats exactly the set we read back. See #707.
 fn batch_format_styles(
     oxfmt: &Path,
     config: Option<&Path>,
@@ -673,6 +679,10 @@ fn batch_format_styles(
     }
 
     let dir = std::env::temp_dir().join(format!("rsvelte-fmt-styles-{}", std::process::id()));
+    // Start from a clean dir: oxfmt walks the whole directory, so a stale file
+    // left by a crashed prior run with a recycled PID must not leak into the
+    // batch (it would waste work and could surface spurious parse errors).
+    let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("creating temp dir {}", dir.display()))?;
 
@@ -696,7 +706,7 @@ fn batch_format_styles(
         cmd.arg("-c").arg(c);
     }
     let out = cmd
-        .args(&paths)
+        .arg(&dir)
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .output()

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -15,6 +15,29 @@ fn bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_rsvelte-fmt"))
 }
 
+/// A fake oxfmt that prepends `/*FMT*/` to every CSS file it formats. Handles
+/// both explicit file arguments and the `<style>` staging directory the batch
+/// hands it (basename `rsvelte-fmt-styles-*`, walked like real oxfmt walks a
+/// directory). Any *other* directory argument — e.g. the project dir from the
+/// non-`.svelte` delegation pass — is ignored, so it never touches the test's
+/// own `.svelte`/`.cjs` files. Shared by the delegation and cache-output tests.
+const MARKER_OXFMT: &str = r#"const fs = require('node:fs');
+const path = require('node:path');
+function fmtFile(p) { fs.writeFileSync(p, '/*FMT*/' + fs.readFileSync(p, 'utf8')); }
+for (const p of process.argv.slice(2)) {
+  if (p.startsWith('-') || p.startsWith('!')) continue;
+  let st;
+  try { st = fs.statSync(p); } catch { continue; }
+  if (st.isFile()) fmtFile(p);
+  else if (st.isDirectory() && path.basename(p).startsWith('rsvelte-fmt-styles-')) {
+    for (const e of fs.readdirSync(p)) {
+      const fp = path.join(p, e);
+      if (fs.statSync(fp).isFile()) fmtFile(fp);
+    }
+  }
+}
+"#;
+
 fn run_stdin(stdin: &str, args: &[&str]) -> (String, String, i32) {
     let mut child = Command::new(bin())
         .args(args)
@@ -120,24 +143,14 @@ fn batched_style_delegation_maps_each_block_to_its_file() {
     let dir = tempdir();
 
     // Fake oxfmt: prepend `/*FMT*/` to every real *file* it receives (in
-    // place). Skips flags (`--…`) and exclude globs (`!…`) and silently ignores
-    // directory arguments — so it tolerates the directory-delegation args
-    // (`--no-error-on-unmatched-pattern !**/*.svelte <dir>`) the non-`.svelte`
-    // pass now passes, while still exercising the temp-file `<style>` batch.
+    // place). Skips flags (`--…`) and exclude globs (`!…`). It walks the
+    // `<style>` staging directory (`rsvelte-fmt-styles-*`) the batch now hands
+    // it (#707), mirroring real oxfmt's directory walk, but ignores any *other*
+    // directory — so the project dir from the non-`.svelte` delegation pass
+    // (`--no-error-on-unmatched-pattern !**/*.svelte <dir>`) is left alone (real
+    // oxfmt covers that tree via its own walker + the .svelte exclude).
     let fake = dir.join("fake-oxfmt.cjs");
-    std::fs::write(
-        &fake,
-        r#"const fs = require('node:fs');
-for (const p of process.argv.slice(2)) {
-  if (p.startsWith('-') || p.startsWith('!')) continue;
-  let st;
-  try { st = fs.statSync(p); } catch { continue; }
-  if (!st.isFile()) continue;
-  fs.writeFileSync(p, '/*FMT*/' + fs.readFileSync(p, 'utf8'));
-}
-"#,
-    )
-    .unwrap();
+    std::fs::write(&fake, MARKER_OXFMT).unwrap();
 
     let c1 = dir.join("c1.svelte");
     let c2 = dir.join("c2.svelte");
@@ -309,12 +322,18 @@ fn write_counting_oxfmt(dir: &std::path::Path) -> PathBuf {
     std::fs::write(
         &fake,
         r#"const fs = require('node:fs');
+const path = require('node:path');
 let touchedFile = false;
 for (const p of process.argv.slice(2)) {
   if (p.startsWith('-') || p.startsWith('!')) continue;
   let st;
   try { st = fs.statSync(p); } catch { continue; }
   if (st.isFile()) touchedFile = true; // identity: leave content as-is
+  else if (st.isDirectory() && path.basename(p).startsWith('rsvelte-fmt-styles-')) {
+    for (const e of fs.readdirSync(p)) {
+      if (fs.statSync(path.join(p, e)).isFile()) touchedFile = true;
+    }
+  }
 }
 if (touchedFile && process.env.FAKE_OXFMT_LOG) {
   fs.appendFileSync(process.env.FAKE_OXFMT_LOG, 'call\n');
@@ -459,19 +478,7 @@ fn style_cache_output_matches_uncached() {
     let dir = tempdir();
     let cache = dir.join("cache");
     let fake = dir.join("marker-oxfmt.cjs");
-    std::fs::write(
-        &fake,
-        r#"const fs = require('node:fs');
-for (const p of process.argv.slice(2)) {
-  if (p.startsWith('-') || p.startsWith('!')) continue;
-  let st;
-  try { st = fs.statSync(p); } catch { continue; }
-  if (!st.isFile()) continue;
-  fs.writeFileSync(p, '/*FMT*/' + fs.readFileSync(p, 'utf8'));
-}
-"#,
-    )
-    .unwrap();
+    std::fs::write(&fake, MARKER_OXFMT).unwrap();
 
     let body = "<div></div>\n<style>.a{color:red}</style>\n";
     let cached = dir.join("cached.svelte");


### PR DESCRIPTION
Closes #707.

## Problem

On a **cold** run (cache miss — first run, or CI without a persisted cache) the batched inline-`<style>` pass stages every extracted CSS body into a temp dir and then invokes oxfmt with **one explicit path per block**:

```
oxfmt -c <.oxfmtrc> <tmp>/rsvelte-fmt-styles-XXXX/s0.css s1.css … sN.css
```

A multi-hundred-entry argv defeats oxfmt's parallel directory walk (#707 measured 2.7× slower for identical content on the reporter's oxfmt build) and, at scale, risks `ARG_MAX`.

## Fix (win #1 from the issue)

Hand the **staging directory** to oxfmt (`oxfmt <dir>`) and read the results back by their known `s{i}` names. The dir is cleared before each batch and holds only our files, so the walk formats exactly the set we read back.

- **Output is byte-identical** — same oxfmt, same forced `-c` config. Verified end-to-end on real `.svelte` files (CSS + SCSS).
- **Warm runs unchanged** — still served from the `<style>` cache (#703); only cache misses reach this batch.
- **Win #2 (overlap the two oxfmt subprocesses)** is already in place: the non-`.svelte` delegation and the CSS batch run concurrently via `rayon::join`.

## Note on measurement

The issue's 2.7× gap did **not** reproduce locally on the pinned **oxfmt 0.53.0** (directory vs explicit-path were at parity in my benchmarks), so the explicit-path slowness appears to have been fixed upstream or was environment-specific. The change is kept regardless because it is strictly **equal-or-better**, output-identical, and removes the `ARG_MAX` risk on large trees — exactly what the issue recommends.

## Tests

The three fake-oxfmt test doubles in `tests/cli.rs` now walk the `rsvelte-fmt-styles-*` staging directory like real oxfmt (shared via a `MARKER_OXFMT` constant), while still ignoring the project dir handed to the non-`.svelte` delegation pass. All 14 `rsvelte_fmt` CLI tests pass; `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)