### PR TITLE
chore(deps): update dependency svelte to v5.56.4

### DIFF
--- a/apps/npm/vite-plugin-svelte/package.json
+++ b/apps/npm/vite-plugin-svelte/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.12",
     "sass": "^1.94.2",
-    "svelte": "^5.45.4",
+    "svelte": "^5.56.4",
     "vite": "^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"oxfmt": "^0.56.0",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.1.0",
-		"svelte": "^5.56.2"
+		"svelte": "^5.56.4"
 	},
 	"packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,16 +19,16 @@ importers:
         version: 0.28.1
       oxfmt:
         specifier: ^0.56.0
-        version: 0.56.0(svelte@5.56.3)
+        version: 0.56.0(svelte@5.56.4)
       prettier:
         specifier: ^3.8.3
         version: 3.8.4
       prettier-plugin-svelte:
         specifier: ^4.1.0
-        version: 4.1.1(prettier@3.8.4)(svelte@5.56.3)
+        version: 4.1.1(prettier@3.8.4)(svelte@5.56.4)
       svelte:
-        specifier: ^5.56.2
-        version: 5.56.3
+        specifier: ^5.56.4
+        version: 5.56.4
 
   apps/npm/compiler:
     publishDirectory: ../../../pkg
@@ -106,7 +106,7 @@ importers:
         version: link:../vite-plugin-svelte-native
       '@sveltejs/vite-plugin-svelte-inspector':
         specifier: ^5.0.0
-        version: 5.0.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0)))(svelte@5.56.3)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0))
+        version: 5.0.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0)))(svelte@5.56.4)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0))
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -127,8 +127,8 @@ importers:
         specifier: ^1.94.2
         version: 1.101.0
       svelte:
-        specifier: ^5.45.4
-        version: 5.56.3
+        specifier: ^5.56.4
+        version: 5.56.4
       vite:
         specifier: ^8.0.0
         version: 8.1.0(esbuild@0.28.1)(sass@1.101.0)
@@ -1400,6 +1400,10 @@ packages:
     resolution: {integrity: sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==}
     engines: {node: '>=18'}
 
+  svelte@5.56.4:
+    resolution: {integrity: sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==}
+    engines: {node: '>=18'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -2014,19 +2018,19 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0)))(svelte@5.56.3)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0)))(svelte@5.56.4)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.4)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0))
       obug: 2.1.3
-      svelte: 5.56.3
+      svelte: 5.56.4
       vite: 8.1.0(esbuild@0.28.1)(sass@1.101.0)
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.3
-      svelte: 5.56.3
+      svelte: 5.56.4
       vite: 8.1.0(esbuild@0.28.1)(sass@1.101.0)
       vitefu: 1.1.3(vite@8.1.0(esbuild@0.28.1)(sass@1.101.0))
 
@@ -2345,7 +2349,7 @@ snapshots:
       '@oxfmt/binding-win32-x64-msvc': 0.53.0
       svelte: 5.56.3
 
-  oxfmt@0.56.0(svelte@5.56.3):
+  oxfmt@0.56.0(svelte@5.56.4):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -2368,7 +2372,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.56.0
       '@oxfmt/binding-win32-ia32-msvc': 0.56.0
       '@oxfmt/binding-win32-x64-msvc': 0.56.0
-      svelte: 5.56.3
+      svelte: 5.56.4
 
   p-filter@2.1.0:
     dependencies:
@@ -2410,10 +2414,10 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier-plugin-svelte@4.1.1(prettier@3.8.4)(svelte@5.56.3):
+  prettier-plugin-svelte@4.1.1(prettier@3.8.4)(svelte@5.56.4):
     dependencies:
       prettier: 3.8.4
-      svelte: 5.56.3
+      svelte: 5.56.4
 
   prettier@2.8.8: {}
 
@@ -2499,6 +2503,28 @@ snapshots:
   strip-bom@3.0.0: {}
 
   svelte@5.56.3:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.17.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.8.1
+      esm-env: 1.2.2
+      esrap: 2.2.12
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+    optional: true
+
+  svelte@5.56.4:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5


### PR DESCRIPTION
Re-creates Renovate #1147 on top of current `main`. #1147 conflicted in `pnpm-lock.yaml` once #1132 (vite 8.1.0) merged — both edit the same importer version strings. This bumps locked `svelte` 5.56.3 → 5.56.4 cleanly against current main, with matching devDependency range bumps. Lockfile installs frozen and is conflict-free.

Note: CI's `pnpm install` will fail the 24h `minimumReleaseAge` gate until svelte@5.56.4 ages past 2026-06-24T18:48Z, after which it self-greens. Merged early per request on the unprotected `main`.

Supersedes #1147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfZpa28FjLaRBVioSS3cDi