### PR TITLE
fix(lint): gate block-lang source-scan fallback behind `native` (fixes wasm Deploy Docs build)

### DIFF
--- a/.changeset/fix-wasm-lint-block-lang-gate.md
+++ b/.changeset/fix-wasm-lint-block-lang-gate.md
@@ -1,0 +1,13 @@
+---
+---
+
+Internal: fix the **Deploy Docs to GitHub Pages** wasm build. The
+`block_lang_source_scan_diagnostics` parse-failure fallback (and its `style_scan`
+helper) in `rsvelte_lint` produce native-only `svelte_check` diagnostics via
+`validator::to_dsev` and `svelte_scan`, but were not gated behind
+`#[cfg(feature = "native")]`. The playground wasm build
+(`wasm-pack build crates/rsvelte_lint --no-default-features --features wasm`)
+therefore failed with E0433/E0432 on `crate::svelte_scan` / `crate::validator`.
+The fallback is only ever invoked from the native `runner`, so it and its
+native-only imports are now gated; the always-compiled `BlockLang` AST rule is
+unchanged. No published package is affected (`rsvelte_lint` is not released).

--- a/crates/rsvelte_lint/src/rules/block_lang.rs
+++ b/crates/rsvelte_lint/src/rules/block_lang.rs
@@ -12,20 +12,29 @@
 //! Port of `eslint-plugin-svelte/src/rules/block-lang.ts`.
 //! Upstream: `meta.type = 'suggestion'`, `hasSuggestions: true`.
 
+// `Path` is only used by the native-only source-scan fallback below.
+#[cfg(feature = "native")]
 use std::path::Path;
 
 use rsvelte_core::ast::css::StyleSheet;
 use rsvelte_core::ast::template::{
     AttributeNode, AttributeValue, AttributeValuePart, Root, Script,
 };
+// `svelte_check` is native-only; only the source-scan fallback below produces
+// `Diagnostic`s, so these imports are gated with it.
+#[cfg(feature = "native")]
 use rsvelte_core::svelte_check::diagnostic::{Diagnostic, Position, Range};
 use serde_json::Value;
 
+// `LintConfig` is only referenced by the native-only source-scan fallback below.
+#[cfg(feature = "native")]
 use crate::config::LintConfig;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
+#[cfg(feature = "native")]
 use crate::line_index::LineIndex;
 use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
+#[cfg(feature = "native")]
 use crate::validator::to_dsev;
 
 static META: RuleMeta = RuleMeta {
@@ -471,6 +480,10 @@ fn build_enforce_style_suggestions(allowed: &[Option<String>], source: &str) -> 
 /// parser cannot fully parse (e.g. files with invalid CSS or TypeScript errors).
 /// When the parser succeeds, [`BlockLang::check_root`] handles the rule via the
 /// normal AST path and this function is a no-op (to avoid double-reporting).
+///
+/// Native-only: it produces `rsvelte_core::svelte_check::Diagnostic`s and is
+/// only invoked from the native `runner`, so it is excluded from the wasm build.
+#[cfg(feature = "native")]
 pub fn block_lang_source_scan_diagnostics(
     source: &str,
     file: &Path,
@@ -569,6 +582,9 @@ pub fn block_lang_source_scan_diagnostics(
 /// Yield `(tag_start_byte, lang)` for every `<style …>` element. `lang` is the
 /// value of a `lang` attribute, or `""` (plain CSS) when absent. Mirrors the
 /// scanner in `valid_style_parse.rs`.
+///
+/// Only used by the native-only source-scan fallback, so gated alongside it.
+#[cfg(feature = "native")]
 fn style_scan(source: &str) -> Vec<(u32, String)> {
     let bytes = source.as_bytes();
     let mut out = Vec::new();


### PR DESCRIPTION
## Problem

The **Deploy Docs to GitHub Pages** workflow has been failing on `main` (e.g. commits `a93f50c0`, `dbf4c1b5`). Its `wasm-pack build crates/rsvelte_lint --target web --no-default-features --features wasm` step fails to compile:

```
error[E0433]: cannot find `svelte_scan` in `crate`
error[E0432]: unresolved import `crate::validator`
  --> crates/rsvelte_lint/src/rules/block_lang.rs
```

## Root cause

`block_lang.rs` exposes a parse-failure fallback `block_lang_source_scan_diagnostics` (plus its `style_scan` helper) that produces `rsvelte_core::svelte_check::Diagnostic`s via `validator::to_dsev` and `svelte_scan`. All three modules are `#[cfg(feature = "native")]`-only, but the function and its imports were **not** gated. Every other `svelte_scan` consumer (`valid_compile`, `valid_style_parse`, `no_unused_props`, the `require_event_*` / `experimental_require_*` meta rules) is already native-gated — `block_lang` was the lone omission, so it broke the wasm build.

## Fix

The fallback is only ever called from the native-only `runner`, so gate it and its native-only imports (`Path`, `Diagnostic`/`Position`/`Range`, `LineIndex`, `LintConfig`, `to_dsev`, `style_scan`) behind `#[cfg(feature = "native")]`. The always-compiled `BlockLang` AST rule (used by the wasm playground) is untouched, so playground coverage is unchanged.

## Verification

- ✅ `wasm-pack build crates/rsvelte_lint --out-dir ../../pkg --target web --no-default-features --features wasm` — the exact CI command — now succeeds (no warnings).
- ✅ `cargo clippy -p rsvelte_lint --all-targets --all-features -- -D warnings` clean (native path unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)