### PR TITLE
fix(fmt): wrap markup expressions by their rendered column

### DIFF
--- a/.changeset/markup-expression-depth.md
+++ b/.changeset/markup-expression-depth.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Wrap markup expressions by the column they render at, matching `prettier-plugin-svelte` (which `oxfmt` delegates `.svelte` to).
+
+Every JS expression was formatted at indent 0 and then spliced into the markup, so wrap decisions used the full print width regardless of nesting: a line that fit at column 0 silently overflowed once nested, and continuation lines stuck at column 0 instead of aligning to the nesting depth.
+
+- `<script>` bodies are narrowed by one indent level before formatting (the body is nested one level under `<script>`).
+- Content expressions (`{expr}`, `{@html}`, `{@render}`, `{@attach}`) thread the markup nesting depth through the walk, narrow the width by `depth × indentWidth`, and re-indent continuation lines to that depth.
+- Block-header expressions (`{#if}`, `{#each}`, `{:else if}`, `{#key}`, `{#await}`, snippet name) are forced onto a single line — `prettier-plugin-svelte` never breaks a block tag's expression regardless of width.
+
+On a 1,115-file Svelte corpus this brings `oxfmt`-divergent files from 180 to ~111, with zero idempotency breaks and zero `svelte` parse breaks. The remaining diffs are attribute-value wrapping, close-tag placement, and snippet-parameter expansion, tracked for follow-up.

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -17,14 +17,20 @@ fn formatter_parse_options() -> OxcParseOptions {
 
 /// Walk a `Fragment` recursively, appending `(start, end, replacement)`
 /// edits for every JS expression we can safely format.
+///
+/// `depth` is the markup nesting level at which this fragment's nodes render
+/// (root fragment is `0`, each enclosing element / block adds one). Content
+/// expressions use it to match prettier-plugin-svelte's wrap column; see
+/// [`format_content_expression`].
 pub(crate) fn collect_template_edits(
     source: &str,
     fragment: &Fragment,
+    depth: usize,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<(), FormatError> {
     for node in &fragment.nodes {
-        collect_node_edits(source, node, options, edits)?;
+        collect_node_edits(source, node, depth, options, edits)?;
     }
     Ok(())
 }
@@ -32,12 +38,14 @@ pub(crate) fn collect_template_edits(
 fn collect_node_edits(
     source: &str,
     node: &TemplateNode,
+    depth: usize,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<(), FormatError> {
+    let child_depth = depth + 1;
     match node {
         TemplateNode::ExpressionTag(tag) => {
-            push_expression_tag(source, tag, options, edits)?;
+            push_expression_tag(source, tag, depth, options, edits)?;
         }
         TemplateNode::HtmlTag(tag) => {
             push_tag_form(
@@ -46,6 +54,7 @@ fn collect_node_edits(
                 tag.end,
                 "@html",
                 &tag.expression,
+                depth,
                 options,
                 edits,
             )?;
@@ -57,6 +66,7 @@ fn collect_node_edits(
                 tag.end,
                 "@render",
                 &tag.expression,
+                depth,
                 options,
                 edits,
             )?;
@@ -68,6 +78,7 @@ fn collect_node_edits(
                 tag.end,
                 "@attach",
                 &tag.expression,
+                depth,
                 options,
                 edits,
             )?;
@@ -84,16 +95,16 @@ fn collect_node_edits(
         // open-tag rewrite in `crate::markup`. Here we only recurse into
         // the children.
         TemplateNode::RegularElement(elem) => {
-            collect_template_edits(source, &elem.fragment, options, edits)?;
+            collect_template_edits(source, &elem.fragment, child_depth, options, edits)?;
         }
         TemplateNode::Component(c) => {
-            collect_template_edits(source, &c.fragment, options, edits)?;
+            collect_template_edits(source, &c.fragment, child_depth, options, edits)?;
         }
         TemplateNode::TitleElement(t) => {
-            collect_template_edits(source, &t.fragment, options, edits)?;
+            collect_template_edits(source, &t.fragment, child_depth, options, edits)?;
         }
         TemplateNode::SlotElement(s) => {
-            collect_template_edits(source, &s.fragment, options, edits)?;
+            collect_template_edits(source, &s.fragment, child_depth, options, edits)?;
         }
         TemplateNode::SvelteHead(s)
         | TemplateNode::SvelteBody(s)
@@ -103,19 +114,33 @@ fn collect_node_edits(
         | TemplateNode::SvelteOptions(s)
         | TemplateNode::SvelteSelf(s)
         | TemplateNode::SvelteWindow(s) => {
-            collect_template_edits(source, &s.fragment, options, edits)?;
+            collect_template_edits(source, &s.fragment, child_depth, options, edits)?;
         }
         TemplateNode::SvelteComponent(c) => {
-            collect_template_edits(source, &c.fragment, options, edits)?;
+            collect_template_edits(source, &c.fragment, child_depth, options, edits)?;
         }
         TemplateNode::SvelteElement(e) => {
-            collect_template_edits(source, &e.fragment, options, edits)?;
+            collect_template_edits(source, &e.fragment, child_depth, options, edits)?;
         }
         TemplateNode::IfBlock(blk) => {
-            push_bare_expression(source, &blk.test, options, edits)?;
-            collect_template_edits(source, &blk.consequent, options, edits)?;
-            if let Some(alt) = &blk.alternate {
-                collect_template_edits(source, alt, options, edits)?;
+            // Walk the `{#if} / {:else if} / {:else}` chain at one consistent
+            // depth — svelte desugars `{:else if}` into an alternate fragment
+            // whose sole child is another IfBlock, so recursing naively would
+            // add a level per branch. Mirrors `crate::indent`.
+            let mut current: &rsvelte_core::ast::template::IfBlock = blk;
+            loop {
+                push_bare_expression(source, &current.test, options, edits)?;
+                collect_template_edits(source, &current.consequent, child_depth, options, edits)?;
+                match &current.alternate {
+                    Some(alt) => match crate::indent::else_if_branch(alt) {
+                        Some(chained) => current = chained,
+                        None => {
+                            collect_template_edits(source, alt, child_depth, options, edits)?;
+                            break;
+                        }
+                    },
+                    None => break,
+                }
             }
         }
         TemplateNode::EachBlock(blk) => {
@@ -126,9 +151,9 @@ fn collect_node_edits(
             if let Some(key) = &blk.key {
                 push_brace_wrapped_expression(source, key, options, edits)?;
             }
-            collect_template_edits(source, &blk.body, options, edits)?;
+            collect_template_edits(source, &blk.body, child_depth, options, edits)?;
             if let Some(fb) = &blk.fallback {
-                collect_template_edits(source, fb, options, edits)?;
+                collect_template_edits(source, fb, child_depth, options, edits)?;
             }
         }
         TemplateNode::AwaitBlock(blk) => {
@@ -140,25 +165,25 @@ fn collect_node_edits(
                 push_pattern_at_span(source, e, options, edits)?;
             }
             if let Some(frag) = &blk.pending {
-                collect_template_edits(source, frag, options, edits)?;
+                collect_template_edits(source, frag, child_depth, options, edits)?;
             }
             if let Some(frag) = &blk.then {
-                collect_template_edits(source, frag, options, edits)?;
+                collect_template_edits(source, frag, child_depth, options, edits)?;
             }
             if let Some(frag) = &blk.catch {
-                collect_template_edits(source, frag, options, edits)?;
+                collect_template_edits(source, frag, child_depth, options, edits)?;
             }
         }
         TemplateNode::KeyBlock(blk) => {
             push_bare_expression(source, &blk.expression, options, edits)?;
-            collect_template_edits(source, &blk.fragment, options, edits)?;
+            collect_template_edits(source, &blk.fragment, child_depth, options, edits)?;
         }
         TemplateNode::SnippetBlock(blk) => {
             push_bare_expression(source, &blk.expression, options, edits)?;
             for p in &blk.parameters {
                 push_param_at_span(source, p, options, edits)?;
             }
-            collect_template_edits(source, &blk.body, options, edits)?;
+            collect_template_edits(source, &blk.body, child_depth, options, edits)?;
         }
         TemplateNode::Text(_) | TemplateNode::Comment(_) => {}
     }
@@ -173,6 +198,7 @@ fn collect_node_edits(
 fn push_expression_tag(
     source: &str,
     tag: &ExpressionTag,
+    depth: usize,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<(), FormatError> {
@@ -189,19 +215,21 @@ fn push_expression_tag(
         return Ok(());
     }
 
-    let formatted = format_expression_source(inner, options)?;
+    let formatted = format_content_expression(inner, options, depth)?;
     edits.push((tag.start, tag.end, format!("{{{formatted}}}")));
     Ok(())
 }
 
 /// Replace `{@<keyword> EXPR}` (full tag span) with the formatted expression
 /// body and a single space after the keyword.
+#[allow(clippy::too_many_arguments)]
 fn push_tag_form(
     source: &str,
     tag_start: u32,
     tag_end: u32,
     keyword: &str,
     expr: &Expression,
+    depth: usize,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<(), FormatError> {
@@ -215,7 +243,7 @@ fn push_tag_form(
     if slice.is_empty() {
         return Ok(());
     }
-    let formatted = format_expression_source(slice, options)?;
+    let formatted = format_content_expression(slice, options, depth)?;
     edits.push((tag_start, tag_end, format!("{{{keyword} {formatted}}}")));
     Ok(())
 }
@@ -253,10 +281,9 @@ fn push_debug_tag(
 }
 
 /// Splice over an expression's enclosing `{ ... }` if the source has
-/// `{ <ws> EXPR <ws> }` around the AST expression span (directive values,
-/// `this={X}` etc.). If no such enclosure is detectable, splice just the
-/// bare expression span (block headers like `{#if EXPR}` fall into this
-/// branch — the `{#if ` keyword stops the back-scan).
+/// `{ <ws> EXPR <ws> }` around the AST expression span (the `{#each … (KEY)}`
+/// key in particular). The expression is forced onto a single line — it sits
+/// in a Svelte block header, which prettier-plugin-svelte never breaks.
 fn push_brace_wrapped_expression(
     source: &str,
     expr: &Expression,
@@ -273,7 +300,7 @@ fn push_brace_wrapped_expression(
     if slice.is_empty() {
         return Ok(());
     }
-    let formatted = format_expression_source(slice, options)?;
+    let formatted = format_inline_expression(slice, options)?;
 
     if let Some((brace_start, brace_end)) = enclosing_braces_span(source, start, end) {
         edits.push((brace_start, brace_end, format!("{{{formatted}}}")));
@@ -286,7 +313,9 @@ fn push_brace_wrapped_expression(
 /// Splice just the bare expression span — preserves whatever surrounds it
 /// in the source. Used for block-header expressions (`{#if EXPR}`,
 /// `{#each EXPR as ...}`, etc.) where the `{` is followed by a Svelte
-/// keyword (`#if` / `#each` / ...) rather than the expression itself.
+/// keyword (`#if` / `#each` / ...) rather than the expression itself. The
+/// expression is forced onto a single line: prettier-plugin-svelte keeps a
+/// block tag's expression inline regardless of width.
 fn push_bare_expression(
     source: &str,
     expr: &Expression,
@@ -303,7 +332,7 @@ fn push_bare_expression(
     if slice.is_empty() {
         return Ok(());
     }
-    let formatted = format_expression_source(slice, options)?;
+    let formatted = format_inline_expression(slice, options)?;
     edits.push((start, end, formatted));
     Ok(())
 }
@@ -406,12 +435,18 @@ pub(crate) fn format_directive_value(
 
 // ─── Expression formatter ───────────────────────────────────────────────
 
-/// Format a single JS expression source. Wraps in parens to force
-/// expression context (so object literals like `{a:1}` aren't parsed as
-/// block statements) and strips the wrapper from the output.
-pub(crate) fn format_expression_source(
+/// Format a single JS expression source at `line_width`. Wraps in parens to
+/// force expression context (so object literals like `{a:1}` aren't parsed as
+/// block statements) and strips the `( … );` wrapper from the output. With
+/// `single_line`, the formatter is held on one line (`Expand::Never` + max
+/// width) for spots where a break can't survive — block headers and the like.
+/// The result may otherwise be multi-line, with continuation lines at
+/// `oxc_formatter`'s own relative indent (measured from column 0).
+fn format_expr_core(
     expr_source: &str,
     options: &FormatOptions,
+    line_width: oxc_formatter_core::LineWidth,
+    single_line: bool,
 ) -> Result<String, FormatError> {
     let allocator = Allocator::default();
     let source_type = if options.typescript {
@@ -428,13 +463,73 @@ pub(crate) fn format_expression_source(
         return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
     }
 
-    let formatted = format_program(&allocator, &parser_ret.program, options.js.clone(), None)
+    let mut js = options.js.clone();
+    js.line_width = line_width;
+    if single_line {
+        js.expand = oxc_formatter::Expand::Never;
+    }
+    let formatted = format_program(&allocator, &parser_ret.program, js, None)
         .print()
         .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
         .into_code();
 
     let s = formatted.trim_end().trim_end_matches(';').trim_end();
     Ok(strip_outer_parens(s).trim().to_string())
+}
+
+/// Format an attribute / directive value expression (`bind:value={ … }`) at
+/// the configured width. Attribute-position wrapping is owned by the open-tag
+/// rewrite in [`crate::markup`], so this applies no markup-depth adjustment.
+pub(crate) fn format_expression_source(
+    expr_source: &str,
+    options: &FormatOptions,
+) -> Result<String, FormatError> {
+    format_expr_core(expr_source, options, options.js.line_width, false)
+}
+
+/// Format a block-header expression (`{#if cond}`, `{#each items …}`) onto a
+/// single line. prettier-plugin-svelte never breaks a block tag's expression
+/// across lines regardless of width, so format at the widest line the
+/// formatter allows (`LineWidth::MAX`) with `Expand::Never` so neither a long
+/// binary chain nor a magic-comma object splits the block header.
+fn format_inline_expression(
+    expr_source: &str,
+    options: &FormatOptions,
+) -> Result<String, FormatError> {
+    let wide = oxc_formatter_core::LineWidth::try_from(oxc_formatter_core::LineWidth::MAX)
+        .unwrap_or(options.js.line_width);
+    format_expr_core(expr_source, options, wide, true)
+}
+
+/// Format a content expression (`{expr}`, `{@html e}`, `{@render e()}`) that
+/// renders at markup nesting `depth`.
+///
+/// The body is formatted at indent 0, so a wrap decision made against the full
+/// `line_width` ignores the `depth` levels of indent it will sit at once
+/// spliced — a line that "fits" at column 0 overflows once nested. Narrow the
+/// width by that lead so breaks land where prettier-plugin-svelte puts them,
+/// then push every continuation line out to the nesting depth (the first line
+/// stays inline after the opening `{`).
+fn format_content_expression(
+    expr_source: &str,
+    options: &FormatOptions,
+    depth: usize,
+) -> Result<String, FormatError> {
+    let indent_width = options.js.indent_width.value() as usize;
+    let lead = depth * indent_width;
+    let narrowed = (options.js.line_width.value() as usize).saturating_sub(lead);
+    let line_width =
+        oxc_formatter_core::LineWidth::try_from(narrowed as u16).unwrap_or(options.js.line_width);
+    let formatted = format_expr_core(expr_source, options, line_width, false)?;
+    if !formatted.contains('\n') {
+        return Ok(formatted);
+    }
+    let prefix = if options.js.indent_style.is_tab() {
+        "\t".repeat(depth)
+    } else {
+        " ".repeat(lead)
+    };
+    Ok(crate::reindent::reindent(&formatted, &prefix, true))
 }
 
 /// Splice a destructuring pattern's source span with its formatted

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -17,6 +17,7 @@ mod expression;
 mod indent;
 mod markup;
 mod options;
+mod reindent;
 mod script;
 mod style;
 
@@ -72,7 +73,7 @@ pub fn format(source: &str, options: &FormatOptions) -> Result<String, FormatErr
     // spans including their attribute lists. The expression and indent
     // passes below target spans outside those rewritten regions.
     markup::collect_open_tag_edits(source, &root.fragment, 0, options, &mut edits)?;
-    expression::collect_template_edits(source, &root.fragment, options, &mut edits)?;
+    expression::collect_template_edits(source, &root.fragment, 0, options, &mut edits)?;
     indent::collect_indent_edits(source, &root.fragment, 0, options, &mut edits)?;
     if let Some(css) = &root.css {
         style::collect_style_edit(source, css, options, &mut edits)?;

--- a/crates/rsvelte_formatter/src/reindent.rs
+++ b/crates/rsvelte_formatter/src/reindent.rs
@@ -1,0 +1,197 @@
+//! Shared re-indentation for spliced `oxc_formatter` output.
+//!
+//! Both `<script>` bodies ([`crate::script`]) and markup `{expr}` content
+//! ([`crate::expression`]) are formatted by `oxc_formatter` at indent 0 and
+//! then spliced back into the document at a deeper nesting level. The spliced
+//! text's continuation lines must gain that nesting indent — but lines that
+//! begin *inside* multi-line template-literal quasi text must be left verbatim:
+//! their leading whitespace is part of the runtime string value, so
+//! re-indenting them would both mutate the string and make formatting
+//! non-idempotent (every pass would add another level) (#686).
+
+/// One level of the scanner stack. We only need to know whether a line begins
+/// inside template-literal *quasi* text (raw string content) versus ordinary
+/// code — the latter is re-indented, the former is left verbatim.
+enum Frame {
+    /// Inside `` `…` `` quasi text (between backticks, outside `${}`).
+    Template,
+    /// Inside a `${ … }` substitution. The `u32` is the `{`-nesting depth
+    /// within the substitution, so the matching `}` is recognised.
+    Subst(u32),
+}
+
+/// Prepend `prefix` to the start of every line of `formatted`, **except** lines
+/// that begin inside multi-line template-literal quasi text. When `skip_first`
+/// is true the first line is also left unprefixed — used when that line is
+/// spliced inline after an opener (e.g. a `{` or `<script>` already positioned
+/// by an outer pass).
+///
+/// The scanner tracks template-literal / `${}` nesting plus string and comment
+/// context so backticks, `${`, and braces inside strings or comments aren't
+/// misread.
+pub(crate) fn reindent(formatted: &str, prefix: &str, skip_first: bool) -> String {
+    let chars: Vec<char> = formatted.chars().collect();
+    let n = chars.len();
+    let mut out = String::with_capacity(formatted.len() + 16);
+    let mut stack: Vec<Frame> = Vec::new();
+    let mut line_comment = false;
+    let mut block_comment = false;
+    let mut string: Option<char> = None;
+    let mut at_line_start = true;
+    let mut seen_newline = false;
+    let mut i = 0;
+
+    while i < n {
+        let c = chars[i];
+
+        if at_line_start {
+            let in_quasi = matches!(stack.last(), Some(Frame::Template));
+            let suppress_first = skip_first && !seen_newline;
+            if c != '\n' && !in_quasi && !suppress_first {
+                out.push_str(prefix);
+            }
+            at_line_start = false;
+        }
+
+        // Line comment: runs to end of line.
+        if line_comment {
+            out.push(c);
+            i += 1;
+            if c == '\n' {
+                line_comment = false;
+                at_line_start = true;
+                seen_newline = true;
+            }
+            continue;
+        }
+
+        // Block comment: runs to `*/`. Interior lines are still re-indented
+        // (code context), matching `oxc_formatter`'s own re-alignment.
+        if block_comment {
+            if c == '*' && chars.get(i + 1) == Some(&'/') {
+                out.push('*');
+                out.push('/');
+                i += 2;
+                block_comment = false;
+                continue;
+            }
+            out.push(c);
+            i += 1;
+            if c == '\n' {
+                at_line_start = true;
+                seen_newline = true;
+            }
+            continue;
+        }
+
+        // Regular string: consumes its own escapes; can't span lines in
+        // well-formed formatter output.
+        if let Some(q) = string {
+            out.push(c);
+            if c == '\\' {
+                if i + 1 < n {
+                    out.push(chars[i + 1]);
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+            i += 1;
+            if c == q {
+                string = None;
+            }
+            continue;
+        }
+
+        if matches!(stack.last(), Some(Frame::Template)) {
+            // Inside template-literal quasi text.
+            match c {
+                '`' => {
+                    stack.pop();
+                    out.push(c);
+                    i += 1;
+                }
+                '\\' => {
+                    out.push(c);
+                    if i + 1 < n {
+                        out.push(chars[i + 1]);
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                '$' if chars.get(i + 1) == Some(&'{') => {
+                    stack.push(Frame::Subst(0));
+                    out.push('$');
+                    out.push('{');
+                    i += 2;
+                }
+                '\n' => {
+                    out.push(c);
+                    at_line_start = true;
+                    seen_newline = true;
+                    i += 1;
+                }
+                _ => {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+        } else {
+            // Ordinary code context (top level or inside `${ … }`).
+            match c {
+                '`' => {
+                    stack.push(Frame::Template);
+                    out.push(c);
+                    i += 1;
+                }
+                '\'' | '"' => {
+                    string = Some(c);
+                    out.push(c);
+                    i += 1;
+                }
+                '/' if chars.get(i + 1) == Some(&'/') => {
+                    line_comment = true;
+                    out.push('/');
+                    out.push('/');
+                    i += 2;
+                }
+                '/' if chars.get(i + 1) == Some(&'*') => {
+                    block_comment = true;
+                    out.push('/');
+                    out.push('*');
+                    i += 2;
+                }
+                '{' => {
+                    if let Some(Frame::Subst(d)) = stack.last_mut() {
+                        *d += 1;
+                    }
+                    out.push(c);
+                    i += 1;
+                }
+                '}' => {
+                    if matches!(stack.last(), Some(Frame::Subst(0))) {
+                        stack.pop();
+                    } else if let Some(Frame::Subst(d)) = stack.last_mut() {
+                        *d -= 1;
+                    }
+                    out.push(c);
+                    i += 1;
+                }
+                '\n' => {
+                    out.push(c);
+                    at_line_start = true;
+                    seen_newline = true;
+                    i += 1;
+                }
+                _ => {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    out
+}

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -57,7 +57,19 @@ pub(crate) fn format_script(
         return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
     }
 
-    let formatted = format_program(&allocator, &parser_ret.program, options.js.clone(), None)
+    // Format the body one indent level narrower than the configured width.
+    // The body is formatted at indent 0 here but then nested one level under
+    // `<script>` (`reindent_body` below), so a line that is exactly
+    // `printWidth` wide at indent 0 would overflow once indented. oxfmt formats
+    // the body already nested, so narrowing the width here matches its wrap
+    // decisions and keeps `<script>` bodies identical to oxfmt.
+    let mut js = options.js.clone();
+    let nested_width = js
+        .line_width
+        .value()
+        .saturating_sub(js.indent_width.value() as u16);
+    js.line_width = oxc_formatter_core::LineWidth::try_from(nested_width).unwrap_or(js.line_width);
+    let formatted = format_program(&allocator, &parser_ret.program, js, None)
         .print()
         .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
         .into_code();
@@ -70,192 +82,10 @@ pub(crate) fn format_script(
     // re-indenting them would both mutate the runtime string and make
     // formatting non-idempotent (every pass adds another level) (#686).
     let unit = indent_unit(&options.js);
-    let body_indented = reindent_body(formatted.trim_end(), &unit);
+    let body_indented = crate::reindent::reindent(formatted.trim_end(), &unit, false);
     let wrapped = format!("\n{body_indented}\n");
 
     Ok(Some((body_start as u32, body_end as u32, wrapped)))
-}
-
-/// One level of the scanner stack used by [`reindent_body`]. We only need
-/// to know whether a line begins inside template-literal *quasi* text (raw
-/// string content) versus ordinary code — the latter is re-indented, the
-/// former is left verbatim.
-enum Frame {
-    /// Inside `` `…` `` quasi text (between backticks, outside `${}`).
-    Template,
-    /// Inside a `${ … }` substitution. The `u32` is the `{`-nesting depth
-    /// within the substitution, so the matching `}` is recognised.
-    Subst(u32),
-}
-
-/// Add `unit` to the start of every line of `formatted`, **except** lines
-/// that begin inside multi-line template-literal quasi text. Such lines'
-/// leading whitespace is significant (part of the string value) and
-/// `oxc_formatter` preserves it verbatim, so re-indenting them would mutate
-/// the string and break idempotency.
-///
-/// The scanner tracks template-literal / `${}` nesting plus string and
-/// comment context so backticks, `${`, and braces inside strings or
-/// comments aren't misread.
-fn reindent_body(formatted: &str, unit: &str) -> String {
-    let chars: Vec<char> = formatted.chars().collect();
-    let n = chars.len();
-    let mut out = String::with_capacity(formatted.len() + 16);
-    let mut stack: Vec<Frame> = Vec::new();
-    let mut line_comment = false;
-    let mut block_comment = false;
-    let mut string: Option<char> = None;
-    let mut at_line_start = true;
-    let mut i = 0;
-
-    while i < n {
-        let c = chars[i];
-
-        if at_line_start {
-            let in_quasi = matches!(stack.last(), Some(Frame::Template));
-            if c != '\n' && !in_quasi {
-                out.push_str(unit);
-            }
-            at_line_start = false;
-        }
-
-        // Line comment: runs to end of line.
-        if line_comment {
-            out.push(c);
-            i += 1;
-            if c == '\n' {
-                line_comment = false;
-                at_line_start = true;
-            }
-            continue;
-        }
-
-        // Block comment: runs to `*/`. Interior lines are still re-indented
-        // (code context), matching `oxc_formatter`'s own re-alignment.
-        if block_comment {
-            if c == '*' && chars.get(i + 1) == Some(&'/') {
-                out.push('*');
-                out.push('/');
-                i += 2;
-                block_comment = false;
-                continue;
-            }
-            out.push(c);
-            i += 1;
-            if c == '\n' {
-                at_line_start = true;
-            }
-            continue;
-        }
-
-        // Regular string: consumes its own escapes; can't span lines in
-        // well-formed formatter output.
-        if let Some(q) = string {
-            out.push(c);
-            if c == '\\' {
-                if i + 1 < n {
-                    out.push(chars[i + 1]);
-                    i += 2;
-                } else {
-                    i += 1;
-                }
-                continue;
-            }
-            i += 1;
-            if c == q {
-                string = None;
-            }
-            continue;
-        }
-
-        if matches!(stack.last(), Some(Frame::Template)) {
-            // Inside template-literal quasi text.
-            match c {
-                '`' => {
-                    stack.pop();
-                    out.push(c);
-                    i += 1;
-                }
-                '\\' => {
-                    out.push(c);
-                    if i + 1 < n {
-                        out.push(chars[i + 1]);
-                        i += 2;
-                    } else {
-                        i += 1;
-                    }
-                }
-                '$' if chars.get(i + 1) == Some(&'{') => {
-                    stack.push(Frame::Subst(0));
-                    out.push('$');
-                    out.push('{');
-                    i += 2;
-                }
-                '\n' => {
-                    out.push(c);
-                    at_line_start = true;
-                    i += 1;
-                }
-                _ => {
-                    out.push(c);
-                    i += 1;
-                }
-            }
-        } else {
-            // Ordinary code context (top level or inside `${ … }`).
-            match c {
-                '`' => {
-                    stack.push(Frame::Template);
-                    out.push(c);
-                    i += 1;
-                }
-                '\'' | '"' => {
-                    string = Some(c);
-                    out.push(c);
-                    i += 1;
-                }
-                '/' if chars.get(i + 1) == Some(&'/') => {
-                    line_comment = true;
-                    out.push('/');
-                    out.push('/');
-                    i += 2;
-                }
-                '/' if chars.get(i + 1) == Some(&'*') => {
-                    block_comment = true;
-                    out.push('/');
-                    out.push('*');
-                    i += 2;
-                }
-                '{' => {
-                    if let Some(Frame::Subst(d)) = stack.last_mut() {
-                        *d += 1;
-                    }
-                    out.push(c);
-                    i += 1;
-                }
-                '}' => {
-                    if matches!(stack.last(), Some(Frame::Subst(0))) {
-                        stack.pop();
-                    } else if let Some(Frame::Subst(d)) = stack.last_mut() {
-                        *d -= 1;
-                    }
-                    out.push(c);
-                    i += 1;
-                }
-                '\n' => {
-                    out.push(c);
-                    at_line_start = true;
-                    i += 1;
-                }
-                _ => {
-                    out.push(c);
-                    i += 1;
-                }
-            }
-        }
-    }
-
-    out
 }
 
 /// Compute the byte range of the script BODY (between the opening tag's

--- a/crates/rsvelte_formatter/tests/markup_expression_indent.rs
+++ b/crates/rsvelte_formatter/tests/markup_expression_indent.rs
@@ -72,7 +72,11 @@ fn content_expression_continuation_scales_with_depth() {
 #[test]
 fn content_expression_under_width_stays_inline() {
     // Comfortably under 100 at depth 1 — no break.
-    let src = concat!("<div>\n", "  {someCondition ? firstValue : secondValue}\n", "</div>\n");
+    let src = concat!(
+        "<div>\n",
+        "  {someCondition ? firstValue : secondValue}\n",
+        "</div>\n"
+    );
     assert_eq!(fmt_at_width(src, 100), src);
 }
 
@@ -98,5 +102,8 @@ fn content_expression_wrap_is_idempotent() {
     );
     let once = fmt_at_width(src, 100);
     let twice = fmt_at_width(&once, 100);
-    assert_eq!(once, twice, "wrapped content expression not idempotent:\n{once}");
+    assert_eq!(
+        once, twice,
+        "wrapped content expression not idempotent:\n{once}"
+    );
 }

--- a/crates/rsvelte_formatter/tests/markup_expression_indent.rs
+++ b/crates/rsvelte_formatter/tests/markup_expression_indent.rs
@@ -1,0 +1,102 @@
+//! Markup expression wrapping must match prettier-plugin-svelte (the engine
+//! `oxfmt` delegates `.svelte` to). Two rules are exercised here:
+//!
+//! 1. A **content** expression (`{expr}`, `{@html}`, …) is formatted at indent
+//!    0 then spliced at its markup nesting depth. The wrap decision must be
+//!    made against the width that remains *after* that indent, and any
+//!    continuation lines must be pushed out to the nesting depth — otherwise a
+//!    line that fits at column 0 silently overflows once nested, or wraps with
+//!    its continuation stuck at column 0.
+//! 2. A **block-header** expression (`{#if cond}`, `{#each …}`) is never broken
+//!    across lines, regardless of width.
+
+use rsvelte_formatter::{FormatOptions, JsFormatOptions, LineWidth, format};
+
+/// Format at an explicit `line_width` (flyle uses 100; the `JsFormatOptions`
+/// default is 80, too narrow for these fixtures).
+fn fmt_at_width(src: &str, line_width: u16) -> String {
+    let opts = FormatOptions {
+        js: JsFormatOptions {
+            line_width: LineWidth::try_from(line_width).expect("valid line width"),
+            ..JsFormatOptions::new()
+        },
+        ..FormatOptions::default()
+    };
+    format(src, &opts).expect("format ok")
+}
+
+#[test]
+fn content_expression_wraps_with_continuation_at_nesting_depth() {
+    // At depth 1 (2-space indent) this ternary clears 100 columns, so it breaks
+    // — `{someCondition` stays inline after the `{`, the `?`/`:` arms land at
+    // depth 2 (4 spaces). Formatted at column 0 it would "fit" and never break.
+    let src = concat!(
+        "<div>\n",
+        "  {someCondition ? aLongFirstBranchValueGoesHere : aLongSecondBranchValueThatClearlyOverflowsThePrintWidthByALot}\n",
+        "</div>\n",
+    );
+    let expected = concat!(
+        "<div>\n",
+        "  {someCondition\n",
+        "    ? aLongFirstBranchValueGoesHere\n",
+        "    : aLongSecondBranchValueThatClearlyOverflowsThePrintWidthByALot}\n",
+        "</div>\n",
+    );
+    assert_eq!(fmt_at_width(src, 100), expected);
+}
+
+#[test]
+fn content_expression_continuation_scales_with_depth() {
+    // One level deeper (inside `{#if}`), the `{` sits at depth 2 (4 spaces) and
+    // its continuation at depth 3 (6 spaces) — the narrowing and re-indent both
+    // track the nesting level.
+    let src = concat!(
+        "<div>\n",
+        "  {#if show}\n",
+        "    {someCondition ? aFirstBranchValueGoesHere : aSecondBranchValueThatClearlyOverflowsThePrintWidthByALot}\n",
+        "  {/if}\n",
+        "</div>\n",
+    );
+    let expected = concat!(
+        "<div>\n",
+        "  {#if show}\n",
+        "    {someCondition\n",
+        "      ? aFirstBranchValueGoesHere\n",
+        "      : aSecondBranchValueThatClearlyOverflowsThePrintWidthByALot}\n",
+        "  {/if}\n",
+        "</div>\n",
+    );
+    assert_eq!(fmt_at_width(src, 100), expected);
+}
+
+#[test]
+fn content_expression_under_width_stays_inline() {
+    // Comfortably under 100 at depth 1 — no break.
+    let src = concat!("<div>\n", "  {someCondition ? firstValue : secondValue}\n", "</div>\n");
+    assert_eq!(fmt_at_width(src, 100), src);
+}
+
+#[test]
+fn block_header_if_condition_stays_inline_over_width() {
+    // 113 columns wide — prettier-plugin-svelte keeps a block tag's expression
+    // on one line regardless. A naive width-based printer would break each
+    // `&&`; the block-header path must force a single line.
+    let src = concat!(
+        "{#if alphaCondition && betaCondition && gammaCondition && deltaCondition && epsilonCondition && zetaConditionHere}\n",
+        "  <span>x</span>\n",
+        "{/if}\n",
+    );
+    assert_eq!(fmt_at_width(src, 100), src);
+}
+
+#[test]
+fn content_expression_wrap_is_idempotent() {
+    let src = concat!(
+        "<div>\n",
+        "  {someCondition ? aLongFirstBranchValueGoesHere : aLongSecondBranchValueThatClearlyOverflowsThePrintWidthByALot}\n",
+        "</div>\n",
+    );
+    let once = fmt_at_width(src, 100);
+    let twice = fmt_at_width(&once, 100);
+    assert_eq!(once, twice, "wrapped content expression not idempotent:\n{once}");
+}


### PR DESCRIPTION
## What

`oxfmt` delegates `.svelte` formatting to `prettier-plugin-svelte`, which decides where a JS expression breaks against the **column it actually renders at**. rsvelte formatted every expression at indent 0 and spliced it in, so wrap decisions used the full print width regardless of nesting — a line that "fit" at column 0 silently overflowed once nested, and continuation lines stuck at column 0 instead of aligning to the nesting depth.

## Changes

- **`<script>`**: narrow the JS body width by one indent level before formatting (the body is nested one level under `<script>`).
- **Content expressions** (`{expr}`, `{@html}`, `{@render}`, `{@attach}`): thread the markup nesting depth through the template walk, narrow the width by `depth × indent_width`, and re-indent continuation lines to that depth.
- **Block headers** (`{#if}`, `{#each}`, `{:else if}`, `{#key}`, `{#await}`, snippet name): force a single line — `prettier-plugin-svelte` never breaks a block tag's expression regardless of width.
- Factor the template-literal-aware re-indent scanner shared by the script and expression paths into `reindent.rs` (was duplicated in `script.rs`).

## Verification

On the flyle-nexus corpus (1,115 `.svelte` files), divergence vs `oxfmt` 0.53 drops **180 → 111**, with **zero idempotency breaks** and **zero `svelte`-parse breaks**.

Remaining divergence (tracked for follow-up): attribute-value depth-aware wrapping & brace-breaking, close-tag placement (`</tag\n>`), and `{#snippet}` parameter expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)