### PR TITLE
refactor(transform): extract ast_rewrite toolkit, dedupe 26 client *_ast.rs passes

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_rewrite.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_rewrite.rs
@@ -1,0 +1,190 @@
+//! Shared driver for the `*_ast.rs` collect-and-splice rewrite passes.
+//!
+//! Every `transform_*_ast` pass in this directory follows the same shape:
+//! parse the current script in a thread-local arena, walk the AST with a
+//! bespoke `Visit` collector that records `(start, end, replacement)` edits,
+//! then splice those edits back into the source text (innermost-first, so a
+//! later fixed-point pass can rewrite an outer node once its children are
+//! settled). The *only* part that differs between passes is the collector.
+//!
+//! This module factors out everything else — arena take/restore, parse-error
+//! bail, edit splicing, and the bounded fixed-point loop — so each pass file
+//! is just its probe + collector + a few lines of wiring. The helpers are
+//! intentionally small and composable rather than a single mega-driver,
+//! because the passes vary along independent axes (TS vs. mjs source type,
+//! `allow_return_outside_function`, single-pass vs. fixed-point, whether
+//! nested edits need innermost-first deferral).
+
+use std::cell::RefCell;
+use std::thread::LocalKey;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program;
+use oxc_parser::{ParseOptions, Parser};
+use oxc_span::SourceType;
+
+/// A single text edit: `(start, end, replacement)` over byte offsets into the
+/// source the edit was collected from. Replacement text is owned so it can
+/// outlive the arena the AST was parsed into.
+pub type Edit = (u32, u32, String);
+
+/// The shared bound on fixed-point iteration. Each pass strictly reduces the
+/// remaining work (a rewritten node no longer matches), so real inputs settle
+/// in one or two passes; the cap is a safety net against pathological nesting.
+pub const MAX_FIXED_POINT_ITERS: usize = 16;
+
+/// Parse `source` in `arena` and hand the program to `f`, restoring the arena
+/// afterwards so it is reused across calls. Returns `None` (without calling
+/// `f`) when the source fails to parse — a malformed intermediate is never the
+/// rewrite pass's responsibility to surface, so it is left untouched.
+///
+/// `f` receives only `&Program`, which is enough to build an
+/// [`oxc_semantic::Semantic`] in-closure when a pass needs scope information.
+pub fn with_program<R>(
+    arena: &'static LocalKey<RefCell<Allocator>>,
+    source: &str,
+    source_type: SourceType,
+    parse_options: ParseOptions,
+    f: impl FnOnce(&Program<'_>) -> Option<R>,
+) -> Option<R> {
+    arena.with(|cell| {
+        let allocator = std::mem::take(&mut *cell.borrow_mut());
+        let parsed = Parser::new(&allocator, source, source_type)
+            .with_options(parse_options)
+            .parse();
+        let out = if parsed.diagnostics.is_empty() {
+            f(&parsed.program)
+        } else {
+            None
+        };
+        *cell.borrow_mut() = allocator;
+        out
+    })
+}
+
+/// Splice `edits` into `source`, returning the rewritten text or `None` when
+/// there is nothing to apply.
+///
+/// When `innermost_only` is set, an edit whose span strictly contains another
+/// edit's span is dropped from this pass: the inner rewrite lands first and a
+/// subsequent fixed-point pass re-collects the (now smaller) outer node. This
+/// is what makes nested rewrites such as `a = b = 1` resolve correctly without
+/// the collector having to reason about overlap. Passes whose edits provably
+/// never nest pass `false` and skip the O(n²) containment check.
+pub fn splice(source: &str, mut edits: Vec<Edit>, innermost_only: bool) -> Option<String> {
+    if edits.is_empty() {
+        return None;
+    }
+
+    if innermost_only {
+        let spans: Vec<(u32, u32)> = edits.iter().map(|&(s, e, _)| (s, e)).collect();
+        edits.retain(|&(s, e, _)| {
+            !spans
+                .iter()
+                .any(|&(s2, e2)| (s2 > s && e2 <= e) || (s2 >= s && e2 < e))
+        });
+        if edits.is_empty() {
+            return None;
+        }
+    }
+
+    // Apply right-to-left so earlier offsets stay valid as we mutate.
+    edits.sort_by_key(|&(start, ..)| std::cmp::Reverse(start));
+    let mut out = source.to_string();
+    for (start, end, replacement) in &edits {
+        out.replace_range(*start as usize..*end as usize, replacement);
+    }
+    Some(out)
+}
+
+/// Convenience: [`with_program`] + collect + [`splice`] in one pass. The
+/// collector closure returns the edits for this parse; the rest is wiring.
+pub fn rewrite_once(
+    arena: &'static LocalKey<RefCell<Allocator>>,
+    source: &str,
+    source_type: SourceType,
+    parse_options: ParseOptions,
+    innermost_only: bool,
+    collect: impl FnOnce(&Program<'_>) -> Vec<Edit>,
+) -> Option<String> {
+    with_program(arena, source, source_type, parse_options, |program| {
+        splice(source, collect(program), innermost_only)
+    })
+}
+
+/// Drive `pass` to a fixed point, capped at [`MAX_FIXED_POINT_ITERS`]. Returns
+/// `Some(rewritten)` if at least one pass changed the source, `None` if the
+/// very first pass was already a no-op. Each call to `pass` re-parses the
+/// previous output, which is how outer nodes pick up their rewritten children.
+pub fn fixed_point(source: &str, mut pass: impl FnMut(&str) -> Option<String>) -> Option<String> {
+    let mut current = pass(source)?;
+    for _ in 1..MAX_FIXED_POINT_ITERS {
+        match pass(&current) {
+            Some(next) => current = next,
+            None => break,
+        }
+    }
+    Some(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splice_empty_is_none() {
+        assert!(splice("abc", vec![], false).is_none());
+    }
+
+    #[test]
+    fn splice_applies_right_to_left() {
+        // Two non-overlapping edits; offsets must stay valid regardless of the
+        // length change from the later edit.
+        let edits = vec![(0, 1, "XX".to_string()), (2, 3, "Y".to_string())];
+        assert_eq!(splice("abc", edits, false).unwrap(), "XXbY");
+    }
+
+    #[test]
+    fn splice_innermost_only_defers_outer() {
+        // Outer span (0,5) strictly contains inner (2,3): only the inner edit
+        // applies this pass.
+        let edits = vec![(0, 5, "OUTER".to_string()), (2, 3, "I".to_string())];
+        assert_eq!(splice("abcde", edits, true).unwrap(), "abIde");
+    }
+
+    #[test]
+    fn splice_innermost_only_keeps_disjoint() {
+        let edits = vec![(0, 1, "X".to_string()), (2, 3, "Y".to_string())];
+        assert_eq!(splice("abc", edits, true).unwrap(), "XbY");
+    }
+
+    #[test]
+    fn fixed_point_returns_none_when_first_pass_noop() {
+        assert!(fixed_point("x", |_| None).is_none());
+    }
+
+    #[test]
+    fn fixed_point_runs_until_stable() {
+        // Replace the first 'a' with 'b' each pass; converges when none remain.
+        let out = fixed_point("aaa", |s| {
+            s.find('a').map(|i| {
+                let mut t = s.to_string();
+                t.replace_range(i..i + 1, "b");
+                t
+            })
+        });
+        assert_eq!(out.unwrap(), "bbb");
+    }
+
+    #[test]
+    fn fixed_point_respects_iteration_cap() {
+        // A pass that always reports a change stops after MAX_FIXED_POINT_ITERS
+        // calls rather than looping forever.
+        let mut calls = 0;
+        let _ = fixed_point("x", |s| {
+            calls += 1;
+            Some(format!("{s}."))
+        });
+        assert_eq!(calls, MAX_FIXED_POINT_ITERS);
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
@@ -26,8 +26,10 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::{GetSpan, SourceType};
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_CONSOLE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -58,60 +60,32 @@ pub fn transform_console_calls_dev_ast(source: &str, is_ts: bool) -> Option<Stri
     // arguments are themselves leaf (no `console.<method>(` lurking
     // in their source span), then re-parse and repeat. Terminates
     // in O(max nesting depth) passes — typically 1.
-    let mut current: Option<String> = None;
-    loop {
-        let src = current.as_deref().unwrap_or(source);
-        match single_pass(src, is_ts) {
-            None => break,
-            Some(rewritten) => current = Some(rewritten),
-        }
-    }
-    current
-}
-
-fn single_pass(source: &str, is_ts: bool) -> Option<String> {
-    MODULE_CONSOLE_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let source_type = if is_ts {
-            SourceType::ts().with_module(true)
-        } else {
-            SourceType::mjs()
-        };
-        let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = ConsoleCollector {
-            source,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Replacements here are guaranteed non-overlapping (the
-        // collector defers calls whose args still contain another
-        // matching call), so right-to-left splice is correct.
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_CONSOLE_ALLOC,
+            src,
+            if is_ts {
+                SourceType::ts().with_module(true)
+            } else {
+                SourceType::mjs()
+            },
+            ParseOptions::default(),
+            false,
+            |program| {
+                let mut collector = ConsoleCollector {
+                    source: src,
+                    replacements: Vec::new(),
+                };
+                collector.visit_program(program);
+                collector.replacements
+            },
+        )
     })
 }
 
 struct ConsoleCollector<'src> {
     source: &'src str,
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'src> Visit<'a> for ConsoleCollector<'src> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/derived_by_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/derived_by_ast.rs
@@ -19,8 +19,10 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::{GetSpan, SourceType};
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_DERIVED_BY_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -31,37 +33,26 @@ thread_local! {
 pub fn transform_derived_by_ast(source: &str, is_ts: bool) -> Option<String> {
     memchr::memmem::find(source.as_bytes(), b"$derived.by")?;
 
-    MODULE_DERIVED_BY_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let source_type = if is_ts {
+    ast_rewrite::rewrite_once(
+        &MODULE_DERIVED_BY_ALLOC,
+        source,
+        if is_ts {
             SourceType::ts().with_module(true)
         } else {
             SourceType::mjs()
-        };
-        let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = DerivedByCollector { spans: Vec::new() };
-        collector.visit_program(&parser_ret.program);
-        let mut spans = collector.spans;
-
-        if spans.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        spans.sort_by_key(|s| std::cmp::Reverse(s.0));
-        let mut out = source.to_string();
-        for (start, end) in &spans {
-            out.replace_range(*start as usize..*end as usize, "$.derived");
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+        },
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = DerivedByCollector { spans: Vec::new() };
+            collector.visit_program(program);
+            collector
+                .spans
+                .into_iter()
+                .map(|(start, end)| (start, end, "$.derived".to_string()))
+                .collect::<Vec<Edit>>()
+        },
+    )
 }
 
 struct DerivedByCollector {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/effect_rune_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/effect_rune_ast.rs
@@ -25,8 +25,10 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_EFFECT_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -39,47 +41,29 @@ pub fn apply_effect_rune_transforms_ast(source: &str, is_ts: bool) -> Option<Str
     // Fast probe — most module scripts don't use $effect at all.
     memchr::memmem::find(source.as_bytes(), b"$effect")?;
 
-    MODULE_EFFECT_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let source_type = if is_ts {
+    ast_rewrite::rewrite_once(
+        &MODULE_EFFECT_ALLOC,
+        source,
+        if is_ts {
             SourceType::ts().with_module(true)
         } else {
             SourceType::mjs()
-        };
-        let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = EffectRuneCollector {
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Non-overlapping by construction (every replacement is a
-        // distinct call expression callee span or a distinct whole
-        // call span). Right-to-left apply preserves offsets.
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+        },
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = EffectRuneCollector {
+                replacements: Vec::new(),
+            };
+            collector.visit_program(program);
+            collector.replacements
+        },
+    )
 }
 
 struct EffectRuneCollector {
     /// Each entry is `(span_start, span_end, replacement_string)`.
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a> Visit<'a> for EffectRuneCollector {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/legacy_state_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/legacy_state_member_mutate_ast.rs
@@ -45,16 +45,16 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
 use oxc_span::Span;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_LEGACY_STATE_MEMBER_MUTATE_ALLOC: RefCell<Allocator> =
         RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `obj.prop = rhs` / `obj[i] = rhs` etc. for
 /// legacy-mode state variables (skipping `non_reactive_state_vars`
@@ -79,78 +79,26 @@ pub fn transform_legacy_state_member_mutate_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(
-            &current,
-            state_vars,
-            non_reactive_state_vars,
-            raw_state_vars,
-        ) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(
-    source: &str,
-    state_vars: &[String],
-    non_reactive_state_vars: &[String],
-    raw_state_vars: &[String],
-) -> Option<String> {
-    MODULE_LEGACY_STATE_MEMBER_MUTATE_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = LegacyStateMemberMutateCollector {
-            source,
-            state_vars,
-            non_reactive_state_vars,
-            raw_state_vars,
-            replacements: Vec::new(),
-            skip_assignment_spans: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Innermost-only per pass — defer outer when its span
-        // strictly contains an inner.
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_LEGACY_STATE_MEMBER_MUTATE_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions::default(),
+            true,
+            |program| {
+                let mut collector = LegacyStateMemberMutateCollector {
+                    source: src,
+                    state_vars,
+                    non_reactive_state_vars,
+                    raw_state_vars,
+                    replacements: Vec::new(),
+                    skip_assignment_spans: Vec::new(),
+                };
+                collector.visit_program(program);
+                collector.replacements
+            },
+        )
     })
 }
 
@@ -159,7 +107,7 @@ struct LegacyStateMemberMutateCollector<'a> {
     state_vars: &'a [String],
     non_reactive_state_vars: &'a [String],
     raw_state_vars: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
     /// Spans of `AssignmentExpression`s that are the second arg of a
     /// `$.mutate(var, <assignment>)` wrap call. Skipping these is what
     /// makes the rewrite idempotent.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/local_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/local_assign_ast.rs
@@ -28,10 +28,12 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::GetSpan;
 use oxc_span::SourceType;
 use oxc_syntax::operator::AssignmentOperator;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_LOCAL_ASSIGN_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -47,42 +49,30 @@ pub fn transform_local_assign_ast(source: &str, var_name: &str) -> Option<String
     memchr::memchr(b'=', source.as_bytes())?;
     memchr::memmem::find(source.as_bytes(), var_name.as_bytes())?;
 
-    MODULE_LOCAL_ASSIGN_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = LocalAssignCollector {
-            source,
-            var_name,
-            matches: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-
-        if collector.matches.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Match the text version: only the FIRST occurrence (smallest start).
-        collector.matches.sort_by_key(|r| r.0);
-        let (start, end, rewrite) = collector.matches.remove(0);
-
-        let mut out = source.to_string();
-        out.replace_range(start as usize..end as usize, &rewrite);
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+    ast_rewrite::rewrite_once(
+        &MODULE_LOCAL_ASSIGN_ALLOC,
+        source,
+        SourceType::mjs(),
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = LocalAssignCollector {
+                source,
+                var_name,
+                matches: Vec::new(),
+            };
+            collector.visit_program(program);
+            // Match the text version: only the FIRST occurrence (smallest start).
+            collector.matches.sort_by_key(|r| r.0);
+            collector.matches.into_iter().take(1).collect()
+        },
+    )
 }
 
 struct LocalAssignCollector<'a> {
     source: &'a str,
     var_name: &'a str,
-    matches: Vec<(u32, u32, String)>,
+    matches: Vec<Edit>,
 }
 
 impl<'a, 'ast> Visit<'ast> for LocalAssignCollector<'a> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -6,6 +6,7 @@
 //! `svelte/packages/svelte/src/compiler/phases/3-transform/client/`.
 
 use std::fmt::Write as _;
+mod ast_rewrite;
 mod ast_state_transform;
 mod class_transforms;
 mod console_dev_ast;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
@@ -42,14 +42,13 @@ use oxc_span::GetSpan;
 use oxc_span::SourceType;
 use oxc_syntax::operator::{AssignmentOperator, UpdateOperator};
 
+use super::ast_rewrite::{self, Edit};
 use super::expression_utils::expression_needs_proxy;
 
 thread_local! {
     static MODULE_PRIVATE_CLASS_ASSIGN_ALLOC: RefCell<Allocator> =
         RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of private-field assignments + updates for
 /// class method bodies. `state_qualified` lists `$state` fields
@@ -72,19 +71,9 @@ pub fn transform_private_class_assign_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, state_qualified, other_qualified) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
+    ast_rewrite::fixed_point(source, |src| {
+        single_pass(src, state_qualified, other_qualified)
+    })
 }
 
 fn single_pass(
@@ -162,31 +151,8 @@ fn single_pass(
             replacements.retain(|(_, e, _)| *e <= src_len);
         }
 
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
         *cell.borrow_mut() = allocator;
-        Some(out)
+        ast_rewrite::splice(source, replacements, true)
     })
 }
 
