### PR TITLE
fix(svelte2tsx): emit numeric DOM attributes as bare numbers (#939)

### DIFF
--- a/.changeset/fix-939-numeric-attr-string-literal.md
+++ b/.changeset/fix-939-numeric-attr-string-literal.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): lower static numeric DOM attribute values to bare numbers so `--tsgo` accepts the idiomatic string-literal form (`tabindex="-1"`, `colspan="2"`, `maxlength="5"`, …). `svelte/elements` types these attributes as `number | undefined | null` (no `string`), so emitting the value as a backtick string made tsgo reject every one with `Type 'string' is not assignable to type 'number'`, while official svelte-check accepted them. A single-`Text` value on a real element whose name is in svelte2tsx's `numberOnlyAttributes` set and which coerces to a number (`!isNaN`) is now emitted as a bare number (`"tabindex":-1,`) instead of `"tabindex":`-1``. Component props, non-listed attributes, and non-numeric values keep their string form. Mirrors upstream svelte2tsx's `needsNumberConversion` in `htmlxtojsx_v2/nodes/Attribute.ts`. Closes #939.

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -3379,7 +3379,7 @@ fn build_attribute_segments(attributes: &[Attribute], source: &str, parent_tag: 
     for attr in attributes {
         match attr {
             Attribute::Attribute(node) => {
-                if let Some(part) = format_attribute_node_segments(node, source) {
+                if let Some(part) = format_attribute_node_segments(node, source, true) {
                     push_with_separator(&mut segs, part);
                     any_pushed = true;
                 }
@@ -3571,7 +3571,7 @@ fn build_component_props_segments(attributes: &[Attribute], source: &str) -> Vec
                 if node.name == "slot" {
                     continue;
                 }
-                if let Some(part) = format_attribute_node_segments(node, source) {
+                if let Some(part) = format_attribute_node_segments(node, source, false) {
                     if node.name.starts_with("--") {
                         // CSS custom property wrap: `--x:val,` →
                         // `...__sveltets_2_cssProp({--x:val}),`. Strip the
@@ -3766,7 +3766,84 @@ fn format_attribute_node(node: &AttributeNode, source: &str) -> Option<String> {
 /// Structured-bake variant of [`format_attribute_node`]. Wraps every
 /// expression site in `Seg::Src` so the resulting MagicString chunks
 /// retain per-character source-map fidelity.
-fn format_attribute_node_segments(node: &AttributeNode, source: &str) -> Option<Vec<Seg>> {
+/// HTML attributes whose `svelte/elements` type is `number | undefined | null`
+/// (no `string`). A static string value (`tabindex="-1"`) must be lowered to a
+/// bare number to type-check. List mirrors svelte2tsx's `numberOnlyAttributes`
+/// (`htmlxtojsx_v2/nodes/Attribute.ts`), itself derived from `elements.d.ts`.
+fn is_number_only_attribute(name: &str) -> bool {
+    const NUMBER_ONLY: &[&str] = &[
+        "aria-colcount",
+        "aria-colindex",
+        "aria-colspan",
+        "aria-level",
+        "aria-posinset",
+        "aria-rowcount",
+        "aria-rowindex",
+        "aria-rowspan",
+        "aria-setsize",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow",
+        "results",
+        "span",
+        "marginheight",
+        "marginwidth",
+        "maxlength",
+        "minlength",
+        "currenttime",
+        "defaultplaybackrate",
+        "volume",
+        "high",
+        "low",
+        "optimum",
+        "start",
+        "size",
+        "border",
+        "cols",
+        "rows",
+        "colspan",
+        "rowspan",
+        "tabindex",
+    ];
+    let lower = name.to_ascii_lowercase();
+    NUMBER_ONLY.contains(&lower.as_str())
+}
+
+/// Mirror JS `!isNaN(Number(s))` for the number-conversion check: an attribute
+/// value coerces to a number. Covers the realistic forms (`-1`, `2`, `1e3`,
+/// `0x1f`) and the JS quirk that an all-whitespace value is `0` (not NaN).
+fn is_js_numeric(data: &str) -> bool {
+    let t = data.trim();
+    if t.is_empty() {
+        return true; // JS: Number("") === 0
+    }
+    let lower = t.to_ascii_lowercase();
+    // `0x` / `0o` / `0b` integer literals coerce via Number().
+    if let Some(rest) = lower.strip_prefix("0x") {
+        return !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_hexdigit());
+    }
+    if let Some(rest) = lower.strip_prefix("0o") {
+        return !rest.is_empty() && rest.bytes().all(|b| (b'0'..=b'7').contains(&b));
+    }
+    if let Some(rest) = lower.strip_prefix("0b") {
+        return !rest.is_empty() && rest.bytes().all(|b| matches!(b, b'0' | b'1'));
+    }
+    // Rust's f64 parser also accepts `inf`/`nan`, which JS `Number` treats as
+    // NaN (only `Infinity` coerces). Disambiguate those keyword spellings.
+    if matches!(
+        lower.as_str(),
+        "inf" | "+inf" | "-inf" | "infinity" | "+infinity" | "-infinity" | "nan"
+    ) {
+        return lower.contains("infinity");
+    }
+    t.parse::<f64>().is_ok()
+}
+
+fn format_attribute_node_segments(
+    node: &AttributeNode,
+    source: &str,
+    is_element: bool,
+) -> Option<Vec<Seg>> {
     let name = &node.name;
     let mut out: Vec<Seg> = Vec::new();
 
@@ -3809,6 +3886,25 @@ fn format_attribute_node_segments(node: &AttributeNode, source: &str) -> Option<
                 } else {
                     segs_push_lit(&mut out, get_expression_text(&expr.expression, source));
                 }
+                segs_push_lit(&mut out, ",");
+                return Some(out);
+            }
+
+            // Numeric DOM attribute written as a string literal (`tabindex="-1"`,
+            // `colspan="2"`, …). `svelte/elements` types these as `number`, so a
+            // backtick string fails to type-check; emit the value as a bare
+            // number instead — but only on a real element (component props keep
+            // the author's string), only for the `numberOnlyAttributes` set, and
+            // only when the value actually coerces to a number (#939). Mirrors
+            // svelte2tsx's `needsNumberConversion` in `Attribute.ts`.
+            if is_element
+                && parts.len() == 1
+                && let AttributeValuePart::Text(text) = &parts[0]
+                && is_number_only_attribute(name)
+                && is_js_numeric(&text.data)
+            {
+                segs_push_lit(&mut out, &format!("\"{}\":", name));
+                segs_push_src(&mut out, text.start, text.end);
                 segs_push_lit(&mut out, ",");
                 return Some(out);
             }

--- a/crates/rsvelte_core/tests/svelte2tsx_number_attribute.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_number_attribute.rs
@@ -1,0 +1,89 @@
+//! Regression test for issue #939.
+//!
+//! Numeric HTML attributes written as string literals (`tabindex="-1"`,
+//! `colspan="2"`, `maxlength="5"`, …) are typed `number | undefined | null`
+//! by `svelte/elements` — no `string`. Lowering the value as a backtick
+//! string (`"tabindex":`-1``) makes `--tsgo` reject it with
+//! `Type 'string' is not assignable to type 'number'`. svelte2tsx must instead
+//! emit a bare number for these attributes when, and only when:
+//!   - the host is a real element (not a component),
+//!   - the attribute is in the `numberOnlyAttributes` set, and
+//!   - the static value coerces to a number.
+//!
+//! Mirrors upstream svelte2tsx's `needsNumberConversion` in `Attribute.ts`.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "T.svelte".to_string(),
+        is_ts_file: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+#[test]
+fn numeric_element_attributes_lower_to_bare_numbers() {
+    let out = to_tsx(
+        "<div tabindex=\"-1\">a</div>\n\
+         <input maxlength=\"5\" size=\"10\" />\n\
+         <td colspan=\"2\" rowspan=\"3\">b</td>\n\
+         <col span=\"2\" />",
+    );
+
+    for expect in [
+        "\"tabindex\":-1,",
+        "\"maxlength\":5,",
+        "\"size\":10,",
+        "\"colspan\":2,",
+        "\"rowspan\":3,",
+        "\"span\":2,",
+    ] {
+        assert!(
+            out.contains(expect),
+            "expected bare-number `{expect}`, got:\n{out}"
+        );
+    }
+
+    // The old backtick-string form must be gone.
+    assert!(
+        !out.contains("\"tabindex\":`"),
+        "tabindex still emitted as a string:\n{out}"
+    );
+}
+
+#[test]
+fn non_numeric_value_stays_a_string() {
+    // A numberOnlyAttribute whose value doesn't coerce to a number keeps its
+    // string form (so the real type error still surfaces, matching official).
+    let out = to_tsx("<div tabindex=\"auto\">a</div>");
+    assert!(
+        out.contains("\"tabindex\":`auto`"),
+        "non-numeric tabindex should stay a string:\n{out}"
+    );
+}
+
+#[test]
+fn non_number_only_attribute_stays_a_string() {
+    // `role` is not in the numberOnlyAttributes set even though its value here
+    // is text; a genuinely numeric-looking non-listed attribute must also keep
+    // its string form (e.g. `data-*`).
+    let out = to_tsx("<div role=\"none\" data-x=\"2\">a</div>");
+    assert!(out.contains("\"role\":`none`"), "role changed:\n{out}");
+    assert!(out.contains("\"data-x\":`2`"), "data-x changed:\n{out}");
+}
+
+#[test]
+fn component_numeric_attribute_stays_a_string() {
+    // On a component the value is a real prop, not a DOM attribute, so the
+    // author's string is preserved (the prop type decides validity).
+    let out = to_tsx(
+        "<script lang=\"ts\">\n  import Foo from './Foo.svelte';\n</script>\n\
+         <Foo tabindex=\"1\" />",
+    );
+    assert!(
+        out.contains("\"tabindex\":`1`"),
+        "component tabindex should stay a string:\n{out}"
+    );
+}


### PR DESCRIPTION
## Problem

Numeric-valued HTML attributes written as **string literals** are rejected by `--tsgo` (#939):

```svelte
<div tabindex="-1">a</div>
<input maxlength="5" size="10" />
<td colspan="2" rowspan="3">b</td>
<col span="2" />
```

Every one fails with `Type 'string' is not assignable to type 'number'`, while official `svelte-check` reports 0 errors. `tabindex={-1}` (a numeric expression) already worked.

## Root cause

`svelte/elements` types these attributes as `number | undefined | null` — there is **no** `string` in the union. rsvelte lowered a static `tabindex="-1"` to a backtick **string** (`"tabindex":`-1``), which is then checked against `number` → TS2322.

This is not a type-definition gap (the `svelte/elements` types are authoritative and correct) — it's the emitted TSX. Upstream svelte2tsx solves it the same way: a `numberOnlyAttributes` set + `needsNumberConversion` that drops the quotes and emits a bare number.

## Fix

`format_attribute_node_segments` (`crates/rsvelte_core/src/svelte2tsx/template/mod.rs`) now emits a single-`Text` value as a **bare number** (using the value's source range, preserving column mapping) when all of:

- the host is a real **element** (not a component — `is_element` threaded through from the element vs. component prop-builder),
- the attribute name is in the `numberOnlyAttributes` set (ported verbatim from `htmlxtojsx_v2/nodes/Attribute.ts`), and
- the value coerces to a number (`is_js_numeric`, mirroring JS `!isNaN(Number(s))`).

Otherwise the existing template-literal/string path is unchanged, so component props, non-listed attributes (`role`, `data-*`), and non-numeric values (`tabindex="auto"`) keep their string form.

## Tests

New `tests/svelte2tsx_number_attribute.rs`:
- numeric element attributes → bare numbers (`"tabindex":-1,`, `"maxlength":5,`, `"size":10,`, `"colspan":2,`, `"rowspan":3,`, `"span":2,`),
- non-numeric value stays a string (`tabindex="auto"`),
- non-listed attributes stay strings (`role="none"`, `data-x="2"`),
- component numeric attribute stays a string (`<Foo tabindex="1" />`).

Full `svelte2tsx_fixtures` suite (253/253) stays green.

Closes #939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)