### PR TITLE
feat(lint): port 6 lint rules (prefer-const, no-reactive-literals/functions, no-extra-reactive-curlies, prefer-writable-derived, no-unnecessary-state-wrap)

### DIFF
--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -60,6 +60,7 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::no_reactive_literals::NoReactiveLiterals;
     use crate::rules::no_store_async::NoStoreAsync;
     use crate::rules::no_top_level_browser_globals::NoTopLevelBrowserGlobals;
+    use crate::rules::no_unnecessary_state_wrap::NoUnnecessaryStateWrap;
     use crate::rules::prefer_const::PreferConst;
     use crate::rules::prefer_derived_over_derived_by::PreferDerivedOverDerivedBy;
     use crate::rules::prefer_svelte_reactivity::PreferSvelteReactivity;
@@ -79,5 +80,6 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
         Box::new(PreferConst),
         Box::new(NoReactiveLiterals),
         Box::new(PreferWritableDerived),
+        Box::new(NoUnnecessaryStateWrap),
     ]
 }

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -57,6 +57,7 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::no_add_event_listener::NoAddEventListener;
     use crate::rules::no_ignored_unsubscribe::NoIgnoredUnsubscribe;
     use crate::rules::no_inner_declarations::NoInnerDeclarations;
+    use crate::rules::no_reactive_literals::NoReactiveLiterals;
     use crate::rules::no_store_async::NoStoreAsync;
     use crate::rules::no_top_level_browser_globals::NoTopLevelBrowserGlobals;
     use crate::rules::prefer_const::PreferConst;
@@ -75,5 +76,6 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
         Box::new(RequireStoreCallbacksUseSetParam),
         Box::new(NoTopLevelBrowserGlobals),
         Box::new(PreferConst),
+        Box::new(NoReactiveLiterals),
     ]
 }

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -59,6 +59,7 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::no_inner_declarations::NoInnerDeclarations;
     use crate::rules::no_store_async::NoStoreAsync;
     use crate::rules::no_top_level_browser_globals::NoTopLevelBrowserGlobals;
+    use crate::rules::prefer_const::PreferConst;
     use crate::rules::prefer_derived_over_derived_by::PreferDerivedOverDerivedBy;
     use crate::rules::prefer_svelte_reactivity::PreferSvelteReactivity;
     use crate::rules::require_store_callbacks_use_set_param::RequireStoreCallbacksUseSetParam;
@@ -73,5 +74,6 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
         Box::new(RequireStoresInit),
         Box::new(RequireStoreCallbacksUseSetParam),
         Box::new(NoTopLevelBrowserGlobals),
+        Box::new(PreferConst),
     ]
 }

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -57,6 +57,7 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::no_add_event_listener::NoAddEventListener;
     use crate::rules::no_ignored_unsubscribe::NoIgnoredUnsubscribe;
     use crate::rules::no_inner_declarations::NoInnerDeclarations;
+    use crate::rules::no_reactive_functions::NoReactiveFunctions;
     use crate::rules::no_reactive_literals::NoReactiveLiterals;
     use crate::rules::no_store_async::NoStoreAsync;
     use crate::rules::no_top_level_browser_globals::NoTopLevelBrowserGlobals;
@@ -81,5 +82,6 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
         Box::new(NoReactiveLiterals),
         Box::new(PreferWritableDerived),
         Box::new(NoUnnecessaryStateWrap),
+        Box::new(NoReactiveFunctions),
     ]
 }

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -55,6 +55,7 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
 /// ESTree program rather than the template tree).
 pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::no_add_event_listener::NoAddEventListener;
+    use crate::rules::no_extra_reactive_curlies::NoExtraReactiveCurlies;
     use crate::rules::no_ignored_unsubscribe::NoIgnoredUnsubscribe;
     use crate::rules::no_inner_declarations::NoInnerDeclarations;
     use crate::rules::no_reactive_functions::NoReactiveFunctions;
@@ -83,5 +84,6 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
         Box::new(PreferWritableDerived),
         Box::new(NoUnnecessaryStateWrap),
         Box::new(NoReactiveFunctions),
+        Box::new(NoExtraReactiveCurlies),
     ]
 }

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -63,6 +63,7 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::prefer_const::PreferConst;
     use crate::rules::prefer_derived_over_derived_by::PreferDerivedOverDerivedBy;
     use crate::rules::prefer_svelte_reactivity::PreferSvelteReactivity;
+    use crate::rules::prefer_writable_derived::PreferWritableDerived;
     use crate::rules::require_store_callbacks_use_set_param::RequireStoreCallbacksUseSetParam;
     use crate::rules::require_stores_init::RequireStoresInit;
     vec![
@@ -77,5 +78,6 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
         Box::new(NoTopLevelBrowserGlobals),
         Box::new(PreferConst),
         Box::new(NoReactiveLiterals),
+        Box::new(PreferWritableDerived),
     ]
 }

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -20,6 +20,7 @@ pub mod no_nested_style_tag;
 pub mod no_not_function_handler;
 pub mod no_object_in_text_mustaches;
 pub mod no_raw_special_elements;
+pub mod no_reactive_functions;
 pub mod no_reactive_literals;
 pub mod no_restricted_html_elements;
 pub mod no_shorthand_style_property_overrides;

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -13,6 +13,7 @@ pub mod no_dupe_on_directives;
 pub mod no_dupe_style_properties;
 pub mod no_dupe_use_directives;
 pub mod no_dynamic_slot_name;
+pub mod no_extra_reactive_curlies;
 pub mod no_ignored_unsubscribe;
 pub mod no_inner_declarations;
 pub mod no_inspect;

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -20,6 +20,7 @@ pub mod no_nested_style_tag;
 pub mod no_not_function_handler;
 pub mod no_object_in_text_mustaches;
 pub mod no_raw_special_elements;
