### PR TITLE
fix(repo): remove stray top-level npm/ NAPI binary committed to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ target
 # target in CI, staged into the matching platform package, never committed)
 /apps/npm/vite-plugin-svelte-native-*/rsvelte.node
 
+# Stray top-level npm/ dir. Published packages live under apps/npm/ — a
+# top-level npm/ only ever appears when a napi build dumps its host-platform
+# .node there (the napi-rs default `npmDir`). Never a real source dir here.
+/npm/
+
 # rsvelte-fmt platform binaries (staged into per-platform npm packages by the
 # release workflow; never committed)
 /apps/npm/fmt-*/rsvelte-fmt


### PR DESCRIPTION
## What

Removes `npm/vite-plugin-svelte-native-darwin-arm64/rsvelte.node` — a **9.9 MB host-platform NAPI binary accidentally committed to `main`** in #1079 — and adds `/npm/` to `.gitignore`.

## Why it's wrong

- The published per-platform packages live under `apps/npm/vite-plugin-svelte-native-*/`, and their `rsvelte.node` artifacts are already gitignored (`/apps/npm/vite-plugin-svelte-native-*/rsvelte.node`) and staged by CI at release time (`scripts/release/stage-vps-binaries.mjs`).
- A **top-level** `npm/` is not a source directory in this repo. It only appears when a `napi build` writes its host-triple artifact into the napi-rs default `npmDir` (`npm/`). Because `.gitignore` only covered `/apps/npm/...`, the stray file slipped through and got committed.
- Only `darwin-arm64` was present (not the other 4 triples) precisely because you can only build the host triple locally — confirming it's a stray local artifact, not an intentional package. The fix is to **remove it**, not to add the others.

No code or published-package change (this blob was never part of any published package), so no changeset.

## Guard

`/npm/` added to `.gitignore`; verified `git check-ignore` now catches `npm/**/rsvelte.node`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)