### PR TITLE
ci: partition test binaries across shards + drop fmt-corpus from shards (sub-5-min CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,18 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: true
+          submodules: false
+
+      # Shallow, selective submodule init instead of `submodules: true`: the
+      # shards only need `svelte` (build.rs version string + generated fixtures),
+      # `language-tools` (svelte2tsx + svelte-check golden tests), and
+      # `eslint-plugin-svelte` (the `eslint_plugin_oracle` fixtures; it soft-skips
+      # when absent, but we keep coverage). The big unused ones — typescript-go
+      # (~534 MB), vize, corsa-bind, and svelte.dev (only the now-removed
+      # fmt-corpus step read it) — are skipped, cutting checkout from ~45 s to
+      # ~15 s on the macOS runners.
+      - name: Checkout needed submodules (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte submodules/language-tools submodules/eslint-plugin-svelte
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,11 +285,13 @@ jobs:
         #
         # The script partitions the integration-test *binaries* across shards so
         # each compiles only its ~1/3 (the build, not the run, is the cost here —
-        # see the matrix comment and the script header). It also runs the lib /
-        # bin unit tests once (shard 1) and applies the dedicated-job exclusion
-        # filter. `generate_compatibility_report` is `#[ignore]`d (reporting-only)
-        # and covered by the `compatibility-report` job. nextest runs no doctests;
-        # this workspace has none.
+        # see the matrix comment and the script header) and applies the
+        # dedicated-job exclusion filter. `--lib` unit tests run in the separate
+        # `test-unit` job; the heavy fan-outs in `test-runtime` /
+        # `test-thread-safety` / `test-fmt-corpus`. `generate_compatibility_report`
+        # is `#[ignore]`d (reporting-only) and covered by the
+        # `compatibility-report` job. nextest runs no doctests; this workspace has
+        # none.
         run: bash scripts/ci/run-test-shard.sh ${{ matrix.shard }} 3
         timeout-minutes: 30
         env:
@@ -462,6 +464,51 @@ jobs:
         env:
           RUST_MIN_STACK: '33554432'
 
+  # The `--lib` (`#[cfg(test)]`) unit tests run here, isolated from the `test`
+  # shards (which now build integration-test *binaries* only — see
+  # scripts/ci/run-test-shard.sh). Folding the unit tests onto one shard made it
+  # build that shard's ~52 integration binaries *plus* every crate's unit-test
+  # binary at once, and the extra concurrent links exhausted the runner's memory
+  # (linker SIGBUS). A dedicated `--lib` job keeps the three shards uniform and
+  # links far fewer binaries here. `--bins` is intentionally omitted: no `[[bin]]`
+  # target has a `#[test]`, and `cargo clippy --all-targets` already compile-checks
+  # them. The unit tests are pure logic (no generated fixtures / Node / oxfmt), so
+  # — like test-thread-safety — only a shallow `svelte` submodule (build.rs version
+  # string) is needed.
+  test-unit:
+    name: Test unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: false
+
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Share (read-only) the `test` job's warm dependency cache.
+          shared-key: test
+          save-if: 'false'
+
+      - name: Run workspace unit tests
+        run: cargo nextest run --profile ci --lib
+        timeout-minutes: 15
+        env:
+          RUST_MIN_STACK: '33554432'
+
   # The two svelte.dev formatter-parity corpus tests (~100 s each: they format
   # every .svelte file + markdown code block from svelte.dev and diff against an
   # oxfmt oracle) are the bulk job's other long pole. Isolate them the same way:
@@ -549,7 +596,7 @@ jobs:
   # needs a protection-rule change. Fails if any of them failed or was cancelled.
   tests:
     name: Tests
-    needs: [test, test-runtime, test-thread-safety, test-fmt-corpus]
+    needs: [test, test-unit, test-runtime, test-thread-safety, test-fmt-corpus]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -558,15 +605,17 @@ jobs:
         shell: bash
         env:
           BULK: ${{ needs.test.result }}
+          UNIT: ${{ needs.test-unit.result }}
           RUNTIME: ${{ needs.test-runtime.result }}
           THREAD_SAFETY: ${{ needs.test-thread-safety.result }}
           FMT_CORPUS: ${{ needs.test-fmt-corpus.result }}
         run: |
           echo "test (shards): $BULK"
+          echo "test-unit: $UNIT"
           echo "test-runtime: $RUNTIME"
           echo "test-thread-safety: $THREAD_SAFETY"
           echo "test-fmt-corpus: $FMT_CORPUS"
-          if [[ "$BULK" != "success" || "$RUNTIME" != "success" || "$THREAD_SAFETY" != "success" || "$FMT_CORPUS" != "success" ]]; then
+          if [[ "$BULK" != "success" || "$UNIT" != "success" || "$RUNTIME" != "success" || "$THREAD_SAFETY" != "success" || "$FMT_CORPUS" != "success" ]]; then
             echo "::error::One or more test jobs did not succeed."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,38 +97,27 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-  # macOS is dropped from the PR matrix to keep PR feedback fast — it
-  # consistently runs ~2x slower than Linux for identical work and the
-  # platform-specific failure modes (PATH, line endings, dylib loading)
-  # are already covered by `rsvelte_capi` and the `Release` workflow.
-  # macOS still runs on every push to `main` and on demand via the
-  # `macos-ci` label, so regressions are caught before the next release.
-  set-test-matrix:
-    name: Set Test matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    outputs:
-      os: ${{ steps.matrix.outputs.os }}
-    steps:
-      - id: matrix
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "push" \
-                || "${{ contains(github.event.pull_request.labels.*.name, 'macos-ci') }}" == "true" ]]; then
-            echo 'os=["ubuntu-latest","macos-latest"]' >> "$GITHUB_OUTPUT"
-          else
-            echo 'os=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
-          fi
-
   test:
     name: Test
