### PR TITLE
fix(svelte-check): rename CLI bin to `rsvelte-check` (#716)

### DIFF
--- a/.changeset/rsvelte-check-bin-rename.md
+++ b/.changeset/rsvelte-check-bin-rename.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/svelte-check": minor
+---
+
+rename the CLI bin from `svelte-check` to `rsvelte-check` (#716)
+
+`@rsvelte/svelte-check` previously shipped its CLI under the bin name `svelte-check`, colliding with the official [`svelte-check`](https://www.npmjs.com/package/svelte-check) package. In a single `node_modules/.bin/` only one `svelte-check` entry can exist, so installing both produced a last-writer-wins shadow and made a safe side-by-side migration impossible.
+
+The bin is now `rsvelte-check`, so both tools can coexist and be addressed unambiguously from npm scripts:
+
+```jsonc
+"type:check": "svelte-check --tsconfig ./tsconfig.json",  // official, authoritative
+"type:check:fast": "rsvelte-check --workspace ."          // rsvelte, PR-time
+```
+
+The CLI arguments and behavior are unchanged. Also fixes the doubled `apps/apps/` in `repository.directory`.

--- a/apps/npm/svelte-check/README.md
+++ b/apps/npm/svelte-check/README.md
@@ -28,13 +28,13 @@ From your project root:
 
 ```bash
 # Compiler + A11y + CSS diagnostics only (fast — no TypeScript)
-npx svelte-check
+npx rsvelte-check
 
 # Plus TypeScript diagnostics via tsgo
-npx svelte-check --tsgo
+npx rsvelte-check --tsgo
 
 # Watch mode with incremental cache
-npx svelte-check --tsgo --watch --incremental
+npx rsvelte-check --tsgo --watch --incremental
 ```
 
 Add it to your `package.json`:
@@ -42,8 +42,8 @@ Add it to your `package.json`:
 ```json
 {
   "scripts": {
-    "check": "svelte-check --tsgo",
-    "check:watch": "svelte-check --tsgo --watch --incremental"
+    "check": "rsvelte-check --tsgo",
+    "check:watch": "rsvelte-check --tsgo --watch --incremental"
   }
 }
 ```
@@ -65,11 +65,11 @@ Add it to your `package.json`:
 | `--watch` | Stay alive and re-check on file changes. Composes with `--incremental`. |
 | `--preserve-watch-output` | In watch mode, don't clear the terminal between runs. |
 
-Run `svelte-check --help` for the authoritative list.
+Run `rsvelte-check --help` for the authoritative list.
 
 ## How it works
 
-`svelte-check` walks your project, parses every `.svelte` file with the rsvelte compiler, and reports compiler / A11y / CSS warnings directly. For TypeScript diagnostics, it generates `.tsx` shadow files (via [`@rsvelte/svelte2tsx`](https://www.npmjs.com/package/@rsvelte/svelte2tsx)) plus an overlay `tsconfig.json` under `.svelte-check/`, then hands the overlay to `tsgo` (preferred) or `tsc`. Diagnostics are remapped back onto the original `.svelte` source via high-resolution source maps so error positions point at the line and column you actually wrote.
+`rsvelte-check` walks your project, parses every `.svelte` file with the rsvelte compiler, and reports compiler / A11y / CSS warnings directly. For TypeScript diagnostics, it generates `.tsx` shadow files (via [`@rsvelte/svelte2tsx`](https://www.npmjs.com/package/@rsvelte/svelte2tsx)) plus an overlay `tsconfig.json` under `.svelte-check/`, then hands the overlay to `tsgo` (preferred) or `tsc`. Diagnostics are remapped back onto the original `.svelte` source via high-resolution source maps so error positions point at the line and column you actually wrote.
 
 Highlights:
 
@@ -88,7 +88,7 @@ If you hit a diagnostic the official `svelte-check` produces and this one doesn'
 
 ## Performance
 
-`svelte-check` is part of the [rsvelte](https://github.com/baseballyama/rsvelte) project. The underlying compiler runs **2.1× faster single-threaded** and **15.8× faster multi-threaded** than the official JS compiler on a 3,654-file corpus. The TypeScript pass via `tsgo` dominates wall-clock time on most projects; the Svelte side rarely registers.
+`rsvelte-check` is part of the [rsvelte](https://github.com/baseballyama/rsvelte) project. The underlying compiler runs **2.1× faster single-threaded** and **15.8× faster multi-threaded** than the official JS compiler on a 3,654-file corpus. The TypeScript pass via `tsgo` dominates wall-clock time on most projects; the Svelte side rarely registers.
 
 ## License
 

--- a/apps/npm/svelte-check/package.json
+++ b/apps/npm/svelte-check/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/svelte-check"
+    "directory": "apps/npm/svelte-check"
   },
   "homepage": "https://github.com/baseballyama/rsvelte/tree/main/apps/npm/svelte-check#readme",
   "bugs": {
@@ -20,7 +20,7 @@
     "rust"
   ],
   "bin": {
-    "svelte-check": "bin/svelte-check.cjs"
+    "rsvelte-check": "bin/svelte-check.cjs"
   },
   "files": [
     "bin/svelte-check.cjs"

--- a/crates/rsvelte_core/src/bin/svelte_check.rs
+++ b/crates/rsvelte_core/src/bin/svelte_check.rs
@@ -32,7 +32,8 @@ use rsvelte_core::svelte_check::{
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "svelte-check",
+    name = "rsvelte-check",
+    bin_name = "rsvelte-check",
     about = "Type-check & diagnose Svelte projects (Rust port of @sveltejs/svelte-check)",
     long_about = None
 )]
@@ -158,7 +159,7 @@ fn main() -> ExitCode {
         if let Err(err) = run_watch(options, watch_opts, |run_result| {
             print_run(run_result, &workspace_for_print, format);
         }) {
-            eprintln!("svelte-check: watch mode failed to start: {err}");
+            eprintln!("rsvelte-check: watch mode failed to start: {err}");
             return ExitCode::from(2);
         }
         ExitCode::SUCCESS


### PR DESCRIPTION
Closes #716.

## Problem

`@rsvelte/svelte-check` declared its CLI bin as `svelte-check` — the same name as the official [`svelte-check`](https://www.npmjs.com/package/svelte-check) package. Only one `svelte-check` can exist in `node_modules/.bin/`, so installing both was last-writer-wins and made a safe side-by-side migration impossible (run fast rsvelte on PR CI while keeping the authoritative official tool on merge).

## Change

- Rename the bin to `rsvelte-check` in `apps/npm/svelte-check/package.json`.
- Align the clap `name` / `bin_name` and the watch-mode error prefix in `crates/rsvelte_core/src/bin/svelte_check.rs` so `--help` and runtime messages say `rsvelte-check`.
- Update the README usage examples (`npx rsvelte-check …`, scripts, `--help`).
- Fix the doubled `apps/apps/` in `repository.directory`.
- Add a `minor` changeset for `@rsvelte/svelte-check`.

Both tools can now coexist:

```jsonc
"type:check": "svelte-check --tsconfig ./tsconfig.json",  // official, authoritative
"type:check:fast": "rsvelte-check --workspace ."          // rsvelte, PR-time
```

CLI args and behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)