### PR TITLE
fix(fmt): wrap attribute values by their nested column (#795 sub-case a)

### DIFF
--- a/.changeset/fmt-attr-value-depth.md
+++ b/.changeset/fmt-attr-value-depth.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): wrap attribute-value expressions by their rendered column, not column 0. Attribute and directive values were formatted at column 0 with the full print width, so a value that fits at column 0 but overflows once the open tag wraps and the attribute renders at its nesting indent stayed inline — diverging from prettier-plugin-svelte, which narrows the value's print width by the attribute's nesting depth. The open-tag rewrite now threads the attribute depth (`depth + 1`) into every value formatter (`render_attribute` → `render_attribute_node` / directive / spread / sequence paths) via a new `format_attribute_value_expression`, so e.g. a long `config={{ … }}` object now breaks across lines (with the existing `render_multi_line` reindent owning the continuation columns) exactly like oxfmt. This is sub-case (a) of #795 (the depth-unaware wrap decision, ~69 of 110 divergent files). Sub-case (b) — the Svelte-5 function-binding `bind:value={getter, setter}` softline brace shape — is left for a follow-up: it needs reconciling oxc's sequence-continuation indent with prettier's, which is a separate change. Partially addresses #795.

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -400,6 +400,7 @@ pub(crate) fn format_directive_value(
     expr: &Expression,
     value_end: u32,
     options: &FormatOptions,
+    attr_depth: usize,
 ) -> Result<Option<String>, FormatError> {
     let Some(expr_start) = expr.start() else {
         return Ok(None);
@@ -436,7 +437,9 @@ pub(crate) fn format_directive_value(
     if inner.is_empty() {
         return Ok(None);
     }
-    Ok(Some(format_expression_source(inner, options)?))
+    Ok(Some(format_attribute_value_expression(
+        inner, options, attr_depth,
+    )?))
 }
 
 // ─── Expression formatter ───────────────────────────────────────────────
@@ -526,6 +529,27 @@ pub(crate) fn format_expression_source(
     options: &FormatOptions,
 ) -> Result<String, FormatError> {
     format_expr_core(expr_source, options, options.js.line_width, false)
+}
+
+/// Format an attribute / directive value expression, narrowing the print
+/// width by the attribute's nesting depth (`attr_depth` indent levels). The
+/// value is formatted at column 0 but rendered at `attr_depth` once the open
+/// tag wraps, so a value that "fits" at column 0 but overflows once nested
+/// must break — narrowing the width makes the break decision land where
+/// prettier-plugin-svelte puts it (#795). Unlike [`format_content_expression`],
+/// this does NOT reindent: the open-tag rewrite (`crate::markup::render_multi_line`)
+/// owns pushing continuation lines out to the attribute column.
+pub(crate) fn format_attribute_value_expression(
+    expr_source: &str,
+    options: &FormatOptions,
+    attr_depth: usize,
+) -> Result<String, FormatError> {
+    let indent_width = options.js.indent_width.value() as usize;
+    let narrowed =
+        (options.js.line_width.value() as usize).saturating_sub(attr_depth * indent_width);
+    let line_width =
+        oxc_formatter_core::LineWidth::try_from(narrowed as u16).unwrap_or(options.js.line_width);
+    format_expr_core(expr_source, options, line_width, false)
 }
 
 /// Format a block-header expression (`{#if cond}`, `{#each items …}`) onto a

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -34,7 +34,7 @@ use rsvelte_core::ast::template::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::error::FormatError;
-use crate::expression::format_expression_source;
+use crate::expression::{format_attribute_value_expression, format_expression_source};
 use crate::indent::else_if_branch;
 use crate::options::FormatOptions;
 
@@ -410,8 +410,13 @@ fn push_open_tag(
     // dropped if we rebuilt the tag from the attribute list alone (#685).
     let mut items: Vec<(u32, String)> = Vec::with_capacity(attributes.len() + 1);
 
+    // When the open tag wraps, each attribute renders at `depth + 1` indent, so
+    // its value expression must make its wrap decision against a width narrowed
+    // by that lead (#795).
+    let attr_depth = depth + 1;
+
     if let Some(expr) = this_expression
-        && let Some(formatted) = format_expression_at(source, expr, options)?
+        && let Some(formatted) = format_expression_at(source, expr, options, attr_depth)?
     {
         // `this={X}` is emitted first regardless of source position.
         items.push((element_start, format!("this={{{formatted}}}")));
@@ -419,7 +424,10 @@ fn push_open_tag(
 
     for attr in attributes {
         let (attr_start, _) = attribute_span(attr);
-        items.push((attr_start, render_attribute(attr, source, options)?));
+        items.push((
+            attr_start,
+            render_attribute(attr, source, options, attr_depth)?,
+        ));
     }
 
     let comments = collect_open_tag_comments(source, element_start, open_tag_end, attributes);
@@ -725,17 +733,18 @@ fn render_attribute(
     attr: &Attribute,
     source: &str,
     options: &FormatOptions,
+    attr_depth: usize,
 ) -> Result<String, FormatError> {
     match attr {
-        Attribute::Attribute(node) => render_attribute_node(node, source, options),
-        Attribute::SpreadAttribute(spread) => render_spread(spread, source, options),
+        Attribute::Attribute(node) => render_attribute_node(node, source, options, attr_depth),
+        Attribute::SpreadAttribute(spread) => render_spread(spread, source, options, attr_depth),
         Attribute::AttachTag(attach) => {
-            let inner =
-                format_expression_at(source, &attach.expression, options)?.unwrap_or_default();
+            let inner = format_expression_at(source, &attach.expression, options, attr_depth)?
+                .unwrap_or_default();
             Ok(format!("{{@attach {inner}}}"))
         }
         Attribute::BindDirective(d) => {
-            let inner = render_directive_value(source, &d.expression, d.end, options)?;
+            let inner = render_directive_value(source, &d.expression, d.end, options, attr_depth)?;
             let modifiers = render_modifiers(&d.modifiers);
             if inner == d.name.as_str() && modifiers.is_empty() {
                 Ok(format!("bind:{}", d.name))
@@ -744,7 +753,7 @@ fn render_attribute(
             }
         }
         Attribute::ClassDirective(d) => {
-            let inner = render_directive_value(source, &d.expression, d.end, options)?;
+            let inner = render_directive_value(source, &d.expression, d.end, options, attr_depth)?;
             if inner == d.name.as_str() {
                 Ok(format!("class:{}", d.name))
             } else {
@@ -754,7 +763,7 @@ fn render_attribute(
         Attribute::OnDirective(d) => {
             let modifiers = render_modifiers(&d.modifiers);
             if let Some(expr) = &d.expression {
-                let inner = render_directive_value(source, expr, d.end, options)?;
+                let inner = render_directive_value(source, expr, d.end, options, attr_depth)?;
                 Ok(format!("on:{}{modifiers}={{{inner}}}", d.name))
             } else {
                 Ok(format!("on:{}{modifiers}", d.name))
@@ -770,7 +779,7 @@ fn render_attribute(
             };
             let modifiers = render_modifiers(&d.modifiers);
             if let Some(expr) = &d.expression {
-                let inner = render_directive_value(source, expr, d.end, options)?;
+                let inner = render_directive_value(source, expr, d.end, options, attr_depth)?;
                 Ok(format!("{prefix}:{}{modifiers}={{{inner}}}", d.name))
             } else {
                 Ok(format!("{prefix}:{}{modifiers}", d.name))
@@ -778,7 +787,7 @@ fn render_attribute(
         }
         Attribute::AnimateDirective(d) => {
             if let Some(expr) = &d.expression {
-                let inner = render_directive_value(source, expr, d.end, options)?;
+                let inner = render_directive_value(source, expr, d.end, options, attr_depth)?;
                 Ok(format!("animate:{}={{{inner}}}", d.name))
             } else {
                 Ok(format!("animate:{}", d.name))
@@ -786,7 +795,7 @@ fn render_attribute(
         }
         Attribute::UseDirective(d) => {
             if let Some(expr) = &d.expression {
-                let inner = render_directive_value(source, expr, d.end, options)?;
+                let inner = render_directive_value(source, expr, d.end, options, attr_depth)?;
                 Ok(format!("use:{}={{{inner}}}", d.name))
             } else {
                 Ok(format!("use:{}", d.name))
@@ -794,7 +803,8 @@ fn render_attribute(
         }
         Attribute::StyleDirective(d) => {
             let modifiers = render_modifiers(&d.modifiers);
-            let value = render_attribute_value_for_directive(&d.value, source, options)?;
+            let value =
+                render_attribute_value_for_directive(&d.value, source, options, attr_depth)?;
             if value.is_empty() {
                 Ok(format!("style:{}{modifiers}", d.name))
             } else {
@@ -846,6 +856,7 @@ fn render_attribute_node(
     node: &AttributeNode,
     source: &str,
     options: &FormatOptions,
+    attr_depth: usize,
 ) -> Result<String, FormatError> {
     match &node.value {
         AttributeValue::True(_) => Ok(node.name.to_string()),
@@ -854,7 +865,7 @@ fn render_attribute_node(
             if inner_src.is_empty() {
                 return Ok(format!("{}={{}}", node.name));
             }
-            let formatted = format_expression_source(inner_src, options)?;
+            let formatted = format_attribute_value_expression(inner_src, options, attr_depth)?;
             // Svelte attribute shorthand: `name={name}` → `{name}`.
             if formatted == node.name.as_str() {
                 Ok(format!("{{{formatted}}}"))
@@ -863,7 +874,7 @@ fn render_attribute_node(
             }
         }
         AttributeValue::Sequence(parts) => {
-            let body = render_attribute_value_sequence(parts, source, options)?;
+            let body = render_attribute_value_sequence(parts, source, options, attr_depth)?;
             Ok(format!("{}=\"{}\"", node.name, body))
         }
     }
@@ -873,6 +884,7 @@ fn render_attribute_value_for_directive(
     value: &AttributeValue,
     source: &str,
     options: &FormatOptions,
+    attr_depth: usize,
 ) -> Result<String, FormatError> {
     match value {
         AttributeValue::True(_) => Ok(String::new()),
@@ -881,11 +893,11 @@ fn render_attribute_value_for_directive(
             if inner_src.is_empty() {
                 return Ok("{}".to_string());
             }
-            let formatted = format_expression_source(inner_src, options)?;
+            let formatted = format_attribute_value_expression(inner_src, options, attr_depth)?;
             Ok(format!("{{{formatted}}}"))
         }
         AttributeValue::Sequence(parts) => {
-            let body = render_attribute_value_sequence(parts, source, options)?;
+            let body = render_attribute_value_sequence(parts, source, options, attr_depth)?;
             Ok(format!("\"{body}\""))
         }
     }
@@ -895,6 +907,7 @@ fn render_attribute_value_sequence(
     parts: &[AttributeValuePart],
     source: &str,
     options: &FormatOptions,
+    attr_depth: usize,
 ) -> Result<String, FormatError> {
     let mut out = String::new();
     for part in parts {
@@ -910,7 +923,8 @@ fn render_attribute_value_sequence(
                 if inner_src.is_empty() {
                     out.push_str("{}");
                 } else {
-                    let formatted = format_expression_source(inner_src, options)?;
+                    let formatted =
+                        format_attribute_value_expression(inner_src, options, attr_depth)?;
                     out.push('{');
                     out.push_str(&formatted);
                     out.push('}');
@@ -925,8 +939,10 @@ fn render_spread(
     spread: &SpreadAttribute,
     source: &str,
     options: &FormatOptions,
+    attr_depth: usize,
 ) -> Result<String, FormatError> {
-    let inner = format_expression_at(source, &spread.expression, options)?.unwrap_or_default();
+    let inner =
+        format_expression_at(source, &spread.expression, options, attr_depth)?.unwrap_or_default();
     Ok(format!("{{...{inner}}}"))
 }
 
@@ -955,17 +971,21 @@ fn render_directive_value(
     expr: &Expression,
     value_end: u32,
     options: &FormatOptions,
+    attr_depth: usize,
 ) -> Result<String, FormatError> {
-    if let Some(s) = crate::expression::format_directive_value(source, expr, value_end, options)? {
+    if let Some(s) =
+        crate::expression::format_directive_value(source, expr, value_end, options, attr_depth)?
+    {
         return Ok(s);
     }
-    Ok(format_expression_at(source, expr, options)?.unwrap_or_default())
+    Ok(format_expression_at(source, expr, options, attr_depth)?.unwrap_or_default())
 }
 
 fn format_expression_at(
     source: &str,
     expr: &Expression,
     options: &FormatOptions,
+    attr_depth: usize,
 ) -> Result<Option<String>, FormatError> {
     let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
         return Ok(None);
@@ -977,5 +997,7 @@ fn format_expression_at(
     if raw.is_empty() {
         return Ok(None);
     }
-    Ok(Some(format_expression_source(raw, options)?))
+    Ok(Some(format_attribute_value_expression(
+        raw, options, attr_depth,
+    )?))
 }

--- a/crates/rsvelte_formatter/tests/markup_wrap.rs
+++ b/crates/rsvelte_formatter/tests/markup_wrap.rs
@@ -136,3 +136,38 @@ fn wrapped_block_element_keeps_tags_unchanged() {
         "block element close > must not break:\n{out}"
     );
 }
+
+// ─── #795: attribute value wrap decision accounts for nesting depth ─────────
+
+#[test]
+fn attribute_object_value_breaks_by_nested_column() {
+    // The object fits at column 0 but overflows once `config` renders at the
+    // attribute column under a wrapped tag, so it must break — matching
+    // prettier-plugin-svelte (which narrows the value width by the attribute's
+    // nesting indent).
+    let out = fmt_at_width(
+        "<Comp config={{ alpha: oneValue, beta: twoValue, gamma: threeValue, delta: fourValue, epsilon: fiveValue }} />",
+        80,
+    );
+    let expected = "<Comp\n  config={{\n    alpha: oneValue,\n    beta: twoValue,\n    gamma: threeValue,\n    delta: fourValue,\n    epsilon: fiveValue,\n  }}\n/>";
+    assert_eq!(
+        out.trim_end(),
+        expected,
+        "object value should break at the nested column:\n{out}"
+    );
+    // Idempotent.
+    assert_eq!(fmt_at_width(&out, 80), out, "must be idempotent");
+}
+
+#[test]
+fn short_attribute_value_stays_inline_when_nested() {
+    // A short value still fits at the nested column, so it stays inline.
+    let out = fmt_at_width(
+        "<div data-x={shortValue} class=\"a-long-classname-to-force-the-tag-to-wrap-here\"></div>",
+        40,
+    );
+    assert!(
+        out.contains("data-x={shortValue}"),
+        "short value should stay inline:\n{out}"
+    );
+}


### PR DESCRIPTION
## Problem

Attribute and directive values were formatted at column 0 with the full print width, so a value that fits at column 0 but overflows once the open tag wraps (and the attribute renders at its nesting indent) stayed inline — diverging from prettier-plugin-svelte, which narrows the value's print width by the attribute's nesting depth:

```svelte
<!-- before: object stays inline (fit at col 0) -->
<Comp
  config={{ alpha: oneValue, beta: twoValue, gamma: threeValue, delta: fourValue, epsilon: fiveValue }}
/>
<!-- after / oxfmt: breaks -->
<Comp
  config={{
    alpha: oneValue,
    beta: twoValue,
    gamma: threeValue,
    delta: fourValue,
    epsilon: fiveValue,
  }}
/>
```

## Fix

The open-tag rewrite threads the attribute depth (`depth + 1`) through `render_attribute` and every value formatter (regular attr / directive value / spread / sequence) via a new `format_attribute_value_expression`, which narrows the print width by `attr_depth * indent_width` (no reindent — `render_multi_line` still owns continuation columns).

This is **sub-case (a)** of #795 (the depth-unaware wrap decision, ~69 of the 110 divergent files). **Sub-case (b)** — the Svelte-5 function-binding `bind:value={getter, setter}` softline brace shape — is deferred: matching it byte-for-byte needs reconciling oxc's sequence-continuation indent with prettier's, a separate change. So #795 stays open for (b).

## Verification

Object-break output matches the issue's oxfmt example byte-for-byte (test asserts exact equality + idempotency). Full `rsvelte_formatter` suite + clippy pass, no regressions.

Partially addresses #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)