-    needs: set-test-matrix
+    # macOS is dropped from the PR matrix to keep PR feedback fast — it
+    # consistently runs ~2x slower than Linux for identical work and the
+    # platform-specific failure modes (PATH, line endings, dylib loading) are
+    # already covered by `rsvelte_capi` and the `Release` workflow. macOS still
+    # runs on every push to `main` and on demand via the `macos-ci` label, so
+    # regressions are caught before the next release.
+    #
+    # The OS list is computed inline rather than in a separate `set-test-matrix`
+    # job: that job added a full job's queue + startup (~1 min) to the serial
+    # path before any shard could begin. The expression below is evaluated at
+    # workflow-parse time, so the shards start immediately. (On a `push` event
+    # `github.event.pull_request` is null; `contains(null.*.name, …)` is a
+    # well-defined `false`, and the `push` term short-circuits anyway.)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(needs.set-test-matrix.outputs.os) }}
+        os: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'macos-ci')) && fromJSON('["ubuntu-latest","macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
         # This job runs the *fast bulk* of the suite, split across 3 runners.
         # The test *execution* is trivial (~8 s/shard); the wall time is almost
         # entirely compiling+linking the ~159 integration-test binaries against

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,37 +245,13 @@ jobs:
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Install oxfmt + svelte for the formatter parity corpus
-        # Isolated install (NOT the root lockfile) so the corpus oracle deps —
-        # oxfmt (a prebuilt native binding) plus a resolvable svelte for oxfmt's
-        # `svelte: true` (bundled prettier-plugin-svelte) — are available without
-        # pulling the root's esbuild/@parcel/watcher, whose build scripts trip
-        # pnpm's ERR_PNPM_IGNORED_BUILDS gate. Versions pinned to the repo's so
-        # the oracle stays deterministic. Used via OXFMT_BIN / FMT_CORPUS_OXFMT.
-        run: |
-          mkdir -p "$RUNNER_TEMP/fmt-oracle"
-          cd "$RUNNER_TEMP/fmt-oracle"
-          npm init -y >/dev/null
-          npm i --ignore-scripts oxfmt@0.53.0 svelte@5.56.2
-          ./node_modules/.bin/oxfmt --version
-
-      - name: Resolve svelte.dev submodule SHA
-        id: svelte-dev-sha
-        shell: bash
-        run: echo "sha=$(git submodule status submodules/svelte.dev | awk '{print $1}' | sed 's/^[+-]//')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache formatter parity corpus
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          # Oracle outputs keyed on the svelte.dev SHA + the canonical config.
-          path: fixtures/fmt-corpus
-          key: fmt-corpus-v1-${{ runner.os }}-${{ steps.svelte-dev-sha.outputs.sha }}-${{ hashFiles('scripts/fixtures/fmt-corpus.oxfmtrc.json') }}
-
-      - name: Generate formatter parity corpus
-        run: pnpm run generate-fmt-corpus
-        timeout-minutes: 15
-        env:
-          OXFMT_BIN: ${{ runner.temp }}/fmt-oracle/node_modules/.bin/oxfmt
+      # NOTE: the oxfmt install + svelte.dev formatter-parity corpus generation
+      # (~130 s on a cold macOS runner) used to live here, but the only tests
+      # that consume `fixtures/fmt-corpus` / `FMT_CORPUS_OXFMT` are
+      # `svelte_dev_corpus` / `svelte_dev_markdown` — both excluded from these
+      # shards and run in the dedicated `test-fmt-corpus` job, which generates
+      # the corpus itself. Generating it here was pure overhead (and a frequent
+      # cold-cache stall on the infrequently-run macOS shards), so it's removed.
 
       - name: Run tests
         # Default features only: `--all-features` would enable `napi`, which only
@@ -306,8 +282,6 @@ jobs:
           # error and bails out before emitting the user-source diagnostics
           # the golden test verifies.
           TSGO_BIN: ${{ github.workspace }}/submodules/svelte/node_modules/.bin/tsc
-          # oxfmt launcher for the svelte.dev corpus tests' <style> / CLI paths.
-          FMT_CORPUS_OXFMT: ${{ runner.temp }}/fmt-oracle/node_modules/.bin/oxfmt
 
       - name: Collect failure artifacts
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,19 +129,24 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.set-test-matrix.outputs.os) }}
-        # This job runs the *fast bulk* of the suite, split across 3 runners with
-        # nextest's count partitioning. The heaviest single `#[test]` functions —
-        # each fans out over 1000+ fixtures internally (runtime legacy/runes, the
-        # compile_module thread-safety stress test, and the two svelte.dev fmt
-        # corpus parity tests at ~100 s each) — are excluded here (see the
-        # `Run tests` filter) and run in their own dedicated jobs (`test-runtime`,
-        # `test-thread-safety`, `test-fmt-corpus`) that compile only their own
-        # test binary, so their long execution floors don't sit behind this job's
-        # full ~2 min workspace build. count-partitioning is weight-blind, so
-        # keeping the heavy tests out is what makes these shards balanced. Every
-        # test still runs (here or in a dedicated job) with full iteration counts
-        # — coverage is unchanged. The `Tests` gate job joins them into one
-        # required status check.
+        # This job runs the *fast bulk* of the suite, split across 3 runners.
+        # The test *execution* is trivial (~8 s/shard); the wall time is almost
+        # entirely compiling+linking the ~159 integration-test binaries against
+        # the large `rsvelte_core` rlib. `cargo nextest run` builds *every*
+        # binary regardless of which tests a `-E` filter runs, so the old
+        # count-partition (split the *run*, build everything 3×) left the build
+        # floor — the real bottleneck — paid three times over.
+        #
+        # `scripts/ci/run-test-shard.sh` instead partitions the *binaries* across
+        # shards (cargo target selection from the authoritative `cargo metadata`
+        # list), so each shard compiles only its ~1/3 and the per-shard build
+        # floor drops roughly 3×. The heaviest single `#[test]` functions — each
+        # fans out over 1000+ fixtures internally (runtime legacy/runes, the
+        # compile_module thread-safety stress test, the two svelte.dev fmt corpus
+        # parity tests at ~100 s each) — still run in their own dedicated jobs
+        # (`test-runtime`, `test-thread-safety`, `test-fmt-corpus`). Coverage is
+        # unchanged: every test runs in exactly one shard or dedicated job. The
+        # `Tests` gate job joins them into one required status check.
         shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -273,25 +278,19 @@ jobs:
           OXFMT_BIN: ${{ runner.temp }}/fmt-oracle/node_modules/.bin/oxfmt
 
       - name: Run tests
