### PR TITLE
fix(fmt): markup-wrap burndown — comment-glued sections + class: directive narrowing

### DIFF
--- a/.changeset/fmt-class-directive-narrow.md
+++ b/.changeset/fmt-class-directive-narrow.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fmt: narrow a wrapped `class:NAME={EXPR}` directive value by its `class:NAME=`
+prefix, like `style:` / `on:` / `use:` already do (#795). When the open tag
+wraps and the directive's full line overflows the print width, its value now
+breaks at the right operator instead of staying flat past the margin.

--- a/.changeset/fmt-comment-glued-to-section.md
+++ b/.changeset/fmt-comment-glued-to-section.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fmt: don't insert a blank line between a comment and the `<style>` / `<script>`
+it leads. The section-reorder pass treated a markup gap that ended with a
+comment glued to the next section (e.g. `</div>\n<!-- … -->\n<style>`) as one
+markup unit, then joined it to the section with a blank line — pushing the
+comment away from the tag it documents. The trailing comment run is now split
+off and attached to the section as its leading comment, so the blank line falls
+before the comment (matching prettier-plugin-svelte / oxfmt). UTF-8 safe for
+multi-byte markup text.

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -1342,7 +1342,20 @@ fn render_attribute(
             }
         }
         Attribute::ClassDirective(d) => {
-            let inner = render_directive_value(source, &d.expression, d.end, options, attr_depth)?;
+            // Columns before the value's `{`: `class:` + name + `=` (the `{` is
+            // counted separately). Narrowing by this prefix once the open tag has
+            // wrapped makes a long value break where prettier-plugin-svelte does
+            // (#795) — matching `style:` / `on:` / `use:` etc.
+            let prefix = visual_width("class:") + visual_width(d.name.as_str()) + 1;
+            let inner = render_directive_value_narrow(
+                source,
+                &d.expression,
+                d.end,
+                options,
+                attr_depth,
+                narrow_value,
+                prefix,
+            )?;
             if inner == d.name.as_str() {
                 Ok(format!("class:{}", d.name))
             } else {

--- a/crates/rsvelte_formatter/src/sort_order.rs
+++ b/crates/rsvelte_formatter/src/sort_order.rs
@@ -66,11 +66,38 @@ pub(crate) fn reorder_sections(out: &str, mut sections: Vec<(u8, usize, usize)>)
     for &(priority, start, end) in &sections {
         let gap = &out[cursor..start];
         let gap_trim = gap.trim();
-        if !gap_trim.is_empty() && is_comment_only(gap) {
-            // The gap is a comment-only block — it becomes the leading comment
-            // of this section.  Preserve the separator between the comment and
-            // the section as it appears in the source: a blank line (`\n\n`)
-            // if the source had one, a single newline otherwise.
+        let section_text = out[start..end].trim();
+
+        // A comment run glued to the section (no other markup between the last
+        // `-->` and the opening tag) is the section's leading comment and travels
+        // with it. This is the whole gap when it is comment-only, or just the
+        // trailing comment run when markup precedes it (e.g.
+        // `</div>\n<!-- … -->\n<style>` — the comment leads `<style>`, not the
+        // markup). The preceding markup, if any, stays a markup unit.
+        let (markup_part, comment_run): (&str, &str) = if gap_trim.is_empty() {
+            ("", "")
+        } else if is_comment_only(gap) {
+            ("", gap_trim)
+        } else {
+            split_trailing_comment_run(gap).unwrap_or((gap_trim, ""))
+        };
+
+        if !markup_part.is_empty() {
+            units.push(Unit {
+                priority: P_MARKUP,
+                text: markup_part.to_string(),
+            });
+        }
+
+        if comment_run.is_empty() {
+            units.push(Unit {
+                priority,
+                text: section_text.to_string(),
+            });
+        } else {
+            // Preserve the separator between the comment and the section as in
+            // the source: a blank line (`\n\n`) if the source had one between the
+            // last `-->` and the opening tag, a single newline otherwise.
             let after_comment_offset = gap.rfind("-->").map_or(0, |i| i + 3);
             let after_comment = &gap[after_comment_offset..];
             let separator = if after_comment.contains("\n\n") || after_comment.contains("\r\n\r\n")
@@ -79,22 +106,9 @@ pub(crate) fn reorder_sections(out: &str, mut sections: Vec<(u8, usize, usize)>)
             } else {
                 "\n"
             };
-            let section_text = out[start..end].trim();
             units.push(Unit {
                 priority,
-                text: format!("{gap_trim}{separator}{section_text}"),
-            });
-        } else {
-            if !gap_trim.is_empty() {
-                units.push(Unit {
-                    priority: P_MARKUP,
-                    text: gap_trim.to_string(),
-                });
-            }
-            let section_text = out[start..end].trim();
-            units.push(Unit {
-                priority,
-                text: section_text.to_string(),
+                text: format!("{comment_run}{separator}{section_text}"),
             });
         }
         cursor = cursor.max(end);
@@ -151,6 +165,59 @@ pub(crate) fn reorder_sections(out: &str, mut sections: Vec<(u8, usize, usize)>)
         result.push('\n');
     }
     result
+}
+
+/// Split a gap that ends with a run of HTML comments glued to the following
+/// section into `(markup_before, trailing_comment_run)`.
+///
+/// The trailing comment run is everything after the last non-comment,
+/// non-whitespace character — i.e. the comments (and whitespace) that sit
+/// directly before the section with no intervening markup. Returns `None` when
+/// there is no markup before it (the comment-only path handles that) or no
+/// trailing comment at all. UTF-8 safe: markup may contain multi-byte text.
+fn split_trailing_comment_run(gap: &str) -> Option<(&str, &str)> {
+    let mut last_markup_end = 0usize;
+    let mut base = 0usize; // byte offset of `rest` within `gap`
+    let mut rest = gap;
+    loop {
+        match rest.find("<!--") {
+            Some(open) => {
+                // Characters before this comment are markup-or-whitespace; record
+                // the byte offset just past the last non-whitespace one.
+                if let Some(p) = rest[..open].rfind(|c: char| !c.is_whitespace()) {
+                    let ch_len = rest[p..].chars().next().map_or(1, char::len_utf8);
+                    last_markup_end = base + p + ch_len;
+                }
+                let after_open = open + 4;
+                match rest[after_open..].find("-->") {
+                    Some(close) => {
+                        let consumed = after_open + close + 3;
+                        base += consumed;
+                        rest = &rest[consumed..];
+                    }
+                    // Unterminated comment — treat the remainder as markup.
+                    None => {
+                        last_markup_end = gap.len();
+                        break;
+                    }
+                }
+            }
+            None => {
+                if let Some(p) = rest.rfind(|c: char| !c.is_whitespace()) {
+                    let ch_len = rest[p..].chars().next().map_or(1, char::len_utf8);
+                    last_markup_end = base + p + ch_len;
+                }
+                break;
+            }
+        }
+    }
+    let markup = gap[..last_markup_end].trim();
+    let comment_run = gap[last_markup_end..].trim();
+    if markup.is_empty() || comment_run.is_empty() {
+        None
+    } else {
+        Some((markup, comment_run))
+    }
 }
 
 /// Whether `s` contains only HTML comments and whitespace.

--- a/crates/rsvelte_formatter/tests/attr_width.rs
+++ b/crates/rsvelte_formatter/tests/attr_width.rs
@@ -41,3 +41,26 @@ fn cjk_width_wrap_is_idempotent() {
         "CJK width-driven wrap is not idempotent:\n{once}"
     );
 }
