### PR TITLE
perf(transform): reuse phase-1-parsed stylesheet instead of re-parsing

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -1794,9 +1794,9 @@ fn transform_client_with_visitors(
         let is_custom_element = analysis.custom_element.is_some();
         let mut css_code = String::new();
         let css_render_result = if is_custom_element {
-            super::css::render_stylesheet_minified(analysis, source, options)
+            super::css::render_stylesheet_minified(analysis, ast.css.as_deref(), source, options)
         } else {
-            super::css::render_stylesheet(analysis, source, options)
+            super::css::render_stylesheet(analysis, ast.css.as_deref(), source, options)
         };
         if let Ok(css_output) = css_render_result {
             css_code = css_output.code;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -346,27 +346,34 @@ fn collect_unused_warnings_from_nodes<'a>(
 }
 
 /// Render the stylesheet for a component.
+///
+/// `preparsed` is the phase-1-parsed `<style>` AST (`Root.css`). When present
+/// and its content offset matches, its `children` are reused directly, avoiding
+/// a full re-parse of the stylesheet here.
 pub fn render_stylesheet(
     analysis: &ComponentAnalysis,
+    ast: Option<&crate::ast::css::StyleSheet>,
     source: &str,
     options: &CompileOptions,
 ) -> Result<CssOutput, TransformError> {
-    render_stylesheet_internal(analysis, source, options, false)
+    render_stylesheet_internal(analysis, ast, source, options, false)
 }
 
 /// Render the stylesheet for a component with optional minification.
 /// Used for injected CSS in SSR which should be minified.
 pub fn render_stylesheet_minified(
     analysis: &ComponentAnalysis,
+    ast: Option<&crate::ast::css::StyleSheet>,
     source: &str,
     options: &CompileOptions,
 ) -> Result<CssOutput, TransformError> {
-    render_stylesheet_internal(analysis, source, options, true)
+    render_stylesheet_internal(analysis, ast, source, options, true)
 }
 
 /// Internal implementation of render_stylesheet with minification option.
 fn render_stylesheet_internal(
     analysis: &ComponentAnalysis,
+    ast: Option<&crate::ast::css::StyleSheet>,
     source: &str,
     options: &CompileOptions,
     minify: bool,
@@ -399,14 +406,29 @@ fn render_stylesheet_internal(
 
     // Extract CSS content and its start position
     if let Some((css_content, css_start)) = extract_css_content(source) {
-        // Parse the CSS with proper start offset
-        let children = parse_css(&css_content, css_start);
+        // Reuse the phase-1-parsed stylesheet when it lines up with the content
+        // extracted here, avoiding a redundant full re-parse (the transform
+        // profile showed this re-parse at ~60% inclusive on CSS-heavy input).
+        // `parse_css` here is the *same* function phase 1 used, so when the
+        // start offsets agree the trees are byte-identical; the offset guard
+        // falls back to re-parsing on any mismatch (e.g. an unusual opener that
+        // the two extraction paths disagree on), preserving current behavior.
+        let reparsed;
+        let children: &[Value] = match ast {
+            Some(ss) if ss.content.start as usize == css_start && !ss.children.is_empty() => {
+                &ss.children
+            }
+            _ => {
+                reparsed = parse_css(&css_content, css_start);
+                &reparsed
+            }
+        };
 
         // Collect keyframe names for animation value replacement
-        let keyframes = collect_keyframe_names(&children);
+        let keyframes = collect_keyframe_names(children);
 
         // Transform the CSS
-        let mut code = transform_css(&children, &selector, hash, &css_content, css_start, &ctx);
+        let mut code = transform_css(children, &selector, hash, &css_content, css_start, &ctx);
 
         // Post-process: replace animation keyframe references
         if !keyframes.is_empty() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -215,7 +215,7 @@ pub fn transform_component(
 
     let css = if analysis.css.has_css && !analysis.inject_styles {
         let _css_start = profile::timer_start();
-        let mut css_output = css::render_stylesheet(analysis, source, options)?;
+        let mut css_output = css::render_stylesheet(analysis, ast.css.as_deref(), source, options)?;
         profile::record_css_render(profile::timer_elapsed(_css_start));
         // Apply preprocessor source map composition to CSS map if needed
         if let Some(ref pp_map_json) = options.sourcemap

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
@@ -91,7 +91,8 @@ pub fn transform_server(
         && !options.custom_element
     {
         // Render the CSS stylesheet with scoping and minification for SSR
-        if let Ok(css_output) = render_stylesheet_minified(analysis, &analysis.source, options)
+        if let Ok(css_output) =
+            render_stylesheet_minified(analysis, ast.css.as_deref(), &analysis.source, options)
             && !css_output.code.is_empty()
         {
             generator.set_injected_css(analysis.css.hash.clone(), css_output.code);


### PR DESCRIPTION
## What

Found by a profiling sweep across input shapes. `render_stylesheet` re-parsed the entire `<style>` block from source via `parse_css(&css_content, css_start)` on **every compile** — even though phase 1 already parsed it into `Root.css` (`StyleSheet.children`). On CSS-heavy input the transform profile showed `CssParser::parse` (`parse_rule` / `parse_selectors` / `create_relative_selector`) at **~60% inclusive** of CSS transform — pure duplicated work.

## Fix

Thread the phase-1 stylesheet (`ast.css`) into `render_stylesheet` / `render_stylesheet_minified` and reuse its `children` directly, **borrowing (no clone)** when they line up with the content extracted here.

`parse_css` used at transform time is the **same function** phase 1 used, so when the content start offsets agree the trees are byte-identical. An offset guard (`ss.content.start == css_start`, non-empty children) **falls back to the original re-parse** on any mismatch (the two extraction paths disagreeing on an unusual opener, or the deferred-parse path) — so behavior is preserved exactly in every case, worst case being current behavior.

## Correctness — byte-identical

- **compatibility_report 16/16**, including the **181-fixture CSS category** — the offset guard matched for all of them, so the reused tree produced output identical to the re-parse (any divergence would fail a CSS fixture).
- **svelte2tsx_fixtures 15/15**; clippy `-D warnings` + `cargo fmt` (1.96.0) clean. Full byte-identity across fixtures re-confirmed by the Compatibility Report CI job.

Independent of (and compatible with) the larger planned migration of the CSS AST off `serde_json::Value` — this removes the redundant parse regardless of node representation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)