### PR TITLE
fix(svelte2tsx): keep type annotation on destructured snippet params (#912)

### DIFF
--- a/.changeset/fix-912-snippet-param-type-annotation.md
+++ b/.changeset/fix-912-snippet-param-type-annotation.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): preserve explicit type annotations on destructured `{#snippet}` parameters (#912). A snippet parameter that destructures and annotates its type (`{#snippet menuitem({ contentId }: { contentId?: string })}`) had its annotation dropped: the lowering spanned only the `{ contentId }` pattern, so svelte2tsx synthesized `{ contentId: any }` — losing both the type and the `?` optionality, and `{@render menuitem({})}` wrongly errored as a missing required property. The parser now folds a destructuring parameter's `typeAnnotation` into its span (mirroring the already-correct identifier-parameter path), so the generated `Snippet<[T]>` parameter type uses the annotation verbatim.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -2492,10 +2492,22 @@ fn convert_formal_parameter_inner(
             }
         }
         BindingPattern::ObjectPattern(obj_pat) => {
-            convert_object_pattern_to_expr(arena, obj_pat, adjusted_offset, line_offsets)
+            let expr =
+                convert_object_pattern_to_expr(arena, obj_pat, adjusted_offset, line_offsets);
+            // A destructuring param can carry a type annotation on the
+            // FormalParameter (`{ a }: { a?: string }`), but the pattern's own
+            // span stops at the closing `}`. The BindingIdentifier branch above
+            // already folds the annotation into its span + attaches
+            // `typeAnnotation`; mirror that for object patterns so the param's
+            // `end` covers the annotation. svelte2tsx slices the snippet
+            // parameter's source by this span — without it the explicit type and
+            // its optionality are lost and the member is inferred as `any` /
+            // required (#912).
+            attach_param_type_annotation(expr, param, adjusted_offset, line_offsets)
         }
         BindingPattern::ArrayPattern(arr_pat) => {
-            convert_array_pattern_to_expr(arena, arr_pat, adjusted_offset, line_offsets)
+            let expr = convert_array_pattern_to_expr(arena, arr_pat, adjusted_offset, line_offsets);
+            attach_param_type_annotation(expr, param, adjusted_offset, line_offsets)
         }
         BindingPattern::AssignmentPattern(assign_pat) => {
             convert_assignment_pattern_to_expr(arena, assign_pat, adjusted_offset, line_offsets)
@@ -2518,6 +2530,39 @@ fn convert_formal_parameter_inner(
     }
 
     pattern_expr
+}
+
+/// Fold a FormalParameter's type annotation into a destructuring-pattern
+/// expression: extend the node's `end` to cover the annotation and attach a
+/// `typeAnnotation` field (mirroring the `BindingIdentifier` branch of
+/// `convert_formal_parameter_inner`). No-op when the parameter is untyped.
+///
+/// `adjusted_offset` is the offset already applied to the pattern's own spans
+/// (the OXC span is relative to the parser's wrapped source); the annotation's
+/// spans use the same base, so callers needing original-source positions
+/// (e.g. the optional-marker remap path) still remap the top-level `end`.
+fn attach_param_type_annotation(
+    expr: Expression,
+    param: &oxc_ast::ast::FormalParameter,
+    adjusted_offset: usize,
+    line_offsets: &[usize],
+) -> Expression {
+    let Some(type_ann) = &param.type_annotation else {
+        return expr;
+    };
+    let mut json = expr.as_json().clone();
+    if let Some(obj) = json.as_object_mut() {
+        let start = obj.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
+        let end = adjusted_offset + type_ann.span.end as usize;
+        obj.insert("end".to_string(), Value::Number((end as i64).into()));
+        if let Some(loc) = create_loc(start, end, line_offsets) {
+            obj.insert("loc".to_string(), loc);
+        }
+        let type_ann_obj =
+            convert_type_annotation_adjusted(type_ann, adjusted_offset, line_offsets);
+        obj.insert("typeAnnotation".to_string(), type_ann_obj);
+    }
+    Expression::Value(json)
 }
 
 /// Convert oxc ObjectPattern to our Expression format (for function parameters).

