### PR TITLE
chore(changeset): correct stale package name in corpus-burndown-wave6

### DIFF
--- a/.changeset/corpus-burndown-wave6.md
+++ b/.changeset/corpus-burndown-wave6.md
@@ -1,5 +1,5 @@
 ---
-"rsvelte": patch
+"@rsvelte/compiler": patch
 ---
 
 Corpus burn-down wave 6: SSR output parity fixes (clean_nodes edge-whitespace/comment handling, Svelte whitespace set so `&nbsp;` survives trimming, SVG single-space removal, load/error capture events from `use:` directives, `<!doctype>` voidness, `$props.id()` string evaluation, nested-snippet hoisting, esrap positional-comment recovery) — real-world corpus known failures 316 → 262.


### PR DESCRIPTION
The `corpus-burndown-wave6` changeset still referenced the pre-rename package name `rsvelte`. The package was renamed to `@rsvelte/compiler` (#976), so `changeset version` throws:

```
🦋 error Found changeset corpus-burndown-wave6 for package rsvelte which is not in the workspace
```

This has **blocked the Release workflow's "Version PR" job since the wave6 changeset landed** — the Jun 12 release runs and the run after #982 all failed here, so no "Version Packages" PR could be opened. Aligning the frontmatter with the other `corpus-burndown-*` changesets (`@rsvelte/compiler: patch`) unblocks the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)