### PR TITLE
docs(bench): publish /benchmark from local stable run (M1 Pro 10-core)

### DIFF
--- a/apps/playground/static/benchmark-results.json
+++ b/apps/playground/static/benchmark-results.json
@@ -1,180 +1,180 @@
 {
-  "generatedAt": "2026-06-25T10:59:22.583Z",
-  "commitSha": "3876a01",
+  "generatedAt": "2026-06-25T13:10:40.303Z",
+  "commitSha": "ee8c5dec",
   "runner": {
-    "label": "ubuntu-24.04-arm (GitHub-hosted, ARM64)",
-    "os": "linux",
+    "label": "local (Apple M1 Pro, 10-core)",
+    "os": "darwin",
     "arch": "arm64",
-    "cpus": 4,
-    "cpuModel": "unknown",
-    "nodeVersion": "24.17.0",
-    "v8Version": "13.6.233.17-node.49",
-    "loadAvg1min": 1,
+    "cpus": 10,
+    "cpuModel": "Apple M1 Pro",
+    "nodeVersion": "24.13.0",
+    "v8Version": "13.6.233.17-node.37",
+    "loadAvg1min": 4.03515625,
     "warmupIterations": 3,
     "benchmarkIterations": 10
   },
   "testFilesCount": 3854,
   "javascript": {
-    "durationMs": 1858.5531044999952,
-    "throughputFilesPerSec": 2073.6561095125867,
-    "minMs": 1811.7008090000018,
-    "maxMs": 1926.4856239999935,
-    "meanMs": 1864.5900696999947,
-    "stdDevMs": 34.30058721833005,
+    "durationMs": 995.2556244999996,
+    "throughputFilesPerSec": 3872.3719867809714,
+    "minMs": 951.8114999999998,
+    "maxMs": 1038.440208,
+    "meanMs": 990.7418333000002,
+    "stdDevMs": 25.508078621950908,
     "samples": 10
   },
   "rustSingleThread": {
-    "durationMs": 724.60095,
-    "throughputFilesPerSec": 5318.789604126244,
-    "minMs": 722.2741,
-    "maxMs": 726.9646,
-    "meanMs": 724.51684,
-    "stdDevMs": 1.2424994512674983,
+    "durationMs": 568.8621,
+    "throughputFilesPerSec": 6774.928405320023,
+    "minMs": 562.6126,
+    "maxMs": 573.295,
+    "meanMs": 568.8446499999999,
+    "stdDevMs": 3.2396409196853817,
     "samples": 10
   },
   "rustMultiThread": {
-    "durationMs": 207.79944999999998,
-    "throughputFilesPerSec": 18546.728588550162,
-    "minMs": 204.0445,
-    "maxMs": 217.8173,
-    "meanMs": 208.99025999999998,
-    "stdDevMs": 3.9991544929397236,
+    "durationMs": 74.67564999999999,
+    "throughputFilesPerSec": 51609.862117035475,
+    "minMs": 73.5743,
+    "maxMs": 87.5836,
+    "meanMs": 76.82827,
+    "stdDevMs": 4.151457341717485,
     "samples": 10
   },
   "speedup": {
-    "singleThreadVsJs": 2.5649332981139414,
-    "multiThreadVsJs": 8.943975089924422
+    "singleThreadVsJs": 1.749555163720697,
+    "multiThreadVsJs": 13.327712909094192
   },
   "parse": {
     "javascript": {
-      "durationMs": 368.49755749999895,
-      "throughputFilesPerSec": 10458.685333348543,
-      "minMs": 361.1250980000477,
-      "maxMs": 411.7929829999921,
-      "meanMs": 371.40505739999935,
-      "stdDevMs": 13.951177077961237,
+      "durationMs": 250.4546044999879,
+      "throughputFilesPerSec": 15388.018150810982,
+      "minMs": 246.1256669999857,
+      "maxMs": 269.51866700002574,
+      "meanMs": 251.8798376999999,
+      "stdDevMs": 6.238722217847398,
       "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 13.3981,
-      "throughputFilesPerSec": 287652.7268791844,
-      "minMs": 13.3288,
-      "maxMs": 13.4847,
-      "meanMs": 13.407569999999998,
-      "stdDevMs": 0.0494230523136726,
+      "durationMs": 12.03095,
+      "throughputFilesPerSec": 320340.4552425203,
+      "minMs": 10.9555,
+      "maxMs": 12.5054,
+      "meanMs": 11.85614,
+      "stdDevMs": 0.4267427520181216,
       "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 3.5999,
-      "throughputFilesPerSec": 1070585.2940359456,
-      "minMs": 3.4999,
-      "maxMs": 3.7624,
-      "meanMs": 3.59501,
-      "stdDevMs": 0.07121775691497174,
+      "durationMs": 2.2102500000000003,
+      "throughputFilesPerSec": 1743694.152245221,
+      "minMs": 1.9693,
+      "maxMs": 2.9708,
+      "meanMs": 2.37299,
+      "stdDevMs": 0.30951985219045325,
       "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 27.50371750472074,
-      "multiThreadVsJs": 102.3632760632237
+      "singleThreadVsJs": 20.8175251746527,
+      "multiThreadVsJs": 113.31505689401104
     }
   },
   "svelte2tsx": {
     "javascript": {
-      "durationMs": 886.7485345000168,
-      "throughputFilesPerSec": 4346.215245986321,
-      "minMs": 822.0005089999759,
-      "maxMs": 937.9136530000251,
-      "meanMs": 882.6149159000022,
-      "stdDevMs": 34.66222182331093,
+      "durationMs": 393.43445850000717,
+      "throughputFilesPerSec": 9795.786608762257,
+      "minMs": 376.7658329999831,
+      "maxMs": 406.8221659999981,
+      "meanMs": 392.7508415999997,
+      "stdDevMs": 7.944115384562037,
       "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 175.95105,
-      "throughputFilesPerSec": 21903.819272462424,
-      "minMs": 175.6439,
-      "maxMs": 176.7048,
-      "meanMs": 176.04058,
-      "stdDevMs": 0.36116608035639364,
+      "durationMs": 173.9991,
+      "throughputFilesPerSec": 22149.539853941777,
+      "minMs": 168.7422,
+      "maxMs": 175.6175,
+      "meanMs": 173.35597,
+      "stdDevMs": 2.1095067158224468,
       "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 47.018299999999996,
-      "throughputFilesPerSec": 81968.08476699499,
-      "minMs": 46.2087,
-      "maxMs": 52.8158,
-      "meanMs": 48.24563,
-      "stdDevMs": 2.272224789517974,
+      "durationMs": 22.69545,
+      "throughputFilesPerSec": 169813.77324529804,
+      "minMs": 21.8462,
+      "maxMs": 25.06,
+      "meanMs": 22.83607,
+      "stdDevMs": 0.9253331638388409,
       "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 5.039745625274852,
-      "multiThreadVsJs": 18.859646871537613
+      "singleThreadVsJs": 2.261129273082488,
+      "multiThreadVsJs": 17.335389185938464
     }
   },
   "fmt": {
     "javascript": {
-      "durationMs": 7721.895310499996,
-      "throughputFilesPerSec": 499.1002655474297,
-      "minMs": 7573.243494000053,
-      "maxMs": 7864.89155499998,
-      "meanMs": 7711.3817696999995,
-      "stdDevMs": 90.21107020902306,
+      "durationMs": 4307.749791499984,
+      "throughputFilesPerSec": 894.6666325896366,
+      "minMs": 4025.9000410000444,
+      "maxMs": 4797.869917000004,
+      "meanMs": 4324.099604000012,
+      "stdDevMs": 179.1835763429499,
       "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 315.54224999999997,
-      "throughputFilesPerSec": 12213.895286605837,
-      "minMs": 314.6312,
-      "maxMs": 316.1609,
-      "meanMs": 315.52941999999996,
-      "stdDevMs": 0.4851042790988466,
+      "durationMs": 232.88675,
+      "throughputFilesPerSec": 16548.816109117415,
+      "minMs": 220.4381,
+      "maxMs": 233.7497,
+      "meanMs": 230.83429,
+      "stdDevMs": 4.065127159007455,
       "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 90.35655,
-      "throughputFilesPerSec": 42653.24428610876,
-      "minMs": 89.6349,
-      "maxMs": 92.6425,
-      "meanMs": 90.62796,
-      "stdDevMs": 0.8481798054657983,
+      "durationMs": 38.3667,
+      "throughputFilesPerSec": 100451.69378653885,
+      "minMs": 37.0844,
+      "maxMs": 40.4962,
+      "meanMs": 38.582100000000004,
+      "stdDevMs": 1.2188694286099728,
       "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 24.4718268647067,
-      "multiThreadVsJs": 85.46027167371925
+      "singleThreadVsJs": 18.497187115625874,
+      "multiThreadVsJs": 112.27835053575063
     }
   },
   "svelteCheck": {
     "javascript": {
-      "durationMs": 1932.0268645,
-      "throughputFilesPerSec": 258.7955732848455,
-      "minMs": 1908.626905,
-      "maxMs": 2002.717659,
-      "meanMs": 1933.752647,
-      "stdDevMs": 27.055927672867007,
+      "durationMs": 1320.9277710000001,
+      "throughputFilesPerSec": 378.52183213733036,
+      "minMs": 1298.468208,
+      "maxMs": 1335.343166,
+      "meanMs": 1318.8918749000002,
+      "stdDevMs": 11.719100523258458,
       "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 109.944118,
-      "throughputFilesPerSec": 4547.764892706675,
-      "minMs": 107.014353,
-      "maxMs": 111.684495,
-      "meanMs": 109.5829828,
-      "stdDevMs": 1.4925907027782792,
+      "durationMs": 72.2611665,
+      "throughputFilesPerSec": 6919.345814878313,
+      "minMs": 67.836083,
+      "maxMs": 76.060625,
+      "meanMs": 72.5734583,
+      "stdDevMs": 2.5939010763926986,
       "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 44.8157805,
-      "throughputFilesPerSec": 11156.784383125938,
-      "minMs": 42.130994,
-      "maxMs": 46.611313,
-      "meanMs": 44.79323229999999,
-      "stdDevMs": 1.1020579301000513,
+      "durationMs": 19.8421875,
+      "throughputFilesPerSec": 25198.834553901877,
+      "minMs": 18.514625,
+      "maxMs": 20.159041,
+      "meanMs": 19.6462749,
+      "stdDevMs": 0.5494378816871752,
       "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 17.57280789227851,
-      "multiThreadVsJs": 43.11041429926675
+      "singleThreadVsJs": 18.27991208805078,
+      "multiThreadVsJs": 66.57168071816679
     },
     "filesCount": 500
   }


### PR DESCRIPTION
Per maintainer preference, publish the `/benchmark` numbers from a **local stable run** on the maintainer's machine (Apple M1 Pro, 10-core) instead of the 4-core CI runner. Taken with `BENCHMARK_WARMUP=3 BENCHMARK_ITERATIONS=10`, stable across three back-to-back runs.

The multi-thread figures reflect rsvelte's rayon parallelism vs the single-threaded JS baseline, so the extra cores raise most ratios:

| Task | CI (4-core) | M1 Pro (10-core) |
|---|---|---|
| compile-client | 8.94x | **13.33x** |
| svelte2tsx | 18.86x | 17.34x¹ |
| svelte-check | 43.11x | **66.57x** |
| parse | 102x | **113x** |
| fmt | 85x | **112x** |

¹ slightly lower on M1 because V8 is faster on Apple silicon (the JS baseline is quicker), not a regression.

Only `apps/playground/static/benchmark-results.json` changes. The Site Benchmark CI workflow (#1189) remains available for reproducible arm64 numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)