### PR TITLE
fix(svelte-check): type-check with tsc by default (not only with --tsgo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ npx svelte-check
 Common flags:
 
 ```bash
-npx svelte-check --workspace .              # type-check the current workspace
-npx svelte-check --tsgo                     # run tsgo against the .svelte overlay (recommended)
+npx svelte-check --workspace .              # type-check the current workspace (uses tsc)
+npx svelte-check --tsgo                     # type-check with tsgo instead of tsc (faster)
+npx svelte-check --no-type-check            # Svelte diagnostics only, skip TypeScript
 npx svelte-check --watch                    # re-check on file changes
 npx svelte-check --incremental              # reuse cached overlay between runs
 npx svelte-check --output machine           # JSON-friendly output for CI
@@ -137,7 +138,11 @@ npx svelte-check --fail-on-warnings         # treat warnings as errors
 npx svelte-check --compiler-warnings "css-unused-selector:ignore"
 ```
 
-See `npx svelte-check --help` for the full list. The CLI flag set is a superset of upstream's — every upstream flag works, plus a few rsvelte-specific ones (`--tsgo`, `--emit-overlay`).
+Type-checking is on by default and runs the stock `tsc` against the
+`.svelte` overlay; pass `--tsgo` to prefer Microsoft's native `tsgo`
+instead, or `--no-type-check` to report only Svelte-side diagnostics.
+
+See `npx svelte-check --help` for the full list. The CLI flag set is a superset of upstream's — every upstream flag works, plus a few rsvelte-specific ones (`--tsgo`, `--no-type-check`, `--emit-overlay`).
 
 ### Convert `.svelte` to `.tsx` (`svelte2tsx`)
 

--- a/crates/rsvelte_core/src/bin/svelte_check.rs
+++ b/crates/rsvelte_core/src/bin/svelte_check.rs
@@ -1,6 +1,7 @@
-//! `svelte-check` CLI binary — Wave 2 of the ecosystem port. v0.1
-//! covers Svelte-side diagnostics only (compile errors + compiler
-//! warnings). tsgo integration is the next milestone.
+//! `svelte-check` CLI binary — Wave 2 of the ecosystem port. Reports
+//! Svelte-side diagnostics (compile errors + compiler warnings) plus
+//! TypeScript type errors. Type-checking runs by default via `tsc`
+//! (or `tsgo` with `--tsgo`); pass `--no-type-check` for Svelte-only.
 
 // Use jemalloc as the global allocator for better multi-threaded
 // performance. Defined per-bin rather than once in the lib because the lib
@@ -55,10 +56,10 @@ struct Cli {
     #[arg(long = "fail-on-warnings", default_value_t = false)]
     fail_on_warnings: bool,
 
-    /// Materialise `.tsx` shadow files + an overlay tsconfig under
-    /// `<workspace>/.svelte-check/`. The directory layout matches the
-    /// JS reference's `--tsgo` cache, so a follow-up step can hand it
-    /// straight to a TypeScript compiler.
+    /// Keep the materialised `.tsx` shadow files + overlay tsconfig under
+    /// `<workspace>/.svelte-check/` on disk (they are written internally
+    /// for type-checking regardless). Useful for inspecting the overlay,
+    /// or combined with `--no-type-check` to emit without compiling.
     #[arg(long = "emit-overlay", default_value_t = false)]
     emit_overlay: bool,
 
@@ -67,11 +68,18 @@ struct Cli {
     #[arg(long = "tsconfig")]
     tsconfig: Option<PathBuf>,
 
-    /// Run `tsgo` (or `tsc`) against the overlay tsconfig and report
-    /// the resulting TypeScript diagnostics mapped back to the
-    /// original `.svelte` source. Implies `--emit-overlay`.
+    /// Prefer Microsoft's native `tsgo` over the stock `tsc` when
+    /// type-checking the overlay. Without this flag type-checking still
+    /// runs, using `tsc`. (`tsgo` falls back to `tsc` and vice-versa if
+    /// the preferred binary isn't installed.)
     #[arg(long = "tsgo", default_value_t = false)]
     tsgo: bool,
+
+    /// Skip the TypeScript type-checking pass entirely and report only
+    /// Svelte-side diagnostics (compile errors + compiler warnings).
+    /// Type-checking is on by default.
+    #[arg(long = "no-type-check", default_value_t = false)]
+    no_type_check: bool,
 
     /// Comma-separated `code:error|ignore` overrides for compiler
     /// warnings. Example: `css-unused-selector:ignore,a11y-no-noninteractive-element-to-interactive-role:error`.
@@ -135,13 +143,17 @@ fn main() -> ExitCode {
     let compiler_warnings = parse_compiler_warnings(cli.compiler_warnings.as_deref());
     let diagnostic_sources = parse_diagnostic_sources(cli.diagnostic_sources.as_deref());
 
+    // Type-checking is on by default; `--no-type-check` opts out. `--tsgo`
+    // only selects which compiler backend is preferred (tsgo vs tsc).
+    let type_check = !cli.no_type_check;
     let options = RunOptions {
         workspace: workspace.clone(),
         ignore,
         fail_on_warnings: cli.fail_on_warnings,
-        emit_overlay: cli.emit_overlay || cli.tsgo,
+        emit_overlay: cli.emit_overlay,
         tsconfig: cli.tsconfig,
-        use_tsgo: cli.tsgo,
+        type_check,
+        prefer_tsgo: cli.tsgo,
         compiler_warnings,
         diagnostic_sources,
         incremental: cli.incremental,

--- a/crates/rsvelte_core/src/svelte_check/runner.rs
+++ b/crates/rsvelte_core/src/svelte_check/runner.rs
@@ -74,10 +74,18 @@ pub struct RunOptions {
     /// Optional path to a project tsconfig.json the overlay should
     /// `extends`. None → write a self-contained overlay tsconfig.
     pub tsconfig: Option<PathBuf>,
-    /// When `true`, also run `tsgo` (or `tsc`) against the overlay
-    /// tsconfig and surface mapped TypeScript diagnostics on the
-    /// original `.svelte` source. Implies `emit_overlay`.
-    pub use_tsgo: bool,
+    /// When `true`, materialise the overlay and run a TypeScript
+    /// compiler (`tsc` by default, or `tsgo` when `prefer_tsgo`) against
+    /// it, surfacing the mapped TypeScript diagnostics on the original
+    /// `.svelte` source. This is the behaviour the `rsvelte-check` CLI
+    /// turns on by default — without it the run only reports Svelte-side
+    /// compile diagnostics. Implies `emit_overlay`.
+    pub type_check: bool,
+    /// Backend preference when `type_check` is set: `true` prefers
+    /// Microsoft's native `tsgo` (falling back to `tsc`), `false` (the
+    /// default) prefers the stock `tsc` (falling back to `tsgo`). Has no
+    /// effect unless `type_check` is set.
+    pub prefer_tsgo: bool,
     /// Compiler-warning overrides keyed by warning code (e.g.
     /// `css-unused-selector` → `Ignore`). Empty = pass all warnings
     /// through unchanged. Mirrors the JS `--compiler-warnings`.
@@ -100,7 +108,8 @@ impl Default for RunOptions {
             fail_on_warnings: false,
             emit_overlay: false,
             tsconfig: None,
-            use_tsgo: false,
+            type_check: false,
+            prefer_tsgo: false,
             compiler_warnings: HashMap::new(),
             diagnostic_sources: None,
             incremental: false,
@@ -113,8 +122,8 @@ impl Default for RunOptions {
 pub struct RunResult {
     pub diagnostics: Vec<Diagnostic>,
     pub files_checked: usize,
-    /// `Some` only when `RunOptions::emit_overlay` was set; mainly used
-    /// by the upcoming tsgo subprocess pipeline.
+    /// `Some` whenever the overlay was materialised — i.e. when
+    /// `RunOptions::emit_overlay` or `RunOptions::type_check` was set.
     pub overlay: Option<OverlayLayout>,
 }
 
@@ -169,7 +178,7 @@ pub fn run(options: &RunOptions) -> RunResult {
         overlay: None,
     };
 
-    let need_overlay = options.emit_overlay || options.use_tsgo;
+    let need_overlay = options.emit_overlay || options.type_check;
     if need_overlay {
         match materialize_overlay_with_kit(
             &options.workspace,
@@ -180,8 +189,13 @@ pub fn run(options: &RunOptions) -> RunResult {
             &kit_settings,
         ) {
             Ok(layout) => {
-                if options.use_tsgo {
-                    run_tsgo_phase(&layout, &options.workspace, &mut result.diagnostics);
+                if options.type_check {
+                    run_type_check_phase(
+                        &layout,
+                        &options.workspace,
+                        options.prefer_tsgo,
+                        &mut result.diagnostics,
+                    );
                 }
                 result.overlay = Some(layout);
             }
@@ -235,16 +249,22 @@ fn apply_filters(diagnostics: &mut Vec<Diagnostic>, options: &RunOptions) {
     }
 }
 
-fn run_tsgo_phase(layout: &OverlayLayout, workspace: &Path, out: &mut Vec<Diagnostic>) {
-    let binary = match find_compiler(workspace) {
+fn run_type_check_phase(
+    layout: &OverlayLayout,
+    workspace: &Path,
+    prefer_tsgo: bool,
+    out: &mut Vec<Diagnostic>,
+) {
+    let binary = match find_compiler(workspace, prefer_tsgo) {
         Ok(b) => b,
         Err(TsgoError::NotFound) => {
             out.push(Diagnostic {
                 file: workspace.to_path_buf(),
                 severity: DiagnosticSeverity::Warning,
-                code: Some("tsgo-not-found".into()),
-                message: "Skipping TypeScript diagnostics: no `tsgo` or `tsc` binary found. \
-                     Install `@typescript/native-preview` or set `TSGO_BIN`."
+                code: Some("ts-compiler-not-found".into()),
+                message: "Skipping TypeScript diagnostics: no `tsc` or `tsgo` binary found. \
+                     Install `typescript` (or `@typescript/native-preview` for `--tsgo`), \
+                     or set `TSGO_BIN`."
                     .into(),
                 range: None,
                 source: "ts",
@@ -255,7 +275,7 @@ fn run_tsgo_phase(layout: &OverlayLayout, workspace: &Path, out: &mut Vec<Diagno
             out.push(Diagnostic {
                 file: workspace.to_path_buf(),
                 severity: DiagnosticSeverity::Error,
-                code: Some("tsgo-error".into()),
+                code: Some("ts-compiler-error".into()),
                 message: format!("{e}"),
                 range: None,
                 source: "ts",
@@ -287,8 +307,8 @@ fn run_tsgo_phase(layout: &OverlayLayout, workspace: &Path, out: &mut Vec<Diagno
             out.push(Diagnostic {
                 file: workspace.to_path_buf(),
                 severity: DiagnosticSeverity::Error,
-                code: Some("tsgo-error".into()),
-                message: format!("tsgo execution failed: {e}"),
+                code: Some("ts-compiler-error".into()),
+                message: format!("TypeScript compiler execution failed: {e}"),
                 range: None,
                 source: "ts",
             });

--- a/crates/rsvelte_core/src/svelte_check/tsgo.rs
+++ b/crates/rsvelte_core/src/svelte_check/tsgo.rs
@@ -1,13 +1,15 @@
-//! tsgo subprocess driver. Spawns Microsoft's `tsgo` (or falls back to
-//! `tsc`) against the overlay tsconfig produced by
-//! `super::overlay::materialize_overlay`, captures the textual diagnostic
-//! stream, and parses it into the `RawTsDiagnostic` shape consumed by
-//! `super::mapper`.
+//! TypeScript compiler subprocess driver. Spawns `tsc` (the default) or
+//! Microsoft's native `tsgo` (with `--tsgo` / `prefer_tsgo`) against the
+//! overlay tsconfig produced by `super::overlay::materialize_overlay`,
+//! captures the textual diagnostic stream, and parses it into the
+//! `RawTsDiagnostic` shape consumed by `super::mapper`. The two compilers
+//! are wire-compatible (`--pretty false` output + flags), so the same
+//! driver handles both; `find_compiler` just decides which binary to run.
 //!
 //! The JS reference (`incremental.ts::runTypeScriptDiagnostics`) spawns
 //! `node <tsgo_js> -p <tsconfig> --pretty true --noErrorTruncation`. Our
-//! version mirrors that, plus a graceful fallback chain when tsgo isn't
-//! installed.
+//! version mirrors that, plus a graceful fallback chain when the preferred
+//! compiler isn't installed.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -55,13 +57,19 @@ pub struct TsgoBinary {
     pub args_prefix: Vec<String>,
 }
 
-/// Locate a TypeScript compiler binary. Resolution order matches the JS
-/// reference's preference plus a couple of common rsvelte dev paths:
-/// 1. `$TSGO_BIN`
-/// 2. `<workspace>/node_modules/.bin/tsgo`
-/// 3. `<workspace>/node_modules/.bin/tsc`
-/// 4. Globally on `$PATH`: `tsgo`, then `tsc`.
-pub fn find_compiler(workspace: &Path) -> Result<TsgoBinary, TsgoError> {
+/// Locate a TypeScript compiler binary.
+///
+/// `$TSGO_BIN` is always honoured first as an explicit override. After
+/// that the search order depends on `prefer_tsgo`:
+///   * `prefer_tsgo == false` (the default, `rsvelte-check` without
+///     `--tsgo`) — prefer the stock `tsc`, falling back to `tsgo`:
+///       1. `<workspace>/node_modules/.bin/tsc`, then `…/tsgo`
+///       2. Globally on `$PATH`: `tsc`, then `tsgo`.
+///   * `prefer_tsgo == true` (`rsvelte-check --tsgo`) — prefer
+///     Microsoft's native `tsgo`, falling back to `tsc`:
+///       1. `<workspace>/node_modules/.bin/tsgo`, then `…/tsc`
+///       2. Globally on `$PATH`: `tsgo`, then `tsc`.
+pub fn find_compiler(workspace: &Path, prefer_tsgo: bool) -> Result<TsgoBinary, TsgoError> {
     if let Ok(explicit) = std::env::var("TSGO_BIN")
         && !explicit.is_empty()
     {
@@ -70,11 +78,15 @@ pub fn find_compiler(workspace: &Path) -> Result<TsgoBinary, TsgoError> {
             args_prefix: Vec::new(),
         });
     }
-    let candidates = [
-        workspace.join("node_modules/.bin/tsgo"),
-        workspace.join("node_modules/.bin/tsc"),
-    ];
-    for path in &candidates {
+    // Binary names in preference order.
+    let names: [&str; 2] = if prefer_tsgo {
+        ["tsgo", "tsc"]
+    } else {
+        ["tsc", "tsgo"]
+    };
+    // 1. Local `node_modules/.bin`, in preference order.
+    for name in names {
+        let path = workspace.join("node_modules/.bin").join(name);
         if path.exists() {
             return Ok(TsgoBinary {
                 program: path.display().to_string(),
@@ -82,17 +94,14 @@ pub fn find_compiler(workspace: &Path) -> Result<TsgoBinary, TsgoError> {
             });
         }
     }
-    if which("tsgo") {
-        return Ok(TsgoBinary {
-            program: "tsgo".into(),
-            args_prefix: Vec::new(),
-        });
-    }
-    if which("tsc") {
-        return Ok(TsgoBinary {
-            program: "tsc".into(),
-            args_prefix: Vec::new(),
-        });
+    // 2. Global `$PATH`, in preference order.
+    for name in names {
+        if which(name) {
+            return Ok(TsgoBinary {
+                program: name.to_string(),
+                args_prefix: Vec::new(),
+            });
+        }
     }
     Err(TsgoError::NotFound)
 }
@@ -180,6 +189,48 @@ mod tests {
         assert_eq!(diags[0].severity, "error");
         assert_eq!(diags[1].severity, "warning");
         assert!(diags[1].message.contains("declared but never used"));
+    }
+
+    #[test]
+    fn find_compiler_respects_backend_preference() {
+        // `TSGO_BIN` is checked before everything else, so this layout-based
+        // test is only meaningful when the override isn't set in the env.
+        if std::env::var_os("TSGO_BIN").is_some() {
+            eprintln!("skip: TSGO_BIN is set in the environment");
+            return;
+        }
+        let dir =
+            std::env::temp_dir().join(format!("rsvelte_find_compiler_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let bin = dir.join("node_modules/.bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        // Both binaries present locally — preference decides the winner.
+        std::fs::write(bin.join("tsc"), "").unwrap();
+        std::fs::write(bin.join("tsgo"), "").unwrap();
+
+        let tsc = find_compiler(&dir, false).expect("tsc found");
+        assert!(
+            tsc.program.ends_with("tsc"),
+            "prefer_tsgo=false should pick tsc, got {}",
+            tsc.program
+        );
+        let tsgo = find_compiler(&dir, true).expect("tsgo found");
+        assert!(
+            tsgo.program.ends_with("tsgo"),
+            "prefer_tsgo=true should pick tsgo, got {}",
+            tsgo.program
+        );
+
+        // Only the non-preferred binary present → fall back to it.
+        std::fs::remove_file(bin.join("tsgo")).unwrap();
+        let fallback = find_compiler(&dir, true).expect("falls back to tsc");
+        assert!(
+            fallback.program.ends_with("tsc"),
+            "prefer_tsgo=true with only tsc present should fall back to tsc, got {}",
+            fallback.program
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/svelte_check_companion_800.rs
+++ b/crates/rsvelte_core/tests/svelte_check_companion_800.rs
@@ -21,7 +21,7 @@ use rsvelte_core::svelte_check::{RunOptions, run};
 #[ignore = "#800: companion .svelte.ts shadows ./Foo.svelte — needs resolution interception (tsgo plugin); repro only"]
 #[test]
 fn companion_svelte_ts_does_not_shadow_component_module() {
-    if find_compiler(&PathBuf::from(".")).is_err() {
+    if find_compiler(&PathBuf::from("."), true).is_err() {
         eprintln!("skip #800: no tsgo/tsc found");
         return;
     }
@@ -66,7 +66,8 @@ fn companion_svelte_ts_does_not_shadow_component_module() {
 
     let opts = RunOptions {
         workspace: dir.clone(),
-        use_tsgo: true,
+        type_check: true,
+        prefer_tsgo: true,
         ignore: vec!["node_modules".to_string()],
         ..RunOptions::default()
     };

--- a/crates/rsvelte_core/tests/svelte_check_golden.rs
+++ b/crates/rsvelte_core/tests/svelte_check_golden.rs
@@ -188,7 +188,7 @@ fn test_error_fixture_emits_expected_ts_error_codes() {
         eprintln!("Skipping: test-error fixture not found");
         return;
     }
-    if find_compiler(&workspace).is_err() {
+    if find_compiler(&workspace, true).is_err() {
         eprintln!(
             "Skipping: no `tsgo` / `tsc` binary on this machine \
              (set TSGO_BIN or install @typescript/native-preview to enable)"
@@ -199,7 +199,8 @@ fn test_error_fixture_emits_expected_ts_error_codes() {
     let opts = RunOptions {
         workspace: workspace.clone(),
         tsconfig: Some(tsconfig.clone()),
-        use_tsgo: true,
+        type_check: true,
+        prefer_tsgo: true,
         ..RunOptions::default()
     };
     let result = run(&opts);


### PR DESCRIPTION
## Problem

`rsvelte-check` only ran TypeScript type-checking when `--tsgo` was passed. Without `--tsgo`, `run()` computed `need_overlay = emit_overlay || use_tsgo` → `false`, so it skipped overlay materialization **and** the compiler entirely, reporting only Svelte-side compile diagnostics. A plain `rsvelte-check` was effectively a silent no-op for type errors (空振り), even though the `tsc`/`tsgo` invocation machinery already existed.

## Fix

Make type-checking and backend selection orthogonal:

- **`RunOptions`**: replace `use_tsgo: bool` with `type_check: bool` (run a TS compiler at all) and `prefer_tsgo: bool` (which binary to prefer). `run()` materializes the overlay and runs the compiler whenever `type_check` is set.
- **`find_compiler(workspace, prefer_tsgo)`**: default prefers stock **`tsc`** (falling back to `tsgo`); `--tsgo` prefers `tsgo` (falling back to `tsc`). `$TSGO_BIN` still wins first as an explicit override.
- **CLI**: type-checking is **on by default** (uses `tsc`). `--tsgo` now only switches the preferred backend; added `--no-type-check` for Svelte-only mode. Backend-neutral diagnostic codes/messages; `run_tsgo_phase` → `run_type_check_phase`.
- Updated README, the two tests referencing the old field/signature, and added a `find_compiler` preference-ordering unit test.

The **library** default (`RunOptions::default()`) stays Svelte-only so existing consumers/tests don't suddenly spawn `tsc`; the "type-check by default" behavior lives in the CLI.

## Verification

- Without `--tsgo` on a workspace with a type error → `tsc` runs and reports `Type 'string' is not assignable to type 'number'` (exit 1). No longer a no-op.
- `--no-type-check` → Svelte-only, 0 errors (exit 0).
- No `tsc`/`tsgo` installed → clear warning instead of silent pass.
- `cargo clippy -- -D warnings` clean; all 6 `svelte_check_*` suites + new tsgo unit test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)