### PR TITLE
feat(esrap): rsvelte_esrap crate — esrap command model + printer core + conformance harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,6 +2143,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsvelte_esrap"
+version = "0.7.11"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
 name = "rsvelte_fmt"
 version = "0.3.14"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "crates/rsvelte_capi",
     "crates/rsvelte_core",
+    "crates/rsvelte_esrap",
     "crates/rsvelte_fmt",
     "crates/rsvelte_fmt_wasm",
     "crates/rsvelte_formatter",

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "rsvelte_esrap"
+version = "0.7.11"
+edition = "2024"
+rust-version = "1.90"
+description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"
+license = "MIT"
+repository = "https://github.com/baseballyama/rsvelte"
+homepage = "https://github.com/baseballyama/rsvelte"
+keywords = ["svelte", "compiler", "esrap", "printer"]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+oxc_allocator = "0.136"
+oxc_ast = "0.136"
+oxc_span = "0.136"
+oxc_syntax = "0.136"
+
+[dev-dependencies]
+oxc_parser = "0.136"
+
+[lints]
+workspace = true

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -1,0 +1,231 @@
+//! The esrap command buffer and its flattening driver.
+//!
+//! A faithful port of the command model in esrap's `src/index.js` /
+//! `src/context.js`. Visitors don't write strings directly; they push
+//! [`Command`]s onto a buffer, and [`print`] flattens that buffer into the
+//! final source text. The indirection is what lets a visitor build a child
+//! layout, [`measure`](crate::context::Context::measure) it, and only then
+//! decide whether to emit it on one line or break it across several — esrap's
+//! whole layout strategy falls out of this.
+//!
+//! The sentinels (`Newline`/`Margin`/`Space`/`Indent`/`Dedent`) mirror the
+//! integer constants esrap pushes onto the same array as strings. `Indent` and
+//! `Dedent` don't emit anything immediately; they grow/shrink the whitespace
+//! prefix that a later `Newline` will emit, exactly as upstream mutates its
+//! `current_newline` string.
+
+/// One entry in the command buffer. Strings are literal output; the sentinels
+/// defer whitespace decisions until the next string is emitted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    /// An extra blank line before the next newline (only meaningful when a
+    /// `Newline` is also pending).
+    Margin,
+    /// Emit the current indentation-aware newline before the next string.
+    Newline,
+    /// Grow the newline prefix by one indent level.
+    Indent,
+    /// Shrink the newline prefix by one indent level.
+    Dedent,
+    /// Emit a single space before the next string (unless a newline supersedes
+    /// it).
+    Space,
+    /// Literal output.
+    Str(String),
+    /// A nested buffer, spliced in place (esrap's nested command arrays).
+    Nested(Vec<Command>),
+    /// A source-map anchor (1-based line, 0-based column) for a following
+    /// string. Carried through the buffer but not yet consumed — source-map
+    /// emission is a later step; for now it only forces the same pending-newline
+    /// flush a string would, matching upstream ordering.
+    Location { line: u32, column: u32 },
+}
+
+/// Flatten `commands` into source text, using `indent` (e.g. `"\t"` or a run
+/// of spaces) for each indentation level. Faithful port of the `run`/`append`
+/// loop in esrap's `print`.
+pub fn print(commands: &[Command], indent: &str) -> String {
+    let mut driver = Driver {
+        code: String::new(),
+        current_newline: String::from("\n"),
+        indent,
+        needs_newline: false,
+        needs_margin: false,
+        needs_space: false,
+    };
+    for command in commands {
+        driver.run(command);
+    }
+    driver.code
+}
+
+struct Driver<'a> {
+    code: String,
+    /// The whitespace emitted on a newline: `"\n"` plus one `indent` per active
+    /// level. `Indent`/`Dedent` mutate this in place.
+    current_newline: String,
+    indent: &'a str,
+    needs_newline: bool,
+    needs_margin: bool,
+    needs_space: bool,
+}
+
+impl Driver<'_> {
+    fn run(&mut self, command: &Command) {
+        match command {
+            Command::Nested(inner) => {
+                for c in inner {
+                    self.run(c);
+                }
+            }
+            Command::Newline => self.needs_newline = true,
+            Command::Margin => self.needs_margin = true,
+            Command::Space => self.needs_space = true,
+            Command::Indent => self.current_newline.push_str(self.indent),
+            Command::Dedent => {
+                let len = self.current_newline.len() - self.indent.len();
+                self.current_newline.truncate(len);
+            }
+            Command::Str(s) => {
+                self.flush_pending();
+                self.code.push_str(s);
+            }
+            Command::Location { .. } => {
+                // Anchors flush pending whitespace just like a string would, so
+                // that adding source-map support later doesn't shift output.
+                self.flush_pending();
+            }
+        }
+    }
+
+    /// Emit any pending newline/space before the next string. A pending newline
+    /// supersedes a pending space; a pending margin adds one blank line ahead of
+    /// the newline.
+    fn flush_pending(&mut self) {
+        if self.needs_newline {
+            if self.needs_margin {
+                self.code.push('\n');
+            }
+            self.code.push_str(&self.current_newline);
+        } else if self.needs_space {
+            self.code.push(' ');
+        }
+        self.needs_newline = false;
+        self.needs_margin = false;
+        self.needs_space = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cmds(v: Vec<Command>) -> String {
+        print(&v, "\t")
+    }
+
+    #[test]
+    fn plain_strings_concatenate() {
+        assert_eq!(
+            cmds(vec![Command::Str("a".into()), Command::Str("b".into())]),
+            "ab"
+        );
+    }
+
+    #[test]
+    fn space_separates_only_before_next_string() {
+        // A trailing Space with no following string emits nothing.
+        assert_eq!(
+            cmds(vec![
+                Command::Str("a".into()),
+                Command::Space,
+                Command::Str("b".into()),
+                Command::Space,
+            ]),
+            "a b"
+        );
+    }
+
+    #[test]
+    fn newline_uses_indent_prefix() {
+        assert_eq!(
+            cmds(vec![
+                Command::Str("{".into()),
+                Command::Indent,
+                Command::Newline,
+                Command::Str("x".into()),
+                Command::Dedent,
+                Command::Newline,
+                Command::Str("}".into()),
+            ]),
+            "{\n\tx\n}"
+        );
+    }
+
+    #[test]
+    fn newline_supersedes_space() {
+        assert_eq!(
+            cmds(vec![
+                Command::Str("a".into()),
+                Command::Space,
+                Command::Newline,
+                Command::Str("b".into()),
+            ]),
+            "a\nb"
+        );
+    }
+
+    #[test]
+    fn margin_adds_blank_line_before_newline() {
+        assert_eq!(
+            cmds(vec![
+                Command::Str("a".into()),
+                Command::Margin,
+                Command::Newline,
+                Command::Str("b".into()),
+            ]),
+            "a\n\nb"
+        );
+    }
+
+    #[test]
+    fn margin_without_newline_does_nothing() {
+        assert_eq!(
+            cmds(vec![
+                Command::Str("a".into()),
+                Command::Margin,
+                Command::Str("b".into())
+            ]),
+            "ab"
+        );
+    }
+
+    #[test]
+    fn nested_commands_splice_in_place() {
+        assert_eq!(
+            cmds(vec![
+                Command::Str("(".into()),
+                Command::Nested(vec![
+                    Command::Str("x".into()),
+                    Command::Space,
+                    Command::Str("y".into())
+                ]),
+                Command::Str(")".into()),
+            ]),
+            "(x y)"
+        );
+    }
+
+    #[test]
+    fn multi_level_indent() {
+        assert_eq!(
+            cmds(vec![
+                Command::Indent,
+                Command::Indent,
+                Command::Newline,
+                Command::Str("x".into()),
+            ]),
+            "\n\t\tx"
+        );
+    }
+}