-        # `--all-features` would enable `napi`, which only links cleanly when
-        # loaded from Node.js — `cargo test` would otherwise hit `rust-lld:
-        # error: undefined symbol: napi_*` on Linux. Default features cover
-        # everything we want exercised in CI (native runtime, parallelism).
+        # Default features only: `--all-features` would enable `napi`, which only
+        # links cleanly when loaded from Node.js (`cargo test` would otherwise hit
+        # `rust-lld: error: undefined symbol: napi_*` on Linux). Default features
+        # cover everything we exercise in CI (native runtime, parallelism).
         #
-        # nextest schedules all tests across all binaries in one pool (vs
-        # `cargo test`'s serial per-binary harness). The `generate_compatibility_report`
-        # test is `#[ignore]`d (reporting-only, re-runs the whole suite) and is
-        # covered by the dedicated `compatibility-report` job below, so it stays
-        # out of this run. nextest does not run doctests; this workspace has none.
-        #
-        # The heavy fan-out tests are excluded and run in their own jobs
-        # (`test-runtime`, `test-thread-safety`, `test-fmt-corpus`).
-        # `--partition count:<shard>/3` then splits the remaining
-        # (uniform-weight) tests evenly across the 3 shards.
-        run: >-
-          cargo nextest run --profile ci
-          -E 'not (test(/test_runtime_legacy/) | test(/test_runtime_runes/) | test(/compile_module_is_thread_safe_under_reuse/) | binary(svelte_dev_markdown) | binary(svelte_dev_corpus))'
-          --partition count:${{ matrix.shard }}/3
+        # The script partitions the integration-test *binaries* across shards so
+        # each compiles only its ~1/3 (the build, not the run, is the cost here —
+        # see the matrix comment and the script header). It also runs the lib /
+        # bin unit tests once (shard 1) and applies the dedicated-job exclusion
+        # filter. `generate_compatibility_report` is `#[ignore]`d (reporting-only)
+        # and covered by the `compatibility-report` job. nextest runs no doctests;
+        # this workspace has none.
+        run: bash scripts/ci/run-test-shard.sh ${{ matrix.shard }} 3
         timeout-minutes: 30
         env:
           # Some fixtures (notably the compatibility_report harness) walk