@@ -194,7 +160,7 @@ struct PrivateClassAssignCollector<'a> {
     source: &'a str,
     state_qualified: &'a [String],
     other_qualified: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 #[derive(Clone, Copy)]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_field_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_field_assign_ast.rs
@@ -56,17 +56,17 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_span::GetSpan;
 use oxc_span::SourceType;
 use oxc_syntax::operator::{AssignmentOperator, UpdateOperator};
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_PRIVATE_FIELD_ASSIGN_ALLOC: RefCell<Allocator> =
         RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `q = expr` / `q <op>= expr` where `q` is a
 /// private-field expression whose source text matches one of
@@ -86,77 +86,33 @@ pub fn transform_private_field_assign_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, qualified_names) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(source: &str, qualified_names: &[String]) -> Option<String> {
-    MODULE_PRIVATE_FIELD_ASSIGN_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        // Class-method bodies often include bare `return`.
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs())
-            .with_options(ParseOptions {
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_PRIVATE_FIELD_ASSIGN_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions {
                 allow_return_outside_function: true,
                 ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = PrivateFieldAssignCollector {
-            source,
-            qualified_names,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Innermost-only per pass.
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+            },
+            true,
+            |program| {
+                let mut collector = PrivateFieldAssignCollector {
+                    source: src,
+                    qualified_names,
+                    replacements: Vec::new(),
+                };
+                collector.visit_program(program);
+                collector.replacements
+            },
+        )
     })
 }
 
 struct PrivateFieldAssignCollector<'a> {
     source: &'a str,
     qualified_names: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'ast> Visit<'ast> for PrivateFieldAssignCollector<'a> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_member_read_wrap_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_member_read_wrap_ast.rs
