### PR TITLE
chore(deps): align all workspace oxc deps to a single revision 71e489a (refs #761)

### DIFF
--- a/.changeset/oxc-formatter-align.md
+++ b/.changeset/oxc-formatter-align.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/fmt": patch
+"@rsvelte/compiler": patch
+---
+
+chore(deps): align all workspace `oxc` / `oxc_formatter` / `oxc_formatter_core` git deps to a single newer revision (71e489a). The split renovate bumps (#675/#676) fail CI because they move only `oxc_formatter`, leaving the ~15 other workspace `oxc` crates on the old revision — producing a duplicate `oxc_allocator` and an `E0308` mismatch. Unifying every `oxc` dep to the same revision fixes that; verified compiler-safe (compatibility report passes) and formatter-safe (all fmt fixtures pass). Step toward oxfmt parity for `<script>` formatting (refs #761).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "phf",
  "proc-macro2 1.0.106",
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1522,12 +1522,12 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 
 [[package]]
 name = "oxc_diagnostics"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1537,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1562,7 +1562,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter"
 version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_core"
 version = "0.53.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1622,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "oxc_jsdoc"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1632,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "itertools 0.14.0",
  "memchr",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1731,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=187e1a52c1e16c43c50c435579e1e2c2173e690f#187e1a52c1e16c43c50c435579e1e2c2173e690f"
+source = "git+https://github.com/oxc-project/oxc?rev=71e489a5c7871f1481d172611b4b10bee76066e5#71e489a5c7871f1481d172611b4b10bee76066e5"
 dependencies = [
  "bitflags",
  "cow-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,18 @@ panic = "unwind"  # Criterion requires unwind for catching panics
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -63,7 +63,7 @@ oxc_syntax = "0.134"
 oxc_semantic = "0.134"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/bin/fmt_benchmark_runner.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -25,8 +25,8 @@ oxc_allocator = "0.134"
 oxc_ast = "0.134"
 oxc_parser = "0.134"
 oxc_span = "0.134"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "187e1a52c1e16c43c50c435579e1e2c2173e690f" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "71e489a5c7871f1481d172611b4b10bee76066e5" }
 thiserror = "2.0"
 unicode-width = "0.1"
 


### PR DESCRIPTION
## What

Pins **every** workspace `oxc*` git dependency (`oxc_formatter`, `oxc_formatter_core`, `oxc_allocator`, `oxc_ast`, `oxc_parser`, `oxc_span`, … — 20 occurrences across the workspace + crate `Cargo.toml`s) to a single newer revision **`71e489a`**.

## Why the split renovate PRs (#675 / #676) fail

Renovate opened #675 (`oxc_formatter`) and #676 (`oxc_formatter_core`) separately. Each moves only its crate and leaves the ~15 other workspace `oxc` git deps on the old `187e1a52`, so the dependency graph ends up with **two copies of `oxc_allocator`**. `format_program(&allocator, &program, …)` then fails to type-check:

```
error[E0308]: arguments to this function are incorrect
  expected `oxc_allocator::Allocator`, found a different `oxc_allocator::Allocator`
note: there are multiple different versions of crate `oxc_allocator` in the dependency graph
```

The workspace already requires rsvelte's AST types to unify with `oxc_formatter`'s transitive deps, so the correct bump moves **all** of them together — which this PR does.

## Verification (dev container)

- `cargo test --test compatibility_report` → **16/16** (compiler-safe; the oxc parser bump is behaviour-preserving across the 3525-fixture report).
- `cargo test -p rsvelte_formatter` → **all fmt fixtures pass**.
- Side effect: normalises `'x'` → `"x"` in computed member access (closer to oxfmt).

## Relationship to #761

This is the working form of #675/#676 and the oxc-alignment step #761's direction calls for. **Caveat:** at `71e489a` the long `type X = Awaited<…>;` alias from #761 still stays on one line, so full `<script>` wrapping parity with **oxfmt 0.53** likely needs the exact revision oxfmt 0.53 embeds. Hence **`refs #761`** (not `closes`) — the dep is now aligned and CI-green, but the maintainer (with oxfmt 0.53 + the corpus) can pin to the precise wrapping-fixing revision on top of this.

Refs #761. Supersedes #675, #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)