### PR TITLE
fix(svelte2tsx): anchor component-child snippet props via $$prop_def (#796)

### DIFF
--- a/.changeset/svelte2tsx-snippet-prop-def-anchor.md
+++ b/.changeset/svelte2tsx-snippet-prop-def-anchor.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): anchor component-child `{#snippet}` props via `inst.$$prop_def` so snippet parameters are inferred for value-typed components (#796). A named `{#snippet}` passed as a direct child of a component is lowered as an implicit prop (`new C({ props: { name:(p) => … } })`, #780). rsvelte used the bare instantiation form and never assigned the instance to a const nor destructured the snippet from `inst.$$prop_def`. For an imported `.svelte` component the contextual typing from the props literal was enough, but for a component whose type comes from a **value** — e.g. Storybook CSF's `const { Story } = defineMeta(…)` — `--tsgo` did not propagate the snippet's `Snippet<[Args]>` type and `{#snippet template(args)}` left `args` as implicit `any`. svelte2tsx now matches the official output exactly: the instance is assigned (`const $$_inst = new C({…})`) and each relocated snippet is anchored with `/*Ωignore*/const {name} = $$_inst.$$prop_def;/*Ωignore*/`, which surfaces the snippet prop types to the type-checker. Closes #796.

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -2144,12 +2144,6 @@ fn handle_component(
     // Check if any children have named slots with let: directives
     let children_have_named_slots = has_named_slot_children(&comp.fragment, source);
 
-    // An instance variable is needed when:
-    // - there are on: directives
-    // - there are let: directives on the component
-    // - there are children with slot="name" that have let: directives
-    let needs_instance = has_events || has_lets || children_have_named_slots;
-
     // Named `{#snippet}` blocks that are direct children of a component are
     // passed as *implicit props* (`props: { name: (params) => … }`), not as
     // standalone `const name = …` declarations, so that TypeScript both
@@ -2164,6 +2158,20 @@ fn handle_component(
             .nodes
             .iter()
             .any(|n| matches!(n, TemplateNode::SnippetBlock(_)));
+
+    // An instance variable is needed when:
+    // - there are on: directives
+    // - there are let: directives on the component
+    // - there are children with slot="name" that have let: directives
+    // - a named `{#snippet}` child is passed as an implicit prop: official
+    //   svelte2tsx assigns the component instance to a const and then
+    //   destructures the snippet from `inst.$$prop_def` to anchor the snippet's
+    //   parameter types. Without that anchor a snippet on a component whose type
+    //   comes from a value (e.g. Storybook's `const { Story } = defineMeta(…)`)
+    //   does not pick up its contextual `Snippet<[Args]>` type and the snippet
+    //   parameter falls back to implicit `any` (#796).
+    let needs_instance =
+        has_events || has_lets || children_have_named_slots || use_snippet_props;
 
     // Check if Svelte 5 children prop is needed
     let is_svelte5 = matches!(options.version, SvelteVersion::V5);
@@ -2320,11 +2328,13 @@ fn handle_component(
         // closes the props object is appended after the final snippet.
         let mut anchor = opening_tag_end;
         let mut last_snippet_end: Option<u32> = None;
+        let mut snippet_names: Vec<String> = Vec::new();
         for node in &comp.fragment.nodes {
             if let TemplateNode::SnippetBlock(s) = node {
                 if s.start >= s.end {
                     continue;
                 }
+                snippet_names.push(get_expression_text(&s.expression, source).to_string());
                 handle_snippet_block_as_component_prop(s, source, options, str, counter);
                 if s.start == anchor {
                     anchor = s.end;
@@ -2336,15 +2346,32 @@ fn handle_component(
                 process_node_inplace(node, source, options, str, counter);
             }
         }
+        // After closing the `new Component({ props: { … } })` statement,
+        // destructure each relocated snippet from the instance's `$$prop_def`
+        // (wrapped in ignore-markers so it never surfaces as a diagnostic). This
+        // mirrors official svelte2tsx and anchors the snippet props' types — in
+        // particular the snippet's `Snippet<[Args]>` parameter type — so the
+        // snippet's parameters are inferred even when the component's type comes
+        // from a value rather than an imported `.svelte` module (#796).
+        let prop_def_suffix = if snippet_names.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "/*\u{03A9}ignore_start\u{03A9}*/const {{{}}} = {}.$$prop_def;/*\u{03A9}ignore_end\u{03A9}*/",
+                snippet_names.join(", "),
+                inst_var
+            )
+        };
+        let closing = format!("{trailer_lit}{prop_def_suffix}");
         // Close the props object right after the last relocated snippet.
         match last_snippet_end {
             Some(end) => {
-                str.append_left(end, &trailer_lit);
+                str.append_left(end, &closing);
             }
             None => {
                 // No usable snippet after all (e.g. only empty-named blocks);
                 // close the props object at the opening-tag boundary.
-                str.prepend_right(opening_tag_end, &trailer_lit);
+                str.prepend_right(opening_tag_end, &closing);
             }
         }
     } else {

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -2170,8 +2170,7 @@ fn handle_component(
     //   comes from a value (e.g. Storybook's `const { Story } = defineMeta(…)`)
     //   does not pick up its contextual `Snippet<[Args]>` type and the snippet
     //   parameter falls back to implicit `any` (#796).
-    let needs_instance =
-        has_events || has_lets || children_have_named_slots || use_snippet_props;
+    let needs_instance = has_events || has_lets || children_have_named_slots || use_snippet_props;
 
     // Check if Svelte 5 children prop is needed
     let is_svelte5 = matches!(options.version, SvelteVersion::V5);

--- a/crates/rsvelte_core/tests/svelte2tsx_snippet_prop_def_anchor.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_snippet_prop_def_anchor.rs
@@ -1,0 +1,110 @@
+//! Regression test for issue #796.
+//!
+//! A named `{#snippet}` passed as a direct child of a component must be wired
+//! as an implicit prop AND anchored via the instance's `$$prop_def`
+//! (`const $$_inst = new C({ props: { name:(args) => … } }); const {name} =
+//! $$_inst.$$prop_def;`). The `$$prop_def` destructuring is what lets
+//! TypeScript infer the snippet's parameters from the prop's `Snippet<[Args]>`
+//! type when the component's type comes from a *value* rather than an imported
+//! `.svelte` module — e.g. Storybook CSF's `const { Story } = defineMeta(…)`.
+//! Without it, `{#snippet template(args)}` inside `<Story>` left `args` as
+//! implicit `any` under `--tsgo`. This mirrors official svelte2tsx, which the
+//! issue confirms reports 0 errors.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn overlay(src: &str, filename: &str) -> String {
+    svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: filename.into(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code
+}
+
+fn braces_balanced(s: &str) -> bool {
+    let mut depth: i32 = 0;
+    let mut in_str: Option<char> = None;
+    let mut prev = '\0';
+    for c in s.chars() {
+        match in_str {
+            Some(q) => {
+                if c == q && prev != '\\' {
+                    in_str = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' | '`' => in_str = Some(c),
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            },
+        }
+        if depth < 0 {
+            return false;
+        }
+        prev = c;
+    }
+    depth == 0
+}
+
+const STORY: &str = "<script module lang=\"ts\">\n\
+    import { defineMeta } from '@storybook/addon-svelte-csf';\n\
+    import B from './B.svelte';\n\
+    const { Story } = defineMeta({ title: 'X/B', component: B, args: { label: 'x' } });\n\
+    </script>\n\
+    <Story name=\"Default\">\n\
+    {#snippet template(args)}\n\
+    <B {...args} />\n\
+    {/snippet}\n\
+    </Story>";
+
+#[test]
+fn storybook_story_template_snippet_is_prop_def_anchored() {
+    let code = overlay(STORY, "B.stories.svelte");
+    // Snippet wired as an implicit prop on the Story instance.
+    assert!(
+        code.contains("template:(args) =>"),
+        "snippet not wired into props:\n{code}"
+    );
+    // Instance assigned to a const so it can be destructured below.
+    assert!(
+        code.contains("const $$_yrotS0 = new $$_yrotS0C("),
+        "component instance not assigned to a const:\n{code}"
+    );
+    // The $$prop_def anchor — what gives `args` its `Snippet<[Args]>` type.
+    assert!(
+        code.contains("const {template} = $$_yrotS0.$$prop_def;"),
+        "snippet not anchored via $$prop_def:\n{code}"
+    );
+    assert!(braces_balanced(&code), "unbalanced overlay:\n{code}");
+}
+
+#[test]
+fn multiple_story_snippets_are_all_anchored() {
+    let src = "<script lang=\"ts\">import List from './List.svelte';</script>\n\
+        <List>\n\
+        {#snippet a()}<p>A</p>{/snippet}\n\
+        {#snippet b(x)}<p>{x}</p>{/snippet}\n\
+        </List>";
+    let code = overlay(src, "T.svelte");
+    assert!(
+        code.contains(".$$prop_def;"),
+        "snippets not anchored:\n{code}"
+    );
+    // Both snippet names appear in the single destructuring.
+    let anchor = code
+        .split(".$$prop_def;")
+        .next()
+        .and_then(|s| s.rfind("const {").map(|i| &s[i..]))
+        .unwrap_or("");
+    assert!(
+        anchor.contains("a") && anchor.contains("b"),
+        "both snippets not in $$prop_def destructuring: {anchor}\n{code}"
+    );
+    assert!(braces_balanced(&code), "unbalanced overlay:\n{code}");
+}


### PR DESCRIPTION
## Why

In a Storybook CSF story, `{#snippet template(args)}` inside `<Story>` had `args` inferred as implicit `any` under `--tsgo` (issue #796 — 116 of 145 `--tsgo` errors in one design-system came from this). Official `svelte-check` reports 0 errors.

A named `{#snippet}` that is a direct child of a component is lowered as an implicit prop (`new C({ props: { name:(p) => … } })`, the #780 path). rsvelte used the **bare** instantiation form and never:
1. assigned the instance to a const, nor
2. destructured the snippet from `inst.$$prop_def`.

For an imported `.svelte` component the contextual typing from the props literal was enough, but for a component whose type comes from a **value** — Storybook's `const { Story } = defineMeta(…)` — `tsgo` does not propagate the snippet's `Snippet<[Args]>` type that way, so `args` fell back to `any`.

## What

Match official svelte2tsx exactly for the snippet-prop region:
- `needs_instance` now includes the snippet-prop path → the instance is assigned (`const $$_inst = new C({…})`).
- After the instantiation, emit `/*Ωignore*/const {name1, name2} = $$_inst.$$prop_def;/*Ωignore*/` for the relocated snippets. This `$$prop_def` access is what anchors the snippet prop types for the type-checker.

Before:
```ts
{ const $$_yrotS0C = __sveltets_2_ensureComponent(Story); new $$_yrotS0C({ … props: { template:(args) => … } }); Story}
```
After (byte-identical to official svelte2tsx):
```ts
{ const $$_yrotS0C = __sveltets_2_ensureComponent(Story); const $$_yrotS0 = new $$_yrotS0C({ … props: { template:(args) => … } });/*Ωignore_startΩ*/const {template} = $$_yrotS0.$$prop_def;/*Ωignore_endΩ*/ Story}
```

## Verification

- **Output parity**: built the official `svelte2tsx` (svelte 5) and confirmed rsvelte's output now equals it byte-for-byte in the snippet-prop region for both the Storybook `<Story>` case and the plain `<List>` case (the project's correctness criterion is exact official-output parity).
- **Type-check harness**: ran `tsc --strict` against the svelte shims + the **real** `@storybook/addon-svelte-csf` types. (Note: `tsc` infers `args` even from the old bare form, so the failure is **tsgo-specific** — tsgo's contextual typing through `new C({props})` for a value-typed component is weaker and needs the `$$prop_def` anchor official emits. tsgo itself isn't runnable in CI here; output parity with official is the verification.)
- No regressions: the 253-fixture svelte2tsx suite + all svelte2tsx unit tests stay green. No fixture covers the component-child snippet path, so only the hand-written #780 tests were affected — they still pass.
- New regression test `svelte2tsx_snippet_prop_def_anchor.rs` asserts the instance-const + `$$prop_def` anchor for the Storybook case and multi-snippet case.

Closes #796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)