@@ -47,15 +47,15 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
+
+use super::ast_rewrite;
 
 thread_local! {
     static MODULE_PRIVATE_MEMBER_READ_WRAP_ALLOC: RefCell<Allocator> =
         RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `q.foo` / `q[i]` reads. Returns `None`
 /// when there's nothing to rewrite or the source fails to parse.
@@ -73,62 +73,36 @@ pub fn transform_private_member_read_wrap_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, qualified_names) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(source: &str, qualified_names: &[String]) -> Option<String> {
-    MODULE_PRIVATE_MEMBER_READ_WRAP_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs())
-            .with_options(ParseOptions {
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_PRIVATE_MEMBER_READ_WRAP_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions {
                 allow_return_outside_function: true,
                 ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = PrivateMemberReadWrapCollector {
-            source,
-            qualified_names,
-            wrap_spans: Vec::new(),
-            skip_spans: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let skip = collector.skip_spans;
-        let mut wraps = collector.wrap_spans;
-        wraps.retain(|(s, e)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
-
-        if wraps.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Build replacements end-to-start.
-        wraps.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end) in &wraps {
-            let qualified = &source[*start as usize..*end as usize];
-            let rewrite = format!("$.get({})", qualified);
-            out.replace_range(*start as usize..*end as usize, &rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+            },
+            true,
+            |program| {
+                let mut collector = PrivateMemberReadWrapCollector {
+                    source: src,
+                    qualified_names,
+                    wrap_spans: Vec::new(),
+                    skip_spans: Vec::new(),
+                };
+                collector.visit_program(program);
+                let skip = collector.skip_spans;
+                let mut wraps = collector.wrap_spans;
+                wraps.retain(|(s, e)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
+                wraps
+                    .into_iter()
+                    .map(|(start, end)| {
+                        let qualified = &src[start as usize..end as usize];
+                        (start, end, format!("$.get({})", qualified))
+                    })
+                    .collect()
+            },
+        )
     })
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_read_wrap_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_read_wrap_ast.rs
@@ -36,15 +36,15 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_PRIVATE_READ_WRAP_ALLOC: RefCell<Allocator> =
         RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `qualified` reads (where `qualified` is
 /// the source-text of a private-field access like `this.#count`)
@@ -57,68 +57,38 @@ pub fn transform_private_read_wrap_ast(source: &str, qualified: &str) -> Option<
     // Fast probe — bail if `qualified` doesn't appear at all.
     memchr::memmem::find(source.as_bytes(), qualified.as_bytes())?;
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, qualified) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(source: &str, qualified: &str) -> Option<String> {
-    MODULE_PRIVATE_READ_WRAP_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        // Callers (class method bodies) often pass fragments with
-        // bare `return` statements at the top level — allow it.
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs())
-            .with_options(ParseOptions {
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_PRIVATE_READ_WRAP_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions {
                 allow_return_outside_function: true,
                 ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = PrivateReadWrapCollector {
-            source,
-            qualified,
-            replacements: Vec::new(),
-            skip_spans: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-        let skip = collector.skip_spans;
-        replacements.retain(|(s, e, _)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+            },
+            true,
+            |program| {
+                let mut collector = PrivateReadWrapCollector {
+                    source: src,
+                    qualified,
+                    replacements: Vec::new(),
+                    skip_spans: Vec::new(),
+                };
+                collector.visit_program(program);
+                let skip = collector.skip_spans;
+                let mut replacements = collector.replacements;
+                replacements
+                    .retain(|(s, e, _)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
+                replacements
+            },
+        )
     })
 }
 
 struct PrivateReadWrapCollector<'a> {
     source: &'a str,
     qualified: &'a str,
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
     /// Spans of `PrivateFieldExpression`s that should NOT be
     /// rewritten (assignment LHS, update target, deeper-member
     /// object, $.get/$.set/$.update/$.update_pre argument).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_v_suffix_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_v_suffix_ast.rs
@@ -39,15 +39,15 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_PRIVATE_V_SUFFIX_ALLOC: RefCell<Allocator> =
         RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of standalone `qualified` reads to
 /// `qualified.v`. Returns `None` when there's nothing to rewrite
@@ -63,67 +63,38 @@ pub fn transform_private_v_suffix_ast(source: &str, qualified_names: &[String]) 
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, qualified_names) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(source: &str, qualified_names: &[String]) -> Option<String> {
-    MODULE_PRIVATE_V_SUFFIX_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        // Constructor bodies often include bare `return`.
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs())
-            .with_options(ParseOptions {
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_PRIVATE_V_SUFFIX_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions {
                 allow_return_outside_function: true,
                 ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = PrivateVSuffixCollector {
-            source,
-            qualified_names,
-            replacements: Vec::new(),
-            skip_spans: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-        let skip = collector.skip_spans;
-        replacements.retain(|(s, e, _)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+            },
+            true,
+            |program| {
+                let mut collector = PrivateVSuffixCollector {
+                    source: src,
+                    qualified_names,
+                    replacements: Vec::new(),
+                    skip_spans: Vec::new(),
+                };
+                collector.visit_program(program);
+                let skip = collector.skip_spans;
+                let mut replacements = collector.replacements;
+                replacements
+                    .retain(|(s, e, _)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
+                replacements
+            },
+        )
     })
 }
 
 struct PrivateVSuffixCollector<'a> {
     source: &'a str,
     qualified_names: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
     skip_spans: Vec<(u32, u32)>,
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
@@ -47,16 +47,16 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::GetSpan;
 use oxc_span::SourceType;
 use oxc_syntax::operator::AssignmentOperator;
 
+use super::ast_rewrite::{self, Edit};
+
 thread_local! {
     static MODULE_PROP_ASSIGN_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `name = expr` / `name <op>= expr` for
 /// the bindings in `prop_vars`. Returns `None` when there's
@@ -72,73 +72,30 @@ pub fn transform_prop_assign_ast(source: &str, prop_vars: &[String]) -> Option<S
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, prop_vars) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(source: &str, prop_vars: &[String]) -> Option<String> {
-    MODULE_PROP_ASSIGN_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = PropAssignCollector {
-            source,
-            prop_vars,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Innermost-only per pass — defer outer when its span
-        // strictly contains an inner. Next iteration picks up the
-        // outer once its RHS has been rewritten.
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_PROP_ASSIGN_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions::default(),
+            true,
+            |program| {
+                let mut collector = PropAssignCollector {
+                    source: src,
+                    prop_vars,
+                    replacements: Vec::new(),
+                };
+                collector.visit_program(program);
+                collector.replacements
+            },
+        )
     })
 }
 
 struct PropAssignCollector<'a> {
     source: &'a str,
     prop_vars: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'ast> Visit<'ast> for PropAssignCollector<'a> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
@@ -56,15 +56,15 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
 use oxc_span::Span;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_PROP_MEMBER_MUTATE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `prop.foo = x` / `prop().foo = x` etc. for
 /// bindable prop variables (skipping `non_bindable_prop_vars`).
@@ -87,69 +87,25 @@ pub fn transform_prop_member_mutate_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, prop_vars, non_bindable_prop_vars) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(
-    source: &str,
-    prop_vars: &[String],
-    non_bindable_prop_vars: &[String],
-) -> Option<String> {
-    MODULE_PROP_MEMBER_MUTATE_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = PropMemberMutateCollector {
-            source,
-            prop_vars,
-            non_bindable_prop_vars,
-            replacements: Vec::new(),
-            skip_assignment_spans: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_PROP_MEMBER_MUTATE_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions::default(),
+            true,
+            |program| {
+                let mut collector = PropMemberMutateCollector {
+                    source: src,
+                    prop_vars,
+                    non_bindable_prop_vars,
+                    replacements: Vec::new(),
+                    skip_assignment_spans: Vec::new(),
+                };
+                collector.visit_program(program);
+                collector.replacements
+            },
+        )
     })
 }
 
