### PR TITLE
chore(esrap): unbreak Documentation CI (ambiguous intra-doc link)

### DIFF
--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -2,7 +2,7 @@
 //!
 //! A faithful port of the command model in esrap's `src/index.js` /
 //! `src/context.js`. Visitors don't write strings directly; they push
-//! [`Command`]s onto a buffer, and [`print`] flattens that buffer into the
+//! [`Command`]s onto a buffer, and the [`print()`] function flattens that buffer into the
 //! final source text. The indirection is what lets a visitor build a child
 //! layout, [`measure`](crate::context::Context::measure) it, and only then
 //! decide whether to emit it on one line or break it across several — esrap's


### PR DESCRIPTION
#1043 introduced `[`print`]` in `rsvelte_esrap`'s `command` module docs. rustdoc flags it as **ambiguous** — `print` is both the function defined there and the std `print!` macro — and the Documentation job runs `cargo doc --no-deps` with `RUSTDOCFLAGS: -Dwarnings`, so it failed and merged red. That makes the Documentation gate red on `main` and therefore on every open PR.

Disambiguate with the `[`print()`]` function form (warning-free, keeps the hyperlink). Verified `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps` is clean workspace-wide.

No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)