### PR TITLE
refactor(ssr): AST-bound await operands in attribute await-extraction

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/await_save_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/await_save_ast.rs
@@ -83,6 +83,46 @@ fn transform_with(allocator: &Allocator, expr: &str) -> Option<String> {
     Some(emit_range(expr, &collector.awaits, 0, expr.len() as u32))
 }
 
+/// Map every `await` keyword position in `expr` to the byte offset where its
+/// operand ends, derived from the parsed `AwaitExpression` spans. Returns
+/// `None` when the expression doesn't parse cleanly (caller falls back to the
+/// textual `find_await_arg_end`) or contains no `await`.
+///
+/// Unlike [`transform_await_to_save_ast`], this includes awaits inside nested
+/// function / arrow bodies: the byte-loop callers (`extract_all_awaits`,
+/// `try_extract_spread_await`) scan every textual `await`, so the lookup must
+/// resolve any of them. The key is the `await` keyword offset (the
+/// `AwaitExpression` span start), which is robust to a parenthesized operand
+/// (`await (x)`) where the argument node starts past the `(`.
+pub(crate) fn await_arg_ends(expr: &str) -> Option<Vec<(u32, u32)>> {
+    AWAIT_SAVE_ALLOC.with(|cell| {
+        let allocator = std::mem::take(&mut *cell.borrow_mut());
+        let out = collect_arg_ends(&allocator, expr);
+        *cell.borrow_mut() = allocator;
+        out
+    })
+}
+
+fn collect_arg_ends(allocator: &Allocator, expr: &str) -> Option<Vec<(u32, u32)>> {
+    let source_type = SourceType::ts().with_module(true);
+    let parsed = Parser::new(allocator, expr, source_type)
+        .with_options(ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        })
+        .parse();
+    if !parsed.diagnostics.is_empty() {
+        return None;
+    }
+    let mut collector = AllAwaitCollector { ends: Vec::new() };
+    collector.visit_program(&parsed.program);
+    if collector.ends.is_empty() {
+        None
+    } else {
+        Some(collector.ends)
+    }
+}
+
 /// Emit `source[lo..hi]`, wrapping each top-level `await` operand within the
 /// range. An `await` is "top-level within the range" when it is not nested
 /// inside an earlier wrapped operand — `emit_range` advances its cursor past
@@ -144,6 +184,20 @@ impl<'a> Visit<'a> for AwaitCollector {
     }
 }
 