@@ -175,7 +131,7 @@ struct PropMemberMutateCollector<'a> {
     source: &'a str,
     prop_vars: &'a [String],
     non_bindable_prop_vars: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
     /// Spans of `AssignmentExpression`s that are the first arg of a
     /// `prop(<assignment>, true)` wrap call. Skipping these is what
     /// makes the rewrite idempotent for the `prop().foo = x` case,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_update_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_update_ast.rs
@@ -35,9 +35,11 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
 use oxc_syntax::operator::UpdateOperator;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_REACTIVE_UPDATE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -63,44 +65,30 @@ pub fn transform_reactive_update_ast(
         return None;
     }
 
-    MODULE_REACTIVE_UPDATE_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = ReactiveUpdateCollector {
-            prop_vars,
-            state_vars,
-            non_reactive_state_vars,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+    ast_rewrite::rewrite_once(
+        &MODULE_REACTIVE_UPDATE_ALLOC,
+        source,
+        SourceType::mjs(),
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = ReactiveUpdateCollector {
+                prop_vars,
+                state_vars,
+                non_reactive_state_vars,
+                replacements: Vec::new(),
+            };
+            collector.visit_program(program);
+            collector.replacements
+        },
+    )
 }
 
 struct ReactiveUpdateCollector<'a> {
     prop_vars: &'a [String],
     state_vars: &'a [String],
     non_reactive_state_vars: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 #[derive(Clone, Copy)]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rest_prop_member_access_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rest_prop_member_access_ast.rs
