### PR TITLE
fix(release): publish @rsvelte/compiler at the release version (unbreak Release)

### DIFF
--- a/.changeset/fix-svelte2tsx-compiler-range.md
+++ b/.changeset/fix-svelte2tsx-compiler-range.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Fix the `@rsvelte/compiler` dependency range. `0.1.13` and `0.1.14` shipped a
+wrong `^0.1.0` range (the same `pkg/` version leak that broke the compiler
+publish caused pnpm to resolve the `workspace:^` range against the stale
+`0.1.0`), which pulled a months-old compiler. This release restores the
+correct `^0.7.x` range.

--- a/.changeset/republish-compiler-correct-version.md
+++ b/.changeset/republish-compiler-correct-version.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Republish at the correct release version. The previous `0.7.6` publish never
+reached npm: the wasm `pkg/` was stamped with the build crate's version
+(`0.1.0`) instead of the release version, so `changeset publish` attempted
+`@rsvelte/compiler@0.1.0`, hit npm's already-published guard (E403), and
+crashed the Release run. This ships the same compiler at a correctly-versioned
+package — there is no functional change to the compiler itself.

--- a/scripts/release/finalize-pkg.mjs
+++ b/scripts/release/finalize-pkg.mjs
@@ -1,13 +1,23 @@
 #!/usr/bin/env node
-// `wasm-pack build` writes `pkg/package.json` based on the Cargo crate name
-// (`rsvelte_core`). We publish under the scoped npm name
-// `@rsvelte/compiler`, so we overlay the npm-side metadata here after the
-// wasm build completes and before `pnpm publish` reads it.
+// `wasm-pack build` writes `pkg/package.json` based on the Cargo crate it
+// builds (currently `rsvelte_lint`, which re-exports the `rsvelte_core`
+// compiler wasm exports — see `crates/rsvelte_lint/src/wasm.rs`). We publish
+// under the scoped npm name `@rsvelte/compiler`, so we overlay the npm-side
+// metadata here after the wasm build completes and before `pnpm publish`
+// reads it.
 //
-// The version is intentionally left as wasm-pack produced it: that comes from
-// `Cargo.toml`, which `sync-version.mjs` has already aligned with the version
-// in `apps/npm/compiler/package.json`. Keeping wasm-pack as the version writer
-// avoids a second source of truth.
+// The version is the changeset-managed `apps/npm/compiler/package.json`
+// version — the single source of truth. We force it here rather than trusting
+// whatever wasm-pack derived from the built crate's `Cargo.toml`, because the
+// built crate is decoupled from the published package's version: when the
+// build switched from `rsvelte_core` to `rsvelte_lint` (#724), wasm-pack
+// started stamping `pkg/package.json` with `rsvelte_lint`'s crate version
+// (`0.1.0`) instead of the release version. That shipped `@rsvelte/compiler`
+// as `0.1.0`, which npm rejected as already-published (E403) and crashed the
+// changesets publish. Owning the version here keeps the published tarball
+// correct no matter which crate the wasm build targets, and is also what
+// `workspace:^` consumers (e.g. `@rsvelte/svelte2tsx`) read when pnpm rewrites
+// their dependency range at publish time.
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -25,6 +35,15 @@ const source = JSON.parse(readFileSync(sourceJsonPath, 'utf8'));
 // redirect into the published package — once pnpm packs from `pkg/`, that
 // field would only confuse downstream consumers if it shipped to the registry.
 generated.name = source.name;
+// Surface any drift between the built crate's version and the release version
+// so a future build-crate swap that desyncs `sync-version.mjs` is debuggable.
+if (generated.version !== source.version) {
+	console.warn(
+		`finalize-pkg: overriding wasm-pack version ${generated.version} -> ${source.version} ` +
+			`(from apps/npm/compiler/package.json). If unexpected, check sync-version.mjs covers the built crate.`,
+	);
+}
+generated.version = source.version;
 if (source.repository) generated.repository = source.repository;
 if (source.homepage) generated.homepage = source.homepage;
 if (source.bugs) generated.bugs = source.bugs;

--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -3,10 +3,19 @@
 // Rust crate's `Cargo.toml` `[package].version` and the repo-root `Cargo.lock`.
 //
 // Why this exists:
