### PR TITLE
feat(playground): add lint as a dedicated tool next to format

### DIFF
--- a/apps/playground/src/lib/compiler.ts
+++ b/apps/playground/src/lib/compiler.ts
@@ -88,7 +88,7 @@ export function lint(source: string, filename = 'Component.svelte'): LintDiagnos
 }
 
 export type CompileMode = 'client' | 'server';
-export type OutputTab = 'result' | 'js' | 'css' | 'ast' | 'lint';
+export type OutputTab = 'result' | 'js' | 'css' | 'ast';
 
 export interface CompileStats {
 	compileTime: number;

--- a/apps/playground/src/lib/tools.ts
+++ b/apps/playground/src/lib/tools.ts
@@ -7,7 +7,13 @@
 // server) — still get a playground entry, but it explains the limitation
 // and links the guide instead of running.
 
-export type ToolId = 'compiler' | 'svelte2tsx' | 'fmt' | 'svelte-check' | 'vite-plugin-svelte';
+export type ToolId =
+	| 'compiler'
+	| 'svelte2tsx'
+	| 'fmt'
+	| 'lint'
+	| 'svelte-check'
+	| 'vite-plugin-svelte';
 
 export interface Tool {
 	/** Stable id, also the `?tool=` value and the `/docs/[slug]`. */
@@ -41,9 +47,16 @@ export const TOOLS: Tool[] = [
 	},
 	{
 		id: 'fmt',
-		label: 'fmt',
+		label: 'format',
 		pkg: '@rsvelte/fmt',
 		tagline: 'Format a .svelte file with the Rust-native formatter built on oxc.',
+		runnable: true
+	},
+	{
+		id: 'lint',
+		label: 'lint',
+		pkg: '@rsvelte/lint',
+		tagline: 'Lint a .svelte component with the Rust-native linter (compiler warnings + a11y + native rules).',
 		runnable: true
 	},
 	{

--- a/apps/playground/src/routes/playground/+page.svelte
+++ b/apps/playground/src/routes/playground/+page.svelte
@@ -102,10 +102,6 @@
 		error = '';
 		const startTime = performance.now();
 		try {
-			// Lint is computed regardless of compile success (it surfaces compile
-			// errors and warnings too, alongside the native rules).
-			lintDiagnostics = lint(input, 'Component.svelte');
-
 			const clientResult = compileClient(input, 'Component');
 			const result = mode === 'client' ? clientResult : compileServer(input, 'Component');
 			const endTime = performance.now();
@@ -198,10 +194,18 @@
 		}
 	}
 
+	// ── lint ──────────────────────────────────────────
+	function runLint() {
+		if (!wasmReady) return;
+		// Surfaces compiler warnings/errors + a11y + the native rsvelte-lint rules.
+		lintDiagnostics = lint(input, 'Component.svelte');
+	}
+
 	function run() {
 		if (tool === 'compiler') compile();
 		else if (tool === 'svelte2tsx') runSvelte2tsx();
 		else if (tool === 'fmt') runFmt();
+		else if (tool === 'lint') runLint();
 	}
 
 	async function selectTool(next: ToolId) {
@@ -282,8 +286,7 @@
 		{ id: 'result', label: 'Result', sub: 'iframe preview' },
 		{ id: 'js', label: 'JS output', sub: 'compiled .js' },
 		{ id: 'css', label: 'CSS output', sub: 'scoped styles' },
-		{ id: 'ast', label: 'AST', sub: 'svelte AST · JSON' },
-		{ id: 'lint', label: 'Lint', sub: lintCount === 1 ? '1 finding' : `${lintCount} findings` }
+		{ id: 'ast', label: 'AST', sub: 'svelte AST · JSON' }
 	]);
 
 	const cliFor = (id: ToolId): { lang: string; code: string } => {
@@ -414,6 +417,12 @@
 							Apply to source
 						</button>
 					</header>
+				{:else if tool === 'lint'}
+					<header class="panel-head">
+						<span class="panel-num">02</span>
+						<h2 class="panel-title">Lint <em>diagnostics</em></h2>
+						<span class="panel-meta">{lintCount === 1 ? '1 finding' : `${lintCount} findings`}</span>
+					</header>
 				{/if}
 
 				<div class="panel-body output-host">
@@ -444,25 +453,6 @@
 									highlightRange={astHighlightRange}
 									onNodeClick={handleAstNodeClick}
 								/>
-							</div>
-						{:else if activeTab === 'lint'}
-							<div class="lint-host">
-								{#if lintDiagnostics.length === 0}
-									<div class="lint-empty">No lint findings — looks clean.</div>
-								{:else}
-									<ul class="lint-list">
-										{#each lintDiagnostics as d (d.line + ':' + d.column + ':' + d.code)}
-											<li class="lint-item">
-												<span class="lint-sev lint-{d.severity}">{d.severity}</span>
-												<span class="lint-loc" title="line {d.line}, column {d.column}">
-													{d.line}:{d.column}
-												</span>
-												<span class="lint-msg">{d.message}</span>
-												<span class="lint-code">{d.code}</span>
-											</li>
-										{/each}
-									</ul>
-								{/if}
 							</div>
 						{:else}
 							<div class="editor-host">
@@ -511,6 +501,25 @@
 								{/key}
 							</div>
 						{/if}
+					{:else if tool === 'lint'}
+						<div class="lint-host">
+							{#if lintDiagnostics.length === 0}
+								<div class="lint-empty">No lint findings — looks clean.</div>
+							{:else}
+								<ul class="lint-list">
+									{#each lintDiagnostics as d (d.line + ':' + d.column + ':' + d.code)}
+										<li class="lint-item">
+											<span class="lint-sev lint-{d.severity}">{d.severity}</span>
+											<span class="lint-loc" title="line {d.line}, column {d.column}">
+												{d.line}:{d.column}
+											</span>
+											<span class="lint-msg">{d.message}</span>
+											<span class="lint-code">{d.code}</span>
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						</div>
 					{/if}
 				</div>
 
@@ -532,9 +541,11 @@
 							<strong>{fmtChanged ? 'reformatted' : 'already formatted'}</strong>
 						</span>
 						{#if fmtVersion}
-							<span><span class="dim">fmt</span> <strong>v{fmtVersion}</strong></span>
+							<span><span class="dim">format</span> <strong>v{fmtVersion}</strong></span>
 						{/if}
 						<span class="note">&lt;style&gt; left verbatim in-browser</span>
+					{:else if tool === 'lint'}
+						<span><span class="dim">findings</span> <strong>{lintCount}</strong></span>
 					{/if}
 					<span class="grow"></span>
 					<span class="status-dot" class:ok={wasmReady && !error} class:err={!!error}></span>

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -34,7 +34,7 @@ use rsvelte_core::ast::template::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::error::FormatError;
-use crate::expression::{format_attribute_value_expression, format_expression_source};
+use crate::expression::format_attribute_value_expression;
 use crate::indent::else_if_branch;
 use crate::options::FormatOptions;
 


### PR DESCRIPTION
Promote the linter from a Compiler output tab to its own runnable tool in the playground tool switcher, placed right after **format** (the `fmt` tool's display label is renamed to `format`).

- New `lint` tool (runnable, wasm) listing diagnostics with a live finding count.
- `fmt` tool label → `format` (id unchanged).
- Removed the lint tab from the Compiler output; dropped `'lint'` from the `OutputTab` union.

Verified: `oxlint` clean on .ts; svelte-check shows no new errors from these changes (only the repo's pre-existing type-noise); the rsvelte_lint wasm (compiler + svelte2tsx + lint) builds and the playground type-checks against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)