### PR TITLE
fix(fmt): keep `{:else if}` branches at the opening `{#if}` depth

### DIFF
--- a/.changeset/fix-else-if-indent.md
+++ b/.changeset/fix-else-if-indent.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Keep `{:else if}` branches at the same indent as the opening `{#if}`, matching `oxfmt` / prettier-plugin-svelte.
+
+svelte desugars `{:else if}` into an `elseif` `IfBlock` nested inside the alternate fragment. Both the whitespace re-indent pass (`indent.rs`) and the open-tag pass (`markup.rs`) recursed into that nested block, adding one extra indent level per chained branch — so `{:else if}` / `{:else}` bodies (and their wrapped attributes) drifted one level deeper than `oxfmt` on every chain. They now follow the chain at the opening `{#if}`'s depth. A plain `{:else}` whose body merely starts with an `{#if}` is unaffected (it still nests one level deeper).
+
+On a 1,115-file Svelte corpus this brings oxfmt-divergent files from 264 to 208.

--- a/crates/rsvelte_formatter/src/indent.rs
+++ b/crates/rsvelte_formatter/src/indent.rs
@@ -15,7 +15,7 @@
 //! (`{#if}` / `{#each}` / ...) add one indent level to their bodies.
 
 use oxc_formatter::JsFormatOptions;
