### PR TITLE
fix(fmt): wrap open tags by visual (East Asian) width

### DIFF
--- a/.changeset/fix-attr-visual-width.md
+++ b/.changeset/fix-attr-visual-width.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Decide open-tag attribute wrapping by visual (East Asian) width, matching `oxfmt` / prettier.
+
+`visual_width` counted bare `chars()`, so CJK-heavy tags were under-measured: fullwidth text (Japanese, fullwidth punctuation, …) is two display columns each but counted as one, so a tag that exceeded `printWidth` on screen stayed on a single line instead of wrapping. Width is now measured with `unicode-width`, so an attribute list whose visual width crosses `printWidth` wraps one-per-line as `oxfmt` does.
+
+On a 1,115-file Svelte corpus this brings oxfmt-divergent files from 208 to 179. (The remaining attribute diffs are expression wrapping *inside* attribute values, which is `oxc_formatter`-driven and tracked in #761.)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,6 +2078,7 @@ dependencies = [
  "oxc_span",
  "rsvelte_core",
  "thiserror",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -28,6 +28,7 @@ oxc_span = "0.134"
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
 oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
 thiserror = "2.0"
+unicode-width = "0.1"
 
 [dev-dependencies]
 criterion = { version = "4.7.0", features = ["html_reports"], package = "codspeed-criterion-compat" }

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -31,6 +31,7 @@ use rsvelte_core::ast::template::{
     Attribute, AttributeNode, AttributeValue, AttributeValuePart, ExpressionTag, Fragment, IfBlock,
     SpreadAttribute, TemplateNode,
 };
+use unicode_width::UnicodeWidthStr;
 
 use crate::error::FormatError;
 use crate::expression::format_expression_source;
@@ -701,11 +702,13 @@ fn indent_visual_width(level: usize, js_opts: &JsFormatOptions) -> usize {
     level * js_opts.indent_width.value() as usize
 }
 
-/// Visual width of a rendered string. Today we count chars (close
-/// enough for ASCII attribute names + values). A proper grapheme /
-/// wide-char-aware count can drop in later if needed.
+/// Visual width of a rendered string, matching how `oxfmt` / prettier measure
+/// line length: East Asian Wide and Fullwidth characters (CJK text, fullwidth
+/// punctuation, …) count as two columns and combining marks as zero. Counting
+/// bare `chars()` under-measured CJK-heavy open tags, so they never crossed
+/// `printWidth` and never wrapped even when `oxfmt` would (#762).
 fn visual_width(s: &str) -> usize {
-    s.chars().count()
+    UnicodeWidthStr::width(s)
 }
 
 // ─── source-scan helpers ────────────────────────────────────────────────

--- a/crates/rsvelte_formatter/tests/attr_width.rs
+++ b/crates/rsvelte_formatter/tests/attr_width.rs
@@ -1,0 +1,43 @@
+//! Open-tag wrapping uses visual (East Asian) width, matching oxfmt /
+//! prettier: a tag that fits in character count but exceeds `printWidth` in
+//! display columns — CJK text counts as two columns — must still wrap onto
+//! one attribute per line.
+
+use rsvelte_formatter::{FormatOptions, format};
+
+fn fmt(src: &str) -> String {
+    format(src, &FormatOptions::default()).expect("format ok")
+}
+
+// A CJK description that is < 80 chars but > 80 display columns once the
+// fullwidth text is counted as 2 each.
+const CJK_TAG: &str = "<Alert pattern=\"info\" description=\"フォームに入力せずに作成した場合、組織名がテナント名になります\" />\n";
+
+#[test]
+fn cjk_attribute_wraps_at_print_width() {
+    let out = fmt(CJK_TAG);
+    assert!(
+        out.starts_with("<Alert\n  pattern=\"info\"\n"),
+        "CJK-heavy tag should wrap (visual width exceeds printWidth):\n{out}"
+    );
+    assert!(
+        out.contains("\n/>"),
+        "self-close should be on its own line:\n{out}"
+    );
+}
+
+#[test]
+fn short_ascii_tag_stays_one_line() {
+    let src = "<Alert pattern=\"info\" />\n";
+    assert_eq!(fmt(src), src, "short ASCII tag should not wrap");
+}
+
+#[test]
+fn cjk_width_wrap_is_idempotent() {
+    let once = fmt(CJK_TAG);
+    let twice = fmt(&once);
+    assert_eq!(
+        once, twice,
+        "CJK width-driven wrap is not idempotent:\n{once}"
+    );
+}


### PR DESCRIPTION
## What

Open-tag attribute wrapping was decided by `visual_width`, which counted bare `chars()`. CJK text (Japanese, fullwidth punctuation, …) is two display columns each but was counted as one, so a tag whose **visual** width exceeds `printWidth` — but whose character count doesn't — stayed on a single line instead of wrapping.

Width is now measured with `unicode-width` (East Asian Wide / Fullwidth → 2, combining marks → 0), matching how `oxfmt` / prettier measure line length. The attribute-wrap machinery (`render_multi_line`) already existed; only the width measurement was off.

Fixes #762.

## Verification

On a 1,115-file Svelte corpus, oxfmt-divergent files drop from **208 to 179**; the attribute-wrap category drops from 96 to 65. The remaining 65 are expression wrapping *inside* attribute values (ternaries, `{#snippet}` param types, `bind:` getter/setter) — that's `oxc_formatter`-driven and tracked in #761, not attribute-list wrapping.

## Tests

`tests/attr_width.rs` — CJK tag wraps at `printWidth`, short ASCII tag stays inline, idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
