### PR TITLE
fix(ssr): emit valid assignment for $derived override and $store write (#969)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2364,17 +2364,29 @@ pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {
 
     for line in script.lines() {
         if let Some(ref mut import_lines) = current_import {
-            // We're inside a multi-line import, accumulate lines
-            import_lines.push(line.to_string());
-            // Check if the import statement is complete (has a semicolon or closing quote/backtick followed by end)
+            // We're inside a multi-line import. The closing line may carry
+            // trailing statements after the import terminator; split them off.
             let trimmed = line.trim();
-            if trimmed.contains(';')
+            let closes = trimmed.contains(';')
                 || trimmed.ends_with('\'')
                 || trimmed.ends_with('"')
-                || trimmed.ends_with('`')
-            {
-                imports.push(import_lines.join("\n"));
-                current_import = None;
+                || trimmed.ends_with('`');
+            if closes {
+                if let Some(end) = import_statement_end(trimmed)
+                    && end < trimmed.len()
+                    && !trimmed[end..].trim().is_empty()
+                {
+                    import_lines.push(trimmed[..end].to_string());
+                    imports.push(import_lines.join("\n"));
+                    current_import = None;
+                    rest.push(trimmed[end..].to_string());
+                } else {
+                    import_lines.push(line.to_string());
+                    imports.push(import_lines.join("\n"));
+                    current_import = None;
+                }
+            } else {
+                import_lines.push(line.to_string());
             }
         } else {
             let trimmed = line.trim();
@@ -2387,7 +2399,19 @@ pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {
                             || trimmed.ends_with('"')
                             || trimmed.ends_with('`')))
                 {
-                    imports.push(line.to_string());
+                    // The line begins with a *complete* import statement but may
+                    // carry trailing statements on the same physical line
+                    // (`import x from 'm'; const a = 1;`). Split the import off so
+                    // the remainder is transformed normally instead of swallowed.
+                    if let Some(end) = import_statement_end(trimmed)
+                        && end < trimmed.len()
+                        && !trimmed[end..].trim().is_empty()
+                    {
+                        imports.push(trimmed[..end].to_string());
+                        rest.push(trimmed[end..].to_string());
+                    } else {
+                        imports.push(line.to_string());
+                    }
                 } else {
                     // Multi-line import starts here
                     current_import = Some(vec![line.to_string()]);
@@ -2416,6 +2440,41 @@ pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {
 /// then a single string literal (single or double quoted), then optional
 /// whitespace until end-of-line. Anything else (bindings, `from`, trailing
 /// content, dynamic `import(...)` calls) returns `false`.
+/// Find the byte index at which the leading import statement in `s` ends.
+///
+/// String literals (single/double quotes and template backticks) are skipped
+/// honouring backslash escapes, so a `;` inside a module specifier is ignored.
+/// If a top-level `;` is found it terminates the statement (index just past it).
+/// Otherwise — ASI — the statement ends just past the last completed top-level
+/// string literal (the module specifier). Returns `None` if neither is present.
+fn import_statement_end(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    let mut last_string_end: Option<usize> = None;
+    while i < bytes.len() {
+        match bytes[i] {
+            b';' => return Some(i + 1),
+            q @ (b'\'' | b'"' | b'`') => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == q {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                last_string_end = Some(i);
+            }
+            _ => i += 1,
+        }
+    }
+    last_string_end
+}
+
 fn is_complete_side_effect_import(trimmed: &str) -> bool {
     // Must start with `import ` (we already know this from the caller, but
     // re-check defensively to keep the helper standalone).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2379,7 +2379,12 @@ pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {
                     import_lines.push(trimmed[..end].to_string());
                     imports.push(import_lines.join("\n"));
                     current_import = None;
-                    rest.push(trimmed[end..].to_string());
+                    // The remainder may itself begin with further imports packed
+                    // on the same line; peel them all before routing the rest.
+                    let remainder = peel_leading_imports(&trimmed[end..], &mut imports);
+                    if !remainder.trim().is_empty() {
+                        rest.push(remainder);
+                    }
                 } else {
                     import_lines.push(line.to_string());
                     imports.push(import_lines.join("\n"));
@@ -2400,17 +2405,15 @@ pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {
                             || trimmed.ends_with('`')))
                 {
                     // The line begins with a *complete* import statement but may
-                    // carry trailing statements on the same physical line
-                    // (`import x from 'm'; const a = 1;`). Split the import off so
-                    // the remainder is transformed normally instead of swallowed.
-                    if let Some(end) = import_statement_end(trimmed)
-                        && end < trimmed.len()
-                        && !trimmed[end..].trim().is_empty()
-                    {
-                        imports.push(trimmed[..end].to_string());
-                        rest.push(trimmed[end..].to_string());
-                    } else {
-                        imports.push(line.to_string());
+                    // carry additional imports and/or statements on the same
+                    // physical line (`import a from 'x';import b from 'y';` or
+                    // `import x from 'm'; const a = 1;`). Peel every packed import
+                    // so each is hoisted, then route any trailing non-import code
+                    // through `rest` so it is transformed normally instead of
+                    // being swallowed into the import string.
+                    let remainder = peel_leading_imports(trimmed, &mut imports);
+                    if !remainder.trim().is_empty() {
+                        rest.push(remainder);
                     }
                 } else {
                     // Multi-line import starts here
@@ -2473,6 +2476,26 @@ fn import_statement_end(s: &str) -> Option<usize> {
         }
     }
     last_string_end
+}
+
+/// Peel every complete leading `import` statement off `s`, pushing each onto
+/// `imports`, and return the remaining tail (front-trimmed).
+///
+/// Handles several imports packed onto one physical line, e.g.
+/// `import a from 'x';import b from 'y';` → both hoisted, empty tail. Stops at
+/// the first non-import token or an *incomplete* import (one that continues on a
+/// following line) and returns it so the caller can route it.
+fn peel_leading_imports(s: &str, imports: &mut Vec<String>) -> String {
+    let mut cur = s.trim_start();
+    while cur.starts_with("import ") || cur.starts_with("import{") {
+        let Some(end) = import_statement_end(cur) else {
+            break;
+        };
+        let (import_part, remainder) = cur.split_at(end);
+        imports.push(import_part.trim().to_string());
+        cur = remainder.trim_start();
+    }
+    cur.to_string()
 }
 
 fn is_complete_side_effect_import(trimmed: &str) -> bool {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -2021,16 +2021,29 @@ fn extract_imports_with_options(script: &str, strip_exports: bool) -> (Vec<Strin
 
     for line in script.lines() {
         if let Some(ref mut import_lines) = current_import {
-            // We're inside a multi-line import, accumulate lines
-            import_lines.push(line.to_string());
+            // We're inside a multi-line import. The closing line may carry
+            // trailing statements after the import terminator; split them off.
             let trimmed = line.trim();
-            if trimmed.contains(';')
+            let closes = trimmed.contains(';')
                 || trimmed.ends_with('\'')
                 || trimmed.ends_with('"')
-                || trimmed.ends_with('`')
-            {
-                imports.push(import_lines.join("\n"));
-                current_import = None;
+                || trimmed.ends_with('`');
+            if closes {
+                if let Some((import_part, remainder)) = split_leading_import(trimmed) {
+                    import_lines.push(import_part.to_string());
+                    imports.push(import_lines.join("\n"));
+                    current_import = None;
+                    if !remainder.trim().is_empty() {
+                        rest.push_str(remainder);
+                        rest.push('\n');
+                    }
+                } else {
+                    import_lines.push(line.to_string());
+                    imports.push(import_lines.join("\n"));
+                    current_import = None;
+                }
+            } else {
+                import_lines.push(line.to_string());
             }
         } else {
             let trimmed = line.trim();
@@ -2042,7 +2055,21 @@ fn extract_imports_with_options(script: &str, strip_exports: bool) -> (Vec<Strin
                             || trimmed.ends_with('"')
                             || trimmed.ends_with('`')))
                 {
-                    imports.push(trimmed.to_string());
+                    // The line begins with a *complete* import statement. It may,
+                    // however, carry additional statements on the same physical
+                    // line (e.g. `import x from 'm'; const a = 1;`). Split the
+                    // import off and route the remainder through `rest` so those
+                    // trailing statements are transformed normally instead of
+                    // being swallowed into the import string.
+                    if let Some((import_part, remainder)) = split_leading_import(trimmed) {
+                        imports.push(import_part.to_string());
+                        if !remainder.trim().is_empty() {
+                            rest.push_str(remainder);
+                            rest.push('\n');
+                        }
+                    } else {
+                        imports.push(trimmed.to_string());
+                    }
                 } else {
                     current_import = Some(vec![line.to_string()]);
                 }
@@ -2067,6 +2094,62 @@ fn extract_imports_with_options(script: &str, strip_exports: bool) -> (Vec<Strin
     } else {
         (imports, rest)
     }
+}
+
+/// Split a `trimmed` line containing a leading/just-completed import statement
+/// into `(import_statement, remainder)` when the line carries additional code
+/// after the import terminator on the same physical line — e.g.
+/// `import x from 'm'; const a = 1;` → `("import x from 'm';", " const a = 1;")`.
+///
+/// Returns `None` when the whole line is just the import (nothing meaningful
+/// follows), so callers can keep their existing behaviour for that case.
+fn split_leading_import(trimmed: &str) -> Option<(&str, &str)> {
+    let end = import_statement_end(trimmed)?;
+    if end >= trimmed.len() {
+        return None;
+    }
+    let (import_part, remainder) = trimmed.split_at(end);
+    if remainder.trim().is_empty() {
+        None
+    } else {
+        Some((import_part, remainder))
+    }
+}
+
+/// Find the byte index at which the leading import statement in `s` ends.
+///
+/// String literals (single/double quotes and template backticks) are skipped
+/// honouring backslash escapes, so a `;` inside a module specifier is ignored.
+/// If a top-level `;` is found it terminates the statement (index just past it).
+/// Otherwise — ASI — the statement ends just past the last completed top-level
+/// string literal (the module specifier). Returns `None` if neither is present
+/// (incomplete import; let the caller fall back to its default handling).
+fn import_statement_end(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    let mut last_string_end: Option<usize> = None;
+    while i < bytes.len() {
+        match bytes[i] {
+            b';' => return Some(i + 1),
+            q @ (b'\'' | b'"' | b'`') => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == q {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                last_string_end = Some(i);
+            }
+            _ => i += 1,
+        }
+    }
+    last_string_end
 }
 
 /// Check whether `trimmed` is a complete *side-effect* import statement —

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -2033,8 +2033,11 @@ fn extract_imports_with_options(script: &str, strip_exports: bool) -> (Vec<Strin
                     import_lines.push(import_part.to_string());
                     imports.push(import_lines.join("\n"));
                     current_import = None;
+                    // The remainder may itself begin with further imports packed
+                    // on the same line; peel them all before routing the rest.
+                    let remainder = peel_leading_imports(remainder, &mut imports);
                     if !remainder.trim().is_empty() {
-                        rest.push_str(remainder);
+                        rest.push_str(&remainder);
                         rest.push('\n');
                     }
                 } else {
@@ -2056,19 +2059,16 @@ fn extract_imports_with_options(script: &str, strip_exports: bool) -> (Vec<Strin
                             || trimmed.ends_with('`')))
                 {
                     // The line begins with a *complete* import statement. It may,
-                    // however, carry additional statements on the same physical
-                    // line (e.g. `import x from 'm'; const a = 1;`). Split the
-                    // import off and route the remainder through `rest` so those
-                    // trailing statements are transformed normally instead of
-                    // being swallowed into the import string.
-                    if let Some((import_part, remainder)) = split_leading_import(trimmed) {
-                        imports.push(import_part.to_string());
-                        if !remainder.trim().is_empty() {
-                            rest.push_str(remainder);
-                            rest.push('\n');
-                        }
-                    } else {
-                        imports.push(trimmed.to_string());
+                    // however, carry additional imports and/or statements on the
+                    // same physical line (e.g. `import a from 'x';import b from
+                    // 'y';` or `import x from 'm'; const a = 1;`). Peel every
+                    // packed import so each is hoisted, then route any trailing
+                    // non-import code through `rest` so it is transformed normally
+                    // instead of being swallowed into the import string.
+                    let remainder = peel_leading_imports(trimmed, &mut imports);
+                    if !remainder.trim().is_empty() {
+                        rest.push_str(&remainder);
+                        rest.push('\n');
                     }
                 } else {
                     current_import = Some(vec![line.to_string()]);
@@ -2114,6 +2114,26 @@ fn split_leading_import(trimmed: &str) -> Option<(&str, &str)> {
     } else {
         Some((import_part, remainder))
     }
+}
+
+/// Peel every complete leading `import` statement off `s`, pushing each onto
+/// `imports`, and return the remaining tail (front-trimmed).
+///
+/// Handles several imports packed onto one physical line, e.g.
+/// `import a from 'x';import b from 'y';` → both hoisted, empty tail. Stops at
+/// the first non-import token or an *incomplete* import (one that continues on a
+/// following line) and returns it so the caller can route it.
+fn peel_leading_imports(s: &str, imports: &mut Vec<String>) -> String {
+    let mut cur = s.trim_start();
+    while cur.starts_with("import ") || cur.starts_with("import{") {
+        let Some(end) = import_statement_end(cur) else {
+            break;
+        };
+        let (import_part, remainder) = cur.split_at(end);
+        imports.push(import_part.trim().to_string());
+        cur = remainder.trim_start();
+    }
+    cur.to_string()
 }
 
 /// Find the byte index at which the leading import statement in `s` ends.

--- a/crates/rsvelte_core/tests/issue_969_single_line_import.rs
+++ b/crates/rsvelte_core/tests/issue_969_single_line_import.rs
@@ -98,3 +98,33 @@ fn server_derived_override_is_setter_call() {
         "derived override must not compile to `x() = 99`:\n{out}"
     );
 }
+
+// Two imports packed onto one physical line — both must be hoisted, not have
+// the second swallowed into `rest` (regression from the print/formatting corpus).
+const TWO_IMPORTS_ONE_LINE: &str = "<script>import { setLocale } from '$lib/x';import { m } from '$lib/y';</script><h1>{m.hi()}</h1>";
+
+#[test]
+fn server_two_imports_one_line_both_hoisted() {
+    let out = server(TWO_IMPORTS_ONE_LINE);
+    assert!(
+        out.contains("import { setLocale } from '$lib/x'"),
+        "first import missing:\n{out}"
+    );
+    assert!(
+        out.contains("import { m } from '$lib/y'"),
+        "second import missing/not hoisted:\n{out}"
+    );
+}
+
+#[test]
+fn client_two_imports_one_line_both_hoisted() {
+    let out = client(TWO_IMPORTS_ONE_LINE);
+    assert!(
+        out.contains("import { setLocale } from '$lib/x'"),
+        "first import missing:\n{out}"
+    );
+    assert!(
+        out.contains("import { m } from '$lib/y'"),
+        "second import missing/not hoisted:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/issue_969_single_line_import.rs
+++ b/crates/rsvelte_core/tests/issue_969_single_line_import.rs
@@ -1,0 +1,100 @@
+//! Regression tests for issue #969.
+//!
+//! When an `import` statement shared a single physical line with subsequent
+//! statements (e.g. `import { writable } from 'svelte/store'; const s = ...;`),
+//! the line-based import extractor in both the server and client transforms
+//! swallowed the whole line as one "import" string. As a result every
+//! statement after the import was emitted verbatim and never lowered — so a
+//! store auto-subscription write (`$s = true`) was left as an invalid
+//! assignment instead of becoming `$.store_set(s, true)`.
+//!
+//! The fix splits the leading import statement off the line and routes the
+//! remainder through the normal script-transform pipeline, matching the
+//! official compiler (which re-prints every statement on its own line).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn server(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Server,
+            ..Default::default()
+        },
+    )
+    .expect("compile server")
+    .js
+    .code
+}
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile client")
+    .js
+    .code
+}
+
+// Single physical line: import + store declaration + store write + read.
+const SINGLE_LINE_STORE: &str = "<script>import {writable} from 'svelte/store'; const s = writable(false); function g(){ $s = true; }</script><p>{$s}</p>";
+
+#[test]
+fn server_single_line_import_lowers_store_write() {
+    let out = server(SINGLE_LINE_STORE);
+    // The store write must become a `$.store_set` call, never an assignment
+    // to a `$.store_get(...)` member (which is an invalid assignment target).
+    assert!(
+        out.contains("$.store_set(s, true)"),
+        "expected `$.store_set(s, true)` in server output, got:\n{out}"
+    );
+    assert!(
+        !out.contains("$.store_get($$store_subs ??= {}, '$s', s) ="),
+        "store write must not compile to an assignment to `$.store_get(...)`:\n{out}"
+    );
+    // The trailing statements must not be swallowed into the import string.
+    assert!(
+        out.contains("const s = writable(false)"),
+        "expected the `const s` declaration to survive, got:\n{out}"
+    );
+}
+
+#[test]
+fn client_single_line_import_lowers_store_write() {
+    let out = client(SINGLE_LINE_STORE);
+    assert!(
+        out.contains("$.store_set(s, true)"),
+        "expected `$.store_set(s, true)` in client output, got:\n{out}"
+    );
+    assert!(
+        out.contains("const s = writable(false)"),
+        "expected the `const s` declaration to survive, got:\n{out}"
+    );
+    // The import must not carry trailing code along with it.
+    assert!(
+        !out.contains("import { writable } from 'svelte/store'; const s"),
+        "trailing statements must be split off the import line:\n{out}"
+    );
+}
+
+// $derived override on the server: `x = 99` must become a setter call `x(99)`,
+// never an assignment to a call expression (`x() = 99`).
+#[test]
+fn server_derived_override_is_setter_call() {
+    let src = "<script>let a = $state(1); let x = $derived(a); function f() { x = 99; }</script>";
+    let out = server(src);
+    assert!(
+        out.contains("x(99)"),
+        "expected derived override to compile to `x(99)`, got:\n{out}"
+    );
+    assert!(
+        !out.contains("x() = 99"),
+        "derived override must not compile to `x() = 99`:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #969 — invalid SSR/CSR codegen when an `import` statement shares a single physical line with subsequent statements.

### Root cause

`extract_imports` (server `helpers.rs` and client `mod.rs`) is line-based. When a line both starts with `import` and is a complete import (`import { writable } from 'svelte/store'; const s = writable(false); function g(){ $s = true; }`), the **entire line** was pushed as one import string. Everything after the import (`const s`, `function g`, the store write) was swallowed into that string and never run through the script-transform pipeline — so:

- the store auto-subscription write `$s = true` was left verbatim instead of becoming `$.store_set(s, true)`, and
- generally any rune/store lowering for statements following an inline import was skipped.

The two bugs in the issue:

- **Bug 1** (`$derived` override `x = 99` → `x(99)`): already handled correctly in the normal case; the only way it regressed was via this same single-line-import swallowing. Verified and covered by a regression test.
- **Bug 2** (`$store` write → `$.store_set`): already correct for multi-line scripts; the single-line-import case was the real trigger. Now fixed.
- **Bug 3** (bits-ui `watch(...)` parse failure under Rolldown): confirmed not a standalone codegen bug — the file compiles cleanly in isolation. Out of scope here; needs a separate build/preprocessing follow-up if it recurs.

### Fix

Added `import_statement_end`, which scans an import-bearing line honouring string literals/escapes to find where the import statement actually ends (its `;`, or under ASI the module-specifier string literal). `extract_imports` now splits the import off and routes the remainder of the line through `rest`, so trailing statements are transformed normally — matching the official compiler, which re-prints each statement on its own line. Applied on both the single-line path and the multi-line-import-closing-line path, in both the server and client transforms.

Server output for the repro now matches upstream byte-for-byte:

```js
function g() { $.store_set(s, true); }
```

### Tests

- New `crates/rsvelte_core/tests/issue_969_single_line_import.rs`: asserts the single-line store write lowers to `$.store_set(s, true)` (server + client) and the `$derived` override compiles to `x(99)` (never the invalid `x() = 99`).
- Full compatibility report stays at **3272/3272 (100%, 0 failures, 0 errors)**.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

### Files changed

- `crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs`
- `crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs`
- `crates/rsvelte_core/tests/issue_969_single_line_import.rs` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)