### PR TITLE
fix(fmt): quote-aware <script> open-tag terminator (#946)

### DIFF
--- a/.changeset/fix-946-fmt-script-generics-tag-end.md
+++ b/.changeset/fix-946-fmt-script-generics-tag-end.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): locate the `<script>` opening-tag terminator with a quote-aware scan so a `>` inside an attribute value no longer corrupts body extraction. A `<script lang="ts" generics="T extends Record<string, unknown>">` has a literal `>` inside the `generics` attribute value; the naive `block.find('>')` in `body_span` matched that one first and started the body slice mid-attribute, so oxc parsed garbage and reported a spurious `Unexpected token` — leaving the whole file unformatted. `find_open_tag_end` now skips any `>` that appears inside single- or double-quoted attribute values, terminating the open tag at the real unquoted `>`. Closes #946.

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -96,12 +96,12 @@ fn body_span(source: &str, script: &Script) -> Result<(usize, usize), FormatErro
         .get(script.start as usize..script.end as usize)
         .ok_or_else(|| FormatError::Parse("script span out of bounds".into()))?;
 
-    // Find the first '>' that terminates the opening <script ...> tag.
-    // (Attribute values can't contain a literal '>' without quoting, but
-    // a string like `class=">"` would defeat naive scanning — punted to
-    // a follow-up; today's CSS/markup verbatim path doesn't exercise it.)
-    let body_start_rel = block
-        .find('>')
+    // Find the '>' that terminates the opening <script ...> tag, skipping any
+    // '>' that appears inside a quoted attribute value. A naive `find('>')`
+    // mis-slices tags like `<script lang="ts" generics="T extends Map<K, V>">`
+    // (the `generics` value contains a literal `>`), starting the body
+    // mid-attribute and corrupting the parse (#946).
+    let body_start_rel = find_open_tag_end(block)
         .ok_or_else(|| FormatError::Parse("script opening tag missing '>'".into()))?
         + 1;
 
@@ -113,4 +113,26 @@ fn body_span(source: &str, script: &Script) -> Result<(usize, usize), FormatErro
         script.start as usize + body_start_rel,
         script.start as usize + body_end_rel,
     ))
+}
+
+/// Byte offset (relative to `block`) of the `>` that closes the opening tag,
+/// ignoring any `>` inside a single- or double-quoted attribute value. Quotes
+/// and `>` are ASCII, so the returned byte index is always a char boundary.
+fn find_open_tag_end(block: &str) -> Option<usize> {
+    let mut quote: Option<u8> = None;
+    for (i, b) in block.bytes().enumerate() {
+        match quote {
+            Some(q) => {
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'"' | b'\'' => quote = Some(b),
+                b'>' => return Some(i),
+                _ => {}
+            },
+        }
+    }
+    None
 }

--- a/crates/rsvelte_formatter/tests/typescript.rs
+++ b/crates/rsvelte_formatter/tests/typescript.rs
@@ -124,6 +124,25 @@ fn non_ts_component_does_not_parse_ts_syntax() {
     );
 }
 
+// ─── #946: `>` inside a `generics` attribute value must not split the body ──
+
+#[test]
+fn script_generics_attr_with_angle_brackets_parses() {
+    // The `generics` attribute value contains a literal `>` (`Record<…>`). A
+    // naive `find('>')` when locating the tag-terminating `>` would start the
+    // body slice mid-attribute, so oxc parsed garbage and reported a spurious
+    // "Unexpected token" — leaving the file unformatted (#946).
+    let src = "<script lang=\"ts\" generics=\"TItem extends Record<string, unknown>\">\n\timport { onMount } from \"svelte\";\n\tconst x = 1;\n</script>\n";
+    let out = format(src, &FormatOptions::default()).expect("format should succeed");
+    assert!(out.contains("import { onMount }"), "body preserved:\n{out}");
+    assert!(out.contains("const x = 1;"), "body preserved:\n{out}");
+    // The open tag (with its generics attribute) survives unchanged.
+    assert!(
+        out.contains("generics=\"TItem extends Record<string, unknown>\""),
+        "generics attribute preserved:\n{out}"
+    );
+}
+
 // ─── #761: <script> body long type-argument wrapping matches oxfmt ──────────
 
 #[test]


### PR DESCRIPTION
## Problem

`rsvelte-fmt` (`@rsvelte/fmt`) failed to parse `<script lang="ts">` bodies on certain files with `script parse failed: ... "Unexpected token"`, leaving the file unformatted (#946). oxfmt formats the same files fine, so the TypeScript is valid.

## Root cause

`body_span` in `crates/rsvelte_formatter/src/script.rs` located the `>` that terminates the `<script …>` opening tag with a naive `block.find('>')`. A Svelte 5 generics clause such as:

```svelte
<script lang="ts" generics="TItem extends Record<string, unknown>">
```

contains a literal `>` *inside* the `generics` attribute value (`Record<…>`). `find('>')` matched that one first, so the body slice started mid-attribute (`">\n\timport …`) and oxc parsed garbage → spurious "Unexpected token" at an offset landing inside the first import line — exactly the symptom in the issue. The flaw was already flagged in the function's own doc comment ("punted to a follow-up").

## Fix

Add `find_open_tag_end`, a small quote-aware scan that skips any `>` appearing inside single- or double-quoted attribute values, terminating the open tag at the real unquoted `>`. Quotes and `>` are ASCII, so the returned byte index is always a char boundary.

## Test

`script_generics_attr_with_angle_brackets_parses` in `tests/typescript.rs` formats a `<script>` whose `generics` value contains angle brackets and asserts the body (imports + statements) and the open tag survive. Full `rsvelte_formatter` suite stays green.

Closes #946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)