### PR TITLE
feat(lint): no-at-const-tags, no-dynamic-slot-name (+ const-tag/slot hooks)

### DIFF
--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -39,6 +39,8 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(NoInspect),
         Box::new(NoUselessMustaches),
         Box::new(NoTargetBlank),
+        Box::new(crate::rules::no_at_const_tags::NoAtConstTags),
+        Box::new(crate::rules::no_dynamic_slot_name::NoDynamicSlotName),
     ]
 }
 

--- a/crates/rsvelte_lint/src/rule.rs
+++ b/crates/rsvelte_lint/src/rule.rs
@@ -6,8 +6,8 @@
 //! only overrides what it cares about.
 
 use rsvelte_core::ast::template::{
-    Attribute, AwaitBlock, Component, DebugTag, EachBlock, ExpressionTag, HtmlTag, IfBlock,
-    RegularElement, Root, SnippetBlock,
+    Attribute, AwaitBlock, Component, ConstTag, DebugTag, EachBlock, ExpressionTag, HtmlTag,
+    IfBlock, RegularElement, Root, SlotElement, SnippetBlock,
 };
 
 use crate::context::LintContext;
@@ -109,6 +109,8 @@ pub trait Rule: Send + Sync {
     fn check_await(&self, ctx: &mut LintContext, block: &AwaitBlock) {}
     fn check_snippet(&self, ctx: &mut LintContext, block: &SnippetBlock) {}
     fn check_debug_tag(&self, ctx: &mut LintContext, tag: &DebugTag) {}
+    fn check_const_tag(&self, ctx: &mut LintContext, tag: &ConstTag) {}
+    fn check_slot(&self, ctx: &mut LintContext, el: &SlotElement) {}
 
     /// Called for every attribute/directive on an element or component, after
     /// the element-level hook. Lets attribute-scoped rules avoid re-walking the

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -4,12 +4,14 @@
 
 pub mod button_has_type;
 pub mod no_add_event_listener;
+pub mod no_at_const_tags;
 pub mod no_at_debug_tags;
 pub mod no_at_html_tags;
 pub mod no_dupe_else_if_blocks;
 pub mod no_dupe_on_directives;
 pub mod no_dupe_style_properties;
 pub mod no_dupe_use_directives;
+pub mod no_dynamic_slot_name;
 pub mod no_ignored_unsubscribe;
 pub mod no_inner_declarations;
 pub mod no_inspect;

--- a/crates/rsvelte_lint/src/rules/no_at_const_tags.rs
+++ b/crates/rsvelte_lint/src/rules/no_at_const_tags.rs
@@ -1,0 +1,77 @@
+//! `svelte/no-at-const-tags` — prefer the `{const …}` declaration tag over the
+//! legacy `{@const …}` tag. Port of the eslint-plugin-svelte rule. Only fires in
+//! runes mode (the upstream rule's `runes === true` gate), since preserving
+//! reactivity outside runes mode would require `$derived(...)`, unavailable
+//! there.
+//!
+//! Detection-parity port: the finding (message + position) matches upstream; the
+//! autofix (`{@const x = e}` → `{const x = $derived(e)}`) is not yet ported, so
+//! the rule advertises `Fixable::No`.
+
+use rsvelte_core::ast::template::ConstTag;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-at-const-tags",
+    category: RuleCategory::Style,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: true,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Prefer `{const ...}` over legacy `{@const ...}`",
+    options_schema: None,
+};
+
+const MESSAGE: &str = "Use `{const ...}` declaration tag instead of legacy `{@const ...}`.";
+
+/// Rune markers whose presence indicates the component is in runes mode. A crude
+/// substring scan is sufficient: in non-runes components none of these appear.
+const RUNE_MARKERS: &[&str] = &[
+    "$state",
+    "$derived",
+    "$props",
+    "$effect",
+    "$bindable",
+    "$inspect",
+    "$host",
+];
+
+fn uses_runes(source: &str) -> bool {
+    RUNE_MARKERS.iter().any(|m| source.contains(m))
+        || source.contains("runes={true}")
+        || source.contains("runes: true")
+}
+
+#[derive(Default)]
+pub struct NoAtConstTags;
+
+impl Rule for NoAtConstTags {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_const_tag(&self, ctx: &mut LintContext, tag: &ConstTag) {
+        if !uses_runes(ctx.source()) {
+            return;
+        }
+        // `tag.start` points at the `{` of `{@const …}`.
+        ctx.report(tag.start, tag.start, MESSAGE);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runes_detection() {
+        assert!(uses_runes("<script>let x = $state(0);</script>"));
+        assert!(uses_runes("<script>const d = $derived(x);</script>"));
+        assert!(!uses_runes("<script>let items = [1,2,3];</script>"));
+    }
+}

--- a/crates/rsvelte_lint/src/rules/no_dynamic_slot_name.rs
+++ b/crates/rsvelte_lint/src/rules/no_dynamic_slot_name.rs
@@ -1,0 +1,78 @@
+//! `svelte/no-dynamic-slot-name` — a `<slot name=…>` must have a static name.
+//! Port of the (upstream-deprecated) eslint-plugin-svelte rule: a `name`
+//! attribute with a mustache value is "cannot be dynamic"; a valueless `name`
+//! attribute is "requires a value".
+//!
+//! Detection-parity port: the findings (messages + positions) match upstream;
+//! the autofix (resolving a const-foldable name to a static string) is not yet
+//! ported, so the rule advertises `Fixable::No`.
+
+use rsvelte_core::ast::template::{Attribute, AttributeValue, AttributeValuePart, SlotElement};
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-dynamic-slot-name",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow a dynamic `<slot name>` value",
+    options_schema: None,
+};
+
+const DYNAMIC: &str = "`<slot>` name cannot be dynamic.";
+const REQUIRE_VALUE: &str = "`<slot>` name requires a value.";
+
+#[derive(Default)]
+pub struct NoDynamicSlotName;
+
+impl Rule for NoDynamicSlotName {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_slot(&self, ctx: &mut LintContext, el: &SlotElement) {
+        for attr in &el.attributes {
+            let Attribute::Attribute(node) = attr else {
+                continue;
+            };
+            if !node.name.eq_ignore_ascii_case("name") {
+                continue;
+            }
+            match &node.value {
+                // `<slot name />` — boolean attribute, no value.
+                AttributeValue::True(_) => {
+                    ctx.report(
+                        node.start,
+                        node.start + node.name.len() as u32,
+                        REQUIRE_VALUE,
+                    );
+                }
+                // `<slot name={expr} />` — single mustache.
+                AttributeValue::Expression(tag) => {
+                    ctx.report(tag.start, tag.end, DYNAMIC);
+                }
+                AttributeValue::Sequence(parts) => {
+                    if parts.is_empty() {
+                        ctx.report(
+                            node.start,
+                            node.start + node.name.len() as u32,
+                            REQUIRE_VALUE,
+                        );
+                    }
+                    for part in parts {
+                        if let AttributeValuePart::ExpressionTag(tag) = part {
+                            ctx.report(tag.start, tag.end, DYNAMIC);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/rsvelte_lint/src/visitor.rs
+++ b/crates/rsvelte_lint/src/visitor.rs
@@ -128,7 +128,13 @@ impl<'r> LintVisitor<'r> {
             TemplateNode::SvelteComponent(c) => self.visit_fragment(ctx, &c.fragment),
             TemplateNode::SvelteElement(e) => self.visit_fragment(ctx, &e.fragment),
             TemplateNode::TitleElement(e) => self.visit_fragment(ctx, &e.fragment),
-            TemplateNode::SlotElement(e) => self.visit_fragment(ctx, &e.fragment),
+            TemplateNode::SlotElement(e) => {
+                for er in &self.rules {
+                    ctx.enter_rule(er.meta, er.severity);
+                    er.rule.check_slot(ctx, e);
+                }
+                self.visit_fragment(ctx, &e.fragment)
+            }
             // The `svelte:*` special elements all wrap a `SvelteElement`.
             TemplateNode::SvelteBody(e)
             | TemplateNode::SvelteDocument(e)
@@ -138,10 +144,15 @@ impl<'r> LintVisitor<'r> {
             | TemplateNode::SvelteOptions(e)
             | TemplateNode::SvelteSelf(e)
             | TemplateNode::SvelteWindow(e) => self.visit_fragment(ctx, &e.fragment),
-            // Leaf nodes with no template children and no Wave-1 hooks.
+            TemplateNode::ConstTag(t) => {
+                for er in &self.rules {
+                    ctx.enter_rule(er.meta, er.severity);
+                    er.rule.check_const_tag(ctx, t);
+                }
+            }
+            // Leaf nodes with no template children and no hooks.
             TemplateNode::Text(_)
             | TemplateNode::Comment(_)
-            | TemplateNode::ConstTag(_)
             | TemplateNode::DeclarationTag(_)
             | TemplateNode::RenderTag(_)
             | TemplateNode::AttachTag(_) => {}

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -115,6 +115,8 @@ const RULES: &[(&str, &str, bool)] = &[
         "svelte/require-store-callbacks-use-set-param",
         false,
     ),
+    ("no-at-const-tags", "svelte/no-at-const-tags", false),
+    ("no-dynamic-slot-name", "svelte/no-dynamic-slot-name", false),
 ];
 
 /// Fixture path substrings to skip, each with the porting gap it exercises.


### PR DESCRIPTION
Adds `check_const_tag` / `check_slot` Rule hooks and ports two template rules (strict oracle now **28 rules**).

| Rule | Issue | Notes |
|------|-------|-------|
| `svelte/no-at-const-tags` | #878 | prefer `{const …}` over legacy `{@const …}`, runes mode only |
| `svelte/no-dynamic-slot-name` | #881 | `<slot name>` must be static — mustache → "cannot be dynamic", valueless → "requires a value" |

Both are detection-parity ports (message + position match upstream); their const-resolution autofixes are deferred (`Fixable::No`).

Refs epic #904. Closes #878, #881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)