### PR TITLE
fix(ssr): AST-based await→$.save wrapping (fix #1036 ternary-consequent await)

### DIFF
--- a/.changeset/ssr-await-save-ast.md
+++ b/.changeset/ssr-await-save-ast.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+Fix invalid SSR codegen when a `{@const}` (or any awaited expression) sits in
+the consequent of a ternary in async mode — e.g.
+`{@const x = cond ? await fn({...}) : undefined}`. The server `await <expr>` →
+`(await $.save(<expr>))()` rewrite used a hand-rolled byte scanner that forgot
+the ternary alternate separator `:`, so `: undefined` leaked into the
+`$.save(...)` argument list and produced unparseable JS (issue #1036, bug 2).
+The operand is now bounded by its parsed `AwaitExpression` span, so everything
+outside it stays untouched.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/await_save_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/await_save_ast.rs
@@ -1,0 +1,204 @@
+//! AST-based `await <expr>` → `(await $.save(<expr>))()` rewrite for the
+//! server target.
+//!
+//! Replaces the hand-rolled byte scanner (`transform_await_to_save` /
+//! `find_await_arg_end` in `helpers.rs`). The old scanner approximated each
+//! `await` operand's extent by enumerating the operators that terminate it;
+//! any token it forgot leaked the rest of the expression into the `$.save(…)`
+//! argument list. The omission that motivated this port was the ternary
+//! alternate separator `:` — `cond ? await fn() : alt` swallowed `: alt`
+//! into `$.save(fn() : alt)` (issue #1036, bug 2).
+//!
+//! Parsing the expression and reading each `AwaitExpression`'s span removes the
+//! entire class of "forgot an operator" bugs: the operand extent is exactly
+//! the argument node's span, so everything outside it (the `:` alternate,
+//! trailing binary operators, …) stays untouched.
+//!
+//! Scope note: awaits inside a nested function / arrow body belong to a
+//! different async region and are left alone, mirroring `expr_contains_await`
+//! (which gates every call site). Only awaits at the current expression level
+//! are wrapped; nested awaits inside a wrapped operand are handled by the
+//! recursive emit, not by a second parse.
+
+use std::cell::RefCell;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::*;
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::{ParseOptions, Parser};
+use oxc_span::{GetSpan, SourceType};
+use oxc_syntax::scope::ScopeFlags;
+
+thread_local! {
+    static AWAIT_SAVE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+}
+
+/// Byte ranges of one `await` operand: the full `await …` span and the inner
+/// argument span. `(await_start, await_end, arg_start, arg_end)`.
+type AwaitSpan = (u32, u32, u32, u32);
+
+/// Transform every top-level `await <operand>` in `expr` into
+/// `(await $.save(<operand>))()`, returning `None` when the expression does
+/// not parse cleanly (the caller falls back to the textual scanner) or when
+/// it contains no expression-level `await`.
+pub(crate) fn transform_await_to_save_ast(expr: &str) -> Option<String> {
+    AWAIT_SAVE_ALLOC.with(|cell| {
+        let allocator = std::mem::take(&mut *cell.borrow_mut());
+        let out = transform_with(&allocator, expr);
+        *cell.borrow_mut() = allocator;
+        out
+    })
+}
+
+fn transform_with(allocator: &Allocator, expr: &str) -> Option<String> {
+    // A bare expression isn't a valid program on its own (e.g. a leading `{`
+    // would parse as a block, top-level `await` needs module mode). Parse it
+    // as a module expression statement: `cond ? await f() : g` is a valid
+    // top-level ExpressionStatement and top-level `await` is allowed in a
+    // module. TS source type keeps `as`/`satisfies` casts parseable.
+    let source_type = SourceType::ts().with_module(true);
+    let parsed = Parser::new(allocator, expr, source_type)
+        .with_options(ParseOptions {
+            // The expression alone may sit outside any function; permit a
+            // stray `return`/`await` rather than bailing to the textual path.
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        })
+        .parse();
+    if !parsed.diagnostics.is_empty() {
+        return None;
+    }
+
+    let mut collector = AwaitCollector {
+        function_depth: 0,
+        awaits: Vec::new(),
+    };
+    collector.visit_program(&parsed.program);
+    if collector.awaits.is_empty() {
+        return None;
+    }
+
+    // Sort by start so the linear emit walks the source left-to-right.
+    collector.awaits.sort_by_key(|&(start, ..)| start);
+    Some(emit_range(expr, &collector.awaits, 0, expr.len() as u32))
+}
+
+/// Emit `source[lo..hi]`, wrapping each top-level `await` operand within the
+/// range. An `await` is "top-level within the range" when it is not nested
+/// inside an earlier wrapped operand — `emit_range` advances its cursor past
+/// each wrapped operand's full span, so awaits inside that span are handled by
+/// the recursive call on the operand range, never re-wrapped here.
+fn emit_range(source: &str, awaits: &[AwaitSpan], lo: u32, hi: u32) -> String {
+    let mut out = String::new();
+    let mut cursor = lo;
+    for &(await_start, await_end, arg_start, arg_end) in awaits {
+        if await_start < cursor || await_end > hi {
+            // Either already consumed by an enclosing operand, or outside the
+            // range we're emitting.
+            continue;
+        }
+        out.push_str(&source[cursor as usize..await_start as usize]);
+        out.push_str("(await $.save(");
+        // Recurse into the operand so nested awaits get wrapped too.
+        out.push_str(&emit_range(source, awaits, arg_start, arg_end));
+        out.push_str("))()");
+        cursor = await_end;
+    }
+    out.push_str(&source[cursor as usize..hi as usize]);
+    out
+}
+
+struct AwaitCollector {
+    function_depth: u32,
+    awaits: Vec<AwaitSpan>,
+}
+
+impl<'a> Visit<'a> for AwaitCollector {
+    fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {
+        // Awaits inside a nested function belong to that function's async
+        // region — skip the whole body.
+        self.function_depth += 1;
+        walk::walk_function(self, it, flags);
+        self.function_depth -= 1;
+    }
+
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
+        self.function_depth += 1;
+        walk::walk_arrow_function_expression(self, it);
+        self.function_depth -= 1;
+    }
+
+    fn visit_await_expression(&mut self, await_expr: &AwaitExpression<'a>) {
+        if self.function_depth == 0 {
+            let arg = await_expr.argument.span();
+            self.awaits.push((
+                await_expr.span.start,
+                await_expr.span.end,
+                arg.start,
+                arg.end,
+            ));
+        }
+        // Walk the operand so a nested `await` inside it is collected too; the
+        // recursive emit relies on having every await span available.
+        walk::walk_await_expression(self, await_expr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ternary_consequent_await_keeps_alternate_outside_save() {
+        // Issue #1036 bug 2: the `: undefined` alternate must stay outside the
+        // `$.save(…)` call.
+        let got = transform_await_to_save_ast(
+            "cond ? await getWorkspacesRetrieve({ path: { id: cond } }) : undefined",
+        )
+        .unwrap();
+        assert_eq!(
+            got,
+            "cond ? (await $.save(getWorkspacesRetrieve({ path: { id: cond } })))() : undefined"
+        );
+    }
+
+    #[test]
+    fn plain_await_wraps_operand() {
+        let got = transform_await_to_save_ast("await foo(1, 2)").unwrap();
+        assert_eq!(got, "(await $.save(foo(1, 2)))()");
+    }
+
+    #[test]
+    fn binary_after_await_stays_outside() {
+        // `await foo > 10` parses as `(await foo) > 10` — only `foo` is the
+        // operand.
+        let got = transform_await_to_save_ast("await foo > 10").unwrap();
+        assert_eq!(got, "(await $.save(foo))() > 10");
+    }
+
+    #[test]
+    fn nested_await_wraps_both() {
+        let got = transform_await_to_save_ast("await foo(await bar())").unwrap();
+        assert_eq!(got, "(await $.save(foo((await $.save(bar()))())))()");
+    }
+
+    #[test]
+    fn await_inside_nested_arrow_is_left_alone() {
+        // The arrow's await belongs to a different async scope.
+        let got = transform_await_to_save_ast("await fn(async () => await inner())");
+        assert_eq!(
+            got.unwrap(),
+            "(await $.save(fn(async () => await inner())))()"
+        );
+    }
+
+    #[test]
+    fn no_await_returns_none() {
+        assert!(transform_await_to_save_ast("a ? b : c").is_none());
+    }
+
+    #[test]
+    fn unparseable_returns_none() {
+        assert!(transform_await_to_save_ast("await (((").is_none());
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -178,7 +178,22 @@ fn skip_braces(bytes: &[u8], start: usize) -> usize {
 /// Transform `await expr` patterns inside an expression to use `$.save()`.
 /// Converts: `await expr` -> `(await $.save(expr))()`
 /// This handles multiple await expressions within the same expression.
+///
+/// Prefers the AST-based rewrite (`await_save_ast`), which reads each
+/// operand's extent from its parsed span and therefore can't mis-bound the
+/// operand the way a hand-rolled scanner does (e.g. swallowing a ternary's
+/// `: alternate` — issue #1036 bug 2). Falls back to the legacy byte scanner
+/// only when the expression doesn't parse cleanly as a standalone expression.
 pub(crate) fn transform_await_to_save(expr: &str) -> String {
+    if let Some(out) = super::await_save_ast::transform_await_to_save_ast(expr) {
+        return out;
+    }
+    transform_await_to_save_textual(expr)
+}
+
+/// Legacy byte-scanning implementation of [`transform_await_to_save`], kept as
+/// a fallback for inputs that don't parse as a standalone expression.
+fn transform_await_to_save_textual(expr: &str) -> String {
     let bytes = expr.as_bytes();
     let len = bytes.len();
     let mut result = String::with_capacity(len + 20);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! This module is organized to match the Svelte compiler structure.
 
+pub(crate) mod await_save_ast;
 pub mod bridge;
 pub mod build;
 pub(crate) mod esrap_layout;


### PR DESCRIPTION
## Why

Issue #1036 reported invalid SSR JS for a `{@const}` whose initializer is a ternary with an awaited consequent:

```svelte
{@const workspace = page.params.id ? await get({ path: { id } }) : undefined}
```

rsvelte emitted (async SSR):

```js
async () => workspace = page.params.id ? (await $.save(get({ path: { id } }) : undefined))()   // ❌ `: undefined` leaked into $.save(...)
```

which is a syntax error and broke the bundler with `PARSE_ERROR`.

### Root cause

The server `await <expr>` → `(await $.save(<expr>))()` rewrite was a hand-rolled byte scanner (`transform_await_to_save` / `find_await_arg_end` in `server/helpers.rs`). It approximated each `await` operand's extent by enumerating the operators that terminate it — `?`, all binary operators, `,` … — but **forgot the ternary alternate separator `:`**. So the operand scan ran past `: undefined`, pulling the alternate inside the `$.save(...)` argument list.

This is the signature failure mode of expression scanning by hand: one missing token corrupts the output. (The same issue's "bug 1", reassigned `$derived` → `x() = v`, was already fixed on `main` by `rewrite_derived_assignments`; verified it no longer reproduces.)

## What

Replace the scanner's core with an AST pass (`server/await_save_ast.rs`):

- parse the expression, read each `AwaitExpression`'s span, wrap exactly the operand node.
- everything outside the operand span (the `:` alternate, trailing binary operators, …) stays verbatim → the whole "forgot an operator" bug class is gone.
- awaits inside nested function/arrow bodies are skipped (different async region — mirrors `expr_contains_await`, which gates every call site); nested awaits inside a wrapped operand are handled by the recursive emit.

The legacy scanner is kept as `transform_await_to_save_textual`, used only as a fallback when the input doesn't parse as a standalone expression.

This is the **first step** of migrating the SSR transform off text surgery onto AST, per `docs/phase3-ast-refactor-plan.md`.

## Verification

- New unit tests in `await_save_ast` (ternary consequent, nested await, binary-after-await, nested-arrow skip, parse-fail fallback).
- Byte-exact suites green: `compiler_fixtures`, `runtime` {legacy, runes, browser, hydration}, `ssr`.
- End-to-end #1036 repro now matches official svelte 5.56.3 output byte-for-byte:
  ```js
  async () => workspace = page.params.workspace_id ? (await $.save(getWorkspacesRetrieve({ path: { workspace_id: page.params.workspace_id } })))() : undefined
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)