### PR TITLE
ci(vscode): publish each registry independently (Open VSX back-fill)

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Decide whether to publish
         id: decide
         env:
+          # Presence of OVSX_PAT lets the check consider Open VSX as a target
+          # (so a missing Open VSX release is back-filled even when the
+          # Marketplace is already up to date). Not used to publish here.
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
           VSCODE_PUBLISH_FORCE: ${{ github.event.inputs.force }}
         run: node scripts/release/publish-vscode.mjs --check
 

--- a/scripts/release/publish-vscode.mjs
+++ b/scripts/release/publish-vscode.mjs
@@ -1,18 +1,21 @@
 #!/usr/bin/env node
-// Publish the `rsvelte-vscode` extension to the VS Code Marketplace (and, best
-// effort, Open VSX). The extension version follows `@rsvelte/language-server`
-// (kept in lockstep by the changesets `fixed` group). Idempotent: it skips when
-// the target version is already on the Marketplace, so it is safe to run on
-// every push to main.
+// Publish the `rsvelte-vscode` extension to the VS Code Marketplace and Open VSX.
+// The extension version follows `@rsvelte/language-server` (kept in lockstep by
+// the changesets `fixed` group).
+//
+// Each registry is checked INDEPENDENTLY and published to only when it is behind
+// the target version, so the script is idempotent and safe to run on every push
+// to main. This also means Open VSX can be back-filled later (after OVSX_PAT is
+// added) even though the Marketplace is already up to date.
 //
 // Usage:
 //   node scripts/release/publish-vscode.mjs --check   # decide only (writes GITHUB_OUTPUT)
-//   node scripts/release/publish-vscode.mjs           # package + publish
+//   node scripts/release/publish-vscode.mjs           # package + publish where behind
 //
 // Env:
-//   VSCE_PAT              required to publish (Azure DevOps PAT, Marketplace > Manage)
-//   OVSX_PAT             optional → also publish to Open VSX
-//   VSCODE_PUBLISH_FORCE  "true" bypasses the already-published guard
+//   VSCE_PAT              required to publish to the Marketplace
+//   OVSX_PAT              optional → also publish to Open VSX (skipped if unset)
+//   VSCODE_PUBLISH_FORCE  "true" bypasses the per-registry up-to-date guard
 
 import { execFileSync } from 'node:child_process';
 import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
@@ -27,6 +30,7 @@ const lsPkgPath = resolve(repoRoot, 'apps/npm/language-server/package.json');
 
 const checkOnly = process.argv.includes('--check');
 const force = process.env.VSCODE_PUBLISH_FORCE === 'true';
+const hasOvsx = Boolean(process.env.OVSX_PAT);
 
 const extPkg = JSON.parse(readFileSync(extPkgPath, 'utf8'));
 const target = JSON.parse(readFileSync(lsPkgPath, 'utf8')).version;
@@ -43,7 +47,7 @@ function cmp(a, b) {
   return 0;
 }
 
