### PR TITLE
fix(svelte-check): suppress imported-library internal diagnostics (#941)

### DIFF
--- a/.changeset/fix-941-suppress-ext-internal-diagnostics.md
+++ b/.changeset/fix-941-suppress-ext-internal-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): stop leaking an imported library's internal diagnostics into a consumer's `--tsgo` run. When a project imports a workspace component library, its `.svelte` components are shadowed under `<cache>/ext/<n>/` so cross-package named exports resolve (#782). Those shadows were also type-checked, so the library's own transitive deps (`Cannot find module '@floating-ui/dom'`, `sortablejs`, `@nexus/types`) and every internal bug surfaced as errors on the consumer — official svelte-check reports 0 because it never type-checks a node_modules `.svelte` as a reported document. `map_tsgo_diagnostics` now drops any diagnostic whose file lives under the `<cache>/ext/` shadow root, matching official behavior while keeping the shadows for #782 export resolution. Closes #941.

--- a/crates/rsvelte_core/src/svelte_check/mapper.rs
+++ b/crates/rsvelte_core/src/svelte_check/mapper.rs
@@ -94,6 +94,15 @@ pub fn map_tsgo_diagnostics(
             by_kit.insert(rel.to_path_buf(), entry);
         }
     }
+    // Shadows for imported external packages live under `<cache>/ext/<n>/`.
+    // Diagnostics landing on those files are library *internals* — official
+    // svelte-check never type-checks a node_modules `.svelte` as a reported
+    // document, so its unresolved transitive deps (`Cannot find module
+    // '@floating-ui/dom'`) and internal errors must not leak to the consumer
+    // (#941). The shadows still exist purely to resolve the imported module's
+    // named-export shape (#782); we only drop their diagnostics here.
+    let ext_root = overlay.cache_dir.join("ext");
+    let ext_root_canon = ext_root.canonicalize().unwrap_or_else(|_| ext_root.clone());
     let mut maps: HashMap<PathBuf, EntryMap> = HashMap::new();
     let mut out: Vec<Diagnostic> = Vec::with_capacity(raw.len());
     // `.svelte` sources whose generated overlay produced a TS1xxx syntax
@@ -112,6 +121,10 @@ pub fn map_tsgo_diagnostics(
             workspace.join(&diag.file)
         };
         let canon = absolute.canonicalize().unwrap_or_else(|_| absolute.clone());
+        // Suppress imported-library-internal diagnostics (see `ext_root` above).
+        if absolute.starts_with(&ext_root) || canon.starts_with(&ext_root_canon) {
+            continue;
+        }
         let kit_match = by_kit
             .get(&canon)
             .copied()
@@ -369,5 +382,59 @@ mod tests {
         assert!(!is_syntactic_ts_code("TS"));
         assert!(!is_syntactic_ts_code("nonsense"));
         assert!(!is_syntactic_ts_code("TS999")); // below the 1000 floor
+    }
+
+    fn empty_layout(workspace: &Path) -> OverlayLayout {
+        OverlayLayout {
+            workspace: workspace.to_path_buf(),
+            cache_dir: workspace.join(".svelte-check"),
+            emit_dir: workspace.join(".svelte-check").join("svelte"),
+            overlay_tsconfig: workspace.join(".svelte-check").join("tsconfig.json"),
+            entries: Vec::new(),
+            kit_entries: Vec::new(),
+        }
+    }
+
+    fn raw(file: &str, code: &str, msg: &str) -> RawTsDiagnostic {
+        RawTsDiagnostic {
+            file: PathBuf::from(file),
+            line: 1,
+            column: 1,
+            severity: "error".to_string(),
+            code: code.to_string(),
+            message: msg.to_string(),
+        }
+    }
+
+    #[test]
+    fn suppresses_external_package_internal_diagnostics() {
+        // #941: a `Cannot find module` on an imported library's shadow under
+        // `<cache>/ext/<n>/` is a library internal — official svelte-check
+        // never reports it, so it must be dropped. A diagnostic on the
+        // consumer's own (non-overlay) file still passes through.
+        let workspace = Path::new("/tmp/ws941");
+        let overlay = empty_layout(workspace);
+        let diags = [
+            raw(
+                ".svelte-check/ext/1/src/lib/Dropdown.svelte.tsx",
+                "TS2307",
+                "Cannot find module '@floating-ui/dom'",
+            ),
+            raw("src/App.svelte.tsx", "TS2304", "Cannot find name 'oops'"),
+        ];
+        let mapped = map_tsgo_diagnostics(&diags, &overlay, workspace);
+        assert_eq!(
+            mapped.diagnostics.len(),
+            1,
+            "ext/<n> internal diagnostic should be suppressed:\n{:#?}",
+            mapped.diagnostics
+        );
+        assert!(
+            mapped.diagnostics[0]
+                .message
+                .contains("Cannot find name 'oops'"),
+            "consumer-file diagnostic must survive:\n{:#?}",
+            mapped.diagnostics
+        );
     }
 }


### PR DESCRIPTION
## Problem

When `--tsgo` checks a package that imports a **workspace component library**, it reports spurious errors that official `svelte-check` does not (#941):

```
.svelte-check/ext/1/src/lib/components/dropdown/Dropdown.svelte.tsx   Cannot find module '@floating-ui/dom'
.svelte-check/ext/1/.../MultiCombobox.svelte.tsx                      Cannot find module '@nexus/types'
.svelte-check/ext/1/src/lib/components/sortable/Sortable.svelte.tsx   Cannot find module 'sortablejs'
```

Plus, every *internal* bug of the imported library (generic-inference, numeric-attr, snippet, …) is inherited by every consumer — a 397-file app accrued hundreds of errors that are entirely design-system-internal. Official reports **0**.

## Root cause

rsvelte shadows an imported workspace library's `.svelte` components under `<cache>/ext/<n>/` and **type-checks** them. That shadowing exists for a good reason — it resolves cross-package **named exports** (`<script module>` exports), which the ambient `*.svelte` wildcard can't (#782). But type-checking the shadows means:

1. the library's own transitive deps don't resolve from the *consumer's* overlay roots → `Cannot find module`, and
2. all of the library's internal diagnostics leak onto the consumer.

Official `svelte-check` never type-checks a `node_modules` `.svelte` as a *reported document* (it ignores any path containing `node_modules` when collecting checked files); it relies on the library's shipped types / resolves the module shape without surfacing its internals.

## Fix

`map_tsgo_diagnostics` (`crates/rsvelte_core/src/svelte_check/mapper.rs`) now drops any diagnostic whose file lives under the `<cache>/ext/` shadow root. This matches official behavior exactly:

- imported-library internals (unresolved deps **and** internal bugs) no longer leak to the consumer,
- the shadows still exist, so #782 cross-package named-export resolution is unchanged,
- consumer-side misuse of a library component still reports — that diagnostic lands on the **consumer's own** overlay file, not the `ext/<n>` shadow.

This is robust regardless of whether the imported library ships `.svelte.d.ts` (the real monorepo case symlinks raw source).

## Tests

- New unit test `suppresses_external_package_internal_diagnostics`: an `ext/<n>` `Cannot find module` is dropped; a consumer-file diagnostic survives.
- `svelte_check_cross_package` (#782) and the rest of the svelte_check suite stay green.

Closes #941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)