### PR TITLE
docs(playground): remove svelte·in·rust nav banner + fix dangling /ecosystem links

### DIFF
--- a/apps/playground/src/lib/components/SiteNav.svelte
+++ b/apps/playground/src/lib/components/SiteNav.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/state';
 	import { themeStore } from '$lib/theme.svelte';
 
-	type Active = 'home' | 'docs' | 'ecosystem' | 'playground' | 'progress' | 'benchmark';
+	type Active = 'home' | 'docs' | 'playground' | 'progress' | 'benchmark';
 
 	interface Props {
 		// Each page passes its own slug so the link gets the `active` style
@@ -34,12 +34,10 @@
 			</svg>
 		</span>
 		<span class="brand-text">rsvelte</span>
-		<span class="brand-tag">svelte&nbsp;·&nbsp;in&nbsp;rust</span>
 	</a>
 
 	<div class="links">
 		<a href="{base}/docs" class:active={isActive('docs')}>Docs</a>
-		<a href="{base}/ecosystem" class:active={isActive('ecosystem')}>Ecosystem</a>
 		<a href="{base}/playground" class:active={isActive('playground')}>Playground</a>
 		<a href="{base}/progress" class:active={isActive('progress')}>Compatibility</a>
 		<a href="{base}/benchmark" class:active={isActive('benchmark')}>Benchmark</a>
@@ -119,19 +117,6 @@
 		letter-spacing: -0.01em;
 	}
 
