### PR TITLE
feat(lint): script-AST infra + JS-module path + no-inner-declarations, prefer-svelte-reactivity, no-store-async

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
@@ -146,6 +146,36 @@ pub fn compute_line_offsets(source: &str, skip: bool) -> Vec<usize> {
     offsets
 }
 
+/// Parse a standalone JavaScript / TypeScript module source into an
+/// ESTree-compatible JSON program (offsets are byte positions in `source`).
+///
+/// Unlike [`parse`], which expects a Svelte component, this parses a whole file
+/// as a JS/TS module — used to lint `*.svelte.js` / `*.svelte.ts` / `*.js`
+/// module files. The program node and its children are materialised eagerly
+/// (resolved through a fresh arena), so the returned value is self-contained.
+pub fn parse_module_to_estree(source: &str, is_typescript: bool) -> serde_json::Value {
+    let arena = crate::ast::arena::ParseArena::new();
+    let line_offsets = compute_line_offsets(source, false);
+    // The serialize arena must be installed for the WHOLE conversion: when the
+    // source contains comments, `parse_program` resolves statement children via
+    // `to_value()` during the parse itself (not just the final `as_json`), so
+    // without the guard active those arena-indexed children (e.g. an import's
+    // `source` / `specifiers`) come back empty.
+    crate::ast::arena::with_serialize_arena(&arena, || {
+        let program = expression::parse_program(
+            &arena,
+            source,
+            0,
+            &line_offsets,
+            is_typescript,
+            &[],
+            0,
+            source.len(),
+        );
+        program.as_json().clone()
+    })
+}
+
 /// Parse multiple Svelte components in parallel.
 ///
 /// Uses rayon to parse files concurrently for maximum performance.

--- a/crates/rsvelte_core/src/compiler/phases/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/mod.rs
@@ -14,6 +14,6 @@ pub mod phase2_analyze;
 pub mod phase3_transform;
 
 // Re-exports for convenience
-pub use phase1_parse::parse;
+pub use phase1_parse::{parse, parse_module_to_estree};
 pub use phase2_analyze::{ComponentAnalysis, analyze_component};
 pub use phase3_transform::{TransformResult, transform_component};

--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -4,13 +4,16 @@
 //! fixes intact). Compiler/validator findings are layered on top by the
 //! native-only [`runner`](crate::runner).
 
+use rsvelte_core::ast::arena::with_serialize_arena;
 use rsvelte_core::{ParseOptions, parse};
+use serde_json::Value;
 
 use crate::config::LintConfig;
 use crate::context::LintContext;
 use crate::diagnostic::LintDiagnostic;
-use crate::registry::all_rules;
-use crate::rule::Severity;
+use crate::registry::{all_rules, all_script_rules};
+use crate::rule::{RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule};
 use crate::visitor::{EnabledRule, LintVisitor};
 
 /// Run every enabled native rule over `source`, returning raw findings.
@@ -40,5 +43,55 @@ pub fn run_native_rules(source: &str, config: &LintConfig) -> Vec<LintDiagnostic
     };
     let mut ctx = LintContext::new(config, source);
     LintVisitor::new(enabled).visit_root(&mut ctx, &root);
+    ctx.into_diagnostics()
+}
+
+/// Run every enabled script-AST rule over `source`, returning raw findings.
+///
+/// Each `<script>` block's ESTree program is materialised as an owned
+/// `serde_json::Value` (with absolute byte offsets) inside the parse arena, then
+/// handed to each rule's `check_program`.
+pub fn run_script_rules(source: &str, config: &LintConfig) -> Vec<LintDiagnostic> {
+    let rules = all_script_rules();
+    let enabled: Vec<(&dyn ScriptRule, &'static RuleMeta, Severity)> = rules
+        .iter()
+        .filter_map(|r| {
+            let meta = r.meta();
+            let severity = config.severity_for(meta);
+            (severity != Severity::Off).then_some((r.as_ref(), meta, severity))
+        })
+        .collect();
+    if enabled.is_empty() {
+        return Vec::new();
+    }
+    let Ok(root) = parse(source, ParseOptions::default()) else {
+        return Vec::new();
+    };
+
+    // Materialise each script program to an owned ESTree JSON value. The
+    // serialization MUST run inside the arena scope (the program body resolves
+    // arena-indexed children) and BEFORE any out-of-scope `as_json` would cache
+    // an empty body — so we parse fresh here and serialize immediately.
+    let programs: Vec<(ScriptKind, Value)> = with_serialize_arena(&root.arena, || {
+        let mut out = Vec::new();
+        if let Some(s) = root.instance.as_ref() {
+            out.push((ScriptKind::Instance, s.content.as_json().clone()));
+        }
+        if let Some(s) = root.module.as_ref() {
+            out.push((ScriptKind::Module, s.content.as_json().clone()));
+        }
+        out
+    });
+    if programs.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ctx = LintContext::new(config, source);
+    for (kind, program) in &programs {
+        for (rule, meta, severity) in &enabled {
+            ctx.enter_rule(meta, *severity);
+            rule.check_program(&mut ctx, program, *kind);
+        }
+    }
     ctx.into_diagnostics()
 }

--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -46,21 +46,78 @@ pub fn run_native_rules(source: &str, config: &LintConfig) -> Vec<LintDiagnostic
     ctx.into_diagnostics()
 }
 
