### PR TITLE
fix(svelte2tsx): hoist exported instance-script types as candidates (#963)

### DIFF
--- a/.changeset/fix-963-exported-instance-type.md
+++ b/.changeset/fix-963-exported-instance-type.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): keep `export type`/`export interface` declarations from the instance `<script>` visible to same-component references under `--tsgo`. In TypeScript these are `TypeAlias`/`Interface` nodes with an `export` modifier, so upstream svelte2tsx's `HoistableInterfaces` collects them like any other type; OXC instead wraps them in an `ExportNamedDeclaration`, so the candidate scan missed them. A dependent `interface Props { phase: Phase }` was then deemed dependency-free and hoisted above `function $$render()` while the exported `Phase` stayed inside it, breaking the reference (`Cannot find name 'Phase'`). Exported instance-script type/interface declarations are now registered as hoist candidates so they hoist with — and before — their dependents. Closes #963.

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -828,6 +828,60 @@ pub fn process_instance_script(
                                     declared_names.insert(id.name.to_string());
                                 }
                             }
+                            // `export interface X { ... }` / `export type X = ...`
+                            // in the instance script. In TS these are
+                            // `Interface`/`TypeAlias` nodes with an `export`
+                            // modifier, so upstream's `HoistableInterfaces`
+                            // collects them just like their non-exported
+                            // counterparts; OXC instead wraps them in an
+                            // `ExportNamedDeclaration`, so we mirror the
+                            // standalone arms here. Without this, a referenced
+                            // exported type (`export type Phase`) is invisible
+                            // to the hoist dependency graph, so a dependent
+                            // interface (`interface Props { phase: Phase }`)
+                            // gets hoisted above `$$render()` while `Phase`
+                            // stays inside it → "Cannot find name 'Phase'"
+                            // (#963). `handle_export_named_decl` strips the
+                            // `export ` keyword to a space; the candidate is
+                            // flagged `exported` so the hoist move starts at the
+                            // inner declaration and doesn't overlap that strip.
+                            oxc::Declaration::TSInterfaceDeclaration(iface) => {
+                                let name = iface.id.name.to_string();
+                                if name == "$$Slots" {
+                                    exported_names.has_slots_type = true;
+                                } else if name == "$$Events" {
+                                    exported_names.has_events_type = true;
+                                }
+                                exported_names.instance_type_names.insert(name.clone());
+                                if !is_special_type_name(&name) {
+                                    candidates.push(HoistCandidate {
+                                        name,
+                                        rel_start: iface.span.start,
+                                        rel_end: iface.span.end,
+                                        exported: true,
+                                    });
+                                }
+                                if is_dts_mode {
+                                    rewrite_interface_to_type_dts(iface, raw_content, offset, str);
+                                }
+                            }
+                            oxc::Declaration::TSTypeAliasDeclaration(type_alias) => {
+                                let name = type_alias.id.name.to_string();
+                                if name == "$$Slots" {
+                                    exported_names.has_slots_type = true;
+                                } else if name == "$$Events" {
+                                    exported_names.has_events_type = true;
+                                }
+                                exported_names.instance_type_names.insert(name.clone());
+                                if !is_special_type_name(&name) {
+                                    candidates.push(HoistCandidate {
+                                        name,
+                                        rel_start: type_alias.span.start,
+                                        rel_end: type_alias.span.end,
+                                        exported: true,
+                                    });
+                                }
+                            }
                             _ => {}
                         }
                     }
@@ -846,6 +900,7 @@ pub fn process_instance_script(
                             name,
                             rel_start: iface.span.start,
                             rel_end: iface.span.end,
+                            exported: false,
                         });
                     }
 
@@ -871,6 +926,7 @@ pub fn process_instance_script(
                             name,
                             rel_start: type_alias.span.start,
                             rel_end: type_alias.span.end,
+                            exported: false,
                         });
                     }
                     // Detect `type X = $$Generic;` or `type X = $$Generic<constraint>;`
@@ -1432,6 +1488,13 @@ struct HoistCandidate {
     /// Span relative to the script content (raw_content).
     rel_start: u32,
     rel_end: u32,
+    /// True when the declaration carried an `export` modifier in the instance
+    /// script (`export type X` / `export interface X`). The `export ` keyword
+    /// is stripped to a space by `handle_export_named_decl`; the hoist move
+    /// must therefore start exactly at the inner declaration (`rel_start`) and
+    /// NOT walk back through the stripped-export trivia, which would overlap
+    /// that overwrite.
+    exported: bool,
 }
 
 /// Names that have a special meaning in svelte2tsx and must never be hoisted.
