### PR TITLE
fix(svelte-check): don't misclassify binder-emitted TS1xxx as syntax errors

### DIFF
--- a/.changeset/svelte-check-binder-1xxx-not-syntactic.md
+++ b/.changeset/svelte-check-binder-1xxx-not-syntactic.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+svelte-check (`--tsgo`): stop misclassifying binder/checker-emitted `TS1xxx`
+codes as syntax errors. The overlay-validity guard treated the entire
+`1000..2000` range as syntactic, but a handful of those codes — most notably
+`TS1192` ("Module has no default export"), plus `TS1259` / `TS1361` / `TS1371`
+— are emitted by the checker, not the parser. They do **not** trigger
+TypeScript's program-wide semantic-diagnostic suppression, so flagging them as
+syntactic raised a spurious `internal error: rsvelte produced invalid TSX … /
+TypeScript suppressed type errors for the rest of the project` banner even
+though every real type error was still reported.
+
+This surfaced on components that have a sibling `Foo.svelte.ts` companion
+module re-exported into the shadow (the `#751` feature): consumers importing
+`import Default, { Named } from './Foo.svelte'` could see `TS1192`, which then
+masqueraded as an overlay parse failure. Unlike official `svelte-check` — which
+classifies by `getSyntacticDiagnostics` / `getSemanticDiagnostics` origin
+rather than by code number — rsvelte only has tsgo's textual code, so the fix
+maintains an explicit denylist of the known binder-emitted `1xxx` codes.

--- a/crates/rsvelte_core/src/svelte_check/mapper.rs
+++ b/crates/rsvelte_core/src/svelte_check/mapper.rs
@@ -22,12 +22,34 @@ struct EntryMap {
     map: SourceMap,
 }
 
+/// TS `1xxx` codes that are emitted by the BINDER/CHECKER (semantic), not the
+/// parser, despite living in the range otherwise reserved for parse errors.
+///
+/// The `1xxx` range is *mostly* syntactic, but TypeScript reuses a handful of
+/// codes in it for module/import semantics that require symbol resolution.
+/// These do NOT cause the parser to fail, so they do NOT trigger the
+/// program-wide semantic-diagnostic suppression that `is_syntactic_ts_code`
+/// guards against — treating them as syntactic raises a spurious
+/// `overlay-invalid-tsx` / `tsgo-semantics-suppressed` alarm when, in fact,
+/// every real type error is still reported (e.g. a `.svelte` component with a
+/// sibling `Foo.svelte.ts` companion re-exported into the shadow can surface
+/// `TS1192` while `TS7006` & friends keep flowing — proof semantics were never
+/// suppressed).
+const SEMANTIC_TS_1XXX_CODES: &[u32] = &[
+    1192, // "Module '{0}' has no default export."
+    1259, // "Module '{0}' can only be default-imported using the '{1}' flag."
+    1361, // "'{0}' cannot be used as a value because it was imported using 'import type'."
+    1371, // "This import is never used as a value and must use 'import type' ..."
+];
+
 /// Whether a TypeScript diagnostic code denotes a SYNTACTIC error.
 ///
 /// TypeScript groups syntax (parse) errors under the `TS1xxx` range — e.g.
 /// `TS1005` (`',' expected`), `TS1109` (`Expression expected`), `TS1128`
 /// (`Declaration or statement expected`), `TS1136` (`Property assignment
-/// expected`). Semantic / type errors live in `TS2xxx`+.
+/// expected`). Semantic / type errors live in `TS2xxx`+ — plus the handful of
+/// binder/checker-emitted `1xxx` codes listed in [`SEMANTIC_TS_1XXX_CODES`],
+/// which are explicitly excluded here.
 ///
 /// This distinction is load-bearing: TypeScript (and tsgo) suppress ALL
 /// semantic diagnostics program-wide as soon as the program contains ANY
