### PR TITLE
fix(parse): emit UTF-16 span offsets, not UTF-8 byte offsets (#793)

### DIFF
--- a/.changeset/parse-utf16-offsets.md
+++ b/.changeset/parse-utf16-offsets.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix(parse): emit AST spans as UTF-16 code-unit offsets, not UTF-8 byte offsets. `parse_svelte` (WASM), `parse` (native), and `parseEnvelope` (native raw-transfer) emitted node `start`/`end` (and `loc` `column`/`character`) as UTF-8 byte offsets, while `svelte/compiler` and the whole JS ecosystem (`magic-string`, `svelte-eslint-parser`, every `String.slice` consumer) use UTF-16 code-unit offsets. For ASCII source the two coincide, but the moment a source contains a non-ASCII character (e.g. Japanese UI strings) before a node, every later span was shifted by `byteLen − utf16Len` — producing wrong slices or a hard `magic-string` "end is out of bounds" crash. All three parse output surfaces now remap byte → UTF-16 on the way out (reusing the same converter the legacy AST path already applied), so `source.slice(node.start, node.end)` is correct regardless of preceding non-ASCII content. ASCII source keeps its fast path (the remap is skipped entirely). Closes #793.

--- a/crates/rsvelte_core/src/compiler/legacy.rs
+++ b/crates/rsvelte_core/src/compiler/legacy.rs
@@ -38,7 +38,12 @@ static REGEX_ENDS_WITH_WHITESPACE: LazyLock<Regex> =
 static REGEX_NOT_WHITESPACE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[^ \t\r\n]").unwrap());
 
 /// Converter from UTF-8 byte positions to UTF-16 code unit positions.
-struct Utf8ToUtf16 {
+///
+/// `pub(crate)` so the modern parse output paths (`wasm::parse_svelte`,
+/// `napi::parse`, and the raw-transfer envelope encoder) can reuse the same
+/// remap the legacy path already applies, keeping every public AST surface on
+/// svelte/compiler's UTF-16 offsets (#793).
+pub(crate) struct Utf8ToUtf16 {
     utf16_pos: Vec<usize>,
     /// (byte offset, utf16 offset) for each line start
     line_starts_byte: Vec<usize>,
@@ -46,7 +51,7 @@ struct Utf8ToUtf16 {
 }
 
 impl Utf8ToUtf16 {
-    fn new(source: &str) -> Self {
+    pub(crate) fn new(source: &str) -> Self {
         let mut utf16_pos = Vec::with_capacity(source.len() + 1);
         let mut utf16_idx = 0;
         let mut line_starts_byte = vec![0];
@@ -75,7 +80,7 @@ impl Utf8ToUtf16 {
         }
     }
 
-    fn convert(&self, utf8_pos: usize) -> usize {
+    pub(crate) fn convert(&self, utf8_pos: usize) -> usize {
         if utf8_pos >= self.utf16_pos.len() {
             *self.utf16_pos.last().unwrap_or(&0)
         } else {
@@ -85,7 +90,7 @@ impl Utf8ToUtf16 {
 
     /// Convert a column from byte offset to UTF-16 code unit offset within a line.
     /// line is 1-based, column is 0-based byte offset from line start.
-    fn convert_column(&self, line: usize, byte_column: usize) -> usize {
+    pub(crate) fn convert_column(&self, line: usize, byte_column: usize) -> usize {
         if line == 0 || line > self.line_starts_byte.len() {
             return byte_column;
         }
@@ -105,7 +110,7 @@ impl Utf8ToUtf16 {
 }
 
 /// Recursively convert positions in JSON from UTF-8 to UTF-16.
-fn convert_positions_to_utf16(value: &mut Value, pos_conv: &Utf8ToUtf16) {
+pub(crate) fn convert_positions_to_utf16(value: &mut Value, pos_conv: &Utf8ToUtf16) {
     match value {
         Value::Object(map) => {
             if let Some(Value::Number(n)) = map.get("start")
@@ -1770,5 +1775,92 @@ fn remove_surrounding_whitespace_nodes(nodes: &mut Vec<TemplateNode>) {
             last.data = new_data.to_string().into();
             last.raw = last.data.clone();
         }
+    }
+}
+
+#[cfg(test)]
+mod utf16_offset_tests {
+    use super::{Utf8ToUtf16, convert_positions_to_utf16};
+    use crate::ast::arena::with_serialize_arena;
+    use crate::compiler::phases::phase1_parse::{ParseOptions, parse};
+    use serde_json::Value;
+
+    /// Walk the AST JSON and, for every `Identifier`, assert that the UTF-16
+    /// slice `[start, end)` of the source equals the identifier's `name`.
+    fn assert_identifiers_utf16_aligned(value: &Value, utf16: &[u16]) {
+        match value {
+            Value::Object(map) => {
+                if map.get("type").and_then(|t| t.as_str()) == Some("Identifier")
+                    && let (Some(name), Some(start), Some(end)) = (
+                        map.get("name").and_then(|v| v.as_str()),
+                        map.get("start").and_then(|v| v.as_u64()),
+                        map.get("end").and_then(|v| v.as_u64()),
+                    )
+                {
+                    let (s, e) = (start as usize, end as usize);
+                    assert!(
+                        e <= utf16.len(),
+                        "end {e} out of bounds (len {})",
+                        utf16.len()
+                    );
+                    let slice = String::from_utf16(&utf16[s..e]).unwrap();
+                    assert_eq!(
+                        slice, name,
+                        "identifier '{name}' span {s}..{e} sliced to '{slice}'"
+                    );
+                }
+                for v in map.values() {
+                    assert_identifiers_utf16_aligned(v, utf16);
+                }
+            }
+            Value::Array(arr) => {
+                for v in arr {
+                    assert_identifiers_utf16_aligned(v, utf16);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Mirrors exactly what `wasm::parse_svelte` / `napi::parse` do for the
+    /// non-ASCII path: serialize the modern AST to a Value and remap byte
+    /// offsets to UTF-16 (#793).
+    #[test]
+    fn modern_parse_emits_utf16_offsets() {
+        // 'あ' is 3 UTF-8 bytes but 1 UTF-16 code unit.
+        let src = "<script>\n  const あ = 1;\n  const target = あ;\n</script>\n<p>{target}</p>";
+        let ast = parse(
+            src,
+            ParseOptions {
+                modern: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let mut value = with_serialize_arena(&ast.arena, || serde_json::to_value(&ast).unwrap());
+        let conv = Utf8ToUtf16::new(src);
+        convert_positions_to_utf16(&mut value, &conv);
+
+        let utf16: Vec<u16> = src.encode_utf16().collect();
+        assert_identifiers_utf16_aligned(&value, &utf16);
+    }
+
+    #[test]
+    fn ascii_offsets_unchanged_by_remap() {
+        let src = "<script>\n  const target = 1;\n</script>\n<p>{target}</p>";
+        let ast = parse(
+            src,
+            ParseOptions {
+                modern: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let before = with_serialize_arena(&ast.arena, || serde_json::to_value(&ast).unwrap());
+        let mut after = before.clone();
+        let conv = Utf8ToUtf16::new(src);
+        convert_positions_to_utf16(&mut after, &conv);
+        // For pure-ASCII source the remap must be a no-op.
+        assert_eq!(before, after);
     }
 }

--- a/crates/rsvelte_core/src/napi.rs
+++ b/crates/rsvelte_core/src/napi.rs
@@ -127,7 +127,17 @@ pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Re
             // Serialize within the AST's arena so `JsNodeId`s in the
             // Serialize impls resolve (mirrors `wasm::parse_svelte`).
             crate::ast::arena::with_serialize_arena(&ast.arena, || {
-                serde_json::to_string(&ast)
+                // Spans are UTF-16 code-unit offsets to match svelte/compiler
+                // (#793). ASCII source needs no remap — keep the fast path.
+                if source.is_ascii() {
+                    return serde_json::to_string(&ast)
+                        .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}")));
+                }
+                let mut value = serde_json::to_value(&ast)
+                    .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}")))?;
+                let conv = crate::compiler::legacy::Utf8ToUtf16::new(&source);
+                crate::compiler::legacy::convert_positions_to_utf16(&mut value, &conv);
+                serde_json::to_string(&value)
                     .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}")))
             })
         }

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -294,8 +294,8 @@ fn write_opt_str<W: Writer>(w: &mut W, s: Option<&str>) {
 #[inline]
 fn write_preamble<W: Writer>(w: &mut W, tag: u8, start: u32, end: u32) {
     write_u8(w, tag);
-    write_u32(w, start);
-    write_u32(w, end);
+    write_u32(w, conv_off(start));
+    write_u32(w, conv_off(end));
 }
 
 /// Serialize a `SourceLocation` as 24 bytes — flattens the nested
@@ -303,11 +303,11 @@ fn write_preamble<W: Writer>(w: &mut W, tag: u8, start: u32, end: u32) {
 /// six u32s. The decoder rebuilds the object form.
 fn write_source_location<W: Writer>(w: &mut W, loc: &crate::ast::span::SourceLocation) {
     write_u32(w, loc.start.line);
-    write_u32(w, loc.start.column);
-    write_u32(w, loc.start.character);
+    write_u32(w, conv_col(loc.start.line, loc.start.column));
+    write_u32(w, conv_off(loc.start.character));
     write_u32(w, loc.end.line);
-    write_u32(w, loc.end.column);
-    write_u32(w, loc.end.character);
+    write_u32(w, conv_col(loc.end.line, loc.end.column));
+    write_u32(w, conv_off(loc.end.character));
 }
 fn write_opt_source_location<W: Writer>(w: &mut W, loc: Option<&crate::ast::span::SourceLocation>) {
     match loc {
@@ -357,7 +357,20 @@ fn write_json_node<W: Writer, T: Serialize + ?Sized>(
         }
     }
     let mut shim = WriterAdapter(w);
-    serde_json::to_writer(&mut shim, value).map_err(std::io::Error::other)?;
+    if offset_remap_active() {
+        // The embedded JSON sub-tree carries byte offsets too; remap them to
+        // UTF-16 so the whole envelope is consistent (#793). Only pay the
+        // serialize-to-Value round-trip when a remap is actually active.
+        let mut json_value = serde_json::to_value(value).map_err(std::io::Error::other)?;
+        OFFSET_CONV.with(|c| {
+            if let Some(conv) = &*c.borrow() {
+                crate::compiler::legacy::convert_positions_to_utf16(&mut json_value, conv);
+            }
+        });
+        serde_json::to_writer(&mut shim, &json_value).map_err(std::io::Error::other)?;
+    } else {
+        serde_json::to_writer(&mut shim, value).map_err(std::io::Error::other)?;
+    }
     let payload_end = shim.0.position();
     w.patch_u32(len_slot, (payload_end - payload_start) as u32);
     Ok(())
@@ -416,6 +429,44 @@ fn css_stub_only() -> bool {
     SKIP_CSS_AST.with(|c| c.get())
 }
 
+thread_local! {
+    // Byte -> UTF-16 offset converter for the current encode. `Some` only when
+    // the source contains non-ASCII; for ASCII source byte == UTF-16 so it is
+    // left `None` and every conversion below is a zero-cost identity (#793).
+    static OFFSET_CONV: std::cell::RefCell<Option<crate::compiler::legacy::Utf8ToUtf16>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Convert an absolute byte offset to a UTF-16 code-unit offset (identity when
+/// no converter is installed, i.e. ASCII source).
+#[inline]
+fn conv_off(v: u32) -> u32 {
+    // `u32::MAX` is the "no span" sentinel (e.g. legacy `Value` expressions);
+    // never remap it.
+    if v == u32::MAX {
+        return v;
+    }
+    OFFSET_CONV.with(|c| match &*c.borrow() {
+        Some(conv) => conv.convert(v as usize) as u32,
+        None => v,
+    })
+}
+
+/// Convert a byte column (0-based, within `line`) to a UTF-16 column.
+#[inline]
+fn conv_col(line: u32, col: u32) -> u32 {
+    OFFSET_CONV.with(|c| match &*c.borrow() {
+        Some(conv) => conv.convert_column(line as usize, col as usize) as u32,
+        None => col,
+    })
+}
+
+/// Whether an offset remap is active for the current encode.
+#[inline]
+fn offset_remap_active() -> bool {
+    OFFSET_CONV.with(|c| c.borrow().is_some())
+}
+
 /// `typed_expr::Loc` — emits a flag byte + 6 u32s (with optional
 /// `character`) when `loc.is_some()`. When the envelope-level
 /// `FLAG_JSNODE_NO_LOC` flag is set the encoder skips this call
@@ -428,20 +479,20 @@ fn write_typed_loc<W: Writer>(w: &mut W, loc: Option<&Loc>) {
         Some(l) => {
             write_u8(w, 1);
             write_u32(w, l.start.line);
-            write_u32(w, l.start.column);
+            write_u32(w, conv_col(l.start.line, l.start.column));
             match l.start.character {
                 Some(c) => {
                     write_u8(w, 1);
-                    write_u32(w, c);
+                    write_u32(w, conv_off(c));
                 }
                 None => write_u8(w, 0),
             }
             write_u32(w, l.end.line);
-            write_u32(w, l.end.column);
+            write_u32(w, conv_col(l.end.line, l.end.column));
             match l.end.character {
                 Some(c) => {
                     write_u8(w, 1);
-                    write_u32(w, c);
+                    write_u32(w, conv_off(c));
                 }
                 None => write_u8(w, 0),
             }
@@ -2078,16 +2129,29 @@ pub fn encode_root_into<W: Writer>(
     struct Guard {
         prev_loc: bool,
         prev_css: bool,
+        prev_conv: Option<crate::compiler::legacy::Utf8ToUtf16>,
     }
     impl Drop for Guard {
         fn drop(&mut self) {
             SKIP_JSNODE_LOC.with(|c| c.set(self.prev_loc));
             SKIP_CSS_AST.with(|c| c.set(self.prev_css));
+            OFFSET_CONV.with(|c| *c.borrow_mut() = self.prev_conv.take());
         }
     }
     let prev_loc = SKIP_JSNODE_LOC.with(|c| c.replace(skip_jsnode_loc));
     let prev_css = SKIP_CSS_AST.with(|c| c.replace(skip_css_ast));
-    let _guard = Guard { prev_loc, prev_css };
+    // Install a byte->UTF-16 converter only for non-ASCII source (#793).
+    let new_conv = if source.is_ascii() {
+        None
+    } else {
+        Some(crate::compiler::legacy::Utf8ToUtf16::new(source))
+    };
+    let prev_conv = OFFSET_CONV.with(|c| c.replace(new_conv));
+    let _guard = Guard {
+        prev_loc,
+        prev_css,
+        prev_conv,
+    };
 
     let _ = crate::ast::arena::with_serialize_arena(&root.arena, || write_root(writer, root));
 

--- a/crates/rsvelte_core/src/wasm.rs
+++ b/crates/rsvelte_core/src/wasm.rs
@@ -88,7 +88,17 @@ pub fn parse_svelte(source: &str) -> ParseResultWasm {
             // arena not set"), which surfaces in the browser as a WASM
             // "unreachable" trap.
             let ast_json = crate::ast::arena::with_serialize_arena(&ast.arena, || {
-                serde_json::to_string_pretty(&ast).unwrap_or_default()
+                // Spans are emitted as UTF-16 code-unit offsets to match
+                // svelte/compiler (#793). For ASCII source byte == UTF-16, so
+                // skip the remap entirely and keep the fast direct-string path.
+                if source.is_ascii() {
+                    serde_json::to_string_pretty(&ast).unwrap_or_default()
+                } else {
+                    let mut value = serde_json::to_value(&ast).unwrap_or(serde_json::Value::Null);
+                    let conv = crate::compiler::legacy::Utf8ToUtf16::new(source);
+                    crate::compiler::legacy::convert_positions_to_utf16(&mut value, &conv);
+                    serde_json::to_string_pretty(&value).unwrap_or_default()
+                }
             });
             ParseResultWasm {
                 success: true,


### PR DESCRIPTION
## Problem

`parse_svelte` (WASM `@rsvelte/compiler`), `parse` (native), and `parseEnvelope` (native raw-transfer) emitted AST node `start`/`end` (and `loc` `column`/`character`) as **UTF-8 byte offsets**, while `svelte/compiler` and the entire JS ecosystem (`magic-string`, `svelte-eslint-parser`, every `String.slice` consumer) use **UTF-16 code-unit offsets**.

For ASCII source the two coincide, so it went unnoticed — but the moment a source contains a non-ASCII char (e.g. Japanese UI strings) before a node, every later span shifts by `byteLen − utf16Len`, producing **silent wrong edits** or a hard `magic-string` "end is out of bounds" crash.

## Fix

- Promote the existing `Utf8ToUtf16` + `convert_positions_to_utf16` (already used by the legacy AST path) to `pub(crate)` and reuse them — single source of truth.
- **JSON paths** (`wasm::parse_svelte`, `napi::parse`): remap the serialized Value's offsets before stringifying. ASCII source keeps the fast direct-string path (remap skipped).
- **Envelope path** (`napi_raw_parse`): thread a thread-local converter through the offset choke points — `write_preamble` (every node span), `write_source_location`, `write_typed_loc`, and the embedded `write_json_node` payload. The `u32::MAX` "no span" sentinel is never remapped; ASCII installs no converter (zero-cost identity). The **binary format is unchanged** — only offset *values* differ, so `decodeParseEnvelope` needs no change.

## Verification

End-to-end in the dev container on the issue's exact `あ` repro (UTF-16 len 69, UTF-8 bytes 73):

```
[parse]         identifiers OK=4 MISALIGNED=0
[parseEnvelope] identifiers OK=4 MISALIGNED=0
```

`code.slice(node.start, node.end) === node.name` for every identifier on both native surfaces. Added `legacy.rs` UTF-16 unit tests (2); envelope encoder tests (10) and the vps-shim smoke test still pass; napi + wasm feature builds compile clean.

Closes #793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)