-/// Run every enabled script-AST rule over `source`, returning raw findings.
-///
-/// Each `<script>` block's ESTree program is materialised as an owned
-/// `serde_json::Value` (with absolute byte offsets) inside the parse arena, then
-/// handed to each rule's `check_program`.
-pub fn run_script_rules(source: &str, config: &LintConfig) -> Vec<LintDiagnostic> {
-    let rules = all_script_rules();
-    let enabled: Vec<(&dyn ScriptRule, &'static RuleMeta, Severity)> = rules
+/// What kind of file the linter is processing, derived from its extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind {
+    /// A `.svelte` component (template + optional `<script>` blocks).
+    Svelte,
+    /// A standalone JS/TS module (`.svelte.js`, `.svelte.ts`, `.js`, `.ts`, …).
+    Module {
+        /// Whether the module is TypeScript.
+        ts: bool,
+    },
+}
+
+/// Classify a file by name/extension. `.svelte` → component; `.ts`/`.mts`/`.cts`
+/// (incl. `.svelte.ts`) → TS module; `.js`/`.mjs`/`.cjs` (incl. `.svelte.js`) →
+/// JS module; anything else defaults to a component.
+pub fn classify_source(filename: &str) -> SourceKind {
+    if filename.ends_with(".svelte") {
+        SourceKind::Svelte
+    } else if filename.ends_with(".ts") || filename.ends_with(".mts") || filename.ends_with(".cts")
+    {
+        SourceKind::Module { ts: true }
+    } else if filename.ends_with(".js") || filename.ends_with(".mjs") || filename.ends_with(".cjs")
+    {
+        SourceKind::Module { ts: false }
+    } else {
+        SourceKind::Svelte
+    }
+}
+
+type EnabledScriptRule<'a> = (&'a dyn ScriptRule, &'static RuleMeta, Severity);
+
+/// The enabled (non-`Off`) script rules for `config`.
+fn enabled_script_rules<'a>(
+    rules: &'a [Box<dyn ScriptRule>],
+    config: &LintConfig,
+) -> Vec<EnabledScriptRule<'a>> {
+    rules
         .iter()
         .filter_map(|r| {
             let meta = r.meta();
             let severity = config.severity_for(meta);
             (severity != Severity::Off).then_some((r.as_ref(), meta, severity))
         })
-        .collect();
+        .collect()
+}
+
+/// Run each enabled script rule over every `(kind, program)` pair.
+fn run_over_programs(
+    programs: &[(ScriptKind, Value)],
+    source: &str,
+    config: &LintConfig,
+    enabled: &[EnabledScriptRule<'_>],
+) -> Vec<LintDiagnostic> {
+    let mut ctx = LintContext::new(config, source);
+    for (kind, program) in programs {
+        for (rule, meta, severity) in enabled {
+            ctx.enter_rule(meta, *severity);
+            rule.check_program(&mut ctx, program, *kind);
+        }
+    }
+    ctx.into_diagnostics()
+}
+
+/// Run every enabled script-AST rule over a Svelte component's `<script>`
+/// block(s), returning raw findings.
+///
+/// Each program is materialised as an owned `serde_json::Value` (with absolute
+/// byte offsets) inside the parse arena, then handed to each rule's
+/// `check_program`.
+pub fn run_script_rules(source: &str, config: &LintConfig) -> Vec<LintDiagnostic> {
+    let rules = all_script_rules();
+    let enabled = enabled_script_rules(&rules, config);
     if enabled.is_empty() {
         return Vec::new();
     }
@@ -85,13 +142,25 @@ pub fn run_script_rules(source: &str, config: &LintConfig) -> Vec<LintDiagnostic
     if programs.is_empty() {
         return Vec::new();
     }
+    run_over_programs(&programs, source, config, &enabled)
+}
 
-    let mut ctx = LintContext::new(config, source);
-    for (kind, program) in &programs {
-        for (rule, meta, severity) in &enabled {
-            ctx.enter_rule(meta, *severity);
-            rule.check_program(&mut ctx, program, *kind);
-        }
+/// Run every enabled script-AST rule over a standalone JS/TS **module** file
+/// (`*.svelte.js` / `*.svelte.ts` / `*.js` / `*.ts`), returning raw findings.
+///
+/// The whole file is parsed as a module program (byte offsets relative to the
+/// file), so script rules report at file-accurate positions.
+pub fn run_script_rules_module(
+    source: &str,
+    is_ts: bool,
+    config: &LintConfig,
+) -> Vec<LintDiagnostic> {
+    let rules = all_script_rules();
+    let enabled = enabled_script_rules(&rules, config);
+    if enabled.is_empty() {
+        return Vec::new();
     }
-    ctx.into_diagnostics()
+    let program = rsvelte_core::compiler::phases::parse_module_to_estree(source, is_ts);
+    let programs = [(ScriptKind::Module, program)];
+    run_over_programs(&programs, source, config, &enabled)
 }

--- a/crates/rsvelte_lint/src/lib.rs
+++ b/crates/rsvelte_lint/src/lib.rs
@@ -28,6 +28,7 @@ pub mod registry;
 pub mod rule;
 pub mod rules;
 pub mod scope;
+pub mod script;
 pub mod suppression;
 pub mod visitor;
 

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -40,3 +40,9 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(NoUselessMustaches),
     ]
 }
+
+/// Construct the full set of script-AST rules (rules that walk the `<script>`
+/// ESTree program rather than the template tree).
+pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
+    vec![]
+}

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -45,9 +45,11 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
 /// ESTree program rather than the template tree).
 pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::no_inner_declarations::NoInnerDeclarations;
+    use crate::rules::no_store_async::NoStoreAsync;
     use crate::rules::prefer_svelte_reactivity::PreferSvelteReactivity;
     vec![
         Box::new(NoInnerDeclarations),
         Box::new(PreferSvelteReactivity),
+        Box::new(NoStoreAsync),
     ]
 }

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -45,5 +45,9 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
 /// ESTree program rather than the template tree).
 pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::no_inner_declarations::NoInnerDeclarations;
-    vec![Box::new(NoInnerDeclarations)]
+    use crate::rules::prefer_svelte_reactivity::PreferSvelteReactivity;
+    vec![
+        Box::new(NoInnerDeclarations),
+        Box::new(PreferSvelteReactivity),
+    ]
 }

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -44,5 +44,6 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
 /// Construct the full set of script-AST rules (rules that walk the `<script>`
 /// ESTree program rather than the template tree).
 pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
-    vec![]
+    use crate::rules::no_inner_declarations::NoInnerDeclarations;
+    vec![Box::new(NoInnerDeclarations)]
 }

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -15,6 +15,7 @@ pub mod no_not_function_handler;
 pub mod no_object_in_text_mustaches;
 pub mod no_raw_special_elements;
 pub mod no_restricted_html_elements;
+pub mod no_store_async;
 pub mod no_svelte_internal;
 pub mod no_useless_children_snippet;
 pub mod no_useless_mustaches;

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -18,5 +18,6 @@ pub mod no_restricted_html_elements;
 pub mod no_svelte_internal;
 pub mod no_useless_children_snippet;
 pub mod no_useless_mustaches;
+pub mod prefer_svelte_reactivity;
 pub mod require_each_key;
 pub mod valid_each_key;

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -9,6 +9,7 @@ pub mod no_dupe_else_if_blocks;
 pub mod no_dupe_on_directives;
 pub mod no_dupe_style_properties;
 pub mod no_dupe_use_directives;
+pub mod no_inner_declarations;
 pub mod no_inspect;
 pub mod no_not_function_handler;
 pub mod no_object_in_text_mustaches;

