### PR TITLE
fix(compiler): valid JS for $state/$derived private class fields in modules (#907)

### DIFF
--- a/.changeset/fix-907-module-class-field-codegen.md
+++ b/.changeset/fix-907-module-class-field-codegen.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): emit valid JS for `$state`/`$derived` private class fields in `.svelte.(js|ts)` modules (#907)
+
+`compileModule` produced **syntactically-invalid** JavaScript for several class-based rune-module shapes (reported against the `runed` library). The output parsed fine in isolation by `compileModule` itself — it only blew up once a bundler re-parsed it — so under Vite 8 + Rolldown, which compiles modules in parallel and aborts on the first bad file it reaches, the failing file set and the parser error text varied between runs. That *looked* like a thread-safety bug, but the per-file output was actually deterministic; the compile path holds no shared mutable state (added a concurrency stress test that compiles the real `runed` corpus across 8 threads and asserts byte-identical output).
+
+Four deterministic codegen bugs in the line-based class-field transform, each now fixed:
+
+- **Trailing line comment swallowed into `$.set(...)`** — `this.#x = getter(); // note` lowered to `$.set(this.#x, getter(); // note, true)` (an unterminated call). RHS extraction now stops at the top-level `;` and re-appends the `; // comment` tail.
+- **Prefix-sibling field corruption** — wrapping a private-field read used a bare `str::replace`, so wrapping `#fps` rewrote the unrelated sibling `#fpsLimitOption` into `$.get(this.#fps)LimitOption`. Reads are now replaced only at a trailing word boundary.
+- **Multi-line constructor RHS split** — `this.#rect = {\n …\n }` was transformed line-by-line, orphaning `this.#rect = {` from its body. Constructor statements are now grouped by bracket depth before the transform runs.
+- **Server `$state` field lowered to a call** — on SSR a `$state` private field is a plain value, but `this.#x = v` was lowered to the call form `this.#x(v)` (and reads to `this.#x()`). `post_process_for_server` now distinguishes `$.derived(...)`-backed fields (callable) from `$state` fields (plain `this.#x` / `this.#x = v`).
+
+Also fixes a spurious `constant_assignment` error (`runed/persisted-state`): a class-method body was not registered in the scope map, so a method-local `let x` that shadowed a top-level function param `x` was misresolved to the outer (constant) binding. Class-method bodies are now registered like function bodies. Closes #907.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -1319,6 +1319,21 @@ impl<'a> ScopeBuilder<'a> {
                     if let Some(value) = element.get("value") {
                         let old_scope = self.push_function_scope();
                         self.function_depth += 1;
+                        // Register the method body scope for the visitor phase, keyed
+                        // by the body's JSON `start` offset (same as the JSON
+                        // `FunctionDeclaration` path above). Without this the visitor
+                        // resolved identifiers inside the method against the outer
+                        // class/module scope, so a method-local `let x` shadowing a
+                        // top-level function param `x` was misresolved to the outer
+                        // (constant) binding and mis-reported as `constant_assignment`
+                        // (issue #907 follow-up: runed `persisted-state`,
+                        // `use-search-params`).
+                        if let Some(fn_body) = value.get("body")
+                            && let Some(start) = fn_body.get("start").and_then(|s| s.as_u64())
+                        {
+                            self.function_scope_map
+                                .insert(start as u32, self.current_scope);
+                        }
                         // Declare function parameters
                         if let Some(params) = value.get("params").and_then(|p| p.as_array()) {
                             for param in params {
@@ -1879,6 +1894,22 @@ impl<'a> ScopeBuilder<'a> {
                             let params = *params;
                             let old_scope = self.push_function_scope();
                             self.function_depth += 1;
+                            // Record method body start -> scope index so the visitor
+                            // phase (`function_expression::visit_typed`) resolves
+                            // identifiers inside the method against the method's own
+                            // scope. Without this the body inherited the class/module
+                            // scope, so a method-local `let x` shadowing a top-level
+                            // function param `x` was misresolved to the outer
+                            // (constant) binding and mis-reported as
+                            // `constant_assignment` (issue #907 follow-up: runed
+                            // `persisted-state`, `use-search-params`). Mirrors the
+                            // typed `FunctionDeclaration` / `FunctionExpression`
+                            // registration above.
+                            if let Some(body_id) = body
+                                && let Some(start) = self.arena.get_js_node(body_id).start()
+                            {
+                                self.function_scope_map.insert(start, self.current_scope);
+                            }
                             // Declare function parameters
                             for param in self.arena.get_js_children(params) {
                                 self.declare_bindings_from_pattern_node(
@@ -2348,6 +2379,19 @@ impl<'a> ScopeBuilder<'a> {
                     // Create a new scope for the method (non-porous)
                     let old_scope = self.push_function_scope();
                     self.function_depth += 1;
+
+                    // Record method body start → scope index so the visitor phase
+                    // (`function_expression::visit`) resolves identifiers against
+                    // the method's own scope. Without this the method body inherited
+                    // the class/module scope, so a method-local `let x` that shadows
+                    // a top-level function param `x` was misresolved to the outer
+                    // (constant) binding and mis-reported as `constant_assignment`
+                    // (issue #907 follow-up: runed `persisted-state`). Mirrors the
+                    // `FunctionDeclaration` / `FunctionExpression` registration.
+                    if let Some(ref body) = method_def.value.body {
+                        let key = (self.current_script_offset + body.span.start as usize) as u32;
+                        self.function_scope_map.insert(key, self.current_scope);
+                    }
 
                     // Declare function parameters in the new scope
                     for param in &method_def.value.params.items {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -14,6 +14,215 @@ fn find_matching_paren_lexical(s: &str) -> Option<usize> {
     find_matching_bracket(s, 0, '(')
 }
 
+/// Replace every occurrence of `needle` in `haystack` with `replacement`, but
+/// only when `needle` is not immediately followed by a JS identifier character.
+///
+/// The class transforms wrap private-field reads by string-replacing
+/// `this.#name` with `$.get(this.#name)`. A bare `str::replace` matches a
+/// field name that is a *prefix* of a longer sibling — e.g. wrapping `#fps`
+/// corrupts `this.#fpsLimitOption` into `$.get(this.#fps)LimitOption` (issue
+/// #907). Anchoring on a trailing word boundary fixes that; `this.` already
+/// anchors the left edge, so only the right edge needs checking.
+fn replace_field_ref_word_boundary(haystack: &str, needle: &str, replacement: &str) -> String {
+    if needle.is_empty() || !haystack.contains(needle) {
+        return haystack.to_string();
+    }
+    let bytes = haystack.as_bytes();
+    let mut out = String::with_capacity(haystack.len());
+    let mut i = 0;
+    while i < haystack.len() {
+        if haystack[i..].starts_with(needle) {
+            let after = i + needle.len();
+            let next_is_ident = bytes
+                .get(after)
+                .is_some_and(|&b| b.is_ascii_alphanumeric() || b == b'_' || b == b'$');
+            if !next_is_ident {
+                out.push_str(replacement);
+                i = after;
+                continue;
+            }
+        }
+        let ch_len = haystack[i..].chars().next().unwrap().len_utf8();
+        out.push_str(&haystack[i..i + ch_len]);
+        i += ch_len;
+    }
+    out
+}
+
+/// Net change in bracket nesting (`()`, `[]`, `{}`) contributed by one source
+/// line, skipping brackets inside string / template literals and `//` / `/*`
+/// comments. Used to group physical lines into complete statements before the
+/// line-based constructor transform runs, so a multi-line RHS such as
+/// `this.#rect = {\n  x: 0,\n  …\n}` is transformed as one unit instead of the
+/// broken first-line fragment `this.#rect = {` (issue #907).
+fn net_bracket_depth(line: &str) -> i32 {
+    let bytes = line.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' | b'"' | b'`' => {
+                let quote = bytes[i];
+                i += 1;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'\\' => i += 2,
+                        b if b == quote => {
+                            i += 1;
+                            break;
+                        }
+                        _ => i += 1,
+                    }
+                }
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => break, // rest of line is a comment
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+                continue;
+            }
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            _ => {}
+        }
+        i += 1;
+    }
+    depth
+}
+
+/// Does `line` start a multi-line *assignment* — an assignment operator at
+/// bracket depth 0 followed by a right-hand side whose brackets are left open,
+/// e.g. `this.#rect = {`? Only such lines should absorb the following lines in
+/// the constructor transform.
+///
+/// A `$effect(() => {` / `if (cond) {` block must NOT be grouped: it has no
+/// top-level `=` (the `=>` lives inside `(...)`), so it stays line-by-line and
+/// the `this.#x = …` statements *inside* the block are still rewritten. Grouping
+/// them was the #907 regression on `class-state-constructor-closure`.
+fn is_multiline_assignment_start(line: &str) -> bool {
+    if net_bracket_depth(line) <= 0 {
+        return false;
+    }
+    let bytes = line.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' | b'"' | b'`' => {
+                let quote = bytes[i];
+                i += 1;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'\\' => i += 2,
+                        b if b == quote => {
+                            i += 1;
+                            break;
+                        }
+                        _ => i += 1,
+                    }
+                }
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => break,
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+                continue;
+            }
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b'=' if depth == 0 => {
+                let next = bytes.get(i + 1).copied();
+                let prev = if i > 0 {
+                    bytes.get(i - 1).copied()
+                } else {
+                    None
+                };
+                // A plain or compound (`+=`, `-=`, …) assignment `=`, not the
+                // `==`/`===`/`=>` operators nor the tail of `==`/`!=`/`<=`/`>=`.
+                if next != Some(b'=')
+                    && next != Some(b'>')
+                    && !matches!(prev, Some(b'=') | Some(b'!') | Some(b'<') | Some(b'>'))
+                {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Split a right-hand-side fragment at its first top-level `;`, returning
+/// `(value, trailing)` where `value` is the assignment expression (trimmed)
+/// and `trailing` is the remainder starting at the `;` (the statement
+/// terminator plus any trailing comment).
+///
+/// The line-based class transforms receive a single physical source line,
+/// which can carry a statement terminator and a trailing comment after the
+/// expression — e.g. `getter(); // set the initial value`. Naively trimming a
+/// trailing `;` (`.trim_end_matches(';')`) leaves the inner `;` and the
+/// comment glued onto the value, so `$.set(this.#x, <value>, true)` becomes the
+/// syntactically-broken `$.set(this.#x, getter(); // comment, true)` (issue
+/// #907). Scanning for the first top-level `;` — skipping brackets, strings,
+/// template literals and comments — extracts just `getter()` and preserves the
+/// `; // comment` tail so it can be re-appended after the rewritten statement.
+fn split_rhs_at_top_level_semi(s: &str) -> (&str, &str) {
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' | b'"' | b'`' => {
+                // Skip the string/template literal body (handles escapes).
+                let quote = bytes[i];
+                i += 1;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'\\' => i += 2,
+                        b if b == quote => {
+                            i += 1;
+                            break;
+                        }
+                        _ => i += 1,
+                    }
+                }
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => break, // line comment → tail
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+                continue;
+            }
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b';' if depth == 0 => return (s[..i].trim(), &s[i..]),
+            _ => {}
+        }
+        i += 1;
+    }
+    // No top-level `;` (and no preceding line comment) — the whole fragment is
+    // the value. If we stopped at a line comment, split there so the comment
+    // stays in the trailing slice.
+    if i < bytes.len() && bytes[i] == b'/' {
+        (s[..i].trim_end().trim_end_matches(';').trim(), &s[i..])
+    } else {
+        (s.trim().trim_end_matches(';').trim(), "")
+    }
+}
+
 /// Represents a class field with $state or $derived rune.
 #[derive(Debug, Clone)]
 pub(super) struct ClassStateField {
@@ -92,10 +301,9 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
         for f in all_fields {
             if f.is_private {
                 let private_ref = format!("this.#{}", f.private_backing_name);
-                if derived_expr.contains(&private_ref) {
-                    let getter = format!("$.get(this.#{})", f.private_backing_name);
-                    derived_expr = derived_expr.replace(&private_ref, &getter);
-                }
+                let getter = format!("$.get(this.#{})", f.private_backing_name);
+                derived_expr =
+                    replace_field_ref_word_boundary(&derived_expr, &private_ref, &getter);
             }
         }
         let wrapped_value = if derived_expr.trim_start().starts_with('{') {
@@ -119,10 +327,9 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
         for f in all_fields {
             if f.is_private {
                 let private_ref = format!("this.#{}", f.private_backing_name);
-                if derived_expr.contains(&private_ref) {
-                    let getter = format!("$.get(this.#{})", f.private_backing_name);
-                    derived_expr = derived_expr.replace(&private_ref, &getter);
-                }
+                let getter = format!("$.get(this.#{})", f.private_backing_name);
+                derived_expr =
+                    replace_field_ref_word_boundary(&derived_expr, &private_ref, &getter);
             }
         }
         let _ = writeln!(output, "\t\t{} = $.derived({});",
@@ -767,13 +974,44 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
                 let _ = writeln!(new_class_body, "\t\tconstructor({}) {{", constructor_params);
 
                 let mut ctor_body = String::new();
+                // Group physical lines into a single statement only when a line
+                // opens a multi-line assignment RHS (e.g. `this.#rect = {\n…\n}`),
+                // so it is rewritten as one unit instead of the broken fragment
+                // `this.#rect = {` (issue #907). Every other line — including
+                // block openers like `$effect(() => {` — is transformed
+                // individually so the `this.#x = …` statements inside the block
+                // are still rewritten.
+                let mut pending = String::new();
+                let mut depth: i32 = 0;
                 for line in constructor_content.lines() {
                     let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
+                    if pending.is_empty() {
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        if is_multiline_assignment_start(trimmed) {
+                            pending.push_str(trimmed);
+                            depth = net_bracket_depth(trimmed);
+                        } else {
+                            let transformed_line =
+                                transform_constructor_assignment(trimmed, &fields);
+                            let _ = writeln!(ctor_body, "\t\t\t{}", transformed_line);
+                        }
+                    } else {
+                        pending.push('\n');
+                        pending.push_str(trimmed);
+                        depth += net_bracket_depth(trimmed);
+                        if depth <= 0 {
+                            let transformed_line =
+                                transform_constructor_assignment(&pending, &fields);
+                            let _ = writeln!(ctor_body, "\t\t\t{}", transformed_line);
+                            pending.clear();
+                            depth = 0;
+                        }
                     }
-
-                    let transformed_line = transform_constructor_assignment(trimmed, &fields);
+                }
+                if !pending.is_empty() {
+                    let transformed_line = transform_constructor_assignment(&pending, &fields);
                     let _ = writeln!(ctor_body, "\t\t\t{}", transformed_line);
                 }
 
@@ -1607,16 +1845,17 @@ pub(super) fn transform_constructor_assignment(line: &str, fields: &[ClassStateF
 
                     if result.starts_with(&pattern) || result.starts_with(&pattern_nospace) {
                         let op_pos = result.find(assign_op).unwrap();
-                        let value = result[op_pos + assign_op.len()..]
-                            .trim()
-                            .trim_end_matches(';');
+                        let (value, trailing) =
+                            split_rhs_at_top_level_semi(&result[op_pos + assign_op.len()..]);
+                        let tail = if trailing.is_empty() { ";" } else { trailing };
                         // Use .v to access the value directly for logical operators
                         return format!(
-                            "$.set(this.#{}, this.#{}.v {} {}, true);",
+                            "$.set(this.#{}, this.#{}.v {} {}, true){}",
                             field.private_backing_name,
                             field.private_backing_name,
                             binary_op,
-                            value
+                            value,
+                            tail
                         );
                     }
                 }
@@ -1637,15 +1876,16 @@ pub(super) fn transform_constructor_assignment(line: &str, fields: &[ClassStateF
 
                     if result.starts_with(&pattern) || result.starts_with(&pattern_nospace) {
                         let op_pos = result.find(assign_op).unwrap();
-                        let value = result[op_pos + assign_op.len()..]
-                            .trim()
-                            .trim_end_matches(';');
+                        let (value, trailing) =
+                            split_rhs_at_top_level_semi(&result[op_pos + assign_op.len()..]);
+                        let tail = if trailing.is_empty() { ";" } else { trailing };
                         return format!(
-                            "$.set(this.#{}, $.get(this.#{}) {} {});",
+                            "$.set(this.#{}, $.get(this.#{}) {} {}){}",
                             field.private_backing_name,
                             field.private_backing_name,
                             binary_op,
-                            value
+                            value,
+                            tail
                         );
                     }
                 }
@@ -1674,18 +1914,26 @@ pub(super) fn transform_constructor_assignment(line: &str, fields: &[ClassStateF
 
                 if result.starts_with(&pattern) || result.starts_with(&pattern_nospace) {
                     let eq_pos = result.find('=').unwrap();
-                    let value = result[eq_pos + 1..].trim().trim_end_matches(';');
+                    // Extract only the RHS expression (stop at the top-level `;`),
+                    // keeping any trailing `; // comment` so it survives after the
+                    // rewritten `$.set(...)` instead of being glued inside the call
+                    // (issue #907).
+                    let (value, trailing) = split_rhs_at_top_level_semi(&result[eq_pos + 1..]);
+                    let tail = if trailing.is_empty() { ";" } else { trailing };
                     // Use private_backing_name for the output
                     // Add proxy flag (true) for $state fields when value could be an object
                     // This matches the official compiler's should_proxy() logic
                     let needs_proxy = field.rune_type == "$state" && expression_needs_proxy(value);
                     if needs_proxy {
                         return format!(
-                            "$.set(this.#{}, {}, true);",
-                            field.private_backing_name, value
+                            "$.set(this.#{}, {}, true){}",
+                            field.private_backing_name, value, tail
                         );
                     } else {
-                        return format!("$.set(this.#{}, {});", field.private_backing_name, value);
+                        return format!(
+                            "$.set(this.#{}, {}){}",
+                            field.private_backing_name, value, tail
+                        );
                     }
                 }
 
@@ -1710,6 +1958,19 @@ pub(super) fn transform_constructor_assignment(line: &str, fields: &[ClassStateF
 #[cfg(test)]
 mod tests {
     use super::transform_class_fields_client;
+
+    #[test]
+    fn is_multiline_assignment_start_classifies_constructor_lines() {
+        // A field assignment with an open RHS bracket — group it (#907).
+        assert!(super::is_multiline_assignment_start("this.#rect = {"));
+        // A block opener with no top-level `=` — keep it line-by-line so the
+        // `this.#x = …` statements inside the block are still rewritten (the
+        // #907 regression on class-state-constructor-closure).
+        assert!(!super::is_multiline_assignment_start("$effect(() => {"));
+        assert!(!super::is_multiline_assignment_start("if (cond) {"));
+        // A complete single-line assignment is not a multiline start.
+        assert!(!super::is_multiline_assignment_start("this.#count = 10;"));
+    }
 
     const COUNTER: &str = "\
 export class Counter {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
@@ -354,6 +354,12 @@ fn post_process_for_server(source: &str) -> String {
     // become stale snapshots and downstream code (`get isValid()` etc.)
     // breaks when the underlying state mutates between calls.
     let derived_names = collect_derived_names(&result);
+    // Private class fields backed by `$.derived(...)` are *callable* on the
+    // server (read via `this.#x()`); `$state` fields are plain values (read via
+    // `this.#x`, set via `this.#x = v`). Collect the derived ones so the
+    // `$.get`/`$.set` member rewrites below pick the right form per field
+    // instead of blindly treating every `this.#x` as callable (issue #907).
+    let derived_private_fields = collect_derived_private_fields(&result);
 
     let finder_effect_root = memmem::Finder::new(b"$.effect_root(");
     let finder_user_effect = memmem::Finder::new(b"$.user_effect(");
@@ -429,10 +435,16 @@ fn post_process_for_server(source: &str) -> String {
                 .to_string();
             // Check if it's a member expression (contains '.')
             if memchr::memchr(b'.', content.as_bytes()).is_some() {
-                // Member expression: keep as function call
-                let mut replacement = String::with_capacity(content.len() + 2);
-                replacement.push_str(&content);
-                replacement.push_str("()");
+                // A private `$state` class field is a plain value on the server
+                // (`this.#x`); only derived fields (and other member exprs) read
+                // as a call (`this.#x()`).
+                let plain_state_field = private_field_name(&content)
+                    .is_some_and(|name| !derived_private_fields.contains(name));
+                let replacement = if plain_state_field {
+                    content.clone()
+                } else {
+                    format!("{content}()")
+                };
                 result = splice!(result, pos, &replacement, call_start + content_end + 1);
             } else if derived_names.contains(content.as_str()) {
                 // Derived simple ident: callable on the server
@@ -466,12 +478,17 @@ fn post_process_for_server(source: &str) -> String {
                     rest
                 };
                 if memchr::memchr(b'.', signal.as_bytes()).is_some() {
-                    // Member expression: function call form
-                    let mut replacement = String::with_capacity(signal.len() + 1 + value.len() + 1);
-                    replacement.push_str(signal);
-                    replacement.push('(');
-                    replacement.push_str(value);
-                    replacement.push(')');
+                    // A private `$state` class field is a plain value on the
+                    // server, so its assignment stays `this.#x = v`; only derived
+                    // fields (and other member exprs) use the setter-call form
+                    // `this.#x(v)`.
+                    let plain_state_field = private_field_name(signal)
+                        .is_some_and(|name| !derived_private_fields.contains(name));
+                    let replacement = if plain_state_field {
+                        format!("{signal} = {value}")
+                    } else {
+                        format!("{signal}({value})")
+                    };
                     result = splice!(result, pos, &replacement, call_start + content_end + 1);
                 } else {
                     // Simple identifier: assignment form
@@ -628,6 +645,63 @@ fn collect_derived_names(source: &str) -> std::collections::HashSet<String> {
         }
     }
     names
+}
+
+/// Scan a client-style class body and return the set of *private* field names
+/// (without the leading `#`) declared as `#name = $.derived(...)` /
+/// `$.derived_by(...)` / `$.derived_safe_equal(...)`.
+///
+/// On the server a private `$derived` field is callable (`this.#name()`), while
+/// a `$state` field is a plain value (`this.#name` / `this.#name = v`). The
+/// `$.get`/`$.set` member rewrites in [`post_process_for_server`] use this set
+/// to pick the right form per field — previously every `this.#x` was treated as
+/// callable, which turned plain `$state` field assignments into the broken
+/// `this.#x(value)` call form (issue #907).
+fn collect_derived_private_fields(source: &str) -> std::collections::HashSet<String> {
+    let mut names = std::collections::HashSet::new();
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix('#') else {
+            continue;
+        };
+        let Some(eq) = rest.find('=') else {
+            continue;
+        };
+        let name = rest[..eq].trim();
+        if name.is_empty()
+            || !name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+        {
+            continue;
+        }
+        let value = rest[eq + 1..].trim_start();
+        if value.starts_with("$.derived(")
+            || value.starts_with("$.derived_by(")
+            || value.starts_with("$.derived_safe_equal(")
+        {
+            names.insert(name.to_string());
+        }
+    }
+    names
+}
+
+/// Extract the private-field name (without `#`) from a member expression like
+/// `this.#current` → `current`. Returns `None` when the expression is not a
+/// direct private-field access (e.g. `obj.prop`, or `this.#x.y` which accesses
+/// a property *of* the field rather than the field itself).
+fn private_field_name(member_expr: &str) -> Option<&str> {
+    let hash = member_expr.rfind(".#")?;
+    let rest = &member_expr[hash + 2..];
+    let end = rest
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$'))
+        .unwrap_or(rest.len());
+    if end == 0 || end != rest.len() {
+        // Empty name, or trailing access (`this.#x.y`) — not a bare field read.
+        None
+    } else {
+        Some(&rest[..end])
+    }
 }
 
 /// Find the byte position of the first comma at bracket-depth 0, skipping

--- a/crates/rsvelte_core/tests/compile_module_thread_safety.rs
+++ b/crates/rsvelte_core/tests/compile_module_thread_safety.rs
@@ -1,0 +1,125 @@
+//! Concurrency regression test for issue #907.
+//!
+//! Under Vite 8 + Rolldown, `compileModule` is invoked from a *reused* pool of
+//! OS threads, with each thread compiling many *different* `.svelte.js` rune
+//! modules in sequence. The reported symptom was non-deterministic spurious
+//! `[PARSE_ERROR]`s on valid modules (the failing file set changed between
+//! runs, and error messages varied — "Cannot assign to this expression",
+//! "Expected `,` or `)` but found `;`", "Unexpected token").
+//!
+//! A single-file 200x sequential loop and 8 worker_threads (each on the same
+//! file) did NOT reproduce it — the trigger is *thread reuse across different
+//! files*: stale per-thread transform state leaking from file A into file B.
+//!
+//! The corpus is the real `runed` package (the library named in the issue),
+//! vendored under `tests/fixtures_runed/`.
+
+use std::sync::Arc;
+use std::thread;
+
+use rsvelte_core::{GenerateMode, compile_module, compiler::ModuleCompileOptions};
+
+fn opts(filename: &str, dev: bool, ssr: bool) -> ModuleCompileOptions {
+    ModuleCompileOptions {
+        filename: Some(filename.to_string()),
+        generate: if ssr {
+            GenerateMode::Server
+        } else {
+            GenerateMode::Client
+        },
+        dev,
+        ..Default::default()
+    }
+}
+
+fn compile_one(src: &str, filename: &str, dev: bool, ssr: bool) -> Result<String, String> {
+    compile_module(src, opts(filename, dev, ssr))
+        .map(|r| r.js.code)
+        .map_err(|e| format!("{e:?}"))
+}
+
+/// Load every vendored `runed` rune module.
+fn corpus() -> Vec<(String, String)> {
+    let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures_runed");
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(dir).expect("read fixtures_runed dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) == Some("js") {
+            let name = path.file_name().unwrap().to_string_lossy().to_string();
+            let src = std::fs::read_to_string(&path).expect("read fixture");
+            out.push((name, src));
+        }
+    }
+    out.sort();
+    assert!(!out.is_empty(), "no runed fixtures found");
+    out
+}
+
+#[test]
+fn compile_module_is_thread_safe_under_reuse() {
+    let corpus = corpus();
+
+    // Single-threaded baseline: the correct output for every (file, dev, ssr).
+    // Modules that legitimately fail to compile (e.g. an unsupported pattern)
+    // are recorded as their error string — the concurrency invariant is that
+    // the *same* input always yields the *same* result, success or failure.
+    // (corpus index, dev, ssr) -> canonical compile result (Ok output / Err msg).
+    type BaselineEntry = ((usize, bool, bool), Result<String, String>);
+    let mut baseline: Vec<BaselineEntry> = Vec::new();
+    for (i, (filename, src)) in corpus.iter().enumerate() {
+        for &dev in &[false, true] {
+            for &ssr in &[false, true] {
+                let out = compile_one(src, filename, dev, ssr);
+                baseline.push(((i, dev, ssr), out));
+            }
+        }
+    }
+    let baseline = Arc::new(baseline);
+    let corpus = Arc::new(corpus);
+
+    let num_threads = 8;
+    let iterations_per_thread = 100;
+
+    let mut handles = Vec::new();
+    for t in 0..num_threads {
+        let baseline = Arc::clone(&baseline);
+        let corpus = Arc::clone(&corpus);
+        handles.push(thread::spawn(move || {
+            let mut mismatches: Vec<String> = Vec::new();
+            for iter in 0..iterations_per_thread {
+                // Walk the corpus in a thread/iteration-dependent order so that
+                // each pooled thread compiles *different* files back-to-back,
+                // mirroring Rolldown's interleaving.
+                for k in 0..baseline.len() {
+                    let idx = (k * 7 + t * 3 + iter) % baseline.len();
+                    let ((file_i, dev, ssr), ref expected) = baseline[idx];
+                    let (filename, src) = &corpus[file_i];
+                    let got = compile_one(src, filename, dev, ssr);
+                    if &got != expected {
+                        mismatches.push(format!(
+                            "NON-DETERMINISTIC RESULT file={filename} dev={dev} ssr={ssr} \
+                             thread={t} iter={iter}\n--- baseline ---\n{expected:?}\n\
+                             --- got ---\n{got:?}"
+                        ));
+                    }
+                    if mismatches.len() >= 3 {
+                        return mismatches; // fail fast with a few samples
+                    }
+                }
+            }
+            mismatches
+        }));
+    }
+
+    let mut all_failures: Vec<String> = Vec::new();
+    for h in handles {
+        all_failures.extend(h.join().expect("worker thread panicked"));
+    }
+
+    assert!(
+        all_failures.is_empty(),
+        "compile_module produced {} non-deterministic results under concurrent reuse:\n\n{}",
+        all_failures.len(),
+        all_failures.join("\n\n========================================\n\n")
+    );
+}

--- a/crates/rsvelte_core/tests/fixtures_runed/animation-frames.svelte.js
+++ b/crates/rsvelte_core/tests/fixtures_runed/animation-frames.svelte.js
@@ -1,0 +1,72 @@
+import { untrack } from "svelte";
+import { extract } from "../extract/index.js";
+import { defaultWindow } from "../../internal/configurable-globals.js";
+/**
+ * Wrapper over {@link https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame requestAnimationFrame},
+ * with controls for pausing and resuming the animation, reactive tracking and optional limiting of fps, and utilities.
+ */
+export class AnimationFrames {
+    #callback;
+    #fpsLimitOption = 0;
+    #fpsLimit = $derived(extract(this.#fpsLimitOption) ?? 0);
+    #previousTimestamp = null;
+    #frame = null;
+    #fps = $state(0);
+    #running = $state(false);
+    #window = defaultWindow;
+    constructor(callback, options = {}) {
+        if (options.window)
+            this.#window = options.window;
+        this.#fpsLimitOption = options.fpsLimit;
+        this.#callback = callback;
+        this.start = this.start.bind(this);
+        this.stop = this.stop.bind(this);
+        this.toggle = this.toggle.bind(this);
+        $effect(() => {
+            if (options.immediate ?? true) {
+                untrack(this.start);
+            }
+            return this.stop;
+        });
+    }
+    #loop(timestamp) {
+        if (!this.#running || !this.#window)
+            return;
+        if (this.#previousTimestamp === null) {
+            this.#previousTimestamp = timestamp;
+        }
+        const delta = timestamp - this.#previousTimestamp;
+        const fps = 1000 / delta;
+        if (this.#fpsLimit && fps > this.#fpsLimit) {
+            this.#frame = this.#window.requestAnimationFrame(this.#loop.bind(this));
+            return;
+        }
+        this.#fps = fps;
+        this.#previousTimestamp = timestamp;
+        this.#callback({ delta, timestamp });
+        this.#frame = this.#window.requestAnimationFrame(this.#loop.bind(this));
+    }
+    start() {
+        if (!this.#window)
+            return;
+        this.#running = true;
+        this.#previousTimestamp = 0;
+        this.#frame = this.#window.requestAnimationFrame(this.#loop.bind(this));
+    }
+    stop() {
+        if (!this.#frame || !this.#window)
+            return;
+        this.#running = false;
+        this.#window.cancelAnimationFrame(this.#frame);
+        this.#frame = null;
+    }
+    toggle() {
+        this.#running ? this.stop() : this.start();
+    }
+    get fps() {
+        return !this.#running ? 0 : this.#fps;
+    }
+    get running() {
+        return this.#running;
+    }
+}

--- a/crates/rsvelte_core/tests/fixtures_runed/debounced.svelte.js
+++ b/crates/rsvelte_core/tests/fixtures_runed/debounced.svelte.js
@@ -1,0 +1,78 @@
+import { useDebounce } from "../use-debounce/use-debounce.svelte.js";
+import { watch } from "../watch/watch.svelte.js";
+import { noop } from "../../internal/utils/function.js";
+/**
+ * A wrapper over {@link useDebounce} that creates a debounced state.
+ * It takes a "getter" function which returns the state you want to debounce.
+ * Every time this state changes a timer (re)starts, the length of which is
+ * configurable with the `wait` arg. When the timer ends the `current` value
+ * is updated.
+ *
+ * @see https://runed.dev/docs/utilities/debounced
+ *
+ * @example
+ *
+ * <script lang="ts">
+ *   import { Debounced } from "runed";
+ *
+ *   let search = $state("");
+ *   const debounced = new Debounced(() => search, 500);
+ * </script>
+ *
+ * <div>
+ *   <input bind:value={search} />
+ *   <p>You searched for: <b>{debounced.current}</b></p>
+ * </div>
+ */
+export class Debounced {
+    #current = $state();
+    #debounceFn;
+    /**
+     * @param getter A function that returns the state to watch.
+     * @param wait The length of time to wait in ms, defaults to 250.
+     */
+    constructor(getter, wait = 250) {
+        this.#current = getter(); // immediately set the initial value
+        this.cancel = this.cancel.bind(this);
+        this.setImmediately = this.setImmediately.bind(this);
+        this.updateImmediately = this.updateImmediately.bind(this);
+        this.#debounceFn = useDebounce(() => {
+            this.#current = getter();
+        }, wait);
+        watch(getter, () => {
+            this.#debounceFn().catch(noop);
+        });
+    }
+    // isn't the name "current" slightly misleading? it sounds like the latest, raw value
+    /**
+     * Get the debounced value.
+     */
+    get current() {
+        return this.#current;
+    }
+    /**
+     * Whether a timer is currently pending.
+     */
+    get pending() {
+        return this.#debounceFn.pending;
+    }
+    /**
+     * Cancel the latest timer.
+     */
+    cancel() {
+        this.#debounceFn.cancel();
+    }
+    /**
+     * Run the debounced function immediately.
+     */
+    updateImmediately() {
+        return this.#debounceFn.runScheduledNow();
+    }
+    /**
+     * Set the `current` value without waiting.
+     */
+    setImmediately(v) {
+        this.cancel();
+        this.#current = v;
+    }
+}

--- a/crates/rsvelte_core/tests/fixtures_runed/element-rect.svelte.js
+++ b/crates/rsvelte_core/tests/fixtures_runed/element-rect.svelte.js
@@ -1,0 +1,85 @@
+import { extract } from "../extract/extract.svelte.js";
+import { useMutationObserver } from "../use-mutation-observer/use-mutation-observer.svelte.js";
+import { useResizeObserver } from "../use-resize-observer/use-resize-observer.svelte.js";
+/**
+ * Returns a reactive value holding the size of `node`.
+ *
+ * Accepts an `options` object with the following properties:
+ * - `initialSize`: The initial size of the element. Defaults to `{ width: 0, height: 0 }`.
+ * - `box`: The box model to use. Can be either `"content-box"` or `"border-box"`. Defaults to `"border-box"`.
+ *
+ * @returns an object with `width` and `height` properties.
+ *
+ * @see {@link https://runed.dev/docs/utilities/element-size}
+ */
+export class ElementRect {
+    #rect = $state({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+    });
+    constructor(node, options = {}) {
+        this.#rect = {
+            width: options.initialRect?.width ?? 0,
+            height: options.initialRect?.height ?? 0,
+            x: options.initialRect?.x ?? 0,
+            y: options.initialRect?.y ?? 0,
+            top: options.initialRect?.top ?? 0,
+            right: options.initialRect?.right ?? 0,
+            bottom: options.initialRect?.bottom ?? 0,
+            left: options.initialRect?.left ?? 0,
+        };
+        const el = $derived(extract(node));
+        const update = () => {
+            if (!el)
+                return;
+            const rect = el.getBoundingClientRect();
+            this.#rect.width = rect.width;
+            this.#rect.height = rect.height;
+            this.#rect.x = rect.x;
+            this.#rect.y = rect.y;
+            this.#rect.top = rect.top;
+            this.#rect.right = rect.right;
+            this.#rect.bottom = rect.bottom;
+            this.#rect.left = rect.left;
+        };
+        useResizeObserver(() => el, update, { window: options.window });
+        $effect(update);
+        useMutationObserver(() => el, update, {
+            attributeFilter: ["style", "class"],
+            window: options.window,
+        });
+    }
+    get x() {
+        return this.#rect.x;
+    }
+    get y() {
+        return this.#rect.y;
+    }
+    get width() {
+        return this.#rect.width;
+    }
+    get height() {
+        return this.#rect.height;
+    }
+    get top() {
+        return this.#rect.top;
+    }
+    get right() {
+        return this.#rect.right;
+    }
+    get bottom() {
+        return this.#rect.bottom;
+    }
+    get left() {
+        return this.#rect.left;
+    }
+    get current() {
+        return this.#rect;
+    }
+}

--- a/crates/rsvelte_core/tests/fixtures_runed/persisted-state.svelte.js
+++ b/crates/rsvelte_core/tests/fixtures_runed/persisted-state.svelte.js
@@ -1,0 +1,194 @@
+import { defaultWindow } from "../../internal/configurable-globals.js";
+import { on } from "svelte/events";
+import { createSubscriber } from "svelte/reactivity";
+function getStorage(storageType, window) {
+    switch (storageType) {
+        case "local":
+            return window.localStorage;
+        case "session":
+            return window.sessionStorage;
+    }
+}
+function proxy(value, root, proxies, subscribe, update, serialize) {
+    if (value === null || typeof value !== "object") {
+        return value;
+    }
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== null && proto !== Object.prototype && !Array.isArray(value)) {
+        return value;
+    }
+    let p = proxies.get(value);
+    if (!p) {
+        p = new Proxy(value, {
+            get: (target, property) => {
+                subscribe?.();
+                return proxy(Reflect.get(target, property), root, proxies, subscribe, update, serialize);
+            },
+            set: (target, property, value) => {
+                update?.();
+                Reflect.set(target, property, value);
+                serialize(root);
+                return true;
+            },
+        });
+        proxies.set(value, p);
+    }
+    return p;
+}
+/**
+ * Creates reactive state that is persisted and synchronized across browser sessions and tabs using Web Storage.
+ * @param key The unique key used to store the state in the storage.
+ * @param initialValue The initial value of the state if not already present in the storage.
+ * @param options Configuration options including storage type, serializer for complex data types, and whether to sync state changes across tabs.
+ *
+ * @see {@link https://runed.dev/docs/utilities/persisted-state}
+ */
+export class PersistedState {
+    #current;
+    #key;
+    #serializer;
+    #storage;
+    #subscribe;
+    #update;
+    #proxies = new WeakMap();
+    #connected;
+    #storageCleanup;
+    #window;
+    #syncTabs;
+    #storageType;
+    constructor(key, initialValue, options = {}) {
+        const { storage: storageType = "local", serializer = { serialize: JSON.stringify, deserialize: JSON.parse }, syncTabs = true, connected = true, } = options;
+        const window = "window" in options ? options.window : defaultWindow; // window is not mockable to be undefined without this, because JavaScript will fill undefined with `= default`
+        this.#current = initialValue;
+        this.#key = key;
+        this.#serializer = serializer;
+        this.#connected = connected;
+        this.#window = window;
+        this.#syncTabs = syncTabs;
+        this.#storageType = storageType;
+        if (window === undefined)
+            return;
+        const storage = getStorage(storageType, window);
+        this.#storage = storage;
+        const existingValue = storage.getItem(key);
+        if (existingValue !== null) {
+            this.#current = this.#deserialize(existingValue);
+        }
+        else if (connected) {
+            this.#serialize(initialValue);
+        }
+        this.#setupStorageListener();
+    }
+    get current() {
+        this.#subscribe?.();
+        let root;
+        if (this.#connected) {
+            // when we're connected to storage, we use storage as the source of truth
+            const storageItem = this.#storage?.getItem(this.#key);
+            root = storageItem ? this.#deserialize(storageItem) : this.#current;
+        }
+        else {
+            // when we're not connected to storage, we use the current value in memory
+            root = this.#current;
+        }
+        return proxy(root, root, this.#proxies, this.#subscribe?.bind(this), this.#update?.bind(this), this.#serialize.bind(this));
+    }
+    set current(newValue) {
+        this.#serialize(newValue);
+        this.#update?.();
+    }
+    #handleStorageEvent = (event) => {
+        if (event.key !== this.#key || event.newValue === null)
+            return;
+        this.#current = this.#deserialize(event.newValue);
+        this.#update?.();
+    };
+    #deserialize(value) {
+        try {
+            return this.#serializer.deserialize(value);
+        }
+        catch (error) {
+            console.error(`Error when parsing "${value}" from persisted store "${this.#key}"`, error);
+            return;
+        }
+    }
+    #serialize(value) {
+        if (!this.#connected) {
+            // when we're not connected to storage, we only update the value in memory
+            this.#current = value;
+            return;
+        }
+        try {
+            if (value !== undefined) {
+                this.#storage?.setItem(this.#key, this.#serializer.serialize(value));
+            }
+        }
+        catch (error) {
+            console.error(`Error when writing value from persisted store "${this.#key}" to ${this.#storage}`, error);
+        }
+    }
+    #setupStorageListener() {
+        if (!this.#window || !this.#connected)
+            return;
+        this.#subscribe = createSubscriber((update) => {
+            this.#update = update;
+            this.#storageCleanup =
+                this.#connected && this.#syncTabs && this.#storageType === "local"
+                    ? on(this.#window, "storage", this.#handleStorageEvent)
+                    : undefined;
+            return () => {
+                this.#storageCleanup?.();
+                this.#storageCleanup = undefined;
+                this.#update = undefined;
+            };
+        });
+    }
+    #teardownStorageListener() {
+        this.#storageCleanup?.();
+        this.#storageCleanup = undefined;
+        this.#subscribe = undefined;
+    }
+    /**
+     * Returns whether the state is currently connected to storage.
+     *
+     * When `connected` is `false`, the state is not connected to storage and any
+     * changes to the state will not be persisted to storage and any changes to storage
+     * will not be reflected in the state.
+     */
+    get connected() {
+        return this.#connected;
+    }
+    /**
+     * Disconnects the state from storage, preventing updates to storage and stopping
+     * cross-tab synchronization. The current value in storage is removed.
+     *
+     * Call `.connect()` to re-enable storage persistence.
+     */
+    disconnect() {
+        if (!this.#connected)
+            return;
+        // capture current value from storage before removing
+        const storageItem = this.#storage?.getItem(this.#key);
+        if (storageItem) {
+            this.#current = this.#deserialize(storageItem);
+        }
+        this.#connected = false;
+        this.#storage?.removeItem(this.#key);
+        this.#teardownStorageListener();
+    }
+    /**
+     * Reconnects the state to storage, enabling storage persistence and cross-tab
+     * synchronization. The current value is immediately persisted to storage.
+     *
+     * **NOTE**: By default, the state is already connected to storage and this method is
+     * only useful to re-enable storage persistence after calling `disconnect()`
+     * or starting with `connected: false` as an option.
+     */
+    connect() {
+        if (this.#connected)
+            return;
+        this.#connected = true;
+        this.#serialize(this.#current);
+        this.#setupStorageListener();
+    }
+}

--- a/crates/rsvelte_core/tests/fixtures_runed/previous.svelte.js
+++ b/crates/rsvelte_core/tests/fixtures_runed/previous.svelte.js
@@ -1,0 +1,25 @@
+/**
+ * Holds the previous value of a getter.
+ *
+ * @see {@link https://runed.dev/docs/utilities/previous}
+ */
+export class Previous {
+    #previousCallback = () => undefined;
+    #previous = $derived.by(() => this.#previousCallback());
+    constructor(getter, initialValue) {
+        let actualPrevious = undefined;
+        if (initialValue !== undefined)
+            actualPrevious = initialValue;
+        this.#previousCallback = () => {
+            try {
+                return actualPrevious;
+            }
+            finally {
+                actualPrevious = getter();
+            }
+        };
+    }
+    get current() {
+        return this.#previous;
+    }
+}

--- a/crates/rsvelte_core/tests/fixtures_runed/throttled.svelte.js
+++ b/crates/rsvelte_core/tests/fixtures_runed/throttled.svelte.js
@@ -1,0 +1,26 @@
+import { useThrottle } from "../use-throttle/use-throttle.svelte.js";
+import { watch } from "../watch/watch.svelte.js";
+import { noop } from "../../internal/utils/function.js";
+export class Throttled {
+    #current = $state();
+    #throttleFn;
+    constructor(getter, wait = 250) {
+        this.#current = getter(); // Immediately set the initial value
+        this.#throttleFn = useThrottle(() => {
+            this.#current = getter();
+        }, wait);
+        watch(getter, () => {
+            this.#throttleFn()?.catch(noop);
+        });
+    }
+    get current() {
+        return this.#current;
+    }
+    cancel() {
+        this.#throttleFn.cancel();
+    }
+    setImmediately(v) {
+        this.cancel();
+        this.#current = v;
+    }
+}

--- a/crates/rsvelte_core/tests/module_class_field_state_codegen.rs
+++ b/crates/rsvelte_core/tests/module_class_field_state_codegen.rs
@@ -1,0 +1,225 @@
+//! Regression tests for issue #907.
+//!
+//! The reporter saw non-deterministic `[PARSE_ERROR]`s from `vite build` on
+//! valid `.svelte.js` rune modules (the `runed` library). The root cause was
+//! *not* thread-safety — it was three deterministic codegen bugs in the
+//! module class-field transform that emit syntactically-invalid JavaScript;
+//! Rolldown then parses that output in parallel and aborts on whichever bad
+//! file it reaches first, so the failing file set (and the parser error text)
+//! varied between runs while the per-file output was actually deterministic.
+//!
+//! The three bugs, each reproduced minimally below:
+//!   1. A trailing `// comment` on a private-field assignment was swallowed
+//!      into the rewritten `$.set(...)` RHS, producing
+//!      `$.set(this.#x, getter(); // comment, true)`.
+//!   2. Wrapping a private-field read used a prefix `str::replace`, so a field
+//!      whose name is a prefix of a sibling (`#fps` vs `#fpsLimitOption`) was
+//!      corrupted into `$.get(this.#fps)LimitOption`.
+//!   3. A multi-line object-literal RHS in a constructor was transformed
+//!      line-by-line, splitting `this.#x = {` from its body.
+//!
+//! Plus a server-specific bug: a `$state` private field assignment was lowered
+//! to the call form `this.#x(v)` instead of the plain `this.#x = v`.
+
+use rsvelte_core::{GenerateMode, compile_module, compiler::ModuleCompileOptions};
+
+fn compile(src: &str, ssr: bool) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("mod.svelte.js".to_string()),
+            generate: if ssr {
+                GenerateMode::Server
+            } else {
+                GenerateMode::Client
+            },
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile_module should succeed")
+    .js
+    .code
+}
+
+/// Lightweight structural validity check: scan the whole module (respecting
+/// strings, template literals and comments) and require every `()`, `[]` and
+/// `{}` to balance and nest correctly. The multi-line-split bug orphaned a
+/// `this.#rect = {` from its `}`, which shows up as an imbalance here; the
+/// comment-swallow and prefix-sibling bugs are pinned by the per-test
+/// substring assertions. A full parse would be stricter, but pulling a JS
+/// parser into the integration-test crate causes a `serde` version clash, and
+/// the real Vite + Rolldown build (which *does* re-parse the output) is the
+/// end-to-end guard.
+fn assert_structurally_valid(code: &str, ctx: &str) {
+    let bytes = code.as_bytes();
+    let mut stack: Vec<u8> = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' | b'"' | b'`' => {
+                let quote = bytes[i];
+                i += 1;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'\\' => i += 2,
+                        b if b == quote => {
+                            i += 1;
+                            break;
+                        }
+                        _ => i += 1,
+                    }
+                }
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+                continue;
+            }
+            b'(' => stack.push(b')'),
+            b'[' => stack.push(b']'),
+            b'{' => stack.push(b'}'),
+            c @ (b')' | b']' | b'}') => {
+                assert_eq!(
+                    stack.pop(),
+                    Some(c),
+                    "mismatched/unbalanced closing bracket ({ctx}):\n{code}"
+                );
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    assert!(stack.is_empty(), "unclosed brackets ({ctx}):\n{code}");
+}
+
+#[test]
+fn private_state_assignment_with_trailing_comment_client() {
+    let src = "export class C {
+  #current = $state();
+  constructor(getter) {
+    this.#current = getter(); // set the initial value
+  }
+}";
+    let out = compile(src, false);
+    // RHS is exactly `getter()`, not `getter(); // set the initial value`.
+    assert!(
+        out.contains("$.set(this.#current, getter(), true)"),
+        "client output should keep the RHS intact:\n{out}"
+    );
+    assert!(
+        !out.contains("getter(); // set the initial value, true)"),
+        "the trailing `;`/comment must not be swallowed into $.set(...):\n{out}"
+    );
+    assert_structurally_valid(&out, "client trailing comment");
+}
+
+#[test]
+fn private_state_assignment_with_trailing_comment_server() {
+    let src = "export class C {
+  #current = $state();
+  constructor(getter) {
+    this.#current = getter(); // set the initial value
+  }
+}";
+    let out = compile(src, true);
+    // On the server a `$state` field is a plain value: assignment stays plain.
+    assert!(
+        out.contains("this.#current = getter();"),
+        "server output should keep a plain assignment:\n{out}"
+    );
+    assert!(
+        !out.contains("this.#current(getter()"),
+        "server must not lower a $state assignment to a call form:\n{out}"
+    );
+    assert_structurally_valid(&out, "server trailing comment");
+}
+
+#[test]
+fn private_state_method_assignment_server_is_plain() {
+    let src = "export class C {
+  #current = $state(0);
+  set(v) { this.#current = v; }
+}";
+    let out = compile(src, true);
+    assert!(
+        out.contains("this.#current = v"),
+        "server $state field set must stay a plain assignment:\n{out}"
+    );
+    assert!(
+        !out.contains("this.#current(v)"),
+        "server must not emit the call form for a $state field:\n{out}"
+    );
+}
+
+#[test]
+fn derived_field_read_does_not_corrupt_prefix_sibling() {
+    // `#fps` (state) and `#fpsLimit` (derived) are prefixes of `#fpsLimitOption`
+    // (a plain field). Wrapping their reads must respect word boundaries.
+    let src = "export class C {
+  #fpsLimitOption = 0;
+  #fps = $state(0);
+  #fpsLimit = $derived(this.#fpsLimitOption + this.#fps);
+  get v() { return this.#fpsLimit; }
+}";
+    for ssr in [false, true] {
+        let out = compile(src, ssr);
+        assert!(
+            out.contains("this.#fpsLimitOption"),
+            "the sibling field name must survive intact (ssr={ssr}):\n{out}"
+        );
+        assert!(
+            !out.contains("#fps)Limit") && !out.contains("#fps()Limit"),
+            "wrapping #fps must not split #fpsLimitOption (ssr={ssr}):\n{out}"
+        );
+        assert_structurally_valid(&out, &format!("prefix-sibling ssr={ssr}"));
+    }
+}
+
+#[test]
+fn multiline_object_literal_constructor_assignment() {
+    let src = "export class C {
+  #rect = $state({ x: 0, y: 0 });
+  constructor() {
+    this.#rect = {
+      x: 1,
+      y: 2,
+    };
+  }
+}";
+    for ssr in [false, true] {
+        let out = compile(src, ssr);
+        // The object body must not be orphaned from the assignment target.
+        assert!(
+            !out.contains("$.set(this.#rect, {,") && !out.contains("this.#rect(\n"),
+            "the multi-line RHS must travel with the assignment (ssr={ssr}):\n{out}"
+        );
+        assert_structurally_valid(&out, &format!("multi-line object assignment ssr={ssr}"));
+    }
+}
+
+#[test]
+fn runed_persisted_state_compiles_without_false_constant_assignment() {
+    // `runed/persisted-state.svelte.js` has a top-level `proxy(value, root, …)`
+    // helper whose param `root` collides with a `let root` inside the class
+    // `get current()`. Before the class-method-body scope was registered for
+    // the visitor phase, the method-local `let root` reassignment was
+    // misresolved to the (constant) outer param and rejected with a spurious
+    // `constant_assignment` analysis error. It must compile cleanly now.
+    let src = include_str!("fixtures_runed/persisted-state.svelte.js");
+    for ssr in [false, true] {
+        // `compile` would panic on the spurious `constant_assignment` error.
+        let out = compile(src, ssr);
+        assert_structurally_valid(&out, &format!("runed persisted-state ssr={ssr}"));
+    }
+}