--- a/scripts/ci/run-test-shard.sh
+++ b/scripts/ci/run-test-shard.sh
@@ -20,13 +20,21 @@
 # is total by construction (no binary is silently dropped) and automatically
 # absorbs newly added `tests/*.rs` files with no edits here.
 #
+# IMPORTANT: all of a shard's targets are selected in a SINGLE `cargo nextest
+# run`. Splitting them across several `cargo` invocations (e.g. one per package)
+# makes cargo re-resolve features per invocation and rebuild shared dependencies
+# (the oxc graph) between them — feature thrashing that is dramatically *slower*
+# than building everything once. Test-target names are unique across the
+# workspace (checked: `… | sort | uniq -d` is empty), so a single invocation
+# listing every `-p`/`--test` has no cross-crate `--test NAME` ambiguity.
+#
 # Coverage is identical to the previous count-partitioned job: every test that
 # ran before still runs in exactly one shard, and the heavy fan-out suites keep
 # running in their dedicated jobs (see the exclusion list / RUN_FILTER below).
 #
 # Portability: must run on the GitHub macOS runners' stock /bin/bash 3.2, so no
 # `declare -A` / `mapfile` (bash 4+) and no `grep -P` (absent on BSD grep) — the
-# partition + grouping is done in awk.
+# partition is done in awk.
 #
 # Usage: run-test-shard.sh <shard 1-based> <total shards>
 set -euo pipefail
@@ -61,28 +69,35 @@ fi
 # This shard's targets: 0-based stable index, modulo partition.
 MINE="$(printf '%s\n' "$ALL_TARGETS" | awk -v s="$SHARD" -v t="$TOTAL" '(NR-1) % t == s-1')"
 