+pub mod no_reactive_literals;
 pub mod no_restricted_html_elements;
 pub mod no_shorthand_style_property_overrides;
 pub mod no_store_async;

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -33,6 +33,7 @@ pub mod no_useless_mustaches;
 pub mod prefer_const;
 pub mod prefer_derived_over_derived_by;
 pub mod prefer_svelte_reactivity;
+pub mod prefer_writable_derived;
 pub mod require_each_key;
 pub mod require_store_callbacks_use_set_param;
 pub mod require_stores_init;

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -29,6 +29,7 @@ pub mod no_top_level_browser_globals;
 pub mod no_unknown_style_directive_property;
 pub mod no_useless_children_snippet;
 pub mod no_useless_mustaches;
+pub mod prefer_const;
 pub mod prefer_derived_over_derived_by;
 pub mod prefer_svelte_reactivity;
 pub mod require_each_key;

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -28,6 +28,7 @@ pub mod no_svelte_internal;
 pub mod no_target_blank;
 pub mod no_top_level_browser_globals;
 pub mod no_unknown_style_directive_property;
+pub mod no_unnecessary_state_wrap;
 pub mod no_useless_children_snippet;
 pub mod no_useless_mustaches;
 pub mod prefer_const;

--- a/crates/rsvelte_lint/src/rules/no_extra_reactive_curlies.rs
+++ b/crates/rsvelte_lint/src/rules/no_extra_reactive_curlies.rs
@@ -3,7 +3,7 @@
 //! one statement doesn't need the braces. Port of the eslint-plugin-svelte rule.
 //!
 //! Runs over the `<script>` ESTree program via the [`ScriptRule`] hook. A `$:`
-//! reactive statement is a [`LabeledStatement`] whose label is `$`; the rule
+//! reactive statement is a `LabeledStatement` whose label is `$`; the rule
 //! flags one whose body is a `BlockStatement` with exactly one statement,
 //! reporting at the block. The upstream fix is suggestion-only (not an autofix),
 //! so the rule reports without an attached fix.

--- a/crates/rsvelte_lint/src/rules/no_extra_reactive_curlies.rs
+++ b/crates/rsvelte_lint/src/rules/no_extra_reactive_curlies.rs
@@ -1,0 +1,76 @@
+//! `svelte/no-extra-reactive-curlies` — disallow wrapping a single reactive
+//! statement in curly braces (`$: { foo = bar; }`). A reactive block with just
+//! one statement doesn't need the braces. Port of the eslint-plugin-svelte rule.
+//!
+//! Runs over the `<script>` ESTree program via the [`ScriptRule`] hook. A `$:`
+//! reactive statement is a [`LabeledStatement`] whose label is `$`; the rule
+//! flags one whose body is a `BlockStatement` with exactly one statement,
+//! reporting at the block. The upstream fix is suggestion-only (not an autofix),
+//! so the rule reports without an attached fix.
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-extra-reactive-curlies",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: true,
+    },
+    type_aware: false,
+    docs: "Disallow wrapping single reactive statements in curly braces",
+    options_schema: None,
+};
+
+const MESSAGE: &str = "Do not wrap reactive statements in curly braces unless necessary.";
+
+#[derive(Default)]
+pub struct NoExtraReactiveCurlies;
+
+impl ScriptRule for NoExtraReactiveCurlies {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        let mut reports: Vec<(u32, u32)> = Vec::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("LabeledStatement") {
+                return;
+            }
+            if node
+                .get("label")
+                .and_then(|l| l.get("name"))
+                .and_then(Value::as_str)
+                != Some("$")
+            {
+                return;
+            }
+            let Some(body) = node.get("body") else { return };
+            if node_type(body) != Some("BlockStatement") {
+                return;
+            }
+            let one_stmt = body
+                .get("body")
+                .and_then(Value::as_array)
+                .is_some_and(|b| b.len() == 1);
+            if !one_stmt {
+                return;
+            }
+            if let (Some(s), Some(e)) = (node_start(body), body.get("end").and_then(Value::as_u64))
+            {
+                reports.push((s, e as u32));
+            }
+        });
+
+        for (start, end) in reports {
+            ctx.report(start, end, MESSAGE);
+        }
+    }
+}

--- a/crates/rsvelte_lint/src/rules/no_reactive_functions.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_functions.rs
@@ -4,7 +4,7 @@
 //! Port of the eslint-plugin-svelte rule.
 //!
 //! Runs over the `<script>` ESTree program via the [`ScriptRule`] hook. A `$:`
-//! reactive statement is a [`LabeledStatement`] whose label is `$`; the rule
+//! reactive statement is a `LabeledStatement` whose label is `$`; the rule
 //! flags one whose body is `ExpressionStatement > AssignmentExpression` with a
 //! function-expression right-hand side. The upstream fix is suggestion-only (not
 //! an autofix), so the rule reports without an attached fix.

