### PR TITLE
fix(fmt): break braces of multi-line function bindings (#795 sub-case b)

### DIFF
--- a/.changeset/fmt-function-binding-brace-break.md
+++ b/.changeset/fmt-function-binding-brace-break.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): break the braces of a multi-line Svelte 5 function binding and drop its outer parens (#795 sub-case b). A function binding `bind:value={getter, setter}` parses as a top-level sequence expression, so it previously went through the generic mustache-sequence path that re-adds the outer parens (`bind:value={(getter, setter)}`, kept for `{(a, b)}` content — #799) and hugged the braces on one line. prettier-plugin-svelte instead prints a function binding *without* the parens and, when the members don't fit on the attribute line (or a member is itself multi-line, e.g. a block-bodied setter), breaks the `{` / `}` onto their own lines with each member indented one level:
+
+```svelte
+<TextInput
+  bind:value={
+    () => model.x ?? '',
+    (value) => {
+      model.x = value;
+    }
+  }
+/>
+```
+
+A new `format_function_binding` in `crate::expression` detects the top-level sequence on a `bind:` directive, formats each member individually (so no outer parens), and either keeps the binding inline (`bind:value={a, b}`) when it fits or emits the broken-brace shape, which the existing open-tag `render_multi_line` reindent then pushes out to the attribute column. Closes #795.

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -4,6 +4,7 @@ use oxc_parser::{ParseOptions as OxcParseOptions, Parser};
 use oxc_span::SourceType;
 use rsvelte_core::ast::js::Expression;
 use rsvelte_core::ast::template::{ExpressionTag, Fragment, TemplateNode};
+use unicode_width::UnicodeWidthStr;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
@@ -402,15 +403,35 @@ pub(crate) fn format_directive_value(
     options: &FormatOptions,
     attr_depth: usize,
 ) -> Result<Option<String>, FormatError> {
-    let Some(expr_start) = expr.start() else {
+    let Some(inner) = directive_brace_inner(source, expr, value_end) else {
         return Ok(None);
     };
+    let inner = inner.trim();
+    if inner.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(format_attribute_value_expression(
+        inner, options, attr_depth,
+    )?))
+}
+
+/// Locate a directive value's `{ … }` braces and return the raw inner source.
+/// The opening brace is found by a whitespace-only back-scan from the
+/// expression start; the closing brace is the byte just before `value_end`
+/// (the directive node's `end`). Returns `None` when the braces can't be
+/// located (e.g. a shorthand `bind:value` with no value).
+fn directive_brace_inner<'a>(
+    source: &'a str,
+    expr: &Expression,
+    value_end: u32,
+) -> Option<&'a str> {
+    let expr_start = expr.start()?;
     let bytes = source.as_bytes();
 
     // Closing brace: the directive node ends just past it.
     let end = value_end as usize;
     if end == 0 || bytes.get(end - 1) != Some(&b'}') {
-        return Ok(None);
+        return None;
     }
     let close = end - 1;
 
@@ -428,18 +449,121 @@ pub(crate) fn format_directive_value(
             _ => break,
         }
     }
-    let Some(open) = open else { return Ok(None) };
+    let open = open?;
     if open >= close {
-        return Ok(None);
+        return None;
     }
+    source.get(open + 1..close)
+}
 