+
+#[test]
+fn class_directive_value_breaks_narrowed_by_its_prefix() {
+    // Once the open tag wraps, a `class:NAME={EXPR}` whose full line overflows
+    // must break its value where prettier does — the value's wrap budget is
+    // narrowed by the `class:NAME=` prefix, matching `style:` / `on:` / `use:`
+    // (#795). Without that, the value's own width check (indent only) keeps the
+    // 107-column line flat past the 100-column print width.
+    let src = "<div\n  role=\"button\"\n  class:template-option-selected={selectedUserDefinedId === templateOption.customPageUserDefinedIdentifier}\n></div>\n";
+    let want = "<div\n  role=\"button\"\n  class:template-option-selected={selectedUserDefinedId ===\n    templateOption.customPageUserDefinedIdentifier}\n></div>\n";
+    assert_eq!(
+        fmt(src),
+        want,
+        "class directive value not narrowed by prefix"
+    );
+}
+
+#[test]
+fn class_directive_value_that_fits_stays_flat() {
+    // A `class:NAME={EXPR}` whose full line fits the print width must NOT break.
+    let src = "<div class:active={isActive}></div>\n";
+    assert_eq!(fmt(src), src, "short class directive should not wrap");
+}

--- a/crates/rsvelte_formatter/tests/blank_lines.rs
+++ b/crates/rsvelte_formatter/tests/blank_lines.rs
@@ -36,7 +36,8 @@ fn comment_glued_to_style_keeps_no_blank_between_comment_and_style() {
     // *before* the comment, not between it and `<style>`. Regression for the
     // section-reorder pass treating the whole markup gap (incl. the trailing
     // comment) as one unit and inserting a blank before `<style>` (#1166).
-    let src = "<div>x</div>\n\n<!-- keep me glued -->\n<style>\n  .a {\n    color: red;\n  }\n</style>\n";
+    let src =
+        "<div>x</div>\n\n<!-- keep me glued -->\n<style>\n  .a {\n    color: red;\n  }\n</style>\n";
     assert_eq!(fmt(src), src);
 }
 