--- a/crates/rsvelte_lint/src/rules/no_reactive_functions.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_functions.rs
@@ -1,0 +1,106 @@
+//! `svelte/no-reactive-functions` — don't create functions inside reactive
+//! statements (`$: foo = () => {…}` / `$: fn = function () {…}`). The function is
+//! recreated on every reactive run for no reason; it should be a plain `const`.
+//! Port of the eslint-plugin-svelte rule.
+//!
+//! Runs over the `<script>` ESTree program via the [`ScriptRule`] hook. A `$:`
+//! reactive statement is a [`LabeledStatement`] whose label is `$`; the rule
+//! flags one whose body is `ExpressionStatement > AssignmentExpression` with a
+//! function-expression right-hand side. The upstream fix is suggestion-only (not
+//! an autofix), so the rule reports without an attached fix.
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-reactive-functions",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: true,
+    },
+    type_aware: false,
+    docs: "Don't create functions inside reactive statements",
+    options_schema: None,
+};
+
+const MESSAGE: &str =
+    "Do not create functions inside reactive statements unless absolutely necessary.";
+
+fn is_function_expr(node: &Value) -> bool {
+    matches!(
+        node_type(node),
+        Some("ArrowFunctionExpression") | Some("FunctionExpression")
+    )
+}
+
+#[derive(Default)]
+pub struct NoReactiveFunctions;
+
+impl ScriptRule for NoReactiveFunctions {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        let mut reports: Vec<(u32, u32)> = Vec::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("LabeledStatement") {
+                return;
+            }
+            if node
+                .get("label")
+                .and_then(|l| l.get("name"))
+                .and_then(Value::as_str)
+                != Some("$")
+            {
+                return;
+            }
+            let Some(body) = node.get("body") else { return };
+            if node_type(body) != Some("ExpressionStatement") {
+                return;
+            }
+            let Some(expr) = body.get("expression") else {
+                return;
+            };
+            if node_type(expr) != Some("AssignmentExpression") {
+                return;
+            }
+            let Some(right) = expr.get("right") else {
+                return;
+            };
+            if !is_function_expr(right) {
+                return;
+            }
+            if let (Some(s), Some(e)) = (node_start(node), node.get("end").and_then(Value::as_u64))
+            {
+                reports.push((s, e as u32));
+            }
+        });
+
+        for (start, end) in reports {
+            ctx.report(start, end, MESSAGE);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn function_expr_detection() {
+        assert!(is_function_expr(
+            &json!({ "type": "ArrowFunctionExpression" })
+        ));
+        assert!(is_function_expr(&json!({ "type": "FunctionExpression" })));
+        assert!(!is_function_expr(&json!({ "type": "Literal" })));
+        assert!(!is_function_expr(&json!({ "type": "Identifier" })));
+    }
+}

--- a/crates/rsvelte_lint/src/rules/no_reactive_literals.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_literals.rs
@@ -4,7 +4,7 @@
 //! `let` declaration. Port of the eslint-plugin-svelte rule.
 //!
 //! Runs over the `<script>` ESTree program via the [`ScriptRule`] hook. A `$:`
-//! reactive statement is a [`LabeledStatement`] whose label is `$`; the rule
+//! reactive statement is a `LabeledStatement` whose label is `$`; the rule
 //! flags one whose body is `ExpressionStatement > AssignmentExpression` with a
 //! right-hand side that is a literal, an empty array, or an empty object.
 //!

--- a/crates/rsvelte_lint/src/rules/no_reactive_literals.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_literals.rs
@@ -1,0 +1,137 @@
+//! `svelte/no-reactive-literals` — don't assign literal values inside a reactive
+//! statement (`$: foo = "foo"` / `$: bar = []` / `$: baz = {}`). Such a value
+//! never changes, so the reactive statement is pointless — it should be a plain
+//! `let` declaration. Port of the eslint-plugin-svelte rule.
+//!
+//! Runs over the `<script>` ESTree program via the [`ScriptRule`] hook. A `$:`
+//! reactive statement is a [`LabeledStatement`] whose label is `$`; the rule
+//! flags one whose body is `ExpressionStatement > AssignmentExpression` with a
+//! right-hand side that is a literal, an empty array, or an empty object.
+//!
+//! The upstream fix is offered only as a *suggestion* (not an autofix), so this
+//! rule reports without an attached fix.
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-reactive-literals",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: true,
+    },
+    type_aware: false,
+    docs: "Don't assign literal values inside reactive statements",
+    options_schema: None,
+};
+
+const MESSAGE: &str =
+    "Do not assign literal values inside reactive statements unless absolutely necessary.";
+
+/// Whether the assignment right-hand side is a literal / empty array / empty
+/// object — the three shapes upstream matches.
+fn is_pointless_rhs(right: &Value) -> bool {
+    match node_type(right) {
+        Some("Literal") => true,
+        Some("ArrayExpression") => right
+            .get("elements")
+            .and_then(Value::as_array)
+            .is_some_and(|e| e.is_empty()),
+        Some("ObjectExpression") => right
+            .get("properties")
+            .and_then(Value::as_array)
+            .is_some_and(|p| p.is_empty()),
+        _ => false,
+    }
+}
+
+#[derive(Default)]
+pub struct NoReactiveLiterals;
+
+impl ScriptRule for NoReactiveLiterals {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        let mut reports: Vec<(u32, u32)> = Vec::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("LabeledStatement") {
+                return;
+            }
+            // `$:` reactive statement.
+            if node
+                .get("label")
+                .and_then(|l| l.get("name"))
+                .and_then(Value::as_str)
+                != Some("$")
+            {
+                return;
+            }
+            let body = match node.get("body") {
+                Some(b) => b,
+                None => return,
+            };
+            if node_type(body) != Some("ExpressionStatement") {
+                return;
+            }
+            let Some(expr) = body.get("expression") else {
+                return;
+            };
+            if node_type(expr) != Some("AssignmentExpression") {
+                return;
+            }
+            let Some(right) = expr.get("right") else {
+                return;
+            };
+            if !is_pointless_rhs(right) {
+                return;
+            }
+            // Report at the whole reactive statement (the `$:`).
+            if let (Some(s), Some(e)) = (node_start(node), node.get("end").and_then(Value::as_u64))
+            {
+                reports.push((s, e as u32));
+            }
+        });
+
+        for (start, end) in reports {
+            ctx.report(start, end, MESSAGE);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn pointless_rhs_detection() {
+        assert!(is_pointless_rhs(
+            &json!({ "type": "Literal", "value": "foo" })
+        ));
+        assert!(is_pointless_rhs(
+            &json!({ "type": "ArrayExpression", "elements": [] })
+        ));
+        assert!(is_pointless_rhs(
+            &json!({ "type": "ObjectExpression", "properties": [] })
+        ));
+        // Non-empty / non-literal shapes are fine.
+        assert!(!is_pointless_rhs(
+            &json!({ "type": "ArrayExpression", "elements": [ { "type": "Literal" } ] })
+        ));
+        assert!(!is_pointless_rhs(
+            &json!({ "type": "ObjectExpression", "properties": [ {} ] })
+        ));
+        assert!(!is_pointless_rhs(&json!({ "type": "TemplateLiteral" })));
+        assert!(!is_pointless_rhs(
+            &json!({ "type": "Identifier", "name": "x" })
+        ));
+    }
+}

