### PR TITLE
feat(lint): complete type-aware no-unused-props (checkImportedTypes, ignore patterns, index sig, nested)

### DIFF
--- a/.changeset/no-unused-props-options.md
+++ b/.changeset/no-unused-props-options.md
@@ -1,0 +1,12 @@
+---
+---
+
+Internal: complete the type-aware `svelte/no-unused-props` port — a faithful
+recursive `checkUnusedProperties` walk over a new on-demand type-graph backend
+API (`TypeBackend::{props_type, type_meta, type_props}`) covering
+`checkImportedTypes` (per-property declaration origin), `ignorePropertyPatterns`
+/ `ignoreTypePatterns` (exact `toRegExp` semantics), `allowUnusedNestedProperties`,
+nested recursion into named/imported types, `isClassType` skipping, and the
+unused-index-signature message. All 76 upstream fixtures pass via the corsa/tsgo
+e2e oracle. No published package is affected (`rsvelte_lint` is not released), so
+this changeset bumps nothing.

--- a/crates/rsvelte_lint/src/rules/no_unused_props.rs
+++ b/crates/rsvelte_lint/src/rules/no_unused_props.rs
@@ -14,8 +14,10 @@
 //! Both handle the destructure form (`const { a, b }: Props = $props()`) and
 //! the whole-object form (`const props: Props = $props()`).
 
+use std::collections::HashSet;
 use std::path::Path;
 
+use crate::type_backend::TypeId;
 use rsvelte_core::svelte_check::diagnostic::Diagnostic;
 
 use crate::config::LintConfig;
@@ -58,11 +60,30 @@ pub fn diagnostics_typed(
     if severity == Severity::Off || !script_is_ts(source) {
         return Vec::new();
     }
+    // Full-fidelity graph walk when the backend exposes the type graph;
+    // otherwise the flat property-list path (a documented degraded mode).
+    if let Some(root) = backend.props_type() {
+        diagnostics_typed_graph(source, file, config, severity, backend, root)
+    } else {
+        diagnostics_typed_flat(source, file, config, severity, backend)
+    }
+}
 
