### PR TITLE
fix(compiler): don't panic on multibyte char in await-block look-back

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_block.rs
@@ -58,7 +58,11 @@ pub fn visit(block: &mut AwaitBlock, context: &mut VisitorContext) -> Result<(),
         if let Some(ref value) = block.value {
             let start = value.start().unwrap_or(0) as usize;
             if start >= 10 {
-                let substr = &context.analysis.source[start.saturating_sub(10)..start];
+                let substr = crate::compiler::utils::char_boundary_lookback(
+                    &context.analysis.source,
+                    start,
+                    10,
+                );
                 // Match pattern: `{` followed by optional whitespace, `:then` followed by space
                 if let Some(captures) = REGEX_THEN_BLOCK.captures(substr)
                     && let Some(whitespace) = captures.get(1)
@@ -76,7 +80,11 @@ pub fn visit(block: &mut AwaitBlock, context: &mut VisitorContext) -> Result<(),
         if let Some(ref error) = block.error {
             let start = error.start().unwrap_or(0) as usize;
             if start >= 10 {
-                let substr = &context.analysis.source[start.saturating_sub(10)..start];
+                let substr = crate::compiler::utils::char_boundary_lookback(
+                    &context.analysis.source,
+                    start,
+                    10,
+                );
                 // Match pattern: `{` followed by optional whitespace, `:catch` followed by space
                 if let Some(captures) = REGEX_CATCH_BLOCK.captures(substr)
                     && let Some(whitespace) = captures.get(1)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -286,7 +286,8 @@ pub(super) fn transform_store_sub_calls(line: &str, store_sub_vars: &[String]) -
                     }
                     // Now check if preceded by `function` keyword
                     if k >= 8 {
-                        let prefix = &before_text[k - 8..k];
+                        let prefix =
+                            crate::compiler::utils::char_boundary_lookback(before_text, k, 8);
                         prefix == "function"
                             && (k == 8
                                 || !{

--- a/crates/rsvelte_core/src/compiler/utils.rs
+++ b/crates/rsvelte_core/src/compiler/utils.rs
@@ -2,6 +2,25 @@
 //!
 //! Corresponds to Svelte's `utils.js`.
 
+/// Slice a fixed-size look-back window ending at `end`, clamped to a UTF-8
+/// char boundary so it can never panic.
+///
+/// Returns `source[lo..end]`, where `lo` is the first char boundary at or after
+/// `end.saturating_sub(window)`. A plain `&source[end - window..end]` panics
+/// with a non-char-boundary slice error when a multibyte character straddles
+/// `end - window` — which a `.svelte` source can contain anywhere. Callers use
+/// these windows to feed ASCII-only scans (e.g. a regex for `{:then`), so a
+/// shorter window on multibyte input is equivalent: the ASCII pattern can't
+/// span a multibyte byte. `end` must already be a char boundary (callers pass
+/// AST token positions); it is clamped to `source.len()` defensively.
+pub fn char_boundary_lookback(source: &str, end: usize, window: usize) -> &str {
+    let end = end.min(source.len());
+    let lo = (end.saturating_sub(window)..end)
+        .find(|&i| source.is_char_boundary(i))
+        .unwrap_or(end);
+    &source[lo..end]
+}
+
 /// List of Element events that will be delegated.
 ///
 /// Corresponds to `DELEGATED_EVENTS` in utils.js.

--- a/crates/rsvelte_core/tests/await_block_multibyte.rs
+++ b/crates/rsvelte_core/tests/await_block_multibyte.rs
@@ -1,0 +1,44 @@
+//! Runes-mode `{#await}` validation uses a fixed-size byte look-back window
+//! before the `then`/`catch` value to detect a stray space (`{ :then`). A
+//! multi-byte character straddling `value_start - 10` made that
+//! `&source[start - 10..start]` slice land mid-character and panic with a
+//! non-char-boundary slice error instead of compiling. Regression guard for
+//! `char_boundary_lookback` (see `compiler::utils`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn go(src: &str, mode: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: mode,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+// `$state(...)` forces runes mode (where the look-back validation runs); the
+// 2-byte `é` in the promise expression sits in the 10-byte window before the
+// `then`/`catch` binding so a fixed `start - 10` byte offset lands mid-`é`.
+const THEN_SRC: &str = "<script>let c = $state(0)</script>{#await éaaa then v}{v}{/await}";
+const CATCH_SRC: &str = "<script>let c = $state(0)</script>{#await éaa catch e}{e}{/await}";
+
+#[test]
+fn multibyte_before_then_binding_does_not_panic() {
+    for mode in [GenerateMode::Client, GenerateMode::Server] {
+        let out = go(THEN_SRC, mode);
+        assert!(!out.contains("COMPILE_ERROR"), "{mode:?}: {out}");
+    }
+}
+
+#[test]
+fn multibyte_before_catch_binding_does_not_panic() {
+    for mode in [GenerateMode::Client, GenerateMode::Server] {
+        let out = go(CATCH_SRC, mode);
+        assert!(!out.contains("COMPILE_ERROR"), "{mode:?}: {out}");
+    }
+}


### PR DESCRIPTION
## Bug

Surfaced by an adversarial panic-safety audit of the codebase. A production compiler must never panic on input — it should return a clean error or compile.

Runes-mode `{#await}` validation scans a fixed **10-byte** look-back window before the `then`/`catch` value to detect a stray space (`{ :then`). It sliced `&source[start - 10..start]` with only an underflow guard (`start >= 10`) and **no char-boundary check**, so a multibyte UTF-8 character straddling `start - 10` produced a non-char-boundary slice → `slice_error_fail` **panic** instead of compiling.

**Reproducer** (crashes the compiler, runes mode):
```svelte
<script>let c = $state(0)</script>{#await éaaa then v}{v}{/await}
```
The 2-byte `é` sits in the look-back window before the `then` binding.

## Fix

Add `compiler::utils::char_boundary_lookback(source, end, window)`, which clamps the window's low bound up to the nearest char boundary. **Byte-identical** for the ASCII windows these scans actually care about — the regex (`{:then`) and the `"function"` comparison only match ASCII, so a multibyte char in the window can't be part of a match anyway; the change only replaces the panic with a clean result.

Applied to:
- both await-block look-back sites (`2_analyze/visitors/await_block.rs`) — the confirmed crash;
- the same-shape `"function"` look-back in `3_transform/client/store_transforms.rs` — latent, same bug class, fixed defensively.

## Verification

- New regression test `tests/await_block_multibyte.rs` compiles the `then` and `catch` repros in **both client and server** modes (panic → clean compile) — **passes**; would panic before the fix.
- `clippy --all-features -- -D warnings` clean · `cargo fmt` (rustc 1.96.0) clean.
- Byte-identity for all existing fixtures is verified by the **Compatibility Report** CI job (ASCII look-back windows are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)