### PR TITLE
fix(css): flag `:is()` branches unreachable through a combinator as unused (#754)

### DIFF
--- a/.changeset/is-branch-combinator-unused.md
+++ b/.changeset/is-branch-combinator-unused.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(css): evaluate each `:is()`/`:where()` branch in the context of its surrounding combinator when detecting unused selectors, so an unreachable branch (e.g. `.a` in `:is(.a, .b) + .c` when `.c` never immediately follows `.a`) is correctly flagged unused — matching the official compiler instead of silently passing (#754)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -109,6 +109,29 @@ pub fn collect_css_unused_warnings(
 ///
 /// For example, `x :is(y, .unused)` - if the overall selector is used but `.unused`
 /// inside :is() doesn't match any DOM element, report it.
+/// Clone `complex` and replace the simple selector at `children[ri].selectors[si]`
+/// (a `:is()` / `:where()` pseudo-class) with `branch_selectors` — the simple
+/// selectors of one of its single-compound argument branches. The rest of the
+/// compound (combinators, sibling/descendant relations, other simple selectors)
+/// is preserved, so the result can be reachability-checked as if that branch
+/// had been written in place of the `:is()`.
+fn substitute_is_branch(
+    complex: &Value,
+    ri: usize,
+    si: usize,
+    branch_selectors: &[Value],
+) -> Value {
+    let mut synth = complex.clone();
+    if let Some(children) = synth.get_mut("children").and_then(|c| c.as_array_mut())
+        && let Some(rel) = children.get_mut(ri)
+        && let Some(sels) = rel.get_mut("selectors").and_then(|s| s.as_array_mut())
+        && si < sels.len()
+    {
+        sels.splice(si..si + 1, branch_selectors.iter().cloned());
+    }
+    synth
+}
+
 fn collect_is_where_unused_warnings(
     complex_selector: &Value,
     css_source: &str,
@@ -121,13 +144,13 @@ fn collect_is_where_unused_warnings(
         None => return,
     };
 
-    for rel in rel_selectors {
+    for (ri, rel) in rel_selectors.iter().enumerate() {
         let selectors = match rel.get("selectors").and_then(|s| s.as_array()) {
             Some(s) => s,
             None => continue,
         };
 
-        for sel in selectors {
+        for (si, sel) in selectors.iter().enumerate() {
             let sel_type = sel.get("type").and_then(|t| t.as_str()).unwrap_or("");
             let sel_name = sel.get("name").and_then(|n| n.as_str()).unwrap_or("");
 
@@ -151,7 +174,34 @@ fn collect_is_where_unused_warnings(
                         continue;
                     }
 
-                    if is_complex_selector_unused(inner_complex, ctx) {
+                    // Evaluate the branch IN THE CONTEXT of the surrounding
+                    // compound, not in isolation: substitute the branch's
+                    // simple selectors in place of the `:is()` / `:where()` in
+                    // the parent complex selector and check whether the whole
+                    // substituted selector is reachable. This catches branches
+                    // that are unreachable only because of a combinator — e.g.
+                    // for `:is(.a, .b) + .c` where `.c` never immediately
+                    // follows `.a`, the `.a` branch is unused even though a
+                    // bare `.a` element exists. Mirrors upstream marking each
+                    // `:is` argument's `metadata.used` during the real walk.
+                    let branch_selectors = inner_complex
+                        .get("children")
+                        .and_then(|c| c.as_array())
+                        .and_then(|a| a.first())
+                        .and_then(|r| r.get("selectors"))
+                        .and_then(|s| s.as_array());
+
+                    let unused = match branch_selectors {
+                        Some(bs) => {
+                            let synth = substitute_is_branch(complex_selector, ri, si, bs);
+                            is_complex_selector_unused(&synth, ctx)
+                        }
+                        // Empty branch (e.g. `:is()`) — fall back to the
+                        // isolated check.
+                        None => is_complex_selector_unused(inner_complex, ctx),
+                    };
+
+                    if unused {
                         let start = inner_complex
                             .get("start")
                             .and_then(|s| s.as_u64())

--- a/crates/rsvelte_core/tests/css_is_branch_combinator.rs
+++ b/crates/rsvelte_core/tests/css_is_branch_combinator.rs
@@ -1,0 +1,73 @@
+//! Regression test for issue #754.
+//!
+//! For `:is(a, b) + .c`, an `:is()` branch must be evaluated **in the context
+//! of the surrounding combinator**, not in isolation. If only one branch can
+//! satisfy the combinator relationship, the other branch is unused even though
+//! a bare element matching it exists. The official Svelte compiler reports the
+//! unreachable branch; rsvelte previously missed it (false negative). Verified
+//! against `submodules/svelte` (v5.56.0).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn css_unused(src: &str) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .iter()
+    .filter(|w| w.code == "css_unused_selector")
+    .map(|w| w.message.lines().next().unwrap_or("").to_string())
+    .collect()
+}
+
+fn unused(s: &str) -> Vec<String> {
+    vec![format!("Unused CSS selector \"{s}\"")]
+}
+
+#[test]
+fn adjacent_unreachable_branch_is_flagged() {
+    // Order a,b,c → `.c` follows `.b` (`.b + .c` matches) but never `.a`.
+    let src = "<div class=\"a\"></div><div class=\"b\"></div><div class=\"c\"></div>\n\
+               <style>:is(.a, .b) + .c { color: red }</style>";
+    assert_eq!(css_unused(src), unused(".a"));
+}
+
+#[test]
+fn adjacent_unreachable_branch_reverse_order() {
+    // Order b,a,c → now `.a + .c` matches, `.b + .c` is unreachable.
+    let src = "<div class=\"b\"></div><div class=\"a\"></div><div class=\"c\"></div>\n\
+               <style>:is(.a, .b) + .c { color: red }</style>";
+    assert_eq!(css_unused(src), unused(".b"));
+}
+
+#[test]
+fn general_sibling_both_branches_reachable() {
+    // `~` allows any previous sibling, so both `.a ~ .c` and `.b ~ .c` match.
+    let src = "<div class=\"a\"></div><div class=\"b\"></div><div class=\"c\"></div>\n\
+               <style>:is(.a, .b) ~ .c { color: red }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn both_branches_adjacent_no_warning() {
+    // Layout a,c,b,c → both `.a + .c` and `.b + .c` are satisfiable.
+    let src = "<div class=\"a\"></div><div class=\"c\"></div><div class=\"b\"></div><div class=\"c\"></div>\n\
+               <style>:is(.a, .b) + .c { color: red }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn is_alone_still_reports_absent_branch() {
+    // Regression guard for #722: `:is(.a, .b)` with only `.a` → flag `.b`.
+    let src = "<div class=\"a\"></div>\n<style>:is(.a, .b) { color: red }</style>";
+    assert_eq!(css_unused(src), unused(".b"));
+}


### PR DESCRIPTION
## Problem (#754, low priority — false negative)

For `:is(.a, .b) + .c`, when only one branch can satisfy the combinator relationship the official compiler flags the other branch unused, but rsvelte did not.

```svelte
<div class="a"></div><div class="b"></div><div class="c"></div>
<style>:is(.a, .b) + .c { color: red }</style>
```

Markup order is `.a .b .c`, so `.c` immediately follows `.b` (`.b + .c` matches) but never `.a`.

- Official `svelte-check`: `Unused CSS selector ".a"`
- rsvelte (before): no warning

## Fix

`collect_is_where_unused_warnings` checked each `:is`/`:where` branch **in isolation** (a bare `.a` element exists → "used"), ignoring the surrounding combinator. Now each single-compound branch is substituted in place of the `:is()` in the parent complex selector (`substitute_is_branch`) and the **whole substituted selector** is reachability-checked — so `.a + .c` is recognised as unreachable and `.a` is reported. Mirrors upstream marking each `:is` argument's `metadata.used` during the real selector walk.

## Verification (vs official Svelte v5.56.0)

| layout | selector | official & rsvelte now |
|---|---|---|
| a,b,c | `:is(.a,.b) + .c` | `.a` |
| b,a,c | `:is(.a,.b) + .c` | `.b` |
| a,b,c | `:is(.a,.b) ~ .c` | none |
| a,c,b,c | `:is(.a,.b) + .c` | none |

The #722 behaviour (`:is(.a, .b)` with `.a` present → flag `.b`) still holds.

## Tests

- New `crates/rsvelte_core/tests/css_is_branch_combinator.rs` (5 cases).
- CSS fixture suite (181) + the #722 guard suite + the full compatibility report (3525) pass with no regressions.

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)