### PR TITLE
fix(svelte2tsx): carry generics onto a runes-mode component type (#801)

### DIFF
--- a/.changeset/svelte2tsx-generics-component-type.md
+++ b/.changeset/svelte2tsx-generics-component-type.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): carry the `generics="…"` clause onto a runes-mode component's type so `Foo<X>` is a valid generic reference. A component declared with `<script lang="ts" generics="T …">` using `$props()` (runes mode) generated a non-generic component type alias (`type Foo__SvelteComponent_ = ReturnType<typeof Foo__SvelteComponent_>`), so referencing its instance type with a type argument (`$state<Foo<'a' | 'b'>>()`, `bind:this`, `ComponentProps<…>`) failed under `--tsgo` with "Type 'Foo__SvelteComponent_' is not generic". The runes-mode component export now emits the declared type parameters on the alias (`type Foo__SvelteComponent_<T …> = ReturnType<typeof Foo__SvelteComponent_>`), matching how the legacy-mode generics path already worked. Closes #801.

--- a/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
@@ -1528,9 +1528,18 @@ pub fn svelte2tsx(
                         "const {} = __sveltets_2_fn_component($$render());\n",
                         safe_name
                     ));
+                    // Carry the `generics="…"` clause onto the component type
+                    // alias so `Foo<X>` is a valid generic reference (#801).
+                    // Without the `<…>` params tsgo reports "Type
+                    // 'Foo__SvelteComponent_' is not generic".
+                    let type_params = if has_generics {
+                        format!("<{}>", generics_params)
+                    } else {
+                        String::new()
+                    };
                     closing.push_str(&format!(
-                        "/*\u{03A9}ignore_start\u{03A9}*/type {} = ReturnType<typeof {}>;\n",
-                        safe_name, safe_name
+                        "/*\u{03A9}ignore_start\u{03A9}*/type {}{} = ReturnType<typeof {}>;\n",
+                        safe_name, type_params, safe_name
                     ));
                     closing.push_str(&format!(
                         "/*\u{03A9}ignore_end\u{03A9}*/export default {};",

--- a/crates/rsvelte_core/tests/svelte2tsx_generics_component_type.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_generics_component_type.rs
@@ -1,0 +1,40 @@
+//! #801: a runes-mode component declared with `generics="…"` must generate a
+//! generic component type alias so `Foo<X>` references type-check under tsgo.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+#[test]
+fn runes_generics_component_type_is_generic() {
+    let src = "<script lang=\"ts\" generics=\"T extends string\">\n  let { items }: { items: T[] } = $props();\n</script>\n{#each items as it}<span>{it}</span>{/each}\n";
+    let opts = Svelte2TsxOptions {
+        filename: "G.svelte".to_string(),
+        is_ts_file: true,
+        ..Default::default()
+    };
+    let code = svelte2tsx(src, opts).expect("svelte2tsx ok").code;
+    // The component type alias must carry the declared type parameters so a
+    // `G<'a' | 'b'>` reference is valid (was non-generic → tsgo "is not generic").
+    assert!(
+        code.contains("type G__SvelteComponent_<T extends string> ="),
+        "component type alias must be generic:\n{code}"
+    );
+    assert!(
+        !code.contains("type G__SvelteComponent_ ="),
+        "non-generic alias must not be emitted:\n{code}"
+    );
+}
+
+#[test]
+fn runes_without_generics_stays_non_generic() {
+    let src = "<script lang=\"ts\">\n  let { n }: { n: number } = $props();\n</script>\n<span>{n}</span>\n";
+    let opts = Svelte2TsxOptions {
+        filename: "P.svelte".to_string(),
+        is_ts_file: true,
+        ..Default::default()
+    };
+    let code = svelte2tsx(src, opts).expect("svelte2tsx ok").code;
+    assert!(
+        code.contains("type P__SvelteComponent_ ="),
+        "non-generic component keeps the plain alias:\n{code}"
+    );
+}

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -34,7 +34,7 @@ use rsvelte_core::ast::template::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::error::FormatError;
-use crate::expression::{format_attribute_value_expression, format_expression_source};
+use crate::expression::format_attribute_value_expression;
 use crate::indent::else_if_branch;
 use crate::options::FormatOptions;
 


### PR DESCRIPTION
## Problem

`<script lang="ts" generics="T …">` with `$props()` (runes mode) generated a **non-generic** component type alias (`type G__SvelteComponent_ = ReturnType<typeof G__SvelteComponent_>`), so `G<X>` references (`$state<G<'a'|'b'>>()`, `bind:this`, `ComponentProps<…>`) failed under `--tsgo`: **"Type 'G__SvelteComponent_' is not generic"**. The runes-mode export branch always took the simple shape and ignored the `generics` clause (only legacy mode was generic-aware).

## Fix

The runes-mode export now carries the type parameters onto the alias: `type G__SvelteComponent_<T extends string> = ReturnType<typeof G__SvelteComponent_>`, making `G<X>` valid. Non-generic runes components unchanged.

## Verification

svelte2tsx fixture suite 15/15 (no regression); focused regression test added.

> Upstream's fully-isomorphic runes+generics shape threads `T` through props too; this is the minimal change resolving the reported tsgo error — the byte-isomorphic shape is a follow-up.

Closes #801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)