### PR TITLE
fix(svelte-check): resolve external package shadow imports from the package's own node_modules

### DIFF
--- a/.changeset/svelte-check-ext-package-node-modules.md
+++ b/.changeset/svelte-check-ext-package-node-modules.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+svelte-check: resolve an external package's `.svelte` shadow imports from the
+package's own `node_modules`.
+
+A monorepo sibling's `.svelte` shadows are emitted under `<cache>/ext/<n>/`.
+Their bare-package imports (`import type { SortableOptions } from 'sortablejs'`,
+including the matching `@types/*` declarations) were resolved by walking up to
+the *workspace* `node_modules`, missing any dependency present only in the
+external package's own tree — the imported type silently became `any`, which
+poisoned `ComponentProps<typeof Foo>` in every consumer (callback props turned
+into spurious implicit-any).
+
+The shadow dir now symlinks `<mirror>/node_modules` → `<real-pkg>/node_modules`,
+so bare imports resolve from the same context as in-place checking — no
+specifier rewriting, `@types` resolution intact. On a large SvelteKit app this
+cleared the cross-package `ComponentProps` cluster (25 → 10 reported errors).

--- a/.changeset/svelte-check-scope-diagnostics-to-workspace.md
+++ b/.changeset/svelte-check-scope-diagnostics-to-workspace.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+svelte-check: scope reported diagnostics to the checked workspace, matching
+official svelte-check, eliminating two classes of false positives.
+
+- **Cross-package source files.** In a monorepo a sibling package pulled in
+  transitively (e.g. `packages/design-system/...` resolved through a workspace
+  symlink) is that package's own concern — official svelte-check only reports
+  the invoked workspace's documents. rsvelte was surfacing the sibling's
+  internal diagnostics (such as a `Foo.svelte` + `Foo.svelte.ts` companion's
+  no-default-export edge) in every consumer's report. Diagnostics whose file
+  lives outside the workspace root are now dropped; use-site errors in the
+  workspace are unaffected.
+
+- **Raw SvelteKit route files.** A `+layout.ts` / `+page.ts` is a program root
+  and was type-checked WITHOUT rsvelte's kit injection (which wraps `load` in
+  `(…) satisfies …Load` so its destructured event is typed), producing false
+  `implicit-any` on un-annotated `load` params. The injected mirror under
+  `<cache>/svelte/…` is the authoritative version, so the raw source route
+  file's pre-injection diagnostics are now dropped.
+
+Together with the alias-import resolution fix, this takes a large SvelteKit app
+from 140 reported errors to 25 (the remainder are deeper svelte2tsx codegen
+divergences — generic-component `ComponentProps` typing and discriminated-union
+narrowing).

--- a/.changeset/svelte-check-scope-diagnostics-to-workspace.md
+++ b/.changeset/svelte-check-scope-diagnostics-to-workspace.md
@@ -21,7 +21,13 @@ official svelte-check, eliminating two classes of false positives.
   `<cache>/svelte/…` is the authoritative version, so the raw source route
   file's pre-injection diagnostics are now dropped.
 
+It also always pairs the workspace source root with the `<cache>/svelte` shadow
+mirror in `rootDirs` (previously the fallback, used when a project declares no
+`rootDirs` of its own, omitted it). Without the pairing a plain `.ts` /
+`.svelte.ts` source file importing `./Foo.svelte` resolved to nothing (`any`),
+silently degrading `ComponentProps<typeof Foo>` to `any`.
+
 Together with the alias-import resolution fix, this takes a large SvelteKit app
-from 140 reported errors to 25 (the remainder are deeper svelte2tsx codegen
-divergences — generic-component `ComponentProps` typing and discriminated-union
-narrowing).
+from 140 reported errors to 25 (the remainder are deeper cross-package
+ext-mirror `ComponentProps` typing and discriminated-union narrowing
+divergences).

--- a/crates/rsvelte_core/src/svelte_check/mapper.rs
+++ b/crates/rsvelte_core/src/svelte_check/mapper.rs
@@ -116,6 +116,22 @@ pub fn map_tsgo_diagnostics(
             by_kit.insert(rel.to_path_buf(), entry);
         }
     }