-echo "::group::Shard ${SHARD}/${TOTAL} target assignment"
-printf '%s\n' "$MINE"
-[ "$SHARD" -eq 1 ] && echo "(+ workspace --lib --bins unit tests)"
-echo "::endgroup::"
-
-rc=0
-
-# Run each package's slice in its own invocation: this avoids cross-crate
-# `--test NAME` ambiguity (a name present in two crates would otherwise build in
-# both), and the shared target dir means each crate lib still compiles once and
-# is reused across invocations. `|| rc=1` preserves the suite's "surface every
-# failure" behaviour across packages rather than bailing on the first.
+# Assemble a single cargo nextest invocation. `--test <name>` selects integration
+# targets; the `-p` set scopes them. Names are workspace-unique, so listing every
+# package the shard touches is unambiguous.
+ARGS=""
+for name in $(printf '%s\n' "$MINE" | cut -f2); do
+  ARGS="$ARGS --test $name"
+done
 for pkg in $(printf '%s\n' "$MINE" | cut -f1 | sort -u); do
-  args="$(printf '%s\n' "$MINE" | awk -F'\t' -v p="$pkg" '$1==p{printf " --test %s", $2}')"
-  # shellcheck disable=SC2086 -- intentional word-splitting of the --test list
-  cargo nextest run --profile ci -p "$pkg" $args -E "$RUN_FILTER" || rc=1
+  ARGS="$ARGS -p $pkg"
 done
 
-# Unit tests (`--lib` / `--bins` `#[cfg(test)]` modules across every crate) run
-# once, on shard 1, so they aren't duplicated across shards.
+# Unit tests (`--lib` / `--bins` `#[cfg(test)]` modules) run once, on shard 1.
+# `--lib`/`--bins` apply to the selected `-p` packages, so shard 1 must scope
+# every workspace package to cover all crates' unit tests.
 if [ "$SHARD" -eq 1 ]; then
-  cargo nextest run --profile ci --lib --bins -E "$RUN_FILTER" || rc=1
+  ARGS="$ARGS --lib --bins"
+  for pkg in $(
+    cargo metadata --no-deps --format-version 1 \
+      | jq -r '.packages[] | select(.targets[].kind | index("test")) | .name' | sort -u
+  ); do
+    case " $ARGS " in *" -p $pkg "*) : ;; *) ARGS="$ARGS -p $pkg" ;; esac
+  done
 fi
 
-exit "$rc"
+echo "::group::Shard ${SHARD}/${TOTAL} selection"
+printf '%s\n' "$MINE"
+[ "$SHARD" -eq 1 ] && echo "(+ workspace --lib --bins unit tests)"
+echo "cargo nextest run --profile ci$ARGS -E '$RUN_FILTER'"
+echo "::endgroup::"
+
+# shellcheck disable=SC2086 -- intentional word-splitting of the assembled args
+exec cargo nextest run --profile ci $ARGS -E "$RUN_FILTER"

