### PR TITLE
test(fmt): byte-parity regression tests for attribute/markup value wrap width (#971)

### DIFF
--- a/crates/rsvelte_formatter/tests/markup_wrap.rs
+++ b/crates/rsvelte_formatter/tests/markup_wrap.rs
@@ -221,3 +221,94 @@ fn short_function_binding_stays_inline_without_parens() {
     );
     assert_eq!(fmt_at_width(&out, 80), out, "must be idempotent");
 }
+
+// ─── #971: value wrap budget subtracts the value's rendered `{` column ───
+//
+// The attribute/directive value's wrap budget must account for the actual
+// column its leading `{` lands at (indent + `name=` + `{`) and the trailing
+// `}`, not just the nesting indent. Otherwise a value up to ~len(name) wide
+// over printWidth wrongly stays inline and emits a line that exceeds the
+// width. Each case below is asserted byte-for-byte against oxfmt(svelte:true).
+
+/// Assert no rendered line exceeds the print width (visual / East-Asian).
+fn assert_no_line_exceeds(out: &str, width: usize) {
+    for (i, line) in out.lines().enumerate() {
+        let w = unicode_width::UnicodeWidthStr::width(line);
+        assert!(
+            w <= width,
+            "line {} is {} cols > printWidth {}:\n{:?}\nfull:\n{}",
+            i + 1,
+            w,
+            width,
+            line,
+            out
+        );
+    }
+}
+
+#[test]
+fn attribute_value_wraps_by_rendered_brace_column() {
+    // The DefinitionListItem repro from #971: at printWidth 100 the value
+    // (`description={…}`, 81-col expr) fits the indent-only budget (92) but its
+    // true rendered line is 103 cols, so oxfmt breaks the ternary. rsvelte must
+    // match byte-for-byte and emit no line > 100.
+    let src = "<div>\n  <div>\n    <div>\n      <DefinitionListItem\n        term=\"最終ログイン\"\n        description={user.lastAccessedAt ? formatDateInOrganizationTimezone(user.lastAccessedAt) : '-'}\n      />\n    </div>\n  </div>\n</div>\n";
+    let out = fmt_at_width(src, 100);
+    let expected = "<div>\n  <div>\n    <div>\n      <DefinitionListItem\n        term=\"最終ログイン\"\n        description={user.lastAccessedAt\n          ? formatDateInOrganizationTimezone(user.lastAccessedAt)\n          : \"-\"}\n      />\n    </div>\n  </div>\n</div>";
+    assert_eq!(out, expected, "value ternary must break (#971):\n{out}");
+    assert_no_line_exceeds(&out, 100);
+    assert_eq!(fmt_at_width(&out, 100), out, "must be idempotent");
+}
+
+#[test]
+fn content_mustache_wraps_by_rendered_column() {
+    // A content mustache shifted right by leading text must break at its own
+    // top-level operator so no line exceeds the width (#971 sibling case).
+    let src = "<div>some text content here {user.lastAccessedAt ? formatDateInOrganizationTimezone(user.lastAccessedAt) : '-'}</div>\n";
+    let out = fmt_at_width(src, 100);
+    let expected = "<div>\n  some text content here {user.lastAccessedAt\n    ? formatDateInOrganizationTimezone(user.lastAccessedAt)\n    : \"-\"}\n</div>";
+    assert_eq!(out, expected, "content mustache must break (#971):\n{out}");
+    assert_no_line_exceeds(&out, 100);
+}
+
+#[test]
+fn directive_value_stays_inline_when_it_fits() {
+    // class:/style: directive values that fit (98/97 cols at indent 2) must
+    // stay inline, matching oxfmt — the prefix narrowing must not over-wrap.
+    let class_src = "<div class:active={user.lastAccessedAt ? formatDateInOrganizationTimezone(user.lastAccessedAt) : '-'}></div>\n";
+    let class_out = fmt_at_width(class_src, 100);
+    let class_expected = "<div\n  class:active={user.lastAccessedAt ? formatDateInOrganizationTimezone(user.lastAccessedAt) : \"-\"}\n></div>";
+    assert_eq!(class_out, class_expected, "class directive:\n{class_out}");
+    assert_no_line_exceeds(&class_out, 100);
+
+    let style_src = "<div style:width={user.lastAccessedAt ? formatDateInOrganizationTimezone(user.lastAccessedAt) : '-'}></div>\n";
+    let style_out = fmt_at_width(style_src, 100);
+    let style_expected = "<div\n  style:width={user.lastAccessedAt ? formatDateInOrganizationTimezone(user.lastAccessedAt) : \"-\"}\n></div>";
+    assert_eq!(style_out, style_expected, "style directive:\n{style_out}");
+    assert_no_line_exceeds(&style_out, 100);
+}
+
+#[test]
+fn on_directive_arrow_handler_breaks_by_prefix() {
+    // An arrow handler whose body overflows the value line must break after the
+    // `=>` and land its body one indent in, matching oxfmt (#971 sibling case).
+    let src = "<button on:click={() => doSomethingQuiteLong(withAnArgument, andAnother, andYetAnotherOne)}>x</button>\n";
+    let out = fmt_at_width(src, 80);
+    let expected = "<button\n  on:click={() =>\n    doSomethingQuiteLong(withAnArgument, andAnother, andYetAnotherOne)}\n  >x</button\n>";
+    assert_eq!(out, expected, "on:click arrow must break (#971):\n{out}");
+    assert_no_line_exceeds(&out, 80);
+}
+
+#[test]
+fn quoted_string_embedded_expr_breaks_by_rendered_column() {
+    // An expression embedded in a quoted attribute string must break its call
+    // args when the rendered line overflows, matching oxfmt (#971 sibling).
+    let src = "<div style=\"width: {computeWidthBasedOnSomeVeryLongComputationFunctionCallHere(a, b)}px;\"></div>\n";
+    let out = fmt_at_width(src, 80);
+    let expected = "<div\n  style=\"width: {computeWidthBasedOnSomeVeryLongComputationFunctionCallHere(\n    a,\n    b,\n  )}px;\"\n></div>";
+    assert_eq!(
+        out, expected,
+        "quoted embedded expr must break (#971):\n{out}"
+    );
+    assert_no_line_exceeds(&out, 80);
+}


