### PR TITLE
feat(site): per-library docs, multi-tool playground, redesign, fmt-formatted

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -103,8 +103,14 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Build WASM
+      - name: Build WASM (compiler + svelte2tsx)
         run: wasm-pack build crates/rsvelte_core --out-dir ../../pkg --target web --no-default-features --features wasm
+
+      - name: Build WASM (formatter)
+        # Powers the playground's `fmt` tool. Separate crate (rsvelte_fmt_wasm)
+        # so the formatter's wasm backend links without re-exporting
+        # rsvelte_core's own #[wasm_bindgen] symbols. Output → pkg-fmt/.
+        run: wasm-pack build crates/rsvelte_fmt_wasm --out-dir ../../pkg-fmt --target web
 
       - name: Build NAPI cdylib
         # apps/playground/rsvelte-shim/compiler.mjs loads

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ target
 
 # WASM build output
 /pkg
+# Formatter WASM build output (rsvelte_fmt_wasm → browser fmt tool)
+/pkg-fmt
 
 # svelte-check platform binaries (staged into per-platform npm packages by the
 # release workflow; never committed)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsvelte_fmt_wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.4.2",
+ "rsvelte_formatter",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "rsvelte_formatter"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/rsvelte_capi",
     "crates/rsvelte_core",
     "crates/rsvelte_fmt",
+    "crates/rsvelte_fmt_wasm",
     "crates/rsvelte_formatter",
 ]
 

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -7,7 +7,7 @@
 		"dev": "node --import ./rsvelte-shim/loader-register.mjs ./node_modules/vite/bin/vite.js dev",
 		"build": "node --import ./rsvelte-shim/loader-register.mjs ./node_modules/vite/bin/vite.js build",
 		"preview": "node --import ./rsvelte-shim/loader-register.mjs ./node_modules/vite/bin/vite.js preview",
-		"build:wasm": "cd ../.. && wasm-pack build crates/rsvelte_core --out-dir ../../pkg --target web --no-default-features --features wasm",
+		"build:wasm": "cd ../.. && wasm-pack build crates/rsvelte_core --out-dir ../../pkg --target web --no-default-features --features wasm && wasm-pack build crates/rsvelte_fmt_wasm --out-dir ../../pkg-fmt --target web",
 		"lint": "oxlint src/**/*.ts --deny-warnings",
 		"format": "oxfmt",
 		"format:check": "oxfmt --check",

--- a/apps/playground/src/lib/compiler.ts
+++ b/apps/playground/src/lib/compiler.ts
@@ -36,6 +36,34 @@ export function compileServer(source: string, name: string): CompileResultWasm {
 	return wasmModule.compile_server(source, name);
 }
 
+export interface Svelte2TsxResult {
+	success: boolean;
+	code?: string;
+	map?: string | null;
+	exportedNames?: { props: string[]; all: string[] };
+	error?: string;
+}
+
+export interface Svelte2TsxOptions {
+	filename?: string;
+	isTsFile?: boolean;
+	mode?: 'ts' | 'dts';
+}
+
+/**
+ * Convert a `.svelte` component to its TSX shadow file. The wasm boundary is a
+ * JSON string in / JSON string out (see `rsvelte_core::wasm::svelte2tsx`).
+ */
+export function svelte2tsx(source: string, options: Svelte2TsxOptions = {}): Svelte2TsxResult {
+	if (!wasmModule) throw new Error('WASM not initialized');
+	const raw = wasmModule.svelte2tsx(source, JSON.stringify(options));
+	try {
+		return JSON.parse(raw) as Svelte2TsxResult;
+	} catch {
+		return { success: false, error: raw };
+	}
+}
+
 export type CompileMode = 'client' | 'server';
 export type OutputTab = 'result' | 'js' | 'css' | 'ast';
 

--- a/apps/playground/src/lib/components/CodeBlock.svelte
+++ b/apps/playground/src/lib/components/CodeBlock.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	interface Props {
+		code: string;
+		lang?: string;
+		caption?: string;
+	}
+
+	let { code, lang = 'text', caption }: Props = $props();
+
+	let copied = $state(false);
+	let resetTimer: ReturnType<typeof setTimeout>;
+
+	async function copy(): Promise<void> {
+		try {
+			await navigator.clipboard.writeText(code);
+			copied = true;
+			clearTimeout(resetTimer);
+			resetTimer = setTimeout(() => (copied = false), 1400);
+		} catch {
+			// Clipboard can be blocked (insecure context / permissions) — the
+			// code is still selectable, so silently degrade.
+		}
+	}
+</script>
+
+<figure class="block">
+	<figcaption class="head">
+		<span class="lang">{caption ?? lang}</span>
+		<button type="button" class="copy" class:copied onclick={copy}>
+			{copied ? 'Copied' : 'Copy'}
+		</button>
+	</figcaption>
+	<pre><code>{code}</code></pre>
+</figure>
+
+<style>
+	.block {
+		margin: 0;
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		overflow: hidden;
+		background: var(--editor-bg);
+	}
+
+	.head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0.4rem 0.7rem;
+		background: var(--paper);
+		border-bottom: 1px solid var(--rule);
+	}
+
+	.lang {
+		font-family: 'JetBrains Mono', ui-monospace, monospace;
+		font-size: 0.66rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--ink-faint);
+	}
+
+	.copy {
+		font-family: 'JetBrains Mono', ui-monospace, monospace;
+		font-size: 0.68rem;
+		padding: 0.2rem 0.55rem;
+		border: 1px solid var(--rule-strong);
+		border-radius: 4px;
+		background: var(--bg);
+		color: var(--ink-soft);
+		cursor: pointer;
+		transition:
+			color 0.15s,
+			border-color 0.15s;
+	}
+
+	.copy:hover {
+		color: var(--ink);
+		border-color: var(--ink);
+	}
+
+	.copy.copied {
+		color: var(--ok);
+		border-color: var(--ok);
+	}
+
+	pre {
+		margin: 0;
+		padding: 0.85rem 0.9rem;
+		overflow-x: auto;
+		font-family: 'JetBrains Mono', ui-monospace, monospace;
+		font-size: 0.8rem;
+		line-height: 1.6;
+		color: var(--editor-ink);
+	}
+
+	code {
+		font-family: inherit;
+		white-space: pre;
+	}
+</style>

--- a/apps/playground/src/lib/components/EcoCard.svelte
+++ b/apps/playground/src/lib/components/EcoCard.svelte
@@ -90,7 +90,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.45rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.64rem;
 		letter-spacing: 0.12em;
 		text-transform: uppercase;
@@ -122,7 +122,7 @@
 		display: inline-flex;
 		align-items: baseline;
 		gap: 0.3rem;
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		/* >=18.66px bold clears the WCAG large-text bar, so the Svelte-orange
 		   number stays AA-legible on the light card background. */
@@ -134,7 +134,7 @@
 	}
 
 	.speed-of {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-weight: 500;
 		font-size: 0.6rem;
 		letter-spacing: 0.06em;
@@ -143,7 +143,7 @@
 	}
 
 	.name {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-weight: 500;
 		font-size: 1.02rem;
 		letter-spacing: -0.01em;
@@ -160,7 +160,7 @@
 
 	.orig {
 		color: var(--svelte);
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.92em;
 		text-decoration: underline;
 		text-decoration-thickness: 1px;
@@ -181,7 +181,7 @@
 
 	.routes {
 		color: var(--ink-faint);
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.82em;
 	}
 
@@ -214,7 +214,7 @@
 	}
 
 	.note {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.68rem;
 		letter-spacing: 0.01em;
 		color: var(--ink-faint);
@@ -230,7 +230,7 @@
 	}
 
 	.install {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink);
 		background: var(--paper);
@@ -244,7 +244,7 @@
 	}
 
 	.src {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink-soft);
 		display: inline-flex;

