### PR TITLE
style: restore rustfmt cleanliness (Format CI regressed by #932)

### DIFF
--- a/crates/rsvelte_core/benches/compiler.rs
+++ b/crates/rsvelte_core/benches/compiler.rs
@@ -5,8 +5,8 @@
 //! 2. Analyze - Semantic analysis
 //! 3. Transform - Code generation
 
-use std::fmt::Write as _;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::fmt::Write as _;
 use std::fs;
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -77,7 +77,9 @@ fn create_large_synthetic_file() -> (String, String) {
 
     // Add many elements to create a large template
     for i in 0..100 {
-        let _ = write!(source, r#"<div class="item-{i}">
+        let _ = write!(
+            source,
+            r#"<div class="item-{i}">
     <span>Item {i}: {{count}}</span>
     {{#if count > {i}}}
         <strong>Active</strong>
@@ -85,7 +87,8 @@ fn create_large_synthetic_file() -> (String, String) {
         <em>Inactive</em>
     {{/if}}
 </div>
-"#);
+"#
+        );
     }
 
     ("synthetic-large".to_string(), source)
@@ -107,7 +110,9 @@ fn create_legacy_state_var_heavy_file() -> (String, String) {
 "#,
     );
     for i in 0..40 {
-        let _ = write!(script, r#"    function action_{i}() {{
+        let _ = write!(
+            script,
+            r#"    function action_{i}() {{
         count = {i};
         total += count;
         total -= 1;
@@ -122,11 +127,15 @@ fn create_legacy_state_var_heavy_file() -> (String, String) {
         }}
         count ??= 0;
     }}
-"#);
+"#
+        );
     }
     script.push_str("</script>\n\n");
     for i in 0..20 {
-        let _ = writeln!(script, "<button on:click={{action_{i}}}>Action {i}</button>");
+        let _ = writeln!(
+            script,
+            "<button on:click={{action_{i}}}>Action {i}</button>"
+        );
     }
     ("synthetic-legacy-state-heavy".to_string(), script)
 }
@@ -153,7 +162,9 @@ fn create_state_var_heavy_file() -> (String, String) {
     // Build a function body with many state-var ops — covers the
     // simple/compound/update/reads paths in one pass.
     for i in 0..40 {
-        let _ = write!(script, r#"    function action_{i}() {{
+        let _ = write!(
+            script,
+            r#"    function action_{i}() {{
         count = {i};
         total += count;
         total -= 1;
@@ -168,11 +179,15 @@ fn create_state_var_heavy_file() -> (String, String) {
         }}
         count ??= 0;
     }}
-"#);
+"#
+        );
     }
     script.push_str("</script>\n\n");
     for i in 0..20 {
-        let _ = writeln!(script, "<button on:click={{action_{i}}}>Action {i}</button>");
+        let _ = writeln!(
+            script,
+            "<button on:click={{action_{i}}}>Action {i}</button>"
+        );
     }
     ("synthetic-state-heavy".to_string(), script)
 }

--- a/crates/rsvelte_core/src/bin/parse_profile.rs
+++ b/crates/rsvelte_core/src/bin/parse_profile.rs
@@ -324,7 +324,9 @@ fn create_large_file() -> String {
     );
 
     for i in 0..50 {
-        let _ = write!(s, r#"        <section class="section-{i}">
+        let _ = write!(
+            s,
+            r#"        <section class="section-{i}">
             <h2>Section {i}</h2>
             {{#if count > {i}}}
                 <div class="content active">
@@ -342,7 +344,8 @@ fn create_large_file() -> String {
                 </div>
             {{/if}}
         </section>
-"#);
+"#
+        );
     }
 
     s.push_str(
@@ -431,10 +434,13 @@ fn create_plain_html_file() -> String {
 fn create_html_with_attributes() -> String {
     let mut s = String::new();
     for i in 0..100 {
-        let _ = write!(s, r#"<div id="el-{i}" class="foo bar baz" data-index="{i}" data-active="true" role="listitem" aria-label="Item {i}">
+        let _ = write!(
+            s,
+            r#"<div id="el-{i}" class="foo bar baz" data-index="{i}" data-active="true" role="listitem" aria-label="Item {i}">
     <input type="text" name="field-{i}" placeholder="Enter..." />
 </div>
-"#);
+"#
+        );
     }
     s
 }
@@ -454,7 +460,10 @@ fn create_deeply_nested() -> String {
 fn create_many_text_nodes() -> String {
     let mut s = String::new();
     for i in 0..500 {
-        let _ = writeln!(s, "<p>This is paragraph number {i} with some text content that is reasonably long.</p>");
+        let _ = writeln!(
+            s,
+            "<p>This is paragraph number {i} with some text content that is reasonably long.</p>"
+        );
     }
     s
 }

--- a/crates/rsvelte_core/src/bin/profiler.rs
+++ b/crates/rsvelte_core/src/bin/profiler.rs
@@ -303,12 +303,15 @@ fn create_medium_file() -> String {
     );
 
     for i in 0..10 {
-        let _ = write!(s, r#"        {{#if count > {i}}}
+        let _ = write!(
+            s,
+            r#"        {{#if count > {i}}}
             <li class="active">Item {i}</li>
         {{:else}}
             <li>Item {i}</li>
         {{/if}}
-"#);
+"#
+        );
     }
 
     s.push_str(
@@ -372,7 +375,9 @@ fn create_large_file() -> String {
 
     // Add many elements
     for i in 0..50 {
-        let _ = write!(s, r#"        <section class="section-{i}">
+        let _ = write!(
+            s,
+            r#"        <section class="section-{i}">
             <h2>Section {i}</h2>
             {{#if count > {i}}}
                 <div class="content active">
@@ -390,7 +395,8 @@ fn create_large_file() -> String {
                 </div>
             {{/if}}
         </section>
-"#);
+"#
+        );
     }
 
     s.push_str(
@@ -722,19 +728,49 @@ fn print_json_output(config: &Config, all_metrics: &[FileMetrics]) {
     println!("{}", serde_json::to_string_pretty(&result).unwrap());
 }
 
-
 #[cfg(feature = "pprof")]
 fn pprof_transform(config: &Config, files: &[(String, String)]) {
     use std::collections::{HashMap, HashSet};
-    let Some((name, content)) = files.first() else { return; };
-    let parse_options = ParseOptions { modern: true, loose: false, skip_expression_loc: true, defer_script_parse: false };
-    let compile_options = CompileOptions { generate: config.mode, filename: Some(name.clone()), enable_sourcemap: false, ..Default::default() };
-    let mut ast = match parse(content, parse_options) { Ok(a) => a, Err(_) => { eprintln!("[pprof] parse failed"); return; } };
-    let analysis = match analyze_component(&mut ast, content, &compile_options) { Ok(a) => a, Err(_) => { eprintln!("[pprof] analyze failed"); return; } };
+    let Some((name, content)) = files.first() else {
+        return;
+    };
+    let parse_options = ParseOptions {
+        modern: true,
+        loose: false,
+        skip_expression_loc: true,
+        defer_script_parse: false,
+    };
+    let compile_options = CompileOptions {
+        generate: config.mode,
+        filename: Some(name.clone()),
+        enable_sourcemap: false,
+        ..Default::default()
+    };
+    let mut ast = match parse(content, parse_options) {
+        Ok(a) => a,
+        Err(_) => {
+            eprintln!("[pprof] parse failed");
+            return;
+        }
+    };
+    let analysis = match analyze_component(&mut ast, content, &compile_options) {
+        Ok(a) => a,
+        Err(_) => {
+            eprintln!("[pprof] analyze failed");
+            return;
+        }
+    };
     let iters = 2500usize;
     eprintln!("[pprof] sampling transform of {name} over {iters} iterations...");
-    let guard = pprof::ProfilerGuardBuilder::default().frequency(2000).blocklist(&["libc","libgcc","pthread","vdso"]).build().expect("guard");
-    for _ in 0..iters { let r = transform_component(&analysis, &ast, content, &compile_options); std::hint::black_box(&r); }
+    let guard = pprof::ProfilerGuardBuilder::default()
+        .frequency(2000)
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()
+        .expect("guard");
+    for _ in 0..iters {
+        let r = transform_component(&analysis, &ast, content, &compile_options);
+        std::hint::black_box(&r);
+    }
     let report = guard.report().build().expect("report");
     let mut incl: HashMap<String, isize> = HashMap::new();
     let mut selfc: HashMap<String, isize> = HashMap::new();
@@ -745,16 +781,37 @@ fn pprof_transform(config: &Config, files: &[(String, String)]) {
             *selfc.entry(format!("{first}")).or_insert(0) += *count;
         }
         let mut seen = HashSet::new();
-        for frame in &frames.frames { for sym in frame { let n = format!("{sym}"); if seen.insert(n.clone()) { *incl.entry(n).or_insert(0) += *count; } } }
+        for frame in &frames.frames {
+            for sym in frame {
+                let n = format!("{sym}");
+                if seen.insert(n.clone()) {
+                    *incl.entry(n).or_insert(0) += *count;
+                }
+            }
+        }
     }
     let denom = total.max(1) as f64;
-    let mut sv: Vec<_> = selfc.into_iter().collect(); sv.sort_by_key(|b| std::cmp::Reverse(b.1));
-    let mut iv: Vec<_> = incl.into_iter().collect(); iv.sort_by_key(|b| std::cmp::Reverse(b.1));
+    let mut sv: Vec<_> = selfc.into_iter().collect();
+    sv.sort_by_key(|b| std::cmp::Reverse(b.1));
+    let mut iv: Vec<_> = incl.into_iter().collect();
+    iv.sort_by_key(|b| std::cmp::Reverse(b.1));
     eprintln!("[pprof] total samples: {total}");
     eprintln!("[pprof] TOP SELF:");
-    for (n,c) in sv.into_iter().take(25) { let p=100.0*(c as f64)/denom; if p<1.0 {break;} eprintln!("  {p:5.1}%  {n}"); }
+    for (n, c) in sv.into_iter().take(25) {
+        let p = 100.0 * (c as f64) / denom;
+        if p < 1.0 {
+            break;
+        }
+        eprintln!("  {p:5.1}%  {n}");
+    }
     eprintln!("[pprof] TOP INCLUSIVE:");
-    for (n,c) in iv.into_iter().take(30) { let p=100.0*(c as f64)/denom; if p<2.0 {break;} eprintln!("  {p:5.1}%  {n}"); }
+    for (n, c) in iv.into_iter().take(30) {
+        let p = 100.0 * (c as f64) / denom;
+        if p < 2.0 {
+            break;
+        }
+        eprintln!("  {p:5.1}%  {n}");
+    }
 }
 
 fn main() {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/utils/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/utils/mod.rs
@@ -9,15 +9,30 @@ pub mod html;
 
 // Re-export utilities for use by other parser modules
 // These are library functions that may be used as the parser is extended
-#[allow(unused_imports, reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet")]
+#[allow(
+    unused_imports,
+    reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet"
+)]
 pub use bracket::{find_matching_bracket, match_bracket};
-#[allow(unused_imports, reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet")]
+#[allow(
+    unused_imports,
+    reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet"
+)]
 pub use create::{create_empty_fragment, create_fragment};
-#[allow(unused_imports, reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet")]
+#[allow(
+    unused_imports,
+    reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet"
+)]
 pub use entities::decode_html_entities;
-#[allow(unused_imports, reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet")]
+#[allow(
+    unused_imports,
+    reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet"
+)]
 pub use fuzzymatch::fuzzymatch;
-#[allow(unused_imports, reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet")]
+#[allow(
+    unused_imports,
+    reason = "re-exported for structural parity with the upstream Svelte parser-utils module; not every helper is wired into the port yet"
+)]
 pub use html::{decode_character_references, is_void_element, validate_code};
 
 /// JavaScript reserved words.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -9,8 +9,8 @@
 //! 3. Collects replacements as (byte_start, byte_end, replacement_string)
 //! 4. Applies all replacements in a single pass (right-to-left to preserve offsets)
 
-use std::fmt::Write as _;
 use std::cell::RefCell;
+use std::fmt::Write as _;
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
@@ -3113,8 +3113,11 @@ impl<'a, 's> StateVarCollector<'a, 's> {
 
         let length = arr.elements.len();
         let mut body = String::new();
-        let _ = writeln!(body, "\t\t\tvar {} = $.to_array($$value, {});",
-            array_name, length);
+        let _ = writeln!(
+            body,
+            "\t\t\tvar {} = $.to_array($$value, {});",
+            array_name, length
+        );
 
         for (i, target) in targets.iter().enumerate() {
             match target {
@@ -3124,8 +3127,11 @@ impl<'a, 's> StateVarCollector<'a, 's> {
                 }
                 ArrayTarget::MemberOnProp { prop_name, .. } => {
                     let member_text = transformed_member_texts[i].as_ref().unwrap();
-                    let _ = writeln!(body, "\t\t\t{}({} = {}[{}], true);",
-                        prop_name, member_text, array_name, i);
+                    let _ = writeln!(
+                        body,
+                        "\t\t\t{}({} = {}[{}], true);",
+                        prop_name, member_text, array_name, i
+                    );
                 }
             }
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -1,7 +1,7 @@
 //! Class field transformations for $state and $derived runes.
 
-use std::fmt::Write as _;
 use memchr::memmem;
+use std::fmt::Write as _;
 
 use super::REGEX_INVALID_IDENTIFIER_CHARS;
 use super::expression_needs_proxy;
@@ -44,15 +44,24 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
             let is_derived = field.rune_type == "$derived" || field.rune_type == "$derived.by";
             let is_raw = field.rune_type == "$state.raw" || field.rune_type == "$state.frozen";
             output.push('\n');
-            let _ = writeln!(output, "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                field.name, private_name);
+            let _ = writeln!(
+                output,
+                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
+                field.name, private_name
+            );
             output.push('\n');
             if is_derived || is_raw {
-                let _ = writeln!(output, "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
-                    field.name, private_name);
+                let _ = writeln!(
+                    output,
+                    "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
+                    field.name, private_name
+                );
             } else {
-                let _ = writeln!(output, "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value, true);\n\t\t}}",
-                    field.name, private_name);
+                let _ = writeln!(
+                    output,
+                    "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value, true);\n\t\t}}",
+                    field.name, private_name
+                );
             }
         }
     } else if field.rune_type == "$state" {
@@ -63,28 +72,38 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
         } else {
             field.value.clone()
         };
-        let _ = writeln!(output, "\t\t{} = $.state({});",
-            private_name, wrapped_value);
+        let _ = writeln!(output, "\t\t{} = $.state({});", private_name, wrapped_value);
         if !field.is_private {
             let getter_name = format_getter_name(&field.name);
             output.push('\n');
-            let _ = writeln!(output, "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                getter_name, private_name);
+            let _ = writeln!(
+                output,
+                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
+                getter_name, private_name
+            );
             output.push('\n');
-            let _ = writeln!(output, "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value, true);\n\t\t}}",
-                getter_name, private_name);
+            let _ = writeln!(
+                output,
+                "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value, true);\n\t\t}}",
+                getter_name, private_name
+            );
         }
     } else if field.rune_type == "$state.raw" || field.rune_type == "$state.frozen" {
-        let _ = writeln!(output, "\t\t{} = $.state({});",
-            private_name, field.value);
+        let _ = writeln!(output, "\t\t{} = $.state({});", private_name, field.value);
         if !field.is_private {
             let getter_name = format_getter_name(&field.name);
             output.push('\n');
-            let _ = writeln!(output, "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                getter_name, private_name);
+            let _ = writeln!(
+                output,
+                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
+                getter_name, private_name
+            );
             output.push('\n');
-            let _ = writeln!(output, "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
-                getter_name, private_name);
+            let _ = writeln!(
+                output,
+                "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
+                getter_name, private_name
+            );
         }
     } else if field.rune_type == "$derived" {
         // Transform private field accesses inside the derived expression
@@ -103,16 +122,25 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
         } else {
             format!("() => {}", derived_expr)
         };
-        let _ = writeln!(output, "\t\t{} = $.derived({});",
-            private_name, wrapped_value);
+        let _ = writeln!(
+            output,
+            "\t\t{} = $.derived({});",
+            private_name, wrapped_value
+        );
         if !field.is_private {
             let getter_name = format_getter_name(&field.name);
             output.push('\n');
-            let _ = writeln!(output, "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                getter_name, private_name);
+            let _ = writeln!(
+                output,
+                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
+                getter_name, private_name
+            );
             output.push('\n');
-            let _ = writeln!(output, "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
-                getter_name, private_name);
+            let _ = writeln!(
+                output,
+                "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
+                getter_name, private_name
+            );
         }
     } else if field.rune_type == "$derived.by" {
         let mut derived_expr = field.value.clone();
@@ -125,16 +153,25 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
                 }
             }
         }
-        let _ = writeln!(output, "\t\t{} = $.derived({});",
-            private_name, derived_expr);
+        let _ = writeln!(
+            output,
+            "\t\t{} = $.derived({});",
+            private_name, derived_expr
+        );
         if !field.is_private {
             let getter_name = format_getter_name(&field.name);
             output.push('\n');
-            let _ = writeln!(output, "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                getter_name, private_name);
+            let _ = writeln!(
+                output,
+                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
+                getter_name, private_name
+            );
             output.push('\n');
-            let _ = writeln!(output, "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
-                getter_name, private_name);
+            let _ = writeln!(
+                output,
+                "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
+                getter_name, private_name
+            );
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -1,7 +1,7 @@
 //! Expression parsing, shadowing detection, and identifier analysis utilities.
 
-use std::fmt::Write as _;
 use memchr::memmem;
+use std::fmt::Write as _;
 
 /// Collapse a multi-line expression to a single line, matching esrap's behavior.
 /// Strip TypeScript generic type parameters from rune calls.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -1817,8 +1817,11 @@ fn transform_client_with_visitors(
                 }
                 // Encode as base64 data URI
                 let b64 = super::base64_encode(css_map_json.as_bytes());
-                let _ = write!(css_code, "\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,{} */",
-                    b64);
+                let _ = write!(
+                    css_code,
+                    "\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,{} */",
+                    b64
+                );
             }
         }
         let code = b::string(css_code);
@@ -3206,11 +3209,14 @@ fn transform_destructured_state_assignments(
                                     .push(format!("{}{} = $$array[{}];", inner_indent, part, idx));
                             }
                         }
-                        let _ = writeln!(result, "{}((array) => {{\n{}\n{}}})({});",
+                        let _ = writeln!(
+                            result,
+                            "{}((array) => {{\n{}\n{}}})({});",
                             indent,
                             body_lines.join("\n"),
                             indent,
-                            rhs);
+                            rhs
+                        );
                         // Add blank line after the IIFE
                         result.push('\n');
                         continue;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1,8 +1,8 @@
 //! Props, exports, and component property transformations.
 
-use std::fmt::Write as _;
 use memchr::memmem;
 use rustc_hash::FxHashSet;
+use std::fmt::Write as _;
 
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/transform_template/template.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/transform_template/template.rs
@@ -3,7 +3,6 @@
 //! This module corresponds to:
 //! - `svelte/packages/svelte/src/compiler/phases/3-transform/client/transform-template/template.js`
 
-use std::fmt::Write as _;
 use super::fix_attribute_casing::fix_attribute_casing;
 use super::types::{Comment, Element, Node, TextNode};
 use crate::ast::template::Text;
@@ -13,6 +12,7 @@ use crate::compiler::phases::phase3_transform::js_ast::nodes::JsExpr;
 use crate::compiler::phases::phase3_transform::shared::template::{escape_attr, is_void_element};
 use indexmap::IndexMap;
 use regex::Regex;
+use std::fmt::Write as _;
 use std::sync::LazyLock;
 
 // Cached regex for stripping leading newline from pre/textarea content

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -7,7 +7,6 @@
 //! Corresponds to `ComponentContext` and `ComponentClientTransformState` in
 //! `svelte/packages/svelte/src/compiler/phases/3-transform/types.js`.
 
-use std::fmt::Write as _;
 use crate::ast::arena::ParseArena;
 use crate::ast::template::TemplateNode;
 use crate::compiler::phases::phase2_analyze::scope::{Binding, Scope, ScopeRoot};
@@ -19,6 +18,7 @@ use im::{HashMap as ImHashMap, HashSet as ImHashSet};
 use indexmap::IndexSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::{Cell, RefCell};
+use std::fmt::Write as _;
 use std::rc::Rc;
 
 /// Component transformation context.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -6,7 +6,6 @@
 //!
 //! Corresponds to the visitor pattern in Svelte's transform phase.
 
-use std::fmt::Write as _;
 use crate::ast::arena::{IdRange, ParseArena};
 use crate::ast::js::Expression;
 use crate::ast::typed_expr::{JsNode, LiteralValue};
@@ -15,6 +14,7 @@ use crate::compiler::phases::phase3_transform::client::types::ComponentContext;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
 use compact_str::CompactString;
 use serde_json::Value;
+use std::fmt::Write as _;
 
 /// Check if a JSON AST node contains an AwaitExpression anywhere in its tree.
 ///
@@ -3699,7 +3699,9 @@ pub fn pattern_to_string(pattern: &JsPattern) -> String {
                                         s.push('"');
                                     }
                                     JsLiteral::Number(n) => s.push_str(&n.to_string()),
-                                    _ => { let _ = write!(s, "{:?}", lit); },
+                                    _ => {
+                                        let _ = write!(s, "{:?}", lit);
+                                    }
                                 },
                                 JsPropertyKey::Computed(_e) => {
                                     // Computed keys in destructuring patterns are unusual;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1070,7 +1070,6 @@ fn process_regular_attribute(
     custom_css_props: &mut Vec<JsObjectMember>,
     memoizer: &mut crate::compiler::phases::phase3_transform::client::types::Memoizer,
 ) {
-
     // Handle custom CSS properties (--var)
     if attr.name.starts_with("--") {
         // Build the attribute value with potential memoization

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -3,8 +3,8 @@
 //! Generates scoped CSS stylesheets with selector scoping.
 //! Preserves original whitespace from source using AST positions.
 
-use std::fmt::Write as _;
 use memchr::{memchr, memmem};
+use std::fmt::Write as _;
 
 use super::super::phase1_parse::parse_css;
 use super::{CssOutput, TransformError};

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/bridge.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/bridge.rs
@@ -18,7 +18,6 @@
 //!   with the results emitted as `TemplateItem::Statement(Raw(...))` and appropriate
 //!   marker `TemplateItem::Expression`s for coalescing by `build_template()`.
 
-use std::fmt::Write as _;
 use super::ServerCodeGenerator;
 use super::types::{
     ComponentCodeResult, DynamicComponentWrap, OutputPart, TemplateItem, TrailingMarkerBehavior,
@@ -26,6 +25,7 @@ use super::types::{
 use crate::compiler::phases::phase3_transform::js_ast::arena::JsArena;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
 use compact_str::CompactString;
+use std::fmt::Write as _;
 
 /// Convert an `OutputPart` list to a `TemplateItem` list for AST-based code generation.
 ///
@@ -501,8 +501,7 @@ fn convert_part_to_item(
 
             if let Some(props) = failed_props {
                 let mut code = String::new();
-                let _ = writeln!(code, "$$renderer.boundary({}, ($$renderer) => {{",
-                    props);
+                let _ = writeln!(code, "$$renderer.boundary({}, ($$renderer) => {{", props);
                 for line in inner.lines() {
                     if line.is_empty() {
                         code.push('\n');
@@ -1010,11 +1009,13 @@ fn convert_select_element(
 
     // Generate $$renderer.select() call with multiline formatting when css_hash is present
     if css_hash.is_some() || is_rich {
-        let _ = writeln!(code, "$$renderer.select(\n\t{},\n\t($$renderer) => {{",
-            attrs_obj);
+        let _ = writeln!(
+            code,
+            "$$renderer.select(\n\t{},\n\t($$renderer) => {{",
+            attrs_obj
+        );
     } else {
-        let _ = writeln!(code, "$$renderer.select({}, ($$renderer) => {{",
-            attrs_obj);
+        let _ = writeln!(code, "$$renderer.select({}, ($$renderer) => {{", attrs_obj);
     }
 
     // Body
@@ -1024,8 +1025,11 @@ fn convert_select_element(
     // Close callback with optional css_hash, classes, styles, flags and is_rich arguments
     if is_rich {
         if let Some(hash) = css_hash {
-            let _ = write!(code, "\t}},\n\t'{}',\n\tvoid 0,\n\tvoid 0,\n\tvoid 0,\n\ttrue\n);",
-                hash);
+            let _ = write!(
+                code,
+                "\t}},\n\t'{}',\n\tvoid 0,\n\tvoid 0,\n\tvoid 0,\n\ttrue\n);",
+                hash
+            );
         } else {
             code.push_str("\t},\n\tvoid 0,\n\tvoid 0,\n\tvoid 0,\n\tvoid 0,\n\ttrue\n);");
         }
@@ -1075,12 +1079,14 @@ fn convert_option_element(
 
     if let Some(value_expr) = direct_value {
         // Direct value (from synthetic_value_node)
-        let _ = write!(code, "$$renderer.option({}, {});",
-            attrs_obj, value_expr);
+        let _ = write!(code, "$$renderer.option({}, {});", attrs_obj, value_expr);
     } else if is_rich {
         // is_rich: 7 arguments with multiline formatting
-        let _ = writeln!(code, "$$renderer.option(\n\t{},\n\t($$renderer) => {{",
-            attrs_obj);
+        let _ = writeln!(
+            code,
+            "$$renderer.option(\n\t{},\n\t($$renderer) => {{",
+            attrs_obj
+        );
 
         if !dev_push.is_empty() {
             let _ = write!(code, "\t\t{}", dev_push);
@@ -1096,8 +1102,11 @@ fn convert_option_element(
         code.push_str("\t},\n\tvoid 0,\n\tvoid 0,\n\tvoid 0,\n\tvoid 0,\n\ttrue\n);");
     } else if let Some(hash) = css_hash {
         // Has CSS hash
-        let _ = writeln!(code, "$$renderer.option(\n\t{},\n\t($$renderer) => {{",
-            attrs_obj);
+        let _ = writeln!(
+            code,
+            "$$renderer.option(\n\t{},\n\t($$renderer) => {{",
+            attrs_obj
+        );
 
         if !dev_push.is_empty() {
             let _ = write!(code, "\t\t{}", dev_push);
@@ -1113,8 +1122,7 @@ fn convert_option_element(
         let _ = write!(code, "\t}},\n\t'{}'\n);", hash);
     } else {
         // Simple case
-        let _ = writeln!(code, "$$renderer.option({}, ($$renderer) => {{",
-            attrs_obj);
+        let _ = writeln!(code, "$$renderer.option({}, ($$renderer) => {{", attrs_obj);
 
         if !dev_push.is_empty() {
             let _ = write!(code, "\t{}", dev_push);
@@ -1588,26 +1596,40 @@ fn convert_each_block(
             code.push_str("$$renderer.child_block(async ($$renderer) => {\n");
         }
 
-        let _ = writeln!(code, "{}const {} = $.ensure_array_like({});\n",
-            effective_indent, array_var, transformed_iterable);
+        let _ = writeln!(
+            code,
+            "{}const {} = $.ensure_array_like({});\n",
+            effective_indent, array_var, transformed_iterable
+        );
 
-        let _ = writeln!(code, "{}if ({}.length !== 0) {{",
-            effective_indent, array_var);
-        let _ = writeln!(code, "{}\t$$renderer.push('<!--[-->');\n",
-            effective_indent);
+        let _ = writeln!(
+            code,
+            "{}if ({}.length !== 0) {{",
+            effective_indent, array_var
+        );
+        let _ = writeln!(code, "{}\t$$renderer.push('<!--[-->');\n", effective_indent);
 
         // For loop inside if
-        let _ = writeln!(code, "{}\tfor (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
-            effective_indent, index_var, array_var, index_var, index_var);
+        let _ = writeln!(
+            code,
+            "{}\tfor (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
+            effective_indent, index_var, array_var, index_var, index_var
+        );
 
         if let Some(ctx_name) = context_name {
-            let _ = writeln!(code, "{}\t\tlet {} = {}[{}];",
-                effective_indent, ctx_name, array_var, index_var);
+            let _ = writeln!(
+                code,
+                "{}\t\tlet {} = {}[{}];",
+                effective_indent, ctx_name, array_var, index_var
+            );
         }
 
         if let Some(alias) = index_alias {
-            let _ = writeln!(code, "{}\t\tlet {} = {};",
-                effective_indent, alias, index_var);
+            let _ = writeln!(
+                code,
+                "{}\t\tlet {} = {};",
+                effective_indent, alias, index_var
+            );
         }
 
         if context_name.is_some() || index_alias.is_some() {
@@ -1622,8 +1644,7 @@ fn convert_each_block(
 
         // Else branch with fallback
         let _ = writeln!(code, "{}}} else {{", effective_indent);
-        let _ = writeln!(code, "{}\t$$renderer.push('<!--[!-->');",
-            effective_indent);
+        let _ = writeln!(code, "{}\t$$renderer.push('<!--[!-->');", effective_indent);
 
         if let Some(fb) = fallback {
             let fallback_code = generate_inner_body_code(
@@ -1660,20 +1681,28 @@ fn convert_each_block(
             code.push_str("$$renderer.child_block(async ($$renderer) => {\n");
         }
 
-        let _ = writeln!(code, "{}const {} = $.ensure_array_like({});\n",
-            effective_indent, array_var, transformed_iterable);
+        let _ = writeln!(
+            code,
+            "{}const {} = $.ensure_array_like({});\n",
+            effective_indent, array_var, transformed_iterable
+        );
 
-        let _ = writeln!(code, "{}for (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
-            effective_indent, index_var, array_var, index_var, index_var);
+        let _ = writeln!(
+            code,
+            "{}for (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
+            effective_indent, index_var, array_var, index_var, index_var
+        );
 
         if let Some(ctx_name) = context_name {
-            let _ = writeln!(code, "{}\tlet {} = {}[{}];",
-                effective_indent, ctx_name, array_var, index_var);
+            let _ = writeln!(
+                code,
+                "{}\tlet {} = {}[{}];",
+                effective_indent, ctx_name, array_var, index_var
+            );
         }
 
         if let Some(alias) = index_alias {
-            let _ = writeln!(code, "{}\tlet {} = {};",
-                effective_indent, alias, index_var);
+            let _ = writeln!(code, "{}\tlet {} = {};", effective_indent, alias, index_var);
         }
 
         if context_name.is_some() || index_alias.is_some() {
@@ -1847,8 +1876,7 @@ fn convert_svelte_head(
     each_counter: &mut usize,
 ) {
     let mut code = String::new();
-    let _ = writeln!(code, "$.head('{}', $$renderer, ($$renderer) => {{",
-        hash);
+    let _ = writeln!(code, "$.head('{}', $$renderer, ($$renderer) => {{", hash);
 
     if !body.is_empty() {
         let body_code = generate_inner_body_code_direct(body, store_subs, each_counter, 1);
@@ -1925,16 +1953,21 @@ fn convert_slot(
 
         let (extracted_consts, modified_props) = extract_await_from_slot_props(props_expr);
         for (i, await_expr) in extracted_consts.iter().enumerate() {
-            let _ = writeln!(code, "\tconst $${} = (await $.save({}))();",
-                i, await_expr);
+            let _ = writeln!(code, "\tconst $${} = (await $.save({}))();", i, await_expr);
         }
 
-        let _ = writeln!(code, "\t$.slot($$renderer, $$props, '{}', {}, {});",
-            name, modified_props, fallback_arg);
+        let _ = writeln!(
+            code,
+            "\t$.slot($$renderer, $$props, '{}', {}, {});",
+            name, modified_props, fallback_arg
+        );
         code.push_str("});");
     } else {
-        let _ = write!(code, "$.slot($$renderer, $$props, '{}', {}, {});",
-            name, props_expr, fallback_arg);
+        let _ = write!(
+            code,
+            "$.slot($$renderer, $$props, '{}', {}, {});",
+            name, props_expr, fallback_arg
+        );
     }
 
     items.push(TemplateItem::Statement(JsStatement::Raw(
@@ -1987,8 +2020,7 @@ fn convert_svelte_boundary_with_pending(
 
     let trimmed = if let Some(props) = failed_props {
         let mut wrapped = String::new();
-        let _ = writeln!(wrapped, "$$renderer.boundary({}, ($$renderer) => {{",
-            props);
+        let _ = writeln!(wrapped, "$$renderer.boundary({}, ($$renderer) => {{", props);
         for line in inner.lines() {
             if line.is_empty() {
                 wrapped.push('\n');
@@ -2048,8 +2080,11 @@ fn convert_await_block(
         } else {
             format!("({}) => {{}}", then_param)
         };
-        let _ = write!(code, "{}$.await($$renderer, {}, () => {{}}, {});",
-            inner_indent, promise, then_fn);
+        let _ = write!(
+            code,
+            "{}$.await($$renderer, {}, () => {{}}, {});",
+            inner_indent, promise, then_fn
+        );
     } else {
         let nested_indent_level = if has_await { 3 } else { 2 };
 
@@ -2130,8 +2165,7 @@ fn convert_svelte_element(
     let mut code = String::new();
 
     if dev {
-        let _ = writeln!(code, "$.validate_dynamic_element_tag(() => {});",
-            tag_expr);
+        let _ = writeln!(code, "$.validate_dynamic_element_tag(() => {});", tag_expr);
     }
 
     if body.is_empty() && attrs_expr.is_none() {
@@ -2140,11 +2174,13 @@ fn convert_svelte_element(
         let attrs_arg = attrs_expr.as_deref().unwrap_or("void 0");
 
         if body.is_empty() {
-            let _ = write!(code, "$.element($$renderer, {}, {});",
-                tag_expr, attrs_arg);
+            let _ = write!(code, "$.element($$renderer, {}, {});", tag_expr, attrs_arg);
         } else {
-            let _ = writeln!(code, "$.element($$renderer, {}, {}, () => {{",
-                tag_expr, attrs_arg);
+            let _ = writeln!(
+                code,
+                "$.element($$renderer, {}, {}, () => {{",
+                tag_expr, attrs_arg
+            );
 
             let body_code = generate_inner_body_code_direct(body, store_subs, each_counter, 1);
             code.push_str(&body_code);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/build.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/build.rs
@@ -2,8 +2,8 @@
 //!
 //! Converts the internal OutputPart representation into the final JavaScript string output.
 
-use std::fmt::Write as _;
 use std::cell::RefCell;
+use std::fmt::Write as _;
 
 use super::ServerCodeGenerator;
 use super::helpers::*;
@@ -2800,15 +2800,24 @@ impl<'a> ServerCodeGenerator<'a> {
                         if declarations.is_empty() {
                             current_html.push_str(&element_html);
                         } else {
-                            let _ = writeln!(body_code, "\n{}$$renderer.child(async ($$renderer) => {{",
-                                indent);
+                            let _ = writeln!(
+                                body_code,
+                                "\n{}$$renderer.child(async ($$renderer) => {{",
+                                indent
+                            );
                             for (var_name, decl_value) in &declarations {
-                                let _ = writeln!(body_code, "{}\tconst {} = {};",
-                                    indent, var_name, decl_value);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\tconst {} = {};",
+                                    indent, var_name, decl_value
+                                );
                             }
                             body_code.push('\n');
-                            let _ = writeln!(body_code, "{}\t$$renderer.push(`{}`);",
-                                indent, transformed_html);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\t$$renderer.push(`{}`);",
+                                indent, transformed_html
+                            );
                             let _ = writeln!(body_code, "{}}});", indent);
                         }
 
@@ -2833,7 +2842,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 OutputPart::AsyncExpression { expr, has_save } => {
                     // Async expression: flush current HTML, then emit as separate push
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
                     // Transform await to use $.save() if needed
@@ -2847,8 +2857,11 @@ impl<'a> ServerCodeGenerator<'a> {
                     } else {
                         ""
                     };
-                    let _ = writeln!(body_code, "{}$$renderer.push({}() => $.escape({}));",
-                        indent, async_kw, transformed_expr);
+                    let _ = writeln!(
+                        body_code,
+                        "{}$$renderer.push({}() => $.escape({}));",
+                        indent, async_kw, transformed_expr
+                    );
                 }
                 OutputPart::AsyncBlock {
                     blocker_indices,
@@ -2881,7 +2894,8 @@ impl<'a> ServerCodeGenerator<'a> {
                     }
 
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -2891,8 +2905,11 @@ impl<'a> ServerCodeGenerator<'a> {
                         .collect::<Vec<_>>()
                         .join(", ");
 
-                    let _ = writeln!(body_code, "{}$$renderer.async_block([{}], {}($$renderer) => {{",
-                        indent, blockers_str, async_keyword);
+                    let _ = writeln!(
+                        body_code,
+                        "{}$$renderer.async_block([{}], {}($$renderer) => {{",
+                        indent, blockers_str, async_keyword
+                    );
 
                     // Render inner content based on type.
                     // Each type is rendered directly to avoid inner <!--]--> markers
@@ -3000,14 +3017,18 @@ impl<'a> ServerCodeGenerator<'a> {
                     }
 
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
                     let blockers_str = blockers.join(", ");
 
-                    let _ = writeln!(body_code, "{}$$renderer.async_block([{}], {}($$renderer) => {{",
-                        indent, blockers_str, async_keyword);
+                    let _ = writeln!(
+                        body_code,
+                        "{}$$renderer.async_block([{}], {}($$renderer) => {{",
+                        indent, blockers_str, async_keyword
+                    );
 
                     // Render inner content
                     if let Some(OutputPart::IfBlock {
@@ -3076,7 +3097,8 @@ impl<'a> ServerCodeGenerator<'a> {
                     // Async-wrapped expression: flush current HTML, then emit
                     // $$renderer.async([$$promises[N], ...], ($$renderer) => $$renderer.push(async () => $.escape(expr)))
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -3099,14 +3121,18 @@ impl<'a> ServerCodeGenerator<'a> {
                     } else {
                         ""
                     };
-                    let _ = writeln!(body_code, "{}$$renderer.async([{}], ($$renderer) => $$renderer.push({}() => $.escape({})));",
-                        indent, blockers_str, async_kw, transformed_expr);
+                    let _ = writeln!(
+                        body_code,
+                        "{}$$renderer.async([{}], ($$renderer) => $$renderer.push({}() => $.escape({})));",
+                        indent, blockers_str, async_kw, transformed_expr
+                    );
                 }
                 OutputPart::AsyncWrappedExpressionCustom { blockers, expr } => {
                     // Async-wrapped expression with custom blocker expressions
                     // (not $$promises indices but const-tag-level like promises_N[M])
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -3125,8 +3151,11 @@ impl<'a> ServerCodeGenerator<'a> {
                     } else {
                         ""
                     };
-                    let _ = writeln!(body_code, "{}$$renderer.async([{}], ($$renderer) => $$renderer.push({}() => $.escape({})));",
-                        indent, blockers_str, async_kw, transformed_expr);
+                    let _ = writeln!(
+                        body_code,
+                        "{}$$renderer.async([{}], ($$renderer) => $$renderer.push({}() => $.escape({})));",
+                        indent, blockers_str, async_kw, transformed_expr
+                    );
                 }
                 OutputPart::AsyncWrappedHtml {
                     blocker_indices,
@@ -3135,7 +3164,8 @@ impl<'a> ServerCodeGenerator<'a> {
                     // Async-wrapped HTML: flush current HTML, then emit
                     // $$renderer.async([$$promises[N], ...], ($$renderer) => $$renderer.push(`html`))
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -3146,8 +3176,11 @@ impl<'a> ServerCodeGenerator<'a> {
                         .join(", ");
 
                     // Use block arrow body: ($$renderer) => { $$renderer.push(...); }
-                    let _ = writeln!(body_code, "{}$$renderer.async([{}], ($$renderer) => {{",
-                        indent, blockers_str);
+                    let _ = writeln!(
+                        body_code,
+                        "{}$$renderer.async([{}], ($$renderer) => {{",
+                        indent, blockers_str
+                    );
                     let _ = writeln!(body_code, "{}\t$$renderer.push(`{}`);", indent, html);
                     let _ = writeln!(body_code, "{}}});", indent);
                 }
@@ -3216,15 +3249,24 @@ impl<'a> ServerCodeGenerator<'a> {
                             // No await found (shouldn't happen, but fallback)
                             current_html.push_str(&element_html);
                         } else {
-                            let _ = writeln!(body_code, "{}$$renderer.child(async ($$renderer) => {{",
-                                indent);
+                            let _ = writeln!(
+                                body_code,
+                                "{}$$renderer.child(async ($$renderer) => {{",
+                                indent
+                            );
                             for (var_name, decl_value) in &declarations {
-                                let _ = writeln!(body_code, "{}\tconst {} = {};",
-                                    indent, var_name, decl_value);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\tconst {} = {};",
+                                    indent, var_name, decl_value
+                                );
                             }
                             body_code.push('\n');
-                            let _ = writeln!(body_code, "{}\t$$renderer.push(`{}`);",
-                                indent, transformed_html);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\t$$renderer.push(`{}`);",
+                                indent, transformed_html
+                            );
                             let _ = writeln!(body_code, "{}}});", indent);
                         }
 
@@ -3240,15 +3282,24 @@ impl<'a> ServerCodeGenerator<'a> {
                     if super::helpers::expr_contains_await(expr) {
                         // Async @html: flush current HTML, then emit child_block
                         if !current_html.is_empty() {
-                            let _ = writeln!(body_code, "{}$$renderer.push(`{}`);",
-                                indent, current_html);
+                            let _ = writeln!(
+                                body_code,
+                                "{}$$renderer.push(`{}`);",
+                                indent, current_html
+                            );
                             current_html.clear();
                         }
                         let transformed = super::helpers::transform_await_to_save(expr);
-                        let _ = writeln!(body_code, "{}$$renderer.child_block(async ($$renderer) => {{",
-                            indent);
-                        let _ = writeln!(body_code, "{}\t$$renderer.push($.html({}));",
-                            indent, transformed);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.child_block(async ($$renderer) => {{",
+                            indent
+                        );
+                        let _ = writeln!(
+                            body_code,
+                            "{}\t$$renderer.push($.html({}));",
+                            indent, transformed
+                        );
                         let _ = writeln!(body_code, "{}}});", indent);
                     } else {
                         let _ = write!(current_html, "${{$.html({})}}", expr);
@@ -3259,7 +3310,8 @@ impl<'a> ServerCodeGenerator<'a> {
                     // Used before/after elements like <style> and <script> that need their
                     // own $$renderer.push() call (matching official Svelte compiler behavior).
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
                 }
@@ -3288,7 +3340,8 @@ impl<'a> ServerCodeGenerator<'a> {
                     // `<!---->` marker — the if/else hydration wrapper supplies
                     // the boundary.
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -3302,16 +3355,22 @@ impl<'a> ServerCodeGenerator<'a> {
 
                     // Generate component call - use $.spread_props if spreads exist
                     if has_spreads(props_and_spreads) {
-                        let _ = writeln!(body_code, "{}{}{}($$renderer, $.spread_props([",
-                            indent, name, call_syntax);
+                        let _ = writeln!(
+                            body_code,
+                            "{}{}{}($$renderer, $.spread_props([",
+                            indent, name, call_syntax
+                        );
 
                         // Add interleaved props and spreads in order
                         for item in props_and_spreads {
                             match item {
                                 ComponentPropItem::Props(props) => {
-                                    let _ = writeln!(body_code, "{}\t{{ {} }},",
+                                    let _ = writeln!(
+                                        body_code,
+                                        "{}\t{{ {} }},",
                                         indent,
-                                        props.join(", "));
+                                        props.join(", ")
+                                    );
                                 }
                                 ComponentPropItem::Spread(expr) => {
                                     let _ = writeln!(body_code, "{}\t{},", indent, expr);
@@ -3331,8 +3390,8 @@ impl<'a> ServerCodeGenerator<'a> {
                             let _ = writeln!(body_code, "{}\t\tget {}() {{", indent, prop_name);
                             let _ = writeln!(body_code, "{}\t\t\treturn {};", indent, getter_expr);
                             let _ = writeln!(body_code, "{}\t\t}},\n", indent);
-                            let _ = writeln!(body_code, "{}\t\tset {}($$value) {{",
-                                indent, prop_name);
+                            let _ =
+                                writeln!(body_code, "{}\t\tset {}($$value) {{", indent, prop_name);
                             let _ = writeln!(body_code, "{}\t\t\t{};", indent, setter_expr);
                             if !is_seq {
                                 let _ = writeln!(body_code, "{}\t\t\t$$settled = false;", indent);
@@ -3380,8 +3439,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                 } else {
                                     format!("$$renderer, {}", params.join(", "))
                                 };
-                                let _ = writeln!(body_code, "{}\tfunction {}({}) {{",
-                                    indent, snippet_name, params_str);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\tfunction {}({}) {{",
+                                    indent, snippet_name, params_str
+                                );
                                 let snippet_body = Self::build_parts_with_store_subs(
                                     body_parts,
                                     indent_level + 2,
@@ -3393,8 +3455,11 @@ impl<'a> ServerCodeGenerator<'a> {
                             }
                         }
 
-                        let _ = writeln!(body_code, "{}{}{}($$renderer, {{",
-                            inner_indent, name, call_syntax);
+                        let _ = writeln!(
+                            body_code,
+                            "{}{}{}($$renderer, {{",
+                            inner_indent, name, call_syntax
+                        );
 
                         // Regular props first
                         for prop in &all_props {
@@ -3409,14 +3474,18 @@ impl<'a> ServerCodeGenerator<'a> {
                             let is_seq =
                                 matches!(binding, ComponentBinding::SequenceExpression { .. });
                             let _ = writeln!(body_code, "{}\tget {}() {{", inner_indent, prop_name);
-                            let _ = writeln!(body_code, "{}\t\treturn {};",
-                                inner_indent, getter_expr);
+                            let _ =
+                                writeln!(body_code, "{}\t\treturn {};", inner_indent, getter_expr);
                             let _ = writeln!(body_code, "{}\t}},\n", inner_indent);
-                            let _ = writeln!(body_code, "{}\tset {}($$value) {{",
-                                inner_indent, prop_name);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\tset {}($$value) {{",
+                                inner_indent, prop_name
+                            );
                             let _ = writeln!(body_code, "{}\t\t{};", inner_indent, setter_expr);
                             if !is_seq {
-                                let _ = writeln!(body_code, "{}\t\t$$settled = false;", inner_indent);
+                                let _ =
+                                    writeln!(body_code, "{}\t\t$$settled = false;", inner_indent);
                             }
                             if idx < binding_count - 1
                                 || has_children
@@ -3443,11 +3512,17 @@ impl<'a> ServerCodeGenerator<'a> {
                                 store_subs,
                             );
                             if *component_dev {
-                                let _ = writeln!(body_code, "{}\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
-                                    inner_indent);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
+                                    inner_indent
+                                );
                             } else {
-                                let _ = writeln!(body_code, "{}\tchildren: ($$renderer) => {{",
-                                    inner_indent);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\tchildren: ($$renderer) => {{",
+                                    inner_indent
+                                );
                             }
                             body_code.push_str(&children_code);
                             if *component_dev {
@@ -3493,8 +3568,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                 slots_entries.push("default: true".to_string());
                             }
                             let slots_str = slots_entries.join(", ");
-                            let _ = writeln!(body_code, "{}\t$$slots: {{ {} }}",
-                                inner_indent, slots_str);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\t$$slots: {{ {} }}",
+                                inner_indent, slots_str
+                            );
                         }
 
                         let _ = writeln!(body_code, "{}}});", inner_indent);
@@ -3549,7 +3627,8 @@ impl<'a> ServerCodeGenerator<'a> {
                     // `<!---->` marker — the `if (expr) { push('<!--[--> ...) }`
                     // wrapper supplies the hydration boundary.
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -3589,8 +3668,11 @@ impl<'a> ServerCodeGenerator<'a> {
                             for (snippet_name, params, body_parts, _) in &true_snippets {
                                 // In dev mode, add prevent_snippet_stringification before function
                                 if *component_dev {
-                                    let _ = writeln!(body_code, "{}\t$.prevent_snippet_stringification({});",
-                                        indent, snippet_name);
+                                    let _ = writeln!(
+                                        body_code,
+                                        "{}\t$.prevent_snippet_stringification({});",
+                                        indent, snippet_name
+                                    );
                                 }
 
                                 let params_str = if params.is_empty() {
@@ -3598,13 +3680,19 @@ impl<'a> ServerCodeGenerator<'a> {
                                 } else {
                                     format!("$$renderer, {}", params.join(", "))
                                 };
-                                let _ = writeln!(body_code, "{}\tfunction {}({}) {{",
-                                    indent, snippet_name, params_str);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\tfunction {}({}) {{",
+                                    indent, snippet_name, params_str
+                                );
 
                                 // In dev mode, add validate_snippet_args
                                 if *component_dev {
-                                    let _ = writeln!(body_code, "{}\t\t$.validate_snippet_args($$renderer);",
-                                        indent);
+                                    let _ = writeln!(
+                                        body_code,
+                                        "{}\t\t$.validate_snippet_args($$renderer);",
+                                        indent
+                                    );
                                 }
 
                                 let snippet_body = Self::build_parts_with_store_subs(
@@ -3683,14 +3771,20 @@ impl<'a> ServerCodeGenerator<'a> {
                                 // not drop the `{...rest}`. Emit
                                 // `Child($$renderer, $.spread_props([…interleaved spreads/props…, { snippets, $$slots }]))`
                                 // mirroring the existing bindings + spread path. (issue #448, H-104/H-105)
-                                let _ = writeln!(body_code, "{}\t{}{}($$renderer, $.spread_props([",
-                                    indent, name, call_syntax);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\t{}{}($$renderer, $.spread_props([",
+                                    indent, name, call_syntax
+                                );
                                 for item in props_and_spreads {
                                     match item {
                                         ComponentPropItem::Props(props) => {
-                                            let _ = writeln!(body_code, "{}\t\t{{ {} }},",
+                                            let _ = writeln!(
+                                                body_code,
+                                                "{}\t\t{{ {} }},",
                                                 indent,
-                                                props.join(", "));
+                                                props.join(", ")
+                                            );
                                         }
                                         ComponentPropItem::Spread(expr) => {
                                             let _ = writeln!(body_code, "{}\t\t{},", indent, expr);
@@ -3699,9 +3793,12 @@ impl<'a> ServerCodeGenerator<'a> {
                                 }
                                 let mut final_entries = props_after_spread.clone();
                                 final_entries.push(format!("$$slots: {{ {} }}", slots_str));
-                                let _ = writeln!(body_code, "{}\t\t{{ {} }}",
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\t\t{{ {} }}",
                                     indent,
-                                    final_entries.join(", "));
+                                    final_entries.join(", ")
+                                );
                                 let _ = writeln!(body_code, "{}\t]));", indent);
                             } else {
                                 // No spread: preserve the existing single-object emission
@@ -3709,14 +3806,21 @@ impl<'a> ServerCodeGenerator<'a> {
                                 let mut all_props: Vec<String> =
                                     collect_all_props(props_and_spreads);
                                 all_props.extend(props_after_spread);
-                                let _ = write!(body_code, "{}\t{}{}($$renderer, {{ ",
-                                    indent, name, call_syntax);
+                                let _ = write!(
+                                    body_code,
+                                    "{}\t{}{}($$renderer, {{ ",
+                                    indent, name, call_syntax
+                                );
                                 if all_props.is_empty() {
-                                    let _ = writeln!(body_code, "$$slots: {{ {} }} }});", slots_str);
+                                    let _ =
+                                        writeln!(body_code, "$$slots: {{ {} }} }});", slots_str);
                                 } else {
-                                    let _ = writeln!(body_code, "{}, $$slots: {{ {} }} }});",
+                                    let _ = writeln!(
+                                        body_code,
+                                        "{}, $$slots: {{ {} }} }});",
                                         all_props.join(", "),
-                                        slots_str);
+                                        slots_str
+                                    );
                                 }
                             }
 
@@ -3733,8 +3837,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                 .iter()
                                 .any(|(n, params, _, _)| n == "default" && !params.is_empty());
 
-                            let _ = writeln!(body_code, "{}{}{}($$renderer, {{",
-                                indent, name, call_syntax);
+                            let _ = writeln!(
+                                body_code,
+                                "{}{}{}($$renderer, {{",
+                                indent, name, call_syntax
+                            );
 
                             // Props
                             for prop in &all_props {
@@ -3743,8 +3850,11 @@ impl<'a> ServerCodeGenerator<'a> {
 
                             // When default slot has let directives, add children: $.invalid_default_snippet
                             if default_has_let_dirs {
-                                let _ = writeln!(body_code, "{}\tchildren: $.invalid_default_snippet,",
-                                    indent);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\tchildren: $.invalid_default_snippet,",
+                                    indent
+                                );
                             }
 
                             // $$slots with inline functions (with params for let directives)
@@ -3758,13 +3868,19 @@ impl<'a> ServerCodeGenerator<'a> {
                                     store_subs,
                                 );
                                 if params.is_empty() {
-                                    let _ = write!(body_code, "{}\t\t{}: ($$renderer) => {{\n{}",
-                                        indent, quoted_name, fn_body);
+                                    let _ = write!(
+                                        body_code,
+                                        "{}\t\t{}: ($$renderer) => {{\n{}",
+                                        indent, quoted_name, fn_body
+                                    );
                                 } else {
                                     // Destructured params from let directives
                                     let params_str = format!("{{ {} }}", params.join(", "));
-                                    let _ = write!(body_code, "{}\t\t{}: ($$renderer, {}) => {{\n{}",
-                                        indent, quoted_name, params_str, fn_body);
+                                    let _ = write!(
+                                        body_code,
+                                        "{}\t\t{}: ($$renderer, {}) => {{\n{}",
+                                        indent, quoted_name, params_str, fn_body
+                                    );
                                 }
                                 let _ = writeln!(body_code, "{}\t\t}},", indent);
                             }
@@ -3783,8 +3899,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                 // ]))
                                 // The last Props group (if any) gets merged into the
                                 // children/$$slots object instead of being a separate entry.
-                                let _ = writeln!(body_code, "{}{}{}($$renderer, $.spread_props([",
-                                    indent, name, call_syntax);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}{}{}($$renderer, $.spread_props([",
+                                    indent, name, call_syntax
+                                );
 
                                 // Separate trailing props from the rest
                                 let trailing_props: Vec<String> =
@@ -3806,9 +3925,12 @@ impl<'a> ServerCodeGenerator<'a> {
                                 for item in items_to_emit.iter() {
                                     match item {
                                         ComponentPropItem::Props(props) => {
-                                            let _ = writeln!(body_code, "{}\t{{ {} }},",
+                                            let _ = writeln!(
+                                                body_code,
+                                                "{}\t{{ {} }},",
                                                 indent,
-                                                props.join(", "));
+                                                props.join(", ")
+                                            );
                                         }
                                         ComponentPropItem::Spread(expr) => {
                                             let _ = writeln!(body_code, "{}\t{},", indent, expr);
@@ -3825,14 +3947,20 @@ impl<'a> ServerCodeGenerator<'a> {
                                 }
 
                                 if has_let_dirs {
-                                    let _ = writeln!(body_code, "{}\t\tchildren: $.invalid_default_snippet,",
-                                        indent);
+                                    let _ = writeln!(
+                                        body_code,
+                                        "{}\t\tchildren: $.invalid_default_snippet,",
+                                        indent
+                                    );
 
                                     let _ = writeln!(body_code, "{}\t\t$$slots: {{", indent);
 
                                     let params_str = format!("{{ {} }}", let_directives.join(", "));
-                                    let _ = writeln!(body_code, "{}\t\t\tdefault: ($$renderer, {}) => {{",
-                                        indent, params_str);
+                                    let _ = writeln!(
+                                        body_code,
+                                        "{}\t\t\tdefault: ($$renderer, {}) => {{",
+                                        indent, params_str
+                                    );
                                     let children_code = Self::build_parts_with_store_subs(
                                         children_parts,
                                         indent_level + 4,
@@ -3851,12 +3979,18 @@ impl<'a> ServerCodeGenerator<'a> {
                                             store_subs,
                                         );
                                         if params.is_empty() {
-                                            let _ = write!(body_code, "{}\t\t\t{}: ($$renderer) => {{\n{}",
-                                                indent, quoted_name, fn_body);
+                                            let _ = write!(
+                                                body_code,
+                                                "{}\t\t\t{}: ($$renderer) => {{\n{}",
+                                                indent, quoted_name, fn_body
+                                            );
                                         } else {
                                             let params_str = format!("{{ {} }}", params.join(", "));
-                                            let _ = write!(body_code, "{}\t\t\t{}: ($$renderer, {}) => {{\n{}",
-                                                indent, quoted_name, params_str, fn_body);
+                                            let _ = write!(
+                                                body_code,
+                                                "{}\t\t\t{}: ($$renderer, {}) => {{\n{}",
+                                                indent, quoted_name, params_str, fn_body
+                                            );
                                         }
                                         let _ = writeln!(body_code, "{}\t\t\t}},", indent);
                                     }
@@ -3865,11 +3999,17 @@ impl<'a> ServerCodeGenerator<'a> {
                                 } else {
                                     // No let directives - standard children callback
                                     if *component_dev {
-                                        let _ = writeln!(body_code, "{}\t\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
-                                            indent);
+                                        let _ = writeln!(
+                                            body_code,
+                                            "{}\t\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
+                                            indent
+                                        );
                                     } else {
-                                        let _ = writeln!(body_code, "{}\t\tchildren: ($$renderer) => {{",
-                                            indent);
+                                        let _ = writeln!(
+                                            body_code,
+                                            "{}\t\tchildren: ($$renderer) => {{",
+                                            indent
+                                        );
                                     }
                                     let children_code = Self::build_parts_with_store_subs(
                                         children_parts,
@@ -3886,7 +4026,8 @@ impl<'a> ServerCodeGenerator<'a> {
 
                                     if has_slot_children {
                                         let _ = writeln!(body_code, "{}\t\t$$slots: {{", indent);
-                                        let _ = writeln!(body_code, "{}\t\t\tdefault: true,", indent);
+                                        let _ =
+                                            writeln!(body_code, "{}\t\t\tdefault: true,", indent);
                                         for (slot_name, params, body_parts, _) in &slot_children {
                                             let quoted_name = quote_prop_name(slot_name);
                                             let fn_body = Self::build_parts_with_store_subs(
@@ -3896,20 +4037,29 @@ impl<'a> ServerCodeGenerator<'a> {
                                                 store_subs,
                                             );
                                             if params.is_empty() {
-                                                let _ = write!(body_code, "{}\t\t\t{}: ($$renderer) => {{\n{}",
-                                                    indent, quoted_name, fn_body);
+                                                let _ = write!(
+                                                    body_code,
+                                                    "{}\t\t\t{}: ($$renderer) => {{\n{}",
+                                                    indent, quoted_name, fn_body
+                                                );
                                             } else {
                                                 let params_str =
                                                     format!("{{ {} }}", params.join(", "));
-                                                let _ = write!(body_code, "{}\t\t\t{}: ($$renderer, {}) => {{\n{}",
-                                                    indent, quoted_name, params_str, fn_body);
+                                                let _ = write!(
+                                                    body_code,
+                                                    "{}\t\t\t{}: ($$renderer, {}) => {{\n{}",
+                                                    indent, quoted_name, params_str, fn_body
+                                                );
                                             }
                                             let _ = writeln!(body_code, "{}\t\t\t}},", indent);
                                         }
                                         let _ = writeln!(body_code, "{}\t\t}}", indent);
                                     } else {
-                                        let _ = writeln!(body_code, "{}\t\t$$slots: {{ default: true }}",
-                                            indent);
+                                        let _ = writeln!(
+                                            body_code,
+                                            "{}\t\t$$slots: {{ default: true }}",
+                                            indent
+                                        );
                                     }
                                 }
 
@@ -3919,8 +4069,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                 // No spreads - use simple object literal
                                 let all_props = collect_all_props(props_and_spreads);
 
-                                let _ = writeln!(body_code, "{}{}{}($$renderer, {{",
-                                    indent, name, call_syntax);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}{}{}($$renderer, {{",
+                                    indent, name, call_syntax
+                                );
 
                                 // Props
                                 for prop in &all_props {
@@ -3939,16 +4092,22 @@ impl<'a> ServerCodeGenerator<'a> {
                                     // Has let directives on the component:
                                     // children: $.invalid_default_snippet,
                                     // $$slots: { default: ($$renderer, { name }) => { ... }, ... }
-                                    let _ = writeln!(body_code, "{}\tchildren: $.invalid_default_snippet,",
-                                        indent);
+                                    let _ = writeln!(
+                                        body_code,
+                                        "{}\tchildren: $.invalid_default_snippet,",
+                                        indent
+                                    );
 
                                     // Build $$slots with default slot function having destructured params
                                     let _ = writeln!(body_code, "{}\t$$slots: {{", indent);
 
                                     // Default slot with destructured let directive params
                                     let params_str = format!("{{ {} }}", let_directives.join(", "));
-                                    let _ = writeln!(body_code, "{}\t\tdefault: ($$renderer, {}) => {{",
-                                        indent, params_str);
+                                    let _ = writeln!(
+                                        body_code,
+                                        "{}\t\tdefault: ($$renderer, {}) => {{",
+                                        indent, params_str
+                                    );
                                     let children_code = Self::build_parts_with_store_subs(
                                         children_parts,
                                         indent_level + 3,
@@ -3968,12 +4127,18 @@ impl<'a> ServerCodeGenerator<'a> {
                                             store_subs,
                                         );
                                         if params.is_empty() {
-                                            let _ = write!(body_code, "{}\t\t{}: ($$renderer) => {{\n{}",
-                                                indent, quoted_name, fn_body);
+                                            let _ = write!(
+                                                body_code,
+                                                "{}\t\t{}: ($$renderer) => {{\n{}",
+                                                indent, quoted_name, fn_body
+                                            );
                                         } else {
                                             let params_str = format!("{{ {} }}", params.join(", "));
-                                            let _ = write!(body_code, "{}\t\t{}: ($$renderer, {}) => {{\n{}",
-                                                indent, quoted_name, params_str, fn_body);
+                                            let _ = write!(
+                                                body_code,
+                                                "{}\t\t{}: ($$renderer, {}) => {{\n{}",
+                                                indent, quoted_name, params_str, fn_body
+                                            );
                                         }
                                         let _ = writeln!(body_code, "{}\t\t}},", indent);
                                     }
@@ -3990,8 +4155,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                         each_counter,
                                         store_subs,
                                     );
-                                    let _ = write!(body_code, "{}\t\tdefault: ($$renderer) => {{\n{}",
-                                        indent, children_code);
+                                    let _ = write!(
+                                        body_code,
+                                        "{}\t\tdefault: ($$renderer) => {{\n{}",
+                                        indent, children_code
+                                    );
                                     let _ = write!(body_code, "{}\t\t}}", indent);
 
                                     // Named slot children
@@ -4005,12 +4173,18 @@ impl<'a> ServerCodeGenerator<'a> {
                                             store_subs,
                                         );
                                         if params.is_empty() {
-                                            let _ = write!(body_code, "{}\t\t{}: ($$renderer) => {{\n{}",
-                                                indent, quoted_name, fn_body);
+                                            let _ = write!(
+                                                body_code,
+                                                "{}\t\t{}: ($$renderer) => {{\n{}",
+                                                indent, quoted_name, fn_body
+                                            );
                                         } else {
                                             let params_str = format!("{{ {} }}", params.join(", "));
-                                            let _ = write!(body_code, "{}\t\t{}: ($$renderer, {}) => {{\n{}",
-                                                indent, quoted_name, params_str, fn_body);
+                                            let _ = write!(
+                                                body_code,
+                                                "{}\t\t{}: ($$renderer, {}) => {{\n{}",
+                                                indent, quoted_name, params_str, fn_body
+                                            );
                                         }
                                         let _ = write!(body_code, "{}\t\t}}", indent);
                                     }
@@ -4019,11 +4193,17 @@ impl<'a> ServerCodeGenerator<'a> {
                                 } else {
                                     // No let directives - standard children callback (no-spreads path)
                                     if *component_dev {
-                                        let _ = writeln!(body_code, "{}\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
-                                            indent);
+                                        let _ = writeln!(
+                                            body_code,
+                                            "{}\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
+                                            indent
+                                        );
                                     } else {
-                                        let _ = writeln!(body_code, "{}\tchildren: ($$renderer) => {{",
-                                            indent);
+                                        let _ = writeln!(
+                                            body_code,
+                                            "{}\tchildren: ($$renderer) => {{",
+                                            indent
+                                        );
                                     }
                                     let children_code = Self::build_parts_with_store_subs(
                                         children_parts,
@@ -4051,22 +4231,31 @@ impl<'a> ServerCodeGenerator<'a> {
                                                 store_subs,
                                             );
                                             if params.is_empty() {
-                                                let _ = write!(body_code, "{}\t\t{}: ($$renderer) => {{\n{}",
-                                                    indent, quoted_name, fn_body);
+                                                let _ = write!(
+                                                    body_code,
+                                                    "{}\t\t{}: ($$renderer) => {{\n{}",
+                                                    indent, quoted_name, fn_body
+                                                );
                                             } else {
                                                 // Destructured params from let directives
                                                 let params_str =
                                                     format!("{{ {} }}", params.join(", "));
-                                                let _ = write!(body_code, "{}\t\t{}: ($$renderer, {}) => {{\n{}",
-                                                    indent, quoted_name, params_str, fn_body);
+                                                let _ = write!(
+                                                    body_code,
+                                                    "{}\t\t{}: ($$renderer, {}) => {{\n{}",
+                                                    indent, quoted_name, params_str, fn_body
+                                                );
                                             }
                                             let _ = writeln!(body_code, "{}\t\t}},", indent);
                                         }
                                         let _ = writeln!(body_code, "{}\t}}", indent);
                                     } else {
                                         // Only default slot
-                                        let _ = writeln!(body_code, "{}\t$$slots: {{ default: true }}",
-                                            indent);
+                                        let _ = writeln!(
+                                            body_code,
+                                            "{}\t$$slots: {{ default: true }}",
+                                            indent
+                                        );
                                     }
                                 }
                                 let _ = writeln!(body_code, "{}}});", indent);
@@ -4179,26 +4368,35 @@ impl<'a> ServerCodeGenerator<'a> {
                                 }
                             }
 
-                            let _ = writeln!(body_code, "{}$$renderer.child_block(async ($$renderer) => {{",
-                                indent);
+                            let _ = writeln!(
+                                body_code,
+                                "{}$$renderer.child_block(async ($$renderer) => {{",
+                                indent
+                            );
                             for decl in &save_decls {
                                 body_code.push_str(decl);
                             }
                             if !save_decls.is_empty() {
                                 body_code.push('\n');
                             }
-                            let _ = writeln!(body_code, "{}\t{}{}($$renderer, $.spread_props([{}]));",
+                            let _ = writeln!(
+                                body_code,
+                                "{}\t{}{}($$renderer, $.spread_props([{}]));",
                                 indent,
                                 name,
                                 call_syntax,
-                                transformed_items.join(", "));
+                                transformed_items.join(", ")
+                            );
                             let _ = writeln!(body_code, "{}}});", indent);
                         } else {
-                            let _ = writeln!(body_code, "{}{}{}($$renderer, $.spread_props([{}]));",
+                            let _ = writeln!(
+                                body_code,
+                                "{}{}{}($$renderer, $.spread_props([{}]));",
                                 indent,
                                 name,
                                 call_syntax,
-                                spread_items.join(", "));
+                                spread_items.join(", ")
+                            );
                         }
                     } else {
                         // No children, no snippets, no spreads - simple call
@@ -4212,17 +4410,26 @@ impl<'a> ServerCodeGenerator<'a> {
                                 .collect::<Vec<_>>()
                                 .join(", ");
                             let inner_indent = format!("{}\t", indent);
-                            let _ = writeln!(body_code, "\n{}$.css_props($$renderer, {}, {{ {} }}, () => {{",
-                                indent, css_props_is_html, css_props_str);
+                            let _ = writeln!(
+                                body_code,
+                                "\n{}$.css_props($$renderer, {}, {{ {} }}, () => {{",
+                                indent, css_props_is_html, css_props_str
+                            );
                             if all_props.is_empty() {
-                                let _ = writeln!(body_code, "{}{}{}($$renderer, {{}});",
-                                    inner_indent, name, call_syntax);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}{}{}($$renderer, {{}});",
+                                    inner_indent, name, call_syntax
+                                );
                             } else {
-                                let _ = writeln!(body_code, "{}{}{}($$renderer, {{ {} }});",
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}{}{}($$renderer, {{ {} }});",
                                     inner_indent,
                                     name,
                                     call_syntax,
-                                    all_props.join(", "));
+                                    all_props.join(", ")
+                                );
                             }
                             // Dynamic components pass a 5th `true` argument to $.css_props()
                             if *dynamic {
@@ -4231,8 +4438,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                 let _ = writeln!(body_code, "{}}});", indent);
                             }
                         } else if all_props.is_empty() {
-                            let _ = writeln!(body_code, "{}{}{}($$renderer, {{}});",
-                                indent, name, call_syntax);
+                            let _ = writeln!(
+                                body_code,
+                                "{}{}{}($$renderer, {{}});",
+                                indent, name, call_syntax
+                            );
                         } else {
                             // Check if any prop value contains await - if so, use PromiseOptimiser pattern
                             let has_await_props = all_props
@@ -4270,26 +4480,35 @@ impl<'a> ServerCodeGenerator<'a> {
                                     }
                                 }
 
-                                let _ = writeln!(body_code, "{}$$renderer.child_block(async ($$renderer) => {{",
-                                    indent);
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}$$renderer.child_block(async ($$renderer) => {{",
+                                    indent
+                                );
                                 for decl in &save_decls {
                                     body_code.push_str(decl);
                                 }
                                 if !save_decls.is_empty() {
                                     body_code.push('\n');
                                 }
-                                let _ = writeln!(body_code, "{}\t{}{}($$renderer, {{ {} }});",
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}\t{}{}($$renderer, {{ {} }});",
                                     indent,
                                     name,
                                     call_syntax,
-                                    transformed_props.join(", "));
+                                    transformed_props.join(", ")
+                                );
                                 let _ = writeln!(body_code, "{}}});", indent);
                             } else {
-                                let _ = writeln!(body_code, "{}{}{}($$renderer, {{ {} }});",
+                                let _ = writeln!(
+                                    body_code,
+                                    "{}{}{}($$renderer, {{ {} }});",
                                     indent,
                                     name,
                                     call_syntax,
-                                    all_props.join(", "));
+                                    all_props.join(", ")
+                                );
                             }
                         }
                     }
@@ -4419,40 +4638,64 @@ impl<'a> ServerCodeGenerator<'a> {
                     if fallback.is_some() {
                         // For fallback case, flush current HTML WITHOUT marker first
                         if !current_html.is_empty() {
-                            let _ = writeln!(body_code, "{}$$renderer.push(`{}`);",
-                                indent, current_html);
+                            let _ = writeln!(
+                                body_code,
+                                "{}$$renderer.push(`{}`);",
+                                indent, current_html
+                            );
                             current_html.clear();
                         }
 
                         if needs_child_block {
-                            let _ = writeln!(body_code, "{}$$renderer.child_block(async ($$renderer) => {{",
-                                indent);
+                            let _ = writeln!(
+                                body_code,
+                                "{}$$renderer.child_block(async ($$renderer) => {{",
+                                indent
+                            );
                         }
 
-                        let _ = writeln!(body_code, "{}const {} = $.ensure_array_like({});\n",
-                            effective_indent, array_var, transformed_iterable);
+                        let _ = writeln!(
+                            body_code,
+                            "{}const {} = $.ensure_array_like({});\n",
+                            effective_indent, array_var, transformed_iterable
+                        );
 
                         // If there's a fallback, wrap in if-else
-                        let _ = writeln!(body_code, "{}if ({}.length !== 0) {{",
-                            effective_indent, array_var);
+                        let _ = writeln!(
+                            body_code,
+                            "{}if ({}.length !== 0) {{",
+                            effective_indent, array_var
+                        );
                         // Add block marker for non-empty case INSIDE the if
-                        let _ = writeln!(body_code, "{}\t$$renderer.push('<!--[-->');\n",
-                            effective_indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}\t$$renderer.push('<!--[-->');\n",
+                            effective_indent
+                        );
 
                         // For loop (indented)
-                        let _ = writeln!(body_code, "{}\tfor (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
-                            effective_indent, index_var, array_var, index_var, index_var);
+                        let _ = writeln!(
+                            body_code,
+                            "{}\tfor (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
+                            effective_indent, index_var, array_var, index_var, index_var
+                        );
 
                         // Context variable (only if there's a context)
                         if let Some(ctx_name) = context_name {
-                            let _ = writeln!(body_code, "{}\t\tlet {} = {}[{}];",
-                                effective_indent, ctx_name, array_var, index_var);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\t\tlet {} = {}[{}];",
+                                effective_indent, ctx_name, array_var, index_var
+                            );
                         }
 
                         // Index alias (when contains_group_binding: `let original_name = $$index_N`)
                         if let Some(alias) = index_alias {
-                            let _ = writeln!(body_code, "{}\t\tlet {} = {};",
-                                effective_indent, alias, index_var);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\t\tlet {} = {};",
+                                effective_indent, alias, index_var
+                            );
                         }
 
                         if context_name.is_some() || index_alias.is_some() {
@@ -4475,8 +4718,11 @@ impl<'a> ServerCodeGenerator<'a> {
                         // Else branch with fallback
                         let _ = writeln!(body_code, "{}}} else {{", effective_indent);
                         // Add block marker for empty case (note the !)
-                        let _ = writeln!(body_code, "{}\t$$renderer.push('<!--[!-->');",
-                            effective_indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}\t$$renderer.push('<!--[!-->');",
+                            effective_indent
+                        );
 
                         // Fallback body
                         if let Some(fb) = fallback {
@@ -4502,31 +4748,47 @@ impl<'a> ServerCodeGenerator<'a> {
                         current_html.push_str("<!--[-->");
 
                         // Flush current HTML (including the marker) before each block
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
 
                         if needs_child_block {
-                            let _ = writeln!(body_code, "{}$$renderer.child_block(async ($$renderer) => {{",
-                                indent);
+                            let _ = writeln!(
+                                body_code,
+                                "{}$$renderer.child_block(async ($$renderer) => {{",
+                                indent
+                            );
                         }
 
-                        let _ = writeln!(body_code, "{}const {} = $.ensure_array_like({});\n",
-                            effective_indent, array_var, transformed_iterable);
+                        let _ = writeln!(
+                            body_code,
+                            "{}const {} = $.ensure_array_like({});\n",
+                            effective_indent, array_var, transformed_iterable
+                        );
 
                         // For loop
-                        let _ = writeln!(body_code, "{}for (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
-                            effective_indent, index_var, array_var, index_var, index_var);
+                        let _ = writeln!(
+                            body_code,
+                            "{}for (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
+                            effective_indent, index_var, array_var, index_var, index_var
+                        );
 
                         // Context variable (only if there's a context)
                         if let Some(ctx_name) = context_name {
-                            let _ = writeln!(body_code, "{}\tlet {} = {}[{}];",
-                                effective_indent, ctx_name, array_var, index_var);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\tlet {} = {}[{}];",
+                                effective_indent, ctx_name, array_var, index_var
+                            );
                         }
 
                         // Index alias (when contains_group_binding: `let original_name = $$index_N`)
                         if let Some(alias) = index_alias {
-                            let _ = writeln!(body_code, "{}\tlet {} = {};",
-                                effective_indent, alias, index_var);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\tlet {} = {};",
+                                effective_indent, alias, index_var
+                            );
                         }
 
                         if context_name.is_some() || index_alias.is_some() {
@@ -4564,7 +4826,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 } => {
                     // Flush current HTML before if block
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -4593,8 +4856,11 @@ impl<'a> ServerCodeGenerator<'a> {
                         );
 
                         // Wrap in $$renderer.child_block(async ($$renderer) => { ... })
-                        let _ = writeln!(body_code, "{}$$renderer.child_block(async ($$renderer) => {{",
-                            indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.child_block(async ($$renderer) => {{",
+                            indent
+                        );
                         body_code.push_str(&if_code);
                         body_code.push('\n');
                         let _ = writeln!(body_code, "{}}});\n", indent);
@@ -4622,32 +4888,43 @@ impl<'a> ServerCodeGenerator<'a> {
                 } => {
                     // Flush current HTML before svelte:element
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
                     // In dev mode, validate the dynamic element tag
                     if *dev {
-                        let _ = writeln!(body_code, "{}$.validate_dynamic_element_tag(() => {});",
-                            indent, tag_expr);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$.validate_dynamic_element_tag(() => {});",
+                            indent, tag_expr
+                        );
                     }
 
                     // Generate $.element call with attributes and body callback
                     if body.is_empty() && attrs_expr.is_none() {
                         // No body and no attributes - simple form
-                        let _ = writeln!(body_code, "{}$.element($$renderer, {});", indent, tag_expr);
+                        let _ =
+                            writeln!(body_code, "{}$.element($$renderer, {});", indent, tag_expr);
                     } else {
                         // Build $.element($$renderer, tag, attrs, () => { ... })
                         let attrs_arg = attrs_expr.as_deref().unwrap_or("void 0");
 
                         if body.is_empty() {
                             // No body, just attributes
-                            let _ = writeln!(body_code, "{}$.element($$renderer, {}, {});",
-                                indent, tag_expr, attrs_arg);
+                            let _ = writeln!(
+                                body_code,
+                                "{}$.element($$renderer, {}, {});",
+                                indent, tag_expr, attrs_arg
+                            );
                         } else {
                             // Has body - use callback form
-                            let _ = writeln!(body_code, "{}$.element($$renderer, {}, {}, () => {{",
-                                indent, tag_expr, attrs_arg);
+                            let _ = writeln!(
+                                body_code,
+                                "{}$.element($$renderer, {}, {}, () => {{",
+                                indent, tag_expr, attrs_arg
+                            );
 
                             // Generate body content
                             let body_code_inner = Self::build_parts_with_store_subs(
@@ -4670,17 +4947,24 @@ impl<'a> ServerCodeGenerator<'a> {
                 } => {
                     // Flush current HTML before select element
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
                     // Generate $$renderer.select() call with multiline formatting when css_hash is present
                     if css_hash.is_some() || *is_rich {
-                        let _ = writeln!(body_code, "{}$$renderer.select(\n{}\t{},\n{}\t($$renderer) => {{",
-                            indent, indent, attrs_obj, indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.select(\n{}\t{},\n{}\t($$renderer) => {{",
+                            indent, indent, attrs_obj, indent
+                        );
                     } else {
-                        let _ = writeln!(body_code, "{}$$renderer.select({}, ($$renderer) => {{",
-                            indent, attrs_obj);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.select({}, ($$renderer) => {{",
+                            indent, attrs_obj
+                        );
                     }
 
                     // Body
@@ -4698,16 +4982,25 @@ impl<'a> ServerCodeGenerator<'a> {
                     if *is_rich {
                         if let Some(hash) = css_hash {
                             // With css_hash: select(attrs, fn, 'hash', void 0, void 0, void 0, true)
-                            let _ = writeln!(body_code, "{}\t}},\n{}\t'{}',\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\ttrue\n{});",
-                                indent, indent, hash, indent, indent, indent, indent, indent);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\t}},\n{}\t'{}',\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\ttrue\n{});",
+                                indent, indent, hash, indent, indent, indent, indent, indent
+                            );
                         } else {
                             // Without css_hash: select(attrs, fn, void 0, void 0, void 0, void 0, true)
-                            let _ = writeln!(body_code, "{}\t}},\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\ttrue\n{});",
-                                indent, indent, indent, indent, indent, indent, indent);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\t}},\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\ttrue\n{});",
+                                indent, indent, indent, indent, indent, indent, indent
+                            );
                         }
                     } else if let Some(hash) = css_hash {
-                        let _ = writeln!(body_code, "{}\t}},\n{}\t'{}'\n{});",
-                            indent, indent, hash, indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}\t}},\n{}\t'{}'\n{});",
+                            indent, indent, hash, indent
+                        );
                     } else {
                         let _ = writeln!(body_code, "{}}});", indent);
                     }
@@ -4722,8 +5015,11 @@ impl<'a> ServerCodeGenerator<'a> {
                 } => {
                     // Flush current HTML before option element
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);\n",
-                            indent, current_html);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.push(`{}`);\n",
+                            indent, current_html
+                        );
                         current_html.clear();
                     }
 
@@ -4746,13 +5042,19 @@ impl<'a> ServerCodeGenerator<'a> {
 
                     // If we have a direct value (from synthetic_value_node), pass it directly
                     if let Some(value_expr) = direct_value {
-                        let _ = writeln!(body_code, "{}$$renderer.option({}, {});",
-                            indent, attrs_obj, value_expr);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.option({}, {});",
+                            indent, attrs_obj, value_expr
+                        );
                     } else if *is_rich {
                         // Build the $$renderer.option() call
                         // If is_rich, we need to pass 7 arguments: attrs, body, void 0, void 0, void 0, void 0, true
-                        let _ = writeln!(body_code, "{}$$renderer.option(\n{}\t{},\n{}\t($$renderer) => {{",
-                            indent, indent, attrs_obj, indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.option(\n{}\t{},\n{}\t($$renderer) => {{",
+                            indent, indent, attrs_obj, indent
+                        );
 
                         // Dev mode: push_element after callback opening
                         if !dev_push.is_empty() {
@@ -4774,12 +5076,18 @@ impl<'a> ServerCodeGenerator<'a> {
                         }
 
                         // Close callback with remaining args
-                        let _ = writeln!(body_code, "{}\t}},\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\ttrue\n{});",
-                            indent, indent, indent, indent, indent, indent, indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}\t}},\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\tvoid 0,\n{}\ttrue\n{});",
+                            indent, indent, indent, indent, indent, indent, indent
+                        );
                     } else if let Some(hash) = css_hash {
                         // Has CSS hash - pass as 3rd argument
-                        let _ = writeln!(body_code, "{}$$renderer.option(\n{}\t{},\n{}\t($$renderer) => {{",
-                            indent, indent, attrs_obj, indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.option(\n{}\t{},\n{}\t($$renderer) => {{",
+                            indent, indent, attrs_obj, indent
+                        );
 
                         // Dev mode: push_element
                         if !dev_push.is_empty() {
@@ -4801,11 +5109,17 @@ impl<'a> ServerCodeGenerator<'a> {
                         }
 
                         // Close callback with CSS hash
-                        let _ = writeln!(body_code, "{}\t}},\n{}\t'{}'\n{});",
-                            indent, indent, hash, indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}\t}},\n{}\t'{}'\n{});",
+                            indent, indent, hash, indent
+                        );
                     } else {
-                        let _ = writeln!(body_code, "{}$$renderer.option({}, ($$renderer) => {{",
-                            indent, attrs_obj);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.option({}, ($$renderer) => {{",
+                            indent, attrs_obj
+                        );
 
                         // Dev mode: push_element
                         if !dev_push.is_empty() {
@@ -4841,7 +5155,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 } => {
                     // Flush current HTML before await block
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -4857,8 +5172,11 @@ impl<'a> ServerCodeGenerator<'a> {
                         (indent_level, indent.clone())
                     };
                     if needs_child_block {
-                        let _ = writeln!(body_code, "{}$$renderer.child_block(async ($$renderer) => {{",
-                            indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.child_block(async ($$renderer) => {{",
+                            indent
+                        );
                     }
 
                     // Generate $.await call with proper callbacks
@@ -4876,8 +5194,11 @@ impl<'a> ServerCodeGenerator<'a> {
                         } else {
                             format!("({}) => {{}}", then_param)
                         };
-                        let _ = writeln!(body_code, "{}$.await($$renderer, {}, () => {{}}, {});",
-                            await_indent, promise, then_fn);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$.await($$renderer, {}, () => {{}}, {});",
+                            await_indent, promise, then_fn
+                        );
                     } else {
                         // Multi-line format
                         let _ = writeln!(body_code, "{}$.await(", await_indent);
@@ -4904,15 +5225,15 @@ impl<'a> ServerCodeGenerator<'a> {
                             if then_param.is_empty() {
                                 let _ = write!(body_code, "{}\t() => {{}}", await_indent);
                             } else {
-                                let _ = write!(body_code, "{}\t({}) => {{}}",
-                                    await_indent, then_param);
+                                let _ =
+                                    write!(body_code, "{}\t({}) => {{}}", await_indent, then_param);
                             }
                         } else {
                             if then_param.is_empty() {
                                 let _ = writeln!(body_code, "{}\t() => {{", await_indent);
                             } else {
-                                let _ = writeln!(body_code, "{}\t({}) => {{",
-                                    await_indent, then_param);
+                                let _ =
+                                    writeln!(body_code, "{}\t({}) => {{", await_indent, then_param);
                             }
                             let then_code = Self::build_parts_with_store_subs(
                                 then_body,
@@ -4945,7 +5266,8 @@ impl<'a> ServerCodeGenerator<'a> {
                     // (b.stmt nodes inside build_template), so they must NOT fuse with
                     // surrounding HTML.
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -4953,12 +5275,18 @@ impl<'a> ServerCodeGenerator<'a> {
 
                     if let Some(props) = failed_props {
                         // Wrap in $$renderer.boundary({props}, ($$renderer) => { ... });
-                        let _ = writeln!(body_code, "\n{}$$renderer.boundary({}, ($$renderer) => {{",
-                            indent, props);
+                        let _ = writeln!(
+                            body_code,
+                            "\n{}$$renderer.boundary({}, ($$renderer) => {{",
+                            indent, props
+                        );
                         let inner_indent_level = indent_level + 1;
                         let inner_indent = "\t".repeat(inner_indent_level);
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);\n",
-                            inner_indent, open_marker);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.push(`{}`);\n",
+                            inner_indent, open_marker
+                        );
                         let _ = writeln!(body_code, "{}{{", inner_indent);
                         if !body.is_empty() {
                             let body_code_inner = Self::build_parts_with_store_subs(
@@ -4974,8 +5302,8 @@ impl<'a> ServerCodeGenerator<'a> {
                         let _ = writeln!(body_code, "{}}});", indent);
                     } else {
                         // Emit open marker, body block, close marker as separate pushes
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);\n",
-                            indent, open_marker);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);\n", indent, open_marker);
                         let _ = writeln!(body_code, "{}{{", indent);
                         if !body.is_empty() {
                             let body_code_inner = Self::build_parts_with_store_subs(
@@ -4998,8 +5326,11 @@ impl<'a> ServerCodeGenerator<'a> {
                 } => {
                     // Flush current HTML before conditional
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);\n",
-                            indent, current_html);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.push(`{}`);\n",
+                            indent, current_html
+                        );
                         current_html.clear();
                     }
 
@@ -5008,8 +5339,11 @@ impl<'a> ServerCodeGenerator<'a> {
                             let indent = "\t".repeat(indent_level);
                             let inner_indent = format!("{}\t", indent);
                             let _ = writeln!(body_code, "{}if ({}) {{", indent, pending_expr);
-                            let _ = writeln!(body_code, "{}$$renderer.push(`<!--[!-->`);",
-                                inner_indent);
+                            let _ = writeln!(
+                                body_code,
+                                "{}$$renderer.push(`<!--[!-->`);",
+                                inner_indent
+                            );
                             if !pending_body.is_empty() {
                                 let pending_code = Self::build_parts_with_store_subs(
                                     pending_body,
@@ -5019,11 +5353,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                 );
                                 body_code.push_str(&pending_code);
                             }
-                            let _ = writeln!(body_code, "{}$$renderer.push(`<!--]-->`);",
-                                inner_indent);
+                            let _ =
+                                writeln!(body_code, "{}$$renderer.push(`<!--]-->`);", inner_indent);
                             let _ = writeln!(body_code, "{}}} else {{", indent);
-                            let _ = writeln!(body_code, "{}$$renderer.push(`<!--[-->`);",
-                                inner_indent);
+                            let _ =
+                                writeln!(body_code, "{}$$renderer.push(`<!--[-->`);", inner_indent);
                             if !main_body.is_empty() {
                                 let main_code = Self::build_parts_with_store_subs(
                                     main_body,
@@ -5033,14 +5367,17 @@ impl<'a> ServerCodeGenerator<'a> {
                                 );
                                 body_code.push_str(&main_code);
                             }
-                            let _ = writeln!(body_code, "{}$$renderer.push(`<!--]-->`);",
-                                inner_indent);
+                            let _ =
+                                writeln!(body_code, "{}$$renderer.push(`<!--]-->`);", inner_indent);
                             let _ = writeln!(body_code, "{}}}", indent);
                         };
 
                     if let Some(props) = failed_props {
-                        let _ = writeln!(body_code, "{}$$renderer.boundary({}, ($$renderer) => {{",
-                            indent, props);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.boundary({}, ($$renderer) => {{",
+                            indent, props
+                        );
                         render_inner(&mut body_code, indent_level + 1, each_counter);
                         let _ = writeln!(body_code, "{}}});", indent);
                     } else {
@@ -5050,13 +5387,17 @@ impl<'a> ServerCodeGenerator<'a> {
                 OutputPart::SvelteHead { hash, body } => {
                     // Flush current HTML before head call
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
                     // Generate $.head('hash', $$renderer, ($$renderer) => { ... });
-                    let _ = writeln!(body_code, "{}$.head('{}', $$renderer, ($$renderer) => {{",
-                        indent, hash);
+                    let _ = writeln!(
+                        body_code,
+                        "{}$.head('{}', $$renderer, ($$renderer) => {{",
+                        indent, hash
+                    );
 
                     if !body.is_empty() {
                         let body_code_inner = Self::build_parts_with_store_subs(
@@ -5073,7 +5414,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 OutputPart::TitleElement { body } => {
                     // Flush current HTML before title call
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -5095,8 +5437,11 @@ impl<'a> ServerCodeGenerator<'a> {
                 OutputPart::TextareaBody { value_expr } => {
                     // Flush current HTML before textarea body
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);\n",
-                            indent, current_html);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.push(`{}`);\n",
+                            indent, current_html
+                        );
                         current_html.clear();
                     }
 
@@ -5115,10 +5460,16 @@ impl<'a> ServerCodeGenerator<'a> {
                     // if ($$body) {
                     //     $$renderer.push(`${$$body}`);
                     // } else {}
-                    let _ = writeln!(body_code, "{}const {} = $.escape({});\n",
-                        indent, var_name, value_expr);
-                    let _ = writeln!(body_code, "{}if ({}) {{\n{}\t$$renderer.push(`${{{}}}`);\n{}}} else {{}}\n",
-                        indent, var_name, indent, var_name, indent);
+                    let _ = writeln!(
+                        body_code,
+                        "{}const {} = $.escape({});\n",
+                        indent, var_name, value_expr
+                    );
+                    let _ = writeln!(
+                        body_code,
+                        "{}if ({}) {{\n{}\t$$renderer.push(`${{{}}}`);\n{}}} else {{}}\n",
+                        indent, var_name, indent, var_name, indent
+                    );
                 }
                 OutputPart::ContentEditableBody {
                     value_expr,
@@ -5126,10 +5477,13 @@ impl<'a> ServerCodeGenerator<'a> {
                 } => {
                     // Flush current HTML before content-editable body
                     if !current_html.is_empty() {
-                        let _ = write!(body_code, "{}$$renderer.push(`{}`);
+                        let _ = write!(
+                            body_code,
+                            "{}$$renderer.push(`{}`);
 
 ",
-                            indent, current_html);
+                            indent, current_html
+                        );
                         current_html.clear();
                     }
 
@@ -5148,8 +5502,11 @@ impl<'a> ServerCodeGenerator<'a> {
                             format!("$$body_{}", textarea_body_count)
                         };
                         textarea_body_count += 1;
-                        let _ = writeln!(body_code, "{}const {} = {};\n",
-                            indent, var_name, value_expr);
+                        let _ = writeln!(
+                            body_code,
+                            "{}const {} = {};\n",
+                            indent, var_name, value_expr
+                        );
                         (var_name.clone(), var_name)
                     };
 
@@ -5160,7 +5517,11 @@ impl<'a> ServerCodeGenerator<'a> {
                     //     /* children */
                     // }
                     let _ = writeln!(body_code, "{}if ({}) {{", indent, condition_expr);
-                    let _ = writeln!(body_code, "{}	$$renderer.push(`${{{}}}`);", indent, push_expr);
+                    let _ = writeln!(
+                        body_code,
+                        "{}	$$renderer.push(`${{{}}}`);",
+                        indent, push_expr
+                    );
                     // Generate children in the else branch
                     let children_code = Self::build_parts_with_store_subs(
                         children_body,
@@ -5169,17 +5530,23 @@ impl<'a> ServerCodeGenerator<'a> {
                         store_subs,
                     );
                     if children_code.trim().is_empty() {
-                        let _ = write!(body_code, "{}}} else {{}}
+                        let _ = write!(
+                            body_code,
+                            "{}}} else {{}}
 
 ",
-                            indent);
+                            indent
+                        );
                     } else {
                         let _ = writeln!(body_code, "{}}} else {{", indent);
                         body_code.push_str(&children_code);
-                        let _ = write!(body_code, "{}}}
+                        let _ = write!(
+                            body_code,
+                            "{}}}
 
 ",
-                            indent);
+                            indent
+                        );
                     }
                 }
                 OutputPart::RenderCall {
@@ -5188,7 +5555,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 } => {
                     // Flush current HTML before render call
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -5204,7 +5572,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 OutputPart::ConstDeclaration(declaration) => {
                     // Flush current HTML before const declaration
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -5214,7 +5583,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 OutputPart::VarDeclaration(declaration) => {
                     // Flush current HTML before var declaration
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -5224,7 +5594,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 OutputPart::BlockScope { body } => {
                     // Flush current HTML before block scope
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -5253,7 +5624,8 @@ impl<'a> ServerCodeGenerator<'a> {
                     // Flush current HTML before slot (+ add <!--[--> marker)
                     current_html.push_str("<!--[-->");
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -5282,8 +5654,11 @@ impl<'a> ServerCodeGenerator<'a> {
                     // which wraps async slot props in child_block.
                     if memmem::find(props_expr.as_bytes(), b"await ").is_some() {
                         let inner_indent = format!("{}\t", indent);
-                        let _ = writeln!(body_code, "{}$$renderer.child_block(async ($$renderer) => {{",
-                            indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.child_block(async ($$renderer) => {{",
+                            indent
+                        );
 
                         // Extract await expressions from props and replace with const vars.
                         // e.g., { message: await 'hello' } -> const $$0 = (await $.save("hello"))();
@@ -5291,16 +5666,25 @@ impl<'a> ServerCodeGenerator<'a> {
                         let (extracted_consts, modified_props) =
                             extract_await_from_slot_props(props_expr);
                         for (i, await_expr) in extracted_consts.iter().enumerate() {
-                            let _ = writeln!(body_code, "{}const $${} = (await $.save({}))();",
-                                inner_indent, i, await_expr);
+                            let _ = writeln!(
+                                body_code,
+                                "{}const $${} = (await $.save({}))();",
+                                inner_indent, i, await_expr
+                            );
                         }
 
-                        let _ = writeln!(body_code, "{}$.slot($$renderer, $$props, '{}', {}, {});",
-                            inner_indent, name, modified_props, fallback_arg);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$.slot($$renderer, $$props, '{}', {}, {});",
+                            inner_indent, name, modified_props, fallback_arg
+                        );
                         let _ = writeln!(body_code, "{}}});", indent);
                     } else {
-                        let _ = writeln!(body_code, "{}$.slot($$renderer, $$props, '{}', {}, {});",
-                            indent, name, props_expr, fallback_arg);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$.slot($$renderer, $$props, '{}', {}, {});",
+                            indent, name, props_expr, fallback_arg
+                        );
                     }
 
                     // Add closing marker
@@ -5318,7 +5702,8 @@ impl<'a> ServerCodeGenerator<'a> {
 
                     // Flush current HTML before async child
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -5327,8 +5712,11 @@ impl<'a> ServerCodeGenerator<'a> {
                     } else {
                         "child"
                     };
-                    let _ = writeln!(body_code, "{}$$renderer.{}(async ($$renderer) => {{",
-                        indent, method);
+                    let _ = writeln!(
+                        body_code,
+                        "{}$$renderer.{}(async ($$renderer) => {{",
+                        indent, method
+                    );
 
                     let inner_indent = format!("{}\t", indent);
 
@@ -5355,7 +5743,8 @@ impl<'a> ServerCodeGenerator<'a> {
                 OutputPart::RawStatement(stmt) => {
                     // Flush current HTML before raw statement
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
@@ -5394,14 +5783,18 @@ impl<'a> ServerCodeGenerator<'a> {
                 } => {
                     // Flush current HTML before function declaration
                     if !current_html.is_empty() {
-                        let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
+                        let _ =
+                            writeln!(body_code, "{}$$renderer.push(`{}`);", indent, current_html);
                         current_html.clear();
                     }
 
                     // In dev mode, add prevent_snippet_stringification before the function
                     if *snippet_dev {
-                        let _ = writeln!(body_code, "{}$.prevent_snippet_stringification({});",
-                            indent, name);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$.prevent_snippet_stringification({});",
+                            indent, name
+                        );
                     }
 
                     // Generate function declaration
@@ -5415,7 +5808,11 @@ impl<'a> ServerCodeGenerator<'a> {
 
                     // In dev mode, add validate_snippet_args
                     if *snippet_dev {
-                        let _ = writeln!(body_code, "{}\t$.validate_snippet_args($$renderer);", indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}\t$.validate_snippet_args($$renderer);",
+                            indent
+                        );
                     }
 
                     // Generate body
@@ -5672,30 +6069,47 @@ impl<'a> ServerCodeGenerator<'a> {
         *each_counter += 1;
 
         if needs_child_block {
-            let _ = writeln!(code, "{}$$renderer.child_block(async ($$renderer) => {{",
-                indent);
+            let _ = writeln!(
+                code,
+                "{}$$renderer.child_block(async ($$renderer) => {{",
+                indent
+            );
         }
 
         if fallback.is_some() {
-            let _ = writeln!(code, "{}const {} = $.ensure_array_like({});\n",
-                effective_indent, array_var, transformed_iterable);
+            let _ = writeln!(
+                code,
+                "{}const {} = $.ensure_array_like({});\n",
+                effective_indent, array_var, transformed_iterable
+            );
 
-            let _ = writeln!(code, "{}if ({}.length !== 0) {{",
-                effective_indent, array_var);
-            let _ = writeln!(code, "{}\t$$renderer.push('<!--[-->');\n",
-                effective_indent);
+            let _ = writeln!(
+                code,
+                "{}if ({}.length !== 0) {{",
+                effective_indent, array_var
+            );
+            let _ = writeln!(code, "{}\t$$renderer.push('<!--[-->');\n", effective_indent);
 
-            let _ = writeln!(code, "{}\tfor (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
-                effective_indent, index_var, array_var, index_var, index_var);
+            let _ = writeln!(
+                code,
+                "{}\tfor (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
+                effective_indent, index_var, array_var, index_var, index_var
+            );
 
             if let Some(ctx_name) = context_name {
-                let _ = writeln!(code, "{}\t\tlet {} = {}[{}];",
-                    effective_indent, ctx_name, array_var, index_var);
+                let _ = writeln!(
+                    code,
+                    "{}\t\tlet {} = {}[{}];",
+                    effective_indent, ctx_name, array_var, index_var
+                );
             }
 
             if let Some(alias) = index_alias {
-                let _ = writeln!(code, "{}\t\tlet {} = {};",
-                    effective_indent, alias, index_var);
+                let _ = writeln!(
+                    code,
+                    "{}\t\tlet {} = {};",
+                    effective_indent, alias, index_var
+                );
             }
 
             if context_name.is_some() || index_alias.is_some() {
@@ -5714,8 +6128,7 @@ impl<'a> ServerCodeGenerator<'a> {
             let _ = writeln!(code, "{}\t}}", effective_indent);
 
             let _ = writeln!(code, "{}}} else {{", effective_indent);
-            let _ = writeln!(code, "{}\t$$renderer.push('<!--[!-->');",
-                effective_indent);
+            let _ = writeln!(code, "{}\t$$renderer.push('<!--[!-->');", effective_indent);
 
             if let Some(fb) = fallback {
                 let fallback_code = Self::build_parts_with_store_subs(
@@ -5730,20 +6143,28 @@ impl<'a> ServerCodeGenerator<'a> {
             let _ = writeln!(code, "{}}}", effective_indent);
         } else {
             // No fallback
-            let _ = writeln!(code, "{}const {} = $.ensure_array_like({});\n",
-                effective_indent, array_var, transformed_iterable);
+            let _ = writeln!(
+                code,
+                "{}const {} = $.ensure_array_like({});\n",
+                effective_indent, array_var, transformed_iterable
+            );
 
-            let _ = writeln!(code, "{}for (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
-                effective_indent, index_var, array_var, index_var, index_var);
+            let _ = writeln!(
+                code,
+                "{}for (let {} = 0, $$length = {}.length; {} < $$length; {}++) {{",
+                effective_indent, index_var, array_var, index_var, index_var
+            );
 
             if let Some(ctx_name) = context_name {
-                let _ = writeln!(code, "{}\tlet {} = {}[{}];",
-                    effective_indent, ctx_name, array_var, index_var);
+                let _ = writeln!(
+                    code,
+                    "{}\tlet {} = {}[{}];",
+                    effective_indent, ctx_name, array_var, index_var
+                );
             }
 
             if let Some(alias) = index_alias {
-                let _ = writeln!(code, "{}\tlet {} = {};",
-                    effective_indent, alias, index_var);
+                let _ = writeln!(code, "{}\tlet {} = {};", effective_indent, alias, index_var);
             }
 
             if context_name.is_some() || index_alias.is_some() {
@@ -5781,8 +6202,11 @@ impl<'a> ServerCodeGenerator<'a> {
         for snippet in hoisted {
             // In dev mode, add prevent_snippet_stringification before the function declaration
             if self.dev {
-                let _ = writeln!(result, "$.prevent_snippet_stringification({});",
-                    snippet.name);
+                let _ = writeln!(
+                    result,
+                    "$.prevent_snippet_stringification({});",
+                    snippet.name
+                );
             }
 
             // Generate function signature
@@ -5833,8 +6257,11 @@ impl<'a> ServerCodeGenerator<'a> {
         for snippet in instance {
             // In dev mode, add prevent_snippet_stringification before the function declaration
             if self.dev {
-                let _ = writeln!(result, "{}$.prevent_snippet_stringification({});",
-                    indent, snippet.name);
+                let _ = writeln!(
+                    result,
+                    "{}$.prevent_snippet_stringification({});",
+                    indent, snippet.name
+                );
             }
 
             // Generate function signature
@@ -5844,14 +6271,16 @@ impl<'a> ServerCodeGenerator<'a> {
                 format!("$$renderer, {}", snippet.params.join(", "))
             };
 
-            let _ = writeln!(result, "{}function {}({}) {{",
-                indent, snippet.name, params);
+            let _ = writeln!(result, "{}function {}({}) {{", indent, snippet.name, params);
 
             // In dev mode, add snippet argument validation
             if self.dev {
                 let inner_indent = "\t".repeat(indent_level + 1);
-                let _ = writeln!(result, "{}$.validate_snippet_args($$renderer);",
-                    inner_indent);
+                let _ = writeln!(
+                    result,
+                    "{}$.validate_snippet_args($$renderer);",
+                    inner_indent
+                );
             }
 
             // Generate body - snippets have their own counter scope
@@ -5888,14 +6317,20 @@ impl<'a> ServerCodeGenerator<'a> {
 
         // If uses_slots, add $$slots = $.sanitize_slots($$props)
         if analysis.uses_slots {
-            let _ = writeln!(result, "{}const $$slots = $.sanitize_slots($$props);",
-                indent);
+            let _ = writeln!(
+                result,
+                "{}const $$slots = $.sanitize_slots($$props);",
+                indent
+            );
         }
 
         // If uses_props or uses_rest_props, add $$sanitized_props
         if analysis.uses_props || analysis.uses_rest_props {
-            let _ = writeln!(result, "{}const $$sanitized_props = $.sanitize_props($$props);",
-                indent);
+            let _ = writeln!(
+                result,
+                "{}const $$sanitized_props = $.sanitize_props($$props);",
+                indent
+            );
         }
 
         // If uses_rest_props, add $$restProps
@@ -5925,8 +6360,11 @@ impl<'a> ServerCodeGenerator<'a> {
                 .map(|p| format!("'{}'", p))
                 .collect::<Vec<_>>()
                 .join(", ");
-            let _ = writeln!(result, "{}const $$restProps = $.rest_props($$sanitized_props, [{}]);",
-                indent, props_array);
+            let _ = writeln!(
+                result,
+                "{}const $$restProps = $.rest_props($$sanitized_props, [{}]);",
+                indent, props_array
+            );
         }
 
         result
@@ -6037,15 +6475,21 @@ impl<'a> ServerCodeGenerator<'a> {
                         // Fallback - no await extracted
                         let _ = writeln!(body_code, "{}$$renderer.push(`{}`);", indent, html);
                     } else {
-                        let _ = writeln!(body_code, "{}$$renderer.child(async ($$renderer) => {{",
-                            indent);
+                        let _ = writeln!(
+                            body_code,
+                            "{}$$renderer.child(async ($$renderer) => {{",
+                            indent
+                        );
                         for (var_name, decl_value) in &declarations {
-                            let _ = writeln!(body_code, "{}\tconst {} = {};",
-                                indent, var_name, decl_value);
+                            let _ = writeln!(
+                                body_code,
+                                "{}\tconst {} = {};",
+                                indent, var_name, decl_value
+                            );
                         }
                         body_code.push('\n');
-                        let _ = writeln!(body_code, "{}\t$$renderer.push(`{}`);",
-                            indent, transformed);
+                        let _ =
+                            writeln!(body_code, "{}\t$$renderer.push(`{}`);", indent, transformed);
                         let _ = writeln!(body_code, "{}}});", indent);
                     }
                 }
@@ -6227,8 +6671,11 @@ impl<'a> ServerCodeGenerator<'a> {
                 code.push_str("{\n");
                 for (snippet_name, params, body_parts, _) in &true_snippets {
                     if component_dev {
-                        let _ = writeln!(code, "\t$.prevent_snippet_stringification({});",
-                            snippet_name);
+                        let _ = writeln!(
+                            code,
+                            "\t$.prevent_snippet_stringification({});",
+                            snippet_name
+                        );
                     }
                     let params_str = if params.is_empty() {
                         "$$renderer".to_string()
@@ -6302,8 +6749,11 @@ impl<'a> ServerCodeGenerator<'a> {
                     // drop the `{...rest}`. Emit
                     // `Child($$renderer, $.spread_props([…interleaved spreads/props…, { snippets, $$slots }]))`
                     // (issue #448, H-104/H-105).
-                    let _ = writeln!(code, "\t{}{}($$renderer, $.spread_props([",
-                        name, call_syntax);
+                    let _ = writeln!(
+                        code,
+                        "\t{}{}($$renderer, $.spread_props([",
+                        name, call_syntax
+                    );
                     for item in props_and_spreads {
                         match item {
                             ComponentPropItem::Props(props) => {
@@ -6325,9 +6775,12 @@ impl<'a> ServerCodeGenerator<'a> {
                     if all_props.is_empty() {
                         let _ = writeln!(code, "$$slots: {{ {} }} }});", slots_str);
                     } else {
-                        let _ = writeln!(code, "{}, $$slots: {{ {} }} }});",
+                        let _ = writeln!(
+                            code,
+                            "{}, $$slots: {{ {} }} }});",
                             all_props.join(", "),
-                            slots_str);
+                            slots_str
+                        );
                     }
                 }
                 code.push_str("}\n");
@@ -6348,12 +6801,18 @@ impl<'a> ServerCodeGenerator<'a> {
                         3,
                     );
                     if params.is_empty() {
-                        let _ = write!(slots_block, "\t\t{}: ($$renderer) => {{\n{}",
-                            quoted_name, fn_body);
+                        let _ = write!(
+                            slots_block,
+                            "\t\t{}: ($$renderer) => {{\n{}",
+                            quoted_name, fn_body
+                        );
                     } else {
                         let params_str = format!("{{ {} }}", params.join(", "));
-                        let _ = write!(slots_block, "\t\t{}: ($$renderer, {}) => {{\n{}",
-                            quoted_name, params_str, fn_body);
+                        let _ = write!(
+                            slots_block,
+                            "\t\t{}: ($$renderer, {}) => {{\n{}",
+                            quoted_name, params_str, fn_body
+                        );
                     }
                     slots_block.push_str("\t\t},\n");
                 }
@@ -6364,8 +6823,7 @@ impl<'a> ServerCodeGenerator<'a> {
                     // `{...rest}`. Emit
                     // `$.spread_props([…interleaved spreads/props…, { [children:…], $$slots: { … } }])`
                     // (issue #448, H-105).
-                    let _ = writeln!(code, "{}{}($$renderer, $.spread_props([",
-                        name, call_syntax);
+                    let _ = writeln!(code, "{}{}($$renderer, $.spread_props([", name, call_syntax);
                     for item in props_and_spreads {
                         match item {
                             ComponentPropItem::Props(props) => {
@@ -6398,8 +6856,7 @@ impl<'a> ServerCodeGenerator<'a> {
             } else if let Some(children_parts) = children {
                 let has_let_dirs = !let_directives.is_empty();
                 if component_has_spreads {
-                    let _ = writeln!(code, "{}{}($$renderer, $.spread_props([",
-                        name, call_syntax);
+                    let _ = writeln!(code, "{}{}($$renderer, $.spread_props([", name, call_syntax);
                     let trailing_props: Vec<String> =
                         if let Some(ComponentPropItem::Props(props)) = props_and_spreads.last() {
                             props.clone()
@@ -6429,8 +6886,7 @@ impl<'a> ServerCodeGenerator<'a> {
                         code.push_str("\t\tchildren: $.invalid_default_snippet,\n");
                         code.push_str("\t\t$$slots: {\n");
                         let params_str = format!("{{ {} }}", let_directives.join(", "));
-                        let _ = writeln!(code, "\t\t\tdefault: ($$renderer, {}) => {{",
-                            params_str);
+                        let _ = writeln!(code, "\t\t\tdefault: ($$renderer, {}) => {{", params_str);
                         let children_code = super::bridge::generate_inner_body_code_direct(
                             children_parts,
                             store_subs,
@@ -6448,12 +6904,18 @@ impl<'a> ServerCodeGenerator<'a> {
                                 4,
                             );
                             if params.is_empty() {
-                                let _ = write!(code, "\t\t\t{}: ($$renderer) => {{\n{}",
-                                    quoted_name, fn_body);
+                                let _ = write!(
+                                    code,
+                                    "\t\t\t{}: ($$renderer) => {{\n{}",
+                                    quoted_name, fn_body
+                                );
                             } else {
                                 let params_str = format!("{{ {} }}", params.join(", "));
-                                let _ = write!(code, "\t\t\t{}: ($$renderer, {}) => {{\n{}",
-                                    quoted_name, params_str, fn_body);
+                                let _ = write!(
+                                    code,
+                                    "\t\t\t{}: ($$renderer, {}) => {{\n{}",
+                                    quoted_name, params_str, fn_body
+                                );
                             }
                             code.push_str("\t\t\t},\n");
                         }
@@ -6490,12 +6952,18 @@ impl<'a> ServerCodeGenerator<'a> {
                                     4,
                                 );
                                 if params.is_empty() {
-                                    let _ = write!(code, "\t\t\t{}: ($$renderer) => {{\n{}",
-                                        quoted_name, fn_body);
+                                    let _ = write!(
+                                        code,
+                                        "\t\t\t{}: ($$renderer) => {{\n{}",
+                                        quoted_name, fn_body
+                                    );
                                 } else {
                                     let params_str = format!("{{ {} }}", params.join(", "));
-                                    let _ = write!(code, "\t\t\t{}: ($$renderer, {}) => {{\n{}",
-                                        quoted_name, params_str, fn_body);
+                                    let _ = write!(
+                                        code,
+                                        "\t\t\t{}: ($$renderer, {}) => {{\n{}",
+                                        quoted_name, params_str, fn_body
+                                    );
                                 }
                                 code.push_str("\t\t\t},\n");
                             }
@@ -6519,8 +6987,7 @@ impl<'a> ServerCodeGenerator<'a> {
                         code.push_str("\tchildren: $.invalid_default_snippet,\n");
                         code.push_str("\t$$slots: {\n");
                         let params_str = format!("{{ {} }}", let_directives.join(", "));
-                        let _ = writeln!(code, "\t\tdefault: ($$renderer, {}) => {{",
-                            params_str);
+                        let _ = writeln!(code, "\t\tdefault: ($$renderer, {}) => {{", params_str);
                         let children_code = super::bridge::generate_inner_body_code_direct(
                             children_parts,
                             store_subs,
@@ -6538,12 +7005,18 @@ impl<'a> ServerCodeGenerator<'a> {
                                 3,
                             );
                             if params.is_empty() {
-                                let _ = write!(code, "\t\t{}: ($$renderer) => {{\n{}",
-                                    quoted_name, fn_body);
+                                let _ = write!(
+                                    code,
+                                    "\t\t{}: ($$renderer) => {{\n{}",
+                                    quoted_name, fn_body
+                                );
                             } else {
                                 let params_str = format!("{{ {} }}", params.join(", "));
-                                let _ = write!(code, "\t\t{}: ($$renderer, {}) => {{\n{}",
-                                    quoted_name, params_str, fn_body);
+                                let _ = write!(
+                                    code,
+                                    "\t\t{}: ($$renderer, {}) => {{\n{}",
+                                    quoted_name, params_str, fn_body
+                                );
                             }
                             code.push_str("\t\t},\n");
                         }
@@ -6556,8 +7029,7 @@ impl<'a> ServerCodeGenerator<'a> {
                             each_counter,
                             3,
                         );
-                        let _ = write!(code, "\t\tdefault: ($$renderer) => {{\n{}",
-                            children_code);
+                        let _ = write!(code, "\t\tdefault: ($$renderer) => {{\n{}", children_code);
                         code.push_str("\t\t}");
                         for (slot_name, params, body_parts, _) in &slot_children {
                             code.push_str(",\n");
@@ -6569,12 +7041,18 @@ impl<'a> ServerCodeGenerator<'a> {
                                 3,
                             );
                             if params.is_empty() {
-                                let _ = write!(code, "\t\t{}: ($$renderer) => {{\n{}",
-                                    quoted_name, fn_body);
+                                let _ = write!(
+                                    code,
+                                    "\t\t{}: ($$renderer) => {{\n{}",
+                                    quoted_name, fn_body
+                                );
                             } else {
                                 let params_str = format!("{{ {} }}", params.join(", "));
-                                let _ = write!(code, "\t\t{}: ($$renderer, {}) => {{\n{}",
-                                    quoted_name, params_str, fn_body);
+                                let _ = write!(
+                                    code,
+                                    "\t\t{}: ($$renderer, {}) => {{\n{}",
+                                    quoted_name, params_str, fn_body
+                                );
                             }
                             code.push_str("\t\t}");
                         }
@@ -6612,12 +7090,18 @@ impl<'a> ServerCodeGenerator<'a> {
                                     3,
                                 );
                                 if params.is_empty() {
-                                    let _ = write!(code, "\t\t{}: ($$renderer) => {{\n{}",
-                                        quoted_name, fn_body);
+                                    let _ = write!(
+                                        code,
+                                        "\t\t{}: ($$renderer) => {{\n{}",
+                                        quoted_name, fn_body
+                                    );
                                 } else {
                                     let params_str = format!("{{ {} }}", params.join(", "));
-                                    let _ = write!(code, "\t\t{}: ($$renderer, {}) => {{\n{}",
-                                        quoted_name, params_str, fn_body);
+                                    let _ = write!(
+                                        code,
+                                        "\t\t{}: ($$renderer, {}) => {{\n{}",
+                                        quoted_name, params_str, fn_body
+                                    );
                                 }
                                 code.push_str("\t\t},\n");
                             }
@@ -6717,16 +7201,22 @@ impl<'a> ServerCodeGenerator<'a> {
                 if !save_decls.is_empty() {
                     code.push('\n');
                 }
-                let _ = writeln!(code, "\t{}{}($$renderer, $.spread_props([{}]));",
+                let _ = writeln!(
+                    code,
+                    "\t{}{}($$renderer, $.spread_props([{}]));",
                     name,
                     call_syntax,
-                    transformed_items.join(", "));
+                    transformed_items.join(", ")
+                );
                 code.push_str("});\n");
             } else {
-                let _ = writeln!(code, "{}{}($$renderer, $.spread_props([{}]));",
+                let _ = writeln!(
+                    code,
+                    "{}{}($$renderer, $.spread_props([{}]));",
                     name,
                     call_syntax,
-                    spread_items.join(", "));
+                    spread_items.join(", ")
+                );
             }
         } else {
             let all_props = collect_all_props(props_and_spreads);
@@ -6736,15 +7226,21 @@ impl<'a> ServerCodeGenerator<'a> {
                     .map(|(n, v)| format!("{}: {}", n, v))
                     .collect::<Vec<_>>()
                     .join(", ");
-                let _ = writeln!(code, "\n$.css_props($$renderer, {}, {{ {} }}, () => {{",
-                    css_props_is_html, css_props_str);
+                let _ = writeln!(
+                    code,
+                    "\n$.css_props($$renderer, {}, {{ {} }}, () => {{",
+                    css_props_is_html, css_props_str
+                );
                 if all_props.is_empty() {
                     let _ = writeln!(code, "\t{}{}($$renderer, {{}});", name, call_syntax);
                 } else {
-                    let _ = writeln!(code, "\t{}{}($$renderer, {{ {} }});",
+                    let _ = writeln!(
+                        code,
+                        "\t{}{}($$renderer, {{ {} }});",
                         name,
                         call_syntax,
-                        all_props.join(", "));
+                        all_props.join(", ")
+                    );
                 }
                 if dynamic {
                     code.push_str("}, true);\n");
@@ -6788,16 +7284,22 @@ impl<'a> ServerCodeGenerator<'a> {
                     if !save_decls.is_empty() {
                         code.push('\n');
                     }
-                    let _ = writeln!(code, "\t{}{}($$renderer, {{ {} }});",
+                    let _ = writeln!(
+                        code,
+                        "\t{}{}($$renderer, {{ {} }});",
                         name,
                         call_syntax,
-                        transformed_props.join(", "));
+                        transformed_props.join(", ")
+                    );
                     code.push_str("});\n");
                 } else {
-                    let _ = writeln!(code, "{}{}($$renderer, {{ {} }});",
+                    let _ = writeln!(
+                        code,
+                        "{}{}($$renderer, {{ {} }});",
                         name,
                         call_syntax,
-                        all_props.join(", "));
+                        all_props.join(", ")
+                    );
                 }
             }
         }
@@ -6905,8 +7407,11 @@ impl<'a> ServerCodeGenerator<'a> {
             }
             let inner_indent = if has_true_snippets { "\t" } else { "" };
 
-            let _ = writeln!(code, "{}{}{}($$renderer, $.spread_props([",
-                inner_indent, name, call_syntax);
+            let _ = writeln!(
+                code,
+                "{}{}{}($$renderer, $.spread_props([",
+                inner_indent, name, call_syntax
+            );
             for item in props_and_spreads {
                 match item {
                     ComponentPropItem::Props(props) => {
@@ -6931,8 +7436,7 @@ impl<'a> ServerCodeGenerator<'a> {
                 let _ = writeln!(code, "{}\t\tget {}() {{", inner_indent, prop_name);
                 let _ = writeln!(code, "{}\t\t\treturn {};", inner_indent, getter_expr);
                 let _ = writeln!(code, "{}\t\t}},\n", inner_indent);
-                let _ = writeln!(code, "{}\t\tset {}($$value) {{",
-                    inner_indent, prop_name);
+                let _ = writeln!(code, "{}\t\tset {}($$value) {{", inner_indent, prop_name);
                 let _ = writeln!(code, "{}\t\t\t{};", inner_indent, setter_expr);
                 if !is_seq {
                     let _ = writeln!(code, "{}\t\t\t$$settled = false;", inner_indent);
@@ -6959,11 +7463,13 @@ impl<'a> ServerCodeGenerator<'a> {
                     if has_true_snippets { 3 } else { 2 },
                 );
                 if component_dev {
-                    let _ = writeln!(code, "{}\t\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
-                        inner_indent);
+                    let _ = writeln!(
+                        code,
+                        "{}\t\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
+                        inner_indent
+                    );
                 } else {
-                    let _ = writeln!(code, "{}\t\tchildren: ($$renderer) => {{",
-                        inner_indent);
+                    let _ = writeln!(code, "{}\t\tchildren: ($$renderer) => {{", inner_indent);
                 }
                 code.push_str(&children_code);
                 if component_dev {
@@ -6993,12 +7499,18 @@ impl<'a> ServerCodeGenerator<'a> {
                             if has_true_snippets { 4 } else { 3 },
                         );
                         if params.is_empty() {
-                            let _ = writeln!(code, "{}\t\t\t{}: ($$renderer) => {{\n{}{}\t\t\t}},",
-                                inner_indent, quoted_name, fn_body, inner_indent);
+                            let _ = writeln!(
+                                code,
+                                "{}\t\t\t{}: ($$renderer) => {{\n{}{}\t\t\t}},",
+                                inner_indent, quoted_name, fn_body, inner_indent
+                            );
                         } else {
                             let params_str = format!("{{ {} }}", params.join(", "));
-                            let _ = writeln!(code, "{}\t\t\t{}: ($$renderer, {}) => {{\n{}{}\t\t\t}},",
-                                inner_indent, quoted_name, params_str, fn_body, inner_indent);
+                            let _ = writeln!(
+                                code,
+                                "{}\t\t\t{}: ($$renderer, {}) => {{\n{}{}\t\t\t}},",
+                                inner_indent, quoted_name, params_str, fn_body, inner_indent
+                            );
                         }
                     } else {
                         let _ = writeln!(code, "{}\t\t\t{}: true,", inner_indent, quoted_name);
@@ -7051,8 +7563,11 @@ impl<'a> ServerCodeGenerator<'a> {
                     code.push_str("\t}\n\n");
                 }
             }
-            let _ = writeln!(code, "{}{}{}($$renderer, {{",
-                inner_indent, name, call_syntax);
+            let _ = writeln!(
+                code,
+                "{}{}{}($$renderer, {{",
+                inner_indent, name, call_syntax
+            );
             for prop in &all_props {
                 let _ = writeln!(code, "{}\t{},", inner_indent, prop);
             }
@@ -7064,8 +7579,7 @@ impl<'a> ServerCodeGenerator<'a> {
                 let _ = writeln!(code, "{}\tget {}() {{", inner_indent, prop_name);
                 let _ = writeln!(code, "{}\t\treturn {};", inner_indent, getter_expr);
                 let _ = writeln!(code, "{}\t}},\n", inner_indent);
-                let _ = writeln!(code, "{}\tset {}($$value) {{",
-                    inner_indent, prop_name);
+                let _ = writeln!(code, "{}\tset {}($$value) {{", inner_indent, prop_name);
                 let _ = writeln!(code, "{}\t\t{};", inner_indent, setter_expr);
                 if !is_seq {
                     let _ = writeln!(code, "{}\t\t$$settled = false;", inner_indent);
@@ -7087,8 +7601,11 @@ impl<'a> ServerCodeGenerator<'a> {
                     2,
                 );
                 if component_dev {
-                    let _ = writeln!(code, "{}\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
-                        inner_indent);
+                    let _ = writeln!(
+                        code,
+                        "{}\tchildren: $.prevent_snippet_stringification(($$renderer) => {{",
+                        inner_indent
+                    );
                 } else {
                     let _ = writeln!(code, "{}\tchildren: ($$renderer) => {{", inner_indent);
                 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -4,11 +4,11 @@
 //! visitor implementations. These were extracted from `transform_server.rs`
 //! to keep the visitor files focused on their specific AST node handling.
 
-use std::fmt::Write as _;
 use super::types::{ConstantFoldResult, OutputPart};
 use crate::ast::template::{Attribute, AttributeValue, AttributeValuePart, Script, TemplateNode};
 use memchr::memmem;
 use rustc_hash::FxHashMap;
+use std::fmt::Write as _;
 
 // Re-export from sibling modules for backward compatibility
 pub(crate) use super::transform_legacy::*;
@@ -1378,8 +1378,11 @@ pub(crate) fn transform_props_spread_ex(
 
             // Case 1: Simple identifier (let props = $$props)
             if !pattern.starts_with('{') {
-                let _ = writeln!(result, "{}{} {{ {}, $$events, ...{} }} = $$props;",
-                    target_indent, decl_keyword, slots_part, pattern);
+                let _ = writeln!(
+                    result,
+                    "{}{} {{ {}, $$events, ...{} }} = $$props;",
+                    target_indent, decl_keyword, slots_part, pattern
+                );
                 continue;
             }
 
@@ -1394,11 +1397,17 @@ pub(crate) fn transform_props_spread_ex(
                     let other_props = inner[..rest_idx].trim().trim_end_matches(',').trim();
 
                     if other_props.is_empty() {
-                        let _ = writeln!(result, "{}{} {{ {}, $$events, ...{} }} = $$props;",
-                            target_indent, decl_keyword, slots_part, rest_name);
+                        let _ = writeln!(
+                            result,
+                            "{}{} {{ {}, $$events, ...{} }} = $$props;",
+                            target_indent, decl_keyword, slots_part, rest_name
+                        );
                     } else {
-                        let _ = writeln!(result, "{}{} {{ {}, {}, $$events, ...{} }} = $$props;",
-                            target_indent, decl_keyword, other_props, slots_part, rest_name);
+                        let _ = writeln!(
+                            result,
+                            "{}{} {{ {}, {}, $$events, ...{} }} = $$props;",
+                            target_indent, decl_keyword, other_props, slots_part, rest_name
+                        );
                     }
                     continue;
                 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_legacy.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_legacy.rs
@@ -4,8 +4,8 @@
 //! for server-side code generation, including `export let` declarations, reactive
 //! `$:` statements, and related helper utilities.
 
-use std::fmt::Write as _;
 use memchr::memmem;
+use std::fmt::Write as _;
 
 /// Check if the declaration string contains a semicolon at depth 0 (not inside braces/parens/brackets).
 /// This is used to determine if an export let declaration is complete.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -4,7 +4,6 @@
 //! for server-side code generation, including rune transformations, class field transforms,
 //! and effect block removal.
 
-use std::fmt::Write as _;
 use super::helpers::sanitize_identifier;
 use super::transform_legacy::transform_export_let_declarations;
 use super::transform_store::{
@@ -12,6 +11,7 @@ use super::transform_store::{
 };
 use memchr::memmem;
 use rustc_hash::FxHashSet;
+use std::fmt::Write as _;
 
 pub(crate) fn transform_script_content_module(script: &str, dev: bool) -> String {
     transform_script_content_inner(
@@ -560,25 +560,43 @@ pub(crate) fn transform_reassigned_destructures(
         for prop in &props {
             match prop {
                 ObjectPatternProp::Simple(name) => {
-                    let _ = write!(transformed, ",\n{}\t{} = {}.{}", indent, name, tmp_name, name);
+                    let _ = write!(
+                        transformed,
+                        ",\n{}\t{} = {}.{}",
+                        indent, name, tmp_name, name
+                    );
                 }
                 ObjectPatternProp::Renamed { key, value } => {
-                    let _ = write!(transformed, ",\n{}\t{} = {}.{}", indent, value, tmp_name, key);
+                    let _ = write!(
+                        transformed,
+                        ",\n{}\t{} = {}.{}",
+                        indent, value, tmp_name, key
+                    );
                 }
                 ObjectPatternProp::WithDefault { name, default } => {
-                    let _ = write!(transformed, ",\n{}\t{} = {}.{} ?? {}",
-                        indent, name, tmp_name, name, default);
+                    let _ = write!(
+                        transformed,
+                        ",\n{}\t{} = {}.{} ?? {}",
+                        indent, name, tmp_name, name, default
+                    );
                 }
                 ObjectPatternProp::RenamedWithDefault {
                     key,
                     value,
                     default,
                 } => {
-                    let _ = write!(transformed, ",\n{}\t{} = {}.{} ?? {}",
-                        indent, value, tmp_name, key, default);
+                    let _ = write!(
+                        transformed,
+                        ",\n{}\t{} = {}.{} ?? {}",
+                        indent, value, tmp_name, key, default
+                    );
                 }
                 ObjectPatternProp::Rest(name) => {
-                    let _ = write!(transformed, ",\n{}\t{} = {}.{}", indent, name, tmp_name, name);
+                    let _ = write!(
+                        transformed,
+                        ",\n{}\t{} = {}.{}",
+                        indent, name, tmp_name, name
+                    );
                 }
             }
         }
@@ -744,8 +762,11 @@ fn transform_object_destructure_state(script: &str) -> String {
                     }
                     ObjectPatternProp::WithDefault { name, default } => {
                         // { a = 5 } -> a = tmp.a ?? 5
-                        let _ = write!(transformed, ", {} = {}.{} ?? {}",
-                            name, tmp_name, name, default);
+                        let _ = write!(
+                            transformed,
+                            ", {} = {}.{} ?? {}",
+                            name, tmp_name, name, default
+                        );
                     }
                     ObjectPatternProp::RenamedWithDefault {
                         key,
@@ -753,8 +774,11 @@ fn transform_object_destructure_state(script: &str) -> String {
                         default,
                     } => {
                         // { a: x = 5 } -> x = tmp.a ?? 5
-                        let _ = write!(transformed, ", {} = {}.{} ?? {}",
-                            value, tmp_name, key, default);
+                        let _ = write!(
+                            transformed,
+                            ", {} = {}.{} ?? {}",
+                            value, tmp_name, key, default
+                        );
                     }
                     ObjectPatternProp::Rest(name) => {
                         // TODO: Handle rest pattern if needed
@@ -901,23 +925,32 @@ fn transform_array_destructure_state(script: &str) -> String {
             if has_rest {
                 let _ = write!(transformed, "{}\t$$array = $.to_array(tmp)", indent);
             } else {
-                let _ = write!(transformed, "{}\t$$array = $.to_array(tmp, {})",
+                let _ = write!(
+                    transformed,
+                    "{}\t$$array = $.to_array(tmp, {})",
                     indent,
-                    vars.len());
+                    vars.len()
+                );
             }
 
             for (i, var) in vars.iter().enumerate() {
                 let var = var.trim();
                 if var.starts_with("...") {
                     let rest_name = var.trim_start_matches("...");
-                    let _ = write!(transformed, ",\n{}\t{} = $$array.slice({})",
-                        indent, rest_name, i);
+                    let _ = write!(
+                        transformed,
+                        ",\n{}\t{} = $$array.slice({})",
+                        indent, rest_name, i
+                    );
                 } else if var.contains('=') {
                     let parts: Vec<&str> = var.splitn(2, '=').collect();
                     let name = parts[0].trim();
                     let default = parts.get(1).map(|s| s.trim()).unwrap_or("void 0");
-                    let _ = write!(transformed, ",\n{}\t{} = $$array[{}] ?? {}",
-                        indent, name, i, default);
+                    let _ = write!(
+                        transformed,
+                        ",\n{}\t{} = $$array[{}] ?? {}",
+                        indent, name, i, default
+                    );
                 } else {
                     let _ = write!(transformed, ",\n{}\t{} = $$array[{}]", indent, var, i);
                 }
@@ -1140,16 +1173,22 @@ pub(crate) fn flatten_store_get_destructures(script: &str) -> String {
                         let _ = write!(transformed, ",\n{}\t{} = tmp.{}", indent, value, key);
                     }
                     ObjectPatternProp::WithDefault { name, default } => {
-                        let _ = write!(transformed, ",\n{}\t{} = tmp.{} ?? {}",
-                            indent, name, name, default);
+                        let _ = write!(
+                            transformed,
+                            ",\n{}\t{} = tmp.{} ?? {}",
+                            indent, name, name, default
+                        );
                     }
                     ObjectPatternProp::RenamedWithDefault {
                         key,
                         value,
                         default,
                     } => {
-                        let _ = write!(transformed, ",\n{}\t{} = tmp.{} ?? {}",
-                            indent, value, key, default);
+                        let _ = write!(
+                            transformed,
+                            ",\n{}\t{} = tmp.{} ?? {}",
+                            indent, value, key, default
+                        );
                     }
                     ObjectPatternProp::Rest(name) => {
                         let _ = write!(transformed, ",\n{}\t{} = tmp.{}", indent, name, name);
@@ -4860,11 +4899,17 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
 
         let _ = writeln!(new_class_body, "\t\t{};", private_name);
         new_class_body.push('\n');
-        let _ = writeln!(new_class_body, "\t\tget {}() {{\n\t\t\treturn this.{}();\n\t\t}}",
-            field.name, private_name);
+        let _ = writeln!(
+            new_class_body,
+            "\t\tget {}() {{\n\t\t\treturn this.{}();\n\t\t}}",
+            field.name, private_name
+        );
         new_class_body.push('\n');
-        let _ = writeln!(new_class_body, "\t\tset {}($$value) {{\n\t\t\treturn this.{}($$value);\n\t\t}}",
-            field.name, private_name);
+        let _ = writeln!(
+            new_class_body,
+            "\t\tset {}($$value) {{\n\t\t\treturn this.{}($$value);\n\t\t}}",
+            field.name, private_name
+        );
     }
 
     for member in &members {
@@ -4913,11 +4958,17 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
                             .is_some_and(|c| c.is_alphanumeric() || c == '_');
                     if is_exact_match {
                         new_class_body.push('\n');
-                        let _ = writeln!(new_class_body, "\t\tget {}() {{\n\t\t\treturn this.{}();\n\t\t}}",
-                            field.name, private_name);
+                        let _ = writeln!(
+                            new_class_body,
+                            "\t\tget {}() {{\n\t\t\treturn this.{}();\n\t\t}}",
+                            field.name, private_name
+                        );
                         new_class_body.push('\n');
-                        let _ = writeln!(new_class_body, "\t\tset {}($$value) {{\n\t\t\treturn this.{}($$value);\n\t\t}}",
-                            field.name, private_name);
+                        let _ = writeln!(
+                            new_class_body,
+                            "\t\tset {}($$value) {{\n\t\t\treturn this.{}($$value);\n\t\t}}",
+                            field.name, private_name
+                        );
                     }
                 }
             }
@@ -4969,7 +5020,8 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
 
                             if let Some(end) = value_end {
                                 let value = after_assign[..end].trim();
-                                let _ = write!(new_transformed, "this.{}({});", private_name, value);
+                                let _ =
+                                    write!(new_transformed, "this.{}({});", private_name, value);
                                 remaining = &after_assign[end + 1..];
                             } else {
                                 // No semicolon found, leave as-is
@@ -5238,13 +5290,19 @@ fn transform_inspect_to_console_log(script: &str) -> String {
 
                     if let Some(callback) = with_callback {
                         // $inspect(args).with(fn) => (fn)('init', args)
-                        let _ = writeln!(result, "({})('init', {});",
+                        let _ = writeln!(
+                            result,
+                            "({})('init', {});",
                             callback.trim(),
-                            args_str.trim());
+                            args_str.trim()
+                        );
                     } else {
                         // $inspect(args) => console.log('$inspect(', args, ')')
-                        let _ = writeln!(result, "console.log('$inspect(', {}, ')');",
-                            args_str.trim());
+                        let _ = writeln!(
+                            result,
+                            "console.log('$inspect(', {}, ')');",
+                            args_str.trim()
+                        );
                     }
                     i = end;
                     continue;
@@ -5621,8 +5679,11 @@ fn transform_reexported_prop_declarations(
                                 .iter()
                                 .find(|(local, _)| local == part_name)
                             {
-                                let _ = write!(result, "{}let {} = $$props['{}'];",
-                                    indent, part_name, prop_name);
+                                let _ = write!(
+                                    result,
+                                    "{}let {} = $$props['{}'];",
+                                    indent, part_name, prop_name
+                                );
                             } else {
                                 let _ = write!(result, "{}let {};", indent, part_name);
                             }
@@ -5634,8 +5695,7 @@ fn transform_reexported_prop_declarations(
                     reexported_props.iter().find(|(local, _)| local == name)
                 {
                     let indent = &line[..line.len() - trimmed.len()];
-                    let _ = write!(result, "{}let {} = $$props['{}'];",
-                        indent, name, prop_name);
+                    let _ = write!(result, "{}let {} = $$props['{}'];", indent, name, prop_name);
                     result.push('\n');
                     continue;
                 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_store.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_store.rs
@@ -68,8 +68,11 @@ pub(crate) fn replace_store_identifier(expr: &str, store_ref: &str, store_name: 
                 };
 
                 if !prev_is_ident && !next_is_ident {
-                    let _ = write!(result, "$.store_get($$store_subs ??= {{}}, '{}', {})",
-                        store_ref, store_name);
+                    let _ = write!(
+                        result,
+                        "$.store_get($$store_subs ??= {{}}, '{}', {})",
+                        store_ref, store_name
+                    );
                     i += store_ref_len;
                     continue;
                 }
@@ -485,8 +488,11 @@ pub(crate) fn replace_store_identifier_in_script(
 
                     if !is_in_store_call && !is_shadowed && !is_param_decl && !is_in_paren_fn_param
                     {
-                        let _ = write!(result, "$.store_get($$store_subs ??= {{}}, '{}', {})",
-                            store_ref, store_name);
+                        let _ = write!(
+                            result,
+                            "$.store_get($$store_subs ??= {{}}, '{}', {})",
+                            store_ref, store_name
+                        );
                         i += store_ref_len;
                         continue;
                     }
@@ -1529,11 +1535,17 @@ fn transform_store_assignments_once(script: &str) -> String {
         match operator {
             "++" | "--" => {
                 if operator == "++" {
-                    let _ = write!(new_result, "$.update_store($$store_subs ??= {{}}, '${0}', {0})",
-                        store_name);
+                    let _ = write!(
+                        new_result,
+                        "$.update_store($$store_subs ??= {{}}, '${0}', {0})",
+                        store_name
+                    );
                 } else {
-                    let _ = write!(new_result, "$.update_store($$store_subs ??= {{}}, '${0}', {0}, -1)",
-                        store_name);
+                    let _ = write!(
+                        new_result,
+                        "$.update_store($$store_subs ??= {{}}, '${0}', {0}, -1)",
+                        store_name
+                    );
                 }
             }
             "=" => {
@@ -1569,8 +1581,11 @@ fn transform_store_assignments_once(script: &str) -> String {
                 let rest = &result[end..];
                 let value_end = find_statement_end(rest);
                 let value = rest[..value_end].trim();
-                let _ = write!(new_result, "$.store_set({}, $.store_get($$store_subs ??= {{}}, '${0}', {0}) {} {})",
-                    store_name, base_op, value);
+                let _ = write!(
+                    new_result,
+                    "$.store_set({}, $.store_get($$store_subs ??= {{}}, '${0}', {0}) {} {})",
+                    store_name, base_op, value
+                );
                 last_end = end + value_end;
                 continue;
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/element.rs
@@ -3,7 +3,6 @@
 //! Contains generate_element() and all element-related methods including
 //! attribute generation, class/style directive handling, and spread attributes.
 
-use std::fmt::Write as _;
 use super::super::ServerCodeGenerator;
 use super::super::helpers::{collapse_whitespace, needs_clsx, prop_string, quote_prop_name};
 use super::super::types::OutputPart;
@@ -18,6 +17,7 @@ use crate::compiler::phases::phase3_transform::shared::{
 use crate::compiler::phases::phase3_transform::utils::{
     is_svelte_whitespace_only, svelte_trim, svelte_trim_end, svelte_trim_start,
 };
+use std::fmt::Write as _;
 
 /// Compute 1-based line number and 0-based column for a byte offset in source.
 pub(crate) fn locate_in_source(source: &str, offset: usize) -> (usize, usize) {
@@ -267,8 +267,11 @@ impl<'a> ServerCodeGenerator<'a> {
                                                     if matches!(eval, AttrExprEval::StringNoWrap) {
                                                         let _ = write!(tmpl, "${{{}}}", expr);
                                                     } else {
-                                                        let _ = write!(tmpl, "${{$.stringify({})}}",
-                                                            expr);
+                                                        let _ = write!(
+                                                            tmpl,
+                                                            "${{$.stringify({})}}",
+                                                            expr
+                                                        );
                                                     }
                                                 }
                                             }
@@ -2882,10 +2885,14 @@ impl<'a> ServerCodeGenerator<'a> {
                                                 let transformed =
                                                     self.transform_store_refs(expr_src);
                                                 if matches!(eval, AttrExprEval::StringNoWrap) {
-                                                    let _ = write!(template, "${{{}}}", transformed);
+                                                    let _ =
+                                                        write!(template, "${{{}}}", transformed);
                                                 } else {
-                                                    let _ = write!(template, "${{$.stringify({})}}",
-                                                        transformed);
+                                                    let _ = write!(
+                                                        template,
+                                                        "${{$.stringify({})}}",
+                                                        transformed
+                                                    );
                                                 }
                                             }
                                         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/select_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/select_element.rs
@@ -1,6 +1,5 @@
 //! Server-side select, textarea, and option element visitors.
 
-use std::fmt::Write as _;
 use super::super::ServerCodeGenerator;
 use super::super::helpers::prop_string;
 use super::super::types::OutputPart;
@@ -10,6 +9,7 @@ use crate::ast::template::{
 use crate::compiler::phases::phase3_transform::TransformError;
 use crate::compiler::phases::phase3_transform::shared::{escape_attr, escape_js_string};
 use crate::compiler::phases::phase3_transform::utils::is_svelte_whitespace_only;
+use std::fmt::Write as _;
 
 impl<'a> ServerCodeGenerator<'a> {
     /// Generate <select> element using $$renderer.select().
@@ -526,8 +526,7 @@ impl<'a> ServerCodeGenerator<'a> {
                                                 let expr = self.source[expr_start..expr_end]
                                                     .trim()
                                                     .to_string();
-                                                let _ = write!(value, "${{$.stringify({})}}",
-                                                    expr);
+                                                let _ = write!(value, "${{$.stringify({})}}", expr);
                                             }
                                         }
                                     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/shared/utils.rs
@@ -3,7 +3,6 @@
 //! This module contains helper functions used by multiple server-side visitors.
 //! It corresponds to `svelte/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js`.
 
-use std::fmt::Write as _;
 use crate::ast::template::{AttributeValuePart, TemplateNode};
 use crate::compiler::constants::{BLOCK_CLOSE, BLOCK_OPEN, BLOCK_OPEN_ELSE, EMPTY_COMMENT};
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
@@ -12,6 +11,7 @@ use crate::compiler::phases::phase3_transform::server::types::{
 };
 use crate::compiler::phases::phase3_transform::shared::{escape_html, sanitize_template_string};
 use compact_str::CompactString;
+use std::fmt::Write as _;
 
 /// Strip TypeScript annotations from an expression string.
 fn strip_ts_from_expr_simple(expr: &str) -> String {
@@ -292,7 +292,7 @@ pub fn build_template(
                                 JsLiteral::Null => last.push_str("null"),
                                 JsLiteral::Undefined => last.push_str("undefined"),
                                 JsLiteral::Regex { pattern, flags } => {
-                                    { let _ = write!(last, "/{}/{}", pattern, flags); }
+                                    let _ = write!(last, "/{}/{}", pattern, flags);
                                 }
                             }
                         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/slot_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/slot_element.rs
@@ -3,12 +3,12 @@
 //! Generates `$.slot()` calls for `<slot>` elements.
 //! Corresponds to SlotElement.js in the official Svelte compiler.
 
-use std::fmt::Write as _;
 use super::super::ServerCodeGenerator;
 use super::super::helpers::prop_string;
 use super::super::types::OutputPart;
 use crate::ast::template::{Attribute, AttributeValue, AttributeValuePart, SlotElement};
 use crate::compiler::phases::phase3_transform::TransformError;
+use std::fmt::Write as _;
 
 impl<'a> ServerCodeGenerator<'a> {
     pub(crate) fn generate_slot_element(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/visitors/svelte_element.rs
@@ -1,12 +1,12 @@
 //! Server-side svelte:element (dynamic element) visitor.
 
-use std::fmt::Write as _;
 use super::super::ServerCodeGenerator;
 use super::super::helpers::{needs_clsx, prop_string};
 use super::super::types::OutputPart;
 use crate::ast::template::{Attribute, AttributeValue, AttributeValuePart, SvelteDynamicElement};
 use crate::compiler::phases::phase3_transform::TransformError;
 use crate::compiler::phases::phase3_transform::shared::template::is_boolean_attribute;
+use std::fmt::Write as _;
 
 impl<'a> ServerCodeGenerator<'a> {
     pub(crate) fn generate_svelte_element(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
@@ -7,8 +7,8 @@
 //!
 //! Corresponds to `transform_body()` in `svelte/packages/svelte/src/compiler/phases/3-transform/shared/transform-async.js`
 
-use std::fmt::Write as _;
 use memchr::memmem;
+use std::fmt::Write as _;
 
 /// Result of the async body transformation.
 pub struct AsyncBodyResult {

--- a/crates/rsvelte_core/src/compiler/preprocess/replace_in_code.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/replace_in_code.rs
@@ -372,8 +372,8 @@ fn merge_tables<T: Clone + Eq>(this_table: &[T], other_table: &[T]) -> (Vec<T>, 
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::types::Location;
+    use super::*;
     use std::sync::Arc;
 
     fn create_test_source(code: &str) -> Source {

--- a/crates/rsvelte_core/src/compiler/print/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/print/helpers.rs
@@ -3,8 +3,8 @@
 //! This module provides utility functions used during the printing process,
 //! such as formatting blocks and handling attributes.
 
-use std::fmt::Write as _;
 use super::Context;
+use std::fmt::Write as _;
 
 /// Threshold for when content should be formatted on separate lines.
 ///

--- a/crates/rsvelte_core/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/magic_string.rs
@@ -5,8 +5,8 @@
 //! of the original string. Chunks can be modified (overwrite, remove, prepend, append)
 //! while preserving position information for accurate source mapping.
 
-use std::fmt::Write as _;
 use std::fmt;
+use std::fmt::Write as _;
 
 use rustc_hash::FxHashMap;
 type HashMap<K, V> = FxHashMap<K, V>;

--- a/crates/rsvelte_core/src/svelte2tsx/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/mod.rs
@@ -1,10 +1,29 @@
-#[allow(clippy::inherent_to_string_shadow_display, reason = "MagicString::to_string mirrors JS `MagicString.toString()`; the inherent name is the ported public API")]
+#[allow(
+    clippy::inherent_to_string_shadow_display,
+    reason = "MagicString::to_string mirrors JS `MagicString.toString()`; the inherent name is the ported public API"
+)]
 pub mod magic_string;
-#[allow(dead_code, clippy::doc_lazy_continuation, clippy::if_same_then_else, reason = "ported svelte2tsx module: retains upstream TS structure (explicit branches / doc layout) and helpers not yet wired into the port; only these specific lints are waived, full rustc + clippy enforcement applies otherwise")]
+#[allow(
+    dead_code,
+    clippy::doc_lazy_continuation,
+    clippy::if_same_then_else,
+    reason = "ported svelte2tsx module: retains upstream TS structure (explicit branches / doc layout) and helpers not yet wired into the port; only these specific lints are waived, full rustc + clippy enforcement applies otherwise"
+)]
 pub mod script;
-#[allow(dead_code, clippy::if_same_then_else, clippy::unnecessary_unwrap, clippy::module_inception, reason = "ported svelte2tsx module: retains upstream TS structure (explicit branches / doc layout) and helpers not yet wired into the port; only these specific lints are waived, full rustc + clippy enforcement applies otherwise")]
+#[allow(
+    dead_code,
+    clippy::if_same_then_else,
+    clippy::unnecessary_unwrap,
+    clippy::module_inception,
+    reason = "ported svelte2tsx module: retains upstream TS structure (explicit branches / doc layout) and helpers not yet wired into the port; only these specific lints are waived, full rustc + clippy enforcement applies otherwise"
+)]
 pub mod svelte2tsx;
-#[allow(dead_code, clippy::doc_lazy_continuation, clippy::doc_overindented_list_items, reason = "ported svelte2tsx module: retains upstream TS structure (explicit branches / doc layout) and helpers not yet wired into the port; only these specific lints are waived, full rustc + clippy enforcement applies otherwise")]
+#[allow(
+    dead_code,
+    clippy::doc_lazy_continuation,
+    clippy::doc_overindented_list_items,
+    reason = "ported svelte2tsx module: retains upstream TS structure (explicit branches / doc layout) and helpers not yet wired into the port; only these specific lints are waived, full rustc + clippy enforcement applies otherwise"
+)]
 pub mod template;
 
 pub use svelte2tsx::{

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -8,8 +8,8 @@
 //! the OXC AST directly. This avoids dependency on the thread-local ParseArena
 //! used by the main compiler, keeping svelte2tsx self-contained.
 
-use std::fmt::Write as _;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write as _;
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast as oxc;
@@ -284,9 +284,10 @@ impl ExportedNames {
 
             // JSDoc named type case: `/** @type {SomeType} */` → `/** @type {SomeType} */({})`
             if let Some(ref jsdoc_type) = self.props_jsdoc_type
-                && !self.has_component_props_typedef {
-                    return format!("/** @type {} */({{}})", jsdoc_type);
-                }
+                && !self.has_component_props_typedef
+            {
+                return format!("/** @type {} */({{}})", jsdoc_type);
+            }
 
             // Otherwise, list the prop entries from $props() destructuring
             // In runes mode, named exports (export { x as y }) are NOT props
@@ -566,7 +567,9 @@ impl ComponentEvents {
     /// Returns (name, value) pairs like ("hi", "__sveltets_2_customEvent").
     pub fn get_event_entries(&self) -> Vec<(String, String)> {
         let mut entries: Vec<(String, String)> = self
-            .events.keys().map(|name| (name.clone(), "__sveltets_2_customEvent".to_string()))
+            .events
+            .keys()
+            .map(|name| (name.clone(), "__sveltets_2_customEvent".to_string()))
             .collect();
         entries.sort_by(|a, b| a.0.cmp(&b.0));
         entries
@@ -967,16 +970,17 @@ pub fn process_instance_script(
 
         for stmt in program.body.iter() {
             if let oxc::Statement::LabeledStatement(labeled) = stmt
-                && labeled.label.name == "$" {
-                    handle_reactive_statement(
-                        labeled,
-                        offset,
-                        str,
-                        raw_content,
-                        &declared_names,
-                        &mut reactive_declared_names,
-                    );
-                }
+                && labeled.label.name == "$"
+            {
+                handle_reactive_statement(
+                    labeled,
+                    offset,
+                    str,
+                    raw_content,
+                    &declared_names,
+                    &mut reactive_declared_names,
+                );
+            }
         }
 
         // Snapshot instance-script value declarations so callers (in particular
@@ -1595,19 +1599,20 @@ fn resolve_hoistable_type_decls(
                 .unwrap_or(e);
             let header = &raw_content[s..header_end];
             if let (Some(lt), Some(gt)) = (header.find('<'), header.rfind('>'))
-                && lt < gt {
-                    let inner = &header[lt + 1..gt];
-                    for part in inner.split(',') {
-                        let trimmed = part.trim();
-                        let name = trimmed
-                            .split(|ch: char| !is_ident_char_for_str(ch))
-                            .find(|s| !s.is_empty())
-                            .unwrap_or("");
-                        if !name.is_empty() {
-                            g.insert(name.to_string());
-                        }
+                && lt < gt
+            {
+                let inner = &header[lt + 1..gt];
+                for part in inner.split(',') {
+                    let trimmed = part.trim();
+                    let name = trimmed
+                        .split(|ch: char| !is_ident_char_for_str(ch))
+                        .find(|s| !s.is_empty())
+                        .unwrap_or("");
+                    if !name.is_empty() {
+                        g.insert(name.to_string());
                     }
                 }
+            }
             g
         })
         .collect();
@@ -2126,13 +2131,14 @@ fn collect_ts_type_assertions_stmt(stmt: &oxc::Statement, out: &mut Vec<(u32, u3
         }
         oxc::Statement::ExportNamedDeclaration(export) => {
             if let Some(decl) = &export.declaration
-                && let oxc::Declaration::VariableDeclaration(var_decl) = decl {
-                    for declarator in var_decl.declarations.iter() {
-                        if let Some(init) = &declarator.init {
-                            collect_ts_type_assertions_expr(init, out);
-                        }
+                && let oxc::Declaration::VariableDeclaration(var_decl) = decl
+            {
+                for declarator in var_decl.declarations.iter() {
+                    if let Some(init) = &declarator.init {
+                        collect_ts_type_assertions_expr(init, out);
                     }
                 }
+            }
         }
         _ => {
             // Other statement kinds (functions, classes, ifs, blocks…) are not
@@ -2312,9 +2318,10 @@ fn handle_export_named_decl(
                         // Update the type annotation on the exported name
                         if let Some(ref ta_text) = type_annotation_text
                             && let Some(name) = binding_pattern_simple_name(&declarator.id)
-                                && let Some(info) = exported_names.get_mut(&name) {
-                                    info.type_annotation = Some(ta_text.clone());
-                                }
+                            && let Some(info) = exported_names.get_mut(&name)
+                        {
+                            info.type_annotation = Some(ta_text.clone());
+                        }
 
                         // For multi-declarator let exports (export let a, b, c;),
                         // replace the comma between declarators with `;let `.
@@ -2348,14 +2355,16 @@ fn handle_export_named_decl(
                             .init
                             .as_ref()
                             .is_some_and(|init| matches!(init, oxc::Expression::BooleanLiteral(_)));
-                        if is_prop && (!has_default || has_type_annotation || has_boolean_init)
-                            && let Some(name) = binding_pattern_simple_name(&declarator.id) {
-                                let inject = format!(
-                                    "/*\u{03A9}ignore_start\u{03A9}*/;{name} = __sveltets_2_any({name});/*\u{03A9}ignore_end\u{03A9}*/",
-                                );
-                                let inject_pos = declarator.span.end + offset;
-                                str.append_left(inject_pos, &inject);
-                            }
+                        if is_prop
+                            && (!has_default || has_type_annotation || has_boolean_init)
+                            && let Some(name) = binding_pattern_simple_name(&declarator.id)
+                        {
+                            let inject = format!(
+                                "/*\u{03A9}ignore_start\u{03A9}*/;{name} = __sveltets_2_any({name});/*\u{03A9}ignore_end\u{03A9}*/",
+                            );
+                            let inject_pos = declarator.span.end + offset;
+                            str.append_left(inject_pos, &inject);
+                        }
 
                         // SvelteKit `+page.svelte` / `+layout.svelte`: inject
                         // `import('./$types.js').*` annotations on the
@@ -2365,53 +2374,51 @@ fn handle_export_named_decl(
                         if is_instance
                             && classify_kit_route_file(basename).is_some()
                             && !has_type_annotation
-                            && let Some(name) = binding_pattern_simple_name(&declarator.id) {
-                                let kit_layout = classify_kit_route_file(basename);
-                                let inject_type: Option<&str> = if !is_let {
-                                    // `export const snapshot = ...`
-                                    match name.as_str() {
-                                        "snapshot" => Some("import('./$types.js').Snapshot"),
-                                        _ => None,
+                            && let Some(name) = binding_pattern_simple_name(&declarator.id)
+                        {
+                            let kit_layout = classify_kit_route_file(basename);
+                            let inject_type: Option<&str> = if !is_let {
+                                // `export const snapshot = ...`
+                                match name.as_str() {
+                                    "snapshot" => Some("import('./$types.js').Snapshot"),
+                                    _ => None,
+                                }
+                            } else {
+                                // `export let data | form | params`
+                                match (name.as_str(), kit_layout) {
+                                    ("data", Some(true)) => {
+                                        Some("import('./$types.js').LayoutData")
                                     }
+                                    ("data", Some(false)) => Some("import('./$types.js').PageData"),
+                                    ("form", Some(false)) => {
+                                        Some("import('./$types.js').ActionData")
+                                    }
+                                    ("params", Some(true)) => {
+                                        Some("import('./$types.js').LayoutProps['params']")
+                                    }
+                                    ("params", Some(false)) => {
+                                        Some("import('./$types.js').PageProps['params']")
+                                    }
+                                    _ => None,
+                                }
+                            };
+                            if let Some(kit_type) = inject_type
+                                && let oxc::BindingPattern::BindingIdentifier(id) = &declarator.id
+                            {
+                                let name_start = id.span.start + offset;
+                                let name_end = id.span.end + offset;
+                                if emit_jsdoc && !is_ts {
+                                    let inject = format!("/** @type {{{}}} */ ", kit_type);
+                                    str.append_left(name_start, &inject);
                                 } else {
-                                    // `export let data | form | params`
-                                    match (name.as_str(), kit_layout) {
-                                        ("data", Some(true)) => {
-                                            Some("import('./$types.js').LayoutData")
-                                        }
-                                        ("data", Some(false)) => {
-                                            Some("import('./$types.js').PageData")
-                                        }
-                                        ("form", Some(false)) => {
-                                            Some("import('./$types.js').ActionData")
-                                        }
-                                        ("params", Some(true)) => {
-                                            Some("import('./$types.js').LayoutProps['params']")
-                                        }
-                                        ("params", Some(false)) => {
-                                            Some("import('./$types.js').PageProps['params']")
-                                        }
-                                        _ => None,
-                                    }
-                                };
-                                if let Some(kit_type) = inject_type
-                                    && let oxc::BindingPattern::BindingIdentifier(id) =
-                                        &declarator.id
-                                    {
-                                        let name_start = id.span.start + offset;
-                                        let name_end = id.span.end + offset;
-                                        if emit_jsdoc && !is_ts {
-                                            let inject = format!("/** @type {{{}}} */ ", kit_type);
-                                            str.append_left(name_start, &inject);
-                                        } else {
-                                            let inject = format!(
-                                                "/*\u{03A9}ignore_start\u{03A9}*/: {}/*\u{03A9}ignore_end\u{03A9}*/",
-                                                kit_type
-                                            );
-                                            str.append_left(name_end, &inject);
-                                        }
-                                    }
+                                    let inject = format!(
+                                        "/*\u{03A9}ignore_start\u{03A9}*/: {}/*\u{03A9}ignore_end\u{03A9}*/",
+                                        kit_type
+                                    );
+                                    str.append_left(name_end, &inject);
+                                }
                             }
+                        }
                     }
                 }
             }
@@ -2458,12 +2465,13 @@ fn handle_export_named_decl(
             if is_instance && is_let {
                 let has_ta = possible.map(|p| p.has_type_annotation).unwrap_or(false);
                 if (!has_init || has_ta)
-                    && let Some(pe) = possible {
-                        let inject = format!(
-                            "/*\u{03A9}ignore_start\u{03A9}*/;{local} = __sveltets_2_any({local});/*\u{03A9}ignore_end\u{03A9}*/"
-                        );
-                        str.append_left(pe.decl_end + offset, &inject);
-                    }
+                    && let Some(pe) = possible
+                {
+                    let inject = format!(
+                        "/*\u{03A9}ignore_start\u{03A9}*/;{local} = __sveltets_2_any({local});/*\u{03A9}ignore_end\u{03A9}*/"
+                    );
+                    str.append_left(pe.decl_end + offset, &inject);
+                }
             }
         }
     }
@@ -2652,15 +2660,16 @@ fn detect_runes_call(
 ) {
     if let Some(ref init) = declarator.init
         && let oxc::Expression::CallExpression(call) = init
-            && let oxc::Expression::Identifier(ref callee) = call.callee
-                && matches!(callee.name.as_str(), "$state" | "$derived" | "$effect") {
-                    // Don't treat as rune if the base name (without $) is already declared
-                    // (e.g., `import { derived } from 'svelte/store'` means $derived is a store)
-                    let base_name = &callee.name[1..];
-                    if !declared_names.contains(base_name) {
-                        exported_names.set_uses_runes(true);
-                    }
-                }
+        && let oxc::Expression::Identifier(ref callee) = call.callee
+        && matches!(callee.name.as_str(), "$state" | "$derived" | "$effect")
+    {
+        // Don't treat as rune if the base name (without $) is already declared
+        // (e.g., `import { derived } from 'svelte/store'` means $derived is a store)
+        let base_name = &callee.name[1..];
+        if !declared_names.contains(base_name) {
+            exported_names.set_uses_runes(true);
+        }
+    }
 }
 
 /// Detect `createEventDispatcher<Type>()` calls and extract the generic type.
@@ -2674,30 +2683,33 @@ fn detect_create_event_dispatcher(
 ) {
     if let Some(ref init) = declarator.init
         && let oxc::Expression::CallExpression(call) = init
-            && let oxc::Expression::Identifier(ref callee) = call.callee
-                && callee.name == "createEventDispatcher" {
-                    // Check for type arguments: createEventDispatcher<Type>()
-                    if let Some(ref type_args) = call.type_arguments
-                        && let Some(first_param) = type_args.params.first() {
-                            let start = first_param.span().start as usize;
-                            let end = first_param.span().end as usize;
-                            if start < end && end <= raw_content.len() {
-                                let type_text = raw_content[start..end].to_string();
-                                events.dispatcher_generic_type = Some(type_text);
-                            }
-                        }
-                    // Also detect dispatch('eventName') calls for individual events
-                    // (but that requires analyzing all call sites, which we skip here)
-                }
+        && let oxc::Expression::Identifier(ref callee) = call.callee
+        && callee.name == "createEventDispatcher"
+    {
+        // Check for type arguments: createEventDispatcher<Type>()
+        if let Some(ref type_args) = call.type_arguments
+            && let Some(first_param) = type_args.params.first()
+        {
+            let start = first_param.span().start as usize;
+            let end = first_param.span().end as usize;
+            if start < end && end <= raw_content.len() {
+                let type_text = raw_content[start..end].to_string();
+                events.dispatcher_generic_type = Some(type_text);
+            }
+        }
+        // Also detect dispatch('eventName') calls for individual events
+        // (but that requires analyzing all call sites, which we skip here)
+    }
 }
 
 /// Check if a variable declarator's init is a `$props()` call.
 fn is_props_call_oxc(declarator: &oxc::VariableDeclarator) -> bool {
     if let Some(ref init) = declarator.init
         && let oxc::Expression::CallExpression(call) = init
-            && let oxc::Expression::Identifier(ref callee) = call.callee {
-                return callee.name == "$props";
-            }
+        && let oxc::Expression::Identifier(ref callee) = call.callee
+    {
+        return callee.name == "$props";
+    }
     false
 }
 
@@ -2737,15 +2749,16 @@ fn is_bindable_call(expr: &oxc::Expression, raw_content: &str) -> (bool, Option<
     };
     if let oxc::Expression::CallExpression(call) = inner
         && let oxc::Expression::Identifier(ref callee) = call.callee
-            && callee.name == "$bindable" {
-                // Get the first argument if any (for type inference)
-                let arg_text = call.arguments.first().map(|arg| {
-                    let start = arg.span().start as usize;
-                    let end = arg.span().end as usize;
-                    raw_content[start..end].to_string()
-                });
-                return (true, arg_text);
-            }
+        && callee.name == "$bindable"
+    {
+        // Get the first argument if any (for type inference)
+        let arg_text = call.arguments.first().map(|arg| {
+            let start = arg.span().start as usize;
+            let end = arg.span().end as usize;
+            raw_content[start..end].to_string()
+        });
+        return (true, arg_text);
+    }
     (false, None)
 }
 
@@ -2783,15 +2796,16 @@ fn infer_type_from_default(expr: &oxc::Expression, raw_content: &str) -> String 
         oxc::Expression::CallExpression(call) => {
             // Check for $bindable() - extract inner type
             if let oxc::Expression::Identifier(ref callee) = call.callee
-                && callee.name == "$bindable" {
-                    if let Some(first_arg) = call.arguments.first() {
-                        if let oxc::Argument::SpreadElement(_) = first_arg {
-                            return "any".to_string();
-                        }
-                        return infer_type_from_default(first_arg.to_expression(), raw_content);
+                && callee.name == "$bindable"
+            {
+                if let Some(first_arg) = call.arguments.first() {
+                    if let oxc::Argument::SpreadElement(_) = first_arg {
+                        return "any".to_string();
                     }
-                    return "any".to_string();
+                    return infer_type_from_default(first_arg.to_expression(), raw_content);
                 }
+                return "any".to_string();
+            }
             "any".to_string()
         }
         oxc::Expression::TSAsExpression(ts_as) => {
@@ -3396,8 +3410,7 @@ fn create_store_declarations(store_names: &[&str]) -> String {
     }
     let mut result = String::from("/*\u{03A9}ignore_start\u{03A9}*/");
     for name in store_names {
-        let _ = write!(result, ";let ${} = __sveltets_2_store_get({});",
-            name, name);
+        let _ = write!(result, ";let ${} = __sveltets_2_store_get({});", name, name);
     }
     result.push_str("/*\u{03A9}ignore_end\u{03A9}*/");
     result
@@ -3470,46 +3483,46 @@ fn inject_store_subscriptions_with_program(
 
             oxc::Statement::ExportNamedDeclaration(export) => {
                 if let Some(ref decl) = export.declaration
-                    && let oxc::Declaration::VariableDeclaration(var_decl) = decl {
-                        let last_decl_end = var_decl
-                            .declarations
-                            .last()
-                            .map(|d| d.span.end)
-                            .unwrap_or(var_decl.span.end);
-                        let inject_pos = last_decl_end + offset;
+                    && let oxc::Declaration::VariableDeclaration(var_decl) = decl
+                {
+                    let last_decl_end = var_decl
+                        .declarations
+                        .last()
+                        .map(|d| d.span.end)
+                        .unwrap_or(var_decl.span.end);
+                    let inject_pos = last_decl_end + offset;
 
-                        for declarator in var_decl.declarations.iter() {
-                            let names = extract_all_names_from_binding_pattern(&declarator.id);
-                            let matching: Vec<String> = names
-                                .into_iter()
-                                .filter(|name| accessed_stores.contains(name))
-                                .collect();
+                    for declarator in var_decl.declarations.iter() {
+                        let names = extract_all_names_from_binding_pattern(&declarator.id);
+                        let matching: Vec<String> = names
+                            .into_iter()
+                            .filter(|name| accessed_stores.contains(name))
+                            .collect();
 
-                            if !matching.is_empty() {
-                                let name_refs: Vec<&str> =
-                                    matching.iter().map(|s| s.as_str()).collect();
-                                let store_decls = create_store_declarations(&name_refs);
-                                str.append_left(inject_pos, &store_decls);
-                            }
+                        if !matching.is_empty() {
+                            let name_refs: Vec<&str> =
+                                matching.iter().map(|s| s.as_str()).collect();
+                            let store_decls = create_store_declarations(&name_refs);
+                            str.append_left(inject_pos, &store_decls);
                         }
                     }
+                }
             }
 
-            oxc::Statement::LabeledStatement(labeled)
-                if labeled.label.name == "$" => {
-                    let names = extract_names_from_labeled_body(&labeled.body);
-                    let matching: Vec<String> = names
-                        .into_iter()
-                        .filter(|n| accessed_stores.contains(n))
-                        .collect();
+            oxc::Statement::LabeledStatement(labeled) if labeled.label.name == "$" => {
+                let names = extract_names_from_labeled_body(&labeled.body);
+                let matching: Vec<String> = names
+                    .into_iter()
+                    .filter(|n| accessed_stores.contains(n))
+                    .collect();
 
-                    if !matching.is_empty() {
-                        let inject_pos = labeled.span.end + offset;
-                        let name_refs: Vec<&str> = matching.iter().map(|s| s.as_str()).collect();
-                        let store_decls = create_store_declarations(&name_refs);
-                        str.append_left(inject_pos, &store_decls);
-                    }
+                if !matching.is_empty() {
+                    let inject_pos = labeled.span.end + offset;
+                    let name_refs: Vec<&str> = matching.iter().map(|s| s.as_str()).collect();
+                    let store_decls = create_store_declarations(&name_refs);
+                    str.append_left(inject_pos, &store_decls);
                 }
+            }
 
             _ => {}
         }

--- a/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
@@ -3,8 +3,8 @@
 //! Converts Svelte component source files into TypeScript/TSX for type checking.
 //! This is a Rust port of the `svelte2tsx` package used by the Svelte language server.
 
-use std::fmt::Write as _;
 use std::fmt;
+use std::fmt::Write as _;
 
 use crate::ast::template::Root;
 use crate::compiler::phases::phase1_parse::{self, ParseOptions};
@@ -277,44 +277,42 @@ pub fn svelte2tsx(
     // The parser stores svelte:options in ast.options (not in fragment.nodes),
     // so we need to handle it separately.
     if let Some(ref options_node) = ast.options
-        && options_node.start < options_node.end {
-            // Build attribute string from options attributes
-            let mut attrs_parts = Vec::new();
-            let mut has_expression_attr = false;
-            for node in &options_node.attributes {
-                match &node.value {
-                    crate::ast::template::AttributeValue::True(_) => {
-                        attrs_parts.push(format!("\"{}\":true,", node.name));
-                    }
-                    crate::ast::template::AttributeValue::Expression(expr) => {
-                        has_expression_attr = true;
-                        let expr_text = &source[expr.expression.start().unwrap_or(0) as usize
-                            ..expr.expression.end().unwrap_or(0) as usize];
-                        attrs_parts.push(format!("\"{}\":{},", node.name, expr_text));
-                    }
-                    _ => {}
+        && options_node.start < options_node.end
+    {
+        // Build attribute string from options attributes
+        let mut attrs_parts = Vec::new();
+        let mut has_expression_attr = false;
+        for node in &options_node.attributes {
+            match &node.value {
+                crate::ast::template::AttributeValue::True(_) => {
+                    attrs_parts.push(format!("\"{}\":true,", node.name));
                 }
+                crate::ast::template::AttributeValue::Expression(expr) => {
+                    has_expression_attr = true;
+                    let expr_text = &source[expr.expression.start().unwrap_or(0) as usize
+                        ..expr.expression.end().unwrap_or(0) as usize];
+                    attrs_parts.push(format!("\"{}\":{},", node.name, expr_text));
+                }
+                _ => {}
             }
-            let attrs_str = if attrs_parts.is_empty() {
-                String::new()
-            } else if has_expression_attr {
-                // Expression attributes: preserve source spacing
-                let extra_spaces = count_tag_to_attr_spaces_in_source(
-                    "svelte:options",
-                    options_node.start,
-                    source,
-                );
-                format!("{}{}", " ".repeat(extra_spaces + 1), attrs_parts.join(""))
-            } else {
-                // Bare boolean attributes only: no extra spacing
-                attrs_parts.join("")
-            };
-            let replacement = format!(
-                " {{ svelteHTML.createElement(\"svelte:options\", {{{}}});}}",
-                attrs_str
-            );
-            str.overwrite(options_node.start, options_node.end, &replacement);
         }
+        let attrs_str = if attrs_parts.is_empty() {
+            String::new()
+        } else if has_expression_attr {
+            // Expression attributes: preserve source spacing
+            let extra_spaces =
+                count_tag_to_attr_spaces_in_source("svelte:options", options_node.start, source);
+            format!("{}{}", " ".repeat(extra_spaces + 1), attrs_parts.join(""))
+        } else {
+            // Bare boolean attributes only: no extra spacing
+            attrs_parts.join("")
+        };
+        let replacement = format!(
+            " {{ svelteHTML.createElement(\"svelte:options\", {{{}}});}}",
+            attrs_str
+        );
+        str.overwrite(options_node.start, options_node.end, &replacement);
+    }
 
     // Step 8: Blank out <style> tag (CSS is not relevant for TSX type checking)
     //
@@ -324,21 +322,22 @@ pub fn svelte2tsx(
     // did not capture (e.g., <style global>, custom attributes).
     let mut blanked_style_ranges: Vec<(usize, usize)> = Vec::new();
     if let Some(ref css) = ast.css
-        && css.start < css.end {
-            // Also blank any trailing whitespace after the style tag
-            let mut blank_end = css.end;
-            let bytes = source.as_bytes();
-            while (blank_end as usize) < bytes.len() {
-                let b = bytes[blank_end as usize];
-                if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
-                    blank_end += 1;
-                } else {
-                    break;
-                }
+        && css.start < css.end
+    {
+        // Also blank any trailing whitespace after the style tag
+        let mut blank_end = css.end;
+        let bytes = source.as_bytes();
+        while (blank_end as usize) < bytes.len() {
+            let b = bytes[blank_end as usize];
+            if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
+                blank_end += 1;
+            } else {
+                break;
             }
-            str.overwrite(css.start, blank_end, "");
-            blanked_style_ranges.push((css.start as usize, blank_end as usize));
         }
+        str.overwrite(css.start, blank_end, "");
+        blanked_style_ranges.push((css.start as usize, blank_end as usize));
+    }
     {
         // Fallback: scan source for <style tags that the parser didn't
         // capture in ast.css (e.g., <style global>, <style lang="...">).
@@ -390,21 +389,22 @@ pub fn svelte2tsx(
                     || next_ch == b'\r'
                     || next_ch == b'\t'
                     || next_ch == b'/')
-                    && let Some(close_off) = source[abs_start..].find("</style>") {
-                        let abs_end = abs_start + close_off + 8; // 8 = len("</style>")
-                        let mut blank_end = abs_end as u32;
-                        while (blank_end as usize) < bytes.len() {
-                            let b = bytes[blank_end as usize];
-                            if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
-                                blank_end += 1;
-                            } else {
-                                break;
-                            }
+                    && let Some(close_off) = source[abs_start..].find("</style>")
+                {
+                    let abs_end = abs_start + close_off + 8; // 8 = len("</style>")
+                    let mut blank_end = abs_end as u32;
+                    while (blank_end as usize) < bytes.len() {
+                        let b = bytes[blank_end as usize];
+                        if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
+                            blank_end += 1;
+                        } else {
+                            break;
                         }
-                        str.overwrite(abs_start as u32, blank_end, "");
-                        search_from = abs_end;
-                        continue;
                     }
+                    str.overwrite(abs_start as u32, blank_end, "");
+                    search_from = abs_end;
+                    continue;
+                }
             }
             search_from = abs_start + 1;
         }
@@ -605,8 +605,11 @@ pub fn svelte2tsx(
             .iter()
             .map(|name| format!("'{}': ''", escape_js_single_quoted(name)))
             .collect();
-        let _ = write!(dollar_decls, " let $$slots = __sveltets_2_slotsType({{{}}});",
-            slots_obj.join(", "));
+        let _ = write!(
+            dollar_decls,
+            " let $$slots = __sveltets_2_slotsType({{{}}});",
+            slots_obj.join(", ")
+        );
     }
 
     // Detect generics attribute from the script tag (available for component export)
@@ -983,19 +986,20 @@ pub fn svelte2tsx(
                 && let (Some(let_pos), Some(type_text)) = (
                     exported_names.props_let_abs_pos,
                     exported_names.props_type_text.as_ref(),
-                ) {
-                    let snippet = if force_inside_render {
-                        format!(";type $$ComponentProps =  {};", type_text)
-                    } else {
-                        // type_already_inserted (auto-generated SvelteKit / fallback type).
-                        // JS reference wraps in surroundWithIgnoreComments.
-                        format!(
-                            "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
-                            type_text
-                        )
-                    };
-                    str.append_left(let_pos, &snippet);
-                }
+                )
+            {
+                let snippet = if force_inside_render {
+                    format!(";type $$ComponentProps =  {};", type_text)
+                } else {
+                    // type_already_inserted (auto-generated SvelteKit / fallback type).
+                    // JS reference wraps in surroundWithIgnoreComments.
+                    format!(
+                        "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
+                        type_text
+                    )
+                };
+                str.append_left(let_pos, &snippet);
+            }
         } else {
             // No imports: overwrite the entire <script> tag at once
             let force_inside_render_no_imports = exported_names.has_component_props_typedef
@@ -1165,17 +1169,18 @@ pub fn svelte2tsx(
                 && let (Some(let_pos), Some(type_text)) = (
                     exported_names.props_let_abs_pos,
                     exported_names.props_type_text.as_ref(),
-                ) {
-                    let snippet = if force_inside_render_no_imports {
-                        format!(";type $$ComponentProps =  {};", type_text)
-                    } else {
-                        format!(
-                            "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
-                            type_text
-                        )
-                    };
-                    str.append_left(let_pos, &snippet);
-                }
+                )
+            {
+                let snippet = if force_inside_render_no_imports {
+                    format!(";type $$ComponentProps =  {};", type_text)
+                } else {
+                    format!(
+                        "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
+                        type_text
+                    )
+                };
+                str.append_left(let_pos, &snippet);
+            }
         }
 
         // Overwrite `</script>` with slot declaration + `async () => {`.
@@ -1424,8 +1429,11 @@ pub fn svelte2tsx(
 
     let mut closing = String::new();
     closing.push_str("};\n");
-    let _ = writeln!(closing, "return {{ props: {}{}{}, slots: {}, events: {} }}}}",
-        props_str, exports_str, bindings_str, slots_str, events_str,);
+    let _ = writeln!(
+        closing,
+        "return {{ props: {}{}{}, slots: {}, events: {} }}}}",
+        props_str, exports_str, bindings_str, slots_str, events_str,
+    );
 
     // Add component documentation as JSDoc comment before the component export
     if let Some(ref doc) = component_doc {
@@ -1492,20 +1500,32 @@ pub fn svelte2tsx(
     match options.version {
         SvelteVersion::V4 => {
             let prop_def = build_prop_def(&exported_names);
-            let _ = write!(closing, "\nexport default class {} extends __sveltets_2_createSvelte2TsxComponent({}) {{\n}}",
-                safe_name, prop_def);
+            let _ = write!(
+                closing,
+                "\nexport default class {} extends __sveltets_2_createSvelte2TsxComponent({}) {{\n}}",
+                safe_name, prop_def
+            );
         }
         SvelteVersion::V5 => {
             let use_ts_syntax = options.is_ts_file || !options.emit_jsdoc;
             if exported_names.is_runes_mode() {
                 if !use_ts_syntax {
                     // JS files with emitJsDoc: use `export const` and JSDoc typedef
-                    let _ = writeln!(closing, "export const {} = __sveltets_2_fn_component($$render());",
-                        safe_name);
-                    let _ = writeln!(closing, "/*\u{03A9}ignore_start\u{03A9}*//** @typedef {{ReturnType<typeof {}>}} {} */",
-                        safe_name, safe_name);
-                    let _ = write!(closing, "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
-                        safe_name);
+                    let _ = writeln!(
+                        closing,
+                        "export const {} = __sveltets_2_fn_component($$render());",
+                        safe_name
+                    );
+                    let _ = writeln!(
+                        closing,
+                        "/*\u{03A9}ignore_start\u{03A9}*//** @typedef {{ReturnType<typeof {}>}} {} */",
+                        safe_name, safe_name
+                    );
+                    let _ = write!(
+                        closing,
+                        "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
+                        safe_name
+                    );
                 } else if has_generics {
                     // Runes + generics: `__sveltets_2_fn_component($$render())`
                     // discards `T` ($$render is called without `<T>` and the
@@ -1539,12 +1559,21 @@ pub fn svelte2tsx(
                         has_slot_elements,
                     );
                 } else {
-                    let _ = writeln!(closing, "const {} = __sveltets_2_fn_component($$render());",
-                        safe_name);
-                    let _ = writeln!(closing, "/*\u{03A9}ignore_start\u{03A9}*/type {} = ReturnType<typeof {}>;",
-                        safe_name, safe_name);
-                    let _ = write!(closing, "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
-                        safe_name);
+                    let _ = writeln!(
+                        closing,
+                        "const {} = __sveltets_2_fn_component($$render());",
+                        safe_name
+                    );
+                    let _ = writeln!(
+                        closing,
+                        "/*\u{03A9}ignore_start\u{03A9}*/type {} = ReturnType<typeof {}>;",
+                        safe_name, safe_name
+                    );
+                    let _ = write!(
+                        closing,
+                        "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
+                        safe_name
+                    );
                 }
             } else if has_generics {
                 // Generics component export: __sveltets_Render + $$IsomorphicComponent
@@ -1562,11 +1591,21 @@ pub fn svelte2tsx(
 
                 // Build __sveltets_Render class
                 let _ = writeln!(closing, "class __sveltets_Render<{}> {{", gp);
-                let _ = writeln!(closing, "    props() {{\n        return $$render<{}>().props;\n    }}",
-                    gn);
-                let _ = writeln!(closing, "    events() {{\n        return __sveltets_2_with_any_event($$render<{}>()).events;\n    }}", gn);
-                let _ = writeln!(closing, "    slots() {{\n        return $$render<{}>().slots;\n    }}",
-                    gn);
+                let _ = writeln!(
+                    closing,
+                    "    props() {{\n        return $$render<{}>().props;\n    }}",
+                    gn
+                );
+                let _ = writeln!(
+                    closing,
+                    "    events() {{\n        return __sveltets_2_with_any_event($$render<{}>()).events;\n    }}",
+                    gn
+                );
+                let _ = writeln!(
+                    closing,
+                    "    slots() {{\n        return $$render<{}>().slots;\n    }}",
+                    gn
+                );
                 let _ = writeln!(closing, "    bindings() {{ return {}; }}", raw_bindings);
                 // exports() returns $$render().exports if there are real exports, {} otherwise
                 let exports_return = if has_real_exports {
@@ -1593,8 +1632,11 @@ pub fn svelte2tsx(
 
                 // Build $$IsomorphicComponent interface
                 closing.push_str("interface $$IsomorphicComponent {\n");
-                let _ = writeln!(closing, "    new <{}>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<{}>['props']>{}>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<{}>['props']>, ReturnType<__sveltets_Render<{}>['events']>, ReturnType<__sveltets_Render<{}>['slots']>> & {{ $$bindings?: ReturnType<__sveltets_Render<{}>['bindings']> }} & ReturnType<__sveltets_Render<{}>['exports']>;",
-                    gp, gn, children_type_suffix, gn, gn, gn, gn, gn);
+                let _ = writeln!(
+                    closing,
+                    "    new <{}>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<{}>['props']>{}>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<{}>['props']>, ReturnType<__sveltets_Render<{}>['events']>, ReturnType<__sveltets_Render<{}>['slots']>> & {{ $$bindings?: ReturnType<__sveltets_Render<{}>['bindings']> }} & ReturnType<__sveltets_Render<{}>['exports']>;",
+                    gp, gn, children_type_suffix, gn, gn, gn, gn, gn
+                );
                 // Functional call signature: add $$slots and children only when component has slots
                 let slots_children_suffix = if has_slot_elements {
                     format!(
@@ -1604,19 +1646,34 @@ pub fn svelte2tsx(
                 } else {
                     String::new()
                 };
-                let _ = writeln!(closing, "    <{}>(internal: unknown, props: ReturnType<__sveltets_Render<{}>['props']> & {{$$events?: ReturnType<__sveltets_Render<{}>['events']>{}}}): ReturnType<__sveltets_Render<{}>['exports']>;",
-                    gp, gn, gn, slots_children_suffix, gn);
-                let _ = writeln!(closing, "    z_$$bindings?: ReturnType<__sveltets_Render<{}>['bindings']>;",
-                    any_params);
+                let _ = writeln!(
+                    closing,
+                    "    <{}>(internal: unknown, props: ReturnType<__sveltets_Render<{}>['props']> & {{$$events?: ReturnType<__sveltets_Render<{}>['events']>{}}}): ReturnType<__sveltets_Render<{}>['exports']>;",
+                    gp, gn, gn, slots_children_suffix, gn
+                );
+                let _ = writeln!(
+                    closing,
+                    "    z_$$bindings?: ReturnType<__sveltets_Render<{}>['bindings']>;",
+                    any_params
+                );
                 closing.push_str("}\n");
 
                 // Component export
-                let _ = writeln!(closing, "const {}: $$IsomorphicComponent = null as any;",
-                    safe_name);
-                let _ = writeln!(closing, "/*\u{03A9}ignore_start\u{03A9}*/type {}<{}> = InstanceType<typeof {}<{}>>;",
-                    safe_name, gp, safe_name, gn);
-                let _ = write!(closing, "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
-                    safe_name);
+                let _ = writeln!(
+                    closing,
+                    "const {}: $$IsomorphicComponent = null as any;",
+                    safe_name
+                );
+                let _ = writeln!(
+                    closing,
+                    "/*\u{03A9}ignore_start\u{03A9}*/type {}<{}> = InstanceType<typeof {}<{}>>;",
+                    safe_name, gp, safe_name, gn
+                );
+                let _ = write!(
+                    closing,
+                    "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
+                    safe_name
+                );
             } else {
                 let prop_def = build_prop_def(&exported_names);
                 let has_non_empty_slots = !template_info.slots.is_empty();
@@ -1625,12 +1682,21 @@ pub fn svelte2tsx(
                 } else {
                     "__sveltets_2_isomorphic_component"
                 };
-                let _ = writeln!(closing, "const {} = {}({});",
-                    safe_name, component_fn, prop_def);
-                let _ = writeln!(closing, "/*\u{03A9}ignore_start\u{03A9}*/type {} = InstanceType<typeof {}>;",
-                    safe_name, safe_name);
-                let _ = write!(closing, "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
-                    safe_name);
+                let _ = writeln!(
+                    closing,
+                    "const {} = {}({});",
+                    safe_name, component_fn, prop_def
+                );
+                let _ = writeln!(
+                    closing,
+                    "/*\u{03A9}ignore_start\u{03A9}*/type {} = InstanceType<typeof {}>;",
+                    safe_name, safe_name
+                );
+                let _ = write!(
+                    closing,
+                    "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
+                    safe_name
+                );
             }
         }
     }
@@ -1697,9 +1763,18 @@ fn emit_runes_generics_component(
     has_slot_elements: bool,
 ) {
     let _ = writeln!(closing, "class __sveltets_Render<{gp}> {{");
-    let _ = writeln!(closing, "    props(): ReturnType<typeof $$render<{gn}>>['props'] {{ return null as any; }}");
-    let _ = writeln!(closing, "    events(): ReturnType<typeof $$render<{gn}>>['events'] {{ return null as any; }}");
-    let _ = writeln!(closing, "    slots(): ReturnType<typeof $$render<{gn}>>['slots'] {{ return null as any; }}");
+    let _ = writeln!(
+        closing,
+        "    props(): ReturnType<typeof $$render<{gn}>>['props'] {{ return null as any; }}"
+    );
+    let _ = writeln!(
+        closing,
+        "    events(): ReturnType<typeof $$render<{gn}>>['events'] {{ return null as any; }}"
+    );
+    let _ = writeln!(
+        closing,
+        "    slots(): ReturnType<typeof $$render<{gn}>>['slots'] {{ return null as any; }}"
+    );
     let _ = writeln!(closing, "    bindings() {{ return {raw_bindings}; }}");
     let _ = writeln!(closing, "    exports() {{ return {exports_return}; }}");
     closing.push_str("}\n\n");
@@ -1712,19 +1787,37 @@ fn emit_runes_generics_component(
     };
 
     closing.push_str("interface $$IsomorphicComponent {\n");
-    let _ = writeln!(closing, "    new <{gp}>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<{gn}>['props']>{children_type_suffix}>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<{gn}>['props']>, ReturnType<__sveltets_Render<{gn}>['events']>, ReturnType<__sveltets_Render<{gn}>['slots']>> & {{ $$bindings?: ReturnType<__sveltets_Render<{gn}>['bindings']> }} & ReturnType<__sveltets_Render<{gn}>['exports']>;");
+    let _ = writeln!(
+        closing,
+        "    new <{gp}>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<{gn}>['props']>{children_type_suffix}>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<{gn}>['props']>, ReturnType<__sveltets_Render<{gn}>['events']>, ReturnType<__sveltets_Render<{gn}>['slots']>> & {{ $$bindings?: ReturnType<__sveltets_Render<{gn}>['bindings']> }} & ReturnType<__sveltets_Render<{gn}>['exports']>;"
+    );
     let slots_children_suffix = if has_slot_elements {
         format!(", $$slots?: ReturnType<__sveltets_Render<{gn}>['slots']>, children?: any")
     } else {
         String::new()
     };
-    let _ = writeln!(closing, "    <{gp}>(internal: unknown, props: ReturnType<__sveltets_Render<{gn}>['props']> & {{$$events?: ReturnType<__sveltets_Render<{gn}>['events']>{slots_children_suffix}}}): ReturnType<__sveltets_Render<{gn}>['exports']>;");
-    let _ = writeln!(closing, "    z_$$bindings?: ReturnType<__sveltets_Render<{any_params}>['bindings']>;");
+    let _ = writeln!(
+        closing,
+        "    <{gp}>(internal: unknown, props: ReturnType<__sveltets_Render<{gn}>['props']> & {{$$events?: ReturnType<__sveltets_Render<{gn}>['events']>{slots_children_suffix}}}): ReturnType<__sveltets_Render<{gn}>['exports']>;"
+    );
+    let _ = writeln!(
+        closing,
+        "    z_$$bindings?: ReturnType<__sveltets_Render<{any_params}>['bindings']>;"
+    );
     closing.push_str("}\n");
 
-    let _ = writeln!(closing, "const {safe_name}: $$IsomorphicComponent = null as any;");
-    let _ = writeln!(closing, "/*\u{03A9}ignore_start\u{03A9}*/type {safe_name}<{gp}> = InstanceType<typeof {safe_name}<{gn}>>;");
-    let _ = write!(closing, "/*\u{03A9}ignore_end\u{03A9}*/export default {safe_name};");
+    let _ = writeln!(
+        closing,
+        "const {safe_name}: $$IsomorphicComponent = null as any;"
+    );
+    let _ = writeln!(
+        closing,
+        "/*\u{03A9}ignore_start\u{03A9}*/type {safe_name}<{gp}> = InstanceType<typeof {safe_name}<{gn}>>;"
+    );
+    let _ = write!(
+        closing,
+        "/*\u{03A9}ignore_end\u{03A9}*/export default {safe_name};"
+    );
 }
 
 /// Escape a string for use as the body of a single-quoted JS string literal.
@@ -1754,7 +1847,6 @@ fn escape_js_single_quoted(s: &str) -> String {
 /// Walks the fragment tree looking for `<slot>` elements and collects their names.
 /// A slot without a `name` attribute is the "default" slot.
 fn collect_slot_names_from_ast(fragment: &crate::ast::template::Fragment) -> Vec<String> {
-    
     let mut names = Vec::new();
     collect_slot_names_recursive(&fragment.nodes, &mut names);
     // Deduplicate while preserving order
@@ -1776,17 +1868,14 @@ fn collect_slot_names_recursive(
                 for attr in &el.attributes {
                     if let crate::ast::template::Attribute::Attribute(node) = attr
                         && node.name == "name"
-                            && let crate::ast::template::AttributeValue::Sequence(parts) =
-                                &node.value
-                            {
-                                for part in parts {
-                                    if let crate::ast::template::AttributeValuePart::Text(text) =
-                                        part
-                                    {
-                                        slot_name = text.raw.to_string();
-                                    }
-                                }
+                        && let crate::ast::template::AttributeValue::Sequence(parts) = &node.value
+                    {
+                        for part in parts {
+                            if let crate::ast::template::AttributeValuePart::Text(text) = part {
+                                slot_name = text.raw.to_string();
                             }
+                        }
+                    }
                 }
                 names.push(slot_name);
                 collect_slot_names_recursive(&el.fragment.nodes, names);
@@ -2476,18 +2565,20 @@ fn is_snippet_module_hoistable(
             continue;
         }
         if let Some(stripped) = ident.strip_prefix('$')
-            && !stripped.is_empty() && !stripped.starts_with('$') {
-                // Auto-store subscription targets — `addDisallowed(getAccessedStores())`
-                // in the JS reference is component-wide, so check both module
-                // and instance scopes.
-                if exported_names.instance_value_names.contains(stripped)
-                    || exported_names.instance_import_names.contains(stripped)
-                    || exported_names.module_value_names.contains(stripped)
-                    || exported_names.module_import_names.contains(stripped)
-                {
-                    return false;
-                }
+            && !stripped.is_empty()
+            && !stripped.starts_with('$')
+        {
+            // Auto-store subscription targets — `addDisallowed(getAccessedStores())`
+            // in the JS reference is component-wide, so check both module
+            // and instance scopes.
+            if exported_names.instance_value_names.contains(stripped)
+                || exported_names.instance_import_names.contains(stripped)
+                || exported_names.module_value_names.contains(stripped)
+                || exported_names.module_import_names.contains(stripped)
+            {
+                return false;
             }
+        }
         if exported_names.instance_value_names.contains(&ident)
             && !exported_names.instance_import_names.contains(&ident)
         {
@@ -2696,15 +2787,17 @@ fn detect_top_level_await(content: &str) -> bool {
             oxc::Statement::VariableDeclaration(decl) => {
                 for declarator in decl.declarations.iter() {
                     if let Some(ref init) = declarator.init
-                        && contains_await_expression(init) {
-                            return true;
-                        }
+                        && contains_await_expression(init)
+                    {
+                        return true;
+                    }
                 }
             }
             oxc::Statement::ExpressionStatement(expr)
-                if contains_await_expression(&expr.expression) => {
-                    return true;
-                }
+                if contains_await_expression(&expr.expression) =>
+            {
+                return true;
+            }
             _ => {}
         }
     }

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -6,7 +6,6 @@
 //! Each template node type has a corresponding handler that overwrites the
 //! original source range with the appropriate TypeScript/TSX code.
 
-use std::fmt::Write as _;
 use crate::ast::template::{
     AttachTag, Attribute, AttributeNode, AttributeValue, AttributeValuePart, AwaitBlock,
     BindDirective, ClassDirective, Comment, Component, ConstTag, DebugTag, EachBlock,
@@ -15,6 +14,7 @@ use crate::ast::template::{
     SvelteDynamicElement, SvelteElement, TemplateNode, Text, TitleElement, TransitionDirective,
     UseDirective,
 };
+use std::fmt::Write as _;
 
 use indexmap::IndexMap;
 
@@ -510,14 +510,15 @@ fn collect_info_from_node(node: &TemplateNode, source: &str, info: &mut Template
             // Collect forwarded events (on:event without handler)
             for attr in &el.attributes {
                 if let Attribute::OnDirective(on) = attr
-                    && on.expression.is_none() {
-                        // Event forwarding: on:click (no handler)
-                        let event_name = on.name.to_string();
-                        let event_value = format!("__sveltets_2_mapElementEvent('{}')", event_name);
-                        if !info.element_events.iter().any(|(n, _)| n == &event_name) {
-                            info.element_events.push((event_name, event_value));
-                        }
+                    && on.expression.is_none()
+                {
+                    // Event forwarding: on:click (no handler)
+                    let event_name = on.name.to_string();
+                    let event_value = format!("__sveltets_2_mapElementEvent('{}')", event_name);
+                    if !info.element_events.iter().any(|(n, _)| n == &event_name) {
+                        info.element_events.push((event_name, event_value));
                     }
+                }
             }
             collect_info_from_fragment(&el.fragment, source, info);
         }
@@ -532,13 +533,14 @@ fn collect_info_from_node(node: &TemplateNode, source: &str, info: &mut Template
             // Also collect forwarded events from special elements
             for attr in &el.attributes {
                 if let Attribute::OnDirective(on) = attr
-                    && on.expression.is_none() {
-                        let event_name = on.name.to_string();
-                        let event_value = format!("__sveltets_2_mapElementEvent('{}')", event_name);
-                        if !info.element_events.iter().any(|(n, _)| n == &event_name) {
-                            info.element_events.push((event_name, event_value));
-                        }
+                    && on.expression.is_none()
+                {
+                    let event_name = on.name.to_string();
+                    let event_value = format!("__sveltets_2_mapElementEvent('{}')", event_name);
+                    if !info.element_events.iter().any(|(n, _)| n == &event_name) {
+                        info.element_events.push((event_name, event_value));
                     }
+                }
             }
             collect_info_from_fragment(&el.fragment, source, info);
         }
@@ -612,11 +614,12 @@ fn collect_slot_prop_entries(attributes: &[Attribute], source: &str) -> Vec<Stri
                 }
                 AttributeValue::Sequence(parts) => {
                     if parts.len() == 1
-                        && let AttributeValuePart::ExpressionTag(expr) = &parts[0] {
-                            let expr_text = get_expression_text(&expr.expression, source);
-                            props.push(format!("{}:{}", node.name, expr_text));
-                            continue;
-                        }
+                        && let AttributeValuePart::ExpressionTag(expr) = &parts[0]
+                    {
+                        let expr_text = get_expression_text(&expr.expression, source);
+                        props.push(format!("{}:{}", node.name, expr_text));
+                        continue;
+                    }
                     // String literal value - not common for slots
                     props.push(format!("{}:{}", node.name, node.name));
                 }
@@ -1371,10 +1374,7 @@ fn handle_await_block(
     // 3. `{#await promise catch error}` catch `{/await}` (no pending, immediate catch)
     // 4. `{#await promise}` pending `{:then value}` then `{:catch error}` catch `{/await}`
 
-    let has_pending = block
-        .pending
-        .as_ref()
-        .is_some_and(|p| !p.nodes.is_empty());
+    let has_pending = block.pending.as_ref().is_some_and(|p| !p.nodes.is_empty());
     let has_then = block.then.is_some();
     let has_catch = block.catch.is_some();
 
@@ -2249,8 +2249,11 @@ fn handle_component(
                     continue;
                 }
                 let expr_text = get_expression_text(&bind.expression, source);
-                let _ = write!(out, "/*\u{03A9}ignore_start\u{03A9}*/() => {} = __sveltets_2_any(null);/*\u{03A9}ignore_end\u{03A9}*/{}.$$bindings = '{}';",
-                    expr_text, inst_var, bind.name);
+                let _ = write!(
+                    out,
+                    "/*\u{03A9}ignore_start\u{03A9}*/() => {} = __sveltets_2_any(null);/*\u{03A9}ignore_end\u{03A9}*/{}.$$bindings = '{}';",
+                    expr_text, inst_var, bind.name
+                );
             }
         }
         out
@@ -2454,9 +2457,10 @@ fn has_named_slot_children(fragment: &Fragment, source: &str) -> bool {
             // for distributing children into a named slot — it shows up here
             // as `SvelteFragment`. Treat it like the others.
             TemplateNode::SvelteFragment(el)
-                if get_slot_attr_value(&el.attributes, source).is_some() => {
-                    return true;
-                }
+                if get_slot_attr_value(&el.attributes, source).is_some() =>
+            {
+                return true;
+            }
             _ => {}
         }
     }
@@ -2646,8 +2650,7 @@ fn handle_named_slot_element(
 ) {
     let slot_name = get_slot_attr_value(&el.attributes, source).unwrap_or_default();
     let let_directives = get_let_directives(&el.attributes);
-    let let_destructure =
-        build_let_destructure_string(&let_directives.to_vec(), source);
+    let let_destructure = build_let_destructure_string(&let_directives.to_vec(), source);
 
     // Build the slot def block opener
     let block_open = format!(
@@ -2695,8 +2698,7 @@ fn handle_named_slot_svelte_fragment(
 ) {
     let slot_name = get_slot_attr_value(&el.attributes, source).unwrap_or_default();
     let let_directives = get_let_directives(&el.attributes);
-    let let_destructure =
-        build_let_destructure_string(&let_directives.to_vec(), source);
+    let let_destructure = build_let_destructure_string(&let_directives.to_vec(), source);
 
     // Leading ` ` matches the JS reference, which produces
     // `\t {const ... ;{ svelteHTML.createElement(...)` after the tab indent
@@ -2760,8 +2762,7 @@ fn handle_named_slot_component(
 ) {
     let slot_name = get_slot_attr_value(&comp.attributes, source).unwrap_or_default();
     let let_directives = get_let_directives(&comp.attributes);
-    let let_destructure =
-        build_let_destructure_string(&let_directives.to_vec(), source);
+    let let_destructure = build_let_destructure_string(&let_directives.to_vec(), source);
 
     // Build the slot def block opener
     let block_open = format!(
@@ -2936,8 +2937,11 @@ fn handle_svelte_component(
     // `htmlxtojsx_v2/nodes/InlineComponent.ts`.
     if has_lets_scomp {
         let destructure = build_let_destructure_string(&let_directives_scomp, source);
-        let _ = write!(opener, "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
-            destructure, inst_var);
+        let _ = write!(
+            opener,
+            "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
+            destructure, inst_var
+        );
     }
 
     str.overwrite(comp.start, opening_tag_end, &opener);
@@ -3262,8 +3266,11 @@ fn handle_svelte_self(
         let inst_name = var_name
             .as_ref()
             .expect("let: directive requires an instance variable name");
-        let _ = write!(opener, "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
-            destructure, inst_name);
+        let _ = write!(
+            opener,
+            "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
+            destructure, inst_name
+        );
     }
 
     if !has_closing_tag {
@@ -3572,12 +3579,13 @@ fn build_component_props_segments(attributes: &[Attribute], source: &str) -> Vec
                         // before wrapping.
                         let mut inner_stripped = part;
                         if let Some(Seg::Lit(last)) = inner_stripped.last_mut()
-                            && last.ends_with(',') {
-                                last.pop();
-                                if last.is_empty() {
-                                    inner_stripped.pop();
-                                }
+                            && last.ends_with(',')
+                        {
+                            last.pop();
+                            if last.is_empty() {
+                                inner_stripped.pop();
                             }
+                        }
                         segs_push_lit(&mut inner, "...__sveltets_2_cssProp({");
                         extend_segs(&mut inner, inner_stripped);
                         segs_push_lit(&mut inner, "}),");
@@ -3722,10 +3730,11 @@ fn format_attribute_node(node: &AttributeNode, source: &str) -> Option<String> {
             // Special case: if the sequence is a single expression like `e="{b}"`,
             // output `"e":b,` (just the expression value) instead of `"e":\`${b}\`,`
             if parts.len() == 1
-                && let AttributeValuePart::ExpressionTag(expr) = &parts[0] {
-                    let expr_text = get_expression_text(&expr.expression, source);
-                    return Some(format!("\"{}\":{},", name, expr_text));
-                }
+                && let AttributeValuePart::ExpressionTag(expr) = &parts[0]
+            {
+                let expr_text = get_expression_text(&expr.expression, source);
+                return Some(format!("\"{}\":{},", name, expr_text));
+            }
 
             // Text or mixed content: `name="text {expr} text"` → `"name":\`text ${expr} text\`,`
             let mut value_parts = Vec::new();
@@ -3791,17 +3800,18 @@ fn format_attribute_node_segments(node: &AttributeNode, source: &str) -> Option<
             // Single-expression sequence stays as a bare expression — same
             // shape as the `Expression` arm.
             if parts.len() == 1
-                && let AttributeValuePart::ExpressionTag(expr) = &parts[0] {
-                    let range = get_expression_range(&expr.expression);
-                    segs_push_lit(&mut out, &format!("\"{}\":", name));
-                    if let Some((s, e)) = range {
-                        segs_push_src(&mut out, s, e);
-                    } else {
-                        segs_push_lit(&mut out, get_expression_text(&expr.expression, source));
-                    }
-                    segs_push_lit(&mut out, ",");
-                    return Some(out);
+                && let AttributeValuePart::ExpressionTag(expr) = &parts[0]
+            {
+                let range = get_expression_range(&expr.expression);
+                segs_push_lit(&mut out, &format!("\"{}\":", name));
+                if let Some((s, e)) = range {
+                    segs_push_src(&mut out, s, e);
+                } else {
+                    segs_push_lit(&mut out, get_expression_text(&expr.expression, source));
                 }
+                segs_push_lit(&mut out, ",");
+                return Some(out);
+            }
 
             // Mixed text + expression sequence → template literal. Each
             // `${EXPR}` slot still preserves the expression chunk.
@@ -4061,10 +4071,11 @@ fn format_slot_prop_node(node: &AttributeNode, source: &str) -> Option<String> {
         AttributeValue::Sequence(parts) => {
             // Same as format_attribute_node for sequences
             if parts.len() == 1
-                && let AttributeValuePart::ExpressionTag(expr) = &parts[0] {
-                    let expr_text = get_expression_text(&expr.expression, source);
-                    return Some(format!("\"{}\":{},", name, expr_text));
-                }
+                && let AttributeValuePart::ExpressionTag(expr) = &parts[0]
+            {
+                let expr_text = get_expression_text(&expr.expression, source);
+                return Some(format!("\"{}\":{},", name, expr_text));
+            }
 
             let mut value_parts = Vec::new();
             for part in parts {
@@ -4196,11 +4207,10 @@ fn build_bind_directive_suffix(
         // with the element instance: `(setFn)(var);` (mirrors Binding.ts).
         if let Some((_, (ss, se))) = get_set_binding_ranges(&bind.expression, source) {
             if bind.name == "this"
-                && let Some(var) = element_var {
-                    let _ = write!(out, "({})({});",
-                        &source[ss as usize..se as usize],
-                        var);
-                }
+                && let Some(var) = element_var
+            {
+                let _ = write!(out, "({})({});", &source[ss as usize..se as usize], var);
+            }
             continue;
         }
         let expr_text = get_expression_text(&bind.expression, source);
@@ -4219,8 +4229,11 @@ fn build_bind_directive_suffix(
             } else {
                 format!("/** @type {{{}}} */ (null)", ty)
             };
-            let _ = write!(out, "{}= /*\u{03A9}ignore_start\u{03A9}*/{}/*\u{03A9}ignore_end\u{03A9}*/;",
-                expr_text, value);
+            let _ = write!(
+                out,
+                "{}= /*\u{03A9}ignore_start\u{03A9}*/{}/*\u{03A9}ignore_end\u{03A9}*/;",
+                expr_text, value
+            );
         } else if is_one_way_binding_attribute(&bind.name) {
             if let Some(var) = element_var {
                 let _ = write!(out, "{}= {}.{};", expr_text, var, bind.name);
@@ -4228,8 +4241,11 @@ fn build_bind_directive_suffix(
         } else {
             // Generic two-way binding: type-widener so TS doesn't infer
             // an overly-narrow type.
-            let _ = write!(out, "/*\u{03A9}ignore_start\u{03A9}*/() => {} = __sveltets_2_any(null);/*\u{03A9}ignore_end\u{03A9}*/",
-                expr_text);
+            let _ = write!(
+                out,
+                "/*\u{03A9}ignore_start\u{03A9}*/() => {} = __sveltets_2_any(null);/*\u{03A9}ignore_end\u{03A9}*/",
+                expr_text
+            );
         }
     }
     out
@@ -4380,11 +4396,17 @@ fn build_directive_prefix_suffix(
                 let id = format!("$$action_{}", action_count);
                 action_count += 1;
                 if let Some(expr_text) = expr {
-                    let _ = write!(prefix, "const {} = __sveltets_2_ensureAction({}(svelteHTML.mapElementTag('{}'),({})));",
-                        id, use_dir.name, tag, expr_text);
+                    let _ = write!(
+                        prefix,
+                        "const {} = __sveltets_2_ensureAction({}(svelteHTML.mapElementTag('{}'),({})));",
+                        id, use_dir.name, tag, expr_text
+                    );
                 } else {
-                    let _ = write!(prefix, "const {} = __sveltets_2_ensureAction({}(svelteHTML.mapElementTag('{}')));",
-                        id, use_dir.name, tag);
+                    let _ = write!(
+                        prefix,
+                        "const {} = __sveltets_2_ensureAction({}(svelteHTML.mapElementTag('{}')));",
+                        id, use_dir.name, tag
+                    );
                 }
             }
             Attribute::TransitionDirective(t) => {
@@ -4476,27 +4498,28 @@ fn count_tag_to_attr_spaces(tag_name: &str, el_start: u32, source: &str) -> usiz
 fn get_slot_name(attributes: &[Attribute], source: &str) -> String {
     for attr in attributes {
         if let Attribute::Attribute(node) = attr
-            && node.name == "name" {
-                match &node.value {
-                    AttributeValue::Sequence(parts) => {
-                        // name="header" → parts is a single Text
-                        let mut name = String::new();
-                        for part in parts {
-                            if let AttributeValuePart::Text(text) = part {
-                                name.push_str(&text.raw);
-                            }
-                        }
-                        if !name.is_empty() {
-                            return name;
+            && node.name == "name"
+        {
+            match &node.value {
+                AttributeValue::Sequence(parts) => {
+                    // name="header" → parts is a single Text
+                    let mut name = String::new();
+                    for part in parts {
+                        if let AttributeValuePart::Text(text) = part {
+                            name.push_str(&text.raw);
                         }
                     }
-                    AttributeValue::Expression(expr) => {
-                        // name={expr} - use the expression text
-                        return get_expression_text(&expr.expression, source).to_string();
+                    if !name.is_empty() {
+                        return name;
                     }
-                    _ => {}
                 }
+                AttributeValue::Expression(expr) => {
+                    // name={expr} - use the expression text
+                    return get_expression_text(&expr.expression, source).to_string();
+                }
+                _ => {}
             }
+        }
     }
     "default".to_string()
 }
@@ -4505,9 +4528,10 @@ fn get_slot_name(attributes: &[Attribute], source: &str) -> String {
 fn get_bind_this_expr<'a>(attributes: &'a [Attribute], source: &'a str) -> Option<String> {
     for attr in attributes {
         if let Attribute::BindDirective(bind) = attr
-            && bind.name == "this" {
-                return Some(get_expression_text(&bind.expression, source).to_string());
-            }
+            && bind.name == "this"
+        {
+            return Some(get_expression_text(&bind.expression, source).to_string());
+        }
     }
     None
 }
@@ -4611,25 +4635,26 @@ fn has_meaningful_children(fragment: &Fragment) -> bool {
 fn get_slot_attr_value(attributes: &[Attribute], source: &str) -> Option<String> {
     for attr in attributes {
         if let Attribute::Attribute(node) = attr
-            && node.name == "slot" {
-                match &node.value {
-                    AttributeValue::Sequence(parts) => {
-                        let mut name = String::new();
-                        for part in parts {
-                            if let AttributeValuePart::Text(text) = part {
-                                name.push_str(&text.raw);
-                            }
-                        }
-                        if !name.is_empty() {
-                            return Some(name);
+            && node.name == "slot"
+        {
+            match &node.value {
+                AttributeValue::Sequence(parts) => {
+                    let mut name = String::new();
+                    for part in parts {
+                        if let AttributeValuePart::Text(text) = part {
+                            name.push_str(&text.raw);
                         }
                     }
-                    AttributeValue::Expression(expr) => {
-                        return Some(get_expression_text(&expr.expression, source).to_string());
+                    if !name.is_empty() {
+                        return Some(name);
                     }
-                    _ => {}
                 }
+                AttributeValue::Expression(expr) => {
+                    return Some(get_expression_text(&expr.expression, source).to_string());
+                }
+                _ => {}
             }
+        }
     }
     None
 }

--- a/crates/rsvelte_core/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_core/src/svelte_check/overlay.rs
@@ -13,8 +13,8 @@
 //! - The emitted overlay tsconfig EXTENDS the original tsconfig.json
 //!   instead of duplicating compiler options.
 
-use std::fmt::Write as _;
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};

--- a/crates/rsvelte_formatter/benches/formatter.rs
+++ b/crates/rsvelte_formatter/benches/formatter.rs
@@ -6,8 +6,8 @@
 //! `<style>` body and the markup, and reassembles the output — so these
 //! numbers cover the full format pipeline, not just the JS pass.
 
-use std::fmt::Write as _;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::fmt::Write as _;
 use std::fs;
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -73,11 +73,17 @@ fn get_sample_files() -> Vec<(String, String)> {
 fn create_script_heavy_file() -> (String, String) {
     let mut src = String::from("<script>\n    let count = $state(0);\n");
     for i in 0..60 {
-        let _ = writeln!(src, "    function handler_{i}(event){{const a={i};const b=a*2;let total=a+b;if(total>{i}){{count=total;}}else{{count=a;}}return count;}}");
+        let _ = writeln!(
+            src,
+            "    function handler_{i}(event){{const a={i};const b=a*2;let total=a+b;if(total>{i}){{count=total;}}else{{count=a;}}return count;}}"
+        );
     }
     src.push_str("</script>\n\n");
     for i in 0..30 {
-        let _ = writeln!(src, "<button onclick={{handler_{i}}}>Item {i}: {{count}}</button>");
+        let _ = writeln!(
+            src,
+            "<button onclick={{handler_{i}}}>Item {i}: {{count}}</button>"
+        );
     }
     ("synthetic-script-heavy".to_string(), src)
 }
@@ -87,7 +93,10 @@ fn create_script_heavy_file() -> (String, String) {
 fn create_markup_heavy_file() -> (String, String) {
     let mut src = String::from("<script>\n  let count = $state(0);\n</script>\n\n");
     for i in 0..80 {
-        let _ = writeln!(src, "<div class=\"item-{i}\" data-index={{ {i} }} aria-label=\"row {i}\"><span>Item {i}: {{count + {i}}}</span>{{#if count > {i}}}<strong>on</strong>{{:else}}<em>off</em>{{/if}}</div>");
+        let _ = writeln!(
+            src,
+            "<div class=\"item-{i}\" data-index={{ {i} }} aria-label=\"row {i}\"><span>Item {i}: {{count + {i}}}</span>{{#if count > {i}}}<strong>on</strong>{{:else}}<em>off</em>{{/if}}</div>"
+        );
     }
     ("synthetic-markup-heavy".to_string(), src)
 }


### PR DESCRIPTION
## Problem

The **Format** CI check has been red on `main` since #932. That PR's `format!()` → `write!()` conversion (the codegen `format!` ban) inserted `use std::fmt::Write as _;` imports in unsorted positions and wrote a number of `write!` / `writeln!` calls as over-long single lines. `cargo fmt --all -- --check` (stable — the CI Format gate) rejects both.

Format was green at #926 (`9de0e4b2`) and went red at #932 (`5ec8d332`).

## Fix

Ran `cargo fmt --all` with **rustc 1.96.0** — the version `dtolnay/rust-toolchain@stable` currently resolves to in CI — and verified `cargo fmt --all -- --check` is clean.

Pure formatting: import ordering, `write!`/`writeln!` argument wrapping, and similar whitespace. **No behavior change** — rustfmt is semantics-preserving, so the compiler output and all fixtures are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)