@@ -37,7 +59,7 @@ struct EntryMap {
 pub fn is_syntactic_ts_code(code: &str) -> bool {
     code.strip_prefix("TS")
         .and_then(|n| n.parse::<u32>().ok())
-        .map(|n| (1000..2000).contains(&n))
+        .map(|n| (1000..2000).contains(&n) && !SEMANTIC_TS_1XXX_CODES.contains(&n))
         .unwrap_or(false)
 }
 
@@ -372,6 +394,18 @@ mod tests {
         // TS2xxx (type), TS6xxx (lint-ish), TS7xxx (implicit-any) are NOT
         // syntactic and must not trip the loud-error path.
         for code in ["TS2322", "TS2304", "TS6133", "TS7006", "TS18047"] {
+            assert!(!is_syntactic_ts_code(code), "{code} should be semantic");
+        }
+    }
+
+    #[test]
+    fn classifies_binder_emitted_ts1xxx_as_semantic() {
+        // A handful of `1xxx` codes are checker/binder-emitted module-import
+        // semantics, NOT parse errors — they must not be treated as syntactic
+        // (which would falsely flag an `overlay-invalid-tsx` and claim
+        // program-wide suppression). Regression guard for the `Foo.svelte` +
+        // sibling `Foo.svelte.ts` companion re-export case (`TS1192`).
+        for code in ["TS1192", "TS1259", "TS1361", "TS1371"] {
             assert!(!is_syntactic_ts_code(code), "{code} should be semantic");
         }
     }

--- a/crates/rsvelte_core/src/svelte_check/mapper.rs
+++ b/crates/rsvelte_core/src/svelte_check/mapper.rs
@@ -48,7 +48,7 @@ const SEMANTIC_TS_1XXX_CODES: &[u32] = &[
 /// `TS1005` (`',' expected`), `TS1109` (`Expression expected`), `TS1128`
 /// (`Declaration or statement expected`), `TS1136` (`Property assignment
 /// expected`). Semantic / type errors live in `TS2xxx`+ — plus the handful of
-/// binder/checker-emitted `1xxx` codes listed in [`SEMANTIC_TS_1XXX_CODES`],
+/// binder/checker-emitted `1xxx` codes listed in `SEMANTIC_TS_1XXX_CODES`,
 /// which are explicitly excluded here.
 ///
 /// This distinction is load-bearing: TypeScript (and tsgo) suppress ALL

--- a/crates/rsvelte_core/src/svelte_check/runner.rs
+++ b/crates/rsvelte_core/src/svelte_check/runner.rs
@@ -655,6 +655,28 @@ mod tests {
     }
 
     #[test]
+    fn loud_binder_emitted_ts1192_is_not_a_syntax_taint() {
+        // A `.svelte` component with a sibling `Foo.svelte.ts` companion
+        // re-exported into its shadow can surface `TS1192` ("Module has no
+        // default export"). That code is checker-emitted, NOT a parse error,
+        // so tsgo keeps reporting real semantics (the `TS7006` below proves
+        // nothing was suppressed). It must therefore raise neither an
+        // `overlay-invalid-tsx` internal error nor a `tsgo-semantics-suppressed`
+        // note — otherwise every consumer of such a component drowns in a
+        // spurious "rsvelte produced invalid TSX" banner.
+        let sources = vec![PathBuf::from("/ws/Foo.svelte")];
+        let mapped = vec![
+            ts_diag("/ws/Foo.svelte", "TS1192", DiagnosticSeverity::Error),
+            ts_diag("/ws/Bar.svelte", "TS7006", DiagnosticSeverity::Error),
+        ];
+        let loud = overlay_syntax_loud_diagnostics(&sources, &mapped, &[], Path::new("/ws"));
+        assert!(
+            loud.is_empty(),
+            "TS1192 is semantic and must not trip the loud syntax-taint path: {loud:?}"
+        );
+    }
+
+    #[test]
     fn loud_overlay_defect_emits_internal_error_and_note() {
         // rsvelte parsed the .svelte cleanly (no svelte-side compile-error)
         // but the generated TSX failed to parse → blame rsvelte loudly.


### PR DESCRIPTION
## Problem

`svelte-check --tsgo` printed a scary, **false** banner on real-world projects:

```
internal error: rsvelte produced invalid TSX for …/+layout.svelte —
TypeScript suppressed type errors for the rest of the project
WARNING TypeScript suppressed all semantic (type) diagnostics program-wide …
```

…even though **no TSX was invalid and nothing was suppressed** — every real type
error was still reported alongside it.

## Root cause

The overlay-validity guard (`#728`) classifies a diagnostic as syntactic purely
by code range: `is_syntactic_ts_code` returned `true` for the entire
`1000..2000` band. That band is *mostly* parser errors, but TypeScript reuses a
few `1xxx` codes for **checker/binder** (semantic) module-import errors —
notably `TS1192` ("Module has no default export"), plus `TS1259` / `TS1361` /
`TS1371`. These do **not** make `getSyntacticDiagnostics` non-empty, so tsgo
never suppresses semantics for them.

Proof from a real run: the overlay emitted **104× `TS7006`** (implicit-any,
semantic) right next to `TS1192`. If `TS1192` were a true syntax error those
104 would have been suppressed — they weren't, so it isn't.

This surfaced on components with a sibling `Foo.svelte.ts` companion module
re-exported into the shadow (the `#751` feature): a consumer doing
`import Default, { Named } from './Foo.svelte'` can legitimately hit `TS1192`,
which then masqueraded as an overlay parse failure and triggered the banner.

Unlike official `svelte-check`, which splits diagnostics by their
`getSyntacticDiagnostics` / `getSemanticDiagnostics` **origin** (parser vs
checker) via the LanguageService API, rsvelte only has tsgo's textual code, so
this fix keeps the range heuristic but subtracts an explicit denylist of the
known binder-emitted `1xxx` codes.

## Fix

`is_syntactic_ts_code` now excludes `SEMANTIC_TS_1XXX_CODES`
(`1192`, `1259`, `1361`, `1371`).

## Verification

- New unit tests: `classifies_binder_emitted_ts1xxx_as_semantic` (mapper) and
  `loud_binder_emitted_ts1192_is_not_a_syntax_taint` (runner).
- End-to-end on a large SvelteKit app (~424 files): before → `internal error …
  suppressed program-wide` + 141 errors / 29 warnings; after → banner gone,
  `140 errors / 28 warnings` (the removed +1/+1 are the spurious
  `overlay-invalid-tsx` error and `tsgo-semantics-suppressed` note themselves).
- `cargo test -p rsvelte_core --lib svelte_check`, `cargo clippy`, `cargo fmt` green.

## Scope / follow-up

This fixes the **false "invalid TSX / suppressed" classification** only. The
underlying `TS1192` on `.svelte` + `.svelte.ts` companion imports resolved via a
path alias (`$lib/…`) — where the import lands on the source companion `.ts`
(no default) instead of the shadow — is a separate overlay-resolution issue and
is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)