-use rsvelte_core::ast::template::{Fragment, TemplateNode};
+use rsvelte_core::ast::template::{Fragment, IfBlock, TemplateNode};
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
@@ -118,9 +118,25 @@ fn recurse_into_children(
             collect_indent_edits(source, &e.fragment, next_depth, options, edits)?;
         }
         TemplateNode::IfBlock(blk) => {
-            collect_indent_edits(source, &blk.consequent, next_depth, options, edits)?;
-            if let Some(alt) = &blk.alternate {
-                collect_indent_edits(source, alt, next_depth, options, edits)?;
+            // Walk the `{#if} / {:else if} / {:else}` chain at one consistent
+            // depth. svelte desugars `{:else if}` into an alternate fragment
+            // whose sole child is another IfBlock (`elseif = true`); prettier
+            // keeps every chained branch at the same indent as the opening
+            // `{#if}`, so follow the chain here rather than recursing (which
+            // would add one level per `{:else if}`).
+            let mut current: &IfBlock = blk;
+            loop {
+                collect_indent_edits(source, &current.consequent, next_depth, options, edits)?;
+                match &current.alternate {
+                    Some(alt) => match else_if_branch(alt) {
+                        Some(chained) => current = chained,
+                        None => {
+                            collect_indent_edits(source, alt, next_depth, options, edits)?;
+                            break;
+                        }
+                    },
+                    None => break,
+                }
             }
         }
         TemplateNode::EachBlock(blk) => {
@@ -149,6 +165,18 @@ fn recurse_into_children(
         _ => {}
     }
     Ok(())
+}
+
+/// If `alt` is the desugared body of an `{:else if}` — a fragment whose sole
+/// child is an `elseif` IfBlock — return that IfBlock so the caller can keep it
+/// at the same depth. A plain `{:else}` whose body merely starts with an
+/// `{#if}` carries surrounding whitespace text nodes (and `elseif == false`),
+/// so it won't match and is indented as a normal nested block.
+pub(crate) fn else_if_branch(alt: &Fragment) -> Option<&IfBlock> {
+    match alt.nodes.as_slice() {
+        [TemplateNode::IfBlock(b)] if b.elseif => Some(b.as_ref()),
+        _ => None,
+    }
 }
 
 fn is_indent_provoking(node: &TemplateNode) -> bool {

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -28,12 +28,13 @@
 use oxc_formatter::JsFormatOptions;
 use rsvelte_core::ast::js::Expression;
 use rsvelte_core::ast::template::{
-    Attribute, AttributeNode, AttributeValue, AttributeValuePart, ExpressionTag, Fragment,
+    Attribute, AttributeNode, AttributeValue, AttributeValuePart, ExpressionTag, Fragment, IfBlock,
     SpreadAttribute, TemplateNode,
 };
 
 use crate::error::FormatError;
 use crate::expression::format_expression_source;
+use crate::indent::else_if_branch;
 use crate::options::FormatOptions;
 
 /// Walk a `Fragment` recursively and append open-tag rewrite edits for
@@ -168,9 +169,23 @@ fn collect_node_open_tag_edits(
         // Blocks have child fragments but no attributes themselves.
         // Their bodies are conceptually one level deeper than the block.
         TemplateNode::IfBlock(blk) => {
-            collect_open_tag_edits(source, &blk.consequent, depth + 1, options, edits)?;
-            if let Some(alt) = &blk.alternate {
-                collect_open_tag_edits(source, alt, depth + 1, options, edits)?;
+            // `{:else if}` chains stay at the same depth as the opening `{#if}`
+            // (svelte nests them as `elseif` IfBlocks in the alternate); follow
+            // the chain instead of recursing so attributes don't gain an extra
+            // indent level per branch. See `indent.rs::else_if_branch`.
+            let mut current: &IfBlock = blk;
+            loop {
+                collect_open_tag_edits(source, &current.consequent, depth + 1, options, edits)?;
+                match &current.alternate {
+                    Some(alt) => match else_if_branch(alt) {
+                        Some(chained) => current = chained,
+                        None => {
+                            collect_open_tag_edits(source, alt, depth + 1, options, edits)?;
+                            break;
+                        }
+                    },
+                    None => break,
+                }
             }
         }
         TemplateNode::EachBlock(blk) => {

--- a/crates/rsvelte_formatter/tests/block_indent.rs
+++ b/crates/rsvelte_formatter/tests/block_indent.rs
@@ -1,0 +1,80 @@
+//! Block-children indentation, matching prettier-plugin-svelte. The headline
+//! case: `{:else if}` branches stay at the same depth as the opening `{#if}`
+//! (svelte desugars them into `elseif` IfBlocks nested in the alternate),
+//! whereas a plain `{:else}` whose body is an `{#if}` is a genuine nested block
+//! and indents one level deeper.
+
+use rsvelte_formatter::{FormatOptions, format};
+
+fn fmt(src: &str) -> String {
+    format(src, &FormatOptions::default()).expect("format ok")
+}
+
+#[test]
+fn else_if_chain_does_not_nest_per_branch() {
+    // `<X>`, `<Y>` and `<Z>` all sit at the same depth; before the fix each
+    // `{:else if}` / `{:else}` branch gained an extra indent level.
+    let src = concat!(
+        "<nav>\n",
+        "  {#if a}\n",
+        "    <X />\n",
+        "  {:else if b}\n",
+        "    <Y />\n",
+        "  {:else}\n",
+        "    <Z />\n",
+        "  {/if}\n",
+        "</nav>\n",
+    );
+    assert_eq!(
+        fmt(src),
+        src,
+        "else-if branches must not gain an indent level each"
+    );
+}
+
+#[test]
+fn else_if_branch_open_tag_at_branch_depth() {
+    // The open-tag (markup.rs) path must also keep `{:else if}` branch elements
+    // at the branch depth, not one level deeper.
+    let src = concat!(
+        "{#if a}\n",
+        "  <Comp x={1} />\n",
+        "{:else if b}\n",
+        "  <Comp first={1} second={2} third={3} fourth={4} />\n",
+        "{/if}\n",
+    );
+    assert_eq!(fmt(src), src, "else-if branch element mis-indented");
+}
+
+#[test]
+fn plain_else_nested_if_indents_one_level_deeper() {
+    // A plain `{:else}` whose body is an `{#if}` is NOT an else-if chain (its
+    // alternate fragment carries whitespace and `elseif == false`), so the
+    // nested `{#if}` indents one level deeper, as prettier does.
+    let src = concat!(
+        "{#if a}\n",
+        "  <X />\n",
+        "{:else}\n",
+        "  {#if b}\n",
+        "    <Y />\n",
+        "  {/if}\n",
+        "{/if}\n",
+    );
+    assert_eq!(fmt(src), src, "plain else nested-if mis-indented");
+}
+
+#[test]
+fn else_if_chain_is_idempotent() {
+    let src = concat!(
+        "{#if a}\n",
+        "  <X />\n",
+        "{:else if b}\n",
+        "  <Y />\n",
+        "{:else if c}\n",
+        "  <Z />\n",
+        "{/if}\n",
+    );
+    let once = fmt(src);
+    let twice = fmt(&once);
+    assert_eq!(once, twice, "else-if indentation not idempotent:\n{once}");
+}


### PR DESCRIPTION
## What

`{:else if}` branches were indented one level too deep per chained branch. svelte desugars `{:else if}` into an `elseif` `IfBlock` nested inside the alternate fragment, and both the whitespace re-indent pass (`indent.rs`) and the open-tag pass (`markup.rs`) recursed into it with `+1` depth — so every chained branch, and its wrapped attributes, drifted one level deeper than `oxfmt` / prettier-plugin-svelte.

Both passes now follow the `{#if}` / `{:else if}` / `{:else}` chain at the opening `{#if}`'s depth (shared `else_if_branch` helper). A plain `{:else}` whose body merely starts with an `{#if}` (whitespace + `elseif == false`) is unaffected and still nests one level deeper.

Fixes #763.

## Verification

On a 1,115-file Svelte corpus, oxfmt-divergent files drop from **264 to 208** (the block-indent category, minus a handful that also carry unrelated attribute-wrap diffs tracked in #762). Zero parse failures, fully idempotent.

## Tests

`tests/block_indent.rs` — else-if chain depth across both the whitespace and open-tag paths, plain-`{:else}` nested-`{#if}` still indenting deeper, and idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
