### PR TITLE
feat(lint): port no-nested-style-tag

### DIFF
--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -41,6 +41,7 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(NoTargetBlank),
         Box::new(crate::rules::no_at_const_tags::NoAtConstTags),
         Box::new(crate::rules::no_dynamic_slot_name::NoDynamicSlotName),
+        Box::new(crate::rules::no_nested_style_tag::NoNestedStyleTag),
         Box::new(
             crate::rules::no_shorthand_style_property_overrides::NoShorthandStylePropertyOverrides,
         ),

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -16,6 +16,7 @@ pub mod no_dynamic_slot_name;
 pub mod no_ignored_unsubscribe;
 pub mod no_inner_declarations;
 pub mod no_inspect;
+pub mod no_nested_style_tag;
 pub mod no_not_function_handler;
 pub mod no_object_in_text_mustaches;
 pub mod no_raw_special_elements;

--- a/crates/rsvelte_lint/src/rules/no_nested_style_tag.rs
+++ b/crates/rsvelte_lint/src/rules/no_nested_style_tag.rs
@@ -1,0 +1,42 @@
+//! `svelte/no-nested-style-tag` — disallow a `<style>` element nested inside
+//! another element or block. Only the component's top-level `<style>` is the
+//! scoped stylesheet (the parser lifts it into `Root.css`); a `<style>` that
+//! remains in the template fragment is nested and unscoped. Port of the
+//! eslint-plugin-svelte rule.
+
+use rsvelte_core::ast::template::RegularElement;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-nested-style-tag",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow `<style>` elements nested inside other elements or blocks",
+    options_schema: None,
+};
+
+const MESSAGE: &str =
+    "Nested `<style>` elements are not scoped and may lead to unintended styles being applied.";
+
+#[derive(Default)]
+pub struct NoNestedStyleTag;
+
+impl Rule for NoNestedStyleTag {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_element(&self, ctx: &mut LintContext, el: &RegularElement) {
+        if el.name.eq_ignore_ascii_case("style") {
+            ctx.report(el.start, el.end, MESSAGE);
+        }
+    }
+}

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -132,6 +132,7 @@ const RULES: &[(&str, &str, bool)] = &[
         "svelte/no-unknown-style-directive-property",
         false,
     ),
+    ("no-nested-style-tag", "svelte/no-nested-style-tag", false),
 ];
 
 /// Fixture path substrings to skip, each with the porting gap it exercises.


### PR DESCRIPTION
`svelte/no-nested-style-tag` (#833) — flag a `<style>` element nested inside another element or block. The top-level `<style>` is lifted into `Root.css`; a `<style>` remaining in the template fragment is nested/unscoped, so `check_element` on `style`-named elements catches exactly the nested cases. Strict oracle now **32 rules**.

Refs epic #904. Closes #833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)