@@ -28,8 +28,10 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_REST_PROP_MEMBER_ACCESS_ALLOC: RefCell<Allocator> =
@@ -53,47 +55,34 @@ pub fn transform_rest_prop_member_access_ast(
         return None;
     }
 
-    MODULE_REST_PROP_MEMBER_ACCESS_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
+    ast_rewrite::rewrite_once(
+        &MODULE_REST_PROP_MEMBER_ACCESS_ALLOC,
+        source,
+        SourceType::mjs(),
+        ParseOptions::default(),
+        true,
+        |program| {
+            let mut collector = RestPropCollector {
+                rest_prop_vars,
+                replacements: Vec::new(),
+                skip_member_spans: Vec::new(),
+            };
+            collector.visit_program(program);
+            let mut replacements = collector.replacements;
+            let skip = collector.skip_member_spans;
 
-        let mut collector = RestPropCollector {
-            rest_prop_vars,
-            replacements: Vec::new(),
-            skip_member_spans: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-        let skip = collector.skip_member_spans;
-
-        // Drop replacements for skipped (single-level-LHS) members.
-        replacements.retain(|(s, e, _)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+            // Drop replacements for skipped (single-level-LHS) members.
+            replacements.retain(|(s, e, _)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
+            replacements
+        },
+    )
 }
 
 struct RestPropCollector<'a> {
     rest_prop_vars: &'a [String],
     /// Replacements: (start, end, new_text). The span here is the
     /// `rest_var` identifier's span, NOT the whole member chain.
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
     /// Spans of `rest_var` identifiers whose immediate parent is a
     /// `StaticMemberExpression` that is itself the LHS of an
     /// `AssignmentExpression`. These match the text version's

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_call_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_call_ast.rs
@@ -36,9 +36,10 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::{GetSpan, SourceType};
 
+use super::ast_rewrite::{self, Edit};
 use super::expression_utils::{collapse_to_single_line, expression_needs_proxy_with_scope};
 
 thread_local! {
@@ -57,43 +58,28 @@ pub fn transform_state_call_ast(
 ) -> Option<String> {
     memchr::memmem::find(source.as_bytes(), b"$state")?;
 
-    MODULE_STATE_CALL_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let source_type = if is_ts {
+    ast_rewrite::rewrite_once(
+        &MODULE_STATE_CALL_ALLOC,
+        source,
+        if is_ts {
             SourceType::ts().with_module(true)
         } else {
             SourceType::mjs()
-        };
-        let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = StateCallCollector {
-            source,
-            non_reactive_vars,
-            non_proxy_vars,
-            current_var: None,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+        },
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = StateCallCollector {
+                source,
+                non_reactive_vars,
+                non_proxy_vars,
+                current_var: None,
+                replacements: Vec::new(),
+            };
+            collector.visit_program(program);
+            collector.replacements
+        },
+    )
 }
 
 /// Stateful visitor — `current_var` tracks the binding name being
@@ -105,7 +91,7 @@ struct StateCallCollector<'a, 'src> {
     non_reactive_vars: &'a [String],
     non_proxy_vars: &'a [String],
     current_var: Option<String>,
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'src, 'ast> Visit<'ast> for StateCallCollector<'a, 'src> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_member_mutate_ast.rs
@@ -37,15 +37,15 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
 use oxc_span::Span;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_STATE_MEMBER_MUTATE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `state.prop = rhs` / `state[i] = rhs` etc.
 /// for the bindings in `state_vars` (excluding `non_reactive_vars`).
@@ -68,71 +68,24 @@ pub fn transform_state_member_mutate_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, state_vars, non_reactive_vars) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(
-    source: &str,
-    state_vars: &[String],
-    non_reactive_vars: &[String],
-) -> Option<String> {
-    MODULE_STATE_MEMBER_MUTATE_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = StateMemberMutateCollector {
-            source,
-            state_vars,
-            non_reactive_vars,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Innermost-only per pass — defer outer when its span
-        // strictly contains an inner. Next iteration picks up the
-        // outer once its RHS has been rewritten.
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_STATE_MEMBER_MUTATE_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions::default(),
+            true,
+            |program| {
+                let mut collector = StateMemberMutateCollector {
+                    source: src,
+                    state_vars,
+                    non_reactive_vars,
+                    replacements: Vec::new(),
+                };
+                collector.visit_program(program);
+                collector.replacements
+            },
+        )
     })
 }
 
@@ -140,7 +93,7 @@ struct StateMemberMutateCollector<'a> {
     source: &'a str,
     state_vars: &'a [String],
     non_reactive_vars: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a> StateMemberMutateCollector<'a> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_raw_frozen_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_raw_frozen_ast.rs
@@ -29,8 +29,10 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::{GetSpan, SourceType};
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_STATE_RAW_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -57,42 +59,27 @@ pub fn transform_state_raw_frozen_ast(
         return None;
     }
 
-    MODULE_STATE_RAW_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let source_type = if is_ts {
+    ast_rewrite::rewrite_once(
+        &MODULE_STATE_RAW_ALLOC,
+        source,
+        if is_ts {
             SourceType::ts().with_module(true)
         } else {
             SourceType::mjs()
-        };
-        let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = StateRawFrozenCollector {
-            source,
-            non_reactive_vars,
-            current_var: None,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+        },
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = StateRawFrozenCollector {
+                source,
+                non_reactive_vars,
+                current_var: None,
+                replacements: Vec::new(),
+            };
+            collector.visit_program(program);
+            collector.replacements
+        },
+    )
 }
 
 /// Stateful visitor — `current_var` tracks the binding being
