### PR TITLE
fix(fmt): keep outer parens of a top-level sequence expression in a mustache (#799)

### DIFF
--- a/.changeset/fmt-sequence-parens.md
+++ b/.changeset/fmt-sequence-parens.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): keep the outer parentheses of a top-level sequence (comma) expression in a mustache, matching prettier-plugin-svelte. `oxc_formatter` intentionally re-adds the outer parens of a top-level `SequenceExpression` (its `NeedsParentheses` impl returns true for an `ExpressionStatement` parent), and prettier-plugin-svelte keeps them — but `format_expr_core` then unconditionally ran `strip_outer_parens`, peeling the parens oxc had just added. So `{((ref = cond ? a : undefined), '')}` was emitted as `{(ref = cond ? a : undefined), ''}`. The strip is now skipped when the parsed top-level expression is a `SequenceExpression`; every other expression keeps the existing redundant-paren strip (`{(a + 1)}` → `{a + 1}` is unchanged). Because the fix lives in the shared `format_expr_core`, it also covers sequences in attribute values, directives, and block headers. Closes #799.

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -463,6 +463,19 @@ fn format_expr_core(
         return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
     }
 
+    // Detect a top-level sequence (comma) expression before `program` is
+    // borrowed by `format_program`. oxc_formatter intentionally re-adds the
+    // outer parens of a top-level `SequenceExpression` (its `NeedsParentheses`
+    // impl returns true for an `ExpressionStatement` parent), and
+    // prettier-plugin-svelte keeps them — so `{((a = 1), '')}` must stay
+    // parenthesized. Stripping them below would wrongly emit `{(a = 1), ''}`
+    // (#799). Every other expression keeps the normal outer-paren strip.
+    let is_top_sequence = matches!(
+        parser_ret.program.body.first(),
+        Some(oxc_ast::ast::Statement::ExpressionStatement(stmt))
+            if matches!(stmt.expression, oxc_ast::ast::Expression::SequenceExpression(_))
+    );
+
     let mut js = options.js.clone();
     js.line_width = line_width;
     if single_line {
@@ -474,7 +487,29 @@ fn format_expr_core(
         .into_code();
 
     let s = formatted.trim_end().trim_end_matches(';').trim_end();
-    Ok(strip_outer_parens(s).trim().to_string())
+    // prettier-plugin-svelte keeps exactly ONE set of outer parens around a
+    // top-level sequence (comma) expression in a mustache / attribute value
+    // (e.g. `{((ref = …), '')}`). These callers slice the full brace-enclosed
+    // source, so the parens belong to the replaced span — normalise to exactly
+    // one pair: strip every redundant outer pair, then re-wrap once. (Member
+    // parens like `(a = 1)` inside `((a = 1), "")` are not outer pairs and
+    // survive.) Block headers (`single_line`) slice the expression span
+    // *without* its surrounding source parens, so wrapping here would
+    // double-wrap (`{#if ((a, b))}`); they keep the plain strip, which leaves
+    // the source parens intact. (#799)
+    if is_top_sequence && !single_line {
+        let mut inner = s.trim();
+        loop {
+            let stripped = strip_outer_parens(inner).trim();
+            if stripped == inner {
+                break;
+            }
+            inner = stripped;
+        }
+        Ok(format!("({inner})"))
+    } else {
+        Ok(strip_outer_parens(s).trim().to_string())
+    }
 }
 
 /// Format an attribute / directive value expression (`bind:value={ … }`) at

--- a/crates/rsvelte_formatter/tests/markup_expressions.rs
+++ b/crates/rsvelte_formatter/tests/markup_expressions.rs
@@ -244,3 +244,62 @@ fn end_to_end_mix() {
     );
     assert!(out.contains("{item}"), "each-body:\n{out}");
 }
+
+// ─── #799: outer parens of a top-level sequence expression are preserved ──
+// prettier-plugin-svelte keeps the redundant outer parens of a sequence
+// (comma) expression in a mustache; only non-sequence redundant parens strip.
+
+#[test]
+fn sequence_keeps_outer_parens_in_mustache() {
+    let out = fmt("{((a = 1), '')}");
+    assert!(
+        out.contains("{((a = 1), \"\")}"),
+        "expected sequence outer parens kept:\n{out}"
+    );
+}
+
+#[test]
+fn bare_sequence_gains_outer_parens() {
+    let out = fmt("<p>{a, b}</p>");
+    assert!(out.contains("{(a, b)}"), "expected (a, b) wrapped:\n{out}");
+}
+
+#[test]
+fn sequence_of_assignments_keeps_parens() {
+    let out = fmt("{(a = 1, b = 2)}");
+    assert!(
+        out.contains("{((a = 1), (b = 2))}"),
+        "expected each assignment + outer wrapped:\n{out}"
+    );
+}
+
+#[test]
+fn non_sequence_redundant_parens_still_strip() {
+    let out = fmt("<p>{(a + 1)}</p>");
+    assert!(
+        out.contains("{a + 1}"),
+        "expected redundant parens stripped:\n{out}"
+    );
+    assert!(
+        !out.contains("{(a + 1)}"),
+        "non-sequence outer parens must still strip:\n{out}"
+    );
+}
+
+#[test]
+fn sequence_in_attribute_value_keeps_parens() {
+    let out = fmt("<div class={(a, b)}></div>");
+    assert!(
+        out.contains("class={(a, b)}"),
+        "expected attr sequence parens kept:\n{out}"
+    );
+}
+
+#[test]
+fn sequence_in_block_header_keeps_parens() {
+    let out = fmt("{#if (a, b)}x{/if}");
+    assert!(
+        out.contains("{#if (a, b)}"),
+        "expected block-header sequence parens kept:\n{out}"
+    );
+}


### PR DESCRIPTION
## Problem

`format_expr_core` unconditionally ran `strip_outer_parens`, peeling the outer parens `oxc_formatter` deliberately re-adds for a top-level `SequenceExpression` (its `NeedsParentheses` impl returns true for an `ExpressionStatement` parent) — which `prettier-plugin-svelte` keeps. So the "render side-effect" idiom `{((headerRightSnippetRef = …), '')}` was emitted as `{(headerRightSnippetRef = …), ''}`.

## Fix

For a top-level sequence in a mustache / attribute value (callers slice the full brace-enclosed source, so the parens are part of the replaced span), normalise to **exactly one** outer pair: strip every redundant outer pair, then re-wrap once. Member-level parens (`(a = 1)` inside `((a = 1), "")`) survive. Block headers (`single_line`) slice the expression span *without* its surrounding source parens, so they keep the plain strip — wrapping there would double-wrap (`{#if ((a, b))}`).

Verified against prettier-plugin-svelte 3.4.0 shapes:
- `{((a = 1), '')}` → `{((a = 1), "")}`
- `<p>{a, b}</p>` → `<p>{(a, b)}</p>`
- `{(a = 1, b = 2)}` → `{((a = 1), (b = 2))}`
- `<p>{(a + 1)}</p>` → `<p>{a + 1}</p>` (non-sequence redundant parens still strip)
- `<div class={(a, b)}>` keeps `class={(a, b)}`; `{#if (a, b)}` keeps its parens.

Full `rsvelte_formatter` suite passes (6 new tests added).

Closes #799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)