### PR TITLE
fix(ci): gate validator-backed lint rules behind native feature (fix wasm build)

### DIFF
--- a/crates/rsvelte_lint/src/lib.rs
+++ b/crates/rsvelte_lint/src/lib.rs
@@ -30,6 +30,9 @@ pub mod rules;
 pub mod scope;
 pub mod script;
 pub mod suppression;
+// Native-only: a source-scan helper shared exclusively by the validator-backed
+// meta-rules (`valid_compile`, `require_event_*`, …), all gated behind `native`.
+#[cfg(feature = "native")]
 pub mod svelte_scan;
 pub mod visitor;
 

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -40,17 +40,25 @@ pub fn registered_rule_metas() -> Vec<&'static RuleMeta> {
 /// [`all_rules`] / [`all_script_rules`]). Currently just `comment-directive`,
 /// whose unused-directive reporting is wired into [`crate::runner::lint_source`].
 pub fn meta_rule_metas() -> impl Iterator<Item = &'static RuleMeta> {
-    [
-        &crate::rules::comment_directive::META,
-        &crate::rules::valid_compile::META,
-        &crate::rules::valid_style_parse::META,
-        &crate::rules::experimental_require_slot_types::META,
-        &crate::rules::experimental_require_strict_events::META,
-        &crate::rules::require_event_dispatcher_types::META,
-        &crate::rules::require_event_prefix::META,
-        &crate::rules::no_unused_props::META,
-    ]
-    .into_iter()
+    let metas: Vec<&'static RuleMeta> = vec![&crate::rules::comment_directive::META];
+    // The validator-backed meta-rules reuse `crate::validator` /
+    // `rsvelte_core::svelte_check`, which are native-only, so they ship only in
+    // the native build (excluded from the wasm playground bundle).
+    #[cfg(feature = "native")]
+    let metas = {
+        let mut metas = metas;
+        metas.extend([
+            &crate::rules::valid_compile::META,
+            &crate::rules::valid_style_parse::META,
+            &crate::rules::experimental_require_slot_types::META,
+            &crate::rules::experimental_require_strict_events::META,
+            &crate::rules::require_event_dispatcher_types::META,
+            &crate::rules::require_event_prefix::META,
+            &crate::rules::no_unused_props::META,
+        ]);
+        metas
+    };
+    metas.into_iter()
 }
 
 /// Construct the full set of native rules.

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -7,7 +7,11 @@ pub mod button_has_type;
 pub mod comment_directive;
 pub mod consistent_selector_style;
 pub mod derived_has_same_inputs_outputs;
+// Native-only: depends on `crate::validator` / `rsvelte_core::svelte_check`,
+// both gated behind the `native` feature (excluded from the wasm build).
+#[cfg(feature = "native")]
 pub mod experimental_require_slot_types;
+#[cfg(feature = "native")]
 pub mod experimental_require_strict_events;
 pub mod first_attribute_linebreak;
 pub mod html_closing_bracket_new_line;
@@ -59,6 +63,7 @@ pub mod no_trailing_spaces;
 pub mod no_unknown_style_directive_property;
 pub mod no_unnecessary_state_wrap;
 pub mod no_unused_class_name;
+#[cfg(feature = "native")]
 pub mod no_unused_props;
 pub mod no_useless_children_snippet;
 pub mod no_useless_mustaches;
@@ -70,7 +75,9 @@ pub mod prefer_style_directive;
 pub mod prefer_svelte_reactivity;
 pub mod prefer_writable_derived;
 pub mod require_each_key;
+#[cfg(feature = "native")]
 pub mod require_event_dispatcher_types;
+#[cfg(feature = "native")]
 pub mod require_event_prefix;
 pub mod require_optimized_style_attribute;
 pub mod require_store_callbacks_use_set_param;
@@ -81,7 +88,9 @@ pub mod shorthand_directive;
 pub mod sort_attributes;
 pub mod spaced_html_comment;
 pub mod store_refs;
+#[cfg(feature = "native")]
 pub mod valid_compile;
 pub mod valid_each_key;
 pub mod valid_prop_names_in_kit_pages;
+#[cfg(feature = "native")]
 pub mod valid_style_parse;


### PR DESCRIPTION
## Problem

The **Deploy Docs to GitHub Pages** workflow on `main` is failing. It builds `rsvelte_lint` to WebAssembly via `wasm-pack build … --no-default-features --features wasm`, which broke after PR #998 added seven validator-backed meta-rules:

- `valid-compile`, `valid-style-parse`
- `experimental-require-slot-types`, `experimental-require-strict-events`
- `require-event-dispatcher-types`, `require-event-prefix`
- `no-unused-props`

Each imports `crate::validator` and `rsvelte_core::svelte_check`, **both gated behind the `native` feature**. Their `pub mod` declarations and `meta_rule_metas()` registry entries were unconditional, so the wasm build failed with 15 unresolved-import errors (`could not find validator in the crate root`, etc.).

The main **CI** workflow does not build wasm, so this slipped through to `main`.

## Fix

Gate behind `#[cfg(feature = "native")]`:
- the seven rule module declarations in `rules/mod.rs`
- the `svelte_scan` helper module (`lib.rs`) — used **only** by those rules
- the seven `META` entries in `registry::meta_rule_metas()`

These are native-only meta-rules wired solely into `runner.rs`. The wasm playground loses nothing — it cannot run the native compiler-backed validator path regardless.

## Verification

- `cargo build --lib --release --target wasm32-unknown-unknown --no-default-features --features wasm` → **finishes, 0 warnings** (was: 15 errors)
- `cargo check -p rsvelte_lint --all-features` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)