### PR TITLE
refactor(transform): route remaining Semantic/special *_ast.rs passes through ast_rewrite

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_source_reads_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_source_reads_ast.rs
@@ -58,11 +58,12 @@ use std::cell::RefCell;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::SourceType;
 use rustc_hash::FxHashSet;
 
+use super::ast_rewrite;
 use super::scope_analysis::is_locally_shadowed;
 
 thread_local! {
@@ -122,51 +123,46 @@ pub fn wrap_prop_source_reads_ast(
     };
     let span_offset: i32 = if needs_paren_wrap { 1 } else { 0 };
 
-    PROP_READ_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, &parse_source, SourceType::mjs())
-            .with_options(ParseOptions {
-                allow_return_outside_function: true,
-                ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-        let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
-        let semantic = &semantic_ret.semantic;
+    ast_rewrite::with_program(
+        &PROP_READ_ALLOC,
+        &parse_source,
+        SourceType::mjs(),
+        ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        },
+        |program| {
+            let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
+            let semantic = &semantic_ret.semantic;
 
-        let mut collector = PropReadCollector {
-            semantic,
-            prop_vars,
-            non_bindable_prop_vars,
-            replacements: Vec::new(),
-            skip_spans: FxHashSet::default(),
-        };
-        collector.visit_program(program);
+            let mut collector = PropReadCollector {
+                semantic,
+                prop_vars,
+                non_bindable_prop_vars,
+                replacements: Vec::new(),
+                skip_spans: FxHashSet::default(),
+            };
+            collector.visit_program(program);
 
-        if collector.replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
+            if collector.replacements.is_empty() {
+                return None;
+            }
 
-        // Sort by span start descending; apply right-to-left to
-        // the ORIGINAL source (adjusting for the synthetic `(`
-        // prefix when in paren-wrap mode).
-        let mut replacements = collector.replacements;
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            let s = (*start as i32 - span_offset) as usize;
-            let e = (*end as i32 - span_offset) as usize;
-            out.replace_range(s..e, rewrite);
-        }
+            // Sort by span start descending; apply right-to-left to
+            // the ORIGINAL source (adjusting for the synthetic `(`
+            // prefix when in paren-wrap mode).
+            let mut replacements = collector.replacements;
+            replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
+            let mut out = source.to_string();
+            for (start, end, rewrite) in &replacements {
+                let s = (*start as i32 - span_offset) as usize;
+                let e = (*end as i32 - span_offset) as usize;
+                out.replace_range(s..e, rewrite);
+            }
 
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+            Some(out)
+        },
+    )
 }
 
 struct PropReadCollector<'a, 'sem> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/read_only_props_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/read_only_props_ast.rs
@@ -46,11 +46,12 @@ use std::cell::RefCell;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::SourceType;
 use rustc_hash::FxHashSet;
 
+use super::ast_rewrite;
 use super::props_transforms::is_valid_js_identifier;
 use super::scope_analysis::is_locally_shadowed;
 
@@ -99,47 +100,42 @@ pub fn transform_read_only_props_ast(
     };
     let span_offset: i32 = if needs_paren_wrap { 1 } else { 0 };
 
-    READ_ONLY_PROPS_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, &parse_source, SourceType::mjs())
-            .with_options(ParseOptions {
-                allow_return_outside_function: true,
-                ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-        let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
-        let semantic = &semantic_ret.semantic;
+    ast_rewrite::with_program(
+        &READ_ONLY_PROPS_ALLOC,
+        &parse_source,
+        SourceType::mjs(),
+        ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        },
+        |program| {
+            let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
+            let semantic = &semantic_ret.semantic;
 
-        let mut collector = ReadOnlyPropsCollector {
-            semantic,
-            read_only_props,
-            replacements: Vec::new(),
-            skip_spans: FxHashSet::default(),
-        };
-        collector.visit_program(program);
+            let mut collector = ReadOnlyPropsCollector {
+                semantic,
+                read_only_props,
+                replacements: Vec::new(),
+                skip_spans: FxHashSet::default(),
+            };
+            collector.visit_program(program);
 
-        let mut replacements = collector.replacements;
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
+            let mut replacements = collector.replacements;
+            if replacements.is_empty() {
+                return None;
+            }
 
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            let s = (*start as i32 - span_offset) as usize;
-            let e = (*end as i32 - span_offset) as usize;
-            out.replace_range(s..e, rewrite);
-        }
+            replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
+            let mut out = source.to_string();
+            for (start, end, rewrite) in &replacements {
+                let s = (*start as i32 - span_offset) as usize;
+                let e = (*end as i32 - span_offset) as usize;
+                out.replace_range(s..e, rewrite);
+            }
 
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+            Some(out)
+        },
+    )
 }
 
 /// See `state_reads_ast::contains_top_level_semicolon`. Duplicated

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
@@ -45,13 +45,14 @@ use std::cell::RefCell;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::{GetSpan, SourceType};
 use oxc_syntax::operator::{AssignmentOperator, UpdateOperator};
 use oxc_syntax::symbol::SymbolId;
 use rustc_hash::FxHashSet;
 