--- a/crates/rsvelte_esrap/src/context.rs
+++ b/crates/rsvelte_esrap/src/context.rs
@@ -1,0 +1,173 @@
+//! The visitor-facing command builder.
+//!
+//! A port of esrap's `Context` (`src/context.js`). A [`Context`] accumulates
+//! [`Command`]s and tracks whether it has gone multiline, which is the signal
+//! visitors use to decide between a one-line and a broken-out layout. Unlike
+//! upstream, dispatch (`visit`) lives in the printer (a `match` over oxc node
+//! kinds), so `Context` is purely the buffer API: `write`, the whitespace
+//! sentinels, `append` (splice a child buffer), `measure`, and `empty`.
+
+use crate::command::Command;
+
+/// Accumulates commands for one syntactic unit. Build a child with
+/// [`Context::child`], fill it, then [`Context::append`] it into the parent.
+#[derive(Default)]
+pub struct Context {
+    commands: Vec<Command>,
+    has_newline: bool,
+    /// `true` once this context (or an appended child) emitted a newline.
+    /// Visitors read it to pick a layout.
+    pub multiline: bool,
+}
+
+impl Context {
+    /// A fresh, empty context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A fresh child context. Named `child` rather than mirroring esrap's `new`
+    /// because in this port it carries no shared visitor table.
+    pub fn child(&self) -> Context {
+        Context::new()
+    }
+
+    /// Grow the newline indentation by one level for subsequent newlines.
+    pub fn indent(&mut self) {
+        self.commands.push(Command::Indent);
+    }
+
+    /// Shrink the newline indentation by one level.
+    pub fn dedent(&mut self) {
+        self.commands.push(Command::Dedent);
+    }
+
+    /// Request a blank line ahead of the next newline.
+    pub fn margin(&mut self) {
+        self.commands.push(Command::Margin);
+    }
+
+    /// Emit an indentation-aware newline before the next write. Marks the
+    /// context multiline.
+    pub fn newline(&mut self) {
+        self.has_newline = true;
+        self.commands.push(Command::Newline);
+    }
+
+    /// Emit a single space before the next write.
+    pub fn space(&mut self) {
+        self.commands.push(Command::Space);
+    }
+
+    /// Append literal `content`. If a newline is already pending in this
+    /// context, writing after it makes the context multiline (mirrors esrap).
+    pub fn write(&mut self, content: impl Into<String>) {
+        self.commands.push(Command::Str(content.into()));
+        if self.has_newline {
+            self.multiline = true;
+        }
+    }
+
+    /// Record a source-map anchor (1-based line, 0-based column).
+    pub fn location(&mut self, line: u32, column: u32) {
+        self.commands.push(Command::Location { line, column });
+    }
+
+    /// Splice `child`'s commands in place, propagating its multiline state.
+    pub fn append(&mut self, child: Context) {
+        let child_multiline = child.multiline;
+        self.commands.push(Command::Nested(child.commands));
+        if self.has_newline || child_multiline {
+            self.multiline = true;
+        }
+    }
+
+    /// `true` when nothing with visible content has been written.
+    pub fn empty(&self) -> bool {
+        !self.commands.iter().any(has_content)
+    }
+
+    /// Total length of the literal strings in this context, ignoring whitespace
+    /// sentinels — esrap's `measure`, used to decide if a layout fits on a line.
+    pub fn measure(&self) -> usize {
+        measure(&self.commands)
+    }
+
+    /// Consume the context, yielding its raw command buffer (for the top-level
+    /// [`print`](crate::command::print) call).
+    pub fn into_commands(self) -> Vec<Command> {
+        self.commands
+    }
+}
+
+fn measure(commands: &[Command]) -> usize {
+    let mut total = 0;
+    for command in commands {
+        match command {
+            Command::Str(s) => total += s.len(),
+            Command::Nested(inner) => total += measure(inner),
+            _ => {}
+        }
+    }
+    total
+}
+
+fn has_content(command: &Command) -> bool {
+    match command {
+        Command::Str(s) => !s.is_empty(),
+        Command::Nested(inner) => inner.iter().any(has_content),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::print;
+
+    #[test]
+    fn measure_counts_only_strings() {
+        let mut ctx = Context::new();
+        ctx.write("abc");
+        ctx.space();
+        ctx.newline();
+        ctx.write("de");
+        assert_eq!(ctx.measure(), 5);
+    }
+
+    #[test]
+    fn empty_ignores_whitespace_sentinels() {
+        let mut ctx = Context::new();
+        ctx.space();
+        ctx.newline();
+        ctx.indent();
+        assert!(ctx.empty());
+        ctx.write("x");
+        assert!(!ctx.empty());
+    }
+
+    #[test]
+    fn append_propagates_multiline() {
+        let mut parent = Context::new();
+        let mut child = parent.child();
+        child.newline();
+        child.write("x");
+        assert!(child.multiline);
+        parent.write("a");
+        parent.append(child);
+        assert!(parent.multiline);
+    }
+
+    #[test]
+    fn append_splices_child_output() {
+        let mut parent = Context::new();
+        parent.write("(");
+        let mut child = parent.child();
+        child.write("x");
+        child.space();
+        child.write("y");
+        parent.append(child);
+        parent.write(")");
+        assert_eq!(print(&parent.into_commands(), "\t"), "(x y)");
+    }
+}

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -1,0 +1,78 @@
+//! `rsvelte_esrap` — a Rust port of [esrap](https://github.com/Rich-Harris/esrap)
+//! that prints an **oxc** AST to JavaScript with esrap's exact layout.
+//!
+//! ## Why
+//!
+//! The official Svelte compiler builds an ESTree and prints it once with esrap.
+//! rsvelte's Phase 3 instead generates JS by string surgery — splicing edits
+//! into source text across hundreds of passes — which is both the root cause of
+//! a class of formatting divergences and, per `docs/phase3-perf-baseline.md`,
+//! ~68% of client-transform time. The durable fix is the same architecture
+//! upstream uses: build an output AST and print it once. This crate is that
+//! printer (plan: `docs/phase3-ast-refactor-plan.md`, step 0).
+//!
+//! ## Model
+//!
+//! Printing is two layers, mirroring esrap:
+//! - a [`command`] buffer with a flattening driver (whitespace/indent
+//!   sentinels + literal strings), and
+//! - a [`context::Context`] the visitors push commands onto, tracking the
+//!   `multiline` signal used to choose layouts.
+//!
+//! The visitor ([`printer`]) walks the oxc AST. Where esrap dispatches through a
+//! `visitors[node.type]` map, this port matches on oxc node kinds; the layout
+//! logic (precedence-based parens, `sequence`, `body`, length-based line
+//! breaking) is ported 1:1.
+//!
+//! ## Conformance
+//!
+//! The official compiler's snapshot outputs (`_expected/**/*.js`, themselves
+//! esrap-printed) are the conformance corpus: parse one with oxc, re-print with
+//! this crate, and assert byte-identity. The `golden` integration test reports
+//! the round-trip rate; it only ever ratchets up as visitor coverage grows.
+
+pub mod command;
+pub mod context;
+pub mod printer;
+
+use oxc_ast::ast::Program;
+
+/// Options controlling output layout. Defaults match esrap's defaults and
+/// rsvelte's conventions (tab indent, single quotes).
+#[derive(Debug, Clone)]
+pub struct PrintOptions {
+    /// The indentation unit for one level (default `"\t"`).
+    pub indent: String,
+    /// Preferred quote character for string literals without a preserved `raw`
+    /// (default single quote).
+    pub quote: QuoteStyle,
+}
+
+/// Quote preference for synthesized string literals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuoteStyle {
+    Single,
+    Double,
+}
+
+impl Default for PrintOptions {
+    fn default() -> Self {
+        Self {
+            indent: String::from("\t"),
+            quote: QuoteStyle::Single,
+        }
+    }
+}
+
+/// Print `program` to JavaScript with the default options.
+pub fn print(program: &Program<'_>) -> String {
+    print_with(program, &PrintOptions::default())
+}
+
+/// Print `program` to JavaScript with explicit options.
+pub fn print_with(program: &Program<'_>, options: &PrintOptions) -> String {
+    let mut printer = printer::Printer::new(options);
+    let mut ctx = context::Context::new();
+    printer.print_program(program, &mut ctx);
+    command::print(&ctx.into_commands(), &options.indent)
+}

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1,0 +1,728 @@
+//! The oxc-AST → JavaScript visitor.
+//!
+//! A port of esrap's `languages/ts` visitor, adapted to oxc's AST. Where esrap
+//! dispatches through a `visitors[node.type]` map, this matches on oxc node
+//! kinds; the layout logic — precedence-based parenthesisation, the `sequence`
+//! helper for comma lists, and the `body` helper for statement lists — is the
+//! same.
+//!
+//! Coverage is intentionally incremental (this is step 0 of the printer port):
+//! the [`golden`](../../tests/golden.rs) test measures how much of the official
+//! snapshot corpus round-trips, and that rate only ratchets up. Nodes that are
+//! not yet handled return [`Unsupported`] so the harness can attribute misses
+//! precisely rather than emit wrong output.
+
+use oxc_ast::ast::*;
+use oxc_syntax::operator::UnaryOperator;
+
+use crate::context::Context;
+use crate::{PrintOptions, QuoteStyle};
+
+/// A node kind the printer does not yet handle. Carries the kind name so the
+/// conformance harness can report exactly which visitors are still missing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unsupported(pub &'static str);
+
+pub struct Printer<'opt> {
+    options: &'opt PrintOptions,
+    /// Set by the first unsupported node encountered; printing continues so the
+    /// harness gets a single representative miss per file.
+    pub missing: Option<Unsupported>,
+}
+
+/// esrap's `EXPRESSIONS_PRECEDENCE`, keyed by oxc `Expression` kind. Higher
+/// binds tighter; a child is parenthesised when its precedence is lower than the
+/// position requires.
+fn expr_precedence(expr: &Expression) -> u8 {
+    match expr {
+        Expression::ArrayExpression(_)
+        | Expression::TaggedTemplateExpression(_)
+        | Expression::ThisExpression(_)
+        | Expression::Identifier(_)
+        | Expression::TemplateLiteral(_)
+        | Expression::SequenceExpression(_) => 20,
+        Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::PrivateFieldExpression(_)
+        | Expression::MetaProperty(_)
+        | Expression::CallExpression(_)
+        | Expression::ChainExpression(_)
+        | Expression::ImportExpression(_)
+        | Expression::NewExpression(_) => 19,
+        Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::StringLiteral(_) => 18,
+        Expression::AwaitExpression(_)
+        | Expression::ClassExpression(_)
+        | Expression::FunctionExpression(_)
+        | Expression::ObjectExpression(_) => 17,
+        Expression::UpdateExpression(_) => 16,
+        Expression::UnaryExpression(_) => 15,
+        Expression::BinaryExpression(_) => 14,
+        Expression::LogicalExpression(_) => 12,
+        Expression::ConditionalExpression(_) => 4,
+        Expression::ArrowFunctionExpression(_) | Expression::AssignmentExpression(_) => 3,
+        Expression::YieldExpression(_) => 2,
+        // Parenthesised wrappers are unwrapped before precedence is consulted.
+        Expression::ParenthesizedExpression(_) => 20,
+        _ => 18,
+    }
+}
+
+/// Binary/logical operator precedence (esrap's `OPERATOR_PRECEDENCE`).
+fn binary_operator_precedence(op: &str) -> u8 {
+    match op {
+        "||" => 2,
+        "&&" => 3,
+        "??" => 4,
+        "|" => 5,
+        "^" => 6,
+        "&" => 7,
+        "==" | "!=" | "===" | "!==" => 8,
+        "<" | ">" | "<=" | ">=" | "in" | "instanceof" => 9,
+        "<<" | ">>" | ">>>" => 10,
+        "+" | "-" => 11,
+        "*" | "%" | "/" => 12,
+        "**" => 13,
+        _ => 0,
+    }
+}
+
+/// Port of esrap's `needs_parens` for a binary/logical operand. `parent_op` is
+/// the enclosing operator and `parent_is_logical` selects its node-type
+/// precedence (12 for logical, 14 for binary).
+fn binary_needs_parens(
+    child: &Expression,
+    parent_is_logical: bool,
+    parent_op: &str,
+    is_right: bool,
+) -> bool {
+    let parent_precedence = if parent_is_logical { 12 } else { 14 };
+
+    // `??` cannot be mixed with `||`/`&&` without parentheses.
+    if parent_is_logical && let Expression::LogicalExpression(c) = child {
+        let child_op = c.operator.as_str();
+        if (parent_op == "??" && child_op != "??") || (parent_op != "??" && child_op == "??") {
+            return true;
+        }
+    }
+
+    let precedence = expr_precedence(child);
+    if precedence != parent_precedence {
+        return (!is_right && precedence == 15 && parent_precedence == 14 && parent_op == "**")
+            || precedence < parent_precedence;
+    }
+
+    // Same node-type precedence — only meaningful for binary (14) / logical (12)
+    // children, where associativity via operator precedence decides parens.
+    if precedence != 12 && precedence != 14 {
+        return false;
+    }
+
+    let child_op = child_binary_op(child);
+    if child_op == "**" && parent_op == "**" {
+        // Exponentiation is right-associative.
+        return !is_right;
+    }
+
+    let co = binary_operator_precedence(child_op);
+    let po = binary_operator_precedence(parent_op);
+    if is_right { co <= po } else { co < po }
+}
+
+/// The operator string of a binary/logical child (only consulted when the child
+/// is known to be one of those).
+fn child_binary_op(expr: &Expression) -> &'static str {
+    match expr {
+        Expression::BinaryExpression(b) => b.operator.as_str(),
+        Expression::LogicalExpression(l) => l.operator.as_str(),
+        _ => "",
+    }
+}
+
+/// Strip `ParenthesizedExpression` wrappers — esrap's input has no paren nodes;
+/// it recomputes them from precedence, so we work on the inner expression.
+fn unparen<'a, 'b>(mut expr: &'b Expression<'a>) -> &'b Expression<'a> {
+    while let Expression::ParenthesizedExpression(p) = expr {
+        expr = &p.expression;
+    }
+    expr
+}
+
+impl<'opt> Printer<'opt> {
+    pub fn new(options: &'opt PrintOptions) -> Self {
+        Self {
+            options,
+            missing: None,
+        }
+    }
+
+    fn unsupported(&mut self, kind: &'static str, ctx: &mut Context) {
+        if self.missing.is_none() {
+            self.missing = Some(Unsupported(kind));
+        }
+        // Emit a marker so output is obviously wrong if a miss slips through a
+        // test that forgot to check `missing`.
+        ctx.write(format!("/*unsupported:{kind}*/"));
+    }
+
+    // ----- statements -------------------------------------------------------
+
+    pub fn print_program(&mut self, program: &Program, ctx: &mut Context) {
+        self.body(&program.body, ctx);
+    }
+
+    /// esrap's `body`: statements on their own lines, with a blank line between
+    /// two multiline statements or a change of statement kind.
+    fn body(&mut self, statements: &[Statement], ctx: &mut Context) {
+        let mut prev: Option<(std::mem::Discriminant<Statement>, bool)> = None;
+        for stmt in statements {
+            if matches!(stmt, Statement::EmptyStatement(_)) {
+                continue;
+            }
+            let mut child = ctx.child();
+            self.print_statement(stmt, &mut child);
+
+            if let Some((prev_disc, prev_multiline)) = prev {
+                if child.multiline || prev_multiline || std::mem::discriminant(stmt) != prev_disc {
+                    ctx.margin();
+                }
+                ctx.newline();
+            }
+            let multiline = child.multiline;
+            ctx.append(child);
+            prev = Some((std::mem::discriminant(stmt), multiline));
+        }
+        // A trailing newline closes the body (matches esrap when loc is present).
+        if !statements.is_empty() {
+            ctx.newline();
+        }
+    }
+
+    fn print_statement(&mut self, stmt: &Statement, ctx: &mut Context) {
+        match stmt {
+            Statement::ExpressionStatement(s) => {
+                // esrap wraps a leading object/function-expression statement in
+                // parens so it isn't parsed as a block/declaration.
+                let inner = unparen(&s.expression);
+                let needs_parens = matches!(
+                    inner,
+                    Expression::ObjectExpression(_) | Expression::FunctionExpression(_)
+                ) || matches!(inner, Expression::AssignmentExpression(a)
+                    if matches!(a.left, AssignmentTarget::ObjectAssignmentTarget(_)));
+                if needs_parens {
+                    ctx.write("(");
+                    self.print_expression(inner, ctx);
+                    ctx.write(");");
+                } else {
+                    self.print_expression(inner, ctx);
+                    ctx.write(";");
+                }
+            }
+            Statement::VariableDeclaration(d) => {
+                self.variable_declaration(d, ctx);
+                ctx.write(";");
+            }
+            Statement::ReturnStatement(s) => {
+                ctx.write("return");
+                if let Some(arg) = &s.argument {
+                    ctx.write(" ");
+                    self.print_expression(unparen(arg), ctx);
+                }
+                ctx.write(";");
+            }
+            Statement::BlockStatement(b) => self.block(&b.body, ctx),
+            Statement::EmptyStatement(_) => {}
+            Statement::BreakStatement(_) => ctx.write("break;"),
+            Statement::ContinueStatement(_) => ctx.write("continue;"),
+            other => self.unsupported(statement_kind(other), ctx),
+        }
+    }
+
+    /// esrap's `BlockStatement|ClassBody`: build the body into a child context,
+    /// and only break it across lines when it has real content (so an empty body
+    /// stays `{}`). The `Newline`s are idempotent flags, so body's trailing
+    /// newline and the closing one collapse to a single line break before `}`.
+    fn block(&mut self, body: &[Statement], ctx: &mut Context) {
+        ctx.write("{");
+        let mut child = ctx.child();
+        self.body(body, &mut child);
+        if !child.empty() {
+            ctx.indent();
+            ctx.newline();
+            ctx.append(child);
+            ctx.dedent();
+            ctx.newline();
+        }
+        ctx.write("}");
+    }
+
+    fn variable_declaration(&mut self, decl: &VariableDeclaration, ctx: &mut Context) {
+        ctx.write(match decl.kind {
+            VariableDeclarationKind::Var => "var ",
+            VariableDeclarationKind::Let => "let ",
+            VariableDeclarationKind::Const => "const ",
+            VariableDeclarationKind::Using => "using ",
+            VariableDeclarationKind::AwaitUsing => "await using ",
+        });
+        for (i, declarator) in decl.declarations.iter().enumerate() {
+            if i > 0 {
+                ctx.write(", ");
+            }
+            self.binding_pattern(&declarator.id, ctx);
+            if let Some(init) = &declarator.init {
+                ctx.write(" = ");
+                self.print_expression(unparen(init), ctx);
+            }
+        }
+    }
+
+    fn binding_pattern(&mut self, pattern: &BindingPattern, ctx: &mut Context) {
+        match pattern {
+            BindingPattern::BindingIdentifier(id) => ctx.write(id.name.as_str()),
+            BindingPattern::AssignmentPattern(a) => {
+                self.binding_pattern(&a.left, ctx);
+                ctx.write(" = ");
+                self.print_expression(unparen(&a.right), ctx);
+            }
+            BindingPattern::ObjectPattern(_) => self.unsupported("ObjectPattern", ctx),
+            BindingPattern::ArrayPattern(_) => self.unsupported("ArrayPattern", ctx),
+        }
+    }
+
+    // ----- expressions ------------------------------------------------------
+
+    fn print_expression(&mut self, expr: &Expression, ctx: &mut Context) {
+        match expr {
+            Expression::ParenthesizedExpression(p) => self.print_expression(&p.expression, ctx),
+            Expression::ChainExpression(c) => match &c.expression {
+                ChainElement::CallExpression(call) => self.call_expression(call, ctx),
+                ChainElement::StaticMemberExpression(m) => self.static_member(m, ctx),
+                ChainElement::ComputedMemberExpression(m) => self.computed_member(m, ctx),
+                ChainElement::PrivateFieldExpression(_) => {
+                    self.unsupported("PrivateFieldExpression", ctx)
+                }
+                _ => self.unsupported("ChainElement", ctx),
+            },
+            Expression::Identifier(id) => ctx.write(id.name.as_str()),
+            Expression::ThisExpression(_) => ctx.write("this"),
+            Expression::BooleanLiteral(b) => ctx.write(if b.value { "true" } else { "false" }),
+            Expression::NullLiteral(_) => ctx.write("null"),
+            Expression::NumericLiteral(n) => ctx
+                .write(literal_raw(n.raw.as_ref().map(|a| a.as_str()), || {
+                    n.value.to_string()
+                })),
+            Expression::BigIntLiteral(n) => ctx
+                .write(literal_raw(n.raw.as_ref().map(|a| a.as_str()), || {
+                    format!("{}n", n.value)
+                })),
+            Expression::StringLiteral(s) => ctx.write(self.string_literal(s)),
+            Expression::TemplateLiteral(_) => self.unsupported("TemplateLiteral", ctx),
+            Expression::BinaryExpression(b) => self.binary_expression(b, ctx),
+            Expression::LogicalExpression(l) => self.logical_expression(l, ctx),
+            Expression::UnaryExpression(u) => self.unary_expression(u, ctx),
+            Expression::CallExpression(c) => self.call_expression(c, ctx),
+            Expression::StaticMemberExpression(m) => self.static_member(m, ctx),
+            Expression::ComputedMemberExpression(m) => self.computed_member(m, ctx),
+            Expression::ArrayExpression(a) => self.array_expression(a, ctx),
+            Expression::ObjectExpression(o) => self.object_expression(o, ctx),
+            Expression::AssignmentExpression(a) => self.assignment_expression(a, ctx),
+            Expression::ConditionalExpression(c) => self.conditional_expression(c, ctx),
+            Expression::SequenceExpression(s) => {
+                for (i, e) in s.expressions.iter().enumerate() {
+                    if i > 0 {
+                        ctx.write(", ");
+                    }
+                    self.print_expression(unparen(e), ctx);
+                }
+            }
+            other => self.unsupported(expression_kind(other), ctx),
+        }
+    }
+
+    /// Print `child` parenthesised iff its precedence is below `min`.
+    fn child_with_parens(&mut self, child: &Expression, min: u8, ctx: &mut Context) {
+        let child = unparen(child);
+        if expr_precedence(child) < min {
+            ctx.write("(");
+            self.print_expression(child, ctx);
+            ctx.write(")");
+        } else {
+            self.print_expression(child, ctx);
+        }
+    }
+
+    fn binary_expression(&mut self, node: &BinaryExpression, ctx: &mut Context) {
+        let op = node.operator.as_str();
+        self.binary_child(&node.left, false, op, false, ctx);
+        ctx.write(format!(" {op} "));
+        self.binary_child(&node.right, false, op, true, ctx);
+    }
+
+    fn logical_expression(&mut self, node: &LogicalExpression, ctx: &mut Context) {
+        let op = node.operator.as_str();
+        self.binary_child(&node.left, true, op, false, ctx);
+        ctx.write(format!(" {op} "));
+        self.binary_child(&node.right, true, op, true, ctx);
+    }
+
+    /// Print one operand of a binary/logical expression, parenthesised per
+    /// esrap's `needs_parens` (operator precedence + associativity + the `**`
+    /// and `??`-mixing special cases).
+    fn binary_child(
+        &mut self,
+        child: &Expression,
+        parent_is_logical: bool,
+        parent_op: &str,
+        is_right: bool,
+        ctx: &mut Context,
+    ) {
+        let child = unparen(child);
+        if binary_needs_parens(child, parent_is_logical, parent_op, is_right) {
+            ctx.write("(");
+            self.print_expression(child, ctx);
+            ctx.write(")");
+        } else {
+            self.print_expression(child, ctx);
+        }
+    }
+
+    fn unary_expression(&mut self, node: &UnaryExpression, ctx: &mut Context) {
+        let op = node.operator.as_str();
+        // `typeof`/`void`/`delete` are word operators and need a trailing space.
+        if matches!(
+            node.operator,
+            UnaryOperator::Typeof | UnaryOperator::Void | UnaryOperator::Delete
+        ) {
+            ctx.write(format!("{op} "));
+        } else {
+            ctx.write(op.to_string());
+        }
+        self.child_with_parens(&node.argument, 15, ctx);
+    }
+
+    fn call_expression(&mut self, node: &CallExpression, ctx: &mut Context) {
+        self.child_with_parens(&node.callee, 19, ctx);
+        if node.optional {
+            ctx.write("?.");
+        }
+        ctx.write("(");
+        self.sequence_arguments(&node.arguments, ctx);
+        ctx.write(")");
+    }
+
+    fn static_member(&mut self, node: &StaticMemberExpression, ctx: &mut Context) {
+        self.child_with_parens(&node.object, 19, ctx);
+        ctx.write(if node.optional { "?." } else { "." });
+        ctx.write(node.property.name.as_str());
+    }
+
+    fn computed_member(&mut self, node: &ComputedMemberExpression, ctx: &mut Context) {
+        self.child_with_parens(&node.object, 19, ctx);
+        if node.optional {
+            ctx.write("?.");
+        }
+        ctx.write("[");
+        self.print_expression(unparen(&node.expression), ctx);
+        ctx.write("]");
+    }
+
+    fn assignment_expression(&mut self, node: &AssignmentExpression, ctx: &mut Context) {
+        self.assignment_target(&node.left, ctx);
+        ctx.write(format!(" {} ", node.operator.as_str()));
+        self.child_with_parens(&node.right, 3, ctx);
+    }
+
+    fn assignment_target(&mut self, target: &AssignmentTarget, ctx: &mut Context) {
+        match target {
+            AssignmentTarget::AssignmentTargetIdentifier(id) => ctx.write(id.name.as_str()),
+            AssignmentTarget::StaticMemberExpression(m) => self.static_member(m, ctx),
+            AssignmentTarget::ComputedMemberExpression(m) => self.computed_member(m, ctx),
+            _ => self.unsupported("AssignmentTarget", ctx),
+        }
+    }
+
+    fn conditional_expression(&mut self, node: &ConditionalExpression, ctx: &mut Context) {
+        self.child_with_parens(&node.test, 5, ctx);
+        ctx.write(" ? ");
+        self.child_with_parens(&node.consequent, 4, ctx);
+        ctx.write(" : ");
+        self.child_with_parens(&node.alternate, 4, ctx);
+    }
+
+    fn array_expression(&mut self, node: &ArrayExpression, ctx: &mut Context) {
+        ctx.write("[");
+        let elems: Vec<Option<&Expression>> = node
+            .elements
+            .iter()
+            .map(|e| match e {
+                ArrayExpressionElement::SpreadElement(_) => None, // handled below
+                ArrayExpressionElement::Elision(_) => None,
+                _ => e.as_expression(),
+            })
+            .collect();
+        // Only the simple (no spread/elision) case is wired for now.
+        if node.elements.iter().any(|e| {
+            matches!(
+                e,
+                ArrayExpressionElement::SpreadElement(_) | ArrayExpressionElement::Elision(_)
+            )
+        }) {
+            self.unsupported("ArraySpreadOrElision", ctx);
+        } else {
+            for (i, el) in elems.iter().enumerate() {
+                if i > 0 {
+                    ctx.write(", ");
+                }
+                if let Some(e) = el {
+                    self.print_expression(unparen(e), ctx);
+                }
+            }
+        }
+        ctx.write("]");
+    }
+
+    fn object_expression(&mut self, node: &ObjectExpression, ctx: &mut Context) {
+        if node.properties.is_empty() {
+            ctx.write("{}");
+            return;
+        }
+        ctx.write("{ ");
+        for (i, prop) in node.properties.iter().enumerate() {
+            if i > 0 {
+                ctx.write(", ");
+            }
+            match prop {
+                ObjectPropertyKind::ObjectProperty(p) => self.object_property(p, ctx),
+                ObjectPropertyKind::SpreadProperty(s) => {
+                    ctx.write("...");
+                    self.print_expression(unparen(&s.argument), ctx);
+                }
+            }
+        }
+        ctx.write(" }");
+    }
+
+    fn object_property(&mut self, prop: &ObjectProperty, ctx: &mut Context) {
+        // Shorthand `{ x }` when key and value are the same identifier.
+        if !prop.computed
+            && prop.kind == PropertyKind::Init
+            && let (PropertyKey::StaticIdentifier(key), Expression::Identifier(val)) =
+                (&prop.key, &prop.value)
+            && key.name == val.name
+        {
+            ctx.write(val.name.as_str());
+            return;
+        }
+        if prop.computed {
+            ctx.write("[");
+            self.property_key(&prop.key, ctx);
+            ctx.write("]: ");
+        } else {
+            self.property_key(&prop.key, ctx);
+            ctx.write(": ");
+        }
+        self.print_expression(unparen(&prop.value), ctx);
+    }
+
+    fn property_key(&mut self, key: &PropertyKey, ctx: &mut Context) {
+        match key {
+            PropertyKey::StaticIdentifier(id) => ctx.write(id.name.as_str()),
+            PropertyKey::PrivateIdentifier(id) => ctx.write(format!("#{}", id.name)),
+            PropertyKey::StringLiteral(s) => ctx.write(self.string_literal(s)),
+            PropertyKey::NumericLiteral(n) => ctx
+                .write(literal_raw(n.raw.as_ref().map(|a| a.as_str()), || {
+                    n.value.to_string()
+                })),
+            _ => {
+                if let Some(e) = key.as_expression() {
+                    self.print_expression(unparen(e), ctx);
+                } else {
+                    self.unsupported("PropertyKey", ctx);
+                }
+            }
+        }
+    }
+
+    fn sequence_arguments(&mut self, args: &[Argument], ctx: &mut Context) {
+        for (i, arg) in args.iter().enumerate() {
+            if i > 0 {
+                ctx.write(", ");
+            }
+            match arg {
+                Argument::SpreadElement(s) => {
+                    ctx.write("...");
+                    self.print_expression(unparen(&s.argument), ctx);
+                }
+                _ => {
+                    if let Some(e) = arg.as_expression() {
+                        self.print_expression(unparen(e), ctx);
+                    } else {
+                        self.unsupported("Argument", ctx);
+                    }
+                }
+            }
+        }
+    }
+
+    // ----- literals ---------------------------------------------------------
+
+    fn string_literal(&self, s: &StringLiteral) -> String {
+        if let Some(raw) = &s.raw {
+            return raw.to_string();
+        }
+        quote(s.value.as_str(), self.options.quote)
+    }
+}
+
+/// esrap prefers a literal's preserved `raw` spelling; only synthesised literals
+/// fall back to a canonical rendering.
+fn literal_raw(raw: Option<&str>, fallback: impl FnOnce() -> String) -> String {
+    match raw {
+        Some(r) => r.to_string(),
+        None => fallback(),
+    }
+}
+
+/// Quote a string value with the preferred quote char, escaping as needed.
+fn quote(value: &str, style: QuoteStyle) -> String {
+    let q = match style {
+        QuoteStyle::Single => '\'',
+        QuoteStyle::Double => '"',
+    };
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push(q);
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c == q => {
+                out.push('\\');
+                out.push(c);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push(q);
+    out
+}
+
+fn statement_kind(stmt: &Statement) -> &'static str {
+    match stmt {
+        Statement::FunctionDeclaration(_) => "FunctionDeclaration",
+        Statement::ClassDeclaration(_) => "ClassDeclaration",
+        Statement::ImportDeclaration(_) => "ImportDeclaration",
+        Statement::ExportNamedDeclaration(_) => "ExportNamedDeclaration",
+        Statement::ExportDefaultDeclaration(_) => "ExportDefaultDeclaration",
+        Statement::IfStatement(_) => "IfStatement",
+        Statement::ForStatement(_) => "ForStatement",
+        Statement::WhileStatement(_) => "WhileStatement",
+        _ => "Statement",
+    }
+}
+
+fn expression_kind(expr: &Expression) -> &'static str {
+    match expr {
+        Expression::ArrowFunctionExpression(_) => "ArrowFunctionExpression",
+        Expression::FunctionExpression(_) => "FunctionExpression",
+        Expression::NewExpression(_) => "NewExpression",
+        Expression::TemplateLiteral(_) => "TemplateLiteral",
+        Expression::AwaitExpression(_) => "AwaitExpression",
+        Expression::UpdateExpression(_) => "UpdateExpression",
+        _ => "Expression",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn roundtrip(src: &str) -> (String, Option<Unsupported>) {
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, src, SourceType::mjs()).parse();
+        assert!(
+            ret.diagnostics.is_empty(),
+            "parse error: {:?}",
+            ret.diagnostics
+        );
+        let opts = PrintOptions::default();
+        let mut printer = Printer::new(&opts);
+        let mut ctx = Context::new();
+        printer.print_program(&ret.program, &mut ctx);
+        (
+            crate::command::print(&ctx.into_commands(), &opts.indent),
+            printer.missing,
+        )
+    }
+
+    fn print_ok(src: &str) -> String {
+        let (out, missing) = roundtrip(src);
+        assert!(
+            missing.is_none(),
+            "unsupported node: {missing:?} for {src:?}"
+        );
+        out
+    }
+
+    #[test]
+    fn simple_var_and_expr() {
+        assert_eq!(print_ok("const x = 1;"), "const x = 1;");
+        assert_eq!(print_ok("let a = b;"), "let a = b;");
+    }
+
+    #[test]
+    fn binary_precedence_parens() {
+        assert_eq!(print_ok("const x = (1 + 2) * 3;"), "const x = (1 + 2) * 3;");
+        assert_eq!(print_ok("const x = 1 + 2 * 3;"), "const x = 1 + 2 * 3;");
+        assert_eq!(print_ok("const x = 1 - (2 - 3);"), "const x = 1 - (2 - 3);");
+    }
+
+    #[test]
+    fn member_and_call() {
+        assert_eq!(print_ok("foo.bar.baz();"), "foo.bar.baz();");
+        assert_eq!(print_ok("a(b, c, d);"), "a(b, c, d);");
+        assert_eq!(print_ok("obj['key'];"), "obj['key'];");
+        assert_eq!(print_ok("a?.b?.();"), "a?.b?.();");
+    }
+
+    #[test]
+    fn unary_and_conditional() {
+        assert_eq!(print_ok("const x = typeof y;"), "const x = typeof y;");
+        assert_eq!(print_ok("const x = !y;"), "const x = !y;");
+        assert_eq!(print_ok("const x = a ? b : c;"), "const x = a ? b : c;");
+    }
+
+    #[test]
+    fn object_and_array() {
+        assert_eq!(print_ok("const x = { a: 1, b };"), "const x = { a: 1, b };");
+        assert_eq!(print_ok("const x = {};"), "const x = {};");
+        assert_eq!(print_ok("const x = [1, 2, 3];"), "const x = [1, 2, 3];");
+    }
+
+    #[test]
+    fn string_raw_preserved() {
+        assert_eq!(print_ok("const x = \"hi\";"), "const x = \"hi\";");
+        assert_eq!(print_ok("const x = 'hi';"), "const x = 'hi';");
+    }
+
+    #[test]
+    fn leading_object_statement_parenthesised() {
+        assert_eq!(print_ok("({ a: 1 });"), "({ a: 1 });");
+    }
+
+    #[test]
+    fn block_layout() {
+        // `return` outside a function won't parse in mjs, so exercise the block
+        // layout with an expression statement instead.
+        assert_eq!(print_ok("{ a; }"), "{\n\ta;\n}");
+        assert_eq!(print_ok("{}"), "{}");
+    }
+}