+/// Flat path: declared = the resolved property-name list from `probe_props`.
+/// Used when the backend has no type-graph support; cannot express
+/// `checkImportedTypes` origin, base-type `ignoreTypePatterns`, index
+/// signatures, or recursion into named/imported nested types.
+fn diagnostics_typed_flat(
+    source: &str,
+    file: &Path,
+    config: &LintConfig,
+    severity: Severity,
+    backend: &mut dyn crate::type_backend::TypeBackend,
+) -> Vec<Diagnostic> {
     // Parsed options (see `options_schema`).
     let opts = config.options_for(META.name);
-    let ignore_prop_patterns = compile_patterns(option_str_list(opts, "ignorePropertyPatterns"));
-    let ignore_type_patterns = compile_patterns(option_str_list(opts, "ignoreTypePatterns"));
+    let ignore_prop_patterns = compile_matchers(option_str_list(opts, "ignorePropertyPatterns"));
+    let ignore_type_patterns = compile_matchers(option_str_list(opts, "ignoreTypePatterns"));
     let allow_unused_nested = option_bool(opts, "allowUnusedNestedProperties").unwrap_or(false);
 
     let li = LineIndex::new(source);
@@ -100,12 +121,12 @@ pub fn diagnostics_typed(
             .property_names
             .iter()
             .filter(|name| {
-                if matches_any(&ignore_prop_patterns, name) {
+                if any_match(&ignore_prop_patterns, name) {
                     return false;
                 }
                 if !ignore_type_patterns.is_empty()
                     && let Some(types) = facts.property_type(name)
-                    && types.iter().any(|t| matches_any(&ignore_type_patterns, t))
+                    && types.iter().any(|t| any_match(&ignore_type_patterns, t))
                 {
                     return false;
                 }
@@ -154,7 +175,7 @@ pub fn diagnostics_typed(
                 };
                 let owner = format!("{}.{}", var_name, name);
                 for nested_name in &nested {
-                    if matches_any(&ignore_prop_patterns, nested_name) {
+                    if any_match(&ignore_prop_patterns, nested_name) {
                         continue;
                     }
                     if !whole_object_member_used(source, &owner, nested_name) {
@@ -179,24 +200,518 @@ pub fn diagnostics_typed(
     out
 }
 
-/// Compile a list of ESLint-style string patterns into regexes. A pattern
-/// wrapped in `/…/` is unwrapped to its inner source; otherwise it is used
-/// verbatim. Invalid patterns are dropped.
-fn compile_patterns(pats: Vec<String>) -> Vec<regex::Regex> {
+/// An ESLint `ignore*Patterns` matcher. Mirrors eslint-plugin-svelte's
+/// `toRegExp` exactly: a `"/body/flags"` string becomes a regex; **any other
+/// string is matched by exact equality** (NOT as a regex) — so e.g. `"^foo$"`
+/// matches only the literal property name `^foo$`, never `foo`.
+enum Matcher {
+    Exact(String),
+    Regex(regex::Regex),
+}
+
+fn compile_matchers(pats: Vec<String>) -> Vec<Matcher> {
     pats.into_iter()
-        .filter_map(|p| {
-            let src = if p.len() >= 2 && p.starts_with('/') && p.ends_with('/') {
-                &p[1..p.len() - 1]
-            } else {
-                p.as_str()
-            };
-            regex::Regex::new(src).ok()
+        .map(|p| {
+            // RE_REGEXP_STR = /^\/(.+)\/([A-Za-z]*)$/ — a `/body/flags` string is
+            // a regex; anything else is matched by exact equality.
+            if p.starts_with('/')
+                && let Some(close) = p.rfind('/')
+                && close > 0
+            {
+                let body = &p[1..close];
+                let flags = &p[close + 1..];
+                if !body.is_empty() && flags.chars().all(|c| c.is_ascii_alphabetic()) {
+                    let mut src = String::new();
+                    if flags.contains('i') {
+                        src.push_str("(?i)");
+                    }
+                    if flags.contains('m') {
+                        src.push_str("(?m)");
+                    }
+                    if flags.contains('s') {
+                        src.push_str("(?s)");
+                    }
+                    src.push_str(body);
+                    if let Ok(re) = regex::Regex::new(&src) {
+                        return Matcher::Regex(re);
+                    }
+                }
+            }
+            Matcher::Exact(p)
         })
         .collect()
 }
 
-fn matches_any(patterns: &[regex::Regex], s: &str) -> bool {
-    patterns.iter().any(|re| re.is_match(s))
+fn any_match(matchers: &[Matcher], s: &str) -> bool {
+    matchers.iter().any(|m| match m {
+        Matcher::Exact(e) => e == s,
+        Matcher::Regex(re) => re.is_match(s),
+    })
+}
+
+/// Graph path: a faithful port of upstream's recursive `checkUnusedProperties`.
+/// Walks the props type via the backend's type graph, handling base types
+/// (`extends`), per-property origin (`checkImportedTypes`), `ignore*Patterns`,
+/// nested object props (named/imported included), and index signatures.
+fn diagnostics_typed_graph(
+    source: &str,
+    file: &Path,
+    config: &LintConfig,
+    severity: Severity,
+    backend: &mut dyn crate::type_backend::TypeBackend,
+    root: TypeId,
+) -> Vec<Diagnostic> {
+    let opts = config.options_for(META.name);
+    let ignore_prop = compile_matchers(option_str_list(opts, "ignorePropertyPatterns"));
+    let ignore_type = compile_matchers(option_str_list(opts, "ignoreTypePatterns"));
+    let check_imported = option_bool(opts, "checkImportedTypes").unwrap_or(false);
+    let allow_unused_nested = option_bool(opts, "allowUnusedNestedProperties").unwrap_or(false);
+
+    let li = LineIndex::new(source);
+    let mut out = Vec::new();
+
+    for block in script_blocks(source) {
+        if block.open_tag_attrs.contains("module") {
+            continue;
+        }
+        let content = &source[block.content_start..block.content_end];
+        let blanked = blank_comments(content);
+        let Some(props_info) = find_props_info(content, &blanked, block.content_start) else {
+            continue;
+        };
+
+        // Assemble declared names + member-access usage paths per form.
+        let (declared, raw_paths, raw_spreads, report_abs) = match &props_info.form {
+            PropForm::Destructure {
+                pattern_open_brace_abs,
+                pattern_text,
+                has_rest,
+            } => {
+                if *has_rest {
+                    // A rest element captures every remaining prop.
+                    continue;
+                }
+                let entries = parse_destructure_entries(pattern_text);
+                if entries.is_empty() {
+                    continue;
+                }
+                let declared: HashSet<String> = entries.iter().map(|(o, _)| o.clone()).collect();
+                let mut paths = Vec::new();
+                let mut spreads = Vec::new();
+                // Only count occurrences AFTER the destructure: the local
+                // bindings don't exist before it, so earlier matches of the
+                // same identifier are unrelated (e.g. an `interface Props { my_foo: … }`
+                // field, or the binding itself). Mirrors upstream walking the
+                // variable's references (which exclude its declaration).
+                let pat_hi = *pattern_open_brace_abs + pattern_text.len();
+                for (orig, local) in &entries {
+                    let (p, sp) = member_chains(source, local, Some((0, pat_hi)));
+                    for mut c in p {
+                        let mut full = vec![orig.clone()];
+                        full.append(&mut c);
+                        paths.push(full);
+                    }
+                    for mut c in sp {
+                        let mut full = vec![orig.clone()];
+                        full.append(&mut c);
+                        spreads.push(full);
+                    }
+                }
+                (declared, paths, spreads, *pattern_open_brace_abs as u32)
+            }
+            PropForm::WholeObject {
+                var_name,
+                var_abs_offset,
+            } => {
+                let (mut paths, spreads) = member_chains(source, var_name, None);
+                // Drop empty (whole-object) chains: they come from the
+                // declaration `let props =` / `$props()` itself, and an empty
+                // path is a prefix of every other path — it would otherwise
+                // absorb all member-access paths in `normalize_used_paths`.
+                // (Spreads keep their empty chain — `{...props}` means all-used.)
+                paths.retain(|c| !c.is_empty());
+                (HashSet::new(), paths, spreads, *var_abs_offset as u32)
+            }
+        };
+
+        let used_paths = normalize_used_paths(raw_paths, allow_unused_nested);
+        let used_spread = normalize_used_paths(raw_spreads, allow_unused_nested);
+        // A spread of the whole object (`{...props}`) marks everything used.
+        if used_spread.iter().any(|s| s.is_empty()) {
+            continue;
+        }
+
+        let mut checked = HashSet::new();
+        let mut reported = HashSet::new();
+        walk_unused(
+            backend,
+            root,
+            &[],
+            &WalkOpts {
+                ignore_prop: &ignore_prop,
+                ignore_type: &ignore_type,
+                check_imported,
+                declared: &declared,
+                used_paths: &used_paths,
+                used_spread: &used_spread,
+            },
+            &mut checked,
+            &mut reported,
+            &mut out,
+            report_abs,
+            file,
+            severity,
+            &li,
+        );
+    }
+
+    out
+}
+
+/// Immutable options/usage threaded through [`walk_unused`].
+struct WalkOpts<'a> {
+    ignore_prop: &'a [Matcher],
+    ignore_type: &'a [Matcher],
+    check_imported: bool,
+    declared: &'a HashSet<String>,
+    used_paths: &'a [String],
+    used_spread: &'a [String],
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_unused(
+    backend: &mut dyn crate::type_backend::TypeBackend,
+    t: TypeId,
+    parent_path: &[String],
+    opts: &WalkOpts,
+    checked: &mut HashSet<String>,
+    reported: &mut HashSet<String>,
+    out: &mut Vec<Diagnostic>,
+    report_abs: u32,
+    file: &Path,
+    severity: Severity,
+    li: &LineIndex,
+) {
+    let Some(meta) = backend.type_meta(t) else {
+        return;
+    };
+    // Class instance types are skipped wholesale (upstream `isClassType`).
+    if meta.is_class {
+        return;
+    }
+    if checked.contains(&meta.text) {
+        return;
+    }
+    checked.insert(meta.text.clone());
+    // `shouldIgnoreType`: skip the whole type if its text matches a pattern.
+    if any_match(opts.ignore_type, &meta.text) {
+        return;
+    }
+
+    let props = backend.type_props(t);
+    if props.is_empty() && meta.base_type_ids.is_empty() {
+        return;
+    }
+
+    // Recurse into base types (`extends`) at the same path level.
+    for base in &meta.base_type_ids {
+        walk_unused(
+            backend,
+            *base,
+            parent_path,
+            opts,
+            checked,
+            reported,
+            out,
+            report_abs,
+            file,
+            severity,
+            li,
+        );
+    }
+
+    for p in &props {
+        if p.is_builtin {
+            continue;
+        }
+        if !opts.check_imported && !p.is_local {
+            continue;
+        }
+        if any_match(opts.ignore_prop, &p.name) {
+            continue;
+        }
+        let mut cur = parent_path.to_vec();
+        cur.push(p.name.clone());
+        let cur_str = cur.join(".");
+        if reported.contains(&cur_str) {
+            continue;
+        }
+
+        let dot = format!("{cur_str}.");
+        let used_this = opts.used_paths.iter().any(|u| u == &cur_str)
+            || opts
+                .used_spread
+                .iter()
+                .any(|s| s.is_empty() || s == &cur_str || s.starts_with(&dot));
+        let used_below = opts.used_paths.iter().any(|u| u.starts_with(&dot));
+
+        if used_this && !used_below {
+            continue;
+        }
+        let used_in_props = opts.declared.contains(&p.name);
+        if !used_below && !used_in_props {
+            reported.insert(cur_str.clone());
+            let msg = if parent_path.is_empty() {
+                format!("'{}' is an unused Props property.", p.name)
+            } else {
+                format!(
+                    "'{}' in '{}' is an unused property.",
+                    p.name,
+                    parent_path.join(".")
+                )
+            };
+            out.push(Diagnostic {
+                file: file.to_path_buf(),
+                severity: to_dsev(severity),
+                range: range_from_byte(li, report_abs, report_abs),
+                message: msg,
+                code: Some(META.name.to_string()),
+                source: "svelte",
+            });
+            continue;
+        }
+        if used_below || used_in_props {
+            walk_unused(
+                backend, p.type_id, &cur, opts, checked, reported, out, report_abs, file, severity,
+                li,
+            );
+        }
+    }
+
+    // Unused index signature (root level only; `hasRestElement` ⇔ declared empty).
+    if parent_path.is_empty() && meta.has_index_signature && !opts.declared.is_empty() {
+        out.push(Diagnostic {
+            file: file.to_path_buf(),
+            severity: to_dsev(severity),
+            range: range_from_byte(li, report_abs, report_abs),
+            message: "Index signature is unused. Consider using rest operator (...) to capture remaining properties.".to_string(),
+            code: Some(META.name.to_string()),
+            source: "svelte",
+        });
+    }
+}
+
+/// Parse a destructure pattern into `(originalKey, localName)` pairs, skipping a
+/// rest element. Mirrors upstream `getUsedPropertyNamesFromPattern`.
+fn parse_destructure_entries(pattern: &str) -> Vec<(String, String)> {
+    let inner = if pattern.starts_with('{') && pattern.ends_with('}') {
+        &pattern[1..pattern.len() - 1]
+    } else {
+        pattern
+    };
+    let mut entries = Vec::new();
+    for seg in split_top_level(inner, b",") {
+        let seg = seg.trim();
+        if seg.is_empty() || seg.starts_with("...") {
+            continue;
+        }
+        let bytes = seg.as_bytes();
+        // Quoted key: `'key': local`
+        if bytes[0] == b'\'' || bytes[0] == b'"' {
+            let q = bytes[0];
+            let Some(end) = bytes[1..].iter().position(|&c| c == q) else {
+                continue;
+            };
+            let key = seg[1..end + 1].to_string();
+            let rest = seg[end + 2..].trim_start();
+            let local = rest
+                .strip_prefix(':')
+                .map(|r| {
+                    let r = r.trim();
+                    let n = r
+                        .as_bytes()
+                        .iter()
+                        .position(|&c| !is_ident_byte(c))
+                        .unwrap_or(r.len());
+                    r[..n].to_string()
+                })
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| key.clone());
+            entries.push((key, local));
+            continue;
+        }
+        // Plain identifier key, optional `: local` / `= default`.
+        let name_end = bytes
+            .iter()
+            .position(|&c| !is_ident_byte(c))
+            .unwrap_or(bytes.len());
+        if name_end == 0 {
+            continue;
+        }
+        let key = seg[..name_end].to_string();
+        let after = seg[name_end..].trim_start();
+        let local = after
+            .strip_prefix(':')
+            .map(|r| {
+                let r = r.trim();
+                let n = r
+                    .as_bytes()
+                    .iter()
+                    .position(|&c| !is_ident_byte(c))
+                    .unwrap_or(r.len());
+                r[..n].to_string()
+            })
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| key.clone());
+        entries.push((key, local));
+    }
+    entries
+}
+
+/// Collect member-access chains for `var` in `source` (e.g. `var.a.b` →
+/// `["a","b"]`), split into non-spread paths and spread paths (`...var.x`).
+/// Approximate (source scan, not scope-precise) but sufficient for prop usage.
+fn member_chains(
+    source: &str,
+    var: &str,
+    exclude: Option<(usize, usize)>,
+) -> (Vec<Vec<String>>, Vec<Vec<String>>) {
+    let bytes = source.as_bytes();
+    let vb = var.as_bytes();
+    let mut paths = Vec::new();
+    let mut spreads = Vec::new();
+    let mut i = 0;
+    while let Some(rel) = source[i..].find(var) {
+        let start = i + rel;
+        let end = start + vb.len();
+        i = end;
+        // Skip occurrences inside an excluded range (e.g. the binding pattern).
+        if let Some((lo, hi)) = exclude
+            && start >= lo
+            && start < hi
+        {
+            continue;
+        }
+        let before = start.checked_sub(1).map(|b| bytes[b]);
+        let after = bytes.get(end).copied();
+        if before.is_some_and(is_ident_byte) || after.is_some_and(is_ident_byte) {
+            continue; // not a whole-word match
+        }
+        let mut p = start;
+        while p > 0 && (bytes[p - 1] as char).is_whitespace() {
+            p -= 1;
+        }
+        let is_spread = p >= 3 && &source[p - 3..p] == "...";
+        // Skip `obj.var` (member access where `var` is the property), but NOT
+        // the spread `...var` (whose preceding char is also `.`).
+        if !is_spread && p > 0 && bytes[p - 1] == b'.' {
+            continue;
+        }
+        // Empty non-spread chains (a bare/whole reference, e.g. shorthand
+        // `{var}`) are kept: they mark the prop as used *wholly* (no deeper
+        // access), which suppresses recursion into it.
+        let chain = parse_member_chain(source, end);
+        if is_spread {
+            spreads.push(chain);
+        } else {
+            paths.push(chain);
+        }
+    }
+    (paths, spreads)
+}
+
+/// Parse a `.a.b` / `["a"]` / `?.a` member chain starting at byte `pos`.
+fn parse_member_chain(source: &str, mut pos: usize) -> Vec<String> {
+    let bytes = source.as_bytes();
+    let mut chain = Vec::new();
+    loop {
+        while pos < bytes.len() && (bytes[pos] as char).is_whitespace() {
+            pos += 1;
+        }
+        if pos >= bytes.len() {
+            break;
+        }
+        let dot = if bytes[pos] == b'.' {
+            Some(pos + 1)
+        } else if bytes[pos] == b'?' && bytes.get(pos + 1) == Some(&b'.') {
+            Some(pos + 2)
+        } else {
+            None
+        };
+        if let Some(mut q) = dot {
+            while q < bytes.len() && (bytes[q] as char).is_whitespace() {
+                q += 1;
+            }
+            let s = q;
+            while q < bytes.len() && is_ident_byte(bytes[q]) {
+                q += 1;
+            }
+            if q == s {
+                break;
+            }
+            chain.push(source[s..q].to_string());
+            pos = q;
+        } else if bytes[pos] == b'[' {
+            let mut q = pos + 1;
+            while q < bytes.len() && (bytes[q] as char).is_whitespace() {
+                q += 1;
+            }
+            if q < bytes.len() && (bytes[q] == b'\'' || bytes[q] == b'"') {
+                let quote = bytes[q];
+                q += 1;
+                let s = q;
+                while q < bytes.len() && bytes[q] != quote {
+                    q += 1;
+                }
+                if q >= bytes.len() {
+                    break;
+                }
+                let name = source[s..q].to_string();
+                q += 1;
+                while q < bytes.len() && (bytes[q] as char).is_whitespace() {
+                    q += 1;
+                }
+                if q < bytes.len() && bytes[q] == b']' {
+                    chain.push(name);
+                    pos = q + 1;
+                } else {
+                    break;
+                }
+            } else {
+                break; // computed/dynamic index
+            }
+        } else {
+            break;
+        }
+    }
+    chain
+}
+
+/// Dedup prefix-paths (keep the shortest) and join with `.`. With
+/// `allow_unused_nested`, truncate each path to its first segment. Mirrors
+/// upstream `normalizeUsedPaths`.
+fn normalize_used_paths(mut paths: Vec<Vec<String>>, allow_unused_nested: bool) -> Vec<String> {
+    paths.sort_by_key(|p| p.len());
+    let mut normalized: Vec<Vec<String>> = Vec::new();
+    for path in paths {
+        let covered = normalized.iter().any(|p| {
+            p.len() <= path.len() && p.iter().enumerate().all(|(i, part)| part == &path[i])
+        });
+        if covered {
+            continue;
+        }
+        normalized.push(path);
+    }
+    normalized
+        .into_iter()
+        .map(|path| {
+            if allow_unused_nested {
+                path.into_iter().take(1).collect::<Vec<_>>().join(".")
+            } else {
+                path.join(".")
+            }
+        })
+        .collect()
 }
 
 fn option_str_list(opts: Option<&serde_json::Value>, key: &str) -> Vec<String> {
@@ -878,6 +1393,201 @@ mod tests {
             .collect()
     }
 
+    // ---- Graph-path mock (the full recursive walk, corsa-free) -------------
+
+    use crate::type_backend::{PropMeta, TypeId, TypeMeta};
+
+    /// One node in a fake type graph.
+    struct GType {
+        text: &'static str,
+        is_class: bool,
+        has_index: bool,
+        bases: Vec<TypeId>,
+        /// (name, is_local, is_builtin, type_id)
+        props: Vec<(&'static str, bool, bool, TypeId)>,
+    }
+
+    /// A backend serving a fixed type graph, exercising [`diagnostics_typed`]'s
+    /// graph path without `corsa`/`tsgo`.
+    struct MockGraph {
+        types: Vec<GType>,
+    }
+    impl TypeBackend for MockGraph {
+        fn probe_props(&mut self) -> Option<TypeFacts> {
+            None
+        }
+        fn probe_expr(&mut self, _off: u32) -> Option<TypeFacts> {
+            None
+        }
+        fn props_type(&mut self) -> Option<TypeId> {
+            (!self.types.is_empty()).then_some(0)
+        }
+        fn type_meta(&mut self, t: TypeId) -> Option<TypeMeta> {
+            self.types.get(t as usize).map(|g| TypeMeta {
+                text: g.text.to_string(),
+                has_index_signature: g.has_index,
+                is_class: g.is_class,
+                base_type_ids: g.bases.clone(),
+            })
+        }
+        fn type_props(&mut self, t: TypeId) -> Vec<PropMeta> {
+            self.types
+                .get(t as usize)
+                .map(|g| {
+                    g.props
+                        .iter()
+                        .map(|&(name, is_local, is_builtin, type_id)| PropMeta {
+                            name: name.to_string(),
+                            is_local,
+                            is_builtin,
+                            type_id,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+    }
+
+    fn graph_msgs(src: &str, cfg_json: &str, types: Vec<GType>) -> Vec<String> {
+        let cfg = LintConfig::from_json_str(cfg_json).unwrap();
+        let mut backend = MockGraph { types };
+        let mut m: Vec<String> =
+            diagnostics_typed(src, &PathBuf::from("T.svelte"), &cfg, &mut backend)
+                .into_iter()
+                .map(|d| d.message)
+                .collect();
+        m.sort();
+        m
+    }
+
+    /// `interface Props extends BaseProps { age }` with `BaseProps` imported.
+    fn props_with_imported_base() -> Vec<GType> {
+        vec![
+            GType {
+                text: "Props",
+                is_class: false,
+                has_index: false,
+                bases: vec![1],
+                props: vec![("age", true, false, 3)],
+            },
+            GType {
+                text: "BaseProps",
+                is_class: false,
+                has_index: false,
+                bases: vec![],
+                props: vec![
+                    ("name", false, false, 3),
+                    ("imported_unused", false, false, 3),
+                ],
+            },
+            GType {
+                text: "User",
+                is_class: true,
+                has_index: false,
+                bases: vec![],
+                props: vec![("klass_member", false, false, 3)],
+            },
+            GType {
+                text: "string",
+                is_class: false,
+                has_index: false,
+                bases: vec![],
+                props: vec![],
+            },
+        ]
+    }
+
+    #[test]
+    fn graph_skips_unused_imported_prop_by_default() {
+        // check_imported defaults false → imported `imported_unused` is skipped;
+        // age/name are used.
+        let src = "<script lang=\"ts\">\n\tlet { age, name }: Props = $props();\n\tconsole.log(age, name);\n</script>";
+        let cfg = r#"{ "rules": { "svelte/no-unused-props": "warn" } }"#;
+        assert!(graph_msgs(src, cfg, props_with_imported_base()).is_empty());
+    }
+
+    #[test]
+    fn graph_reports_unused_imported_prop_when_enabled() {
+        let src = "<script lang=\"ts\">\n\tlet { age, name }: Props = $props();\n\tconsole.log(age, name);\n</script>";
+        let cfg = r#"{ "rules": { "svelte/no-unused-props": ["warn", { "checkImportedTypes": true }] } }"#;
+        assert_eq!(
+            graph_msgs(src, cfg, props_with_imported_base()),
+            vec!["'imported_unused' is an unused Props property.".to_string()]
+        );
+    }
+
+    #[test]
+    fn graph_nested_unused_and_class_skipped() {
+        // props.user.name used; props.user.location unused → nested report.
+        // props.acct is a class instance → not recursed (no member reports).
+        let types = vec![
+            GType {
+                text: "Props",
+                is_class: false,
+                has_index: false,
+                bases: vec![],
+                props: vec![("user", true, false, 1), ("acct", true, false, 2)],
+            },
+            GType {
+                text: "{ name: string; location: string; }",
+                is_class: false,
+                has_index: false,
+                bases: vec![],
+                props: vec![("name", true, false, 3), ("location", true, false, 3)],
+            },
+            GType {
+                text: "Account",
+                is_class: true,
+                has_index: false,
+                bases: vec![],
+                props: vec![("balance", true, false, 3)],
+            },
+            GType {
+                text: "string",
+                is_class: false,
+                has_index: false,
+                bases: vec![],
+                props: vec![],
+            },
+        ];
+        let src = "<script lang=\"ts\">\n\tlet props: Props = $props();\n\tconsole.log(props.user.name, props.acct);\n</script>";
+        let cfg = r#"{ "rules": { "svelte/no-unused-props": "warn" } }"#;
+        assert_eq!(
+            graph_msgs(src, cfg, types),
+            vec!["'location' in 'user' is an unused property.".to_string()]
+        );
+    }
+
+    #[test]
+    fn graph_index_signature_without_rest() {
+        let types = vec![
+            GType {
+                text: "Props",
+                is_class: false,
+                has_index: true,
+                bases: vec![],
+                props: vec![("a", true, false, 1)],
+            },
+            GType {
+                text: "string",
+                is_class: false,
+                has_index: false,
+                bases: vec![],
+                props: vec![],
+            },
+        ];
+        // Destructure without rest → the index signature is reported unused.
+        let src =
+            "<script lang=\"ts\">\n\tlet { a }: Props = $props();\n\tconsole.log(a);\n</script>";
+        let cfg = r#"{ "rules": { "svelte/no-unused-props": "warn" } }"#;
+        assert_eq!(
+            graph_msgs(src, cfg, types),
+            vec![
+                "Index signature is unused. Consider using rest operator (...) to capture remaining properties.".to_string()
+            ]
+        );
+    }
+
     #[test]
     fn typed_flat_resolves_inherited_props() {
         // Mirrors `extends-unused`: the checker reports id/type/role/name/email;
@@ -927,18 +1637,38 @@ mod tests {
 
     #[test]
     fn typed_ignore_property_patterns() {
+        // `toRegExp` semantics: a `/…/` string is a regex; a plain string is an
+        // EXACT match. So the regex form ignores `skip_me`, the plain form does not.
         let src = "<script lang=\"ts\">\n\tconst { bar }: Props = $props();\n</script>";
-        let cfg = LintConfig::from_json_str(
-            r#"{ "rules": { "svelte/no-unused-props": ["warn", { "ignorePropertyPatterns": ["^skip_"] }] } }"#,
+        let regex_cfg = LintConfig::from_json_str(
+            r#"{ "rules": { "svelte/no-unused-props": ["warn", { "ignorePropertyPatterns": ["/^skip_/"] }] } }"#,
         )
         .unwrap();
         let mut backend = MockProps(facts(&["bar", "skip_me"], &["string", "string"]));
-        let msgs: Vec<String> =
-            diagnostics_typed(src, &PathBuf::from("T.svelte"), &cfg, &mut backend)
+        let regex_msgs: Vec<String> =
+            diagnostics_typed(src, &PathBuf::from("T.svelte"), &regex_cfg, &mut backend)
                 .into_iter()
                 .map(|d| d.message)
                 .collect();
-        // `skip_me` is filtered out; `bar` is used → no findings.
-        assert!(msgs.is_empty(), "got {msgs:?}");
+        assert!(
+            regex_msgs.is_empty(),
+            "regex form should ignore skip_me; got {regex_msgs:?}"
+        );
+
+        // Plain string `"skip_me"` is exact-match → ignores the literal name.
+        let exact_cfg = LintConfig::from_json_str(
+            r#"{ "rules": { "svelte/no-unused-props": ["warn", { "ignorePropertyPatterns": ["skip_me"] }] } }"#,
+        )
+        .unwrap();
+        let mut backend2 = MockProps(facts(&["bar", "skip_me"], &["string", "string"]));
+        let exact_msgs: Vec<String> =
+            diagnostics_typed(src, &PathBuf::from("T.svelte"), &exact_cfg, &mut backend2)
+                .into_iter()
+                .map(|d| d.message)
+                .collect();
+        assert!(
+            exact_msgs.is_empty(),
+            "exact form should ignore skip_me; got {exact_msgs:?}"
+        );
     }
 }

--- a/crates/rsvelte_lint/src/type_backend.rs
+++ b/crates/rsvelte_lint/src/type_backend.rs
@@ -96,4 +96,66 @@ pub trait TypeBackend {
     /// `<a href={...}>` attribute. Returns `None` when the offset does not map
     /// to a probable expression or the probe failed.
     fn probe_expr(&mut self, svelte_offset: u32) -> Option<TypeFacts>;
+
+    // ---- Type-graph walk (full `no-unused-props` fidelity) ------------------
+    //
+    // The flat `probe_props` only yields a property-name list, which cannot
+    // express per-property declaration origin (`checkImportedTypes`), base-type
+    // structure (`ignoreTypePatterns` on bases), index signatures, or recursion
+    // into named/imported nested types. These three methods expose the type
+    // graph on demand so the rule can mirror upstream's recursive
+    // `checkUnusedProperties` walk. Backends that don't support it return
+    // `None`/empty (the default), and the rule degrades to the flat path.
+
+    /// The component's props type, as an opaque [`TypeId`] the backend can
+    /// resolve. `None` ⇒ no typed props, or this backend has no graph support.
+    fn props_type(&mut self) -> Option<TypeId> {
+        None
+    }
+
+    /// Metadata for a type: its rendered text, whether it carries a (non-`any`)
+    /// index signature, and its base types (`extends`). `None` ⇒ unresolved.
+    fn type_meta(&mut self, _type: TypeId) -> Option<TypeMeta> {
+        None
+    }
+
+    /// The directly-declared properties of a type (not including base-type
+    /// members — those are reached via [`TypeMeta::base_type_ids`]).
+    fn type_props(&mut self, _type: TypeId) -> Vec<PropMeta> {
+        Vec::new()
+    }
+}
+
+/// An opaque, backend-managed handle to a TypeScript type. Stable for the
+/// lifetime of a single backend instance.
+pub type TypeId = u32;
+
+/// Metadata about a type, used by the `no-unused-props` graph walk.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TypeMeta {
+    /// `typeChecker.typeToString(type)` — the visited-set key and the string
+    /// matched by `ignoreTypePatterns` (`shouldIgnoreType`).
+    pub text: String,
+    /// Whether the type has a string/number index signature whose value type is
+    /// not `any` (upstream's `hasIndexSignature`).
+    pub has_index_signature: bool,
+    /// Whether this is a class (instance) type. Upstream's `isClassType` skips
+    /// such types entirely — class members are methods/fields, not props.
+    pub is_class: bool,
+    /// Immediate base types (`getBaseTypes`), each recursed into separately.
+    pub base_type_ids: Vec<TypeId>,
+}
+
+/// A single declared property of a type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropMeta {
+    pub name: String,
+    /// `isInternalProperty`: every declaration of this property is in the
+    /// component's own file (vs. an imported type). Gates `checkImportedTypes`.
+    pub is_local: bool,
+    /// `isBuiltInProperty`: declared in TypeScript's bundled lib (`lib.*.d.ts`),
+    /// so it is not a user-authored prop.
+    pub is_builtin: bool,
+    /// The property's own type, for recursing into nested object props.
+    pub type_id: TypeId,
 }

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1562,6 +1562,8 @@ dependencies = [
  "corsa_runtime",
  "rsvelte_core",
  "rsvelte_lint",
+ "serde",
+ "serde_json",
  "serde_yaml",
 ]
 

--- a/crates/rsvelte_lint_types/Cargo.toml
+++ b/crates/rsvelte_lint_types/Cargo.toml
@@ -30,6 +30,8 @@ corsa_client = { path = "../../submodules/corsa-bind/src/core/corsa_client" }
 corsa_runtime = { path = "../../submodules/corsa-bind/src/core/corsa_runtime" }
 
 [dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_yaml = "0.9"
 
 [lints]

--- a/crates/rsvelte_lint_types/src/lib.rs
+++ b/crates/rsvelte_lint_types/src/lib.rs
@@ -16,14 +16,16 @@
 //! See the crate `Cargo.toml` header for why this lives outside the main
 //! workspace.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use corsa_client::api::{
-    ApiMode, ApiSpawnConfig, FileChangeSummary, FileChanges, ProjectSession, TypeProbeOptions,
+    ApiMode, ApiSpawnConfig, FileChangeSummary, FileChanges, ProjectSession, TypeHandle,
+    TypeProbeOptions,
 };
 use corsa_runtime::block_on;
 use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
-use rsvelte_lint::type_backend::{TypeBackend, TypeFacts};
+use rsvelte_lint::type_backend::{PropMeta, TypeBackend, TypeFacts, TypeId, TypeMeta};
 
 mod resolver;
 pub use resolver::resolve_tsgo;
@@ -80,6 +82,16 @@ const TSCONFIG: &str = r#"{
 }
 "#;
 
+/// TypeScript `ObjectFlags.Class` (`1 << 0`) — set on class *instance* types.
+const OBJECT_FLAGS_CLASS: u32 = 1;
+
+/// An interned type: its `corsa` handle (absent when unresolved) and the
+/// `ObjectFlags` bitset captured when it was first seen.
+struct TypeSlot {
+    handle: Option<TypeHandle>,
+    object_flags: u32,
+}
+
 /// A corsa/tsgo-backed [`TypeBackend`] for a single Svelte component.
 pub struct CorsaTypeBackend {
     session: ProjectSession,
@@ -97,6 +109,13 @@ pub struct CorsaTypeBackend {
     /// On-disk path of the virtual document (removed on drop).
     virtual_path: PathBuf,
     closed: bool,
+    /// Interned `corsa` types, indexed by [`TypeId`]. A `None` handle is a type
+    /// that could not be resolved (yields no metadata).
+    types: Vec<TypeSlot>,
+    /// Dedup map: handle string → [`TypeId`].
+    type_index: HashMap<String, TypeId>,
+    /// Memoized result of [`Self::props_type`].
+    props_type_cache: Option<Option<TypeId>>,
 }
 
 impl CorsaTypeBackend {
@@ -182,7 +201,70 @@ impl CorsaTypeBackend {
             virtual_wire,
             virtual_path,
             closed: false,
+            types: Vec::new(),
+            type_index: HashMap::new(),
+            props_type_cache: None,
         })
+    }
+
+    /// Intern a type (handle + `ObjectFlags`) into a stable [`TypeId`], deduping
+    /// by handle string. `None` handle ⇒ an unresolved type.
+    fn intern(&mut self, handle: Option<TypeHandle>, object_flags: u32) -> TypeId {
+        if let Some(h) = &handle {
+            if let Some(&id) = self.type_index.get(h.as_str()) {
+                return id;
+            }
+            let id = self.types.len() as TypeId;
+            self.type_index.insert(h.as_str().to_string(), id);
+            self.types.push(TypeSlot {
+                handle: Some(h.clone()),
+                object_flags,
+            });
+            id
+        } else {
+            let id = self.types.len() as TypeId;
+            self.types.push(TypeSlot {
+                handle: None,
+                object_flags,
+            });
+            id
+        }
+    }
+
+    fn handle_of(&self, id: TypeId) -> Option<TypeHandle> {
+        self.types.get(id as usize).and_then(|s| s.handle.clone())
+    }
+
+    fn object_flags_of(&self, id: TypeId) -> u32 {
+        self.types
+            .get(id as usize)
+            .map(|s| s.object_flags)
+            .unwrap_or(0)
+    }
+
+    /// Resolve the props type handle from the injected anchor.
+    fn compute_props_type(&mut self) -> Option<TypeId> {
+        let offset = self.props_anchor?;
+        let utf16 = byte_to_utf16(&self.tsx, offset);
+        let file = self.virtual_wire.clone();
+        let mut resp: Option<(TypeHandle, u32)> = None;
+        if let Some(sym) = block_on(self.session.get_symbol_at_position(file.clone(), utf16))
+            .ok()
+            .flatten()
+        {
+            resp = block_on(self.session.get_type_of_symbol(sym.id))
+                .ok()
+                .flatten()
+                .map(|t| (t.id, t.object_flags.unwrap_or(0)));
+        }
+        if resp.is_none() {
+            resp = block_on(self.session.get_type_at_position(file, utf16))
+                .ok()
+                .flatten()
+                .map(|t| (t.id, t.object_flags.unwrap_or(0)));
+        }
+        let (handle, flags) = resp?;
+        Some(self.intern(Some(handle), flags))
     }
 
     fn probe(&self, generated_offset: u32, load_property_types: bool) -> Option<TypeFacts> {
@@ -232,6 +314,108 @@ impl TypeBackend for CorsaTypeBackend {
         let generated = map_offset_forward(&self.forward_map, svelte_offset)?;
         self.probe(generated, false)
     }
+
+    fn props_type(&mut self) -> Option<TypeId> {
+        if let Some(cached) = self.props_type_cache {
+            return cached;
+        }
+        let computed = self.compute_props_type();
+        self.props_type_cache = Some(computed);
+        computed
+    }
+
+    fn type_meta(&mut self, t: TypeId) -> Option<TypeMeta> {
+        let handle = self.handle_of(t)?;
+        let text =
+            block_on(self.session.type_to_string(handle.clone(), None, None)).unwrap_or_default();
+        let snap = self.session.snapshot().handle.clone();
+        let proj = self.session.project_handle();
+        let has_index_signature = block_on(self.session.client().get_index_infos_of_type(
+            snap.clone(),
+            proj.clone(),
+            handle.clone(),
+        ))
+        .map(|infos| {
+            infos
+                .iter()
+                .any(|i| !type_texts_are_any(&i.value_type.texts))
+        })
+        .unwrap_or(false);
+        let bases =
+            block_on(self.session.client().get_base_types(snap, proj, handle)).unwrap_or_default();
+        let base_type_ids = bases
+            .into_iter()
+            .map(|t| self.intern(Some(t.id), t.object_flags.unwrap_or(0)))
+            .collect();
+        Some(TypeMeta {
+            text,
+            has_index_signature,
+            is_class: self.object_flags_of(t) & OBJECT_FLAGS_CLASS != 0,
+            base_type_ids,
+        })
+    }
+
+    fn type_props(&mut self, t: TypeId) -> Vec<PropMeta> {
+        let Some(handle) = self.handle_of(t) else {
+            return Vec::new();
+        };
+        let props = block_on(self.session.get_properties_of_type(handle)).unwrap_or_default();
+        let mut out = Vec::with_capacity(props.len());
+        for sym in props {
+            let decl_paths: Vec<String> = sym
+                .declarations
+                .iter()
+                .filter_map(|d| node_handle_path(d.as_str()))
+                .collect();
+            let is_local = !decl_paths.is_empty()
+                && decl_paths.iter().all(|p| same_file(p, &self.virtual_wire));
+            let is_builtin = decl_paths.first().is_some_and(|p| is_lib_path(p));
+            let ptype = block_on(self.session.get_type_of_symbol(sym.id))
+                .ok()
+                .flatten();
+            let type_id = self.intern(
+                ptype.as_ref().map(|t| t.id.clone()),
+                ptype.as_ref().and_then(|t| t.object_flags).unwrap_or(0),
+            );
+            out.push(PropMeta {
+                name: sym.name.as_str().to_string(),
+                is_local,
+                is_builtin,
+                type_id,
+            });
+        }
+        out
+    }
+}
+
+/// Whether rendered type texts denote `any` (so an index signature with this
+/// value type is "any-typed" and ignored, mirroring upstream `isAnyType`).
+fn type_texts_are_any(texts: &[impl AsRef<str>]) -> bool {
+    !texts.is_empty() && texts.iter().all(|t| t.as_ref() == "any")
+}
+
+/// Extract the source-file path from a `corsa` [`NodeHandle`] string. The wire
+/// form is `<pos>.<kind>.<path>` (numeric components then the path, which begins
+/// at the first non-numeric/non-`.` character — i.e. the leading `/` of an
+/// absolute path). `NodeHandle::parse()` assumes a 3-number layout that the
+/// current worker doesn't emit, so we strip the numeric prefix directly.
+fn node_handle_path(h: &str) -> Option<String> {
+    let path = h.trim_start_matches(|c: char| c.is_ascii_digit() || c == '.');
+    (!path.is_empty()).then(|| path.to_string())
+}
+
+/// Compare two file paths for `isInternalProperty`. The worker lowercases paths
+/// (and macOS is case-insensitive), so compare case-insensitively.
+fn same_file(a: &str, b: &str) -> bool {
+    a.eq_ignore_ascii_case(b)
+}
+
+/// Heuristic for `isBuiltInProperty`: a property declared in TypeScript's
+/// bundled lib (`lib.*.d.ts`) or the `typescript`/native-preview lib dir.
+fn is_lib_path(p: &str) -> bool {
+    p.contains("node_modules/typescript/lib/")
+        || p.contains("native-preview")
+        || (p.contains("/lib.") && p.ends_with(".d.ts"))
 }
 
 impl Drop for CorsaTypeBackend {

--- a/crates/rsvelte_lint_types/tests/no_unused_props_fixtures.rs
+++ b/crates/rsvelte_lint_types/tests/no_unused_props_fixtures.rs
@@ -1,0 +1,171 @@
+//! Fixture-driven typed oracle for `svelte/no-unused-props`: runs the REAL
+//! eslint-plugin-svelte fixtures (including the type-checker-only ones the
+//! corsa-free oracle skips) through the graph path + real `tsgo`, asserting
+//! `(line, column, message)` parity with the sibling `*-errors.yaml`.
+//!
+//! Gated on a discoverable `tsgo` binary and the `eslint-plugin-svelte`
+//! submodule; no-ops with a notice when either is absent.
+
+use std::path::{Path, PathBuf};
+
+use rsvelte_lint::config::LintConfig;
+use rsvelte_lint::line_index::LineIndex;
+use rsvelte_lint::rules::no_unused_props;
+use rsvelte_lint_types::{CorsaTypeBackend, resolve_tsgo};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct ExpectedError {
+    message: String,
+    line: u32,
+    column: u32,
+}
+
+fn repo_root() -> PathBuf {
+    // crates/rsvelte_lint_types → repo root
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn fixture_root() -> Option<PathBuf> {
+    let p = repo_root().join(
+        "submodules/eslint-plugin-svelte/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props",
+    );
+    p.is_dir().then_some(p)
+}
+
+/// Build a `LintConfig` enabling the rule at `warn` with the fixture's options
+/// (from `<name>-config.json`'s `options[0]`, if present).
+fn config_for(config_path: &Path) -> LintConfig {
+    let options = std::fs::read_to_string(config_path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|v| v.get("options").and_then(|o| o.as_array()).cloned());
+
+    let rule_value = match options.and_then(|o| o.into_iter().next()) {
+        Some(opt) => serde_json::json!(["warn", opt]),
+        None => serde_json::json!("warn"),
+    };
+    let cfg = serde_json::json!({ "rules": { "svelte/no-unused-props": rule_value } });
+    LintConfig::from_json_str(&cfg.to_string()).expect("valid lint config")
+}
+
+/// Run one fixture through the typed graph path; returns `(line, column1, message)`
+/// tuples (column is 1-based to match the fixtures).
+fn run_fixture(input: &Path, tsgo: &Path) -> Vec<(u32, u32, String)> {
+    let source = std::fs::read_to_string(input).unwrap();
+    let stem = input.file_stem().unwrap().to_string_lossy();
+    let stem = stem.strip_suffix("-input").unwrap_or(&stem);
+
+    let dir = std::env::temp_dir().join(format!(
+        "rsvelte-nup-{}-{}",
+        std::process::id(),
+        stem.replace(['/', '.'], "_")
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    // Copy sibling shared-types.ts so imported-type fixtures resolve.
+    if let Some(parent) = input.parent() {
+        let shared = parent.join("shared-types.ts");
+        if shared.is_file() {
+            let _ = std::fs::copy(&shared, dir.join("shared-types.ts"));
+        }
+    }
+    let svelte_path = dir.join(format!("{stem}.svelte"));
+    std::fs::write(&svelte_path, &source).unwrap();
+
+    let config_path = input.with_file_name(format!("{stem}-config.json"));
+    let cfg = config_for(&config_path);
+
+    let mut backend = CorsaTypeBackend::new(&source, &svelte_path, tsgo).expect("backend");
+    let diags = no_unused_props::diagnostics_typed(&source, &svelte_path, &cfg, &mut backend);
+    drop(backend);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let li = LineIndex::new(&source);
+    let mut out: Vec<(u32, u32, String)> = diags
+        .into_iter()
+        .filter_map(|d| {
+            let r = d.range?;
+            // Diagnostic columns are 0-based UTF-16; fixtures are 1-based.
+            Some((r.start.line, r.start.column + 1, d.message))
+        })
+        .collect();
+    let _ = &li;
+    out.sort();
+    out
+}
+
+fn expected_for(input: &Path) -> Vec<(u32, u32, String)> {
+    let stem = input.file_stem().unwrap().to_string_lossy();
+    let stem = stem.strip_suffix("-input").unwrap_or(&stem);
+    let yaml = input.with_file_name(format!("{stem}-errors.yaml"));
+    let Ok(text) = std::fs::read_to_string(&yaml) else {
+        return Vec::new();
+    };
+    let errs: Vec<ExpectedError> = serde_yaml::from_str(&text).unwrap_or_default();
+    let mut out: Vec<(u32, u32, String)> = errs
+        .into_iter()
+        .map(|e| (e.line, e.column, e.message))
+        .collect();
+    out.sort();
+    out
+}
+
+fn collect_inputs(dir: &Path) -> Vec<PathBuf> {
+    let mut v = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.extension().and_then(|x| x.to_str()) == Some("svelte")
+                && p.file_stem()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| s.ends_with("-input"))
+            {
+                v.push(p);
+            }
+        }
+    }
+    v.sort();
+    v
+}
+
+#[test]
+fn no_unused_props_typed_oracle() {
+    let Some(tsgo) = resolve_tsgo(Path::new(env!("CARGO_MANIFEST_DIR"))) else {
+        eprintln!("SKIP no_unused_props_typed_oracle: no tsgo binary found");
+        return;
+    };
+    let Some(root) = fixture_root() else {
+        eprintln!("SKIP no_unused_props_typed_oracle: eslint-plugin-svelte submodule absent");
+        return;
+    };
+
+    let mut failures = Vec::new();
+    let mut checked = 0;
+    for kind in ["invalid", "valid"] {
+        for input in collect_inputs(&root.join(kind)) {
+            let name = format!("{kind}/{}", input.file_stem().unwrap().to_string_lossy());
+            let actual = run_fixture(&input, &tsgo);
+            let expected = expected_for(&input);
+            checked += 1;
+            if actual != expected {
+                failures.push(format!(
+                    "  {name}\n    expected: {expected:?}\n    actual:   {actual:?}"
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{}/{} no-unused-props fixtures diverged:\n{}",
+        failures.len(),
+        checked,
+        failures.join("\n")
+    );
+    eprintln!("no_unused_props_typed_oracle: {checked} fixtures OK");
+}

--- a/docs/eslint-rule-port-status.md
+++ b/docs/eslint-rule-port-status.md
@@ -52,9 +52,19 @@ These are intentionally not yet ported; each needs work outside "add a rule".
 > `extends`/intersection/generics/imported/nested props (no-unused-props) and the
 > `$app/types` `ResolvedPathname`/nullish type allowance (no-navigation), proven
 > end-to-end against `tsgo` by that crate's `*_e2e` tests. See
-> `docs/svelte-lint-design.md` → "Wave 3 — type-aware path — landed". The
-> remaining option-origin edge cases (`checkImportedTypes`, `ignore*Patterns`
-> exact semantics, index-signature message) are tracked follow-ups.
+> `docs/svelte-lint-design.md` → "Wave 3 — type-aware path — landed".
+>
+> **`no-unused-props` is now a complete port** of upstream's recursive
+> `checkUnusedProperties` over a type-graph API
+> (`TypeBackend::{props_type, type_meta, type_props}`): `checkImportedTypes`
+> (per-property origin via `SymbolResponse.declarations`),
+> `ignorePropertyPatterns` / `ignoreTypePatterns` (exact `toRegExp` semantics —
+> plain strings are exact-match, only `/…/` is a regex), `allowUnusedNestedProperties`,
+> nested recursion into named/imported types, `isClassType` skipping, and the
+> unused-index-signature message. **All 76 upstream fixtures pass** via
+> `rsvelte_lint_types`'s `no_unused_props_fixtures` oracle (plus corsa-free
+> mock-graph unit tests). Remaining follow-up: a `require-event-prefix` typed
+> path for imported Props types (its local-type fixtures already pass).
 
 Three of the six rules upstream files under "type-aware" need **no** type checker
 — they only check for the *presence* of TS syntax — and are ported as

--- a/docs/svelte-lint-design.md
+++ b/docs/svelte-lint-design.md
@@ -465,21 +465,32 @@ The typed path is now implemented and exercised end-to-end against a real
   `corsa-bind` submodule is private (CI cannot clone it) and a path dep — even
   optional — would break the default build. Built/tested locally only. This is
   the doc's "fail-open in editor / gated spike, not in CI" stance made concrete.
-- **Rules wired** — `svelte/no-unused-props::diagnostics_typed` (extends /
-  intersection / generics / imported / nested object props) and
-  `svelte/no-navigation-without-resolve::diagnostics_typed` (the
-  `expressionIsAllowedType` `ResolvedPathname` / nullish check, threaded through
-  `is_value_allowed`). Both flipped to `type_aware: true`. Validated end-to-end
-  by `rsvelte_lint_types`'s `type_aware_e2e` / `nav_type_aware_e2e` tests.
+- **Rules wired** — `svelte/no-unused-props::diagnostics_typed` and
+  `svelte/no-navigation-without-resolve::diagnostics_typed`
+  (`expressionIsAllowedType` `ResolvedPathname` / nullish check, threaded through
+  `is_value_allowed`). Both flipped to `type_aware: true`.
 
-Remaining typed follow-ups (tracked, not blocking): `no-unused-props` options
-edge cases (`checkImportedTypes` symbol-origin tracking via `SymbolResponse.declarations`,
-`ignore*-patterns` exact ESLint semantics, the index-signature-unused message,
-`custom-config-combination`); `require-event-prefix` typed path for imported
-Props types (its local-type fixtures already pass syntactically); Gate 1
-serial-probe latency measurement; the warm-session daemon (Wave 4); the
-serial-probe concurrency bridge (R3); and CLI integration (the CLI cannot depend
-on the private backend, so type-aware linting runs via `rsvelte_lint_types`).
+- **`no-unused-props` — full upstream fidelity.** A faithful port of upstream's
+  recursive `checkUnusedProperties` over an on-demand type-graph API
+  (`TypeBackend::{props_type, type_meta, type_props}`, exposing per-property
+  origin via `SymbolResponse.declarations` → `isInternalProperty`, base types,
+  index signatures, and `ObjectFlags.Class`). Covers ALL options:
+  `checkImportedTypes` (skip unused imported-origin props by default),
+  `ignorePropertyPatterns` / `ignoreTypePatterns` (with exact `toRegExp`
+  semantics — a plain string is exact-match, only `/…/` is a regex),
+  `allowUnusedNestedProperties`, nested recursion into named/imported types,
+  `isClassType` skipping, and the unused-index-signature message. **All 76
+  upstream `no-unused-props` fixtures pass** via the corsa e2e oracle
+  (`rsvelte_lint_types::tests::no_unused_props_fixtures`); the rule logic also
+  has corsa-free mock-graph unit tests in CI. The flat `probe_props` path is
+  retained as a degraded fallback for backends without graph support.
+
+Remaining typed follow-ups (tracked, not blocking): `require-event-prefix` typed
+path for imported Props types (its local-type fixtures already pass
+syntactically); Gate 1 serial-probe latency measurement; the warm-session daemon
+(Wave 4); the serial-probe concurrency bridge (R3); and CLI integration (the CLI
+cannot depend on the private backend, so type-aware linting runs via
+`rsvelte_lint_types`).
 
 ### Not yet started
 


### PR DESCRIPTION
## What

Completes the remaining Wave-3 type-aware follow-ups for `svelte/no-unused-props` — the option/edge cases the flat path couldn't express (`checkImportedTypes`, `ignore*Patterns`, index signatures, nested recursion into named/imported types, class skipping). Builds on #1029.

## How

**Type-graph backend API** (`rsvelte_lint::type_backend`)
- `TypeBackend::{props_type, type_meta, type_props}` expose the props type graph on demand (default impls → the existing flat `probe_props` path remains as a degraded fallback).
- `TypeMeta` { text, has_index_signature, is_class, base_type_ids }; `PropMeta` { name, is_local, is_builtin, type_id }.

**`CorsaTypeBackend`** (`rsvelte_lint_types`) implements the graph over corsa: `get_properties_of_type` (→ declarations → source-file path → `is_local` = `isInternalProperty`), `get_base_types`, `get_index_infos_of_type`, and `ObjectFlags.Class`. (Gotchas handled: the worker lowercases paths → case-insensitive compare; the `NodeHandle` wire layout isn't the documented 3-number form → manual path extraction.)

**Rule** (`no_unused_props::diagnostics_typed`) dispatches to a faithful recursive port of upstream's `checkUnusedProperties` when the graph is available:
- `checkImportedTypes` (skip unused imported-origin props by default)
- `ignorePropertyPatterns` / `ignoreTypePatterns` with exact `toRegExp` semantics (**plain string = exact match**, only `/…/` is a regex)
- `allowUnusedNestedProperties`, base-type recursion, nested named/imported types, `isClassType` skipping, the unused-index-signature message
- upstream's usage-path model (member chains + spread + `normalizeUsedPaths`, excluding the destructure binding and pre-declaration text)

## Testing
- **All 76 upstream `no-unused-props` fixtures pass** via a new corsa/tsgo e2e oracle (`rsvelte_lint_types::tests::no_unused_props_fixtures`) — including every previously-skipped type-checker-only case (extends / intersection / generics / imported / nested / index-signature / ignore-patterns / `custom-config-combination`).
- corsa-free **mock-graph unit tests** in `rsvelte_lint` cover the graph logic in CI (which can't run corsa).
- Full `rsvelte_lint` native suite (177) + oracle, isolated-crate e2e (nav + props), wasm build, `clippy --all-targets --all-features -D warnings`, and the doc build all green.

## Notes
- `rsvelte_lint_types` remains outside the workspace (CI can't clone the private corsa submodule), so the e2e oracle runs locally; the rule logic is mock-tested in CI.
- Remaining typed follow-up (separate): a `require-event-prefix` typed path for imported Props types (its local-type fixtures already pass syntactically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)