+use super::ast_rewrite::{self, Edit};
 use super::expression_utils::{
     expression_needs_proxy_with_scope, needs_compound_assignment_parens,
 };
@@ -60,8 +61,6 @@ use super::scope_analysis::{find_state_var_symbols, is_state_var_reference_or_un
 thread_local! {
     static STATE_ASSIGNS_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// Run the combined simple + compound + update assignment pass on
 /// `source`. Returns `Some(rewritten)` if anything changed, `None`
@@ -91,24 +90,9 @@ pub fn transform_state_assigns_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(
-            &current,
-            state_vars,
-            raw_state_vars,
-            is_runes,
-            non_proxy_vars,
-        ) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-    if any_changed { Some(current) } else { None }
+    ast_rewrite::fixed_point(source, |src| {
+        single_pass(src, state_vars, raw_state_vars, is_runes, non_proxy_vars)
+    })
 }
 
 fn single_pass(
@@ -118,64 +102,34 @@ fn single_pass(
     is_runes: bool,
     non_proxy_vars: &[String],
 ) -> Option<String> {
-    STATE_ASSIGNS_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs())
-            .with_options(ParseOptions {
-                allow_return_outside_function: true,
-                ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-        let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
-        let semantic = &semantic_ret.semantic;
-        let state_var_symbols = find_state_var_symbols(semantic, state_vars);
+    ast_rewrite::with_program(
+        &STATE_ASSIGNS_ALLOC,
+        source,
+        SourceType::mjs(),
+        ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        },
+        |program| {
+            let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
+            let semantic = &semantic_ret.semantic;
+            let state_var_symbols = find_state_var_symbols(semantic, state_vars);
 
-        let mut collector = CombinedCollector {
-            source,
-            semantic,
-            state_vars,
-            raw_state_vars,
-            is_runes,
-            non_proxy_vars,
-            state_var_symbols,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(program);
+            let mut collector = CombinedCollector {
+                source,
+                semantic,
+                state_vars,
+                raw_state_vars,
+                is_runes,
+                non_proxy_vars,
+                state_var_symbols,
+                replacements: Vec::new(),
+            };
+            collector.visit_program(program);
 
-        let mut replacements = collector.replacements;
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Innermost-only per pass — nested wraps get picked up on
-        // the next fixed-point iteration once their inner contents
-        // are no longer assignments/updates.
-        let spans: Vec<(u32, u32)> = replacements.iter().map(|r| (r.0, r.1)).collect();
-        replacements.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+            ast_rewrite::splice(source, collector.replacements, true)
+        },
+    )
 }
 
 struct CombinedCollector<'a, 'sem> {
@@ -186,7 +140,7 @@ struct CombinedCollector<'a, 'sem> {
     is_runes: bool,
     non_proxy_vars: &'a [String],
     state_var_symbols: FxHashSet<SymbolId>,
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'sem, 'ast> Visit<'ast> for CombinedCollector<'a, 'sem> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
@@ -39,13 +39,14 @@ use std::cell::RefCell;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::{GetSpan, SourceType};
 use oxc_syntax::operator::{AssignmentOperator, UpdateOperator};
 use oxc_syntax::symbol::SymbolId;
 use rustc_hash::FxHashSet;
 
+use super::ast_rewrite::{self, Edit};
 use super::expression_utils::{
     expression_needs_proxy_with_scope, needs_compound_assignment_parens,
 };
@@ -54,8 +55,6 @@ use super::scope_analysis::{find_state_var_symbols, is_state_var_reference_or_un
 thread_local! {
     static STATE_PIPELINE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
 }
-
-const MAX_FIXED_POINT_ITERS: usize = 16;
 
 /// Run the combined assigns + reads pipeline on `source`. Returns
 /// `Some(rewritten)` when any change was made, `None` otherwise.
@@ -92,25 +91,16 @@ pub fn transform_state_pipeline_ast(
         return None;
     }
 
-    let mut current = source.to_string();
-    let mut any_changed = false;
-    for _ in 0..MAX_FIXED_POINT_ITERS {
-        match single_pass(
-            &current,
+    ast_rewrite::fixed_point(source, |src| {
+        single_pass(
+            src,
             state_vars,
             raw_state_vars,
             is_runes,
             non_proxy_vars,
             &effective_read_names,
-        ) {
-            Some(next) => {
-                current = next;
-                any_changed = true;
-            }
-            None => break,
-        }
-    }
-    if any_changed { Some(current) } else { None }
+        )
+    })
 }
 
 fn single_pass(
@@ -121,78 +111,52 @@ fn single_pass(
     non_proxy_vars: &[String],
     effective_read_names: &[String],
 ) -> Option<String> {
-    STATE_PIPELINE_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, source, SourceType::mjs())
-            .with_options(ParseOptions {
-                allow_return_outside_function: true,
-                ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-        let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
-        let semantic = &semantic_ret.semantic;
-        let state_var_symbols = find_state_var_symbols(semantic, state_vars);
+    ast_rewrite::with_program(
+        &STATE_PIPELINE_ALLOC,
+        source,
+        SourceType::mjs(),
+        ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        },
+        |program| {
+            let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
+            let semantic = &semantic_ret.semantic;
+            let state_var_symbols = find_state_var_symbols(semantic, state_vars);
 
-        let mut visitor = PipelineVisitor {
-            source,
-            semantic,
-            state_vars,
-            raw_state_vars,
-            is_runes,
-            non_proxy_vars,
-            effective_read_names,
-            state_var_symbols,
-            read_replacements: Vec::new(),
-            assigns_replacements: Vec::new(),
-            skip_spans: FxHashSet::default(),
-        };
-        visitor.visit_program(program);
+            let mut visitor = PipelineVisitor {
+                source,
+                semantic,
+                state_vars,
+                raw_state_vars,
+                is_runes,
+                non_proxy_vars,
+                effective_read_names,
+                state_var_symbols,
+                read_replacements: Vec::new(),
+                assigns_replacements: Vec::new(),
+                skip_spans: FxHashSet::default(),
+            };
+            visitor.visit_program(program);
 
-        // Final replacements: assigns spans take precedence — reads
-        // that fall within an assigns span have already been
-        // incorporated into the assigns rewrite, drop them.
-        let assigns = visitor.assigns_replacements;
-        let reads: Vec<(u32, u32, String)> = visitor
-            .read_replacements
-            .into_iter()
-            .filter(|(s, e, _)| {
-                !assigns
-                    .iter()
-                    .any(|(as_s, as_e, _)| *s >= *as_s && *e <= *as_e)
-            })
-            .collect();
+            // Final replacements: assigns spans take precedence — reads
+            // that fall within an assigns span have already been
+            // incorporated into the assigns rewrite, drop them.
+            let assigns = visitor.assigns_replacements;
+            let reads: Vec<Edit> = visitor
+                .read_replacements
+                .into_iter()
+                .filter(|(s, e, _)| {
+                    !assigns
+                        .iter()
+                        .any(|(as_s, as_e, _)| *s >= *as_s && *e <= *as_e)
+                })
+                .collect();
 
-        let mut all: Vec<(u32, u32, String)> = assigns.into_iter().chain(reads).collect();
-        if all.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-        // Innermost-only across all replacements — handles nested
-        // assignments via fixed-point.
-        let spans: Vec<(u32, u32)> = all.iter().map(|r| (r.0, r.1)).collect();
-        all.retain(|(s, e, _)| {
-            !spans
-                .iter()
-                .any(|(s2, e2)| (*s2 > *s && *e2 <= *e) || (*s2 >= *s && *e2 < *e))
-        });
-        if all.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-        all.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &all {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+            let all: Vec<Edit> = assigns.into_iter().chain(reads).collect();
+            ast_rewrite::splice(source, all, true)
+        },
+    )
 }
 
 struct PipelineVisitor<'a, 'sem> {
@@ -208,9 +172,9 @@ struct PipelineVisitor<'a, 'sem> {
     /// Collected as the visitor walks; filtered post-walk to drop
     /// any that fall within an assigns span (those are
     /// incorporated into the assigns rewrite directly).
-    read_replacements: Vec<(u32, u32, String)>,
+    read_replacements: Vec<Edit>,
     /// Assignment / update wraps.
-    assigns_replacements: Vec<(u32, u32, String)>,
+    assigns_replacements: Vec<Edit>,
     /// Identifier spans claimed by a parent handler — used so the
     /// `visit_identifier_reference` bare-read path doesn't fire on
     /// LHS of assignments, update targets, first arg of $.set /

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_reads_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_reads_ast.rs
@@ -63,12 +63,13 @@ use std::cell::RefCell;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_parser::ParseOptions;
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::SourceType;
 use oxc_syntax::symbol::SymbolId;
 use rustc_hash::FxHashSet;
 
+use super::ast_rewrite;
 use super::scope_analysis::{find_state_var_symbols, is_state_var_reference_or_unresolved};
 
 thread_local! {
@@ -210,51 +211,46 @@ pub fn transform_state_reads_ast(
     };
     let span_offset: i32 = if needs_paren_wrap { 1 } else { 0 };
 
-    STATE_READS_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let parser_ret = Parser::new(&allocator, &parse_source, SourceType::mjs())
-            .with_options(ParseOptions {
-                allow_return_outside_function: true,
-                ..ParseOptions::default()
-            })
-            .parse();
-        if !parser_ret.diagnostics.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-        let program: &Program = allocator.alloc(parser_ret.program);
-        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
-        let semantic = &semantic_ret.semantic;
-        let effective_names: Vec<String> = effective.iter().map(|s| s.to_string()).collect();
-        let state_var_symbols = find_state_var_symbols(semantic, &effective_names);
+    ast_rewrite::with_program(
+        &STATE_READS_ALLOC,
+        &parse_source,
+        SourceType::mjs(),
+        ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        },
+        |program| {
+            let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
+            let semantic = &semantic_ret.semantic;
+            let effective_names: Vec<String> = effective.iter().map(|s| s.to_string()).collect();
+            let state_var_symbols = find_state_var_symbols(semantic, &effective_names);
 
-        let mut collector = StateReadsCollector {
-            semantic,
-            effective: &effective,
-            effective_names: &effective_names,
-            state_var_symbols,
-            replacements: Vec::new(),
-            skip_spans: FxHashSet::default(),
-        };
-        collector.visit_program(program);
+            let mut collector = StateReadsCollector {
+                semantic,
+                effective: &effective,
+                effective_names: &effective_names,
+                state_var_symbols,
+                replacements: Vec::new(),
+                skip_spans: FxHashSet::default(),
+            };
+            collector.visit_program(program);
 
-        let mut replacements = collector.replacements;
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
+            let mut replacements = collector.replacements;
+            if replacements.is_empty() {
+                return None;
+            }
 
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            let s = (*start as i32 - span_offset) as usize;
-            let e = (*end as i32 - span_offset) as usize;
-            out.replace_range(s..e, rewrite);
-        }
+            replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
+            let mut out = source.to_string();
+            for (start, end, rewrite) in &replacements {
+                let s = (*start as i32 - span_offset) as usize;
+                let e = (*end as i32 - span_offset) as usize;
+                out.replace_range(s..e, rewrite);
+            }
 
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+            Some(out)
+        },
+    )
 }
 
 struct StateReadsCollector<'a, 'sem> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
@@ -21,9 +21,11 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::Parser;
+use oxc_parser::ParseOptions;
 use oxc_span::{GetSpan, SourceType};
 use oxc_syntax::operator::BinaryOperator;
+
+use super::ast_rewrite::{self, Edit};
 
 thread_local! {
     /// Reuse one OXC allocator per thread across calls; matches the
@@ -76,47 +78,26 @@ fn contains_strict_op(s: &str) -> bool {
 /// outer rewrites are deferred to the next iteration so they see the
 /// rewritten inner text. Returns `None` when nothing changed.
 fn single_pass(source: &str, is_ts: bool) -> Option<String> {
-    MODULE_STRICT_EQ_ALLOC.with(|cell| {
-        let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let source_type = if is_ts {
-            SourceType::ts().with_module(true)
-        } else {
-            SourceType::mjs()
-        };
-        let parser_ret = Parser::new(&allocator, source, source_type).parse();
-        if !parser_ret.diagnostics.is_empty() {
-            // Parse error — keep the source untouched. Module scripts
-            // that don't parse here would already fail elsewhere; the
-            // strict-equals rewrite isn't responsible for surfacing
-            // that error.
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        let mut collector = StrictEqualsCollector {
-            source,
-            replacements: Vec::new(),
-        };
-        collector.visit_program(&parser_ret.program);
-        let mut replacements = collector.replacements;
-
-        if replacements.is_empty() {
-            *cell.borrow_mut() = allocator;
-            return None;
-        }
-
-        // Replacements collected here never overlap (we only emit
-        // leaf-level rewrites), so sorting by start desc + splicing
-        // is correct.
-        replacements.sort_by_key(|r| std::cmp::Reverse(r.0));
-        let mut out = source.to_string();
-        for (start, end, rewrite) in &replacements {
-            out.replace_range(*start as usize..*end as usize, rewrite);
-        }
-
-        *cell.borrow_mut() = allocator;
-        Some(out)
-    })
+    let source_type = if is_ts {
+        SourceType::ts().with_module(true)
+    } else {
+        SourceType::mjs()
+    };
+    ast_rewrite::rewrite_once(
+        &MODULE_STRICT_EQ_ALLOC,
+        source,
+        source_type,
+        ParseOptions::default(),
+        false,
+        |program| {
+            let mut collector = StrictEqualsCollector {
+                source,
+                replacements: Vec::new(),
+            };
+            collector.visit_program(program);
+            collector.replacements
+        },
+    )
 }
 
 /// Per-call AST visitor: collects `(start, end, replacement_string)`
@@ -126,7 +107,7 @@ fn single_pass(source: &str, is_ts: bool) -> Option<String> {
 /// iteration in the caller.
 struct StrictEqualsCollector<'src> {
     source: &'src str,
-    replacements: Vec<(u32, u32, String)>,
+    replacements: Vec<Edit>,
 }
 
 impl<'a, 'src> Visit<'a> for StrictEqualsCollector<'src> {


### PR DESCRIPTION
Stacked on #1035.

## What

Finishes the `*_ast.rs` consolidation. After this, **no client rewrite pass hand-rolls** arena `mem::take` / `Parser::new(...).parse()` / diagnostic bail / arena restore — every pass routes through `ast_rewrite::with_program`, which also unifies the parse-error policy.

| file | shape | toolkit usage |
|---|---|---|
| `state_assigns_combined` | fixed-point + Semantic + innermost dedup | `fixed_point` + `with_program` + `splice(.., true)` |
| `state_pipeline` | fixed-point + Semantic + two-set merge | `fixed_point` + `with_program`; merge kept, tail → `splice(.., true)` |
| `state_reads`, `prop_source_reads`, `read_only_props` | single-pass + Semantic + paren-wrap/`span_offset` | `with_program` only (the offset splice is genuinely bespoke: parse-source ≠ splice-source — kept verbatim in-closure) |
| `strict_equals` | custom guard-loop | loop kept; inner `single_pass` → `rewrite_once` |

`SemanticBuilder::build` takes `&Program`, so the Semantic-using passes build their `Semantic` inside the `with_program` closure — no more `allocator.alloc(parser_ret.program)`.

Collectors, visitors, helpers, doc comments and tests are untouched.

## Verification — byte-identical

- `cargo test -p rsvelte_core --lib` — **1283 passed**
- byte-exact suites: `compiler_fixtures` 17 ✓, `runtime` 19 ✓, `ssr` 16 ✓ (0 failed)
- clippy clean, fmt clean