### PR TITLE
fix(svelte2tsx): infer generic component T into its prop params (#923)

### DIFF
--- a/.changeset/fix-923-generic-prop-inference.md
+++ b/.changeset/fix-923-generic-prop-inference.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): infer a generic component's `T` into its `T`-dependent prop params (#923). A runes-mode generic component (`<script generics="T">` + `$props()`) was lowered with `__sveltets_2_fn_component($$render())`, which discards `T` — `$$render()` is called without `<T>` and the component type alias (`type C<T> = ReturnType<typeof C>`) never consumes its own `<T>`. So `T` could not be inferred at the call site, and sibling props whose types depend on it — callback props `(row: T) => …` and snippet props `Snippet<[{ row: T }]>` — collapsed to `unknown` ("'row' is of type 'unknown'"). This was the dominant remaining `--tsgo` blocker on real generic table/list components. rsvelte now emits the upstream `__sveltets_Render<T>` + `$$IsomorphicComponent` shape (byte-identical to svelte2tsx) for runes generics, whose generic constructor / call signatures let TypeScript infer `T` from the supplied props and flow it into every `T`-dependent prop parameter. The previous `#801` fix (making `Foo<X>` a valid generic *reference*) is preserved by the new shape's `type Foo<T> = InstanceType<typeof Foo<T>>` alias.

--- a/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
@@ -1523,23 +1523,46 @@ pub fn svelte2tsx(
                         "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
                         safe_name
                     ));
