### PR TITLE
fix(svelte2tsx): valid TSX for pending-only / pending+catch `{#await}` blocks

### DIFF
--- a/.changeset/await-pending-only-tsx.md
+++ b/.changeset/await-pending-only-tsx.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): generate valid TSX for pending-only `{#await p}…{/await}` (and `{#await p}…{:catch e}…{/await}` with no `{:then}`). These shapes previously never opened the block, dropped the `await(promise)` entirely, and ignored the catch — producing brace-unbalanced TSX that tripped the program-wide `--tsgo` suppression. Now mirrors upstream `handleAwait`.

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -1506,14 +1506,55 @@ fn handle_await_block(
                 }
             }
         } else {
-            // No then after pending
+            // No `:then` after the pending block. Covers
+            // `{#await p}pending{/await}` (pending only) and
+            // `{#await p}pending{:catch e}…{/await}` (pending + catch, no then).
+            // Previously this branch emitted only a trailing `}` — it never
+            // opened the block, dropped the `await(promise)` entirely, and
+            // ignored the catch, producing brace-unbalanced / invalid TSX.
+            // Mirror upstream `handleAwait`: `{ <pending> [try {] await(p);
+            // [} catch($$_e) { … }] }`.
             let pending_end = if !pending.nodes.is_empty() {
                 pending.nodes.last().unwrap().end()
             } else {
                 pending_start
             };
-            if pending_end < block.end {
-                str.overwrite(pending_end, block.end, "}");
+
+            // Opening `{ ` — consume the `{#await PROMISE}` opener (PROMISE is
+            // re-emitted as `await(...)` after the pending body).
+            str.overwrite(block.start, pending_start, "   { ");
+            process_fragment_inplace(pending, source, options, str, counter);
+
+            if let Some(ref catch) = block.catch {
+                let catch_start = if !catch.nodes.is_empty() {
+                    catch.nodes[0].start()
+                } else {
+                    block.end
+                };
+                let header = if !error_text.is_empty() {
+                    format!(
+                        "try {{ await ({});}} catch($$_e) {{ const {} = __sveltets_2_any();",
+                        expr_text, error_text
+                    )
+                } else {
+                    format!("try {{ await ({});}} catch($$_e) {{ ", expr_text)
+                };
+                if pending_end < catch_start {
+                    str.overwrite(pending_end, catch_start, &header);
+                } else {
+                    str.append_left(pending_end, &header);
+                }
+                process_fragment_inplace(catch, source, options, str, counter);
+                let catch_end = if !catch.nodes.is_empty() {
+                    catch.nodes.last().unwrap().end()
+                } else {
+                    catch_start
+                };
+                if catch_end < block.end {
+                    str.overwrite(catch_end, block.end, "}}");
+                }
+            } else if pending_end < block.end {
+                str.overwrite(pending_end, block.end, &format!("await ({});}}", expr_text));
             }
         }
     } else if has_then {

--- a/crates/rsvelte_core/tests/svelte2tsx_await_pending_only.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_await_pending_only.rs
@@ -1,0 +1,81 @@
+//! Regression test: pending-only / pending+catch `{#await}` blocks.
+//!
+//! `{#await p}…{/await}` (pending only, no `{:then}`/`{:catch}`) and
+//! `{#await p}…{:catch e}…{/await}` (pending + catch, no then) previously
+//! generated invalid TSX — the block was never opened, the `await(promise)`
+//! was dropped entirely, and the catch was ignored — so the overlay was
+//! brace-unbalanced (which trips the program-wide tsgo suppression). Now
+//! mirrors upstream `handleAwait`.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "T.svelte".to_string(),
+        is_ts_file: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+fn braces_balanced(s: &str) -> bool {
+    let mut depth: i32 = 0;
+    let mut in_str: Option<char> = None;
+    let mut prev = '\0';
+    for c in s.chars() {
+        match in_str {
+            Some(q) => {
+                if c == q && prev != '\\' {
+                    in_str = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' | '`' => in_str = Some(c),
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            },
+        }
+        if depth < 0 {
+            return false;
+        }
+        prev = c;
+    }
+    depth == 0
+}
+
+const PRELUDE: &str = "<script lang=\"ts\">const p = Promise.resolve(true);</script>\n";
+
+#[test]
+fn pending_only_is_balanced_and_awaits_promise() {
+    let out = to_tsx(&format!("{PRELUDE}{{#await p}}wait{{/await}}"));
+    assert!(braces_balanced(&out), "unbalanced:\n{out}");
+    assert!(out.contains("await (p)"), "promise not awaited:\n{out}");
+}
+
+#[test]
+fn pending_then_catch_no_then_is_balanced() {
+    let out = to_tsx(&format!(
+        "{PRELUDE}{{#await p}}wait{{:catch e}}{{e}}{{/await}}"
+    ));
+    assert!(braces_balanced(&out), "unbalanced:\n{out}");
+    assert!(out.contains("await (p)"), "promise not awaited:\n{out}");
+    assert!(
+        out.contains("} catch($$_e) {"),
+        "missing balanced catch:\n{out}"
+    );
+    assert!(
+        out.contains("const e = __sveltets_2_any();"),
+        "catch var lost:\n{out}"
+    );
+}
+
+#[test]
+fn pending_catch_no_var_is_balanced() {
+    let out = to_tsx(&format!("{PRELUDE}{{#await p}}wait{{:catch}}err{{/await}}"));
+    assert!(braces_balanced(&out), "unbalanced:\n{out}");
+    assert!(
+        out.contains("} catch($$_e) {"),
+        "missing balanced catch:\n{out}"
+    );
+}


### PR DESCRIPTION
## Problem

`{#await p}pending{/await}` (pending only, no `{:then}`/`{:catch}`) and `{#await p}pending{:catch e}…{/await}` (pending + catch, no then) generated **invalid TSX**: the no-`{:then}` pending branch emitted only a trailing `}` — it never opened the block, dropped the `await(promise)` entirely, and ignored the catch. The overlay was brace-unbalanced, which trips the program-wide `--tsgo` semantic-diagnostic suppression (the #728 path → hides all real type errors).

Discovered while fixing #753 (that PR scoped its regression to the catch cases and explicitly noted this as a separate pre-existing bug).

## Fix

Mirror upstream `handleAwait`: emit `{ <pending> [try {] await(p); [} catch($$_e) { … }] }`, processing the pending and catch fragments in place. Pending-only → `{ <pending> await(p); }`; pending+catch → wraps the await in `try { … } catch($$_e) { … }`.

## Tests

- New `crates/rsvelte_core/tests/svelte2tsx_await_pending_only.rs` — asserts whole-overlay brace balance, that `await(p)` is emitted, and the balanced `catch($$_e)` shape.
- `#753` await regression suite and the full svelte2tsx fixture suite (253) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)