### PR TITLE
fix(esrap): never parenthesize `super` as a call callee

### DIFF
--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -109,6 +109,9 @@ fn expr_precedence(expr: &Expression) -> u8 {
         | Expression::ThisExpression(_)
         | Expression::Identifier(_)
         | Expression::TemplateLiteral(_)
+        // `super` as a callee (`super(...)`) must never be parenthesized;
+        // esrap leaves its precedence undefined, so the `<` test is false.
+        | Expression::Super(_)
         | Expression::SequenceExpression(_) => 20,
         Expression::StaticMemberExpression(_)
         | Expression::ComputedMemberExpression(_)


### PR DESCRIPTION
`super(value)` was printed as `(super)(value)`. `Super` fell through to the default expression precedence (18), below the call-callee threshold (19), so `child_with_parens` wrapped it. esrap leaves `super`'s precedence undefined, so its `<` paren test is always false and a super call is never parenthesized. Classify `Super` at the top precedence (20) to match.

Broad real-component oracle: **+14 byte-exact (5310 → 5324 / 5536)**. Snapshot golden stays **72/72**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)