### PR TITLE
chore(deps): unify oxc crates + oxc_formatter to rev 7537c58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1561,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1578,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "phf",
  "proc-macro2 1.0.106",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1621,12 +1621,12 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 
 [[package]]
 name = "oxc_diagnostics"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1651,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1661,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter"
 version = "0.56.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1687,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_core"
 version = "0.56.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "oxc_jsdoc"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "itertools 0.15.0",
  "memchr",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=e1886a0c7685de47d0a2f93568663b6c7ca8f0d2#e1886a0c7685de47d0a2f93568663b6c7ca8f0d2"
+source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,18 +67,18 @@ type_complexity = "allow"
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -70,7 +70,7 @@ oxc_semantic = "0.137"
 oxc_resolver = "11"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/bin/fmt_benchmark_runner.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -25,8 +25,8 @@ oxc_allocator = "0.137"
 oxc_ast = "0.137"
 oxc_parser = "0.137"
 oxc_span = "0.137"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
 thiserror = "2.0"
 unicode-width = "0.2"
 

--- a/crates/rsvelte_lint_types/Cargo.toml
+++ b/crates/rsvelte_lint_types/Cargo.toml
@@ -53,18 +53,18 @@ type_complexity = "allow"
 # Mirror the root workspace's oxc unification patch so the path-dep rsvelte
 # crates build with the same oxc rev. MUST match crates/../Cargo.toml.
 [patch.crates-io]
-oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
-oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "e1886a0c7685de47d0a2f93568663b6c7ca8f0d2" }
+oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }


### PR DESCRIPTION
Follow-up to #1158. Renovate opened new oxc digest PRs (#1168 `oxc_formatter`, #1169 `oxc_formatter_core`) targeting newer rev `7537c58`. They can't pass alone (single-rev `[patch.crates-io]` unification). Moves the whole stack `e1886a0` → `7537c58` (both oxc 0.137.0, digest-only). Single rev in Cargo.lock, no duplicate oxc packages.

Validation: `cargo check --workspace --all-targets` clean; rsvelte_core + formatter + fmt suites pass.

Supersedes #1168 and #1169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfZpa28FjLaRBVioSS3cDi