### PR TITLE
chore(esrap): unbreak Documentation CI (private intra-doc link in printer.rs)

### DIFF
--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -51,7 +51,7 @@ pub fn line_starts(source: &str) -> Vec<u32> {
 }
 
 /// A comment to interleave, pre-resolved to byte offsets, 1-based line numbers,
-/// and its delimiter-stripped value (so [`Printer::write_comment`] can rebuild
+/// and its delimiter-stripped value (so `Printer::write_comment` can rebuild
 /// it exactly as esrap does, re-indenting multi-line block bodies).
 #[derive(Debug, Clone)]
 pub struct Cmt {


### PR DESCRIPTION
A newer `rsvelte_esrap` change left `Cmt`'s public doc linking to the private `Printer::write_comment`. rustdoc rejects that under `RUSTDOCFLAGS: -Dwarnings` (`private_intra_doc_links`), so the Documentation job is red on `main` again, blocking the gate on every open PR. Demote it to plain code (`` `Printer::write_comment` ``).

Verified `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps` is clean workspace-wide. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)