### PR TITLE
feat(lint): port no-top-level-browser-globals

### DIFF
--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -51,6 +51,7 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::no_ignored_unsubscribe::NoIgnoredUnsubscribe;
     use crate::rules::no_inner_declarations::NoInnerDeclarations;
     use crate::rules::no_store_async::NoStoreAsync;
+    use crate::rules::no_top_level_browser_globals::NoTopLevelBrowserGlobals;
     use crate::rules::prefer_derived_over_derived_by::PreferDerivedOverDerivedBy;
     use crate::rules::prefer_svelte_reactivity::PreferSvelteReactivity;
     use crate::rules::require_store_callbacks_use_set_param::RequireStoreCallbacksUseSetParam;
@@ -64,5 +65,6 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
         Box::new(NoIgnoredUnsubscribe),
         Box::new(RequireStoresInit),
         Box::new(RequireStoreCallbacksUseSetParam),
+        Box::new(NoTopLevelBrowserGlobals),
     ]
 }

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -22,6 +22,7 @@ pub mod no_restricted_html_elements;
 pub mod no_store_async;
 pub mod no_svelte_internal;
 pub mod no_target_blank;
+pub mod no_top_level_browser_globals;
 pub mod no_useless_children_snippet;
 pub mod no_useless_mustaches;
 pub mod prefer_derived_over_derived_by;

