### PR TITLE
fix(svelte2tsx): char-boundary-safe JSDoc terminator probe (fix playground "unreachable")

### DIFF
--- a/.changeset/svelte2tsx-multibyte-comment-boundary.md
+++ b/.changeset/svelte2tsx-multibyte-comment-boundary.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Fix a panic in svelte2tsx when a declaration is immediately preceded by a
+multi-byte character (e.g. a `─` box-drawing char in a `// ── … ──` comment
+banner). `leading_jsdoc_comment` probed the block-comment terminator by slicing
+`&source[p - 2..p]`, which lands mid-char and panics on a non-char-boundary
+index; in the wasm playground this surfaced as a bare `unreachable` trap. The
+terminator is now tested with `source[..p].ends_with("*/")`.

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -4399,8 +4399,12 @@ fn leading_jsdoc_comment(source: &str, before: usize) -> Option<String> {
     while p > 0 && bytes[p - 1].is_ascii_whitespace() {
         p -= 1;
     }
-    // Require a block comment terminator `*/` right there.
-    if p < 2 || &source[p - 2..p] != "*/" {
+    // Require a block comment terminator `*/` right there. `p` is a valid char
+    // boundary (it was stepped back only over ASCII whitespace), but the two
+    // bytes ending at `p` may land inside a multi-byte char (e.g. a `─` in a
+    // preceding comment), so test with `ends_with` instead of slicing — a raw
+    // `source[p - 2..p]` would panic on a non-char-boundary index.
+    if !source[..p].ends_with("*/") {
         return None;
     }
     // Find the matching `/*` opener. Official `getDoc` captures ANY leading

--- a/crates/rsvelte_core/tests/svelte2tsx_multibyte_comment_boundary.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_multibyte_comment_boundary.rs
@@ -1,0 +1,32 @@
+//! Regression test: svelte2tsx must not panic on a multi-byte char immediately
+//! before a declaration.
+//!
+//! `leading_jsdoc_comment` (script/mod.rs) probes the two bytes ending at the
+//! declaration start for a `*/` block-comment terminator. It used to slice
+//! `&source[p - 2..p]` directly, which panics ("byte index is not a char
+//! boundary") when the byte before the declaration is part of a multi-byte
+//! char — e.g. a `─` box-drawing character in a preceding line comment. In the
+//! wasm playground this surfaced as a bare `unreachable` trap. The playground's
+//! default example uses exactly these `// ── … ──` comment banners.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+#[test]
+fn multibyte_char_before_declaration_does_not_panic() {
+    // The `─` (U+2500) box-drawing chars are multi-byte; the declaration that
+    // follows starts right after the comment line's whitespace.
+    let src = "<script>\n\
+        \t// ── $state ────────────────────────────────────\n\
+        \tlet count = $state(0);\n\
+        </script>\n\
+        <p>{count}</p>";
+
+    let opts = Svelte2TsxOptions {
+        filename: "Component.svelte".to_string(),
+        is_ts_file: true,
+        ..Default::default()
+    };
+
+    let result = svelte2tsx(src, opts).expect("svelte2tsx should not panic");
+    assert!(result.code.contains("count"), "output:\n{}", result.code);
+}


### PR DESCRIPTION
## Problem

Running **svelte2tsx** in the WASM playground showed:

```
svelte2tsx error
unreachable
```

The default playground example uses `// ── … ──` comment banners (box-drawing chars) to separate rune sections. `─` (U+2500) is a 3-byte UTF-8 char.

`leading_jsdoc_comment` (`crates/rsvelte_core/src/svelte2tsx/script/mod.rs`) probes the two bytes ending at a declaration start for a `*/` block-comment terminator by slicing `&source[p - 2..p]`. When the byte immediately before the declaration is part of a multi-byte char, `p - 2` lands **inside** that char and the slice panics:

```
start byte index 137 is not a char boundary; it is inside '─' (bytes 136..139 of string)
```

In a native build this is a clean panic; in WASM it surfaces as a bare `unreachable` trap, which the playground catches and displays verbatim.

## Fix

Test the terminator with `source[..p].ends_with("*/")` instead of slicing. `p` is a valid char boundary (it was only stepped back over ASCII whitespace), so `source[..p]` is safe, and once it's confirmed to end with `*/` the downstream `p - 2` indices are guaranteed ASCII boundaries too.

## Note on #1024

Related crate (the playground's `rsvelte_lint` WASM), but a different problem: #1024 fixed a **wasm build error** (native-only lint rules leaking into the wasm feature). This is a **runtime panic** in `svelte2tsx` that #1024 does not touch.

## Verification

- New regression test `crates/rsvelte_core/tests/svelte2tsx_multibyte_comment_boundary.rs` — passes (panicked before the fix).
- The playground's full default example now compiles instead of trapping.
- All 253 `svelte2tsx` fixtures still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)