### PR TITLE
chore(deps): update napi-derive to 3.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,9 +1345,9 @@ checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.6"
+version = "3.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
+checksum = "61d66f70256ad5aef58659966064471d0ad90e2897bc36a5a5e0389c85aabc1e"
 dependencies = [
  "convert_case",
  "ctor",
@@ -1359,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.4"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+checksum = "81b4b08f15eed7a2a20c3f4c6314013fc3ac890a3afa9892b594485299ebdb2d"
 dependencies = [
  "convert_case",
  "proc-macro2 1.0.106",


### PR DESCRIPTION
Re-creates Renovate #1166 on current main. #1166 failed CI only because its base predated the `napi` 3.9.4 bump now on main — napi-derive 3.5.7's macro expands to `napi::bindgen_prelude::decorate_field_error`, which exists in napi ≥3.9. On current main (napi 3.9.4) it compiles cleanly (`cargo check -p rsvelte_core --features napi` green). Supersedes #1166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfZpa28FjLaRBVioSS3cDi