### PR TITLE
perf(transform): drop clean_nodes clone + redundant generate_id hash

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -3114,7 +3114,12 @@ impl Memoizer {
         // stored copy is cloned.
         let mut conflicts = self.conflicts.borrow_mut();
         let mut next_suffix = self.next_suffix.borrow_mut();
-        let mut n = next_suffix.get(sanitized).copied().unwrap_or(1);
+        // One hash of the base: read the current suffix and keep the slot so we
+        // can bump it after the loop without a second lookup. The slot borrows
+        // `next_suffix`, but the loop only touches `conflicts`, so holding it
+        // across the loop is fine.
+        let slot = next_suffix.get_mut(sanitized);
+        let mut n = slot.as_deref().copied().unwrap_or(1);
         let mut name = String::with_capacity(sanitized.len() + 4);
         let mut itoa_buf = itoa::Buffer::new();
         loop {
@@ -3132,7 +3137,7 @@ impl Memoizer {
             n += 1;
         }
 
-        match next_suffix.get_mut(sanitized) {
+        match slot {
             Some(slot) => *slot = n + 1,
             None => {
                 next_suffix.insert(sanitized.to_string(), n + 1);
@@ -3157,7 +3162,9 @@ impl Memoizer {
 
         let mut conflicts = self.conflicts.borrow_mut();
         let mut next_suffix = self.next_suffix.borrow_mut();
-        let mut n = next_suffix.get(sanitized.as_str()).copied().unwrap_or(1);
+        // One hash of the base (see `generate_id`): read + bump via one slot.
+        let slot = next_suffix.get_mut(sanitized.as_str());
+        let mut n = slot.as_deref().copied().unwrap_or(1);
         let mut name = String::with_capacity(sanitized.len() + 4);
         let mut itoa_buf = itoa::Buffer::new();
         loop {
@@ -3175,7 +3182,7 @@ impl Memoizer {
             n += 1;
         }
 
-        match next_suffix.get_mut(sanitized.as_str()) {
+        match slot {
             Some(slot) => *slot = n + 1,
             None => {
                 next_suffix.insert(sanitized, n + 1);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -193,7 +193,13 @@ pub fn svelte_trim_end(s: &str) -> &str {
 ///
 /// This is only needed in legacy (non-runes) mode to match Svelte 4 behavior
 /// where const declarations can reference each other in any order.
-fn sort_const_tags(nodes: Vec<TemplateNode>) -> Vec<TemplateNode> {
+/// Returns `Some(reordered)` only when there is more than one `{@const}` tag to
+/// sort; otherwise returns `None` so the caller can keep borrowing the original
+/// slice instead of cloning it. With 0 or 1 const tags the order is already
+/// correct, so cloning to return an identical Vec was pure waste — and the
+/// common case for `clean_nodes`, which runs over every sibling group in the
+/// tree in legacy mode.
+fn sort_const_tags(nodes: &[TemplateNode]) -> Option<Vec<TemplateNode>> {
     // Collect const tags with their indices, declared names, and dependencies
     struct ConstTagInfo {
         index: usize,
@@ -218,7 +224,7 @@ fn sort_const_tags(nodes: Vec<TemplateNode>) -> Vec<TemplateNode> {
     }
 
     if const_infos.len() <= 1 {
-        return nodes;
+        return None;
     }
 
     // Build a map from declared name to const tag index (within const_infos)
@@ -271,29 +277,25 @@ fn sort_const_tags(nodes: Vec<TemplateNode>) -> Vec<TemplateNode> {
     }
 
     // Build result: sorted const tags first, then other nodes in original order
-    // This matches the official implementation: [...sorted, ...other]
+    // This matches the official implementation: [...sorted, ...other].
+    // Each original index is used exactly once (the const-tag and other-node
+    // index sets partition `0..nodes.len()`), so cloning per index clones every
+    // node exactly once — the same total work as the previous move-based path,
+    // but only on this rare reorder branch rather than on every call.
     let mut result: Vec<TemplateNode> = Vec::with_capacity(nodes.len());
-
-    // We need to consume `nodes` to move elements out
-    // Convert to a vec of Option so we can take elements
-    let mut nodes_opt: Vec<Option<TemplateNode>> = nodes.into_iter().map(Some).collect();
 
     // Add sorted const tags first
     for &tag_idx in &sorted_tag_indices {
         let original_index = const_infos[tag_idx].index;
-        if let Some(node) = nodes_opt[original_index].take() {
-            result.push(node);
-        }
+        result.push(nodes[original_index].clone());
     }
 
     // Add other nodes in original order
     for &other_idx in &other_indices {
-        if let Some(node) = nodes_opt[other_idx].take() {
-            result.push(node);
-        }
+        result.push(nodes[other_idx].clone());
     }
 
-    result
+    Some(result)
 }
 
 /// Extract declared names and referenced identifiers from a ConstTag declaration.
@@ -624,9 +626,12 @@ pub fn clean_nodes<'a>(
 ) -> CleanedNodes<'a> {
     // Sort const tags topologically in legacy (non-runes) mode
     // This matches the official compiler's behavior in clean_nodes (utils.js line 138-139)
+    // In legacy mode `sort_const_tags` returns `Some` only when it actually
+    // reorders (more than one `{@const}`); otherwise `None` lets us keep
+    // borrowing `nodes` below instead of cloning the whole slice every call.
     let is_legacy = !analysis.runes;
     let sorted_nodes = if is_legacy {
-        Some(sort_const_tags(nodes.to_vec()))
+        sort_const_tags(nodes)
     } else {
         None
     };


### PR DESCRIPTION
## What

Two byte-identical performance wins surfaced by an **adversarial perf review of #934** and confirmed on the same pprof transform profile (18 KB `a11y-role-supports-aria-props` fixture).

### 1. `clean_nodes` no longer clones the sibling slice when there's nothing to reorder
In legacy (non-runes) mode, `clean_nodes` ran `sort_const_tags(nodes.to_vec())` on **every** sibling group — deep-cloning the entire `TemplateNode` slice. But `sort_const_tags` is a no-op whenever there are ≤ 1 `{@const}` tags (the overwhelmingly common case), so that clone was pure waste.

`sort_const_tags` now borrows `&[TemplateNode]` and returns `Some(reordered)` **only** when it actually reorders (> 1 const tag); otherwise `None` lets the caller keep borrowing the original slice (like the runes branch already does).

Result on the profile: `clean_nodes` (~8.7% inclusive) and the `TemplateNode::clone` it drove (~5.4%) **both drop out of the transform hot frames entirely.**

### 2. `generate_id` hashes the `next_suffix` key once, not twice
The conflict path did `next_suffix.get(base)` before the loop and `next_suffix.get_mut(base)` after. Holding a single `get_mut` slot across the loop (which only touches the separate `conflicts` map) folds those into one lookup. ~5% on the conflict-path microbench.

## Correctness — byte-identical

- `sort_const_tags` returns the same order in all cases (the ≤1 path already returned nodes unchanged; the > 1 path clones each node exactly once, same total work as the previous move-based path, but only on the rare reorder branch).
- `generate_id` suffix sequence and `next_suffix` bookkeeping are untouched.
- **`compatibility_report`: 16/16** categories · **`svelte2tsx_fixtures`: 15/15** · `clippy --all-features -- -D warnings` clean · `cargo fmt` (rustc 1.96.0) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)