### PR TITLE
docs(changeset): svelte-check tsc-by-default type-checking

### DIFF
--- a/.changeset/svelte-check-tsc-default.md
+++ b/.changeset/svelte-check-tsc-default.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/svelte-check": minor
+---
+
+svelte-check: type-check with `tsc` by default (previously only with `--tsgo`)
+
+Running `rsvelte-check` without `--tsgo` used to skip TypeScript type-checking entirely, reporting only Svelte-side compile diagnostics — a silent no-op for type errors. Type-checking is now on by default and runs the stock `tsc` against the `.svelte` overlay. `--tsgo` switches the preferred backend to Microsoft's native `tsgo` (each falls back to the other; `$TSGO_BIN` still wins as an explicit override), and a new `--no-type-check` flag restores Svelte-only mode.


### PR DESCRIPTION
Changeset for #1135.

`@rsvelte/svelte-check` (minor): type-checking now runs `tsc` by default instead of only with `--tsgo`; adds `--no-type-check` for Svelte-only mode and `--tsgo` to prefer the native `tsgo` backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)