### PR TITLE
fix(svelte2tsx): wire named snippet child into component props (#780)

### DIFF
--- a/.changeset/svelte2tsx-named-snippet-component-prop.md
+++ b/.changeset/svelte2tsx-named-snippet-component-prop.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): wire a named `{#snippet}` child of a component into its `props` object. A snippet passed to a component (`<Comp>{#snippet row(..)}…{/snippet}</Comp>`) was lowered as a standalone `const row = …` emitted *after* the instantiation, so the component was constructed with empty props and `--tsgo` reported a false `Property 'row' is missing in type '{}' but required in type '$$ComponentProps'`. The snippet is now emitted as an implicit prop inside the `props: { … }` object literal (`props: { row: (params) => … }`), mirroring upstream svelte2tsx's `addImplicitSnippetProp` — relocated there via `MagicString::move_range`. This satisfies required snippet props and lets TypeScript contextually type the snippet's parameters from the prop's `Snippet<[T]>` type (so a destructured `{#snippet row({ id })}` no longer trips `noImplicitAny`). Verified against real `tsgo` on the issue repro (0 errors). Closes #780.

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -1808,6 +1808,36 @@ fn handle_snippet_block(
     str: &mut MagicString,
     counter: &mut Counter,
 ) {
+    handle_snippet_block_inner(block, source, options, str, counter, false);
+}
+
+/// Transform a `{#snippet name(params)}` block that is a direct child of a
+/// component into an **implicit prop**: `name:(params) => { async () => { …body…
+/// };return __sveltets_2_any(0)},`. Unlike the standalone form there is no
+/// leading `const`, no `: ReturnType<…>` annotation, and the closing ends in a
+/// `,` so the result drops straight into the component's `props: { … }` object
+/// literal (the caller relocates the range there via `move_range`). This mirrors
+/// upstream svelte2tsx `addImplicitSnippetProp`, and lets TypeScript
+/// contextually type the snippet's parameters from the prop's `Snippet<[T]>`
+/// type while satisfying required snippet props (#780).
+fn handle_snippet_block_as_component_prop(
+    block: &SnippetBlock,
+    source: &str,
+    options: &Svelte2TsxOptions,
+    str: &mut MagicString,
+    counter: &mut Counter,
+) {
+    handle_snippet_block_inner(block, source, options, str, counter, true);
+}
+
+fn handle_snippet_block_inner(
+    block: &SnippetBlock,
+    source: &str,
+    options: &Svelte2TsxOptions,
+    str: &mut MagicString,
+    counter: &mut Counter,
+    as_component_prop: bool,
+) {
     if block.start >= block.end {
         return;
     }
@@ -1848,7 +1878,17 @@ fn handle_snippet_block(
         (true, Some(tp)) => format!("<{}>", tp),
         _ => String::new(),
     };
-    let header = if use_ts_syntax {
+    // Implicit-prop form (`name:(params) => …`) vs standalone declaration
+    // (`const name = (params): ReturnType<…> => …`). The implicit form omits the
+    // leading `const`, the return-type annotation, and the generic `<typeParams>`
+    // — mirroring upstream's `addImplicitSnippetProp` transforms — and closes
+    // with a trailing `,` so it slots into the component `props` object literal.
+    let header = if as_component_prop {
+        format!(
+            "{}:({}) => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
+            name_text, params_text
+        )
+    } else if use_ts_syntax {
         format!(
             "  const {}/*\u{03A9}ignore_position\u{03A9}*/ = {}({})/*\u{03A9}ignore_start\u{03A9}*/: ReturnType<import('svelte').Snippet>/*\u{03A9}ignore_end\u{03A9}*/ => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
             name_text, type_params_str, params_text
@@ -1862,6 +1902,11 @@ fn handle_snippet_block(
             name_text, params_text
         )
     };
+    let closing = if as_component_prop {
+        "};return __sveltets_2_any(0)},"
+    } else {
+        "};return __sveltets_2_any(0)};"
+    };
     if has_body_nodes {
         str.overwrite(block.start, body_start, &header);
         // Process body
@@ -1870,7 +1915,7 @@ fn handle_snippet_block(
         let body_end = block.body.nodes.last().unwrap().end();
         if body_end < block.end {
             // Overwrite `{/snippet}` with closing
-            str.overwrite(body_end, block.end, "};return __sveltets_2_any(0)};");
+            str.overwrite(body_end, block.end, closing);
         }
     } else {
         // Empty body: collapse the whole `{#snippet name(params)}{/snippet}`
@@ -1878,7 +1923,7 @@ fn handle_snippet_block(
         // `};return __sveltets_2_any(0)};` was never emitted because both the
         // body-start overwrite and the would-be closing overwrite landed at
         // the same offset.
-        let combined = format!("{}}};return __sveltets_2_any(0)}};", header);
+        let combined = format!("{}{}", header, closing);
         str.overwrite(block.start, block.end, &combined);
     }
 }
@@ -2105,6 +2150,21 @@ fn handle_component(
     // - there are children with slot="name" that have let: directives
     let needs_instance = has_events || has_lets || children_have_named_slots;
 
+    // Named `{#snippet}` blocks that are direct children of a component are
+    // passed as *implicit props* (`props: { name: (params) => … }`), not as
+    // standalone `const name = …` declarations, so that TypeScript both
+    // satisfies required snippet props and contextually types the snippet's
+    // parameters from the prop's `Snippet<[T]>` type (#780). This relocation is
+    // only wired through the simple-children path; when the component also uses
+    // `let:` / named slots the children go through `process_component_children_with_slots`,
+    // which owns its own block scoping, so the snippets stay standalone there.
+    let use_snippet_props = !(has_lets || children_have_named_slots)
+        && comp
+            .fragment
+            .nodes
+            .iter()
+            .any(|n| matches!(n, TemplateNode::SnippetBlock(_)));
+
     // Check if Svelte 5 children prop is needed
     let is_svelte5 = matches!(options.version, SvelteVersion::V5);
 
@@ -2220,7 +2280,12 @@ fn handle_component(
     let mut opener_segs: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 2);
     opener_segs.push(Seg::Lit(header_lit));
     opener_segs.extend(attr_segs);
-    opener_segs.push(Seg::Lit(trailer_lit));
+    if !use_snippet_props {
+        // The snippet-prop path leaves the `props: { … ` object literal open so
+        // the relocated `{#snippet}` props can be appended inside it; the trailer
+        // (which closes the object) is emitted after the moves (see below).
+        opener_segs.push(Seg::Lit(trailer_lit.clone()));
+    }
     let opener_segs = bake_out_of_order_src(opener_segs, source);
     emit_segmented_overwrite(str, comp.start, opening_tag_end, &opener_segs);
 
@@ -2240,6 +2305,48 @@ fn handle_component(
             str,
             counter,
         );
+    } else if use_snippet_props {
+        // Process children, turning each direct `{#snippet}` child into an
+        // implicit prop relocated into the still-open `props: { … }` object.
+        //
+        // `move_range(s.start, s.end, anchor)` detaches the transformed snippet
+        // chunk and re-links it immediately before the chunk that *starts* at
+        // `anchor`. Moving snippets in source order to a fixed `anchor` preserves
+        // their order (each new one lands right before the anchor chunk, i.e.
+        // after the previously moved one). A leading run of snippets that sit
+        // natively at the anchor (no intervening whitespace) is already in the
+        // right place — moving them would be a no-op self-move (which the API
+        // forbids) — so we just advance the anchor past them. The trailer that
+        // closes the props object is appended after the final snippet.
+        let mut anchor = opening_tag_end;
+        let mut last_snippet_end: Option<u32> = None;
+        for node in &comp.fragment.nodes {
+            if let TemplateNode::SnippetBlock(s) = node {
+                if s.start >= s.end {
+                    continue;
+                }
+                handle_snippet_block_as_component_prop(s, source, options, str, counter);
+                if s.start == anchor {
+                    anchor = s.end;
+                } else {
+                    str.move_range(s.start, s.end, anchor);
+                }
+                last_snippet_end = Some(s.end);
+            } else {
+                process_node_inplace(node, source, options, str, counter);
+            }
+        }
+        // Close the props object right after the last relocated snippet.
+        match last_snippet_end {
+            Some(end) => {
+                str.append_left(end, &trailer_lit);
+            }
+            None => {
+                // No usable snippet after all (e.g. only empty-named blocks);
+                // close the props object at the opening-tag boundary.
+                str.prepend_right(opening_tag_end, &trailer_lit);
+            }
+        }
     } else {
         // Simple children processing (no slot scoping needed)
         process_fragment_inplace(&comp.fragment, source, options, str, counter);

--- a/crates/rsvelte_core/tests/svelte2tsx_snippet_component_prop.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_snippet_component_prop.rs
@@ -1,0 +1,138 @@
+//! Regression test for issue #780.
+//!
+//! A named `{#snippet}` block that is a direct child of a component
+//! (`<Comp>{#snippet row(..)}…{/snippet}</Comp>`) must be lowered as an
+//! *implicit prop* inside the component's `props: { … }` object literal, not as
+//! a standalone `const row = …` emitted after the instantiation. Otherwise the
+//! component is constructed with empty props and TypeScript reports
+//! `Property 'row' is missing in type '{}' but required in type '$$ComponentProps'`.
+//! Placing the snippet inside the props literal both satisfies the required
+//! snippet prop and lets TypeScript contextually type the snippet's parameters
+//! from the prop's `Snippet<[T]>` type.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn overlay(src: &str) -> String {
+    svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".into(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code
+}
+
+fn braces_balanced(s: &str) -> bool {
+    let mut depth: i32 = 0;
+    let mut in_str: Option<char> = None;
+    let mut prev = '\0';
+    for c in s.chars() {
+        match in_str {
+            Some(q) => {
+                if c == q && prev != '\\' {
+                    in_str = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' | '`' => in_str = Some(c),
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            },
+        }
+        if depth < 0 {
+            return false;
+        }
+        prev = c;
+    }
+    depth == 0
+}
+
+const USE: &str = "<script lang=\"ts\">\n\
+                   import List from './List.svelte';\n\
+                   </script>\n\
+                   <List>\n\
+                   {#snippet row({ id })}<p>{id}</p>{/snippet}\n\
+                   </List>";
+
+#[test]
+fn named_snippet_is_emitted_inside_component_props() {
+    let code = overlay(USE);
+    // The snippet's arrow function must appear inside the props object literal as
+    // a `row:` property, directly assigned so its `{ id }` parameter is
+    // contextually typed from the prop's `Snippet<[…]>` type.
+    assert!(
+        code.contains("props: {row:({ id }) =>"),
+        "snippet not wired into props object:\n{code}"
+    );
+}
+
+#[test]
+fn named_snippet_not_emitted_as_standalone_const() {
+    let code = overlay(USE);
+    assert!(
+        !code.contains("const row"),
+        "snippet should not be a standalone `const row`:\n{code}"
+    );
+}
+
+#[test]
+fn snippet_prop_overlay_is_brace_balanced() {
+    let code = overlay(USE);
+    assert!(braces_balanced(&code), "unbalanced overlay:\n{code}");
+}
+
+#[test]
+fn snippet_prop_keeps_ensurecomponent_instantiation() {
+    let code = overlay(USE);
+    assert!(
+        code.contains("__sveltets_2_ensureComponent(List)"),
+        "component instantiation missing:\n{code}"
+    );
+    // props object must be closed right after the relocated snippet.
+    assert!(
+        code.contains("};return __sveltets_2_any(0)},}});"),
+        "props object not closed after snippet:\n{code}"
+    );
+}
+
+#[test]
+fn multiple_named_snippets_preserve_order() {
+    let src = "<script lang=\"ts\">import List from './List.svelte';</script>\n\
+               <List>\n\
+               {#snippet a()}<p>A</p>{/snippet}\n\
+               {#snippet b()}<p>B</p>{/snippet}\n\
+               </List>";
+    let code = overlay(src);
+    assert!(braces_balanced(&code), "unbalanced overlay:\n{code}");
+    let ai = code.find("a:() =>").expect("snippet a missing");
+    let bi = code.find("b:() =>").expect("snippet b missing");
+    assert!(ai < bi, "snippet order not preserved:\n{code}");
+}
+
+#[test]
+fn empty_body_snippet_prop_is_balanced() {
+    let src = "<script lang=\"ts\">import List from './List.svelte';</script>\n\
+               <List>{#snippet row()}{/snippet}</List>";
+    let code = overlay(src);
+    assert!(braces_balanced(&code), "unbalanced overlay:\n{code}");
+    assert!(
+        code.contains("props: {row:() =>"),
+        "empty-body snippet not wired into props:\n{code}"
+    );
+}
+
+#[test]
+fn standalone_snippet_still_const() {
+    // Guard: a snippet that is NOT a component child stays a standalone const.
+    let src = "<script lang=\"ts\"></script>\n\
+               {#snippet row()}<p>x</p>{/snippet}";
+    let code = overlay(src);
+    assert!(
+        code.contains("const row"),
+        "standalone snippet should remain a const:\n{code}"
+    );
+}


### PR DESCRIPTION
Closes #780. Follow-up to #752 (part 2).

## Problem

A named `{#snippet}` block passed as a direct child of a component —
`<Comp>{#snippet row(..)}…{/snippet}</Comp>` — was lowered as a standalone
`const row = …` emitted **after** the component instantiation, so the component
was constructed with an **empty props object** and `--tsgo` reported a false:

```
Property 'row' is missing in type '{}' but required in type '$$ComponentProps'.
```

Official `svelte-check`: 0 errors.

## Fix

Named snippet children are now emitted as **implicit props** inside the
component's `props: { … }` object literal, mirroring upstream svelte2tsx's
`addImplicitSnippetProp`:

```tsx
{ const $$_tsiL0CC = __sveltets_2_ensureComponent(List);
  new $$_tsiL0CC({ target: __sveltets_2_any(), props: {row:({ id }) => { async () => {<p>{id}</p>};return __sveltets_2_any(0)},}}); List }
```

- `handle_snippet_block` gained an implicit-prop mode (`name:(params) => …`, no
  `const`, no return-type annotation, trailing `,`).
- In `handle_component`, when the simple-children path applies, the props object
  literal is left open; each snippet child is transformed in place and relocated
  into it via `MagicString::move_range` (a stable-anchor walk preserves source
  order and avoids the self-move panic when a snippet sits flush against the
  opening tag); the trailer that closes the object is appended after the last
  relocated snippet.

Because the snippet's arrow is now the **direct value** of the `row` property in
the props literal (checked against `$$ComponentProps`), TypeScript contextually
types the snippet's parameters from the prop's `Snippet<[T]>` type — so a
destructured `{#snippet row({ id })}` no longer trips `noImplicitAny` either.

Only the simple-children path is rerouted; components that also use `let:` /
named slots keep the existing `process_component_children_with_slots` flow.

## Verification

- **Real `tsgo`** (7.0.0-dev) on the exact issue repro (`List.svelte` +
  `Use.svelte`, `strict: true`): **0 errors**.
- `svelte2tsx` fixtures: unchanged (no regressions).
- `svelte2tsx_component_snippet_children` (#752 part 1): still green.
- New `crates/rsvelte_core/tests/svelte2tsx_snippet_component_prop.rs` (7 cases):
  snippet-in-props shape, no standalone `const`, brace balance, multi-snippet
  order, empty-body snippet, and a standalone-snippet guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)