+/// Collects `(await_keyword_start, arg_end)` for every `AwaitExpression`,
+/// including those inside nested function / arrow bodies.
+struct AllAwaitCollector {
+    ends: Vec<(u32, u32)>,
+}
+
+impl<'a> Visit<'a> for AllAwaitCollector {
+    fn visit_await_expression(&mut self, await_expr: &AwaitExpression<'a>) {
+        self.ends
+            .push((await_expr.span.start, await_expr.argument.span().end));
+        walk::walk_await_expression(self, await_expr);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,6 +249,26 @@ mod tests {
     #[test]
     fn no_await_returns_none() {
         assert!(transform_await_to_save_ast("a ? b : c").is_none());
+    }
+
+    #[test]
+    fn arg_ends_bounds_operand_before_ternary_colon() {
+        // `...await fn({a:1}) : x` — the operand ends at the call's `)`, not at
+        // the ternary `:` (issue #1036 in the attribute-extraction path).
+        let expr = "cond ? await fn({ a: 1 }) : undefined";
+        let kw = expr.find("await").unwrap() as u32;
+        let ends = await_arg_ends(expr).unwrap();
+        let (_, end) = ends.iter().find(|&&(s, _)| s == kw).unwrap();
+        // operand text is `fn({ a: 1 })`
+        assert_eq!(&expr[kw as usize + 6..*end as usize], "fn({ a: 1 })");
+    }
+
+    #[test]
+    fn arg_ends_includes_nested_function_awaits() {
+        let expr = "fn(async () => await inner())";
+        let ends = await_arg_ends(expr).unwrap();
+        // the await inside the nested arrow is present
+        assert_eq!(ends.len(), 1);
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -259,6 +259,25 @@ fn transform_await_to_save_textual(expr: &str) -> String {
     result
 }
 
+/// Resolve the end of an `await` operand at keyword position `kw_pos`, using
+/// the AST-derived `arg_ends` map when available and falling back to the
+/// byte scanner [`find_await_arg_end`] otherwise. `arg_ends` maps each
+/// `await` keyword offset to its operand end (see `await_save_ast::await_arg_ends`).
+fn await_arg_end_for_keyword(
+    arg_ends: &Option<Vec<(u32, u32)>>,
+    kw_pos: usize,
+    bytes: &[u8],
+    arg_start: usize,
+    len: usize,
+) -> usize {
+    if let Some(ends) = arg_ends
+        && let Some(&(_, end)) = ends.iter().find(|&&(start, _)| start as usize == kw_pos)
+    {
+        return end as usize;
+    }
+    find_await_arg_end(bytes, arg_start, len)
+}
+
 /// Find the end of an `await` argument expression.
 ///
 /// `await` has unary-expression precedence, so it only binds to the
@@ -2628,6 +2647,9 @@ fn try_extract_spread_await(
     let mut i = 0;
     let mut result = String::with_capacity(len);
 
+    // Operand extents from the parsed AST (see `extract_all_awaits`).
+    let arg_ends = super::await_save_ast::await_arg_ends(expr);
+
     while i < len {
         // Skip string literals
         if matches!(bytes[i], b'\'' | b'"' | b'`') {
@@ -2660,7 +2682,8 @@ fn try_extract_spread_await(
                     {
                         arg_start += 1;
                     }
-                    let arg_end = find_await_arg_end(bytes, arg_start, len);
+                    // `k` is the `await` keyword offset.
+                    let arg_end = await_arg_end_for_keyword(&arg_ends, k, bytes, arg_start, len);
                     let arg = &expr[arg_start..arg_end];
 
                     let var_name = format!("$${}", *var_counter);
@@ -2694,6 +2717,14 @@ fn extract_all_awaits(
     let mut result = String::with_capacity(len);
     let mut i = 0;
 
+    // Operand extents from the parsed AST, keyed by the `await` keyword
+    // position. Bounding each operand by its `AwaitExpression` span instead of
+    // the hand-rolled `find_await_arg_end` scanner removes the "forgot an
+    // operator" bug class (e.g. a ternary `:` swallowed into the operand —
+    // issue #1036). Falls back to the scanner when the expression doesn't
+    // parse as a standalone expression.
+    let arg_ends = super::await_save_ast::await_arg_ends(expr);
+
     while i < len {
         // Skip string literals
         if matches!(bytes[i], b'\'' | b'"' | b'`') {
@@ -2717,7 +2748,7 @@ fn extract_all_awaits(
                 while arg_start < len && matches!(bytes[arg_start], b' ' | b'\t' | b'\n' | b'\r') {
                     arg_start += 1;
                 }
-                let arg_end = find_await_arg_end(bytes, arg_start, len);
+                let arg_end = await_arg_end_for_keyword(&arg_ends, i, bytes, arg_start, len);
                 let arg = &expr[arg_start..arg_end];
 
                 let var_name = format!("$${}", *var_counter);


### PR DESCRIPTION
## Why

Follow-up to #1039. The attribute-value await-extraction path (`extract_await_from_expression` → `extract_all_awaits` / `try_extract_spread_await` in `server/helpers.rs`) still used the hand-rolled `find_await_arg_end` byte scanner to bound each `await` operand. That scanner has the **same "forgot an operator" failure mode** #1039 fixed for the main await→save path — e.g. a ternary `:` after an awaited consequent is swallowed into the operand, and any other operator the scanner doesn't enumerate.

## What

Bound each operand by its parsed `AwaitExpression` span instead:

- new `await_save_ast::await_arg_ends(expr)` → maps each `await` keyword offset to its operand end. Unlike the wrap helper from #1039, it **includes awaits inside nested function/arrow bodies**, because these byte-loop callers scan every textual `await` and must resolve any of them. Keying by the keyword offset is robust to a parenthesized operand (`await (x)`).
- `await_arg_end_for_keyword` looks the operand up and falls back to `find_await_arg_end` only when the expression doesn't parse as a standalone expression.

`find_await_arg_end` itself stays (still the fallback); a later PR removes it once no caller depends on it.

## Verification

- New unit tests for `await_arg_ends` (ternary-colon bound, nested-function awaits).
- Byte-exact suites green: `compiler_fixtures`, `runtime` {legacy, runes, browser, hydration}, `ssr`.

Part of the SSR text-surgery → AST migration (`docs/phase3-ast-refactor-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)