--- a/scripts/ci/run-test-shard.sh
+++ b/scripts/ci/run-test-shard.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Build + run one CI `test` shard's slice of the suite.
+#
+# Why this exists
+# ---------------
+# `cargo nextest run` always *builds* every workspace test binary, regardless of
+# which tests a `-E` filter selects to *run*. This workspace links ~159 separate
+# integration-test binaries against the large `rsvelte_core` rlib, and a push
+# that touches `rsvelte_core` recompiles all of them — so on a CI runner the
+# build is ~95% of each shard's wall time (the test *run* itself is ~8 s).
+# Count-partitioning (`--partition count:N/3`) splits the *run* evenly but every
+# shard still builds all 159 binaries, so the build floor — the actual
+# bottleneck — was paid three times over.
+#
+# Instead we partition the *binaries* across shards by cargo target selection:
+# each shard compiles only its ~1/Nth of the integration-test targets, cutting
+# the per-shard build floor roughly N-fold. The partition is derived from
+# `cargo metadata`'s authoritative target list via a stable sort + modulo, so it
+# is total by construction (no binary is silently dropped) and automatically
+# absorbs newly added `tests/*.rs` files with no edits here.
+#
+# Coverage is identical to the previous count-partitioned job: every test that
+# ran before still runs in exactly one shard, and the heavy fan-out suites keep
+# running in their dedicated jobs (see the exclusion list / RUN_FILTER below).
+#
+# Portability: must run on the GitHub macOS runners' stock /bin/bash 3.2, so no
+# `declare -A` / `mapfile` (bash 4+) and no `grep -P` (absent on BSD grep) — the
+# partition + grouping is done in awk.
+#
+# Usage: run-test-shard.sh <shard 1-based> <total shards>
+set -euo pipefail
+
+SHARD="${1:?usage: run-test-shard.sh <shard 1-based> <total>}"
+TOTAL="${2:?usage: run-test-shard.sh <shard 1-based> <total>}"
+
+# Heavy `#[test]` functions that run in a dedicated job but live in a binary we
+# still build here for its lighter siblings: the `runtime` binary's hydration /
+# browser / listing tests run in the shards, while its two 1000+-fixture
+# fan-outs run in "Test runtime". Excluding by name is a no-op on shards that
+# don't build `runtime`, so the same filter is safe to pass to every shard.
+RUN_FILTER='not (test(/test_runtime_legacy/) | test(/test_runtime_runes/) | test(/compile_module_is_thread_safe_under_reuse/))'
+
+# "<pkg>\t<name>" for every integration-test target, minus the binaries that are
+# built+run wholesale in their own dedicated jobs (and have no lighter siblings
+# we need here): compile_module_thread_safety -> "Test thread-safety";
+# svelte_dev_corpus / svelte_dev_markdown -> "Test fmt corpus". Stably sorted so
+# the modulo partition is deterministic across shards.
+ALL_TARGETS="$(
+  cargo metadata --no-deps --format-version 1 \
+    | jq -r '.packages[] as $p | $p.targets[] | select(.kind | index("test")) | "\($p.name)\t\(.name)"' \
+    | awk -F'\t' '$2 != "compile_module_thread_safety" && $2 != "svelte_dev_corpus" && $2 != "svelte_dev_markdown"' \
+    | sort
+)"
+
+if [ -z "$ALL_TARGETS" ]; then
+  echo "::error::no integration-test targets found via cargo metadata" >&2
+  exit 1
+fi
+
+# This shard's targets: 0-based stable index, modulo partition.
+MINE="$(printf '%s\n' "$ALL_TARGETS" | awk -v s="$SHARD" -v t="$TOTAL" '(NR-1) % t == s-1')"
+
+echo "::group::Shard ${SHARD}/${TOTAL} target assignment"
+printf '%s\n' "$MINE"
+[ "$SHARD" -eq 1 ] && echo "(+ workspace --lib --bins unit tests)"
+echo "::endgroup::"
+
+rc=0
+
+# Run each package's slice in its own invocation: this avoids cross-crate
+# `--test NAME` ambiguity (a name present in two crates would otherwise build in
+# both), and the shared target dir means each crate lib still compiles once and
+# is reused across invocations. `|| rc=1` preserves the suite's "surface every
+# failure" behaviour across packages rather than bailing on the first.
+for pkg in $(printf '%s\n' "$MINE" | cut -f1 | sort -u); do
+  args="$(printf '%s\n' "$MINE" | awk -F'\t' -v p="$pkg" '$1==p{printf " --test %s", $2}')"
+  # shellcheck disable=SC2086 -- intentional word-splitting of the --test list
+  cargo nextest run --profile ci -p "$pkg" $args -E "$RUN_FILTER" || rc=1
+done
+
+# Unit tests (`--lib` / `--bins` `#[cfg(test)]` modules across every crate) run
+# once, on shard 1, so they aren't duplicated across shards.
+if [ "$SHARD" -eq 1 ]; then
+  cargo nextest run --profile ci --lib --bins -E "$RUN_FILTER" || rc=1
+fi
+
+exit "$rc"

