### PR TITLE
fix(analyze): valid nested <dl> wrongly errors — use parent rule for <dt>/<dd> (#721)

### DIFF
--- a/.changeset/dt-dd-placement-parent-rule.md
+++ b/.changeset/dt-dd-placement-parent-rule.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(analyze): validate `<dt>`/`<dd>` placement against the parent rule, not an ancestor check, so a valid nested `<dl>` inside `<dd>` is accepted (#721)

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -325,6 +325,19 @@ fn is_direct_only_disallowed(ancestor_tag: &str) -> bool {
     )
 }
 
+/// Tags that "reset" a disallowed-descendant rule for `ancestor_tag`, mirroring
+/// upstream `autoclosing_children[tag].reset_by` in `html-tree-validation.js`.
+///
+/// `<dt>`/`<dd>` may not be descendants of `<dt>`/`<dd>`, *but* a nested `<dl>`
+/// between them resets the rule (a `<dl>` re-opens a valid description-list
+/// context). So a valid nested `<dl>` inside a `<dd>` must not error (#721).
+fn get_descendant_reset_by(ancestor_tag: &str) -> Option<&'static [&'static str]> {
+    match ancestor_tag {
+        "dt" | "dd" => Some(&["dl"]),
+        _ => None,
+    }
+}
+
 /// Check if a tag is valid with an ancestor.
 /// Returns an error message if invalid, or None if valid.
 fn is_tag_valid_with_ancestor(child_tag: &str, ancestors: &[String]) -> Option<String> {
@@ -888,6 +901,19 @@ pub fn visit(
                 // outermost-first, so the direct parent is the last entry (H-082).
                 let is_direct_parent = i + 1 == context.element_ancestors.len();
                 if is_direct_only_disallowed(ancestor_name) && !is_direct_parent {
+                    continue;
+                }
+
+                // `reset_by` rules: if any element between this ancestor and the
+                // current element re-opens the context (e.g. a nested `<dl>`
+                // between an outer `<dd>` and an inner `<dt>`), the descendant
+                // restriction no longer applies. Mirrors upstream's `reset_by`
+                // walk in `is_tag_valid_with_ancestor` (#721).
+                if let Some(reset_by) = get_descendant_reset_by(ancestor_name)
+                    && context.element_ancestors[i + 1..]
+                        .iter()
+                        .any(|a| reset_by.contains(&a.as_str()))
+                {
                     continue;
                 }
 

--- a/crates/rsvelte_core/tests/svelte_component_validation.rs
+++ b/crates/rsvelte_core/tests/svelte_component_validation.rs
@@ -103,3 +103,40 @@ fn h053_special_element_event_capture_excludes_pointercapture() {
         "got:\n{out}"
     );
 }
+
+// --- #721: <dt>/<dd> placement uses the parent-based reset_by rule ----------
+
+#[test]
+fn issue721_nested_dl_inside_dd_compiles() {
+    // A valid nested `<dl>` inside a `<dd>` must NOT error: the inner `<dt>`/`<dd>`
+    // are direct children of the inner `<dl>`, which resets the descendant rule.
+    // Mirrors upstream `autoclosing_children.dt/dd.reset_by = ['dl']`.
+    try_compile(
+        r#"<dl>
+  <dt>term</dt>
+  <dd>
+    <dl>
+      <dt>nested term</dt>
+      <dd>nested desc</dd>
+    </dl>
+  </dd>
+</dl>"#,
+    )
+    .expect("nested <dl> inside <dd> should compile");
+}
+
+#[test]
+fn issue721_dt_dd_inside_div_inside_dl_compiles() {
+    // `<dl><div><dt>/<dd></div></dl>` is valid HTML; `<div>` does not restrict
+    // `<dt>`/`<dd>` and there is no `<dt>`/`<dd>` ancestor, so no error.
+    try_compile(r#"<dl><div><dt>term</dt><dd>desc</dd></div></dl>"#)
+        .expect("<dt>/<dd> inside <div> inside <dl> should compile");
+}
+
+#[test]
+fn issue721_dt_descendant_of_dd_without_reset_still_errors() {
+    // No `<dl>` resets the context between the outer `<dd>` and the inner `<dt>`,
+    // so the descendant restriction still applies (don't over-suppress).
+    let err = try_compile(r#"<dd><span><dt>x</dt></span></dd>"#).expect_err("should error");
+    assert_eq!(err, "node_invalid_placement", "got `{err}`");
+}


### PR DESCRIPTION
## Problem (#721)

This valid nested `<dl>` was wrongly reported as an error by rsvelte (official svelte-check: 0 errors):

```svelte
<dl>
  <dt>term</dt>
  <dd>
    <dl>
      <dt>nested term</dt>
      <dd>nested desc</dd>
    </dl>
  </dd>
</dl>
```

rsvelte emitted: `node_invalid_placement: <dt> cannot be a descendant of <dd>.`

## Root cause

rsvelte's ancestor-restriction loop in `regular_element.rs` treated `<dt>`/`<dd>` as a plain disallowed-descendant rule and errored whenever **any** ancestor was a `<dt>`/`<dd>` — ignoring the `<dl>` in between.

Upstream `html-tree-validation.js` models these as:

```js
dt: { descendant: ['dt', 'dd'], reset_by: ['dl'] },
dd: { descendant: ['dt', 'dd'], reset_by: ['dl'] },
```

The `reset_by: ['dl']` means a `<dl>` between the ancestor and the element re-opens a valid description-list context, so the inner `<dt>`/`<dd>` (direct children of the inner `<dl>`) are valid. rsvelte never ported the `reset_by` walk.

## Fix

Port the upstream `reset_by` branch of `is_tag_valid_with_ancestor`:

- Add `get_descendant_reset_by()` mirroring `autoclosing_children[tag].reset_by`.
- In the ancestor-restriction loop, when checking a `<dt>`/`<dd>` ancestor, skip the restriction if any element **between** that ancestor and the current element is a `<dl>`.

This is faithful to upstream — no invented rule. Genuinely invalid placements still error (e.g. `<dd><span><dt>` with no `<dl>` reset → `node_invalid_placement`). The `<li>` path already used the correct direct-parent rule and is unchanged.

Upstream ref: `submodules/svelte/packages/svelte/src/html-tree-validation.js` (`is_tag_valid_with_ancestor` `reset_by` branch).

## Secondary observation (resolved, no separate bug)

In a real component (`<dl>` + `{#each}` + `class:` directives) the same misclassification surfaced as **two** diagnostics — `node_invalid_placement_ssr` and `hydration_mismatch`, both at `1:1`. These were downstream symptoms of the same rule: `node_invalid_placement_ssr` is the block-aware warn variant of the placement check, and the hydration mismatch followed from it. With the `reset_by` fix the placement is correctly recognized as valid, and both disappear (verified: 0 errors / 0 warnings). No separate double-report bug was found.

## Tests

- New regression tests in `crates/rsvelte_core/tests/svelte_component_validation.rs`:
  - `issue721_nested_dl_inside_dd_compiles`
  - `issue721_dt_dd_inside_div_inside_dl_compiles`
  - `issue721_dt_descendant_of_dd_without_reset_still_errors`
- `cargo test -p rsvelte_core --test validator --test svelte_component_validation` green.
- Compatibility report (release) green: validator 100%, overall 0 failed / 0 errors.
- `cargo fmt --check` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)