### PR TITLE
chore(ci): stop Renovate oxc git-digest treadmill

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "The oxc_* crates are redirected through [patch.crates-io] to a single pinned git rev so rsvelte's AST types unify with oxc_formatter's transitive deps. Renovate's per-crate git-digest PRs can never pass CI on their own: bumping one crate's rev leaves the lockfile with two distinct oxc revs and the Program<'a> types fail to unify. The whole stack must be moved together as a manual unified bump. Disable digest (git-rev) auto-updates for the oxc crates so these unmergeable PRs stop being opened; version updates (e.g. 0.137 -> 0.138) are still surfaced.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["/^oxc/"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Why

The `oxc_*` crates are redirected through `[patch.crates-io]` to **one** pinned git rev so rsvelte's AST types unify with `oxc_formatter`'s transitive deps. Renovate's per-crate git-digest PRs (`oxc_formatter` / `oxc_formatter_core`) **can never pass CI on their own** — bumping one crate's rev leaves the lockfile with two distinct oxc revs and the `Program<'a>` types fail to unify. The whole stack must move together as a manual unified bump (#1148, #1158, #1182).

This session alone Renovate opened **three** such unmergeable batches (`3f574f5`, `e1886a0`, `7537c58`, with `2580eda` already queued), each requiring a manual unified bump to clear.

## What

Adds a `packageRule` disabling **digest** (git-rev) auto-updates for the oxc crates. Semver version updates (e.g. `0.137` → `0.138`) are still surfaced — only the noisy per-commit digest PRs stop. Trivially reversible if you'd rather group them instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfZpa28FjLaRBVioSS3cDi