-/** Latest version on the Marketplace, or null if not published / query failed. */
+/** Latest version on the VS Code Marketplace, or null. */
 function marketplaceVersion() {
   try {
     const out = execFileSync(
@@ -51,38 +55,58 @@ function marketplaceVersion() {
       ['--yes', '@vscode/vsce@^3', 'show', id, '--json'],
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
     );
-    const j = JSON.parse(out);
-    return j?.versions?.[0]?.version ?? null;
+    return JSON.parse(out)?.versions?.[0]?.version ?? null;
   } catch {
     return null;
   }
 }
 
-const published = marketplaceVersion();
-const shouldPublish =
-  force || published === null || cmp(target, published) > 0;
+/** Latest version on Open VSX, or null (queried via the public API). */
+async function openvsxVersion() {
+  try {
+    const r = await fetch(
+      `https://open-vsx.org/api/${extPkg.publisher}/${extPkg.name}`,
+    );
+    if (!r.ok) return null;
+    return (await r.json())?.version ?? null;
+  } catch {
+    return null;
+  }
+}
 
-console.log(`extension:           ${id}`);
-console.log(`target version:      ${target} (follows @rsvelte/language-server)`);
-console.log(`marketplace version: ${published ?? '(none)'}`);
-console.log(`should publish:      ${shouldPublish}${force ? ' (forced)' : ''}`);
+const mpPublished = marketplaceVersion();
+const ovsxPublished = await openvsxVersion();
+
+const needMp = force || mpPublished === null || cmp(target, mpPublished) > 0;
+// Only consider Open VSX when a token is available to publish there.
+const needOvsx =
+  hasOvsx && (force || ovsxPublished === null || cmp(target, ovsxPublished) > 0);
+const shouldPublish = needMp || needOvsx;
+
+console.log(`extension:            ${id}`);
+console.log(`target version:       ${target} (follows @rsvelte/language-server)`);
+console.log(`marketplace version:  ${mpPublished ?? '(none)'}  → publish: ${needMp}`);
+console.log(
+  `open vsx version:     ${ovsxPublished ?? '(none)'}  → publish: ${needOvsx}` +
+    (hasOvsx ? '' : ' (OVSX_PAT unset)'),
+);
 
 if (process.env.GITHUB_OUTPUT) {
   appendFileSync(
     process.env.GITHUB_OUTPUT,
-    `version=${target}\npublished=${published ?? ''}\nshould_publish=${shouldPublish}\n`,
+    `version=${target}\nneed_marketplace=${needMp}\nneed_openvsx=${needOvsx}\nshould_publish=${shouldPublish}\n`,
   );
 }
 
 if (checkOnly) process.exit(0);
 
 if (!shouldPublish) {
-  console.log('Marketplace is already up to date — nothing to publish.');
+  console.log('Both registries are up to date — nothing to publish.');
   process.exit(0);
 }
 
-if (!process.env.VSCE_PAT) {
-  console.error('VSCE_PAT is not set — cannot publish.');
+if (needMp && !process.env.VSCE_PAT) {
+  console.error('VSCE_PAT is not set — cannot publish to the Marketplace.');
   process.exit(1);
 }
 
@@ -95,31 +119,46 @@ if (extPkg.version !== target) {
 
 const vsix = resolve(extDir, `${extPkg.name}-${target}.vsix`);
 
-// `vsce package` runs `vscode:prepublish` (build.mjs), which needs the
-// language-server bundle to already exist (built by the workflow).
+// Package once (shared by both registries). `vsce package` runs
+// `vscode:prepublish` (build.mjs), which needs the language-server bundle to
+// already exist (built by the workflow).
 execFileSync(
   'npx',
   ['--yes', '@vscode/vsce@^3', 'package', '--no-dependencies', '-o', vsix],
   { cwd: extDir, stdio: 'inherit' },
 );
 
-execFileSync(
-  'npx',
-  [
-    '--yes',
-    '@vscode/vsce@^3',
-    'publish',
-    '--no-dependencies',
-    '--packagePath',
-    vsix,
-    '-p',
-    process.env.VSCE_PAT,
-  ],
-  { cwd: extDir, stdio: 'inherit' },
-);
-console.log('✓ published to VS Code Marketplace');
+if (needMp) {
+  execFileSync(
+    'npx',
+    [
+      '--yes',
+      '@vscode/vsce@^3',
+      'publish',
+      '--no-dependencies',
+      '--packagePath',
+      vsix,
+      '-p',
+      process.env.VSCE_PAT,
+    ],
+    { cwd: extDir, stdio: 'inherit' },
+  );
+  console.log('✓ published to VS Code Marketplace');
+} else {
+  console.log('Marketplace already up to date — skipping.');
+}
 
-if (process.env.OVSX_PAT) {
+if (needOvsx) {
+  // Ensure the namespace exists (idempotent — ignore "already exists").
+  try {
+    execFileSync(
+      'npx',
+      ['--yes', 'ovsx@^0', 'create-namespace', extPkg.publisher, '-p', process.env.OVSX_PAT],
+      { cwd: extDir, stdio: 'inherit' },
+    );
+  } catch {
+    /* namespace already exists, or not permitted — publish will report fatal errors */
+  }
   try {
     execFileSync(
       'npx',
@@ -130,6 +169,8 @@ if (process.env.OVSX_PAT) {
   } catch (e) {
     console.warn(`Open VSX publish failed (continuing): ${e?.message ?? e}`);
   }
-} else {
+} else if (!hasOvsx) {
   console.log('OVSX_PAT not set — skipping Open VSX.');
+} else {
+  console.log('Open VSX already up to date — skipping.');
 }


### PR DESCRIPTION
## Why

**Cursor (and VS Codium / Gitpod / Windsurf) resolve extensions from Open VSX, not the VS Code Marketplace.** `rsvelte-vscode` was only published to the Marketplace (OVSX_PAT was unset), so it doesn't appear in Cursor.

The previous `publish-vscode.mjs` gated on the Marketplace version alone and ran vsce→ovsx sequentially. Once the Marketplace had `0.2.0`, force-publishing to back-fill Open VSX would hit a duplicate-version error on `vsce publish` before ever reaching `ovsx publish`.

## What

Each registry is now checked and published **independently**:
- query Marketplace (`vsce show`) and Open VSX (public API) versions separately
- publish to a registry only when it is **behind** the target version
- package the vsix once; skip `vsce` when the Marketplace is current, skip `ovsx` when Open VSX is current or `OVSX_PAT` is unset (best-effort; `create-namespace` first)
- the `check` job now also gets `OVSX_PAT`, so a missing Open VSX release triggers the publish job even when the Marketplace is already up to date

Verified locally: with `OVSX_PAT` unset → both up to date (no-op); with `OVSX_PAT` set → Marketplace `publish: false`, Open VSX `publish: true` (back-fills only Open VSX, no vsce duplicate).

## To actually publish to Open VSX (user setup)
1. Sign in at https://open-vsx.org with GitHub and **sign the Eclipse publisher agreement** (one-time).
2. Create the `baseballyama` namespace (the workflow also runs `ovsx create-namespace`, but the agreement must be signed first).
3. Generate an **Access Token** and add it as repo secret **`OVSX_PAT`**.
4. Run the **Publish VS Code Extension** workflow via `workflow_dispatch` — it will back-fill Open VSX `0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)