### PR TITLE
fix(svelte-check): resolve aliased .svelte imports to their shadow .tsx (oxc_resolver)

### DIFF
--- a/.changeset/svelte-check-resolve-aliased-svelte-imports.md
+++ b/.changeset/svelte-check-resolve-aliased-svelte-imports.md
@@ -1,0 +1,22 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+svelte-check: resolve tsconfig-alias `.svelte` imports (e.g. `$lib/Foo.svelte`)
+to their shadow `.tsx` so type-checking sees the real component type.
+
+The overlay bridges each `.svelte` source to its generated shadow `.tsx` via
+`rootDirs`, but TypeScript applies `rootDirs` only to **relative** specifiers —
+an aliased import (`import X from '$lib/Foo.svelte'`) is resolved through
+`paths` and lands on the raw source `.svelte`, where no `.tsx` shadow exists.
+The component therefore resolved to `any` (every callback prop became a
+spurious `TS7006` implicit-any) or, when a sibling `Foo.svelte.ts` companion
+existed, to the companion (spurious `TS1192` "no default export").
+
+Each generated shadow's non-relative `.svelte` import is now pre-resolved with
+`oxc_resolver` (which honours the project tsconfig `paths`/`baseUrl`/`extends`)
+and rewritten to a concrete relative path at the target's shadow `.tsx`, so the
+backing TypeScript compiler resolves it directly — matching what official
+svelte-check achieves with its in-memory `resolveModuleNames` hook. On a large
+SvelteKit app this dropped reported errors from 140 to 43 (the remainder are
+unrelated SvelteKit route-load typing and companion-module edges).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +829,26 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -1006,7 +1041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1110,6 +1145,15 @@ name = "json-escape-simd"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c2a6c0b4b5637c41719973ef40c6a1cf564f9db6958350de6193fbee9c23f5"
+
+[[package]]
+name = "json-strip-comments"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9301b34ecbe81051a62001a2dfa56d906628efdfbc68153e0a4d5eba58181ece"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "kqueue"
@@ -1487,7 +1531,7 @@ version = "0.137.0"
 source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "allocator-api2",
- "hashbrown",
+ "hashbrown 0.17.1",
  "oxc_data_structures",
  "oxc_estree",
  "rustc-hash",
@@ -1695,6 +1739,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_resolver"
+version = "11.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5632fcd47d4fdaf7ef5ee150c7001fa8ed814ce38d1a073536a366dbfc239aad"
+dependencies = [
+ "cfg-if",
+ "compact_str",
+ "fast-glob",
+ "indexmap",
+ "json-strip-comments",
+ "nodejs-built-in-modules",
+ "once_cell",
+ "papaya",
+ "rustc-hash",
+ "rustix",
+ "self_cell",
+ "serde",
+ "serde_json",
+ "simd-json",
+ "simdutf8",
+ "thiserror",
+ "tracing",
+ "url",
+ "windows",
+]
+
+[[package]]
 name = "oxc_semantic"
 version = "0.137.0"
 source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
@@ -1749,7 +1820,7 @@ version = "0.137.0"
 source = "git+https://github.com/oxc-project/oxc?rev=8339ad49f2c144a582ad5d63adb281bf0444424e#8339ad49f2c144a582ad5d63adb281bf0444424e"
 dependencies = [
  "compact_str",
- "hashbrown",
+ "hashbrown 0.17.1",
  "oxc_allocator",
  "oxc_estree",
  "serde",
@@ -1773,6 +1844,16 @@ dependencies = [
  "phf",
  "serde",
  "unicode-id-start",
+]
+
+[[package]]
+name = "papaya"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+dependencies = [
+ "equivalent",
+ "seize",
 ]
 
 [[package]]
@@ -1988,6 +2069,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,6 +2157,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_formatter",
  "oxc_parser",
+ "oxc_resolver",
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
@@ -2208,6 +2310,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,6 +2408,24 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-json"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+dependencies = [
+ "halfbrown",
+ "ref-cast",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -2667,6 +2797,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +2919,18 @@ checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "value-trait"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
 ]
 
 [[package]]
