### PR TITLE
fix(esrap): catch(e) spacing + template-literal multiline propagation

### DIFF
--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -673,9 +673,18 @@ impl<'opt> Printer<'opt> {
             ctx.write(format!("{raw}${{"));
             self.print_expression(unparen(expr), ctx);
             ctx.write("}");
+            // A newline *inside* the literal makes the enclosing context
+            // multiline (esrap), which drives statement-margin decisions.
+            if raw.contains('\n') {
+                ctx.multiline = true;
+            }
         }
         if let Some(last) = node.quasis.last() {
-            ctx.write(format!("{}`", last.value.raw));
+            let raw = last.value.raw.as_str();
+            ctx.write(format!("{raw}`"));
+            if raw.contains('\n') {
+                ctx.multiline = true;
+            }
         }
     }
 
@@ -900,7 +909,8 @@ impl<'opt> Printer<'opt> {
         if let Some(handler) = &node.handler {
             ctx.write(" ");
             if let Some(param) = &handler.param {
-                ctx.write("catch (");
+                // esrap emits `catch(e)` with no space after the keyword.
+                ctx.write("catch(");
                 self.binding_pattern(&param.pattern, ctx);
                 ctx.write(") ");
             } else {
@@ -2136,7 +2146,7 @@ mod tests {
         );
         assert_eq!(
             print_ok("try { a(); } catch (e) { b(); }"),
-            "try {\n\ta();\n} catch (e) {\n\tb();\n}"
+            "try {\n\ta();\n} catch(e) {\n\tb();\n}"
         );
         assert_eq!(
             print_ok("try { a(); } finally { c(); }"),


### PR DESCRIPTION
Two printer fidelity fixes for the `rsvelte_esrap` port, burned down against the broad real-component oracle (5,536 official-compiler outputs): **+37 byte-exact (5048 → 5085 / 5536)**.

- **`catch(e)` spacing** — esrap emits the `catch` clause with no space after the keyword (`write_keyword(ctx, handler, 'catch', '(')`). The printer now matches.
- **Template-literal multiline propagation** — a newline *inside* a template literal now marks the enclosing context multiline, the signal that drives statement-margin (blank-line) decisions. SSR `$$renderer.push(\`...\`)` templates span many lines, so this restores the blank line before the following statement (the dominant remaining diff class on the server side).

Snapshot golden stays **72/72**; broad oracle **5085/5536**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)