### PR TITLE
test(fmt): lock <script> long type-arg wrapping to oxfmt parity (#761)

### DIFF
--- a/.changeset/fmt-761-script-wrap-regression.md
+++ b/.changeset/fmt-761-script-wrap-regression.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+test(fmt): lock `<script>` long type-argument wrapping to oxfmt parity (#761). The `<script>`-body reflow divergence in #761 (e.g. a long `type … = Awaited<ReturnType<…>>;` kept on one line instead of breaking its outer type-argument list) was an `oxc_formatter` digest skew, already aligned across the workspace in #771. This adds a regression test pinning the now-matching output at the pinned rev so a future digest bump that regresses the wrapping is caught. Closes #761.

--- a/crates/rsvelte_formatter/tests/typescript.rs
+++ b/crates/rsvelte_formatter/tests/typescript.rs
@@ -123,3 +123,41 @@ fn non_ts_component_does_not_parse_ts_syntax() {
         "expected a parse error for `as` in a JS component"
     );
 }
+
+// ─── #761: <script> body long type-argument wrapping matches oxfmt ──────────
+
+#[test]
+fn script_long_type_alias_wraps_like_oxfmt() {
+    // Regression lock for #761: a long type alias must break its outer
+    // `Awaited<…>` type-argument list across lines exactly like oxfmt 0.53.
+    // The divergence was an oxc_formatter digest skew, aligned in #771; this
+    // test pins the now-matching output at the workspace's pinned rev so a
+    // future bump that regresses the wrapping is caught.
+    let src = "<script lang=\"ts\">\n  type AccountDisabledBody = Awaited<ReturnType<Extract<MfaVerifyResponse, { status: 403 }>['json']>>;\n</script>\n";
+    let out = format(
+        src,
+        &FormatOptions {
+            typescript: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format ok");
+    let expected = "<script lang=\"ts\">\n  type AccountDisabledBody = Awaited<\n    ReturnType<Extract<MfaVerifyResponse, { status: 403 }>[\"json\"]>\n  >;\n</script>\n";
+    assert_eq!(
+        out, expected,
+        "long type alias should wrap like oxfmt:\n{out}"
+    );
+    // Idempotent.
+    assert_eq!(
+        format(
+            &out,
+            &FormatOptions {
+                typescript: true,
+                ..FormatOptions::default()
+            }
+        )
+        .expect("fmt"),
+        out,
+        "must be idempotent"
+    );
+}


### PR DESCRIPTION
## Why

#761 reported that `<script>`-body type/expression wrapping diverged from `oxfmt` (e.g. a long `type AccountDisabledBody = Awaited<ReturnType<…>>;` stayed on one line instead of breaking its outer type-argument list). The root cause was an `oxc_formatter` / `oxc_formatter_core` **digest skew** vs the revision `oxfmt` embeds.

That skew was already aligned across the workspace in **#771** ("align all workspace oxc deps to a single revision 71e489a"). At the current pinned rev, the issue's canonical example now wraps **identically to oxfmt**:

```ts
type AccountDisabledBody = Awaited<
  ReturnType<Extract<MfaVerifyResponse, { status: 403 }>["json"]>
>;
```

## What

Adds a regression test (`script_long_type_alias_wraps_like_oxfmt`) pinning that output (plus idempotency) so a future `oxc_formatter` digest bump that regresses the wrapping is caught.

## Note

Corpus-wide byte-parity re-verification across the original 1,115-file flyle-nexus corpus remains a manual follow-up — it needs the external corpus, which isn't available in CI. The canonical divergence from the issue is resolved and now locked.

Closes #761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)