### PR TITLE
fix(esrap): flush leading comments before object properties

### DIFF
--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1659,6 +1659,11 @@ impl<'opt> Printer<'opt> {
             .iter()
             .map(|prop| {
                 let mut child = ctx.child();
+                // esrap's `sequence` visits each property through the `_`
+                // wildcard, which flushes any comment positioned before it
+                // (`{ /** doc */ key: … }`). Mirror that per property.
+                let start = prop.span().start;
+                self.flush_leading(&mut child, start, self.line_of(start));
                 let obj_or_array = match prop {
                     ObjectPropertyKind::ObjectProperty(p) => {
                         self.object_property(p, &mut child);


### PR DESCRIPTION
An object built via `assemble_sequence` rendered each property directly, without the per-node leading-comment flush that esrap's `sequence` gets for free (it visits each child through the `_` wildcard). So a comment before a property, method, or accessor — `{ /** doc */ key: … }`, `{ a, // note\n get b() {} }` — was dropped and re-emitted elsewhere. Flush leading comments before each property into its child context.

Broad real-component oracle: **+9 byte-exact (5476 → 5485 / 5536)**. Snapshot golden stays **72/72**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)