### PR TITLE
fix(npm): correct doubled apps/apps/npm in repository.directory

### DIFF
--- a/.changeset/fix-repository-directory-doubled-apps.md
+++ b/.changeset/fix-repository-directory-doubled-apps.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+"@rsvelte/svelte-check": patch
+"@rsvelte/svelte2tsx": patch
+---
+
+Fix the doubled `apps/apps/npm/...` path in the published `repository.directory`
+metadata. The correct location is `apps/npm/<pkg>`, so the "source" link on
+each package's npm page now resolves instead of 404ing. This corrects the
+remaining packages missed when `@rsvelte/svelte-check` was fixed in #977: the
+`svelte-check-*` and `vite-plugin-svelte-native*` prebuilt-binary packages and
+`@rsvelte/svelte2tsx`. The `fixed` changeset groups carry the patch bump to
+every native sub-package.

--- a/apps/npm/svelte-check-darwin-arm64/package.json
+++ b/apps/npm/svelte-check-darwin-arm64/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/svelte-check-darwin-arm64"
+    "directory": "apps/npm/svelte-check-darwin-arm64"
   },
   "os": [
     "darwin"

--- a/apps/npm/svelte-check-darwin-x64/package.json
+++ b/apps/npm/svelte-check-darwin-x64/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/svelte-check-darwin-x64"
+    "directory": "apps/npm/svelte-check-darwin-x64"
   },
   "os": [
     "darwin"

--- a/apps/npm/svelte-check-linux-arm64-gnu/package.json
+++ b/apps/npm/svelte-check-linux-arm64-gnu/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/svelte-check-linux-arm64-gnu"
+    "directory": "apps/npm/svelte-check-linux-arm64-gnu"
   },
   "os": [
     "linux"

--- a/apps/npm/svelte-check-linux-x64-gnu/package.json
+++ b/apps/npm/svelte-check-linux-x64-gnu/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/svelte-check-linux-x64-gnu"
+    "directory": "apps/npm/svelte-check-linux-x64-gnu"
   },
   "os": [
     "linux"

--- a/apps/npm/svelte-check-win32-x64-msvc/package.json
+++ b/apps/npm/svelte-check-win32-x64-msvc/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/svelte-check-win32-x64-msvc"
+    "directory": "apps/npm/svelte-check-win32-x64-msvc"
   },
   "os": [
     "win32"

--- a/apps/npm/svelte2tsx/package.json
+++ b/apps/npm/svelte2tsx/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/svelte2tsx"
+    "directory": "apps/npm/svelte2tsx"
   },
   "homepage": "https://github.com/baseballyama/rsvelte/tree/main/apps/npm/svelte2tsx#readme",
   "bugs": {

--- a/apps/npm/vite-plugin-svelte-native-darwin-arm64/package.json
+++ b/apps/npm/vite-plugin-svelte-native-darwin-arm64/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/vite-plugin-svelte-native-darwin-arm64"
+    "directory": "apps/npm/vite-plugin-svelte-native-darwin-arm64"
   },
   "os": [
     "darwin"

--- a/apps/npm/vite-plugin-svelte-native-darwin-x64/package.json
+++ b/apps/npm/vite-plugin-svelte-native-darwin-x64/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/vite-plugin-svelte-native-darwin-x64"
+    "directory": "apps/npm/vite-plugin-svelte-native-darwin-x64"
   },
   "os": [
     "darwin"

--- a/apps/npm/vite-plugin-svelte-native-linux-arm64-gnu/package.json
+++ b/apps/npm/vite-plugin-svelte-native-linux-arm64-gnu/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/vite-plugin-svelte-native-linux-arm64-gnu"
+    "directory": "apps/npm/vite-plugin-svelte-native-linux-arm64-gnu"
   },
   "os": [
     "linux"

--- a/apps/npm/vite-plugin-svelte-native-linux-x64-gnu/package.json
+++ b/apps/npm/vite-plugin-svelte-native-linux-x64-gnu/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/vite-plugin-svelte-native-linux-x64-gnu"
+    "directory": "apps/npm/vite-plugin-svelte-native-linux-x64-gnu"
   },
   "os": [
     "linux"

--- a/apps/npm/vite-plugin-svelte-native-win32-x64-msvc/package.json
+++ b/apps/npm/vite-plugin-svelte-native-win32-x64-msvc/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/vite-plugin-svelte-native-win32-x64-msvc"
+    "directory": "apps/npm/vite-plugin-svelte-native-win32-x64-msvc"
   },
   "os": [
     "win32"

--- a/apps/npm/vite-plugin-svelte-native/package.json
+++ b/apps/npm/vite-plugin-svelte-native/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baseballyama/rsvelte.git",
-    "directory": "apps/apps/npm/vite-plugin-svelte-native"
+    "directory": "apps/npm/vite-plugin-svelte-native"
   },
   "homepage": "https://github.com/baseballyama/rsvelte/tree/main/apps/npm/vite-plugin-svelte-native#readme",
   "bugs": {


### PR DESCRIPTION
## What

12 published packages had `repository.directory` set to `apps/apps/npm/<pkg>` — a doubled `apps/`. The real location is `apps/npm/<pkg>`, so the "source" link on each npm page 404'd. This corrects all of them.

## Why

`apps/apps/npm` doesn't exist in the repo. #977 fixed this for the top-level `@rsvelte/svelte-check` only; the prebuilt-binary sub-packages and `@rsvelte/svelte2tsx` were left doubled (confirmed by `grep -rn "apps/apps"`).

## Packages fixed

- `@rsvelte/svelte2tsx`
- `@rsvelte/vite-plugin-svelte-native` (+ all 5 `-native-*` prebuilt packages)
- `@rsvelte/svelte-check-*` (all 5 prebuilt packages)

Metadata-only change — no code, no runtime behavior. A changeset bumps the affected `fixed` groups so the corrected metadata gets published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)