+    // The raw source route file (`+layout.ts` / `+page.ts`) is a program root
+    // and is type-checked WITHOUT rsvelte's kit injection (which wraps `load`
+    // in `(… ) satisfies …Load` so its destructured event is typed). That
+    // un-injected check yields false `implicit-any` on un-annotated `load`
+    // params. The injected mirror under `<cache>/svelte/…` (matched via
+    // `by_kit` → `out_path`) is the authoritative version, so drop diagnostics
+    // landing directly on the raw source route file.
+    let mut kit_source_paths: HashSet<PathBuf> = HashSet::new();
+    for entry in &overlay.kit_entries {
+        let canon = entry
+            .source_path
+            .canonicalize()
+            .unwrap_or_else(|_| entry.source_path.clone());
+        kit_source_paths.insert(canon);
+        kit_source_paths.insert(entry.source_path.clone());
+    }
     // Shadows for imported external packages live under `<cache>/ext/<n>/`.
     // Diagnostics landing on those files are library *internals* — official
     // svelte-check never type-checks a node_modules `.svelte` as a reported
@@ -145,6 +161,11 @@ pub fn map_tsgo_diagnostics(
         let canon = absolute.canonicalize().unwrap_or_else(|_| absolute.clone());
         // Suppress imported-library-internal diagnostics (see `ext_root` above).
         if absolute.starts_with(&ext_root) || canon.starts_with(&ext_root_canon) {
+            continue;
+        }
+        // Drop the raw (pre-injection) source route file's diagnostics; the
+        // injected kit mirror is the authoritative version (see above).
+        if kit_source_paths.contains(&canon) || kit_source_paths.contains(&absolute) {
             continue;
         }
         let kit_match = by_kit

--- a/crates/rsvelte_core/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_core/src/svelte_check/overlay.rs
@@ -540,7 +540,7 @@ fn looks_like_ts_svelte(source: &str) -> bool {
 fn build_overlay_tsconfig(
     cache_dir: &Path,
     original: Option<&Path>,
-    _workspace: &Path,
+    workspace: &Path,
     ext_root_dir_pairs: &[(PathBuf, PathBuf)],
 ) -> String {
     let mut obj: BTreeMap<&str, serde_json::Value> = BTreeMap::new();
@@ -568,7 +568,20 @@ fn build_overlay_tsconfig(
     let mut root_dirs_abs = original
         .map(resolve_root_dirs_abs)
         .filter(|v| !v.is_empty())
-        .unwrap_or_else(|| vec![cache_dir.to_path_buf()]);
+        .unwrap_or_default();
+    // Always pair the workspace source root with the `<cache>/svelte` shadow
+    // mirror. `rootDirs` is what bridges a `.svelte` import to its generated
+    // `.tsx` shadow, but TS applies it only to RELATIVE specifiers resolved
+    // across the listed roots — so a plain `.ts` / `.svelte.ts` source file
+    // importing `./Foo.svelte` needs the workspace root present to reach the
+    // mirror. SvelteKit projects declare `rootDirs: ["..", …]` (workspace
+    // included), but a project without its own `rootDirs` would otherwise fall
+    // back to the cache dir alone and lose the bridge entirely — every
+    // `.svelte` import from a `.ts` file then resolves to nothing (`any`),
+    // which silently poisons e.g. `ComponentProps<typeof Foo>`.
+    if !root_dirs_abs.iter().any(|p| p == workspace) {
+        root_dirs_abs.push(workspace.to_path_buf());
+    }
     root_dirs_abs.push(cache_dir.join("svelte"));
     // Each external package contributes a `rootDirs` pair: its real source dir
     // and the cache mirror holding its shadows. TypeScript then treats both as

--- a/crates/rsvelte_core/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_core/src/svelte_check/overlay.rs
@@ -429,7 +429,39 @@ fn discover_external_svelte_packages(workspace: &Path, cache_dir: &Path) -> Vec<
 /// its cache mirror, preserving each file's path relative to the package root.
 /// Non-incremental (external packages change rarely and are bounded by the
 /// dependency set).
+/// Symlink `<dst>` → `<src>` (a directory), cross-platform.
+fn symlink_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(src, dst)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(src, dst)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (src, dst);
+        Ok(())
+    }
+}
+
 fn emit_external_shadows(pkg: &ExternalPackage) -> Result<(), OverlayError> {
+    // Mirror the package's own `node_modules` into the shadow dir so the
+    // shadow's bare-package imports (`import type { X } from 'sortablejs'`,
+    // incl. its `@types/*` declarations) resolve from the SAME context as the
+    // real package. The shadows live under `<cache>/ext/<n>/`, where TS's
+    // walk-up would otherwise reach the *workspace* `node_modules` and miss a
+    // dependency present only in the external package's tree — silently
+    // degrading the imported type to `any` (and poisoning `ComponentProps<…>`
+    // in every consumer). A symlink keeps resolution identical to in-place
+    // checking without copying or rewriting specifiers.
+    let real_nm = pkg.real_dir.join("node_modules");
+    let mirror_nm = pkg.mirror_dir.join("node_modules");
+    if real_nm.is_dir() && !mirror_nm.exists() {
+        fs::create_dir_all(&pkg.mirror_dir)?;
+        let _ = symlink_dir(&real_nm, &mirror_nm);
+    }
     for abs_source in &pkg.svelte_files {
         let rel = abs_source.strip_prefix(&pkg.real_dir).unwrap_or(abs_source);
         let tsx_path = pkg.mirror_dir.join(append_extension(rel, ".tsx"));

--- a/crates/rsvelte_core/src/svelte_check/runner.rs
+++ b/crates/rsvelte_core/src/svelte_check/runner.rs
@@ -215,9 +215,36 @@ pub fn run(options: &RunOptions) -> RunResult {
         }
     }
 
+    // Scope reported diagnostics to the workspace being checked. Official
+    // svelte-check only reports the invoked workspace's own documents; a
+    // monorepo sibling pulled in transitively (e.g.
+    // `packages/frontend/design-system/...` resolved through a workspace
+    // symlink) is that package's own concern — its internal diagnostics (such
+    // as a `Foo.svelte` + `Foo.svelte.ts` companion's no-default-export edge)
+    // must not leak into every consumer's report. Errors at the *use* site in
+    // the workspace are unaffected; only diagnostics whose file lives outside
+    // the workspace root are dropped.
+    drop_out_of_workspace_diagnostics(&mut result.diagnostics, &options.workspace);
+
     apply_filters(&mut result.diagnostics, options);
 
     result
+}
+
+/// Drop diagnostics whose file lives outside the checked workspace root.
+fn drop_out_of_workspace_diagnostics(diagnostics: &mut Vec<Diagnostic>, workspace: &Path) {
+    let ws = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+    diagnostics.retain(|d| {
+        let abs = if d.file.is_absolute() {
+            d.file.clone()
+        } else {
+            workspace.join(&d.file)
+        };
+        let canon = abs.canonicalize().unwrap_or(abs);
+        canon.starts_with(&ws)
+    });
 }
 
 /// Apply compiler-warnings + diagnostic-source filters in place.


### PR DESCRIPTION
## Problem

`ComponentProps<typeof Sortable>['options']` (and similar) resolved to `any` for
a component imported from a monorepo-sibling package, turning every inline
callback prop into a spurious `implicit-any`. On a large SvelteKit app this was
the dominant remaining cluster (~15 errors).

Root cause: an external package's `.svelte` shadows are emitted under
`<cache>/ext/<n>/`. A shadow's bare-package import —

```ts
import type { SortableOptions } from 'sortablejs';
```

— was resolved by walking up from the **cache** dir to the **workspace**
`node_modules`. A dependency present only in the external package's own tree
(`sortablejs` + its `@types/sortablejs` declarations live in
`packages/design-system/node_modules`, not the app's) was therefore not found,
and `SortableOptions` silently became `any` — which poisoned the component's
prop type and every `ComponentProps<typeof …>` consumer.

## Fix

Symlink `<mirror>/node_modules` → `<real-pkg>/node_modules` so the shadow
resolves bare imports (and their `@types/*`) from the **same context as in-place
checking** — exactly what official svelte-check gets from its in-memory virtual
FS, with no specifier rewriting.

## Verification

- `cargo test -p rsvelte_core --lib svelte_check` (64 pass), `cargo clippy`, `cargo fmt`.
- End-to-end on the SvelteKit app: **25 → 10** reported errors (the cross-package
  `ComponentProps` cluster cleared); official `svelte-check` reports 0 on the
  same app.

## Cumulative

With the four prior svelte-check fixes (`0.3.0`/`0.3.1`) this brings the app from
**140 → 10**. The remaining 10 are heterogeneous, codegen-identical
narrowing / inference divergences (discriminated-union narrowing through a
`$bindable` deep property, `Promise.then` param inference, a couple of `null`
casts) — each a separate deep investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)