### PR TITLE
feat(lint): no-target-blank, no-add-event-listener, prefer-derived-over-derived-by

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css/analyze.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css/analyze.rs
@@ -845,10 +845,7 @@ fn is_relative_selector_global_strict(relative_selector: &serde_json::Value) -> 
     if !first
         .as_object()
         .is_some_and(|obj| obj.contains_key("args"))
-        || first
-            .get("args")
-            .and_then(|a| if a.is_null() { None } else { Some(a) })
-            .is_none()
+        || first.get("args").filter(|&a| !a.is_null()).is_none()
     {
         return true;
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -1035,11 +1035,10 @@ pub(super) fn parse_constructor_state_assignment(
     } else if let Some(rest) = rhs.strip_prefix("$derived.by(") {
         let end = find_matching_paren_lexical(rest)?;
         ("$derived.by", rest[..end].to_string())
-    } else if let Some(rest) = rhs.strip_prefix("$derived(") {
+    } else {
+        let rest = rhs.strip_prefix("$derived(")?;
         let end = find_matching_paren_lexical(rest)?;
         ("$derived", rest[..end].to_string())
-    } else {
-        return None;
     };
     // Strip quotes from name for private backing name generation
     // e.g., "'1'" -> "1" -> "_" (sanitized)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -1339,10 +1339,9 @@ pub(super) fn split_multi_declarator(line: &str) -> Option<Vec<String>> {
         ("let", r)
     } else if let Some(r) = trimmed.strip_prefix("const ") {
         ("const", r)
-    } else if let Some(r) = trimmed.strip_prefix("var ") {
-        ("var", r)
     } else {
-        return None;
+        let r = trimmed.strip_prefix("var ")?;
+        ("var", r)
     };
 
     // Check if there's a comma at depth 0 (indicating multiple declarators)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -1603,10 +1603,9 @@ fn build_bind_this_each_block(
     let property_path =
         if let Some(stripped) = get_str.strip_prefix(&format!("$.get({})", item_name)) {
             stripped.trim_start_matches('.').to_string()
-        } else if let Some(stripped) = get_str.strip_prefix(&format!("{}.", item_name)) {
-            stripped.to_string()
         } else {
-            return None;
+            let stripped = get_str.strip_prefix(&format!("{}.", item_name))?;
+            stripped.to_string()
         };
 
     if property_path.is_empty() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -1459,16 +1459,14 @@ fn convert_object_pattern_property_from_node(
                         .unwrap_or(false);
 
                     let (conv_key, fallback_name) = if key_type == "Literal" {
-                        if let Some(val) = key_val.get("value") {
+                        {
+                            let val = key_val.get("value")?;
                             if let Some(s) = val.as_str() {
                                 (JsPropertyKey::Literal(JsLiteral::String(s.into())), None)
-                            } else if let Some(n) = val.as_f64() {
-                                (JsPropertyKey::Literal(JsLiteral::Number(n)), None)
                             } else {
-                                return None;
+                                let n = val.as_f64()?;
+                                (JsPropertyKey::Literal(JsLiteral::Number(n)), None)
                             }
-                        } else {
-                            return None;
                         }
                     } else if key_type == "Identifier" {
                         let name = key_val.get("name").and_then(|n| n.as_str())?;
@@ -1556,7 +1554,8 @@ fn convert_object_pattern_prop_inner(
         }
         JsNode::Raw(v) => {
             // Delegate to Value-based property key conversion
-            if let Some(obj) = v.as_object() {
+            {
+                let obj = v.as_object()?;
                 let key_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
                 if key_type == "Identifier" && !computed {
                     let name = obj
@@ -1578,8 +1577,6 @@ fn convert_object_pattern_prop_inner(
                         None,
                     )
                 }
-            } else {
-                return None;
             }
         }
         _ => {
@@ -3546,7 +3543,8 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
                                 // Handle Identifier keys, Literal keys, and computed keys
                                 let (key, fallback_name) = if key_type == "Literal" {
                                     // Literal key: { 'the-area': area } or { 2: sum }
-                                    if let Some(val) = key_val.get("value") {
+                                    {
+                                        let val = key_val.get("value")?;
                                         if let Some(s) = val.as_str() {
                                             (
                                                 JsPropertyKey::Literal(JsLiteral::String(
@@ -3559,13 +3557,10 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
                                                 JsPropertyKey::Literal(JsLiteral::Number(n as f64)),
                                                 None,
                                             )
-                                        } else if let Some(n) = val.as_f64() {
-                                            (JsPropertyKey::Literal(JsLiteral::Number(n)), None)
                                         } else {
-                                            return None;
+                                            let n = val.as_f64()?;
+                                            (JsPropertyKey::Literal(JsLiteral::Number(n)), None)
                                         }
-                                    } else {
-                                        return None;
                                     }
                                 } else if key_type == "Identifier" {
                                     // Identifier key: { x } or { x: y }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_legacy.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_legacy.rs
@@ -529,7 +529,7 @@ fn is_string_literal(s: &str) -> bool {
 
     // Note: backtick template literals are TemplateLiteral AST nodes (not Literal), so they
     // are NOT simple by the official Svelte compiler's definition.
-    for &quote in [b'"', b'\''].iter() {
+    for &quote in b"\"'".iter() {
         if trimmed.as_bytes()[0] == quote && trimmed.as_bytes()[trimmed.len() - 1] == quote {
             let inner = &trimmed[1..trimmed.len() - 1];
             let bytes = inner.as_bytes();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
@@ -2673,10 +2673,9 @@ fn extract_function_decl_name(s: &str) -> Option<String> {
         r.trim()
     } else if let Some(r) = s.strip_prefix("function*") {
         r.trim()
-    } else if let Some(r) = s.strip_prefix("function ") {
-        r.trim()
     } else {
-        return None;
+        let r = s.strip_prefix("function ")?;
+        r.trim()
     };
 
     let mut i = 0;

--- a/crates/rsvelte_core/src/vps/hmr.rs
+++ b/crates/rsvelte_core/src/vps/hmr.rs
@@ -79,9 +79,9 @@ fn extract_script(source: &str, module: bool) -> Option<String> {
         let abs_open = i + open;
         let after_open = abs_open + "<script".len();
         // Find the closing `>` of the opening tag.
-        let close_attrs = match source[after_open..].find('>') {
-            Some(p) => after_open + p,
-            None => return None,
+        let close_attrs = {
+            let p = source[after_open..].find('>')?;
+            after_open + p
         };
         let tag_attrs = &source[after_open..close_attrs];
         let is_module = is_module_script_attrs(tag_attrs);

--- a/crates/rsvelte_core/tests/real_world.rs
+++ b/crates/rsvelte_core/tests/real_world.rs
@@ -101,21 +101,13 @@ fn load_fixture(dir: &Path) -> Option<RealWorldFixture> {
     let options_str = fs::read_to_string(&options_path).ok()?;
     let options: FixtureOptions = serde_json::from_str(&options_str).ok()?;
 
-    let expected_client = fs::read_to_string(&client_path).ok().and_then(|s| {
-        if s.starts_with("// COMPILE ERROR") {
-            None
-        } else {
-            Some(s)
-        }
-    });
+    let expected_client = fs::read_to_string(&client_path)
+        .ok()
+        .filter(|s| !s.starts_with("// COMPILE ERROR"));
 
-    let expected_server = fs::read_to_string(&server_path).ok().and_then(|s| {
-        if s.starts_with("// COMPILE ERROR") {
-            None
-        } else {
-            Some(s)
-        }
-    });
+    let expected_server = fs::read_to_string(&server_path)
+        .ok()
+        .filter(|s| !s.starts_with("// COMPILE ERROR"));
 
     Some(RealWorldFixture {
         name,

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -13,7 +13,7 @@ use crate::rules::{
     no_object_in_text_mustaches::NoObjectInTextMustaches,
     no_raw_special_elements::NoRawSpecialElements,
     no_restricted_html_elements::NoRestrictedHtmlElements, no_svelte_internal::NoSvelteInternal,
-    no_useless_children_snippet::NoUselessChildrenSnippet,
+    no_target_blank::NoTargetBlank, no_useless_children_snippet::NoUselessChildrenSnippet,
     no_useless_mustaches::NoUselessMustaches, require_each_key::RequireEachKey,
     valid_each_key::ValidEachKey,
 };
@@ -38,18 +38,23 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(NoSvelteInternal),
         Box::new(NoInspect),
         Box::new(NoUselessMustaches),
+        Box::new(NoTargetBlank),
     ]
 }
 
 /// Construct the full set of script-AST rules (rules that walk the `<script>`
 /// ESTree program rather than the template tree).
 pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
+    use crate::rules::no_add_event_listener::NoAddEventListener;
     use crate::rules::no_inner_declarations::NoInnerDeclarations;
     use crate::rules::no_store_async::NoStoreAsync;
+    use crate::rules::prefer_derived_over_derived_by::PreferDerivedOverDerivedBy;
     use crate::rules::prefer_svelte_reactivity::PreferSvelteReactivity;
     vec![
         Box::new(NoInnerDeclarations),
         Box::new(PreferSvelteReactivity),
         Box::new(NoStoreAsync),
+        Box::new(NoAddEventListener),
+        Box::new(PreferDerivedOverDerivedBy),
     ]
 }

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -3,6 +3,7 @@
 //! [`registry`](crate::registry).
 
 pub mod button_has_type;
+pub mod no_add_event_listener;
 pub mod no_at_debug_tags;
 pub mod no_at_html_tags;
 pub mod no_dupe_else_if_blocks;
@@ -17,8 +18,10 @@ pub mod no_raw_special_elements;
 pub mod no_restricted_html_elements;
 pub mod no_store_async;
 pub mod no_svelte_internal;
+pub mod no_target_blank;
 pub mod no_useless_children_snippet;
 pub mod no_useless_mustaches;
+pub mod prefer_derived_over_derived_by;
 pub mod prefer_svelte_reactivity;
 pub mod require_each_key;
 pub mod valid_each_key;

--- a/crates/rsvelte_lint/src/rules/no_add_event_listener.rs
+++ b/crates/rsvelte_lint/src/rules/no_add_event_listener.rs
@@ -1,0 +1,150 @@
+//! `svelte/no-add-event-listener` — warn against the use of `addEventListener`.
+//!
+//! Port of eslint-plugin-svelte's `no-add-event-listener` rule. In Svelte 5 the
+//! recommended way to attach DOM event listeners is the `on` function from
+//! `svelte/events` (which respects the component lifecycle), so any direct use of
+//! `addEventListener` should be flagged.
+//!
+//! Runs over the `<script>` (instance / module) ESTree program via the
+//! [`ScriptRule`] hook. Upstream offers a *suggestion* (rewrite to `on(...)`),
+//! but the rsvelte oracle only checks detection, so this is detection-only
+//! ([`Fixable::No`]).
+//!
+//! A `CallExpression` is reported when its callee is either:
+//!   - a non-computed `MemberExpression` whose property is an `Identifier`
+//!     named `addEventListener` (e.g. `el.addEventListener(...)`), or
+//!   - a bare `Identifier` named `addEventListener` (e.g. `addEventListener(...)`,
+//!     i.e. the global on `window`).
+//!
+//! The finding is reported at the `CallExpression` node start so the column
+//! matches upstream.
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+const MESSAGE: &str =
+    "Do not use `addEventListener`. Use the `on` function from `svelte/events` instead.";
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-add-event-listener",
+    category: RuleCategory::Style,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Warns against the use of `addEventListener`",
+    options_schema: None,
+};
+
+#[derive(Default)]
+pub struct NoAddEventListener;
+
+impl ScriptRule for NoAddEventListener {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        let mut reports: Vec<u32> = Vec::new();
+        walk_js(program, |node, _ancestors| {
+            if node_type(node) != Some("CallExpression") {
+                return;
+            }
+            let Some(callee) = node.get("callee") else {
+                return;
+            };
+            if !is_add_event_listener_callee(callee) {
+                return;
+            }
+            if let Some(start) = node_start(node) {
+                reports.push(start);
+            }
+        });
+
+        for start in reports {
+            ctx.report(start, start, MESSAGE.to_string());
+        }
+    }
+}
+
+/// Whether a `CallExpression` callee targets `addEventListener` — either a
+/// `<obj>.addEventListener` member access (non-computed, property identifier) or
+/// a bare `addEventListener` identifier (the global on `window`).
+fn is_add_event_listener_callee(callee: &Value) -> bool {
+    match node_type(callee) {
+        Some("MemberExpression") => {
+            // `obj["addEventListener"](...)` (computed) is NOT matched upstream.
+            if callee.get("computed").and_then(Value::as_bool) == Some(true) {
+                return false;
+            }
+            let property = callee.get("property");
+            property.and_then(|p| {
+                if node_type(p) != Some("Identifier") {
+                    return None;
+                }
+                p.get("name").and_then(Value::as_str)
+            }) == Some("addEventListener")
+        }
+        Some("Identifier") => {
+            callee.get("name").and_then(Value::as_str) == Some("addEventListener")
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn matches_member_property() {
+        let callee = json!({
+            "type": "MemberExpression",
+            "computed": false,
+            "object": { "type": "Identifier", "name": "window" },
+            "property": { "type": "Identifier", "name": "addEventListener" }
+        });
+        assert!(is_add_event_listener_callee(&callee));
+    }
+
+    #[test]
+    fn matches_bare_identifier() {
+        let callee = json!({ "type": "Identifier", "name": "addEventListener" });
+        assert!(is_add_event_listener_callee(&callee));
+    }
+
+    #[test]
+    fn rejects_computed_member() {
+        let callee = json!({
+            "type": "MemberExpression",
+            "computed": true,
+            "object": { "type": "Identifier", "name": "window" },
+            "property": { "type": "Literal", "value": "addEventListener" }
+        });
+        assert!(!is_add_event_listener_callee(&callee));
+    }
+
+    #[test]
+    fn rejects_other_property() {
+        let callee = json!({
+            "type": "MemberExpression",
+            "computed": false,
+            "object": { "type": "Identifier", "name": "window" },
+            "property": { "type": "Identifier", "name": "removeEventListener" }
+        });
+        assert!(!is_add_event_listener_callee(&callee));
+    }
+
+    #[test]
+    fn rejects_other_identifier() {
+        let callee = json!({ "type": "Identifier", "name": "on" });
+        assert!(!is_add_event_listener_callee(&callee));
+    }
+}

--- a/crates/rsvelte_lint/src/rules/no_target_blank.rs
+++ b/crates/rsvelte_lint/src/rules/no_target_blank.rs
@@ -1,0 +1,234 @@
+//! `svelte/no-target-blank` — disallow `target="_blank"` on links that point to
+//! a "dangerous" (external or, when enforced, dynamic) destination without a
+//! secure `rel="noopener noreferrer"`. Port of the eslint-plugin-svelte rule.
+//!
+//! For each element that carries a static `target="_blank"` attribute, the rule:
+//!   1. skips the element when it has a *secure* `rel` (lowercased, space-split:
+//!      contains `noopener` AND, unless `allowReferrer`, `noreferrer`);
+//!   2. otherwise reports the `target` attribute when the link is *dangerous* —
+//!      it has an external `href` (first static text part matching
+//!      `/^(?:\w+:|\/\/)/`), or (with `enforceDynamicLinks === "always"`) a
+//!      dynamic `href` (mustache value, shorthand `href`, or `bind:href`).
+//!
+//! Options (`options[0]`): `{ allowReferrer?: boolean = false,
+//! enforceDynamicLinks?: "always" | "never" = "always" }`.
+
+use rsvelte_core::ast::template::{Attribute, AttributeValue, AttributeValuePart, RegularElement};
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-target-blank",
+    category: RuleCategory::Style,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "disallow `target=\"_blank\"` attribute without `rel=\"noopener noreferrer\"`",
+    options_schema: Some(
+        r#"{"type":"object","properties":{"allowReferrer":{"type":"boolean"},"enforceDynamicLinks":{"enum":["always","never"]}},"additionalProperties":false}"#,
+    ),
+};
+
+const MESSAGE: &str =
+    "Using target=\"_blank\" without rel=\"noopener noreferrer\" is a security risk.";
+
+/// The static text value of an attribute value, if it is exactly one text part
+/// (no mustaches). Mirrors upstream `getStaticAttributeValue`: a value made of a
+/// single `SvelteLiteral` returns its text, anything else returns `None`.
+fn static_attribute_value(value: &AttributeValue) -> Option<&str> {
+    match value {
+        AttributeValue::True(_) => None,
+        AttributeValue::Expression(_) => None,
+        AttributeValue::Sequence(parts) => match parts.as_slice() {
+            [AttributeValuePart::Text(text)] => Some(text.data.as_str()),
+            _ => None,
+        },
+    }
+}
+
+/// Whether the lowercased, space-split `rel` tag set is "secure": contains
+/// `noopener` and (unless referrers are allowed) `noreferrer`.
+fn is_secure_rel(rel: &str, allow_referrer: bool) -> bool {
+    let tags: Vec<String> = rel.to_lowercase().split(' ').map(str::to_string).collect();
+    tags.iter().any(|t| t == "noopener")
+        && (allow_referrer || tags.iter().any(|t| t == "noreferrer"))
+}
+
+/// Whether a static `href` text value is an absolute/protocol URL,
+/// matching `/^(?:\w+:|\/\/)/` (a `scheme:` prefix or a `//` prefix).
+fn is_external_href(href: &str) -> bool {
+    if href.starts_with("//") {
+        return true;
+    }
+    // `\w+:` — one or more [A-Za-z0-9_] followed by `:`.
+    let mut saw_word = false;
+    for c in href.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            saw_word = true;
+            continue;
+        }
+        return saw_word && c == ':';
+    }
+    false
+}
+
+#[derive(Default)]
+pub struct NoTargetBlank;
+
+impl NoTargetBlank {
+    /// `target="_blank"` (static literal exactly `_blank`).
+    fn target_blank_attr(
+        el: &RegularElement,
+    ) -> Option<&rsvelte_core::ast::template::AttributeNode> {
+        for attr in &el.attributes {
+            if let Attribute::Attribute(node) = attr
+                && node.name == "target"
+                && static_attribute_value(&node.value) == Some("_blank")
+            {
+                return Some(node);
+            }
+        }
+        None
+    }
+
+    /// True when the element has a secure `rel` attribute.
+    fn has_secure_rel(el: &RegularElement, allow_referrer: bool) -> bool {
+        for attr in &el.attributes {
+            if let Attribute::Attribute(node) = attr
+                && node.name == "rel"
+            {
+                // Upstream concatenates only the SvelteLiteral parts; a value
+                // with a mustache contributes no tags.
+                if let AttributeValue::Sequence(parts) = &node.value {
+                    let mut rel = String::new();
+                    for part in parts {
+                        if let AttributeValuePart::Text(text) = part {
+                            if !rel.is_empty() {
+                                rel.push(' ');
+                            }
+                            rel.push_str(text.data.as_str());
+                        }
+                    }
+                    return is_secure_rel(&rel, allow_referrer);
+                }
+                return false;
+            }
+        }
+        false
+    }
+
+    /// True when any `href` attribute's first static text part is an external URL.
+    fn has_external_link(el: &RegularElement) -> bool {
+        for attr in &el.attributes {
+            if let Attribute::Attribute(node) = attr
+                && node.name == "href"
+                && let AttributeValue::Sequence(parts) = &node.value
+                && let Some(AttributeValuePart::Text(text)) = parts.first()
+                && is_external_href(text.data.as_str())
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// True when the link's `href` is dynamic: a mustache in the value, a
+    /// shorthand `href` (`{href}`), or `bind:href`.
+    fn has_dynamic_link(el: &RegularElement) -> bool {
+        let mut href_attr: Option<&AttributeValue> = None;
+        for attr in &el.attributes {
+            match attr {
+                Attribute::Attribute(node) if node.name == "href" => {
+                    href_attr = Some(&node.value);
+                }
+                Attribute::BindDirective(bind) if bind.name == "href" => {
+                    return true;
+                }
+                _ => {}
+            }
+        }
+        match href_attr {
+            // A normal `href` attribute: dynamic when any value part is a mustache.
+            Some(AttributeValue::Sequence(parts)) => parts
+                .iter()
+                .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_))),
+            // `href={expr}` (single expression value) is also a mustache value.
+            Some(AttributeValue::Expression(_)) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Rule for NoTargetBlank {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_element(&self, ctx: &mut LintContext, el: &RegularElement) {
+        let allow_referrer = ctx.option_bool("allowReferrer", false);
+        let enforce_dynamic_links = ctx
+            .option0()
+            .and_then(|o| o.get("enforceDynamicLinks"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("always");
+
+        let Some(target) = Self::target_blank_attr(el) else {
+            return;
+        };
+        if Self::has_secure_rel(el, allow_referrer) {
+            return;
+        }
+
+        let has_danger_href = Self::has_external_link(el)
+            || (enforce_dynamic_links == "always" && Self::has_dynamic_link(el));
+
+        if has_danger_href {
+            ctx.report(target.start, target.end, MESSAGE);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_external_href, is_secure_rel};
+
+    #[test]
+    fn external_href_matches_protocol_and_slashes() {
+        assert!(is_external_href("https://svelte.dev/"));
+        assert!(is_external_href("http://example.com"));
+        assert!(is_external_href("mailto:a@b.com"));
+        assert!(is_external_href("//cdn.example.com/x"));
+        assert!(is_external_href("tel:123"));
+    }
+
+    #[test]
+    fn external_href_rejects_relative() {
+        assert!(!is_external_href("/foo"));
+        assert!(!is_external_href("foo/bar"));
+        assert!(!is_external_href("./a"));
+        assert!(!is_external_href(""));
+        assert!(!is_external_href("#anchor"));
+    }
+
+    #[test]
+    fn secure_rel_requires_noopener() {
+        assert!(is_secure_rel("noopener noreferrer", false));
+        assert!(is_secure_rel("NoOpener NoReferrer", false));
+        assert!(!is_secure_rel("noopener", false));
+        assert!(!is_secure_rel("noreferrer", false));
+        assert!(!is_secure_rel("noopenernoreferrer", false));
+        assert!(!is_secure_rel("3", false));
+    }
+
+    #[test]
+    fn secure_rel_allow_referrer_drops_noreferrer_requirement() {
+        assert!(is_secure_rel("noopener", true));
+        assert!(is_secure_rel("noopener noreferrer", true));
+        assert!(!is_secure_rel("noreferrer", true));
+    }
+}

--- a/crates/rsvelte_lint/src/rules/prefer_derived_over_derived_by.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_derived_over_derived_by.rs
@@ -87,12 +87,11 @@ fn returned_expression(arg: &Value, kind: &str) -> Option<Value> {
         let stmts = body.get("body").and_then(Value::as_array)?;
         if stmts.len() == 1 {
             let stmt = &stmts[0];
-            if node_type(stmt) == Some("ReturnStatement") {
-                if let Some(argument) = stmt.get("argument") {
-                    if !argument.is_null() {
-                        return Some(argument.clone());
-                    }
-                }
+            if node_type(stmt) == Some("ReturnStatement")
+                && let Some(argument) = stmt.get("argument")
+                && !argument.is_null()
+            {
+                return Some(argument.clone());
             }
         }
     }

--- a/crates/rsvelte_lint/src/rules/prefer_derived_over_derived_by.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_derived_over_derived_by.rs
@@ -1,0 +1,310 @@
+//! `svelte/prefer-derived-over-derived-by` — disallow unnecessary
+//! `$derived.by()` when `$derived()` is sufficient. Port of the
+//! eslint-plugin-svelte rule, over the script ESTree program via the
+//! [`ScriptRule`] hook.
+//!
+//! The rule fires on a `$derived.by(fn)` call whose single argument is a
+//! parameter-less, non-async, non-generator arrow/function expression that
+//! merely returns a single expression — either a concise arrow body or a block
+//! body containing exactly one `return <expr>;`. It autofixes the whole call to
+//! `$derived(<expr>)`, splicing the returned expression's source text verbatim.
+//!
+//! Because `$derived.by` only exists in runes mode, matching the syntactic
+//! pattern is sufficient (no separate runes-mode detection is needed).
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::diagnostic::{Fix, TextEdit};
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/prefer-derived-over-derived-by",
+    category: RuleCategory::Style,
+    fixable: Fixable::Code,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow unnecessary `$derived.by()` when `$derived()` is sufficient",
+    options_schema: None,
+};
+
+const MESSAGE: &str =
+    "Unnecessary use of `$derived.by()`. Use `$derived()` directly for simple expressions.";
+
+fn ident_name(node: &Value) -> Option<&str> {
+    if node_type(node) == Some("Identifier") {
+        node.get("name").and_then(Value::as_str)
+    } else {
+        None
+    }
+}
+
+/// Whether `callee` is a non-computed member expression `$derived.by`.
+fn is_derived_by_callee(callee: &Value) -> bool {
+    node_type(callee) == Some("MemberExpression")
+        && callee.get("computed").and_then(Value::as_bool) != Some(true)
+        && callee.get("object").and_then(ident_name) == Some("$derived")
+        && callee.get("property").and_then(ident_name) == Some("by")
+}
+
+/// Whether `arg` is a parameter-less, non-async, non-generator
+/// arrow/function expression. Returns the node type when so.
+fn simple_thunk_kind(arg: &Value) -> Option<&str> {
+    let kind = node_type(arg)?;
+    if kind != "ArrowFunctionExpression" && kind != "FunctionExpression" {
+        return None;
+    }
+    let params_empty = arg
+        .get("params")
+        .and_then(Value::as_array)
+        .map(|p| p.is_empty())
+        .unwrap_or(false);
+    if !params_empty {
+        return None;
+    }
+    if arg.get("async").and_then(Value::as_bool) == Some(true) {
+        return None;
+    }
+    if arg.get("generator").and_then(Value::as_bool) == Some(true) {
+        return None;
+    }
+    Some(kind)
+}
+
+/// The single returned expression node of a simple thunk, if it returns one:
+/// a concise arrow body, or a block body of exactly one `return <expr>;`.
+fn returned_expression(arg: &Value, kind: &str) -> Option<Value> {
+    let body = arg.get("body")?;
+    if kind == "ArrowFunctionExpression" && node_type(body) != Some("BlockStatement") {
+        return Some(body.clone());
+    }
+    if node_type(body) == Some("BlockStatement") {
+        let stmts = body.get("body").and_then(Value::as_array)?;
+        if stmts.len() == 1 {
+            let stmt = &stmts[0];
+            if node_type(stmt) == Some("ReturnStatement") {
+                if let Some(argument) = stmt.get("argument") {
+                    if !argument.is_null() {
+                        return Some(argument.clone());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[derive(Default)]
+pub struct PreferDerivedOverDerivedBy;
+
+impl ScriptRule for PreferDerivedOverDerivedBy {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        // (call_start, call_end, expr_start, expr_end)
+        let mut reports: Vec<(u32, u32, u32, u32)> = Vec::new();
+
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("CallExpression") {
+                return;
+            }
+            let Some(callee) = node.get("callee") else {
+                return;
+            };
+            if !is_derived_by_callee(callee) {
+                return;
+            }
+            let Some(args) = node.get("arguments").and_then(Value::as_array) else {
+                return;
+            };
+            if args.len() != 1 {
+                return;
+            }
+            let arg = &args[0];
+            let Some(kind) = simple_thunk_kind(arg) else {
+                return;
+            };
+            let Some(expr) = returned_expression(arg, kind) else {
+                return;
+            };
+            let (Some(call_start), Some(call_end)) = (node_start(node), node_end(node)) else {
+                return;
+            };
+            let (Some(expr_start), Some(expr_end)) = (node_start(&expr), node_end(&expr)) else {
+                return;
+            };
+            reports.push((call_start, call_end, expr_start, expr_end));
+        });
+
+        reports.sort_unstable();
+        reports.dedup();
+        for (call_start, call_end, expr_start, expr_end) in reports {
+            let expr_text = ctx.slice(expr_start, expr_end);
+            let new_text = format!("$derived({expr_text})");
+            let fix = Fix {
+                message: MESSAGE.to_string(),
+                edits: vec![TextEdit {
+                    start: call_start,
+                    end: call_end,
+                    new_text,
+                }],
+            };
+            ctx.report_with_fix(call_start, call_end, MESSAGE, fix);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn detects_derived_by_callee() {
+        assert!(is_derived_by_callee(&json!({
+            "type": "MemberExpression",
+            "computed": false,
+            "object": { "type": "Identifier", "name": "$derived" },
+            "property": { "type": "Identifier", "name": "by" }
+        })));
+        // computed member access does not match
+        assert!(!is_derived_by_callee(&json!({
+            "type": "MemberExpression",
+            "computed": true,
+            "object": { "type": "Identifier", "name": "$derived" },
+            "property": { "type": "Identifier", "name": "by" }
+        })));
+        // wrong object / property
+        assert!(!is_derived_by_callee(&json!({
+            "type": "MemberExpression",
+            "computed": false,
+            "object": { "type": "Identifier", "name": "$derived" },
+            "property": { "type": "Identifier", "name": "from" }
+        })));
+        assert!(!is_derived_by_callee(&json!({
+            "type": "MemberExpression",
+            "computed": false,
+            "object": { "type": "Identifier", "name": "derived" },
+            "property": { "type": "Identifier", "name": "by" }
+        })));
+    }
+
+    #[test]
+    fn simple_thunk_kind_filters() {
+        assert_eq!(
+            simple_thunk_kind(&json!({
+                "type": "ArrowFunctionExpression",
+                "params": [], "async": false, "generator": false
+            })),
+            Some("ArrowFunctionExpression")
+        );
+        assert_eq!(
+            simple_thunk_kind(&json!({
+                "type": "FunctionExpression",
+                "params": [], "async": false, "generator": false
+            })),
+            Some("FunctionExpression")
+        );
+        // params present
+        assert_eq!(
+            simple_thunk_kind(&json!({
+                "type": "ArrowFunctionExpression",
+                "params": [{ "type": "Identifier", "name": "x" }],
+                "async": false, "generator": false
+            })),
+            None
+        );
+        // async
+        assert_eq!(
+            simple_thunk_kind(&json!({
+                "type": "ArrowFunctionExpression",
+                "params": [], "async": true, "generator": false
+            })),
+            None
+        );
+        // generator
+        assert_eq!(
+            simple_thunk_kind(&json!({
+                "type": "FunctionExpression",
+                "params": [], "async": false, "generator": true
+            })),
+            None
+        );
+        // not a function
+        assert_eq!(
+            simple_thunk_kind(&json!({ "type": "Identifier", "name": "f" })),
+            None
+        );
+    }
+
+    #[test]
+    fn returned_expression_concise_arrow() {
+        let arg = json!({
+            "type": "ArrowFunctionExpression",
+            "params": [], "async": false, "generator": false,
+            "body": { "type": "MemberExpression", "start": 10, "end": 13 }
+        });
+        let expr = returned_expression(&arg, "ArrowFunctionExpression").unwrap();
+        assert_eq!(node_type(&expr), Some("MemberExpression"));
+    }
+
+    #[test]
+    fn returned_expression_block_single_return() {
+        let arg = json!({
+            "type": "ArrowFunctionExpression",
+            "params": [], "async": false, "generator": false,
+            "body": {
+                "type": "BlockStatement",
+                "body": [
+                    { "type": "ReturnStatement",
+                      "argument": { "type": "Identifier", "name": "a", "start": 5, "end": 6 } }
+                ]
+            }
+        });
+        let expr = returned_expression(&arg, "ArrowFunctionExpression").unwrap();
+        assert_eq!(node_type(&expr), Some("Identifier"));
+    }
+
+    #[test]
+    fn returned_expression_rejects_multi_statement_and_bare_return() {
+        // multi-statement block
+        let multi = json!({
+            "type": "ArrowFunctionExpression",
+            "body": {
+                "type": "BlockStatement",
+                "body": [
+                    { "type": "VariableDeclaration" },
+                    { "type": "ReturnStatement", "argument": { "type": "Identifier" } }
+                ]
+            }
+        });
+        assert!(returned_expression(&multi, "ArrowFunctionExpression").is_none());
+
+        // bare `return;`
+        let bare = json!({
+            "type": "ArrowFunctionExpression",
+            "body": {
+                "type": "BlockStatement",
+                "body": [ { "type": "ReturnStatement", "argument": null } ]
+            }
+        });
+        assert!(returned_expression(&bare, "ArrowFunctionExpression").is_none());
+
+        // block-bodied arrow but the single statement is not a return
+        let no_return = json!({
+            "type": "ArrowFunctionExpression",
+            "body": {
+                "type": "BlockStatement",
+                "body": [ { "type": "ExpressionStatement" } ]
+            }
+        });
+        assert!(returned_expression(&no_return, "ArrowFunctionExpression").is_none());
+    }
+}

--- a/crates/rsvelte_lint/src/runner.rs
+++ b/crates/rsvelte_lint/src/runner.rs
@@ -86,9 +86,12 @@ pub fn fix_source(source: &str, config: &LintConfig) -> FixResult {
     let line_index = LineIndex::new(source);
     let suppressions = Suppressions::collect(source);
 
-    // Gather candidate edits from non-suppressed fixable findings.
+    // Gather candidate edits from non-suppressed fixable findings — from both
+    // the template-walk rules and the script-AST rules (e.g. the autofix of
+    // `$derived.by(() => x)` → `$derived(x)`).
     let mut edits: Vec<TextEdit> = run_native_rules(source, config)
         .into_iter()
+        .chain(run_script_rules(source, config))
         .filter(|d| !suppressions.is_suppressed(&d.rule, line_index.line(d.start)))
         .filter_map(|d| d.fix)
         .flat_map(|f| f.edits)

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -93,6 +93,17 @@ const RULES: &[(&str, &str, bool)] = &[
         false,
     ),
     ("no-store-async", "svelte/no-store-async", false),
+    ("no-target-blank", "svelte/no-target-blank", false),
+    (
+        "no-add-event-listener",
+        "svelte/no-add-event-listener",
+        false,
+    ),
+    (
+        "prefer-derived-over-derived-by",
+        "svelte/prefer-derived-over-derived-by",
+        true,
+    ),
 ];
 
 /// Fixture path substrings to skip, each with the porting gap it exercises.
@@ -114,6 +125,11 @@ const SKIP: &[&str] = &[
     // modules exercising the export path (flag exported `new X()` even without
     // mutation), which is not ported — the mutation path covers the rest.
     "prefer-svelte-reactivity/invalid/exports",
+    // `no-add-event-listener` TS-cast case: `(window.addEventListener as any)(…)`.
+    // rsvelte's ESTree strips the TS `as` cast, so the call's callee looks like a
+    // plain `window.addEventListener` member (upstream keeps it a TSAsExpression
+    // and skips it). The non-cast member/identifier cases are covered.
+    "no-add-event-listener/invalid/typescript01",
 ];
 
 /// One expected error from a `*-errors.yaml` file.


### PR DESCRIPTION
Three more syntactic rules, verified against the upstream eslint-plugin-svelte fixtures via the strict compat oracle (now **23 rules**).

| Rule | Issue | Notes |
|------|-------|-------|
| `svelte/no-target-blank` | #890 | flag `target="_blank"` without secure `rel="noopener[ noreferrer]"` on an external/dynamic link (options: `allowReferrer`, `enforceDynamicLinks`) |
| `svelte/no-add-event-listener` | #877 | flag `addEventListener` calls — use `on` from `svelte/events`. Script-AST rule. |
| `svelte/prefer-derived-over-derived-by` | #895 | **fixable** — flag `$derived.by(() => expr)` (zero-param, non-async/generator, single-return) → rewrite to `$derived(expr)`. Script-AST rule. |

Also: `fix_source` now gathers autofixes from script-AST rules too (not just template rules), so the prefer-derived fix applies.

The `no-add-event-listener` TS-cast fixture (`(window.addEventListener as any)(…)`) is oracle-SKIPped: rsvelte's ESTree strips the TS `as` cast, making the callee indistinguishable from a plain member access (upstream keeps the `TSAsExpression` and skips it). The non-cast member/identifier cases are covered.

Refs epic #904. Closes #877, #890, #895.

🤖 Generated with [Claude Code](https://claude.com/claude-code)