### PR TITLE
fix(svelte2tsx): wire named snippet children into component props (#780)

### DIFF
--- a/.changeset/svelte2tsx-component-snippet-prop.md
+++ b/.changeset/svelte2tsx-component-snippet-prop.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): wire named snippet children into component props. A named snippet passed as a direct child of a component (`<List>{#snippet row(..)}…{/snippet}</List>`) was lowered to a standalone `const row = …` inside the component block while the props object stayed empty, so TypeScript reported a false `Property 'row' is missing in type '{}' but required in type '$$ComponentProps'` for any required `Snippet` prop. The overlay now adds a `row` shorthand prop and relocates the snippet declaration to before the component block (so the reference is in scope and its `: ReturnType<import('svelte').Snippet>` return type keeps it assignable to the prop), mirroring upstream's implicit-snippet-prop behaviour. Verified with tsc: the false "missing prop" error is gone (0 errors, matching official svelte-check).

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -2096,6 +2096,31 @@ fn handle_component(
     // Check if component has meaningful children
     let has_children = has_component_slot_children(&comp.fragment, source);
 
+    // Direct `{#snippet name(..)}` children become implicit props of the
+    // component (`<List>{#snippet row(..)}…{/snippet}</List>` → `row` prop),
+    // satisfying required `Snippet` props and matching official svelte-check
+    // (0 errors). Mirrors upstream's `addImplicitSnippetProp`. Rather than
+    // relocate the snippet body *into* the props literal (which would need an
+    // insertable boundary mid-props), each snippet keeps its normal `const
+    // name = (..) => {…}` lowering and is `move_range`d to just before the
+    // component block, so a `name` shorthand prop can reference it without a
+    // temporal-dead-zone error. The const's `: ReturnType<import('svelte').
+    // Snippet>` return type keeps it assignable to the `Snippet<…>` prop.
+    // See #780 / #752.
+    let snippet_prop_children: Vec<(String, u32, u32)> = comp
+        .fragment
+        .nodes
+        .iter()
+        .filter_map(|n| match n {
+            TemplateNode::SnippetBlock(b) if b.start < b.end => Some((
+                get_expression_text(&b.expression, source).to_string(),
+                b.start,
+                b.end,
+            )),
+            _ => None,
+        })
+        .collect();
+
     // Check if any children have named slots with let: directives
     let children_have_named_slots = has_named_slot_children(&comp.fragment, source);
 
@@ -2155,6 +2180,21 @@ fn handle_component(
             prefixed.push(Seg::Lit(format!("{}{}", leading_ws, children_text)));
             prefixed.extend(attr_segs);
             attr_segs = prefixed;
+        }
+    }
+
+    // Append a `name,` shorthand prop for each direct `{#snippet}` child so the
+    // (hoisted-before-the-block) snippet declaration satisfies the component's
+    // `Snippet` prop. Added after the attribute/children props.
+    if !snippet_prop_children.is_empty() {
+        let props_lit: String = snippet_prop_children
+            .iter()
+            .map(|(name, _, _)| format!("{},", name))
+            .collect();
+        if segs_is_empty(&attr_segs) {
+            attr_segs = vec![Seg::Lit(format!(" {}", props_lit))];
+        } else {
+            attr_segs.push(Seg::Lit(props_lit));
         }
     }
 
@@ -2243,6 +2283,14 @@ fn handle_component(
     } else {
         // Simple children processing (no slot scoping needed)
         process_fragment_inplace(&comp.fragment, source, options, str, counter);
+    }
+
+    // Relocate each direct `{#snippet}` child (now lowered to a `const name =
+    // …;` declaration) to just before the component block, so the `name`
+    // shorthand prop added above references an already-declared binding rather
+    // than hitting a temporal dead zone inside the props object.
+    for (_, s, e) in &snippet_prop_children {
+        str.move_range(*s, *e, comp.start);
     }
 
     // For components with `let:` but NO children (in either bracketed

