### PR TITLE
fix(svelte-check): resolve Foo.svelte.ts companion-module named imports (#751)

### DIFF
--- a/.changeset/svelte-check-companion-module.md
+++ b/.changeset/svelte-check-companion-module.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): resolve `Foo.svelte.ts` / `Foo.svelte.js` companion-module named imports. A component and its sibling companion module collide on the same TypeScript basename — `import X from './Foo.svelte'` and `import { y } from './Foo.svelte.js'` both resolve to the single `Foo.svelte.{ts,tsx,d.ts}` family — so the companion's named exports were invisible and TypeScript reported a spurious `TS2614: has no exported member 'y'`. The overlay now folds the companion's named exports into the component shadow (`export * from "<companion>.js"`), so the one resolvable module exposes both the component default export and the companion's named exports.

--- a/crates/rsvelte_core/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_core/src/svelte_check/overlay.rs
@@ -232,7 +232,20 @@ pub fn materialize_overlay_with(
                 file: abs_source.clone(),
                 message: format!("{e}"),
             })?;
-            fs::write(&tsx_path, &result.code)?;
+            // A sibling companion module (`Foo.svelte.ts` / `Foo.svelte.js`
+            // next to `Foo.svelte`) collides with the component shadow on the
+            // same TypeScript basename: `import X from './Foo.svelte'` and
+            // `import { y } from './Foo.svelte.js'` both resolve to the single
+            // `Foo.svelte.{ts,tsx,d.ts}` family. Rather than emit a competing
+            // `Foo.svelte.ts` (which would win the `.svelte`-strip fallback and
+            // hide the component's default export), fold the companion's named
+            // exports into the component shadow so the one resolvable module
+            // exposes both the component default and the companion's exports.
+            let mut tsx_code = result.code.clone();
+            if let Some(spec) = companion_reexport_specifier(abs_source, &tsx_path) {
+                tsx_code.push_str(&format!("\nexport * from \"{spec}\";\n"));
+            }
+            fs::write(&tsx_path, &tsx_code)?;
 
             // `<name>.svelte.d.ts` re-exports default + named so module
             // resolution by `import Foo from './Foo.svelte'` still works.
