### PR TITLE
fix(svelte-check): `--workspace .` discovers 0 files / silent false-pass (#718)

### DIFF
--- a/.changeset/svelte-check-workspace-dot.md
+++ b/.changeset/svelte-check-workspace-dot.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): `--workspace .` / `./` / `=.` no longer discover 0 files and silently pass (#718)
+
+The project walker pruned any entry whose name starts with `.` (the hidden-dir skip). When the workspace root was `.` or `./`, walkdir reports the root entry's `file_name()` as the bare path string (`.`), so the **root itself** was pruned and the whole tree discarded — `--workspace .` reported `found 0 errors … in 0 files` and exited 0 even with `.svelte` files present (a silent false-pass in CI). Absolute and `..`-relative roots carry a real final component, so they were unaffected.
+
+The walk root (depth 0) is now never pruned — it's the workspace the user explicitly pointed at — which also honours a workspace directory whose own name starts with `.`. Additionally, the CLI now prints a warning to **stderr** (never stdout, so machine formats stay parseable) when zero `.svelte` files are found, so a misconfigured path can't masquerade as a passing check.

--- a/crates/rsvelte_core/src/bin/svelte_check.rs
+++ b/crates/rsvelte_core/src/bin/svelte_check.rs
@@ -165,6 +165,17 @@ fn main() -> ExitCode {
         ExitCode::SUCCESS
     } else {
         let result = run(&options);
+        // Finding nothing is almost always a misconfigured workspace path, not
+        // a clean project. Surface it on stderr (never stdout, so machine
+        // formats stay parseable) so "checked nothing" can't masquerade as
+        // "passed" (issue #718).
+        if result.files_checked == 0 {
+            eprintln!(
+                "rsvelte-check: warning: no .svelte files found under {} — nothing was checked. \
+                 Is the --workspace path correct?",
+                workspace.display()
+            );
+        }
         print_run(&result, &workspace, format);
         ExitCode::from(result.exit_code(cli.fail_on_warnings) as u8)
     }

--- a/crates/rsvelte_core/src/svelte_check/walker.rs
+++ b/crates/rsvelte_core/src/svelte_check/walker.rs
@@ -30,6 +30,15 @@ pub fn find_svelte_files(root: &Path, filter_paths: &[String]) -> Vec<PathBuf> {
         .follow_links(false)
         .into_iter()
         .filter_entry(|e| {
+            // Never prune the walk root itself — it's the workspace the user
+            // explicitly pointed us at. `WalkDir::new(".")` / `"./"` reports a
+            // depth-0 entry whose `file_name()` falls back to the path string
+            // (`.`), which would otherwise trip the hidden-dir skip below and
+            // silently discard the entire tree (issue #718). The same guard
+            // also honours a workspace dir whose own name starts with `.`.
+            if e.depth() == 0 {
+                return true;
+            }
             let name = e.file_name().to_string_lossy();
             // Always skip node_modules and hidden directories — matches
             // the JS `excludePattern: /node_modules/.*\..*$/` plus the
@@ -69,6 +78,10 @@ pub fn find_relevant_files(
         .follow_links(false)
         .into_iter()
         .filter_entry(|e| {
+            // Never prune the walk root — see `find_svelte_files` (issue #718).
+            if e.depth() == 0 {
+                return true;
+            }
             let name = e.file_name().to_string_lossy();
             if name == "node_modules" || name.starts_with('.') {
                 return false;
@@ -145,6 +158,31 @@ mod tests {
         assert!(
             !names.contains(&"Hidden.svelte".into()),
             "hidden dirs skipped"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn walk_root_is_never_pruned_by_hidden_skip() {
+        // Regression for #718: when the walk root's own name starts with `.`
+        // (as `WalkDir::new(".")` / `"./"` reports it at depth 0), the
+        // hidden-dir skip must not discard the entire tree. A workspace dir
+        // literally named `.app` exercises the same depth-0 guard.
+        let tmp = std::env::temp_dir().join(format!(".svc_walker_dot_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        setup_project(&tmp);
+        let files = find_svelte_files(&tmp, &[]);
+        let names: Vec<_> = files
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        assert!(
+            names.contains(&"App.svelte".into()),
+            "files under a dot-named root must still be found, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"Hidden.svelte".into()),
+            "descendant hidden dirs are still skipped"
         );
         let _ = fs::remove_dir_all(&tmp);
     }


### PR DESCRIPTION
Closes #718.

## Problem

`@rsvelte/svelte-check --workspace .` (and `./`, `--workspace=.`) discovered **0 files**, printed `found 0 errors and 0 warnings in 0 files`, and exited 0 — even with `.svelte` files present. A silent false-pass: a green type-check that checked nothing.

## Root cause

`crates/rsvelte_core/src/svelte_check/walker.rs` prunes any entry whose name starts with `.` (the hidden-dir skip). For root `.` / `./`, `WalkDir` reports the **depth-0 root entry**'s `file_name()` as the bare path string (`.` — `Path::file_name()` is `None` for a lone `CurDir`, and walkdir falls back to the path), so the root itself matched the hidden-dir skip and the whole tree was discarded. Absolute and `..`-relative roots carry a real final component, which is exactly why the issue's table shows them working.

## Fix

- **Never prune the walk root (depth 0)** in both `find_svelte_files` and `find_relevant_files` — it's the workspace the user explicitly pointed at. This also honours a workspace directory whose own name starts with `.` (e.g. `/foo/.config`), a latent variant of the same bug.
- **Warn on stderr when 0 `.svelte` files are found** (never stdout, so machine / github-actions formats stay parseable), so a misconfigured path can't masquerade as "passed".
- Adds a regression test (`walk_root_is_never_pruned_by_hidden_skip`).

## Verification

```
--- no flag ---        found 0 errors and 0 warnings in 1 file
--- --workspace . ---  found 0 errors and 0 warnings in 1 file   # was 0 files
--- --workspace ./ --- found 0 errors and 0 warnings in 1 file   # was 0 files
--- --workspace=. ---  found 0 errors and 0 warnings in 1 file   # was 0 files
```

Empty workspace now emits on stderr (stdout stays clean):
```
rsvelte-check: warning: no .svelte files found under <path> — nothing was checked. Is the --workspace path correct?
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)