### PR TITLE
fix(svelte2tsx): no spurious `children` prop for snippet-only component children (#752 part 1)

### DIFF
--- a/.changeset/component-snippet-children-prop.md
+++ b/.changeset/component-snippet-children-prop.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): don't synthesize a `children` prop when a component's only children are `{#snippet}` blocks (or comments/whitespace), so `--tsgo` no longer reports a false `'children' does not exist in type '$$ComponentProps'`. Mirrors upstream `handleImplicitChildren`. (partial fix for #752 — snippet-parameter typing is tracked separately)

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -2192,6 +2192,14 @@ fn has_component_slot_children(fragment: &Fragment, source: &str) -> bool {
                     }
                 }
             }
+            // `{#snippet}` blocks are passed as implicit *props*, not as
+            // default-slot content, so they must not trigger the synthetic
+            // `children` prop (which would otherwise produce a false
+            // `'children' does not exist in type '$$ComponentProps'`).
+            // Comments are likewise ignorable. Mirrors upstream
+            // `handleImplicitChildren`, which skips `SnippetBlock` / `Comment`
+            // and only fakes a `children` prop for a real default-slot child.
+            TemplateNode::SnippetBlock(_) | TemplateNode::Comment(_) => {}
             _ => return true,
         }
     }

--- a/crates/rsvelte_core/tests/svelte2tsx_component_snippet_children.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_component_snippet_children.rs
@@ -1,0 +1,63 @@
+//! Regression test for issue #752 (part 1: spurious `children` prop).
+//!
+//! Passing only `{#snippet}` blocks (plus whitespace/comments) to a component
+//! must NOT synthesize a `children` prop — snippets are implicit props, not
+//! default-slot content. Otherwise `--tsgo` reports a false
+//! `'children' does not exist in type '$$ComponentProps'`. Mirrors upstream
+//! `handleImplicitChildren`, which only fakes a `children` prop when there is
+//! a real (non-snippet, non-comment, non-whitespace) default-slot child.
+//!
+//! NOTE: the second half of #752 — typing `{#snippet row({id})}` parameters
+//! from the component's `Snippet<[…]>` prop (currently inferred as `any`) —
+//! requires lowering the snippet as an implicit prop and is tracked
+//! separately; it is NOT addressed by this test.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "T.svelte".to_string(),
+        is_ts_file: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+const CHILDREN_PROP: &str = "children:() => { return __sveltets_2_any(0); },";
+
+#[test]
+fn snippet_only_children_do_not_add_children_prop() {
+    let out = to_tsx(
+        "<script lang=\"ts\">import List from './List.svelte';</script>\n\
+         <List>\n  {#snippet row({ id })}{id}{/snippet}\n</List>",
+    );
+    assert!(
+        !out.contains(CHILDREN_PROP),
+        "snippet-only children must not add a `children` prop:\n{out}"
+    );
+}
+
+#[test]
+fn real_default_content_still_adds_children_prop() {
+    let out = to_tsx(
+        "<script lang=\"ts\">import List from './List.svelte';</script>\n\
+         <List>hello</List>",
+    );
+    assert!(
+        out.contains(CHILDREN_PROP),
+        "real default-slot content should still add a `children` prop:\n{out}"
+    );
+}
+
+#[test]
+fn mixed_snippet_and_content_adds_children_prop() {
+    // A non-snippet child alongside a snippet → still a default-slot child.
+    let out = to_tsx(
+        "<script lang=\"ts\">import List from './List.svelte';</script>\n\
+         <List>text{#snippet row({ id })}{id}{/snippet}</List>",
+    );
+    assert!(
+        out.contains(CHILDREN_PROP),
+        "mixed content should still add a `children` prop:\n{out}"
+    );
+}


### PR DESCRIPTION
## Problem (#752, part 1)

Passing only `{#snippet}` blocks to a component synthesized a `children` prop the component never declared, so `--tsgo` reported a false error:

```
'children' does not exist in type '$$ComponentProps'
```

(~42 such errors in one design system.) Official `svelte-check`: 0 errors.

## Fix

`has_component_slot_children` returned `true` for any non-whitespace child, including `{#snippet}` blocks. But snippets are passed as implicit **props**, not as default-slot content, so they must not trigger the synthetic `children` prop. Skip `SnippetBlock` / `Comment` children — mirroring upstream `handleImplicitChildren`, which only fakes a `children` prop for a real default-slot child. A non-snippet child alongside a snippet still gets the `children` prop.

## Tests

- New `crates/rsvelte_core/tests/svelte2tsx_component_snippet_children.rs` (snippet-only → no children prop; real content → children prop; mixed → children prop).
- Full svelte2tsx fixture suite (253) passes.

## Scope — does NOT close #752

This is **part 1**. The second half of #752 — typing `{#snippet row({id})}` parameters from the component's `Snippet<[…]>` prop (currently inferred as `any`, ~105 errors) — requires lowering the snippet as an **implicit prop** (relocating it into the props object so it is contextually typed via `$$prop_def`), which is a substantially larger and riskier change. It is tracked separately and this PR intentionally leaves #752 open.

Refs #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)