### PR TITLE
chore(fmt): unbreak Format CI on main (client/mod.rs import order)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5,8 +5,8 @@
 //! This module mirrors the official Svelte compiler structure at
 //! `svelte/packages/svelte/src/compiler/phases/3-transform/client/`.
 
-use std::fmt::Write as _;
 pub(crate) use super::shared::ast_rewrite;
+use std::fmt::Write as _;
 mod ast_state_transform;
 mod class_transforms;
 mod console_dev_ast;


### PR DESCRIPTION
#1040 added `pub(crate) use super::shared::ast_rewrite;` directly after `use std::fmt::Write as _;` in `client/mod.rs` and merged with a **failing Format check** — so `cargo fmt --all -- --check` is currently red on `main`, which blocks the Format gate on every open PR.

rustfmt orders the `pub(crate) use` re-export before the `std` import. This one-line reorder restores `cargo fmt --all -- --check` to green.

No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)