### PR TITLE
chore(deps): unify oxc crates + oxc_formatter to 0.137 (single git rev)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1495,8 +1495,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "allocator-api2",
  "hashbrown",
@@ -1508,8 +1508,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1525,8 +1525,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "phf",
  "proc-macro2 1.0.106",
@@ -1536,8 +1536,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1547,8 +1547,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1568,13 +1568,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1583,8 +1583,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1598,8 +1598,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1608,8 +1608,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.55.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.56.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1634,8 +1634,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter_core"
-version = "0.55.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.56.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1659,8 +1659,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_jsdoc"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1669,8 +1669,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1692,8 +1692,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1708,10 +1708,10 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "memchr",
  "oxc_allocator",
  "oxc_ast",
@@ -1730,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174d2498c2390ccfab0a9caaf47ef5accda1d509aaa34a5be8f45e00e5299f04"
+checksum = "9ac6db7d8c33f46a0b9ebb702c077364abcd6b64c3a3a97bb86b9f5b3554833c"
 dependencies = [
  "base64-simd",
  "json-escape-simd",
@@ -1743,8 +1743,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1757,8 +1757,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "compact_str",
  "hashbrown",
@@ -1769,8 +1769,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=aa79b5be9915068f60bc361febf2e7496b92fc24#aa79b5be9915068f60bc361febf2e7496b92fc24"
+version = "0.137.0"
+source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1795,9 +1795,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -1816,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1829,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,18 +67,18 @@ type_complexity = "allow"
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -54,18 +54,18 @@ smallvec = { version = "1.13", features = ["serde"] }
 rustc-hash = "2.0"
 
 # JavaScript parsing and code generation
-oxc_allocator = "0.136"
-oxc_parser = "0.136"
-oxc_ast = { version = "0.136", features = ["serialize"] }
-oxc_span = "0.136"
-oxc_diagnostics = "0.136"
-oxc_codegen = "0.136"
+oxc_allocator = "0.137"
+oxc_parser = "0.137"
+oxc_ast = { version = "0.137", features = ["serialize"] }
+oxc_span = "0.137"
+oxc_diagnostics = "0.137"
+oxc_codegen = "0.137"
 rsvelte_esrap = { path = "../rsvelte_esrap" }
-oxc_syntax = "0.136"
-oxc_semantic = "0.136"
+oxc_syntax = "0.137"
+oxc_semantic = "0.137"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
 
 # Error handling
 thiserror = "2.0"
@@ -113,7 +113,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 getrandom = { version = "0.4", optional = true }
 lazy_static = "1.5.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
-oxc_ast_visit = "0.136"
+oxc_ast_visit = "0.137"
 
 # Better multi-threaded memory allocator (optional, Unix/Mac only)
 [target.'cfg(all(not(windows), not(target_arch = "wasm32")))'.dependencies]

--- a/crates/rsvelte_core/src/compiler/preprocess/types.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/types.rs
@@ -5,6 +5,15 @@
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
+// Re-export the exact `FxHashMap` (and its hasher) that the preprocess attribute
+// maps are built from. With `resolver = "3"`, `rustc-hash` is compiled separately
+// for the normal and build-dependency graphs (oxc_formatter pulls the oxc stack
+// into the build graph), so an integration test that names `rustc_hash::FxHashMap`
+// directly can resolve a *different* `FxBuildHasher` instance than this crate's
+// `AttributeValue` map uses. Tests construct attribute maps through this re-export
+// so the hasher type always unifies with the library's.
+pub use rustc_hash::FxHashMap as PreprocessAttributeMap;
+
 /// The result of a preprocessor run.
 ///
 /// If the preprocessor does not return a result, it is assumed that the code is unchanged.

--- a/crates/rsvelte_core/tests/common/preprocess_fixtures.rs
+++ b/crates/rsvelte_core/tests/common/preprocess_fixtures.rs
@@ -4,10 +4,10 @@
 //! `_config.js` JS preprocessor into Rust closures here.
 
 use rsvelte_core::compiler::preprocess::types::{
-    AttributeValue, MarkupPreprocessorFn, MarkupPreprocessorOptions, PreprocessorFn,
-    PreprocessorGroup, PreprocessorOptions, PreprocessorResult, Processed,
+    AttributeValue, MarkupPreprocessorFn, MarkupPreprocessorOptions,
+    PreprocessAttributeMap as FxHashMap, PreprocessorFn, PreprocessorGroup, PreprocessorOptions,
+    PreprocessorResult, Processed,
 };
-use rustc_hash::FxHashMap;
 
 /// Read a string attribute value, panicking if it isn't a `String`.
 pub fn attr_str<'a>(attrs: &'a FxHashMap<String, AttributeValue>, name: &str) -> Option<&'a str> {

--- a/crates/rsvelte_core/tests/preprocess_attributes.rs
+++ b/crates/rsvelte_core/tests/preprocess_attributes.rs
@@ -4,10 +4,9 @@
 
 use rsvelte_core::compiler::preprocess::preprocess;
 use rsvelte_core::compiler::preprocess::types::{
-    AttributeValue, PreprocessError, PreprocessorFn, PreprocessorGroup, PreprocessorOptions,
-    PreprocessorResult, Processed,
+    AttributeValue, PreprocessAttributeMap as FxHashMap, PreprocessError, PreprocessorFn,
+    PreprocessorGroup, PreprocessorOptions, PreprocessorResult, Processed,
 };
