### PR TITLE
fix(svelte2tsx): panic on multibyte/CJK `<script>` content (#719)

### DIFF
--- a/.changeset/svelte2tsx-cjk-char-boundary.md
+++ b/.changeset/svelte2tsx-cjk-char-boundary.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): don't panic on multibyte/CJK `<script>` content (#719)
+
+`collect_type_body_deps`'s `typeof` lookbehind sliced `&body[j - 6..j]` with raw byte arithmetic. When non-ASCII (e.g. Japanese / CJK) text preceded an identifier in a `<script lang="ts">` type body — such as `必須) */` ahead of `imageSrc` — `j - 6` could land inside a multibyte UTF-8 char, and the `&str` slice panicked, aborting the entire `--emit-overlay` / `--tsgo` run (and with it every diagnostic for the project). The slice is now guarded with `str::is_char_boundary`; the six bytes can only spell the ASCII keyword `typeof` when `j - 6` is already a char boundary, so behavior is unchanged for ASCII input.

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -1502,8 +1502,15 @@ fn collect_type_body_deps(
             while j > 0 && matches!(bytes[j - 1], b' ' | b'\t' | b'\r' | b'\n') {
                 j -= 1;
             }
-            let preceded_by_typeof =
-                j >= 6 && &body[j - 6..j] == "typeof" && (j == 6 || !is_ident_byte(bytes[j - 7]));
+            // `&body[j - 6..j]` is raw byte arithmetic: when non-ASCII (e.g.
+            // CJK) text precedes the identifier, `j - 6` can land inside a
+            // multibyte char and panic the whole run (issue #719). Guard the
+            // slice with `is_char_boundary` — the 6 bytes can only spell the
+            // ASCII keyword `typeof` when `j - 6` is already a boundary.
+            let preceded_by_typeof = j >= 6
+                && body.is_char_boundary(j - 6)
+                && &body[j - 6..j] == "typeof"
+                && (j == 6 || !is_ident_byte(bytes[j - 7]));
             // Detect property-key context: `key:` or `key?:` (with optional
             // whitespace) — these are object-type member keys, not type
             // references, so they shouldn't count as deps even if they
@@ -3732,6 +3739,45 @@ fn extract_names_from_labeled_body(body: &oxc::Statement) -> Vec<String> {
 mod tests {
     use super::*;
     use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+    #[test]
+    fn collect_type_body_deps_handles_multibyte_before_ident() {
+        // Regression for #719: the `typeof` lookbehind sliced `&body[j - 6..j]`
+        // with raw byte arithmetic, which panicked when a multibyte (CJK)
+        // char preceded an identifier (here `必須) */` before `imageSrc`).
+        let body = "interface Props {\n\
+            \u{20}\u{20}/** \u{30A2}\u{30D0}\u{30BF}\u{30FC} */\n\
+            \u{20}\u{20}content: 'image' | 'initial' | 'count';\n\
+            \u{20}\u{20}/** \u{753B}\u{50CF} (content='image' \u{306E}\u{5834}\u{5408}\u{306B}\u{5FC5}\u{9808}) */\n\
+            \u{20}\u{20}imageSrc?: string;\n}";
+        let candidates: HashSet<String> = HashSet::new();
+        let generics: HashSet<String> = HashSet::new();
+        let values: HashSet<String> = HashSet::new();
+        let imports: HashSet<String> = HashSet::new();
+        // Must not panic.
+        let (_value_deps, _type_deps) =
+            collect_type_body_deps(body, &candidates, "Props", &generics, &values, &imports);
+    }
+
+    #[test]
+    fn svelte2tsx_does_not_panic_on_cjk_jsdoc() {
+        // End-to-end guard for #719: a `<script lang="ts">` whose JSDoc
+        // comments contain CJK characters used to abort the whole svelte2tsx
+        // run with a char-boundary panic during overlay generation.
+        let source = "<script lang=\"ts\">\n\
+            \u{20}\u{20}interface Props {\n\
+            \u{20}\u{20}\u{20}\u{20}/** \u{30A2}\u{30D0}\u{30BF}\u{30FC}\u{306E}\u{30B3}\u{30F3}\u{30C6}\u{30F3}\u{30C4} */\n\
+            \u{20}\u{20}\u{20}\u{20}content: 'image' | 'initial' | 'count';\n\
+            \u{20}\u{20}\u{20}\u{20}/** \u{753B}\u{50CF}\u{306E}\u{30BD}\u{30FC}\u{30B9} (content='image' \u{306E}\u{5834}\u{5408}\u{306B}\u{5FC5}\u{9808}) */\n\
+            \u{20}\u{20}\u{20}\u{20}imageSrc?: string;\n\
+            \u{20}\u{20}}\n\
+            \u{20}\u{20}const { content, imageSrc }: Props = $props();\n\
+            </script>\n\
+            <p>{content}{imageSrc}</p>\n";
+        let out = svelte2tsx(source, Svelte2TsxOptions::default()).expect("svelte2tsx ok");
+        // Smoke check: the prop identifiers survived into the overlay.
+        assert!(out.code.contains("imageSrc"));
+    }
 
     #[test]
     fn test_exported_names_empty() {


### PR DESCRIPTION
Closes #719.

## Problem

`svelte-check --emit-overlay` / `--tsgo` panicked on `.svelte` files whose `<script lang="ts">` contained multibyte (e.g. Japanese / CJK) characters in a particular byte layout:

```
thread 'main' panicked at crates/rsvelte_core/src/svelte2tsx/script/mod.rs:1506:32:
start byte index 173 is not a char boundary; it is inside '須' (bytes 172..175)
```

The whole run aborted — so for a codebase with any non-ASCII identifiers/comments/strings in `<script>`, a single offending file killed every diagnostic.

## Root cause

In `collect_type_body_deps`, the `typeof` lookbehind sliced `&body[j - 6..j]` using raw byte arithmetic. `j` is a char boundary, but `j - 6` is not necessarily one: when CJK text precedes the identifier (e.g. `必須) */` ahead of `imageSrc`), `j - 6` lands inside a multibyte char and the `&str` index panics.

(The issue speculated TS-AST UTF-16 positions; the actual cause is this lexer's fixed-offset byte math. The forward scan and `&body[start..i]` are already boundary-safe — only this one slice was affected.)

## Fix

Guard the slice with `str::is_char_boundary(j - 6)`. The six bytes can only spell the ASCII keyword `typeof` when `j - 6` is already a char boundary, so ASCII behavior is byte-for-byte unchanged; non-ASCII just short-circuits to "not preceded by typeof" (correct).

## Tests

- `collect_type_body_deps_handles_multibyte_before_ident` — unit test on the exact CJK layout.
- `svelte2tsx_does_not_panic_on_cjk_jsdoc` — end-to-end svelte2tsx run on the issue's repro.
- Full `svelte2tsx_fixtures` suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)