--- a/crates/rsvelte_esrap/tests/golden.rs
+++ b/crates/rsvelte_esrap/tests/golden.rs
@@ -1,0 +1,162 @@
+//! Conformance harness for the esrap port.
+//!
+//! The official Svelte compiler prints its output with esrap, so its committed
+//! snapshot outputs (`tests/snapshot/samples/*/_expected/**/*.svelte.js`) are an
+//! exact oracle for this crate: parse one with oxc, re-print it, and the bytes
+//! must match. Coverage is incremental, so this test does not require every file
+//! to round-trip — it reports two rates and ratchets a floor so coverage can
+//! only grow:
+//!
+//! - **coverage** — files printed without hitting an unsupported node, and
+//! - **exact** — files whose re-print is byte-identical to esrap's.
+//!
+//! Set `ESRAP_GOLDEN_VERBOSE=1` to print a sample of the remaining misses while
+//! expanding visitor coverage.
+
+use std::path::{Path, PathBuf};
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_esrap::printer::Printer;
+use rsvelte_esrap::{PrintOptions, command, context::Context};
+
+/// The exact-match floor. Raise this as visitor coverage grows; CI fails if a
+/// change drops below it, so the printer can only get more conformant.
+const EXACT_FLOOR: usize = 0;
+
+fn samples_dir() -> Option<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../submodules/svelte/packages/svelte/tests/snapshot/samples");
+    dir.is_dir().then_some(dir)
+}
+
+fn collect_expected(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "js")
+                && path.to_string_lossy().contains("_expected")
+            {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+struct Reprint {
+    output: String,
+    missing: Option<String>,
+}
+
+fn reprint(source: &str) -> Option<Reprint> {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
+    if !ret.diagnostics.is_empty() {
+        return None; // not parseable as a module — skip (e.g. TS-only constructs)
+    }
+    let opts = PrintOptions::default();
+    let mut printer = Printer::new(&opts);
+    let mut ctx = Context::new();
+    printer.print_program(&ret.program, &mut ctx);
+    Some(Reprint {
+        output: command::print(&ctx.into_commands(), &opts.indent),
+        missing: printer.missing.map(|m| m.0.to_string()),
+    })
+}
+
+// `EXACT_FLOOR` is intentionally 0 today (visitor coverage is nascent), so the
+// ratchet comparison is trivially true; the allow keeps the floor a single knob
+// to raise as coverage lands rather than restructuring the guard.
+#[allow(clippy::absurd_extreme_comparisons)]
+#[test]
+fn golden_roundtrip_ratchet() {
+    let Some(dir) = samples_dir() else {
+        eprintln!("snapshot samples not found (submodule not initialised); skipping golden test");
+        return;
+    };
+
+    let files = collect_expected(&dir);
+    let total = files.len();
+    let mut parseable = 0usize;
+    let mut covered = 0usize;
+    let mut exact = 0usize;
+    let mut miss_kinds: std::collections::BTreeMap<String, usize> = Default::default();
+    let mut sample_diffs: Vec<String> = Vec::new();
+    let verbose = std::env::var("ESRAP_GOLDEN_VERBOSE").is_ok();
+
+    for path in &files {
+        let Ok(source) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let Some(result) = reprint(&source) else {
+            continue;
+        };
+        parseable += 1;
+
+        match &result.missing {
+            Some(kind) => *miss_kinds.entry(kind.clone()).or_default() += 1,
+            None => {
+                covered += 1;
+                if result.output == source {
+                    exact += 1;
+                } else if verbose && sample_diffs.len() < 5 {
+                    sample_diffs.push(format!(
+                        "DIFF {}\n  expected: {:?}\n  actual:   {:?}",
+                        path.strip_prefix(&dir).unwrap_or(path).display(),
+                        first_diff_window(&source, &result.output).0,
+                        first_diff_window(&source, &result.output).1,
+                    ));
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "esrap golden: {total} files | {parseable} parseable | {covered} covered (no unsupported node) | {exact} byte-exact"
+    );
+    if !miss_kinds.is_empty() {
+        let mut kinds: Vec<_> = miss_kinds.iter().collect();
+        kinds.sort_by(|a, b| b.1.cmp(a.1));
+        eprintln!(
+            "  top unsupported nodes: {:?}",
+            &kinds[..kinds.len().min(10)]
+        );
+    }
+    for d in &sample_diffs {
+        eprintln!("{d}");
+    }
+
+    // Ratchet: once coverage produces byte-exact files, raise EXACT_FLOOR so a
+    // regression fails CI. While the floor is 0 there is nothing to assert.
+    if EXACT_FLOOR > 0 {
+        assert!(
+            exact >= EXACT_FLOOR,
+            "esrap golden exact-match count {exact} dropped below floor {EXACT_FLOOR}"
+        );
+    }
+}
+
+/// A small window around the first byte difference, for readable diffs.
+fn first_diff_window(a: &str, b: &str) -> (String, String) {
+    let i = a
+        .bytes()
+        .zip(b.bytes())
+        .position(|(x, y)| x != y)
+        .unwrap_or(a.len().min(b.len()));
+    let start = i.saturating_sub(20);
+    let win = |s: &str| {
+        let end = (i + 20).min(s.len());
+        s.get(start..end).unwrap_or("").to_string()
+    };
+    (win(a), win(b))
+}


### PR DESCRIPTION
**Step 0** of the Phase-3 architecture move (`docs/phase3-ast-refactor-plan.md`), justified by `docs/phase3-perf-baseline.md` (#1038): the durable fix for Phase-3's string surgery (~68% of client-transform time) is to build an output AST and print it once with esrap, as upstream Svelte does. This PR lands the printer's foundation.

## What (faithful port of esrap 2.2.11)

| module | role |
|---|---|
| `command` | command buffer + flattening driver — whitespace/indent sentinels + literal strings + nested buffers; `Indent`/`Dedent` grow/shrink the newline prefix, `Newline`/`Margin`/`Space` are deferred flags (1:1 with esrap `index.js`) |
| `context` | visitor-facing builder (`write`/`newline`/`append`/`measure`/`empty` + `multiline`), from `context.js` |
| `printer` | the oxc-AST visitor — dispatch matches oxc node kinds; precedence-based parens (`needs_parens`: binary/logical, `**` right-assoc, `??` mixing) and the `body` statement-list layout ported as-is |

Coverage so far is the core expression/statement set (literals, members, calls, binary/logical, conditional, objects/arrays, assignments, var decls, blocks, chains…). Unhandled nodes surface as a tracked `Unsupported` instead of wrong output.

## Conformance harness (the ratchet)

The official compiler's snapshot outputs (`_expected/**/*.js`, themselves esrap-printed) are an exact oracle: parse with oxc → re-print → assert byte-identity. The `golden` test reports **coverage** (no unsupported node) + **byte-exact** rates and ratchets `EXACT_FLOOR` so later visitor PRs can only improve it. Current honest baseline: `ImportDeclaration` is the top remaining node; follow-ups add imports/functions/arrows/templates + the multiline `sequence` layout.

## Risk

Standalone crate, **not yet wired into the compiler** — zero risk to current output. clippy clean; 20 unit tests + the golden harness pass.