--- a/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
+++ b/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
@@ -1,0 +1,280 @@
+//! `svelte/no-unnecessary-state-wrap` — disallow wrapping an already-reactive
+//! class instance in `$state(...)`. The reactive classes from `svelte/reactivity`
+//! (`SvelteSet`, `SvelteMap`, `SvelteURL`, `SvelteURLSearchParams`, `SvelteDate`,
+//! `MediaQuery`) are deeply reactive on their own, so `$state(new SvelteSet())`
+//! is redundant. Port of the eslint-plugin-svelte rule.
+//!
+//! Runs over the `<script>` ESTree program via the [`ScriptRule`] hook. Built-in
+//! reactive classes are matched through the `svelte/reactivity` import (alias
+//! aware — `import { SvelteSet as S }` then `$state(new S())` reports
+//! `SvelteSet`); the `additionalReactiveClasses` option matches by callee name
+//! directly. With `allowReassign`, a wrapped binding that is later reassigned
+//! (including via a two-way `bind:`) is left alone. The upstream fix is
+//! suggestion-only, so the rule reports without an autofix.
+
+use std::collections::{HashMap, HashSet};
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-unnecessary-state-wrap",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: true,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow unnecessary `$state` wrapping of reactive classes",
+    options_schema: Some(
+        r#"{ "type": "object", "properties": {
+            "additionalReactiveClasses": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+            "allowReassign": { "type": "boolean" }
+        }, "additionalProperties": false }"#,
+    ),
+};
+
+const REACTIVE_CLASSES: &[&str] = &[
+    "SvelteSet",
+    "SvelteMap",
+    "SvelteURL",
+    "SvelteURLSearchParams",
+    "SvelteDate",
+    "MediaQuery",
+];
+
+/// The callee Identifier name of a `new X()` / `X()` argument, if any.
+fn ctor_callee_name(arg: &Value) -> Option<&str> {
+    match node_type(arg) {
+        Some("NewExpression") | Some("CallExpression") => arg
+            .get("callee")
+            .filter(|c| node_type(c) == Some("Identifier"))
+            .and_then(|c| c.get("name"))
+            .and_then(Value::as_str),
+        _ => None,
+    }
+}
+
+/// Whether `node` is a `$state(...)` call.
+fn is_state_call(node: &Value) -> bool {
+    node_type(node) == Some("CallExpression")
+        && node
+            .get("callee")
+            .filter(|c| node_type(c) == Some("Identifier"))
+            .and_then(|c| c.get("name"))
+            .and_then(Value::as_str)
+            == Some("$state")
+}
+
+#[derive(Default)]
+pub struct NoUnnecessaryStateWrap;
+
+impl ScriptRule for NoUnnecessaryStateWrap {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        let opts = ctx.option0();
+        let additional: HashSet<String> = opts
+            .and_then(|o| o.get("additionalReactiveClasses"))
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let allow_reassign = opts
+            .and_then(|o| o.get("allowReassign"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        // `svelte/reactivity` imports: local name → exported (canonical) name,
+        // restricted to the known reactive classes.
+        let mut import_map: HashMap<String, String> = HashMap::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("ImportDeclaration") {
+                return;
+            }
+            if node
+                .get("source")
+                .and_then(|s| s.get("value"))
+                .and_then(Value::as_str)
+                != Some("svelte/reactivity")
+            {
+                return;
+            }
+            let Some(specs) = node.get("specifiers").and_then(Value::as_array) else {
+                return;
+            };
+            for spec in specs {
+                if node_type(spec) != Some("ImportSpecifier") {
+                    continue;
+                }
+                let imported = spec
+                    .get("imported")
+                    .and_then(|i| i.get("name"))
+                    .and_then(Value::as_str);
+                let local = spec
+                    .get("local")
+                    .and_then(|l| l.get("name"))
+                    .and_then(Value::as_str);
+                if let (Some(imported), Some(local)) = (imported, local)
+                    && REACTIVE_CLASSES.contains(&imported)
+                {
+                    import_map.insert(local.to_string(), imported.to_string());
+                }
+            }
+        });
+
+        // Reassignment set (only needed when `allowReassign` is on). Covers
+        // `x = ...` and `bind:` getter/setter writes via the analyzed scope, plus
+        // shorthand `bind:x` two-way bindings detected from the source.
+        let reassigned: HashSet<String> = if allow_reassign {
+            let mut set: HashSet<String> = crate::scope::analyze_scope(ctx.source())
+                .map(|a| {
+                    a.root
+                        .bindings
+                        .iter()
+                        .filter(|b| b.reassigned)
+                        .map(|b| b.name.clone())
+                        .collect()
+                })
+                .unwrap_or_default();
+            collect_shorthand_bind_names(ctx.source(), &mut set);
+            set
+        } else {
+            HashSet::new()
+        };
+
+        // Each `$state(...)` must sit in a `const/let x = $state(...)` declarator
+        // (VariableDeclarator with an Identifier id); associate the wrap with that
+        // binding so the allow-reassign skip can apply.
+        let mut valid_reports: Vec<(u32, String)> = Vec::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("VariableDeclarator") {
+                return;
+            }
+            let id_name = node
+                .get("id")
+                .filter(|i| node_type(i) == Some("Identifier"))
+                .and_then(|i| i.get("name"))
+                .and_then(Value::as_str);
+            let Some(id_name) = id_name else { return };
+            let Some(init) = node.get("init").filter(|i| !i.is_null()) else {
+                return;
+            };
+            if !is_state_call(init) {
+                return;
+            }
+            if allow_reassign && reassigned.contains(id_name) {
+                return;
+            }
+            let Some(args) = init.get("arguments").and_then(Value::as_array) else {
+                return;
+            };
+            for arg in args {
+                let Some(name) = ctor_callee_name(arg) else {
+                    continue;
+                };
+                let class_name = if let Some(canonical) = import_map.get(name) {
+                    canonical.clone()
+                } else if additional.contains(name) {
+                    name.to_string()
+                } else {
+                    continue;
+                };
+                if let Some(s) = node_start(arg) {
+                    valid_reports.push((s, class_name));
+                }
+            }
+        });
+
+        for (start, class_name) in valid_reports {
+            ctx.report(
+                start,
+                start,
+                format!("{class_name} is already reactive, $state wrapping is unnecessary."),
+            );
+        }
+    }
+}
+
+/// Add variables targeted by a shorthand two-way binding (`bind:name` with no
+/// `={...}`) to `set`. These are write references upstream's `isReassigned` sees
+/// but that don't appear as an assignment in the analyzed scope.
+fn collect_shorthand_bind_names(source: &str, set: &mut HashSet<String>) {
+    let bytes = source.as_bytes();
+    let needle = b"bind:";
+    let mut i = 0;
+    while i + needle.len() < bytes.len() {
+        if &bytes[i..i + needle.len()] == needle {
+            let mut j = i + needle.len();
+            let start = j;
+            while j < bytes.len() {
+                let c = bytes[j];
+                if c == b'_' || c == b'$' || c.is_ascii_alphanumeric() {
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+            if j > start {
+                let name = &source[start..j];
+                // Shorthand only: not followed by `=` (which would be a
+                // `bind:name={...}` getter/setter form already covered by scope).
+                let next = bytes.get(j).copied();
+                if next != Some(b'=') {
+                    set.insert(name.to_string());
+                }
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ctor_name_detection() {
+        assert_eq!(
+            ctor_callee_name(
+                &json!({ "type": "NewExpression", "callee": { "type": "Identifier", "name": "SvelteSet" } })
+            ),
+            Some("SvelteSet")
+        );
+        assert_eq!(
+            ctor_callee_name(
+                &json!({ "type": "CallExpression", "callee": { "type": "Identifier", "name": "foo" } })
+            ),
+            Some("foo")
+        );
+        assert_eq!(
+            ctor_callee_name(&json!({ "type": "Literal", "value": 42 })),
+            None
+        );
+    }
+
+    #[test]
+    fn shorthand_bind_scan() {
+        let mut set = HashSet::new();
+        collect_shorthand_bind_names("<Bug3 bind:svelteSet />", &mut set);
+        assert!(set.contains("svelteSet"));
+
+        // Getter/setter form is not a shorthand → not added here.
+        let mut set2 = HashSet::new();
+        collect_shorthand_bind_names("<Bug3 bind:svelteSet={x} />", &mut set2);
+        assert!(!set2.contains("svelteSet"));
+    }
+}

--- a/crates/rsvelte_lint/src/rules/prefer_const.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_const.rs
@@ -1,0 +1,270 @@
+//! `svelte/prefer-const` — suggest `const` for a `let` binding that is never
+//! reassigned. Port of the core ESLint `prefer-const` rule's behaviour exercised
+//! by the eslint-plugin-svelte fixtures, plus the plugin's `excludedRunes`
+//! option (a `let` initialised by an excluded rune call — `$props()` /
+//! `$derived(...)` by default — is left alone, since those require `let`).
+//!
+//! Implemented as a script-AST rule: the `<script>` ESTree program gives the
+//! real initializer (so `excludedRunes` is detected from the actual `$props` /
+//! `$derived` callee, not the rune-stripped binding value) and the declaration
+//! identifier positions; reassignment comes from the analyzed scope
+//! ([`analyze_scope`](crate::scope::analyze_scope)).
+
+use std::collections::HashSet;
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::diagnostic::{Fix, TextEdit};
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/prefer-const",
+    category: RuleCategory::Style,
+    fixable: Fixable::Code,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Suggest `const` for never-reassigned `let` bindings",
+    options_schema: Some(
+        r#"{ "type": "object", "properties": {
+            "destructuring": { "enum": ["any", "all"] },
+            "ignoreReadBeforeAssign": { "type": "boolean" },
+            "excludedRunes": { "type": "array", "items": { "type": "string" } }
+        }, "additionalProperties": true }"#,
+    ),
+};
+
+fn ident_name(node: &Value) -> Option<&str> {
+    if node_type(node) == Some("Identifier") {
+        node.get("name").and_then(Value::as_str)
+    } else {
+        None
+    }
+}
+
+/// The callee identifier name of an init expression that is a rune call:
+/// `$props()` → `$props`, `$derived.by(...)` → `$derived` (member object).
+fn init_rune_callee(init: &Value) -> Option<&str> {
+    if node_type(init) != Some("CallExpression") {
+        return None;
+    }
+    let callee = init.get("callee")?;
+    match node_type(callee) {
+        Some("Identifier") => ident_name(callee),
+        Some("MemberExpression") => callee.get("object").and_then(ident_name),
+        _ => None,
+    }
+}
+
+/// Collect the bound Identifier leaves of a declarator `id` pattern.
+fn collect_pattern_idents<'a>(id: &'a Value, out: &mut Vec<&'a Value>) {
+    match node_type(id) {
+        Some("Identifier") => out.push(id),
+        Some("ObjectPattern") => {
+            if let Some(props) = id.get("properties").and_then(Value::as_array) {
+                for p in props {
+                    match node_type(p) {
+                        // `{ a }` / `{ a: b }` → the value is the binding.
+                        Some("Property") => {
+                            if let Some(v) = p.get("value") {
+                                collect_pattern_idents(v, out);
+                            }
+                        }
+                        // `{ ...rest }`
+                        Some("RestElement") => {
+                            if let Some(arg) = p.get("argument") {
+                                collect_pattern_idents(arg, out);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        Some("ArrayPattern") => {
+            if let Some(els) = id.get("elements").and_then(Value::as_array) {
+                for e in els.iter().filter(|e| !e.is_null()) {
+                    collect_pattern_idents(e, out);
+                }
+            }
+        }
+        // `let a = 1` default in a pattern: `{ a = 1 }` → left is the binding.
+        Some("AssignmentPattern") => {
+            if let Some(left) = id.get("left") {
+                collect_pattern_idents(left, out);
+            }
+        }
+        Some("RestElement") => {
+            if let Some(arg) = id.get("argument") {
+                collect_pattern_idents(arg, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[derive(Default)]
+pub struct PreferConst;
+
+impl ScriptRule for PreferConst {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        // Reassignment info from the analyzed scope (reliable per the R9 audit).
+        let Some(analysis) = crate::scope::analyze_scope(ctx.source()) else {
+            return;
+        };
+        let reassigned: HashSet<&str> = analysis
+            .root
+            .bindings
+            .iter()
+            .filter(|b| b.reassigned)
+            .map(|b| b.name.as_str())
+            .collect();
+
+        let opts = ctx.option0();
+        let excluded: Vec<String> = opts
+            .and_then(|o| o.get("excludedRunes"))
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_else(|| vec!["$props".to_string(), "$derived".to_string()]);
+        let destructuring_all = opts
+            .and_then(|o| o.get("destructuring"))
+            .and_then(Value::as_str)
+            == Some("all");
+
+        let mut reports: Vec<(u32, u32, String, Option<u32>)> = Vec::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("VariableDeclaration")
+                || node.get("kind").and_then(Value::as_str) != Some("let")
+            {
+                return;
+            }
+            let Some(declarators) = node.get("declarations").and_then(Value::as_array) else {
+                return;
+            };
+
+            // `excludedRunes`: skip the whole declaration if any declarator's
+            // init is a call to an excluded rune.
+            let skip = declarators.iter().any(|d| {
+                d.get("init")
+                    .filter(|i| !i.is_null())
+                    .and_then(init_rune_callee)
+                    .is_some_and(|c| excluded.iter().any(|e| e == c))
+            });
+            if skip {
+                return;
+            }
+
+            // Per-declarator bound identifiers that are const-able (init present,
+            // never reassigned).
+            let mut decl_idents: Vec<&Value> = Vec::new(); // const-able to report
+            let mut all_const_able = true; // every bound id (with init) is const-able
+            let mut every_declarator_has_init = true;
+            for d in declarators {
+                let has_init = d.get("init").is_some_and(|i| !i.is_null());
+                if !has_init {
+                    every_declarator_has_init = false;
+                }
+                let mut ids = Vec::new();
+                if let Some(id) = d.get("id") {
+                    collect_pattern_idents(id, &mut ids);
+                }
+                for id in ids {
+                    let name = ident_name(id).unwrap_or("");
+                    let is_reassigned = reassigned.contains(name);
+                    if has_init && !is_reassigned {
+                        decl_idents.push(id);
+                    } else {
+                        all_const_able = false;
+                    }
+                }
+            }
+            if decl_idents.is_empty() {
+                return;
+            }
+
+            // The whole declaration can be auto-fixed to `const` only when every
+            // declarator has an init and every bound id is const-able.
+            let fixable = every_declarator_has_init && all_const_able;
+            // `destructuring: "all"` only reports when the whole declaration is
+            // const-able (default "any" reports each const-able id).
+            if destructuring_all && !all_const_able {
+                return;
+            }
+            let fix_start = if fixable { node_start(node) } else { None };
+
+            for id in decl_idents {
+                if let (Some(s), Some(e)) = (node_start(id), id.get("end").and_then(Value::as_u64))
+                {
+                    let name = ident_name(id).unwrap_or("");
+                    reports.push((
+                        s,
+                        e as u32,
+                        format!("'{name}' is never reassigned. Use 'const' instead."),
+                        fix_start,
+                    ));
+                }
+            }
+        });
+
+        for (start, end, msg, fix_start) in reports {
+            match fix_start {
+                Some(decl_start) => ctx.report_with_fix(
+                    start,
+                    end,
+                    msg,
+                    Fix {
+                        message: "Use `const` instead.".to_string(),
+                        edits: vec![TextEdit {
+                            start: decl_start,
+                            end: decl_start + 3, // the `let` keyword
+                            new_text: "const".to_string(),
+                        }],
+                    },
+                ),
+                None => ctx.report(start, end, msg),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rune_callee_detection() {
+        let props = json!({ "type": "CallExpression", "callee": { "type": "Identifier", "name": "$props" } });
+        assert_eq!(init_rune_callee(&props), Some("$props"));
+        let derived_by = json!({ "type": "CallExpression", "callee": { "type": "MemberExpression", "object": { "type": "Identifier", "name": "$derived" }, "property": { "type": "Identifier", "name": "by" } } });
+        assert_eq!(init_rune_callee(&derived_by), Some("$derived"));
+        let plain =
+            json!({ "type": "CallExpression", "callee": { "type": "Identifier", "name": "calc" } });
+        assert_eq!(init_rune_callee(&plain), Some("calc"));
+    }
+
+    #[test]
+    fn pattern_idents() {
+        let obj = json!({ "type": "ObjectPattern", "properties": [
+            { "type": "Property", "value": { "type": "Identifier", "name": "a" } },
+            { "type": "Property", "value": { "type": "Identifier", "name": "b" } }
+        ] });
+        let mut out = Vec::new();
+        collect_pattern_idents(&obj, &mut out);
+        let names: Vec<_> = out.iter().filter_map(|n| ident_name(n)).collect();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+}

--- a/crates/rsvelte_lint/src/rules/prefer_writable_derived.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_writable_derived.rs
@@ -1,0 +1,233 @@
+//! `svelte/prefer-writable-derived` — prefer a writable `$derived` over the
+//! `$state` + `$effect` pattern. When an `$effect(() => { x = expr })` body does
+//! nothing but reassign a `$state`-declared variable `x`, the whole thing can be
+//! a writable `$derived` (`let x = $derived(expr)`). Port of the
+//! eslint-plugin-svelte rule.
+//!
+//! Runs over the `<script>` ESTree program via the [`ScriptRule`] hook. The
+//! upstream fix is suggestion-only (not an autofix), so the rule reports without
+//! an attached fix. Reports at the `$state` declarator (matching upstream's
+//! `node: def.node`), once per offending `$effect` / `$effect.pre` call.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/prefer-writable-derived",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: true,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Prefer using writable `$derived` instead of `$state` and `$effect`",
+    options_schema: None,
+};
+
+const MESSAGE: &str = "Prefer using writable $derived instead of $state and $effect";
+
+/// The callee identifier of a `$state(...)` call init, if any.
+fn is_state_call(init: &Value) -> bool {
+    node_type(init) == Some("CallExpression")
+        && init
+            .get("callee")
+            .filter(|c| node_type(c) == Some("Identifier"))
+            .and_then(|c| c.get("name"))
+            .and_then(Value::as_str)
+            == Some("$state")
+}
+
+/// Whether `node` is a `$effect(...)` or `$effect.pre(...)` call.
+fn is_effect_call(node: &Value) -> bool {
+    let Some(callee) = node.get("callee") else {
+        return false;
+    };
+    match node_type(callee) {
+        Some("Identifier") => callee.get("name").and_then(Value::as_str) == Some("$effect"),
+        Some("MemberExpression") => {
+            let object_is_effect = callee
+                .get("object")
+                .filter(|o| node_type(o) == Some("Identifier"))
+                .and_then(|o| o.get("name"))
+                .and_then(Value::as_str)
+                == Some("$effect");
+            let prop_is_pre = callee
+                .get("property")
+                .filter(|p| node_type(p) == Some("Identifier"))
+                .and_then(|p| p.get("name"))
+                .and_then(Value::as_str)
+                == Some("pre");
+            object_is_effect && prop_is_pre
+        }
+        _ => false,
+    }
+}
+
+/// The single bare `x = <expr>` target name of a zero-param function argument
+/// whose block body is exactly one assignment statement.
+fn single_assignment_target(arg: &Value) -> Option<&str> {
+    match node_type(arg) {
+        Some("FunctionExpression") | Some("ArrowFunctionExpression") => {}
+        _ => return None,
+    }
+    if !arg
+        .get("params")
+        .and_then(Value::as_array)
+        .is_some_and(|p| p.is_empty())
+    {
+        return None;
+    }
+    let body = arg.get("body")?;
+    if node_type(body) != Some("BlockStatement") {
+        return None;
+    }
+    let stmts = body.get("body").and_then(Value::as_array)?;
+    if stmts.len() != 1 {
+        return None;
+    }
+    let stmt = &stmts[0];
+    if node_type(stmt) != Some("ExpressionStatement") {
+        return None;
+    }
+    let expr = stmt.get("expression")?;
+    if node_type(expr) != Some("AssignmentExpression")
+        || expr.get("operator").and_then(Value::as_str) != Some("=")
+    {
+        return None;
+    }
+    let left = expr.get("left")?;
+    if node_type(left) != Some("Identifier") {
+        return None;
+    }
+    left.get("name").and_then(Value::as_str)
+}
+
+#[derive(Default)]
+pub struct PreferWritableDerived;
+
+impl ScriptRule for PreferWritableDerived {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+        // name → `$state` declarator start offset.
+        let mut state_decls: HashMap<String, u32> = HashMap::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("VariableDeclarator") {
+                return;
+            }
+            let Some(id) = node.get("id") else { return };
+            if node_type(id) != Some("Identifier") {
+                return;
+            }
+            let Some(name) = id.get("name").and_then(Value::as_str) else {
+                return;
+            };
+            let Some(init) = node.get("init").filter(|i| !i.is_null()) else {
+                return;
+            };
+            if is_state_call(init)
+                && let Some(s) = node_start(node)
+            {
+                state_decls.insert(name.to_string(), s);
+            }
+        });
+
+        let mut reports: Vec<(u32, u32)> = Vec::new();
+        walk_js(program, |node, _| {
+            if node_type(node) != Some("CallExpression") || !is_effect_call(node) {
+                return;
+            }
+            let args = node.get("arguments").and_then(Value::as_array);
+            let Some(args) = args else { return };
+            if args.len() != 1 {
+                return;
+            }
+            let Some(target) = single_assignment_target(&args[0]) else {
+                return;
+            };
+            if let Some(&decl_start) = state_decls.get(target) {
+                reports.push((decl_start, decl_start));
+            }
+        });
+
+        // Report each at the `$state` declarator; the end offset is unused for
+        // the column (start drives it), so point start==end at the declarator.
+        for (start, _end) in reports {
+            ctx.report(start, start, MESSAGE);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn effect_call_detection() {
+        assert!(is_effect_call(
+            &json!({ "type": "CallExpression", "callee": { "type": "Identifier", "name": "$effect" } })
+        ));
+        assert!(is_effect_call(
+            &json!({ "type": "CallExpression", "callee": {
+            "type": "MemberExpression",
+            "object": { "type": "Identifier", "name": "$effect" },
+            "property": { "type": "Identifier", "name": "pre" }
+        } })
+        ));
+        assert!(!is_effect_call(
+            &json!({ "type": "CallExpression", "callee": { "type": "Identifier", "name": "setInterval" } })
+        ));
+    }
+
+    #[test]
+    fn state_call_detection() {
+        assert!(is_state_call(
+            &json!({ "type": "CallExpression", "callee": { "type": "Identifier", "name": "$state" } })
+        ));
+        assert!(!is_state_call(
+            &json!({ "type": "CallExpression", "callee": { "type": "Identifier", "name": "$derived" } })
+        ));
+    }
+
+    #[test]
+    fn single_assignment_target_shapes() {
+        let ok = json!({
+            "type": "ArrowFunctionExpression",
+            "params": [],
+            "body": { "type": "BlockStatement", "body": [
+                { "type": "ExpressionStatement", "expression": {
+                    "type": "AssignmentExpression", "operator": "=",
+                    "left": { "type": "Identifier", "name": "x" },
+                    "right": { "type": "Identifier", "name": "y" }
+                } }
+            ] }
+        });
+        assert_eq!(single_assignment_target(&ok), Some("x"));
+
+        // Two statements → not a match.
+        let two = json!({
+            "type": "ArrowFunctionExpression",
+            "params": [],
+            "body": { "type": "BlockStatement", "body": [ {}, {} ] }
+        });
+        assert_eq!(single_assignment_target(&two), None);
+
+        // Has params → not a match.
+        let with_params = json!({
+            "type": "ArrowFunctionExpression",
+            "params": [ { "type": "Identifier", "name": "p" } ],
+            "body": { "type": "BlockStatement", "body": [] }
+        });
+        assert_eq!(single_assignment_target(&with_params), None);
+    }
+}

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -112,6 +112,11 @@ const RULES: &[(&str, &str, bool)] = &[
         false,
     ),
     (
+        "no-unnecessary-state-wrap",
+        "svelte/no-unnecessary-state-wrap",
+        false,
+    ),
+    (
         "no-ignored-unsubscribe",
         "svelte/no-ignored-unsubscribe",
         false,

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -107,6 +107,11 @@ const RULES: &[(&str, &str, bool)] = &[
     ("prefer-const", "svelte/prefer-const", true),
     ("no-reactive-literals", "svelte/no-reactive-literals", false),
     (
+        "prefer-writable-derived",
+        "svelte/prefer-writable-derived",
+        false,
+    ),
+    (
         "no-ignored-unsubscribe",
         "svelte/no-ignored-unsubscribe",
         false,

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -104,6 +104,7 @@ const RULES: &[(&str, &str, bool)] = &[
         "svelte/prefer-derived-over-derived-by",
         true,
     ),
+    ("prefer-const", "svelte/prefer-const", true),
     (
         "no-ignored-unsubscribe",
         "svelte/no-ignored-unsubscribe",
@@ -423,7 +424,10 @@ fn oracle_strict_parity() {
                 && let Some(opath) = output_path(&input)
                 && let Ok(expected_out) = std::fs::read_to_string(&opath)
             {
-                let cfg = LintConfig::empty().with_override(*code, Severity::Error);
+                let mut cfg = LintConfig::empty().with_override(*code, Severity::Error);
+                if let Some(opts) = load_options(&input) {
+                    cfg = cfg.with_options(*code, opts);
+                }
                 let fixed = fix_source(&src, &cfg).output;
                 if fixed != expected_out {
                     failures.push(format!(

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -107,6 +107,11 @@ const RULES: &[(&str, &str, bool)] = &[
     ("prefer-const", "svelte/prefer-const", true),
     ("no-reactive-literals", "svelte/no-reactive-literals", false),
     (
+        "no-reactive-functions",
+        "svelte/no-reactive-functions",
+        false,
+    ),
+    (
         "prefer-writable-derived",
         "svelte/prefer-writable-derived",
         false,

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -112,6 +112,11 @@ const RULES: &[(&str, &str, bool)] = &[
         false,
     ),
     (
+        "no-extra-reactive-curlies",
+        "svelte/no-extra-reactive-curlies",
+        false,
+    ),
+    (
         "prefer-writable-derived",
         "svelte/prefer-writable-derived",
         false,

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -105,6 +105,7 @@ const RULES: &[(&str, &str, bool)] = &[
         true,
     ),
     ("prefer-const", "svelte/prefer-const", true),
+    ("no-reactive-literals", "svelte/no-reactive-literals", false),
     (
         "no-ignored-unsubscribe",
         "svelte/no-ignored-unsubscribe",


### PR DESCRIPTION
Port six more eslint-plugin-svelte rules into native `rsvelte_lint`, all at strict oracle parity.

## `svelte/prefer-const` (#870)
Hybrid script-AST rule: real initializer from the `<script>` ESTree program (so `excludedRunes` is detected from the actual `$props`/`$derived` callee, not the rune-stripped binding value) + `analyze_scope` for reassignment. Reports each never-reassigned `let` identifier and attaches a `let`→`const` fix when the whole declaration is const-able. Supports `destructuring` and `excludedRunes` options.

Also fixes the strict oracle's autofix-parity path to load fixture options (previously ran `fix_source` without `with_options`).

## `svelte/no-reactive-literals`
Flag a `$:` reactive statement whose body assigns a literal / empty-array / empty-object. Suggestion-only.

## `svelte/no-reactive-functions`
Flag a `$:` reactive statement whose body assigns a function expression. Suggestion-only.

## `svelte/no-extra-reactive-curlies`
Flag `$: { single statement }` — a reactive block with exactly one statement needs no braces. Suggestion-only.

## `svelte/prefer-writable-derived`
Flag the `$state` + `$effect(() => { x = expr })` pattern (incl. `$effect.pre`) where the effect only reassigns a `$state` var. Reports at the declarator. Suggestion-only.

## `svelte/no-unnecessary-state-wrap`
Flag `$state(new SvelteSet())` etc. where the wrapped class is already reactive. Built-ins matched via the `svelte/reactivity` import (alias-aware); `additionalReactiveClasses` matched by name; `allowReassign` skips bindings later reassigned (incl. shorthand `bind:`). Suggestion-only.

## Verification
Strict oracle parity over all fixtures for the six rules. `cargo +stable test/fmt/clippy/doc` clean for `rsvelte_lint`.

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)