### PR TITLE
fix(css): report only the unused `:is()`/`:where()` branch, not the whole compound (#722)

### DIFF
--- a/.changeset/css-is-where-branch-unused.md
+++ b/.changeset/css-is-where-branch-unused.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(css): treat `:is()`/`:where()` as an OR-set in unused-selector detection so a compound like `:is(.a, .b) + .c` is recognised as used and only the genuinely-unreachable branch (`.b`) is flagged, instead of the whole selector (#722)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -2290,45 +2290,75 @@ struct SelectorInfo {
     classes: Vec<String>,
     id: Option<String>,
     is_universal: bool,
+    /// `:is(...)` / `:where(...)` argument groups present in this compound. Each
+    /// group is the set of branch selectors; the group is satisfied when **any**
+    /// branch matches the element (an OR set), mirroring CSS `:is()` semantics.
+    /// A multi-part branch (one containing combinators) is recorded as a
+    /// universal branch so it conservatively matches, matching upstream's
+    /// treatment of complex `:is()` arguments as used.
+    is_groups: Vec<Vec<SelectorInfo>>,
 }
 
 fn extract_selector_info(rel_selector: &Value) -> SelectorInfo {
-    let mut info = SelectorInfo {
-        tag_name: None,
-        classes: Vec::new(),
-        id: None,
-        is_universal: false,
-    };
-
     if let Some(selectors) = rel_selector.get("selectors").and_then(|s| s.as_array()) {
-        for sel in selectors {
-            let sel_type = sel.get("type").and_then(|t| t.as_str());
-            match sel_type {
-                Some("TypeSelector") => {
-                    if let Some(name) = sel.get("name").and_then(|n| n.as_str()) {
-                        if name == "*" {
-                            info.is_universal = true;
-                        } else {
-                            info.tag_name = Some(name.to_string());
-                        }
-                    }
-                }
-                Some("ClassSelector") => {
-                    if let Some(name) = sel.get("name").and_then(|n| n.as_str()) {
-                        info.classes.push(name.to_string());
-                    }
-                }
-                Some("IdSelector") => {
-                    if let Some(name) = sel.get("name").and_then(|n| n.as_str()) {
-                        info.id = Some(name.to_string());
-                    }
-                }
-                _ => {}
-            }
+        extract_selector_info_from_selectors(selectors)
+    } else {
+        SelectorInfo {
+            tag_name: None,
+            classes: Vec::new(),
+            id: None,
+            is_universal: false,
+            is_groups: Vec::new(),
         }
     }
+}
 
-    info
+/// Build `:is(...)` / `:where(...)` OR-groups from a compound's simple selectors.
+/// Each returned group is the set of branch [`SelectorInfo`]s; the group is
+/// satisfied when any branch matches (see [`selector_matches_element`]).
+fn extract_is_groups(selectors: &[Value]) -> Vec<Vec<SelectorInfo>> {
+    let mut groups = Vec::new();
+    for sel in selectors {
+        if sel.get("type").and_then(|t| t.as_str()) != Some("PseudoClassSelector") {
+            continue;
+        }
+        let name = sel.get("name").and_then(|n| n.as_str()).unwrap_or("");
+        if name != "is" && name != "where" {
+            continue;
+        }
+        let Some(children) = sel
+            .get("args")
+            .and_then(|a| a.get("children"))
+            .and_then(|c| c.as_array())
+        else {
+            continue;
+        };
+        let mut branches: Vec<SelectorInfo> = Vec::new();
+        for branch in children {
+            let rels = branch.get("children").and_then(|c| c.as_array());
+            match rels {
+                // Single compound (no combinator): match against its constraints.
+                Some(rs) if rs.len() == 1 => {
+                    if let Some(inner) = rs[0].get("selectors").and_then(|s| s.as_array()) {
+                        branches.push(extract_selector_info_from_selectors(inner));
+                    }
+                }
+                // Multi-part or empty branch: conservatively treat as matching,
+                // mirroring upstream marking complex `:is()` args as used.
+                _ => branches.push(SelectorInfo {
+                    tag_name: None,
+                    classes: Vec::new(),
+                    id: None,
+                    is_universal: true,
+                    is_groups: Vec::new(),
+                }),
+            }
+        }
+        if !branches.is_empty() {
+            groups.push(branches);
+        }
+    }
+    groups
 }
 
 fn selector_matches_element(
@@ -2362,8 +2392,23 @@ fn selector_matches_element(
         return false;
     }
 
+    // Check `:is()` / `:where()` groups: each group must have at least one
+    // branch that matches the element (OR within a group, AND across groups).
+    for group in &info.is_groups {
+        if !group
+            .iter()
+            .any(|branch| selector_matches_element(branch, el))
+        {
+            return false;
+        }
+    }
+
     // If no selector specified, it matches nothing specific
-    info.tag_name.is_some() || !info.classes.is_empty() || info.id.is_some() || info.is_universal
+    info.tag_name.is_some()
+        || !info.classes.is_empty()
+        || info.id.is_some()
+        || info.is_universal
+        || !info.is_groups.is_empty()
 }
 
 fn has_sibling_match(
@@ -3247,6 +3292,7 @@ fn extract_selector_info_from_selectors(selectors: &[Value]) -> SelectorInfo {
         classes: Vec::new(),
         id: None,
         is_universal: false,
+        is_groups: extract_is_groups(selectors),
     };
 
     for sel in selectors {
@@ -3271,7 +3317,8 @@ fn extract_selector_info_from_selectors(selectors: &[Value]) -> SelectorInfo {
                     info.id = Some(decode_css_escape(name));
                 }
             }
-            // Skip pseudo-classes like :has(), :not(), etc.
+            // `:is()` / `:where()` handled via is_groups; skip other pseudo-classes
+            // (`:has()`, `:not()`, etc.).
             _ => {}
         }
     }

--- a/crates/rsvelte_core/tests/css_is_where_branch.rs
+++ b/crates/rsvelte_core/tests/css_is_where_branch.rs
@@ -1,0 +1,101 @@
+//! Regression test for issue #722.
+//!
+//! `:is()` / `:where()` is an OR-set: it matches when **any** argument branch
+//! matches. The unused-CSS-selector check must therefore (a) treat a compound
+//! containing `:is(...)` as *used* whenever one branch is reachable — including
+//! across sibling combinators — and (b) report only the genuinely-unreachable
+//! individual branch, not the whole compound.
+//!
+//! Note: the original issue report expected **0 warnings** for these cases, but
+//! the official Svelte compiler in fact reports the unused *branch* (e.g. `.b`).
+//! The real bug was that rsvelte over-reported the whole `:is(.a, .b) + .c`
+//! compound instead of just `.b`. These assertions match the official compiler
+//! (verified against `submodules/svelte`, v5.56.0).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn css_unused(src: &str) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .iter()
+    .filter(|w| w.code == "css_unused_selector")
+    .map(|w| w.message.lines().next().unwrap_or("").to_string())
+    .collect()
+}
+
+fn unused(s: &str) -> Vec<String> {
+    vec![format!("Unused CSS selector \"{s}\"")]
+}
+
+#[test]
+fn is_with_adjacent_sibling_reports_only_unused_branch() {
+    // `.a` and `.c` are present and adjacent → the compound is used;
+    // only the unreachable `.b` branch is reported (not the whole selector).
+    let src = "<div class=\"a\"></div><div class=\"c\"></div>\n\
+               <style>:is(.a, .b) + .c { color: red }</style>";
+    assert_eq!(css_unused(src), unused(".b"));
+}
+
+#[test]
+fn is_alone_reports_only_unused_branch() {
+    let src = "<div class=\"a\"></div>\n<style>:is(.a, .b) { color: red }</style>";
+    assert_eq!(css_unused(src), unused(".b"));
+}
+
+#[test]
+fn where_alone_reports_only_unused_branch() {
+    let src = "<div class=\"a\"></div>\n<style>:where(.a, .b) { color: red }</style>";
+    assert_eq!(css_unused(src), unused(".b"));
+}
+
+#[test]
+fn is_descendant_no_match_reports_whole() {
+    // No descendant of `div` matches `.a`/`.b` → whole selector unused.
+    let src = "<div class=\"a\"></div>\n<style>div :is(.a, .b) { color: red }</style>";
+    assert_eq!(css_unused(src), unused("div :is(.a, .b)"));
+}
+
+#[test]
+fn is_sibling_no_branch_present_reports_whole() {
+    // Neither branch is present → whole compound unused.
+    let src = "<style>:is(.x, .y) + .c { color: red }</style>";
+    assert_eq!(css_unused(src), unused(":is(.x, .y) + .c"));
+}
+
+#[test]
+fn is_adjacent_sibling_not_adjacent_reports_whole() {
+    // `.a` present but not adjacent to `.c` (a `<span>` sits between) → the `+`
+    // relationship fails, so the whole compound is unused.
+    let src = "<div class=\"a\"></div><span></span><div class=\"c\"></div>\n\
+               <style>:is(.a, .b) + .c { color: red }</style>";
+    assert_eq!(css_unused(src), unused(":is(.a, .b) + .c"));
+}
+
+#[test]
+fn is_general_sibling_reports_only_unused_branch() {
+    // `~` allows a non-adjacent previous sibling, so the compound is used; only
+    // the unreachable `.b` is reported.
+    let src = "<div class=\"a\"></div><span></span><div class=\"c\"></div>\n\
+               <style>:is(.a, .b) ~ .c { color: red }</style>";
+    assert_eq!(css_unused(src), unused(".b"));
+}
+
+#[test]
+fn is_with_multipart_branch_is_used() {
+    // A multi-part branch (`.a .nope`) is treated conservatively as matching, so
+    // the compound is used; only the simple unreachable `.b` is reported.
+    let src = "<div class=\"a\"></div><div class=\"c\"></div>\n\
+               <style>:is(.a .nope, .b) + .c { color: red }</style>";
+    assert_eq!(css_unused(src), unused(".b"));
+}


