### PR TITLE
fix(parse-envelope): remap typed-arrow Raw JSON offsets to UTF-16 (#908)

### DIFF
--- a/.changeset/fix-908-envelope-typed-arrow-utf16.md
+++ b/.changeset/fix-908-envelope-typed-arrow-utf16.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix(parse-envelope): remap typed-arrow `JsNode::Raw` offsets to UTF-16 (#908). A typed function parameter (`(r: number[]) => …`) is lowered to a `JsNode::Raw` JSON sub-tree, which the raw-transfer envelope encoder serialized verbatim — keeping its byte offsets while every other span was remapped to UTF-16. With non-ASCII source preceding the arrow, the whole arrow (params **and** body) drifted by `byteLen − utf16Len`, so `decodeParseEnvelope` spans no longer matched `parse` (JSON) and `source.slice(node.start, node.end)` broke (`magic-string` out-of-bounds). The `JsNode::Raw` writer now applies the same `convert_positions_to_utf16` remap as `write_json_node`, so the envelope is fully UTF-16-consistent.

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -2049,7 +2049,23 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
                 }
             }
             let mut shim = A(w);
-            serde_json::to_writer(&mut shim, value).map_err(std::io::Error::other)?;
+            if offset_remap_active() {
+                // A `Raw` sub-tree (e.g. a typed function parameter, or a whole
+                // typed arrow lowered to legacy JSON) carries byte offsets too.
+                // Remap them to UTF-16 so the envelope stays consistent with the
+                // JSON `parse` path (#793, #908). Without this, every descendant
+                // of a typed-parameter arrow keeps its byte offsets and drifts
+                // past any preceding non-ASCII source.
+                let mut json_value = value.clone();
+                OFFSET_CONV.with(|c| {
+                    if let Some(conv) = &*c.borrow() {
+                        crate::compiler::legacy::convert_positions_to_utf16(&mut json_value, conv);
+                    }
+                });
+                serde_json::to_writer(&mut shim, &json_value).map_err(std::io::Error::other)?;
+            } else {
+                serde_json::to_writer(&mut shim, value).map_err(std::io::Error::other)?;
+            }
             let p1 = shim.0.position();
             w.patch_u32(len_slot, (p1 - p0) as u32);
         }
@@ -2185,6 +2201,88 @@ mod tests {
         let root_off = u32::from_le_bytes(buf[12..16].try_into().unwrap()) as usize;
         // Root must be the binary TAG_ROOT, not the JSON fallback.
         assert_eq!(buf[root_off], TAG_ROOT);
+    }
+
+    /// #908: a typed arrow parameter (`(r: number[]) => …`) is lowered to a
+    /// `JsNode::Raw` JSON sub-tree. That JSON carries byte offsets, which must
+    /// be remapped to UTF-16 like every other span when the source contains
+    /// non-ASCII characters — otherwise the whole arrow (params + body) drifts
+    /// past the preceding multibyte text and `source.slice(start, end)` breaks.
+    #[test]
+    fn typed_arrow_raw_json_offsets_are_utf16() {
+        use std::collections::HashSet;
+
+        // 4 multibyte chars precede the typed arrow, so a leaked byte offset
+        // would be shifted by +8 (4 chars × 2 extra bytes) versus UTF-16.
+        let src = concat!(
+            "<script lang=\"ts\">\n",
+            "  const \u{30E9}\u{30D9}\u{30EB} = \"\u{3042}\";\n",
+            "  let last = 0;\n",
+            "  const set = (r: number[]) => { last = r.length; };\n",
+            "</script>\n",
+            "<p>{\u{30E9}\u{30D9}\u{30EB}}{last}{set}</p>",
+        );
+        let ast = parse(src, ParseOptions::default()).unwrap();
+
+        // Canonical UTF-16 offsets — exactly what the JSON `parse` path emits.
+        let valid: HashSet<i64> = crate::ast::arena::with_serialize_arena(&ast.arena, || {
+            let mut value = serde_json::to_value(&ast).unwrap();
+            let conv = crate::compiler::legacy::Utf8ToUtf16::new(src);
+            crate::compiler::legacy::convert_positions_to_utf16(&mut value, &conv);
+            let mut set = HashSet::new();
+            collect_offsets(&value, &mut set);
+            set
+        });
+
+        let buf = encode_root_to_vec(&ast, src);
+        // Raw-JSON sub-trees are the only place `"start":`/`"end":` appears as
+        // text in the binary envelope (typed nodes store offsets as raw u32).
+        let text = String::from_utf8_lossy(&buf);
+        let mut checked = 0usize;
+        for key in ["\"start\":", "\"end\":"] {
+            let mut from = 0;
+            while let Some(rel) = text[from..].find(key) {
+                let num_start = from + rel + key.len();
+                let digits: String = text[num_start..]
+                    .chars()
+                    .take_while(|c| c.is_ascii_digit())
+                    .collect();
+                from = num_start;
+                if let Ok(n) = digits.parse::<i64>() {
+                    assert!(
+                        valid.contains(&n),
+                        "envelope raw-JSON offset {n} is not a UTF-16 node offset \
+                         (byte offsets leaked — #908)"
+                    );
+                    checked += 1;
+                }
+            }
+        }
+        assert!(
+            checked > 0,
+            "expected the typed arrow to produce raw-JSON offsets to check"
+        );
+    }
+
+    fn collect_offsets(value: &serde_json::Value, out: &mut std::collections::HashSet<i64>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                for (k, v) in map {
+                    if (k == "start" || k == "end")
+                        && let Some(n) = v.as_i64()
+                    {
+                        out.insert(n);
+                    }
+                    collect_offsets(v, out);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for it in items {
+                    collect_offsets(it, out);
+                }
+            }
+            _ => {}
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`decodeParseEnvelope` returned **byte offsets** for the sub-tree of a TS-typed arrow parameter (`(r: number[]) => { … }`), even though the JSON `parse(...)` path is correctly UTF-16 (after #793). When a non-ASCII character precedes such an arrow, every node from the arrow down drifted by the accumulated `byteLen − utf16Len`, so `source.slice(node.start, node.end)` was wrong and `magic-string` threw `end is out of bounds`.

## Root cause

A typed parameter is lowered to an `Expression::Value` → `JsNode::Raw(json)` sub-tree. The raw-transfer envelope encoder's `JsNode::Raw` arm in `crates/rsvelte_core/src/napi_raw_parse.rs` serialized that JSON **verbatim**, unlike `write_json_node` which applies `convert_positions_to_utf16` when a remap is active. So the embedded JSON (the whole typed arrow — params *and* body) kept its byte offsets while every surrounding binary span was UTF-16.

## Fix

Apply the same `convert_positions_to_utf16` remap inside the `JsNode::Raw` writer when `offset_remap_active()`. The envelope is now fully UTF-16-consistent with the JSON path.

## Test

Adds `typed_arrow_raw_json_offsets_are_utf16` (the issue's repro shape: 4 multibyte chars + a typed arrow). It computes the canonical UTF-16 node-offset set via the JSON path and asserts **every** `"start"`/`"end"` that appears as text in the encoded envelope (i.e. every raw-JSON offset) is a member of that set. Before the fix the leaked byte offsets fail this; after, all pass.

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)