-    let inner = source.get(open + 1..close).unwrap_or("").trim();
+/// Format a Svelte 5 **function binding** — `bind:value={get, set}`, whose value
+/// is a top-level sequence (comma) expression — as the value part (including the
+/// surrounding `{ … }`).
+///
+/// Unlike a mustache sequence (`{(a, b)}`, which keeps its outer parens — #799),
+/// prettier-plugin-svelte prints a function binding *without* the parens and,
+/// when the members don't fit on the attribute line (or any member is itself
+/// multi-line), breaks the `{` / `}` onto their own lines with each member
+/// indented one level (#795 sub-case b):
+///
+/// ```svelte
+/// bind:value={
+///   () => model.x ?? '',
+///   (value) => {
+///     model.x = value;
+///   }
+/// }
+/// ```
+///
+/// Returns `None` when the value is not a top-level sequence — the caller then
+/// falls back to the normal single-expression directive path. `lead_cols` is the
+/// visual column at which the value's opening `{` lands once the open tag wraps
+/// (`attr_depth` indent + `bind:name=` prefix), used for the inline-fit check.
+pub(crate) fn format_function_binding(
+    source: &str,
+    expr: &Expression,
+    value_end: u32,
+    options: &FormatOptions,
+    attr_depth: usize,
+    lead_cols: usize,
+) -> Result<Option<String>, FormatError> {
+    use oxc_span::GetSpan;
+
+    let Some(inner) = directive_brace_inner(source, expr, value_end) else {
+        return Ok(None);
+    };
+    let inner = inner.trim();
     if inner.is_empty() {
         return Ok(None);
     }
-    Ok(Some(format_attribute_value_expression(
-        inner, options, attr_depth,
-    )?))
+
+    // Detect a top-level sequence and recover each member's source span.
+    let allocator = Allocator::default();
+    let source_type = if options.typescript {
+        SourceType::ts()
+    } else {
+        SourceType::default()
+    };
+    let wrapped = format!("({inner});");
+    let parser_ret = Parser::new(&allocator, &wrapped, source_type)
+        .with_options(formatter_parse_options())
+        .parse();
+    if !parser_ret.errors.is_empty() {
+        return Ok(None);
+    }
+    let Some(oxc_ast::ast::Statement::ExpressionStatement(stmt)) = parser_ret.program.body.first()
+    else {
+        return Ok(None);
+    };
+    let oxc_ast::ast::Expression::SequenceExpression(seq) = &stmt.expression else {
+        return Ok(None);
+    };
+
+    // Members render one level deeper than the brace line, so narrow each
+    // member's wrap width by that extra level.
+    let members: Vec<String> = seq
+        .expressions
+        .iter()
+        .map(|e| {
+            let span = e.span();
+            let member_src = wrapped
+                .get(span.start as usize..span.end as usize)
+                .unwrap_or("")
+                .trim();
+            format_attribute_value_expression(member_src, options, attr_depth + 1)
+        })
+        .collect::<Result<_, _>>()?;
+
+    let indent_width = options.js.indent_width.value() as usize;
+    let line_width = options.js.line_width.value() as usize;
+    let any_multiline = members.iter().any(|m| m.contains('\n'));
+
+    // Inline candidate: `{m1, m2}` on one line. Keep it inline only when no
+    // member is multi-line and the whole value fits at its rendered column.
+    let inline = members.join(", ");
+    let inline_cols = lead_cols + 1 + UnicodeWidthStr::width(inline.as_str()) + 1;
+    if !any_multiline && inline_cols <= line_width {
+        return Ok(Some(format!("{{{inline}}}")));
+    }
+
+    // Broken form: each member on its own line, indented one level, braces on
+    // their own lines. The caller's open-tag rewrite re-indents these
+    // continuation lines out to the attribute column.
+    let one_level = if options.js.indent_style.is_tab() {
+        "\t".to_string()
+    } else {
+        " ".repeat(indent_width)
+    };
+    let mut out = String::from("{\n");
+    for (i, m) in members.iter().enumerate() {
+        out.push_str(&crate::reindent::reindent(m, &one_level, false));
+        if i + 1 < members.len() {
+            out.push(',');
+        }
+        out.push('\n');
+    }
+    out.push('}');
+    Ok(Some(out))
 }
 
 // ─── Expression formatter ───────────────────────────────────────────────

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -744,8 +744,23 @@ fn render_attribute(
             Ok(format!("{{@attach {inner}}}"))
         }
         Attribute::BindDirective(d) => {
-            let inner = render_directive_value(source, &d.expression, d.end, options, attr_depth)?;
             let modifiers = render_modifiers(&d.modifiers);
+            // A Svelte 5 function binding `bind:value={get, set}` (a top-level
+            // sequence expression) renders without outer parens and breaks its
+            // braces onto their own lines when the members don't fit (#795b).
+            let lead_cols = attr_depth * options.js.indent_width.value() as usize
+                + visual_width(&format!("bind:{}{modifiers}=", d.name));
+            if let Some(value) = crate::expression::format_function_binding(
+                source,
+                &d.expression,
+                d.end,
+                options,
+                attr_depth,
+                lead_cols,
+            )? {
+                return Ok(format!("bind:{}{modifiers}={value}", d.name));
+            }
+            let inner = render_directive_value(source, &d.expression, d.end, options, attr_depth)?;
             if inner == d.name.as_str() && modifiers.is_empty() {
                 Ok(format!("bind:{}", d.name))
             } else {

--- a/crates/rsvelte_formatter/tests/markup_wrap.rs
+++ b/crates/rsvelte_formatter/tests/markup_wrap.rs
@@ -171,3 +171,46 @@ fn short_attribute_value_stays_inline_when_nested() {
         "short value should stay inline:\n{out}"
     );
 }
+
+// ─── #795 sub-case (b): function-binding brace break ────────────────────────
+
+#[test]
+fn function_binding_breaks_braces_when_multiline() {
+    // A Svelte 5 function binding `bind:value={get, set}` whose setter has a
+    // block body can't sit on one line; prettier-plugin-svelte breaks the
+    // `{` / `}` onto their own lines (no outer parens) with each member
+    // indented one level.
+    let out = fmt_at_width(
+        "<TextInput bind:value={() => model.data.samlMetadataUrl ?? '', (value) => { model.data.samlMetadataUrl = value; }} />",
+        80,
+    );
+    let expected = "<TextInput
+  bind:value={
+    () => model.data.samlMetadataUrl ?? \"\",
+    (value) => {
+      model.data.samlMetadataUrl = value;
+    }
+  }
+/>";
+    assert_eq!(
+        out.trim_end(),
+        expected,
+        "function binding should break its braces:\n{out}"
+    );
+    // Idempotent.
+    assert_eq!(fmt_at_width(&out, 80), out, "must be idempotent");
+}
+
+#[test]
+fn short_function_binding_stays_inline_without_parens() {
+    // A short function binding fits on one line and stays inline — and must
+    // NOT gain the outer parens a mustache sequence keeps (#799 is a separate
+    // path).
+    let out = fmt_at_width("<X bind:value={() => a, (v) => (a = v)} />", 80);
+    assert_eq!(
+        out.trim_end(),
+        "<X bind:value={() => a, (v) => (a = v)} />",
+        "short function binding stays inline:\n{out}"
+    );
+    assert_eq!(fmt_at_width(&out, 80), out, "must be idempotent");
+}


### PR DESCRIPTION
## Why

`@rsvelte/fmt` aims for byte parity with `oxfmt` (= `prettier-plugin-svelte`). #795 has two sub-cases; sub-case (a) (depth-aware value wrap) landed in #813. This PR finishes **sub-case (b)**: the Svelte 5 **function binding** `bind:value={getter, setter}`.

A function binding parses as a top-level **sequence expression**, so it previously went through the generic mustache-sequence path which:
1. re-adds the outer parens (correct for `{(a, b)}` mustache content — #799 — but **wrong** for a function binding), and
2. hugs the braces on one line.

```svelte
<!-- before -->
<TextInput
  bind:value={(() => model.data.samlMetadataUrl ?? "",
    (value) => {
      model.data.samlMetadataUrl = value;
    })}
/>
```

`prettier-plugin-svelte` prints a function binding **without** the parens and, when the members don't fit on the attribute line (or a member is multi-line, e.g. a block-bodied setter), breaks the `{` / `}` onto their own lines with each member indented one level.

## What

```svelte
<!-- after (matches oxfmt) -->
<TextInput
  bind:value={
    () => model.data.samlMetadataUrl ?? "",
    (value) => {
      model.data.samlMetadataUrl = value;
    }
  }
/>
```

- New `format_function_binding` in `crate::expression`: extracts the directive's brace-inner source (via a refactored-out `directive_brace_inner` helper, now shared with `format_directive_value`), detects a top-level sequence, formats **each member individually** (so no outer parens), then:
  - keeps the binding **inline** (`bind:value={a, b}`) when it fits at its rendered column and no member is multi-line, else
  - emits the **broken-brace** shape, which the existing open-tag `render_multi_line` reindent pushes out to the attribute column.
- Wired into `render_attribute`'s `BindDirective` arm (only `bind:` directives; other directives keep the existing path). Non-sequence bindings (`bind:value={x}`) are untouched.

## Verification

- New tests in `markup_wrap.rs`: `function_binding_breaks_braces_when_multiline` (exact expected output + idempotent) and `short_function_binding_stays_inline_without_parens` (inline + no parens regression vs #799).
- Full `rsvelte_formatter` suite green (run per-test-binary to avoid the known all-at-once link OOM).

Closes #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)