+                } else if has_generics {
+                    // Runes + generics: `__sveltets_2_fn_component($$render())`
+                    // discards `T` ($$render is called without `<T>` and the
+                    // component type alias never consumes its own `<T>`), so a
+                    // generic component's `T` could not be inferred at the call
+                    // site and `T`-dependent sibling props (callbacks, snippet
+                    // params) collapsed to `unknown` (#923). The #801 fix only
+                    // made `Foo<X>` a valid *reference*. Emit the upstream
+                    // `__sveltets_Render<T>` + `$$IsomorphicComponent` shape
+                    // instead, which threads `T` through generic constructor /
+                    // call signatures so TypeScript infers it from the props.
+                    let gn = &generics_names;
+                    let raw_bindings = exported_names.create_raw_bindings_str(is_svelte5);
+                    let raw_exports = exported_names.create_raw_exports_str(
+                        is_svelte5,
+                        effective_accessors,
+                        options.is_ts_file,
+                    );
+                    let exports_return = if raw_exports == "$$HAS_EXPORTS$$" {
+                        format!("$$render<{gn}>().exports")
+                    } else {
+                        raw_exports.clone()
+                    };
+                    emit_runes_generics_component(
+                        &mut closing,
+                        &safe_name,
+                        &generics_params,
+                        gn,
+                        &raw_bindings,
+                        &exports_return,
+                        has_slot_elements,
+                    );
                 } else {
                     closing.push_str(&format!(
                         "const {} = __sveltets_2_fn_component($$render());\n",
                         safe_name
                     ));
-                    // Carry the `generics="…"` clause onto the component type
-                    // alias so `Foo<X>` is a valid generic reference (#801).
-                    // Without the `<…>` params tsgo reports "Type
-                    // 'Foo__SvelteComponent_' is not generic".
-                    let type_params = if has_generics {
-                        format!("<{}>", generics_params)
-                    } else {
-                        String::new()
-                    };
                     closing.push_str(&format!(
-                        "/*\u{03A9}ignore_start\u{03A9}*/type {}{} = ReturnType<typeof {}>;\n",
-                        safe_name, type_params, safe_name
+                        "/*\u{03A9}ignore_start\u{03A9}*/type {} = ReturnType<typeof {}>;\n",
+                        safe_name, safe_name
                     ));
                     closing.push_str(&format!(
                         "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
@@ -1693,6 +1716,78 @@ pub fn svelte2tsx(
         exported_names,
         events,
     })
+}
+
+/// Emit the `__sveltets_Render<T>` + `$$IsomorphicComponent` component export
+/// for a **runes-mode generic** component (`<script generics="T">` + runes).
+///
+/// Unlike a non-generic runes component (which uses
+/// `__sveltets_2_fn_component($$render())`), this threads the generic params
+/// through a generic constructor / call signature so TypeScript can *infer* `T`
+/// from the props supplied at the call site and flow it into sibling
+/// `T`-dependent prop types (callback params, `Snippet<[…T…]>` params). The
+/// `fn_component` form discards `T` (`$$render()` is called without `<T>` and
+/// the component type alias never uses its own `<T>`), so those prop params
+/// collapsed to `unknown` (#923). The shape mirrors upstream svelte2tsx's
+/// `addComponentExport` for Svelte 5 runes generics — the render-class methods
+/// carry explicit `ReturnType<typeof $$render<T>>[…]` annotations.
+#[allow(clippy::too_many_arguments)]
+fn emit_runes_generics_component(
+    closing: &mut String,
+    safe_name: &str,
+    gp: &str,
+    gn: &str,
+    raw_bindings: &str,
+    exports_return: &str,
+    has_slot_elements: bool,
+) {
+    closing.push_str(&format!("class __sveltets_Render<{gp}> {{\n"));
+    closing.push_str(&format!(
+        "    props(): ReturnType<typeof $$render<{gn}>>['props'] {{ return null as any; }}\n"
+    ));
+    closing.push_str(&format!(
+        "    events(): ReturnType<typeof $$render<{gn}>>['events'] {{ return null as any; }}\n"
+    ));
+    closing.push_str(&format!(
+        "    slots(): ReturnType<typeof $$render<{gn}>>['slots'] {{ return null as any; }}\n"
+    ));
+    closing.push_str(&format!("    bindings() {{ return {raw_bindings}; }}\n"));
+    closing.push_str(&format!("    exports() {{ return {exports_return}; }}\n"));
+    closing.push_str("}\n\n");
+
+    let any_params = gn.split(',').map(|_| "any").collect::<Vec<_>>().join(",");
+    let children_type_suffix = if has_slot_elements {
+        "& {children?: any}"
+    } else {
+        ""
+    };
+
+    closing.push_str("interface $$IsomorphicComponent {\n");
+    closing.push_str(&format!(
+        "    new <{gp}>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<{gn}>['props']>{children_type_suffix}>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<{gn}>['props']>, ReturnType<__sveltets_Render<{gn}>['events']>, ReturnType<__sveltets_Render<{gn}>['slots']>> & {{ $$bindings?: ReturnType<__sveltets_Render<{gn}>['bindings']> }} & ReturnType<__sveltets_Render<{gn}>['exports']>;\n"
+    ));
+    let slots_children_suffix = if has_slot_elements {
+        format!(", $$slots?: ReturnType<__sveltets_Render<{gn}>['slots']>, children?: any")
+    } else {
+        String::new()
+    };
+    closing.push_str(&format!(
+        "    <{gp}>(internal: unknown, props: ReturnType<__sveltets_Render<{gn}>['props']> & {{$$events?: ReturnType<__sveltets_Render<{gn}>['events']>{slots_children_suffix}}}): ReturnType<__sveltets_Render<{gn}>['exports']>;\n"
+    ));
+    closing.push_str(&format!(
+        "    z_$$bindings?: ReturnType<__sveltets_Render<{any_params}>['bindings']>;\n"
+    ));
+    closing.push_str("}\n");
+
+    closing.push_str(&format!(
+        "const {safe_name}: $$IsomorphicComponent = null as any;\n"
+    ));
+    closing.push_str(&format!(
+        "/*\u{03A9}ignore_start\u{03A9}*/type {safe_name}<{gp}> = InstanceType<typeof {safe_name}<{gn}>>;\n"
+    ));
+    closing.push_str(&format!(
+        "/*\u{03A9}ignore_end\u{03A9}*/export default {safe_name};"
+    ));
 }
 
 /// Escape a string for use as the body of a single-quoted JS string literal.

--- a/crates/rsvelte_core/tests/svelte2tsx_generics_prop_inference.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_generics_prop_inference.rs
@@ -1,0 +1,96 @@
+//! Regression test for issue #923.
+//!
+//! A runes-mode generic component (`<script generics="T">` + `$props()`) whose
+//! `T` is inferred from one prop must thread `T` into its other `T`-dependent
+//! props (callback / snippet params). Previously rsvelte emitted
+//! `__sveltets_2_fn_component($$render())`, which discards `T` (the component
+//! type alias `type C<T> = ReturnType<typeof C>` never consumes its own `<T>`),
+//! so `T` could not be inferred at the call site and those params collapsed to
+//! `unknown`. The fix emits the upstream `__sveltets_Render<T>` +
+//! `$$IsomorphicComponent` shape, whose generic constructor / call signatures
+//! let TypeScript infer `T` from the supplied props.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn overlay(src: &str) -> String {
+    svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "G.svelte".into(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code
+}
+
+const GENERIC: &str = "<script lang=\"ts\" generics=\"T\">\n\
+    import type { Snippet } from 'svelte';\n\
+    let { rows, getKey, rowSnippet }: { rows: T[]; getKey: (row: T) => string; rowSnippet: Snippet<[{ row: T }]>; } = $props();\n\
+    </script>\n\
+    {#each rows as r}{getKey(r)}{@render rowSnippet({ row: r })}{/each}";
+
+#[test]
+fn runes_generic_component_uses_isomorphic_component_shape() {
+    let code = overlay(GENERIC);
+    // The generic must be threaded through a generic constructor / call sig so
+    // TypeScript can infer it from the props at the call site.
+    assert!(
+        code.contains("class __sveltets_Render<T>"),
+        "missing generic __sveltets_Render<T>:\n{code}"
+    );
+    assert!(
+        code.contains("props(): ReturnType<typeof $$render<T>>['props']"),
+        "render props() not annotated with the generic render return type:\n{code}"
+    );
+    assert!(
+        code.contains("interface $$IsomorphicComponent") && code.contains("new <T>(options:"),
+        "missing $$IsomorphicComponent with a generic constructor:\n{code}"
+    );
+}
+
+#[test]
+fn runes_generic_component_does_not_discard_generic_via_fn_component() {
+    let code = overlay(GENERIC);
+    // The `fn_component` form discarded `T`; it must not be used for a generic
+    // component, and the type alias must consume its own `<T>`.
+    assert!(
+        !code.contains("__sveltets_2_fn_component"),
+        "generic component still lowered via fn_component (discards T):\n{code}"
+    );
+    assert!(
+        code.contains("type G__SvelteComponent_<T> = InstanceType<typeof G__SvelteComponent_<T>>"),
+        "component type alias does not consume its own <T>:\n{code}"
+    );
+}
+
+#[test]
+fn t_dependent_prop_types_are_preserved_in_props() {
+    let code = overlay(GENERIC);
+    // The props type must keep the `T`-dependent prop signatures verbatim so
+    // that, once `T` is inferred, the callback / snippet params resolve.
+    assert!(
+        code.contains("getKey: (row: T) => string"),
+        "callback prop type lost T:\n{code}"
+    );
+    assert!(
+        code.contains("rowSnippet: Snippet<[{ row: T }]>"),
+        "snippet prop type lost T:\n{code}"
+    );
+}
+
+#[test]
+fn non_generic_runes_component_still_uses_fn_component() {
+    // Guard: the common (non-generic) runes path is unchanged.
+    let src = "<script lang=\"ts\">let { a }: { a: number } = $props();</script>";
+    let code = overlay(src);
+    assert!(
+        code.contains("__sveltets_2_fn_component($$render())"),
+        "non-generic runes component should still use fn_component:\n{code}"
+    );
+    assert!(
+        !code.contains("$$IsomorphicComponent"),
+        "non-generic runes component should not emit IsomorphicComponent:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

A runes-mode generic component (`<script generics="T">` + `$props()`) whose `T` is **inferred** from one prop did not propagate `T` into its **other** `T`-dependent props — callback props `(row: T) => …` and snippet props `Snippet<[{ row: T }]>`. At the call site those params collapsed to `unknown`:

```
Use.svelte: 'row' is of type 'unknown'.
```

Official `svelte-check` infers `T` correctly. This was the **dominant** remaining `--tsgo` blocker on real generic table/list components (a single generic component cascades `'<x>' is of type 'unknown'` to all of its consumers).

## Root cause

Runes generics were lowered as `__sveltets_2_fn_component($$render())`, which **discards `T`**:
- `$$render()` is called without `<T>`, and
- the component type alias `type C<T> = ReturnType<typeof C>` never consumes its own `<T>` (the #801 fix made `Foo<X>` a valid *reference*, but the parameter went unused).

So TypeScript had no generic to infer at the instantiation, and every `T`-dependent prop parameter widened to `unknown`.

## Fix

Emit the upstream `__sveltets_Render<T>` + `$$IsomorphicComponent` shape for runes generics (new `emit_runes_generics_component`) — **byte-identical to svelte2tsx's `addComponentExport`** (verified against `ts-runes-generics.v5/expectedv2.ts`). Its generic signatures

```ts
new <T>(options: ComponentConstructorOptions<ReturnType<__sveltets_Render<T>['props']>>): …
<T>(internal: unknown, props: ReturnType<__sveltets_Render<T>['props']> & {…}): …
```

let TypeScript infer `T` from the supplied props: `new __sveltets_2_ensureComponent(G)({ props: { rows: items, … } })` infers `T` from `rows={items}` and flows it into `getKey`'s and `rowSnippet`'s `row` param. The `type Foo<T> = InstanceType<typeof Foo<T>>` alias keeps explicit `Foo<X>` references (#801) working.

Non-generic runes components are unchanged (`__sveltets_2_fn_component`); the legacy (`$$Generic`) generics path is untouched.

## Tests

- `svelte2tsx_generics_prop_inference.rs`: asserts the IsomorphicComponent shape, that `fn_component` is **not** used for a generic component, that `T`-dependent prop types survive, and (guard) that non-generic runes components still use `fn_component`.
- No regression: the svelte2tsx fixture suite (253) — now byte-matching upstream for `ts-runes-generics.v5` — plus the generics/snippet suites stay green.

Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)