### PR TITLE
fix(svelte2tsx): keep instance export decls + component generics in scope (#963, #964)

### DIFF
--- a/.changeset/fix-instance-export-and-generics-scope.md
+++ b/.changeset/fix-instance-export-and-generics-scope.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Fix two `--tsgo` / svelte-check overlay scoping bugs where an instance-`<script>`
+type declaration was relocated out of the scope where the rest of the script
+referenced it, producing spurious "Cannot find name" errors (official
+svelte-check reports 0 errors):
+
+- #963: an instance `export type` / `export interface` referenced by a hoisted
+  `Props` interface is now registered as a hoist candidate (with its `export`
+  keyword preserved) so it travels with the interface and stays in scope.
+- #964: a local generic `type` alias no longer knocks the component's
+  `generics=` parameters out of scope. Hoisting is now gated on the props
+  interface itself being hoistable (mirroring upstream
+  `HoistableInterfaces.moveHoistableInterfaces`); when it references a component
+  generic, nothing is hoisted out of `function $$render<…>()`, keeping the
+  generics in scope for local aliases.

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -1091,6 +1091,50 @@ pub fn process_instance_script(
                                     exported_names.set_uses_runes(true);
                                 }
                             }
+                            // `export type X = ...` / `export interface X { ... }`.
+                            //
+                            // In TypeScript these are still TypeAliasDeclaration /
+                            // InterfaceDeclaration nodes (the `export` is just a
+                            // modifier), so official svelte2tsx
+                            // (`HoistableInterfaces.analyzeInstanceScriptNode`)
+                            // treats them exactly like their non-exported forms —
+                            // they become hoist candidates and `instance_type_names`
+                            // entries. OXC instead wraps them in an
+                            // `ExportNamedDeclaration`, so we have to unwrap and
+                            // register the inner declaration here. Without this an
+                            // exported type that another (hoisted) interface depends
+                            // on stays trapped inside `$$render()` and goes out of
+                            // scope (#963).
+                            //
+                            // The candidate span starts at the `export` keyword so
+                            // the modifier travels with the declaration when it is
+                            // moved above `$$render()`, preserving the component's
+                            // public type surface.
+                            oxc::Declaration::TSTypeAliasDeclaration(type_alias) => {
+                                let name = type_alias.id.name.to_string();
+                                exported_names.instance_type_names.insert(name.clone());
+                                if !is_special_type_name(&name) {
+                                    candidates.push(HoistCandidate {
+                                        name,
+                                        rel_start: export.span.start,
+                                        rel_end: type_alias.span.end,
+                                    });
+                                }
+                            }
+                            oxc::Declaration::TSInterfaceDeclaration(iface) => {
+                                let name = iface.id.name.to_string();
+                                exported_names.instance_type_names.insert(name.clone());
+                                if !is_special_type_name(&name) {
+                                    candidates.push(HoistCandidate {
+                                        name,
+                                        rel_start: export.span.start,
+                                        rel_end: iface.span.end,
+                                    });
+                                }
+                                if is_dts_mode {
+                                    rewrite_interface_to_type_dts(iface, raw_content, offset, str);
+                                }
+                            }
                             _ => {}
                         }
                     }
