### PR TITLE
fix(parse): exact identifier spans for switch discriminant & assignment-pattern defaults (#916)

### DIFF
--- a/.changeset/fix-916-switch-discriminant-span.md
+++ b/.changeset/fix-916-switch-discriminant-span.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+"@rsvelte/compiler": patch
+---
+
+fix(parse): give `switch` discriminants and assignment-pattern defaults exact identifier spans (#916). In program/script context the statement converter routed a `switch (X)` discriminant, a `case X:` test, a `do … while (X)` test, and the default value of a destructuring `AssignmentPattern` through `convert_expression` (which subtracts the synthetic-paren offset) instead of `convert_expression_for_program`. That shifted those spans one code unit to the left — `switch (x)` spanned the `x` as `(`, and the `$bindable` callee in `let { open = $bindable(false) }` spanned as ` $bindabl` — so span-based edits (`magic-string`, svelte-shaker) corrupted the source. All four now use the program-context converter, so every identifier satisfies `source.slice(start, end) === name`.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7086,7 +7086,12 @@ fn convert_statement_for_program(
             let end = offset + switch_stmt.span.end as usize;
             let loc = create_typed_loc(start, end, line_offsets);
 
-            let discriminant = expr_to_node(convert_expression(
+            // Program context: the offset is already program-adjusted, so use
+            // `convert_expression_for_program` (no `-1` paren shift) like every
+            // other statement here. Using `convert_expression` double-counts the
+            // paren and shifts the discriminant span one unit left onto the `(`
+            // (#916).
+            let discriminant = expr_to_node(convert_expression_for_program(
                 arena,
                 &switch_stmt.discriminant,
                 offset,
@@ -7102,7 +7107,7 @@ fn convert_statement_for_program(
                     let case_loc = create_typed_loc(case_start, case_end, line_offsets);
 
                     let test = case.test.as_ref().map(|test| {
-                        arena.alloc_js_node(expr_to_node(convert_expression(
+                        arena.alloc_js_node(expr_to_node(convert_expression_for_program(
                             arena,
                             test,
                             offset,
@@ -7141,7 +7146,7 @@ fn convert_statement_for_program(
             let end = offset + do_while_stmt.span.end as usize;
             let loc = create_typed_loc(start, end, line_offsets);
 
-            let test = expr_to_node(convert_expression(
+            let test = expr_to_node(convert_expression_for_program(
                 arena,
                 &do_while_stmt.test,
                 offset,
@@ -8971,7 +8976,13 @@ fn convert_assignment_pattern(
             offset,
             line_offsets,
         )),
-        right: arena.alloc_js_node(expr_to_node(convert_expression(
+        // Program context: `offset` is already program-adjusted (the pattern's
+        // own `start`/`end` and `left` use it raw), so the default value must
+        // also use `convert_expression_for_program`. `convert_expression` would
+        // re-apply the synthetic-paren `-1`, shifting the default expression one
+        // unit left — e.g. the `$bindable` callee in `let { open = $bindable() }`
+        // spanned ` $bindabl` (#916).
+        right: arena.alloc_js_node(expr_to_node(convert_expression_for_program(
             arena,
             &assign_pat.right,
             offset,

--- a/crates/rsvelte_core/tests/parser_identifier_span.rs
+++ b/crates/rsvelte_core/tests/parser_identifier_span.rs
@@ -1,0 +1,109 @@
+//! Regression test for issue #916.
+//!
+//! The identifier in a `switch (X)` discriminant (and a do-while test) was
+//! spanned one code unit to the left — it started on the `(` instead of on the
+//! identifier — because the program-context statement converter routed those
+//! expressions through `convert_expression` (which subtracts the synthetic
+//! paren offset) instead of `convert_expression_for_program`. A sibling
+//! off-by-one hit the `$bindable` callee in `let { open = $bindable(false) }`
+//! (the `AssignmentPattern` default ran through the same `-1` path).
+//!
+//! The invariant asserted here is simple and general: for an ASCII source,
+//! every `Identifier` node must satisfy `source[start..end] == name`.
+
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{ParseOptions, parse};
+
+fn ast_json(src: &str) -> serde_json::Value {
+    let ast = parse(src, ParseOptions::default()).expect("parse");
+    let s = with_serialize_arena(&ast.arena, || serde_json::to_string(&ast).unwrap());
+    serde_json::from_str(&s).unwrap()
+}
+
+/// Visit every node; for each `Identifier` with a name + span, run `f`.
+fn for_each_identifier(
+    value: &serde_json::Value,
+    src: &str,
+    f: &mut impl FnMut(&str, usize, usize),
+) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.get("type").and_then(|t| t.as_str()) == Some("Identifier")
+                && let Some(name) = map.get("name").and_then(|n| n.as_str())
+                && let Some(start) = map.get("start").and_then(|s| s.as_u64())
+                && let Some(end) = map.get("end").and_then(|e| e.as_u64())
+            {
+                let _ = src; // src used by caller
+                f(name, start as usize, end as usize);
+            }
+            for v in map.values() {
+                for_each_identifier(v, src, f);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for it in items {
+                for_each_identifier(it, src, f);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_all_identifiers_slice_to_name(src: &str) -> usize {
+    let json = ast_json(src);
+    let mut count = 0usize;
+    for_each_identifier(&json, src, &mut |name, start, end| {
+        assert!(
+            end <= src.len() && src.is_char_boundary(start) && src.is_char_boundary(end),
+            "identifier {name:?} has an out-of-bounds span {start}..{end} (src len {})",
+            src.len()
+        );
+        assert_eq!(
+            &src[start..end],
+            name,
+            "identifier {name:?} span {start}..{end} slices to {:?}",
+            &src[start..end]
+        );
+        count += 1;
+    });
+    count
+}
+
+#[test]
+fn switch_discriminant_identifier_span_is_exact() {
+    let src = "<script>\n  let x = 1;\n  switch (x) { case 1: break; }\n</script>";
+    let n = assert_all_identifiers_slice_to_name(src);
+    assert!(n > 0, "expected identifiers in the script");
+    // Make sure the discriminant identifier was actually present.
+    let json = ast_json(src);
+    let mut saw_x = false;
+    for_each_identifier(&json, src, &mut |name, start, end| {
+        if name == "x" && &src[start..end] == "x" {
+            saw_x = true;
+        }
+    });
+    assert!(saw_x, "switch discriminant identifier `x` not found");
+}
+
+#[test]
+fn switch_case_test_and_do_while_spans_are_exact() {
+    let src = "<script>\n  let x = 1;\n  switch (x) { case x: break; }\n  do { x; } while (x);\n</script>";
+    assert_all_identifiers_slice_to_name(src);
+}
+
+#[test]
+fn bindable_callee_span_is_exact() {
+    let src = "<script>\n  let { open = $bindable(false) } = $props();\n</script>";
+    assert_all_identifiers_slice_to_name(src);
+    let json = ast_json(src);
+    let mut saw_bindable = false;
+    for_each_identifier(&json, src, &mut |name, start, end| {
+        if name == "$bindable" && &src[start..end] == "$bindable" {
+            saw_bindable = true;
+        }
+    });
+    assert!(
+        saw_bindable,
+        "`$bindable` callee identifier not found / mis-spanned"
+    );
+}


### PR DESCRIPTION
## Summary

The identifier in a `switch (X)` **discriminant** was spanned one code unit to the left — it started on the `(` instead of on the identifier. `svelte/compiler` spans it correctly. A sibling off-by-one hit the `$bindable` callee in `let { open = $bindable(false) }` (` $bindabl`). Because the span is wrong, a tool that slices/edits by `node.start..node.end` (magic-string, svelte-shaker) overwrites the wrong range, producing corrupted output like `switch ("single"e)`.

```
svelte : 32..33 = "x"
rsvelte: 31..32 = "("   (before this PR)
```

## Root cause

In `convert_statement_for_program`, four expressions were converted with `convert_expression` instead of `convert_expression_for_program`:

- `switch (X)` discriminant
- `case X:` test
- `do … while (X)` test
- the default value (`right`) of a destructuring `AssignmentPattern` (`convert_assignment_pattern`)

`convert_expression` subtracts the synthetic-paren `-1` that's only correct for a standalone, paren-wrapped template expression. In program context the offset is already adjusted (the statement's own `start`/`end` and the pattern's `left` use it raw), so the `-1` double-counts and shifts the span left. Every *other* expression in that converter already uses `convert_expression_for_program` (e.g. `if`/`while` tests).

## Fix

Route all four through `convert_expression_for_program`.

## Test

`parser_identifier_span.rs` asserts the general invariant — for ASCII source, **every** `Identifier` node satisfies `source[start..end] == name` — across switch discriminant, case test, do-while test, and `$bindable` destructuring defaults.

No regression: `parser_fixtures` (modern + legacy), `compiler_fixtures` (snapshot codegen), `print` (round-trip), and `runtime` (runes / legacy / hydration) all green.

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)