### PR TITLE
feat(fmt): warm oxfmt daemon for inline <style> formatting (POSIX)

### DIFF
--- a/.changeset/fmt-oxfmt-daemon.md
+++ b/.changeset/fmt-oxfmt-daemon.md
@@ -1,0 +1,24 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fmt: format inline `<style>` blocks through a warm oxfmt daemon (POSIX) instead
+of spawning `oxfmt` per block. Spawning paid a Node cold start (~370ms measured)
+every time a changed `<style>` block was re-formatted — the dominant cost of
+format-on-save once `.svelte`/`.ts`/`.js` moved in-process. A long-lived daemon
+(`daemon.mjs`, shipped in the package) keeps oxfmt loaded; the binary connects
+over a Unix socket and gets each block back in ~ms (~370ms → ~5ms warm).
+
+The daemon is deliberately "dumb": the Rust side resolves the per-block oxfmt
+options (base `.oxfmtrc` + the block's print width) and sends them inline, so the
+daemon never reads config files or applies `overrides` — its output is
+byte-identical to the spawn path (verified 555/555 on a real-world `.svelte`
+corpus, daemon vs spawn). Any failure (no Node, no bundle, connect/spawn/protocol
+error) falls back to spawning `oxfmt`, so correctness never depends on it; Windows
+stays on the spawn path. `RSVELTE_FMT_NO_DAEMON=1` forces the spawn path.
+
+The daemon is version-keyed by oxfmt fingerprint + protocol version (an oxfmt
+upgrade starts a fresh one), idle-exits after 60s, and handles concurrent
+invocations (e.g. `pnpm -r`) on one instance. Directory delegation stays a single
+`oxfmt` invocation — oxfmt already parallelizes its own directory walk there, so
+routing it per-file through the daemon would be slower, not faster.

--- a/apps/npm/fmt/README.md
+++ b/apps/npm/fmt/README.md
@@ -48,6 +48,14 @@ If your package manager **gates install scripts** (e.g. pnpm's
 Without it (or with `--ignore-scripts`, or on Windows) a small Node launcher is
 used instead — identical output, just a little slower to start.
 
+### oxfmt daemon (warm CSS formatting)
+
+On POSIX, inline `<style>` blocks are formatted through a short-lived oxfmt
+daemon kept warm across invocations, so re-formatting a changed `<style>` costs
+a ~ms socket round-trip instead of a fresh `oxfmt` Node start (~370ms → ~5ms).
+It idle-exits after 60s and is keyed to your oxfmt version. Output is identical
+to the non-daemon path; set `RSVELTE_FMT_NO_DAEMON=1` to disable it.
+
 ### oxfmt (optional, bring-your-own version)
 
 Non-`.svelte` files and the CSS inside `<style>` blocks are formatted by

--- a/apps/npm/fmt/daemon/daemon.mjs
+++ b/apps/npm/fmt/daemon/daemon.mjs
@@ -1,0 +1,155 @@
+// Persistent oxfmt formatting daemon for @rsvelte/fmt (POSIX).
+//
+// Spawning `oxfmt` per `<style>` block pays a Node cold start (~370ms measured)
+// every time — the dominant cost when format-on-save re-formats a changed CSS
+// block. This long-lived process keeps oxfmt warm: the Rust binary connects
+// over a Unix socket and sends already-resolved format requests, getting
+// results back in ~ms instead of paying a fresh Node start per block.
+//
+// Deliberately "dumb": the Rust side resolves the per-file oxfmt options (base
+// `.oxfmtrc` + the per-`<style>` print width) and sends them inline, so this
+// daemon never touches config files or `overrides` — it just calls
+// `format(fileName, content, options)`. That keeps the byte output identical to
+// the spawn path (same engine, same options) with no config logic to drift.
+//
+// Protocol: newline-delimited JSON over the socket.
+//   request : {"id": <number>, "fileName": "inline.css", "content": "...",
+//              "options": { ...oxfmt FormatConfig... }}
+//   response: {"id": <number>, "ok": <bool>, "code": "..."}            (success)
+//             {"id": <number>, "ok": false, "code": "...", "error": "..."} (format
+//              errors — `code` echoes the input unchanged, matching how the CLI
+//              leaves an unparseable file untouched)
+//
+// Lifecycle: the socket path is version-keyed by the Rust side (oxfmt
+// fingerprint + this protocol version), so an oxfmt upgrade naturally starts a
+// fresh daemon. The daemon exits after `IDLE_TIMEOUT_MS` with no activity, and
+// loses the listen race (EADDRINUSE) cleanly when another instance got there
+// first.
+
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Bump when the wire protocol changes. The Rust side mixes this into the socket
+// path so old and new binaries never share an incompatible daemon.
+const PROTOCOL_VERSION = 1;
+const IDLE_TIMEOUT_MS = 60_000;
+
+const socketPath = process.argv[2];
+const oxfmtPkgDir = process.argv[3];
+
+if (!socketPath || !oxfmtPkgDir) {
+	console.error('usage: daemon.mjs <socketPath> <oxfmtPkgDir>');
+	process.exit(2);
+}
+
+/// Resolve oxfmt's ESM entry from its package directory and import `format`.
+/// Reading the package's own `package.json` keeps this robust across oxfmt
+/// versions (no hard-coded `dist/index.js`).
+async function loadOxfmtFormat(pkgDir) {
+	const pkgJson = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8'));
+	const exp = pkgJson.exports && pkgJson.exports['.'];
+	const entryRel =
+		(exp && (exp.default || exp.import || (typeof exp === 'string' ? exp : null))) ||
+		pkgJson.module ||
+		pkgJson.main ||
+		'index.js';
+	const entryUrl = pathToFileURL(path.join(pkgDir, entryRel));
+	const mod = await import(entryUrl.href);
+	if (typeof mod.format !== 'function') {
+		throw new Error('oxfmt module has no format() export');
+	}
+	return mod.format;
+}
+
+let format;
+try {
+	format = await loadOxfmtFormat(oxfmtPkgDir);
+} catch (err) {
+	// Can't load oxfmt — never listen, so the client's connect fails fast and it
+	// falls back to spawning oxfmt directly.
+	console.error(`[rsvelte-fmt daemon] failed to load oxfmt: ${err.message}`);
+	process.exit(1);
+}
+
+let idleTimer = null;
+function resetIdle() {
+	if (idleTimer) clearTimeout(idleTimer);
+	idleTimer = setTimeout(() => {
+		server.close(() => cleanupAndExit(0));
+	}, IDLE_TIMEOUT_MS);
+}
+
+function cleanupAndExit(code) {
+	try {
+		fs.unlinkSync(socketPath);
+	} catch {
+		// already gone
+	}
+	process.exit(code);
+}
+
+async function handleRequest(req) {
+	const { id, fileName, content, options } = req;
+	try {
+		const result = await format(fileName, content, options || {});
+		const ok = !result.errors || result.errors.length === 0;
+		// On parse/format errors the CLI leaves the file unchanged; mirror that by
+		// echoing the input so the caller round-trips it (and doesn't cache it).
+		return { id, ok, code: ok ? result.code : content };
+	} catch (err) {
+		return { id, ok: false, code: content, error: String(err && err.message ? err.message : err) };
+	}
+}
+
+const server = net.createServer((socket) => {
+	resetIdle();
+	socket.setEncoding('utf8');
+	let buf = '';
+	socket.on('data', (chunk) => {
+		resetIdle();
+		buf += chunk;
+		let nl;
+		while ((nl = buf.indexOf('\n')) >= 0) {
+			const line = buf.slice(0, nl);
+			buf = buf.slice(nl + 1);
+			if (!line) continue;
+			let req;
+			try {
+				req = JSON.parse(line);
+			} catch {
+				continue; // ignore malformed lines
+			}
+			// Process concurrently; respond as each completes (client matches by id).
+			handleRequest(req).then((res) => {
+				if (!socket.destroyed) socket.write(JSON.stringify(res) + '\n');
+			});
+		}
+	});
+	socket.on('error', () => {
+		// Client went away mid-request; nothing to do.
+	});
+});
+
+server.on('error', (err) => {
+	if (err.code === 'EADDRINUSE') {
+		// Another daemon won the race (or a stale socket the client will clear and
+		// retry). Exit without removing the socket — it isn't ours.
+		process.exit(0);
+	}
+	console.error(`[rsvelte-fmt daemon] server error: ${err.message}`);
+	process.exit(1);
+});
+
+// A stale socket file from a crashed prior daemon would block listen with
+// EADDRINUSE even though nothing is listening. The client unlinks a confirmed-
+// stale socket before spawning us, so here we just listen; a genuine race
+// surfaces as EADDRINUSE above and we bow out.
+server.listen(socketPath, () => {
+	resetIdle();
+});
+
+for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+	process.on(sig, () => cleanupAndExit(0));
+}

--- a/apps/npm/fmt/package.json
+++ b/apps/npm/fmt/package.json
@@ -30,7 +30,8 @@
   "files": [
     "bin/rsvelte-fmt",
     "install.js",
-    "lib/resolve.cjs"
+    "lib/resolve.cjs",
+    "daemon/daemon.mjs"
   ],
   "optionalDependencies": {
     "@rsvelte/fmt-darwin-arm64": "workspace:^",

--- a/crates/rsvelte_fmt/src/daemon.rs
+++ b/crates/rsvelte_fmt/src/daemon.rs
@@ -1,0 +1,243 @@
+//! Unix-socket client for the persistent oxfmt formatting daemon (POSIX only).
+//!
+//! Formatting a `<style>` block by spawning `oxfmt` pays a Node cold start
+//! (~370ms measured) every time. This client talks to a long-lived daemon
+//! (`apps/npm/fmt/daemon/daemon.mjs`, shipped in `@rsvelte/fmt`) that keeps
+//! oxfmt warm, turning each block into a ~ms socket round-trip. The daemon is
+//! deliberately "dumb": we resolve the oxfmt options here and send them inline,
+//! so its output is byte-identical to the spawn path (same engine, same
+//! options). Any failure — no Node, no bundle, connect/spawn/protocol error —
+//! returns `None` so the caller falls back to spawning `oxfmt` directly.
+//!
+//! Windows has no Unix sockets here and stays on the spawn path; the daemon is a
+//! pure speedup, never a correctness dependency.
+
+#![cfg(unix)]
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Wire-protocol version. Must match `PROTOCOL_VERSION` in `daemon.mjs`; it is
+/// mixed into the socket path so incompatible binaries never share a daemon.
+const PROTOCOL_VERSION: u32 = 1;
+
+/// How long to wait for a freshly-spawned daemon to start accepting.
+const SPAWN_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const SPAWN_CONNECT_POLL: Duration = Duration::from_millis(10);
+
+/// A connected daemon session for one `rsvelte-fmt` invocation.
+pub(crate) struct DaemonClient {
+    reader: BufReader<UnixStream>,
+    writer: UnixStream,
+    next_id: u64,
+}
+
+impl DaemonClient {
+    /// Try to connect to (or spawn) the daemon for this `oxfmt`. Returns `None`
+    /// when the daemon can't be used (no Node interpreter, no bundle, or any
+    /// connect/spawn failure) — the caller then falls back to spawning oxfmt.
+    pub(crate) fn try_start(oxfmt: &Path) -> Option<Self> {
+        // Escape hatch: force the spawn path (also how the parity tests pin the
+        // two paths against each other).
+        if std::env::var_os("RSVELTE_FMT_NO_DAEMON").is_some_and(|v| !v.is_empty() && v != "0") {
+            return None;
+        }
+        // The daemon is a Node script: without a known interpreter (oxfmt
+        // installed as a native binary on `$PATH`), there's nothing to run it.
+        let node = crate::oxfmt_node()?;
+        let bundle = daemon_bundle_path()?;
+        let pkg_dir = oxfmt_pkg_dir(oxfmt)?;
+        let socket = socket_path(oxfmt)?;
+
+        let stream = connect_or_spawn(&socket, &node, &bundle, &pkg_dir)?;
+        let reader = BufReader::new(stream.try_clone().ok()?);
+        Some(DaemonClient {
+            reader,
+            writer: stream,
+            next_id: 0,
+        })
+    }
+
+    /// Format a group of `(css, lang)` blocks at the given resolved `options`
+    /// (already including the per-block `printWidth`). Returns the formatted
+    /// bodies in input order plus whether every block formatted cleanly, or
+    /// `None` on any I/O / protocol error (caller falls back to spawn).
+    pub(crate) fn format_group(
+        &mut self,
+        styles: &[(&str, &str)],
+        options: &serde_json::Value,
+    ) -> Option<(Vec<String>, bool)> {
+        // Send every request, then read every response, matching by id. The
+        // daemon answers each as it completes (possibly out of order).
+        let base = self.next_id;
+        let mut want: Vec<u64> = Vec::with_capacity(styles.len());
+        for (i, (css, lang)) in styles.iter().enumerate() {
+            let id = base + i as u64;
+            want.push(id);
+            let req = serde_json::json!({
+                "id": id,
+                "fileName": format!("inline.{}", crate::oxfmt_ext(lang)),
+                "content": css,
+                "options": options,
+            });
+            let mut line = serde_json::to_string(&req).ok()?;
+            line.push('\n');
+            self.writer.write_all(line.as_bytes()).ok()?;
+        }
+        self.writer.flush().ok()?;
+        self.next_id = base + styles.len() as u64;
+
+        // Collect responses by id.
+        let mut by_id: std::collections::HashMap<u64, (String, bool)> =
+            std::collections::HashMap::with_capacity(styles.len());
+        while by_id.len() < styles.len() {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).ok()?;
+            if n == 0 {
+                return None; // daemon closed the connection early
+            }
+            let trimmed = line.trim_end();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let value: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+            let id = value.get("id").and_then(serde_json::Value::as_u64)?;
+            let ok = value
+                .get("ok")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            let code = value.get("code").and_then(serde_json::Value::as_str)?;
+            by_id.insert(id, (code.to_string(), ok));
+        }
+
+        let mut results = Vec::with_capacity(styles.len());
+        let mut all_ok = true;
+        for id in want {
+            let (code, ok) = by_id.remove(&id)?;
+            all_ok &= ok;
+            results.push(code);
+        }
+        Some((results, all_ok))
+    }
+}
+
+/// Connect to the socket, or spawn the daemon and connect once it's up. A
+/// confirmed-stale socket (file exists but refuses connections) is removed
+/// before spawning.
+fn connect_or_spawn(
+    socket: &Path,
+    node: &Path,
+    bundle: &Path,
+    pkg_dir: &Path,
+) -> Option<UnixStream> {
+    if let Ok(stream) = UnixStream::connect(socket) {
+        return Some(stream);
+    }
+
+    // No live daemon. Clear a stale socket file so the daemon can bind.
+    if socket.exists() {
+        let _ = std::fs::remove_file(socket);
+    }
+
+    spawn_daemon(socket, node, bundle, pkg_dir)?;
+
+    // Poll for the daemon to start accepting. Multiple concurrent invocations
+    // may each spawn a daemon; all but one lose the listen race and exit, and
+    // everyone connects to the winner.
+    let deadline = Instant::now() + SPAWN_CONNECT_TIMEOUT;
+    loop {
+        if let Ok(stream) = UnixStream::connect(socket) {
+            return Some(stream);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(SPAWN_CONNECT_POLL);
+    }
+}
+
+/// Spawn the daemon detached so it outlives this invocation. Best-effort: a
+/// spawn error returns `None` (caller falls back to spawning oxfmt).
+fn spawn_daemon(socket: &Path, node: &Path, bundle: &Path, pkg_dir: &Path) -> Option<()> {
+    use std::os::unix::process::CommandExt;
+    Command::new(node)
+        .arg(bundle)
+        .arg(socket)
+        .arg(pkg_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        // New process group so it isn't killed with the parent's group and
+        // survives to serve later invocations.
+        .process_group(0)
+        .spawn()
+        .ok()
+        .map(|_| ())
+}
+
+/// Locate the `daemon.mjs` bundle. A test/dev override comes first; otherwise it
+/// sits next to the installed binary at `<pkg>/daemon/daemon.mjs` (the binary
+/// lives at `<pkg>/bin/rsvelte-fmt`).
+fn daemon_bundle_path() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("RSVELTE_FMT_DAEMON_BUNDLE").filter(|v| !v.is_empty()) {
+        let p = PathBuf::from(p);
+        return p.is_file().then_some(p);
+    }
+    let exe = std::env::current_exe().ok()?;
+    let pkg = exe.parent()?.parent()?;
+    let bundle = pkg.join("daemon").join("daemon.mjs");
+    bundle.is_file().then_some(bundle)
+}
+
+/// Derive oxfmt's package directory from its launcher path
+/// (`<pkg>/bin/oxfmt` → `<pkg>`), verifying a `package.json` is there. Returns
+/// `None` for an oxfmt that isn't a resolvable npm package (e.g. a bare native
+/// binary on `$PATH`), in which case the daemon can't `import('oxfmt')`.
+fn oxfmt_pkg_dir(oxfmt: &Path) -> Option<PathBuf> {
+    let pkg = oxfmt.parent()?.parent()?;
+    pkg.join("package.json")
+        .is_file()
+        .then(|| pkg.to_path_buf())
+}
+
+/// Version-keyed socket path: `<tmp>/rsvelte-fmt-d-<hash>.sock`, where the hash
+/// covers the oxfmt fingerprint + protocol version. An oxfmt upgrade or a
+/// protocol bump yields a different path, so a fresh daemon is started rather
+/// than reusing an incompatible one. Kept short for the `sun_path` limit.
+fn socket_path(oxfmt: &Path) -> Option<PathBuf> {
+    let dir = runtime_dir();
+    let mut h = DefaultHasher::new();
+    PROTOCOL_VERSION.hash(&mut h);
+    oxfmt_fingerprint(oxfmt).hash(&mut h);
+    let hash = h.finish();
+    Some(dir.join(format!("rsvelte-fmt-d-{hash:016x}.sock")))
+}
+
+/// Prefer `$XDG_RUNTIME_DIR` (short, user-private), else the system temp dir.
+fn runtime_dir() -> PathBuf {
+    std::env::var_os("XDG_RUNTIME_DIR")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+}
+
+/// Cheap oxfmt identity (path + size + mtime) so a reinstall of a new version
+/// rotates the socket. Mirrors the style cache's fingerprint; a path that can't
+/// be stat'd contributes just its bytes (a bare `$PATH` command).
+fn oxfmt_fingerprint(oxfmt: &Path) -> Vec<u8> {
+    let mut fp = oxfmt.to_string_lossy().into_owned().into_bytes();
+    if let Ok(md) = std::fs::metadata(oxfmt) {
+        fp.extend_from_slice(&md.len().to_le_bytes());
+        if let Ok(mtime) = md.modified()
+            && let Ok(dur) = mtime.duration_since(std::time::UNIX_EPOCH)
+        {
+            fp.extend_from_slice(&dur.as_nanos().to_le_bytes());
+        }
+    }
+    fp
+}

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -18,6 +18,7 @@ use rayon::prelude::*;
 use rsvelte_formatter::{FormatOptions, format, format_js_source, reindent};
 
 mod config;
+mod daemon;
 mod oxfmt_ignore;
 mod style_cache;
 use config::OxfmtConfig;
@@ -416,14 +417,10 @@ fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> FormatOptions {
 /// a non-JSON / unreadable base. Configs are cached by width under a per-process
 /// temp dir.
 fn css_config_for_width(base: Option<&Path>, width: usize) -> Option<PathBuf> {
-    let mut json: serde_json::Value = base
-        .and_then(|p| std::fs::read_to_string(p).ok())
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
-    let Some(obj) = json.as_object_mut() else {
+    let json = css_options_for_width(base, width);
+    if !json.is_object() {
         return base.map(Path::to_path_buf);
-    };
-    obj.insert("printWidth".into(), serde_json::Value::from(width));
+    }
     let dir = std::env::temp_dir().join(format!("rsvelte-fmt-css-cfg-{}", std::process::id()));
     if std::fs::create_dir_all(&dir).is_err() {
         return base.map(Path::to_path_buf);
@@ -433,6 +430,21 @@ fn css_config_for_width(base: Option<&Path>, width: usize) -> Option<PathBuf> {
         Ok(()) => Some(p),
         Err(_) => base.map(Path::to_path_buf),
     }
+}
+
+/// The resolved oxfmt options for an inline `<style>` block at `width`: the base
+/// `.oxfmtrc` (if any) with `printWidth` forced to the block's column. Returned
+/// as a JSON value so the daemon path can send it inline as `format()`'s options
+/// and the spawn path can serialize it to a temp config — both at byte parity.
+fn css_options_for_width(base: Option<&Path>, width: usize) -> serde_json::Value {
+    let mut json: serde_json::Value = base
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    if let Some(obj) = json.as_object_mut() {
+        obj.insert("printWidth".into(), serde_json::Value::from(width));
+    }
+    json
 }
 
 fn make_oxfmt_style_formatter(
@@ -937,6 +949,14 @@ fn batch_format_styles(
         by_width.entry(s.width).or_default().push(i);
     }
 
+    // Prefer the warm daemon (POSIX): one socket round-trip per block instead of
+    // a fresh `oxfmt` Node start. The daemon is dumb — it formats with the
+    // options we resolve here — so its output is byte-identical to the spawn
+    // path. Any failure disables it for the rest of this run and we fall back to
+    // spawning oxfmt, so correctness never depends on it.
+    #[cfg(unix)]
+    let mut daemon = daemon::DaemonClient::try_start(oxfmt);
+
     let mut results = vec![String::new(); styles.len()];
     let mut all_ok = true;
     for (width, idxs) in by_width {
@@ -944,13 +964,37 @@ fn batch_format_styles(
             .iter()
             .map(|&i| (styles[i].css, styles[i].lang))
             .collect();
-        // Narrow the project config to this width so oxfmt wraps embedded CSS at
-        // the same column the block renders at (falls back to the base config).
-        let cfg = css_config_for_width(config, width);
-        let (formatted, ok) = batch_format_styles_group(oxfmt, cfg.as_deref(), &group)?;
-        all_ok &= ok;
-        for (slot, css) in idxs.into_iter().zip(formatted) {
-            results[slot] = css;
+
+        // `mut`/`placed` are only mutated on unix (the daemon branch); on other
+        // targets the spawn path below always runs.
+        #[allow(unused_mut)]
+        let mut placed = false;
+        #[cfg(unix)]
+        if let Some(d) = daemon.as_mut() {
+            let options = css_options_for_width(config, width);
+            match d.format_group(&group, &options) {
+                Some((formatted, ok)) => {
+                    all_ok &= ok;
+                    for (&slot, css) in idxs.iter().zip(formatted) {
+                        results[slot] = css;
+                    }
+                    placed = true;
+                }
+                // Drop the daemon and fall back to spawning for this group and
+                // every group after it.
+                None => daemon = None,
+            }
+        }
+
+        if !placed {
+            // Narrow the project config to this width so oxfmt wraps embedded CSS
+            // at the same column the block renders at (falls back to base config).
+            let cfg = css_config_for_width(config, width);
+            let (formatted, ok) = batch_format_styles_group(oxfmt, cfg.as_deref(), &group)?;
+            all_ok &= ok;
+            for (slot, css) in idxs.into_iter().zip(formatted) {
+                results[slot] = css;
+            }
         }
     }
     Ok((results, all_ok))

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -910,6 +910,127 @@ fn native_js_respects_override_print_width() {
     );
 }
 
+// ─── oxfmt daemon (#1179 follow-up) ───────────────────────────────────────
+
+/// `node` on `$PATH`, or `None` to skip a daemon test on a host without it.
+fn node_bin() -> Option<PathBuf> {
+    let ok = Command::new("node")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    ok.then(|| PathBuf::from("node"))
+}
+
+/// Absolute path to the shipped daemon bundle, from this crate's manifest dir.
+fn daemon_bundle() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../apps/npm/fmt/daemon/daemon.mjs")
+}
+
+/// Stand up a fake `oxfmt` npm package the daemon will `import()`: its `format()`
+/// prefixes `/*DMON*/` so we can prove the daemon (not the spawn fallback)
+/// formatted the block. `bin/oxfmt` is an inert stub — if the daemon path failed
+/// and we fell back to spawning it, it would format nothing (no marker), so the
+/// marker's presence pins the result to the daemon.
+fn write_fake_oxfmt_pkg(dir: &std::path::Path) -> PathBuf {
+    let pkg = dir.join("oxfmt");
+    std::fs::create_dir_all(pkg.join("bin")).unwrap();
+    std::fs::write(
+        pkg.join("package.json"),
+        r#"{ "name": "oxfmt", "type": "module", "exports": { ".": { "default": "./index.mjs" } }, "bin": { "oxfmt": "bin/oxfmt" } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg.join("index.mjs"),
+        "export async function format(fileName, content, options) {\n  return { code: '/*DMON*/' + content, errors: [] };\n}\n",
+    )
+    .unwrap();
+    // Inert stub launcher (spawn fallback would run this and format nothing).
+    std::fs::write(pkg.join("bin").join("oxfmt"), "process.exit(0)\n").unwrap();
+    pkg.join("bin").join("oxfmt")
+}
+
+/// The daemon path formats inline `<style>` blocks: with `RSVELTE_FMT_NODE` +
+/// the bundle set and a fake oxfmt package, the binary connects to (spawns) the
+/// daemon and the fake `format()` marker lands in the file.
+#[test]
+fn daemon_formats_inline_style() {
+    let Some(node) = node_bin() else {
+        eprintln!("skipping: no node on PATH");
+        return;
+    };
+    let dir = tempdir();
+    let oxfmt_bin = write_fake_oxfmt_pkg(&dir);
+
+    let file = dir.join("c.svelte");
+    std::fs::write(&file, "<div></div>\n<style>.a{color:red}</style>\n").unwrap();
+
+    let status = Command::new(bin())
+        .args([
+            file.to_str().unwrap(),
+            "--write",
+            "--no-style-cache",
+            "--oxfmt-bin",
+            oxfmt_bin.to_str().unwrap(),
+        ])
+        .env("RSVELTE_FMT_NODE", &node)
+        .env("RSVELTE_FMT_DAEMON_BUNDLE", daemon_bundle())
+        .env_remove("RSVELTE_FMT_NO_DAEMON")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "exit code: {:?}", status.code());
+
+    let out = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        out.contains("/*DMON*/"),
+        "daemon-formatted marker missing — daemon path not taken:\n{out}"
+    );
+    assert!(out.contains(".a"), "selector lost:\n{out}");
+}
+
+/// `RSVELTE_FMT_NO_DAEMON` forces the spawn path: with the inert stub oxfmt the
+/// block is left unformatted (no daemon marker), proving the escape hatch
+/// bypasses the daemon entirely.
+#[test]
+fn no_daemon_env_forces_spawn_path() {
+    let Some(node) = node_bin() else {
+        eprintln!("skipping: no node on PATH");
+        return;
+    };
+    let dir = tempdir();
+    let oxfmt_bin = write_fake_oxfmt_pkg(&dir);
+
+    let file = dir.join("c.svelte");
+    std::fs::write(&file, "<div></div>\n<style>.a{color:red}</style>\n").unwrap();
+
+    let status = Command::new(bin())
+        .args([
+            file.to_str().unwrap(),
+            "--write",
+            "--no-style-cache",
+            "--oxfmt-bin",
+            oxfmt_bin.to_str().unwrap(),
+        ])
+        .env("RSVELTE_FMT_NODE", &node)
+        .env("RSVELTE_FMT_DAEMON_BUNDLE", daemon_bundle())
+        .env("RSVELTE_FMT_NO_DAEMON", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "exit code: {:?}", status.code());
+
+    let out = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        !out.contains("/*DMON*/"),
+        "daemon marker present — NO_DAEMON should have bypassed the daemon:\n{out}"
+    );
+}
+
 // ─── native-direct install (runtime sidecar) ─────────────────────────────
 
 /// When the binary is installed native-direct (the npm JS launcher replaced by


### PR DESCRIPTION
> #1179 (native-direct binary) has merged; this PR is rebased onto `main` and now contains only the daemon change.

## What

Formats inline `<style>` blocks through a **warm oxfmt daemon** (POSIX) instead of spawning `oxfmt` per block.

After #1177 (`.svelte`/`.ts`/`.js` in-process) and #1179 (native-direct binary), the dominant remaining format-on-save cost was the `oxfmt` Node cold start whenever a changed `<style>` block re-formats. Measured on the native binary:

| inline `<style>` path | time |
|---|---|
| cold spawn (before) | **~370ms** |
| warm daemon (after) | **~5ms** |
| warm style cache (unchanged block) | ~0ms (unchanged) |

## How

- **`daemon/daemon.mjs`** — Unix-socket NDJSON server shipped in `@rsvelte/fmt`. Deliberately **"dumb"**: it calls `format(fileName, content, options)` with options the Rust side already resolved, so it never reads config files or applies `overrides` — output stays byte-identical to the spawn path. Version-keyed socket (oxfmt fingerprint + protocol), 60s idle-exit, `EADDRINUSE` race-safe, serves concurrent invocations (`pnpm -r`) on one instance.
- **`src/daemon.rs`** — Unix-socket client. Resolves Node + the oxfmt package dir, connect-or-spawn (clearing a confirmed-stale socket), pipelines a batch by id. **Any** failure (no Node, no bundle, connect/spawn/protocol error) returns `None` and the caller falls back to spawning `oxfmt` — the daemon is a pure speedup, never a correctness dependency. **Windows stays on the spawn path.**
- `batch_format_styles` tries the daemon per width-group, falling back to the existing spawn path; `css_options_for_width` shares the resolved options between both. `RSVELTE_FMT_NO_DAEMON=1` forces spawn.

## Scope rationale

Only the inline `<style>` path is routed through the daemon. **Directory delegation stays a single `oxfmt` invocation** — oxfmt already parallelizes its own directory walk there, so sending files one-by-one to the daemon would be *slower*, not faster. The standalone-`.css`/`.md` stdin path stays on spawn too (lower frequency; would need full `overrides` resolution to match oxfmt).

## Parity / safety

**555/555 identical** (daemon vs spawn) across a real-world `.svelte` corpus. New cli tests:
- `daemon_formats_inline_style` — daemon path formats via a fake oxfmt package it `import()`s
- `no_daemon_env_forces_spawn_path` — the escape hatch bypasses the daemon

All 27 cli tests pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)