--- a/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
+++ b/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
@@ -1,0 +1,820 @@
+//! `svelte/no-top-level-browser-globals` — disallow using browser global
+//! variables (`window`, `document`, `location`, `localStorage`, …) at the
+//! top level of a `<script>` / `*.svelte.[js|ts]` module, where the code also
+//! runs during SSR. Port of the eslint-plugin-svelte rule, over the script
+//! ESTree program via the [`ScriptRule`] hook.
+//!
+//! ## Scope of this port
+//!
+//! This is a SCRIPT-AST rule, so it only sees each `<script>` program — it
+//! cannot inspect template expressions or `{#if browser}` template blocks.
+//! The fixtures that exercise template usage (`invalid/in-template01`, and the
+//! `valid/in-template*` / `valid/complex-guards*` cases) are therefore not the
+//! responsibility of this rule (the valid ones expect zero findings, which we
+//! satisfy trivially; the single invalid template fixture cannot be satisfied
+//! here — see the module note in the integrator's skip list).
+//!
+//! ## Algorithm (faithful to upstream)
+//!
+//! Upstream resolves real scopes via `ReferenceTracker`; we approximate by
+//! walking the ESTree JSON:
+//!
+//! 1. Collect *guards* — expressions that prove the browser environment is
+//!    available for a sub-region of the program:
+//!    - `esm-env` `BROWSER` / `$app/environment` `browser` reads (direct or via
+//!      a namespace import), and `import.meta.env.SSR` (inverted).
+//!    - browser-global references that themselves appear in a guard position
+//!      (`typeof window !== 'undefined'`, `if (globalThis.window)`,
+//!      `globalThis.location?.href`, `globalThis.window instanceof X`,
+//!      `globalThis.window !== undefined`, `… && …`, …).
+//! 2. Every *other* top-level browser-global reference that is not covered by a
+//!    guard region (and is not inside a TS type annotation) is reported at the
+//!    reference's start offset with the global's name.
+//!
+//! The browser-globals set below is fixture-derived (the upstream rule uses the
+//! `globals` npm package's `browser` minus `node` keys, which we cannot import);
+//! it covers every global named in the invalid fixtures (`window`, `document`,
+//! `location`, `localStorage`) plus the obvious browser DOM/Web globals.
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-top-level-browser-globals",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow using top-level browser global variables",
+    options_schema: None,
+};
+
+/// Fixture-derived browser-global set. Upstream derives this from
+/// `globals.browser` minus `globals.node`; the names below cover every global
+/// referenced in the invalid fixtures (`window`, `document`, `location`,
+/// `localStorage`) plus the obvious browser-only globals so the rule behaves
+/// sensibly outside the fixtures too.
+const BROWSER_GLOBALS: &[&str] = &[
+    "window",
+    "document",
+    "location",
+    "navigator",
+    "history",
+    "localStorage",
+    "sessionStorage",
+    "screen",
+    "frames",
+    "parent",
+    "top",
+    "self",
+    "alert",
+    "confirm",
+    "prompt",
+    "requestAnimationFrame",
+    "cancelAnimationFrame",
+    "matchMedia",
+    "getComputedStyle",
+    "scrollTo",
+    "scrollBy",
+    "open",
+    "indexedDB",
+];
+
+fn is_browser_global(name: &str) -> bool {
+    BROWSER_GLOBALS.contains(&name)
+}
+
+fn ident_name(node: &Value) -> Option<&str> {
+    if node_type(node) == Some("Identifier") {
+        node.get("name").and_then(Value::as_str)
+    } else {
+        None
+    }
+}
+
+/// A region of the source in which a guard makes the browser environment (or a
+/// specific global) available.
+#[derive(Clone)]
+enum Region {
+    /// `[start, end)` byte span.
+    Range(u32, u32),
+    /// Only the exact node at `start` is available (optional-chain self guard).
+    Just(u32),
+    /// Union of two regions (logical `&&` left guard + parent guard).
+    Or(Box<Region>, Box<Region>),
+}
+
+impl Region {
+    fn covers(&self, start: u32, end: u32) -> bool {
+        match self {
+            Region::Range(s, e) => *s <= start && end <= *e,
+            Region::Just(s) => *s == start,
+            Region::Or(a, b) => a.covers(start, end) || b.covers(start, end),
+        }
+    }
+}
+
+struct Guard {
+    region: Region,
+    /// `true` if the guard establishes the whole browser environment (protects
+    /// any global). `false` if it only protects the matching `name`.
+    browser_environment: bool,
+    /// The global name this guard protects when `browser_environment` is false.
+    name: Option<String>,
+}
+
+/// Static value of an operand, restricted to the forms the guard logic needs.
+#[derive(Debug, PartialEq)]
+enum StaticVal {
+    Str(String),
+    Undefined,
+    Null,
+}
+
+fn static_value(node: &Value) -> Option<StaticVal> {
+    match node_type(node)? {
+        "Identifier" => {
+            if node.get("name").and_then(Value::as_str) == Some("undefined") {
+                Some(StaticVal::Undefined)
+            } else {
+                None
+            }
+        }
+        "Literal" => {
+            let raw = node.get("raw").and_then(Value::as_str);
+            if raw == Some("null") {
+                return Some(StaticVal::Null);
+            }
+            match node.get("value") {
+                Some(Value::String(s)) => Some(StaticVal::Str(s.clone())),
+                // A JSON-null `value` with no `regex` is the `null` literal
+                // (covers serializers that omit/normalise `raw`).
+                Some(Value::Null) if node.get("regex").is_none() => Some(StaticVal::Null),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn is_member(node: &Value) -> bool {
+    node_type(node) == Some("MemberExpression")
+}
+
+/// Non-computed property name of a `MemberExpression`, if any.
+fn member_prop_name(node: &Value) -> Option<&str> {
+    if node.get("computed").and_then(Value::as_bool) == Some(true) {
+        return None;
+    }
+    node.get("property").and_then(ident_name)
+}
+
+/// Whether `node` is `globalThis.<global>` (non-computed). Returns the global.
+fn global_this_member(node: &Value) -> Option<&str> {
+    if !is_member(node) {
+        return None;
+    }
+    let obj = node.get("object")?;
+    if ident_name(obj) != Some("globalThis") {
+        return None;
+    }
+    let prop = member_prop_name(node)?;
+    if is_browser_global(prop) {
+        Some(prop)
+    } else {
+        None
+    }
+}
+
+/// Whether the ancestor chain places the node inside a function/arrow body.
+fn in_function(ancestors: &[&Value]) -> bool {
+    ancestors.iter().any(|n| {
+        matches!(
+            node_type(n),
+            Some("FunctionDeclaration")
+                | Some("FunctionExpression")
+                | Some("ArrowFunctionExpression")
+        )
+    })
+}
+
+/// Whether the ancestor chain places the node inside a TS type annotation.
+fn in_type_annotation(ancestors: &[&Value]) -> bool {
+    ancestors
+        .iter()
+        .any(|n| node_type(n).is_some_and(|t| t.starts_with("TS")))
+}
+
+/// Whether all execution paths of a statement end in a jump
+/// (`return`/`continue`/`break`). Mirrors upstream's `hasJumpStatementInAllPath`.
+fn has_jump_in_all_paths(stmt: &Value) -> bool {
+    match node_type(stmt) {
+        Some("ReturnStatement") | Some("ContinueStatement") | Some("BreakStatement") => true,
+        Some("BlockStatement") => stmt
+            .get("body")
+            .and_then(Value::as_array)
+            .is_some_and(|b| b.iter().any(has_jump_in_all_paths)),
+        Some("IfStatement") => {
+            let Some(alt) = stmt.get("alternate") else {
+                return false;
+            };
+            if alt.is_null() {
+                return false;
+            }
+            has_jump_in_all_paths(alt) && stmt.get("consequent").is_some_and(has_jump_in_all_paths)
+        }
+        _ => false,
+    }
+}
+
+fn range(node: &Value) -> Option<(u32, u32)> {
+    Some((
+        node.get("start").and_then(Value::as_u64)? as u32,
+        node.get("end").and_then(Value::as_u64)? as u32,
+    ))
+}
+
+fn region_of(node: &Value) -> Option<Region> {
+    let (s, e) = range(node)?;
+    Some(Region::Range(s, e))
+}
+
+/// Pointer-identity comparison of two ESTree node references (they come from
+/// the same arena, so identity is reliable).
+fn same(a: &Value, b: &Value) -> bool {
+    std::ptr::eq(a, b)
+}
+
+/// Whether `node` is the (non-computed) `.property` of its parent member access
+/// (e.g. the `browser` in `env.browser`, or the `window` in `x.window`).
+fn is_member_property(node: &Value, ancestors: &[&Value]) -> bool {
+    let Some(parent) = ancestors.last() else {
+        return false;
+    };
+    node_type(parent) == Some("MemberExpression")
+        && parent.get("property").is_some_and(|p| same(p, node))
+        && parent.get("computed").and_then(Value::as_bool) != Some(true)
+}
+
+/// Port of upstream `getGuardChecker`. `path` is the ancestor chain with the
+/// "guard node" as the LAST element; recursion drops the last element to move
+/// up to the parent. `not` inverts the guard sense.
+fn get_guard_checker(path: &[&Value], not: bool) -> Option<Region> {
+    if path.len() < 2 {
+        return None;
+    }
+    let node = path[path.len() - 1];
+    let parent = path[path.len() - 2];
+    match node_type(parent) {
+        Some("ConditionalExpression") => {
+            let branch = if not { "alternate" } else { "consequent" };
+            region_of(parent.get(branch)?)
+        }
+        Some("UnaryExpression") if parent.get("operator").and_then(Value::as_str) == Some("!") => {
+            get_guard_checker(&path[..path.len() - 1], !not)
+        }
+        Some("IfStatement") if parent.get("test").is_some_and(|t| same(t, node)) => {
+            if !not {
+                return region_of(parent.get("consequent")?);
+            }
+            // not: prefer the `else` branch.
+            if let Some(alt) = parent.get("alternate")
+                && !alt.is_null()
+            {
+                return region_of(alt);
+            }
+            // No else: if the consequent always jumps, the region after the if
+            // (to the end of the enclosing block) is guarded.
+            let consequent = parent.get("consequent")?;
+            if !has_jump_in_all_paths(consequent) {
+                return None;
+            }
+            // parent's parent must be a Block/Program (it is path[len-3]).
+            if path.len() < 3 {
+                return None;
+            }
+            let pp = path[path.len() - 3];
+            if !matches!(node_type(pp), Some("BlockStatement") | Some("Program")) {
+                return None;
+            }
+            let start = range(parent)?.1;
+            let end = range(pp)?.1;
+            Some(Region::Range(start, end))
+        }
+        Some("LogicalExpression") => {
+            let op = parent.get("operator").and_then(Value::as_str);
+            if !not && op == Some("&&") {
+                let parent_checker = get_guard_checker(&path[..path.len() - 1], not);
+                let left = parent.get("left");
+                if left.is_some_and(|l| same(l, node)) {
+                    let right_region = region_of(parent.get("right")?)?;
+                    let combined = match parent_checker {
+                        Some(pc) => Region::Or(Box::new(right_region), Box::new(pc)),
+                        None => right_region,
+                    };
+                    return Some(combined);
+                }
+                return parent_checker;
+            }
+            if not && op == Some("||") {
+                return get_guard_checker(&path[..path.len() - 1], not);
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Port of upstream `getGuardCheckerFromReference`. Given a browser-global
+/// reference (`path` last element is the reference node), decide whether the
+/// reference is in a guard position and, if so, return the guarded region.
+fn guard_checker_from_reference(path: &[&Value]) -> Option<Region> {
+    let node = path[path.len() - 1];
+    if path.len() < 2 {
+        return None;
+    }
+    let parent = path[path.len() - 2];
+
+    match node_type(parent) {
+        Some("BinaryExpression") => {
+            let op = parent.get("operator").and_then(Value::as_str)?;
+            let left = parent.get("left");
+            let right = parent.get("right");
+            let node_is_left = left.is_some_and(|l| same(l, node));
+            let node_is_right = right.is_some_and(|r| same(r, node));
+
+            if op == "instanceof" && node_is_left && is_member(node) {
+                // e.g. if (globalThis.window instanceof X)
+                return get_guard_checker(&path[..path.len() - 1], false);
+            }
+
+            let operand = if node_is_left {
+                right
+            } else if node_is_right {
+                left
+            } else {
+                None
+            }?;
+            let sv = static_value(operand)?;
+
+            if sv == StaticVal::Undefined && is_member(node) {
+                return match op {
+                    "!==" | "!=" => get_guard_checker(&path[..path.len() - 1], false),
+                    "===" | "==" => get_guard_checker(&path[..path.len() - 1], true),
+                    _ => None,
+                };
+            }
+            if sv == StaticVal::Null && is_member(node) {
+                return match op {
+                    "!=" => get_guard_checker(&path[..path.len() - 1], false),
+                    "==" => get_guard_checker(&path[..path.len() - 1], true),
+                    _ => None,
+                };
+            }
+            None
+        }
+        Some("UnaryExpression")
+            if parent.get("operator").and_then(Value::as_str) == Some("typeof")
+                && parent.get("argument").is_some_and(|a| same(a, node)) =>
+        {
+            if path.len() < 3 {
+                return None;
+            }
+            let pp = path[path.len() - 3];
+            if node_type(pp) != Some("BinaryExpression") {
+                return None;
+            }
+            let op = pp.get("operator").and_then(Value::as_str)?;
+            let left = pp.get("left");
+            let other = if left.is_some_and(|l| same(l, parent)) {
+                pp.get("right")
+            } else {
+                left
+            }?;
+            let sv = static_value(other)?;
+            let sv_str = match &sv {
+                StaticVal::Str(s) => s.as_str(),
+                _ => return None,
+            };
+            if sv_str != "undefined" && sv_str != "object" {
+                return None;
+            }
+            // pp is at path[len-3]; the guard node for getGuardChecker is pp.
+            let pp_path = &path[..path.len() - 2];
+            match op {
+                "!==" | "!=" => {
+                    if sv_str == "undefined" {
+                        get_guard_checker(pp_path, false)
+                    } else {
+                        get_guard_checker(pp_path, true)
+                    }
+                }
+                "===" | "==" => {
+                    if sv_str == "undefined" {
+                        get_guard_checker(pp_path, true)
+                    } else {
+                        get_guard_checker(pp_path, false)
+                    }
+                }
+                _ => None,
+            }
+        }
+        _ => {
+            // node is `globalThis.<global>` member.
+            if !is_member(node) {
+                return None;
+            }
+            let parent_is_optional_use = (node_type(parent) == Some("CallExpression")
+                && parent.get("callee").is_some_and(|c| same(c, node)))
+                || (node_type(parent) == Some("MemberExpression")
+                    && parent.get("object").is_some_and(|o| same(o, node)));
+            if parent_is_optional_use
+                && parent.get("optional").and_then(Value::as_bool) == Some(true)
+            {
+                // e.g. globalThis.location?.href — only the node itself.
+                return Some(Region::Just(range(node)?.0));
+            }
+            // e.g. if (globalThis.window) — the node itself is the guard.
+            get_guard_checker(path, false)
+        }
+    }
+}
+
+/// Is `node` the full `import.meta.env.SSR` member chain?
+///
+/// rsvelte's parser does not emit a `MetaProperty` node for `import.meta`; it
+/// represents it as a placeholder `Identifier` spanning the text `import.meta`.
+/// So the innermost object is matched by its source slice rather than by type.
+fn is_import_meta_env_ssr(node: &Value, source: &str) -> bool {
+    if !is_member(node) || member_prop_name(node) != Some("SSR") {
+        return false;
+    }
+    let Some(env_member) = node.get("object") else {
+        return false;
+    };
+    if !is_member(env_member) || member_prop_name(env_member) != Some("env") {
+        return false;
+    }
+    let Some(meta) = env_member.get("object") else {
+        return false;
+    };
+    range(meta)
+        .and_then(|(s, e)| source.get(s as usize..e as usize))
+        .map(|slice| slice == "import.meta")
+        .unwrap_or(false)
+}
+
+#[derive(Default)]
+pub struct NoTopLevelBrowserGlobals;
+
+impl ScriptRule for NoTopLevelBrowserGlobals {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        let source = ctx.source();
+        // --- 1. Resolve browser-checker module imports. ---
+        // local names bound to `browser`/`BROWSER` reads, and namespace imports.
+        let mut browser_locals: Vec<String> = Vec::new();
+        let mut env_namespaces: Vec<String> = Vec::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("ImportDeclaration") {
+                return;
+            }
+            let source = node
+                .get("source")
+                .and_then(|s| s.get("value"))
+                .and_then(Value::as_str);
+            let is_env_module = matches!(source, Some("$app/environment") | Some("esm-env"));
+            if !is_env_module {
+                return;
+            }
+            let Some(specs) = node.get("specifiers").and_then(Value::as_array) else {
+                return;
+            };
+            for spec in specs {
+                match node_type(spec) {
+                    Some("ImportSpecifier") => {
+                        let imported = spec.get("imported").and_then(ident_name).or_else(|| {
+                            spec.get("imported")
+                                .and_then(|i| i.get("value"))
+                                .and_then(Value::as_str)
+                        });
+                        if matches!(imported, Some("browser") | Some("BROWSER"))
+                            && let Some(local) = spec.get("local").and_then(ident_name)
+                        {
+                            browser_locals.push(local.to_string());
+                        }
+                    }
+                    Some("ImportNamespaceSpecifier") => {
+                        if let Some(local) = spec.get("local").and_then(ident_name) {
+                            env_namespaces.push(local.to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let mut guards: Vec<Guard> = Vec::new();
+
+        // --- 2. import.meta.env.SSR guards (inverted: SSR true == server). ---
+        walk_js(program, |node, ancestors| {
+            if !is_import_meta_env_ssr(node, source) || in_function(ancestors) {
+                return;
+            }
+            let mut path: Vec<&Value> = ancestors.to_vec();
+            path.push(node);
+            if let Some(region) = get_guard_checker(&path, true) {
+                guards.push(Guard {
+                    region,
+                    browser_environment: true,
+                    name: None,
+                });
+            }
+        });
+
+        // --- 3. esm-env / $app/environment browser-read guards. ---
+        if !browser_locals.is_empty() || !env_namespaces.is_empty() {
+            walk_js(program, |node, ancestors| {
+                if in_function(ancestors) {
+                    return;
+                }
+                let is_browser_ref = match node_type(node) {
+                    Some("Identifier") => {
+                        let name = node.get("name").and_then(Value::as_str);
+                        // A bare read of an imported `browser`/`BROWSER` local,
+                        // not itself a member property or import binding.
+                        name.is_some_and(|n| browser_locals.iter().any(|l| l == n))
+                            && is_value_reference(node, ancestors)
+                            && !is_member_property(node, ancestors)
+                    }
+                    Some("MemberExpression") => {
+                        // `env.browser` / `env.BROWSER` namespace access.
+                        let obj_is_ns = node
+                            .get("object")
+                            .and_then(ident_name)
+                            .is_some_and(|o| env_namespaces.iter().any(|n| n == o));
+                        let prop = member_prop_name(node);
+                        obj_is_ns && matches!(prop, Some("browser") | Some("BROWSER"))
+                    }
+                    _ => false,
+                };
+                if !is_browser_ref {
+                    return;
+                }
+                let mut path: Vec<&Value> = ancestors.to_vec();
+                path.push(node);
+                if let Some(region) = get_guard_checker(&path, false) {
+                    guards.push(Guard {
+                        region,
+                        browser_environment: true,
+                        name: None,
+                    });
+                }
+            });
+        }
+
+        // --- 4. Collect browser-global references. ---
+        // Each is either a bare global identifier or `globalThis.<global>`.
+        // We record its node, name, and full ancestor path for guard analysis.
+        let mut report_candidates: Vec<(u32, u32, String)> = Vec::new();
+
+        walk_js(program, |node, ancestors| {
+            let name: String = match node_type(node) {
+                Some("Identifier") => {
+                    let Some(n) = node.get("name").and_then(Value::as_str) else {
+                        return;
+                    };
+                    if !is_browser_global(n) || !is_value_reference(node, ancestors) {
+                        return;
+                    }
+                    // Skip the property side of `globalThis.<global>` (handled by
+                    // the MemberExpression branch) and `x.<global>` accesses.
+                    if is_member_property(node, ancestors) {
+                        return;
+                    }
+                    n.to_string()
+                }
+                Some("MemberExpression") => {
+                    let Some(n) = global_this_member(node) else {
+                        return;
+                    };
+                    n.to_string()
+                }
+                _ => return,
+            };
+            if in_function(ancestors) || in_type_annotation(ancestors) {
+                return;
+            }
+            let Some((start, end)) = range(node) else {
+                return;
+            };
+
+            let mut path: Vec<&Value> = ancestors.to_vec();
+            path.push(node);
+
+            if let Some(region) = guard_checker_from_reference(&path) {
+                // This reference is itself a guard.
+                let browser_environment = name == "window" || name == "document";
+                guards.push(Guard {
+                    region,
+                    browser_environment,
+                    name: Some(name),
+                });
+            } else {
+                report_candidates.push((start, end, name));
+            }
+        });
+
+        // --- 5. Report candidates not covered by any guard. ---
+        for (start, end, name) in report_candidates {
+            if is_available(&guards, start, end, &name) {
+                continue;
+            }
+            ctx.report(
+                start,
+                end,
+                format!("Unexpected top-level browser global variable \"{name}\"."),
+            );
+        }
+    }
+}
+
+/// Whether a reference at `[start, end)` named `name` is covered by a guard.
+/// Mirrors upstream `isAvailableLocation` (reverse iteration order).
+fn is_available(guards: &[Guard], start: u32, end: u32, name: &str) -> bool {
+    for guard in guards.iter().rev() {
+        if guard.region.covers(start, end)
+            && (guard.browser_environment || guard.name.as_deref() == Some(name))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether an Identifier node is a *value reference* (vs. a declaration id,
+/// property key, label, import/export binding, etc.). Used to avoid treating
+/// declarations or member-property names as global references.
+fn is_value_reference(node: &Value, ancestors: &[&Value]) -> bool {
+    let Some(parent) = ancestors.last() else {
+        return true;
+    };
+    match node_type(parent) {
+        // Declaration ids and binding positions.
+        Some("VariableDeclarator") => !parent.get("id").is_some_and(|i| same(i, node)),
+        Some("FunctionDeclaration")
+        | Some("FunctionExpression")
+        | Some("ClassDeclaration")
+        | Some("ClassExpression") => !parent.get("id").is_some_and(|i| same(i, node)),
+        // Import/export bindings.
+        Some("ImportSpecifier")
+        | Some("ImportDefaultSpecifier")
+        | Some("ImportNamespaceSpecifier")
+        | Some("ExportSpecifier") => false,
+        // Object/class property keys (non-computed).
+        Some("Property") | Some("PropertyDefinition") | Some("MethodDefinition") => {
+            !(parent.get("key").is_some_and(|k| same(k, node))
+                && parent.get("computed").and_then(Value::as_bool) != Some(true))
+        }
+        // Labels.
+        Some("LabeledStatement") | Some("BreakStatement") | Some("ContinueStatement") => false,
+        // Member property handled separately by the caller.
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn globals_set_covers_fixtures() {
+        for g in ["window", "document", "location", "localStorage"] {
+            assert!(is_browser_global(g), "missing {g}");
+        }
+        assert!(!is_browser_global("foo"));
+    }
+
+    #[test]
+    fn region_covers_range() {
+        let r = Region::Range(10, 20);
+        assert!(r.covers(12, 15));
+        assert!(r.covers(10, 20));
+        assert!(!r.covers(9, 15));
+        assert!(!r.covers(12, 21));
+    }
+
+    #[test]
+    fn region_just_matches_start_only() {
+        let r = Region::Just(5);
+        assert!(r.covers(5, 9));
+        assert!(!r.covers(6, 9));
+    }
+
+    #[test]
+    fn region_or_unions() {
+        let r = Region::Or(
+            Box::new(Region::Range(0, 5)),
+            Box::new(Region::Range(10, 15)),
+        );
+        assert!(r.covers(1, 4));
+        assert!(r.covers(11, 14));
+        assert!(!r.covers(6, 8));
+    }
+
+    #[test]
+    fn static_value_forms() {
+        assert_eq!(
+            static_value(&json!({"type":"Identifier","name":"undefined"})),
+            Some(StaticVal::Undefined)
+        );
+        assert_eq!(
+            static_value(&json!({"type":"Literal","value":null,"raw":"null"})),
+            Some(StaticVal::Null)
+        );
+        assert_eq!(
+            static_value(&json!({"type":"Literal","value":"undefined","raw":"'undefined'"})),
+            Some(StaticVal::Str("undefined".to_string()))
+        );
+        assert!(static_value(&json!({"type":"Identifier","name":"x"})).is_none());
+    }
+
+    #[test]
+    fn global_this_member_detection() {
+        let m = json!({
+            "type":"MemberExpression","computed":false,
+            "object":{"type":"Identifier","name":"globalThis"},
+            "property":{"type":"Identifier","name":"window"}
+        });
+        assert_eq!(global_this_member(&m), Some("window"));
+        let not_global = json!({
+            "type":"MemberExpression","computed":false,
+            "object":{"type":"Identifier","name":"foo"},
+            "property":{"type":"Identifier","name":"window"}
+        });
+        assert_eq!(global_this_member(&not_global), None);
+    }
+
+    #[test]
+    fn jump_in_all_paths() {
+        // { continue; } -> true
+        let block = json!({
+            "type":"BlockStatement",
+            "body":[{"type":"ContinueStatement"}]
+        });
+        assert!(has_jump_in_all_paths(&block));
+        // if/else both jump -> true
+        let if_both = json!({
+            "type":"IfStatement",
+            "consequent":{"type":"ContinueStatement"},
+            "alternate":{"type":"BreakStatement"}
+        });
+        assert!(has_jump_in_all_paths(&if_both));
+        // if without else -> false
+        let if_no_else = json!({
+            "type":"IfStatement",
+            "consequent":{"type":"ContinueStatement"},
+            "alternate":null
+        });
+        assert!(!has_jump_in_all_paths(&if_no_else));
+        // plain block, no jump -> false
+        let plain = json!({
+            "type":"BlockStatement",
+            "body":[{"type":"ExpressionStatement"}]
+        });
+        assert!(!has_jump_in_all_paths(&plain));
+    }
+
+    #[test]
+    fn import_meta_env_ssr_detection() {
+        // rsvelte emits `import.meta` as a placeholder Identifier; matched by slice.
+        let source = "import.meta.env.SSR";
+        let node = json!({
+            "type":"MemberExpression","computed":false,"start":0,"end":19,
+            "property":{"type":"Identifier","name":"SSR","start":16,"end":19},
+            "object":{
+                "type":"MemberExpression","computed":false,"start":0,"end":15,
+                "property":{"type":"Identifier","name":"env","start":12,"end":15},
+                "object":{"type":"Identifier","name":"unknown","start":0,"end":11}
+            }
+        });
+        assert!(is_import_meta_env_ssr(&node, source));
+        let other = json!({
+            "type":"MemberExpression","computed":false,"start":0,"end":5,
+            "property":{"type":"Identifier","name":"foo","start":2,"end":5},
+            "object":{"type":"Identifier","name":"x","start":0,"end":1}
+        });
+        assert!(!is_import_meta_env_ssr(&other, "x.foo"));
+    }
+}

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -117,6 +117,11 @@ const RULES: &[(&str, &str, bool)] = &[
     ),
     ("no-at-const-tags", "svelte/no-at-const-tags", false),
     ("no-dynamic-slot-name", "svelte/no-dynamic-slot-name", false),
+    (
+        "no-top-level-browser-globals",
+        "svelte/no-top-level-browser-globals",
+        false,
+    ),
 ];
 
 /// Fixture path substrings to skip, each with the porting gap it exercises.
@@ -138,6 +143,11 @@ const SKIP: &[&str] = &[
     // modules exercising the export path (flag exported `new X()` even without
     // mutation), which is not ported — the mutation path covers the rest.
     "prefer-svelte-reactivity/invalid/exports",
+    // `no-top-level-browser-globals` template-position case: the globals are used
+    // in markup (`{location.href}` / `{#if browser}`), not in `<script>`. This is
+    // a script-AST rule, so template usage is out of scope (would need a separate
+    // template-AST pass). All `<script>`-based fixtures are covered.
+    "no-top-level-browser-globals/invalid/in-template01",
     // `no-add-event-listener` TS-cast case: `(window.addEventListener as any)(…)`.
     // rsvelte's ESTree strips the TS `as` cast, so the call's callee looks like a
     // plain `window.addEventListener` member (upstream keeps it a TSAsExpression


### PR DESCRIPTION
`svelte/no-top-level-browser-globals` (#891) — disallow top-level browser globals (`window`/`document`/`location`/…) in a `<script>` / `*.svelte.[js|ts]` module that also runs during SSR. Strict oracle now **29 rules**.

Script-AST rule with a faithful port of the guard analysis: `typeof`/`if`/conditional/logical guards, `globalThis.x` (incl. optional-chaining + `instanceof`), `esm-env` `BROWSER` / `$app/environment` `browser` reads, and `import.meta.env.SSR` (inverted). Excludes references inside functions and TS type annotations.

Notes:
- rsvelte represents `import.meta` as a placeholder identifier (no `MetaProperty` node), so the SSR guard matches the `import.meta` source slice.
- The single template-position fixture (`in-template01`) is oracle-SKIPped: a script-AST rule can't see template expressions (`{location.href}`). All `<script>`-based fixtures pass.

Refs epic #904. Closes #891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)