--- a/crates/rsvelte_formatter/tests/blank_lines.rs
+++ b/crates/rsvelte_formatter/tests/blank_lines.rs
@@ -30,6 +30,24 @@ fn keeps_blank_line_before_style() {
 }
 
 #[test]
+fn comment_glued_to_style_keeps_no_blank_between_comment_and_style() {
+    // A comment that immediately precedes `<style>` (no blank line between the
+    // `-->` and the tag) is the style's leading comment: the blank line goes
+    // *before* the comment, not between it and `<style>`. Regression for the
+    // section-reorder pass treating the whole markup gap (incl. the trailing
+    // comment) as one unit and inserting a blank before `<style>` (#1166).
+    let src = "<div>x</div>\n\n<!-- keep me glued -->\n<style>\n  .a {\n    color: red;\n  }\n</style>\n";
+    assert_eq!(fmt(src), src);
+}
+
+#[test]
+fn comment_glued_to_style_is_idempotent() {
+    let src = "<div>x</div>\n\n<!-- c -->\n<style>\n  .a {\n    color: red;\n  }\n</style>\n";
+    let once = fmt(src);
+    assert_eq!(fmt(&once), once, "comment-before-style not idempotent");
+}
+
+#[test]
 fn keeps_single_blank_line_between_siblings() {
     let src = "<div>a</div>\n\n<div>b</div>\n";
     assert_eq!(fmt(src), src);


### PR DESCRIPTION
Two formatter-parity fixes from running rsvelte-fmt over a real ~1,150-component Svelte corpus (continuation of the `<style>` write-path fix in #1170). Corpus divergence from oxfmt: **48 → 36**.

## 1. Keep a comment glued to the `<style>` / `<script>` it leads

The section-reorder pass treated a markup gap ending with a comment glued to the next section (`</div>\n<!-- … -->\n<style>`) as one markup unit, then joined it to the section with a blank line — pushing the comment away from the tag it documents:

```svelte
<!-- before -->          <!-- after / prettier-plugin-svelte -->
</div>                   </div>

<!-- note -->
                         <!-- note -->     ← stray blank gone
<style>                  <style>
```

The trailing comment run is now split off and attached to the section as its leading comment. UTF-8 safe for multi-byte markup. (−10 corpus files.)

## 2. Narrow a wrapped `class:NAME={EXPR}` value by its prefix

`class:` was the one directive still using the non-narrowing value path (`style:` / `on:` / `use:` / `transition:` / … all narrow by their `name=` prefix per #795). So once an open tag wrapped, a long `class:` value stayed flat past the print width instead of breaking at its operator. (−2 corpus files.)

## Tests

- `comment_glued_to_style_keeps_no_blank_between_comment_and_style` + idempotence
- `class_directive_value_breaks_narrowed_by_its_prefix` + `class_directive_value_that_fits_stays_flat`

`cargo test` (rsvelte_formatter + rsvelte_fmt), `cargo clippy`, `cargo fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)