-// - `@rsvelte/compiler` ← `crates/rsvelte_core`: `wasm-pack build` derives
-//   `pkg/package.json` from the crate's Cargo.toml, so keeping them aligned is
-//   what makes "bump the workspace package.json via changesets, then publish
-//   the freshly built pkg/" produce a coherent npm release.
+// - `@rsvelte/compiler` ← `crates/rsvelte_core` AND `crates/rsvelte_lint`:
+//   `@rsvelte/compiler` ships the wasm built from `crates/rsvelte_lint`
+//   (`build:wasm:core`), which re-exports the `rsvelte_core` compiler wasm
+//   API. Both crates embed their own `env!("CARGO_PKG_VERSION")` into the wasm
+//   module: `rsvelte_core` backs the compiler `version()` export and
+//   `rsvelte_lint` backs `lint_version()`. Keeping BOTH aligned with the
+//   release version keeps those runtime version strings honest. (The published
+//   `pkg/package.json` version itself is forced by `finalize-pkg.mjs`, which is
+//   what actually guards against a build-crate/version desync — but we still
+//   mirror both crates so the in-wasm version exports don't drift.)
+//   `crates/rsvelte_lint` was added here after #724 switched `build:wasm:core`
+//   from `rsvelte_core` to `rsvelte_lint`; without it `lint_version()` reported
+//   a stale `0.1.0`.
 // - `@rsvelte/fmt` ← `crates/rsvelte_fmt`: the `rsvelte-fmt` binary reports its
 //   version from `env!("CARGO_PKG_VERSION")` (clap `#[command(version)]`).
 //   Without this sync the crate stayed at `0.1.0` no matter how many releases
@@ -29,6 +38,12 @@ const MAPPINGS = [
 		npm: 'apps/npm/compiler/package.json',
 		cargoToml: 'crates/rsvelte_core/Cargo.toml',
 		lockName: 'rsvelte_core',
+	},
+	{
+		// The crate `build:wasm:core` actually builds into `pkg/` → `@rsvelte/compiler`.
+		npm: 'apps/npm/compiler/package.json',
+		cargoToml: 'crates/rsvelte_lint/Cargo.toml',
+		lockName: 'rsvelte_lint',
 	},
 	{
 		npm: 'apps/npm/fmt/package.json',


### PR DESCRIPTION
## What broke

The `Release` run for `chore(release): version packages (#852)` failed in the `Publish` job:

```
🦋 error TypeError: Cannot read properties of undefined (reading 'includes')
    at isAlreadyPublishedError (@changesets/cli@2.31.0/.../changesets-cli.cjs.js:873:17)
    at internalPublish (...:957:41)
```

Of the 6 packages in #852, **only `@rsvelte/compiler@0.7.6` failed to publish** — the other 5 (`fmt@0.3.10`, `svelte-check@0.2.10`, `svelte2tsx@0.1.14`, and the two win32 platform packages) published successfully. The release is half-completed.

## Root cause

`@rsvelte/compiler` ships the wasm built from **`crates/rsvelte_lint`** (PR #724 switched `build:wasm:core` from `rsvelte_core` → `rsvelte_lint`, because `rsvelte_lint` re-exports the `rsvelte_core` compiler wasm API as a superset for the playground).

But two release scripts still assumed `rsvelte_core`:

- `sync-version.mjs` only synced `rsvelte_core`'s `Cargo.toml`, never `rsvelte_lint`'s.
- `finalize-pkg.mjs` deliberately kept whatever version `wasm-pack` produced.

So `pkg/package.json` was stamped with `rsvelte_lint`'s crate version **`0.1.0`**. `changeset publish` then tried to publish `@rsvelte/compiler@0.1.0` — already on npm — which npm rejects with **E403**. Under OIDC trusted publishing that error JSON has no `summary`, so changesets 2.31.0's `isAlreadyPublishedError(json.error.summary)` crashed on `undefined.includes(...)`.

The same `0.1.0` leak also **corrupted `@rsvelte/svelte2tsx`'s dependency range to `^0.1.0`** (it was `^0.7.5` through `0.1.12`): pnpm resolved svelte2tsx's `workspace:^` against the stale `pkg/` version at publish time.

This is the first release after #724 — 0.7.5 (built from `rsvelte_core`) published fine before it.

## Fix

- **`finalize-pkg.mjs`** now forces `pkg/package.json` version to the changeset-managed `apps/npm/compiler/package.json` version (the single source of truth), decoupling the published version from whichever crate the wasm build targets. A warning surfaces any drift for future debuggability.
- **`sync-version.mjs`** also mirrors the release version into `crates/rsvelte_lint`, so the wasm-embedded `lint_version()` export stays honest (the compiler `version()` export already came from `rsvelte_core`).

Both verified locally: `sync-version` now bumps `rsvelte_lint` → `0.7.6`, and `finalize-pkg` rewrites a `0.1.0` `pkg/package.json` to the release version.

## Recovery

Rather than republish the failed `0.7.6`, this PR includes changesets to **roll forward**:

- `@rsvelte/compiler` → **0.7.7** (publishes the compiler at a correctly-versioned package)
- `@rsvelte/svelte2tsx` → **0.1.15** (cascade patch; rewrites its dependency range back to the correct `^0.7.x`)

The other #852 packages are already published and won't be re-touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)