--- a/apps/playground/src/lib/components/Guide.svelte
+++ b/apps/playground/src/lib/components/Guide.svelte
@@ -1,0 +1,321 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import type { Guide } from '$lib/docs';
+	import SiteNav from '$lib/components/SiteNav.svelte';
+	import SiteFooter from '$lib/components/SiteFooter.svelte';
+	import CodeBlock from '$lib/components/CodeBlock.svelte';
+
+	interface Props {
+		guide: Guide;
+	}
+
+	let { guide }: Props = $props();
+</script>
+
+<div class="page">
+	<SiteNav active="docs" />
+
+	<main class="wrap">
+		<nav class="crumbs" aria-label="Breadcrumb">
+			<a href="{base}/docs">Docs</a>
+			<span aria-hidden="true">/</span>
+			<span class="here">{guide.title}</span>
+		</nav>
+
+		<header class="head">
+			<p class="eyebrow"><span class="rule"></span>{guide.pkg}</p>
+			<h1 class="title">{guide.title}</h1>
+			<p class="dropin">drop-in for <code>{guide.dropInFor}</code></p>
+			<p class="tagline">{guide.tagline}</p>
+
+			<div class="actions">
+				{#if guide.runnable}
+					<a class="btn primary" href="{base}/playground?tool={guide.id}">Open in playground →</a>
+				{:else}
+					<span class="btn disabled" title="This tool can't run in a browser">
+						Not runnable in browser
+					</span>
+				{/if}
+			</div>
+
+			<div class="install">
+				<CodeBlock code={guide.install} lang="bash" caption="install" />
+			</div>
+		</header>
+
+		<div class="sections">
+			{#each guide.sections as section (section.title)}
+				<section class="sec">
+					<h2 class="sec-title">{section.title}</h2>
+
+					{#if section.body}
+						{#each section.body as p (p)}
+							<p class="prose">{p}</p>
+						{/each}
+					{/if}
+
+					{#if section.list}
+						<ul class="bullets">
+							{#each section.list as item (item)}
+								<li>{item}</li>
+							{/each}
+						</ul>
+					{/if}
+
+					{#if section.code}
+						<div class="code">
+							<CodeBlock
+								code={section.code.code}
+								lang={section.code.lang}
+								caption={section.code.caption}
+							/>
+						</div>
+					{/if}
+
+					{#if section.table}
+						<div class="table-wrap">
+							<table>
+								<thead>
+									<tr>
+										{#each section.table.head as h (h)}
+											<th>{h}</th>
+										{/each}
+									</tr>
+								</thead>
+								<tbody>
+									{#each section.table.rows as row, i (i)}
+										<tr>
+											{#each row as cell, j (j)}
+												{#if j === 0}
+													<td><code>{cell}</code></td>
+												{:else}
+													<td>{cell}</td>
+												{/if}
+											{/each}
+										</tr>
+									{/each}
+								</tbody>
+							</table>
+						</div>
+					{/if}
+				</section>
+			{/each}
+		</div>
+	</main>
+
+	<SiteFooter />
+</div>
+
+<style>
+	.page {
+		min-height: 100vh;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.wrap {
+		flex: 1;
+		width: 100%;
+		max-width: 56rem;
+		margin: 0 auto;
+		padding: clamp(1.4rem, 3vh, 2.2rem) clamp(1rem, 4vw, 2rem) 3rem;
+	}
+
+	.crumbs {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.72rem;
+		color: var(--ink-faint);
+		margin-bottom: 1.4rem;
+	}
+
+	.crumbs a {
+		color: var(--ink-soft);
+		border-bottom: 1px solid transparent;
+	}
+
+	.crumbs a:hover {
+		color: var(--ink);
+		border-bottom-color: var(--ink);
+	}
+
+	.crumbs .here {
+		color: var(--ink);
+	}
+
+	.eyebrow {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.72rem;
+		letter-spacing: 0.06em;
+		color: var(--rust);
+		margin: 0;
+	}
+
+	.eyebrow .rule {
+		display: inline-block;
+		width: 20px;
+		height: 1px;
+		background: var(--rust);
+	}
+
+	.title {
+		font-weight: 800;
+		font-size: clamp(1.8rem, 4vw, 2.6rem);
+		letter-spacing: -0.025em;
+		color: var(--ink);
+		margin: 0.5rem 0 0.3rem;
+	}
+
+	.dropin {
+		font-size: 0.9rem;
+		color: var(--ink-soft);
+		margin: 0 0 0.8rem;
+	}
+
+	.dropin code {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.82rem;
+		color: var(--ink);
+		background: var(--paper-2);
+		padding: 0.1rem 0.35rem;
+		border-radius: 3px;
+	}
+
+	.tagline {
+		font-size: 1.02rem;
+		line-height: 1.65;
+		color: var(--ink-soft);
+		max-width: 42rem;
+		margin: 0 0 1.2rem;
+	}
+
+	.actions {
+		display: flex;
+		gap: 0.6rem;
+		margin-bottom: 1rem;
+	}
+
+	.btn {
+		display: inline-flex;
+		align-items: center;
+		font-size: 0.88rem;
+		font-weight: 600;
+		padding: 0.5rem 1rem;
+		border-radius: 5px;
+		border: 1px solid transparent;
+	}
+
+	.btn.primary {
+		background: var(--svelte);
+		color: #fff;
+	}
+
+	.btn.primary:hover {
+		background: var(--svelte-hover);
+	}
+
+	.btn.disabled {
+		background: var(--paper-2);
+		color: var(--ink-faint);
+		cursor: not-allowed;
+	}
+
+	.install {
+		max-width: 32rem;
+	}
+
+	.sections {
+		margin-top: 2.4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 2.2rem;
+	}
+
+	.sec-title {
+		font-size: 1.2rem;
+		font-weight: 700;
+		letter-spacing: -0.01em;
+		color: var(--ink);
+		margin: 0 0 0.7rem;
+		padding-bottom: 0.4rem;
+		border-bottom: 1px solid var(--rule);
+	}
+
+	.prose {
+		font-size: 0.95rem;
+		line-height: 1.7;
+		color: var(--ink-soft);
+		margin: 0 0 0.7rem;
+	}
+
+	.prose:last-child {
+		margin-bottom: 0;
+	}
+
+	.bullets {
+		margin: 0.2rem 0 0.4rem;
+		padding-left: 1.1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.bullets li {
+		font-size: 0.93rem;
+		line-height: 1.6;
+		color: var(--ink-soft);
+	}
+
+	.code {
+		margin-top: 0.8rem;
+	}
+
+	.table-wrap {
+		margin-top: 0.8rem;
+		overflow-x: auto;
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.86rem;
+	}
+
+	th,
+	td {
+		text-align: left;
+		padding: 0.5rem 0.75rem;
+		border-bottom: 1px solid var(--rule);
+	}
+
+	th {
+		font-weight: 600;
+		color: var(--ink);
+		background: var(--paper);
+		font-size: 0.76rem;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+
+	tbody tr:last-child td {
+		border-bottom: 0;
+	}
+
+	td {
+		color: var(--ink-soft);
+		vertical-align: top;
+	}
+
+	td code {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.8rem;
+		color: var(--ink);
+	}
+</style>

--- a/apps/playground/src/lib/components/SiteFooter.svelte
+++ b/apps/playground/src/lib/components/SiteFooter.svelte
@@ -53,7 +53,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.55rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink-soft);
 		flex-wrap: wrap;

--- a/apps/playground/src/lib/components/SiteNav.svelte
+++ b/apps/playground/src/lib/components/SiteNav.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/state';
 	import { themeStore } from '$lib/theme.svelte';
 
-	type Active = 'home' | 'ecosystem' | 'playground' | 'progress' | 'benchmark';
+	type Active = 'home' | 'docs' | 'ecosystem' | 'playground' | 'progress' | 'benchmark';
 
 	interface Props {
 		// Each page passes its own slug so the link gets the `active` style
@@ -38,6 +38,7 @@
 	</a>
 
 	<div class="links">
+		<a href="{base}/docs" class:active={isActive('docs')}>Docs</a>
 		<a href="{base}/ecosystem" class:active={isActive('ecosystem')}>Ecosystem</a>
 		<a href="{base}/playground" class:active={isActive('playground')}>Playground</a>
 		<a href="{base}/progress" class:active={isActive('progress')}>Compatibility</a>
@@ -119,7 +120,7 @@
 	}
 
 	.brand-tag {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.62rem;
 		letter-spacing: 0.12em;
 		text-transform: uppercase;
@@ -203,10 +204,10 @@
 			gap: 0.7rem;
 			font-size: 0.84rem;
 		}
-		/* Keep the two primary destinations (Ecosystem, Playground) on phones;
+		/* Keep the primary destinations (Docs, Ecosystem, Playground) on phones;
 		   Compatibility + Benchmark are reachable from the home page. */
-		.links a:nth-child(3),
-		.links a:nth-child(4) {
+		.links a:nth-child(4),
+		.links a:nth-child(5) {
 			display: none;
 		}
 	}

--- a/apps/playground/src/lib/docs.ts
+++ b/apps/playground/src/lib/docs.ts
@@ -1,0 +1,297 @@
+// Data-driven per-library usage guides rendered by `Guide.svelte`. One entry
+// per shipped package, keyed by the same slug as `tools.ts` and the
+// `/docs/[slug]` route. Keep prose terse and code copy-pasteable; these are
+// drop-in replacements, so the APIs mirror the upstream tools they replace.
+
+import { type ToolId } from './tools';
+
+export interface GuideCode {
+	lang: string;
+	code: string;
+	/** Optional caption shown above the block. */
+	caption?: string;
+}
+
+export interface GuideSection {
+	title: string;
+	/** Paragraphs of body copy. */
+	body?: string[];
+	/** A bullet list. */
+	list?: string[];
+	/** A code block. */
+	code?: GuideCode;
+	/** A small reference table (e.g. CLI flags). */
+	table?: { head: string[]; rows: string[][] };
+}
+
+export interface Guide {
+	id: ToolId;
+	title: string;
+	pkg: string;
+	dropInFor: string;
+	tagline: string;
+	/** Install command. */
+	install: string;
+	/** Whether the playground can run this tool in-browser. */
+	runnable: boolean;
+	sections: GuideSection[];
+}
+
+const compiler: Guide = {
+	id: 'compiler',
+	title: 'Compiler',
+	pkg: '@rsvelte/compiler',
+	dropInFor: 'svelte/compiler',
+	tagline:
+		'The whole compile pipeline — parse, analyze, transform — for client, SSR and hydration, with output that matches the official compiler across the in-scope test suite.',
+	install: 'npm i @rsvelte/compiler',
+	runnable: true,
+	sections: [
+		{
+			title: 'Compile a component',
+			body: [
+				'The API mirrors `svelte/compiler`, so most code can switch import paths and keep working. `compile` returns the generated `js` and `css` plus warnings.'
+			],
+			code: {
+				lang: 'js',
+				code: `import { compile } from '@rsvelte/compiler';
+
+const { js, css, warnings } = compile(source, {
+  name: 'App',
+  generate: 'client', // 'client' | 'server'
+  css: 'external'     // 'injected' | 'external'
+});
+
+console.log(js.code);   // generated JavaScript
+console.log(css?.code); // scoped styles, when external`
+			}
+		},
+		{
+			title: 'Parse to an AST',
+			body: ['`parse` returns the Svelte AST — the same shape the official parser produces.'],
+			code: {
+				lang: 'js',
+				code: `import { parse } from '@rsvelte/compiler';
+
+const ast = parse(source, { modern: true });
+// walk ast.fragment / ast.instance / ast.module / ast.css`
+			}
+		},
+		{
+			title: 'Why it is fast',
+			list: [
+				'Written in Rust, shipped as a native NAPI addon — no per-call JS ↔ engine round-trips.',
+				'Memory-efficient AST (u32 spans, compact strings) and direct phase-to-phase AST passing.',
+				'Parser alone runs ~96× the JavaScript parser; the full pipeline ~13×.'
+			]
+		}
+	]
+};
+
+const svelte2tsx: Guide = {
+	id: 'svelte2tsx',
+	title: 'svelte2tsx',
+	pkg: '@rsvelte/svelte2tsx',
+	dropInFor: 'svelte2tsx',
+	tagline:
+		'Turns a .svelte component into the TSX shadow file the TypeScript checker reads, with column-accurate source maps.',
+	install: 'npm i @rsvelte/svelte2tsx',
+	runnable: true,
+	sections: [
+		{
+			title: 'Generate a TSX shadow file',
+			body: [
+				'Pass the component source and a filename. You get back the generated `code`, a source `map`, and the exported prop names the type-checker needs.'
+			],
+			code: {
+				lang: 'ts',
+				code: `import { svelte2tsx } from '@rsvelte/svelte2tsx';
+
+const { code, map, exportedNames } = svelte2tsx(source, {
+  filename: 'App.svelte',
+  isTsFile: true,
+  mode: 'ts' // 'ts' | 'dts'
+});
+
+console.log(exportedNames.props); // ['count', 'label', …]`
+			}
+		},
+		{
+			title: 'Options',
+			table: {
+				head: ['Option', 'Type', 'Meaning'],
+				rows: [
+					['filename', 'string', 'Source filename, used in diagnostics & maps'],
+					['isTsFile', 'boolean', 'Treat `<script>` as TypeScript'],
+					['mode', "'ts' | 'dts'", 'Emit a checking shadow or a `.d.ts`'],
+					['namespace', "'html' | 'svg' | 'mathml'", 'Element namespace for the template']
+				]
+			}
+		},
+		{
+			title: 'Notes',
+			list: [
+				'100% of the upstream svelte2tsx fixtures pass.',
+				'Source maps are hi-res so diagnostics land on the exact column in the original `.svelte`.',
+				'This is the engine `@rsvelte/svelte-check` drives for the TypeScript half.'
+			]
+		}
+	]
+};
+
+const fmt: Guide = {
+	id: 'fmt',
+	title: 'fmt',
+	pkg: '@rsvelte/fmt',
+	dropInFor: 'prettier-plugin-svelte',
+	tagline:
+		'A Rust-native formatter for .svelte files — in-process, with no Node startup and no Prettier doc-IR round-trip. JS / TS go through oxc_formatter; CSS routes to oxfmt.',
+	install: 'npm i -D @rsvelte/fmt',
+	runnable: true,
+	sections: [
+		{
+			title: 'Format files',
+			code: {
+				lang: 'bash',
+				code: `# Check formatting (non-zero exit if any file would change)
+rsvelte-fmt --check "src/**/*.svelte"
+
+# Rewrite files in place
+rsvelte-fmt --write "src/**/*.svelte"`
+			}
+		},
+		{
+			title: 'Flags',
+			table: {
+				head: ['Flag', 'Default', 'Meaning'],
+				rows: [
+					['--check', '—', 'Exit non-zero if any file is unformatted'],
+					['--write', '—', 'Rewrite files in place'],
+					['--use-tabs', 'false', 'Indent with tabs instead of spaces'],
+					['--tab-width', '2', 'Spaces per indent level'],
+					['--print-width', '80', 'Target line width']
+				]
+			}
+		},
+		{
+			title: 'Configuration',
+			body: [
+				'JS / TS keys (quotes, semicolons, trailing commas, …) are read from an `.oxfmtrc` so inline `<script>` blocks format identically to standalone files.'
+			],
+			code: {
+				lang: 'json',
+				caption: '.oxfmtrc',
+				code: `{
+  "useTabs": true,
+  "printWidth": 100,
+  "semicolons": "always",
+  "quoteStyle": "single"
+}`
+			}
+		},
+		{
+			title: 'In the browser',
+			body: [
+				'The playground runs the formatter on WebAssembly. `<style>` bodies are left verbatim there — CSS formatting needs the native `oxfmt` subprocess, which the CLI uses but a browser cannot spawn.'
+			]
+		}
+	]
+};
+
+const svelteCheck: Guide = {
+	id: 'svelte-check',
+	title: 'svelte-check',
+	pkg: '@rsvelte/svelte-check',
+	dropInFor: 'svelte-check',
+	tagline:
+		'The project type-checker CLI. A Rust walker + svelte2tsx overlay drives tsgo for the TypeScript half; diagnostics map back to .svelte positions. Watch + incremental cache included.',
+	install: 'npm i -D @rsvelte/svelte-check',
+	runnable: false,
+	sections: [
+		{
+			title: 'Run a check',
+			code: {
+				lang: 'bash',
+				code: `# Type-check the current project
+rsvelte-check
+
+# Point at a workspace folder and tsconfig
+rsvelte-check --workspace . --tsconfig ./tsconfig.json
+
+# Re-check on change
+rsvelte-check --watch`
+			}
+		},
+		{
+			title: 'Flags',
+			table: {
+				head: ['Flag', 'Meaning'],
+				rows: [
+					['--workspace <dir>', 'Root folder to discover `.svelte` files under'],
+					['--tsconfig <path>', 'tsconfig to type-check against'],
+					['--watch', 'Watch and re-check incrementally'],
+					['--threshold <level>', 'Minimum severity to report (warning | error)'],
+					['--output <format>', 'Reporter: human | machine | machine-verbose']
+				]
+			}
+		},
+		{
+			title: 'Why it cannot run in the playground',
+			body: [
+				'svelte-check type-checks an entire project through the native `tsgo` backend, which has no WebAssembly build. The Rust walker discovers files, generates a TSX overlay per component, runs `tsgo`, then maps diagnostics back to `.svelte` positions — none of which works in a browser sandbox. Run the CLI in your project instead.'
+			]
+		},
+		{
+			title: 'Notes',
+			list: [
+				'Incremental cache (incl. a per-file warning cache) keeps re-checks fast.',
+				'Parallel compile + hi-res svelte2tsx source maps for column-accurate diagnostics.',
+				'SvelteKit generated kit-files are augmented so `$app/*` / route types resolve.'
+			]
+		}
+	]
+};
+
+const vitePlugin: Guide = {
+	id: 'vite-plugin-svelte',
+	title: 'vite-plugin-svelte',
+	pkg: '@rsvelte/vite-plugin-svelte',
+	dropInFor: '@sveltejs/vite-plugin-svelte',
+	tagline:
+		'A fork of the Vite plugin whose every transform / HMR / preprocess call routes through the rsvelte compiler over NAPI. Your vite.config.js does not change.',
+	install: 'npm i -D @rsvelte/vite-plugin-svelte',
+	runnable: false,
+	sections: [
+		{
+			title: 'Use it in vite.config',
+			body: ['Swap the import — the plugin API matches upstream, so the rest of your config is unchanged.'],
+			code: {
+				lang: 'js',
+				caption: 'vite.config.js',
+				code: `import { defineConfig } from 'vite';
+import { svelte } from '@rsvelte/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()]
+});`
+			}
+		},
+		{
+			title: 'Why it cannot run in the playground',
+			body: [
+				'A Vite plugin only means anything inside a running Vite / Node dev server — it hooks `transform` and `hotUpdate` and talks to the rsvelte compiler over a native NAPI binding. There is no component to "run" in a browser tab. Install it in your project and your existing dev / build commands pick it up.'
+			]
+		},
+		{
+			title: 'Notes',
+			list: [
+				'Every `transform` / `hotUpdate` / preprocess call routes through the Rust NAPI binding.',
+				'Public API matches `@sveltejs/vite-plugin-svelte`, so config and SvelteKit setups are unchanged.'
+			]
+		}
+	]
+};
+
+export const GUIDES: Guide[] = [compiler, svelte2tsx, fmt, svelteCheck, vitePlugin];
+
+export const guideById = (id: string): Guide | undefined => GUIDES.find((g) => g.id === id);

--- a/apps/playground/src/lib/fmt.ts
+++ b/apps/playground/src/lib/fmt.ts
@@ -1,0 +1,50 @@
+// Lazy loader for the formatter WASM module (built from `crates/rsvelte_fmt_wasm`
+// into `pkg-fmt/`). Kept separate from `compiler.ts` because it is a distinct
+// wasm binary, loaded on demand only when the `fmt` playground tool is opened.
+
+let fmtModule: typeof import('../../../../pkg-fmt/rsvelte_fmt_wasm') | null = null;
+let initPromise: Promise<void> | null = null;
+
+export interface FmtOptions {
+	useTabs?: boolean;
+	tabWidth?: number;
+	printWidth?: number;
+}
+
+export interface FmtResult {
+	success: boolean;
+	code?: string;
+	error?: string;
+}
+
+export async function initFmt(): Promise<void> {
+	if (fmtModule) return;
+	if (initPromise) return initPromise;
+
+	initPromise = (async () => {
+		const wasm = await import('../../../../pkg-fmt/rsvelte_fmt_wasm');
+		await wasm.default();
+		fmtModule = wasm;
+	})();
+
+	return initPromise;
+}
+
+export function getFmtVersion(): string {
+	if (!fmtModule) throw new Error('fmt WASM not initialized');
+	return fmtModule.version();
+}
+
+/**
+ * Format a `.svelte` source string. `<style>` bodies survive verbatim — the
+ * CLI formats them via a native `oxfmt` subprocess that can't run in a browser.
+ */
+export function formatSvelte(source: string, options: FmtOptions = {}): FmtResult {
+	if (!fmtModule) throw new Error('fmt WASM not initialized');
+	const raw = fmtModule.format_svelte(source, JSON.stringify(options));
+	try {
+		return JSON.parse(raw) as FmtResult;
+	} catch {
+		return { success: false, error: raw };
+	}
+}

--- a/apps/playground/src/lib/monaco/MonacoEditor.svelte
+++ b/apps/playground/src/lib/monaco/MonacoEditor.svelte
@@ -48,7 +48,7 @@
 			automaticLayout: true,
 			minimap: { enabled: false },
 			fontSize: 14,
-			fontFamily: "'Fira Mono', 'Fira Code', 'JetBrains Mono', Menlo, monospace",
+			fontFamily: "'JetBrains Mono', 'Fira Code', ui-monospace, Menlo, monospace",
 			lineNumbers: 'on',
 			lineHeight: 22,
 			padding: { top: 16 },

--- a/apps/playground/src/lib/tools.ts
+++ b/apps/playground/src/lib/tools.ts
@@ -1,0 +1,71 @@
+// Single source of truth for the toolchain entries surfaced by the docs
+// guides (`/docs`) and the multi-tool playground (`/playground?tool=…`).
+//
+// `runnable` marks the tools that can execute entirely in the browser on
+// WebAssembly. The two that can't — svelte-check (drives the native `tsgo`
+// type-checker) and vite-plugin-svelte (needs a running Vite / Node dev
+// server) — still get a playground entry, but it explains the limitation
+// and links the guide instead of running.
+
+export type ToolId = 'compiler' | 'svelte2tsx' | 'fmt' | 'svelte-check' | 'vite-plugin-svelte';
+
+export interface Tool {
+	/** Stable id, also the `?tool=` value and the `/docs/[slug]`. */
+	id: ToolId;
+	/** Short switcher label, e.g. "Compiler". */
+	label: string;
+	/** Published package / tool name, e.g. "@rsvelte/compiler". */
+	pkg: string;
+	/** One-line description for switcher tooltips and guide headers. */
+	tagline: string;
+	/** Whether the tool runs in-browser on WASM. */
+	runnable: boolean;
+	/** When not runnable, why — shown in the playground panel. */
+	cantRunReason?: string;
+}
+
+export const TOOLS: Tool[] = [
+	{
+		id: 'compiler',
+		label: 'Compiler',
+		pkg: '@rsvelte/compiler',
+		tagline: 'Compile a .svelte component to client / SSR JavaScript, CSS and AST.',
+		runnable: true
+	},
+	{
+		id: 'svelte2tsx',
+		label: 'svelte2tsx',
+		pkg: '@rsvelte/svelte2tsx',
+		tagline: 'Turn a component into the TSX shadow file the TypeScript checker reads.',
+		runnable: true
+	},
+	{
+		id: 'fmt',
+		label: 'fmt',
+		pkg: '@rsvelte/fmt',
+		tagline: 'Format a .svelte file with the Rust-native formatter built on oxc.',
+		runnable: true
+	},
+	{
+		id: 'svelte-check',
+		label: 'svelte-check',
+		pkg: '@rsvelte/svelte-check',
+		tagline: 'Project type-checker CLI — a Rust walker + overlay driving tsgo.',
+		runnable: false,
+		cantRunReason:
+			'svelte-check type-checks a whole project through the native tsgo backend, which has no WebAssembly build — so it cannot run in a browser. Use the CLI; the guide shows how.'
+	},
+	{
+		id: 'vite-plugin-svelte',
+		label: 'vite-plugin-svelte',
+		pkg: '@rsvelte/vite-plugin-svelte',
+		tagline: 'Drop-in Vite plugin routing every transform / HMR call through rsvelte.',
+		runnable: false,
+		cantRunReason:
+			'The Vite plugin only has meaning inside a running Vite / Node dev server (it hooks transform & HMR), so there is nothing to run in a browser. Use it in your project; the guide shows the config.'
+	}
+];
+
+export const toolById = (id: string): Tool | undefined => TOOLS.find((t) => t.id === id);
+
+export const isToolId = (v: string): v is ToolId => TOOLS.some((t) => t.id === v);

--- a/apps/playground/src/routes/+layout.svelte
+++ b/apps/playground/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
 	<link
-		href="https://fonts.googleapis.com/css2?family=Overpass:wght@400;500;600;700;800&family=Fira+Mono:wght@400;500;700&display=swap"
+		href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
 		rel="stylesheet"
 	/>
 </svelte:head>
@@ -40,59 +40,66 @@
 	:global(:root),
 	:global(:root[data-theme='light']) {
 		--bg: #ffffff;
-		--paper: #faf9f5;
-		--paper-2: #f3f1e9;
-		--ink: #14130f;
-		--ink-soft: #5a5750;
-		--ink-faint: #97938a;
-		--rule: #ececdf;
-		--rule-strong: #d8d4c4;
-		--selection: #ffe9d6;
+		--paper: #f7f8fa;
+		--paper-2: #eef1f4;
+		--ink: #0f1419;
+		--ink-soft: #4a5560;
+		--ink-faint: #8b96a2;
+		--rule: #e7eaee;
+		--rule-strong: #d2d7dd;
+		--selection: #ffe0cc;
 
 		--svelte: #ff3e00;
 		--svelte-hover: #e83700;
-		--rust: #b7410e;
-		--rust-soft: #cf7a4a;
+		/* Single accent is the Svelte orange; the former "rust" hue is now a
+		   restrained cool slate so eyebrows / labels read as neutral. */
+		--rust: #5c6773;
+		--rust-soft: #8b96a2;
 
-		--ok: #2c7a3a;
+		--ok: #1f9d55;
 		--warn: #b07a00;
-		--bad: #b1280a;
+		--bad: #d23a1f;
 
-		/* Editor / monaco surface — slightly off-white in light, lifted ink in dark */
-		--editor-bg: #fbf9f2;
-		--editor-ink: #14130f;
+		/* Editor / monaco surface — cool off-white in light, lifted ink in dark */
+		--editor-bg: #f7f8fa;
+		--editor-ink: #0f1419;
+
+		/* Blueprint-grid hairline, used for subtle technical backgrounds. */
+		--grid: #eceff3;
 
 		color-scheme: light;
 	}
 
 	:global(:root[data-theme='dark']) {
-		--bg: #0d0c09;
-		--paper: #16140f;
-		--paper-2: #1d1a13;
-		--ink: #f1ecdf;
-		--ink-soft: #b0a994;
-		--ink-faint: #75705f;
-		--rule: #2a2620;
-		--rule-strong: #3a3528;
+		--bg: #0e1116;
+		--paper: #161b22;
+		--paper-2: #1c232c;
+		--ink: #e6edf3;
+		--ink-soft: #9aa7b4;
+		--ink-faint: #6b7681;
+		--rule: #232b34;
+		--rule-strong: #313b45;
 		--selection: #5a2a10;
 
-		--svelte: #ff6634;
-		--svelte-hover: #ff7d50;
-		--rust: #e58050;
-		--rust-soft: #c46640;
+		--svelte: #ff6a39;
+		--svelte-hover: #ff855c;
+		--rust: #8b96a2;
+		--rust-soft: #6b7681;
 
-		--ok: #6cc870;
+		--ok: #3fb950;
 		--warn: #e0b240;
-		--bad: #e85a3c;
+		--bad: #f0613f;
 
-		--editor-bg: #14110b;
-		--editor-ink: #efe9da;
+		--editor-bg: #0f141a;
+		--editor-ink: #e6edf3;
+
+		--grid: #1a212a;
 
 		color-scheme: dark;
 	}
 
 	:global(body) {
-		font-family: 'Overpass', ui-sans-serif, -apple-system, BlinkMacSystemFont, sans-serif;
+		font-family: 'Hanken Grotesk', ui-sans-serif, -apple-system, BlinkMacSystemFont, sans-serif;
 		background: var(--bg);
 		color: var(--ink);
 		line-height: 1.6;
@@ -110,7 +117,7 @@
 
 	:global(code),
 	:global(pre) {
-		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
 	:global(::selection) {

--- a/apps/playground/src/routes/+page.svelte
+++ b/apps/playground/src/routes/+page.svelte
@@ -383,7 +383,7 @@
 
 	code,
 	pre {
-		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
 	/* HERO */
@@ -405,7 +405,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.7rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.75rem;
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
@@ -421,7 +421,7 @@
 	}
 
 	.title {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		font-size: clamp(2.3rem, 6.2vw, 4.6rem);
 		line-height: 1.02;
@@ -468,7 +468,7 @@
 		align-items: center;
 		gap: 0.5rem;
 		padding: 0.78rem 1.25rem;
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 600;
 		font-size: 0.95rem;
 		border-radius: 4px;
@@ -507,7 +507,7 @@
 	}
 
 	.install {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.9rem;
 		color: var(--ink-soft);
 		margin-top: 2.2rem;
@@ -547,7 +547,7 @@
 	}
 
 	.section-head .num {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.7rem;
 		letter-spacing: 0.18em;
 		color: var(--rust);
@@ -556,7 +556,7 @@
 	}
 
 	.section-head h2 {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: clamp(1.65rem, 3.2vw, 2.6rem);
 		line-height: 1.1;
@@ -576,7 +576,7 @@
 	.section-head h2 code,
 	.compat .lede code,
 	.perf .lede code {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.78em;
 		font-weight: 500;
 		padding: 0.1em 0.45em;
@@ -624,7 +624,7 @@
 	}
 
 	.bars-sub {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.72rem;
 		color: var(--ink-soft);
 	}
@@ -651,7 +651,7 @@
 	}
 
 	.bar-k {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.78rem;
 		font-weight: 500;
 		color: var(--ink);
@@ -659,7 +659,7 @@
 	}
 
 	.bar-s {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		color: var(--ink-faint);
 		letter-spacing: 0.02em;
@@ -711,7 +711,7 @@
 	}
 
 	.bar-t {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.82rem;
 		color: var(--ink);
 		font-variant-numeric: tabular-nums;
@@ -725,7 +725,7 @@
 		gap: 0.55rem;
 		flex-wrap: wrap;
 		padding: 0.85rem 1.25rem 1rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.7rem;
 		color: var(--ink-faint);
 		border-top: 1px solid var(--rule);
@@ -742,7 +742,7 @@
 
 	.bars-empty {
 		padding: 2rem 1.25rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.85rem;
 		color: var(--ink-faint);
 	}
@@ -759,7 +759,7 @@
 	}
 
 	.toolchain-k {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		letter-spacing: 0.12em;
 		text-transform: uppercase;
@@ -794,19 +794,19 @@
 	}
 
 	.tc-name {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.8rem;
 		color: var(--ink);
 	}
 
 	.tc-sub {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		color: var(--ink-faint);
 	}
 
 	.tc-x {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		font-size: 1.45rem;
 		line-height: 1;
@@ -816,7 +816,7 @@
 	}
 
 	.tc-x .x {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-weight: 500;
 		font-size: 0.42em;
 		margin-left: 0.1em;
@@ -825,14 +825,14 @@
 	}
 
 	.toolchain-empty {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		color: var(--ink-faint);
 		padding: 1rem 0;
 	}
 
 	.toolchain-link {
 		margin-top: 0.9rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.78rem;
 		color: var(--ink-soft);
 		display: inline-flex;
@@ -878,7 +878,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.5rem;
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 600;
 		font-size: 0.95rem;
 		color: var(--svelte);
@@ -908,7 +908,7 @@
 		background: var(--paper);
 		border: 1px solid var(--rule);
 		border-radius: 6px;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		overflow: hidden;
 	}
 
@@ -986,7 +986,7 @@
 	}
 
 	.capi-tag {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.78rem;
 		letter-spacing: 0.02em;
 		color: var(--ink);
@@ -995,7 +995,7 @@
 	}
 
 	.capi-langs code {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.85em;
 		color: var(--ink);
 	}
@@ -1015,7 +1015,7 @@
 	}
 
 	.big-pct {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		color: var(--ink);
 		letter-spacing: -0.01em;
@@ -1071,14 +1071,14 @@
 	.spec-pct {
 		margin-left: auto;
 		padding-left: 0.85rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.82rem;
 		color: var(--ink);
 		font-variant-numeric: tabular-nums;
 	}
 
 	.spec-n {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: 1.15rem;
 		color: var(--ink);
@@ -1097,7 +1097,7 @@
 	}
 
 	.spec-s {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink-soft);
 	}
@@ -1145,14 +1145,14 @@
 	}
 
 	.why-n {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.72rem;
 		letter-spacing: 0.16em;
 		color: var(--rust);
 	}
 
 	.why-body h3 {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: 1.18rem;
 		letter-spacing: -0.015em;

--- a/apps/playground/src/routes/benchmark/+page.svelte
+++ b/apps/playground/src/routes/benchmark/+page.svelte
@@ -310,7 +310,7 @@
 
 	code,
 	pre {
-		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
 	/* HERO */
@@ -324,7 +324,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.7rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.75rem;
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
@@ -340,7 +340,7 @@
 	}
 
 	.title {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		font-size: clamp(2rem, 4.6vw, 3.4rem);
 		line-height: 1.05;
@@ -372,7 +372,7 @@
 	}
 
 	.hero-meta dt {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		letter-spacing: 0.14em;
 		text-transform: uppercase;
@@ -380,7 +380,7 @@
 	}
 
 	.hero-meta dd {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.86rem;
 		color: var(--ink);
 		margin: 0;
@@ -422,7 +422,7 @@
 	}
 
 	.stat-k {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.7rem;
 		letter-spacing: 0.06em;
 		text-transform: uppercase;
@@ -430,7 +430,7 @@
 	}
 
 	.stat-n {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		font-size: clamp(1.9rem, 3vw, 2.5rem);
 		line-height: 1;
@@ -446,7 +446,7 @@
 	}
 
 	.stat-x {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-weight: 500;
 		font-size: 0.42em;
 		margin-left: 0.18em;
@@ -487,7 +487,7 @@
 	}
 
 	.chart-title {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: clamp(1.2rem, 2.2vw, 1.5rem);
 		line-height: 1.1;
@@ -497,7 +497,7 @@
 	}
 
 	.chart-sub {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.72rem;
 		color: var(--ink-soft);
 		margin: 0;
@@ -534,7 +534,7 @@
 	}
 
 	.task-panel-label {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: 0.98rem;
 		color: var(--ink);
@@ -542,7 +542,7 @@
 	}
 
 	.task-panel-sub {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.7rem;
 		color: var(--ink-faint);
 	}
@@ -551,7 +551,7 @@
 		display: inline-flex;
 		align-items: baseline;
 		gap: 0.4rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.72rem;
 		color: var(--ink-soft);
 	}
@@ -562,7 +562,7 @@
 	}
 
 	.task-panel-speedup-n {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: 0.95rem;
 		color: var(--rust);
@@ -572,7 +572,7 @@
 	}
 
 	.task-panel-speedup-n .x {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-weight: 500;
 		font-size: 0.72em;
 		margin-left: 0.06em;
@@ -585,7 +585,7 @@
 	}
 
 	.task-panel-speedup-st {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink-soft);
 	}
@@ -597,7 +597,7 @@
 		color: var(--ink);
 		padding: 0.45rem 0.85rem;
 		border-radius: 4px;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.76rem;
 		cursor: pointer;
 		display: inline-flex;
@@ -637,14 +637,14 @@
 	}
 
 	.bar-name {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.82rem;
 		font-weight: 500;
 		color: var(--ink);
 	}
 
 	.bar-sub {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		color: var(--ink-faint);
 	}
@@ -685,7 +685,7 @@
 	}
 
 	.bar-time {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.84rem;
 		color: var(--ink);
 		font-variant-numeric: tabular-nums;
@@ -709,14 +709,14 @@
 	}
 
 	.section-head .num {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.7rem;
 		letter-spacing: 0.18em;
 		color: var(--rust);
 	}
 
 	.section-head h2 {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: clamp(1.6rem, 3vw, 2.4rem);
 		line-height: 1.1;
@@ -731,7 +731,7 @@
 		border: 1px solid var(--rule);
 		border-radius: 6px;
 		overflow: hidden;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 	}
 
 	.diff figcaption {
@@ -778,7 +778,7 @@
 	}
 
 	.empty h1 {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: clamp(2rem, 4.6vw, 3rem);
 		line-height: 1.05;
@@ -800,7 +800,7 @@
 		border: 1px solid var(--rule);
 		border-radius: 6px;
 		padding: 1rem 1.2rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.85rem;
 		color: var(--ink);
 		line-height: 1.7;

--- a/apps/playground/src/routes/docs/+page.svelte
+++ b/apps/playground/src/routes/docs/+page.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import { GUIDES } from '$lib/docs';
+	import SiteNav from '$lib/components/SiteNav.svelte';
+	import SiteFooter from '$lib/components/SiteFooter.svelte';
+</script>
+
+<svelte:head>
+	<title>Docs · rsvelte</title>
+	<meta
+		name="description"
+		content="Usage guides for every rsvelte package — the compiler, svelte2tsx, the formatter, svelte-check and the Vite plugin."
+	/>
+</svelte:head>
+
+<div class="page">
+	<SiteNav active="docs" />
+
+	<main class="wrap">
+		<header class="head">
+			<p class="eyebrow"><span class="rule"></span>Documentation</p>
+			<h1 class="title">Guides</h1>
+			<p class="lede">
+				One guide per package in the rsvelte toolchain — install, API, examples and flags.
+				Three of them (compiler, svelte2tsx, fmt) also run live in the
+				<a href="{base}/playground">playground</a>.
+			</p>
+		</header>
+
+		<div class="grid">
+			{#each GUIDES as guide (guide.id)}
+				<a class="card" href="{base}/docs/{guide.id}">
+					<div class="card-head">
+						<h2 class="card-title">{guide.title}</h2>
+						{#if guide.runnable}
+							<span class="badge run">runs in browser</span>
+						{:else}
+							<span class="badge cli">CLI only</span>
+						{/if}
+					</div>
+					<code class="pkg">{guide.pkg}</code>
+					<p class="blurb">{guide.tagline}</p>
+					<p class="dropin">drop-in for <code>{guide.dropInFor}</code></p>
+					<span class="more">Read guide →</span>
+				</a>
+			{/each}
+		</div>
+	</main>
+
+	<SiteFooter />
+</div>
+
+<style>
+	.page {
+		min-height: 100vh;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.wrap {
+		flex: 1;
+		width: 100%;
+		max-width: 64rem;
+		margin: 0 auto;
+		padding: clamp(1.6rem, 4vh, 2.6rem) clamp(1rem, 4vw, 2rem) 3rem;
+	}
+
+	.eyebrow {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.72rem;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--rust);
+		margin: 0;
+	}
+
+	.eyebrow .rule {
+		display: inline-block;
+		width: 20px;
+		height: 1px;
+		background: var(--rust);
+	}
+
+	.title {
+		font-weight: 800;
+		font-size: clamp(2rem, 5vw, 3rem);
+		letter-spacing: -0.03em;
+		color: var(--ink);
+		margin: 0.4rem 0 0.6rem;
+	}
+
+	.lede {
+		font-size: 1.05rem;
+		line-height: 1.65;
+		color: var(--ink-soft);
+		max-width: 44rem;
+		margin: 0;
+	}
+
+	.lede a {
+		color: var(--svelte);
+		border-bottom: 1px solid currentColor;
+	}
+
+	.grid {
+		margin-top: 2.2rem;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr));
+		gap: 1rem;
+	}
+
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding: 1.1rem 1.1rem 1rem;
+		border: 1px solid var(--rule);
+		border-radius: 8px;
+		background: var(--bg);
+		transition:
+			border-color 0.18s,
+			transform 0.18s,
+			box-shadow 0.18s;
+	}
+
+	.card:hover {
+		border-color: var(--rule-strong);
+		transform: translateY(-2px);
+		box-shadow: 0 6px 20px -12px rgba(0, 0, 0, 0.25);
+	}
+
+	.card-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+	}
+
+	.card-title {
+		font-size: 1.15rem;
+		font-weight: 700;
+		letter-spacing: -0.01em;
+		color: var(--ink);
+		margin: 0;
+	}
+
+	.badge {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.6rem;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		padding: 0.2rem 0.45rem;
+		border-radius: 999px;
+		white-space: nowrap;
+	}
+
+	.badge.run {
+		color: var(--svelte);
+		background: color-mix(in srgb, var(--svelte) 12%, transparent);
+	}
+
+	.badge.cli {
+		color: var(--ink-faint);
+		background: var(--paper-2);
+	}
+
+	.pkg {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.74rem;
+		color: var(--ink-soft);
+	}
+
+	.blurb {
+		font-size: 0.88rem;
+		line-height: 1.55;
+		color: var(--ink-soft);
+		margin: 0;
+		flex: 1;
+	}
+
+	.dropin {
+		font-size: 0.76rem;
+		color: var(--ink-faint);
+		margin: 0;
+	}
+
+	.dropin code {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.72rem;
+		color: var(--ink-soft);
+	}
+
+	.more {
+		font-size: 0.82rem;
+		font-weight: 600;
+		color: var(--svelte);
+		margin-top: 0.2rem;
+	}
+</style>

--- a/apps/playground/src/routes/docs/[slug]/+page.svelte
+++ b/apps/playground/src/routes/docs/[slug]/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Guide from '$lib/components/Guide.svelte';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+	<title>{data.guide.title} · rsvelte docs</title>
+	<meta name="description" content={data.guide.tagline} />
+</svelte:head>
+
+<Guide guide={data.guide} />

--- a/apps/playground/src/routes/docs/[slug]/+page.ts
+++ b/apps/playground/src/routes/docs/[slug]/+page.ts
@@ -1,0 +1,14 @@
+import { error } from '@sveltejs/kit';
+import type { EntryGenerator, PageLoad } from './$types';
+import { GUIDES, guideById } from '$lib/docs';
+
+// Enumerate every guide slug so adapter-static prerenders a real HTML file per
+// page (build/docs/<slug>/index.html). Without this the SPA fallback would
+// 404 on a direct deep link under GitHub Pages.
+export const entries: EntryGenerator = () => GUIDES.map((g) => ({ slug: g.id }));
+
+export const load: PageLoad = ({ params }) => {
+	const guide = guideById(params.slug);
+	if (!guide) error(404, `Unknown guide: ${params.slug}`);
+	return { guide };
+};

--- a/apps/playground/src/routes/ecosystem/+page.svelte
+++ b/apps/playground/src/routes/ecosystem/+page.svelte
@@ -127,7 +127,7 @@
 	}
 
 	code {
-		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
 	/* HERO */
@@ -141,7 +141,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.7rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.75rem;
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
@@ -157,7 +157,7 @@
 	}
 
 	.title {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		font-size: clamp(2.1rem, 5.4vw, 3.8rem);
 		line-height: 1.04;
@@ -226,7 +226,7 @@
 	}
 
 	.hero-meta dt {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		letter-spacing: 0.14em;
 		text-transform: uppercase;
@@ -241,7 +241,7 @@
 	}
 
 	.hero-meta .big {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		font-size: 1.7rem;
 		line-height: 1;
@@ -262,7 +262,7 @@
 	}
 
 	.hero-meta .dim {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.76rem;
 		color: var(--ink-soft);
 	}
@@ -283,7 +283,7 @@
 	}
 
 	.section-head .num {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.7rem;
 		letter-spacing: 0.18em;
 		color: var(--rust);
@@ -292,7 +292,7 @@
 	}
 
 	.section-head h2 {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: clamp(1.5rem, 3vw, 2.3rem);
 		line-height: 1.1;

--- a/apps/playground/src/routes/playground/+page.svelte
+++ b/apps/playground/src/routes/playground/+page.svelte
@@ -1,21 +1,29 @@
 <script lang="ts">
 	import { onMount, untrack } from 'svelte';
+	import { base } from '$app/paths';
+	import { page } from '$app/state';
+	import { replaceState } from '$app/navigation';
 	import {
 		initCompiler,
 		getVersion,
 		parse,
 		compileClient,
 		compileServer,
+		svelte2tsx,
 		type CompileMode,
 		type OutputTab,
 		type CompileStats
 	} from '$lib/compiler';
+	import { initFmt, formatSvelte, getFmtVersion } from '$lib/fmt';
 	import { generatePreviewHtml } from '$lib/preview';
 	import { DEFAULT_EXAMPLE } from '$lib/examples';
+	import { TOOLS, toolById, isToolId, type ToolId } from '$lib/tools';
 	import MonacoEditor from '$lib/monaco/MonacoEditor.svelte';
 	import AstViewer from '$lib/components/AstViewer.svelte';
+	import CodeBlock from '$lib/components/CodeBlock.svelte';
 	import SiteNav from '$lib/components/SiteNav.svelte';
 
+	let tool = $state<ToolId>('compiler');
 	let input = $state(DEFAULT_EXAMPLE);
 
 	let mode: CompileMode = $state('client');
@@ -24,24 +32,38 @@
 	let version = $state('');
 	let error = $state('');
 
+	// ── compiler outputs ──────────────────────────────
 	let outputJs = $state('');
 	let outputCss = $state('');
 	let outputAst = $state<object | null>(null);
 	let outputAstString = $state('');
 	let previewHtml = $state('');
 	let stats: CompileStats = $state({ compileTime: 0, outputSize: 0 });
-
 	let cursorPosition = $state(0);
 	let selectedAstRange = $state<{ start: number; end: number } | null>(null);
 
+	// ── svelte2tsx outputs ────────────────────────────
+	let tsxMode = $state<'ts' | 'dts'>('ts');
+	let tsxOutput = $state('');
+	let tsxNames = $state<string[]>([]);
+	let tsxError = $state('');
+
+	// ── fmt outputs ───────────────────────────────────
+	let fmtReady = $state(false);
+	let fmtVersion = $state('');
+	let fmtOutput = $state('');
+	let fmtError = $state('');
+	let fmtChanged = $state(false);
+
 	let debounceTimer: ReturnType<typeof setTimeout>;
 
+	const currentTool = $derived(toolById(tool)!);
+
+	// ── compiler ──────────────────────────────────────
 	function compile() {
 		if (!wasmReady) return;
-
 		error = '';
 		const startTime = performance.now();
-
 		try {
 			const clientResult = compileClient(input, 'Component');
 			const result = mode === 'client' ? clientResult : compileServer(input, 'Component');
@@ -84,9 +106,86 @@
 		}
 	}
 
+	// ── svelte2tsx ────────────────────────────────────
+	function runSvelte2tsx() {
+		if (!wasmReady) return;
+		tsxError = '';
+		try {
+			const res = svelte2tsx(input, {
+				filename: 'Component.svelte',
+				isTsFile: true,
+				mode: tsxMode
+			});
+			if (!res.success) {
+				tsxError = res.error || 'svelte2tsx failed';
+				tsxOutput = '';
+				tsxNames = [];
+				return;
+			}
+			tsxOutput = res.code || '';
+			tsxNames = res.exportedNames?.props ?? [];
+		} catch (e) {
+			tsxError = e instanceof Error ? e.message : String(e);
+			tsxOutput = '';
+			tsxNames = [];
+		}
+	}
+
+	// ── fmt ───────────────────────────────────────────
+	async function ensureFmt() {
+		if (fmtReady) return;
+		await initFmt();
+		fmtReady = true;
+		fmtVersion = getFmtVersion();
+	}
+
+	function runFmt() {
+		if (!fmtReady) return;
+		fmtError = '';
+		try {
+			const res = formatSvelte(input, {});
+			if (!res.success) {
+				fmtError = res.error || 'Formatting failed';
+				fmtOutput = '';
+				return;
+			}
+			fmtOutput = res.code ?? '';
+			fmtChanged = fmtOutput !== input;
+		} catch (e) {
+			fmtError = e instanceof Error ? e.message : String(e);
+			fmtOutput = '';
+		}
+	}
+
+	function run() {
+		if (tool === 'compiler') compile();
+		else if (tool === 'svelte2tsx') runSvelte2tsx();
+		else if (tool === 'fmt') runFmt();
+	}
+
+	async function selectTool(next: ToolId) {
+		if (next === tool) return;
+		tool = next;
+		try {
+			replaceState(`${base}/playground?tool=${next}`, page.state);
+		} catch {
+			// replaceState can throw if the router isn't ready yet — the in-memory
+			// `tool` state still drives the UI, so the deep link is best-effort.
+		}
+		if (next === 'fmt') await ensureFmt();
+		run();
+	}
+
+	function applyFormatted() {
+		if (fmtOutput) {
+			input = fmtOutput;
+			fmtChanged = false;
+		}
+	}
+
 	function handleInputChange() {
 		clearTimeout(debounceTimer);
-		debounceTimer = setTimeout(compile, 300);
+		debounceTimer = setTimeout(run, 300);
 	}
 
 	function handleCursorPositionChange(offset: number) {
@@ -99,35 +198,35 @@
 	}
 
 	onMount(async () => {
+		const t = page.url.searchParams.get('tool');
+		if (t && isToolId(t)) tool = t;
 		try {
 			await initCompiler();
 			wasmReady = true;
 			version = getVersion();
-			compile();
+			if (tool === 'fmt') await ensureFmt();
+			run();
 		} catch (e) {
 			error = `Failed to load WASM: ${e instanceof Error ? e.message : String(e)}`;
 		}
 	});
 
+	// Re-run the active tool when its inputs (tool, mode, tsxMode) change, or
+	// once the relevant WASM module finishes loading.
 	$effect(() => {
-		const currentMode = mode;
-		if (wasmReady && currentMode) {
-			untrack(() => compile());
-		}
+		void [tool, mode, tsxMode, fmtReady, wasmReady];
+		if (wasmReady) untrack(() => run());
 	});
 
 	const monacoLanguage = $derived(
 		activeTab === 'js' ? 'javascript' : activeTab === 'css' ? 'css' : 'json'
 	);
-
 	const monacoValue = $derived(
 		activeTab === 'js' ? outputJs : activeTab === 'css' ? outputCss : outputAstString
 	);
-
 	const astHighlightRange = $derived<{ start: number; end: number } | null>(
 		activeTab === 'ast' ? { start: cursorPosition, end: cursorPosition } : null
 	);
-
 	const inputHighlightRange = $derived<{ start: number; end: number } | null>(selectedAstRange);
 
 	const formatBytes = (b: number): string => {
@@ -141,13 +240,23 @@
 		{ id: 'css', label: 'CSS output', sub: 'scoped styles' },
 		{ id: 'ast', label: 'AST', sub: 'svelte AST · JSON' }
 	];
+
+	const cliFor = (id: ToolId): { lang: string; code: string } => {
+		if (id === 'svelte-check') {
+			return { lang: 'bash', code: 'npm i -D @rsvelte/svelte-check\nrsvelte-check --watch' };
+		}
+		return {
+			lang: 'js',
+			code: `import { svelte } from '@rsvelte/vite-plugin-svelte';\n\nexport default { plugins: [svelte()] };`
+		};
+	};
 </script>
 
 <svelte:head>
 	<title>Playground · rsvelte</title>
 	<meta
 		name="description"
-		content="A live playground for rsvelte, the Rust port of the Svelte ecosystem — edit a component and see the generated JS, CSS, AST and rendered preview."
+		content="A live playground for rsvelte, the Rust port of the Svelte ecosystem — run the compiler, svelte2tsx and formatter on WebAssembly, right in the browser."
 	/>
 </svelte:head>
 
@@ -162,120 +271,218 @@
 				<span class="version">v{version}</span>
 			{/if}
 		</div>
-		<div class="play-head-r" role="radiogroup" aria-label="Compilation mode">
-			<span class="mode-label">Generate</span>
-			<div class="mode-switch">
+
+		<div class="tool-switch" role="tablist" aria-label="Tool">
+			{#each TOOLS as t (t.id)}
 				<button
-					class:active={mode === 'client'}
-					onclick={() => (mode = 'client')}
-					disabled={!wasmReady}
+					role="tab"
+					aria-selected={tool === t.id}
+					class:active={tool === t.id}
+					class:muted={!t.runnable}
+					title={t.tagline}
+					onclick={() => selectTool(t.id)}
 				>
-					Client
+					{t.label}
+					{#if !t.runnable}<span class="cli-dot" aria-hidden="true">CLI</span>{/if}
 				</button>
-				<button
-					class:active={mode === 'server'}
-					onclick={() => (mode = 'server')}
-					disabled={!wasmReady}
-				>
-					Server
-				</button>
-			</div>
+			{/each}
 		</div>
 	</header>
 
-	<main class="workspace">
-		<!-- LEFT — source editor, fills its half -->
-		<section class="panel panel-input">
-			<header class="panel-head">
-				<span class="panel-num">01</span>
-				<h2 class="panel-title">Source <em>.svelte</em></h2>
-				<span class="panel-meta">debounced 300 ms</span>
-			</header>
-			<div class="panel-body editor-host">
-				{#if wasmReady}
-					<MonacoEditor
-						bind:value={input}
-						onchange={handleInputChange}
-						onCursorPositionChange={handleCursorPositionChange}
-						highlightRange={inputHighlightRange}
-					/>
-				{:else}
-					<div class="loading">Loading editor…</div>
-				{/if}
-			</div>
-		</section>
-
-		<!-- RIGHT — tabbed output (Result / JS / CSS / AST) -->
-		<section class="panel panel-output">
-			<header class="panel-head tab-head" role="tablist" aria-label="Output tab">
-				{#each tabs as t (t.id)}
-					<button
-						role="tab"
-						class="tab"
-						class:active={activeTab === t.id}
-						aria-selected={activeTab === t.id}
-						onclick={() => (activeTab = t.id)}
-					>
-						<span class="tab-label">{t.label}</span>
-						<span class="tab-sub">{t.sub}</span>
-					</button>
-				{/each}
-			</header>
-
-			<div class="panel-body output-host">
-				{#if !wasmReady && !error}
-					<div class="loading">Loading WASM module…</div>
-				{:else if error}
-					<div class="error">
-						<span class="error-tag">parse / compile error</span>
-						<pre>{error}</pre>
-					</div>
-				{:else if activeTab === 'result'}
-					<div class="preview-host">
-						{#if previewHtml}
-							<iframe
-								srcdoc={previewHtml}
-								title="Preview"
-								sandbox="allow-scripts allow-popups allow-forms"
-							></iframe>
-						{:else}
-							<div class="loading">No preview available</div>
-						{/if}
-					</div>
-				{:else if activeTab === 'ast'}
-					<div class="ast-host">
-						<AstViewer
-							ast={outputAst}
-							highlightRange={astHighlightRange}
-							onNodeClick={handleAstNodeClick}
+	{#if currentTool.runnable}
+		<main class="workspace">
+			<!-- LEFT — source editor -->
+			<section class="panel panel-input">
+				<header class="panel-head">
+					<span class="panel-num">01</span>
+					<h2 class="panel-title">Source <em>.svelte</em></h2>
+					<span class="panel-meta">debounced 300 ms</span>
+				</header>
+				<div class="panel-body editor-host">
+					{#if wasmReady}
+						<MonacoEditor
+							bind:value={input}
+							onchange={handleInputChange}
+							onCursorPositionChange={handleCursorPositionChange}
+							highlightRange={inputHighlightRange}
 						/>
-					</div>
-				{:else}
-					<div class="editor-host">
-						{#key `${activeTab}-${mode}-${monacoValue}`}
-							<MonacoEditor value={monacoValue} language={monacoLanguage} readonly={true} />
-						{/key}
-					</div>
-				{/if}
-			</div>
+					{:else}
+						<div class="loading">Loading editor…</div>
+					{/if}
+				</div>
+			</section>
 
-			<footer class="panel-foot">
-				<span>
-					<span class="dim">compile</span>
-					<strong>{stats.compileTime.toFixed(2)}<span class="unit">ms</span></strong>
-				</span>
-				<span>
-					<span class="dim">js</span>
-					<strong>{formatBytes(stats.outputSize)}</strong>
-				</span>
-				<span class="grow"></span>
-				<span class="status-dot" class:ok={wasmReady && !error} class:err={!!error}></span>
-				<span class="status-text">
-					{#if !wasmReady}Initialising{:else if error}Error{:else}Live{/if}
-				</span>
-			</footer>
-		</section>
-	</main>
+			<!-- RIGHT — output, depends on the active tool -->
+			<section class="panel panel-output">
+				{#if tool === 'compiler'}
+					<header class="panel-head tab-head" role="tablist" aria-label="Output tab">
+						{#each tabs as t (t.id)}
+							<button
+								role="tab"
+								class="tab"
+								class:active={activeTab === t.id}
+								aria-selected={activeTab === t.id}
+								onclick={() => (activeTab = t.id)}
+							>
+								<span class="tab-label">{t.label}</span>
+								<span class="tab-sub">{t.sub}</span>
+							</button>
+						{/each}
+						<div class="head-aside" role="radiogroup" aria-label="Compilation mode">
+							<button class:active={mode === 'client'} onclick={() => (mode = 'client')}>
+								Client
+							</button>
+							<button class:active={mode === 'server'} onclick={() => (mode = 'server')}>
+								Server
+							</button>
+						</div>
+					</header>
+				{:else if tool === 'svelte2tsx'}
+					<header class="panel-head">
+						<span class="panel-num">02</span>
+						<h2 class="panel-title">TSX <em>shadow</em></h2>
+						<div class="head-aside">
+							<button class:active={tsxMode === 'ts'} onclick={() => (tsxMode = 'ts')}>ts</button>
+							<button class:active={tsxMode === 'dts'} onclick={() => (tsxMode = 'dts')}>
+								d.ts
+							</button>
+						</div>
+					</header>
+				{:else if tool === 'fmt'}
+					<header class="panel-head">
+						<span class="panel-num">02</span>
+						<h2 class="panel-title">Formatted <em>output</em></h2>
+						<button class="apply" disabled={!fmtChanged} onclick={applyFormatted}>
+							Apply to source
+						</button>
+					</header>
+				{/if}
+
+				<div class="panel-body output-host">
+					{#if !wasmReady && !error}
+						<div class="loading">Loading WASM module…</div>
+					{:else if tool === 'compiler'}
+						{#if error}
+							<div class="error">
+								<span class="error-tag">parse / compile error</span>
+								<pre>{error}</pre>
+							</div>
+						{:else if activeTab === 'result'}
+							<div class="preview-host">
+								{#if previewHtml}
+									<iframe
+										srcdoc={previewHtml}
+										title="Preview"
+										sandbox="allow-scripts allow-popups allow-forms"
+									></iframe>
+								{:else}
+									<div class="loading">No preview available</div>
+								{/if}
+							</div>
+						{:else if activeTab === 'ast'}
+							<div class="ast-host">
+								<AstViewer
+									ast={outputAst}
+									highlightRange={astHighlightRange}
+									onNodeClick={handleAstNodeClick}
+								/>
+							</div>
+						{:else}
+							<div class="editor-host">
+								{#key `${activeTab}-${mode}-${monacoValue}`}
+									<MonacoEditor value={monacoValue} language={monacoLanguage} readonly={true} />
+								{/key}
+							</div>
+						{/if}
+					{:else if tool === 'svelte2tsx'}
+						{#if tsxError}
+							<div class="error">
+								<span class="error-tag">svelte2tsx error</span>
+								<pre>{tsxError}</pre>
+							</div>
+						{:else}
+							<div class="tsx-host">
+								<div class="names">
+									<span class="names-label">exported props</span>
+									{#if tsxNames.length}
+										{#each tsxNames as n (n)}
+											<code class="chip">{n}</code>
+										{/each}
+									{:else}
+										<span class="names-empty">none</span>
+									{/if}
+								</div>
+								<div class="editor-host">
+									{#key `tsx-${tsxMode}-${tsxOutput}`}
+										<MonacoEditor value={tsxOutput} language="typescript" readonly={true} />
+									{/key}
+								</div>
+							</div>
+						{/if}
+					{:else if tool === 'fmt'}
+						{#if fmtError}
+							<div class="error">
+								<span class="error-tag">format error</span>
+								<pre>{fmtError}</pre>
+							</div>
+						{:else if !fmtReady}
+							<div class="loading">Loading formatter…</div>
+						{:else}
+							<div class="editor-host">
+								{#key `fmt-${fmtOutput}`}
+									<MonacoEditor value={fmtOutput} language="html" readonly={true} />
+								{/key}
+							</div>
+						{/if}
+					{/if}
+				</div>
+
+				<footer class="panel-foot">
+					{#if tool === 'compiler'}
+						<span>
+							<span class="dim">compile</span>
+							<strong>{stats.compileTime.toFixed(2)}<span class="unit">ms</span></strong>
+						</span>
+						<span>
+							<span class="dim">js</span>
+							<strong>{formatBytes(stats.outputSize)}</strong>
+						</span>
+					{:else if tool === 'svelte2tsx'}
+						<span><span class="dim">props</span> <strong>{tsxNames.length}</strong></span>
+					{:else if tool === 'fmt'}
+						<span>
+							<span class="dim">status</span>
+							<strong>{fmtChanged ? 'reformatted' : 'already formatted'}</strong>
+						</span>
+						{#if fmtVersion}
+							<span><span class="dim">fmt</span> <strong>v{fmtVersion}</strong></span>
+						{/if}
+						<span class="note">&lt;style&gt; left verbatim in-browser</span>
+					{/if}
+					<span class="grow"></span>
+					<span class="status-dot" class:ok={wasmReady && !error} class:err={!!error}></span>
+					<span class="status-text">
+						{#if !wasmReady}Initialising{:else if error}Error{:else}Live{/if}
+					</span>
+				</footer>
+			</section>
+		</main>
+	{:else}
+		<!-- Non-runnable tools: explain why and link the guide + CLI -->
+		<main class="explainer">
+			<div class="explain-card">
+				<p class="eyebrow"><span class="rule"></span>{currentTool.pkg}</p>
+				<h2 class="explain-title">{currentTool.label} can't run in a browser</h2>
+				<p class="explain-body">{currentTool.cantRunReason}</p>
+				<div class="explain-actions">
+					<a class="btn primary" href="{base}/docs/{currentTool.id}">Read the guide →</a>
+				</div>
+				<div class="explain-code">
+					<CodeBlock code={cliFor(currentTool.id).code} lang={cliFor(currentTool.id).lang} />
+				</div>
+			</div>
+		</main>
+	{/if}
 </div>
 
 <style>
@@ -287,12 +494,12 @@
 
 	code,
 	pre {
-		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
 	/* PAGE HEAD */
 	.play-head {
-		max-width: 1600px;
+		max-width: 100%;
 		margin: 0 auto;
 		width: 100%;
 		padding: clamp(1.4rem, 3vh, 2rem) clamp(1rem, 3vw, 2rem) clamp(0.8rem, 2vh, 1.2rem);
@@ -314,7 +521,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.6rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.7rem;
 		letter-spacing: 0.1em;
 		text-transform: uppercase;
@@ -330,7 +537,7 @@
 	}
 
 	.title {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		font-size: clamp(1.5rem, 2.5vw, 2rem);
 		letter-spacing: -0.025em;
@@ -339,7 +546,7 @@
 	}
 
 	.version {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--rust);
 		padding: 0.2rem 0.5rem;
@@ -348,61 +555,60 @@
 		line-height: 1;
 	}
 
-	.play-head-r {
+	/* TOOL SWITCHER */
+	.tool-switch {
+		display: inline-flex;
+		flex-wrap: wrap;
+		gap: 0.3rem;
+		padding: 0.25rem;
+		border: 1px solid var(--rule-strong);
+		border-radius: 6px;
+		background: var(--paper);
+	}
+
+	.tool-switch button {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.7rem;
-	}
-
-	.mode-label {
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.7rem;
-		letter-spacing: 0.1em;
-		text-transform: uppercase;
-		color: var(--ink-soft);
-	}
-
-	.mode-switch {
-		display: inline-flex;
-		border: 1px solid var(--rule-strong);
-		border-radius: 4px;
-		overflow: hidden;
-		background: var(--bg);
-	}
-
-	.mode-switch button {
-		font-family: 'Fira Mono', monospace;
-		font-size: 0.78rem;
-		padding: 0.45rem 0.95rem;
+		gap: 0.4rem;
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.76rem;
+		padding: 0.4rem 0.7rem;
 		background: transparent;
 		border: 0;
+		border-radius: 4px;
 		color: var(--ink-soft);
 		cursor: pointer;
-		border-right: 1px solid var(--rule);
-		transition: background 0.18s, color 0.18s;
+		transition:
+			background 0.16s,
+			color 0.16s;
 	}
 
-	.mode-switch button:last-child {
-		border-right: 0;
-	}
-
-	.mode-switch button:hover:not(:disabled) {
+	.tool-switch button:hover {
 		color: var(--ink);
 	}
 
-	.mode-switch button.active {
-		background: var(--ink);
-		color: var(--bg);
+	.tool-switch button.active {
+		background: var(--bg);
+		color: var(--ink);
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
 	}
 
-	.mode-switch button:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
+	.tool-switch button.active.muted {
+		color: var(--ink-soft);
 	}
 
-	/* WORKSPACE — two equal columns, Svelte REPL style */
+	.cli-dot {
+		font-size: 0.56rem;
+		letter-spacing: 0.06em;
+		color: var(--ink-faint);
+		border: 1px solid var(--rule-strong);
+		border-radius: 999px;
+		padding: 0.05rem 0.3rem;
+	}
+
+	/* WORKSPACE — two equal columns, full width */
 	.workspace {
-		max-width: 1600px;
+		max-width: 100%;
 		margin: 0 auto;
 		width: 100%;
 		padding: 0 clamp(1rem, 3vw, 2rem) clamp(1.5rem, 4vh, 2.5rem);
@@ -424,10 +630,7 @@
 		overflow: hidden;
 	}
 
-	.panel-input {
-		min-height: 70vh;
-	}
-
+	.panel-input,
 	.panel-output {
 		min-height: 70vh;
 	}
@@ -443,14 +646,14 @@
 	}
 
 	.panel-num {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		letter-spacing: 0.16em;
 		color: var(--rust);
 	}
 
 	.panel-title {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: 0.92rem;
 		letter-spacing: -0.01em;
@@ -466,12 +669,71 @@
 	}
 
 	.panel-meta {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		color: var(--ink-faint);
 	}
 
-	/* RIGHT-PANEL TABS — replace the title header on the output panel */
+	/* small inline button groups in panel heads (mode / ts-dts) */
+	.head-aside {
+		display: inline-flex;
+		border: 1px solid var(--rule-strong);
+		border-radius: 4px;
+		overflow: hidden;
+		background: var(--bg);
+		flex-shrink: 0;
+	}
+
+	.head-aside button {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.72rem;
+		padding: 0.35rem 0.7rem;
+		background: transparent;
+		border: 0;
+		border-right: 1px solid var(--rule);
+		color: var(--ink-soft);
+		cursor: pointer;
+		transition:
+			background 0.16s,
+			color 0.16s;
+	}
+
+	.head-aside button:last-child {
+		border-right: 0;
+	}
+
+	.head-aside button:hover {
+		color: var(--ink);
+	}
+
+	.head-aside button.active {
+		background: var(--ink);
+		color: var(--bg);
+	}
+
+	.apply {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.72rem;
+		padding: 0.35rem 0.7rem;
+		border: 1px solid var(--rule-strong);
+		border-radius: 4px;
+		background: var(--bg);
+		color: var(--ink-soft);
+		cursor: pointer;
+		flex-shrink: 0;
+	}
+
+	.apply:hover:not(:disabled) {
+		color: var(--ink);
+		border-color: var(--ink);
+	}
+
+	.apply:disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
+	}
+
+	/* RIGHT-PANEL TABS */
 	.tab-head {
 		gap: 0;
 		padding: 0;
@@ -493,11 +755,10 @@
 		color: var(--ink-soft);
 		cursor: pointer;
 		text-align: left;
-		transition: background 0.18s, color 0.18s, border-color 0.18s;
-	}
-
-	.tab:last-child {
-		border-right: 0;
+		transition:
+			background 0.18s,
+			color 0.18s,
+			border-color 0.18s;
 	}
 
 	.tab:hover {
@@ -512,20 +773,25 @@
 	}
 
 	.tab-label {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 600;
 		font-size: 0.86rem;
 		letter-spacing: -0.005em;
 	}
 
 	.tab-sub {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.62rem;
 		color: var(--ink-faint);
 	}
 
 	.tab.active .tab-sub {
 		color: var(--ink-soft);
+	}
+
+	.tab-head .head-aside {
+		margin: 0 0.5rem;
+		align-self: center;
 	}
 
 	.panel-body {
@@ -574,7 +840,7 @@
 		flex: 1;
 		min-height: 240px;
 		padding: 2rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.82rem;
 		color: var(--ink-faint);
 	}
@@ -587,6 +853,49 @@
 		background: var(--editor-bg);
 	}
 
+	/* svelte2tsx exported-names strip */
+	.tsx-host {
+		flex: 1;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.names {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.5rem 0.7rem;
+		border-bottom: 1px solid var(--rule);
+		background: var(--paper);
+	}
+
+	.names-label {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.64rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--ink-faint);
+		margin-right: 0.3rem;
+	}
+
+	.names-empty {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.74rem;
+		color: var(--ink-faint);
+	}
+
+	.chip {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.72rem;
+		color: var(--ink);
+		background: var(--paper-2);
+		border: 1px solid var(--rule);
+		border-radius: 3px;
+		padding: 0.1rem 0.4rem;
+	}
+
 	.error {
 		flex: 1;
 		padding: 1.2rem;
@@ -594,7 +903,7 @@
 		flex-direction: column;
 		gap: 0.55rem;
 		background: color-mix(in srgb, var(--bad) 5%, var(--bg));
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 	}
 
 	.error-tag {
@@ -617,7 +926,7 @@
 		align-items: center;
 		gap: 1rem;
 		padding: 0.55rem 0.9rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.76rem;
 		color: var(--ink);
 		background: var(--paper);
@@ -633,6 +942,11 @@
 	.panel-foot strong {
 		font-weight: 600;
 		color: var(--ink);
+	}
+
+	.panel-foot .note {
+		color: var(--ink-faint);
+		font-size: 0.7rem;
 	}
 
 	.unit {
@@ -663,6 +977,62 @@
 
 	.status-text {
 		color: var(--ink-soft);
+	}
+
+	/* NON-RUNNABLE TOOL EXPLAINER */
+	.explainer {
+		flex: 1;
+		display: flex;
+		align-items: flex-start;
+		justify-content: center;
+		padding: clamp(1.5rem, 5vh, 3.5rem) clamp(1rem, 4vw, 2rem) 3rem;
+	}
+
+	.explain-card {
+		width: 100%;
+		max-width: 40rem;
+		border: 1px solid var(--rule);
+		border-radius: 10px;
+		background: var(--bg);
+		padding: clamp(1.4rem, 3vw, 2.2rem);
+	}
+
+	.explain-title {
+		font-family: 'Hanken Grotesk', sans-serif;
+		font-weight: 800;
+		font-size: clamp(1.3rem, 3vw, 1.7rem);
+		letter-spacing: -0.02em;
+		color: var(--ink);
+		margin: 0.5rem 0 0.7rem;
+	}
+
+	.explain-body {
+		font-size: 0.96rem;
+		line-height: 1.7;
+		color: var(--ink-soft);
+		margin: 0 0 1.3rem;
+	}
+
+	.explain-actions {
+		margin-bottom: 1.2rem;
+	}
+
+	.btn {
+		display: inline-flex;
+		align-items: center;
+		font-size: 0.88rem;
+		font-weight: 600;
+		padding: 0.5rem 1rem;
+		border-radius: 5px;
+	}
+
+	.btn.primary {
+		background: var(--svelte);
+		color: #fff;
+	}
+
+	.btn.primary:hover {
+		background: var(--svelte-hover);
 	}
 
 	/* RESPONSIVE */

--- a/apps/playground/src/routes/progress/+page.svelte
+++ b/apps/playground/src/routes/progress/+page.svelte
@@ -272,11 +272,11 @@
 
 	code,
 	pre {
-		font-family: 'Fira Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
 	.mono {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 	}
 
 	/* HERO */
@@ -290,7 +290,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.7rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.75rem;
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
@@ -306,7 +306,7 @@
 	}
 
 	.title {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		font-size: clamp(2rem, 4.6vw, 3.4rem);
 		line-height: 1.06;
@@ -317,7 +317,7 @@
 	}
 
 	.title code {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.7em;
 		font-weight: 500;
 		padding: 0.06em 0.42em;
@@ -350,7 +350,7 @@
 	}
 
 	.hero-meta dt {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		letter-spacing: 0.14em;
 		text-transform: uppercase;
@@ -367,7 +367,7 @@
 	}
 
 	.hero-meta .big {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
 		font-size: 1.6rem;
 		font-variant-numeric: tabular-nums;
@@ -376,7 +376,7 @@
 	}
 
 	.hero-meta .dim {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.78rem;
 		color: var(--ink-soft);
 	}
@@ -402,7 +402,7 @@
 	}
 
 	.section-head .num {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.7rem;
 		letter-spacing: 0.18em;
 		color: var(--rust);
@@ -411,7 +411,7 @@
 	}
 
 	.section-head h2 {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: clamp(1.65rem, 3.2vw, 2.6rem);
 		line-height: 1.1;
@@ -507,7 +507,7 @@
 	}
 
 	.spec-n {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: 1.2rem;
 		color: var(--ink);
@@ -526,7 +526,7 @@
 	}
 
 	.spec-s {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink-soft);
 	}
@@ -575,7 +575,7 @@
 	}
 
 	.spec-pct {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.82rem;
 		color: var(--ink);
 		font-variant-numeric: tabular-nums;
@@ -607,7 +607,7 @@
 		border: 1px solid var(--rule-strong);
 		border-radius: 4px;
 		padding: 0.45rem 0.85rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink);
 		cursor: pointer;
@@ -646,7 +646,7 @@
 		background: var(--bg);
 		border: 1px solid var(--rule-strong);
 		border-radius: 4px;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 	}
 
 	.search:focus-within {
@@ -685,7 +685,7 @@
 		border-radius: 4px;
 		background: var(--bg);
 		overflow: hidden;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 	}
 
 	.cat-select:focus-within {
@@ -736,7 +736,7 @@
 	}
 
 	.status-tabs button {
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.72rem;
 		letter-spacing: 0.06em;
 		padding: 0 1rem;
@@ -796,7 +796,7 @@
 		grid-template-columns: 1fr 12rem 7rem;
 		gap: 1rem;
 		padding: 0.7rem 1rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.66rem;
 		letter-spacing: 0.18em;
 		text-transform: uppercase;
@@ -821,7 +821,7 @@
 		grid-template-columns: 1fr 12rem 7rem;
 		gap: 1rem;
 		padding: 0.65rem 1rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.8rem;
 		border-bottom: 1px solid var(--rule);
 		align-items: center;
@@ -868,7 +868,7 @@
 		margin: 0.4rem 0 0;
 		padding: 0.55rem 0.7rem;
 		background: var(--paper);
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.74rem;
 		color: var(--ink-soft);
 		white-space: pre-wrap;
@@ -888,7 +888,7 @@
 		padding: 3rem 1rem;
 		text-align: center;
 		color: var(--ink-faint);
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.82rem;
 	}
 
@@ -899,7 +899,7 @@
 		border-top: 0;
 		border-bottom-left-radius: 6px;
 		border-bottom-right-radius: 6px;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.78rem;
 		color: var(--ink);
 		display: flex;
@@ -918,7 +918,7 @@
 	}
 
 	.empty h1 {
-		font-family: 'Overpass', sans-serif;
+		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 700;
 		font-size: clamp(2rem, 4.6vw, 3rem);
 		line-height: 1.05;
@@ -940,7 +940,7 @@
 		border: 1px solid var(--rule);
 		border-radius: 6px;
 		padding: 1rem 1.2rem;
-		font-family: 'Fira Mono', monospace;
+		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.85rem;
 		color: var(--ink);
 		line-height: 1.7;

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -25,7 +25,16 @@ trace-fastpath = []
 # jemalloc is disabled (e.g. `--no-default-features --features napi`).
 napi = ["dep:napi", "dep:napi-derive", "dep:napi-build", "tikv-jemallocator?/disable_initial_exec_tls"]
 jemalloc = ["dep:tikv-jemallocator"]
-wasm = ["wasm-bindgen", "console_error_panic_hook", "getrandom/wasm_js"]
+# `wasm` exports this crate's own `#[wasm_bindgen]` surface (the `wasm`
+# module — `parse_svelte`, `compile_client`, `svelte2tsx`, …) and is what
+# `pkg/` is built with.
+wasm = ["wasm-deps"]
+# `wasm-deps` pulls only the wasm-bindgen toolchain + the wasm `getrandom`
+# backend, *without* enabling the `wasm` bindings module. Downstream wasm
+# crates (e.g. `rsvelte_fmt_wasm`) depend on `rsvelte_core` with this
+# feature so they reuse the parser on a wasm target without re-exporting
+# `rsvelte_core`'s `#[wasm_bindgen]` symbols (which collide at link time).
+wasm-deps = ["wasm-bindgen", "console_error_panic_hook", "getrandom/wasm_js"]
 
 [dependencies]
 # Serialization

--- a/crates/rsvelte_fmt_wasm/Cargo.toml
+++ b/crates/rsvelte_fmt_wasm/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rsvelte_fmt_wasm"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.90"
+description = "WebAssembly bindings for the rsvelte Svelte formatter"
+license = "MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Pull the formatter on its wasm backend so `rsvelte_core` links without
+# rayon / jemalloc and without re-exporting `rsvelte_core`'s own
+# `#[wasm_bindgen]` surface (which would collide with this crate's).
+rsvelte_formatter = { path = "../rsvelte_formatter", default-features = false, features = ["wasm"] }
+wasm-bindgen = "0.2"
+serde_json = "1.0"
+console_error_panic_hook = "0.1"
+getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/crates/rsvelte_fmt_wasm/src/lib.rs
+++ b/crates/rsvelte_fmt_wasm/src/lib.rs
@@ -14,6 +14,7 @@
 use rsvelte_formatter::{
     FormatOptions, IndentStyle, IndentWidth, JsFormatOptions, LineWidth, format,
 };
+use serde_json::Value;
 use wasm_bindgen::prelude::*;
 
 /// Initialize the panic hook for readable errors in the browser console.
@@ -52,28 +53,21 @@ pub fn format_svelte(source: &str, options_json: &str) -> String {
 fn parse_options(options_json: &str) -> FormatOptions {
     let mut js = JsFormatOptions::new();
 
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(options_json) {
-        if let Some(obj) = value.as_object() {
-            if obj
-                .get("useTabs")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false)
-            {
-                js.indent_style = IndentStyle::Tab;
-            } else {
-                js.indent_style = IndentStyle::Space;
-            }
-            if let Some(w) = obj.get("tabWidth").and_then(|v| v.as_u64()) {
-                if let Ok(width) = IndentWidth::try_from(w as u8) {
-                    js.indent_width = width;
-                }
-            }
-            if let Some(w) = obj.get("printWidth").and_then(|v| v.as_u64()) {
-                if let Ok(width) = LineWidth::try_from(w as u16) {
-                    js.line_width = width;
-                }
-            }
-        }
+    let value = serde_json::from_str::<serde_json::Value>(options_json).unwrap_or(Value::Null);
+    let obj = value.as_object();
+    let get_bool = |k: &str| obj.and_then(|o| o.get(k)).and_then(Value::as_bool);
+    let get_u64 = |k: &str| obj.and_then(|o| o.get(k)).and_then(Value::as_u64);
+
+    js.indent_style = if get_bool("useTabs").unwrap_or(false) {
+        IndentStyle::Tab
+    } else {
+        IndentStyle::Space
+    };
+    if let Some(width) = get_u64("tabWidth").and_then(|w| IndentWidth::try_from(w as u8).ok()) {
+        js.indent_width = width;
+    }
+    if let Some(width) = get_u64("printWidth").and_then(|w| LineWidth::try_from(w as u16).ok()) {
+        js.line_width = width;
     }
 
     FormatOptions {

--- a/crates/rsvelte_fmt_wasm/src/lib.rs
+++ b/crates/rsvelte_fmt_wasm/src/lib.rs
@@ -1,0 +1,85 @@
+//! WebAssembly bindings for the rsvelte Svelte formatter.
+//!
+//! Wraps [`rsvelte_formatter::format`] so the formatter runs in the browser
+//! (e.g. the docs playground's `fmt` tool). Like the `svelte2tsx` wasm
+//! binding in `rsvelte_core`, the boundary stays at primitive types:
+//! `options_json` and the return value are JSON strings, so no bespoke
+//! `wasm_bindgen` struct is needed.
+//!
+//! Note: the `<style>` formatter callback is `None` here. The CLI wires that
+//! up to spawn `oxfmt`, which is a native subprocess and cannot run in a
+//! browser — so `<style>` bodies survive verbatim, matching the CLI's own
+//! WASM limitation.
+
+use rsvelte_formatter::{
+    FormatOptions, IndentStyle, IndentWidth, JsFormatOptions, LineWidth, format,
+};
+use wasm_bindgen::prelude::*;
+
+/// Initialize the panic hook for readable errors in the browser console.
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+}
+
+/// Get the formatter crate version.
+#[wasm_bindgen]
+pub fn version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Format a `.svelte` source string. Returns a JSON string:
+///
+/// ```json
+/// { "success": true, "code": "<formatted source>" }
+/// { "success": false, "error": "<message>" }
+/// ```
+///
+/// `options_json` accepts the same knobs as `.oxfmtrc` (all optional):
+/// `useTabs` (bool), `tabWidth` (number), `printWidth` (number).
+#[wasm_bindgen]
+pub fn format_svelte(source: &str, options_json: &str) -> String {
+    let options = parse_options(options_json);
+    match format(source, &options) {
+        Ok(code) => serde_json::json!({ "success": true, "code": code }).to_string(),
+        Err(e) => serde_json::json!({ "success": false, "error": format!("{e}") }).to_string(),
+    }
+}
+
+/// Parse the JSON options blob into [`FormatOptions`]. Unknown / missing keys
+/// fall back to the formatter defaults. Mirrors `build_format_options` in the
+/// `rsvelte-fmt` CLI, minus the native-only `<style>` formatter callback.
+fn parse_options(options_json: &str) -> FormatOptions {
+    let mut js = JsFormatOptions::new();
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(options_json) {
+        if let Some(obj) = value.as_object() {
+            if obj
+                .get("useTabs")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                js.indent_style = IndentStyle::Tab;
+            } else {
+                js.indent_style = IndentStyle::Space;
+            }
+            if let Some(w) = obj.get("tabWidth").and_then(|v| v.as_u64()) {
+                if let Ok(width) = IndentWidth::try_from(w as u8) {
+                    js.indent_width = width;
+                }
+            }
+            if let Some(w) = obj.get("printWidth").and_then(|v| v.as_u64()) {
+                if let Ok(width) = LineWidth::try_from(w as u16) {
+                    js.line_width = width;
+                }
+            }
+        }
+    }
+
+    FormatOptions {
+        js,
+        style_formatter: None,
+        // `format` re-derives this per-document from `<script lang="ts">`.
+        typescript: false,
+    }
+}

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -10,8 +10,17 @@ publish = false
 [lib]
 crate-type = ["rlib"]
 
+[features]
+default = ["native"]
+# Forward the backend choice down to `rsvelte_core`: `native` keeps rayon /
+# miette / jemalloc; `wasm` swaps them for the wasm-bindgen toolchain so the
+# formatter (and the parser it reuses) link cleanly on wasm32 — see
+# `crates/rsvelte_fmt_wasm`.
+native = ["rsvelte_core/native"]
+wasm = ["rsvelte_core/wasm-deps"]
+
 [dependencies]
-rsvelte_core = { path = "../rsvelte_core", default-features = false, features = ["native"] }
+rsvelte_core = { path = "../rsvelte_core", default-features = false }
 oxc_allocator = "0.134"
 oxc_ast = "0.134"
 oxc_parser = "0.134"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:wasm": "wasm-pack build crates/rsvelte_core --out-dir ../../pkg --target web --release -- --features wasm --no-default-features",
+    "build:wasm": "pnpm run build:wasm:core && pnpm run build:wasm:fmt",
+    "build:wasm:core": "wasm-pack build crates/rsvelte_core --out-dir ../../pkg --target web --release -- --features wasm --no-default-features",
+    "build:wasm:fmt": "wasm-pack build crates/rsvelte_fmt_wasm --out-dir ../../pkg-fmt --target web --release",
     "build:wasm:clean": "cargo clean && pnpm run build:wasm",
     "clean:cache": "rm -rf apps/playground/node_modules/.vite",
     "dev": "pnpm run build:wasm && pnpm run clean:cache && cd apps/playground && pnpm run dev",


### PR DESCRIPTION
## What this does

Overhauls the rsvelte docs site (`apps/playground`) to cover the whole toolchain.

1. **Per-library usage guides** — data-driven `/docs` index + `/docs/[slug]` pages for all 5 packages (compiler, svelte2tsx, fmt, svelte-check, vite-plugin-svelte). Content lives in `src/lib/docs.ts` and renders through shared `Guide.svelte` / `CodeBlock.svelte` (install, API, examples, flags). `[slug]` pages are **prerendered via `entries`** so deep links return 200 on GitHub Pages.
2. **Multi-library playground** — a tool switcher. **compiler, svelte2tsx and fmt run interactively in-browser** on WebAssembly. `svelte-check` (native `tsgo`) and `vite-plugin-svelte` (needs a running Vite/Node) can't run in a browser, so the switcher shows a short "can't run here" panel that links the guide + CLI usage.
3. **Full-width playground** — removed the `max-width: 1600px` cap; the workspace is now `width: 100%`. Tool selection is a `?tool=` deep link (used by the "Open in playground" button on each guide).
4. **Redesign** — moved off the warm brown/rust palette + Overpass to a restrained **cool-neutral** scheme with a single Svelte-orange accent, **Hanken Grotesk / JetBrains Mono**. Theme token *names* are unchanged, so every page re-themes from `+layout.svelte` alone.

### New crate: `crates/rsvelte_fmt_wasm`

A `cdylib` wrapping `rsvelte_formatter::format` and exposing `format_svelte(source, optionsJson)` → built to `pkg-fmt/` via wasm-pack. To link cleanly:
- `rsvelte_core` gained a **`wasm-deps`** feature (wasm-bindgen toolchain + wasm `getrandom`, but **not** the bindings module) so the formatter reuses the parser without re-exporting `rsvelte_core`'s own `#[wasm_bindgen]` exports (which collide at link time).
- `rsvelte_formatter` gained `native` / `wasm` features that forward the backend choice down to `rsvelte_core`.

Build wiring: root + `apps/playground` `build:wasm` and `.github/workflows/deploy-docs.yml` now also build `pkg-fmt`; `pkg-fmt/` is gitignored.

## Verified (in the dev container)
- `wasm-pack build` of **both** `pkg/` (compiler + svelte2tsx) and `pkg-fmt/` (formatter) succeeds.
- `format_svelte` reformats correctly (script reindented; `<style>` left verbatim — no `oxfmt` in the browser).
- Native build still green: `cargo check -p rsvelte_formatter -p rsvelte_fmt` with the feature refactor.
- `vite build` (via the NAPI shim) succeeds; **all routes prerender**, including all 5 `/docs/<slug>` guides → HTML.
- `cargo fmt` clean on the new crate; `oxlint` clean on the playground TS.

## Notes / out of scope
- **clippy**: the repo's `cargo clippy --all-targets --all-features` surfaces ~12 pre-existing lints in `rsvelte_core` under the dev container's newer nightly clippy. Confirmed identical on an unmodified baseline checkout — **not introduced by this PR**, and unrelated to the new crate (which is clippy-clean).
- The optional "run the whole site tree through `@rsvelte/fmt`" cosmetic step from the original draft is **intentionally skipped** (it would add an `@rsvelte/fmt` devDependency + app-lockfile churn for no functional gain). The app's `format` script still uses `oxfmt`.
- `--grid` blueprint token was added to the theme but is not applied to a hero background yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)