### PR TITLE
fix(css): `#id` selector not flagged unused when element id is dynamic (#723)

### DIFF
--- a/.changeset/css-dynamic-id-unused.md
+++ b/.changeset/css-dynamic-id-unused.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(css): don't flag a `#id` selector as unused when the element's `id` is dynamic (`{id}` shorthand, `id={expr}`, an interpolated `id="a{x}"`, or set via a spread) — only a static `id="..."` is matched literally (#723)

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -2036,6 +2036,12 @@ pub struct CssAnalysis {
     /// If true, class selectors cannot be safely pruned
     pub has_dynamic_classes: bool,
 
+    /// Whether any element has a dynamically-valued `id` (`id={expr}`, the `{id}`
+    /// shorthand, an interpolated `id="a{x}"`, or a spread that could set `id`).
+    /// A dynamic id can resolve to any value at runtime, so when this is true no
+    /// `#id` selector can be safely pruned. Mirrors `has_dynamic_classes`.
+    pub has_dynamic_ids: bool,
+
     /// Whether the template has control flow (if/each/await/snippet) that affects sibling relationships
     /// If true, sibling combinator unused detection cannot be safely performed
     pub has_control_flow: bool,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -699,17 +699,32 @@ pub fn visit(
                     }
                 }
                 "id" => {
-                    // Extract ID from attribute value
-                    if let AttributeValue::Sequence(parts) = &attr_node.value {
-                        for part in parts {
-                            if let AttributeValuePart::Text(text) = part {
-                                let id = text.data.trim();
-                                if !id.is_empty() {
-                                    context.analysis.css.used_ids.insert(id.to_string());
-                                    element_id = Some(id.to_string());
+                    match &attr_node.value {
+                        AttributeValue::Sequence(parts) => {
+                            // An interpolated id (`id="a{x}"`) has an unknown runtime
+                            // value, so it could match any #id selector.
+                            let has_dynamic_part = parts
+                                .iter()
+                                .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)));
+                            if has_dynamic_part {
+                                context.analysis.css.has_dynamic_ids = true;
+                            } else {
+                                for part in parts {
+                                    if let AttributeValuePart::Text(text) = part {
+                                        let id = text.data.trim();
+                                        if !id.is_empty() {
+                                            context.analysis.css.used_ids.insert(id.to_string());
+                                            element_id = Some(id.to_string());
+                                        }
+                                    }
                                 }
                             }
                         }
+                        // `id={expr}` or the `{id}` shorthand: dynamic, unknown value.
+                        AttributeValue::Expression(_) => {
+                            context.analysis.css.has_dynamic_ids = true;
+                        }
+                        _ => {}
                     }
                 }
                 _ => {}

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/spread_attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/spread_attribute.rs
@@ -13,8 +13,9 @@ pub fn visit(
     attribute: &SpreadAttribute,
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
-    // Spreads can contain class/style, so we can't safely prune CSS
+    // Spreads can contain class/style/id, so we can't safely prune CSS
     context.analysis.css.has_dynamic_classes = true;
+    context.analysis.css.has_dynamic_ids = true;
 
     // Check if this is a $$restProps or $$props spread (for legacy mode)
     if !context.analysis.runes

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -67,14 +67,24 @@ pub fn visit(
                     _ => {}
                 }
             }
-            Attribute::Attribute(attr_node) if attr_node.name == "id" => {
-                if let AttributeValue::Sequence(parts) = &attr_node.value
-                    && parts.len() == 1
-                    && let Some(AttributeValuePart::Text(text)) = parts.first()
-                {
-                    element_id = Some(text.data.to_string());
+            Attribute::Attribute(attr_node) if attr_node.name == "id" => match &attr_node.value {
+                AttributeValue::Sequence(parts) => {
+                    let has_dynamic_part = parts
+                        .iter()
+                        .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)));
+                    if has_dynamic_part {
+                        context.analysis.css.has_dynamic_ids = true;
+                    } else if parts.len() == 1
+                        && let Some(AttributeValuePart::Text(text)) = parts.first()
+                    {
+                        element_id = Some(text.data.to_string());
+                    }
                 }
-            }
+                AttributeValue::Expression(_) => {
+                    context.analysis.css.has_dynamic_ids = true;
+                }
+                _ => {}
+            },
             Attribute::ClassDirective(cd) => {
                 context
                     .analysis

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -26,6 +26,9 @@ struct CssContext<'a> {
     has_dynamic_elements: bool,
     /// Whether there are dynamic class expressions
     has_dynamic_classes: bool,
+    /// Whether any element has a dynamically-valued `id` (so `#id` selectors
+    /// cannot be pruned — a dynamic id can resolve to any value at runtime)
+    has_dynamic_ids: bool,
     /// Whether template has control flow (if/each/await/snippet/slot)
     has_control_flow: bool,
     /// Whether template has opaque elements (slots/snippets/render tags) or
@@ -77,6 +80,7 @@ pub fn collect_css_unused_warnings(
         used_ids: &analysis.css.used_ids,
         has_dynamic_elements: analysis.css.has_dynamic_elements,
         has_dynamic_classes: analysis.css.has_dynamic_classes,
+        has_dynamic_ids: analysis.css.has_dynamic_ids,
         has_control_flow: analysis.css.has_control_flow,
         has_opaque_sibling_boundaries: analysis.css.has_opaque_elements,
         dom_structure: &analysis.css.dom_structure,
@@ -333,6 +337,7 @@ fn render_stylesheet_internal(
         used_ids: &analysis.css.used_ids,
         has_dynamic_elements: analysis.css.has_dynamic_elements,
         has_dynamic_classes: analysis.css.has_dynamic_classes,
+        has_dynamic_ids: analysis.css.has_dynamic_ids,
         has_control_flow: analysis.css.has_control_flow,
         has_opaque_sibling_boundaries: analysis.css.has_opaque_elements,
         dom_structure: &analysis.css.dom_structure,
@@ -3314,6 +3319,11 @@ fn is_simple_selector_unused(sel: &Value, ctx: &CssContext) -> bool {
         }
         Some("IdSelector") => {
             if let Some(name) = sel.get("name").and_then(|n| n.as_str()) {
+                // If any element has a dynamically-valued id, it could resolve to
+                // any value at runtime, so any #id selector is potentially used.
+                if ctx.has_dynamic_ids {
+                    return false;
+                }
                 // Decode CSS escape sequences for comparison
                 let decoded = decode_css_escape(name);
                 return !ctx.used_ids.contains(&decoded);
@@ -3713,6 +3723,9 @@ fn is_is_inner_selector_unused(complex: &Value, ctx: &CssContext) -> bool {
                         }
                     }
                     Some("IdSelector") => {
+                        if ctx.has_dynamic_ids {
+                            return false;
+                        }
                         if let Some(name) = sel.get("name").and_then(|n| n.as_str()) {
                             let decoded = decode_css_escape(name);
                             if !ctx.used_ids.contains(&decoded) {
@@ -5903,6 +5916,7 @@ mod tests {
                 used_ids: &used_ids,
                 has_dynamic_elements: false,
                 has_dynamic_classes: false,
+                has_dynamic_ids: false,
                 has_control_flow: false,
                 has_opaque_sibling_boundaries: false,
                 dom_structure: &dom_structure,
@@ -5945,6 +5959,7 @@ mod tests {
                 used_ids: &used_ids,
                 has_dynamic_elements: false,
                 has_dynamic_classes: false,
+                has_dynamic_ids: false,
                 has_control_flow: false,
                 has_opaque_sibling_boundaries: false,
                 dom_structure: &dom_structure,

--- a/crates/rsvelte_core/tests/css_dynamic_id.rs
+++ b/crates/rsvelte_core/tests/css_dynamic_id.rs
@@ -1,0 +1,70 @@
+//! Regression test for issue #723.
+//!
+//! A `#id` CSS selector must not be reported as unused when the matching
+//! element's `id` is set dynamically (`<div {id}>` shorthand or `id={expr}`).
+//! Because the value is unknown at compile time it could equal any id, so the
+//! selector must be treated as potentially-matching. The official Svelte
+//! compiler emits no warning in these cases. Only a static `id="..."` should
+//! be matched literally.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn css_unused(src: &str) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .iter()
+    .filter(|w| w.code == "css_unused_selector")
+    .map(|w| w.message.lines().next().unwrap_or("").to_string())
+    .collect()
+}
+
+#[test]
+fn dynamic_id_shorthand_suppresses_unused() {
+    let src = "<script>let id = 'editor';</script>\n\
+               <div {id}></div>\n\
+               <style>#editor { color: red }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn dynamic_id_expression_suppresses_unused() {
+    let src = "<script>let x = 'editor';</script>\n\
+               <div id={x}></div>\n\
+               <style>#editor { color: red }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn interpolated_id_suppresses_unused() {
+    let src = "<script>let x = 'tor';</script>\n\
+               <div id=\"edi{x}\"></div>\n\
+               <style>#editor { color: red }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn static_id_match_still_no_warning() {
+    let src = "<div id=\"editor\"></div>\n<style>#editor { color: red }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn static_id_mismatch_still_warns() {
+    // No dynamic id anywhere → a genuinely-unmatched #id must still warn.
+    let src = "<div id=\"editor\"></div>\n<style>#missing { color: red }</style>";
+    assert_eq!(
+        css_unused(src),
+        vec!["Unused CSS selector \"#missing\"".to_string()]
+    );
+}


### PR DESCRIPTION
## Problem (#723)

A `#id` CSS selector was reported as **unused** when the matching element's `id` is set dynamically:

```svelte
<script lang="ts">let id = 'editor';</script>
<div {id}></div>            <!-- or id={x}, or id="edi{x}" -->
<style>#editor { color: red }</style>
```

rsvelte emitted `Unused CSS selector "#editor"`. The runtime value is unknown and could equal `editor` (in fact a dynamic id can resolve to *any* value), so the official Svelte compiler treats every `#id` selector as potentially-matching and emits **0 warnings**. Only a static `id="editor"` should be matched literally.

## Fix

Mirrors the existing `has_dynamic_classes` mechanism:

- New `has_dynamic_ids` flag on `CssAnalysis` / `CssContext`.
- The `regular_element` and `svelte:element` visitors set it for `id={expr}`, the `{id}` shorthand, and interpolated `id="a{x}"`; the `spread_attribute` visitor sets it too (a `{...rest}` spread could set `id`).
- `is_simple_selector_unused` — and the `:is()`-inner `IdSelector` branch — short-circuit to "used" when `has_dynamic_ids` is set, exactly like the class path does for `has_dynamic_classes`.

A static `id` is still matched literally, so a genuinely-unmatched `#missing` continues to warn.

Verified against the official Svelte compiler: dynamic shorthand, `id={expr}`, interpolated id, and spread all yield 0 warnings.

## Tests

- New `crates/rsvelte_core/tests/css_dynamic_id.rs` (shorthand / expression / interpolated → no warning; static match → no warning; static mismatch → still warns).
- Full CSS fixture suite and the compatibility report (`--test css --test compatibility_report`) pass with no regressions.

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)