### PR TITLE
fix(css): `&.CLASS` nesting not flagged unused when CLASS is a `class:` directive (#720)

### DIFF
--- a/.changeset/css-nesting-class-directive-unused.md
+++ b/.changeset/css-nesting-class-directive-unused.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(css): don't flag a nested `&.CLASS` selector as unused when `CLASS` comes from a `class:CLASS={...}` directive (or a spread) rather than a static `class="..."` attribute (#720)

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -2105,6 +2105,11 @@ pub struct CssDomElement {
     pub has_spread: bool,
     /// Whether this element has a class directive (class:name)
     pub has_class_directive: bool,
+    /// Class names contributed by `class:NAME={...}` directives.
+    /// These are classes that the element may carry at runtime in addition to
+    /// any static `class="..."` names, so compound selector matching (e.g. the
+    /// `&.NAME` native-nesting path) must consult them as well as `classes`.
+    pub class_directive_names: FxHashSet<String>,
     /// Whether this element has a style directive (style:name)
     pub has_style_directive: bool,
     /// Parent element index (in elements array), None for root

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -452,6 +452,7 @@ pub fn visit(
     let mut dynamic_attribute_names: FxHashSet<String> = FxHashSet::default();
     let mut has_spread = false;
     let mut has_class_directive = false;
+    let mut class_directive_names: FxHashSet<String> = FxHashSet::default();
     let mut has_style_directive = false;
 
     // Track class names and IDs from attributes
@@ -721,8 +722,9 @@ pub fn visit(
         } else if let Attribute::BindDirective(bind) = attr {
             // bind:name is a dynamic attribute
             dynamic_attribute_names.insert(bind.name.to_string());
-        } else if let Attribute::ClassDirective(_) = attr {
+        } else if let Attribute::ClassDirective(class_dir) = attr {
             has_class_directive = true;
+            class_directive_names.insert(class_dir.name.to_string());
         } else if let Attribute::StyleDirective(_) = attr {
             has_style_directive = true;
         }
@@ -984,6 +986,7 @@ pub fn visit(
         dynamic_attribute_names,
         has_spread,
         has_class_directive,
+        class_directive_names,
         has_style_directive,
         parent_idx,
         children_idx: Vec::new(),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -98,6 +98,7 @@ pub fn visit(
         dynamic_attribute_names: FxHashSet::default(),
         has_spread: false,
         has_class_directive: false,
+        class_directive_names: FxHashSet::default(),
         has_style_directive: false,
         parent_idx,
         children_idx: Vec::new(),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -1605,10 +1605,14 @@ fn is_nesting_compound_unused(rel_selectors: &[Value], ctx: &CssContext) -> bool
 
             // Check if any DOM element satisfies ALL the combined constraints
             let any_element_matches = ctx.dom_structure.elements.iter().any(|elem| {
-                // Check all required classes are present on the element
-                let classes_match = all_required_classes
-                    .iter()
-                    .all(|c| elem.classes.contains(*c));
+                // Check all required classes are present on the element. A class may
+                // be carried statically (`class="..."`), via a `class:NAME` directive,
+                // or potentially via a spread (`{...rest}`), which could set anything.
+                let classes_match = all_required_classes.iter().all(|c| {
+                    elem.has_spread
+                        || elem.classes.contains(*c)
+                        || elem.class_directive_names.contains(*c)
+                });
 
                 // Check all required ids match
                 let ids_match = all_required_ids

--- a/crates/rsvelte_core/tests/css_nesting_class_directive.rs
+++ b/crates/rsvelte_core/tests/css_nesting_class_directive.rs
@@ -1,0 +1,57 @@
+//! Regression test for issue #720.
+//!
+//! A nested `&.CLASS` selector must not be reported as an unused CSS selector
+//! when `CLASS` is applied via a `class:CLASS={...}` directive (rather than a
+//! static `class="..."` attribute). `&.active` expands to `.box.active`, and
+//! the element can carry `active` at runtime through the directive, so the
+//! selector is reachable. The official Svelte compiler emits no warning here.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn css_unused(src: &str) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .iter()
+    .filter(|w| w.code == "css_unused_selector")
+    .map(|w| w.message.lines().next().unwrap_or("").to_string())
+    .collect()
+}
+
+#[test]
+fn nesting_compound_with_class_directive_is_used() {
+    // `&.active` reachable via `class:active` directive — no warning.
+    let src = "<script>let on = true;</script>\n\
+               <div class=\"box\" class:active={on}></div>\n\
+               <style>.box { color: red; &.active { color: blue; } }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn nesting_compound_with_static_class_is_used() {
+    // Control: the static-class form was already correct.
+    let src = "<div class=\"box active\"></div>\n\
+               <style>.box { color: red; &.active { color: blue; } }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn nesting_compound_truly_unused_still_warns() {
+    // `&.missing` is genuinely unreachable (no static class, no directive) — must warn.
+    let src = "<div class=\"box\"></div>\n\
+               <style>.box { color: red; &.missing { color: blue; } }</style>";
+    assert_eq!(
+        css_unused(src),
+        vec!["Unused CSS selector \"&.missing\"".to_string()]
+    );
+}


### PR DESCRIPTION
## Problem (#720)

The unused-CSS-selector check reported a false positive for a nested `&.CLASS` selector when `CLASS` is applied via a `class:CLASS={...}` **directive** rather than a static `class="..."` attribute:

```svelte
<script lang="ts">let on = true;</script>
<div class="box" class:active={on}></div>
<style>
  .box { color: red; &.active { color: blue; } }
</style>
```

rsvelte emitted `Unused CSS selector "&.active"`. `&.active` expands to `.box.active`, which is reachable because the `<div>` can carry `active` at runtime through the directive. The official Svelte compiler emits **0 warnings**.

## Root cause

The flat-selector path (`.box.active`) already resolved correctly because it consults the global `used_classes` set, which includes `class:` directive names. But the **native-nesting compound path** (`is_nesting_compound_unused`) does a stricter per-element check: it requires every class in the expanded compound (`box` **and** `active`) to be present on the *same* DOM element — and it only looked at the element's **static** `classes` set, ignoring `class:` directives (and spreads).

## Fix

- Track per-element `class:NAME` directive names on `CssDomElement` as `class_directive_names` (populated in the `regular_element` visitor).
- In `is_nesting_compound_unused`, treat a compound class requirement as satisfied when the class is present **statically**, via a **`class:` directive**, or potentially via a **spread** (`{...rest}`) — mirroring upstream's `attribute_matches` handling for `ClassDirective` / spread.

Verified against the official Svelte compiler: the directive case and the static-class control both yield 0 warnings, while a genuinely-unreachable `&.missing` still warns.

## Tests

- New `crates/rsvelte_core/tests/css_nesting_class_directive.rs` (3 cases: directive-reachable → no warning, static control → no warning, truly-unused → still warns).
- Full CSS fixture suite (`cargo test --test css`) passes.

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)