### PR TITLE
feat(lint): port svelte/no-inline-styles

### DIFF
--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -48,6 +48,7 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(
             crate::rules::no_unknown_style_directive_property::NoUnknownStyleDirectiveProperty,
         ),
+        Box::new(crate::rules::no_inline_styles::NoInlineStyles),
     ]
 }
 

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -16,6 +16,7 @@ pub mod no_dynamic_slot_name;
 pub mod no_extra_reactive_curlies;
 pub mod no_goto_without_base;
 pub mod no_ignored_unsubscribe;
+pub mod no_inline_styles;
 pub mod no_inner_declarations;
 pub mod no_inspect;
 pub mod no_nested_style_tag;

--- a/crates/rsvelte_lint/src/rules/no_inline_styles.rs
+++ b/crates/rsvelte_lint/src/rules/no_inline_styles.rs
@@ -1,0 +1,64 @@
+//! `svelte/no-inline-styles` — disallow attributes and directives that produce
+//! inline styles on HTML elements: a `style="…"` attribute, a `style:…`
+//! directive, and (when `allowTransitions` is `false`) a `transition:` / `in:` /
+//! `out:` directive. Port of the eslint-plugin-svelte rule.
+//!
+//! A template-walk rule (`check_element`): only HTML elements are inspected,
+//! mirroring upstream's `node.kind === 'html'` guard (components and
+//! `svelte:*` specials are separate AST nodes and never reach `check_element`).
+
+use rsvelte_core::ast::template::{Attribute, RegularElement};
+use serde_json::Value;
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
+
+static META: RuleMeta = RuleMeta {
+    name: "svelte/no-inline-styles",
+    category: RuleCategory::Style,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow attributes and directives that produce inline styles",
+    options_schema: Some(
+        r#"{ "type": "object", "properties": {
+            "allowTransitions": { "type": "boolean" }
+        }, "additionalProperties": false }"#,
+    ),
+};
+
+#[derive(Default)]
+pub struct NoInlineStyles;
+
+impl Rule for NoInlineStyles {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_element(&self, ctx: &mut LintContext, el: &RegularElement) {
+        let allow_transitions = ctx
+            .option0()
+            .and_then(|o| o.get("allowTransitions"))
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+
+        for attr in &el.attributes {
+            match attr {
+                Attribute::StyleDirective(d) => {
+                    ctx.report(d.start, d.end, "Found disallowed style directive.");
+                }
+                Attribute::Attribute(a) if a.name == "style" => {
+                    ctx.report(a.start, a.end, "Found disallowed style attribute.");
+                }
+                Attribute::TransitionDirective(t) if !allow_transitions => {
+                    ctx.report(t.start, t.end, "Found disallowed transition.");
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -117,6 +117,7 @@ const RULES: &[(&str, &str, bool)] = &[
         false,
     ),
     ("no-goto-without-base", "svelte/no-goto-without-base", false),
+    ("no-inline-styles", "svelte/no-inline-styles", false),
     (
         "prefer-writable-derived",
         "svelte/prefer-writable-derived",


### PR DESCRIPTION
Port eslint-plugin-svelte's `svelte/no-inline-styles` into native `rsvelte_lint`.

## What
A template-walk rule: on HTML elements, flag attributes/directives that produce inline styles —
- a `style="…"` attribute → `Found disallowed style attribute.`
- a `style:…` directive → `Found disallowed style directive.`
- a `transition:` / `in:` / `out:` directive, only when `allowTransitions: false` → `Found disallowed transition.`

Only HTML elements are inspected (components and `svelte:*` specials are separate AST nodes and never reach `check_element`), mirroring upstream's `node.kind === 'html'` guard. `allowTransitions` defaults to `true`.

## Verification
Strict oracle parity over all `no-inline-styles` fixtures (style attribute, style directive, `allowTransitions:false` transitions, and valid class-attribute/class-directive/default-transition cases). `cargo +stable test/fmt/clippy/doc` clean for `rsvelte_lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)