### PR DESCRIPTION
Closes #907.

## What was actually wrong

The report — non-deterministic `[PARSE_ERROR]`s from `vite build` on valid `runed` rune modules, suspected NAPI thread-safety — turned out **not** to be a concurrency bug. `compileModule` produces **deterministic but syntactically-invalid** JavaScript for several class-based rune-module shapes. The bad output only blows up when a bundler *re-parses* it, and Vite 8 + Rolldown compiles modules in parallel and aborts on the first bad file it reaches — so the failing file set and the parser error text varied between runs even though each file's output was identical every time.

I verified the compile path is genuinely thread-safe: an 8-thread stress test compiling the real `runed` corpus produces byte-identical output to the single-threaded baseline (added as a regression test). The "non-determinism" was purely Rolldown's parallel first-error reporting.

## The bugs (all deterministic)

Four codegen bugs in the line-based class-field transform:

1. **Trailing line comment swallowed into `$.set(...)`** — `this.#x = getter(); // note` → `$.set(this.#x, getter(); // note, true)` (unterminated call). RHS extraction now stops at the top-level `;` and re-appends the `; // comment` tail.
2. **Prefix-sibling field corruption** — a bare `str::replace` wrapping `#fps` also rewrote the sibling `#fpsLimitOption` into `$.get(this.#fps)LimitOption`. Reads are now replaced only at a trailing word boundary.
3. **Multi-line constructor RHS split** — `this.#rect = {\n …\n }` was transformed line-by-line, orphaning `this.#rect = {`. Constructor statements are now grouped by bracket depth first.
4. **Server `$state` field lowered to a call** — on SSR a `$state` private field is a plain value, but `this.#x = v` became `this.#x(v)` (and reads `this.#x()`). `post_process_for_server` now distinguishes `$.derived(...)`-backed fields (callable) from `$state` fields (plain).

Plus a spurious `constant_assignment` error (`runed/persisted-state`): a class-method body was not registered in the scope map, so a method-local `let x` shadowing a top-level function param `x` was misresolved to the outer (constant) binding. Class-method bodies are now registered like function bodies.

## Verification

- New `module_class_field_state_codegen` regression tests (6) + `compile_module_thread_safety` stress test — pass.
- Full `compatibility_report` suite — unchanged (no regressions).
- A real Vite 8 + Rolldown SSR build importing all of `runed` now succeeds 12/12 runs (was failing every run with the varying `[PARSE_ERROR]`s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)