@@ -2884,6 +3057,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +3088,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2923,6 +3128,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -2975,6 +3190,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -64,6 +64,11 @@ rsvelte_esrap = { path = "../rsvelte_esrap" }
 oxc_syntax = "0.137"
 oxc_semantic = "0.137"
 
+# Module resolution for the svelte-check overlay: resolves `.svelte` imports
+# (including tsconfig `paths`/`baseUrl` aliases like `$lib/...`) so aliased
+# imports can be rewritten to point straight at their generated shadow `.tsx`.
+oxc_resolver = "11"
+
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "8339ad49f2c144a582ad5d63adb281bf0444424e" }
 

--- a/crates/rsvelte_core/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_core/src/svelte_check/overlay.rs
@@ -173,6 +173,12 @@ pub fn materialize_overlay_with(
         manifest::prune_deleted(&mut manifest, &abs_files);
     }
 
+    // Resolver used to re-point tsconfig-alias `.svelte` imports at their
+    // shadow `.tsx` (see `rewrite_aliased_svelte_imports`). Built once and
+    // reused across files; `None` when there is no project tsconfig (a
+    // self-contained overlay has no path aliases to resolve).
+    let svelte_resolver = build_svelte_import_resolver(tsconfig_path);
+
     let mut entries = Vec::with_capacity(files.len());
     for abs_source in &abs_files {
         let rel = abs_source
@@ -245,6 +251,19 @@ pub fn materialize_overlay_with(
             let mut tsx_code = result.code.clone();
             if let Some(spec) = companion_reexport_specifier(abs_source, &tsx_path) {
                 let _ = writeln!(tsx_code, "\nexport * from \"{spec}\";");
+            }
+            // Re-point tsconfig-alias `.svelte` imports (`$lib/Foo.svelte`) at
+            // their shadow `.tsx`. Relative `.svelte` imports already resolve to
+            // shadows via the overlay's `rootDirs`, but TS applies `rootDirs`
+            // ONLY to relative specifiers — an aliased import lands on the raw
+            // source `.svelte` (no shadow there → unresolved `any` / spurious
+            // `TS1192`). oxc_resolver honours the project tsconfig
+            // `paths`/`baseUrl`, so we resolve each alias and rewrite it to a
+            // concrete shadow-relative path that tsgo resolves directly.
+            if let Some(resolver) = svelte_resolver.as_ref() {
+                tsx_code = rewrite_aliased_svelte_imports(
+                    &tsx_code, abs_source, &tsx_path, workspace, &emit_dir, resolver,
+                );
             }
             fs::write(&tsx_path, &tsx_code)?;
 
@@ -999,6 +1018,205 @@ fn companion_reexport_specifier(abs_source: &Path, tsx_path: &Path) -> Option<St
     None
 }
 
+/// Build the module resolver used to re-point tsconfig-alias `.svelte` imports
+/// at their shadow `.tsx`. `None` when there is no project tsconfig (aliases
+/// can only come from a tsconfig's `paths`/`baseUrl`).
+fn build_svelte_import_resolver(tsconfig: Option<&Path>) -> Option<oxc_resolver::Resolver> {
+    use oxc_resolver::{
+        ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
+    };
+    let tsconfig = tsconfig?;
+    Some(Resolver::new(ResolveOptions {
+        extensions: vec![
+            ".svelte".into(),
+            ".ts".into(),
+            ".tsx".into(),
+            ".js".into(),
+            ".jsx".into(),
+            ".json".into(),
+        ],
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: tsconfig.to_path_buf(),
+            references: TsconfigReferences::Auto,
+        })),
+        condition_names: vec!["svelte".into(), "import".into(), "default".into()],
+        ..ResolveOptions::default()
+    }))
+}
+
+/// Rewrite non-relative `.svelte` import specifiers (tsconfig path aliases like
+/// `$lib/Foo.svelte`) in a generated shadow `.tsx` so they point straight at
+/// the target component's shadow `.tsx` under `emit_dir`. Relative `.svelte`
+/// imports are left as-is — the overlay's `rootDirs` already bridges those to
+/// shadows, and TS only applies `rootDirs` to relative specifiers.
+///
+/// Only specifiers that oxc_resolver maps to a `.svelte` file UNDER the
+/// workspace are rewritten; bare packages, `.svelte.ts` companions and
+/// cross-package components are untouched.
+fn rewrite_aliased_svelte_imports(
+    tsx: &str,
+    abs_source: &Path,
+    tsx_path: &Path,
+    workspace: &Path,
+    emit_dir: &Path,
+    resolver: &oxc_resolver::Resolver,
+) -> String {
+    let (Some(source_dir), Some(generated_dir)) = (abs_source.parent(), tsx_path.parent()) else {
+        return tsx.to_string();
+    };
+    // oxc_resolver returns canonicalised paths (symlinks resolved), so compare
+    // against a canonicalised workspace — otherwise a symlinked root (e.g.
+    // macOS `/var` → `/private/var`) makes `strip_prefix` spuriously fail and
+    // no alias gets rewritten.
+    let workspace_canon = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+
+    let decide = |spec: &str| -> Option<String> {
+        if spec.starts_with('.') {
+            return None;
+        }
+        let path_part = spec.split(['?', '#']).next().unwrap_or(spec);
+        if !path_part.ends_with(".svelte") {
+            return None;
+        }
+        let resolution = resolver.resolve(source_dir, spec).ok()?;
+        let resolved = resolution.path();
+        if resolved.extension().and_then(|e| e.to_str()) != Some("svelte") {
+            return None;
+        }
+        let resolved_canon = resolved
+            .canonicalize()
+            .unwrap_or_else(|_| resolved.to_path_buf());
+        let rel = resolved_canon.strip_prefix(&workspace_canon).ok()?;
+        let shadow = append_extension(&emit_dir.join(rel), ".tsx");
+        let mut rewritten = lexical_relative_posix(generated_dir, &shadow);
+        if !rewritten.starts_with('.') {
+            rewritten = format!("./{rewritten}");
+        }
+        Some(rewritten)
+    };
+
+    rewrite_module_specifiers(tsx, &decide)
+}
+
+/// Scan `text` for `from "<spec>"` / `import("<spec>")` module specifiers and
+/// replace each one for which `decide` returns `Some(replacement)`. String
+/// literals and line comments are skipped so only real specifiers are touched.
+/// (Same scanner shape as svelte2tsx's `rewrite_external_specifiers_in_text`.)
+fn rewrite_module_specifiers(text: &str, decide: &dyn Fn(&str) -> Option<String>) -> String {
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let is_ws = |b: u8| matches!(b, b' ' | b'\t' | b'\n' | b'\r');
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'$';
+    let mut out = String::with_capacity(len);
+    let mut copied = 0usize;
+    let mut i = 0usize;
+    let emit = |spec_start: usize, spec_end: usize, out: &mut String, copied: &mut usize| {
+        if let Some(rep) = decide(&text[spec_start..spec_end]) {
+            out.push_str(&text[*copied..spec_start]);
+            out.push_str(&rep);
+            *copied = spec_end;
+        }
+    };
+    while i < len {
+        let b = bytes[i];
+        if b == b'\'' || b == b'"' {
+            let q = b;
+            i += 1;
+            while i < len && bytes[i] != q {
+                if bytes[i] == b'\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                i += 1;
+            }
+            i = (i + 1).min(len);
+            continue;
+        }
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if b == b'f' && i + 4 <= len && &bytes[i..i + 4] == b"from" {
+            let prev_ok = i == 0 || !is_ident(bytes[i - 1]);
+            if prev_ok {
+                let mut j = i + 4;
+                while j < len && is_ws(bytes[j]) {
+                    j += 1;
+                }
+                if j < len && (bytes[j] == b'\'' || bytes[j] == b'"') {
+                    let q = bytes[j];
+                    let spec_start = j + 1;
+                    let mut spec_end = spec_start;
+                    while spec_end < len && bytes[spec_end] != q {
+                        spec_end += 1;
+                    }
+                    emit(spec_start, spec_end, &mut out, &mut copied);
+                    i = (spec_end + 1).min(len);
+                    continue;
+                }
+            }
+        }
+        if b == b'i' && i + 6 <= len && &bytes[i..i + 6] == b"import" {
+            let prev_ok = i == 0 || !is_ident(bytes[i - 1]);
+            if prev_ok {
+                let mut j = i + 6;
+                while j < len && is_ws(bytes[j]) {
+                    j += 1;
+                }
+                if j < len && bytes[j] == b'(' {
+                    j += 1;
+                    while j < len && is_ws(bytes[j]) {
+                        j += 1;
+                    }
+                    if j < len && (bytes[j] == b'\'' || bytes[j] == b'"') {
+                        let q = bytes[j];
+                        let spec_start = j + 1;
+                        let mut spec_end = spec_start;
+                        while spec_end < len && bytes[spec_end] != q {
+                            spec_end += 1;
+                        }
+                        emit(spec_start, spec_end, &mut out, &mut copied);
+                        i = (spec_end + 1).min(len);
+                        continue;
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    if copied < text.len() {
+        out.push_str(&text[copied..]);
+    }
+    out
+}
+
+/// Lexical POSIX relative path from `from_dir` to `to_path` — no filesystem
+/// access (the shadow `.tsx` may not be written yet), so symlink resolution
+/// can't skew the result the way [`path_relative`]'s `canonicalize` would.
+fn lexical_relative_posix(from_dir: &Path, to_path: &Path) -> String {
+    use std::path::Component;
+    let comps = |p: &Path| -> Vec<String> {
+        p.components()
+            .filter(|c| !matches!(c, Component::RootDir | Component::Prefix(_)))
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect()
+    };
+    let from = comps(from_dir);
+    let to = comps(to_path);
+    let common = from.iter().zip(&to).take_while(|(a, b)| a == b).count();
+    let mut parts: Vec<String> = vec!["..".to_string(); from.len() - common];
+    parts.extend(to[common..].iter().cloned());
+    if parts.is_empty() {
+        ".".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
 fn path_relative(from_dir: &Path, to_path: &Path) -> String {
     use std::path::Component;
     let from_abs = from_dir
@@ -1342,6 +1560,74 @@ mod tests {
         assert!(
             !include.iter().any(|i| i.contains("../../../")),
             "glob rebase produced a mangled path: {include:?}"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn rewrite_module_specifiers_targets_only_real_specifiers() {
+        let src = "import A from '$lib/A.svelte';\n\
+                   export { x } from '$lib/B.svelte';\n\
+                   const m = import(\"./rel.svelte\");\n\
+                   const s = \"$lib/A.svelte is not a specifier\";\n";
+        let out = rewrite_module_specifiers(src, &|spec| {
+            spec.strip_prefix("$lib/")
+                .map(|rest| format!("./shadow/{rest}"))
+        });
+        // `from '<alias>'` (import + re-export) is rewritten …
+        assert!(out.contains("from './shadow/A.svelte'"), "{out}");
+        assert!(out.contains("from './shadow/B.svelte'"), "{out}");
+        // … the relative dynamic import is left alone by this decider …
+        assert!(out.contains("import(\"./rel.svelte\")"), "{out}");
+        // … and a bare string literal that merely looks like a specifier is
+        // not touched (the scanner skips string-literal bodies).
+        assert!(
+            out.contains("\"$lib/A.svelte is not a specifier\""),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn aliased_svelte_import_is_rewritten_to_its_shadow() {
+        let tmp = std::env::temp_dir().join(format!("svc_alias_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src/lib")).unwrap();
+        fs::write(
+            tmp.join("tsconfig.json"),
+            "{\"compilerOptions\":{\"paths\":{\"$lib/*\":[\"./src/lib/*\"]}}}",
+        )
+        .unwrap();
+        fs::write(
+            tmp.join("src/lib/Button.svelte"),
+            "<script lang=\"ts\">let { n }: { n: number } = $props();</script>\n<button>{n}</button>\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.join("src/App.svelte"),
+            "<script lang=\"ts\">import Button from '$lib/Button.svelte';</script>\n<Button n={1} />\n",
+        )
+        .unwrap();
+
+        let files = vec![
+            tmp.join("src/App.svelte"),
+            tmp.join("src/lib/Button.svelte"),
+        ];
+        let tsconfig = tmp.join("tsconfig.json");
+        materialize_overlay_with(&tmp, &files, Some(&tsconfig), false).unwrap();
+
+        let app_tsx =
+            fs::read_to_string(tmp.join(".svelte-check/svelte/src/App.svelte.tsx")).unwrap();
+        // The `$lib/Button.svelte` alias is gone, replaced by a concrete
+        // relative path at Button's shadow `.tsx` (which TS resolves directly,
+        // unlike the alias `rootDirs` can't bridge).
+        assert!(
+            !app_tsx.contains("$lib/Button.svelte"),
+            "alias was not rewritten:\n{app_tsx}"
+        );
+        assert!(
+            app_tsx.contains("Button.svelte.tsx"),
+            "rewrite did not point at the shadow:\n{app_tsx}"
         );
 
         let _ = fs::remove_dir_all(&tmp);


### PR DESCRIPTION
## Problem

On a real SvelteKit app, `rsvelte-check` reported **140 errors** that official
`svelte-check` does not — overwhelmingly `TS7006` "Parameter implicitly has an
'any' type" on callback props, plus some `TS1192` "Module has no default
export".

Root cause: the overlay materialises each `.svelte` source's typed shadow into
a separate mirror dir (`<cache>/svelte/…`) and bridges source → shadow with
`rootDirs`. But **TypeScript applies `rootDirs` only to *relative* module
specifiers.** An aliased import —

```ts
import Button from '$lib/components/.../Foo.svelte';
```

— is resolved through `paths`, which points at the raw source dir. There is no
`.tsx` shadow there, so:

- with no companion → the module is **unresolved → `any`**, and every inline
  callback prop on the component becomes a spurious implicit-any;
- with a sibling `Foo.svelte.ts` companion → it resolves to the **companion**
  (no default export) → spurious `TS1192`.

A minimal repro confirms the asymmetry (same `rootDirs`, file only in the
mirror): a relative `./x.svelte` import resolves through `rootDirs`, an aliased
`$lib/x.svelte` import gets `TS2307`. This is standard TS resolution — not a
tsgo/tsc bug.

Official `svelte-check` avoids all of this by resolving `.svelte` **in place**
via a `LanguageServiceHost.resolveModuleNames` hook + a virtual FS — a
programmatic API rsvelte can't use when it shells out to `tsgo`/`tsc`.

## Fix

Pre-resolve every **non-relative** `.svelte` import in each generated shadow
`.tsx` with **`oxc_resolver`** (which natively honours the project tsconfig
`paths` / `baseUrl` / `extends`), and rewrite it to a concrete relative path at
the target component's shadow `.tsx`. The backing compiler then resolves it
directly — the on-disk-CLI equivalent of svelte-check's in-memory resolver
hook. Relative `.svelte` imports are left untouched (they already bridge via
`rootDirs`); bare packages, `.svelte.ts` companions and cross-package
components are skipped.

- New dep: `oxc_resolver` (independent crate; no conflict with the git-pinned
  oxc AST crates).
- New helpers in `overlay.rs`: `build_svelte_import_resolver`,
  `rewrite_aliased_svelte_imports`, `rewrite_module_specifiers`,
  `lexical_relative_posix`.

## Verification

- New unit tests: `rewrite_module_specifiers_targets_only_real_specifiers`,
  `aliased_svelte_import_is_rewritten_to_its_shadow`.
- `cargo test -p rsvelte_core --lib svelte_check` (64 pass), `cargo clippy`,
  `cargo fmt`, `cargo doc` green.
- End-to-end on the same SvelteKit app: **140 → 43 errors** (`TS7006` 104 → 17).

## Scope / follow-up

This closes the **alias → shadow** resolution gap. The remaining 43 are
separate issues, not import resolution:

- SvelteKit route-load auto-typing — un-annotated `export const load = ({ parent, params }) => …`
  in `+layout.ts`/`+page.ts` (the proxy/`$types` typing official svelte-check applies).
- `Foo.svelte` + sibling `Foo.svelte.ts` companion edge cases (circular re-export / no default export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)