### PR TITLE
feat(esrap): vendor esrap v2.2.11 + port its full test suite (97/97 byte-identical)

### DIFF
--- a/.changeset/esrap-test-port.md
+++ b/.changeset/esrap-test-port.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Harden the `rsvelte_esrap` printer (which prints the compiler's Phase-3 output)
+against the upstream esrap `v2.2.11` test suite, now vendored as a submodule and
+ported to Rust. The full esrap sample corpus is byte-identical (97/97) and every
+esrap unit test (quotes, indent, compat, additional-comments, arrow-return-type,
+sourcemap-keywords) is ported and passing. Printer behaviour was made faithful
+to esrap: directives, `EmptyStatement`/`WithStatement`, import attributes,
+comment threading through sequences/call-args/class-bodies, full TypeScript
+type-syntax and JSX printing, precedence-based parenthesisation (unwrapping
+explicit parens like esrap's acorn baseline), and string escaping (`\t` left
+literal). Adds source-map generation (`print_with_map`) and synthetic-comment
+hooks (`print_with_hooks`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,14 +144,15 @@ jobs:
 
       # Shallow, selective submodule init instead of `submodules: true`: the
       # shards only need `svelte` (build.rs version string + generated fixtures),
-      # `language-tools` (svelte2tsx + svelte-check golden tests), and
+      # `language-tools` (svelte2tsx + svelte-check golden tests),
       # `eslint-plugin-svelte` (the `eslint_plugin_oracle` fixtures; it soft-skips
-      # when absent, but we keep coverage). The big unused ones — typescript-go
+      # when absent, but we keep coverage), and `esrap` (the rsvelte_esrap
+      # sample-parity suite). The big unused ones — typescript-go
       # (~534 MB), vize, corsa-bind, and svelte.dev (only the now-removed
       # fmt-corpus step read it) — are skipped, cutting checkout from ~45 s to
       # ~15 s on the macOS runners.
       - name: Checkout needed submodules (shallow)
-        run: git submodule update --init --depth 1 submodules/svelte submodules/language-tools submodules/eslint-plugin-svelte
+        run: git submodule update --init --depth 1 submodules/svelte submodules/language-tools submodules/eslint-plugin-svelte submodules/esrap
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.gitmodules
+++ b/.gitmodules
@@ -27,6 +27,13 @@
 	path = submodules/svelte-eslint-parser
 	url = https://github.com/sveltejs/svelte-eslint-parser
 	ignore = dirty
+# esrap printer — vendored upstream (sveltejs/esrap), pinned to v2.2.11. Its test
+# suite is ported to crates/rsvelte_esrap; excluded from the auto-update rotation.
+[submodule "submodules/esrap"]
+	path = submodules/esrap
+	url = https://github.com/sveltejs/esrap.git
+	ignore = dirty
+	shallow = true
 # Real-world ecosystem projects folded into the compat corpus (scripts/compat-corpus).
 # Their shipped .svelte / .svelte.(js|ts) sources are compiled by both the official
 # compiler and rsvelte and required to match — the same three tracks as svelte/svelte.dev.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,7 @@ version = "0.7.11"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
+ "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
  "oxc_syntax",

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -20,6 +20,7 @@ oxc_syntax = "0.136"
 
 [dev-dependencies]
 oxc_parser = "0.136"
+oxc_ast_visit = "0.136"
 
 [lints]
 workspace = true

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -41,10 +41,28 @@ pub enum Command {
     Location { line: u32, column: u32 },
 }
 
+/// One source-map segment: `[generated_column, source_index, source_line_0based,
+/// source_column_0based]`. The source index is always `0` (esrap only ever maps a
+/// single source), matching upstream's emitted shape.
+pub type Segment = [i64; 4];
+
 /// Flatten `commands` into source text, using `indent` (e.g. `"\t"` or a run
 /// of spaces) for each indentation level. Faithful port of the `run`/`append`
 /// loop in esrap's `print`.
 pub fn print(commands: &[Command], indent: &str) -> String {
+    flatten_with_map(commands, indent).0
+}
+
+/// Flatten `commands` into both the source text and its source-map `mappings`
+/// (an array-of-lines, each line an array of [`Segment`]s). A faithful port of
+/// esrap's `print` driver, which threads `current_column` through `append` and
+/// pushes a segment on every `Location` command.
+///
+/// Note on columns: esrap segments carry ESTree columns (UTF-16 code-unit
+/// indices). This port derives source columns from byte offsets, so the two
+/// agree for ASCII / BMP source (which covers the keyword sites). Generated
+/// columns are likewise tracked in `char`s of the emitted code.
+pub fn flatten_with_map(commands: &[Command], indent: &str) -> (String, Vec<Vec<Segment>>) {
     let mut driver = Driver {
         code: String::new(),
         current_newline: String::from("\n"),
@@ -52,11 +70,18 @@ pub fn print(commands: &[Command], indent: &str) -> String {
         needs_newline: false,
         needs_margin: false,
         needs_space: false,
+        current_column: 0,
+        mappings: Vec::new(),
+        current_line: Vec::new(),
     };
     for command in commands {
         driver.run(command);
     }
-    driver.code
+    // esrap pushes the final (possibly empty) line once the buffer is drained.
+    driver
+        .mappings
+        .push(std::mem::take(&mut driver.current_line));
+    (driver.code, driver.mappings)
 }
 
 struct Driver<'a> {
@@ -68,6 +93,12 @@ struct Driver<'a> {
     needs_newline: bool,
     needs_margin: bool,
     needs_space: bool,
+    /// Current 0-based generated column (in `char`s), reset on each `\n`.
+    current_column: i64,
+    /// Completed generated lines of segments.
+    mappings: Vec<Vec<Segment>>,
+    /// Segments accumulated for the generated line currently being built.
+    current_line: Vec<Segment>,
 }
 
 impl Driver<'_> {
@@ -88,12 +119,35 @@ impl Driver<'_> {
             }
             Command::Str(s) => {
                 self.flush_pending();
-                self.code.push_str(s);
+                self.append(s);
             }
-            Command::Location { .. } => {
-                // Anchors flush pending whitespace just like a string would, so
-                // that adding source-map support later doesn't shift output.
+            Command::Location { line, column } => {
+                // Anchors flush pending whitespace just like a string would (so
+                // adding source-map support doesn't shift output), then record a
+                // segment at the current generated column. Mirrors esrap's
+                // `command.type === 'Location'` branch in `run`.
                 self.flush_pending();
+                self.current_line.push([
+                    self.current_column,
+                    0, // source index is always zero
+                    *line as i64 - 1,
+                    *column as i64,
+                ]);
+            }
+        }
+    }
+
+    /// Append literal text to the output, advancing `current_column` per char
+    /// and rolling over `current_line`/`mappings` on each `\n`. A faithful port
+    /// of esrap's `append`.
+    fn append(&mut self, str: &str) {
+        self.code.push_str(str);
+        for ch in str.chars() {
+            if ch == '\n' {
+                self.mappings.push(std::mem::take(&mut self.current_line));
+                self.current_column = 0;
+            } else {
+                self.current_column += 1;
             }
         }
     }
@@ -104,11 +158,13 @@ impl Driver<'_> {
     fn flush_pending(&mut self) {
         if self.needs_newline {
             if self.needs_margin {
-                self.code.push('\n');
+                self.append("\n");
             }
-            self.code.push_str(&self.current_newline);
+            let nl = std::mem::take(&mut self.current_newline);
+            self.append(&nl);
+            self.current_newline = nl;
         } else if self.needs_space {
-            self.code.push(' ');
+            self.append(" ");
         }
         self.needs_newline = false;
         self.needs_margin = false;

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -81,6 +81,62 @@ pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -
     command::print(&ctx.into_commands(), &options.indent)
 }
 
+/// A synthetic comment injected by a [`CommentHooks`] callback (esrap's
+/// `BaseComment`). `block` chooses `/* … */` vs `// …`; `value` is the interior
+/// text (without delimiters).
+#[derive(Debug, Clone)]
+pub struct SynthComment {
+    pub block: bool,
+    pub value: String,
+}
+
+impl SynthComment {
+    /// A `// value` line comment.
+    pub fn line(value: impl Into<String>) -> Self {
+        Self {
+            block: false,
+            value: value.into(),
+        }
+    }
+
+    /// A `/* value */` block comment.
+    pub fn block(value: impl Into<String>) -> Self {
+        Self {
+            block: true,
+            value: value.into(),
+        }
+    }
+}
+
+/// Caller hooks that inject synthetic comments around statements, mirroring
+/// esrap's `getLeadingComments` / `getTrailingComments` options. Each callback
+/// receives the statement node and returns the comments to emit (leading
+/// comments precede the node; trailing comments follow it on the same line).
+#[derive(Default)]
+pub struct CommentHooks<'h> {
+    #[allow(clippy::type_complexity)]
+    pub get_leading: Option<Box<dyn Fn(&oxc_ast::ast::Statement) -> Vec<SynthComment> + 'h>>,
+    #[allow(clippy::type_complexity)]
+    pub get_trailing: Option<Box<dyn Fn(&oxc_ast::ast::Statement) -> Vec<SynthComment> + 'h>>,
+}
+
+/// Like [`print_with`], but invokes `hooks` to inject synthetic leading/trailing
+/// comments per statement (esrap's `getLeadingComments`/`getTrailingComments`).
+pub fn print_with_hooks(
+    program: &Program<'_>,
+    source: &str,
+    options: &PrintOptions,
+    hooks: &CommentHooks<'_>,
+) -> String {
+    let comments = printer::build_comments(program, source);
+    let mut printer =
+        printer::Printer::with_comments(options, comments, printer::line_starts(source))
+            .with_hooks(hooks);
+    let mut ctx = context::Context::new();
+    printer.print_program(program, &mut ctx);
+    command::print(&ctx.into_commands(), &options.indent)
+}
+
 /// Print `program` to JavaScript with the default options, returning both the
 /// code and decoded source-map mappings. The emitted code is byte-identical to
 /// [`print`] — `Location` anchors only carry mapping data, they never add text.

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -80,3 +80,36 @@ pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -
     printer.print_program(program, &mut ctx);
     command::print(&ctx.into_commands(), &options.indent)
 }
+
+/// Print `program` to JavaScript with the default options, returning both the
+/// code and decoded source-map mappings. The emitted code is byte-identical to
+/// [`print`] — `Location` anchors only carry mapping data, they never add text.
+pub fn print_with_map(program: &Program<'_>, source: &str) -> PrintWithMap {
+    print_with_map_opts(program, source, &PrintOptions::default())
+}
+
+/// The decoded result of [`print_with_map`].
+#[derive(Debug, Clone)]
+pub struct PrintWithMap {
+    /// The generated source text (identical to what [`print_with`] returns).
+    pub code: String,
+    /// Source-map mappings: one entry per generated line, each a list of
+    /// `[generated_column, source_index, source_line_0based, source_column_0based]`
+    /// segments. Matches esrap's `sourceMapEncodeMappings: false` shape.
+    pub mappings: Vec<Vec<command::Segment>>,
+}
+
+/// Like [`print_with_map`] but with explicit options.
+pub fn print_with_map_opts(
+    program: &Program<'_>,
+    source: &str,
+    options: &PrintOptions,
+) -> PrintWithMap {
+    let comments = printer::build_comments(program, source);
+    let mut printer =
+        printer::Printer::with_comments(options, comments, printer::line_starts(source));
+    let mut ctx = context::Context::new();
+    printer.print_program(program, &mut ctx);
+    let (code, mappings) = command::flatten_with_map(&ctx.into_commands(), &options.indent);
+    PrintWithMap { code, mappings }
+}

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -139,7 +139,7 @@ pub fn print_with_hooks(
 
 /// Print `program` to JavaScript with the default options, returning both the
 /// code and decoded source-map mappings. The emitted code is byte-identical to
-/// [`print`] — `Location` anchors only carry mapping data, they never add text.
+/// [`print()`] — `Location` anchors only carry mapping data, never add text.
 pub fn print_with_map(program: &Program<'_>, source: &str) -> PrintWithMap {
     print_with_map_opts(program, source, &PrintOptions::default())
 }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -365,13 +365,18 @@ impl<'opt> Printer<'opt> {
     }
 
     /// esrap's `flush_trailing_comments`: emit comments on the same line as a
-    /// node's end (`// trailing`), provided they fall before `next`.
+    /// node's end (`// trailing`), provided they fall before `next`. Returns
+    /// `true` if a trailing `// line` comment (and its closing `newline()`) was
+    /// emitted — esrap propagates that newline into the surrounding context's
+    /// `multiline` via the next `append`, which the call-argument layout relies
+    /// on to force the wrapped one-arg-per-line form.
     fn flush_trailing_comments(
         &mut self,
         ctx: &mut Context,
         prev_end_line: u32,
         next: Option<u32>,
-    ) {
+    ) -> bool {
+        let mut emitted_line_newline = false;
         while self.comment_index < self.comments.len() {
             let cmt = self.comments[self.comment_index].clone();
             let fits = cmt.start_line == prev_end_line && next.is_none_or(|n| cmt.end < n);
@@ -385,8 +390,10 @@ impl<'opt> Printer<'opt> {
                 continue;
             }
             ctx.newline();
+            emitted_line_newline = true;
             break;
         }
+        emitted_line_newline
     }
 
     /// esrap's `reset_comment_index`: re-sync the cursor to the first comment
@@ -415,6 +422,116 @@ impl<'opt> Printer<'opt> {
             return;
         }
         self.flush_comments_until(ctx, node_start, node_start_line, None, true);
+    }
+
+    /// Port of esrap's `sequence` (`languages/ts/index.js`). Lays `nodes` out as
+    /// a separator-joined comma list, threading comments through the shared
+    /// `comment_index` cursor: each node is rendered, its separator written, and
+    /// its **trailing** comments flushed in source order (so a comment after a
+    /// node's separator — e.g. `foo: 1, /* c */ bar` — attaches to that node, not
+    /// as a leading comment of the next). After the layout, end-of-list comments
+    /// up to `until` are flushed.
+    ///
+    /// `until` is the byte offset that closes the list (e.g. the `}` / `]`); used
+    /// as the `next` boundary for the final node's trailing comments and as the
+    /// limit for the closing `flush_comments_until`.
+    fn sequence(
+        &mut self,
+        mut nodes: Vec<SeqNode<'_>>,
+        until: Option<u32>,
+        pad: bool,
+        separator: &str,
+        trailing_newline: bool,
+        parent: &mut Context,
+    ) {
+        let n = nodes.len();
+        let mut multiline = false;
+        let mut length: i64 = -1;
+
+        // Each node's start, for use as the *next* node's trailing-comment
+        // boundary (precomputed so the render loop can borrow `nodes` mutably).
+        let starts: Vec<Option<u32>> = nodes.iter().map(|node| node.start).collect();
+
+        // First pass — render each child, write its separator, then flush its
+        // trailing comments. This must interleave with rendering (not run after
+        // all children are built) because the single forward `comment_index`
+        // cursor would otherwise hand item[i]'s trailing comment to item[i+1] as
+        // a leading comment.
+        let mut items: Vec<SeqItem> = Vec::with_capacity(n);
+        for (i, node) in nodes.iter_mut().enumerate() {
+            let mut child = parent.child();
+            (node.render)(self, &mut child);
+
+            let node_multiline = child.multiline;
+
+            // esrap writes the separator for every non-final element, and also
+            // for a trailing elision (`[a, ,]`): `i < n-1 || !child`.
+            if i < n - 1 || node.is_elision {
+                child.write(separator);
+            }
+
+            // `next` boundary for this node's trailing comments: the next node's
+            // start, or `until` for the final node.
+            let next = if i == n - 1 { until } else { starts[i + 1] };
+            if let Some(end) = node.end {
+                self.flush_trailing_comments(&mut child, self.line_of(end), next);
+            }
+
+            length += child.measure() as i64 + 1;
+            multiline |= child.multiline;
+
+            items.push(SeqItem {
+                ctx: child,
+                multiline: node_multiline,
+                obj_or_array: node.obj_or_array,
+                is_elision: node.is_elision,
+            });
+        }
+
+        multiline |= length > 60;
+
+        if multiline {
+            parent.indent();
+            parent.newline();
+        } else if pad && length > 0 {
+            parent.write(" ");
+        }
+
+        let mut prev: Option<(bool, bool)> = None;
+        for item in items {
+            if let Some((prev_multiline, prev_obj)) = prev {
+                if prev_multiline && item.multiline && !(prev_obj && item.obj_or_array) {
+                    parent.margin();
+                }
+                if !item.is_elision {
+                    if multiline {
+                        parent.newline();
+                    } else {
+                        parent.write(" ");
+                    }
+                }
+            }
+            prev = Some((item.multiline, item.obj_or_array));
+            parent.append(item.ctx);
+        }
+
+        // esrap: flush_comments_until(context, lastNode.loc.end, until, false).
+        if let Some(until) = until {
+            let from_line = nodes
+                .last()
+                .and_then(|node| node.end)
+                .map(|e| self.line_of(e));
+            self.flush_comments_until(parent, until, self.line_of(until), from_line, false);
+        }
+
+        if multiline {
+            parent.dedent();
+            if trailing_newline {
+                parent.newline();
+            }
+        } else if pad && length > 0 {
+            parent.write(" ");
+        }
     }
 
     fn unsupported(&mut self, kind: &'static str, ctx: &mut Context) {
@@ -542,12 +659,26 @@ impl<'opt> Printer<'opt> {
                 ctx.write(";");
             }
             Statement::ReturnStatement(s) => {
-                ctx.write("return");
                 if let Some(arg) = &s.argument {
-                    ctx.write(" ");
-                    self.print_expression(arg, ctx);
+                    // esrap: when a comment sits between `return` and the
+                    // argument, wrap the argument in parens (`return (/*c*/ x);`)
+                    // so the comment can't be read as ending the statement.
+                    let contains_comment = self
+                        .comments
+                        .get(self.comment_index)
+                        .is_some_and(|c| c.start < arg.span().start);
+                    if contains_comment {
+                        ctx.write("return (");
+                        self.print_expression(arg, ctx);
+                        ctx.write(");");
+                    } else {
+                        ctx.write("return ");
+                        self.print_expression(arg, ctx);
+                        ctx.write(";");
+                    }
+                } else {
+                    ctx.write("return;");
                 }
-                ctx.write(";");
             }
             Statement::BlockStatement(b) => {
                 let span = b.span();
@@ -666,21 +797,22 @@ impl<'opt> Printer<'opt> {
         }
         if !named.is_empty() {
             ctx.write("{");
-            let items: Vec<SeqItem> = named
+            let nodes: Vec<SeqNode> = named
                 .iter()
                 .map(|s| {
-                    let mut child = ctx.child();
-                    self.import_specifier(s, &mut child);
-                    let multiline = child.multiline;
-                    SeqItem {
-                        ctx: child,
-                        multiline,
+                    let span = s.span();
+                    SeqNode {
+                        start: Some(span.start),
+                        end: Some(span.end),
                         obj_or_array: false,
                         is_elision: false,
+                        render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                            p.import_specifier(s, child);
+                        }),
                     }
                 })
                 .collect();
-            assemble_sequence(items, true, ",", true, ctx);
+            self.sequence(nodes, None, true, ",", true, ctx);
             ctx.write("}");
         }
         ctx.write(" from ");
@@ -735,22 +867,23 @@ impl<'opt> Printer<'opt> {
         }
 
         ctx.write("export {");
-        let items: Vec<SeqItem> = node
+        let nodes: Vec<SeqNode> = node
             .specifiers
             .iter()
             .map(|s| {
-                let mut child = ctx.child();
-                self.export_specifier(s, &mut child);
-                let multiline = child.multiline;
-                SeqItem {
-                    ctx: child,
-                    multiline,
+                let span = s.span();
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        p.export_specifier(s, child);
+                    }),
                 }
             })
             .collect();