--- a/scripts/ci/run-test-shard.sh
+++ b/scripts/ci/run-test-shard.sh
@@ -72,6 +72,13 @@ MINE="$(printf '%s\n' "$ALL_TARGETS" | awk -v s="$SHARD" -v t="$TOTAL" '(NR-1) %
 # Assemble a single cargo nextest invocation. `--test <name>` selects integration
 # targets; the `-p` set scopes them. Names are workspace-unique, so listing every
 # package the shard touches is unambiguous.
+#
+# Only integration-test *binaries* are partitioned here. The `--lib` / `--bins`
+# `#[cfg(test)]` unit tests run in their own `test-unit` job — folding them onto
+# one shard made that shard link its ~52 integration binaries *plus* every
+# crate's unit-test binary at once, and the extra concurrent links exhausted the
+# runner's memory (linker SIGBUS). Keeping the shards integration-only makes all
+# three uniform (~52 binaries each, the load shards 2/3 already linked cleanly).
 ARGS=""
 for name in $(printf '%s\n' "$MINE" | cut -f2); do
   ARGS="$ARGS --test $name"
@@ -80,22 +87,8 @@ for pkg in $(printf '%s\n' "$MINE" | cut -f1 | sort -u); do
   ARGS="$ARGS -p $pkg"
 done
 
-# Unit tests (`--lib` / `--bins` `#[cfg(test)]` modules) run once, on shard 1.
-# `--lib`/`--bins` apply to the selected `-p` packages, so shard 1 must scope
-# every workspace package to cover all crates' unit tests.
-if [ "$SHARD" -eq 1 ]; then
-  ARGS="$ARGS --lib --bins"
-  for pkg in $(
-    cargo metadata --no-deps --format-version 1 \
-      | jq -r '.packages[] | select(.targets[].kind | index("test")) | .name' | sort -u
-  ); do
-    case " $ARGS " in *" -p $pkg "*) : ;; *) ARGS="$ARGS -p $pkg" ;; esac
-  done
-fi
-
 echo "::group::Shard ${SHARD}/${TOTAL} selection"
 printf '%s\n' "$MINE"
-[ "$SHARD" -eq 1 ] && echo "(+ workspace --lib --bins unit tests)"
 echo "cargo nextest run --profile ci$ARGS -E '$RUN_FILTER'"
 echo "::endgroup::"
 


### PR DESCRIPTION
## Goal
Get `main`'s CI comfortably under 5 minutes. (The deploy-docs/wasm regression
from #1008 was fixed independently by #1029, so this PR is CI-speed only.)

## Root cause
The `test` job's wall time is ~95% **compiling/linking the ~159 integration-test
binaries** against the big `rsvelte_core` rlib — the test *execution* is only
~8 s/shard. `cargo nextest run` builds *every* binary regardless of the `-E`
run filter, so the old `--partition count:<shard>/3` split the *run* but every
shard still rebuilt all 159 binaries. On macOS (infrequent → cold caches) the
shards also paid ~78 s to build the Svelte compiler and **~134 s to generate the
fmt-corpus** that the shards don't even use, pushing the legs past 8 minutes.

## Changes
1. **Partition the binaries, not just the run** (`scripts/ci/run-test-shard.sh`):
   stable-sorted modulo over the `cargo metadata` target list → each shard
   compiles only its ~1/3 (total by construction; auto-absorbs new `tests/*.rs`).
   One `cargo nextest run` per shard (workspace-unique test names, no `-p`
   ambiguity). The 3 dedicated-job binaries are skipped at build time.
2. **Dedicated `test-unit` job** for `--lib` unit tests, so no shard links its
   integration binaries *plus* every crate's unit-test binary at once (that
   overloaded the linker → SIGBUS). `--bins` dropped (no bin has a `#[test]`;
   clippy `--all-targets` compile-checks them).
3. **Drop fmt-corpus generation from the shards** — only `svelte_dev_corpus` /
   `svelte_dev_markdown` (both excluded, run in `test-fmt-corpus`) consume it.

## Result (PR run, full macOS matrix)
ubuntu shards ~2.7-3 m, macOS shards (cold) down from ~9 m. Coverage identical:
every test runs in exactly one shard or its existing dedicated job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)