### PR TITLE
fix(svelte2tsx): lower `class:`/`style:` directives as statements, not HTMLProps keys (#750)

### DIFF
--- a/.changeset/class-style-directive-tsx.md
+++ b/.changeset/class-style-directive-tsx.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): lower `class:`/`style:` directives as statements after the element's `createElement(...)` call instead of as `HTMLProps` object keys, so `--tsgo` no longer reports false `'"class:NAME"' does not exist in type 'HTMLProps<…>'` excess-property errors (#750)

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -1888,10 +1888,17 @@ fn handle_regular_element(
         options.is_ts_file,
     );
 
-    // When all surviving props are empty but a `bind:` directive was
-    // stripped, JS reference still leaves whitespace inside `{ }`. Add a
-    // single space so `createElement("div", { })` matches.
-    if segs_is_empty(&attr_segs) && !bind_suffix.is_empty() {
+    // `class:` / `style:` directives are lowered to statements appended after
+    // the `createElement(...)` call (NOT as typed props keys). See
+    // `build_class_style_directive_suffix_segments`.
+    let class_style_suffix_segs =
+        build_class_style_directive_suffix_segments(&el.attributes, source);
+
+    // When all surviving props are empty but a `bind:` / `class:` / `style:`
+    // directive was stripped, JS reference still leaves whitespace inside
+    // `{ }`. Add a single space so `createElement("div", { })` matches.
+    if segs_is_empty(&attr_segs) && (!bind_suffix.is_empty() || !class_style_suffix_segs.is_empty())
+    {
         attr_segs.push(Seg::Lit(" ".into()));
     }
 
@@ -1905,27 +1912,31 @@ fn handle_regular_element(
     } else {
         String::new()
     };
-    let (header_lit, trailer_lit) = if !directive_prefix.is_empty() {
-        (
-            format!(
-                " {{{}{{ {}svelteHTML.createElement(\"{}\"{}, {{",
-                directive_prefix, element_var_decl, el.name, actions_arg,
-            ),
-            format!("}});{}{}", directive_suffix, bind_suffix),
+    let header_lit = if !directive_prefix.is_empty() {
+        format!(
+            " {{{}{{ {}svelteHTML.createElement(\"{}\"{}, {{",
+            directive_prefix, element_var_decl, el.name, actions_arg,
         )
     } else {
-        (
-            format!(
-                " {{ {}svelteHTML.createElement(\"{}\"{}, {{",
-                element_var_decl, el.name, actions_arg,
-            ),
-            format!("}});{}{}", directive_suffix, bind_suffix),
+        format!(
+            " {{ {}svelteHTML.createElement(\"{}\"{}, {{",
+            element_var_decl, el.name, actions_arg,
         )
     };
-    let mut opener_segs: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 2);
+    // The trailer closes the props object + createElement call (`}});`), then
+    // appends the `class:` / `style:` directive statements (segmented, so their
+    // expression chunks keep their source mapping), then the transition/animate
+    // (`directive_suffix`) and `bind:` (`bind_suffix`) suffixes.
+    let mut opener_segs: Vec<Seg> =
+        Vec::with_capacity(attr_segs.len() + class_style_suffix_segs.len() + 3);
     opener_segs.push(Seg::Lit(header_lit));
     opener_segs.extend(attr_segs);
-    opener_segs.push(Seg::Lit(trailer_lit));
+    // Close the props object + createElement call: `});` (one `}` for the
+    // props brace, then `)` + `;`). The outer block `{` is closed after the
+    // children by the closing-tag overwrite.
+    opener_segs.push(Seg::Lit("});".to_string()));
+    opener_segs.extend(class_style_suffix_segs);
+    opener_segs.push(Seg::Lit(format!("{}{}", directive_suffix, bind_suffix)));
     emit_segmented_overwrite(str, el.start, opening_tag_end, &opener_segs);
 
     // Process children
@@ -3162,15 +3173,15 @@ fn build_attribute_segments(attributes: &[Attribute], source: &str, parent_tag: 
                 push_with_separator(&mut segs, part);
                 any_pushed = true;
             }
-            Attribute::ClassDirective(class) => {
-                let part = format_class_directive_segments(class, source);
-                push_with_separator(&mut segs, part);
-                any_pushed = true;
-            }
-            Attribute::StyleDirective(style) => {
-                let part = format_style_directive_segments(style, source);
-                push_with_separator(&mut segs, part);
-                any_pushed = true;
+            Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => {
+                // `class:`/`style:` are directives, not attributes — they must
+                // NOT be emitted as `HTMLProps` keys (the props object is
+                // type-checked against `HTMLProps<tag, …>`, which has no
+                // `class:NAME` / `style:PROP` keys, so they would trip the
+                // excess-property check). They are lowered to statements
+                // appended *after* the `createElement(...)` call by
+                // `build_class_style_directive_suffix_segments`, mirroring
+                // upstream `htmlxtojsx_v2/nodes/{Class,StyleDirective}.ts`.
             }
             Attribute::TransitionDirective(_)
             | Attribute::UseDirective(_)
@@ -3655,6 +3666,83 @@ fn format_on_directive_segments(on: &OnDirective, source: &str) -> Vec<Seg> {
     } else {
         // Event forwarding has no expression to preserve.
         segs_push_lit(&mut out, &format!("\"on:{}\":undefined,", on.name));
+    }
+    out
+}
+
+/// Lower `class:` / `style:` directives as statements appended *after* the
+/// element's `svelteHTML.createElement(...)` call, instead of as keys in the
+/// (typed) props object. Mirrors upstream `htmlxtojsx_v2/nodes/Class.ts`
+/// (`class:xx={yyy}` → `yyy;`) and `StyleDirective.ts`
+/// (`style:xx={yy}` → `__sveltets_2_ensureType(String, Number, yy);`). The
+/// expression chunks are preserved as `Seg::Src` so type errors map back to
+/// the original column.
+fn build_class_style_directive_suffix_segments(attributes: &[Attribute], source: &str) -> Vec<Seg> {
+    let mut out: Vec<Seg> = Vec::new();
+    for attr in attributes {
+        match attr {
+            Attribute::ClassDirective(class) => {
+                // `class:xx={expr}` → ` expr;` — type-check the toggle
+                // expression as a standalone statement.
+                segs_push_lit(&mut out, " ");
+                if let Some((s, e)) = get_expression_range(&class.expression) {
+                    segs_push_src(&mut out, s, e);
+                } else {
+                    segs_push_lit(&mut out, get_expression_text(&class.expression, source));
+                }
+                segs_push_lit(&mut out, ";");
+            }
+            Attribute::StyleDirective(style) => {
+                // `style:xx={expr}` → ` __sveltets_2_ensureType(String, Number, expr);`
+                segs_push_lit(&mut out, " __sveltets_2_ensureType(String, Number, ");
+                match &style.value {
+                    AttributeValue::True(_) => {
+                        // Shorthand `style:color` → `…, color);` (implicit
+                        // reference to the `color` binding; synthesised from
+                        // the directive name, so no source range to pin).
+                        segs_push_lit(&mut out, &style.name);
+                    }
+                    AttributeValue::Expression(expr) => {
+                        if let Some((s, e)) = get_expression_range(&expr.expression) {
+                            segs_push_src(&mut out, s, e);
+                        } else {
+                            segs_push_lit(&mut out, get_expression_text(&expr.expression, source));
+                        }
+                    }
+                    AttributeValue::Sequence(parts) => {
+                        // `style:xx="a{b}"` → a template string `` `a${b}` ``.
+                        segs_push_lit(&mut out, "`");
+                        for part in parts {
+                            match part {
+                                AttributeValuePart::Text(text) => {
+                                    let escaped = text
+                                        .raw
+                                        .replace('\\', "\\\\")
+                                        .replace('`', "\\`")
+                                        .replace('$', "\\$");
+                                    segs_push_lit(&mut out, &escaped);
+                                }
+                                AttributeValuePart::ExpressionTag(expr) => {
+                                    segs_push_lit(&mut out, "${");
+                                    if let Some((s, e)) = get_expression_range(&expr.expression) {
+                                        segs_push_src(&mut out, s, e);
+                                    } else {
+                                        segs_push_lit(
+                                            &mut out,
+                                            get_expression_text(&expr.expression, source),
+                                        );
+                                    }
+                                    segs_push_lit(&mut out, "}");
+                                }
+                            }
+                        }
+                        segs_push_lit(&mut out, "`");
+                    }
+                }
+                segs_push_lit(&mut out, ");");
+            }
+            _ => {}
+        }
     }
     out
 }

--- a/crates/rsvelte_core/tests/svelte2tsx_class_style_directive.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_class_style_directive.rs
@@ -1,0 +1,107 @@
+//! Regression test for issue #750.
+//!
+//! `class:NAME` and `style:PROP` are **directives**, not attributes, so
+//! svelte2tsx must not emit them as keys in the element's `createElement`
+//! props object (typed as `HTMLProps<tag, …>`, which has no `class:` /
+//! `style:` keys — they would trip the excess-property check). Upstream
+//! svelte2tsx lowers them to statements appended *after* the
+//! `createElement(...)` call:
+//!   `class:xx={yyy}` → `yyy;`
+//!   `style:xx={yy}`  → `__sveltets_2_ensureType(String, Number, yy);`
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "T.svelte".to_string(),
+        is_ts_file: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+#[test]
+fn class_and_style_directives_are_not_props_keys() {
+    let out = to_tsx(
+        "<script lang=\"ts\">\n  let on = $state(true);\n  let z = 5;\n</script>\n\
+         <div class:checked={on} style:z-index={z}>hi</div>",
+    );
+
+    // The directive keys must NOT appear in the typed props object.
+    assert!(
+        !out.contains("\"class:checked\""),
+        "class: directive leaked into props object:\n{out}"
+    );
+    assert!(
+        !out.contains("\"style:z-index\""),
+        "style: directive leaked into props object:\n{out}"
+    );
+
+    // The props object is empty for this element.
+    assert!(
+        out.contains("svelteHTML.createElement(\"div\", { });"),
+        "expected empty props object, got:\n{out}"
+    );
+
+    // class: lowers to a bare expression statement; style: to ensureType.
+    assert!(
+        out.contains("); on;"),
+        "class: expr statement missing:\n{out}"
+    );
+    assert!(
+        out.contains("__sveltets_2_ensureType(String, Number, z);"),
+        "style: ensureType statement missing:\n{out}"
+    );
+}
+
+#[test]
+fn class_shorthand_directive_is_not_props_key() {
+    // `class:active` shorthand → `active;` (implicit `={active}`).
+    let out = to_tsx(
+        "<script lang=\"ts\">\n  let active = $state(true);\n</script>\n\
+         <div class:active>hi</div>",
+    );
+    assert!(
+        !out.contains("\"class:active\""),
+        "class: shorthand leaked into props:\n{out}"
+    );
+    assert!(
+        out.contains("); active;"),
+        "class: shorthand statement missing:\n{out}"
+    );
+}
+
+#[test]
+fn style_shorthand_directive_uses_ensure_type() {
+    // `style:color` shorthand → `__sveltets_2_ensureType(String, Number, color);`
+    let out = to_tsx(
+        "<script lang=\"ts\">\n  let color = 'red';\n</script>\n\
+         <div style:color>hi</div>",
+    );
+    assert!(
+        !out.contains("\"style:color\""),
+        "style: shorthand leaked into props:\n{out}"
+    );
+    assert!(
+        out.contains("__sveltets_2_ensureType(String, Number, color);"),
+        "style: shorthand ensureType missing:\n{out}"
+    );
+}
+
+#[test]
+fn class_style_alongside_real_attributes() {
+    // A real attribute stays in props; the directive does not.
+    let out = to_tsx(
+        "<script lang=\"ts\">\n  let on = $state(true);\n</script>\n\
+         <div id=\"x\" class:checked={on}>hi</div>",
+    );
+    assert!(out.contains("\"id\":"), "real attribute dropped:\n{out}");
+    assert!(
+        !out.contains("\"class:checked\""),
+        "class: directive leaked into props:\n{out}"
+    );
+    assert!(
+        out.contains("); on;"),
+        "class: expr statement missing:\n{out}"
+    );
+}


### PR DESCRIPTION
## Problem (#750)

`class:NAME` and `style:PROP` **directives** were emitted as string-literal keys in the element's `createElement` props object:

```tsx
{ svelteHTML.createElement("div", {  "class:checked":on,"style:z-index":z,});  }
```

That object is type-checked against `HTMLProps<tag, …>`, which has no `class:` / `style:` keys, so `--tsgo` reported a false error for every such directive:

```
Object literal may only specify known properties, and '"class:checked"' does not exist in type 'HTMLProps<"div", HTMLAttributes<any>>'.
```

High-impact: any component using `class:`/`style:` fails `--tsgo` (≈156 false errors in one design system). Official `svelte-check`: 0 errors.

## Root cause

`svelte/elements` HTML attribute types have no `` [key: `class:${string}`] `` / `` [key: `style:${string}`] `` index signatures, so directives must not be props keys. Upstream svelte2tsx lowers them to **statements appended after** the `createElement(...)` call (`htmlxtojsx_v2/nodes/{Class,StyleDirective}.ts`). rsvelte was baking them into the props object — a gap not covered by any existing fixture (no svelte2tsx sample uses an element `class:`/`style:` directive).

## Fix

- `build_attribute_segments` now skips `ClassDirective`/`StyleDirective` (no props contribution).
- New `build_class_style_directive_suffix_segments` emits them as statements into the element body, mirroring upstream:
  - `class:xx={yyy}` → `yyy;`
  - `style:xx={yy}` → `__sveltets_2_ensureType(String, Number, yy);`
  - `style:xx="a{b}"` → `__sveltets_2_ensureType(String, Number, ` + "`a${b}`" + `);`
  - `style:xx` (shorthand) → `__sveltets_2_ensureType(String, Number, xx);`
- Expression chunks are preserved as `Seg::Src` for column-accurate diagnostics.

Verified the generated overlay is balanced TSX with the directive keys gone:

```tsx
async () => {
 { svelteHTML.createElement("div", { }); on; __sveltets_2_ensureType(String, Number, z);  }};
```

## Tests

- New `crates/rsvelte_core/tests/svelte2tsx_class_style_directive.rs` (4 cases: class+style, class shorthand, style shorthand, directive alongside a real attribute).
- The full svelte2tsx fixture suite (253) passes with no regressions.

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)