### PR TITLE
ci(vscode): automate Marketplace + Open VSX publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -26,6 +26,10 @@
       "@rsvelte/fmt-linux-arm64-gnu",
       "@rsvelte/fmt-linux-x64-gnu",
       "@rsvelte/fmt-win32-x64-msvc"
+    ],
+    [
+      "@rsvelte/language-server",
+      "rsvelte-vscode"
     ]
   ],
   "linked": [],

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,0 +1,106 @@
+name: Publish VS Code Extension
+
+# Publishes `rsvelte-vscode` to the VS Code Marketplace (+ Open VSX). The
+# extension version follows `@rsvelte/language-server` (kept in lockstep by the
+# changesets `fixed` group), so a normal release — merging the "Version
+# Packages" PR — bumps both and pushes to main, which triggers this workflow.
+# A cheap `check` job queries the Marketplace and only fans out to the heavy
+# build+publish `publish` job when the target version isn't published yet.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/npm/vscode/**'
+      - 'apps/npm/language-server/**'
+      - 'crates/rsvelte_lint/**'
+      - 'scripts/release/publish-vscode.mjs'
+      - '.github/workflows/publish-vscode.yml'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Publish even if the target version is already on the Marketplace'
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-vscode
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_publish: ${{ steps.decide.outputs.should_publish }}
+      version: ${{ steps.decide.outputs.version }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Decide whether to publish
+        id: decide
+        env:
+          VSCODE_PUBLISH_FORCE: ${{ github.event.inputs.force }}
+        run: node scripts/release/publish-vscode.mjs --check
+
+  publish:
+    name: Publish extension
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: false
+
+      # rsvelte_core's build.rs reads the Svelte version string from the submodule.
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: language-server
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Build the lint wasm (nodejs target) + the language-server bundle the
+      # extension embeds; vsce's prepublish (build.mjs) copies it next to the
+      # extension bundle.
+      - name: Build language server
+        run: pnpm run build:language-server
+
+      - name: Publish to Marketplace (+ Open VSX)
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          VSCODE_PUBLISH_FORCE: ${{ github.event.inputs.force }}
+        run: node scripts/release/publish-vscode.mjs

--- a/apps/npm/vscode/package.json
+++ b/apps/npm/vscode/package.json
@@ -1,11 +1,11 @@
 {
   "name": "rsvelte-vscode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "displayName": "rsvelte",
   "description": "Rust-powered Svelte formatting and linting for VS Code (rsvelte-fmt + rsvelte_lint)",
   "license": "MIT",
-  "publisher": "rsvelte",
+  "publisher": "baseballyama",
   "icon": "icon.png",
   "repository": {
     "type": "git",

--- a/scripts/release/publish-vscode.mjs
+++ b/scripts/release/publish-vscode.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Publish the `rsvelte-vscode` extension to the VS Code Marketplace (and, best
+// effort, Open VSX). The extension version follows `@rsvelte/language-server`
+// (kept in lockstep by the changesets `fixed` group). Idempotent: it skips when
+// the target version is already on the Marketplace, so it is safe to run on
+// every push to main.
+//
+// Usage:
+//   node scripts/release/publish-vscode.mjs --check   # decide only (writes GITHUB_OUTPUT)
+//   node scripts/release/publish-vscode.mjs           # package + publish
+//
+// Env:
+//   VSCE_PAT              required to publish (Azure DevOps PAT, Marketplace > Manage)
+//   OVSX_PAT             optional → also publish to Open VSX
+//   VSCODE_PUBLISH_FORCE  "true" bypasses the already-published guard
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+const extDir = resolve(repoRoot, 'apps/npm/vscode');
+const extPkgPath = resolve(extDir, 'package.json');
+const lsPkgPath = resolve(repoRoot, 'apps/npm/language-server/package.json');
+
+const checkOnly = process.argv.includes('--check');
+const force = process.env.VSCODE_PUBLISH_FORCE === 'true';
+
+const extPkg = JSON.parse(readFileSync(extPkgPath, 'utf8'));
+const target = JSON.parse(readFileSync(lsPkgPath, 'utf8')).version;
+const id = `${extPkg.publisher}.${extPkg.name}`;
+
+/** Numeric semver compare for simple `x.y.z` versions (no pre-release). */
+function cmp(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+/** Latest version on the Marketplace, or null if not published / query failed. */
+function marketplaceVersion() {
+  try {
+    const out = execFileSync(
+      'npx',
+      ['--yes', '@vscode/vsce@^3', 'show', id, '--json'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    const j = JSON.parse(out);
+    return j?.versions?.[0]?.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const published = marketplaceVersion();
+const shouldPublish =
+  force || published === null || cmp(target, published) > 0;
+
+console.log(`extension:           ${id}`);
+console.log(`target version:      ${target} (follows @rsvelte/language-server)`);
+console.log(`marketplace version: ${published ?? '(none)'}`);
+console.log(`should publish:      ${shouldPublish}${force ? ' (forced)' : ''}`);
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `version=${target}\npublished=${published ?? ''}\nshould_publish=${shouldPublish}\n`,
+  );
+}
+
+if (checkOnly) process.exit(0);
+
+if (!shouldPublish) {
+  console.log('Marketplace is already up to date — nothing to publish.');
+  process.exit(0);
+}
+
+if (!process.env.VSCE_PAT) {
+  console.error('VSCE_PAT is not set — cannot publish.');
+  process.exit(1);
+}
+
+// Pin the extension version to the language-server version for this publish.
+if (extPkg.version !== target) {
+  extPkg.version = target;
+  writeFileSync(extPkgPath, `${JSON.stringify(extPkg, null, 2)}\n`);
+  console.log(`set extension version → ${target}`);
+}
+
+const vsix = resolve(extDir, `${extPkg.name}-${target}.vsix`);
+
+// `vsce package` runs `vscode:prepublish` (build.mjs), which needs the
+// language-server bundle to already exist (built by the workflow).
+execFileSync(
+  'npx',
+  ['--yes', '@vscode/vsce@^3', 'package', '--no-dependencies', '-o', vsix],
+  { cwd: extDir, stdio: 'inherit' },
+);
+
+execFileSync(
+  'npx',
+  [
+    '--yes',
+    '@vscode/vsce@^3',
+    'publish',
+    '--no-dependencies',
+    '--packagePath',
+    vsix,
+    '-p',
+    process.env.VSCE_PAT,
+  ],
+  { cwd: extDir, stdio: 'inherit' },
+);
+console.log('✓ published to VS Code Marketplace');
+
+if (process.env.OVSX_PAT) {
+  try {
+    execFileSync(
+      'npx',
+      ['--yes', 'ovsx@^0', 'publish', vsix, '-p', process.env.OVSX_PAT],
+      { cwd: extDir, stdio: 'inherit' },
+    );
+    console.log('✓ published to Open VSX');
+  } catch (e) {
+    console.warn(`Open VSX publish failed (continuing): ${e?.message ?? e}`);
+  }
+} else {
+  console.log('OVSX_PAT not set — skipping Open VSX.');
+}


### PR DESCRIPTION
## What

Automates publishing the **rsvelte-vscode** extension to the VS Code Marketplace
(and best-effort **Open VSX**) via GitHub Actions, so future releases need no
manual `vsce` steps.

### How it works
- **`.github/workflows/publish-vscode.yml`** — a cheap `check` job queries the
  Marketplace for the currently-published version; only when the target version
  is newer does it fan out to a heavy `publish` job (Rust + wasm-pack + bundle +
  publish). Triggers: push to `main` (guarded by the version check) and
  `workflow_dispatch` (with a `force` input).
- **`scripts/release/publish-vscode.mjs`** — resolves the target version (it
  **follows `@rsvelte/language-server`**), compares against the Marketplace, and
  when newer packages the vsix with `vsce` and publishes to Marketplace +
  Open VSX. Idempotent (safe to run every push); Open VSX is skipped if
  `OVSX_PAT` is unset.
- **changeset `fixed` group** ties `rsvelte-vscode` to `@rsvelte/language-server`
  so a release bumps both in lockstep (the extension bundles the LS + lint wasm).
  The extension stays `private` (never npm-published); version pinned to `0.2.0`
  to match the published language server.

### Release flow after this lands
Merge a "Version Packages" PR → both packages bump → push to main →
`@rsvelte/language-server` publishes to npm (existing release.yml) **and**
`rsvelte-vscode` publishes to the Marketplace (this workflow).

## ⚠️ Required before this can publish (user setup)
1. **Marketplace publisher** created at https://marketplace.visualstudio.com/manage.
   The `publisher` field in `apps/npm/vscode/package.json` is currently
   `baseballyama` — **confirm/adjust to match the real publisher ID**.
2. Repo secret **`VSCE_PAT`** — Azure DevOps PAT (scope: Marketplace > Manage,
   all orgs).
3. (Optional) Open VSX namespace + repo secret **`OVSX_PAT`**.

Until the publisher + `VSCE_PAT` exist, the `publish` job will fail (re-runnable
once configured). The `check` job is harmless without secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)