@@ -106,7 +93,7 @@ struct StateRawFrozenCollector<'a, 'src> {
     source: &'src str,
     non_reactive_vars: &'a [String],
     current_var: Option<String>,
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'src, 'ast> Visit<'ast> for StateRawFrozenCollector<'a, 'src> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_set_reactive_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_set_reactive_ast.rs
@@ -32,16 +32,16 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::GetSpan;
 use oxc_span::SourceType;
 use oxc_syntax::operator::AssignmentOperator;
 
+use super::ast_rewrite::{self, Edit};
+
 thread_local! {
     static MODULE_STATE_SET_REACTIVE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `name = expr` for reactive state variables
 /// (excluding `non_reactive_vars`). Returns `None` when there's
@@ -65,71 +65,27 @@ pub fn transform_state_set_reactive_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, state_vars, non_reactive_vars) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(
-    source: &str,
-    state_vars: &[String],
-    non_reactive_vars: &[String],
-) -> Option<String> {
-    MODULE_STATE_SET_REACTIVE_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = StateSetCollector {
-            source,
-            state_vars,
-            non_reactive_vars,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Innermost-only per pass — defer outer when its span
-        // strictly contains an inner. Next iteration picks up the
-        // outer once its RHS has been rewritten.
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+    // Innermost-only per pass — defer an outer assignment when its span
+    // strictly contains an inner one (`a = b = 1`); the next fixed-point
+    // iteration picks up the outer once its RHS has been rewritten.
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_STATE_SET_REACTIVE_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions::default(),
+            true,
+            |program| {
+                let mut collector = StateSetCollector {
+                    source: src,
+                    state_vars,
+                    non_reactive_vars,
+                    replacements: Vec::new(),
+                };
+                collector.visit_program(program);
+                collector.replacements
+            },
+        )
     })
 }
 
@@ -137,7 +93,7 @@ struct StateSetCollector<'a> {
     source: &'a str,
     state_vars: &'a [String],
     non_reactive_vars: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'ast> Visit<'ast> for StateSetCollector<'a> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_snapshot_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_snapshot_ast.rs
@@ -20,8 +20,10 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::{GetSpan, SourceType};
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_SNAPSHOT_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -33,39 +35,26 @@ pub fn transform_state_snapshot_ast(source: &str, is_ts: bool) -> Option<String>
     // Fast probe — most module scripts don't reference $state.snapshot.
     memchr::memmem::find(source.as_bytes(), b"$state.snapshot")?;
 
-    MODULE_SNAPSHOT_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let source_type = if is_ts {
+    ast_rewrite::rewrite_once(
+        &MODULE_SNAPSHOT_ALLOC,
+        source,
+        if is_ts {
             SourceType::ts().with_module(true)
         } else {
             SourceType::mjs()
-        };
-        let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = SnapshotCollector { spans: Vec::new() };
-        collector.visit_program(&parser_ret.program);
-        let mut spans = collector.spans;
-
-        if spans.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Each replacement is a callee swap on a distinct call, so
-        // spans don't overlap. Right-to-left splice preserves offsets.
-        spans.sort_by_key(|s| std::cmp::Reverse(s.0));
-        let mut out = source.to_string();
-        for (start, end) in &spans {
-            out.replace_range(*start as usize..*end as usize, "$.snapshot");
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+        },
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = SnapshotCollector { spans: Vec::new() };
+            collector.visit_program(program);
+            collector
+                .spans
+                .into_iter()
+                .map(|(start, end)| (start, end, "$.snapshot".to_string()))
+                .collect::<Vec<Edit>>()
+        },
+    )
 }
 
 struct SnapshotCollector {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_assign_ast.rs
@@ -39,16 +39,16 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::GetSpan;
 use oxc_span::SourceType;
 use oxc_syntax::operator::AssignmentOperator;
 
+use super::ast_rewrite::{self, Edit};
+
 thread_local! {
     static MODULE_STORE_ASSIGN_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// Map a compound assignment operator to the binary operator it expands to for
 /// `$.store_set(access, $sub() <op> rhs)` lowering. Returns `None` only for the
@@ -102,82 +102,26 @@ pub fn transform_store_assign_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(
-            &current,
-            store_sub_vars,
-            prop_vars,
-            state_vars,
-            non_reactive_state_vars,
-        ) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(
-    source: &str,
-    store_sub_vars: &[String],
-    prop_vars: &[String],
-    state_vars: &[String],
-    non_reactive_state_vars: &[String],
-) -> Option<String> {
-    MODULE_STORE_ASSIGN_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = StoreAssignCollector {
-            source,
-            store_sub_vars,
-            prop_vars,
-            state_vars,
-            non_reactive_state_vars,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Filter out any replacement whose span strictly contains
-        // another replacement's span — only emit the innermost set
-        // this pass. The outer is picked up by the next fixed-point
-        // iteration once its RHS has been rewritten.
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_STORE_ASSIGN_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions::default(),
+            true,
+            |program| {
+                let mut collector = StoreAssignCollector {
+                    source: src,
+                    store_sub_vars,
+                    prop_vars,
+                    state_vars,
+                    non_reactive_state_vars,
+                    replacements: Vec::new(),
+                };
+                collector.visit_program(program);
+                collector.replacements
+            },
+        )
     })
 }
 
