### PR TITLE
fix(esrap): flush comments inside an otherwise-empty block body

### DIFF
--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -474,14 +474,16 @@ impl<'opt> Printer<'opt> {
             prev = Some((std::mem::discriminant(*stmt), multiline));
         }
 
-        if !non_empty.is_empty() {
-            // A trailing newline closes the body (no-op at top level — nothing
-            // follows to flush it), then any comments after the last statement.
-            ctx.newline();
-            if !self.comments.is_empty() {
-                let from_line = non_empty.last().map(|s| self.line_of(s.span().end));
-                self.flush_comments_until(ctx, body_end, self.line_of(body_end), from_line, false);
-            }
+        // esrap's body tail (`if (node.loc)`) runs unconditionally: a trailing
+        // newline closes the body (a no-op flag at top level — nothing follows
+        // to flush it), then any comments up to the body end. Doing this even
+        // for an empty body emits an interior comment inside an otherwise empty
+        // block (`() => { /* x */ }`); the lone pending newline keeps the block
+        // `empty()`, so a comment-free `{}` is unaffected.
+        ctx.newline();
+        if !self.comments.is_empty() {
+            let from_line = non_empty.last().map(|s| self.line_of(s.span().end));
+            self.flush_comments_until(ctx, body_end, self.line_of(body_end), from_line, false);
         }
     }
 


### PR DESCRIPTION
`body` only emitted its end-of-body comment flush when the body had at least one statement, so a comment that is the sole content of a block — `() => { /* ... */ }` or `function f() { // ... }` — was dropped from the block and re-emitted after the call/declaration. esrap runs the tail flush unconditionally (`if (node.loc)`): a trailing newline plus the flush up to the body end. Mirror that; the lone pending newline keeps an empty context `empty()`, so a comment-free `{}` is unaffected.

Broad real-component oracle: **+4 byte-exact (5472 → 5476 / 5536)**. Snapshot golden stays **72/72**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)