### PR TITLE
fix(fmt): parse typed {@const name: T = value} as TS variable declaration (#973)

### DIFF
--- a/.changeset/fix-typed-const-tag.md
+++ b/.changeset/fix-typed-const-tag.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Fix a regression where a `{@const}` tag carrying a TypeScript type annotation
+(`{@const name: Type = value}`, e.g. an exhaustiveness check
+`{@const _: never = column}`) failed with `script parse failed`. The collapse
+path was formatting the tag body as a bare expression (`(name: Type = value);`),
+which is not valid; it is now formatted as the TS variable declaration it
+actually is (`const name: Type = value;`) using the same TS-aware parse path as
+`<script lang="ts">`, so the type annotation is parsed and preserved.

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -91,14 +91,17 @@ fn collect_node_edits(
             push_debug_tag(source, tag.start, tag.end, &tag.identifiers, options, edits)?;
         }
         TemplateNode::ConstTag(tag) => {
-            // `{@const x = e}` — the declaration is an assignment expression
-            // (`x = e`); format it like any content expression so quotes /
-            // spacing normalize (`{@const foo = 'bar'}` → `{@const foo = "bar"}`).
-            push_tag_form(
+            // `{@const x = e}` — the declaration is a `const` variable
+            // declaration (the parser records its full source span, *including*
+            // any TypeScript type annotation, on `tag.declaration`). Format it
+            // as a `const` declaration so a type annotation like
+            // `{@const _: never = x}` parses (a bare assignment-expression parse
+            // would reject the `: Type`), while quotes / spacing still normalize
+            // (`{@const foo = 'bar'}` → `{@const foo = "bar"}`).
+            push_const_tag(
                 source,
                 tag.start,
                 tag.end,
-                "@const",
                 &tag.declaration,
                 depth,
                 options,
@@ -471,6 +474,38 @@ fn push_tag_form(
     }
     let formatted = format_content_expression(slice, options, depth)?;
     edits.push((tag_start, tag_end, format!("{{{keyword} {formatted}}}")));
+    Ok(())
+}
+
+/// Replace `{@const <decl>}` by formatting `<decl>` as the body of a `const`
+/// variable declaration.
+///
+/// Unlike [`push_tag_form`], the body is parsed as `const <decl>;` rather than
+/// as a bare expression, so a TypeScript type annotation on the binding
+/// (`{@const _: never = x}`, `{@const name: Type = value}`) parses and round
+/// trips. The declaration's source span (recorded by the parser) covers the
+/// whole body including the annotation.
+fn push_const_tag(
+    source: &str,
+    tag_start: u32,
+    tag_end: u32,
+    decl: &Expression,
+    depth: usize,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) -> Result<(), FormatError> {
+    let (Some(start), Some(end)) = (decl.start(), decl.end()) else {
+        return Ok(());
+    };
+    let slice = source
+        .get(start as usize..end as usize)
+        .ok_or_else(|| FormatError::Parse("const declaration span out of bounds".into()))?
+        .trim();
+    if slice.is_empty() {
+        return Ok(());
+    }
+    let formatted = format_const_declaration(slice, options, depth)?;
+    edits.push((tag_start, tag_end, format!("{{@const {formatted}}}")));
     Ok(())
 }
 
@@ -1324,6 +1359,73 @@ fn format_content_expression(
     } else {
         formatted
     };
+    if !formatted.contains('\n') {
+        return Ok(formatted);
+    }
+    let prefix = if options.js.indent_style.is_tab() {
+        "\t".repeat(depth)
+    } else {
+        " ".repeat(lead)
+    };
+    Ok(crate::reindent::reindent(&formatted, &prefix, true))
+}
+
+/// Format the body of a `{@const <decl>}` tag — the `<decl>` is the body of a
+/// `const` variable declaration (`<binding>[: Type] = <init>`).
+///
+/// The body is parsed as `const <decl>;` (TypeScript when `options.typescript`)
+/// so a type annotation parses, then the `const ` prefix and trailing `;` are
+/// sliced back off, leaving the formatted declaration body. Width handling
+/// mirrors [`format_content_expression`]: the body is formatted at indent 0 and
+/// the wrap width narrowed by the markup `depth`, then continuation lines are
+/// re-indented to that depth.
+fn format_const_declaration(
+    decl_source: &str,
+    options: &FormatOptions,
+    depth: usize,
+) -> Result<String, FormatError> {
+    let allocator = Allocator::default();
+    let source_type = if options.typescript {
+        SourceType::ts()
+    } else {
+        SourceType::default()
+    };
+
+    let wrapped = format!("const {decl_source};");
+    let parser_ret = Parser::new(&allocator, &wrapped, source_type)
+        .with_options(formatter_parse_options())
+        .parse();
+    if !parser_ret.diagnostics.is_empty() {
+        return Err(FormatError::ScriptParse(format!(
+            "{:?}",
+            parser_ret.diagnostics
+        )));
+    }
+
+    let indent_width = options.js.indent_width.value() as usize;
+    let lead = depth * indent_width;
+    let full_width = options.js.line_width.value() as usize;
+    // Narrow by the markup lead plus the `{@const ` prefix + closing `}` so a
+    // break decision lands where it will once the declaration is spliced back
+    // into the tag.
+    let narrowed = full_width.saturating_sub(lead + "{@const ".len() + 1);
+    let line_width =
+        oxc_formatter_core::LineWidth::try_from(narrowed as u16).unwrap_or(options.js.line_width);
+
+    let mut js = options.js.clone();
+    js.line_width = line_width;
+    let formatted = format_program(&allocator, &parser_ret.program, js, None)
+        .print()
+        .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
+        .into_code();
+
+    // Output shape: `const <decl>;\n`. Strip the leading `const ` and the
+    // trailing `;` to recover the declaration body.
+    let s = formatted.trim_end();
+    let s = s.strip_prefix("const ").unwrap_or(s);
+    let s = s.strip_suffix(';').unwrap_or(s);
+    let formatted = s.trim_end().to_string();
+
     if !formatted.contains('\n') {
         return Ok(formatted);
     }

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -1405,10 +1405,14 @@ fn format_const_declaration(
     let indent_width = options.js.indent_width.value() as usize;
     let lead = depth * indent_width;
     let full_width = options.js.line_width.value() as usize;
-    // Narrow by the markup lead plus the `{@const ` prefix + closing `}` so a
-    // break decision lands where it will once the declaration is spliced back
-    // into the tag.
-    let narrowed = full_width.saturating_sub(lead + "{@const ".len() + 1);
+    // Narrow so the JS formatter's break decision lands where it will once the
+    // declaration is spliced back into the tag. The body is measured by the JS
+    // formatter as `const <body>;`, which already accounts for `const ` (6) +
+    // `;` (1); the real rendered affixes are `{@const ` (8) + `}` (1). So beyond
+    // the markup `lead`, only the affix delta `(8 - 6) + (1 - 1) = 2` must be
+    // subtracted — subtracting the full `{@const }` width here would
+    // double-count `const ;` and wrongly break tags that fit inline.
+    let narrowed = full_width.saturating_sub(lead + 2);
     let line_width =
         oxc_formatter_core::LineWidth::try_from(narrowed as u16).unwrap_or(options.js.line_width);
 

--- a/crates/rsvelte_formatter/tests/typescript.rs
+++ b/crates/rsvelte_formatter/tests/typescript.rs
@@ -124,6 +124,53 @@ fn non_ts_component_does_not_parse_ts_syntax() {
     );
 }
 
+// ─── #973: `{@const}` with a TypeScript type annotation ──────────────────
+//
+// A `{@const}` declaration is a `const` variable declaration with an optional
+// TS type annotation (`{@const _: never = x}`). The parity burndown (#906)
+// parsed the body as a bare assignment expression, which rejected the `: Type`
+// ("script parse failed"). Parsing it as a `const` declaration fixes that.
+
+#[test]
+fn const_tag_typed_annotation_round_trips() {
+    for markup in [
+        "<div>\n  {#if true}\n    {@const _: never = x}\n  {/if}\n</div>",
+        "<div>\n  {#if true}\n    {@const name: Type = value}\n  {/if}\n</div>",
+        "<div>\n  {#if true}\n    {@const n: number = 1}\n  {/if}\n</div>",
+    ] {
+        let out = fmt_ts(markup);
+        // Each typed declaration must survive verbatim (no annotation drop, no
+        // parse error).
+        let decl = markup
+            .lines()
+            .find(|l| l.contains("{@const"))
+            .unwrap()
+            .trim();
+        assert!(out.contains(decl), "expected `{decl}` from:\n{out}");
+    }
+}
+
+#[test]
+fn const_tag_typed_destructuring_round_trips() {
+    let out = fmt_ts("<div>\n  {#if true}\n    {@const { a, b }: Point = obj}\n  {/if}\n</div>");
+    assert!(out.contains("{@const { a, b }: Point = obj}"), "{out}");
+}
+
+#[test]
+fn const_tag_untyped_still_normalizes() {
+    // The fix must not regress untyped `{@const}` — quotes still normalize and
+    // the declaration round-trips in both JS and TS components.
+    let out = format(
+        "<div>\n  {#if true}\n    {@const foo = 'bar'}\n  {/if}\n</div>",
+        &FormatOptions::default(),
+    )
+    .expect("format ok");
+    assert!(out.contains("{@const foo = \"bar\"}"), "{out}");
+
+    let out_ts = fmt_ts("<div>\n  {#if true}\n    {@const y = x}\n  {/if}\n</div>");
+    assert!(out_ts.contains("{@const y = x}"), "{out_ts}");
+}
+
 // ─── #946: `>` inside a `generics` attribute value must not split the body ──
 
 #[test]

--- a/crates/rsvelte_formatter/tests/typescript.rs
+++ b/crates/rsvelte_formatter/tests/typescript.rs
@@ -276,3 +276,27 @@ fn plain_script_valid_js_is_untouched_by_fallback() {
         "{out}"
     );
 }
+
+#[test]
+fn const_tag_inline_not_overbroken() {
+    // Regression for #973 fix: `{@const}` bodies that fit must stay inline
+    // (oxfmt/prettier keeps them on one line). The const-declaration parse path
+    // must not double-count the `const ;` wrapper against the width budget.
+    let src = "{#each xs as post, i}\n  {@const show_comma = post.authors.length > 2 && i < post.authors.length - 1}\n{/each}\n";
+    let out =
+        rsvelte_formatter::format(src, &rsvelte_formatter::FormatOptions::default()).expect("ok");
+    assert!(
+        out.contains(
+            "{@const show_comma = post.authors.length > 2 && i < post.authors.length - 1}"
+        ),
+        "const tag was wrongly broken:\n{out}"
+    );
+
+    let src2 = "{#if box}\n  {@const { area, volume } = calculate(box.width, box.height, constant)}\n{/if}\n";
+    let out2 =
+        rsvelte_formatter::format(src2, &rsvelte_formatter::FormatOptions::default()).expect("ok");
+    assert!(
+        out2.contains("{@const { area, volume } = calculate(box.width, box.height, constant)}"),
+        "destructuring const tag was wrongly broken:\n{out2}"
+    );
+}


### PR DESCRIPTION
## Problem

`@rsvelte/fmt` failed to parse a `{@const}` tag carrying a TypeScript **type annotation**, e.g.

```svelte
<div>
  {#if true}
    {@const _: never = x}
  {/if}
</div>
```

It errored with `script parse failed` (`Expected `=>` but found `;`` / `Expected `,` or `)` but found `:``). Untyped `{@const y = x}` worked fine — only typed `{@const}` broke. This was a regression from the parity burndown (#906).

## Root cause

The collapse/format path routed the `{@const}` body through `format_content_expression`, which parses the source span as a **bare expression** by wrapping it `(<body>);`. The parser records the declaration's *full* source span — including the type annotation — on `tag.declaration`, so the body is `_: never = x`; wrapping that as `(_: never = x);` is not a valid expression and oxc rejected the `: Type`.

## Fix

A `{@const}` declaration *is* a `const` variable declaration with an optional type annotation, so format it as one. New `push_const_tag` / `format_const_declaration` wrap the body as `const <body>;`, parse it with the **TS-aware** source type (the same dialect `<script lang="ts">` and other markup expressions use), format it, then slice the `const ` prefix and trailing `;` back off. Width/indent handling mirrors `format_content_expression`. Untyped `{@const}` keeps its existing quote/spacing normalization (`{@const foo = 'bar'}` → `{@const foo = "bar"}`).

## Tests

Added to `crates/rsvelte_formatter/tests/typescript.rs`:
- `const_tag_typed_annotation_round_trips` — `{@const _: never = x}`, `{@const name: Type = value}`, `{@const n: number = 1}`
- `const_tag_typed_destructuring_round_trips` — `{@const { a, b }: Point = obj}`
- `const_tag_untyped_still_normalizes` — guards quote normalization + JS/TS round-trip

`cargo test -p rsvelte_formatter` and `-p rsvelte_fmt` pass; `cargo clippy --all-targets --all-features -- -D warnings` clean. Verified the original repro through the built formatter.

Fixes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)