### PR TITLE
fix(fmt): re-indent batched <style> bodies in the write/check path

### DIFF
--- a/.changeset/fmt-style-reindent-write-path.md
+++ b/.changeset/fmt-style-reindent-write-path.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fmt: fix inline `<style>` blocks being mangled in the file (`--write` / `--check`)
+path. The batched style pipeline records each raw `<style>` body and emits a
+single-line placeholder during the format pass, then formats every body in one
+`oxfmt` call and splices the results back. The splice was a plain string
+replace, so the in-process formatter's re-indentation never reached the
+multi-line CSS: every line after the first stayed at column 0 and `oxfmt`'s
+trailing newline leaked in as a blank line before `</style>`. On a real corpus
+this diverged ~33% of components from the `--stdin` path (which re-indents
+correctly). The splice now re-indents with the same routine the single-file /
+stdin path uses, so both paths are byte-identical.
+
+The batch also formatted every `<style>` body at the base print width, so a
+column-sensitive long selector or value wrapped differently from `oxfmt` (which
+narrows by the block's indentation). Bodies are now grouped by their rendered
+width — one `oxfmt` call per distinct width — so wrapping matches the stdin path
+while still batching (nearly every block shares one width). The `<style>` cache
+key now includes the width so the same body at two indentations can't collide.

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -14,7 +14,7 @@ use ignore::WalkBuilder;
 use oxc_formatter::JsFormatOptions;
 use oxc_formatter_core::{IndentStyle, IndentWidth, LineWidth};
 use rayon::prelude::*;
-use rsvelte_formatter::{FormatOptions, format};
+use rsvelte_formatter::{FormatOptions, format, reindent};
 
 mod config;
 mod oxfmt_ignore;
@@ -500,11 +500,24 @@ fn is_svelte(p: &Path) -> bool {
 
 // ─── Svelte pipeline ────────────────────────────────────────────────────
 
-/// A `<style>` body captured during pass 1, to be formatted in the
-/// single batched `oxfmt` call instead of one spawn per block.
+/// A `<style>` body captured during pass 1, to be formatted in a batched
+/// `oxfmt` call (one per distinct print width) instead of one spawn per block.
 struct CollectedStyle {
     css: String,
     lang: String,
+    /// Print width the block must format at — the global width narrowed by the
+    /// block's indentation, exactly as the single-file/stdin path computes it.
+    /// Blocks are batched per width so column-sensitive wrapping matches oxfmt.
+    width: usize,
+}
+
+/// A `<style>` body to format, borrowing from the per-file [`CollectedStyle`]s.
+/// Carries the print width so the batch pass can group blocks by width.
+#[derive(Clone, Copy)]
+struct Style<'a> {
+    css: &'a str,
+    lang: &'a str,
+    width: usize,
 }
 
 /// Result of pass 1 for a single `.svelte` file.
@@ -521,6 +534,34 @@ struct Pass1 {
 /// the substitution can't collide with real content.
 fn style_placeholder(local_idx: usize) -> String {
     format!("\u{0}RSVELTE_FMT_STYLE_{local_idx}\u{0}")
+}
+
+/// Splice one batched-`oxfmt` `<style>` result back in place of its placeholder.
+///
+/// Pass 1 records each raw `<style>` body and emits a single-line placeholder; the
+/// in-process formatter positions that placeholder at the body's indent (one level
+/// past the `<style>` tag) but, being one line, never re-indents the multi-line CSS
+/// that replaces it here. A plain `String::replace` therefore left every CSS line
+/// after the first at column 0 and kept oxfmt's trailing newline (a stray blank
+/// line before `</style>`). Re-indent with the *same* [`reindent`] the single-file
+/// / stdin path applies, so both paths are byte-identical (#1166).
+///
+/// The placeholder sits alone on its line, preceded only by the body indent, so
+/// that leading whitespace is the indent to apply. If it is ever not alone on its
+/// line (it shouldn't be), fall back to a verbatim replace rather than corrupt the
+/// output.
+fn substitute_style(out: &mut String, placeholder: &str, css: &str) {
+    let Some(pos) = out.find(placeholder) else {
+        return;
+    };
+    let line_start = out[..pos].rfind('\n').map_or(0, |i| i + 1);
+    let indent = &out[line_start..pos];
+    if indent.bytes().all(|b| b == b' ' || b == b'\t') {
+        let reindented = reindent(css, indent);
+        out.replace_range(line_start..pos + placeholder.len(), &reindented);
+    } else {
+        out.replace_range(pos..pos + placeholder.len(), css);
+    }
 }
 
 /// Format every `.svelte` file, batching all their `<style>` bodies into a
@@ -547,12 +588,16 @@ fn run_svelte_files(
         .collect();
 
     // ── Flatten collected styles across all files, keyed by (file, local) ──
-    let mut slot_css: Vec<(&str, &str)> = Vec::new(); // (css, lang) in batch order
+    let mut slot_css: Vec<Style> = Vec::new(); // (css, lang, width) in batch order
     let mut slot_owner: Vec<(usize, usize)> = Vec::new(); // (file_idx, local_idx)
     for (fi, p1) in pass1.iter().enumerate() {
         if let Ok((_, styles)) = &p1.outcome {
             for (li, st) in styles.iter().enumerate() {
-                slot_css.push((&st.css, &st.lang));
+                slot_css.push(Style {
+                    css: &st.css,
+                    lang: &st.lang,
+                    width: st.width,
+                });
                 slot_owner.push((fi, li));
             }
         }
@@ -598,7 +643,7 @@ fn run_svelte_files(
         };
         for li in 0..styles.len() {
             let css = per_file[fi].get(li).cloned().unwrap_or_default();
-            out = out.replace(&style_placeholder(li), &css);
+            substitute_style(&mut out, &style_placeholder(li), &css);
         }
         match apply_output(&p1.path, &p1.source, &out, mode) {
             Ok(true) => status.files_changed += 1,
@@ -629,17 +674,18 @@ fn format_collecting(path: &Path, options: &FormatOptions) -> Pass1 {
     let styles: Arc<std::sync::Mutex<Vec<CollectedStyle>>> = Arc::default();
     let sink = styles.clone();
     let mut opts = options.clone();
-    // The multi-file batch path collects all `<style>` bodies for one batched
-    // oxfmt call shared across files, so it formats them at the base print width
-    // (per-width narrowing — see make_oxfmt_style_formatter — would defeat the
-    // batch). CSS whose wrapping is sensitive to the style's column is a minor
-    // edge here; the single-file / stdin path narrows correctly.
-    opts.style_formatter = Some(Arc::new(move |body: &str, lang: &str, _width: usize| {
+    // Record each `<style>` body with the print width it must format at (the
+    // global width narrowed by the block's indentation). The batch pass groups
+    // blocks by width and runs one oxfmt call per distinct width, so
+    // column-sensitive wrapping matches the single-file / stdin path (and oxfmt)
+    // while still batching — nearly every block shares one width (#1166).
+    opts.style_formatter = Some(Arc::new(move |body: &str, lang: &str, width: usize| {
         let mut v = sink.lock().expect("style sink poisoned");
         let idx = v.len();
         v.push(CollectedStyle {
             css: body.to_string(),
             lang: lang.to_string(),
+            width,
         });
         Ok(style_placeholder(idx))
     }));
@@ -673,7 +719,7 @@ fn format_collecting(path: &Path, options: &FormatOptions) -> Pass1 {
 fn format_styles_cached(
     oxfmt: &Path,
     config: Option<&Path>,
-    styles: &[(&str, &str)],
+    styles: &[Style],
     cache: Option<&StyleCache>,
 ) -> Result<Vec<String>> {
     if styles.is_empty() {
@@ -685,16 +731,18 @@ fn format_styles_cached(
         return Ok(batch_format_styles(oxfmt, config, styles)?.0);
     };
 
-    // Partition into cache hits and misses, preserving input order.
+    // Partition into cache hits and misses, preserving input order. The cache
+    // key includes the width, so the same body at two indentations is two
+    // distinct entries (its wrapping differs).
     let mut results: Vec<Option<String>> = Vec::with_capacity(styles.len());
-    let mut miss_styles: Vec<(&str, &str)> = Vec::new();
+    let mut miss_styles: Vec<Style> = Vec::new();
     let mut miss_slots: Vec<usize> = Vec::new();
-    for (i, (css, lang)) in styles.iter().enumerate() {
-        match cache.get(css, lang) {
+    for (i, s) in styles.iter().enumerate() {
+        match cache.get(s.css, s.lang, s.width) {
             Some(hit) => results.push(Some(hit)),
             None => {
                 results.push(None);
-                miss_styles.push((css, lang));
+                miss_styles.push(*s);
                 miss_slots.push(i);
             }
         }
@@ -707,8 +755,8 @@ fn format_styles_cached(
             // body round-trips unchanged; caching that would pin the unformatted
             // form, so skip it and let the next run retry.
             if ok {
-                let (body, lang) = styles[*slot];
-                cache.put(body, lang, &css);
+                let s = styles[*slot];
+                cache.put(s.css, s.lang, s.width, &css);
             }
             results[*slot] = Some(css);
         }
@@ -717,17 +765,60 @@ fn format_styles_cached(
     Ok(results.into_iter().map(|r| r.unwrap_or_default()).collect())
 }
 
-/// Format every collected `<style>` body in a single `oxfmt` invocation by
-/// staging each into a temp directory and running `oxfmt <dir>` (in-place),
-/// then reading them back. Returns the formatted CSS in input order plus
-/// whether oxfmt exited successfully (so callers can decide whether to cache).
+/// Format a set of `<style>` bodies, grouping by print width so each block wraps
+/// at the column it renders at (matching the single-file / stdin path and oxfmt).
+///
+/// Column-sensitive CSS — a long selector or value near the wrap point — must be
+/// formatted at the global width *minus its indentation*, or it diverges from
+/// oxfmt. Nearly every block shares one width, so grouping costs at most a couple
+/// of extra oxfmt round-trips while restoring parity. Results are returned in the
+/// input order. The combined `ok` is false if any width group's oxfmt failed.
+fn batch_format_styles(
+    oxfmt: &Path,
+    config: Option<&Path>,
+    styles: &[Style],
+) -> Result<(Vec<String>, bool)> {
+    if styles.is_empty() {
+        return Ok((Vec::new(), true));
+    }
+
+    let mut by_width: std::collections::BTreeMap<usize, Vec<usize>> =
+        std::collections::BTreeMap::new();
+    for (i, s) in styles.iter().enumerate() {
+        by_width.entry(s.width).or_default().push(i);
+    }
+
+    let mut results = vec![String::new(); styles.len()];
+    let mut all_ok = true;
+    for (width, idxs) in by_width {
+        let group: Vec<(&str, &str)> = idxs
+            .iter()
+            .map(|&i| (styles[i].css, styles[i].lang))
+            .collect();
+        // Narrow the project config to this width so oxfmt wraps embedded CSS at
+        // the same column the block renders at (falls back to the base config).
+        let cfg = css_config_for_width(config, width);
+        let (formatted, ok) = batch_format_styles_group(oxfmt, cfg.as_deref(), &group)?;
+        all_ok &= ok;
+        for (slot, css) in idxs.into_iter().zip(formatted) {
+            results[slot] = css;
+        }
+    }
+    Ok((results, all_ok))
+}
+
+/// Format one same-width group of `<style>` bodies in a single `oxfmt`
+/// invocation by staging each into a temp directory and running `oxfmt <dir>`
+/// (in-place), then reading them back. Returns the formatted CSS in input order
+/// plus whether oxfmt exited successfully (so callers can decide whether to
+/// cache). `config` is the (width-narrowed) config to force via `-c`.
 ///
 /// The styles are handed to oxfmt as a single **directory** argument rather
 /// than N explicit file paths: oxfmt parallelizes its directory walk, and on
 /// large trees a multi-thousand-entry argv can also be slower (or hit
 /// `ARG_MAX`). The staging dir holds only our `s{i}.{ext}` files, so the walk
 /// formats exactly the set we read back. See #707.
-fn batch_format_styles(
+fn batch_format_styles_group(
     oxfmt: &Path,
     config: Option<&Path>,
     styles: &[(&str, &str)],

--- a/crates/rsvelte_fmt/src/style_cache.rs
+++ b/crates/rsvelte_fmt/src/style_cache.rs
@@ -58,17 +58,18 @@ impl StyleCache {
         Some(StyleCache { dir, salt })
     }
 
-    /// Look up the formatted form of `(body, lang)`. Returns the cached bytes
-    /// on a hit, `None` on a miss.
-    pub(crate) fn get(&self, body: &str, lang: &str) -> Option<String> {
-        let key = self.key(body, lang);
+    /// Look up the formatted form of `(body, lang, width)`. Returns the cached
+    /// bytes on a hit, `None` on a miss. The width is part of the key because the
+    /// same body wraps differently when narrowed to a different column.
+    pub(crate) fn get(&self, body: &str, lang: &str, width: usize) -> Option<String> {
+        let key = self.key(body, lang, width);
         std::fs::read_to_string(self.path_for(&key)).ok()
     }
 
-    /// Store `formatted` as the canonical form of `(body, lang)`. Best-effort:
-    /// any I/O error is ignored (the cache is purely an optimization).
-    pub(crate) fn put(&self, body: &str, lang: &str, formatted: &str) {
-        let key = self.key(body, lang);
+    /// Store `formatted` as the canonical form of `(body, lang, width)`.
+    /// Best-effort: any I/O error is ignored (the cache is purely an optimization).
+    pub(crate) fn put(&self, body: &str, lang: &str, width: usize, formatted: &str) {
+        let key = self.key(body, lang, width);
         let path = self.path_for(&key);
         if let Some(parent) = path.parent()
             && std::fs::create_dir_all(parent).is_err()
@@ -88,9 +89,9 @@ impl StyleCache {
     /// 128-bit content key as hex (two SipHashes with distinct salts —
     /// collision probability is astronomically small for content addressing,
     /// and a key only needs to be stable within a single binary build).
-    fn key(&self, body: &str, lang: &str) -> String {
-        let h0 = hash_parts(0xA5, &self.salt, lang, body);
-        let h1 = hash_parts(0x5A, &self.salt, lang, body);
+    fn key(&self, body: &str, lang: &str, width: usize) -> String {
+        let h0 = hash_parts(0xA5, &self.salt, lang, body, width);
+        let h1 = hash_parts(0x5A, &self.salt, lang, body, width);
         format!("{h0:016x}{h1:016x}")
     }
 
@@ -100,7 +101,7 @@ impl StyleCache {
     }
 }
 
-fn hash_parts(salt_byte: u8, run_salt: &[u8], lang: &str, body: &str) -> u64 {
+fn hash_parts(salt_byte: u8, run_salt: &[u8], lang: &str, body: &str, width: usize) -> u64 {
     let mut h = std::collections::hash_map::DefaultHasher::new();
     // `Hash` for slices/strings writes a length prefix, so the parts are
     // unambiguously delimited (no concatenation collisions).
@@ -108,6 +109,7 @@ fn hash_parts(salt_byte: u8, run_salt: &[u8], lang: &str, body: &str) -> u64 {
     run_salt.hash(&mut h);
     lang.hash(&mut h);
     body.hash(&mut h);
+    width.hash(&mut h);
     h.finish()
 }
 

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -608,6 +608,183 @@ fn check_excludes_svelte_via_prettierignore() {
     assert_eq!(out.status.code(), Some(1));
 }
 
+// ─── Batched `<style>` re-indentation + per-width parity (#1166) ──────────
+
+/// An identity fake oxfmt: in `<style>` staging mode it leaves the (already
+/// dedented) bodies untouched, and in the stdin per-block mode it copies stdin
+/// to stdout verbatim. This isolates the *re-embedding* (re-indent + trailing
+/// newline handling) the dispatcher does around oxfmt, so the batch (`--write`)
+/// path and the single-block (`--stdin`) path must produce identical output.
+const IDENTITY_OXFMT: &str = r#"const fs = require('node:fs');
+const path = require('node:path');
+const args = process.argv.slice(2);
+// Mimic the surrounding-whitespace normalization a real CSS formatter applies:
+// strip a leading blank line and trailing whitespace, end with one newline. The
+// dispatcher hands oxfmt the *dedented* body (which has a leading empty line from
+// the newline after `<style>`); a real oxfmt drops it, so identity must too.
+const norm = (s) => s.replace(/^[ \t]*\n/, '').replace(/\s+$/, '') + '\n';
+if (args.includes('--stdin-filepath')) {
+  process.stdout.write(norm(fs.readFileSync(0, 'utf8')));
+} else {
+  for (const p of args) {
+    if (p.startsWith('-') || p.startsWith('!')) continue;
+    let st; try { st = fs.statSync(p); } catch { continue; }
+    if (st.isFile() && !p.endsWith('.json')) fs.writeFileSync(p, norm(fs.readFileSync(p, 'utf8')));
+    else if (st.isDirectory() && path.basename(p).startsWith('rsvelte-fmt-styles-')) {
+      for (const e of fs.readdirSync(p)) { const fp = path.join(p, e); if (fs.statSync(fp).isFile()) fs.writeFileSync(fp, norm(fs.readFileSync(fp, 'utf8'))); }
+    }
+  }
+}
+"#;
+
+/// Regression: the batched `--write` path must re-indent a multi-line `<style>`
+/// body one level under the tag — not leave lines 2..N at column 0 with a stray
+/// blank line before `</style>` (the bug behind ~33% of a real corpus diverging).
+#[test]
+fn write_path_reindents_multiline_style_body() {
+    let dir = tempdir();
+    let fake = dir.join("identity-oxfmt.cjs");
+    std::fs::write(&fake, IDENTITY_OXFMT).unwrap();
+
+    let file = dir.join("C.svelte");
+    std::fs::write(
+        &file,
+        "<div>x</div>\n\n<style>\n  .a {\n    color: red;\n    background: blue;\n  }\n</style>\n",
+    )
+    .unwrap();
+
+    let status = Command::new(bin())
+        .args([
+            file.to_str().unwrap(),
+            "--write",
+            "--no-style-cache",
+            "--oxfmt-bin",
+            fake.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "exit code: {:?}", status.code());
+
+    let out = std::fs::read_to_string(&file).unwrap();
+    let want =
+        "<div>x</div>\n\n<style>\n  .a {\n    color: red;\n    background: blue;\n  }\n</style>\n";
+    assert_eq!(
+        out, want,
+        "style body not re-indented under the tag:\n{out}"
+    );
+}
+
+/// The batched `--write` path and the single-block `--stdin` path must be
+/// byte-identical for the same `<style>` file: both dedent the body, run it
+/// through oxfmt, and re-embed with the same re-indentation.
+#[test]
+fn write_and_stdin_paths_agree_on_style() {
+    let dir = tempdir();
+    let fake = dir.join("identity-oxfmt.cjs");
+    std::fs::write(&fake, IDENTITY_OXFMT).unwrap();
+
+    let src = "<section>\n  <p>hi</p>\n</section>\n\n<style>\n  .a {\n    color: red;\n  }\n\n  .b > .c {\n    margin: 0;\n  }\n</style>\n";
+
+    // stdin path → stdout
+    let (stdout, _stderr, code) = run_stdin(
+        src,
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            "x.svelte",
+            "--oxfmt-bin",
+            fake.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0, "stdin path failed");
+
+    // write path → file
+    let file = dir.join("x.svelte");
+    std::fs::write(&file, src).unwrap();
+    let status = Command::new(bin())
+        .args([
+            file.to_str().unwrap(),
+            "--write",
+            "--no-style-cache",
+            "--oxfmt-bin",
+            fake.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let written = std::fs::read_to_string(&file).unwrap();
+
+    assert_eq!(written, stdout, "write and stdin paths diverged");
+}
+
+/// Each `<style>` block must be formatted at its own print width (global width
+/// minus its indentation), so a top-level block and a deeper nested block reach
+/// oxfmt with *different* `printWidth` configs — even when batched together.
+/// A fake oxfmt stamps the `printWidth` it was handed via `-c`.
+#[test]
+fn batched_styles_format_at_per_block_width() {
+    let dir = tempdir();
+    let fake = dir.join("width-oxfmt.cjs");
+    std::fs::write(
+        &fake,
+        r#"const fs = require('node:fs');
+const path = require('node:path');
+const args = process.argv.slice(2);
+let width = '?';
+const ci = args.indexOf('-c');
+if (ci >= 0 && args[ci + 1]) {
+  try { const j = JSON.parse(fs.readFileSync(args[ci + 1], 'utf8')); if (j.printWidth != null) width = String(j.printWidth); } catch {}
+}
+function stamp(p) { fs.writeFileSync(p, `/*W=${width}*/ ` + fs.readFileSync(p, 'utf8')); }
+for (const p of args) {
+  if (p.startsWith('-') || p.startsWith('!')) continue;
+  let st; try { st = fs.statSync(p); } catch { continue; }
+  if (st.isFile() && !p.endsWith('.json')) stamp(p);
+  else if (st.isDirectory() && path.basename(p).startsWith('rsvelte-fmt-styles-')) {
+    for (const e of fs.readdirSync(p)) { const fp = path.join(p, e); if (fs.statSync(fp).isFile()) stamp(fp); }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    // Top-level <style> renders at body indent 2 (width 100-2=98); the nested
+    // <style> inside <div> renders deeper at body indent 4 (width 100-4=96).
+    let file = dir.join("W.svelte");
+    std::fs::write(
+        &file,
+        "<div>\n  <style>.x {\n    color: red;\n  }</style>\n</div>\n\n<style>.y {\n  color: blue;\n}</style>\n",
+    )
+    .unwrap();
+
+    let status = Command::new(bin())
+        .args([
+            file.to_str().unwrap(),
+            "--write",
+            "--no-style-cache",
+            "--print-width",
+            "100",
+            "--oxfmt-bin",
+            fake.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "exit code: {:?}", status.code());
+
+    let out = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        out.contains("/*W=98*/"),
+        "top-level block width wrong:\n{out}"
+    );
+    assert!(out.contains("/*W=96*/"), "nested block width wrong:\n{out}");
+}
+
 fn tempdir() -> PathBuf {
     let mut dir = std::env::temp_dir();
     dir.push(format!(

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -27,6 +27,7 @@ mod style;
 
 pub use error::FormatError;
 pub use options::{FormatOptions, StyleFormatter};
+pub use style::reindent;
 
 // Re-exports so consumers don't need to depend on `oxc_formatter` directly.
 pub use oxc_formatter::JsFormatOptions;

--- a/crates/rsvelte_formatter/src/style.rs
+++ b/crates/rsvelte_formatter/src/style.rs
@@ -264,8 +264,13 @@ fn dedent(s: &str) -> String {
 
 /// Prefix every non-empty line of `s` with `indent`, dropping any trailing
 /// newline (the splice adds its own surrounding newlines). Lines inside a
-/// multi-line `/* … */` comment are left verbatim (see [`dedent`]).
-fn reindent(s: &str, indent: &str) -> String {
+/// multi-line `/* … */` comment are left verbatim (the inverse of `dedent`).
+///
+/// Exposed for the `rsvelte-fmt` CLI: its batched `<style>` path collects raw
+/// bodies during the format pass (returning a placeholder) and formats them in
+/// one oxfmt call afterwards, so it must re-indent the formatted CSS with the
+/// *same* routine the single-file/stdin path uses here to stay byte-identical.
+pub fn reindent(s: &str, indent: &str) -> String {
     let trimmed = s.trim_end_matches('\n');
     let cont = comment_continuation_flags(trimmed);
     let mut out = Vec::new();


### PR DESCRIPTION
## Problem

`rsvelte-fmt` mangled inline `<style>` blocks in the **file** path (`--write` / `--check`), while the `--stdin` path was correct. On a real 1,148-component corpus this diverged **376 files (~33%)** from oxfmt — almost all of them `<style>`-bearing.

The batched style pipeline records each raw `<style>` body and emits a single-line placeholder during the format pass, then formats every body in one `oxfmt` call and splices the results back. The splice was a plain `String::replace`, so the in-process formatter's re-indentation only ever positioned the placeholder (one line) — never the multi-line CSS that replaced it:

```css
/* before (write path) */            /* after / stdin / oxfmt */
<style>                              <style>
  .a {                                 .a {
  color: red;        ← col 0             color: red;
}                    ← col 0           }
                     ← stray blank    </style>
</style>
```

Every CSS line after the first stayed at column 0, and oxfmt's trailing newline leaked in as a blank line before `</style>`.

## Fix

1. **Re-indent on splice.** Expose `reindent` from `rsvelte_formatter` and use it when substituting the batched result, so the write/check path re-embeds CSS exactly like the single-file/stdin path. **Both paths are now byte-identical.** (376 → 48 on the corpus; the remaining 48 are pre-existing markup-wrapping divergences, unrelated to `<style>`.)
2. **Per-block width.** The batch formatted every body at the base print width, so a column-sensitive long selector/value wrapped differently from oxfmt (which narrows by the block's indentation). Bodies are now grouped by rendered width — one oxfmt call per distinct width — restoring parity while still batching (nearly every block shares one width). The `<style>` cache key now includes the width so the same body at two indentations can't collide.

## Tests

- `write_path_reindents_multiline_style_body` — regression for the splice bug
- `write_and_stdin_paths_agree_on_style` — the byte-identical invariant
- `batched_styles_format_at_per_block_width` — top-level vs nested reach oxfmt at different widths

`cargo test` (rsvelte_fmt + rsvelte_formatter), `cargo clippy`, `cargo fmt`, and a full `cargo build --workspace` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)