### PR TITLE
feat(playground): reflect editor contents into the URL for sharing

### DIFF
--- a/.changeset/playground-share-url.md
+++ b/.changeset/playground-share-url.md
@@ -1,0 +1,4 @@
+---
+---
+
+Playground: editing code now reflects into the URL (`#code=…`) so a session can be shared by copying the link, with a one-click **Share** button. No published package is affected (the playground is a private app).

--- a/apps/playground/src/lib/share.ts
+++ b/apps/playground/src/lib/share.ts
@@ -1,0 +1,41 @@
+// Encode / decode the playground source so it can ride along in the URL and be
+// shared by copy-pasting the link. We keep the editor contents in the URL
+// *hash* (`#code=…`) rather than a query parameter so it never reaches the
+// static server, has no practical length limit, and stays out of request logs.
+//
+// The payload is the UTF-8 bytes of the source, base64url-encoded (RFC 4648
+// §5: `+`→`-`, `/`→`_`, padding stripped). This is dependency-free and fully
+// synchronous, which keeps the reactive URL-sync path simple. base64 inflates
+// the byte length by ~33%, which is fine for the few-kB snippets a playground
+// deals with.
+
+/** base64url-encode the UTF-8 bytes of `code`. */
+export function encodeCode(code: string): string {
+	const bytes = new TextEncoder().encode(code);
+	let binary = '';
+	// Chunk to stay well under any arg-count limits on String.fromCharCode.
+	const CHUNK = 0x8000;
+	for (let i = 0; i < bytes.length; i += CHUNK) {
+		binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+	}
+	return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Inverse of {@link encodeCode}. Returns `null` if the payload is malformed. */
+export function decodeCode(encoded: string): string | null {
+	try {
+		const b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+		const binary = atob(b64);
+		const bytes = Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
+		return new TextDecoder().decode(bytes);
+	} catch {
+		return null;
+	}
+}
+
+/** Read the shared source out of a URL hash like `#code=…` (or `code=…`). */
+export function readSharedCode(hash: string): string | null {
+	const params = new URLSearchParams(hash.replace(/^#/, ''));
+	const code = params.get('code');
+	return code ? decodeCode(code) : null;
+}

--- a/apps/playground/src/routes/playground/+page.svelte
+++ b/apps/playground/src/routes/playground/+page.svelte
@@ -16,6 +16,7 @@
 	} from '$lib/compiler';
 	import { initFmt, formatSvelte, getFmtVersion } from '$lib/fmt';
 	import { generatePreviewHtml } from '$lib/preview';
+	import { encodeCode, readSharedCode } from '$lib/share';
 	import { DEFAULT_EXAMPLE } from '$lib/examples';
 	import { TOOLS, toolById, isToolId, type ToolId } from '$lib/tools';
 	import MonacoEditor from '$lib/monaco/MonacoEditor.svelte';
@@ -57,7 +58,40 @@
 
 	let debounceTimer: ReturnType<typeof setTimeout>;
 
+	// ── share ─────────────────────────────────────────
+	let copied = $state(false);
+	let copyTimer: ReturnType<typeof setTimeout>;
+
 	const currentTool = $derived(toolById(tool)!);
+
+	// Reflect the current tool + editor contents into the URL so the page can be
+	// shared by copying the link. The source rides in the hash (`#code=…`) to
+	// keep it off the server and free of length limits; the tool stays a query
+	// param for backwards-compatible deep links.
+	function syncUrl() {
+		try {
+			const url = new URL(page.url);
+			url.searchParams.set('tool', tool);
+			url.hash = input ? `code=${encodeCode(input)}` : '';
+			replaceState(url, page.state);
+		} catch {
+			// replaceState can throw if the router isn't ready yet — the in-memory
+			// state still drives the UI, so URL sync is best-effort.
+		}
+	}
+
+	async function copyShareLink() {
+		syncUrl();
+		try {
+			await navigator.clipboard.writeText(location.href);
+			copied = true;
+			clearTimeout(copyTimer);
+			copyTimer = setTimeout(() => (copied = false), 1500);
+		} catch {
+			// Clipboard can be blocked (insecure context / permissions); the URL
+			// in the address bar is already up to date, so this is non-fatal.
+		}
+	}
 
 	// ── compiler ──────────────────────────────────────
 	function compile() {
@@ -166,12 +200,7 @@
 	async function selectTool(next: ToolId) {
 		if (next === tool) return;
 		tool = next;
-		try {
-			replaceState(`${base}/playground?tool=${next}`, page.state);
-		} catch {
-			// replaceState can throw if the router isn't ready yet — the in-memory
-			// `tool` state still drives the UI, so the deep link is best-effort.
-		}
+		syncUrl();
 		if (next === 'fmt') await ensureFmt();
 		run();
 	}
@@ -180,12 +209,16 @@
 		if (fmtOutput) {
 			input = fmtOutput;
 			fmtChanged = false;
+			syncUrl();
 		}
 	}
 
 	function handleInputChange() {
 		clearTimeout(debounceTimer);
-		debounceTimer = setTimeout(run, 300);
+		debounceTimer = setTimeout(() => {
+			run();
+			syncUrl();
+		}, 300);
 	}
 
 	function handleCursorPositionChange(offset: number) {
@@ -200,6 +233,8 @@
 	onMount(async () => {
 		const t = page.url.searchParams.get('tool');
 		if (t && isToolId(t)) tool = t;
+		const shared = readSharedCode(page.url.hash);
+		if (shared !== null) input = shared;
 		try {
 			await initCompiler();
 			wasmReady = true;
@@ -272,20 +307,33 @@
 			{/if}
 		</div>
 
-		<div class="tool-switch" role="tablist" aria-label="Tool">
-			{#each TOOLS as t (t.id)}
+		<div class="head-r">
+			<div class="tool-switch" role="tablist" aria-label="Tool">
+				{#each TOOLS as t (t.id)}
+					<button
+						role="tab"
+						aria-selected={tool === t.id}
+						class:active={tool === t.id}
+						class:muted={!t.runnable}
+						title={t.tagline}
+						onclick={() => selectTool(t.id)}
+					>
+						{t.label}
+						{#if !t.runnable}<span class="cli-dot" aria-hidden="true">CLI</span>{/if}
+					</button>
+				{/each}
+			</div>
+
+			{#if currentTool.runnable}
 				<button
-					role="tab"
-					aria-selected={tool === t.id}
-					class:active={tool === t.id}
-					class:muted={!t.runnable}
-					title={t.tagline}
-					onclick={() => selectTool(t.id)}
+					class="share"
+					class:copied
+					onclick={copyShareLink}
+					title="Copy a link to this code"
 				>
-					{t.label}
-					{#if !t.runnable}<span class="cli-dot" aria-hidden="true">CLI</span>{/if}
+					{copied ? 'Link copied' : 'Share'}
 				</button>
-			{/each}
+			{/if}
 		</div>
 	</header>
 
@@ -553,6 +601,40 @@
 		border: 1px solid currentColor;
 		border-radius: 2px;
 		line-height: 1;
+	}
+
+	.head-r {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.6rem;
+		flex-wrap: wrap;
+	}
+
+	/* SHARE */
+	.share {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.76rem;
+		padding: 0.45rem 0.85rem;
+		border: 1px solid var(--rule-strong);
+		border-radius: 6px;
+		background: var(--paper);
+		color: var(--ink-soft);
+		cursor: pointer;
+		white-space: nowrap;
+		transition:
+			background 0.16s,
+			color 0.16s,
+			border-color 0.16s;
+	}
+
+	.share:hover {
+		color: var(--ink);
+		border-color: var(--ink);
+	}
+
+	.share.copied {
+		color: var(--ok);
+		border-color: var(--ok);
 	}
 
 	/* TOOL SWITCHER */


### PR DESCRIPTION
## What

The playground now mirrors the active tool **and** the editor source into the URL so a session can be shared just by copying the link.

- The source rides in the URL **hash** (`#code=…`) as base64url-encoded UTF-8 — it never reaches the static server, has no practical length limit, and stays out of request logs. The `?tool=` query is preserved for backwards-compatible deep links.
- The address bar stays in sync as you type (debounced, reusing the existing 300 ms compile debounce), on tool switch, and on **Apply to source** from the formatter.
- A new **Share** button copies the link to the clipboard and flips to “Link copied” for 1.5 s. It's only shown for the runnable (in-browser) tools.
- On load, a `#code=…` payload is decoded back into the editor before the WASM compiler initialises.

## Implementation

- New `src/lib/share.ts` — dependency-free, synchronous `encodeCode` / `decodeCode` / `readSharedCode` (base64url of UTF-8, malformed payloads decode to `null`).
- `playground/+page.svelte` — `syncUrl()` helper writes the URL via `replaceState`; wired into input-change, tool switch, and apply-formatted paths; `onMount` reads the shared code.

## Testing

- `svelte/compiler` compiles `+page.svelte` cleanly (0 warnings).
- `oxlint` clean on `share.ts` and the page (no new warnings).
- Encode/decode roundtrip verified for ASCII, multibyte UTF-8, emoji, empty, and 50 kB inputs; garbage input decodes to `null`.

The playground is a private app, so no published package is affected (empty-frontmatter changeset included to satisfy the changeset gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)