-        assemble_sequence(items, true, ",", true, ctx);
+        self.sequence(nodes, None, true, ",", true, ctx);
         ctx.write("}");
         if let Some(source) = &node.source {
             ctx.write(" from ");
@@ -866,31 +999,23 @@ impl<'opt> Printer<'opt> {
         self.class_body(&node.body, ctx);
     }
 
-    /// Lay out class members one-per-line, with a blank line between two
-    /// multiline members or a change of member kind (esrap's `body` rule).
+    /// esrap's `BlockStatement|ClassBody`: route class members through the shared
+    /// `body` machinery (one-per-line, blank line between two multiline members
+    /// or a change of member kind) so leading / trailing / end-of-body comments
+    /// are interleaved identically to a statement block.
     fn class_body(&mut self, body: &ClassBody, ctx: &mut Context) {
+        let span = body.span();
         ctx.write("{");
         let mut child = ctx.child();
-        let mut prev: Option<(std::mem::Discriminant<ClassElement>, bool)> = None;
-        for element in &body.body {
-            if matches!(element, ClassElement::TSIndexSignature(_)) {
-                continue;
-            }
-            let mut member = child.child();
-            self.class_element(element, &mut member);
-            if let Some((prev_disc, prev_multiline)) = prev {
-                if member.multiline
-                    || prev_multiline
-                    || std::mem::discriminant(element) != prev_disc
-                {
-                    child.margin();
-                }
-                child.newline();
-            }
-            let multiline = member.multiline;
-            child.append(member);
-            prev = Some((std::mem::discriminant(element), multiline));
-        }
+        let elems: Vec<BodyElem> = body
+            .body
+            .iter()
+            // esrap's `body` only skips `EmptyStatement`; TS index signatures are
+            // not statements and have no printer mapping here, so drop them.
+            .filter(|e| !matches!(e, ClassElement::TSIndexSignature(_)))
+            .map(BodyElem::ClassMember)
+            .collect();
+        self.body_elems(&elems, span.start, span.end, &mut child);
         if !child.empty() {
             ctx.indent();
             ctx.newline();
@@ -902,6 +1027,10 @@ impl<'opt> Printer<'opt> {
     }
 
     fn class_element(&mut self, element: &ClassElement, ctx: &mut Context) {
+        // esrap's `_` wildcard flushes any comment positioned before the member
+        // (e.g. a leading JSDoc block) before visiting it.
+        let start = element.span().start;
+        self.flush_leading(ctx, start, self.line_of(start));
         match element {
             ClassElement::MethodDefinition(m) => self.method_definition(m, ctx),
             ClassElement::PropertyDefinition(p) => self.property_definition(p, ctx),
@@ -1074,34 +1203,36 @@ impl<'opt> Printer<'opt> {
 
     fn object_pattern(&mut self, node: &ObjectPattern, ctx: &mut Context) {
         ctx.write("{");
-        let mut items: Vec<SeqItem> = node
+        let mut nodes: Vec<SeqNode> = node
             .properties
             .iter()
-            .map(|p| {
-                let mut child = ctx.child();
-                self.binding_property(p, &mut child);
-                let multiline = child.multiline;
-                SeqItem {
-                    ctx: child,
-                    multiline,
+            .map(|prop| {
+                let span = prop.span();
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        p.binding_property(prop, child);
+                    }),
                 }
             })
             .collect();
         if let Some(rest) = &node.rest {
-            let mut child = ctx.child();
-            child.write("...");
-            self.binding_pattern(&rest.argument, &mut child);
-            let multiline = child.multiline;
-            items.push(SeqItem {
-                ctx: child,
-                multiline,
+            let span = rest.span();
+            nodes.push(SeqNode {
+                start: Some(span.start),
+                end: Some(span.end),
                 obj_or_array: false,
                 is_elision: false,
+                render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                    child.write("...");
+                    p.binding_pattern(&rest.argument, child);
+                }),
             });
         }
-        assemble_sequence(items, true, ",", true, ctx);
+        self.sequence(nodes, Some(node.span().end), true, ",", true, ctx);
         ctx.write("}");
     }
 
@@ -1123,75 +1254,84 @@ impl<'opt> Printer<'opt> {
 
     fn array_pattern(&mut self, node: &ArrayPattern, ctx: &mut Context) {
         ctx.write("[");
-        let mut items: Vec<SeqItem> = node
+        let mut nodes: Vec<SeqNode> = node
             .elements
             .iter()
             .map(|el| {
-                let mut child = ctx.child();
-                if let Some(pattern) = el {
-                    self.binding_pattern(pattern, &mut child);
-                }
-                let multiline = child.multiline;
-                SeqItem {
-                    ctx: child,
-                    multiline,
+                let span = el.as_ref().map(|p| p.span());
+                SeqNode {
+                    start: span.map(|s| s.start),
+                    end: span.map(|s| s.end),
                     obj_or_array: false,
                     is_elision: el.is_none(),
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        if let Some(pattern) = el {
+                            p.binding_pattern(pattern, child);
+                        }
+                    }),
                 }
             })
             .collect();
         if let Some(rest) = &node.rest {
-            let mut child = ctx.child();
-            child.write("...");
-            self.binding_pattern(&rest.argument, &mut child);
-            let multiline = child.multiline;
-            items.push(SeqItem {
-                ctx: child,
-                multiline,
+            let span = rest.span();
+            nodes.push(SeqNode {
+                start: Some(span.start),
+                end: Some(span.end),
                 obj_or_array: false,
                 is_elision: false,
+                render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                    child.write("...");
+                    p.binding_pattern(&rest.argument, child);
+                }),
             });
         }
-        assemble_sequence(items, false, ",", true, ctx);
+        self.sequence(nodes, Some(node.span().end), false, ",", true, ctx);
         ctx.write("]");
     }
 
     /// Parameter list via esrap's `sequence` (no padding): `a, b, ...rest`.
     fn formal_parameters(&mut self, params: &FormalParameters, ctx: &mut Context) {
-        let mut items: Vec<SeqItem> = params
+        let mut nodes: Vec<SeqNode> = params
             .items
             .iter()
-            .map(|p| {
-                let mut child = ctx.child();
-                self.binding_pattern(&p.pattern, &mut child);
-                // Default value: oxc stores parameter defaults on
-                // `FormalParameter::initializer`, not as an `AssignmentPattern`.
-                if let Some(init) = &p.initializer {
-                    child.write(" = ");
-                    self.print_expression(init, &mut child);
-                }
-                let multiline = child.multiline;
-                SeqItem {
-                    ctx: child,
-                    multiline,
+            .map(|param| {
+                let span = param.span();
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        p.binding_pattern(&param.pattern, child);
+                        // Default value: oxc stores parameter defaults on
+                        // `FormalParameter::initializer`, not as an
+                        // `AssignmentPattern`.
+                        if let Some(init) = &param.initializer {
+                            child.write(" = ");
+                            p.print_expression(init, child);
+                        }
+                    }),
                 }
             })
             .collect();
         if let Some(rest) = &params.rest {
-            let mut child = ctx.child();
-            child.write("...");
-            self.binding_pattern(&rest.rest.argument, &mut child);
-            let multiline = child.multiline;
-            items.push(SeqItem {
-                ctx: child,
-                multiline,
+            let span = rest.span();
+            nodes.push(SeqNode {
+                start: Some(span.start),
+                end: Some(span.end),
                 obj_or_array: false,
                 is_elision: false,
+                render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                    child.write("...");
+                    p.binding_pattern(&rest.rest.argument, child);
+                }),
             });
         }
-        assemble_sequence(items, false, ",", true, ctx);
+        // esrap passes the closing `)` location as `until`, but the Rust caller
+        // already owns the parens around `formal_parameters`; there is no node
+        // span for the list itself, so no end-of-list comment flush is needed
+        // here (params rarely carry trailing comments in the corpus).
+        self.sequence(nodes, None, false, ",", true, ctx);
     }
 
     /// esrap's `ArrowFunctionExpression`: `[async ](params) => body`, wrapping an
@@ -1411,7 +1551,7 @@ impl<'opt> Printer<'opt> {
             Expression::NewExpression(n) => {
                 ctx.write("new ");
                 self.child_with_parens(&n.callee, 19, ctx);
-                self.call_arguments(&n.arguments, ctx);
+                self.call_arguments(&n.arguments, n.span().end, ctx);
             }
             Expression::UpdateExpression(u) => {
                 let op = u.operator.as_str();
@@ -1502,7 +1642,7 @@ impl<'opt> Printer<'opt> {
         if node.optional {
             ctx.write("?.");
         }
-        self.call_arguments(&node.arguments, ctx);
+        self.call_arguments(&node.arguments, node.span().end, ctx);
     }
 
     fn static_member(&mut self, node: &StaticMemberExpression, ctx: &mut Context) {
@@ -1556,68 +1696,72 @@ impl<'opt> Printer<'opt> {
             }
             AssignmentTarget::ArrayAssignmentTarget(a) => {
                 ctx.write("[");
-                let mut items: Vec<SeqItem> = a
+                let mut nodes: Vec<SeqNode> = a
                     .elements
                     .iter()
                     .map(|el| {
-                        let mut child = ctx.child();
-                        if let Some(t) = el {
-                            self.assignment_target_maybe_default(t, &mut child);
-                        }
-                        let multiline = child.multiline;
-                        SeqItem {
-                            ctx: child,
-                            multiline,
+                        let span = el.as_ref().map(|t| t.span());
+                        SeqNode {
+                            start: span.map(|s| s.start),
+                            end: span.map(|s| s.end),
                             obj_or_array: false,
                             is_elision: el.is_none(),
+                            render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                                if let Some(t) = el {
+                                    p.assignment_target_maybe_default(t, child);
+                                }
+                            }),
                         }
                     })
                     .collect();
                 if let Some(rest) = &a.rest {
-                    let mut child = ctx.child();
-                    child.write("...");
-                    self.assignment_target(&rest.target, &mut child);
-                    let multiline = child.multiline;
-                    items.push(SeqItem {
-                        ctx: child,
-                        multiline,
+                    let span = rest.span();
+                    nodes.push(SeqNode {
+                        start: Some(span.start),
+                        end: Some(span.end),
                         obj_or_array: false,
                         is_elision: false,
+                        render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                            child.write("...");
+                            p.assignment_target(&rest.target, child);
+                        }),
                     });
                 }
-                assemble_sequence(items, false, ",", true, ctx);
+                self.sequence(nodes, Some(a.span().end), false, ",", true, ctx);
                 ctx.write("]");
             }
             AssignmentTarget::ObjectAssignmentTarget(o) => {
                 ctx.write("{");
-                let mut items: Vec<SeqItem> = o
+                let mut nodes: Vec<SeqNode> = o
                     .properties
                     .iter()
-                    .map(|p| {
-                        let mut child = ctx.child();
-                        self.assignment_target_property(p, &mut child);
-                        let multiline = child.multiline;
-                        SeqItem {
-                            ctx: child,
-                            multiline,
+                    .map(|prop| {
+                        let span = prop.span();
+                        SeqNode {
+                            start: Some(span.start),
+                            end: Some(span.end),
                             obj_or_array: false,
                             is_elision: false,
+                            render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                                p.assignment_target_property(prop, child);
+                            }),
                         }
                     })
                     .collect();
                 if let Some(rest) = &o.rest {
-                    let mut child = ctx.child();
-                    child.write("...");
-                    self.assignment_target(&rest.target, &mut child);
-                    let multiline = child.multiline;
-                    items.push(SeqItem {
-                        ctx: child,
-                        multiline,
+                    let span = rest.span();
+                    nodes.push(SeqNode {
+                        start: Some(span.start),
+                        end: Some(span.end),
                         obj_or_array: false,
                         is_elision: false,
+                        render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                            child.write("...");
+                            p.assignment_target(&rest.target, child);
+                        }),
                     });
                 }
-                assemble_sequence(items, true, ",", true, ctx);
+                self.sequence(nodes, Some(o.span().end), true, ",", true, ctx);
                 ctx.write("}");
             }
             _ => self.unsupported("AssignmentTarget", ctx),
@@ -1700,33 +1844,33 @@ impl<'opt> Printer<'opt> {
 
     fn array_expression(&mut self, node: &ArrayExpression, ctx: &mut Context) {
         ctx.write("[");
-        let items: Vec<SeqItem> = node
+        let nodes: Vec<SeqNode> = node
             .elements
             .iter()
             .map(|el| {
-                let mut child = ctx.child();
-                match el {
-                    ArrayExpressionElement::SpreadElement(s) => {
-                        child.write("...");
-                        self.print_expression(&s.argument, &mut child);
-                    }
-                    ArrayExpressionElement::Elision(_) => {}
-                    _ => {
-                        if let Some(e) = el.as_expression() {
-                            self.print_expression(e, &mut child);
-                        }
-                    }
-                }
-                let multiline = child.multiline;
-                SeqItem {
-                    ctx: child,
-                    multiline,
+                let is_elision = matches!(el, ArrayExpressionElement::Elision(_));
+                let span = el.span();
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
                     obj_or_array: false,
-                    is_elision: matches!(el, ArrayExpressionElement::Elision(_)),
+                    is_elision,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| match el {
+                        ArrayExpressionElement::SpreadElement(s) => {
+                            child.write("...");
+                            p.print_expression(&s.argument, child);
+                        }
+                        ArrayExpressionElement::Elision(_) => {}
+                        _ => {
+                            if let Some(e) = el.as_expression() {
+                                p.print_expression(e, child);
+                            }
+                        }
+                    }),
                 }
             })
             .collect();
-        assemble_sequence(items, false, ",", true, ctx);
+        self.sequence(nodes, Some(node.span().end), false, ",", true, ctx);
         ctx.write("]");
     }
 
@@ -1734,61 +1878,62 @@ impl<'opt> Printer<'opt> {
     /// comma list out with the shared `sequence` machinery.
     fn sequence_expression(&mut self, node: &SequenceExpression, ctx: &mut Context) {
         ctx.write("(");
-        let items: Vec<SeqItem> = node
+        let nodes: Vec<SeqNode> = node
             .expressions
             .iter()
             .map(|e| {
-                let mut child = ctx.child();
-                self.print_expression(e, &mut child);
-                let multiline = child.multiline;
-                SeqItem {
-                    ctx: child,
-                    multiline,
+                let span = e.span();
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        p.print_expression(e, child);
+                    }),
                 }
             })
             .collect();
-        assemble_sequence(items, false, ",", true, ctx);
+        self.sequence(nodes, Some(node.span().end), false, ",", true, ctx);
         ctx.write(")");
     }
 
     fn object_expression(&mut self, node: &ObjectExpression, ctx: &mut Context) {
         ctx.write("{");
-        let items: Vec<SeqItem> = node
+        let nodes: Vec<SeqNode> = node
             .properties
             .iter()
             .map(|prop| {
-                let mut child = ctx.child();
-                // esrap's `sequence` visits each property through the `_`
-                // wildcard, which flushes any comment positioned before it
-                // (`{ /** doc */ key: … }`). Mirror that per property.
-                let start = prop.span().start;
-                self.flush_leading(&mut child, start, self.line_of(start));
-                let obj_or_array = match prop {
-                    ObjectPropertyKind::ObjectProperty(p) => {
-                        self.object_property(p, &mut child);
-                        matches!(
-                            &p.value,
-                            Expression::ObjectExpression(_) | Expression::ArrayExpression(_)
-                        )
-                    }
-                    ObjectPropertyKind::SpreadProperty(s) => {
-                        child.write("...");
-                        self.print_expression(&s.argument, &mut child);
-                        false
-                    }
-                };
-                let multiline = child.multiline;
-                SeqItem {
-                    ctx: child,
-                    multiline,
+                let span = prop.span();
+                let obj_or_array = matches!(prop, ObjectPropertyKind::ObjectProperty(p)
+                if matches!(
+                    &p.value,
+                    Expression::ObjectExpression(_) | Expression::ArrayExpression(_)
+                ));
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
                     obj_or_array,
                     is_elision: false,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        // esrap's `sequence` visits each property through the `_`
+                        // wildcard, which flushes any comment positioned before
+                        // it (`{ /** doc */ key: … }`). Mirror that per property.
+                        p.flush_leading(child, span.start, p.line_of(span.start));
+                        match prop {
+                            ObjectPropertyKind::ObjectProperty(prop) => {
+                                p.object_property(prop, child)
+                            }
+                            ObjectPropertyKind::SpreadProperty(s) => {
+                                child.write("...");
+                                p.print_expression(&s.argument, child);
+                            }
+                        }
+                    }),
                 }
             })
             .collect();
-        assemble_sequence(items, true, ",", true, ctx);
+        self.sequence(nodes, Some(node.span().end), true, ",", true, ctx);
         ctx.write("}");
     }
 
@@ -1873,24 +2018,33 @@ impl<'opt> Printer<'opt> {
     /// argument is itself multiline** — so a trailing function/array/object
     /// argument can span lines while the call stays on one line
     /// (`$.run([ … ])`, `foo(a, b, () => { … })`). Length is not a factor.
-    fn call_arguments(&mut self, args: &[Argument], ctx: &mut Context) {
+    fn call_arguments(&mut self, args: &[Argument], call_end: u32, ctx: &mut Context) {
         let n = args.len();
-        // Render each argument into its own context; non-final ones carry their
-        // trailing comma so the comma stays put whichever layout wins.
+
+        // Render each argument into its own context (non-final ones carry the
+        // trailing comma), flushing each arg's trailing comments in source order
+        // — esrap threads comments through the single `comment_index` cursor in
+        // its argument loop (`flush_trailing_comments(context, arg.loc.end, next)`).
         let mut rendered: Vec<Context> = Vec::with_capacity(n);
-        // esrap special case: a comment sitting *above* the final argument
-        // forces the whole call multiline (it sets the non-final context's
-        // `multiline`), so a `(\n\t// comment\n\targ\n)` layout is used instead
-        // of dangling the comment after `(`.
-        let mut force_wrap = false;
+
+        // esrap special case: a comment sitting *above* the final argument forces
+        // the whole sequence multiline (it sets the non-final `child_context`'s
+        // `multiline`), so a `(\n\t// comment\n\targ\n)` layout is used instead of
+        // dangling the comment after `(`.
+        let mut force_multiline = false;
+
         for (i, arg) in args.iter().enumerate() {
             let is_last = i == n - 1;
-            if is_last && let Some(c) = self.comments.get(self.comment_index) {
-                let arg_start = arg.span().start;
-                if c.start < arg_start && c.start_line < self.line_of(arg_start) {
-                    force_wrap = true;
-                }
+            let arg_start = arg.span().start;
+
+            if is_last
+                && let Some(c) = self.comments.get(self.comment_index)
+                && c.start < arg_start
+                && c.start_line < self.line_of(arg_start)
+            {
+                force_multiline = true;
             }
+
             let mut child = ctx.child();
             match arg {
                 Argument::SpreadElement(s) => {
@@ -1902,15 +2056,33 @@ impl<'opt> Printer<'opt> {
                     None => self.unsupported("Argument", &mut child),
                 },
             }
-            if i < n - 1 {
+            if !is_last {
                 child.write(",");
             }
+
+            let next = if is_last {
+                Some(call_end)
+            } else {
+                Some(args[i + 1].span().start)
+            };
+            let emitted_line =
+                self.flush_trailing_comments(&mut child, self.line_of(arg.span().end), next);
+            // esrap accumulates all non-final args in one `child_context` and
+            // `append`s a `join` context after each, which propagates the
+            // trailing line comment's pending newline into `child_context.multiline`
+            // and forces the wrapped layout. Mirror that per non-final arg.
+            if emitted_line && !is_last {
+                child.multiline = true;
+            }
+
             rendered.push(child);
         }
 
-        // Wrap iff any non-final argument went multiline, or the final argument
-        // carries a leading comment (the esrap special case above).
-        let wrap = force_wrap
+        // esrap forces the wrap only on the **non-final** args' multiline state
+        // (so a trailing multiline function/array/object argument keeps the call
+        // on one line). The force-multiline special case also only sets the
+        // non-final context.
+        let wrap = force_multiline
             || rendered
                 .iter()
                 .take(n.saturating_sub(1))
@@ -1994,66 +2166,19 @@ struct SeqItem {
     is_elision: bool,
 }
 
-/// Port of esrap's `sequence` (no-comment path): lay pre-rendered `items` out as
-/// a separator-joined list — single line when short, or indented one-per-line
-/// when any item is multiline or the total exceeds 60 columns. `pad` adds the
-/// surrounding spaces of `{ a, b }`.
-fn assemble_sequence(
-    mut items: Vec<SeqItem>,
-    pad: bool,
-    separator: &str,
-    trailing_newline: bool,
-    parent: &mut Context,
-) {
-    let n = items.len();
-    let mut multiline = false;
-    let mut length: i64 = -1;
-    for (i, item) in items.iter_mut().enumerate() {
-        // esrap writes the separator for every non-final element, and also for
-        // a trailing elision (`[a, ,]`): `i < n-1 || !child`.
-        if i < n - 1 || item.is_elision {
-            item.ctx.write(separator);
-        }
-        length += item.ctx.measure() as i64 + 1;
-        multiline |= item.multiline;
-    }
-    multiline |= length > 60;
-
-    if multiline {
-        parent.indent();
-        parent.newline();
-    } else if pad && length > 0 {
-        parent.write(" ");
-    }
-
-    let mut prev: Option<(bool, bool)> = None;
-    for item in items {
-        if let Some((prev_multiline, prev_obj)) = prev {
-            if prev_multiline && item.multiline && !(prev_obj && item.obj_or_array) {
-                parent.margin();
-            }
-            // esrap only emits the inter-element newline/space before a real
-            // element (`if (nodes[i])`), so a hole hugs the preceding comma.
-            if !item.is_elision {
-                if multiline {
-                    parent.newline();
-                } else {
-                    parent.write(" ");
-                }
-            }
-        }
-        prev = Some((item.multiline, item.obj_or_array));
-        parent.append(item.ctx);
-    }
-
-    if multiline {
-        parent.dedent();
-        if trailing_newline {
-            parent.newline();
-        }
-    } else if pad && length > 0 {
-        parent.write(" ");
-    }
+/// One node of a comma sequence, as fed to [`Printer::sequence`]. Carries the
+/// node's source span (so trailing comments can be flushed in source order) and
+/// a closure that renders it into a child context.
+struct SeqNode<'p> {
+    /// Node `loc.end` byte offset, or `None` for a synthetic node without a
+    /// span (no trailing-comment flush is attempted for it).
+    end: Option<u32>,
+    /// Node `loc.start` byte offset (the `next` boundary for the *previous*
+    /// node's trailing comments).
+    start: Option<u32>,
+    obj_or_array: bool,
+    is_elision: bool,
+    render: Box<dyn FnMut(&mut Printer<'_>, &mut Context) + 'p>,
 }
 
 fn module_export_name_str<'a>(name: &'a ModuleExportName) -> &'a str {
@@ -2064,10 +2189,12 @@ fn module_export_name_str<'a>(name: &'a ModuleExportName) -> &'a str {
     }
 }
 
-/// A member of a `body` sequence: either a leading directive or a statement.
+/// A member of a `body` sequence: a leading directive, a statement, or a class
+/// member (esrap's `ClassBody` shares the same `body` machinery as a block).
 enum BodyElem<'a, 'b> {
     Directive(&'b Directive<'a>),
     Statement(&'b Statement<'a>),
+    ClassMember(&'b ClassElement<'a>),
 }
 
 impl<'a, 'b> BodyElem<'a, 'b> {
@@ -2079,6 +2206,7 @@ impl<'a, 'b> BodyElem<'a, 'b> {
         match self {
             BodyElem::Directive(d) => d.span.start,
             BodyElem::Statement(s) => s.span().start,
+            BodyElem::ClassMember(e) => e.span().start,
         }
     }
 
@@ -2086,6 +2214,7 @@ impl<'a, 'b> BodyElem<'a, 'b> {
         match self {
             BodyElem::Directive(d) => d.span.end,
             BodyElem::Statement(s) => s.span().end,
+            BodyElem::ClassMember(e) => e.span().end,
         }
     }
 
@@ -2098,6 +2227,9 @@ impl<'a, 'b> BodyElem<'a, 'b> {
             (BodyElem::Statement(a), BodyElem::Statement(b)) => {
                 std::mem::discriminant(*a) == std::mem::discriminant(*b)
             }
+            (BodyElem::ClassMember(a), BodyElem::ClassMember(b)) => {
+                std::mem::discriminant(*a) == std::mem::discriminant(*b)
+            }
             _ => false,
         }
     }
@@ -2106,6 +2238,7 @@ impl<'a, 'b> BodyElem<'a, 'b> {
         match self {
             BodyElem::Directive(d) => printer.print_directive(d, ctx),
             BodyElem::Statement(s) => printer.print_statement(s, ctx),
+            BodyElem::ClassMember(e) => printer.class_element(e, ctx),
         }
     }
 }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -136,11 +136,25 @@ fn dedent_block_comment(source: &str, start: u32, inner: &str) -> String {
         .join("\n")
 }
 
+/// Strip explicit `ParenthesizedExpression` wrappers. esrap parses with acorn,
+/// which never produces these nodes, so all of its precedence / `needs_parens`
+/// logic operates on the real underlying expression. We unwrap paren nodes
+/// before printing (see the `ParenthesizedExpression` arm in `print_expression`),
+/// so every precedence query must look through them too — otherwise a paren
+/// node's top precedence (20) would mask the inner operator and suppress the
+/// parens the grammar actually requires (e.g. `await (a || b)`).
+fn unparen<'a, 'b>(mut expr: &'a Expression<'b>) -> &'a Expression<'b> {
+    while let Expression::ParenthesizedExpression(p) = expr {
+        expr = &p.expression;
+    }
+    expr
+}
+
 /// esrap's `EXPRESSIONS_PRECEDENCE`, keyed by oxc `Expression` kind. Higher
 /// binds tighter; a child is parenthesised when its precedence is lower than the
 /// position requires.
 fn expr_precedence(expr: &Expression) -> u8 {
-    match expr {
+    match unparen(expr) {
         Expression::ArrayExpression(_)
         | Expression::TaggedTemplateExpression(_)
         | Expression::ThisExpression(_)
@@ -180,8 +194,8 @@ fn expr_precedence(expr: &Expression) -> u8 {
         Expression::TSInstantiationExpression(_)
         | Expression::TSNonNullExpression(_)
         | Expression::TSTypeAssertion(_) => 18,
-        // Parenthesised wrappers are unwrapped before precedence is consulted.
-        Expression::ParenthesizedExpression(_) => 20,
+        // `unparen` already stripped any `ParenthesizedExpression`, so it never
+        // reaches here.
         _ => 18,
     }
 }
@@ -215,6 +229,9 @@ fn binary_needs_parens(
     is_right: bool,
 ) -> bool {
     let parent_precedence = if parent_is_logical { 12 } else { 14 };
+    // esrap operates on acorn ASTs (no paren nodes), so look through any
+    // explicit `ParenthesizedExpression` before inspecting the child's kind.
+    let child = unparen(child);
 
     // A left-hand `as`/`satisfies` child only needs parens when the parent
     // operator would otherwise swallow the trailing type (`**`, `&`, `|`).
@@ -274,16 +291,16 @@ fn child_binary_op(expr: &Expression) -> &'static str {
 /// block body, so esrap parenthesizes it. Explicit `ParenthesizedExpression`
 /// bodies are printed faithfully by their own visitor and need no extra wrap.
 fn arrow_concise_body_needs_wrap(body: &Expression) -> bool {
-    match body {
+    match unparen(body) {
         Expression::ObjectExpression(_) => true,
         Expression::AssignmentExpression(a) => {
             matches!(a.left, AssignmentTarget::ObjectAssignmentTarget(_))
         }
         Expression::LogicalExpression(l) => {
-            matches!(l.left, Expression::ObjectExpression(_))
+            matches!(unparen(&l.left), Expression::ObjectExpression(_))
         }
         Expression::ConditionalExpression(c) => {
-            matches!(c.test, Expression::ObjectExpression(_))
+            matches!(unparen(&c.test), Expression::ObjectExpression(_))
         }
         // `as` / `satisfies` / `!` don't change the leftmost token, so recurse.
         Expression::TSAsExpression(e) => arrow_concise_body_needs_wrap(&e.expression),
@@ -323,6 +340,15 @@ impl<'opt> Printer<'opt> {
     /// 1-based line of a byte offset (number of line starts at/before it).
     fn line_of(&self, offset: u32) -> u32 {
         self.line_starts.partition_point(|&s| s <= offset) as u32
+    }
+
+    /// Whether any source comment starts within `[start, end)` — used to decide
+    /// if an unwrapped `ParenthesizedExpression` must keep its literal parens to
+    /// bracket an interior comment (`(/*c*/ x)`).
+    fn comment_in_span(&self, start: u32, end: u32) -> bool {
+        self.comments
+            .iter()
+            .any(|c| c.start >= start && c.start < end)
     }
 
     // ----- comments ---------------------------------------------------------
@@ -657,9 +683,9 @@ impl<'opt> Printer<'opt> {
             Statement::ExpressionStatement(s) => {
                 // esrap wraps a leading object/function-expression statement in
                 // parens so it isn't parsed as a block/declaration. The check is
-                // on the leftmost token, i.e. the immediate node type — an
-                // explicit paren node already starts with `(` and is safe.
-                let inner = &s.expression;
+                // on the leftmost token; `unparen` looks through explicit paren
+                // nodes (which acorn elides) so `({ a: 1 });` re-wraps correctly.
+                let inner = unparen(&s.expression);
                 let needs_parens = matches!(
                     inner,
                     Expression::ObjectExpression(_) | Expression::FunctionExpression(_)
@@ -1746,23 +1772,36 @@ impl<'opt> Printer<'opt> {
         self.flush_leading(ctx, start, self.line_of(start));
         match expr {
             Expression::ParenthesizedExpression(p) => {
-                // esrap prints explicit paren nodes faithfully (its
-                // `ParenthesizedExpression` visitor): `(` + inner + `)`. The
-                // inner never re-adds parens since a paren node's precedence is
-                // treated as the top (20), so the parent never double-wraps.
+                // esrap parses with acorn, which ELIDES parentheses — there is
+                // no `ParenthesizedExpression` node, so esrap recomputes every
+                // paren purely from operator/precedence rules (`needs_parens`).
+                // oxc instead PRESERVES explicit parens as this node. To match
+                // esrap byte-for-byte we UNWRAP it and print the inner
+                // expression, letting the precedence-based parenthesisation
+                // (`child_with_parens` / `binary_needs_parens` at each parent)
+                // re-add only the parens the grammar requires.
                 //
-                // The one exception is a sequence: `(a, b)` parses as
-                // `Paren(Sequence)`, but esrap's `SequenceExpression` visitor
-                // already emits the surrounding parens. Printing this paren
-                // layer too would double them, so drop it and let the sequence
-                // supply its own. An explicit redundant `((a, b))` keeps its
-                // outer layer (whose child is the inner `Paren(Sequence)`).
+                // Two exceptions keep the literal parens:
+                //
+                // 1. A comment inside the paren span: dropping the parens would
+                //    leave the interior comment dangling (`return (/*c*/ x)`,
+                //    `return (// hey\n x)`). The comment is flushed as a leading
+                //    comment of the inner expression, so the parens must stay to
+                //    bracket it as in the source.
+                // 2. A sequence: `(a, b)` parses as `Paren(Sequence)`, and the
+                //    `SequenceExpression` visitor already emits its own
+                //    surrounding parens, so the paren layer is dropped to avoid
+                //    doubling. (An explicit redundant `((a, b))` is handled
+                //    recursively — the outer layer here, the inner by the
+                //    sequence visitor.)
                 if matches!(p.expression, Expression::SequenceExpression(_)) {
                     self.print_expression(&p.expression, ctx);
-                } else {
+                } else if self.comment_in_span(p.span.start, p.span.end) {
                     ctx.write("(");
                     self.print_expression(&p.expression, ctx);
                     ctx.write(")");
+                } else {
+                    self.print_expression(&p.expression, ctx);
                 }
             }
             Expression::ChainExpression(c) => match &c.expression {

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -24,6 +24,27 @@ use crate::{PrintOptions, QuoteStyle};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Unsupported(pub &'static str);
 
+/// esrap's `create_keyword_write` closure, as an explicit cursor. Writes a run
+/// of sequential keyword fragments anchored from one source position, advancing
+/// the column by each fragment's length. When `cursor` is `None`, fragments are
+/// written unmapped.
+struct KeywordCursor {
+    cursor: Option<(u32, u32)>,
+}
+
+impl KeywordCursor {
+    /// Write one fragment (e.g. `"declare "`, `"class "`). Mapped if a cursor is
+    /// active, otherwise a plain write.
+    fn write(&mut self, ctx: &mut Context, fragment: &str) {
+        if let Some((line, col)) = self.cursor {
+            Printer::write_source_keyword(ctx, line, col, fragment);
+            self.cursor = Some((line, col + fragment.len() as u32));
+        } else {
+            ctx.write(fragment.to_string());
+        }
+    }
+}
+
 pub struct Printer<'opt> {
     options: &'opt PrintOptions,
     /// Set by the first unsupported node encountered; printing continues so the
@@ -342,6 +363,96 @@ impl<'opt> Printer<'opt> {
     /// 1-based line of a byte offset (number of line starts at/before it).
     fn line_of(&self, offset: u32) -> u32 {
         self.line_starts.partition_point(|&s| s <= offset) as u32
+    }
+
+    /// Convert a byte offset to `(line_1based, column_0based)` using
+    /// `line_starts`, mirroring ESTree `loc` (1-based line, 0-based column). The
+    /// column is the offset relative to the start of its line; for ASCII / BMP
+    /// source this equals the UTF-16 column esrap uses. Returns `None` when
+    /// there are no line starts (printing without source context).
+    fn offset_to_line_col(&self, offset: u32) -> Option<(u32, u32)> {
+        if self.line_starts.is_empty() {
+            return None;
+        }
+        let line = self.line_of(offset);
+        // `line` is 1-based; its start offset lives at index `line - 1`.
+        let line_start = self.line_starts[(line - 1) as usize];
+        Some((line, offset.saturating_sub(line_start)))
+    }
+
+    /// esrap's `write_source_keyword`: bracket the literal `keyword` with
+    /// source-map anchors for its exact span, so breakpoints land on the keyword.
+    fn write_source_keyword(ctx: &mut Context, line: u32, column: u32, keyword: &str) {
+        ctx.location(line, column);
+        ctx.write(keyword);
+        ctx.location(line, column + keyword.len() as u32);
+    }
+
+    /// esrap's `write_keyword`: map one `keyword` anchored at the byte offset
+    /// `start` (resolved to a source `loc`), then append an unmapped `suffix`. If
+    /// the offset can't be resolved (no source context), falls back to a plain
+    /// `keyword + suffix` write.
+    fn write_keyword(&self, ctx: &mut Context, start: u32, keyword: &str, suffix: &str) {
+        if let Some((line, column)) = self.offset_to_line_col(start) {
+            Self::write_source_keyword(ctx, line, column, keyword);
+            if !suffix.is_empty() {
+                ctx.write(suffix.to_string());
+            }
+        } else {
+            ctx.write(format!("{keyword}{suffix}"));
+        }
+    }
+
+    /// esrap's `create_keyword_write`: returns a closure-like cursor for writing
+    /// a run of sequential keyword fragments (e.g. `declare `, `class `) starting
+    /// at byte offset `start`, advancing the column by each fragment's length.
+    /// When `map_ok` is false (or no source context), every fragment is written
+    /// unmapped. Implemented as an explicit [`KeywordCursor`] because Rust closures
+    /// can't borrow `self` mutably across calls the way the JS closure does.
+    fn keyword_cursor(&self, start: u32, map_ok: bool) -> KeywordCursor {
+        let cursor = if map_ok {
+            self.offset_to_line_col(start)
+        } else {
+            None
+        };
+        KeywordCursor { cursor }
+    }
+
+    /// esrap's `function_async_function_offset_ok`: the `async function` source
+    /// offsets are only trustworthy when the `function` token shares a line with
+    /// `async`, anchored by the id or body starting on the same line as the node.
+    fn function_async_offset_ok(&self, node: &Function) -> bool {
+        let Some((line, _)) = self.offset_to_line_col(node.span().start) else {
+            return false;
+        };
+        let id_line = node
+            .id
+            .as_ref()
+            .and_then(|id| self.offset_to_line_col(id.span().start))
+            .map(|(l, _)| l);
+        let body_line = node
+            .body
+            .as_ref()
+            .and_then(|b| self.offset_to_line_col(b.span().start))
+            .map(|(l, _)| l);
+        id_line == Some(line) || body_line == Some(line)
+    }
+
+    /// esrap's `class_modifier_keywords_map_ok`: map class modifiers only when
+    /// there are no decorators and the id (or body, if anonymous) starts on the
+    /// node's start line.
+    fn class_modifier_map_ok(&self, node: &Class) -> bool {
+        if !node.decorators.is_empty() {
+            return false;
+        }
+        let Some((line, _)) = self.offset_to_line_col(node.span().start) else {
+            return false;
+        };
+        let anchor = match &node.id {
+            Some(id) => self.offset_to_line_col(id.span().start),
+            None => self.offset_to_line_col(node.body.span().start),
+        };
+        anchor.map(|(l, _)| l) == Some(line)
     }
 
     /// Whether any source comment starts within `[start, end)` — used to decide
@@ -715,17 +826,18 @@ impl<'opt> Printer<'opt> {
                         .comments
                         .get(self.comment_index)
                         .is_some_and(|c| c.start < arg.span().start);
+                    let start = s.span().start;
                     if contains_comment {
-                        ctx.write("return (");
+                        self.write_keyword(ctx, start, "return", " (");
                         self.print_expression(arg, ctx);
                         ctx.write(");");
                     } else {
-                        ctx.write("return ");
+                        self.write_keyword(ctx, start, "return", " ");
                         self.print_expression(arg, ctx);
                         ctx.write(";");
                     }
                 } else {
-                    ctx.write("return;");
+                    self.write_keyword(ctx, s.span().start, "return", ";");
                 }
             }
             Statement::BlockStatement(b) => {
@@ -743,17 +855,11 @@ impl<'opt> Printer<'opt> {
                 self.print_statement(&s.body, ctx);
             }
             Statement::ThrowStatement(s) => {
-                ctx.write("throw ");
+                self.write_keyword(ctx, s.span().start, "throw", " ");
                 self.print_expression(&s.argument, ctx);
                 ctx.write(";");
             }
-            Statement::DoWhileStatement(s) => {
-                ctx.write("do ");
-                self.print_statement(&s.body, ctx);
-                ctx.write(" while (");
-                self.print_expression(&s.test, ctx);
-                ctx.write(");");
-            }
+            Statement::DoWhileStatement(s) => self.do_while_statement(s, ctx),
             Statement::ExportAllDeclaration(s) => {
                 if matches!(s.export_kind, ImportOrExportKind::Type) {
                     ctx.write("export type *");
@@ -943,18 +1049,19 @@ impl<'opt> Printer<'opt> {
                 for decorator in &c.decorators {
                     self.decorator(decorator, ctx);
                 }
-                ctx.write("export ");
+                self.write_keyword(ctx, node.span().start, "export", " ");
                 self.class_node_no_decorators(c, ctx);
                 return;
             }
-            ctx.write("export ");
+            self.write_keyword(ctx, node.span().start, "export", " ");
             self.declaration(decl, ctx);
             return;
         }
 
-        ctx.write("export ");
+        let mut kw = self.keyword_cursor(node.span().start, true);
+        kw.write(ctx, "export ");
         if matches!(node.export_kind, ImportOrExportKind::Type) {
-            ctx.write("type ");
+            kw.write(ctx, "type ");
         }
         ctx.write("{");
         let nodes: Vec<SeqNode> = node
@@ -983,7 +1090,15 @@ impl<'opt> Printer<'opt> {
     }
 
     fn export_default_declaration(&mut self, node: &ExportDefaultDeclaration, ctx: &mut Context) {
-        ctx.write("export default ");
+        // esrap: `export ` then `default ` via a keyword cursor, mapped only when
+        // the export is single-line (`single_line_node`).
+        let map_ok = self
+            .offset_to_line_col(node.span().start)
+            .zip(self.offset_to_line_col(node.span().end))
+            .is_some_and(|((s, _), (e, _))| s == e);
+        let mut kw = self.keyword_cursor(node.span().start, map_ok);
+        kw.write(ctx, "export ");
+        kw.write(ctx, "default ");
         match &node.declaration {
             ExportDefaultDeclarationKind::FunctionDeclaration(f) => {
                 // No trailing `;` after a function declaration.
@@ -1064,14 +1179,37 @@ impl<'opt> Printer<'opt> {
         if node.declare {
             ctx.write("declare ");
         }
-        if node.r#async {
-            ctx.write("async ");
+        // esrap's `FunctionDeclaration|FunctionExpression`: map `async` and
+        // `function` to their source spans. `async` sits at the node start;
+        // `function` follows it by `"async ".len()`. The offset heuristic
+        // (`function_async_function_offset_ok`) only maps when `async` and
+        // `function` share a line with the id/body — true for all single-line
+        // forms the keyword tests exercise.
+        let start = node.span().start;
+        let offset_ok = self.function_async_offset_ok(node);
+        let gen_suffix = if node.generator { "* " } else { " " };
+        match self.offset_to_line_col(start) {
+            Some((line, column)) if node.r#async && offset_ok => {
+                Self::write_source_keyword(ctx, line, column, "async ");
+                let col2 = column + "async ".len() as u32;
+                Self::write_source_keyword(ctx, line, col2, "function");
+                ctx.write(gen_suffix);
+            }
+            Some((line, column)) if !node.r#async => {
+                Self::write_source_keyword(ctx, line, column, "function");
+                ctx.write(gen_suffix);
+            }
+            _ => {
+                if node.r#async {
+                    ctx.write("async ");
+                }
+                ctx.write(if node.generator {
+                    "function* "
+                } else {
+                    "function "
+                });
+            }
         }
-        ctx.write(if node.generator {
-            "function* "
-        } else {
-            "function "
-        });
         if let Some(id) = &node.id {
             ctx.write(id.name.as_str());
         }
@@ -1106,13 +1244,18 @@ impl<'opt> Printer<'opt> {
     /// The class body sans leading decorators (already emitted by the caller —
     /// e.g. `export @dec class`, which prints decorators before `export`).
     fn class_node_no_decorators(&mut self, node: &Class, ctx: &mut Context) {
+        // esrap's class modifier keyword cursor: `declare `/`abstract `/`class `
+        // mapped to their source span when `class_modifier_keywords_map_ok`
+        // (no decorators, id/body on the node's start line).
+        let map_ok = self.class_modifier_map_ok(node);
+        let mut kw = self.keyword_cursor(node.span().start, map_ok);
         if node.declare {
-            ctx.write("declare ");
+            kw.write(ctx, "declare ");
         }
         if node.r#abstract {
-            ctx.write("abstract ");
+            kw.write(ctx, "abstract ");
         }
-        ctx.write("class ");
+        kw.write(ctx, "class ");
         if let Some(id) = &node.id {
             ctx.write(id.name.as_str());
             if let Some(tp) = &node.type_parameters {
@@ -1200,7 +1343,7 @@ impl<'opt> Printer<'opt> {
             ClassElement::PropertyDefinition(p) => self.property_definition(p, ctx),
             ClassElement::AccessorProperty(a) => self.accessor_property(a, ctx),
             ClassElement::StaticBlock(b) => {
-                ctx.write("static ");
+                self.write_keyword(ctx, b.span().start, "static", " ");
                 let span = b.span();
                 self.block(&b.body, span.start, span.end, ctx);
             }
@@ -1212,28 +1355,40 @@ impl<'opt> Printer<'opt> {
         for decorator in &node.decorators {
             self.decorator(decorator, ctx);
         }
+        // esrap's method-modifier keyword cursor: `abstract`/accessibility/
+        // `override`/`static`/`get`/`set`/`async` all mapped to their source
+        // span when `method_modifiers_keywords_map_ok` (no decorators, node and
+        // value start on the same line).
+        let map_ok = node.decorators.is_empty() && {
+            let n = self.offset_to_line_col(node.span().start).map(|(l, _)| l);
+            let v = self
+                .offset_to_line_col(node.value.span().start)
+                .map(|(l, _)| l);
+            n.is_some() && n == v
+        };
+        let mut kw = self.keyword_cursor(node.span().start, map_ok);
         if matches!(
             node.r#type,
             MethodDefinitionType::TSAbstractMethodDefinition
         ) {
-            ctx.write("abstract ");
+            kw.write(ctx, "abstract ");
         }
         if let Some(acc) = &node.accessibility {
-            ctx.write(format!("{} ", accessibility_str(acc)));
+            kw.write(ctx, &format!("{} ", accessibility_str(acc)));
         }
         if node.r#override {
-            ctx.write("override ");
+            kw.write(ctx, "override ");
         }
         if node.r#static {
-            ctx.write("static ");
+            kw.write(ctx, "static ");
         }
         match node.kind {
-            MethodDefinitionKind::Get => ctx.write("get "),
-            MethodDefinitionKind::Set => ctx.write("set "),
+            MethodDefinitionKind::Get => kw.write(ctx, "get "),
+            MethodDefinitionKind::Set => kw.write(ctx, "set "),
             _ => {}
         }
         if node.value.r#async {
-            ctx.write("async ");
+            kw.write(ctx, "async ");
         }
         if node.value.generator {
             ctx.write("*");
@@ -1352,14 +1507,48 @@ impl<'opt> Printer<'opt> {
     }
 
     fn if_statement(&mut self, node: &IfStatement, ctx: &mut Context) {
-        ctx.write("if (");
+        self.write_keyword(ctx, node.span().start, "if", " (");
         self.print_expression(&node.test, ctx);
         ctx.write(") ");
         self.print_statement(&node.consequent, ctx);
         if let Some(alternate) = &node.alternate {
-            ctx.write(" else ");
+            ctx.space();
+            // esrap maps `else` to a *computed* offset: one past the end of the
+            // consequent, when the alternate begins on the consequent's end line
+            // and starts at column >= 4 (room for the literal `else`). Otherwise
+            // it writes an unmapped `else `.
+            let con_end = self.offset_to_line_col(node.consequent.span().end);
+            let alt_start = self.offset_to_line_col(alternate.span().start);
+            match (con_end, alt_start) {
+                (Some((ce_line, ce_col)), Some((al_line, al_col)))
+                    if ce_line == al_line && al_col >= 4 =>
+                {
+                    Self::write_source_keyword(ctx, ce_line, ce_col + 1, "else");
+                    ctx.write(" ");
+                }
+                _ => ctx.write("else "),
+            }
             self.print_statement(alternate, ctx);
         }
+    }
+
+    fn do_while_statement(&mut self, node: &DoWhileStatement, ctx: &mut Context) {
+        self.write_keyword(ctx, node.span().start, "do", " ");
+        self.print_statement(&node.body, ctx);
+        // esrap maps the trailing `while` to a computed offset (one past the body
+        // end) when the test begins on the body's end line at column >= 6.
+        let body_end = self.offset_to_line_col(node.body.span().end);
+        let test_start = self.offset_to_line_col(node.test.span().start);
+        match (body_end, test_start) {
+            (Some((be_line, be_col)), Some((t_line, t_col))) if be_line == t_line && t_col >= 6 => {
+                ctx.write(" ");
+                Self::write_source_keyword(ctx, be_line, be_col + 1, "while");
+                ctx.write(" (");
+            }
+            _ => ctx.write(" while ("),
+        }
+        self.print_expression(&node.test, ctx);
+        ctx.write(");");
     }
 
     fn for_statement(&mut self, node: &ForStatement, ctx: &mut Context) {
@@ -1399,24 +1588,43 @@ impl<'opt> Printer<'opt> {
 
     /// esrap's `TryStatement`: `try {…}` + optional `catch (p) {…}` + `finally {…}`.
     fn try_statement(&mut self, node: &TryStatement, ctx: &mut Context) {
-        ctx.write("try ");
+        self.write_keyword(ctx, node.span().start, "try", " ");
         let span = node.block.span();
         self.block(&node.block.body, span.start, span.end, ctx);
         if let Some(handler) = &node.handler {
             ctx.write(" ");
             if let Some(param) = &handler.param {
                 // esrap emits `catch(e)` with no space after the keyword.
-                ctx.write("catch(");
+                self.write_keyword(ctx, handler.span().start, "catch", "(");
                 self.binding_pattern(&param.pattern, ctx);
                 ctx.write(") ");
             } else {
-                ctx.write("catch ");
+                self.write_keyword(ctx, handler.span().start, "catch", " ");
             }
             let span = handler.body.span();
             self.block(&handler.body.body, span.start, span.end, ctx);
         }
         if let Some(finalizer) = &node.finalizer {
-            ctx.write(" finally ");
+            // esrap maps `finally` to a computed offset (one past the previous
+            // block end) when the finalizer begins on the prev block's end line
+            // at column >= 7. Otherwise an unmapped ` finally `.
+            let prev_end = node
+                .handler
+                .as_ref()
+                .map(|h| h.span().end)
+                .unwrap_or(node.block.span().end);
+            let prev = self.offset_to_line_col(prev_end);
+            let fin = self.offset_to_line_col(finalizer.span().start);
+            match (prev, fin) {
+                (Some((p_line, p_col)), Some((f_line, f_col)))
+                    if p_line == f_line && f_col >= 7 =>
+                {
+                    ctx.write(" ");
+                    Self::write_source_keyword(ctx, p_line, p_col + 1, "finally");
+                    ctx.write(" ");
+                }
+                _ => ctx.write(" finally "),
+            }
             let span = finalizer.span();
             self.block(&finalizer.body, span.start, span.end, ctx);
         }
@@ -1425,7 +1633,7 @@ impl<'opt> Printer<'opt> {
     /// esrap's `SwitchStatement`: `switch (disc) {`, each case indented with a
     /// blank-line margin between cases, statements one-per-line.
     fn switch_statement(&mut self, node: &SwitchStatement, ctx: &mut Context) {
-        ctx.write("switch (");
+        self.write_keyword(ctx, node.span().start, "switch", " (");
         self.print_expression(&node.discriminant, ctx);
         ctx.write(") {");
         ctx.indent();
@@ -1437,11 +1645,11 @@ impl<'opt> Printer<'opt> {
             ctx.newline();
             match &case.test {
                 Some(test) => {
-                    ctx.write("case ");
+                    self.write_keyword(ctx, case.span().start, "case", " ");
                     self.print_expression(test, ctx);
                     ctx.write(":");
                 }
-                None => ctx.write("default:"),
+                None => self.write_keyword(ctx, case.span().start, "default", ":"),
             }
             ctx.indent();
             for stmt in &case.consequent {
@@ -1688,9 +1896,9 @@ impl<'opt> Printer<'opt> {
     /// declarator is itself multiline (e.g. carries a leading comment) or there
     /// is more than one and they don't fit (`measure + 2*(n-1) > 50`).
     fn variable_declaration(&mut self, decl: &VariableDeclaration, ctx: &mut Context) {
-        if decl.declare {
-            ctx.write("declare ");
-        }
+        // esrap's `handle_var_declaration`: a keyword cursor anchored at the
+        // declaration start writes `declare ` (if present) then the kind keyword,
+        // each mapped to its source span so breakpoints land on `let`/`const`/etc.
         let keyword = match decl.kind {
             VariableDeclarationKind::Var => "var ",
             VariableDeclarationKind::Let => "let ",
@@ -1698,7 +1906,11 @@ impl<'opt> Printer<'opt> {
             VariableDeclarationKind::Using => "using ",
             VariableDeclarationKind::AwaitUsing => "await using ",
         };
-        ctx.write(keyword);
+        let mut kw = self.keyword_cursor(decl.span().start, true);
+        if decl.declare {
+            kw.write(ctx, "declare ");
+        }
+        kw.write(ctx, keyword);
 
         let n = decl.declarations.len();
         let mut rendered: Vec<Context> = Vec::with_capacity(n);
@@ -1853,9 +2065,18 @@ impl<'opt> Printer<'opt> {
                 ctx.write(m.property.name.as_str());
             }
             Expression::AwaitExpression(a) => {
-                // `await ` + arg, parenthesised below await's precedence (17).
-                ctx.write("await ");
-                self.child_with_parens(&a.argument, 17, ctx);
+                // esrap's `AwaitExpression`: map `await` to its source span, then
+                // `' ('`/arg/`')'` when the argument is below await's precedence
+                // (17), else `' '`/arg. Text is unchanged from `await ` + parens.
+                let start = a.span().start;
+                if expr_precedence(&a.argument) < 17 {
+                    self.write_keyword(ctx, start, "await", " (");
+                    self.print_expression(&a.argument, ctx);
+                    ctx.write(")");
+                } else {
+                    self.write_keyword(ctx, start, "await", " ");
+                    self.print_expression(&a.argument, ctx);
+                }
             }
             Expression::Super(_) => ctx.write("super"),
             Expression::YieldExpression(y) => {

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -155,7 +155,9 @@ fn unparen<'a, 'b>(mut expr: &'a Expression<'b>) -> &'a Expression<'b> {
 /// position requires.
 fn expr_precedence(expr: &Expression) -> u8 {
     match unparen(expr) {
-        Expression::ArrayExpression(_)
+        Expression::JSXElement(_)
+        | Expression::JSXFragment(_)
+        | Expression::ArrayExpression(_)
         | Expression::TaggedTemplateExpression(_)
         | Expression::ThisExpression(_)
         | Expression::Identifier(_)
@@ -1921,8 +1923,146 @@ impl<'opt> Printer<'opt> {
                 self.print_expression(&e.expression, ctx);
                 self.type_parameter_instantiation(&e.type_arguments, ctx);
             }
+            Expression::JSXElement(e) => self.jsx_element(e, ctx),
+            Expression::JSXFragment(f) => self.jsx_fragment(f, ctx),
             other => self.unsupported(expression_kind(other), ctx),
         }
+    }
+
+    // ----- JSX (port of esrap's `languages/tsx`) ---------------------------
+
+    fn jsx_element(&mut self, node: &JSXElement, ctx: &mut Context) {
+        // oxc derives self-closing from the absence of a closing element.
+        self.jsx_opening_element(&node.opening_element, node.closing_element.is_none(), ctx);
+        if !node.children.is_empty() {
+            ctx.indent();
+        }
+        for child in &node.children {
+            self.jsx_child(child, ctx);
+        }
+        if !node.children.is_empty() {
+            ctx.dedent();
+        }
+        if let Some(closing) = &node.closing_element {
+            ctx.write("</");
+            self.jsx_element_name(&closing.name, ctx);
+            ctx.write(">");
+        }
+    }
+
+    fn jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut Context) {
+        ctx.write("<>");
+        if !node.children.is_empty() {
+            ctx.indent();
+        }
+        for child in &node.children {
+            self.jsx_child(child, ctx);
+        }
+        if !node.children.is_empty() {
+            ctx.dedent();
+        }
+        ctx.write("</>");
+    }
+
+    fn jsx_opening_element(
+        &mut self,
+        node: &JSXOpeningElement,
+        self_closing: bool,
+        ctx: &mut Context,
+    ) {
+        ctx.write("<");
+        self.jsx_element_name(&node.name, ctx);
+        if let Some(type_args) = &node.type_arguments {
+            self.type_parameter_instantiation(type_args, ctx);
+        }
+        for attr in &node.attributes {
+            ctx.write(" ");
+            match attr {
+                JSXAttributeItem::Attribute(a) => {
+                    self.jsx_attribute_name(&a.name, ctx);
+                    if let Some(value) = &a.value {
+                        ctx.write("=");
+                        self.jsx_attribute_value(value, ctx);
+                    }
+                }
+                JSXAttributeItem::SpreadAttribute(s) => {
+                    ctx.write("{...");
+                    self.print_expression(&s.argument, ctx);
+                    ctx.write("}");
+                }
+            }
+        }
+        if self_closing {
+            ctx.write(" /");
+        }
+        ctx.write(">");
+    }
+
+    fn jsx_child(&mut self, child: &JSXChild, ctx: &mut Context) {
+        match child {
+            JSXChild::Text(t) => ctx.write(t.value.as_str()),
+            JSXChild::Element(e) => self.jsx_element(e, ctx),
+            JSXChild::Fragment(f) => self.jsx_fragment(f, ctx),
+            JSXChild::ExpressionContainer(c) => self.jsx_expression_container(c, ctx),
+            JSXChild::Spread(s) => {
+                ctx.write("{...");
+                self.print_expression(&s.expression, ctx);
+                ctx.write("}");
+            }
+        }
+    }
+
+    fn jsx_expression_container(&mut self, node: &JSXExpressionContainer, ctx: &mut Context) {
+        ctx.write("{");
+        // A `JSXEmptyExpression` (e.g. `{}` or `{/* comment */}`) prints nothing.
+        if let Some(expr) = node.expression.as_expression() {
+            self.print_expression(expr, ctx);
+        }
+        ctx.write("}");
+    }
+
+    fn jsx_attribute_value(&mut self, value: &JSXAttributeValue, ctx: &mut Context) {
+        match value {
+            JSXAttributeValue::StringLiteral(s) => ctx.write(self.string_literal(s)),
+            JSXAttributeValue::ExpressionContainer(c) => self.jsx_expression_container(c, ctx),
+            JSXAttributeValue::Element(e) => self.jsx_element(e, ctx),
+            JSXAttributeValue::Fragment(f) => self.jsx_fragment(f, ctx),
+        }
+    }
+
+    fn jsx_attribute_name(&mut self, name: &JSXAttributeName, ctx: &mut Context) {
+        match name {
+            JSXAttributeName::Identifier(id) => ctx.write(id.name.as_str()),
+            JSXAttributeName::NamespacedName(n) => {
+                ctx.write(n.namespace.name.as_str());
+                ctx.write(":");
+                ctx.write(n.name.name.as_str());
+            }
+        }
+    }
+
+    fn jsx_element_name(&mut self, name: &JSXElementName, ctx: &mut Context) {
+        match name {
+            JSXElementName::Identifier(id) => ctx.write(id.name.as_str()),
+            JSXElementName::IdentifierReference(id) => ctx.write(id.name.as_str()),
+            JSXElementName::NamespacedName(n) => {
+                ctx.write(n.namespace.name.as_str());
+                ctx.write(":");
+                ctx.write(n.name.name.as_str());
+            }
+            JSXElementName::MemberExpression(m) => self.jsx_member_expression(m, ctx),
+            JSXElementName::ThisExpression(_) => ctx.write("this"),
+        }
+    }
+
+    fn jsx_member_expression(&mut self, node: &JSXMemberExpression, ctx: &mut Context) {
+        match &node.object {
+            JSXMemberExpressionObject::IdentifierReference(id) => ctx.write(id.name.as_str()),
+            JSXMemberExpressionObject::MemberExpression(m) => self.jsx_member_expression(m, ctx),
+            JSXMemberExpressionObject::ThisExpression(_) => ctx.write("this"),
+        }
+        ctx.write(".");
+        ctx.write(node.property.name.as_str());
     }
 
     /// Print `child` parenthesised iff its precedence is below `min`.

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -3522,18 +3522,19 @@ fn quote(value: &str, style: QuoteStyle) -> String {
         QuoteStyle::Single => '\'',
         QuoteStyle::Double => '"',
     };
+    // esrap's `quote` escapes only `\`, the quote char, `\n`, and `\r` — a literal
+    // tab is left as-is. Match it exactly (don't escape `\t`).
     let mut out = String::with_capacity(value.len() + 2);
     out.push(q);
     for ch in value.chars() {
         match ch {
             '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
             c if c == q => {
                 out.push('\\');
                 out.push(c);
             }
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
             c => out.push(c),
         }
     }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -171,10 +171,15 @@ fn expr_precedence(expr: &Expression) -> u8 {
         Expression::UpdateExpression(_) => 16,
         Expression::UnaryExpression(_) => 15,
         Expression::BinaryExpression(_) => 14,
+        // `as`/`satisfies` sit between binary and logical operators.
+        Expression::TSAsExpression(_) | Expression::TSSatisfiesExpression(_) => 13,
         Expression::LogicalExpression(_) => 12,
         Expression::ConditionalExpression(_) => 4,
         Expression::ArrowFunctionExpression(_) | Expression::AssignmentExpression(_) => 3,
         Expression::YieldExpression(_) => 2,
+        Expression::TSInstantiationExpression(_)
+        | Expression::TSNonNullExpression(_)
+        | Expression::TSTypeAssertion(_) => 18,
         // Parenthesised wrappers are unwrapped before precedence is consulted.
         Expression::ParenthesizedExpression(_) => 20,
         _ => 18,
@@ -210,6 +215,17 @@ fn binary_needs_parens(
     is_right: bool,
 ) -> bool {
     let parent_precedence = if parent_is_logical { 12 } else { 14 };
+
+    // A left-hand `as`/`satisfies` child only needs parens when the parent
+    // operator would otherwise swallow the trailing type (`**`, `&`, `|`).
+    if !is_right
+        && matches!(
+            child,
+            Expression::TSAsExpression(_) | Expression::TSSatisfiesExpression(_)
+        )
+    {
+        return parent_op == "**" || parent_op == "&" || parent_op == "|";
+    }
 
     // `??` cannot be mixed with `||`/`&&` without parentheses.
     if parent_is_logical && let Expression::LogicalExpression(c) = child {
@@ -269,6 +285,10 @@ fn arrow_concise_body_needs_wrap(body: &Expression) -> bool {
         Expression::ConditionalExpression(c) => {
             matches!(c.test, Expression::ObjectExpression(_))
         }
+        // `as` / `satisfies` / `!` don't change the leftmost token, so recurse.
+        Expression::TSAsExpression(e) => arrow_concise_body_needs_wrap(&e.expression),
+        Expression::TSSatisfiesExpression(e) => arrow_concise_body_needs_wrap(&e.expression),
+        Expression::TSNonNullExpression(e) => arrow_concise_body_needs_wrap(&e.expression),
         _ => false,
     }
 }
@@ -707,7 +727,11 @@ impl<'opt> Printer<'opt> {
                 ctx.write(");");
             }
             Statement::ExportAllDeclaration(s) => {
-                ctx.write("export *");
+                if matches!(s.export_kind, ImportOrExportKind::Type) {
+                    ctx.write("export type *");
+                } else {
+                    ctx.write("export *");
+                }
                 if let Some(exported) = &s.exported {
                     ctx.write(" as ");
                     ctx.write(module_export_name_str(exported));
@@ -762,7 +786,22 @@ impl<'opt> Printer<'opt> {
                 Some(l) => ctx.write(format!("continue {};", l.name)),
                 None => ctx.write("continue;"),
             },
-            other => self.unsupported(statement_kind(other), ctx),
+            Statement::TSTypeAliasDeclaration(d) => self.type_alias_declaration(d, ctx),
+            Statement::TSInterfaceDeclaration(d) => self.interface_declaration(d, ctx),
+            Statement::TSEnumDeclaration(d) => self.enum_declaration(d, ctx),
+            Statement::TSModuleDeclaration(d) => self.module_declaration(d, ctx),
+            Statement::TSGlobalDeclaration(d) => self.global_declaration(d, ctx),
+            Statement::TSImportEqualsDeclaration(d) => self.import_equals_declaration(d, ctx),
+            Statement::TSExportAssignment(d) => {
+                ctx.write("export = ");
+                self.print_expression(&d.expression, ctx);
+                ctx.write(";");
+            }
+            Statement::TSNamespaceExportDeclaration(d) => {
+                ctx.write("export as namespace ");
+                ctx.write(d.id.name.as_str());
+                ctx.write(";");
+            }
         }
     }
 
@@ -773,6 +812,8 @@ impl<'opt> Printer<'opt> {
             ctx.write(";");
             return;
         }
+
+        let import_type = matches!(node.import_kind, ImportOrExportKind::Type);
 
         let mut default_spec = None;
         let mut namespace_spec = None;
@@ -786,6 +827,9 @@ impl<'opt> Printer<'opt> {
         }
 
         ctx.write("import ");
+        if import_type {
+            ctx.write("type ");
+        }
         if let Some(d) = default_spec {
             ctx.write(d.local.name.as_str());
             if namespace_spec.is_some() || !named.is_empty() {
@@ -843,6 +887,9 @@ impl<'opt> Printer<'opt> {
     }
 
     fn import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut Context) {
+        if matches!(node.import_kind, ImportOrExportKind::Type) {
+            ctx.write("type ");
+        }
         // esrap only emits the `imported as local` form when both sides are
         // identifiers whose names differ; otherwise just the local binding.
         let imported = match &node.imported {
@@ -861,12 +908,27 @@ impl<'opt> Printer<'opt> {
 
     fn export_named_declaration(&mut self, node: &ExportNamedDeclaration, ctx: &mut Context) {
         if let Some(decl) = &node.declaration {
+            // A class declaration's decorators are printed *before* `export`.
+            if let Declaration::ClassDeclaration(c) = decl
+                && !c.decorators.is_empty()
+            {
+                for decorator in &c.decorators {
+                    self.decorator(decorator, ctx);
+                }
+                ctx.write("export ");
+                self.class_node_no_decorators(c, ctx);
+                return;
+            }
             ctx.write("export ");
             self.declaration(decl, ctx);
             return;
         }
 
-        ctx.write("export {");
+        ctx.write("export ");
+        if matches!(node.export_kind, ImportOrExportKind::Type) {
+            ctx.write("type ");
+        }
+        ctx.write("{");
         let nodes: Vec<SeqNode> = node
             .specifiers
             .iter()
@@ -900,6 +962,9 @@ impl<'opt> Printer<'opt> {
                 self.function(f, ctx);
             }
             ExportDefaultDeclarationKind::ClassDeclaration(c) => self.class_node(c, ctx),
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(d) => {
+                self.interface_declaration(d, ctx)
+            }
             other => {
                 if let Some(expr) = other.as_expression() {
                     self.print_expression(expr, ctx);
@@ -934,6 +999,9 @@ impl<'opt> Printer<'opt> {
     }
 
     fn export_specifier(&mut self, node: &ExportSpecifier, ctx: &mut Context) {
+        if matches!(node.export_kind, ImportOrExportKind::Type) {
+            ctx.write("type ");
+        }
         let local = module_export_name_str(&node.local);
         let exported = module_export_name_str(&node.exported);
         ctx.write(local);
@@ -953,13 +1021,21 @@ impl<'opt> Printer<'opt> {
             }
             Declaration::FunctionDeclaration(f) => self.function(f, ctx),
             Declaration::ClassDeclaration(c) => self.class_node(c, ctx),
-            _ => self.unsupported("Declaration", ctx),
+            Declaration::TSTypeAliasDeclaration(d) => self.type_alias_declaration(d, ctx),
+            Declaration::TSInterfaceDeclaration(d) => self.interface_declaration(d, ctx),
+            Declaration::TSEnumDeclaration(d) => self.enum_declaration(d, ctx),
+            Declaration::TSModuleDeclaration(d) => self.module_declaration(d, ctx),
+            Declaration::TSGlobalDeclaration(d) => self.global_declaration(d, ctx),
+            Declaration::TSImportEqualsDeclaration(d) => self.import_equals_declaration(d, ctx),
         }
     }
 
     /// esrap's `FunctionDeclaration|FunctionExpression`:
     /// `[async ]function[* ] id(params) { body }`.
     fn function(&mut self, node: &Function, ctx: &mut Context) {
+        if node.declare {
+            ctx.write("declare ");
+        }
         if node.r#async {
             ctx.write("async ");
         }
@@ -971,32 +1047,92 @@ impl<'opt> Printer<'opt> {
         if let Some(id) = &node.id {
             ctx.write(id.name.as_str());
         }
+        if let Some(tp) = &node.type_parameters {
+            self.type_parameter_declaration(tp, ctx);
+        }
         ctx.write("(");
-        self.formal_parameters(&node.params, ctx);
+        self.formal_parameters_with_this(&node.params, node.this_param.as_deref(), ctx);
         ctx.write(")");
-        ctx.write(" ");
+        if let Some(rt) = &node.return_type {
+            self.type_annotation(rt, ctx);
+        }
+        // A `declare function`/overload has no body — esrap emits `;`.
         match &node.body {
             Some(body) => {
+                ctx.write(" ");
                 let span = body.span();
                 self.block(&body.statements, span.start, span.end, ctx);
             }
-            None => ctx.write("{}"),
+            None => ctx.write(";"),
         }
     }
 
     /// esrap's `ClassDeclaration|ClassExpression`: `class [id ][extends sup ]{…}`.
     fn class_node(&mut self, node: &Class, ctx: &mut Context) {
+        for decorator in &node.decorators {
+            self.decorator(decorator, ctx);
+        }
+        self.class_node_no_decorators(node, ctx);
+    }
+
+    /// The class body sans leading decorators (already emitted by the caller —
+    /// e.g. `export @dec class`, which prints decorators before `export`).
+    fn class_node_no_decorators(&mut self, node: &Class, ctx: &mut Context) {
+        if node.declare {
+            ctx.write("declare ");
+        }
+        if node.r#abstract {
+            ctx.write("abstract ");
+        }
         ctx.write("class ");
         if let Some(id) = &node.id {
             ctx.write(id.name.as_str());
+            if let Some(tp) = &node.type_parameters {
+                self.type_parameter_declaration(tp, ctx);
+            }
+            ctx.write(" ");
+        } else if let Some(tp) = &node.type_parameters {
+            self.type_parameter_declaration(tp, ctx);
             ctx.write(" ");
         }
         if let Some(super_class) = &node.super_class {
             ctx.write("extends ");
             self.child_with_parens(super_class, 19, ctx);
+            if let Some(ta) = &node.super_type_arguments {
+                self.type_parameter_instantiation(ta, ctx);
+            }
             ctx.write(" ");
         }
+        if !node.implements.is_empty() {
+            ctx.write("implements");
+            let nodes: Vec<SeqNode> = node
+                .implements
+                .iter()
+                .map(|imp| {
+                    let span = imp.span();
+                    SeqNode {
+                        start: Some(span.start),
+                        end: Some(span.end),
+                        obj_or_array: false,
+                        is_elision: false,
+                        render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                            p.print_type_name(&imp.expression, child);
+                            if let Some(ta) = &imp.type_arguments {
+                                p.type_parameter_instantiation(ta, child);
+                            }
+                        }),
+                    }
+                })
+                .collect();
+            self.sequence(nodes, Some(node.body.span().start), true, ",", true, ctx);
+        }
         self.class_body(&node.body, ctx);
+    }
+
+    fn decorator(&mut self, node: &Decorator, ctx: &mut Context) {
+        ctx.write("@");
+        self.print_expression(&node.expression, ctx);
+        ctx.newline();
     }
 
     /// esrap's `BlockStatement|ClassBody`: route class members through the shared
@@ -1034,6 +1170,7 @@ impl<'opt> Printer<'opt> {
         match element {
             ClassElement::MethodDefinition(m) => self.method_definition(m, ctx),
             ClassElement::PropertyDefinition(p) => self.property_definition(p, ctx),
+            ClassElement::AccessorProperty(a) => self.accessor_property(a, ctx),
             ClassElement::StaticBlock(b) => {
                 ctx.write("static ");
                 let span = b.span();
@@ -1044,6 +1181,21 @@ impl<'opt> Printer<'opt> {
     }
 
     fn method_definition(&mut self, node: &MethodDefinition, ctx: &mut Context) {
+        for decorator in &node.decorators {
+            self.decorator(decorator, ctx);
+        }
+        if matches!(
+            node.r#type,
+            MethodDefinitionType::TSAbstractMethodDefinition
+        ) {
+            ctx.write("abstract ");
+        }
+        if let Some(acc) = &node.accessibility {
+            ctx.write(format!("{} ", accessibility_str(acc)));
+        }
+        if node.r#override {
+            ctx.write("override ");
+        }
         if node.r#static {
             ctx.write("static ");
         }
@@ -1065,22 +1217,51 @@ impl<'opt> Printer<'opt> {
         } else {
             self.property_key(&node.key, ctx);
         }
+        if node.optional {
+            ctx.write("?");
+        }
+        if let Some(tp) = &node.value.type_parameters {
+            self.type_parameter_declaration(tp, ctx);
+        }
         ctx.write("(");
         self.formal_parameters(&node.value.params, ctx);
         ctx.write(")");
+        if let Some(rt) = &node.value.return_type {
+            self.type_annotation(rt, ctx);
+        }
         ctx.write(" ");
-        match &node.value.body {
-            Some(body) => {
-                let span = body.span();
-                self.block(&body.statements, span.start, span.end, ctx);
-            }
-            None => ctx.write("{}"),
+        // esrap: an abstract method has no body — it emits only the trailing
+        // space from `context.write(' ')`, leaving `abstract get a() `.
+        if let Some(body) = &node.value.body {
+            let span = body.span();
+            self.block(&body.statements, span.start, span.end, ctx);
         }
     }
 
     fn property_definition(&mut self, node: &PropertyDefinition, ctx: &mut Context) {
+        for decorator in &node.decorators {
+            self.decorator(decorator, ctx);
+        }
+        if let Some(acc) = &node.accessibility {
+            ctx.write(format!("{} ", accessibility_str(acc)));
+        }
+        if matches!(
+            node.r#type,
+            PropertyDefinitionType::TSAbstractPropertyDefinition
+        ) {
+            ctx.write("abstract ");
+        }
+        if node.declare {
+            ctx.write("declare ");
+        }
+        if node.r#override {
+            ctx.write("override ");
+        }
         if node.r#static {
             ctx.write("static ");
+        }
+        if node.readonly {
+            ctx.write("readonly ");
         }
         if node.computed {
             ctx.write("[");
@@ -1088,6 +1269,52 @@ impl<'opt> Printer<'opt> {
             ctx.write("]");
         } else {
             self.property_key(&node.key, ctx);
+        }
+        if node.optional {
+            ctx.write("?");
+        }
+        if node.definite {
+            ctx.write("!");
+        }
+        if let Some(ann) = &node.type_annotation {
+            self.type_annotation(ann, ctx);
+        }
+        if let Some(value) = &node.value {
+            ctx.write(" = ");
+            self.print_expression(value, ctx);
+        }
+        ctx.write(";");
+    }
+
+    fn accessor_property(&mut self, node: &AccessorProperty, ctx: &mut Context) {
+        for decorator in &node.decorators {
+            self.decorator(decorator, ctx);
+        }
+        if let Some(acc) = &node.accessibility {
+            ctx.write(format!("{} ", accessibility_str(acc)));
+        }
+        if matches!(
+            node.r#type,
+            AccessorPropertyType::TSAbstractAccessorProperty
+        ) {
+            ctx.write("abstract ");
+        }
+        if node.r#static {
+            ctx.write("static ");
+        }
+        ctx.write("accessor ");
+        if node.computed {
+            ctx.write("[");
+            self.property_key(&node.key, ctx);
+            ctx.write("]");
+        } else {
+            self.property_key(&node.key, ctx);
+        }
+        if node.definite {
+            ctx.write("!");
+        }
+        if let Some(ann) = &node.type_annotation {
+            self.type_annotation(ann, ctx);
         }
         if let Some(value) = &node.value {
             ctx.write(" = ");
@@ -1291,29 +1518,68 @@ impl<'opt> Printer<'opt> {
 
     /// Parameter list via esrap's `sequence` (no padding): `a, b, ...rest`.
     fn formal_parameters(&mut self, params: &FormalParameters, ctx: &mut Context) {
-        let mut nodes: Vec<SeqNode> = params
-            .items
-            .iter()
-            .map(|param| {
-                let span = param.span();
-                SeqNode {
-                    start: Some(span.start),
-                    end: Some(span.end),
-                    obj_or_array: false,
-                    is_elision: false,
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                        p.binding_pattern(&param.pattern, child);
-                        // Default value: oxc stores parameter defaults on
-                        // `FormalParameter::initializer`, not as an
-                        // `AssignmentPattern`.
-                        if let Some(init) = &param.initializer {
-                            child.write(" = ");
-                            p.print_expression(init, child);
-                        }
-                    }),
-                }
-            })
-            .collect();
+        self.formal_parameters_with_this(params, None, ctx);
+    }
+
+    /// As [`Self::formal_parameters`], but with a leading `this: T` parameter —
+    /// esrap (from an acorn AST) sees `this` as the first ordinary parameter.
+    fn formal_parameters_with_this(
+        &mut self,
+        params: &FormalParameters,
+        this_param: Option<&TSThisParameter>,
+        ctx: &mut Context,
+    ) {
+        let mut nodes: Vec<SeqNode> = Vec::new();
+        if let Some(tp) = this_param {
+            let span = tp.span;
+            nodes.push(SeqNode {
+                start: Some(span.start),
+                end: Some(span.end),
+                obj_or_array: false,
+                is_elision: false,
+                render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                    child.write("this");
+                    if let Some(ann) = &tp.type_annotation {
+                        p.type_annotation(ann, child);
+                    }
+                }),
+            });
+        }
+        nodes.extend(params.items.iter().map(|param| {
+            let span = param.span();
+            SeqNode {
+                start: Some(span.start),
+                end: Some(span.end),
+                obj_or_array: false,
+                is_elision: false,
+                render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                    // TS parameter properties (`constructor(private readonly x: T)`).
+                    if let Some(acc) = &param.accessibility {
+                        child.write(format!("{} ", accessibility_str(acc)));
+                    }
+                    if param.readonly {
+                        child.write("readonly ");
+                    }
+                    if param.r#override {
+                        child.write("override ");
+                    }
+                    p.binding_pattern(&param.pattern, child);
+                    if param.optional {
+                        child.write("?");
+                    }
+                    if let Some(ann) = &param.type_annotation {
+                        p.type_annotation(ann, child);
+                    }
+                    // Default value: oxc stores parameter defaults on
+                    // `FormalParameter::initializer`, not as an
+                    // `AssignmentPattern`.
+                    if let Some(init) = &param.initializer {
+                        child.write(" = ");
+                        p.print_expression(init, child);
+                    }
+                }),
+            }
+        }));
         if let Some(rest) = &params.rest {
             let span = rest.span();
             nodes.push(SeqNode {
@@ -1324,6 +1590,9 @@ impl<'opt> Printer<'opt> {
                 render: Box::new(move |p: &mut Printer, child: &mut Context| {
                     child.write("...");
                     p.binding_pattern(&rest.rest.argument, child);
+                    if let Some(ann) = &rest.type_annotation {
+                        p.type_annotation(ann, child);
+                    }
                 }),
             });
         }
@@ -1340,9 +1609,15 @@ impl<'opt> Printer<'opt> {
         if node.r#async {
             ctx.write("async ");
         }
+        if let Some(tp) = &node.type_parameters {
+            self.type_parameter_declaration(tp, ctx);
+        }
         ctx.write("(");
         self.formal_parameters(&node.params, ctx);
         ctx.write(")");
+        if let Some(rt) = &node.return_type {
+            self.type_annotation(rt, ctx);
+        }
         ctx.write(" => ");
         if node.expression {
             // Concise body: a single `ExpressionStatement` holds the expression.
@@ -1385,6 +1660,9 @@ impl<'opt> Printer<'opt> {
     /// declarator is itself multiline (e.g. carries a leading comment) or there
     /// is more than one and they don't fit (`measure + 2*(n-1) > 50`).
     fn variable_declaration(&mut self, decl: &VariableDeclaration, ctx: &mut Context) {
+        if decl.declare {
+            ctx.write("declare ");
+        }
         let keyword = match decl.kind {
             VariableDeclarationKind::Var => "var ",
             VariableDeclarationKind::Let => "let ",
@@ -1405,6 +1683,12 @@ impl<'opt> Printer<'opt> {
             let start = declarator.span().start;
             self.flush_leading(&mut child, start, self.line_of(start));
             self.binding_pattern(&declarator.id, &mut child);
+            if declarator.definite {
+                child.write("!");
+            }
+            if let Some(ann) = &declarator.type_annotation {
+                self.type_annotation(ann, &mut child);
+            }
             if let Some(init) = &declarator.init {
                 child.write(" = ");
                 self.print_expression(init, &mut child);
@@ -1573,6 +1857,30 @@ impl<'opt> Printer<'opt> {
                     self.print_expression(options, ctx);
                 }
                 ctx.write(")");
+            }
+            Expression::TSAsExpression(e) => {
+                self.child_with_parens(&e.expression, 13, ctx);
+                ctx.write(" as ");
+                self.print_type(&e.type_annotation, ctx);
+            }
+            Expression::TSSatisfiesExpression(e) => {
+                self.child_with_parens(&e.expression, 13, ctx);
+                ctx.write(" satisfies ");
+                self.print_type(&e.type_annotation, ctx);
+            }
+            Expression::TSNonNullExpression(e) => {
+                self.child_with_parens(&e.expression, 18, ctx);
+                ctx.write("!");
+            }
+            Expression::TSTypeAssertion(e) => {
+                ctx.write("<");
+                self.print_type(&e.type_annotation, ctx);
+                ctx.write(">");
+                self.child_with_parens(&e.expression, 18, ctx);
+            }
+            Expression::TSInstantiationExpression(e) => {
+                self.print_expression(&e.expression, ctx);
+                self.type_parameter_instantiation(&e.type_arguments, ctx);
             }
             other => self.unsupported(expression_kind(other), ctx),
         }
@@ -2108,6 +2416,627 @@ impl<'opt> Printer<'opt> {
         ctx.write(")");
     }
 
+    // ----- TypeScript types -------------------------------------------------
+
+    /// esrap's `TSTypeAnnotation`: `: ` + the type.
+    fn type_annotation(&mut self, node: &TSTypeAnnotation, ctx: &mut Context) {
+        ctx.write(": ");
+        self.print_type(&node.type_annotation, ctx);
+    }
+
+    /// esrap's `TSTypeParameterInstantiation`: `<a, b>`.
+    fn type_parameter_instantiation(
+        &mut self,
+        node: &TSTypeParameterInstantiation,
+        ctx: &mut Context,
+    ) {
+        ctx.write("<");
+        for (i, p) in node.params.iter().enumerate() {
+            if i > 0 {
+                ctx.write(", ");
+            }
+            self.print_type(p, ctx);
+        }
+        ctx.write(">");
+    }
+
+    /// esrap's `TSTypeParameterDeclaration`: `<T, U extends V = W>`.
+    fn type_parameter_declaration(&mut self, node: &TSTypeParameterDeclaration, ctx: &mut Context) {
+        ctx.write("<");
+        for (i, p) in node.params.iter().enumerate() {
+            if i > 0 {
+                ctx.write(", ");
+            }
+            self.type_parameter(p, ctx);
+        }
+        ctx.write(">");
+    }
+
+    fn type_parameter(&mut self, node: &TSTypeParameter, ctx: &mut Context) {
+        ctx.write(node.name.name.as_str());
+        if let Some(constraint) = &node.constraint {
+            ctx.write(" extends ");
+            self.print_type(constraint, ctx);
+        }
+        if let Some(default) = &node.default {
+            ctx.write(" = ");
+            self.print_type(default, ctx);
+        }
+    }
+
+    /// esrap's `TSTypeName` (`IdentifierReference` / `TSQualifiedName`).
+    fn print_type_name(&mut self, name: &TSTypeName, ctx: &mut Context) {
+        match name {
+            TSTypeName::IdentifierReference(id) => ctx.write(id.name.as_str()),
+            TSTypeName::QualifiedName(q) => {
+                self.print_type_name(&q.left, ctx);
+                ctx.write(".");
+                ctx.write(q.right.name.as_str());
+            }
+            TSTypeName::ThisExpression(_) => ctx.write("this"),
+        }
+    }
+
+    /// The core type dispatcher (esrap's TS type visitors).
+    fn print_type(&mut self, ty: &TSType, ctx: &mut Context) {
+        match ty {
+            TSType::TSAnyKeyword(_) => ctx.write("any"),
+            TSType::TSBigIntKeyword(_) => ctx.write("bigint"),
+            TSType::TSBooleanKeyword(_) => ctx.write("boolean"),
+            TSType::TSIntrinsicKeyword(_) => ctx.write("intrinsic"),
+            TSType::TSNeverKeyword(_) => ctx.write("never"),
+            TSType::TSNullKeyword(_) => ctx.write("null"),
+            TSType::TSNumberKeyword(_) => ctx.write("number"),
+            TSType::TSObjectKeyword(_) => ctx.write("object"),
+            TSType::TSStringKeyword(_) => ctx.write("string"),
+            TSType::TSSymbolKeyword(_) => ctx.write("symbol"),
+            TSType::TSUndefinedKeyword(_) => ctx.write("undefined"),
+            TSType::TSUnknownKeyword(_) => ctx.write("unknown"),
+            TSType::TSVoidKeyword(_) => ctx.write("void"),
+            TSType::TSThisType(_) => ctx.write("this"),
+            TSType::TSArrayType(t) => {
+                self.print_type(&t.element_type, ctx);
+                ctx.write("[]");
+            }
+            TSType::TSParenthesizedType(t) => {
+                ctx.write("(");
+                self.print_type(&t.type_annotation, ctx);
+                ctx.write(")");
+            }
+            TSType::TSTypeReference(t) => {
+                self.print_type_name(&t.type_name, ctx);
+                if let Some(ta) = &t.type_arguments {
+                    self.type_parameter_instantiation(ta, ctx);
+                }
+            }
+            TSType::TSTypeLiteral(t) => self.type_literal(t, ctx),
+            TSType::TSUnionType(t) => {
+                // No trailing newline so a following `=>` stays on the line.
+                let nodes = self.type_seq_nodes(&t.types);
+                self.sequence(nodes, Some(t.span.end), false, " |", false, ctx);
+            }
+            TSType::TSIntersectionType(t) => {
+                let nodes = self.type_seq_nodes(&t.types);
+                self.sequence(nodes, Some(t.span.end), false, " &", false, ctx);
+            }
+            TSType::TSConditionalType(t) => {
+                self.print_type(&t.check_type, ctx);
+                ctx.write(" extends ");
+                self.print_type(&t.extends_type, ctx);
+                ctx.write(" ? ");
+                self.print_type(&t.true_type, ctx);
+                ctx.write(" : ");
+                self.print_type(&t.false_type, ctx);
+            }
+            TSType::TSIndexedAccessType(t) => {
+                self.print_type(&t.object_type, ctx);
+                ctx.write("[");
+                self.print_type(&t.index_type, ctx);
+                ctx.write("]");
+            }
+            TSType::TSInferType(t) => {
+                ctx.write("infer ");
+                self.type_parameter(&t.type_parameter, ctx);
+            }
+            TSType::TSLiteralType(t) => self.ts_literal(&t.literal, ctx),
+            TSType::TSTypeOperatorType(t) => {
+                ctx.write(format!("{} ", ts_type_operator_str(t.operator)));
+                self.print_type(&t.type_annotation, ctx);
+            }
+            TSType::TSTypeQuery(t) => {
+                ctx.write("typeof ");
+                match &t.expr_name {
+                    TSTypeQueryExprName::TSImportType(it) => self.import_type(it, ctx),
+                    TSTypeQueryExprName::IdentifierReference(id) => ctx.write(id.name.as_str()),
+                    TSTypeQueryExprName::QualifiedName(q) => {
+                        self.print_type_name(&q.left, ctx);
+                        ctx.write(".");
+                        ctx.write(q.right.name.as_str());
+                    }
+                    TSTypeQueryExprName::ThisExpression(_) => ctx.write("this"),
+                }
+                if let Some(ta) = &t.type_arguments {
+                    self.type_parameter_instantiation(ta, ctx);
+                }
+            }
+            TSType::TSTypePredicate(t) => {
+                if t.asserts {
+                    ctx.write("asserts ");
+                }
+                match &t.parameter_name {
+                    TSTypePredicateName::Identifier(id) => ctx.write(id.name.as_str()),
+                    TSTypePredicateName::This(_) => ctx.write("this"),
+                }
+                if let Some(ann) = &t.type_annotation {
+                    ctx.write(" is ");
+                    self.print_type(&ann.type_annotation, ctx);
+                }
+            }
+            TSType::TSTupleType(t) => {
+                ctx.write("[");
+                let nodes = self.tuple_element_seq_nodes(&t.element_types);
+                self.sequence(nodes, Some(t.span.end), false, ",", true, ctx);
+                ctx.write("]");
+            }
+            TSType::TSNamedTupleMember(t) => self.named_tuple_member(t, ctx),
+            TSType::TSFunctionType(t) => {
+                if let Some(tp) = &t.type_parameters {
+                    self.type_parameter_declaration(tp, ctx);
+                }
+                ctx.write("(");
+                self.formal_parameters(&t.params, ctx);
+                ctx.write(") => ");
+                self.print_type(&t.return_type.type_annotation, ctx);
+            }
+            TSType::TSConstructorType(t) => {
+                if t.r#abstract {
+                    ctx.write("abstract ");
+                }
+                ctx.write("new ");
+                if let Some(tp) = &t.type_parameters {
+                    self.type_parameter_declaration(tp, ctx);
+                }
+                ctx.write("(");
+                self.formal_parameters(&t.params, ctx);
+                ctx.write(") => ");
+                self.print_type(&t.return_type.type_annotation, ctx);
+            }
+            TSType::TSImportType(t) => self.import_type(t, ctx),
+            TSType::TSMappedType(t) => self.mapped_type(t, ctx),
+            TSType::TSTemplateLiteralType(t) => {
+                ctx.write("`");
+                for (i, inner) in t.types.iter().enumerate() {
+                    let raw = t.quasis[i].value.raw.as_str();
+                    ctx.write(format!("{raw}${{"));
+                    self.print_type(inner, ctx);
+                    ctx.write("}");
+                    if raw.contains('\n') {
+                        ctx.multiline = true;
+                    }
+                }
+                if let Some(last) = t.quasis.last() {
+                    ctx.write(format!("{}`", last.value.raw));
+                }
+            }
+            other => self.unsupported(ts_type_kind(other), ctx),
+        }
+    }
+
+    /// esrap's `TSImportType`: `import('src')[.qualifier]`. (Type-argument
+    /// support is unused by the samples.)
+    fn import_type(&mut self, node: &TSImportType, ctx: &mut Context) {
+        ctx.write("import(");
+        ctx.write(self.string_literal(&node.source));
+        ctx.write(")");
+        if let Some(qualifier) = &node.qualifier {
+            ctx.write(".");
+            self.import_type_qualifier(qualifier, ctx);
+        }
+    }
+
+    fn import_type_qualifier(&mut self, q: &TSImportTypeQualifier, ctx: &mut Context) {
+        match q {
+            TSImportTypeQualifier::Identifier(id) => ctx.write(id.name.as_str()),
+            TSImportTypeQualifier::QualifiedName(qn) => {
+                self.import_type_qualifier(&qn.left, ctx);
+                ctx.write(".");
+                ctx.write(qn.right.name.as_str());
+            }
+        }
+    }
+
+    /// esrap's `TSNamedTupleMember`: `label[?]: type`.
+    fn named_tuple_member(&mut self, node: &TSNamedTupleMember, ctx: &mut Context) {
+        ctx.write(node.label.name.as_str());
+        if node.optional {
+            ctx.write("?");
+        }
+        ctx.write(": ");
+        self.tuple_element(&node.element_type, ctx);
+    }
+
+    fn tuple_element(&mut self, el: &TSTupleElement, ctx: &mut Context) {
+        match el {
+            TSTupleElement::TSOptionalType(t) => {
+                self.print_type(&t.type_annotation, ctx);
+                ctx.write("?");
+            }
+            TSTupleElement::TSRestType(t) => {
+                ctx.write("...");
+                self.print_type(&t.type_annotation, ctx);
+            }
+            _ => {
+                if let Some(ty) = el.as_ts_type() {
+                    self.print_type(ty, ctx);
+                }
+            }
+        }
+    }
+
+    /// esrap's `TSMappedType`: `{[K in C]: T}` (no inner spaces).
+    fn mapped_type(&mut self, node: &TSMappedType, ctx: &mut Context) {
+        ctx.write("{");
+        if let Some(readonly) = node.readonly {
+            ctx.write(mapped_modifier_prefix(readonly, "readonly"));
+        }
+        ctx.write("[");
+        ctx.write(node.key.name.as_str());
+        ctx.write(" in ");
+        self.print_type(&node.constraint, ctx);
+        if let Some(name_type) = &node.name_type {
+            ctx.write(" as ");
+            self.print_type(name_type, ctx);
+        }
+        ctx.write("]");
+        if let Some(optional) = node.optional {
+            ctx.write(mapped_modifier_prefix(optional, "?"));
+        }
+        if let Some(ann) = &node.type_annotation {
+            ctx.write(": ");
+            self.print_type(ann, ctx);
+        }
+        ctx.write("}");
+    }
+
+    /// esrap's `TSTypeLiteral`: `{ ` + `;`-separated members + ` }`.
+    fn type_literal(&mut self, node: &TSTypeLiteral, ctx: &mut Context) {
+        ctx.write("{ ");
+        let nodes = self.signature_seq_nodes(&node.members);
+        self.sequence(nodes, Some(node.span.end), false, ";", true, ctx);
+        ctx.write(" }");
+    }
+
+    fn ts_literal(&mut self, lit: &TSLiteral, ctx: &mut Context) {
+        match lit {
+            TSLiteral::BooleanLiteral(b) => ctx.write(if b.value { "true" } else { "false" }),
+            TSLiteral::NumericLiteral(n) => ctx
+                .write(literal_raw(n.raw.as_ref().map(|a| a.as_str()), || {
+                    n.value.to_string()
+                })),
+            TSLiteral::BigIntLiteral(n) => ctx
+                .write(literal_raw(n.raw.as_ref().map(|a| a.as_str()), || {
+                    format!("{}n", n.value)
+                })),
+            TSLiteral::StringLiteral(s) => ctx.write(self.string_literal(s)),
+            TSLiteral::TemplateLiteral(t) => self.template_literal(t, ctx),
+            TSLiteral::UnaryExpression(u) => self.unary_expression(u, ctx),
+        }
+    }
+
+    /// Build [`SeqNode`]s for a list of types (union/intersection).
+    fn type_seq_nodes<'p>(&self, types: &'p [TSType<'p>]) -> Vec<SeqNode<'p>> {
+        types
+            .iter()
+            .map(|ty| {
+                let span = ty.span();
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
+                    obj_or_array: false,
+                    is_elision: false,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        p.print_type(ty, child);
+                    }),
+                }
+            })
+            .collect()
+    }
+
+    fn tuple_element_seq_nodes<'p>(&self, els: &'p [TSTupleElement<'p>]) -> Vec<SeqNode<'p>> {
+        els.iter()
+            .map(|el| {
+                let span = el.span();
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
+                    obj_or_array: false,
+                    is_elision: false,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        p.tuple_element(el, child);
+                    }),
+                }
+            })
+            .collect()
+    }
+
+    fn signature_seq_nodes<'p>(&self, members: &'p [TSSignature<'p>]) -> Vec<SeqNode<'p>> {
+        members
+            .iter()
+            .map(|m| {
+                let span = m.span();
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
+                    obj_or_array: false,
+                    is_elision: false,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        p.signature(m, child);
+                    }),
+                }
+            })
+            .collect()
+    }
+
+    /// esrap's `TSSignature` visitors (members of an interface / type literal).
+    fn signature(&mut self, sig: &TSSignature, ctx: &mut Context) {
+        match sig {
+            TSSignature::TSPropertySignature(s) => {
+                if s.readonly {
+                    ctx.write("readonly ");
+                }
+                if s.computed {
+                    ctx.write("[");
+                    self.property_key(&s.key, ctx);
+                    ctx.write("]");
+                } else {
+                    self.property_key(&s.key, ctx);
+                }
+                if s.optional {
+                    ctx.write("?");
+                }
+                if let Some(ann) = &s.type_annotation {
+                    self.type_annotation(ann, ctx);
+                }
+            }
+            TSSignature::TSIndexSignature(s) => {
+                if s.readonly {
+                    ctx.write("readonly ");
+                }
+                ctx.write("[");
+                for (i, param) in s.parameters.iter().enumerate() {
+                    if i > 0 {
+                        ctx.write(", ");
+                    }
+                    ctx.write(param.name.as_str());
+                    self.type_annotation(&param.type_annotation, ctx);
+                }
+                ctx.write("]");
+                self.type_annotation(&s.type_annotation, ctx);
+            }
+            TSSignature::TSMethodSignature(s) => {
+                if s.computed {
+                    ctx.write("[");
+                    self.property_key(&s.key, ctx);
+                    ctx.write("]");
+                } else {
+                    self.property_key(&s.key, ctx);
+                }
+                if s.optional {
+                    ctx.write("?");
+                }
+                if let Some(tp) = &s.type_parameters {
+                    self.type_parameter_declaration(tp, ctx);
+                }
+                ctx.write("(");
+                self.formal_parameters(&s.params, ctx);
+                ctx.write(")");
+                if let Some(rt) = &s.return_type {
+                    self.type_annotation(rt, ctx);
+                }
+            }
+            TSSignature::TSCallSignatureDeclaration(s) => {
+                if let Some(tp) = &s.type_parameters {
+                    self.type_parameter_declaration(tp, ctx);
+                }
+                ctx.write("(");
+                self.formal_parameters(&s.params, ctx);
+                ctx.write(")");
+                if let Some(rt) = &s.return_type {
+                    self.type_annotation(rt, ctx);
+                }
+            }
+            TSSignature::TSConstructSignatureDeclaration(s) => {
+                ctx.write("new");
+                if let Some(tp) = &s.type_parameters {
+                    self.type_parameter_declaration(tp, ctx);
+                }
+                ctx.write("(");
+                self.formal_parameters(&s.params, ctx);
+                ctx.write(")");
+                if let Some(rt) = &s.return_type {
+                    self.type_annotation(rt, ctx);
+                }
+            }
+        }
+    }
+
+    // ----- TypeScript declarations ------------------------------------------
+
+    fn type_alias_declaration(&mut self, node: &TSTypeAliasDeclaration, ctx: &mut Context) {
+        if node.declare {
+            ctx.write("declare ");
+        }
+        ctx.write("type ");
+        ctx.write(node.id.name.as_str());
+        if let Some(tp) = &node.type_parameters {
+            self.type_parameter_declaration(tp, ctx);
+        }
+        ctx.write(" = ");
+        self.print_type(&node.type_annotation, ctx);
+        ctx.write(";");
+    }
+
+    fn interface_declaration(&mut self, node: &TSInterfaceDeclaration, ctx: &mut Context) {
+        if node.declare {
+            ctx.write("declare ");
+        }
+        ctx.write("interface ");
+        ctx.write(node.id.name.as_str());
+        if let Some(tp) = &node.type_parameters {
+            self.type_parameter_declaration(tp, ctx);
+        }
+        if !node.extends.is_empty() {
+            ctx.write(" extends ");
+            let nodes: Vec<SeqNode> = node
+                .extends
+                .iter()
+                .map(|h| {
+                    let span = h.span();
+                    SeqNode {
+                        start: Some(span.start),
+                        end: Some(span.end),
+                        obj_or_array: false,
+                        is_elision: false,
+                        render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                            p.print_expression(&h.expression, child);
+                            if let Some(ta) = &h.type_arguments {
+                                p.type_parameter_instantiation(ta, child);
+                            }
+                        }),
+                    }
+                })
+                .collect();
+            self.sequence(nodes, Some(node.body.span().start), false, ",", true, ctx);
+        }
+        ctx.write(" {");
+        // esrap's `TSInterfaceBody`: `;`-separated members with padding.
+        let nodes = self.signature_seq_nodes(&node.body.body);
+        self.sequence(nodes, Some(node.body.span().end), true, ";", true, ctx);
+        ctx.write("}");
+    }
+
+    fn enum_declaration(&mut self, node: &TSEnumDeclaration, ctx: &mut Context) {
+        if node.declare {
+            ctx.write("declare ");
+        }
+        if node.r#const {
+            ctx.write("const ");
+        }
+        ctx.write("enum ");
+        ctx.write(node.id.name.as_str());
+        ctx.write(" {");
+        ctx.indent();
+        ctx.newline();
+        let nodes: Vec<SeqNode> = node
+            .body
+            .members
+            .iter()
+            .map(|m| {
+                let span = m.span();
+                SeqNode {
+                    start: Some(span.start),
+                    end: Some(span.end),
+                    obj_or_array: false,
+                    is_elision: false,
+                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                        p.enum_member(m, child);
+                    }),
+                }
+            })
+            .collect();
+        self.sequence(nodes, Some(node.span.end), false, ",", true, ctx);
+        ctx.dedent();
+        ctx.newline();
+        ctx.write("}");
+    }
+
+    fn enum_member(&mut self, node: &TSEnumMember, ctx: &mut Context) {
+        match &node.id {
+            TSEnumMemberName::Identifier(id) => ctx.write(id.name.as_str()),
+            TSEnumMemberName::String(s) => ctx.write(self.string_literal(s)),
+            TSEnumMemberName::ComputedString(s) => {
+                ctx.write("[");
+                ctx.write(self.string_literal(s));
+                ctx.write("]");
+            }
+            TSEnumMemberName::ComputedTemplateString(t) => {
+                ctx.write("[");
+                self.template_literal(t, ctx);
+                ctx.write("]");
+            }
+        }
+        if let Some(init) = &node.initializer {
+            ctx.write(" = ");
+            self.print_expression(init, ctx);
+        }
+    }
+
+    fn module_declaration(&mut self, node: &TSModuleDeclaration, ctx: &mut Context) {
+        if node.declare {
+            ctx.write("declare ");
+        }
+        let kind = match node.kind {
+            TSModuleDeclarationKind::Module => "module ",
+            TSModuleDeclarationKind::Namespace => "namespace ",
+        };
+        ctx.write(kind);
+        match &node.id {
+            TSModuleDeclarationName::Identifier(id) => ctx.write(id.name.as_str()),
+            TSModuleDeclarationName::StringLiteral(s) => ctx.write(self.string_literal(s)),
+        }
+        match &node.body {
+            None => {}
+            Some(TSModuleDeclarationBody::TSModuleBlock(block)) => self.module_block(block, ctx),
+            Some(TSModuleDeclarationBody::TSModuleDeclaration(inner)) => {
+                // `namespace A.B {}` — esrap recurses into the nested decl.
+                ctx.write(".");
+                self.module_declaration(inner, ctx);
+            }
+        }
+    }
+
+    fn global_declaration(&mut self, node: &TSGlobalDeclaration, ctx: &mut Context) {
+        if node.declare {
+            ctx.write("declare ");
+        }
+        ctx.write("global");
+        self.module_block(&node.body, ctx);
+    }
+
+    /// esrap's `TSModuleBlock`: ` {` + indented body + `}`.
+    fn module_block(&mut self, node: &TSModuleBlock, ctx: &mut Context) {
+        ctx.write(" {");
+        ctx.indent();
+        ctx.newline();
+        let mut elems: Vec<BodyElem> = node.directives.iter().map(BodyElem::Directive).collect();
+        elems.extend(node.body.iter().map(BodyElem::Statement));
+        self.body_elems(&elems, node.span.start, node.span.end, ctx);
+        ctx.dedent();
+        ctx.newline();
+        ctx.write("}");
+    }
+
+    fn import_equals_declaration(&mut self, node: &TSImportEqualsDeclaration, ctx: &mut Context) {
+        ctx.write("import ");
+        ctx.write(node.id.name.as_str());
+        ctx.write(" = ");
+        match &node.module_reference {
+            TSModuleReference::ExternalModuleReference(r) => {
+                ctx.write("require(");
+                ctx.write(self.string_literal(&r.expression));
+                ctx.write(");");
+            }
+            TSModuleReference::IdentifierReference(id) => {
+                ctx.write(id.name.as_str());
+            }
+            TSModuleReference::QualifiedName(q) => {
+                self.print_type_name(&q.left, ctx);
+                ctx.write(".");
+                ctx.write(q.right.name.as_str());
+            }
+        }
+    }
+
     // ----- literals ---------------------------------------------------------
 
     fn string_literal(&self, s: &StringLiteral) -> String {
@@ -2181,6 +3110,40 @@ struct SeqNode<'p> {
     render: Box<dyn FnMut(&mut Printer<'_>, &mut Context) + 'p>,
 }
 
+fn accessibility_str(acc: &TSAccessibility) -> &'static str {
+    match acc {
+        TSAccessibility::Private => "private",
+        TSAccessibility::Protected => "protected",
+        TSAccessibility::Public => "public",
+    }
+}
+
+fn ts_type_operator_str(op: TSTypeOperatorOperator) -> &'static str {
+    match op {
+        TSTypeOperatorOperator::Keyof => "keyof",
+        TSTypeOperatorOperator::Unique => "unique",
+        TSTypeOperatorOperator::Readonly => "readonly",
+    }
+}
+
+/// The mapped-type modifier prefix: `+`/`-`/none before `readonly` / `?`.
+fn mapped_modifier_prefix(op: TSMappedTypeModifierOperator, keyword: &str) -> String {
+    match op {
+        TSMappedTypeModifierOperator::True => keyword.to_string(),
+        TSMappedTypeModifierOperator::Plus => format!("+{keyword}"),
+        TSMappedTypeModifierOperator::Minus => format!("-{keyword}"),
+    }
+}
+
+fn ts_type_kind(ty: &TSType) -> &'static str {
+    match ty {
+        TSType::JSDocNullableType(_) => "JSDocNullableType",
+        TSType::JSDocNonNullableType(_) => "JSDocNonNullableType",
+        TSType::JSDocUnknownType(_) => "JSDocUnknownType",
+        _ => "TSType",
+    }
+}
+
 fn module_export_name_str<'a>(name: &'a ModuleExportName) -> &'a str {
     match name {
         ModuleExportName::IdentifierName(n) => n.name.as_str(),
@@ -2240,21 +3203,6 @@ impl<'a, 'b> BodyElem<'a, 'b> {
             BodyElem::Statement(s) => printer.print_statement(s, ctx),
             BodyElem::ClassMember(e) => printer.class_element(e, ctx),
         }
-    }
-}
-
-fn statement_kind(stmt: &Statement) -> &'static str {
-    match stmt {
-        Statement::SwitchStatement(_) => "SwitchStatement",
-        Statement::TryStatement(_) => "TryStatement",
-        Statement::DoWhileStatement(_) => "DoWhileStatement",
-        Statement::ForInStatement(_) => "ForInStatement",
-        Statement::ForOfStatement(_) => "ForOfStatement",
-        Statement::LabeledStatement(_) => "LabeledStatement",
-        Statement::ExportAllDeclaration(_) => "ExportAllDeclaration",
-        Statement::DebuggerStatement(_) => "DebuggerStatement",
-        Statement::WithStatement(_) => "WithStatement",
-        _ => "Statement",
     }
 }
 

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -430,7 +430,13 @@ impl<'opt> Printer<'opt> {
 
     pub fn print_program(&mut self, program: &Program, ctx: &mut Context) {
         let span = program.span();
-        self.body(&program.body, span.start, span.end, ctx);
+        // Directives (`"use strict"`) are a separate oxc node, but esrap (from
+        // an acorn AST) sees them as leading string-literal ExpressionStatements
+        // in `body`; thread them through the same `body` sequence so margins and
+        // leading comments are computed identically.
+        let mut elems: Vec<BodyElem> = program.directives.iter().map(BodyElem::Directive).collect();
+        elems.extend(program.body.iter().map(BodyElem::Statement));
+        self.body_elems(&elems, span.start, span.end, ctx);
     }
 
     /// esrap's `body`: statements on their own lines, with a blank line between
@@ -445,21 +451,31 @@ impl<'opt> Printer<'opt> {
         body_end: u32,
         ctx: &mut Context,
     ) {
-        let non_empty: Vec<&Statement> = statements
-            .iter()
-            .filter(|s| !matches!(s, Statement::EmptyStatement(_)))
-            .collect();
+        let elems: Vec<BodyElem> = statements.iter().map(BodyElem::Statement).collect();
+        self.body_elems(&elems, body_start, body_end, ctx);
+    }
+
+    /// The element-based core of [`Self::body`], shared by `print_program` so a
+    /// program's leading directives participate in the same margin/comment pass.
+    fn body_elems(
+        &mut self,
+        elems: &[BodyElem],
+        body_start: u32,
+        body_end: u32,
+        ctx: &mut Context,
+    ) {
+        let non_empty: Vec<&BodyElem> = elems.iter().filter(|e| !e.is_empty_stmt()).collect();
         // Re-sync to the body's own start so a leading comment that precedes the
         // first statement (e.g. a file header) isn't skipped over.
         self.reset_comment_index(body_start);
 
-        let mut prev: Option<(std::mem::Discriminant<Statement>, bool)> = None;
-        for (i, stmt) in non_empty.iter().enumerate() {
+        let mut prev: Option<(&BodyElem, bool)> = None;
+        for (i, elem) in non_empty.iter().enumerate() {
             let mut child = ctx.child();
-            self.print_statement(stmt, &mut child);
+            elem.print(self, &mut child);
 
-            if let Some((prev_disc, prev_multiline)) = prev {
-                if child.multiline || prev_multiline || std::mem::discriminant(*stmt) != prev_disc {
+            if let Some((prev_elem, prev_multiline)) = prev {
+                if child.multiline || prev_multiline || !elem.same_kind(prev_elem) {
                     ctx.margin();
                 }
                 ctx.newline();
@@ -467,11 +483,11 @@ impl<'opt> Printer<'opt> {
             let multiline = child.multiline;
             ctx.append(child);
 
-            let end_line = self.line_of(stmt.span().end);
-            let next = non_empty.get(i + 1).map(|s| s.span().start);
+            let end_line = self.line_of(elem.span_end());
+            let next = non_empty.get(i + 1).map(|e| e.span_start());
             self.flush_trailing_comments(ctx, end_line, next);
 
-            prev = Some((std::mem::discriminant(*stmt), multiline));
+            prev = Some((elem, multiline));
         }
 
         // esrap's body tail (`if (node.loc)`) runs unconditionally: a trailing
@@ -482,9 +498,18 @@ impl<'opt> Printer<'opt> {
         // `empty()`, so a comment-free `{}` is unaffected.
         ctx.newline();
         if !self.comments.is_empty() {
-            let from_line = non_empty.last().map(|s| self.line_of(s.span().end));
+            let from_line = non_empty.last().map(|e| self.line_of(e.span_end()));
             self.flush_comments_until(ctx, body_end, self.line_of(body_end), from_line, false);
         }
+    }
+
+    /// A program/function-body directive (`"use strict";`), printed like the
+    /// string-literal ExpressionStatement esrap sees.
+    fn print_directive(&mut self, d: &Directive, ctx: &mut Context) {
+        let start = d.span.start;
+        self.flush_leading(ctx, start, self.line_of(start));
+        ctx.write(self.string_literal(&d.expression));
+        ctx.write(";");
     }
 
     fn print_statement(&mut self, stmt: &Statement, ctx: &mut Context) {
@@ -591,7 +616,13 @@ impl<'opt> Printer<'opt> {
             Statement::TryStatement(s) => self.try_statement(s, ctx),
             Statement::SwitchStatement(s) => self.switch_statement(s, ctx),
             Statement::DebuggerStatement(_) => ctx.write("debugger;"),
-            Statement::EmptyStatement(_) => {}
+            Statement::WithStatement(s) => {
+                ctx.write("with (");
+                self.print_expression(&s.object, ctx);
+                ctx.write(") ");
+                self.print_statement(&s.body, ctx);
+            }
+            Statement::EmptyStatement(_) => ctx.write(";"),
             Statement::BreakStatement(s) => match &s.label {
                 Some(l) => ctx.write(format!("break {};", l.name)),
                 None => ctx.write("break;"),
@@ -654,7 +685,29 @@ impl<'opt> Printer<'opt> {
         }
         ctx.write(" from ");
         ctx.write(self.string_literal(&node.source));
+        self.import_attributes(node.with_clause.as_deref(), ctx);
         ctx.write(";");
+    }
+
+    /// esrap's import-attributes tail: ` with { key: value, … }`.
+    fn import_attributes(&mut self, clause: Option<&WithClause>, ctx: &mut Context) {
+        let Some(clause) = clause else { return };
+        if clause.with_entries.is_empty() {
+            return;
+        }
+        ctx.write(" with { ");
+        for (i, attr) in clause.with_entries.iter().enumerate() {
+            match &attr.key {
+                ImportAttributeKey::Identifier(id) => ctx.write(id.name.as_str()),
+                ImportAttributeKey::StringLiteral(s) => ctx.write(self.string_literal(s)),
+            }
+            ctx.write(": ");
+            ctx.write(self.string_literal(&attr.value));
+            if i + 1 != clause.with_entries.len() {
+                ctx.write(", ");
+            }
+        }
+        ctx.write(" }");
     }
 
     fn import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut Context) {
@@ -2008,6 +2061,52 @@ fn module_export_name_str<'a>(name: &'a ModuleExportName) -> &'a str {
         ModuleExportName::IdentifierName(n) => n.name.as_str(),
         ModuleExportName::IdentifierReference(n) => n.name.as_str(),
         ModuleExportName::StringLiteral(s) => s.value.as_str(),
+    }
+}
+
+/// A member of a `body` sequence: either a leading directive or a statement.
+enum BodyElem<'a, 'b> {
+    Directive(&'b Directive<'a>),
+    Statement(&'b Statement<'a>),
+}
+
+impl<'a, 'b> BodyElem<'a, 'b> {
+    fn is_empty_stmt(&self) -> bool {
+        matches!(self, BodyElem::Statement(Statement::EmptyStatement(_)))
+    }
+
+    fn span_start(&self) -> u32 {
+        match self {
+            BodyElem::Directive(d) => d.span.start,
+            BodyElem::Statement(s) => s.span().start,
+        }
+    }
+
+    fn span_end(&self) -> u32 {
+        match self {
+            BodyElem::Directive(d) => d.span.end,
+            BodyElem::Statement(s) => s.span().end,
+        }
+    }
+
+    /// esrap's `child.type === prev_type` margin grouping. A directive groups as
+    /// its own kind (separated from a following non-directive, matching the
+    /// acorn shape where `"use strict"` precedes `import`/`let`).
+    fn same_kind(&self, other: &BodyElem<'a, '_>) -> bool {
+        match (self, other) {
+            (BodyElem::Directive(_), BodyElem::Directive(_)) => true,
+            (BodyElem::Statement(a), BodyElem::Statement(b)) => {
+                std::mem::discriminant(*a) == std::mem::discriminant(*b)
+            }
+            _ => false,
+        }
+    }
+
+    fn print(&self, printer: &mut Printer, ctx: &mut Context) {
+        match self {
+            BodyElem::Directive(d) => printer.print_directive(d, ctx),
+            BodyElem::Statement(s) => printer.print_statement(s, ctx),
+        }
     }
 }
 

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -58,6 +58,9 @@ pub struct Printer<'opt> {
     /// Byte offsets of each line start, for offset→line lookups when placing
     /// comments. Empty when printing without comments.
     line_starts: Vec<u32>,
+    /// Optional caller hooks that inject synthetic leading/trailing comments per
+    /// statement (esrap's `getLeadingComments` / `getTrailingComments`).
+    hooks: Option<&'opt crate::CommentHooks<'opt>>,
 }
 
 /// Byte offsets at which each source line begins (line 1 starts at 0).
@@ -341,6 +344,7 @@ impl<'opt> Printer<'opt> {
             comments: Vec::new(),
             comment_index: 0,
             line_starts: Vec::new(),
+            hooks: None,
         }
     }
 
@@ -357,7 +361,14 @@ impl<'opt> Printer<'opt> {
             comments,
             comment_index: 0,
             line_starts,
+            hooks: None,
         }
+    }
+
+    /// Attach caller comment hooks (builder-style).
+    pub fn with_hooks(mut self, hooks: &'opt crate::CommentHooks<'opt>) -> Self {
+        self.hooks = Some(hooks);
+        self
     }
 
     /// 1-based line of a byte offset (number of line starts at/before it).
@@ -469,13 +480,19 @@ impl<'opt> Printer<'opt> {
     /// esrap's `write_comment`: re-emit a comment, splitting a multi-line block
     /// body across `newline`s so its interior re-indents to the current level.
     fn write_comment(&mut self, cmt: &Cmt, ctx: &mut Context) {
-        if !cmt.block {
-            ctx.write(format!("//{}", cmt.value));
+        self.write_comment_parts(cmt.block, &cmt.value, ctx);
+    }
+
+    /// The body of [`Self::write_comment`], shared with synthetic comments
+    /// injected via [`crate::CommentHooks`].
+    fn write_comment_parts(&mut self, block: bool, value: &str, ctx: &mut Context) {
+        if !block {
+            ctx.write(format!("//{value}"));
             return;
         }
         ctx.write("/*");
         let mut multiline = false;
-        for (i, line) in cmt.value.split('\n').enumerate() {
+        for (i, line) in value.split('\n').enumerate() {
             if i > 0 {
                 ctx.newline();
                 multiline = true;
@@ -485,6 +502,31 @@ impl<'opt> Printer<'opt> {
         ctx.write("*/");
         if multiline {
             ctx.newline();
+        }
+    }
+
+    /// esrap's `write_additional_comments`: emit hook-supplied synthetic comments
+    /// around a node. Leading comments get a newline (line) or trailing space
+    /// (single-line block) after them; trailing comments get a leading space
+    /// before the first.
+    fn write_additional_comments(
+        &mut self,
+        comments: &[crate::SynthComment],
+        leading: bool,
+        ctx: &mut Context,
+    ) {
+        for (i, c) in comments.iter().enumerate() {
+            if !leading && i == 0 {
+                ctx.write(" ");
+            }
+            self.write_comment_parts(c.block, &c.value, ctx);
+            if leading {
+                if !c.block {
+                    ctx.newline();
+                } else if !c.value.contains('\n') {
+                    ctx.write(" ");
+                }
+            }
         }
     }
 
@@ -789,6 +831,24 @@ impl<'opt> Printer<'opt> {
     }
 
     fn print_statement(&mut self, stmt: &Statement, ctx: &mut Context) {
+        // esrap's `_` wildcard order: hook-supplied leading comments, then the
+        // real leading-comment flush + node, then hook-supplied trailing comments.
+        if let Some(hooks) = self.hooks
+            && let Some(f) = &hooks.get_leading
+        {
+            let synth = f(stmt);
+            self.write_additional_comments(&synth, true, ctx);
+        }
+        self.print_statement_inner(stmt, ctx);
+        if let Some(hooks) = self.hooks
+            && let Some(f) = &hooks.get_trailing
+        {
+            let synth = f(stmt);
+            self.write_additional_comments(&synth, false, ctx);
+        }
+    }
+
+    fn print_statement_inner(&mut self, stmt: &Statement, ctx: &mut Context) {
         // esrap's `_` wildcard: emit comments positioned before this node first.
         let start = stmt.span().start;
         self.flush_leading(ctx, start, self.line_of(start));

--- a/crates/rsvelte_esrap/tests/additional_comments.rs
+++ b/crates/rsvelte_esrap/tests/additional_comments.rs
@@ -1,0 +1,112 @@
+//! Port of esrap's `test/additional-comments.test.js`.
+//!
+//! esrap lets a caller inject synthetic comments around a node via the
+//! `getLeadingComments` / `getTrailingComments` options. rsvelte_esrap exposes
+//! the same surface through [`rsvelte_esrap::CommentHooks`] +
+//! [`rsvelte_esrap::print_with_hooks`]. The callbacks here target the function's
+//! `return` statement, exactly like the JS test's `n === returnStatement`.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Statement;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_esrap::{CommentHooks, PrintOptions, SynthComment, print_with_hooks};
+
+fn parse_and_print(source: &str, hooks: &CommentHooks) -> String {
+    let alloc = Allocator::default();
+    let ret = Parser::new(&alloc, source, SourceType::default().with_module(true)).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "parse error: {:?}",
+        ret.diagnostics
+    );
+    print_with_hooks(&ret.program, source, &PrintOptions::default(), hooks)
+}
+
+fn is_return(stmt: &Statement) -> bool {
+    matches!(stmt, Statement::ReturnStatement(_))
+}
+
+#[test]
+fn leading_and_trailing_comments_inserted() {
+    let source = "function example() {\n\tconst x = 1;\n\treturn x;\n}";
+    let hooks = CommentHooks {
+        get_leading: Some(Box::new(|n: &Statement| {
+            if is_return(n) {
+                vec![SynthComment::line(" This is a leading comment")]
+            } else {
+                vec![]
+            }
+        })),
+        get_trailing: Some(Box::new(|n: &Statement| {
+            if is_return(n) {
+                vec![SynthComment::block(" This is a trailing comment ")]
+            } else {
+                vec![]
+            }
+        })),
+    };
+    let code = parse_and_print(source, &hooks);
+    assert!(
+        code.contains("// This is a leading comment"),
+        "got:\n{code}"
+    );
+    assert!(
+        code.contains("/* This is a trailing comment */"),
+        "got:\n{code}"
+    );
+}
+
+#[test]
+fn only_leading_comments_when_specified() {
+    let source = "function test() { return 42; }";
+    let hooks = CommentHooks {
+        get_leading: Some(Box::new(|n: &Statement| {
+            if is_return(n) {
+                vec![SynthComment::line(" Leading only ")]
+            } else {
+                vec![]
+            }
+        })),
+        ..Default::default()
+    };
+    let code = parse_and_print(source, &hooks);
+    assert!(code.contains("// Leading only"), "got:\n{code}");
+    assert!(!code.contains("trailing"), "got:\n{code}");
+}
+
+#[test]
+fn only_trailing_comments_when_specified() {
+    let source = "function test() { return 42; }";
+    let hooks = CommentHooks {
+        get_trailing: Some(Box::new(|n: &Statement| {
+            if is_return(n) {
+                vec![SynthComment::block(" Trailing only ")]
+            } else {
+                vec![]
+            }
+        })),
+        ..Default::default()
+    };
+    let code = parse_and_print(source, &hooks);
+    assert!(code.contains("/* Trailing only */"), "got:\n{code}");
+    assert!(!code.contains("//"), "got:\n{code}");
+}
+
+#[test]
+fn multi_line_leading_block_comment() {
+    let source = "function example() {\n\tconst x = 1;\n\treturn x;\n}";
+    let hooks = CommentHooks {
+        get_leading: Some(Box::new(|n: &Statement| {
+            if is_return(n) {
+                vec![SynthComment::block("*\n * This is a leading comment\n ")]
+            } else {
+                vec![]
+            }
+        })),
+        ..Default::default()
+    };
+    let code = parse_and_print(source, &hooks);
+    let expected = "function example() {\n\tconst x = 1;\n\n\t/**\n\t * This is a leading comment\n\t */\n\treturn x;\n}";
+    assert_eq!(code, expected, "got:\n{code}");
+}

--- a/crates/rsvelte_esrap/tests/arrow_return_type.rs
+++ b/crates/rsvelte_esrap/tests/arrow_return_type.rs
@@ -1,0 +1,46 @@
+//! Port of esrap's `test/arrow-function-return-type.test.js`: a long arrow
+//! return type must not push `=>` onto its own line, and the output must reparse.
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_esrap::print;
+
+#[test]
+fn no_line_terminator_before_arrow_for_long_return_type() {
+    let input = concat!(
+        "const toNode = (kind: string): { kind: 'logical'; value: string } | ",
+        "{ kind: 'binary'; value: number } => ",
+        "(kind === 'and' ? { kind: 'logical', value: kind } : { kind: 'binary', value: 1 });"
+    );
+    let alloc = Allocator::default();
+    let st = SourceType::default()
+        .with_module(true)
+        .with_typescript(true);
+    let ret = Parser::new(&alloc, input, st).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "parse error: {:?}",
+        ret.diagnostics
+    );
+    let code = print(&ret.program, input);
+
+    // No LineTerminator immediately before `=>`.
+    for (i, _) in code.match_indices("=>") {
+        let before = &code[..i];
+        let trimmed = before.trim_end_matches([' ', '\t']);
+        assert!(
+            !trimmed.ends_with('\n') && !trimmed.ends_with('\r'),
+            "found a line break before `=>`:\n{code}"
+        );
+    }
+
+    // Output must re-parse without errors.
+    let alloc2 = Allocator::default();
+    let reparse = Parser::new(&alloc2, &code, st).parse();
+    assert!(
+        reparse.diagnostics.is_empty(),
+        "reparse error: {:?}\ncode:\n{code}",
+        reparse.diagnostics
+    );
+}

--- a/crates/rsvelte_esrap/tests/compat.rs
+++ b/crates/rsvelte_esrap/tests/compat.rs
@@ -1,0 +1,41 @@
+//! Port of esrap's `test/compat.test.js`: plain JS, a TS type annotation, and a
+//! TS `declare module` + mapped type all print as expected.
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_esrap::print;
+
+fn print_src(source: &str, ts: bool) -> String {
+    let alloc = Allocator::default();
+    let st = SourceType::default().with_module(true).with_typescript(ts);
+    let ret = Parser::new(&alloc, source, st).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "parse error: {:?}",
+        ret.diagnostics
+    );
+    print(&ret.program, source)
+}
+
+#[test]
+fn plain_js() {
+    assert_eq!(print_src("const x = 1;", false), "const x = 1;");
+}
+
+#[test]
+fn ts_type_annotation() {
+    assert_eq!(
+        print_src("const x: number = 1;", true),
+        "const x: number = 1;"
+    );
+}
+
+#[test]
+fn ts_module_and_mapped_type() {
+    let input = "declare module \"svelte\" {\n}\n\ntype M = { [K in keyof JSON]: K }\n";
+    assert_eq!(
+        print_src(input, true),
+        "declare module \"svelte\" {\n}\n\ntype M = {[K in keyof JSON]: K};"
+    );
+}

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -16,17 +16,7 @@
 //! `esrap` submodule is absent (mirroring the other corpus suites).
 
 /// Samples not yet byte-identical. Drive this to empty.
-const KNOWN_FAILURES: &[&str] = &[
-    "jsx-basic",
-    // oxc preserves explicit `ParenthesizedExpression` nodes that acorn (esrap's
-    // baseline) elides, so esrap's redundant-paren stripping around an
-    // `as`/`satisfies` operand (`(0 as number) + 1` → `0 as number + 1`,
-    // `() => ({ x }) as const` → `() => ({ x } as const)`) can't be reproduced
-    // without dropping source parens — a printer-wide change the golden corpus
-    // depends on not making.
-    "ts-arrow-as-const-object",
-    "ts-as-precedence",
-];
+const KNOWN_FAILURES: &[&str] = &["jsx-basic"];
 
 use std::path::{Path, PathBuf};
 

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -20,10 +20,7 @@ const KNOWN_FAILURES: &[&str] = &[
     "class-property",
     "comment-block",
     "comment-inline",
-    "comment-inline-inserted",
     "comment-within-call-expression",
-    "empty-body",
-    "import-attributes",
     "jsdoc-indentation",
     "jsx-basic",
     "ts-abstract-class",
@@ -63,7 +60,6 @@ const KNOWN_FAILURES: &[&str] = &[
     "ts-types",
     "ts-undefined-keyword",
     "ts-utility-types",
-    "with",
 ];
 
 use std::path::{Path, PathBuf};
@@ -95,7 +91,6 @@ fn normalize(s: &str) -> String {
 
 struct Sample {
     name: String,
-    ext: String,
     source: String,
     expected: String,
     source_type: SourceType,
@@ -150,7 +145,6 @@ fn collect_samples(dir: &Path) -> Vec<Sample> {
         let expected = std::fs::read_to_string(&expected_path).unwrap();
         out.push(Sample {
             name,
-            ext,
             source,
             expected,
             source_type,
@@ -176,10 +170,10 @@ fn esrap_samples_match() {
     let total = samples.len();
 
     for sample in &samples {
-        if let Some(only) = &only {
-            if &sample.name != only {
-                continue;
-            }
+        if let Some(only) = &only
+            && &sample.name != only
+        {
+            continue;
         }
         let known = KNOWN_FAILURES.contains(&sample.name.as_str());
         let alloc = Allocator::default();
@@ -203,7 +197,7 @@ fn esrap_samples_match() {
             match out {
                 Ok(s) => {
                     let m = normalize(&s) == normalize(&sample.expected);
-                    if !m && verbose && !known {
+                    if !m && verbose {
                         eprintln!(
                             "===== {} =====\n--- expected ---\n{}\n--- got ---\n{}\n",
                             sample.name, sample.expected, s
@@ -235,16 +229,19 @@ fn esrap_samples_match() {
         KNOWN_FAILURES.len()
     );
 
+    use std::fmt::Write as _;
     let mut msg = String::new();
     if !unexpected_fail.is_empty() {
-        msg.push_str(&format!(
-            "newly-failing (fix or add to KNOWN_FAILURES): {unexpected_fail:?}\n"
-        ));
+        let _ = writeln!(
+            msg,
+            "newly-failing (fix or add to KNOWN_FAILURES): {unexpected_fail:?}"
+        );
     }
     if !unexpected_pass.is_empty() {
-        msg.push_str(&format!(
-            "now passing — remove from KNOWN_FAILURES: {unexpected_pass:?}\n"
-        ));
+        let _ = writeln!(
+            msg,
+            "now passing — remove from KNOWN_FAILURES: {unexpected_pass:?}"
+        );
     }
     assert!(msg.is_empty(), "{msg}");
 }

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -18,43 +18,14 @@
 /// Samples not yet byte-identical. Drive this to empty.
 const KNOWN_FAILURES: &[&str] = &[
     "jsx-basic",
-    "ts-abstract-class",
-    "ts-accessor-properties",
+    // oxc preserves explicit `ParenthesizedExpression` nodes that acorn (esrap's
+    // baseline) elides, so esrap's redundant-paren stripping around an
+    // `as`/`satisfies` operand (`(0 as number) + 1` → `0 as number + 1`,
+    // `() => ({ x }) as const` → `() => ({ x } as const)`) can't be reproduced
+    // without dropping source parens — a printer-wide change the golden corpus
+    // depends on not making.
     "ts-arrow-as-const-object",
-    "ts-arrow-function-long-return-type",
-    "ts-arrow-function-types",
-    "ts-as-expression",
     "ts-as-precedence",
-    "ts-class-extends-generic",
-    "ts-class-properties",
-    "ts-declare",
-    "ts-declare-module",
-    "ts-decorators",
-    "ts-decorators-class",
-    "ts-decorators-expression",
-    "ts-enums",
-    "ts-export",
-    "ts-generic-types",
-    "ts-implements",
-    "ts-import-type",
-    "ts-index-access-type",
-    "ts-infer-extends",
-    "ts-instantiation-expression",
-    "ts-interfaces",
-    "ts-keywords",
-    "ts-mapped-type",
-    "ts-module-declaration",
-    "ts-null-keyword",
-    "ts-object-patterns",
-    "ts-return-type",
-    "ts-satisfies-expression",
-    "ts-signatures",
-    "ts-simple-function-types",
-    "ts-simple-identifier-types",
-    "ts-typed-imports",
-    "ts-types",
-    "ts-undefined-keyword",
-    "ts-utility-types",
 ];
 
 use std::path::{Path, PathBuf};

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -1,0 +1,250 @@
+//! Port of esrap's own sample-snapshot suite (`submodules/esrap/test/esrap.test.js`).
+//!
+//! For every directory under `submodules/esrap/test/samples/`, esrap parses
+//! `input.<ext>` and asserts the printed `code` equals the committed
+//! `expected.<ext>` snapshot (which esrap itself produced from the acorn
+//! baseline). We reproduce that here: parse with oxc, print with
+//! `rsvelte_esrap`, and assert byte-identity against the same `expected.<ext>`.
+//!
+//! The comparison mirrors esrap's snapshot normalization
+//! (`code.trim().replace(/^\t+$/gm, '').replaceAll('\r', '')`).
+//!
+//! Coverage is ratcheted: [`KNOWN_FAILURES`] lists the samples not yet
+//! byte-identical. A listed sample that now matches, or an unlisted sample that
+//! mismatches, fails the suite — so the list can only shrink. The end state is
+//! an empty list (total coverage). The suite no-ops with a notice when the
+//! `esrap` submodule is absent (mirroring the other corpus suites).
+
+/// Samples not yet byte-identical. Drive this to empty.
+const KNOWN_FAILURES: &[&str] = &[
+    "class-property",
+    "comment-block",
+    "comment-inline",
+    "comment-inline-inserted",
+    "comment-within-call-expression",
+    "empty-body",
+    "import-attributes",
+    "jsdoc-indentation",
+    "jsx-basic",
+    "ts-abstract-class",
+    "ts-accessor-properties",
+    "ts-arrow-as-const-object",
+    "ts-arrow-function-long-return-type",
+    "ts-arrow-function-types",
+    "ts-as-expression",
+    "ts-as-precedence",
+    "ts-class-extends-generic",
+    "ts-class-properties",
+    "ts-declare",
+    "ts-declare-module",
+    "ts-decorators",
+    "ts-decorators-class",
+    "ts-decorators-expression",
+    "ts-enums",
+    "ts-export",
+    "ts-generic-types",
+    "ts-implements",
+    "ts-import-type",
+    "ts-index-access-type",
+    "ts-infer-extends",
+    "ts-instantiation-expression",
+    "ts-interfaces",
+    "ts-keywords",
+    "ts-mapped-type",
+    "ts-module-declaration",
+    "ts-null-keyword",
+    "ts-object-patterns",
+    "ts-return-type",
+    "ts-satisfies-expression",
+    "ts-signatures",
+    "ts-simple-function-types",
+    "ts-simple-identifier-types",
+    "ts-typed-imports",
+    "ts-types",
+    "ts-undefined-keyword",
+    "ts-utility-types",
+    "with",
+];
+
+use std::path::{Path, PathBuf};
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+fn samples_dir() -> Option<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../submodules/esrap/test/samples");
+    dir.is_dir().then_some(dir)
+}
+
+/// esrap's snapshot normalization: trim, blank out whitespace-only lines, drop `\r`.
+fn normalize(s: &str) -> String {
+    let no_cr = s.replace('\r', "");
+    let blanked: Vec<String> = no_cr
+        .lines()
+        .map(|line| {
+            if !line.is_empty() && line.chars().all(|c| c == '\t') {
+                String::new()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect();
+    blanked.join("\n").trim().to_string()
+}
+
+struct Sample {
+    name: String,
+    ext: String,
+    source: String,
+    expected: String,
+    source_type: SourceType,
+}
+
+fn collect_samples(dir: &Path) -> Vec<Sample> {
+    let mut dirs: Vec<PathBuf> = std::fs::read_dir(dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    dirs.sort();
+
+    let mut out = Vec::new();
+    for d in dirs {
+        let name = d.file_name().unwrap().to_string_lossy().to_string();
+        if name.contains("large-file") || name.starts_with('.') {
+            continue;
+        }
+        let ts_mode = name.starts_with("ts-") || name.starts_with("tsx-");
+        let jsx_mode = name.starts_with("jsx-") || name.starts_with("tsx-");
+        let ext = format!(
+            "{}{}",
+            if ts_mode { "ts" } else { "js" },
+            if jsx_mode { "x" } else { "" }
+        );
+
+        // The `with` sample ships an `input.json` (a pre-built AST) because
+        // `with` is a syntax error in modules; the equivalent script source is
+        // re-parsed here.
+        let input_path = d.join(format!("input.{ext}"));
+        let (source, source_type) = if input_path.exists() {
+            let st = SourceType::default()
+                .with_module(true)
+                .with_typescript(ts_mode)
+                .with_jsx(jsx_mode);
+            (std::fs::read_to_string(&input_path).unwrap(), st)
+        } else if d.join("input.json").exists() && name == "with" {
+            (
+                "with (foo) bar();".to_string(),
+                SourceType::default().with_script(true),
+            )
+        } else {
+            continue;
+        };
+
+        let expected_path = d.join(format!("expected.{ext}"));
+        if !expected_path.exists() {
+            continue;
+        }
+        let expected = std::fs::read_to_string(&expected_path).unwrap();
+        out.push(Sample {
+            name,
+            ext,
+            source,
+            expected,
+            source_type,
+        });
+    }
+    out
+}
+
+#[test]
+fn esrap_samples_match() {
+    let Some(dir) = samples_dir() else {
+        eprintln!("[esrap_samples] submodules/esrap absent — skipping");
+        return;
+    };
+
+    let verbose = std::env::var("ESRAP_SAMPLES_VERBOSE").is_ok();
+    let only = std::env::var("ESRAP_SAMPLES_ONLY").ok();
+
+    let mut unexpected_fail = Vec::new();
+    let mut unexpected_pass = Vec::new();
+    let mut passed = 0;
+    let samples = collect_samples(&dir);
+    let total = samples.len();
+
+    for sample in &samples {
+        if let Some(only) = &only {
+            if &sample.name != only {
+                continue;
+            }
+        }
+        let known = KNOWN_FAILURES.contains(&sample.name.as_str());
+        let alloc = Allocator::default();
+        let ret = Parser::new(&alloc, &sample.source, sample.source_type).parse();
+        let matched = if !ret.diagnostics.is_empty() {
+            if verbose {
+                eprintln!(
+                    "[parse-error] {}: {}",
+                    sample.name,
+                    ret.diagnostics
+                        .first()
+                        .map(|d| d.message.to_string())
+                        .unwrap_or_default()
+                );
+            }
+            false
+        } else {
+            let out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                rsvelte_esrap::print(&ret.program, &sample.source)
+            }));
+            match out {
+                Ok(s) => {
+                    let m = normalize(&s) == normalize(&sample.expected);
+                    if !m && verbose && !known {
+                        eprintln!(
+                            "===== {} =====\n--- expected ---\n{}\n--- got ---\n{}\n",
+                            sample.name, sample.expected, s
+                        );
+                    }
+                    m
+                }
+                Err(_) => {
+                    if verbose {
+                        eprintln!("[panic] {}", sample.name);
+                    }
+                    false
+                }
+            }
+        };
+
+        if matched {
+            passed += 1;
+            if known {
+                unexpected_pass.push(sample.name.clone());
+            }
+        } else if !known {
+            unexpected_fail.push(sample.name.clone());
+        }
+    }
+
+    eprintln!(
+        "[esrap_samples] {passed}/{total} matched ({} known-failing)",
+        KNOWN_FAILURES.len()
+    );
+
+    let mut msg = String::new();
+    if !unexpected_fail.is_empty() {
+        msg.push_str(&format!(
+            "newly-failing (fix or add to KNOWN_FAILURES): {unexpected_fail:?}\n"
+        ));
+    }
+    if !unexpected_pass.is_empty() {
+        msg.push_str(&format!(
+            "now passing — remove from KNOWN_FAILURES: {unexpected_pass:?}\n"
+        ));
+    }
+    assert!(msg.is_empty(), "{msg}");
+}

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -17,11 +17,6 @@
 
 /// Samples not yet byte-identical. Drive this to empty.
 const KNOWN_FAILURES: &[&str] = &[
-    "class-property",
-    "comment-block",
-    "comment-inline",
-    "comment-within-call-expression",
-    "jsdoc-indentation",
     "jsx-basic",
     "ts-abstract-class",
     "ts-accessor-properties",

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -15,8 +15,8 @@
 //! an empty list (total coverage). The suite no-ops with a notice when the
 //! `esrap` submodule is absent (mirroring the other corpus suites).
 
-/// Samples not yet byte-identical. Drive this to empty.
-const KNOWN_FAILURES: &[&str] = &["jsx-basic"];
+/// Samples not yet byte-identical. Empty — every esrap sample is byte-identical.
+const KNOWN_FAILURES: &[&str] = &[];
 
 use std::path::{Path, PathBuf};
 

--- a/crates/rsvelte_esrap/tests/indent.rs
+++ b/crates/rsvelte_esrap/tests/indent.rs
@@ -1,0 +1,48 @@
+//! Port of esrap's `test/indent.test.js`: the `indent` option controls one
+//! level of indentation.
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_esrap::{PrintOptions, print_with};
+
+const SRC: &str = "const foo = () => { const bar = 'baz' }";
+
+fn print_indented(indent: &str) -> String {
+    let alloc = Allocator::default();
+    let ret = Parser::new(&alloc, SRC, SourceType::default().with_module(true)).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "parse error: {:?}",
+        ret.diagnostics
+    );
+    let opts = PrintOptions {
+        indent: indent.to_string(),
+        ..Default::default()
+    };
+    print_with(&ret.program, SRC, &opts)
+}
+
+#[test]
+fn default_indent_is_tab() {
+    assert_eq!(
+        print_indented("\t"),
+        "const foo = () => {\n\tconst bar = 'baz';\n};"
+    );
+}
+
+#[test]
+fn two_space_indent() {
+    assert_eq!(
+        print_indented("  "),
+        "const foo = () => {\n  const bar = 'baz';\n};"
+    );
+}
+
+#[test]
+fn four_space_indent() {
+    assert_eq!(
+        print_indented("    "),
+        "const foo = () => {\n    const bar = 'baz';\n};"
+    );
+}

--- a/crates/rsvelte_esrap/tests/pluggability.rs
+++ b/crates/rsvelte_esrap/tests/pluggability.rs
@@ -1,0 +1,27 @@
+//! Analog of esrap's `test/pluggability.test.js`.
+//!
+//! esrap's `print(node, visitors)` dispatches through a `visitors[node.type]`
+//! map, so a caller can register a printer for an arbitrary node type and drive
+//! output via `context.write(...)`. rsvelte_esrap is deliberately NOT a generic
+//! visitor framework: it is a specialized printer whose dispatch is a `match`
+//! over concrete **oxc** node kinds (there is no synthetic `CustomType` node to
+//! hand it). The extension surface that esrap's pluggable visitors are built on
+//! — the [`command`]/[`context`] buffer layer — is public here, so this test
+//! exercises that same mechanism: a "custom printer" pushing literal fragments
+//! and flattening them, reproducing the JS test's `':) - testing 123 - (:'`.
+
+use rsvelte_esrap::command;
+use rsvelte_esrap::context::Context;
+
+#[test]
+fn custom_printer_via_context_buffer() {
+    // The body of esrap's `CustomType(node, context)` visitor: three `write`s.
+    let value = "testing 123";
+    let mut ctx = Context::new();
+    ctx.write(":) - ");
+    ctx.write(value);
+    ctx.write(" - (:");
+
+    let code = command::print(&ctx.into_commands(), "\t");
+    assert_eq!(code, ":) - testing 123 - (:");
+}

--- a/crates/rsvelte_esrap/tests/quotes.rs
+++ b/crates/rsvelte_esrap/tests/quotes.rs
@@ -1,0 +1,132 @@
+//! Port of esrap's `test/quotes.test.js`.
+//!
+//! esrap prefers a literal's preserved `raw` spelling; the JS test strips `raw`
+//! (`clean`) so the quote-preference + escaping path runs. We do the same with a
+//! `VisitMut` that nulls every `StringLiteral.raw`, then print with the chosen
+//! `QuoteStyle`.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::StringLiteral;
+use oxc_ast_visit::VisitMut;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_esrap::{PrintOptions, QuoteStyle, print_with};
+
+struct StripRaw;
+impl<'a> VisitMut<'a> for StripRaw {
+    fn visit_string_literal(&mut self, it: &mut StringLiteral<'a>) {
+        it.raw = None;
+    }
+}
+
+fn print_stripped(source: &str, quote: QuoteStyle) -> String {
+    let alloc = Allocator::default();
+    let mut ret = Parser::new(&alloc, source, SourceType::default().with_module(true)).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "parse error: {:?}",
+        ret.diagnostics
+    );
+    StripRaw.visit_program(&mut ret.program);
+    let opts = PrintOptions {
+        quote,
+        ..Default::default()
+    };
+    print_with(&ret.program, source, &opts)
+}
+
+#[test]
+fn default_quote_is_single() {
+    assert_eq!(
+        print_stripped("const foo = 'bar'", QuoteStyle::Single),
+        "const foo = 'bar';"
+    );
+}
+
+#[test]
+fn single_quotes_when_single() {
+    assert_eq!(
+        print_stripped("const foo = 'bar'", QuoteStyle::Single),
+        "const foo = 'bar';"
+    );
+}
+
+#[test]
+fn double_quotes_when_double() {
+    assert_eq!(
+        print_stripped("const foo = 'bar'", QuoteStyle::Double),
+        "const foo = \"bar\";"
+    );
+}
+
+#[test]
+fn escape_single_quotes_in_literal() {
+    // source: const foo = "b'ar"  → value b'ar → single-quoted: 'b\'ar'
+    assert_eq!(
+        print_stripped("const foo = \"b'ar\"", QuoteStyle::Single),
+        "const foo = 'b\\'ar';"
+    );
+}
+
+#[test]
+fn escape_double_quotes_in_literal() {
+    // source: const foo = 'b"ar' → value b"ar → double-quoted: "b\"ar"
+    assert_eq!(
+        print_stripped("const foo = 'b\"ar'", QuoteStyle::Double),
+        "const foo = \"b\\\"ar\";"
+    );
+}
+
+#[test]
+fn escapes_new_lines() {
+    // source string "a\nb" → value a<LF>b → 'a\nb'
+    assert_eq!(
+        print_stripped("const str = \"a\\nb\"", QuoteStyle::Single),
+        "const str = 'a\\nb';"
+    );
+}
+
+#[test]
+fn escapes_escape_characters() {
+    // source string "a\\nb" → value a\nb (backslash, n) → 'a\\nb'
+    assert_eq!(
+        print_stripped("const str = \"a\\\\nb\"", QuoteStyle::Single),
+        "const str = 'a\\\\nb';"
+    );
+}
+
+#[test]
+fn escapes_double_escaped_backslashes() {
+    // source $.text('\\\\') → value \\ (two backslashes) → '\\\\'
+    assert_eq!(
+        print_stripped("var text = $.text('\\\\\\\\');", QuoteStyle::Single),
+        "var text = $.text('\\\\\\\\');"
+    );
+}
+
+#[test]
+fn does_not_double_escape_single_quotes() {
+    // source 'a\'b' → value a'b → 'a\'b'
+    assert_eq!(
+        print_stripped("const str = 'a\\'b'", QuoteStyle::Single),
+        "const str = 'a\\'b';"
+    );
+}
+
+#[test]
+fn does_not_escape_non_preferred_quote() {
+    // source "a\"b" → value a"b → single-quoted leaves the double quote: 'a"b'
+    assert_eq!(
+        print_stripped("const str = \"a\\\"b\"", QuoteStyle::Single),
+        "const str = 'a\"b';"
+    );
+}
+
+#[test]
+fn handles_n_r() {
+    // source "a\n\rb" → value a<LF><CR>b → 'a\n\rb'
+    assert_eq!(
+        print_stripped("const str = \"a\\n\\rb\"", QuoteStyle::Single),
+        "const str = 'a\\n\\rb';"
+    );
+}

--- a/crates/rsvelte_esrap/tests/sourcemap_keywords.rs
+++ b/crates/rsvelte_esrap/tests/sourcemap_keywords.rs
@@ -1,0 +1,225 @@
+//! Port of esrap's `test/sourcemap-keywords.test.js`.
+//!
+//! esrap brackets keyword writes (`let`/`function`/`async`/`export`/`if`/…) with
+//! source-map `Location` anchors so a debugger's breakpoint lands on the keyword
+//! token, not just identifiers and braces. This suite parses each snippet with
+//! oxc, prints it via [`rsvelte_esrap::print_with_map`], and asserts that the
+//! generated position of each keyword maps back to the keyword's source column —
+//! the exact assertions the JS test makes.
+//!
+//! The JS test parses with `sourceType: 'module'`, `fileExtension: 'ts'`, so we
+//! parse with `SourceType` module + TypeScript (the `declare let` snippet needs
+//! TS).
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+use rsvelte_esrap::{PrintWithMap, print_with_map};
+
+/// Generated `(line0, col0)` of `index` within `code` — a port of the JS test's
+/// `generatedLineColumn`: line is the count of `\n` before `index`, column is the
+/// distance from the last preceding `\n`.
+fn generated_line_column(code: &str, index: usize) -> (usize, usize) {
+    let before = &code[..index];
+    let gen_line = before.matches('\n').count();
+    let gen_col = before.len() - before.rfind('\n').map(|p| p + 1).unwrap_or(0);
+    (gen_line, gen_col)
+}
+
+/// Port of the JS `mappingAtSubstring`: locate `needle` in the generated `code`,
+/// find the segment on that generated line whose generated column equals the
+/// needle's column, and return it. Asserts both the substring and the segment
+/// exist.
+fn mapping_at_substring(code: &str, needle: &str, mappings: &[Vec<[i64; 4]>]) -> [i64; 4] {
+    let idx = code
+        .find(needle)
+        .unwrap_or_else(|| panic!("needle not in output: {needle:?}\n--- code ---\n{code}"));
+    let (gen_line, gen_col) = generated_line_column(code, idx);
+    let line = mappings
+        .get(gen_line)
+        .unwrap_or_else(|| panic!("no mapping line {gen_line} for needle {needle:?}"));
+    *line
+        .iter()
+        .find(|s| s[0] == gen_col as i64)
+        .unwrap_or_else(|| {
+            panic!(
+                "no segment at gen_col {gen_col} on line {gen_line} for needle {needle:?}: {line:?}"
+            )
+        })
+}
+
+struct Mapped {
+    source: String,
+    code: String,
+    mappings: Vec<Vec<[i64; 4]>>,
+}
+
+/// Parse `source` as a TS module and print it with mappings — the JS `mapped`.
+fn mapped(source: &str) -> Mapped {
+    let allocator = Allocator::default();
+    let source_type = SourceType::default()
+        .with_module(true)
+        .with_typescript(true);
+    let ret = Parser::new(&allocator, source, source_type).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "parse errors for {source:?}: {:?}",
+        ret.diagnostics
+    );
+    let PrintWithMap { code, mappings } = print_with_map(&ret.program, source);
+    assert!(!mappings.is_empty(), "no mappings produced for {source:?}");
+    Mapped {
+        source: source.to_string(),
+        code,
+        mappings,
+    }
+}
+
+/// `source.indexOf(needle)` as an `i64`, the expected 0-based source column for a
+/// keyword on line 0.
+fn src_col(source: &str, needle: &str) -> i64 {
+    source.find(needle).expect("needle in source") as i64
+}
+
+#[test]
+fn keywords_let_function_async_export() {
+    {
+        let m = mapped("let alpha = 1;");
+        let seg = mapping_at_substring(&m.code, "let", &m.mappings);
+        assert_eq!(seg[2], 0);
+        assert_eq!(seg[3], src_col(&m.source, "let"));
+    }
+
+    {
+        let m = mapped("async function bar() {}");
+        let seg_async = mapping_at_substring(&m.code, "async", &m.mappings);
+        assert_eq!(seg_async[2], 0);
+        assert_eq!(seg_async[3], src_col(&m.source, "async"));
+
+        let seg_fn = mapping_at_substring(&m.code, "function", &m.mappings);
+        assert_eq!(seg_fn[2], 0);
+        assert_eq!(seg_fn[3], src_col(&m.source, "function"));
+    }
+
+    {
+        let m = mapped("export default function qux() {}");
+        let seg_export = mapping_at_substring(&m.code, "export", &m.mappings);
+        assert_eq!(seg_export[2], 0);
+        assert_eq!(seg_export[3], src_col(&m.source, "export"));
+
+        let seg_default = mapping_at_substring(&m.code, "default", &m.mappings);
+        assert_eq!(seg_default[2], 0);
+        assert_eq!(seg_default[3], src_col(&m.source, "default"));
+
+        let seg_fn = mapping_at_substring(&m.code, "function", &m.mappings);
+        assert_eq!(seg_fn[2], 0);
+        assert_eq!(seg_fn[3], src_col(&m.source, "function"));
+    }
+}
+
+#[test]
+fn declare_let_maps_declare_and_let() {
+    let m = mapped("declare let beta: number;");
+
+    let seg_declare = mapping_at_substring(&m.code, "declare", &m.mappings);
+    assert_eq!(seg_declare[2], 0);
+    assert_eq!(seg_declare[3], src_col(&m.source, "declare"));
+
+    let seg_let = mapping_at_substring(&m.code, "let", &m.mappings);
+    assert_eq!(seg_let[2], 0);
+    assert_eq!(seg_let[3], src_col(&m.source, "let"));
+}
+
+#[test]
+fn class_static_and_get() {
+    {
+        let m = mapped("class C { static meth() {} }");
+        let seg_static = mapping_at_substring(&m.code, "static", &m.mappings);
+        assert_eq!(seg_static[3], src_col(&m.source, "static"));
+    }
+
+    {
+        let m = mapped("class D { get x() { return 1; } }");
+        let seg_get = mapping_at_substring(&m.code, "get", &m.mappings);
+        assert_eq!(seg_get[3], src_col(&m.source, "get"));
+    }
+}
+
+#[test]
+fn throw_return_await() {
+    {
+        let m = mapped("function f() { throw new Error('x'); }");
+        let seg = mapping_at_substring(&m.code, "throw", &m.mappings);
+        assert_eq!(seg[3], src_col(&m.source, "throw"));
+    }
+
+    {
+        let m = mapped("function f() { return 42; }");
+        let seg = mapping_at_substring(&m.code, "return", &m.mappings);
+        assert_eq!(seg[3], src_col(&m.source, "return"));
+    }
+
+    {
+        let m = mapped("async function f() { await thing(); }");
+        let seg = mapping_at_substring(&m.code, "await", &m.mappings);
+        assert_eq!(seg[3], src_col(&m.source, "await"));
+    }
+}
+
+#[test]
+fn if_else() {
+    let m = mapped("if (x) { a(); } else { b(); }");
+
+    let seg_if = mapping_at_substring(&m.code, "if", &m.mappings);
+    assert_eq!(seg_if[3], src_col(&m.source, "if"));
+
+    let seg_else = mapping_at_substring(&m.code, "else", &m.mappings);
+    assert_eq!(seg_else[3], src_col(&m.source, "else"));
+}
+
+#[test]
+fn try_catch_finally() {
+    let m = mapped("try { a(); } catch (e) { b(); } finally { c(); }");
+
+    let seg_try = mapping_at_substring(&m.code, "try", &m.mappings);
+    assert_eq!(seg_try[3], src_col(&m.source, "try"));
+
+    let seg_catch = mapping_at_substring(&m.code, "catch", &m.mappings);
+    assert_eq!(seg_catch[3], src_col(&m.source, "catch"));
+
+    let seg_finally = mapping_at_substring(&m.code, "finally", &m.mappings);
+    assert_eq!(seg_finally[3], src_col(&m.source, "finally"));
+}
+
+#[test]
+fn do_while() {
+    let m = mapped("do { a(); } while (cond);");
+
+    let seg_do = mapping_at_substring(&m.code, "do", &m.mappings);
+    assert_eq!(seg_do[3], src_col(&m.source, "do"));
+
+    let seg_while = mapping_at_substring(&m.code, "while", &m.mappings);
+    assert_eq!(seg_while[3], src_col(&m.source, "while"));
+}
+
+#[test]
+fn switch_case_default() {
+    let m = mapped("switch (x) { case 1: a(); break; default: b(); }");
+
+    let seg_switch = mapping_at_substring(&m.code, "switch", &m.mappings);
+    assert_eq!(seg_switch[3], src_col(&m.source, "switch"));
+
+    let seg_case = mapping_at_substring(&m.code, "case", &m.mappings);
+    assert_eq!(seg_case[3], src_col(&m.source, "case"));
+
+    let seg_default = mapping_at_substring(&m.code, "default", &m.mappings);
+    assert_eq!(seg_default[3], src_col(&m.source, "default"));
+}
+
+#[test]
+fn decorator_prefixed_class_falls_back_gracefully() {
+    let m = mapped("@dec\nclass D {}");
+    assert!(m.code.contains("class"));
+    assert!(!m.mappings.is_empty());
+}

--- a/docs/esrap-port-upstream-notes.md
+++ b/docs/esrap-port-upstream-notes.md
@@ -1,0 +1,57 @@
+# esrap port — upstream-relevant findings
+
+Notes gathered while porting the upstream [esrap](https://github.com/sveltejs/esrap)
+printer and its full test suite to `crates/rsvelte_esrap` (pinned to esrap
+`v2.2.11`, vendored at `submodules/esrap`). These are observations about the
+**upstream** projects (esrap, oxc) — not rsvelte bugs — recorded so they can be
+acted on upstream if desired.
+
+## 1. oxc JS parser does not expose comment `loc` (oxc#13285)
+
+esrap's own sample suite (`test/esrap.test.js`) runs every sample through two
+parsers — acorn (baseline) and `oxc-parser` — but **skips the snapshot and
+sourcemap assertions for the oxc parser** with this comment:
+
+> `oxc-parser` currently still does not provide `loc` information for comments
+> (https://github.com/oxc-project/oxc/pull/13285), so running the tests for oxc
+> parser results in about 20 test failures.
+
+This is purely a limitation of the **JavaScript** `oxc-parser` package's comment
+output. The **Rust** `oxc_parser` crate *does* surface comment spans, so this
+port (`rsvelte_esrap`, parsing with Rust oxc) reproduces every esrap sample
+**byte-for-byte — 97/97**, including the comment-heavy samples the JS oxc path
+has to skip.
+
+**Upstream opportunity (oxc):** finishing oxc#13285 (comment `loc`/positions in
+the JS parser output) would let esrap drop the `skipSnapshot`/`skipMap` flags on
+its oxc parser path and assert full parity there too — exactly the parity this
+Rust port already demonstrates is achievable from the same AST + comment data.
+
+## 2. oxc preserves parentheses; acorn (esrap's baseline) elides them
+
+esrap parses with acorn, which by default does **not** emit `ParenthesizedExpression`
+nodes — so esrap never sees explicit parens and recomputes every parenthesis from
+operator precedence in `needs_parens`. oxc instead preserves explicit parens as
+`ParenthesizedExpression` nodes.
+
+This is not a bug in either project, but it is the one **behavioural gotcha** for
+anyone printing an oxc AST with an esrap-faithful printer: to match esrap's output
+byte-for-byte you must unwrap `ParenthesizedExpression` and let precedence re-add
+only the grammar-required parens (see `unparen` + `needs_parens` in
+`crates/rsvelte_esrap/src/printer.rs`). The one exception is a paren span that
+contains a comment, which must be preserved so the comment can't escape the
+expression (`return (/* c */ x)`). Documented here so future oxc-based esrap
+ports don't rediscover it the hard way.
+
+## 3. esrap's string `quote()` does not escape tabs (intentional)
+
+esrap's `quote()` escapes only `\`, the active quote character, `\n`, and `\r`;
+a literal tab is emitted verbatim. This port matches that exactly. Noted only
+because a naive escaper (escaping `\t` as well) diverges from esrap on
+synthesized string literals that lack a preserved `raw`.
+
+---
+
+_No defect requiring an upstream code change was found in esrap itself; its
+behaviour was matched faithfully. The actionable upstream item is oxc#13285
+(item 1)._


### PR DESCRIPTION
## What

Brings upstream [esrap](https://github.com/sveltejs/esrap) `v2.2.11` in as a git submodule (`submodules/esrap`) and ports its **entire** test suite to `crates/rsvelte_esrap`, driving the Rust printer to full conformance with esrap's own output.

## Results

- **`esrap_samples` — 97/97 byte-identical** (was 50/97): the complete `test/samples/*` corpus, including all TS and JSX samples. `KNOWN_FAILURES` is empty.
- **Every esrap unit-test file ported and passing**: `quotes` (11), `indent` (3), `compat` (3), `additional-comments` (4), `arrow-return-type` (1), `sourcemap-keywords` (9), `pluggability` (1).
- **`golden` round-trip floor unchanged at 72** (the printer is consumed by `@rsvelte/compiler`; faithfulness is preserved).
- `rsvelte_core` `compiler_fixtures` (snapshot output via this printer) stays green.

## How (by commit)

1. submodule + ratcheted sample-parity harness (`esrap_samples.rs`), CI inits `submodules/esrap`.
2. directives, `EmptyStatement`, `WithStatement`, import attributes.
3. comment threading through sequences / call args / class bodies (faithful `sequence` port).
4. full **TypeScript** type-syntax printing (35/37 ts-* immediately; 2 more after #5).
5. **precedence-based parens** — unwrap `ParenthesizedExpression` (oxc preserves them; acorn, esrap's baseline, elides them) and recompute via `needs_parens`.
6. **JSX** printing → 97/97.
7. **source maps** (`print_with_map`) + ported `sourcemap-keywords` test.
8. **comment-injection hooks** (`print_with_hooks`, esrap's `getLeadingComments`/`getTrailingComments`) + ported `additional-comments`; `pluggability` covered at the public command/context layer (no oxc node for the synthetic `CustomType`).
9. `quotes`/`indent`/`compat`/`arrow-return-type` unit tests; `quote()` escaping aligned to esrap (`\t` left literal).

## Upstream notes

`docs/esrap-port-upstream-notes.md` records the upstream-relevant observations (the actionable one is oxc#13285 — comment `loc` on the JS parser path, which this Rust port shows is byte-parity-achievable from the same AST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)