--- a/crates/rsvelte_core/tests/svelte2tsx_snippet_param_type.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_snippet_param_type.rs
@@ -1,0 +1,68 @@
+//! Regression test for issue #912.
+//!
+//! An explicit type annotation on a `{#snippet}` parameter that uses a
+//! destructuring pattern (`{ contentId }: { contentId?: string }`) must be
+//! carried verbatim into the generated arrow's parameter list. Previously the
+//! lowering spanned only the destructuring pattern (`{ contentId }`), dropping
+//! the annotation — so the parameter was inferred as `{ contentId: any }`
+//! (losing both the type and the `?` optionality), and `{@render menuitem({})}`
+//! wrongly errored as "missing required property".
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn overlay(src: &str) -> String {
+    svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "T.svelte".into(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code
+}
+
+#[test]
+fn object_pattern_snippet_param_keeps_type_annotation() {
+    let src = "<script lang=\"ts\">let v = 1;</script>\n\
+               {#snippet menuitem({ contentId }: { contentId?: string })}\n\
+               <button id={contentId}>{v}</button>\n\
+               {/snippet}\n\
+               {@render menuitem({})}";
+    let code = overlay(src);
+    assert!(
+        code.contains("{ contentId }: { contentId?: string }"),
+        "snippet param type annotation dropped:\n{code}"
+    );
+}
+
+#[test]
+fn array_pattern_snippet_param_keeps_type_annotation() {
+    let src = "<script lang=\"ts\">let v = 1;</script>\n\
+               {#snippet row([first]: [string?])}\n\
+               <button>{first}{v}</button>\n\
+               {/snippet}\n\
+               {@render row([])}";
+    let code = overlay(src);
+    assert!(
+        code.contains("[first]: [string?]"),
+        "array-pattern snippet param type annotation dropped:\n{code}"
+    );
+}
+
+#[test]
+fn identifier_snippet_param_type_annotation_unaffected() {
+    // Guard: the already-working identifier-with-annotation path still emits
+    // its annotation (it is folded into the span in convert_formal_parameter).
+    let src = "<script lang=\"ts\">let v = 1;</script>\n\
+               {#snippet item(id: string)}\n\
+               <button>{id}{v}</button>\n\
+               {/snippet}\n\
+               {@render item('a')}";
+    let code = overlay(src);
+    assert!(
+        code.contains("id: string"),
+        "identifier snippet param type annotation dropped:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

An explicit type annotation on a **destructured** `{#snippet}` parameter was ignored by `--tsgo`:

```svelte
{#snippet menuitem({ contentId }: { contentId?: string })}
  <button id={contentId}>{v}</button>
{/snippet}
{@render menuitem({})}
```

Official `svelte-check`: 0 errors (`contentId: string | undefined`, optional). rsvelte `--tsgo` wrongly emitted:

```
Binding element 'contentId' implicitly has an 'any' type.
Property 'contentId' is missing in type '{}' but required in type '{ contentId: any; }'.
```

## Root cause

`convert_object_pattern_to_expr` / `convert_array_pattern_to_expr` span only the destructuring pattern, so the parameter Expression ended at the closing `}` of `{ contentId }` — dropping the `: { contentId?: string }` annotation that lives on the `FormalParameter`. svelte2tsx slices the snippet parameter's source text by that span, so it emitted `({ contentId })` and TypeScript inferred `{ contentId: any }` (losing the type **and** the `?`).

The `BindingIdentifier` branch of `convert_formal_parameter_inner` already folds a typed parameter's annotation into its span; the object/array branches didn't.

## Fix

New `attach_param_type_annotation` helper extends a destructuring parameter's `end` to cover the annotation and attaches `typeAnnotation` (mirroring the identifier branch). The corrected span flows to svelte2tsx, the JSON AST, and the raw-transfer envelope alike.

## Tests

- `svelte2tsx_snippet_param_type.rs`: object-pattern, array-pattern, and (guard) identifier snippet parameter type annotations.
- No regression: `compiler_fixtures` (snapshot codegen), `print` (round-trip), `svelte2tsx_fixtures`, `parser_fixtures`, `snippet_param_destructuring` all green.

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)