### PR TITLE
fix(fmt): hug open `>` / break close `>` for inline-text wrapped elements (#798)

### DIFF
--- a/.changeset/fmt-inline-text-tag-wrap.md
+++ b/.changeset/fmt-inline-text-tag-wrap.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): place the `>` correctly when a wrapped element has whitespace-sensitive inline content. When an element's open tag wraps to the multi-line shape, `render_multi_line` always emitted the closing `>` on its own line at the outer indent. For an element whose children are whitespace-sensitive inline content (e.g. text directly touching the tag, `>x</button>`), moving the `>` to its own line injects significant whitespace before the text — so prettier-plugin-svelte instead keeps the open `>` glued to the last attribute (`}}>x`) and breaks the *closing* tag's `>` onto its own line (`</button\n>`). rsvelte now mirrors that: `push_open_tag` reports whether it wrapped, and the open `>` hugs / close `>` breaks when the content is non-whitespace-adjacent to the tag. Block content (children on their own line, whitespace before/after) is unaffected. Closes #798.

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -63,7 +63,7 @@ fn collect_node_open_tag_edits(
 ) -> Result<(), FormatError> {
     match node {
         TemplateNode::RegularElement(elem) => {
-            push_open_tag(
+            let wrapped = push_open_tag(
                 source,
                 elem.start,
                 elem.name.as_str(),
@@ -73,11 +73,19 @@ fn collect_node_open_tag_edits(
                 options,
                 edits,
             )?;
-            push_close_tag(source, elem.end, elem.name.as_str(), edits);
+            push_close_tag(
+                source,
+                elem.end,
+                elem.name.as_str(),
+                wrapped,
+                depth,
+                options,
+                edits,
+            );
             collect_open_tag_edits(source, &elem.fragment, depth + 1, options, edits)?;
         }
         TemplateNode::Component(c) => {
-            push_open_tag(
+            let wrapped = push_open_tag(
                 source,
                 c.start,
                 c.name.as_str(),
@@ -87,11 +95,19 @@ fn collect_node_open_tag_edits(
                 options,
                 edits,
             )?;
-            push_close_tag(source, c.end, c.name.as_str(), edits);
+            push_close_tag(
+                source,
+                c.end,
+                c.name.as_str(),
+                wrapped,
+                depth,
+                options,
+                edits,
+            );
             collect_open_tag_edits(source, &c.fragment, depth + 1, options, edits)?;
         }
         TemplateNode::TitleElement(t) => {
-            push_open_tag(
+            let wrapped = push_open_tag(
                 source,
                 t.start,
                 t.name.as_str(),
@@ -101,11 +117,19 @@ fn collect_node_open_tag_edits(
                 options,
                 edits,
             )?;
-            push_close_tag(source, t.end, t.name.as_str(), edits);
+            push_close_tag(
+                source,
+                t.end,
+                t.name.as_str(),
+                wrapped,
+                depth,
+                options,
+                edits,
+            );
             collect_open_tag_edits(source, &t.fragment, depth + 1, options, edits)?;
         }
         TemplateNode::SlotElement(s) => {
-            push_open_tag(
+            let wrapped = push_open_tag(
                 source,
                 s.start,
                 s.name.as_str(),
@@ -115,7 +139,15 @@ fn collect_node_open_tag_edits(
                 options,
                 edits,
             )?;
-            push_close_tag(source, s.end, s.name.as_str(), edits);
+            push_close_tag(
+                source,
+                s.end,
+                s.name.as_str(),
+                wrapped,
+                depth,
+                options,
+                edits,
+            );
             collect_open_tag_edits(source, &s.fragment, depth + 1, options, edits)?;
         }
         TemplateNode::SvelteHead(s)
@@ -126,7 +158,7 @@ fn collect_node_open_tag_edits(
         | TemplateNode::SvelteOptions(s)
         | TemplateNode::SvelteSelf(s)
         | TemplateNode::SvelteWindow(s) => {
-            push_open_tag(
+            let wrapped = push_open_tag(
                 source,
                 s.start,
                 s.name.as_str(),
@@ -136,11 +168,19 @@ fn collect_node_open_tag_edits(
                 options,
                 edits,
             )?;
-            push_close_tag(source, s.end, s.name.as_str(), edits);
+            push_close_tag(
+                source,
+                s.end,
+                s.name.as_str(),
+                wrapped,
+                depth,
+                options,
+                edits,
+            );
             collect_open_tag_edits(source, &s.fragment, depth + 1, options, edits)?;
         }
         TemplateNode::SvelteComponent(c) => {
-            push_open_tag(
+            let wrapped = push_open_tag(
                 source,
                 c.start,
                 c.name.as_str(),
@@ -150,11 +190,19 @@ fn collect_node_open_tag_edits(
                 options,
                 edits,
             )?;
-            push_close_tag(source, c.end, c.name.as_str(), edits);
+            push_close_tag(
+                source,
+                c.end,
+                c.name.as_str(),
+                wrapped,
+                depth,
+                options,
+                edits,
+            );
             collect_open_tag_edits(source, &c.fragment, depth + 1, options, edits)?;
         }
         TemplateNode::SvelteElement(e) => {
-            push_open_tag(
+            let wrapped = push_open_tag(
                 source,
                 e.start,
                 e.name.as_str(),
@@ -164,7 +212,15 @@ fn collect_node_open_tag_edits(
                 options,
                 edits,
             )?;
-            push_close_tag(source, e.end, e.name.as_str(), edits);
+            push_close_tag(
+                source,
+                e.end,
+                e.name.as_str(),
+                wrapped,
+                depth,
+                options,
+                edits,
+            );
             collect_open_tag_edits(source, &e.fragment, depth + 1, options, edits)?;
         }
         // Blocks have child fragments but no attributes themselves.
@@ -223,12 +279,34 @@ fn push_close_tag(
     source: &str,
     element_end: u32,
     tag_name: &str,
+    open_wrapped: bool,
+    depth: usize,
+    options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) {
     let Some((start, end)) = find_close_tag_span(source, element_end, tag_name) else {
         return;
     };
-    edits.push((start, end, format!("</{tag_name}>")));
+    // When the open tag wrapped and the element's content is whitespace-
+    // sensitive inline content (the last content char touches the close tag
+    // with no whitespace), prettier-plugin-svelte breaks the closing `>` onto
+    // its own line at the element's indent (`</button\n>`) so the trailing
+    // newline lands *inside* the close tag and no whitespace is added after the
+    // content (#798).
+    // Symmetric with `hug_open`: only break the close `>` when text content
+    // touches it. A trailing `>` (the end of a child element `</child>`) is not
+    // text, so the close `>` can break normally.
+    let hug_close = open_wrapped
+        && (start as usize)
+            .checked_sub(1)
+            .and_then(|i| source.as_bytes().get(i))
+            .is_some_and(|&b| !b.is_ascii_whitespace() && b != b'>');
+    if hug_close {
+        let indent = indent_str(depth, &options.js);
+        edits.push((start, end, format!("</{tag_name}\n{indent}>")));
+    } else {
+        edits.push((start, end, format!("</{tag_name}>")));
+    }
 }
 
 /// Locate the element's closing tag `</tagname ...>` that ends exactly at
@@ -289,6 +367,9 @@ fn find_close_tag_span(source: &str, element_end: u32, tag_name: &str) -> Option
 ///   `>` (or `/>`) on a new line at `depth` indent. Used when the
 ///   one-liner would overflow.
 #[allow(clippy::too_many_arguments)]
+/// Returns `true` when the open tag was rendered in the wrapped (multi-line)
+/// shape — the caller threads this into [`push_close_tag`] so the closing `>`
+/// of a whitespace-sensitive inline element can break onto its own line.
 fn push_open_tag(
     source: &str,
     element_start: u32,
@@ -298,12 +379,28 @@ fn push_open_tag(
     depth: usize,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
-) -> Result<(), FormatError> {
+) -> Result<bool, FormatError> {
     let Some(open_tag_end) = find_open_tag_end(source, element_start, attributes) else {
-        return Ok(());
+        return Ok(false);
     };
 
     let self_closing = is_self_closing(source, open_tag_end);
+
+    // When the open tag wraps, the closing `>` normally lands on its own line at
+    // the outer indent. But if the element's content is whitespace-sensitive
+    // inline content (the first content char touches the `>` with no
+    // whitespace), moving the `>` to its own line would inject significant
+    // whitespace before the content — so prettier-plugin-svelte keeps the `>`
+    // glued to the last attribute (`}}>text`) instead (#798).
+    // Only text content (not a child element `<…>` and not an empty element
+    // whose `>` is immediately followed by its own `</tag>`) is treated as
+    // whitespace-sensitive here — matching #798's "inline text children". A
+    // leading `<` means the next thing is a tag, so the `>` can safely break.
+    let hug_open = !self_closing
+        && source
+            .as_bytes()
+            .get(open_tag_end as usize)
+            .is_some_and(|&b| !b.is_ascii_whitespace() && b != b'<');
 
     // Build the list of fully-rendered open-tag items (attributes plus any
     // comments interleaved between them), each tagged with its source
@@ -353,14 +450,22 @@ fn push_open_tag(
         && !any_multiline_attr
         && leading_indent_width + visual_width(&one_liner) <= line_width;
 
-    let rendered = if rendered_attrs.is_empty() || fits_one_line {
-        one_liner
+    let wrapped = !(rendered_attrs.is_empty() || fits_one_line);
+    let rendered = if wrapped {
+        render_multi_line(
+            tag_name,
+            &rendered_attrs,
+            self_closing,
+            depth,
+            &options.js,
+            hug_open,
+        )
     } else {
-        render_multi_line(tag_name, &rendered_attrs, self_closing, depth, &options.js)
+        one_liner
     };
 
     edits.push((element_start, open_tag_end, rendered));
-    Ok(())
+    Ok(wrapped)
 }
 
 /// A comment found between attributes inside an element's open tag.
@@ -471,6 +576,7 @@ fn render_multi_line(
     self_closing: bool,
     depth: usize,
     js_opts: &JsFormatOptions,
+    hug_open: bool,
 ) -> String {
     let inner_indent = indent_str(depth + 1, js_opts);
     let outer_indent = indent_str(depth, js_opts);
@@ -488,12 +594,19 @@ fn render_multi_line(
         // indent was already emitted before it.
         out.push_str(&crate::reindent::reindent(a, &inner_indent, true));
     }
-    out.push('\n');
-    out.push_str(&outer_indent);
-    if self_closing {
-        out.push_str("/>");
-    } else {
+    if hug_open && !self_closing {
+        // Whitespace-sensitive inline content: glue the `>` to the last
+        // attribute line (`}}>text`) so no significant whitespace is injected
+        // before the content (#798).
         out.push('>');
+    } else {
+        out.push('\n');
+        out.push_str(&outer_indent);
+        if self_closing {
+            out.push_str("/>");
+        } else {
+            out.push('>');
+        }
     }
     out
 }

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -366,10 +366,11 @@ fn find_close_tag_span(source: &str, element_end: u32, tag_name: &str) -> Option
 ///   Each attribute on its own line at `depth + 1` indent, the closing
 ///   `>` (or `/>`) on a new line at `depth` indent. Used when the
 ///   one-liner would overflow.
-#[allow(clippy::too_many_arguments)]
+///
 /// Returns `true` when the open tag was rendered in the wrapped (multi-line)
 /// shape — the caller threads this into [`push_close_tag`] so the closing `>`
 /// of a whitespace-sensitive inline element can break onto its own line.
+#[allow(clippy::too_many_arguments)]
 fn push_open_tag(
     source: &str,
     element_start: u32,

--- a/crates/rsvelte_formatter/tests/markup_open_tag.rs
+++ b/crates/rsvelte_formatter/tests/markup_open_tag.rs
@@ -264,7 +264,10 @@ fn multiline_attr_expression_reindented_to_attribute_column() {
     // column 0 (#692).
     let src = "<div>\n  <div>\n    <button\n      onclick={() => {\n        foo();\n        bar();\n      }}\n    >x</button>\n  </div>\n</div>\n";
     let out = fmt(src);
-    let expected = "    <button\n      onclick={() => {\n        foo();\n        bar();\n      }}\n    >x</button>";
+    // The element has whitespace-sensitive inline text content (`x`), so the
+    // open `>` hugs the last attribute and the close `>` breaks onto its own
+    // line at the element's indent (#798), matching prettier-plugin-svelte.
+    let expected = "    <button\n      onclick={() => {\n        foo();\n        bar();\n      }}>x</button\n    >";
     assert!(
         out.contains(expected),
         "multi-line attr not re-indented to nesting level:\n{out}"
@@ -285,9 +288,11 @@ fn multiline_attr_forces_multiline_tag_even_when_short() {
     // Closing brace of the handler aligns under the attribute (2 spaces), and
     // the body one JS level deeper (4 spaces).
     assert!(out.contains("\n    a();\n"), "body not re-indented:\n{out}");
+    // Whitespace-sensitive inline text (`x`): open `>` hugs `}}`, close `>`
+    // breaks onto its own line (#798).
     assert!(
-        out.contains("\n  }}\n"),
-        "closing brace not aligned:\n{out}"
+        out.contains("\n  }}>x</button\n>"),
+        "expected hugged open `>` and broken close `>`:\n{out}"
     );
 }
 

--- a/crates/rsvelte_formatter/tests/markup_wrap.rs
+++ b/crates/rsvelte_formatter/tests/markup_wrap.rs
@@ -93,8 +93,46 @@ fn directive_with_modifiers_wraps_as_one_attr() {
         "<button class=\"primary\" on:click|preventDefault={handleClickWithLongName}>x</button>",
         40,
     );
+    // The directive stays on one line; the element has inline text (`x`) so the
+    // open `>` hugs the last attribute and the close `>` breaks (#798).
     assert!(
-        out.contains("\n  on:click|preventDefault={handleClickWithLongName}\n"),
-        "expected directive on one line when wrapped:\n{out}"
+        out.contains("\n  on:click|preventDefault={handleClickWithLongName}>x</button\n>"),
+        "expected directive on one line + hugged tag:\n{out}"
+    );
+}
+
+// ─── #798: whitespace-sensitive inline element — hug open `>`, break close ──
+
+#[test]
+fn inline_text_element_hugs_open_and_breaks_close() {
+    let src = "<button onclick={() => { doSomethingWithAVeryLongName(); doAnotherThingWithLongName(); doThird(); }}>x</button>";
+    let out = fmt_at_width(src, 80);
+    // Open `>` glued to the last attribute line (`}}>x`), not on its own line.
+    assert!(out.contains("}}>x"), "open > should hug content:\n{out}");
+    assert!(
+        !out.contains("\n>x"),
+        "open > must not sit on its own line:\n{out}"
+    );
+    // Close tag broken: `</button` then `>` on its own line.
+    assert!(
+        out.contains("</button\n>"),
+        "close > should break onto its own line:\n{out}"
+    );
+    // Idempotent.
+    assert_eq!(fmt_at_width(&out, 80), out, "formatting must be idempotent");
+}
+
+#[test]
+fn wrapped_block_element_keeps_tags_unchanged() {
+    // Child on its own line => content not whitespace-adjacent => no hug.
+    let src = "<div data-thing={someValueHere} class=\"a-fairly-long-classname-goes-here\">\n  <span>child</span>\n</div>";
+    let out = fmt_at_width(src, 40);
+    assert!(
+        out.contains("</div>"),
+        "block element close tag stays intact:\n{out}"
+    );
+    assert!(
+        !out.contains("</div\n"),
+        "block element close > must not break:\n{out}"
     );
 }


### PR DESCRIPTION
## Problem

When an element's open tag wraps to the multi-line shape, `render_multi_line` always put the closing `>` on its own line at the outer indent. For an element whose children are whitespace-sensitive inline **text** (`>x</button>`), that injects significant whitespace before the text. `prettier-plugin-svelte` instead keeps the open `>` glued to the last attribute and breaks the *closing* tag's `>`:

```svelte
<button
  onclick={() => {
    doSomethingWithAVeryLongName();
    doAnotherThingWithLongName();
    doThird();
  }}>x</button
>
```

## Fix

- `push_open_tag` returns whether it wrapped; for text-adjacent content it emits the open `>` hugging the last attribute (`}}>x`).
- `push_close_tag` takes that flag + depth and, when wrapped and text touches the close tag, breaks `</tag\n<indent>>`.
- Hugging is gated to **text** content (next char not `<`, prev char not `>`), so empty elements (`<span></span>`) and elements with child-element / block content keep the `>` on its own line.

Verified the output byte-for-byte against the issue's example (and the nested-at-depth-2 variant). Updated the 3 open-tag/wrap tests that encoded the old placement; full `rsvelte_formatter` suite passes.

Closes #798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)