### PR DESCRIPTION
## Problem (#722)

`:is(a, b, …)` / `:where(a, b, …)` is an **OR-set**: it matches when *any* argument branch matches. The unused-CSS-selector check mishandled this across a sibling combinator:

```svelte
<div class="a"></div><div class="c"></div>
<style>:is(.a, .b) + .c { color: red }</style>
```

`.a` and `.c` are present and adjacent, so the rule applies — but rsvelte reported the **whole** `Unused CSS selector ":is(.a, .b) + .c"`.

### A note on the expected output

The issue expected **0 warnings**, but the official Svelte compiler actually reports the unused **branch** (`.b`) here — verified against `submodules/svelte` (v5.56.0):

| selector | elements | official Svelte | rsvelte (before) |
|---|---|---|---|
| `:is(.a, .b) + .c` | `.a`,`.c` adjacent | `.b` | `:is(.a, .b) + .c` ❌ |
| `:is(.a, .b)` | `.a` | `.b` | `.b` ✅ |
| `div :is(.a, .b)` | `.a` (no descendant) | `div :is(.a, .b)` | `div :is(.a, .b)` ✅ |

So the real bug was **over-reporting the whole compound** instead of the single unreachable branch.

## Root cause

`extract_selector_info` (used by the sibling/`:has` matchers) dropped `:is()`/`:where()` arguments entirely, so for `:is(.a, .b) + .c` the "before" selector was empty and never matched the adjacent `.a` element → the whole compound was declared unused, and the per-branch walk (which only runs when the compound is *used*) never fired.

## Fix

- `SelectorInfo` now carries `:is()`/`:where()` OR-groups (`is_groups`), built by a new `extract_is_groups` helper (recursive, shared by both extractors).
- `selector_matches_element` requires each group to have **at least one** matching branch (OR within a group, AND across groups).
- Multi-part branches (`:is(.a .b, …)`) are recorded as **universal** so they conservatively match — mirroring upstream treating complex `:is()` arguments as used.

With the compound correctly recognised as used, the existing per-branch walk reports only the genuinely-unreachable argument (`.b`).

## Tests

- New `crates/rsvelte_core/tests/css_is_where_branch.rs` — 8 cases (adjacent sibling, general sibling, descendant no-match, all-absent, non-adjacent `+`, multi-part branch, `:is`/`:where` alone), each asserting the exact official-Svelte output.
- Full CSS fixture suite and compatibility report (`--test css --test compatibility_report`) pass with no regressions.

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)