-	.brand-tag {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.62rem;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: var(--rust);
-		padding: 0.2rem 0.45rem;
-		border: 1px solid currentColor;
-		border-radius: 2px;
-		line-height: 1;
-		margin-left: 0.2rem;
-	}
-
 	.links {
 		display: flex;
 		align-items: center;
@@ -197,17 +182,14 @@
 	}
 
 	@media (max-width: 640px) {
-		.brand-tag {
-			display: none;
-		}
 		.links {
 			gap: 0.7rem;
 			font-size: 0.84rem;
 		}
-		/* Keep the primary destinations (Docs, Ecosystem, Playground) on phones;
+		/* Keep the primary destinations (Docs, Playground) on phones;
 		   Compatibility + Benchmark are reachable from the home page. */
-		.links a:nth-child(4),
-		.links a:nth-child(5) {
+		.links a:nth-child(3),
+		.links a:nth-child(4) {
 			display: none;
 		}
 	}

--- a/apps/playground/src/routes/+page.svelte
+++ b/apps/playground/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 	import SiteNav from '$lib/components/SiteNav.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 	import EcoCard from '$lib/components/EcoCard.svelte';
-	import { shipped, counts } from '$lib/ecosystem';
+	import { shipped, planned, delegated, counts } from '$lib/ecosystem';
 
 	let bench = $state<BenchmarkResults | null>(null);
 	let tests = $state<TestResults | null>(null);
@@ -144,8 +144,8 @@
 		</p>
 
 		<div class="cta">
-			<a href="{base}/ecosystem" class="btn btn-primary">
-				Explore the ecosystem <span aria-hidden="true">→</span>
+			<a href="#ecosystem" class="btn btn-primary">
+				Explore the ecosystem <span aria-hidden="true">↓</span>
 			</a>
 			<a href="{base}/playground" class="btn btn-ghost">
 				Open playground <span aria-hidden="true">→</span>
@@ -245,28 +245,42 @@
 		</div>
 	</section>
 
-	<section class="eco">
+	<section class="eco" id="ecosystem">
 		<div class="section-head">
 			<span class="num">02</span>
 			<h2>Not just a <em>compiler</em>.</h2>
 			<p class="lede">
 				rsvelte ports the hot path of every common Svelte workflow. {counts.shipped} drop-in
-				packages ship today, each a byte-for-byte replacement for its upstream tool.
+				packages ship today — each a byte-for-byte replacement for its upstream tool — with
+				{counts.planned} more planned and {counts.delegated} deliberately delegated to the wider
+				<a class="link" href="https://oxc.rs/" target="_blank" rel="noopener">OXC</a> toolchain.
 			</p>
 		</div>
 
+		<h3 class="eco-tier">Shipped <span class="eco-tier-n">· usable today</span></h3>
 		<div class="eco-grid">
 			{#each shipped as c (c.name)}
 				<EcoCard {c} compact />
 			{/each}
 		</div>
 
-		<div class="eco-foot">
-			<a class="eco-link" href="{base}/ecosystem">
-				See the full inventory — shipped, planned &amp; delegated
-				<span aria-hidden="true">→</span>
-			</a>
-		</div>
+		{#if planned.length > 0}
+			<h3 class="eco-tier">Planned <span class="eco-tier-n">· on the roadmap</span></h3>
+			<div class="eco-grid">
+				{#each planned as c (c.name)}
+					<EcoCard {c} compact />
+				{/each}
+			</div>
+		{/if}
+
+		{#if delegated.length > 0}
+			<h3 class="eco-tier">Delegated <span class="eco-tier-n">· routed to OXC / JS</span></h3>
+			<div class="eco-grid">
+				{#each delegated as c (c.name)}
+					<EcoCard {c} compact />
+				{/each}
+			</div>
+		{/if}
 	</section>
 
 	<section class="dropin">
@@ -857,6 +871,11 @@
 	.eco {
 		max-width: 1080px;
 		margin: 0 auto;
+		/* Bottom breathing room (previously provided by the removed `.eco-foot`). */
+		padding-bottom: clamp(2rem, 4vh, 3rem);
+		/* Anchor target from the hero CTA — offset so the heading isn't hidden
+		   under the sticky nav. */
+		scroll-margin-top: 5rem;
 	}
 
 	.eco-grid {
@@ -868,32 +887,26 @@
 		gap: 1rem;
 	}
 
-	.eco-foot {
+	/* Sub-group heading inside the ecosystem section (Shipped / Planned /
+	   Delegated). */
+	.eco-tier {
 		max-width: 1080px;
-		margin: 0 auto;
-		padding: 1.6rem clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
-	}
-
-	.eco-link {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
+		margin: 1.8rem auto 0.8rem;
+		padding: 0 clamp(1rem, 4vw, 2.5rem);
 		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 600;
+		font-weight: 700;
 		font-size: 0.95rem;
-		color: var(--svelte);
+		letter-spacing: -0.01em;
+		color: var(--ink);
 	}
 
-	.eco-link span {
-		transition: transform 0.18s;
+	.eco-tier:first-of-type {
+		margin-top: 0;
 	}
 
-	.eco-link:hover {
-		color: var(--svelte-hover);
-	}
-
-	.eco-link:hover span {
-		transform: translateX(3px);
+	.eco-tier-n {
+		font-weight: 500;
+		color: var(--ink-faint);
 	}
 
 	/* DROP-IN */


### PR DESCRIPTION
Follow-up to #1213, fixing two things:

### 1. The banner — it was the nav brand pill, not the hero eyebrow
The "banner" to remove is the **`svelte · in rust`** pill next to the logo in the nav. Removed it (and its CSS). The home hero eyebrow ("Svelte ecosystem · written in Rust") is **kept**.

### 2. #1213 left dangling links to the deleted /ecosystem route
The route was deleted but the **nav "Ecosystem" link** and the **home hero CTA** still pointed at it (404), and the inventory wasn't surfaced on the home page. Now:
- Nav: "Ecosystem" link removed; mobile `nth-child` hiding fixed for the new link count.
- Home: hero CTA → on-page `#ecosystem` anchor; the ecosystem section carries the **full inventory** (Shipped / Planned / Delegated tiers); old "see full inventory" link dropped.

Both components compile cleanly (one pre-existing unrelated CSS warning on home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)