-use rustc_hash::FxHashMap;
 use std::future::Future;
 
 fn ok<F>(f: F) -> PreprocessorResult

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["svelte", "compiler", "esrap", "printer"]
 crate-type = ["rlib"]
 
 [dependencies]
-oxc_allocator = "0.136"
-oxc_ast = "0.136"
-oxc_span = "0.136"
-oxc_syntax = "0.136"
+oxc_allocator = "0.137"
+oxc_ast = "0.137"
+oxc_span = "0.137"
+oxc_syntax = "0.137"
 
 [dev-dependencies]
-oxc_parser = "0.136"
-oxc_ast_visit = "0.136"
+oxc_parser = "0.137"
+oxc_ast_visit = "0.137"
 
 [lints]
 workspace = true

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/bin/fmt_benchmark_runner.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -21,12 +21,12 @@ wasm = ["rsvelte_core/wasm-deps"]
 
 [dependencies]
 rsvelte_core = { path = "../rsvelte_core", default-features = false }
-oxc_allocator = "0.136"
-oxc_ast = "0.136"
-oxc_parser = "0.136"
-oxc_span = "0.136"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
+oxc_allocator = "0.137"
+oxc_ast = "0.137"
+oxc_parser = "0.137"
+oxc_span = "0.137"
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
 thiserror = "2.0"
 unicode-width = "0.2"
 

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -50,11 +50,11 @@ rayon = { version = "1.10", optional = true }
 
 # OXC — same git rev as rsvelte_core (unified by the workspace `[patch]`),
 # used only to statically parse `eslint.config.js` for the config importer.
-oxc_allocator = { version = "0.136", optional = true }
-oxc_parser = { version = "0.136", optional = true }
-oxc_ast = { version = "0.136", optional = true }
-oxc_ast_visit = { version = "0.136", optional = true }
-oxc_span = { version = "0.136", optional = true }
+oxc_allocator = { version = "0.137", optional = true }
+oxc_parser = { version = "0.137", optional = true }
+oxc_ast = { version = "0.137", optional = true }
+oxc_ast_visit = { version = "0.137", optional = true }
+oxc_span = { version = "0.137", optional = true }
 
 # wasm-only.
 wasm-bindgen = { version = "0.2", optional = true }

--- a/crates/rsvelte_lint_types/Cargo.toml
+++ b/crates/rsvelte_lint_types/Cargo.toml
@@ -53,18 +53,18 @@ type_complexity = "allow"
 # Mirror the root workspace's oxc unification patch so the path-dep rsvelte
 # crates build with the same oxc rev. MUST match crates/../Cargo.toml.
 [patch.crates-io]
-oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
-oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "aa79b5be9915068f60bc361febf2e7496b92fc24" }
+oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
+oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }


### PR DESCRIPTION
## Summary

Renovate's individual oxc-crate PRs can **never** pass CI on their own: every published `oxc_*` crate is redirected through `[patch.crates-io]` to a single pinned git rev, so bumping one crate's version constraint leaves the lockfile holding both the patched 0.136 git crates **and** a 0.137 registry crate — the two `Program<'a>` types then fail to unify against `oxc_formatter`'s transitive deps.

This bumps **everything to one rev** instead:

- Point every `[patch.crates-io]` `oxc_*` entry, plus the `oxc_formatter` / `oxc_formatter_core` git deps (`rsvelte_core`, `rsvelte_fmt`, `rsvelte_formatter`) and the `rsvelte_lint_types` git deps, to oxc rev `8339ad49` (oxc **0.137.0** — the same commit Renovate's `oxc_formatter` digest PR targeted).
- Bump the published-version constraints `0.136` → `0.137` in `rsvelte_esrap`, `rsvelte_core`, `rsvelte_formatter`, `rsvelte_lint`.

### `resolver = "3"` rustc-hash fix

`oxc_formatter` pulls the oxc stack into the **build-dependency** graph, so under `resolver = "3"` `rustc-hash` is now compiled separately for the normal and build graphs. Integration tests that named `rustc_hash::FxHashMap` directly resolved a *different* `FxBuildHasher` than `AttributeValue`'s map uses. Fixed by re-exporting the library's exact map type as `PreprocessAttributeMap` and having the preprocess tests build attribute maps through it.

## Verification (local)

- `cargo build --workspace` ✅
- `rsvelte_core` tests: 1472+ passed, 0 failed
- `rsvelte_esrap` / `rsvelte_formatter` / `rsvelte_fmt`: all passed, 0 failed
- `rsvelte_lint` (`--features native`): 211+ passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` ✅ clean
- `cargo fmt --check` ✅ clean

## Replaces

Closes #1109, #1110, #1113, #1114, #1115, #1116 — these are superseded by this unified bump and will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xs3n7NzYYaYpr1F8evw4f