### PR DESCRIPTION
## Issue

`@rsvelte/fmt` could emit lines **wider than `printWidth`** because the attribute / markup value wrap budget did not subtract the rendered column the value's `{` actually lands at — it narrowed only by the nesting indent (`printWidth − depth × indent`, from #813), not by the `attrname={` prefix and trailing `}`. A value up to ~`len(attrname)` over `printWidth` wrongly stayed inline.

### Repro (printWidth 100)

```svelte
<DefinitionListItem
  term="最終ログイン"
  description={user.lastAccessedAt ? formatDateInOrganizationTimezone(user.lastAccessedAt) : '-'}
/>
```

Arithmetic: the expr alone is 81 cols. The indent-only budget was `100 − 8 = 92`, and `81 ≤ 92` ⇒ "fits" ⇒ no wrap. But the true rendered line is `indent(8) + "description={"(13) + expr(81) + "}"(1) = 103 > 100`, so oxfmt (= prettier-plugin-svelte) breaks the ternary.

## Root cause & fix status

**Already fixed at HEAD.** The two-pass open-tag rewrite in `crates/rsvelte_formatter/src/markup.rs` re-renders attribute/directive values once the tag is known to wrap, narrowing each value by its **true rendered prefix** (`indent + name= + {`) and the trailing `}`:

- `render_single_expression_value` / `render_directive_value_narrow` / `render_attribute_value_for_directive` apply `extra_lead = prefix` (the `name=`/directive-name columns plus the `{`) for *shallow* values (ternary / binary / logical / member chain) via the `narrow_value` + `is_shallow_value` machinery, and a `prefix − indent` re-narrow for arrow/block-bodied values.
- Content mustaches narrow by their rendered column in `format_content_expression`.

This landed with the formatter-parity corpus burndown (the `narrow_value` path) rather than as the single-function budget tweak the issue anticipated.

## What this PR adds

Focused **byte-for-byte regression tests** (each verified against `oxfmt(svelte: true)`), so the behavior is locked and cannot silently regress:

- the original #971 repro (ternary breaks; no line > 100)
- content mustache shifted right by leading text
- `class:` / `style:` directive values that **stay inline** when they fit (98/97 cols) — guarding against over-wrapping
- an `on:click` arrow handler that breaks after `=>`
- an expression embedded in a quoted attribute string (`style="width: {…}px;"`) that breaks its call args

Every test asserts the exact oxfmt output **and** that no rendered line exceeds `printWidth`.

## Verification

- `cargo test -p rsvelte_formatter` — all suites pass (markup_wrap now 19/19, +5 new).
- Each new case confirmed byte-for-byte against `oxfmt@0.54.0` with `svelte:true` at the relevant width.
- `cargo fmt` + `cargo clippy --all-targets --all-features -D warnings` clean.
- No source-logic change → corpus oracle (Linux) unaffected; baselines untouched per the macOS-source-of-truth rule.

Fixes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)