--- a/crates/rsvelte_core/tests/svelte2tsx_component_snippet_prop.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_component_snippet_prop.rs
@@ -1,0 +1,133 @@
+//! Regression test for issue #780.
+//!
+//! A named snippet passed as a direct child of a component
+//! (`<List>{#snippet row(..)}…{/snippet}</List>`) must be wired into the
+//! component's props so a required `Snippet` prop is satisfied. Previously the
+//! snippet was emitted as a standalone `const row = …` *inside* the component
+//! block while the props object stayed empty, so TypeScript reported a false
+//! `Property 'row' is missing in type '{}' but required in type
+//! '$$ComponentProps'`. The fix adds a `row` shorthand prop and relocates the
+//! snippet declaration to before the component block (so the reference is in
+//! scope), mirroring upstream's implicit-snippet-prop behaviour. Verified
+//! end-to-end with tsc: the false "missing prop" error is gone (0 errors,
+//! matching official svelte-check).
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "Use.svelte".into(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code
+}
+
+fn braces_balanced(s: &str) -> bool {
+    let mut depth: i32 = 0;
+    let mut in_str: Option<char> = None;
+    let mut prev = '\0';
+    for c in s.chars() {
+        match in_str {
+            Some(q) => {
+                if c == q && prev != '\\' {
+                    in_str = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' | '`' => in_str = Some(c),
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            },
+        }
+        if depth < 0 {
+            return false;
+        }
+        prev = c;
+    }
+    depth == 0
+}
+
+/// The opener line carrying `new $$_…({ … props: { … } })`.
+fn opener(out: &str) -> String {
+    out.lines()
+        .find(|l| l.contains("ensureComponent"))
+        .unwrap_or("")
+        .to_string()
+}
+
+#[test]
+fn named_snippet_child_becomes_prop() {
+    let src = "<script lang=\"ts\">\n  import List from './List.svelte';\n</script>\n\
+               <List>\n  {#snippet row({ id })}<p>{id}</p>{/snippet}\n</List>";
+    let out = to_tsx(src);
+    assert!(braces_balanced(&out), "unbalanced overlay:\n{out}");
+    let op = opener(&out);
+    // `row` is wired into the props object …
+    assert!(
+        op.contains("props: { row,"),
+        "snippet prop not wired:\n{op}"
+    );
+    // … and the snippet declaration is hoisted before the component block.
+    let const_pos = out.find("const row").expect("snippet const");
+    let block_pos = out
+        .find("__sveltets_2_ensureComponent(List)")
+        .expect("block");
+    assert!(
+        const_pos < block_pos,
+        "snippet const must precede the component block:\n{out}"
+    );
+}
+
+#[test]
+fn multiple_named_snippets_all_wired() {
+    let src = "<script lang=\"ts\">import L from './L.svelte';</script>\n\
+               <L>{#snippet a()}<p>x</p>{/snippet}{#snippet b(n)}<p>{n}</p>{/snippet}</L>";
+    let out = to_tsx(src);
+    assert!(braces_balanced(&out), "unbalanced overlay:\n{out}");
+    let op = opener(&out);
+    assert!(
+        op.contains("props: { a,b,"),
+        "both snippets not wired:\n{op}"
+    );
+}
+
+#[test]
+fn snippet_prop_alongside_attribute() {
+    let src = "<script lang=\"ts\">import L from './L.svelte';let v=1;</script>\n\
+               <L x={v}>{#snippet a()}<p>x</p>{/snippet}</L>";
+    let out = to_tsx(src);
+    assert!(braces_balanced(&out), "unbalanced overlay:\n{out}");
+    let op = opener(&out);
+    assert!(op.contains("\"x\":v,"), "attribute prop lost:\n{op}");
+    assert!(op.contains("a,}"), "snippet prop not appended:\n{op}");
+}
+
+#[test]
+fn snippet_prop_alongside_real_children() {
+    // Non-snippet content keeps the `children` prop; the snippet is appended.
+    let src = "<script lang=\"ts\">import L from './L.svelte';</script>\n\
+               <L>hello{#snippet a()}<p>x</p>{/snippet}</L>";
+    let out = to_tsx(src);
+    assert!(braces_balanced(&out), "unbalanced overlay:\n{out}");
+    let op = opener(&out);
+    assert!(op.contains("children:"), "children prop lost:\n{op}");
+    assert!(op.contains(",a,}"), "snippet prop not appended:\n{op}");
+}
+
+#[test]
+fn self_closing_component_unchanged() {
+    // No snippet children → no snippet props, behaviour untouched.
+    let src = "<script lang=\"ts\">import L from './L.svelte';</script>\n<L/>";
+    let out = to_tsx(src);
+    assert!(braces_balanced(&out), "unbalanced overlay:\n{out}");
+    assert!(
+        !out.contains("const a"),
+        "unexpected snippet emission:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #780. Follow-up to #752.

## Problem

A named snippet passed as a direct child of a component is a Svelte 5 way to fill a `Snippet` prop:

```svelte
<List>
  {#snippet row({ id })}<p>{id}</p>{/snippet}
</List>
```

The overlay lowered the snippet to a standalone `const row = …` **inside** the component block while the props object stayed empty:

```tsx
{ const $$_tsiL0C = __sveltets_2_ensureComponent(List);
  new $$_tsiL0C({ target: __sveltets_2_any(), props: {} });   // <-- empty
  const row = (…) => { … };                                   // <-- standalone, never wired
  List }
```

So for a required prop `let { row }: { row: Snippet<[{ id: string }]> } = $props()`, TypeScript reported a false `Property 'row' is missing in type '{}' but required in type '$$ComponentProps'`. Official svelte-check reports 0 errors.

## Fix

For each direct `{#snippet name(..)}` child of a component:
1. add a `name` shorthand prop to the component's props object, and
2. `move_range` the (normally-lowered) `const name = (..) => {…}` declaration to **before** the component block, so the prop reference is in scope (no temporal dead zone).

The snippet const keeps its `: ReturnType<import('svelte').Snippet>` return type, which stays assignable to the `Snippet<…>` prop. This mirrors upstream's `addImplicitSnippetProp` intent without needing an insertable boundary inside the props literal.

```tsx
const row = (…): ReturnType<import('svelte').Snippet> => { … };
{ const $$_tsiL0C = __sveltets_2_ensureComponent(List);
  new $$_tsiL0C({ target: __sveltets_2_any(), props: { row, } });
  List }
```

## Validation

- **tsc oracle** on the exact issue repro (List.svelte + Use.svelte): **0 errors** — the false "missing prop" is gone, matching official svelte-check.
- svelte2tsx fixtures: **253/253** (no component-child-snippet fixtures existed, so none change).
- New `crates/rsvelte_core/tests/svelte2tsx_component_snippet_prop.rs`: single snippet (prop wired + const hoisted before block), multiple snippets, snippet + attribute, snippet + real children (keeps `children` prop), self-closing guard, all brace-balanced.

Note: this fixes the false-positive (the reported bug). Per-parameter contextual typing from the prop's `Snippet<[T]>` (params currently widen to the snippet's own inference) is a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)