@@ -187,7 +131,7 @@ struct StoreAssignCollector<'a> {
     prop_vars: &'a [String],
     state_vars: &'a [String],
     non_reactive_state_vars: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'ast> Visit<'ast> for StoreAssignCollector<'a> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
@@ -35,15 +35,15 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
 use oxc_span::Span;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_STORE_MEMBER_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `$store.prop = x` / `$store[i]++` etc. for
 /// the bindings in `store_subs`. Returns `None` when there's
@@ -72,67 +72,24 @@ pub fn transform_store_member_mutate_ast_with_props(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, store_subs, prop_store_names) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(source: &str, store_subs: &[String], prop_store_names: &[String]) -> Option<String> {
-    MODULE_STORE_MEMBER_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = MemberMutateCollector {
-            source,
-            store_subs,
-            prop_store_names,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Innermost-only per pass — defer outer when its span
-        // strictly contains an inner. Next iteration picks up the
-        // outer once its child has been rewritten.
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_STORE_MEMBER_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions::default(),
+            true,
+            |program| {
+                let mut collector = MemberMutateCollector {
+                    source: src,
+                    store_subs,
+                    prop_store_names,
+                    replacements: Vec::new(),
+                };
+                collector.visit_program(program);
+                collector.replacements
+            },
+        )
     })
 }
 
@@ -140,7 +97,7 @@ struct MemberMutateCollector<'a> {
     source: &'a str,
     store_subs: &'a [String],
     prop_store_names: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a> MemberMutateCollector<'a> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_unsub_wrap_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_unsub_wrap_ast.rs
@@ -32,15 +32,15 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_STORE_UNSUB_WRAP_ALLOC: RefCell<Allocator> =
         RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// AST-based rewrite of `$.set(var, expr[, true])` wraps for
 /// state vars that have a corresponding store-sub binding.
@@ -57,72 +57,29 @@ pub fn transform_store_unsub_wrap_ast(
     // Fast probe — bail if no `$.set(` appears at all.
     memchr::memmem::find(source.as_bytes(), b"$.set(")?;
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(&current, state_vars, store_sub_vars) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-
-    if any_changed { Some(current) } else { None }
-}
-
-fn single_pass(source: &str, state_vars: &[String], store_sub_vars: &[String]) -> Option<String> {
-    MODULE_STORE_UNSUB_WRAP_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = StoreUnsubWrapCollector {
-            source,
-            state_vars,
-            store_sub_vars,
-            replacements: Vec::new(),
-            skip_set_spans: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-        let skip = collector.skip_set_spans;
-        replacements.retain(|(s, e, _)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Innermost-only per pass — `$.set(a, $.set(b, 5))` has the
-        // outer's span strictly containing the inner's. Applying
-        // both end-to-start corrupts bytes. Defer the outer; the
-        // next fixed-point iteration picks it up once its child is
-        // rewritten.
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
+    ast_rewrite::fixed_point(source, |src| {
+        ast_rewrite::rewrite_once(
+            &MODULE_STORE_UNSUB_WRAP_ALLOC,
+            src,
+            SourceType::mjs(),
+            ParseOptions::default(),
+            true,
+            |program| {
+                let mut collector = StoreUnsubWrapCollector {
+                    source: src,
+                    state_vars,
+                    store_sub_vars,
+                    replacements: Vec::new(),
+                    skip_set_spans: Vec::new(),
+                };
+                collector.visit_program(program);
+                let mut replacements = collector.replacements;
+                let skip = collector.skip_set_spans;
+                replacements
+                    .retain(|(s, e, _)| !skip.iter().any(|(s2, e2)| *s2 == *s && *e2 == *e));
+                replacements
+            },
+        )
     })
 }
 
@@ -130,7 +87,7 @@ struct StoreUnsubWrapCollector<'a> {
     source: &'a str,
     state_vars: &'a [String],
     store_sub_vars: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
     /// Spans of `$.set(...)` calls already wrapped in
     /// `$.store_unsub`.
     skip_set_spans: Vec<(u32, u32)>,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_update_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_update_ast.rs
@@ -36,9 +36,11 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
 use oxc_syntax::operator::UpdateOperator;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_STORE_UPDATE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -70,39 +72,24 @@ pub fn transform_store_update_ast(
         return None;
     }
 
-    MODULE_STORE_UPDATE_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = StoreUpdateCollector {
-            store_sub_vars,
-            prop_vars,
-            state_vars,
-            non_reactive_state_vars,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Spans don't overlap (each is a distinct UpdateExpression).
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+    ast_rewrite::rewrite_once(
+        &MODULE_STORE_UPDATE_ALLOC,
+        source,
+        SourceType::mjs(),
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = StoreUpdateCollector {
+                store_sub_vars,
+                prop_vars,
+                state_vars,
+                non_reactive_state_vars,
+                replacements: Vec::new(),
+            };
+            collector.visit_program(program);
+            collector.replacements
+        },
+    )
 }
 
 struct StoreUpdateCollector<'a> {
@@ -110,7 +97,7 @@ struct StoreUpdateCollector<'a> {
     prop_vars: &'a [String],
     state_vars: &'a [String],
     non_reactive_state_vars: &'a [String],
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'ast> Visit<'ast> for StoreUpdateCollector<'a> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/strip_rune_generics_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/strip_rune_generics_ast.rs
@@ -26,8 +26,10 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::{GetSpan, SourceType};
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_STRIP_GENERICS_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -52,38 +54,24 @@ pub fn strip_rune_generic_params_ast(source: &str, is_ts: bool) -> Option<String
         return None;
     }
 