--- a/crates/rsvelte_lint/src/rules/no_inner_declarations.rs
+++ b/crates/rsvelte_lint/src/rules/no_inner_declarations.rs
@@ -1,0 +1,183 @@
+//! `svelte/no-inner-declarations` — disallow `function` / `var` declarations in
+//! nested blocks. Port of the core ESLint `no-inner-declarations` rule (the
+//! eslint-plugin-svelte extension just re-parents through `SvelteScriptElement`,
+//! which in rsvelte is already the script `Program`). Runs over the `<script>`
+//! ESTree program via the [`ScriptRule`] hook.
+//!
+//! Options (ESLint ≥9 shape — the plugin's `v8` fixtures are skipped by the
+//! oracle): `[ "functions" | "both", { "blockScopedFunctions": "allow" | "disallow" } ]`.
+//! `"functions"` checks only function declarations; `"both"` also checks `var`
+//! declarations. Because a `<script>` is always a module (strict mode), a
+//! block-scoped function declaration is only reported when
+//! `blockScopedFunctions` is `"disallow"` (the default `"allow"` permits it).
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-inner-declarations",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Error,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow variable or `function` declarations in nested blocks",
+    options_schema: None,
+};
+
+#[derive(Default)]
+pub struct NoInnerDeclarations;
+
+impl ScriptRule for NoInnerDeclarations {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        let opts = ctx.options();
+        let mode = opts
+            .and_then(|a| a.get(0))
+            .and_then(Value::as_str)
+            .unwrap_or("functions");
+        let check_vars = mode == "both";
+        let block_scoped_functions = opts
+            .and_then(|a| a.get(1))
+            .and_then(|o| o.get("blockScopedFunctions"))
+            .and_then(Value::as_str)
+            .unwrap_or("allow");
+        // A `<script>` is always a module (strict mode), so block-scoped function
+        // declarations are only an error when explicitly disallowed.
+        let check_functions = block_scoped_functions == "disallow";
+
+        let mut reports: Vec<(u32, &'static str, &'static str)> = Vec::new();
+        walk_js(program, |node, ancestors| {
+            let kind = match node_type(node) {
+                Some("FunctionDeclaration") if check_functions => "function",
+                Some("VariableDeclaration")
+                    if check_vars && node.get("kind").and_then(Value::as_str) == Some("var") =>
+                {
+                    "variable"
+                }
+                _ => return,
+            };
+            if !is_inner(ancestors) {
+                return;
+            }
+            let Some(start) = node_start(node) else {
+                return;
+            };
+            let place = body_root(ancestors);
+            reports.push((start, kind, place));
+        });
+
+        for (start, kind, place) in reports {
+            ctx.report(
+                start,
+                start,
+                format!("Move {kind} declaration to {place} root."),
+            );
+        }
+    }
+}
+
+/// Whether a declaration with the given `ancestors` (nearest parent last) sits
+/// in a nested block — i.e. NOT directly in a `Program`, a function body, or a
+/// class static block. Mirrors core ESLint's `no-inner-declarations` check.
+fn is_inner(ancestors: &[&Value]) -> bool {
+    let Some(parent) = ancestors.last() else {
+        return false;
+    };
+    match node_type(parent) {
+        Some("Program") | Some("StaticBlock") => false,
+        Some("BlockStatement") => {
+            // Valid only when the block is a function body.
+            let gp = ancestors.get(ancestors.len().wrapping_sub(2));
+            !matches!(
+                gp.and_then(|g| node_type(g)),
+                Some("FunctionDeclaration")
+                    | Some("FunctionExpression")
+                    | Some("ArrowFunctionExpression")
+            )
+        }
+        _ => true,
+    }
+}
+
+/// `"function body"` when there is an enclosing function, else `"program"`.
+fn body_root(ancestors: &[&Value]) -> &'static str {
+    let in_function = ancestors.iter().rev().any(|n| {
+        matches!(
+            node_type(n),
+            Some("FunctionDeclaration")
+                | Some("FunctionExpression")
+                | Some("ArrowFunctionExpression")
+        )
+    });
+    if in_function {
+        "function body"
+    } else {
+        "program"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn anc(types: &[&str]) -> Vec<Value> {
+        types
+            .iter()
+            .map(|t| json!({ "type": t }))
+            .collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn top_level_is_not_inner() {
+        let a = anc(&["Program"]);
+        let refs: Vec<&Value> = a.iter().collect();
+        assert!(!is_inner(&refs));
+    }
+
+    #[test]
+    fn function_body_is_not_inner() {
+        let a = anc(&["Program", "FunctionDeclaration", "BlockStatement"]);
+        let refs: Vec<&Value> = a.iter().collect();
+        assert!(!is_inner(&refs));
+    }
+
+    #[test]
+    fn block_in_if_is_inner() {
+        let a = anc(&["Program", "IfStatement", "BlockStatement"]);
+        let refs: Vec<&Value> = a.iter().collect();
+        assert!(is_inner(&refs));
+    }
+
+    #[test]
+    fn directly_in_if_is_inner() {
+        let a = anc(&["Program", "IfStatement"]);
+        let refs: Vec<&Value> = a.iter().collect();
+        assert!(is_inner(&refs));
+    }
+
+    #[test]
+    fn body_root_picks_function_or_program() {
+        let prog = anc(&["Program", "IfStatement", "BlockStatement"]);
+        let refs: Vec<&Value> = prog.iter().collect();
+        assert_eq!(body_root(&refs), "program");
+        let func = anc(&[
+            "Program",
+            "FunctionDeclaration",
+            "BlockStatement",
+            "IfStatement",
+        ]);
+        let refs2: Vec<&Value> = func.iter().collect();
+        assert_eq!(body_root(&refs2), "function body");
+    }
+}

--- a/crates/rsvelte_lint/src/rules/no_store_async.rs
+++ b/crates/rsvelte_lint/src/rules/no_store_async.rs
@@ -1,0 +1,184 @@
+//! `svelte/no-store-async` — disallow passing an `async` function to a
+//! `svelte/store` creator (`writable` / `readable` / `derived`). An async start
+//! function breaks the store's auto-unsubscribe behaviour. Port of the
+//! eslint-plugin-svelte rule, over the script ESTree program via the
+//! [`ScriptRule`] hook (so it also lints `*.svelte.js` / `*.js` module files).
+//!
+//! The store creators are resolved from their `svelte/store` import — including
+//! aliases (`import { writable as w }`) and namespace imports
+//! (`import * as stores from 'svelte/store'` → `stores.writable(...)`). The
+//! finding is reported at the offending function (covering its `async` keyword),
+//! matching upstream's `start .. start + 5` location.
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-store-async",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Error,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow async functions passed to svelte stores",
+    options_schema: None,
+};
+
+const STORE_CREATORS: &[&str] = &["writable", "readable", "derived"];
+
+const MESSAGE: &str = "Do not pass async functions to svelte stores.";
+
+fn ident_name(node: &Value) -> Option<&str> {
+    if node_type(node) == Some("Identifier") {
+        node.get("name").and_then(Value::as_str)
+    } else {
+        None
+    }
+}
+
+fn is_async_function(node: &Value) -> bool {
+    matches!(
+        node_type(node),
+        Some("ArrowFunctionExpression") | Some("FunctionExpression")
+    ) && node.get("async").and_then(Value::as_bool) == Some(true)
+}
+
+#[derive(Default)]
+pub struct NoStoreAsync;
+
+impl ScriptRule for NoStoreAsync {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        // Resolve `svelte/store` imports: local names bound to a store creator,
+        // and any namespace import alias.
+        let mut direct: Vec<String> = Vec::new(); // local names of writable/readable/derived
+        let mut namespaces: Vec<String> = Vec::new(); // `import * as X`
+
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("ImportDeclaration") {
+                return;
+            }
+            if node
+                .get("source")
+                .and_then(|s| s.get("value"))
+                .and_then(Value::as_str)
+                != Some("svelte/store")
+            {
+                return;
+            }
+            let Some(specs) = node.get("specifiers").and_then(Value::as_array) else {
+                return;
+            };
+            for spec in specs {
+                match node_type(spec) {
+                    Some("ImportSpecifier") => {
+                        let imported = spec
+                            .get("imported")
+                            .and_then(ident_name)
+                            // string-literal imported names (`import { "x" as y }`)
+                            .or_else(|| {
+                                spec.get("imported")
+                                    .and_then(|i| i.get("value"))
+                                    .and_then(Value::as_str)
+                            });
+                        if let Some(imported) = imported
+                            && STORE_CREATORS.contains(&imported)
+                            && let Some(local) = spec.get("local").and_then(ident_name)
+                        {
+                            direct.push(local.to_string());
+                        }
+                    }
+                    Some("ImportNamespaceSpecifier") => {
+                        if let Some(local) = spec.get("local").and_then(ident_name) {
+                            namespaces.push(local.to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        if direct.is_empty() && namespaces.is_empty() {
+            return;
+        }
+
+        // Find store-creator calls and report an async second argument.
+        let mut reports: Vec<u32> = Vec::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("CallExpression") {
+                return;
+            }
+            let Some(callee) = node.get("callee") else {
+                return;
+            };
+            let is_creator = match node_type(callee) {
+                Some("Identifier") => {
+                    ident_name(callee).is_some_and(|n| direct.iter().any(|d| d == n))
+                }
+                Some("MemberExpression") => {
+                    callee.get("computed").and_then(Value::as_bool) != Some(true)
+                        && callee
+                            .get("object")
+                            .and_then(ident_name)
+                            .is_some_and(|o| namespaces.iter().any(|n| n == o))
+                        && callee
+                            .get("property")
+                            .and_then(ident_name)
+                            .is_some_and(|p| STORE_CREATORS.contains(&p))
+                }
+                _ => false,
+            };
+            if !is_creator {
+                return;
+            }
+            let Some(args) = node.get("arguments").and_then(Value::as_array) else {
+                return;
+            };
+            if let Some(fn_arg) = args.get(1)
+                && is_async_function(fn_arg)
+                && let Some(start) = node_start(fn_arg)
+            {
+                reports.push(start);
+            }
+        });
+
+        reports.sort_unstable();
+        reports.dedup();
+        for start in reports {
+            // Upstream reports a 5-wide span starting at the function (its
+            // `async` keyword); only the start column is asserted.
+            ctx.report(start, start + 5, MESSAGE);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn detects_async_arrow_and_function() {
+        assert!(is_async_function(
+            &json!({ "type": "ArrowFunctionExpression", "async": true })
+        ));
+        assert!(is_async_function(
+            &json!({ "type": "FunctionExpression", "async": true })
+        ));
+        assert!(!is_async_function(
+            &json!({ "type": "ArrowFunctionExpression", "async": false })
+        ));
+        assert!(!is_async_function(
+            &json!({ "type": "Identifier", "name": "f" })
+        ));
+    }
+}

--- a/crates/rsvelte_lint/src/rules/prefer_svelte_reactivity.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_svelte_reactivity.rs
@@ -1,0 +1,295 @@
+//! `svelte/prefer-svelte-reactivity` — flag a mutated instance of a built-in
+//! `Date` / `Map` / `Set` / `URL` / `URLSearchParams` where `svelte/reactivity`
+//! offers a reactive alternative (`SvelteDate`, …). Port of the eslint-plugin-svelte
+//! rule, over the `<script>` ESTree program via the [`ScriptRule`] hook.
+//!
+//! A `new <Class>(…)` is flagged only when the constructed instance is later
+//! *mutated*:
+//!   - `Date` — a `setX` method call (`setDate`, `setFullYear`, …);
+//!   - `Map` — `clear` / `delete` / `set`;
+//!   - `Set` — `add` / `clear` / `delete`;
+//!   - `URLSearchParams` — `append` / `delete` / `set` / `sort`;
+//!   - `URL` — an assignment to a mutable property (`hash`, `host`, …).
+//!
+//! The constructor identifier must resolve to the global built-in: if a binding
+//! of that name exists in the script (e.g. `import { SvelteMap as Map }` or
+//! `import { Date } from "pkg"`), it is shadowed and never flagged. Read-only
+//! usage (`date.getTime()`, `map.get(k)`) is fine.
+//!
+//! The plugin additionally flags exported instances in `*.svelte.js` /
+//! `*.svelte.ts` modules; those fixtures are `.svelte.js` files (not collected
+//! by the component oracle) and that path is intentionally not ported here.
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/prefer-svelte-reactivity",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Error,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Prefer svelte/reactivity built-ins for mutated Date/Map/Set/URL/URLSearchParams",
+    options_schema: None,
+};
+
+const DATE_MUT: &[&str] = &[
+    "setDate",
+    "setFullYear",
+    "setHours",
+    "setMilliseconds",
+    "setMinutes",
+    "setMonth",
+    "setSeconds",
+    "setTime",
+    "setUTCDate",
+    "setUTCFullYear",
+    "setUTCHours",
+    "setUTCMilliseconds",
+    "setUTCMinutes",
+    "setUTCMonth",
+    "setUTCSeconds",
+    "setYear",
+];
+const MAP_MUT: &[&str] = &["clear", "delete", "set"];
+const SET_MUT: &[&str] = &["add", "clear", "delete"];
+const USP_MUT: &[&str] = &["append", "delete", "set", "sort"];
+const URL_PROPS: &[&str] = &[
+    "hash", "host", "hostname", "href", "password", "pathname", "port", "protocol", "search",
+    "username",
+];
+
+/// Method names that mutate an instance of `class`. `URL` mutates via property
+/// assignment, not methods, so it has no method mutators.
+fn method_mutators(class: &str) -> &'static [&'static str] {
+    match class {
+        "Date" => DATE_MUT,
+        "Map" => MAP_MUT,
+        "Set" => SET_MUT,
+        "URLSearchParams" => USP_MUT,
+        _ => &[],
+    }
+}
+
+fn class_message(class: &str) -> Option<String> {
+    let alt = match class {
+        "Date" => "SvelteDate",
+        "Map" => "SvelteMap",
+        "Set" => "SvelteSet",
+        "URL" => "SvelteURL",
+        "URLSearchParams" => "SvelteURLSearchParams",
+        _ => return None,
+    };
+    Some(format!(
+        "Found a mutable instance of the built-in {class} class. Use {alt} instead."
+    ))
+}
+
+fn ident_name(node: &Value) -> Option<&str> {
+    if node_type(node) == Some("Identifier") {
+        node.get("name").and_then(Value::as_str)
+    } else {
+        None
+    }
+}
+
+/// The constructor class name of a `NewExpression` with a plain `Identifier`
+/// callee, when that name is one we care about.
+fn new_class(node: &Value) -> Option<&str> {
+    if node_type(node) != Some("NewExpression") {
+        return None;
+    }
+    let name = ident_name(node.get("callee")?)?;
+    matches!(name, "Date" | "Map" | "Set" | "URL" | "URLSearchParams").then_some(name)
+}
+
+#[derive(Default)]
+pub struct PreferSvelteReactivity;
+
+impl ScriptRule for PreferSvelteReactivity {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        // 1. Names bound in the script — a built-in shadowed by one of these is
+        //    never the global, so its `new` is never flagged.
+        let mut shadowed: Vec<String> = Vec::new();
+        // 2. instance variable name -> (class, new-expression start).
+        let mut instances: Vec<(String, &'static str, u32)> = Vec::new();
+
+        walk_js(program, |node, _| match node_type(node) {
+            Some("ImportSpecifier")
+            | Some("ImportDefaultSpecifier")
+            | Some("ImportNamespaceSpecifier") => {
+                if let Some(n) = node.get("local").and_then(ident_name) {
+                    shadowed.push(n.to_string());
+                }
+            }
+            Some("FunctionDeclaration") | Some("ClassDeclaration") => {
+                if let Some(n) = node.get("id").and_then(ident_name) {
+                    shadowed.push(n.to_string());
+                }
+            }
+            Some("VariableDeclarator") => {
+                if let Some(n) = node.get("id").and_then(ident_name) {
+                    shadowed.push(n.to_string());
+                    if let Some(init) = node.get("init")
+                        && let Some(class) = new_class(init)
+                        && let Some(start) = node_start(init)
+                    {
+                        instances.push((n.to_string(), class_static(class), start));
+                    }
+                }
+            }
+            _ => {}
+        });
+
+        let is_shadowed = |class: &str| shadowed.iter().any(|s| s == class);
+        // Live instances: those whose constructor class is not shadowed.
+        let live: Vec<(String, &'static str, u32)> = instances
+            .into_iter()
+            .filter(|(_, class, _)| !is_shadowed(class))
+            .collect();
+
+        // 3. Find mutations and collect the new-expression starts to report.
+        let mut mutated: Vec<(u32, &'static str)> = Vec::new();
+        let mut mark = |class: &'static str, start: u32| {
+            if !mutated.iter().any(|(s, _)| *s == start) {
+                mutated.push((start, class));
+            }
+        };
+
+        walk_js(program, |node, _| {
+            match node_type(node) {
+                // Method-call mutation: `obj.<mutator>(...)`.
+                Some("CallExpression") => {
+                    let Some(callee) = node.get("callee") else {
+                        return;
+                    };
+                    if node_type(callee) != Some("MemberExpression") {
+                        return;
+                    }
+                    let Some(prop) = member_prop(callee) else {
+                        return;
+                    };
+                    let obj = callee.get("object").unwrap_or(&Value::Null);
+                    // Instance variable.
+                    if let Some(name) = ident_name(obj) {
+                        for (var, class, start) in &live {
+                            if var == name && method_mutators(class).contains(&prop) {
+                                mark(class, *start);
+                            }
+                        }
+                    }
+                    // Inline `new X().<mutator>()`.
+                    if let Some(class) = new_class(obj)
+                        && !is_shadowed(class)
+                        && method_mutators(class).contains(&prop)
+                        && let Some(start) = node_start(obj)
+                    {
+                        mark(class_static(class), start);
+                    }
+                }
+                // URL property assignment: `url.<prop> = ...`.
+                Some("AssignmentExpression") => {
+                    let Some(left) = node.get("left") else {
+                        return;
+                    };
+                    if node_type(left) != Some("MemberExpression") {
+                        return;
+                    }
+                    let Some(prop) = member_prop(left) else {
+                        return;
+                    };
+                    if !URL_PROPS.contains(&prop) {
+                        return;
+                    }
+                    let obj = left.get("object").unwrap_or(&Value::Null);
+                    if let Some(name) = ident_name(obj) {
+                        for (var, class, start) in &live {
+                            if var == name && *class == "URL" {
+                                mark(class, *start);
+                            }
+                        }
+                    }
+                    if new_class(obj) == Some("URL")
+                        && !is_shadowed("URL")
+                        && let Some(start) = node_start(obj)
+                    {
+                        mark("URL", start);
+                    }
+                }
+                _ => {}
+            }
+        });
+
+        mutated.sort_by_key(|(s, _)| *s);
+        for (start, class) in mutated {
+            if let Some(msg) = class_message(class) {
+                ctx.report(start, start, msg);
+            }
+        }
+    }
+}
+
+/// The non-computed property name of a `MemberExpression`, or `None` when the
+/// access is computed (`obj[expr]`).
+fn member_prop(member: &Value) -> Option<&str> {
+    if member.get("computed").and_then(Value::as_bool) == Some(true) {
+        return None;
+    }
+    ident_name(member.get("property")?)
+}
+
+/// Map a class name to its `&'static str` (the set is closed, so this is total
+/// for any value returned by [`new_class`]).
+fn class_static(class: &str) -> &'static str {
+    match class {
+        "Date" => "Date",
+        "Map" => "Map",
+        "Set" => "Set",
+        "URL" => "URL",
+        "URLSearchParams" => "URLSearchParams",
+        _ => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn new_class_recognises_builtins() {
+        let n =
+            json!({ "type": "NewExpression", "callee": { "type": "Identifier", "name": "Map" } });
+        assert_eq!(new_class(&n), Some("Map"));
+        let other =
+            json!({ "type": "NewExpression", "callee": { "type": "Identifier", "name": "Foo" } });
+        assert_eq!(new_class(&other), None);
+    }
+
+    #[test]
+    fn method_mutator_sets() {
+        assert!(method_mutators("Map").contains(&"set"));
+        assert!(!method_mutators("Map").contains(&"get"));
+        assert!(method_mutators("Date").contains(&"setFullYear"));
+        assert!(method_mutators("URL").is_empty());
+    }
+
+    #[test]
+    fn member_prop_skips_computed() {
+        let m = json!({ "type": "MemberExpression", "computed": false, "property": { "type": "Identifier", "name": "set" } });
+        assert_eq!(member_prop(&m), Some("set"));
+        let c = json!({ "type": "MemberExpression", "computed": true, "property": { "type": "Identifier", "name": "set" } });
+        assert_eq!(member_prop(&c), None);
+    }
+}

--- a/crates/rsvelte_lint/src/runner.rs
+++ b/crates/rsvelte_lint/src/runner.rs
@@ -8,7 +8,7 @@ use rsvelte_core::svelte_check::diagnostic::Diagnostic;
 
 use crate::config::LintConfig;
 use crate::diagnostic::TextEdit;
-use crate::engine::run_native_rules;
+use crate::engine::{run_native_rules, run_script_rules};
 use crate::line_index::LineIndex;
 use crate::suppression::Suppressions;
 
@@ -26,6 +26,11 @@ pub fn lint_source(
 
     // 2. Native rule engine — single shared DFS over the template AST.
     for d in run_native_rules(source, config) {
+        diagnostics.push(d.to_output(file, &line_index));
+    }
+
+    // 2a. Script-AST rules — walk the `<script>` ESTree program(s).
+    for d in run_script_rules(source, config) {
         diagnostics.push(d.to_output(file, &line_index));
     }
 

--- a/crates/rsvelte_lint/src/runner.rs
+++ b/crates/rsvelte_lint/src/runner.rs
@@ -21,24 +21,39 @@ pub fn lint_source(
 ) -> Vec<Diagnostic> {
     let line_index = LineIndex::new(source);
 
-    // 1. Validator wrap — compiler warnings/errors/a11y (config applied inside).
-    let mut diagnostics = crate::validator::validator_diagnostics(source, file, options, config);
+    let mut diagnostics = match crate::engine::classify_source(&file.to_string_lossy()) {
+        // A standalone JS/TS module file (`*.svelte.js` / `*.svelte.ts` / `*.js`
+        // / `*.ts`): no template or compiler-warning pass — only script-AST rules
+        // run, over the whole-file module program.
+        crate::engine::SourceKind::Module { ts } => {
+            let mut diags = Vec::new();
+            for d in crate::engine::run_script_rules_module(source, ts, config) {
+                diags.push(d.to_output(file, &line_index));
+            }
+            diags
+        }
+        crate::engine::SourceKind::Svelte => {
+            // 1. Validator wrap — compiler warnings/errors/a11y (config applied inside).
+            let mut diags = crate::validator::validator_diagnostics(source, file, options, config);
 
-    // 2. Native rule engine — single shared DFS over the template AST.
-    for d in run_native_rules(source, config) {
-        diagnostics.push(d.to_output(file, &line_index));
-    }
+            // 2. Native rule engine — single shared DFS over the template AST.
+            for d in run_native_rules(source, config) {
+                diags.push(d.to_output(file, &line_index));
+            }
 
-    // 2a. Script-AST rules — walk the `<script>` ESTree program(s).
-    for d in run_script_rules(source, config) {
-        diagnostics.push(d.to_output(file, &line_index));
-    }
+            // 2a. Script-AST rules — walk the `<script>` ESTree program(s).
+            for d in run_script_rules(source, config) {
+                diags.push(d.to_output(file, &line_index));
+            }
 
-    // 2b. Scope-based rules (Wave 2). No-op until scope rules ship; this skips
-    // the analysis pass entirely when none are enabled.
-    for d in crate::scope::scope_diagnostics(source, config) {
-        diagnostics.push(d.to_output(file, &line_index));
-    }
+            // 2b. Scope-based rules (Wave 2). No-op until scope rules ship; this
+            // skips the analysis pass entirely when none are enabled.
+            for d in crate::scope::scope_diagnostics(source, config) {
+                diags.push(d.to_output(file, &line_index));
+            }
+            diags
+        }
+    };
 
     // 3. Suppression directives (eslint-disable* + svelte-ignore).
     let suppressions = Suppressions::collect(source);

--- a/crates/rsvelte_lint/src/script.rs
+++ b/crates/rsvelte_lint/src/script.rs
@@ -1,0 +1,145 @@
+//! Script-AST rules: rules that inspect the `<script>` (instance / module)
+//! JavaScript/TypeScript AST rather than the template tree.
+//!
+//! Many eslint-plugin-svelte rules are written as plain ESTree visitors over the
+//! script (import checks, rune-call checks, declaration-nesting, etc.). The
+//! rsvelte parser stores each script's program in an arena owned by the parsed
+//! [`Root`](rsvelte_core::ast::template::Root); serializing the program node
+//! inside [`with_serialize_arena`](rsvelte_core::ast::arena::with_serialize_arena)
+//! materialises a full ESTree-compatible `serde_json::Value` with absolute byte
+//! offsets in `start`/`end` (so a finding's column matches upstream by reporting
+//! at `node["start"]`).
+//!
+//! A [`ScriptRule`] receives the whole program `Value` for each script and walks
+//! it itself (so it can do multi-pass work — e.g. collect imports, then inspect
+//! calls — despite the rule being a zero-sized stateless struct). The
+//! [`walk_js`] helper provides a depth-first traversal that hands every node its
+//! ancestor stack.
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::RuleMeta;
+
+/// Which `<script>` block a program came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScriptKind {
+    /// The instance script (`<script>`).
+    Instance,
+    /// The module script (`<script context="module">` / `<script module>`).
+    Module,
+}
+
+/// A rule that inspects a script's ESTree JSON program.
+#[allow(unused_variables)]
+pub trait ScriptRule: Send + Sync {
+    fn meta(&self) -> &'static RuleMeta;
+
+    /// Called once per script block with the full ESTree program `Value`.
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, kind: ScriptKind);
+}
+
+/// Depth-first walk over an ESTree JSON tree. `f` is called for every node (an
+/// object with a string `"type"` field) with its ancestor stack, nearest parent
+/// last (empty for the root). The `loc` subtree is skipped (it has no nodes).
+pub fn walk_js<'a, F: FnMut(&'a Value, &[&'a Value])>(node: &'a Value, mut f: F) {
+    let mut stack: Vec<&'a Value> = Vec::new();
+    walk_inner(node, &mut stack, &mut f);
+}
+
+fn walk_inner<'a, F: FnMut(&'a Value, &[&'a Value])>(
+    node: &'a Value,
+    stack: &mut Vec<&'a Value>,
+    f: &mut F,
+) {
+    match node {
+        Value::Object(map) => {
+            let is_node = map.get("type").and_then(Value::as_str).is_some();
+            if is_node {
+                f(node, stack);
+                stack.push(node);
+            }
+            for (k, v) in map {
+                // `loc` holds {start,end} position objects, never AST nodes.
+                if k != "loc" {
+                    walk_inner(v, stack, f);
+                }
+            }
+            if is_node {
+                stack.pop();
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                walk_inner(v, stack, f);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Convenience accessors for ESTree JSON nodes.
+pub fn node_type(node: &Value) -> Option<&str> {
+    node.get("type").and_then(Value::as_str)
+}
+
+/// The `start` byte offset of an ESTree node (absolute in the source).
+pub fn node_start(node: &Value) -> Option<u32> {
+    node.get("start").and_then(Value::as_u64).map(|n| n as u32)
+}
+
+/// The `end` byte offset of an ESTree node (absolute in the source).
+pub fn node_end(node: &Value) -> Option<u32> {
+    node.get("end").and_then(Value::as_u64).map(|n| n as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn walk_visits_every_node_with_ancestors() {
+        let program = json!({
+            "type": "Program",
+            "body": [
+                { "type": "VariableDeclaration", "declarations": [
+                    { "type": "VariableDeclarator", "id": { "type": "Identifier", "name": "a" } }
+                ] }
+            ]
+        });
+        let mut seen: Vec<(String, usize)> = Vec::new();
+        walk_js(&program, |node, ancestors| {
+            seen.push((node_type(node).unwrap().to_string(), ancestors.len()));
+        });
+        assert_eq!(
+            seen,
+            vec![
+                ("Program".to_string(), 0),
+                ("VariableDeclaration".to_string(), 1),
+                ("VariableDeclarator".to_string(), 2),
+                ("Identifier".to_string(), 3),
+            ]
+        );
+    }
+
+    #[test]
+    fn walk_parent_is_nearest_node() {
+        let program = json!({
+            "type": "Program",
+            "body": [ { "type": "IfStatement", "consequent": {
+                "type": "BlockStatement", "body": [ { "type": "FunctionDeclaration" } ]
+            } } ]
+        });
+        let mut fn_parent: Option<String> = None;
+        walk_js(&program, |node, ancestors| {
+            if node_type(node) == Some("FunctionDeclaration") {
+                fn_parent = ancestors
+                    .last()
+                    .and_then(|p| node_type(p))
+                    .map(str::to_string);
+            }
+        });
+        assert_eq!(fn_parent.as_deref(), Some("BlockStatement"));
+    }
+}

--- a/crates/rsvelte_lint/src/wasm.rs
+++ b/crates/rsvelte_lint/src/wasm.rs
@@ -106,8 +106,11 @@ pub fn lint(source: &str, filename: &str) -> String {
         }),
     }
 
-    // 2. Native rules.
-    for d in run_native_rules(source, &config) {
+    // 2. Native rules (template walk) + script-AST rules.
+    let native = run_native_rules(source, &config)
+        .into_iter()
+        .chain(crate::engine::run_script_rules(source, &config));
+    for d in native {
         let (l, c) = line_index.position(d.start);
         if suppressions.is_suppressed(&d.rule, l) {
             continue;

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -92,6 +92,7 @@ const RULES: &[(&str, &str, bool)] = &[
         "svelte/prefer-svelte-reactivity",
         false,
     ),
+    ("no-store-async", "svelte/no-store-async", false),
 ];
 
 /// Fixture path substrings to skip, each with the porting gap it exercises.
@@ -109,6 +110,10 @@ const SKIP: &[&str] = &[
     // semantics). rsvelte mirrors the ESLint ≥9 rule, exercised by the
     // sibling non-`v8` fixtures.
     "no-inner-declarations/invalid/v8",
+    // `prefer-svelte-reactivity` exported-instance fixtures are `.svelte.js`
+    // modules exercising the export path (flag exported `new X()` even without
+    // mutation), which is not ported — the mutation path covers the rest.
+    "prefer-svelte-reactivity/invalid/exports",
 ];
 
 /// One expected error from a `*-errors.yaml` file.
@@ -158,8 +163,10 @@ fn collect_inputs(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn is_input(name: &str) -> bool {
-    let is_svelte = name.ends_with(".svelte") || name.ends_with(".svelte.ts");
-    if !is_svelte {
+    // `.svelte` components plus standalone JS/TS module fixtures
+    // (`*.svelte.js`, `*.svelte.ts`, `*.js`, `*.ts`).
+    let is_lintable = name.ends_with(".svelte") || name.ends_with(".js") || name.ends_with(".ts");
+    if !is_lintable {
         return false;
     }
     // stem (minus all extensions) ends with `input`, or a SvelteKit `+page` etc.
@@ -250,20 +257,21 @@ fn svelte5_in_range(range: &str) -> bool {
     !(r.contains('3') || r.contains('4'))
 }
 
-fn findings_for(source: &str, code: &str, options: &Option<Value>) -> Vec<Diagnostic> {
+fn findings_for(source: &str, file: &Path, code: &str, options: &Option<Value>) -> Vec<Diagnostic> {
     let mut cfg = LintConfig::empty().with_override(code, Severity::Error);
     if let Some(opts) = options {
         cfg = cfg.with_options(code, opts.clone());
     }
-    lint_source(
-        source,
-        &PathBuf::from("Fixture.svelte"),
-        &CompileOptions::default(),
-        &cfg,
-    )
-    .into_iter()
-    .filter(|d| d.code.as_deref() == Some(code))
-    .collect()
+    // Use the fixture's real filename so the linter classifies `.js`/`.ts`
+    // module fixtures (not just `.svelte` components) correctly.
+    let name = file
+        .file_name()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("Fixture.svelte"));
+    lint_source(source, &name, &CompileOptions::default(), &cfg)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some(code))
+        .collect()
 }
 
 /// `(line, column-1-based, message)` for an emitted diagnostic.
@@ -301,7 +309,7 @@ fn oracle_strict_parity() {
             let Ok(src) = std::fs::read_to_string(&input) else {
                 continue;
             };
-            let found = findings_for(&src, code, &load_options(&input));
+            let found = findings_for(&src, &input, code, &load_options(&input));
             checked += 1;
             if !found.is_empty() {
                 failures.push(format!(
@@ -338,10 +346,11 @@ fn oracle_strict_parity() {
                 .iter()
                 .map(|e| (e.line, e.column, e.message.clone()))
                 .collect();
-            let mut act: Vec<(u32, u32, String)> = findings_for(&src, code, &load_options(&input))
-                .iter()
-                .map(actual_tuple)
-                .collect();
+            let mut act: Vec<(u32, u32, String)> =
+                findings_for(&src, &input, code, &load_options(&input))
+                    .iter()
+                    .map(actual_tuple)
+                    .collect();
             exp.sort();
             act.sort();
             if exp != act {

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -87,6 +87,11 @@ const RULES: &[(&str, &str, bool)] = &[
         "svelte/no-inner-declarations",
         false,
     ),
+    (
+        "prefer-svelte-reactivity",
+        "svelte/prefer-svelte-reactivity",
+        false,
+    ),
 ];
 
 /// Fixture path substrings to skip, each with the porting gap it exercises.

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -82,6 +82,11 @@ const RULES: &[(&str, &str, bool)] = &[
     ("no-svelte-internal", "svelte/no-svelte-internal", false),
     ("no-inspect", "svelte/no-inspect", false),
     ("no-useless-mustaches", "svelte/no-useless-mustaches", true),
+    (
+        "no-inner-declarations",
+        "svelte/no-inner-declarations",
+        false,
+    ),
 ];
 
 /// Fixture path substrings to skip, each with the porting gap it exercises.
@@ -95,6 +100,10 @@ const SKIP: &[&str] = &[
     // whole condition (column 11). Logic/count are correct; only the column of
     // that one compound branch differs.
     "no-dupe-else-if-blocks/invalid/test02",
+    // ESLint ≤8 `no-inner-declarations` fixtures (older option/strict-mode
+    // semantics). rsvelte mirrors the ESLint ≥9 rule, exercised by the
+    // sibling non-`v8` fixtures.
+    "no-inner-declarations/invalid/v8",
 ];
 
 /// One expected error from a `*-errors.yaml` file.


### PR DESCRIPTION
Adds **script-AST rule infrastructure** to `rsvelte_lint`, a **JS/TS-module lint path**, and ports three recommended-syntactic rules that operate on the `<script>` (or whole-module) AST. Each is verified against the upstream eslint-plugin-svelte fixtures via the strict compat oracle (now **20 rules**).

## Infrastructure

- `script::ScriptRule` trait — `check_program(ctx, program: &serde_json::Value, kind)`; rules walk the ESTree program themselves.
- `script::walk_js(node, |node, ancestors|)` — DFS handing each node its ancestor stack.
- `engine::run_script_rules` — materialises each `<script>` program to an **owned ESTree JSON value with absolute byte offsets** inside `with_serialize_arena(&root.arena, …)` (a plain `Script::content.as_json()` returns an empty body — children are arena-indexed).
- **JS/TS-module path**: `rsvelte_core::…::parse_module_to_estree(source, is_ts)` parses a whole `*.svelte.js` / `*.svelte.ts` / `*.js` / `*.ts` file to an ESTree program; `engine::classify_source` + `run_script_rules_module` + runner dispatch run script-AST rules on module files (no template/compiler pass). This also fixes a latent `parse_program` bug: with comments present it resolves statement children via `to_value()` during the parse, so the serialize arena must be installed for the whole conversion (else an import's `source`/`specifiers` came back empty).

Wired into the native runner and the wasm entry point.

## Rules

| Rule | Issue | Notes |
|------|-------|-------|
| `svelte/no-inner-declarations` | #884 | core ESLint port — `function` (and `var` in `"both"`) declarations nested in blocks; `<script>` is strict, so functions only flagged with `blockScopedFunctions: "disallow"`. Oracle skips the ESLint ≤8 (`v8`) fixtures. |
| `svelte/prefer-svelte-reactivity` | #896 | flag a **mutated** built-in `Date`/`Map`/`Set`/`URL`/`URLSearchParams` (use the `svelte/reactivity` equivalents); read-only / shadowed constructors are fine. |
| `svelte/no-store-async` | #888 | flag an `async` function passed as the 2nd arg to a `svelte/store` creator (`writable`/`readable`/`derived`), resolving creators via their import (incl. aliases + namespace imports). Lints `.js` module files via the new path. |

## Not included (each needs a distinct, separate addition — tracked under epic #904)

- **require-event-dispatcher-types (#897)** — Svelte **3/4-only** (`conditions: svelteVersions: ['3/4']`); every fixture is gated to `svelte ^3 || ^4`, so none run under the Svelte-5 oracle.
- **no-unused-svelte-ignore (#892)** — needs compiler-warning correlation (compile → collect warnings → diff against `<!-- svelte-ignore -->` comments) — a separate subsystem.
- `prefer-svelte-reactivity`'s `*.svelte.js` **exported-instance** fixtures (flag exported `new X()` without mutation) are skipped — the mutation path covers the rest.

Refs epic #904. Closes #884, #888, #896.

🤖 Generated with [Claude Code](https://claude.com/claude-code)