@@ -802,6 +815,33 @@ fn resolve_root_dirs_abs(tsconfig_path: &Path) -> Vec<PathBuf> {
 
 /// POSIX-style relative path from `from_dir` to `to_path` (so the
 /// generated tsconfig is consumable on every platform).
+/// If `abs_source` (`…/Foo.svelte`) has a sibling companion module
+/// (`Foo.svelte.ts` or `Foo.svelte.js`), return a module specifier — relative
+/// to the component shadow's directory and ending in `.js` so TS strips it and
+/// finds the real file — suitable for an `export * from "…"` re-export appended
+/// to the shadow `.tsx`. Returns `None` when no companion exists.
+fn companion_reexport_specifier(abs_source: &Path, tsx_path: &Path) -> Option<String> {
+    let from_dir = tsx_path.parent()?;
+    for ext in [".ts", ".js"] {
+        let mut cand = abs_source.as_os_str().to_os_string();
+        cand.push(ext);
+        let cand = PathBuf::from(cand);
+        if cand.is_file() {
+            let mut spec = path_relative(from_dir, &cand);
+            if !spec.starts_with('.') {
+                spec = format!("./{spec}");
+            }
+            // TS resolves `./x.svelte.js` by stripping `.js` and finding the
+            // real `.ts`/`.js`; normalise a `.ts` companion's specifier to `.js`.
+            if let Some(stripped) = spec.strip_suffix(".ts") {
+                spec = format!("{stripped}.js");
+            }
+            return Some(spec);
+        }
+    }
+    None
+}
+
 fn path_relative(from_dir: &Path, to_path: &Path) -> String {
     use std::path::Component;
     let from_abs = from_dir

--- a/crates/rsvelte_core/tests/svelte_check_companion_module.rs
+++ b/crates/rsvelte_core/tests/svelte_check_companion_module.rs
@@ -1,0 +1,109 @@
+//! Regression test for issue #751.
+//!
+//! A `Foo.svelte` component and a sibling companion module
+//! `Foo.svelte.ts` (or `.js`) collide on the same TypeScript basename:
+//! `import X from './Foo.svelte'` and `import { y } from './Foo.svelte.js'`
+//! both resolve to the single `Foo.svelte.{ts,tsx,d.ts}` family. The overlay
+//! emits the component shadow as `Foo.svelte.tsx`; without special handling a
+//! companion's named exports (`{ y }`) are invisible — TS reports a spurious
+//! `TS2614: has no exported member 'y'`.
+//!
+//! The fix folds the companion's named exports into the component shadow via an
+//! appended `export * from "<companion>.js"`, so the one resolvable module
+//! carries both the component default export and the companion's named exports.
+
+use rsvelte_core::svelte_check::overlay::materialize_overlay;
+use std::fs;
+use std::path::PathBuf;
+
+fn workspace(tag: &str) -> PathBuf {
+    let ws = std::env::temp_dir().join(format!("svc_751_{}_{}", tag, std::process::id()));
+    let _ = fs::remove_dir_all(&ws);
+    fs::create_dir_all(&ws).unwrap();
+    ws
+}
+
+fn read_tsx(ws: &std::path::Path, name: &str) -> String {
+    fs::read_to_string(ws.join(".svelte-check/svelte").join(name)).unwrap()
+}
+
+#[test]
+fn component_shadow_reexports_sibling_ts_companion() {
+    let ws = workspace("ts");
+    fs::write(
+        ws.join("Tip.svelte.ts"),
+        "export const tip = (x: number): number => x * 2;\n",
+    )
+    .unwrap();
+    fs::write(
+        ws.join("Tip.svelte"),
+        "<script lang=\"ts\">let { n }: { n: number } = $props();</script>\n<p>{n}</p>\n",
+    )
+    .unwrap();
+
+    let files = vec![ws.join("Tip.svelte")];
+    materialize_overlay(&ws, &files, None).expect("overlay");
+
+    let tsx = read_tsx(&ws, "Tip.svelte.tsx");
+    // Default export (the component) is preserved …
+    assert!(
+        tsx.contains("export default Tip__SvelteComponent_;"),
+        "component default export missing:\n{tsx}"
+    );
+    // … and the companion's named exports are folded in via re-export.
+    assert!(
+        tsx.contains("export * from \"../../Tip.svelte.js\";"),
+        "companion re-export missing:\n{tsx}"
+    );
+}
+
+#[test]
+fn component_shadow_reexports_sibling_js_companion() {
+    let ws = workspace("js");
+    fs::write(ws.join("Tip.svelte.js"), "export const tip = 1;\n").unwrap();
+    fs::write(ws.join("Tip.svelte"), "<p>hi</p>\n").unwrap();
+
+    let files = vec![ws.join("Tip.svelte")];
+    materialize_overlay(&ws, &files, None).expect("overlay");
+
+    let tsx = read_tsx(&ws, "Tip.svelte.tsx");
+    assert!(
+        tsx.contains("export * from \"../../Tip.svelte.js\";"),
+        "js companion re-export missing:\n{tsx}"
+    );
+}
+
+#[test]
+fn no_companion_means_no_reexport() {
+    let ws = workspace("none");
+    fs::write(ws.join("Tip.svelte"), "<p>hi</p>\n").unwrap();
+
+    let files = vec![ws.join("Tip.svelte")];
+    materialize_overlay(&ws, &files, None).expect("overlay");
+
+    let tsx = read_tsx(&ws, "Tip.svelte.tsx");
+    assert!(
+        !tsx.contains("export * from \"../../Tip.svelte.js\";"),
+        "unexpected companion re-export with no companion present:\n{tsx}"
+    );
+}
+
+#[test]
+fn nested_component_reexport_path_is_correct() {
+    let ws = workspace("nested");
+    fs::create_dir_all(ws.join("src/lib")).unwrap();
+    fs::write(ws.join("src/lib/Tip.svelte.ts"), "export const tip = 2;\n").unwrap();
+    fs::write(ws.join("src/lib/Tip.svelte"), "<p>hi</p>\n").unwrap();
+
+    let files = vec![ws.join("src/lib/Tip.svelte")];
+    materialize_overlay(&ws, &files, None).expect("overlay");
+
+    // Shadow lives at <emit>/src/lib/Tip.svelte.tsx; the real companion is at
+    // <ws>/src/lib/Tip.svelte.ts → up out of `.svelte-check/svelte` (2 levels)
+    // then back down the mirrored subpath.
+    let tsx = fs::read_to_string(ws.join(".svelte-check/svelte/src/lib/Tip.svelte.tsx")).unwrap();
+    assert!(
+        tsx.contains("export * from \"../../../../src/lib/Tip.svelte.js\";"),
+        "nested companion re-export path wrong:\n{tsx}"
+    );
+}


### PR DESCRIPTION
Fixes #751.

## Problem

A Svelte component `Foo.svelte` and a sibling companion module `Foo.svelte.ts` (or `.js`) collide on the same TypeScript basename. With `allowArbitraryExtensions`, both:

- `import X from './Foo.svelte'` (the component) — strips `.svelte`, falls back to the `Foo.svelte.*` family, and
- `import { y } from './Foo.svelte.js'` (the companion) — strips `.js` → `Foo.svelte.{ts,tsx,d.ts}`

resolve to the **same** `Foo.svelte.*` file. The svelte-check overlay emits the component shadow as `Foo.svelte.tsx` (+ `Foo.svelte.d.ts`), so the user's real companion module — which lives at the workspace root, outside the overlay `rootDirs`/`include` — is never seen, and TypeScript reports a spurious `TS2614: Module './Foo.svelte.js' has no exported member 'y'`.

Emitting a competing `Foo.svelte.ts` into the emit dir does **not** work: a `.ts` wins the `.svelte`-strip fallback, which then hides the component's default export (`TS1192`). A flat shadow directory fundamentally cannot keep the two roles separate, because both specifiers reduce to the same basename.

## Fix

Since both specifiers resolve to the single `Foo.svelte.tsx` shadow anyway, that one module should carry **both** roles. When a component has a sibling companion module, the overlay now appends an `export * from "<relative>/Foo.svelte.js"` re-export to the component shadow, pulling the real companion's named exports into the resolvable module. The component's `export default` is preserved (a star re-export never re-exports `default`).

Result:
- `import X from './Foo.svelte'` → component default ✓
- `import { y } from './Foo.svelte.js'` → companion named export ✓

Verified end-to-end with tsgo/tsc on a faithful overlay repro: both imports resolve with no `TS2614` / `TS1192`.

## Tests

New `crates/rsvelte_core/tests/svelte_check_companion_module.rs` covers `.ts` / `.js` companions, the no-companion case (no re-export emitted), and the nested-directory relative-path computation. Existing `svelte_check` lib suite (49 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)