### PR TITLE
fix(svelte-check): malformed overlay silently suppresses all type errors (#728)

### DIFF
--- a/.changeset/tsgo-overlay-syntax-loud.md
+++ b/.changeset/tsgo-overlay-syntax-loud.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): a syntactically-invalid generated `.tsx` overlay no longer silently suppresses all real type errors — `--tsgo` now reports it loudly and exits non-zero instead of producing a false pass (#728)

--- a/crates/rsvelte_core/src/svelte_check/mapper.rs
+++ b/crates/rsvelte_core/src/svelte_check/mapper.rs
@@ -3,7 +3,7 @@
 //! diagnostics into `Diagnostic` records that point at the user's
 //! Svelte source.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use sourcemap::SourceMap;
@@ -22,6 +22,40 @@ struct EntryMap {
     map: SourceMap,
 }
 
+/// Whether a TypeScript diagnostic code denotes a SYNTACTIC error.
+///
+/// TypeScript groups syntax (parse) errors under the `TS1xxx` range — e.g.
+/// `TS1005` (`',' expected`), `TS1109` (`Expression expected`), `TS1128`
+/// (`Declaration or statement expected`), `TS1136` (`Property assignment
+/// expected`). Semantic / type errors live in `TS2xxx`+.
+///
+/// This distinction is load-bearing: TypeScript (and tsgo) suppress ALL
+/// semantic diagnostics program-wide as soon as the program contains ANY
+/// syntactic error. So a single generated `.tsx` overlay that fails to
+/// parse silently drops every real type error in the whole project — the
+/// dangerous false-negative this module guards against (#728).
+pub fn is_syntactic_ts_code(code: &str) -> bool {
+    code.strip_prefix("TS")
+        .and_then(|n| n.parse::<u32>().ok())
+        .map(|n| (1000..2000).contains(&n))
+        .unwrap_or(false)
+}
+
+/// Result of mapping a tsgo diagnostic stream back to `.svelte` source.
+pub struct MappedTsDiagnostics {
+    /// Diagnostics with `file` / `range` pointing at the original source.
+    pub diagnostics: Vec<Diagnostic>,
+    /// `.svelte` source files whose GENERATED overlay `.tsx` produced at
+    /// least one SYNTACTIC (`TS1xxx`) diagnostic. Because TypeScript
+    /// suppresses every semantic diagnostic program-wide once any syntax
+    /// error exists, a syntactically-invalid overlay hides all real type
+    /// errors elsewhere. The runner cross-references these against the
+    /// Svelte-side compile errors to decide whether the bad TSX is an
+    /// rsvelte/svelte2tsx defect (overlay generated from a `.svelte` that
+    /// rsvelte itself parsed cleanly) and surfaces it loudly.
+    pub overlay_syntax_sources: Vec<PathBuf>,
+}
+
 /// Map every tsgo diagnostic to a `Diagnostic` whose `file` / `range`
 /// point at the original `.svelte` source. Diagnostics on `.tsx` files
 /// without a sourcemap are passed through unchanged (file points at the
@@ -30,7 +64,7 @@ pub fn map_tsgo_diagnostics(
     raw: &[RawTsDiagnostic],
     overlay: &OverlayLayout,
     workspace: &Path,
-) -> Vec<Diagnostic> {
+) -> MappedTsDiagnostics {
     // Build a lookup from absolute / canonicalised tsx path → entry.
     // tsc emits paths relative to its cwd (= workspace), so we key on
     // (a) the absolute tsx_path, (b) its canonicalised form, and
@@ -62,6 +96,12 @@ pub fn map_tsgo_diagnostics(
     }
     let mut maps: HashMap<PathBuf, EntryMap> = HashMap::new();
     let mut out: Vec<Diagnostic> = Vec::with_capacity(raw.len());
+    // `.svelte` sources whose generated overlay produced a TS1xxx syntax
+    // diagnostic, in first-seen order (deduped). Recorded regardless of
+    // whether the position mapped back cleanly — any syntax error on a
+    // generated `.tsx` is overlay-attributable.
+    let mut overlay_syntax_sources: Vec<PathBuf> = Vec::new();
+    let mut overlay_syntax_seen: HashSet<PathBuf> = HashSet::new();
     for diag in raw {
         // tsc emits relative paths (cwd = workspace). Resolve them
         // against `workspace` so canonicalize / map lookup work even
@@ -87,6 +127,14 @@ pub fn map_tsgo_diagnostics(
             .or_else(|| by_tsx.get(&absolute).copied())
             .or_else(|| by_tsx.get(&diag.file).copied());
         if let Some(entry) = entry_match {
+            // A syntax error in this generated `.tsx` overlay taints the
+            // whole program's semantic checking — record its `.svelte`
+            // source so the runner can surface it loudly.
+            if is_syntactic_ts_code(&diag.code)
+                && overlay_syntax_seen.insert(entry.source_path.clone())
+            {
+                overlay_syntax_sources.push(entry.source_path.clone());
+            }
             let entry_map = match maps.get(&entry.tsx_path) {
                 Some(em) => em,
                 None => match build_entry_map(entry) {
@@ -143,7 +191,10 @@ pub fn map_tsgo_diagnostics(
             out.push(passthrough(diag, &diag.file, workspace));
         }
     }
-    out
+    MappedTsDiagnostics {
+        diagnostics: out,
+        overlay_syntax_sources,
+    }
 }
 
 /// Map a tsc/tsgo diagnostic on the augmented kit-file overlay back to
@@ -288,5 +339,35 @@ fn passthrough(diag: &RawTsDiagnostic, file: &Path, _workspace: &Path) -> Diagno
             },
         }),
         source: "ts",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_ts1xxx_as_syntactic() {
+        // Representative TS1xxx syntax codes.
+        for code in ["TS1005", "TS1109", "TS1128", "TS1136", "TS1003"] {
+            assert!(is_syntactic_ts_code(code), "{code} should be syntactic");
+        }
+    }
+
+    #[test]
+    fn classifies_ts2xxx_plus_as_semantic() {
+        // TS2xxx (type), TS6xxx (lint-ish), TS7xxx (implicit-any) are NOT
+        // syntactic and must not trip the loud-error path.
+        for code in ["TS2322", "TS2304", "TS6133", "TS7006", "TS18047"] {
+            assert!(!is_syntactic_ts_code(code), "{code} should be semantic");
+        }
+    }
+
+    #[test]
+    fn classifies_malformed_codes_as_non_syntactic() {
+        assert!(!is_syntactic_ts_code(""));
+        assert!(!is_syntactic_ts_code("TS"));
+        assert!(!is_syntactic_ts_code("nonsense"));
+        assert!(!is_syntactic_ts_code("TS999")); // below the 1000 floor
     }
 }

--- a/crates/rsvelte_core/src/svelte_check/runner.rs
+++ b/crates/rsvelte_core/src/svelte_check/runner.rs
@@ -16,7 +16,7 @@ use super::kit_file::load_kit_files_settings;
 use super::manifest::{
     self, CachedDiagnostics, SerializableDiagnostic, WarningCache, current_stats,
 };
-use super::mapper::map_tsgo_diagnostics;
+use super::mapper::{is_syntactic_ts_code, map_tsgo_diagnostics};
 use super::overlay::{OverlayLayout, materialize_overlay_with_kit};
 use super::tsgo::{TsgoError, find_compiler, run_tsgo};
 use super::walker::find_relevant_files;
@@ -256,7 +256,22 @@ fn run_tsgo_phase(layout: &OverlayLayout, workspace: &Path, out: &mut Vec<Diagno
     match run_tsgo(&binary, &layout.overlay_tsconfig, workspace) {
         Ok(raw) => {
             let mapped = map_tsgo_diagnostics(&raw, layout, workspace);
-            out.extend(mapped);
+            // Before merging tsgo's output, guard against the silent
+            // false-negative in #728: a syntactically-invalid generated
+            // overlay makes TypeScript suppress every SEMANTIC diagnostic
+            // program-wide, so a malformed overlay would otherwise look
+            // like a clean pass. `out` already holds the Svelte-side
+            // diagnostics, which lets us tell an rsvelte/svelte2tsx defect
+            // (clean Svelte compile but broken TSX) from the user's own
+            // syntax error (reported on the Svelte side already).
+            let loud = overlay_syntax_loud_diagnostics(
+                &mapped.overlay_syntax_sources,
+                &mapped.diagnostics,
+                out,
+                workspace,
+            );
+            out.extend(mapped.diagnostics);
+            out.extend(loud);
         }
         Err(e) => {
             out.push(Diagnostic {
@@ -269,6 +284,100 @@ fn run_tsgo_phase(layout: &OverlayLayout, workspace: &Path, out: &mut Vec<Diagno
             });
         }
     }
+}
+
+/// Build the loud, attention-grabbing diagnostics that keep a
+/// syntactically-invalid generated overlay from looking like a clean pass
+/// (#728).
+///
+/// TypeScript/tsgo suppress every SEMANTIC diagnostic (`TS2xxx`+)
+/// program-wide the moment the program contains ANY syntactic error
+/// (`TS1xxx`). So if one generated `.tsx` overlay fails to parse, tsgo
+/// prints only syntax errors and silently drops every real type error in
+/// the whole project — a silent false negative, the worst failure mode for
+/// a type-checker.
+///
+/// We distinguish two cases:
+///   * **rsvelte/svelte2tsx defect** — the overlay came from a `.svelte`
+///     file that rsvelte itself parsed cleanly (no Svelte-side
+///     `compile-error`), yet the generated TSX failed to parse. This is
+///     our bug; emit an `internal error … please report this` per file.
+///   * **user's own syntax error** — the `.svelte`/`.ts` source is itself
+///     malformed. That's already reported (on the Svelte side for
+///     `.svelte`, or as a passthrough TS1xxx for plain `.ts`), so we don't
+///     blame rsvelte — but semantics are STILL suppressed program-wide, so
+///     we attach one note so the hidden type errors aren't a surprise.
+///
+/// Returns an empty vec for clean programs (no `TS1xxx` anywhere), so the
+/// common all-overlays-valid path is untouched and never gains a false
+/// positive.
+fn overlay_syntax_loud_diagnostics(
+    overlay_syntax_sources: &[PathBuf],
+    mapped_ts: &[Diagnostic],
+    svelte_side: &[Diagnostic],
+    workspace: &Path,
+) -> Vec<Diagnostic> {
+    // Any syntactic diagnostic anywhere in the overlay program — including
+    // passthrough TS1xxx on plain user `.ts`/`.js` files that never went
+    // through svelte2tsx — means semantics were suppressed program-wide.
+    let any_syntactic = mapped_ts
+        .iter()
+        .any(|d| d.source == "ts" && d.code.as_deref().is_some_and(is_syntactic_ts_code));
+    if !any_syntactic {
+        return Vec::new();
+    }
+
+    // `.svelte` files whose own source rsvelte failed to parse — the user's
+    // bug, already surfaced on the Svelte side, so the matching invalid TSX
+    // is a downstream symptom, not an rsvelte codegen defect.
+    let svelte_failed: HashSet<&Path> = svelte_side
+        .iter()
+        .filter(|d| {
+            d.source == "svelte"
+                && d.severity == DiagnosticSeverity::Error
+                && d.code.as_deref() == Some("compile-error")
+        })
+        .map(|d| d.file.as_path())
+        .collect();
+
+    let mut loud = Vec::new();
+    for source in overlay_syntax_sources {
+        if svelte_failed.contains(source.as_path()) {
+            continue;
+        }
+        let rel = source.strip_prefix(workspace).unwrap_or(source);
+        loud.push(Diagnostic {
+            file: source.clone(),
+            severity: DiagnosticSeverity::Error,
+            code: Some("overlay-invalid-tsx".into()),
+            message: format!(
+                "internal error: rsvelte produced invalid TSX for {} — \
+                 TypeScript suppressed type errors for the rest of the project; \
+                 please report this at https://github.com/baseballyama/rsvelte/issues",
+                rel.display()
+            ),
+            range: None,
+            source: "ts",
+        });
+    }
+
+    // One program-wide note. Always emitted when syntax errors exist, even
+    // when every one is the user's own — semantics are suppressed either
+    // way, so this makes the hidden type errors explicit. Non-zero exit is
+    // already guaranteed by the underlying syntax Error(s) / internal error.
+    loud.push(Diagnostic {
+        file: workspace.to_path_buf(),
+        severity: DiagnosticSeverity::Warning,
+        code: Some("tsgo-semantics-suppressed".into()),
+        message: "TypeScript suppressed all semantic (type) diagnostics \
+             program-wide because the overlay program contains a syntax error; \
+             real type errors elsewhere may be hidden until it is resolved."
+            .into(),
+        range: None,
+        source: "ts",
+    });
+
+    loud
 }
 
 /// Compile every `.svelte` file in `files` and return diagnostics in
@@ -483,6 +592,114 @@ mod tests {
         apply_filters(&mut diags, &opts);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
+    }
+
+    fn ts_diag(file: &str, code: &str, sev: DiagnosticSeverity) -> Diagnostic {
+        Diagnostic {
+            file: PathBuf::from(file),
+            severity: sev,
+            code: Some(code.into()),
+            message: "msg".into(),
+            range: None,
+            source: "ts",
+        }
+    }
+
+    fn svelte_error(file: &str, code: &str) -> Diagnostic {
+        Diagnostic {
+            file: PathBuf::from(file),
+            severity: DiagnosticSeverity::Error,
+            code: Some(code.into()),
+            message: "compile boom".into(),
+            range: None,
+            source: "svelte",
+        }
+    }
+
+    #[test]
+    fn loud_clean_program_emits_nothing() {
+        // Only semantic diagnostics → no syntax taint → no loud output, so
+        // the common all-overlays-valid path gains no false positive.
+        let mapped = vec![ts_diag("/ws/A.svelte", "TS2322", DiagnosticSeverity::Error)];
+        let loud = overlay_syntax_loud_diagnostics(&[], &mapped, &[], Path::new("/ws"));
+        assert!(loud.is_empty(), "{loud:?}");
+    }
+
+    #[test]
+    fn loud_overlay_defect_emits_internal_error_and_note() {
+        // rsvelte parsed the .svelte cleanly (no svelte-side compile-error)
+        // but the generated TSX failed to parse → blame rsvelte loudly.
+        let sources = vec![PathBuf::from("/ws/Foo.svelte")];
+        let mapped = vec![ts_diag(
+            "/ws/Foo.svelte",
+            "TS1005",
+            DiagnosticSeverity::Error,
+        )];
+        let loud = overlay_syntax_loud_diagnostics(&sources, &mapped, &[], Path::new("/ws"));
+        let internal = loud
+            .iter()
+            .find(|d| d.code.as_deref() == Some("overlay-invalid-tsx"))
+            .expect("internal error emitted");
+        assert_eq!(internal.severity, DiagnosticSeverity::Error);
+        assert!(
+            internal.message.contains("Foo.svelte"),
+            "{}",
+            internal.message
+        );
+        assert!(
+            internal.message.contains("please report"),
+            "{}",
+            internal.message
+        );
+        assert!(
+            loud.iter()
+                .any(|d| d.code.as_deref() == Some("tsgo-semantics-suppressed")),
+            "suppression note emitted: {loud:?}"
+        );
+        // The internal error guarantees a non-zero exit.
+        let result = RunResult {
+            diagnostics: loud,
+            ..RunResult::default()
+        };
+        assert_eq!(result.exit_code(false), 1);
+    }
+
+    #[test]
+    fn loud_user_svelte_syntax_error_is_not_blamed_on_rsvelte() {
+        // The .svelte itself failed rsvelte's own parse → user's bug,
+        // already reported on the svelte side. Don't emit an internal
+        // error, but still note the program-wide semantic suppression.
+        let sources = vec![PathBuf::from("/ws/Bad.svelte")];
+        let mapped = vec![ts_diag(
+            "/ws/Bad.svelte",
+            "TS1109",
+            DiagnosticSeverity::Error,
+        )];
+        let svelte_side = vec![svelte_error("/ws/Bad.svelte", "compile-error")];
+        let loud =
+            overlay_syntax_loud_diagnostics(&sources, &mapped, &svelte_side, Path::new("/ws"));
+        assert!(
+            !loud
+                .iter()
+                .any(|d| d.code.as_deref() == Some("overlay-invalid-tsx")),
+            "must not blame rsvelte for the user's own syntax error: {loud:?}"
+        );
+        assert!(
+            loud.iter()
+                .any(|d| d.code.as_deref() == Some("tsgo-semantics-suppressed")),
+            "{loud:?}"
+        );
+    }
+
+    #[test]
+    fn loud_user_plain_ts_syntax_error_only_notes_suppression() {
+        // A syntax error in a plain user `.ts` (passthrough, never went
+        // through svelte2tsx) → no overlay source recorded → no internal
+        // error, just the program-wide suppression note.
+        let mapped = vec![ts_diag("/ws/App.ts", "TS1128", DiagnosticSeverity::Error)];
+        let loud = overlay_syntax_loud_diagnostics(&[], &mapped, &[], Path::new("/ws"));
+        assert_eq!(loud.len(), 1);
+        assert_eq!(loud[0].code.as_deref(), Some("tsgo-semantics-suppressed"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem (#728)

TypeScript (and tsgo) gate **semantic** diagnostics on the program being **syntactically** valid: as soon as the program contains *any* syntactic error (a `TS1xxx` code), every semantic diagnostic (`TS2xxx`+) is suppressed **program-wide**. This is demonstrable with plain `tsc` on two files — a syntax error in one file suppresses a `TS2322` in another.

`svelte-check --tsgo` generates one `.tsx` overlay per `.svelte` component and runs tsgo/tsc over an overlay tsconfig. So if a **single** generated overlay fails to parse (e.g. the #725 generic-arrow / #726 function-binding mis-lowerings, or any future svelte2tsx output that doesn't parse), tsgo prints only the syntax errors and **silently drops every real type error in the whole project** — a silent false negative, the most dangerous failure mode for a type-checker. The fragility is structural, not tied to any one generator.

## Hardening implemented

A malformed overlay must never look like a clean pass. This PR:

- **Classifies syntactic vs semantic** — `mapper::is_syntactic_ts_code` maps `TS1xxx` → syntactic, `TS2xxx`+ → semantic. `map_tsgo_diagnostics` now also returns the `.svelte` sources whose **generated** overlay produced a `TS1xxx` diagnostic (overlay-attributable, since those `.tsx` files are 100% rsvelte output).
- **Distinguishes rsvelte defect from the user's own bug** — the runner cross-references the overlay-syntax sources against the Svelte-side compile errors already in the stream:
  - **Clean Svelte parse + broken TSX** → rsvelte/svelte2tsx codegen defect → loud `internal error: rsvelte produced invalid TSX for <X.svelte> … please report this` (severity Error → non-zero exit).
  - **User wrote a syntax error** in their `.svelte`/`.ts` → already surfaced (Svelte-side `compile-error`, or a passthrough `TS1xxx`), so rsvelte is **not** blamed.
- **Always notes program-wide suppression** when any syntax error exists, so the hidden/suppressed type errors are explicit rather than a surprise.
- **No false positives** — clean programs (no `TS1xxx`) emit nothing new; the common all-overlays-valid path is untouched and not slowed.

### What I deliberately did NOT do
Full per-file program isolation (compiling each overlay in its own TS program so one bad overlay can't taint the rest) — that's a large, perf-sensitive change that would materially slow the common valid path. The loud-error approach fully satisfies the core requirement ("never a false pass") at near-zero cost, so isolation is left for a follow-up.

## Tests
- `mapper`: classifier unit tests (TS1xxx syntactic, TS2xxx+ semantic, malformed codes).
- `runner`: the four loud-diagnostic paths — clean (nothing emitted), overlay defect (internal error + note + non-zero exit), user `.svelte` syntax error (not blamed on rsvelte), user `.ts` syntax error (suppression note only).
- `cargo test -p rsvelte_core --test svelte_check_golden --test svelte_check_pin` green; `--test compatibility_report` green in release (3525/3525). `cargo fmt` + `clippy -D warnings` clean.

> tsgo/tsc was **not** available in this environment, so the end-to-end `--tsgo` run was not executed; the logic is exercised via the diagnostics-classification code path and unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)