### PR TITLE
fix(ecosystem-ci): stop poll stdout pollution causing spurious failure issues (#729)

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -26,8 +26,13 @@ on:
     # Nightly at 02:00 UTC. Adjust if the matrix grows past 4–5 targets.
     - cron: '0 2 * * *'
 
+# Scope the concurrency group by the dispatched target/tag so that the poll
+# workflow's per-target dispatches do not cancel each other (each changed
+# target is a separate run). Re-dispatching the SAME target still supersedes
+# its in-flight run. Schedule (full sweep) and PR runs fall back to the event
+# name, keeping their existing "latest wins per ref" behaviour.
 concurrency:
-  group: ecosystem-ci-${{ github.ref }}
+  group: ecosystem-ci-${{ github.ref }}-${{ github.event.inputs.target || github.event.inputs.tag || github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -147,7 +152,10 @@ jobs:
   summary:
     name: Summary
     needs: run
-    if: always() && needs.run.result != 'skipped'
+    # Skip on `skipped` (nothing ran) and `cancelled` (superseded by a newer
+    # run via concurrency, or manually aborted — not a real failure). This
+    # avoids spurious failure issues (see issue #729).
+    if: always() && needs.run.result != 'skipped' && needs.run.result != 'cancelled'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/ecosystem/ecosystem-ci-issues.mjs
+++ b/scripts/ecosystem/ecosystem-ci-issues.mjs
@@ -416,8 +416,18 @@ async function main() {
 		process.exit(2);
 	}
 
-	const results = loadResults();
 	const matrixResult = process.env.MATRIX_RESULT ?? '';
+	// A `cancelled` matrix result means this run was superseded (concurrency
+	// cancel-in-progress) or manually aborted — never a real failure signal.
+	// The surviving/newer run reports its own status, so bail out entirely:
+	// no history row, no failure issue. This prevents spurious failure issues
+	// (see issue #729) when the poll workflow re-dispatches a target.
+	if (matrixResult === 'cancelled') {
+		log('skipping: matrix result is "cancelled" (superseded/aborted run)');
+		return 0;
+	}
+
+	const results = loadResults();
 	const summary = classify(results, matrixResult);
 
 	const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';

--- a/scripts/ecosystem/ecosystem-ci.mjs
+++ b/scripts/ecosystem/ecosystem-ci.mjs
@@ -39,7 +39,12 @@ const VPS_FORK = path.join(
 );
 
 function log(msg) {
-	console.log(`[ecosystem-ci] ${msg}`);
+	// Diagnostics go to stderr so that machine-readable stdout (notably the
+	// `poll` command, whose stdout is captured into `changed.txt` and fed
+	// line-by-line to `gh workflow run -f target=...`) stays free of noise.
+	// Letting log lines leak onto stdout previously caused spurious dispatches
+	// with garbage target names (see issue #729).
+	console.error(`[ecosystem-ci] ${msg}`);
 }
 
 function ensureDirs() {


### PR DESCRIPTION
## Root cause (closes #729)

The ecosystem-ci poll workflow runs `node scripts/ecosystem-ci.mjs poll > changed.txt`, then dispatches one `ecosystem-ci.yml` run per **line** of `changed.txt` via `gh workflow run -f target=<line>`. The `poll` command's stdout is therefore a machine-readable contract: one target name per line.

But `log()` in `ecosystem-ci.mjs` wrote diagnostics to **stdout**, so lines like:

```
[ecosystem-ci] poll: bits-ui changed (new) -> f1536759
```

leaked into `changed.txt` and got dispatched as a bogus `target` input. That is exactly the garbage string in #729's title: `target=[ecosystem-ci] poll: bits-ui changed (new) -> f1536759`.

These extra dispatches all shared one concurrency group (`ecosystem-ci-${{ github.ref }}`, `cancel-in-progress: true`) and cancelled each other. The cancelled runs still executed their `summary` job (`if: always() && needs.run.result != 'skipped'`), and `ecosystem-ci-issues.mjs` treats `MATRIX_RESULT=cancelled` as a failure → spurious `ecosystem-ci-failure` issue.

## Fix (defence-in-depth)

1. **`scripts/ecosystem-ci.mjs`** — route `log()` to **stderr** so `poll`/`report` stdout stays clean. *(root cause)*
2. **`.github/workflows/ecosystem-ci.yml`** — scope the concurrency group by dispatched target/tag so genuine per-target poll dispatches no longer cancel each other; re-dispatching the same target still supersedes its in-flight run.
3. **`.github/workflows/ecosystem-ci.yml`** — skip the `summary` job on `cancelled` (superseded/aborted ≠ failure).
4. **`scripts/ecosystem-ci-issues.mjs`** — bail out entirely on `cancelled` matrix result (no history row, no failure issue).

## Verification

- `node --check` passes on both scripts.
- Simulated `log()`→stderr: `poll` stdout contains only `bits-ui`, diagnostics on stderr.
- `MATRIX_RESULT=cancelled node scripts/ecosystem-ci-issues.mjs` → bails with exit 0, no API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)