@@ -1758,7 +1821,17 @@ fn resolve_hoistable_type_decls(
         // (whitespace + line / block comments) so JSDoc and explanatory
         // comments on the declaration travel with the hoisted chunk.
         // Matches TypeScript's `node.pos`, which spans leading trivia.
-        let start = walk_back_through_trivia(raw_bytes, c.rel_start as usize);
+        //
+        // Exception: for an exported declaration the `export ` keyword has
+        // already been overwritten to a space by `handle_export_named_decl`.
+        // Walking back through that space would make the move range overlap
+        // that overwrite (a MagicString conflict), so start exactly at the
+        // inner declaration.
+        let start = if c.exported {
+            c.rel_start as usize
+        } else {
+            walk_back_through_trivia(raw_bytes, c.rel_start as usize)
+        };
         exported_names
             .hoistable_type_ranges
             .push((start as u32 + offset, c.rel_end + offset));

--- a/crates/rsvelte_core/tests/svelte2tsx_exported_instance_type.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_exported_instance_type.rs
@@ -1,0 +1,66 @@
+//! #963: a type/interface declared with `export` in the **instance**
+//! `<script>` (`export type Phase = …`) must stay visible to same-component
+//! references under `--tsgo`.
+//!
+//! In TypeScript, `export type Phase` is a `TypeAliasDeclaration` carrying an
+//! `export` modifier, so upstream svelte2tsx's `HoistableInterfaces` collects
+//! it like any other type. OXC instead wraps it in an `ExportNamedDeclaration`,
+//! so rsvelte used to miss it: a dependent `interface Props { phase: Phase }`
+//! got hoisted above `function $$render()` while the exported `Phase` stayed
+//! inside, breaking the reference (`Cannot find name 'Phase'`).
+//!
+//! The fix registers exported instance-script type/interface declarations as
+//! hoist candidates, so `Phase` hoists *with* (and before) `Props`.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn tsx(src: &str) -> String {
+    svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "PreReleaseLabel.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx ok")
+    .code
+}
+
+#[test]
+fn exported_instance_type_hoists_with_dependent_interface() {
+    let src = "<script lang=\"ts\">\n  export type Phase = 'a' | 'b';\n  interface Props { phase: Phase }\n  let { phase }: Props = $props();\n  const labels: Record<Phase, string> = { a: 'A', b: 'B' };\n</script>\n<span>{labels[phase]}</span>\n";
+    let code = tsx(src);
+
+    let render_pos = code.find("function $$render").expect("must emit $$render");
+    let phase_pos = code
+        .find("type Phase =")
+        .expect("exported `Phase` must survive in the overlay");
+    let props_pos = code
+        .find("interface Props")
+        .expect("`Props` must survive in the overlay");
+
+    // Both the exported type and the dependent interface must be hoisted above
+    // `function $$render()` so the `interface Props { phase: Phase }` reference
+    // resolves at module scope.
+    assert!(
+        phase_pos < render_pos,
+        "exported `type Phase` must be hoisted above $$render():\n{code}"
+    );
+    assert!(
+        props_pos < render_pos,
+        "`interface Props` must be hoisted above $$render():\n{code}"
+    );
+    // Topological order: the dependency (`Phase`) must precede the dependent
+    // (`Props`).
+    assert!(
+        phase_pos < props_pos,
+        "`type Phase` must precede `interface Props`:\n{code}"
+    );
+    // The `export` keyword is stripped from the instance script (it's not a
+    // real module export of the overlay).
+    assert!(
+        !code.contains("export type Phase"),
+        "instance `export` keyword must be stripped:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #963.

A type/interface declared with `export` in the **instance `<script>`** (`export type Phase = …`) was invisible to same-component references under `--tsgo`, surfacing as `Cannot find name 'Phase'`.

### Root cause

In TypeScript, `export type Phase` is a `TypeAliasDeclaration` carrying an `export` modifier, so upstream svelte2tsx's `HoistableInterfaces` collects it like any non-exported type. OXC instead parses it as `ExportNamedDeclaration { declaration: TSTypeAliasDeclaration }`, and the Pass-1 candidate scan only matched **top-level** `TSInterfaceDeclaration` / `TSTypeAliasDeclaration` statements — so exported types were never registered as hoist candidates.

Consequently a dependent `interface Props { phase: Phase }` was deemed dependency-free (its dep `Phase` wasn't a known candidate) and got hoisted above `function $$render()`, while the exported `Phase` stayed inside it → the reference broke.

### Fix

Register `export interface X` / `export type X` in the instance script as hoist candidates (and in `instance_type_names`), mirroring the standalone arms. The candidate carries an `exported` flag so the hoist move starts at the inner declaration and does **not** walk back through the `export `-keyword strip that `handle_export_named_decl` already applies (which would overlap that MagicString overwrite).

`Phase` now hoists with — and before — `Props`, so the reference resolves.

### Verification

- New overlay-shape regression test `svelte2tsx_exported_instance_type.rs`.
- Verified end-to-end with **real tsgo**: the issue repro now reports **0 errors** (was `Cannot find name 'Phase'` + downstream index error).
- `svelte2tsx_fixtures` (253) and the svelte2tsx/svelte-check suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)