### PR TITLE
fix(ci): break Benchmark cold-cache timeout deadlock

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -90,10 +90,28 @@ jobs:
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # This job times out on a cold cache (oxc is built from a git rev,
+          # so the first compile is ~15 min and used to eat most of the
+          # `Run criterion` budget — see below). rust-cache defaults to NOT
+          # saving on a failed job, so a single timeout left the cache cold
+          # forever: every subsequent run recompiled from scratch and timed
+          # out again. Saving on failure breaks that deadlock — the compiled
+          # `target/` is preserved even if a later step fails.
+          cache-on-failure: true
+
+      - name: Build benchmarks
+        # Compile the bench harnesses separately so the cold-cache build
+        # (~15 min) is not charged against the `Run criterion` measurement
+        # budget below. On a warm cache this is a quick no-op.
+        run: cargo bench --bench parser --bench compiler --no-run
+        timeout-minutes: 30
 
       - name: Run criterion
-        # `--save-baseline pr` saves results so a follow-up job (or the next
-        # commit) can diff against this baseline with `--baseline pr`.
+        # Benches are already compiled by the step above, so this only spends
+        # time measuring. `--save-baseline pr` saves results so a follow-up
+        # job (or the next commit) can diff against this baseline with
+        # `--baseline pr`.
         run: cargo bench --bench parser --bench compiler -- --save-baseline pr
         timeout-minutes: 30
 


### PR DESCRIPTION
## Problem

The `Benchmark` workflow (`bench.yml`) has **never passed** — every run on `main` fails with:

```
##[error]The action 'Run criterion' has timed out after 30 minutes.
```

### Root cause: a self-reinforcing cold-cache deadlock

1. `Swatinem/rust-cache` defaults to **not** saving the cache when the job fails (`CACHE_ON_FAILURE: false`, visible in the run env).
2. The very first run timed out, so `target/` was never cached.
3. Every subsequent run therefore recompiled from a **cold** cache — and because `oxc` is pulled from a git rev, that compile takes **~15 min**.
4. That left only ~14 min of the 30-min `Run criterion` step for the actual suite (~64 criterion cases × ~10s each), so it timed out again → cache stayed cold → repeat forever.

Timeline from the latest failed run confirms it: compile `02:08 → 02:24` (16 min), benchmarks `02:24 → 02:38` (timed out mid-`single_parse`).

## Fix

- **`cache-on-failure: true`** on the rust-cache step — the compiled `target/` is now preserved even when a later step fails, so the next run starts warm. This is what breaks the deadlock.
- **Split compilation out** into a dedicated `cargo bench … --no-run` step so the cold build is no longer charged against the `Run criterion` measurement budget. On a warm cache it's a quick no-op.

Both bench params and measurement fidelity are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)