-    MODULE_STRIP_GENERICS_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret =
-            Parser::new(&allocator, source, SourceType::ts().with_module(true)).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = StripGenericsCollector {
-            spans_to_strip: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut spans = collector.spans_to_strip;
-
-        if spans.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Spans are guaranteed non-overlapping (each is the type-args
-        // region of a distinct call); right-to-left splice preserves
-        // offsets.
-        spans.sort_by_key(|s| std::cmp::Reverse(s.0));
-        let mut out = source.to_string();
-        for (start, end) in &spans {
-            out.replace_range(*start as usize..*end as usize, "");
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+    ast_rewrite::rewrite_once(
+        &MODULE_STRIP_GENERICS_ALLOC,
+        source,
+        SourceType::ts().with_module(true),
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = StripGenericsCollector {
+                spans_to_strip: Vec::new(),
+            };
+            collector.visit_program(program);
+            collector
+                .spans_to_strip
+                .into_iter()
+                .map(|(start, end)| (start, end, String::new()))
+                .collect::<Vec<Edit>>()
+        },
+    )
 }
 
 struct StripGenericsCollector {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_class_field_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_class_field_ast.rs
@@ -25,8 +25,10 @@ use std::cell::RefCell;
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_span::{GetSpan, SourceType, Span};
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static CLASS_TAG_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -45,38 +47,23 @@ pub fn wrap_state_derived_with_tag_class_fields_ast(source: &str) -> Option<Stri
     }
     memchr::memmem::find(source.as_bytes(), b"class ")?;
 
-    CLASS_TAG_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs())
-            .with_options(ParseOptions {
-                allow_return_outside_function: true,
-                ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut replacements = Vec::new();
-        for stmt in &parser_ret.program.body {
-            walk_statement_for_classes(stmt, source, &mut replacements);
-        }
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+    ast_rewrite::rewrite_once(
+        &CLASS_TAG_ALLOC,
+        source,
+        SourceType::mjs(),
+        ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        },
+        false,
+        |program| {
+            let mut replacements: Vec<Edit> = Vec::new();
+            for stmt in &program.body {
+                walk_statement_for_classes(stmt, source, &mut replacements);
+            }
+            replacements
+        },
+    )
 }
 
 fn walk_statement_for_classes<'a>(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_declarator_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_declarator_ast.rs
@@ -34,8 +34,10 @@ use std::cell::RefCell;
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::{GetSpan, SourceType};
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     static MODULE_TAG_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -55,41 +57,24 @@ pub fn wrap_state_derived_with_tag_declarators_ast(source: &str, is_ts: bool) ->
         return None;
     }
 
-    MODULE_TAG_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let source_type = if is_ts {
+    ast_rewrite::rewrite_once(
+        &MODULE_TAG_ALLOC,
+        source,
+        if is_ts {
             SourceType::ts().with_module(true)
         } else {
             SourceType::mjs()
-        };
-        let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut replacements = Vec::new();
-        for stmt in &parser_ret.program.body {
-            walk_statement_for_declarators(stmt, source, &mut replacements);
-        }
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Non-overlapping by construction (each is a distinct
-        // declarator init span). Right-to-left splice preserves
-        // offsets.
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+        },
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut replacements: Vec<Edit> = Vec::new();
+            for stmt in &program.body {
+                walk_statement_for_declarators(stmt, source, &mut replacements);
+            }
+            replacements
+        },
+    )
 }
 
 /// Recursive top-down walk that finds VariableDeclarations anywhere


### PR DESCRIPTION
## Why

Phase 3's `client/*_ast.rs` collect-and-splice passes each hand-rolled the **same** scaffolding — thread-local arena take/restore, parse + diagnostic bail, innermost-first edit dedup, reverse-sort + `replace_range` splice, and a bounded fixed-point loop. The only thing that differed between ~26 files was the `Visit` collector. That's a textbook DRY violation and the kind of churn a compiler reviewer would flag immediately.

This is the first PR in a series to raise Phase 3 to a presentable, world-class bar (see `docs/phase3-ast-refactor-plan.md`).

## What

New composable toolkit `client/ast_rewrite.rs`:

| helper | role |
|---|---|
| `with_program` | arena take/restore + parse + parse-error bail; hands `&Program` to a closure (which may build `Semantic` in-line) |
| `splice` | reverse-sort + `replace_range`, with optional innermost-only deferral for nested rewrites (`a = b = 1`) |
| `rewrite_once` | `with_program` + collect + `splice` |
| `fixed_point` | the `MAX_FIXED_POINT_ITERS`-bounded driver |

Intentionally **small composable helpers, not one mega-driver**, because the passes vary along independent axes (TS vs. mjs source type, `allow_return_outside_function`, single-pass vs. fixed-point, innermost dedup on/off). Each migrated file keeps its exact shape; every collector, helper, and test is untouched.

## Notes

- `console_dev`'s previously **unbounded** nesting loop now shares the bounded `fixed_point` driver — identical output for all converging inputs, and no infinite-loop risk.
- `private_class_assign` keeps its bespoke `single_pass` (it has a class-wrapper reparse fallback the single-parse helpers can't express) but routes its splice/dedup tail and driver through the toolkit.
- Semantic-based passes (`state_reads`, `state_pipeline`, `state_assigns_combined`, `prop_source_reads`, `read_only_props`) and `strict_equals`'s custom guard-loop are deferred to a follow-up PR.

## Impact

**Net ~711 fewer lines.** Each pass file is now just its probe + collector + a few lines of wiring.

## Verification — output is byte-identical

- `cargo test -p rsvelte_core --lib` — **1283 passed**
- byte-exact suites: `compiler_fixtures` 17 ✓, `runtime` 19 ✓, `ssr` 16 ✓ (0 failed)
- clippy clean, fmt clean

Labeled `bench` so CodSpeed runs the `phase3_transform_*` benchmarks in CI; this refactor is perf-neutral by construction (same parse/splice/loop operations, now shared).