### PR TITLE
refactor(ssr): AST-based expr_contains_await predicate

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/await_save_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/await_save_ast.rs
@@ -83,6 +83,43 @@ fn transform_with(allocator: &Allocator, expr: &str) -> Option<String> {
     Some(emit_range(expr, &collector.awaits, 0, expr.len() as u32))
 }
 
+/// Whether `expr` contains an expression-level `await` — one that is *not*
+/// nested inside a function / arrow body (those belong to a different async
+/// region). Returns `None` when `expr` doesn't parse as a standalone module,
+/// so the caller can fall back to the textual scanner.
+///
+/// Mirrors `helpers::expr_contains_await`'s nesting semantics via real AST
+/// scoping instead of a byte scan with hand-rolled `function`/`=>` body
+/// skipping. Callers should keep a cheap `memmem("await")` pre-check before
+/// calling this (parsing is only worth it when the word is actually present).
+pub(crate) fn contains_top_level_await(expr: &str) -> Option<bool> {
+    AWAIT_SAVE_ALLOC.with(|cell| {
+        let allocator = std::mem::take(&mut *cell.borrow_mut());
+        let out = contains_with(&allocator, expr);
+        *cell.borrow_mut() = allocator;
+        out
+    })
+}
+
+fn contains_with(allocator: &Allocator, expr: &str) -> Option<bool> {
+    let source_type = SourceType::ts().with_module(true);
+    let parsed = Parser::new(allocator, expr, source_type)
+        .with_options(ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        })
+        .parse();
+    if !parsed.diagnostics.is_empty() {
+        return None;
+    }
+    let mut collector = AwaitCollector {
+        function_depth: 0,
+        awaits: Vec::new(),
+    };
+    collector.visit_program(&parsed.program);
+    Some(!collector.awaits.is_empty())
+}
+
 /// Map every `await` keyword position in `expr` to the byte offset where its
 /// operand ends, derived from the parsed `AwaitExpression` spans. Returns
 /// `None` when the expression doesn't parse cleanly (caller falls back to the
@@ -201,6 +238,31 @@ impl<'a> Visit<'a> for AllAwaitCollector {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn contains_top_level_await_basic() {
+        assert_eq!(contains_top_level_await("await foo()"), Some(true));
+        assert_eq!(contains_top_level_await("foo + bar"), Some(false));
+    }
+
+    #[test]
+    fn contains_top_level_await_ignores_nested_function() {
+        // The await belongs to a nested arrow's async region, not the top level.
+        assert_eq!(
+            contains_top_level_await("fn(async () => await inner())"),
+            Some(false)
+        );
+        // But a top-level await alongside a nested one still counts.
+        assert_eq!(
+            contains_top_level_await("await outer(async () => await inner())"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn contains_top_level_await_unparseable_is_none() {
+        assert_eq!(contains_top_level_await("await ((("), None);
+    }
 
     #[test]
     fn ternary_consequent_await_keeps_alternate_outside_save() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -18,7 +18,25 @@ pub(crate) use super::transform_store::*;
 /// Check if a JavaScript expression string contains `await` at the expression level
 /// (not inside nested function expressions or arrow functions).
 /// This is used to detect async expression tags that need special handling.
+///
+/// Cheap path first: if the word `await` doesn't appear at all, there's
+/// nothing to find (this is the common case across the thousands of guard
+/// calls). Otherwise prefer the AST predicate (scope-accurate nesting), and
+/// fall back to the byte scanner only when the fragment doesn't parse as a
+/// standalone module.
 pub(crate) fn expr_contains_await(expr: &str) -> bool {
+    if memmem::find(expr.as_bytes(), b"await").is_none() {
+        return false;
+    }
+    if let Some(found) = super::await_save_ast::contains_top_level_await(expr) {
+        return found;
+    }
+    expr_contains_await_textual(expr)
+}
+
+/// Byte-scanning fallback for [`expr_contains_await`], used when the fragment
+/// doesn't parse as a standalone expression.
+fn expr_contains_await_textual(expr: &str) -> bool {
     let bytes = expr.as_bytes();
     let len = bytes.len();
     let mut i = 0;


### PR DESCRIPTION
## Why

`expr_contains_await` — the await-presence guard called from ~60 sites across the server transform — was a byte scanner that skipped strings / comments and hand-rolled `function` / `=>` body skipping to ignore awaits in nested async regions. Same byte-reconstruction approach as the other SSR scanners this migration is replacing.

## What

Route it through a new `await_save_ast::contains_top_level_await`: parse the fragment and check for any `AwaitExpression` outside a nested function/arrow body (scope-accurate via the existing `AwaitCollector`). Two guards keep it cheap and safe:

- a `memmem("await")` pre-check returns `false` instantly for the common case (no `await` word at all), so the parse cost is only paid when it could actually matter — this keeps the hot guard cheap;
- a parse failure falls back to the byte scanner (`expr_contains_await_textual`), so fragments that aren't standalone expressions behave exactly as before.

## Verification

- New unit tests (nested-arrow await ignored, top-level await counted, unparseable → `None`).
- Byte-exact suites green: `compiler_fixtures`, `runtime` {legacy, runes, browser, hydration}, `ssr`.

Part of the SSR text-surgery → AST migration (`docs/phase3-ast-refactor-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)