### PR TITLE
fix(release): sync Rust crate versions with changeset npm bumps so `--version` is accurate (#745)

### DIFF
--- a/.changeset/sync-crate-version.md
+++ b/.changeset/sync-crate-version.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(release): sync the Rust crate version into `crates/rsvelte_fmt/Cargo.toml` (and `Cargo.lock`) during the release, so `rsvelte-fmt --version` matches the published `@rsvelte/fmt` package instead of reporting a stale `0.1.0`. `sync-version.mjs` previously only mirrored `@rsvelte/compiler` → `rsvelte_core`; it now also mirrors `@rsvelte/fmt` → `rsvelte_fmt` (#745)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_fmt"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_fmt"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Fast Svelte + JS/TS/CSS formatter — dispatches .svelte to rsvelte_formatter and other files to oxfmt"

--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -1,12 +1,19 @@
 #!/usr/bin/env node
-// Sync the npm package version from `apps/npm/compiler/package.json`
-// (managed by changesets) into `crates/rsvelte_core/Cargo.toml` and the
-// repo-root `Cargo.lock`.
+// Sync each npm package version (managed by changesets) into the matching
+// Rust crate's `Cargo.toml` `[package].version` and the repo-root `Cargo.lock`.
 //
-// `wasm-pack build` derives `pkg/package.json` from the rsvelte_core
-// crate's Cargo.toml, so keeping these aligned is what makes "bump the
-// workspace package.json via changesets, then publish the freshly built
-// pkg/" produce a coherent npm release.
+// Why this exists:
+// - `@rsvelte/compiler` ← `crates/rsvelte_core`: `wasm-pack build` derives
+//   `pkg/package.json` from the crate's Cargo.toml, so keeping them aligned is
+//   what makes "bump the workspace package.json via changesets, then publish
+//   the freshly built pkg/" produce a coherent npm release.
+// - `@rsvelte/fmt` ← `crates/rsvelte_fmt`: the `rsvelte-fmt` binary reports its
+//   version from `env!("CARGO_PKG_VERSION")` (clap `#[command(version)]`).
+//   Without this sync the crate stayed at `0.1.0` no matter how many releases
+//   shipped, so `rsvelte-fmt --version` reported a stale version that never
+//   matched the published `@rsvelte/fmt` package (issue #745).
+//
+// Each binary's `--version` must match the npm package it ships in.
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -14,47 +21,75 @@ import { dirname, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../..');
-const npmPkgPath = resolve(repoRoot, 'apps/npm/compiler/package.json');
-const cargoTomlPath = resolve(repoRoot, 'crates/rsvelte_core/Cargo.toml');
+
+// npm package.json (changeset-managed) → Rust crate to mirror into.
+// `lockName` is the crate's `name` in Cargo.lock.
+const MAPPINGS = [
+	{
+		npm: 'apps/npm/compiler/package.json',
+		cargoToml: 'crates/rsvelte_core/Cargo.toml',
+		lockName: 'rsvelte_core',
+	},
+	{
+		npm: 'apps/npm/fmt/package.json',
+		cargoToml: 'crates/rsvelte_fmt/Cargo.toml',
+		lockName: 'rsvelte_fmt',
+	},
+];
+
 const cargoLockPath = resolve(repoRoot, 'Cargo.lock');
 
-const targetVersion = JSON.parse(readFileSync(npmPkgPath, 'utf8')).version;
-if (!targetVersion) {
-	console.error(`No "version" field in ${npmPkgPath}`);
-	process.exit(1);
+function readTargetVersion(npmRelPath) {
+	const npmPkgPath = resolve(repoRoot, npmRelPath);
+	const version = JSON.parse(readFileSync(npmPkgPath, 'utf8')).version;
+	if (!version) {
+		console.error(`No "version" field in ${npmPkgPath}`);
+		process.exit(1);
+	}
+	return version;
 }
 
-function patchCargoToml() {
+function patchCargoToml(cargoRelPath, targetVersion) {
+	const cargoTomlPath = resolve(repoRoot, cargoRelPath);
 	const original = readFileSync(cargoTomlPath, 'utf8');
 	// Replace the version line in the top-level [package] table only.
 	// `[package]` is the very first table in Cargo.toml; we match from it up
-	// to the next `[` (start of any other table) to scope the replacement.
+	// to its `version = "..."` line to scope the replacement.
 	const re = /(\[package\][\s\S]*?\nversion\s*=\s*")([^"]+)(")/;
 	const match = original.match(re);
 	if (!match) {
-		throw new Error('Failed to find [package].version in Cargo.toml');
+		throw new Error(`Failed to find [package].version in ${cargoRelPath}`);
 	}
 	if (match[2] === targetVersion) return;
 	writeFileSync(cargoTomlPath, original.replace(re, `$1${targetVersion}$3`));
 }
 
-function patchCargoLock() {
-	const original = readFileSync(cargoLockPath, 'utf8');
+function patchCargoLock(original, lockName, targetVersion) {
 	// Each package entry in Cargo.lock looks like:
 	//   [[package]]
-	//   name = "rsvelte_core"
+	//   name = "rsvelte_fmt"
 	//   version = "0.1.0"
 	// Match exactly the entry whose name is the crate we publish.
-	const re =
-		/(\[\[package\]\]\nname = "rsvelte_core"\nversion = ")([^"]+)(")/;
+	const re = new RegExp(
+		`(\\[\\[package\\]\\]\\nname = "${lockName}"\\nversion = ")([^"]+)(")`,
+	);
 	const match = original.match(re);
 	if (!match) {
-		throw new Error('Failed to find rsvelte_core entry in Cargo.lock');
+		throw new Error(`Failed to find ${lockName} entry in Cargo.lock`);
 	}
-	if (match[2] === targetVersion) return;
-	writeFileSync(cargoLockPath, original.replace(re, `$1${targetVersion}$3`));
+	if (match[2] === targetVersion) return original;
+	return original.replace(re, `$1${targetVersion}$3`);
 }
 
-patchCargoToml();
-patchCargoLock();
-console.log(`Synced version ${targetVersion} into Cargo.toml and Cargo.lock`);
+let lock = readFileSync(cargoLockPath, 'utf8');
+const synced = [];
+for (const { npm, cargoToml, lockName } of MAPPINGS) {
+	const targetVersion = readTargetVersion(npm);
+	patchCargoToml(cargoToml, targetVersion);
+	lock = patchCargoLock(lock, lockName, targetVersion);
+	synced.push(`${lockName}@${targetVersion}`);
+}
+writeFileSync(cargoLockPath, lock);
+console.log(
+	`Synced versions into Cargo.toml and Cargo.lock: ${synced.join(', ')}`,
+);


### PR DESCRIPTION
## Problem (#745)

`rsvelte-fmt --version` reported `rsvelte_fmt 0.1.0` while the published `@rsvelte/fmt` package was already `0.3.0`:

```sh
npm i -D @rsvelte/fmt@0.3.0
./node_modules/@rsvelte/fmt-<platform>/rsvelte-fmt --version
# => rsvelte_fmt 0.1.0   (expected 0.3.0)
```

The binary's version comes from `env!("CARGO_PKG_VERSION")` (clap `#[command(version)]`), but the release-time `scripts/release/sync-version.mjs` only mirrored `@rsvelte/compiler` → `crates/rsvelte_core/Cargo.toml`. `crates/rsvelte_fmt/Cargo.toml` was never bumped, so its `--version` was frozen at the first release.

## Fix

- Generalise `sync-version.mjs` from a single hard-coded crate to a list of `(npm package.json → crate Cargo.toml + Cargo.lock name)` mappings, and add `@rsvelte/fmt` → `rsvelte_fmt`. (`@rsvelte/compiler` → `rsvelte_core` is unchanged.)
- Bump `crates/rsvelte_fmt/Cargo.toml` (and its `Cargo.lock` entry) to the current `0.3.0` so the repo is immediately consistent; the changeset carries it forward on the next release.

Only `rsvelte-fmt` exposes a `--version` flag among the shipped binaries — `svelte_check` has none and the vps-native package is a library — so `rsvelte_fmt` is the one crate that needed syncing.

## Verification

```
$ cargo run --bin rsvelte-fmt -- --version
rsvelte_fmt 0.3.0      # was 0.1.0
```

`cargo metadata` confirms the lockfile stays consistent.

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)