@@ -1310,13 +1354,39 @@ pub fn process_instance_script(
         // including the early-exit `if (!this.props_interface.name) return;`
         // — without a `$props()` typed annotation there's nothing for the
         // hoisted types to feed, so we leave them in place.
-        if props_rune_info.is_some() {
+        if let Some(ref info) = props_rune_info {
+            // Determine the props-interface for gating. Mirrors official
+            // `HoistableInterfaces.analyze$propsRune` / `moveHoistableInterfaces`:
+            // when the `$props()` annotation is a bare named reference
+            // (`: Props`), that interface IS the props interface; otherwise the
+            // synthetic `$$ComponentProps` (built from the inline annotation) is.
+            // Either way, NOTHING is hoisted unless the props interface itself is
+            // hoistable — see `resolve_hoistable_type_decls`.
+            let props_named_ref: Option<String> = if info.is_named_type_reference {
+                info.type_text.as_ref().map(|t| {
+                    // `Props` or `Props<T>` → root name `Props`.
+                    t.split(|ch: char| !is_ident_char_for_str(ch))
+                        .find(|s| !s.is_empty())
+                        .unwrap_or("")
+                        .to_string()
+                })
+            } else {
+                None
+            };
+            let props_inline_type: Option<&str> =
+                if info.is_named_type_reference || !info.has_type_annotation {
+                    None
+                } else {
+                    info.type_text.as_deref()
+                };
             resolve_hoistable_type_decls(
                 &candidates,
                 raw_content,
                 offset,
                 exported_names,
                 script_generic_names,
+                props_named_ref.as_deref(),
+                props_inline_type,
             );
         }
 
@@ -1994,6 +2064,13 @@ fn resolve_hoistable_type_decls(
     offset: u32,
     exported_names: &mut ExportedNames,
     script_generic_names: &HashSet<String>,
+    // Name of the props interface when `$props()` is annotated with a bare named
+    // reference (`: Props` → `Some("Props")`).
+    props_named_ref: Option<&str>,
+    // The inline `$props()` annotation text when it is NOT a bare named reference
+    // (e.g. `: { item: Wrapper<L> }`). Used to build the synthetic
+    // `$$ComponentProps` props-interface dependency set.
+    props_inline_type: Option<&str>,
 ) {
     if candidates.is_empty() {
         return;
@@ -2169,6 +2246,86 @@ fn resolve_hoistable_type_decls(
                 progress = true;
             }
         }
+    }
+
+    // Gate the entire move on the props interface being hoistable. Mirrors
+    // `HoistableInterfaces.moveHoistableInterfaces`, which only moves anything
+    // when `hoistable.has(this.props_interface.name)` — if the props interface
+    // can't be hoisted (e.g. it references a `<script generics=...>` parameter),
+    // NOTHING is moved and every type/interface stays inside `function
+    // $$render<...>()` so the generic parameters remain in scope (#964).
+    let props_interface_hoistable = if let Some(named) = props_named_ref {
+        // Bare `: Props` reference. The props interface is the candidate named
+        // `Props`; it's hoistable iff that candidate was promoted.
+        candidates
+            .iter()
+            .position(|c| c.name == named)
+            .map(|idx| hoistable[idx])
+            // A named ref that isn't a local candidate (e.g. an imported type)
+            // doesn't constrain hoisting — nothing of ours references a generic
+            // through it, so fall back to "hoistable" and let per-candidate
+            // analysis decide.
+            .unwrap_or(true)
+    } else if let Some(inline) = props_inline_type {
+        // Synthetic `$$ComponentProps` built from the inline annotation. It's
+        // hoistable iff every type dependency is a hoistable candidate (or an
+        // outside reference such as an import) AND it doesn't reference a
+        // `<script generics=...>` parameter and has no disallowed value deps.
+        let (value_deps, type_deps) = collect_type_body_deps(
+            inline,
+            &candidate_names,
+            // No self-name for the synthetic interface.
+            "",
+            // No own generics on the synthetic props interface.
+            &HashSet::new(),
+            &exported_names.instance_value_names,
+            &exported_names.instance_import_names,
+        );
+        let mut ok = true;
+        // Generic references make the synthetic props interface non-hoistable.
+        if !script_generic_names.is_empty() {
+            for g in script_generic_names.iter() {
+                if has_whole_ident(inline, g) {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if ok {
+            for dep in &type_deps {
+                if let Some(idx) = candidates.iter().position(|c| &c.name == dep)
+                    && (blocked[idx] || !hoistable[idx])
+                {
+                    ok = false;
+                    break;
+                }
+                // A type dep that isn't a local candidate is an outside
+                // reference (import / global) — fine to reference from a hoisted
+                // declaration.
+            }
+        }
+        if ok {
+            for v in &value_deps {
+                let resolved: &str = v.strip_prefix('$').filter(|s| !s.is_empty()).unwrap_or(v);
+                let in_instance_value = exported_names.instance_value_names.contains(resolved);
+                let in_instance_import = exported_names.instance_import_names.contains(resolved);
+                let in_module = exported_names.module_value_names.contains(resolved)
+                    || exported_names.module_import_names.contains(resolved);
+                if in_instance_value && !in_instance_import && !in_module {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        ok
+    } else {
+        // Whole-object / untyped `$props()` — no props interface to gate on, so
+        // preserve the previous behaviour of hoisting per-candidate.
+        true
+    };
+
+    if !props_interface_hoistable {
+        return;
     }
 
     let raw_bytes = raw_content.as_bytes();
@@ -2693,7 +2850,19 @@ fn handle_export_named_decl(
 
         // For instance scripts: remove the 'export ' keyword (replace with space).
         // For module scripts: keep the 'export' keyword (it's a real module export).
-        if is_instance && decl_start > node_start {
+        //
+        // Type-only declarations (`export type X` / `export interface X`) are the
+        // exception: official svelte2tsx keeps their `export` keyword (they're
+        // moved verbatim by `HoistableInterfaces` and re-surface as part of the
+        // component's type API), so stripping it here would both diverge from
+        // upstream and, once the declaration is hoisted above `$$render()`,
+        // leave a dangling space. Skip the strip for those.
+        let is_type_only_decl = matches!(
+            decl,
+            oxc::Declaration::TSTypeAliasDeclaration(_)
+                | oxc::Declaration::TSInterfaceDeclaration(_)
+        );
+        if is_instance && !is_type_only_decl && decl_start > node_start {
             str.overwrite(node_start, decl_start, " ");
         }
 

--- a/crates/rsvelte_core/tests/svelte2tsx_instance_scope_963_964.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_instance_scope_963_964.rs
@@ -1,0 +1,127 @@
+//! Regression tests for the `--tsgo` / svelte-check overlay scoping bugs
+//! #963 and #964. Both were cases where the TSX overlay relocated an
+//! instance-`<script>` type declaration out of the scope where the rest of the
+//! script referenced it, so a name went out of scope and tsgo reported a
+//! spurious "Cannot find name" error. Official svelte-check reports 0 errors
+//! for every component below.
+//!
+//! The assertions check the structural property that makes tsgo resolve the
+//! names — i.e. the overlay matches official svelte2tsx's scoping strategy
+//! (`HoistableInterfaces.moveHoistableInterfaces`):
+//!   * a hoisted interface's type dependencies are hoisted with it (#963), and
+//!   * nothing is hoisted out of `function $$render<...>()` when the props
+//!     interface references a component `generics=` parameter, so the generic
+//!     parameters stay in scope for local type aliases (#964).
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(name: &str, src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: format!("{name}.svelte"),
+        is_ts_file: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+/// Byte index of `function $$render` in the overlay — the boundary between
+/// module scope (before) and the render-function body (after).
+fn render_start(code: &str) -> usize {
+    code.find("function $$render")
+        .unwrap_or_else(|| panic!("no $$render in:\n{code}"))
+}
+
+/// #963: an instance `export type` that a hoisted interface depends on must be
+/// hoisted with it (i.e. kept in scope), and its `export` keyword preserved.
+#[test]
+fn issue_963_exported_type_referenced_by_props_interface_stays_in_scope() {
+    let src = "<script lang=\"ts\">\n  export type Phase = 'a' | 'b';\n  interface Props { phase: Phase }\n  let { phase }: Props = $props();\n  const labels: Record<Phase, string> = { a: 'A', b: 'B' };\n</script>\n<span>{labels[phase]}</span>\n";
+    let code = convert("Issue963", src);
+    let render = render_start(&code);
+
+    // `export type Phase` is hoisted ABOVE `$$render` (so the also-hoisted
+    // `interface Props` that references it can see it) and keeps its `export`.
+    let phase_pos = code
+        .find("export type Phase")
+        .unwrap_or_else(|| panic!("Phase export dropped:\n{code}"));
+    assert!(
+        phase_pos < render,
+        "`export type Phase` must be hoisted before $$render:\n{code}"
+    );
+
+    // `interface Props` is also above `$$render` and AFTER `Phase` (dependency
+    // ordering — a type lands before the interface that depends on it).
+    let props_pos = code
+        .find("interface Props")
+        .unwrap_or_else(|| panic!("no interface Props:\n{code}"));
+    assert!(
+        props_pos < render && phase_pos < props_pos,
+        "`Phase` must precede `interface Props`, both before $$render:\n{code}"
+    );
+}
+
+/// #964: a local generic `type` alias must not displace the component
+/// `generics=` parameters. Because the props interface references `L`, nothing
+/// is hoisted out of `$$render<L>()`, so both `L` and the alias's own `<A>`
+/// coexist.
+#[test]
+fn issue_964_local_generic_alias_keeps_component_generics_in_scope() {
+    let src = "<script lang=\"ts\" generics=\"L\">\n  type Wrapper<A> = { value: A };\n  let { item }: { item: Wrapper<L> } = $props();\n</script>\n<span>{item.value}</span>\n";
+    let code = convert("Issue964", src);
+    let render = render_start(&code);
+
+    // The render function is generic over `L`.
+    assert!(
+        code.contains("function $$render<L>"),
+        "render function must be generic over L:\n{code}"
+    );
+
+    // The local alias stays INSIDE $$render<L>() (not hoisted to module scope).
+    let wrapper_pos = code
+        .find("type Wrapper<A>")
+        .unwrap_or_else(|| panic!("no Wrapper alias:\n{code}"));
+    assert!(
+        wrapper_pos > render,
+        "`type Wrapper<A>` must stay inside $$render:\n{code}"
+    );
+
+    // The synthetic props type referencing `L` also stays INSIDE $$render<L>().
+    let cp_pos = code
+        .find("type $$ComponentProps")
+        .unwrap_or_else(|| panic!("no $$ComponentProps:\n{code}"));
+    assert!(
+        cp_pos > render,
+        "`type $$ComponentProps` referencing L must stay inside $$render:\n{code}"
+    );
+    assert!(
+        code.contains("Wrapper<L>"),
+        "props type must reference Wrapper<L>:\n{code}"
+    );
+}
+
+/// #964 two-parameter variant: `generics="L, R"` + local `type Q<A, B>`.
+#[test]
+fn issue_964_two_param_generics_with_local_alias() {
+    let src = "<script lang=\"ts\" generics=\"L, R\">\n  type Q<A, B> = { a: A; b: B };\n  let { q }: { q: Q<L, R> } = $props();\n</script>\n<span>{q.a}</span>\n";
+    let code = convert("Issue964b", src);
+    let render = render_start(&code);
+
+    assert!(
+        code.contains("function $$render<L, R>"),
+        "render function must be generic over L, R:\n{code}"
+    );
+    let q_pos = code
+        .find("type Q<A, B>")
+        .unwrap_or_else(|| panic!("no Q alias:\n{code}"));
+    let cp_pos = code
+        .find("type $$ComponentProps")
+        .unwrap_or_else(|| panic!("no $$ComponentProps:\n{code}"));
+    assert!(
+        q_pos > render && cp_pos > render,
+        "local alias and $$ComponentProps must stay inside $$render<L, R>:\n{code}"
+    );
+    assert!(
+        code.contains("Q<L, R>"),
+        "props type must reference Q<L, R>:\n{code}"
+    );
+}


### PR DESCRIPTION
Fixes two related `--tsgo` / svelte-check overlay scoping bugs. In both, the TSX overlay relocated an instance-`<script>` type declaration out of the scope where the rest of the script referenced it, so a name went out of scope and tsgo reported a spurious `Cannot find name` error. Official svelte-check reports **0 errors** for both. Both fixes mirror official svelte2tsx (`HoistableInterfaces`) exactly.

## #963 — instance `export type` / `export const` not visible to same-component references

```svelte
<script lang="ts">
  export type Phase = 'a' | 'b';
  interface Props { phase: Phase }
  let { phase }: Props = $props();
  const labels: Record<Phase, string> = { a: 'A', b: 'B' };
</script>
<span>{labels[phase]}</span>
```

**Root cause:** OXC wraps `export type` / `export interface` in an `ExportNamedDeclaration`. Unlike TypeScript (where they stay `TypeAlias`/`Interface` nodes that official's `analyzeInstanceScriptNode` handles directly), rsvelte never registered them as hoist candidates or `instance_type_names`. So when `interface Props` was hoisted above `$$render()`, its dependency `Phase` stayed trapped *inside* `$$render()` → out of scope for the hoisted interface.

**Fix:** unwrap exported type/interface declarations in the `ExportNamedDeclaration` arm and register them as hoist candidates (candidate span starts at `export` so the modifier travels with the move). Also stop stripping the `export` keyword from type-only declarations — official keeps it as part of the component's public type API.

## #964 — local generic `type` alias breaks the component `generics=` params

```svelte
<script lang="ts" generics="L">
  type Wrapper<A> = { value: A };
  let { item }: { item: Wrapper<L> } = $props();
</script>
<span>{item.value}</span>
```

**Root cause:** rsvelte hoisted each candidate independently, so a local `type Wrapper<A>` was moved to module scope and the synthetic `type $$ComponentProps = { item: Wrapper<L> }` (which references the render generic `L`) landed *before* `function $$render<L>()` — putting `L` out of scope. Official `moveHoistableInterfaces` instead gates the **whole** move on `hoistable.has(props_interface.name)`: since `$$ComponentProps` references the disallowed generic `L`, nothing moves and every type alias stays inside `$$render<L>()`, where both `L` and the alias's own `<A>` are in scope.

**Fix:** gate `resolve_hoistable_type_decls` on the props interface (named ref *or* synthetic `$$ComponentProps`) being hoistable — when it isn't, hoist nothing. Verified for the `generics="L, R"` two-parameter variant too.

## Tests

- New regression tests: `crates/rsvelte_core/tests/svelte2tsx_instance_scope_963_964.rs` (both repros + the `generics="L, R"` variant).
- All 253 existing svelte2tsx fixtures still pass (250/253 strict; the 3 strict diffs — `attributes-foreign-ns`, `import-equal`, `ts-await-generics.v5` — are pre-existing and unchanged by this PR).
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Verification method

Structural comparison of the generated `.svelte.tsx` overlay against **official svelte2tsx** output (built from `submodules/language-tools`) for both repros and the two-param variant. The overlay now matches upstream's scoping, which is exactly what makes tsgo resolve the names. No real `tsgo` binary was available in this environment, so verification is overlay-structural rather than a live tsgo run.

Fixes #963
Fixes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)