### PR TITLE
chore(deps): unified oxc bump (44ae845 → 37a34a1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -617,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1089,7 +1089,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1498,9 +1498,9 @@ checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "oxc-miette"
-version = "2.7.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
+checksum = "b776084bf11ad750806cb63f9ed2606a12ab374cf458f36a7731eba1f5d753fc"
 dependencies = [
  "cfg-if",
  "owo-colors",
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette-derive"
-version = "2.7.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
+checksum = "66e0bafc397eee2f94c5bf89bb5a82ba6d522d1b79e2924c8169f053febb433f"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -1524,8 +1524,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1537,8 +1537,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1554,8 +1554,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "phf",
  "proc-macro2 1.0.106",
@@ -1565,8 +1565,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1576,8 +1576,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1588,7 +1588,7 @@ dependencies = [
  "oxc_data_structures",
  "oxc_index",
  "oxc_semantic",
- "oxc_sourcemap",
+ "oxc_sourcemap 8.0.1",
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
@@ -1597,13 +1597,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1612,8 +1612,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1627,8 +1627,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1637,8 +1637,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.54.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.55.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1663,8 +1663,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter_core"
-version = "0.54.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.55.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1688,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_jsdoc"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1698,8 +1698,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1721,8 +1721,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1737,14 +1737,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "itertools 0.14.0",
  "memchr",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
+ "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",
@@ -1770,9 +1771,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_sourcemap"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "174d2498c2390ccfab0a9caaf47ef5accda1d509aaa34a5be8f45e00e5299f04"
+dependencies = [
+ "base64-simd",
+ "json-escape-simd",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "oxc_span"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1785,8 +1799,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1797,8 +1811,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.134.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44ae845fe19d3700128e50e7e61d98c7a85f3f47#44ae845fe19d3700128e50e7e61d98c7a85f3f47"
+version = "0.136.0"
+source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2213,7 +2227,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2442,7 +2456,7 @@ checksum = "e3329e20c442a41a696da22dd806277d00c1918921c5866a144e70d8e891afc7"
 dependencies = [
  "memchr",
  "oxc_index",
- "oxc_sourcemap",
+ "oxc_sourcemap 7.0.0",
  "regex",
  "rustc-hash",
  "serde",
@@ -2546,7 +2560,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2979,7 +2993,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ type_complexity = "allow"
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -54,17 +54,17 @@ smallvec = { version = "1.13", features = ["serde"] }
 rustc-hash = "2.0"
 
 # JavaScript parsing and code generation
-oxc_allocator = "0.134"
-oxc_parser = "0.134"
-oxc_ast = { version = "0.134", features = ["serialize"] }
-oxc_span = "0.134"
-oxc_diagnostics = "0.134"
-oxc_codegen = "0.134"
-oxc_syntax = "0.134"
-oxc_semantic = "0.134"
+oxc_allocator = "0.136"
+oxc_parser = "0.136"
+oxc_ast = { version = "0.136", features = ["serialize"] }
+oxc_span = "0.136"
+oxc_diagnostics = "0.136"
+oxc_codegen = "0.136"
+oxc_syntax = "0.136"
+oxc_semantic = "0.136"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
 
 # Error handling
 thiserror = "2.0"
@@ -112,7 +112,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 getrandom = { version = "0.4", optional = true }
 lazy_static = "1.5.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
-oxc_ast_visit = "0.134"
+oxc_ast_visit = "0.136"
 
 # Better multi-threaded memory allocator (optional, Unix/Mac only)
 [target.'cfg(all(not(windows), not(target_arch = "wasm32")))'.dependencies]

--- a/crates/rsvelte_core/src/bin/canonicalize_and_compare.rs
+++ b/crates/rsvelte_core/src/bin/canonicalize_and_compare.rs
@@ -32,7 +32,7 @@ fn try_canonicalize(code: &str) -> Option<String> {
     let allocator = Allocator::new();
     let source_type = SourceType::mjs();
     let parsed = Parser::new(&allocator, &code, source_type).parse();
-    if parsed.panicked || !parsed.errors.is_empty() {
+    if parsed.panicked || !parsed.diagnostics.is_empty() {
         return None;
     }
     let options = CodegenOptions {

--- a/crates/rsvelte_core/src/bin/canonicalize_js.rs
+++ b/crates/rsvelte_core/src/bin/canonicalize_js.rs
@@ -33,7 +33,7 @@ fn main() {
     let source_type = SourceType::mjs();
     let parsed = Parser::new(&allocator, &input, source_type).parse();
 
-    if parsed.panicked || !parsed.errors.is_empty() {
+    if parsed.panicked || !parsed.diagnostics.is_empty() {
         // Parse failure: fall back to whitespace-collapsed text so two
         // formatting-only different inputs still compare close.
         let normalized = normalize_whitespace(&input);

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1477,7 +1477,7 @@ pub fn parse_destructuring_pattern(
             let parser = OxcParser::new(allocator, &wrapped, source_type);
             let result = parser.parse();
 
-            if !result.errors.is_empty() {
+            if !result.diagnostics.is_empty() {
                 return None;
             }
 
@@ -1593,12 +1593,11 @@ pub fn check_js_parse_error_with_pos(content: &str) -> Option<(String, usize)> {
         with_oxc_allocator(|allocator| {
             let parser = OxcParser::new(allocator, &wrapped, source_type);
             let result = parser.parse();
-            if let Some(first_error) = result.errors.first() {
+            if let Some(first_error) = result.diagnostics.first() {
                 let pos = first_error
                     .labels
-                    .as_ref()
-                    .and_then(|labels| labels.first())
-                    .map(|label| label.offset() + label.len())
+                    .first()
+                    .map(|label| label.offset() as usize + label.len() as usize)
                     .map(|wrapped_end| {
                         // Strip the leading `(` we added and clamp.
                         wrapped_end.saturating_sub(1).min(content.len())
@@ -1654,12 +1653,15 @@ pub fn check_params_parse_error(params: &str, ts: bool) -> Option<(String, usize
             SourceType::mjs()
         };
         let result = OxcParser::new(allocator, &wrapped, source_type).parse();
-        result.errors.first().map(|first_error| {
+        result.diagnostics.first().map(|first_error| {
             let pos = first_error
                 .labels
-                .as_ref()
-                .and_then(|labels| labels.first())
-                .map(|label| label.offset().saturating_sub(1).min(params.len()))
+                .first()
+                .map(|label| {
+                    (label.offset() as usize)
+                        .saturating_sub(1)
+                        .min(params.len())
+                })
                 .unwrap_or(0);
             (first_error.message.to_string(), pos)
         })
@@ -1681,12 +1683,11 @@ pub fn check_js_statement_parse_error(content: &str, ts: bool) -> Option<(String
             SourceType::mjs()
         };
         let result = OxcParser::new(allocator, content, source_type).parse();
-        result.errors.first().map(|first_error| {
+        result.diagnostics.first().map(|first_error| {
             let pos = first_error
                 .labels
-                .as_ref()
-                .and_then(|labels| labels.first())
-                .map(|label| label.offset().min(content.len()))
+                .first()
+                .map(|label| (label.offset() as usize).min(content.len()))
                 .unwrap_or(0);
             (first_error.message.to_string(), pos)
         })
@@ -1718,10 +1719,10 @@ pub fn trailing_token_offset(content: &str) -> Option<usize> {
     let probe = |source_type: SourceType| -> Option<usize> {
         with_oxc_allocator(|allocator| {
             let result = OxcParser::new(allocator, &wrapped, source_type).parse();
-            let first_error = result.errors.first()?;
-            let label = first_error.labels.as_ref()?.first()?;
+            let first_error = result.diagnostics.first()?;
+            let label = first_error.labels.first()?;
             // Map the label's *start* back into `content` (strip the leading `(`).
-            let start = label.offset();
+            let start = label.offset() as usize;
             if start == 0 {
                 return None;
             }
@@ -1800,7 +1801,7 @@ fn parse_expression_with_typescript(
         let parser = OxcParser::new(allocator, &wrapped, source_type);
         let result = parser.parse();
 
-        if result.errors.is_empty()
+        if result.diagnostics.is_empty()
             && let Some(oxc_ast::ast::Statement::ExpressionStatement(expr_stmt)) =
                 result.program.body.first()
         {
@@ -2249,7 +2250,7 @@ pub fn parse_typescript_params(
         let parser = OxcParser::new(allocator, &wrapped, source_type);
         let result = parser.parse();
 
-        if result.errors.is_empty()
+        if result.diagnostics.is_empty()
             && let Some(oxc_ast::ast::Statement::ExpressionStatement(expr_stmt)) =
                 result.program.body.first()
             && let OxcExpression::ArrowFunctionExpression(arrow) = &expr_stmt.expression
@@ -2281,7 +2282,7 @@ pub fn parse_typescript_params(
         let cleaned_parser = OxcParser::new(allocator, &cleaned_wrapped, source_type);
         let cleaned_result = cleaned_parser.parse();
 
-        if cleaned_result.errors.is_empty()
+        if cleaned_result.diagnostics.is_empty()
             && let Some(oxc_ast::ast::Statement::ExpressionStatement(expr_stmt)) =
                 cleaned_result.program.body.first()
             && let OxcExpression::ArrowFunctionExpression(arrow) = &expr_stmt.expression
@@ -2327,7 +2328,7 @@ pub fn parse_typescript_params(
             let single_result_expr = with_oxc_allocator(|allocator| {
                 let single_parser = OxcParser::new(allocator, &single_wrapped, source_type);
                 let single_result = single_parser.parse();
-                if single_result.errors.is_empty()
+                if single_result.diagnostics.is_empty()
                     && let Some(oxc_ast::ast::Statement::ExpressionStatement(expr_stmt)) =
                         single_result.program.body.first()
                     && let OxcExpression::ArrowFunctionExpression(arrow) = &expr_stmt.expression
@@ -6091,12 +6092,11 @@ pub fn parse_program_with_error(
         // Mirror upstream acorn's throw-on-error behaviour: capture the first
         // parse error (acorn reports `err.pos` where it stopped consuming
         // input; OXC's first label is the closest equivalent).
-        let mut parse_error = result.errors.first().map(|first_error| {
+        let mut parse_error = result.diagnostics.first().map(|first_error| {
             let pos = first_error
                 .labels
-                .as_ref()
-                .and_then(|labels| labels.first())
-                .map(|label| label.offset().min(content.len()))
+                .first()
+                .map(|label| (label.offset() as usize).min(content.len()))
                 .unwrap_or(0)
                 + offset;
             crate::error::ParseError::svelte(
@@ -9775,10 +9775,10 @@ pub fn parse_binding_pattern(
         let parser = OxcParser::new(allocator, &wrapped, source_type);
         let result = parser.parse();
 
-        if !result.errors.is_empty() {
+        if !result.diagnostics.is_empty() {
             let trimmed = content.trim();
             if trimmed.starts_with('{') || trimmed.starts_with('[') {
-                let err = &result.errors[0];
+                let err = &result.diagnostics[0];
                 let msg = format!("{}", err);
                 let clean_msg = msg.split('\n').next().unwrap_or(&msg).trim().to_string();
                 let err_pos = offset;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -608,7 +608,7 @@ impl<'a> ScopeBuilder<'a> {
             let mut alloc = cell.borrow_mut();
             alloc.reset();
             let ret = OxcParser::new(&alloc, content, source_type).parse();
-            if ret.errors.is_empty() {
+            if ret.diagnostics.is_empty() {
                 self.process_program(&ret.program);
             }
         });

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -488,7 +488,7 @@ pub fn strip_typescript(source: &str) -> String {
     let parser = Parser::new(&allocator, source, source_type);
     let result = parser.parse();
 
-    if !result.errors.is_empty() {
+    if !result.diagnostics.is_empty() {
         // If parsing fails, return original source and let downstream handle errors
         return source.to_string();
     }
@@ -625,7 +625,7 @@ pub fn blank_typescript(source: &str) -> String {
     let parser = Parser::new(&allocator, source, source_type);
     let result = parser.parse();
 
-    if !result.errors.is_empty() {
+    if !result.diagnostics.is_empty() {
         return source.to_string();
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -3729,7 +3729,7 @@ pub(super) fn transform_state_vars_ast(
         let source_type = SourceType::mjs();
         let parsed = Parser::new(alloc, script, source_type).parse();
 
-        if parsed.panicked || !parsed.errors.is_empty() {
+        if parsed.panicked || !parsed.diagnostics.is_empty() {
             // Parse error - fall back to text-based transform
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
@@ -78,7 +78,7 @@ fn single_pass(source: &str, is_ts: bool) -> Option<String> {
             SourceType::mjs()
         };
         let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/derived_by_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/derived_by_ast.rs
@@ -39,7 +39,7 @@ pub fn transform_derived_by_ast(source: &str, is_ts: bool) -> Option<String> {
             SourceType::mjs()
         };
         let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/effect_rune_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/effect_rune_ast.rs
@@ -47,7 +47,7 @@ pub fn apply_effect_rune_transforms_ast(source: &str, is_ts: bool) -> Option<Str
             SourceType::mjs()
         };
         let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
@@ -558,7 +558,7 @@ pub(crate) fn normalize_js_with_oxc(js: &str, indent_level: usize) -> String {
         let source_type = SourceType::mjs();
         let parsed = Parser::new(allocator, js, source_type).parse();
 
-        if !parsed.errors.is_empty() {
+        if !parsed.diagnostics.is_empty() {
             return js.to_string();
         }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/legacy_state_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/legacy_state_member_mutate_ast.rs
@@ -108,7 +108,7 @@ fn single_pass(
     MODULE_LEGACY_STATE_MEMBER_MUTATE_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/local_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/local_assign_ast.rs
@@ -50,7 +50,7 @@ pub fn transform_local_assign_ast(source: &str, var_name: &str) -> Option<String
     MODULE_LOCAL_ASSIGN_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
@@ -108,13 +108,13 @@ fn single_pass(
             .parse();
 
         const CLASS_PREFIX: &str = "class _Dummy_ {\n";
-        let (parse_str_owned, span_offset): (Option<String>, u32) = if !parser_ret.errors.is_empty()
-        {
-            let wrapped = format!("{}{}\n}}", CLASS_PREFIX, source);
-            (Some(wrapped), CLASS_PREFIX.len() as u32)
-        } else {
-            (None, 0u32)
-        };
+        let (parse_str_owned, span_offset): (Option<String>, u32) =
+            if !parser_ret.diagnostics.is_empty() {
+                let wrapped = format!("{}{}\n}}", CLASS_PREFIX, source);
+                (Some(wrapped), CLASS_PREFIX.len() as u32)
+            } else {
+                (None, 0u32)
+            };
 
         let parse_str: &str = match &parse_str_owned {
             Some(s) => s.as_str(),
@@ -128,7 +128,7 @@ fn single_pass(
                     ..ParseOptions::default()
                 })
                 .parse();
-            if !ret.errors.is_empty() {
+            if !ret.diagnostics.is_empty() {
                 *cell.borrow_mut() = allocator;
                 return None;
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_field_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_field_assign_ast.rs
@@ -111,7 +111,7 @@ fn single_pass(source: &str, qualified_names: &[String]) -> Option<String> {
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_member_read_wrap_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_member_read_wrap_ast.rs
@@ -97,7 +97,7 @@ fn single_pass(source: &str, qualified_names: &[String]) -> Option<String> {
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_read_wrap_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_read_wrap_ast.rs
@@ -83,7 +83,7 @@ fn single_pass(source: &str, qualified: &str) -> Option<String> {
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_v_suffix_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_v_suffix_ast.rs
@@ -88,7 +88,7 @@ fn single_pass(source: &str, qualified_names: &[String]) -> Option<String> {
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
@@ -91,7 +91,7 @@ fn single_pass(source: &str, prop_vars: &[String]) -> Option<String> {
     MODULE_PROP_ASSIGN_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
@@ -110,7 +110,7 @@ fn single_pass(
     MODULE_PROP_MEMBER_MUTATE_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_source_reads_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_source_reads_ast.rs
@@ -130,12 +130,12 @@ pub fn wrap_prop_source_reads_ast(
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }
         let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().build(program);
+        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
         let semantic = &semantic_ret.semantic;
 
         let mut collector = PropReadCollector {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_update_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_update_ast.rs
@@ -66,7 +66,7 @@ pub fn transform_reactive_update_ast(
     MODULE_REACTIVE_UPDATE_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/read_only_props_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/read_only_props_ast.rs
@@ -107,12 +107,12 @@ pub fn transform_read_only_props_ast(
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }
         let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().build(program);
+        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
         let semantic = &semantic_ret.semantic;
 
         let mut collector = ReadOnlyPropsCollector {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rest_prop_member_access_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rest_prop_member_access_ast.rs
@@ -56,7 +56,7 @@ pub fn transform_rest_prop_member_access_ast(
     MODULE_REST_PROP_MEMBER_ACCESS_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/scope_analysis.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/scope_analysis.rs
@@ -59,13 +59,13 @@ where
             ..ParseOptions::default()
         })
         .parse();
-    if !parser_ret.errors.is_empty() {
+    if !parser_ret.diagnostics.is_empty() {
         return None;
     }
     // Move the program into the arena so both it and the Semantic
     // can be borrowed for the closure lifetime.
     let program: &Program = allocator.alloc(parser_ret.program);
-    let semantic_ret = SemanticBuilder::new().build(program);
+    let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
     Some(f(program, &semantic_ret.semantic))
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
@@ -126,12 +126,12 @@ fn single_pass(
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }
         let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().build(program);
+        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
         let semantic = &semantic_ret.semantic;
         let state_var_symbols = find_state_var_symbols(semantic, state_vars);
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_call_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_call_ast.rs
@@ -65,7 +65,7 @@ pub fn transform_state_call_ast(
             SourceType::mjs()
         };
         let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_member_mutate_ast.rs
@@ -91,7 +91,7 @@ fn single_pass(
     MODULE_STATE_MEMBER_MUTATE_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
@@ -129,12 +129,12 @@ fn single_pass(
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }
         let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().build(program);
+        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
         let semantic = &semantic_ret.semantic;
         let state_var_symbols = find_state_var_symbols(semantic, state_vars);
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_raw_frozen_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_raw_frozen_ast.rs
@@ -65,7 +65,7 @@ pub fn transform_state_raw_frozen_ast(
             SourceType::mjs()
         };
         let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_reads_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_reads_ast.rs
@@ -218,12 +218,12 @@ pub fn transform_state_reads_ast(
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }
         let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().build(program);
+        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
         let semantic = &semantic_ret.semantic;
         let effective_names: Vec<String> = effective.iter().map(|s| s.to_string()).collect();
         let state_var_symbols = find_state_var_symbols(semantic, &effective_names);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_set_reactive_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_set_reactive_ast.rs
@@ -88,7 +88,7 @@ fn single_pass(
     MODULE_STATE_SET_REACTIVE_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_snapshot_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_snapshot_ast.rs
@@ -41,7 +41,7 @@ pub fn transform_state_snapshot_ast(source: &str, is_ts: bool) -> Option<String>
             SourceType::mjs()
         };
         let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_assign_ast.rs
@@ -133,7 +133,7 @@ fn single_pass(
     MODULE_STORE_ASSIGN_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
@@ -91,7 +91,7 @@ fn single_pass(source: &str, store_subs: &[String], prop_store_names: &[String])
     MODULE_STORE_MEMBER_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_unsub_wrap_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_unsub_wrap_ast.rs
@@ -76,7 +76,7 @@ fn single_pass(source: &str, state_vars: &[String], store_sub_vars: &[String]) -
     MODULE_STORE_UNSUB_WRAP_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_update_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_update_ast.rs
@@ -73,7 +73,7 @@ pub fn transform_store_update_ast(
     MODULE_STORE_UPDATE_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
@@ -84,7 +84,7 @@ fn single_pass(source: &str, is_ts: bool) -> Option<String> {
             SourceType::mjs()
         };
         let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             // Parse error — keep the source untouched. Module scripts
             // that don't parse here would already fail elsewhere; the
             // strict-equals rewrite isn't responsible for surfacing

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/strip_rune_generics_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/strip_rune_generics_ast.rs
@@ -56,7 +56,7 @@ pub fn strip_rune_generic_params_ast(source: &str, is_ts: bool) -> Option<String
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let parser_ret =
             Parser::new(&allocator, source, SourceType::ts().with_module(true)).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_class_field_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_class_field_ast.rs
@@ -53,7 +53,7 @@ pub fn wrap_state_derived_with_tag_class_fields_ast(source: &str) -> Option<Stri
                 ..ParseOptions::default()
             })
             .parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_declarator_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_declarator_ast.rs
@@ -63,7 +63,7 @@ pub fn wrap_state_derived_with_tag_declarators_ast(source: &str, is_ts: bool) ->
             SourceType::mjs()
         };
         let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/build.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/build.rs
@@ -66,7 +66,7 @@ fn normalize_script_with_oxc(js: &str, indent_level: usize) -> String {
         let source_type = SourceType::mjs();
         let parsed = Parser::new(&alloc, &stripped, source_type).parse();
 
-        if !parsed.errors.is_empty() {
+        if !parsed.diagnostics.is_empty() {
             // OXC parse failed - return original code
             return js.to_string();
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/esrap_layout.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/esrap_layout.rs
@@ -63,7 +63,7 @@ pub(crate) fn reflow_template_expr(expr: &str) -> String {
     let multiline = LAYOUT_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
         let ret = Parser::new(&allocator, &wrapped, SourceType::mjs()).parse();
-        let result = if ret.errors.is_empty() {
+        let result = if ret.diagnostics.is_empty() {
             let mut walker = Walker {
                 src: &wrapped,
                 forced: false,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/template_rune_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/template_rune_ast.rs
@@ -68,7 +68,7 @@ fn single_pass(source: &str) -> Option<String> {
         // shape OXC expects. `mjs()` is permissive enough; on parse
         // failure we just return None and the caller keeps the source.
         let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.errors.is_empty() {
+        if !parser_ret.diagnostics.is_empty() {
             *cell.borrow_mut() = allocator;
             return None;
         }

--- a/crates/rsvelte_core/tests/oxc_formatter_probe.rs
+++ b/crates/rsvelte_core/tests/oxc_formatter_probe.rs
@@ -18,9 +18,9 @@ fn formats_unformatted_js() {
     let parser_ret = Parser::new(&allocator, source, SourceType::default()).parse();
 
     assert!(
-        parser_ret.errors.is_empty(),
+        parser_ret.diagnostics.is_empty(),
         "parse errors: {:?}",
-        parser_ret.errors
+        parser_ret.diagnostics
     );
 
     let formatted = format_program(

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/bin/fmt_benchmark_runner.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -21,12 +21,12 @@ wasm = ["rsvelte_core/wasm-deps"]
 
 [dependencies]
 rsvelte_core = { path = "../rsvelte_core", default-features = false }
-oxc_allocator = "0.134"
-oxc_ast = "0.134"
-oxc_parser = "0.134"
-oxc_span = "0.134"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "44ae845fe19d3700128e50e7e61d98c7a85f3f47" }
+oxc_allocator = "0.136"
+oxc_ast = "0.136"
+oxc_parser = "0.136"
+oxc_span = "0.136"
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "37a34a128fa81a37955c38783b7d3474aadb84a6" }
 thiserror = "2.0"
 unicode-width = "0.2"
 

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -606,7 +606,7 @@ fn block_header_expr_needs_parens(expr_source: &str, typescript: bool) -> bool {
     let parser_ret = Parser::new(&allocator, &wrapped, source_type)
         .with_options(formatter_parse_options())
         .parse();
-    if !parser_ret.errors.is_empty() {
+    if !parser_ret.diagnostics.is_empty() {
         return false;
     }
     let Some(oxc_ast::ast::Statement::ExpressionStatement(stmt)) = parser_ret.program.body.first()
@@ -1080,7 +1080,7 @@ pub(crate) fn format_function_binding(
     let parser_ret = Parser::new(&allocator, &wrapped, source_type)
         .with_options(formatter_parse_options())
         .parse();
-    if !parser_ret.errors.is_empty() {
+    if !parser_ret.diagnostics.is_empty() {
         return Ok(None);
     }
     let Some(oxc_ast::ast::Statement::ExpressionStatement(stmt)) = parser_ret.program.body.first()
@@ -1188,8 +1188,11 @@ fn format_expr_core(
     let parser_ret = Parser::new(&allocator, &wrapped, source_type)
         .with_options(formatter_parse_options())
         .parse();
-    if !parser_ret.errors.is_empty() {
-        return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
+    if !parser_ret.diagnostics.is_empty() {
+        return Err(FormatError::ScriptParse(format!(
+            "{:?}",
+            parser_ret.diagnostics
+        )));
     }
 
     // Detect a top-level sequence (comma) expression before `program` is
@@ -1518,8 +1521,11 @@ fn format_snippet_header_source(
     let parser_ret = Parser::new(&allocator, &wrapped, source_type)
         .with_options(formatter_parse_options())
         .parse();
-    if !parser_ret.errors.is_empty() {
-        return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
+    if !parser_ret.diagnostics.is_empty() {
+        return Err(FormatError::ScriptParse(format!(
+            "{:?}",
+            parser_ret.diagnostics
+        )));
     }
 
     let indent_width = options.js.indent_width.value() as usize;
@@ -1592,8 +1598,11 @@ pub(crate) fn format_pattern_source(
     let parser_ret = Parser::new(&allocator, &wrapped, source_type)
         .with_options(formatter_parse_options())
         .parse();
-    if !parser_ret.errors.is_empty() {
-        return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
+    if !parser_ret.diagnostics.is_empty() {
+        return Err(FormatError::ScriptParse(format!(
+            "{:?}",
+            parser_ret.diagnostics
+        )));
     }
 
     // Build a single-line copy of JsFormatOptions for this pattern only.

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -59,7 +59,7 @@ pub(crate) fn format_script(
     let mut parser_ret = Parser::new(&allocator, body, source_type)
         .with_options(formatter_parse_options())
         .parse();
-    if !parser_ret.errors.is_empty() && !script.is_typescript {
+    if !parser_ret.diagnostics.is_empty() && !script.is_typescript {
         // oxfmt parses `<script>` content leniently — TS is a superset of JS, so
         // TS-only syntax in a script without `lang="ts"` (common in docs) still
         // formats. Fall back to the TS parser when the JS parse fails. Valid JS
@@ -68,8 +68,11 @@ pub(crate) fn format_script(
             .with_options(formatter_parse_options())
             .parse();
     }
-    if !parser_ret.errors.is_empty() {
-        return Err(FormatError::ScriptParse(format!("{:?}", parser_ret.errors)));
+    if !parser_ret.diagnostics.is_empty() {
+        return Err(FormatError::ScriptParse(format!(
+            "{:?}",
+            parser_ret.diagnostics
+        )));
     }
 
     // Format the body one indent level narrower than the configured width.
@@ -143,14 +146,14 @@ pub(crate) fn format_nested_script(
     let mut parser_ret = Parser::new(&allocator, body, source_type)
         .with_options(formatter_parse_options())
         .parse();
-    if !parser_ret.errors.is_empty() && !is_ts {
+    if !parser_ret.diagnostics.is_empty() && !is_ts {
         // Fall back to the TS parser (superset of JS) — matches oxfmt's lenient
         // parse of a `<script>` without `lang="ts"` that uses TS-only syntax.
         parser_ret = Parser::new(&allocator, body, SourceType::ts())
             .with_options(formatter_parse_options())
             .parse();
     }
-    if !parser_ret.errors.is_empty() {
+    if !parser_ret.diagnostics.is_empty() {
         // Can't parse → leave the nested script untouched.
         return Ok(None);
     }

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -49,11 +49,11 @@ rayon = { version = "1.10", optional = true }
 
 # OXC — same git rev as rsvelte_core (unified by the workspace `[patch]`),
 # used only to statically parse `eslint.config.js` for the config importer.
-oxc_allocator = { version = "0.134", optional = true }
-oxc_parser = { version = "0.134", optional = true }
-oxc_ast = { version = "0.134", optional = true }
-oxc_ast_visit = { version = "0.134", optional = true }
-oxc_span = { version = "0.134", optional = true }
+oxc_allocator = { version = "0.136", optional = true }
+oxc_parser = { version = "0.136", optional = true }
+oxc_ast = { version = "0.136", optional = true }
+oxc_ast_visit = { version = "0.136", optional = true }
+oxc_span = { version = "0.136", optional = true }
 
 # wasm-only.
 wasm-bindgen = { version = "0.2", optional = true }

--- a/crates/rsvelte_lint/src/eslint_import.rs
+++ b/crates/rsvelte_lint/src/eslint_import.rs
@@ -42,7 +42,7 @@ fn extract(allocator: &Allocator, source: &str) -> Vec<(String, Severity)> {
     // (CJS `module.exports = [...]`) if the module parse errors.
     for source_type in [SourceType::mjs(), SourceType::cjs()] {
         let ret = Parser::new(allocator, source, source_type).parse();
-        if ret.errors.is_empty() {
+        if ret.diagnostics.is_empty() {
             let mut collector = Collector { rules: Vec::new() };
             collector.visit_program(&ret.program);
             return collector.rules;


### PR DESCRIPTION
## What

Unified bump of **every** oxc reference from rev `44ae845` to `37a34a1` (oxc-project/oxc, 2026-06-15) in a single change:

- Root `Cargo.toml` `[patch.crates-io]`: all 15 oxc_* crates.
- `crates/rsvelte_formatter`, `crates/rsvelte_core`, `crates/rsvelte_fmt`: `oxc_formatter` / `oxc_formatter_core`.

The new rev is oxc **0.136.0** (was 0.134), so the crates.io version requirements were bumped `0.134` → `0.136` in `rsvelte_core` / `rsvelte_formatter` / `rsvelte_lint`. This is required: a `[patch]` only applies when its version satisfies the original requirement, so leaving `"0.134"` would have pulled in a second, real `0.134.0` copy of every oxc crate from crates.io alongside the git `0.136` copy — exactly the type-unification break this PR is meant to avoid.

## Why this supersedes #996 and #997

The individual Renovate PRs (#996, #997) bump only `oxc_formatter` / `oxc_formatter_core` and leave the `[patch.crates-io]` `oxc_*` crates at the old rev. That mismatches rsvelte's AST types against oxc_formatter's transitive deps (two oxc versions in the graph), so those PRs can **never** pass CI on their own. Bumping all oxc references to the same rev together is the only configuration that resolves cleanly.

## oxc API breakage fixed

1. **`ParserReturn.errors` → `ParserReturn.diagnostics`** (field rename, ~70 sites). The new `Diagnostics` type derefs to `Vec<OxcDiagnostic>`, so `.is_empty()` / `.first()` / indexing / iteration are unchanged.
2. **`OxcDiagnostic.labels`** is now a `Labels` enum that derefs to `[LabeledSpan]` (was `Option<Vec<LabeledSpan>>`): `.labels.as_ref().and_then(|l| l.first())` → `.labels.first()`; `.labels.as_ref()?.first()?` → `.labels.first()?`.
3. **`LabeledSpan::offset()` / `len()`** now return `u32` (was `usize`): cast to `usize` at each call site, preserving the surrounding `usize` position arithmetic and the `Option<(String, usize)>` signatures.
4. **`SemanticBuilder` no longer builds AST nodes by default** (`with_build_nodes` defaults to `false`, leaving `Semantic::nodes()` empty). All six `SemanticBuilder::new().build(program)` sites that read `semantic.nodes()` now call `.with_build_nodes(true)`, restoring the prior behavior. Without this, 16 `rsvelte_core` lib tests panicked with `index out of bounds: the len is 0`.

## Verification

- `cargo build --workspace --all-targets` — green.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p rsvelte_formatter` — pass.
- `cargo test -p rsvelte_fmt` — pass.
- `cargo test -p rsvelte_lint` — pass (167 + others).
- `cargo test -p rsvelte_core --lib` — 1276 pass / 0 fail (was 16 failing before the `with_build_nodes` fix).
- `cargo test -p rsvelte_core --test compatibility_report` — pass (canonicalize_js helper tests, which exercise the touched oxc parser path). The full fixture-driven `generate_compatibility_report` is reporting-only/ignored and needs `pnpm run generate-fixtures` (not available in this environment); it should be validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)