### PR TITLE
refactor(parse): type more script statements (shrink JsNode::Raw toward serde_json removal)

### DIFF
--- a/crates/rsvelte_core/src/ast/arena.rs
+++ b/crates/rsvelte_core/src/ast/arena.rs
@@ -319,6 +319,7 @@ mod tests {
             end: 0,
             loc: None,
             name: CompactString::new(name),
+            type_annotation: None,
         }
     }
 

--- a/crates/rsvelte_core/src/ast/js.rs
+++ b/crates/rsvelte_core/src/ast/js.rs
@@ -108,6 +108,7 @@ impl Expression {
             end,
             loc: typed_loc,
             name: name.into(),
+            type_annotation: None,
         }))
     }
 

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -307,12 +307,22 @@ pub enum JsNode {
         end: u32,
         loc: Option<Box<Loc>>,
         properties: IdRange,
+        /// Opaque, output-only TS `typeAnnotation` boundary blob for an
+        /// annotated destructuring declarator id (`let { a }: T = …`). Analyze
+        /// never walks into it; it lets such a pattern route through the typed
+        /// walker while serializing its annotation verbatim. `None` for the
+        /// overwhelming majority of object patterns (serializes identically to
+        /// an un-annotated pattern — no stray `typeAnnotation` key).
+        type_annotation: Option<Box<serde_json::Value>>,
     },
     ArrayPattern {
         start: u32,
         end: u32,
         loc: Option<Box<Loc>>,
         elements: Vec<Option<JsNode>>,
+        /// See `ObjectPattern::type_annotation`. Opaque output-only TS annotation
+        /// for an annotated array-destructuring declarator id (`let [ a ]: T = …`).
+        type_annotation: Option<Box<serde_json::Value>>,
     },
     AssignmentPattern {
         start: u32,
@@ -1186,6 +1196,7 @@ impl Serialize for JsNode {
                 end,
                 loc,
                 properties,
+                type_annotation,
             } => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "ObjectPattern")?;
@@ -1193,6 +1204,9 @@ impl Serialize for JsNode {
                 map.serialize_entry("end", end)?;
                 ser_loc!(map, loc);
                 ser_children!(map, "properties", properties);
+                if let Some(ta) = type_annotation {
+                    map.serialize_entry("typeAnnotation", ta.as_ref())?;
+                }
                 map.end()
             }
             JsNode::ArrayPattern {
@@ -1200,6 +1214,7 @@ impl Serialize for JsNode {
                 end,
                 loc,
                 elements,
+                type_annotation,
             } => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "ArrayPattern")?;
@@ -1207,6 +1222,9 @@ impl Serialize for JsNode {
                 map.serialize_entry("end", end)?;
                 ser_loc!(map, loc);
                 map.serialize_entry("elements", elements)?;
+                if let Some(ta) = type_annotation {
+                    map.serialize_entry("typeAnnotation", ta.as_ref())?;
+                }
                 map.end()
             }
             JsNode::AssignmentPattern {
@@ -2287,12 +2305,14 @@ impl JsNode {
                         end,
                         loc,
                         properties: convert_array(obj, "properties"),
+                        type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
                     },
                     "ArrayPattern" => JsNode::ArrayPattern {
                         start,
                         end,
                         loc,
                         elements: convert_nullable_array(obj, "elements"),
+                        type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
                     },
                     "AssignmentPattern" => JsNode::AssignmentPattern {
                         start,

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -90,6 +90,13 @@ pub enum JsNode {
         end: u32,
         loc: Option<Box<Loc>>,
         name: CompactString,
+        /// Opaque, output-only TS `typeAnnotation` boundary blob (ESTree
+        /// `TSTypeAnnotation`). Analyze never walks into it; it exists solely so
+        /// a TS-annotated binding/declarator identifier can route through the
+        /// typed walker while still serializing its annotation verbatim. `None`
+        /// for the overwhelming majority of identifiers (serializes identically
+        /// to an un-annotated id — no stray `typeAnnotation` key).
+        type_annotation: Option<Box<serde_json::Value>>,
     },
     PrivateIdentifier {
         start: u32,
@@ -688,6 +695,7 @@ impl Serialize for JsNode {
                 end,
                 loc,
                 name,
+                type_annotation,
             } => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "Identifier")?;
@@ -695,6 +703,9 @@ impl Serialize for JsNode {
                 map.serialize_entry("end", end)?;
                 ser_loc!(map, loc);
                 map.serialize_entry("name", name.as_str())?;
+                if let Some(ta) = type_annotation {
+                    map.serialize_entry("typeAnnotation", ta.as_ref())?;
+                }
                 map.end()
             }
             JsNode::PrivateIdentifier {
@@ -2043,6 +2054,7 @@ impl JsNode {
                         end,
                         loc,
                         name: get_str(obj, "name"),
+                        type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
                     },
                     "PrivateIdentifier" => JsNode::PrivateIdentifier {
                         start,

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -342,6 +342,13 @@ pub enum JsNode {
         leading_comments: Option<Vec<Value>>,
         /// Trailing comments on the Program node (all JS comments in the program).
         trailing_comments: Option<Vec<Value>>,
+        /// Map from a JS AST node's absolute `start` offset to the raw `svelte-ignore`
+        /// comment value texts that were attached to it as leading comments (at any
+        /// depth in this program). This lets Phase-2 analyze surface `svelte-ignore`
+        /// suppression for typed nodes without materializing them as `JsNode::Raw`
+        /// just to carry a `leadingComments` array. Empty when the script has no
+        /// `svelte-ignore` comments (the common case). Internal-only: not serialized.
+        ignore_comment_map: Vec<(u32, Vec<CompactString>)>,
     },
     ExpressionStatement {
         start: u32,
@@ -1253,6 +1260,8 @@ impl Serialize for JsNode {
                 source_type,
                 leading_comments,
                 trailing_comments,
+                // Internal analyze-only metadata; never part of the ESTree output.
+                ignore_comment_map: _,
             } => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "Program")?;
@@ -2309,6 +2318,10 @@ impl JsNode {
                         trailing_comments: obj
                             .get("trailingComments")
                             .and_then(|v| v.as_array().cloned()),
+                        // Reconstructed-from-Value programs carry no analyze-only
+                        // svelte-ignore map; comment-bearing nodes in that path keep
+                        // their leadingComments and go through the Value walker.
+                        ignore_comment_map: Vec::new(),
                     },
                     "ExpressionStatement" => JsNode::ExpressionStatement {
                         start,

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -1099,19 +1099,37 @@ fn remove_typescript_from_ast(ast: &mut crate::ast::Root) -> Result<(), crate::e
     fn strip_ts_from_script(
         script: &mut crate::ast::Script,
     ) -> Result<(), crate::error::ParseError> {
-        let val = match &mut script.content {
-            crate::ast::js::Expression::Value(v) => v,
-            crate::ast::js::Expression::Typed(_) | crate::ast::js::Expression::Lazy { .. } => {
-                // Convert Typed/Lazy to Value for mutation
+        use crate::ast::js::Expression;
+        match &mut script.content {
+            // Typed path: mutate the arena-backed typed tree in place, keeping
+            // the script `Expression::Typed` (no expensive `as_json()` round
+            // trip). The serialize arena is installed by the caller's
+            // `SerializeArenaGuard`, so it backs this Program's children.
+            Expression::Typed(te) => crate::ast::arena::with_current_serialize_arena(|arena| {
+                phases::phase1_parse::remove_typescript_nodes::remove_typescript_nodes_typed(
+                    &mut te.node,
+                    arena,
+                )
+            }),
+            // Legacy Value path (kept for the rare `Expression::Value` case).
+            Expression::Value(v) => {
+                phases::phase1_parse::remove_typescript_nodes::remove_typescript_nodes(v, &[])
+            }
+            // Lazy expressions are resolved before this point; fall back defensively.
+            Expression::Lazy { .. } => {
                 let json = script.content.as_json().clone();
-                script.content = crate::ast::js::Expression::Value(json);
+                script.content = Expression::Value(json);
                 match &mut script.content {
-                    crate::ast::js::Expression::Value(v) => v,
+                    Expression::Value(v) => {
+                        phases::phase1_parse::remove_typescript_nodes::remove_typescript_nodes(
+                            v,
+                            &[],
+                        )
+                    }
                     _ => unreachable!(),
                 }
             }
-        };
-        phases::phase1_parse::remove_typescript_nodes::remove_typescript_nodes(val, &[])
+        }
     }
 
     // In Svelte, if ANY script has lang="ts", ALL scripts are treated as TypeScript.
@@ -1142,16 +1160,28 @@ fn remove_typescript_from_ast(ast: &mut crate::ast::Root) -> Result<(), crate::e
 fn strip_ts_from_expression(
     expr: &mut crate::ast::js::Expression,
 ) -> Result<(), crate::error::ParseError> {
-    // Ensure we have a Value variant for mutation
-    if matches!(expr, crate::ast::js::Expression::Typed(_)) {
-        let json = expr.as_json().clone();
-        *expr = crate::ast::js::Expression::Value(json);
-    }
+    use crate::ast::js::Expression;
     match expr {
-        crate::ast::js::Expression::Value(val) => {
+        // Typed path: mutate the arena-backed typed tree in place (no `as_json()`).
+        Expression::Typed(te) => crate::ast::arena::with_current_serialize_arena(|arena| {
+            phases::phase1_parse::remove_typescript_nodes::remove_typescript_nodes_typed(
+                &mut te.node,
+                arena,
+            )
+        }),
+        Expression::Value(val) => {
             phases::phase1_parse::remove_typescript_nodes::remove_typescript_nodes(val, &[])
         }
-        _ => unreachable!(),
+        Expression::Lazy { .. } => {
+            let json = expr.as_json().clone();
+            *expr = Expression::Value(json);
+            match expr {
+                Expression::Value(val) => {
+                    phases::phase1_parse::remove_typescript_nodes::remove_typescript_nodes(val, &[])
+                }
+                _ => unreachable!(),
+            }
+        }
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7062,10 +7062,25 @@ fn convert_statement_for_program(
                 arena.alloc_js_node(expr_to_node(super_class_value))
             });
 
-            // body (ClassBody) — kept as a Raw value (mirrors ClassExpression).
-            let body_value =
-                convert_class_body_for_program(arena, &class_decl.body, offset, line_offsets);
-            let body = arena.alloc_js_node(JsNode::Raw(body_value));
+            // body (ClassBody) — typed when every member is plain JS; otherwise a
+            // Raw blob fallback (TS modifiers / decorators / declare / accessor).
+            let body = match convert_class_body_for_program_as_node(
+                arena,
+                &class_decl.body,
+                offset,
+                line_offsets,
+            ) {
+                Some(node) => arena.alloc_js_node(node),
+                None => {
+                    let body_value = convert_class_body_for_program(
+                        arena,
+                        &class_decl.body,
+                        offset,
+                        line_offsets,
+                    );
+                    arena.alloc_js_node(JsNode::Raw(body_value))
+                }
+            };
 
             // Decorators: include so remove_typescript_nodes can detect them.
             let decorators = if class_decl.decorators.is_empty() {
@@ -8508,8 +8523,20 @@ fn convert_expression_for_program(
                 )))
             });
 
-            let body =
-                convert_class_body_for_program(arena, &class_expr.body, offset, line_offsets);
+            let body = match convert_class_body_for_program_as_node(
+                arena,
+                &class_expr.body,
+                offset,
+                line_offsets,
+            ) {
+                Some(node) => arena.alloc_js_node(node),
+                None => arena.alloc_js_node(JsNode::Raw(convert_class_body_for_program(
+                    arena,
+                    &class_expr.body,
+                    offset,
+                    line_offsets,
+                ))),
+            };
 
             Expression::from_node(JsNode::ClassExpression {
                 start: start as u32,
@@ -8517,7 +8544,7 @@ fn convert_expression_for_program(
                 loc: create_typed_loc(start, end, line_offsets),
                 id,
                 super_class,
-                body: arena.alloc_js_node(JsNode::Raw(body)),
+                body,
             })
         }
         OxcExpression::Super(super_expr) => {
@@ -9003,6 +9030,151 @@ fn convert_class_body_for_program(
     obj.insert("body".to_string(), Value::Array(body_elements));
 
     Value::Object(obj)
+}
+
+/// Outcome of attempting to build a typed program-path class member.
+enum TypedClassElem {
+    /// A fully typed member node.
+    Node(JsNode),
+    /// Element intentionally dropped (mirrors the Value path's `None`).
+    Skip,
+    /// Member carries data the typed variants can't represent byte-identically
+    /// (TS modifiers / decorators / `declare` / accessor); the whole class body
+    /// must fall back to a `JsNode::Raw(Value)` blob.
+    Bail,
+}
+
+/// Typed twin of [`convert_class_body_for_program`]. Returns `Some(ClassBody)`
+/// when every member can be represented byte-identically by the typed
+/// `MethodDefinition` / `PropertyDefinition` variants; returns `None` when any
+/// member carries TS modifiers / decorators / `declare` / accessor (the caller
+/// then falls back to the `Raw(Value)` blob via `convert_class_body_for_program`).
+///
+/// Serializes byte-identically to the Value blob (modulo the method value's
+/// `expression: false` field, which the official ESTree output also emits and
+/// the `convert_function_expression_for_program` Value blob was missing — same
+/// improvement landed in D2 for top-level `FunctionExpression`s).
+fn convert_class_body_for_program_as_node(
+    arena: &ParseArena,
+    body: &oxc_ast::ast::ClassBody,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Option<JsNode> {
+    let start = offset + body.span.start as usize;
+    let end = offset + body.span.end as usize;
+
+    let mut members: Vec<JsNode> = Vec::with_capacity(body.body.len());
+    for element in &body.body {
+        match convert_class_element_for_program_as_node(arena, element, offset, line_offsets) {
+            TypedClassElem::Node(node) => members.push(node),
+            TypedClassElem::Skip => {}
+            TypedClassElem::Bail => return None,
+        }
+    }
+
+    Some(JsNode::ClassBody {
+        start: start as u32,
+        end: end as u32,
+        loc: create_typed_loc(start, end, line_offsets),
+        body: arena.alloc_js_children(members),
+    })
+}
+
+/// Typed twin of [`convert_class_element_for_program`]. Bails (to a `Raw` class
+/// body) on any member that carries TS modifiers / decorators / `declare` /
+/// accessor, so the typed path is only taken for plain-JS class members whose
+/// shape matches the Value blob exactly.
+fn convert_class_element_for_program_as_node(
+    arena: &ParseArena,
+    element: &oxc_ast::ast::ClassElement,
+    offset: usize,
+    line_offsets: &[usize],
+) -> TypedClassElem {
+    match element {
+        oxc_ast::ast::ClassElement::MethodDefinition(method) => {
+            // Abstract methods are dropped by the Value path (`return None`).
+            if method.r#type == oxc_ast::ast::MethodDefinitionType::TSAbstractMethodDefinition {
+                return TypedClassElem::Skip;
+            }
+            // TS modifiers / decorators have no typed representation here.
+            if !method.decorators.is_empty()
+                || method.r#override
+                || method.optional
+                || method.accessibility.is_some()
+            {
+                return TypedClassElem::Bail;
+            }
+            let start = offset + method.span.start as usize;
+            let end = offset + method.span.end as usize;
+            let kind = match method.kind {
+                oxc_ast::ast::MethodDefinitionKind::Constructor => "constructor",
+                oxc_ast::ast::MethodDefinitionKind::Method => "method",
+                oxc_ast::ast::MethodDefinitionKind::Get => "get",
+                oxc_ast::ast::MethodDefinitionKind::Set => "set",
+            };
+            let key = convert_property_key(arena, &method.key, offset, line_offsets);
+            let value = convert_function_expression_for_program_as_node(
+                arena,
+                &method.value,
+                offset,
+                line_offsets,
+            );
+            TypedClassElem::Node(JsNode::MethodDefinition {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                key: arena.alloc_js_node(key),
+                value: arena.alloc_js_node(value),
+                kind: CompactString::from(kind),
+                r#static: method.r#static,
+                computed: method.computed,
+            })
+        }
+        oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
+            if prop.r#type == oxc_ast::ast::PropertyDefinitionType::TSAbstractPropertyDefinition {
+                return TypedClassElem::Skip;
+            }
+            // The Value path emits a conditional `declare` field and never the
+            // other TS modifiers / decorators — bail so those still route through
+            // the Raw blob unchanged.
+            if !prop.decorators.is_empty()
+                || prop.declare
+                || prop.r#override
+                || prop.optional
+                || prop.definite
+                || prop.readonly
+                || prop.accessibility.is_some()
+                || prop.type_annotation.is_some()
+            {
+                return TypedClassElem::Bail;
+            }
+            let start = offset + prop.span.start as usize;
+            let end = offset + prop.span.end as usize;
+            let key = convert_property_key(arena, &prop.key, offset, line_offsets);
+            let value = prop.value.as_ref().map(|value| {
+                arena.alloc_js_node(expr_to_node(convert_expression_for_program(
+                    arena,
+                    value,
+                    offset,
+                    line_offsets,
+                )))
+            });
+            TypedClassElem::Node(JsNode::PropertyDefinition {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                key: arena.alloc_js_node(key),
+                value,
+                r#static: prop.r#static,
+                computed: prop.computed,
+            })
+        }
+        // AccessorProperty: the Value path emits a `PropertyDefinition` with an
+        // `accessor: true` field that the typed variant can't carry.
+        oxc_ast::ast::ClassElement::AccessorProperty(_) => TypedClassElem::Bail,
+        // StaticBlock and TS-only members are dropped by the Value path (`_ => None`).
+        _ => TypedClassElem::Skip,
+    }
 }
 
 /// Convert a class element to JSON value (for program context).

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -2708,6 +2708,7 @@ fn convert_object_pattern_to_expr(
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         properties: arena.alloc_js_children(properties),
+        type_annotation: None,
     })
 }
 
@@ -2758,6 +2759,7 @@ fn convert_array_pattern_to_expr(
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         elements,
+        type_annotation: None,
     })
 }
 
@@ -4914,6 +4916,7 @@ fn convert_object_assignment_target(
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         properties: arena.alloc_js_children(properties),
+        type_annotation: None,
     }
 }
 
@@ -4961,6 +4964,7 @@ fn convert_array_assignment_target(
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         elements,
+        type_annotation: None,
     }
 }
 
@@ -8129,6 +8133,34 @@ fn convert_variable_declarator_for_program(
                 name,
                 type_annotation: Some(Box::new(ts_value)),
             }),
+            // Annotated destructuring declarator id (`let { a }: T` / `let [ a ]: T`):
+            // keep the pattern typed and carry the TS annotation as an opaque
+            // boundary blob (mirrors the Identifier branch above). The outer
+            // `end`/`loc` extend to cover the annotation; the pattern's own
+            // children keep their original spans — byte-identical to the former
+            // `JsNode::Raw(to_value + typeAnnotation/end/loc override)` shape.
+            JsNode::ObjectPattern {
+                start: p_start,
+                properties,
+                ..
+            } => arena.alloc_js_node(JsNode::ObjectPattern {
+                start: p_start,
+                end: ts_end as u32,
+                loc: create_typed_loc(p_start as usize, ts_end, line_offsets),
+                properties,
+                type_annotation: Some(Box::new(ts_value)),
+            }),
+            JsNode::ArrayPattern {
+                start: p_start,
+                elements,
+                ..
+            } => arena.alloc_js_node(JsNode::ArrayPattern {
+                start: p_start,
+                end: ts_end as u32,
+                loc: create_typed_loc(p_start as usize, ts_end, line_offsets),
+                elements,
+                type_annotation: Some(Box::new(ts_value)),
+            }),
             other => {
                 let mut id_value = other.to_value();
                 if let Value::Object(ref mut id_obj) = id_value {
@@ -9621,6 +9653,7 @@ fn convert_object_pattern(
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         properties: arena.alloc_js_children(properties),
+        type_annotation: None,
     }
 }
 
@@ -9665,6 +9698,7 @@ fn convert_array_pattern(
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         elements,
+        type_annotation: None,
     }
 }
 
@@ -9841,6 +9875,7 @@ fn convert_object_assignment_target_for_program(
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         properties: arena.alloc_js_children(properties),
+        type_annotation: None,
     }
 }
 
@@ -9892,6 +9927,7 @@ fn convert_array_assignment_target_for_program(
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         elements,
+        type_annotation: None,
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -2656,9 +2656,13 @@ fn convert_object_pattern_to_expr(
         .map(|prop| {
             let prop_start = adjusted_offset + prop.span.start as usize;
             let prop_end = adjusted_offset + prop.span.end as usize;
-            let key_value =
-                convert_property_key_for_param(arena, &prop.key, adjusted_offset, line_offsets);
-            let value_value = convert_binding_pattern_for_param(
+            let key_node = convert_property_key_for_param_as_node(
+                arena,
+                &prop.key,
+                adjusted_offset,
+                line_offsets,
+            );
+            let value_node = convert_binding_pattern_for_param_as_node(
                 arena,
                 &prop.value,
                 adjusted_offset,
@@ -2671,8 +2675,8 @@ fn convert_object_pattern_to_expr(
                 method: false,
                 shorthand: prop.shorthand,
                 computed: prop.computed,
-                key: arena.alloc_js_node(JsNode::Raw(key_value)),
-                value: arena.alloc_js_node(JsNode::Raw(value_value)),
+                key: arena.alloc_js_node(key_node),
+                value: arena.alloc_js_node(value_node),
                 kind: CompactString::from("init"),
             }
         })
@@ -2681,13 +2685,17 @@ fn convert_object_pattern_to_expr(
     if let Some(rest) = &obj_pat.rest {
         let rest_start = adjusted_offset + rest.span.start as usize;
         let rest_end = adjusted_offset + rest.span.end as usize;
-        let argument =
-            convert_binding_pattern_for_param(arena, &rest.argument, adjusted_offset, line_offsets);
+        let argument = convert_binding_pattern_for_param_as_node(
+            arena,
+            &rest.argument,
+            adjusted_offset,
+            line_offsets,
+        );
         properties.push(JsNode::RestElement {
             start: rest_start as u32,
             end: rest_end as u32,
             loc: create_typed_loc(rest_start, rest_end, line_offsets),
-            argument: arena.alloc_js_node(JsNode::Raw(argument)),
+            argument: arena.alloc_js_node(argument),
         });
     }
 
@@ -2714,12 +2722,12 @@ fn convert_array_pattern_to_expr(
         .iter()
         .map(|elem| {
             elem.as_ref().map(|pattern| {
-                JsNode::Raw(convert_binding_pattern_for_param(
+                convert_binding_pattern_for_param_as_node(
                     arena,
                     pattern,
                     adjusted_offset,
                     line_offsets,
-                ))
+                )
             })
         })
         .collect();
@@ -2727,13 +2735,17 @@ fn convert_array_pattern_to_expr(
     if let Some(rest) = &arr_pat.rest {
         let rest_start = adjusted_offset + rest.span.start as usize;
         let rest_end = adjusted_offset + rest.span.end as usize;
-        let argument =
-            convert_binding_pattern_for_param(arena, &rest.argument, adjusted_offset, line_offsets);
+        let argument = convert_binding_pattern_for_param_as_node(
+            arena,
+            &rest.argument,
+            adjusted_offset,
+            line_offsets,
+        );
         elements.push(Some(JsNode::RestElement {
             start: rest_start as u32,
             end: rest_end as u32,
             loc: create_typed_loc(rest_start, rest_end, line_offsets),
-            argument: arena.alloc_js_node(JsNode::Raw(argument)),
+            argument: arena.alloc_js_node(argument),
         }));
     }
 
@@ -2755,10 +2767,19 @@ fn convert_assignment_pattern_to_expr(
     let start = adjusted_offset + assign_pat.span.start as usize;
     let end = adjusted_offset + assign_pat.span.end as usize;
 
-    let left =
-        convert_binding_pattern_for_param(arena, &assign_pat.left, adjusted_offset, line_offsets);
+    let left = convert_binding_pattern_for_param_as_node(
+        arena,
+        &assign_pat.left,
+        adjusted_offset,
+        line_offsets,
+    );
 
-    // Convert right (the default value) - simplified for now
+    // Convert right (the default value) - simplified for now. This top-level
+    // param assignment-pattern path emits a bare `{ type: "Expression" }`
+    // placeholder (no real expression conversion); keep it as `JsNode::Raw`
+    // since it is not a well-formed typed node. (The recursive
+    // `convert_binding_pattern_for_param_as_node` AssignmentPattern arm DOES
+    // produce a real typed default value.)
     let right_start = adjusted_offset + assign_pat.right.span().start as usize;
     let right_end = adjusted_offset + assign_pat.right.span().end as usize;
     let mut right_obj = Map::new();
@@ -2773,69 +2794,9 @@ fn convert_assignment_pattern_to_expr(
         start: start as u32,
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
-        left: arena.alloc_js_node(JsNode::Raw(left)),
+        left: arena.alloc_js_node(left),
         right: arena.alloc_js_node(JsNode::Raw(Value::Object(right_obj))),
     })
-}
-
-/// Convert oxc PropertyKey to our JSON format (for function parameters).
-fn convert_property_key_for_param(
-    arena: &ParseArena,
-    key: &oxc_ast::ast::PropertyKey,
-    adjusted_offset: usize,
-    line_offsets: &[usize],
-) -> Value {
-    use oxc_ast::ast::PropertyKey;
-
-    match key {
-        PropertyKey::StaticIdentifier(id) => {
-            let start = adjusted_offset + id.span.start as usize;
-            let end = adjusted_offset + id.span.end as usize;
-            let mut obj = Map::new();
-            obj.insert("type".to_string(), Value::String("Identifier".to_string()));
-            obj.insert("name".to_string(), Value::String(id.name.to_string()));
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
-            Value::Object(obj)
-        }
-        PropertyKey::PrivateIdentifier(id) => {
-            let start = adjusted_offset + id.span.start as usize;
-            let end = adjusted_offset + id.span.end as usize;
-            let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("PrivateIdentifier".to_string()),
-            );
-            obj.insert("name".to_string(), Value::String(id.name.to_string()));
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
-            Value::Object(obj)
-        }
-        _ => {
-            // For computed keys, convert the expression properly.
-            // Must use with_serialize_arena to resolve IdRange children
-            // allocated in the parse arena during serialization.
-            if let Some(expr) = key.as_expression() {
-                let converted = convert_expression(arena, expr, adjusted_offset, line_offsets);
-                crate::ast::arena::with_serialize_arena(arena, || converted.as_json().clone())
-            } else {
-                // Fallback placeholder for truly unhandled cases
-                let mut obj = Map::new();
-                obj.insert("type".to_string(), Value::String("Identifier".to_string()));
-                obj.insert(
-                    "name".to_string(),
-                    Value::String("__computed__".to_string()),
-                );
-                Value::Object(obj)
-            }
-        }
-    }
 }
 
 /// Convert oxc BindingPattern to our JSON format (for function parameters).
@@ -2962,6 +2923,118 @@ fn convert_binding_pattern_for_param(
             obj.insert("right".to_string(), right_val);
 
             Value::Object(obj)
+        }
+    }
+}
+
+/// Typed object-pattern property-key converter (param path).
+///
+/// Produces a typed `JsNode` (Identifier / PrivateIdentifier / converted
+/// expression) that serializes identically to the Value form, so object-pattern
+/// keys route through the typed analyze walker instead of `JsNode::Raw`. Falls
+/// back to `JsNode::Raw` only for the truly-unhandled placeholder
+/// (`{ type: "Identifier", name: "__computed__" }`), which carries no span and
+/// is therefore not representable as a well-formed typed `Identifier`.
+fn convert_property_key_for_param_as_node(
+    arena: &ParseArena,
+    key: &oxc_ast::ast::PropertyKey,
+    adjusted_offset: usize,
+    line_offsets: &[usize],
+) -> JsNode {
+    use oxc_ast::ast::PropertyKey;
+
+    match key {
+        PropertyKey::StaticIdentifier(id) => {
+            let start = adjusted_offset + id.span.start as usize;
+            let end = adjusted_offset + id.span.end as usize;
+            expr_to_node(create_identifier(&id.name, start, end, line_offsets))
+        }
+        PropertyKey::PrivateIdentifier(id) => {
+            let start = adjusted_offset + id.span.start as usize;
+            let end = adjusted_offset + id.span.end as usize;
+            expr_to_node(create_private_identifier(
+                &id.name,
+                start,
+                end,
+                line_offsets,
+            ))
+        }
+        _ => {
+            if let Some(expr) = key.as_expression() {
+                expr_to_node(convert_expression(
+                    arena,
+                    expr,
+                    adjusted_offset,
+                    line_offsets,
+                ))
+            } else {
+                // Fallback placeholder for truly unhandled cases (no span).
+                let mut obj = Map::new();
+                obj.insert("type".to_string(), Value::String("Identifier".to_string()));
+                obj.insert(
+                    "name".to_string(),
+                    Value::String("__computed__".to_string()),
+                );
+                JsNode::Raw(Value::Object(obj))
+            }
+        }
+    }
+}
+
+/// Typed sibling of [`convert_binding_pattern_for_param`].
+///
+/// Produces typed `JsNode` pattern subtrees (Identifier / ObjectPattern /
+/// ArrayPattern / AssignmentPattern) that serialize byte-identically to the
+/// Value form, so pattern interiors route through the typed analyze walker
+/// instead of `JsNode::Raw`. The ObjectPattern / ArrayPattern arms delegate to
+/// the now-fully-typed `convert_object_pattern_to_expr` /
+/// `convert_array_pattern_to_expr`; the AssignmentPattern arm mirrors the Value
+/// arm exactly — the default value uses `convert_expression` (the param-path
+/// converter, with its synthetic-paren offset semantics), NOT the program-path
+/// `convert_expression_for_program`.
+fn convert_binding_pattern_for_param_as_node(
+    arena: &ParseArena,
+    pattern: &oxc_ast::ast::BindingPattern,
+    adjusted_offset: usize,
+    line_offsets: &[usize],
+) -> JsNode {
+    use oxc_ast::ast::BindingPattern;
+
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => {
+            let start = adjusted_offset + id.span.start as usize;
+            let end = adjusted_offset + id.span.end as usize;
+            expr_to_node(create_identifier(&id.name, start, end, line_offsets))
+        }
+        BindingPattern::ObjectPattern(obj_pat) => expr_to_node(convert_object_pattern_to_expr(
+            arena,
+            obj_pat,
+            adjusted_offset,
+            line_offsets,
+        )),
+        BindingPattern::ArrayPattern(arr_pat) => expr_to_node(convert_array_pattern_to_expr(
+            arena,
+            arr_pat,
+            adjusted_offset,
+            line_offsets,
+        )),
+        BindingPattern::AssignmentPattern(assign_pat) => {
+            let start = adjusted_offset + assign_pat.span.start as usize;
+            let end = adjusted_offset + assign_pat.span.end as usize;
+            let left = convert_binding_pattern_for_param_as_node(
+                arena,
+                &assign_pat.left,
+                adjusted_offset,
+                line_offsets,
+            );
+            let right = convert_expression(arena, &assign_pat.right, adjusted_offset, line_offsets);
+            JsNode::AssignmentPattern {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                left: arena.alloc_js_node(left),
+                right: arena.alloc_js_node(expr_to_node(right)),
+            }
         }
     }
 }
@@ -5242,13 +5315,17 @@ fn create_arrow_function(
     if let Some(rest) = &arrow.params.rest {
         let rest_start = offset + rest.span.start as usize - 1;
         let rest_end = offset + rest.span.end as usize - 1;
-        let argument =
-            convert_binding_pattern_for_param(arena, &rest.rest.argument, offset - 1, line_offsets);
+        let argument = convert_binding_pattern_for_param_as_node(
+            arena,
+            &rest.rest.argument,
+            offset - 1,
+            line_offsets,
+        );
         params.push(JsNode::RestElement {
             start: rest_start as u32,
             end: rest_end as u32,
             loc: create_typed_loc(rest_start, rest_end, line_offsets),
-            argument: arena.alloc_js_node(JsNode::Raw(argument)),
+            argument: arena.alloc_js_node(argument),
         });
     }
 
@@ -5489,12 +5566,12 @@ fn convert_statement(
                 let h_start = offset + handler.span.start as usize - 1;
                 let h_end = offset + handler.span.end as usize - 1;
                 let param = handler.param.as_ref().map(|param| {
-                    arena.alloc_js_node(JsNode::Raw(convert_binding_pattern_for_param(
+                    arena.alloc_js_node(convert_binding_pattern_for_param_as_node(
                         arena,
                         &param.pattern,
                         offset - 1,
                         line_offsets,
-                    )))
+                    ))
                 });
                 let h_body_start = offset + handler.body.span.start as usize - 1;
                 let h_body_end = offset + handler.body.span.end as usize - 1;
@@ -5581,7 +5658,7 @@ fn convert_statement(
             if let Some(rest) = &func_decl.params.rest {
                 let rest_start = offset + rest.span.start as usize - 1;
                 let rest_end = offset + rest.span.end as usize - 1;
-                let argument = convert_binding_pattern_for_param(
+                let argument = convert_binding_pattern_for_param_as_node(
                     arena,
                     &rest.rest.argument,
                     offset - 1,
@@ -5591,7 +5668,7 @@ fn convert_statement(
                     start: rest_start as u32,
                     end: rest_end as u32,
                     loc: create_typed_loc(rest_start, rest_end, line_offsets),
-                    argument: arena.alloc_js_node(JsNode::Raw(argument)),
+                    argument: arena.alloc_js_node(argument),
                 });
             }
 
@@ -5664,13 +5741,13 @@ fn convert_variable_declarator(
     let end = offset + decl.span.end as usize - 1;
 
     // Convert id (pattern) with type annotation
-    let id = JsNode::Raw(convert_binding_pattern_for_decl(
+    let id = convert_binding_pattern_for_decl_as_node(
         arena,
         &decl.id,
         offset,
         line_offsets,
         decl.type_annotation.as_deref(),
-    ));
+    );
 
     // Convert init
     let init = decl.init.as_ref().map(|expr| {
@@ -5736,6 +5813,51 @@ fn convert_binding_pattern_for_decl(
         oxc_ast::ast::BindingPattern::AssignmentPattern(assign_pat) => {
             convert_assignment_pattern(arena, assign_pat, offset - 1, line_offsets).to_value()
         }
+    }
+}
+
+/// Typed sibling of [`convert_binding_pattern_for_decl`].
+///
+/// Returns the typed `JsNode` directly so a variable declarator id routes
+/// through the typed analyze walker instead of `JsNode::Raw`. The
+/// Object / Array / Assignment pattern arms reuse the already-typed program-path
+/// converters (`offset - 1`), exactly as the Value form does before its
+/// `.to_value()`. A bare `BindingIdentifier` produces a typed `Identifier`.
+///
+/// A TS-type-annotated `BindingIdentifier` carries a `typeAnnotation` field that
+/// is not representable on the typed `Identifier` node, so that single case
+/// stays `JsNode::Raw` (deferred to a later TS-aware stage).
+fn convert_binding_pattern_for_decl_as_node(
+    arena: &ParseArena,
+    pattern: &oxc_ast::ast::BindingPattern,
+    offset: usize,
+    line_offsets: &[usize],
+    type_annotation: Option<&oxc_ast::ast::TSTypeAnnotation>,
+) -> JsNode {
+    match pattern {
+        oxc_ast::ast::BindingPattern::BindingIdentifier(id) if type_annotation.is_none() => {
+            let start = offset + id.span.start as usize - 1;
+            let end = offset + id.span.end as usize - 1;
+            expr_to_node(create_identifier(&id.name, start, end, line_offsets))
+        }
+        oxc_ast::ast::BindingPattern::ObjectPattern(obj_pat) => {
+            convert_object_pattern(arena, obj_pat, offset - 1, line_offsets)
+        }
+        oxc_ast::ast::BindingPattern::ArrayPattern(arr_pat) => {
+            convert_array_pattern(arena, arr_pat, offset - 1, line_offsets)
+        }
+        oxc_ast::ast::BindingPattern::AssignmentPattern(assign_pat) => {
+            convert_assignment_pattern(arena, assign_pat, offset - 1, line_offsets)
+        }
+        // TS-annotated `BindingIdentifier` only — keep the Value form (its
+        // `typeAnnotation` field is not yet representable as a typed node).
+        _ => JsNode::Raw(convert_binding_pattern_for_decl(
+            arena,
+            pattern,
+            offset,
+            line_offsets,
+            type_annotation,
+        )),
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6692,53 +6692,7 @@ fn convert_statement_for_program(
             })
         }
         oxc_ast::ast::Statement::FunctionDeclaration(func_decl) => {
-            // Filter out TypeScript declare functions and function overload signatures (no body)
-            if func_decl.r#type == oxc_ast::ast::FunctionType::TSDeclareFunction
-                || func_decl.body.is_none()
-            {
-                return None;
-            }
-            let start = offset + func_decl.span.start as usize;
-            let end = offset + func_decl.span.end as usize;
-            let loc = create_typed_loc(start, end, line_offsets);
-
-            let id_node = func_decl.id.as_ref().map(|id| {
-                let id_start = offset + id.span.start as usize;
-                let id_end = offset + id.span.end as usize;
-                let id_expr = create_identifier(&id.name, id_start, id_end, line_offsets);
-                arena.alloc_js_node(expr_to_node(id_expr))
-            });
-
-            // Convert params
-            let params: Vec<JsNode> = func_decl
-                .params
-                .items
-                .iter()
-                .map(|param| {
-                    expr_to_node(convert_formal_parameter(arena, param, offset, line_offsets))
-                })
-                .collect();
-
-            // Convert body
-            let body_node = func_decl.body.as_ref().map(|body| {
-                arena.alloc_js_node(convert_function_body_for_program_as_node(
-                    arena,
-                    body,
-                    offset,
-                    line_offsets,
-                ))
-            });
-
-            Some(JsNode::FunctionDeclaration {
-                start: start as u32,
-                end: end as u32,
-                loc,
-                id: id_node,
-                params: arena.alloc_js_children(params),
-                body: body_node,
-                generator: func_decl.generator,
-                r#async: func_decl.r#async,
-            })
+            convert_function_declaration_as_node(arena, func_decl, offset, line_offsets)
         }
         oxc_ast::ast::Statement::ExportNamedDeclaration(export_decl) => {
             let start = offset + export_decl.span.start as usize;
@@ -6747,8 +6701,12 @@ fn convert_statement_for_program(
 
             // Handle declaration if present (e.g., export let x;)
             let declaration = export_decl.declaration.as_ref().map(|decl| {
-                let decl_value = convert_declaration_for_program(arena, decl, offset, line_offsets);
-                arena.alloc_js_node(JsNode::Raw(decl_value))
+                arena.alloc_js_node(convert_declaration_for_program_as_node(
+                    arena,
+                    decl,
+                    offset,
+                    line_offsets,
+                ))
             });
 
             // Handle specifiers
@@ -6885,8 +6843,21 @@ fn convert_statement_for_program(
                         r#async: func_decl.r#async,
                     }
                 }
+                oxc_ast::ast::ExportDefaultDeclarationKind::ClassDeclaration(class_decl)
+                    if !class_decl.declare
+                        && !class_decl.r#abstract
+                        && class_decl.implements.is_empty()
+                        && class_decl.decorators.is_empty() =>
+                {
+                    // Plain-JS class: the typed `ClassDeclaration` node omits the
+                    // TS-only `abstract`/`declare`/`implements`/`decorators`
+                    // fields, so it serializes byte-identical to the former Value
+                    // blob while routing the class body through the typed walker.
+                    convert_class_declaration_as_node(arena, class_decl, offset, line_offsets)
+                }
                 oxc_ast::ast::ExportDefaultDeclarationKind::ClassDeclaration(class_decl) => {
-                    // Class declarations in export default are complex, use Raw fallback
+                    // Class declarations with TS modifiers / decorators are not
+                    // representable in the byte-identical typed shape; use Raw.
                     let class_start = offset + class_decl.span.start as usize;
                     let class_end = offset + class_decl.span.end as usize;
                     let mut class_obj = Map::new();
@@ -7042,79 +7013,9 @@ fn convert_statement_for_program(
                 body: arena.alloc_js_children(body),
             })
         }
-        oxc_ast::ast::Statement::ClassDeclaration(class_decl) => {
-            let start = offset + class_decl.span.start as usize;
-            let end = offset + class_decl.span.end as usize;
-            let loc = create_typed_loc(start, end, line_offsets);
-
-            // id
-            let id = class_decl.id.as_ref().map(|id| {
-                let id_start = offset + id.span.start as usize;
-                let id_end = offset + id.span.end as usize;
-                let id_expr = create_identifier(&id.name, id_start, id_end, line_offsets);
-                arena.alloc_js_node(expr_to_node(id_expr))
-            });
-
-            // superClass
-            let super_class = class_decl.super_class.as_ref().map(|super_class| {
-                let super_class_value =
-                    convert_expression_for_program(arena, super_class, offset, line_offsets);
-                arena.alloc_js_node(expr_to_node(super_class_value))
-            });
-
-            // body (ClassBody) — typed when every member is plain JS; otherwise a
-            // Raw blob fallback (TS modifiers / decorators / declare / accessor).
-            let body = match convert_class_body_for_program_as_node(
-                arena,
-                &class_decl.body,
-                offset,
-                line_offsets,
-            ) {
-                Some(node) => arena.alloc_js_node(node),
-                None => {
-                    let body_value = convert_class_body_for_program(
-                        arena,
-                        &class_decl.body,
-                        offset,
-                        line_offsets,
-                    );
-                    arena.alloc_js_node(JsNode::Raw(body_value))
-                }
-            };
-
-            // Decorators: include so remove_typescript_nodes can detect them.
-            let decorators = if class_decl.decorators.is_empty() {
-                IdRange::empty()
-            } else {
-                let decorator_nodes: Vec<JsNode> = class_decl
-                    .decorators
-                    .iter()
-                    .map(|dec| {
-                        let dec_start = offset + dec.span.start as usize;
-                        let dec_end = offset + dec.span.end as usize;
-                        JsNode::Decorator {
-                            start: dec_start as u32,
-                            end: dec_end as u32,
-                            loc: None,
-                        }
-                    })
-                    .collect();
-                arena.alloc_js_children(decorator_nodes)
-            };
-
-            Some(JsNode::ClassDeclaration {
-                start: start as u32,
-                end: end as u32,
-                loc,
-                id,
-                super_class,
-                body,
-                declare: class_decl.declare,
-                r#abstract: class_decl.r#abstract,
-                implements: !class_decl.implements.is_empty(),
-                decorators,
-            })
-        }
+        oxc_ast::ast::Statement::ClassDeclaration(class_decl) => Some(
+            convert_class_declaration_as_node(arena, class_decl, offset, line_offsets),
+        ),
         oxc_ast::ast::Statement::ReturnStatement(ret_stmt) => {
             let start = offset + ret_stmt.span.start as usize;
             let end = offset + ret_stmt.span.end as usize;
@@ -7649,6 +7550,196 @@ fn convert_statement_for_program(
 }
 
 /// Convert a Declaration to JSON value (for program context).
+/// Convert a `FunctionDeclaration` to a typed `JsNode` (program context, no -1
+/// offset adjustment). Returns `None` for TypeScript `declare function` and
+/// overload signatures (no body) so the caller can drop them, mirroring the
+/// `remove_typescript_nodes` filter. Note: rest parameters are not emitted (only
+/// `params.items`); callers that need rest-param fidelity must route through the
+/// `JsNode::Raw` Value form (`convert_declaration_for_program`).
+fn convert_function_declaration_as_node(
+    arena: &ParseArena,
+    func_decl: &oxc_ast::ast::Function,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Option<JsNode> {
+    // Filter out TypeScript declare functions and function overload signatures (no body)
+    if func_decl.r#type == oxc_ast::ast::FunctionType::TSDeclareFunction || func_decl.body.is_none()
+    {
+        return None;
+    }
+    let start = offset + func_decl.span.start as usize;
+    let end = offset + func_decl.span.end as usize;
+    let loc = create_typed_loc(start, end, line_offsets);
+
+    let id_node = func_decl.id.as_ref().map(|id| {
+        let id_start = offset + id.span.start as usize;
+        let id_end = offset + id.span.end as usize;
+        let id_expr = create_identifier(&id.name, id_start, id_end, line_offsets);
+        arena.alloc_js_node(expr_to_node(id_expr))
+    });
+
+    // Convert params
+    let params: Vec<JsNode> = func_decl
+        .params
+        .items
+        .iter()
+        .map(|param| expr_to_node(convert_formal_parameter(arena, param, offset, line_offsets)))
+        .collect();
+
+    // Convert body
+    let body_node = func_decl.body.as_ref().map(|body| {
+        arena.alloc_js_node(convert_function_body_for_program_as_node(
+            arena,
+            body,
+            offset,
+            line_offsets,
+        ))
+    });
+
+    Some(JsNode::FunctionDeclaration {
+        start: start as u32,
+        end: end as u32,
+        loc,
+        id: id_node,
+        params: arena.alloc_js_children(params),
+        body: body_node,
+        generator: func_decl.generator,
+        r#async: func_decl.r#async,
+    })
+}
+
+/// Convert a `ClassDeclaration` to a typed `JsNode` (program context, no -1
+/// offset adjustment). The body is typed when every member is plain JS,
+/// otherwise it falls back to a `JsNode::Raw` blob (TS modifiers / decorators /
+/// declare / accessor).
+fn convert_class_declaration_as_node(
+    arena: &ParseArena,
+    class_decl: &oxc_ast::ast::Class,
+    offset: usize,
+    line_offsets: &[usize],
+) -> JsNode {
+    let start = offset + class_decl.span.start as usize;
+    let end = offset + class_decl.span.end as usize;
+    let loc = create_typed_loc(start, end, line_offsets);
+
+    // id
+    let id = class_decl.id.as_ref().map(|id| {
+        let id_start = offset + id.span.start as usize;
+        let id_end = offset + id.span.end as usize;
+        let id_expr = create_identifier(&id.name, id_start, id_end, line_offsets);
+        arena.alloc_js_node(expr_to_node(id_expr))
+    });
+
+    // superClass
+    let super_class = class_decl.super_class.as_ref().map(|super_class| {
+        let super_class_value =
+            convert_expression_for_program(arena, super_class, offset, line_offsets);
+        arena.alloc_js_node(expr_to_node(super_class_value))
+    });
+
+    // body (ClassBody) — typed when every member is plain JS; otherwise a
+    // Raw blob fallback (TS modifiers / decorators / declare / accessor).
+    let body =
+        match convert_class_body_for_program_as_node(arena, &class_decl.body, offset, line_offsets)
+        {
+            Some(node) => arena.alloc_js_node(node),
+            None => {
+                let body_value =
+                    convert_class_body_for_program(arena, &class_decl.body, offset, line_offsets);
+                arena.alloc_js_node(JsNode::Raw(body_value))
+            }
+        };
+
+    // Decorators: include so remove_typescript_nodes can detect them.
+    let decorators = if class_decl.decorators.is_empty() {
+        IdRange::empty()
+    } else {
+        let decorator_nodes: Vec<JsNode> = class_decl
+            .decorators
+            .iter()
+            .map(|dec| {
+                let dec_start = offset + dec.span.start as usize;
+                let dec_end = offset + dec.span.end as usize;
+                JsNode::Decorator {
+                    start: dec_start as u32,
+                    end: dec_end as u32,
+                    loc: None,
+                }
+            })
+            .collect();
+        arena.alloc_js_children(decorator_nodes)
+    };
+
+    JsNode::ClassDeclaration {
+        start: start as u32,
+        end: end as u32,
+        loc,
+        id,
+        super_class,
+        body,
+        declare: class_decl.declare,
+        r#abstract: class_decl.r#abstract,
+        implements: !class_decl.implements.is_empty(),
+        decorators,
+    }
+}
+
+/// Typed sibling of `convert_declaration_for_program`: returns a typed `JsNode`
+/// for the plain-JS `VariableDeclaration` / `FunctionDeclaration` /
+/// `ClassDeclaration` cases (so an `export <decl>` declaration routes through the
+/// typed analyze walker instead of `JsNode::Raw`). Cases whose byte-identical
+/// serialization needs the Value form — TS `declare`/overload functions, rest
+/// parameters (the typed function path drops `params.rest`), abstract / declare
+/// / implements / decorated classes, and all TS-only declarations — fall back to
+/// `JsNode::Raw(convert_declaration_for_program(...))`.
+fn convert_declaration_for_program_as_node(
+    arena: &ParseArena,
+    decl: &oxc_ast::ast::Declaration,
+    offset: usize,
+    line_offsets: &[usize],
+) -> JsNode {
+    use oxc_ast::ast::Declaration;
+    match decl {
+        Declaration::VariableDeclaration(var_decl) => {
+            convert_variable_declaration_as_node(arena, var_decl, offset, line_offsets)
+        }
+        // The typed function path emits only `params.items`, so a rest parameter
+        // would be dropped relative to the Value form — keep Raw in that case.
+        Declaration::FunctionDeclaration(func_decl)
+            if func_decl.r#type != oxc_ast::ast::FunctionType::TSDeclareFunction
+                && func_decl.body.is_some()
+                && func_decl.params.rest.is_none() =>
+        {
+            convert_function_declaration_as_node(arena, func_decl, offset, line_offsets)
+                .unwrap_or_else(|| {
+                    JsNode::Raw(convert_declaration_for_program(
+                        arena,
+                        decl,
+                        offset,
+                        line_offsets,
+                    ))
+                })
+        }
+        // The typed class node adds `abstract` / `declare` / `implements` /
+        // `decorators` fields that the Value form omits, so only the plain-JS
+        // shape is byte-identical.
+        Declaration::ClassDeclaration(class_decl)
+            if !class_decl.declare
+                && !class_decl.r#abstract
+                && class_decl.implements.is_empty()
+                && class_decl.decorators.is_empty() =>
+        {
+            convert_class_declaration_as_node(arena, class_decl, offset, line_offsets)
+        }
+        _ => JsNode::Raw(convert_declaration_for_program(
+            arena,
+            decl,
+            offset,
+            line_offsets,
+        )),
+    }
+}
+
 fn convert_declaration_for_program(
     arena: &ParseArena,
     decl: &oxc_ast::ast::Declaration,
@@ -9683,12 +9774,12 @@ fn convert_assignment_target_for_program(
                 optional: member.optional,
             }
         }
-        AssignmentTarget::ObjectAssignmentTarget(obj_target) => JsNode::Raw(
-            convert_object_assignment_target_for_program(arena, obj_target, offset, line_offsets),
-        ),
-        AssignmentTarget::ArrayAssignmentTarget(arr_target) => JsNode::Raw(
-            convert_array_assignment_target_for_program(arena, arr_target, offset, line_offsets),
-        ),
+        AssignmentTarget::ObjectAssignmentTarget(obj_target) => {
+            convert_object_assignment_target_for_program(arena, obj_target, offset, line_offsets)
+        }
+        AssignmentTarget::ArrayAssignmentTarget(arr_target) => {
+            convert_array_assignment_target_for_program(arena, arr_target, offset, line_offsets)
+        }
         AssignmentTarget::PrivateFieldExpression(member) => {
             // `this.#field = …` LHS in a function-body statement (program
             // context). Without this arm it falls to `JsNode::Null`, so the
@@ -9723,28 +9814,18 @@ fn convert_assignment_target_for_program(
     }
 }
 
-/// Convert an ObjectAssignmentTarget to ObjectPattern JSON (no -1 offset adjustment).
+/// Convert an ObjectAssignmentTarget to a typed `ObjectPattern` `JsNode`
+/// (no -1 offset adjustment).
 fn convert_object_assignment_target_for_program(
     arena: &ParseArena,
     obj_target: &oxc_ast::ast::ObjectAssignmentTarget,
     offset: usize,
     line_offsets: &[usize],
-) -> Value {
+) -> JsNode {
     let start = offset + obj_target.span.start as usize;
     let end = offset + obj_target.span.end as usize;
 
-    let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("ObjectPattern".to_string()),
-    );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
-
-    let mut properties: Vec<Value> = obj_target
+    let mut properties: Vec<JsNode> = obj_target
         .properties
         .iter()
         .map(|prop| {
@@ -9756,62 +9837,50 @@ fn convert_object_assignment_target_for_program(
     if let Some(rest) = &obj_target.rest {
         let rest_start = offset + rest.span.start as usize;
         let rest_end = offset + rest.span.end as usize;
-
-        let mut rest_obj = Map::new();
-        rest_obj.insert("type".to_string(), Value::String("RestElement".to_string()));
-        rest_obj.insert(
-            "start".to_string(),
-            Value::Number((rest_start as i64).into()),
-        );
-        rest_obj.insert("end".to_string(), Value::Number((rest_end as i64).into()));
-        if let Some(loc) = create_loc(rest_start, rest_end, line_offsets) {
-            rest_obj.insert("loc".to_string(), loc);
-        }
-        rest_obj.insert(
-            "argument".to_string(),
-            convert_assignment_target_for_program(arena, &rest.target, offset, line_offsets)
-                .to_value(),
-        );
-        properties.push(Value::Object(rest_obj));
+        properties.push(JsNode::RestElement {
+            start: rest_start as u32,
+            end: rest_end as u32,
+            loc: create_typed_loc(rest_start, rest_end, line_offsets),
+            argument: arena.alloc_js_node(convert_assignment_target_for_program(
+                arena,
+                &rest.target,
+                offset,
+                line_offsets,
+            )),
+        });
     }
 
-    obj.insert("properties".to_string(), Value::Array(properties));
-
-    Value::Object(obj)
+    JsNode::ObjectPattern {
+        start: start as u32,
+        end: end as u32,
+        loc: create_typed_loc(start, end, line_offsets),
+        properties: arena.alloc_js_children(properties),
+    }
 }
 
-/// Convert an ArrayAssignmentTarget to ArrayPattern JSON (no -1 offset adjustment).
+/// Convert an ArrayAssignmentTarget to a typed `ArrayPattern` `JsNode`
+/// (no -1 offset adjustment).
 fn convert_array_assignment_target_for_program(
     arena: &ParseArena,
     arr_target: &oxc_ast::ast::ArrayAssignmentTarget,
     offset: usize,
     line_offsets: &[usize],
-) -> Value {
+) -> JsNode {
     let start = offset + arr_target.span.start as usize;
     let end = offset + arr_target.span.end as usize;
 
-    let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("ArrayPattern".to_string()),
-    );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
-
-    let mut elements: Vec<Value> = arr_target
+    let mut elements: Vec<Option<JsNode>> = arr_target
         .elements
         .iter()
-        .map(|elem| match elem {
-            Some(target) => convert_assignment_target_maybe_default_for_program(
-                arena,
-                target,
-                offset,
-                line_offsets,
-            ),
-            None => Value::Null,
+        .map(|elem| {
+            elem.as_ref().map(|target| {
+                convert_assignment_target_maybe_default_for_program(
+                    arena,
+                    target,
+                    offset,
+                    line_offsets,
+                )
+            })
         })
         .collect();
 
@@ -9819,37 +9888,35 @@ fn convert_array_assignment_target_for_program(
     if let Some(rest) = &arr_target.rest {
         let rest_start = offset + rest.span.start as usize;
         let rest_end = offset + rest.span.end as usize;
-
-        let mut rest_obj = Map::new();
-        rest_obj.insert("type".to_string(), Value::String("RestElement".to_string()));
-        rest_obj.insert(
-            "start".to_string(),
-            Value::Number((rest_start as i64).into()),
-        );
-        rest_obj.insert("end".to_string(), Value::Number((rest_end as i64).into()));
-        if let Some(loc) = create_loc(rest_start, rest_end, line_offsets) {
-            rest_obj.insert("loc".to_string(), loc);
-        }
-        rest_obj.insert(
-            "argument".to_string(),
-            convert_assignment_target_for_program(arena, &rest.target, offset, line_offsets)
-                .to_value(),
-        );
-        elements.push(Value::Object(rest_obj));
+        elements.push(Some(JsNode::RestElement {
+            start: rest_start as u32,
+            end: rest_end as u32,
+            loc: create_typed_loc(rest_start, rest_end, line_offsets),
+            argument: arena.alloc_js_node(convert_assignment_target_for_program(
+                arena,
+                &rest.target,
+                offset,
+                line_offsets,
+            )),
+        }));
     }
 
-    obj.insert("elements".to_string(), Value::Array(elements));
-
-    Value::Object(obj)
+    JsNode::ArrayPattern {
+        start: start as u32,
+        end: end as u32,
+        loc: create_typed_loc(start, end, line_offsets),
+        elements,
+    }
 }
 
-/// Convert an AssignmentTargetProperty to Property JSON (no -1 offset adjustment).
+/// Convert an AssignmentTargetProperty to a typed `Property` `JsNode`
+/// (no -1 offset adjustment).
 fn convert_assignment_target_property_for_program(
     arena: &ParseArena,
     prop: &oxc_ast::ast::AssignmentTargetProperty,
     offset: usize,
     line_offsets: &[usize],
-) -> Value {
+) -> JsNode {
     use oxc_ast::ast::AssignmentTargetProperty;
 
     match prop {
@@ -9857,81 +9924,72 @@ fn convert_assignment_target_property_for_program(
             let start = offset + id_prop.span.start as usize;
             let end = offset + id_prop.span.end as usize;
 
-            let mut obj = Map::new();
-            obj.insert("type".to_string(), Value::String("Property".to_string()));
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
-            obj.insert("method".to_string(), Value::Bool(false));
-            obj.insert("shorthand".to_string(), Value::Bool(true));
-            obj.insert("computed".to_string(), Value::Bool(false));
-            obj.insert("kind".to_string(), Value::String("init".to_string()));
-
             let id_start = offset + id_prop.binding.span.start as usize;
             let id_end = offset + id_prop.binding.span.end as usize;
-            let identifier =
-                create_identifier(&id_prop.binding.name, id_start, id_end, line_offsets)
-                    .as_json()
-                    .clone();
+            let make_identifier = || {
+                expr_to_node(create_identifier(
+                    &id_prop.binding.name,
+                    id_start,
+                    id_end,
+                    line_offsets,
+                ))
+            };
 
-            obj.insert("key".to_string(), identifier.clone());
+            let key = arena.alloc_js_node(make_identifier());
 
-            if let Some(init) = &id_prop.init {
-                let mut assign_pat = Map::new();
-                assign_pat.insert(
-                    "type".to_string(),
-                    Value::String("AssignmentPattern".to_string()),
-                );
-                assign_pat.insert("start".to_string(), Value::Number((id_start as i64).into()));
+            let value = if let Some(init) = &id_prop.init {
                 let init_end = offset + init.span().end as usize;
-                assign_pat.insert("end".to_string(), Value::Number((init_end as i64).into()));
-                if let Some(loc) = create_loc(id_start, init_end, line_offsets) {
-                    assign_pat.insert("loc".to_string(), loc);
-                }
-                assign_pat.insert("left".to_string(), identifier);
-                assign_pat.insert(
-                    "right".to_string(),
-                    convert_expression_for_program(arena, init, offset, line_offsets)
-                        .as_json()
-                        .clone(),
-                );
-                obj.insert("value".to_string(), Value::Object(assign_pat));
+                arena.alloc_js_node(JsNode::AssignmentPattern {
+                    start: id_start as u32,
+                    end: init_end as u32,
+                    loc: create_typed_loc(id_start, init_end, line_offsets),
+                    left: arena.alloc_js_node(make_identifier()),
+                    right: arena.alloc_js_node(expr_to_node(convert_expression_for_program(
+                        arena,
+                        init,
+                        offset,
+                        line_offsets,
+                    ))),
+                })
             } else {
-                obj.insert("value".to_string(), identifier);
-            }
+                arena.alloc_js_node(make_identifier())
+            };
 
-            Value::Object(obj)
+            JsNode::Property {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                key,
+                value,
+                kind: CompactString::from("init"),
+                method: false,
+                shorthand: true,
+                computed: false,
+            }
         }
         AssignmentTargetProperty::AssignmentTargetPropertyProperty(prop_prop) => {
             let start = offset + prop_prop.span.start as usize;
             let end = offset + prop_prop.span.end as usize;
 
-            let mut obj = Map::new();
-            obj.insert("type".to_string(), Value::String("Property".to_string()));
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
-            obj.insert("method".to_string(), Value::Bool(false));
-            obj.insert("shorthand".to_string(), Value::Bool(false));
-            obj.insert("computed".to_string(), Value::Bool(prop_prop.computed));
-            obj.insert("kind".to_string(), Value::String("init".to_string()));
-
             let key = convert_property_key(arena, &prop_prop.name, offset, line_offsets);
-            obj.insert("key".to_string(), key.to_value());
-
             let value = convert_assignment_target_maybe_default_for_program(
                 arena,
                 &prop_prop.binding,
                 offset,
                 line_offsets,
             );
-            obj.insert("value".to_string(), value);
 
-            Value::Object(obj)
+            JsNode::Property {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                key: arena.alloc_js_node(key),
+                value: arena.alloc_js_node(value),
+                kind: CompactString::from("init"),
+                method: false,
+                shorthand: false,
+                computed: prop_prop.computed,
+            }
         }
     }
 }
@@ -10021,13 +10079,15 @@ fn convert_simple_assignment_target_for_program(
     }
 }
 
-/// Convert an AssignmentTargetMaybeDefault to JSON (no -1 offset adjustment).
+/// Convert an AssignmentTargetMaybeDefault to a typed `JsNode` (no -1 offset
+/// adjustment). A `WithDefault` becomes an `AssignmentPattern`; a bare target
+/// delegates to `convert_assignment_target_for_program`.
 fn convert_assignment_target_maybe_default_for_program(
     arena: &ParseArena,
     target: &oxc_ast::ast::AssignmentTargetMaybeDefault,
     offset: usize,
     line_offsets: &[usize],
-) -> Value {
+) -> JsNode {
     use oxc_ast::ast::AssignmentTargetMaybeDefault;
 
     match target {
@@ -10035,40 +10095,29 @@ fn convert_assignment_target_maybe_default_for_program(
             let start = offset + with_default.span.start as usize;
             let end = offset + with_default.span.end as usize;
 
-            let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("AssignmentPattern".to_string()),
-            );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
-            obj.insert(
-                "left".to_string(),
-                convert_assignment_target_for_program(
+            JsNode::AssignmentPattern {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                left: arena.alloc_js_node(convert_assignment_target_for_program(
                     arena,
                     &with_default.binding,
                     offset,
                     line_offsets,
-                )
-                .to_value(),
-            );
-            obj.insert(
-                "right".to_string(),
-                convert_expression_for_program(arena, &with_default.init, offset, line_offsets)
-                    .as_json()
-                    .clone(),
-            );
-
-            Value::Object(obj)
+                )),
+                right: arena.alloc_js_node(expr_to_node(convert_expression_for_program(
+                    arena,
+                    &with_default.init,
+                    offset,
+                    line_offsets,
+                ))),
+            }
         }
         _ => {
             if let Some(inner) = target.as_assignment_target() {
-                convert_assignment_target_for_program(arena, inner, offset, line_offsets).to_value()
+                convert_assignment_target_for_program(arena, inner, offset, line_offsets)
             } else {
-                Value::Null
+                JsNode::Null
             }
         }
     }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -8184,12 +8184,7 @@ fn convert_expression_for_program(
                     line_offsets,
                 ))
             } else {
-                JsNode::Raw(convert_function_body_for_program(
-                    arena,
-                    &arrow.body,
-                    offset,
-                    line_offsets,
-                ))
+                convert_function_body_for_program_as_node(arena, &arrow.body, offset, line_offsets)
             };
 
             Expression::from_node(JsNode::ArrowFunctionExpression {
@@ -8204,9 +8199,9 @@ fn convert_expression_for_program(
                 body: arena.alloc_js_node(body_node),
             })
         }
-        OxcExpression::FunctionExpression(func) => Expression::from_node(JsNode::Raw(
-            convert_function_expression_for_program(arena, func, offset, line_offsets),
-        )),
+        OxcExpression::FunctionExpression(func) => Expression::from_node(
+            convert_function_expression_for_program_as_node(arena, func, offset, line_offsets),
+        ),
         OxcExpression::StaticMemberExpression(member) => {
             let start = offset + member.span.start as usize;
             let end = offset + member.span.end as usize;
@@ -9073,6 +9068,66 @@ fn convert_function_expression_for_program(
     }
 
     Value::Object(obj)
+}
+
+/// Typed twin of `convert_function_expression_for_program`: builds a typed
+/// `JsNode::FunctionExpression` (program-offset convention) instead of a
+/// `JsNode::Raw(Value)` blob, so the function body subtree routes through the
+/// typed analyze walker. Serializes byte-identically to the Value blob (modulo
+/// the `expression: false` field, which the official ESTree output also emits
+/// and the Value blob was missing). `id` is always `null` to match the Value
+/// blob, and params keep the TS-aware `convert_formal_parameter` shape (TS bits
+/// fall through to `JsNode::Raw` via `expr_to_node`).
+fn convert_function_expression_for_program_as_node(
+    arena: &ParseArena,
+    func: &oxc_ast::ast::Function,
+    offset: usize,
+    line_offsets: &[usize],
+) -> JsNode {
+    let start = offset + func.span.start as usize;
+    let end = offset + func.span.end as usize;
+
+    // params
+    let mut params: Vec<JsNode> = func
+        .params
+        .items
+        .iter()
+        .map(|param| expr_to_node(convert_formal_parameter(arena, param, offset, line_offsets)))
+        .collect();
+    if let Some(rest) = &func.params.rest {
+        let rest_start = offset + rest.span.start as usize;
+        let rest_end = offset + rest.span.end as usize;
+        let argument =
+            convert_binding_pattern_for_param(arena, &rest.rest.argument, offset, line_offsets);
+        params.push(JsNode::RestElement {
+            start: rest_start as u32,
+            end: rest_end as u32,
+            loc: create_typed_loc(rest_start, rest_end, line_offsets),
+            argument: arena.alloc_js_node(JsNode::Raw(argument)),
+        });
+    }
+
+    // body
+    let body = func.body.as_ref().map(|body| {
+        arena.alloc_js_node(convert_function_body_for_program_as_node(
+            arena,
+            body,
+            offset,
+            line_offsets,
+        ))
+    });
+
+    JsNode::FunctionExpression {
+        start: start as u32,
+        end: end as u32,
+        loc: create_typed_loc(start, end, line_offsets),
+        id: None,
+        params: arena.alloc_js_children(params),
+        body,
+        generator: func.generator,
+        r#async: func.r#async,
+        expression: false,
+    }
 }
 
 /// Convert a function body (statement or expression) to JSON value.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6258,14 +6258,28 @@ pub fn parse_program_with_error(
                 .collect();
 
             // Distribute comments to nested bodies within each statement.
-            // We convert each statement to a mutable Value, run distribution, then wrap back.
+            //
+            // A statement only needs the `JsNode::Raw(Value)` representation if it
+            // actually carries comment payload:
+            //   - it already has its own `leadingComments` (already wrapped as Raw above), or
+            //   - distribution attaches `leadingComments` to a nested statement body.
+            // Otherwise we keep the typed `JsNode` so downstream typed walkers don't
+            // have to fall back to a serde_json::Value walk for it.
             for node in body_nodes.iter_mut() {
-                let mut val = node.to_value();
-                distribute_comments_to_node(&mut val, &comment_entries);
-                // Check if the value was actually modified (has nested leadingComments added)
-                // by comparing against the original. Since distribute_comments_to_node modifies
-                // in-place, we always wrap back as Raw to preserve any changes.
-                *node = JsNode::Raw(val);
+                if matches!(node, JsNode::Raw(_)) {
+                    // Already Raw (had its own leading comments). Run distribution on
+                    // the existing Value in place so nested bodies still get comments.
+                    if let JsNode::Raw(val) = node {
+                        distribute_comments_to_node(val, &comment_entries);
+                    }
+                } else {
+                    // Typed node: distribute onto a throwaway Value and only convert
+                    // to Raw if distribution actually inserted nested comments.
+                    let mut val = node.to_value();
+                    if distribute_comments_to_node(&mut val, &comment_entries) {
+                        *node = JsNode::Raw(val);
+                    }
+                }
             }
 
             body_nodes
@@ -6373,10 +6387,13 @@ struct CommentEntry {
 /// This function operates entirely in-place: it never clones statement Values.
 /// Comments are attached by inserting `leadingComments` directly into existing
 /// statement Map objects via mutable references.
-fn distribute_comments_to_node(node: &mut Value, comments: &[CommentEntry]) {
+/// Distribute comments to nested statement bodies. Returns `true` if any
+/// `leadingComments` field was actually inserted (i.e. the node was mutated).
+fn distribute_comments_to_node(node: &mut Value, comments: &[CommentEntry]) -> bool {
     let Some(obj) = node.as_object_mut() else {
-        return;
+        return false;
     };
+    let mut modified = false;
 
     let node_type = obj
         .get("type")
@@ -6422,6 +6439,7 @@ fn distribute_comments_to_node(node: &mut Value, comments: &[CommentEntry]) {
 
                         if !leading.is_empty() {
                             stmt_obj.insert("leadingComments".to_string(), Value::Array(leading));
+                            modified = true;
                         }
                     }
 
@@ -6459,14 +6477,16 @@ fn distribute_comments_to_node(node: &mut Value, comments: &[CommentEntry]) {
             if child.is_array() {
                 if let Some(items) = child.as_array_mut() {
                     for item in items {
-                        distribute_comments_to_node(item, comments);
+                        modified |= distribute_comments_to_node(item, comments);
                     }
                 }
             } else if child.is_object() {
-                distribute_comments_to_node(child, comments);
+                modified |= distribute_comments_to_node(child, comments);
             }
         }
     }
+
+    modified
 }
 
 /// Convert a statement to JSON value (for program context, no -1 offset adjustment).

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6196,14 +6196,34 @@ pub fn parse_program_with_error(
         }
 
         // Build body as Vec<JsNode> (typed, no Value conversion needed for common case).
+        //
+        // `ignore_comment_map` accumulates `node_start -> [svelte-ignore comment text]`
+        // for every node that carries a `svelte-ignore` leading comment (at any depth).
+        // It replaces the former `JsNode::Raw(value_with_leadingComments)` wrapping: the
+        // only Phase-2 consumer of those statement-level `leadingComments` is svelte-ignore
+        // warning suppression, so we keep the statement TYPED and surface just the ignore
+        // texts. Comments still reach `Root.comments` independently via `record_oxc_comment`
+        // above, and codegen re-parses script text, so dropping the Raw wrapping changes no
+        // output.
+        let mut ignore_comment_map: Vec<(u32, Vec<CompactString>)> = Vec::new();
         let body: Vec<JsNode> = if has_comments {
-            // When there are comments, we need to:
-            // 1. Attach leadingComments to individual statements
-            // 2. Distribute comments to nested bodies
-            // For statements with comments, we wrap as JsNode::Raw(Value) since
-            // leadingComments is a JSON-only concept not modeled in JsNode variants.
             let mut comment_idx = 0;
             let mut body_nodes: Vec<JsNode> = Vec::with_capacity(program.body.len());
+
+            // Pre-compute comment entries (absolute positions + Value) once, used for
+            // distributing comments onto nested statement bodies.
+            let comment_entries: Vec<CommentEntry> = all_comments
+                .iter()
+                .map(|comment| {
+                    let comment_start = offset + comment.span.start as usize;
+                    let comment_end = offset + comment.span.end as usize;
+                    CommentEntry {
+                        start: comment_start as u32,
+                        end: comment_end as u32,
+                        value: build_comment_value(comment, content, offset),
+                    }
+                })
+                .collect();
 
             for stmt in program.body.iter() {
                 if let Some(stmt_node) =
@@ -6211,7 +6231,8 @@ pub fn parse_program_with_error(
                 {
                     let stmt_start = stmt.span().start;
 
-                    // Collect comments that appear before this statement
+                    // Collect comments that appear before this statement (its own leading
+                    // comments).
                     let mut stmt_leading = Vec::new();
                     while comment_idx < all_comments.len()
                         && all_comments[comment_idx].span.end <= stmt_start
@@ -6228,57 +6249,21 @@ pub fn parse_program_with_error(
                         comment_idx += 1;
                     }
 
-                    if !stmt_leading.is_empty() {
-                        // Convert to Value to attach leadingComments, then wrap as Raw
-                        let mut stmt_value = stmt_node.to_value();
-                        if let Value::Object(ref mut obj) = stmt_value {
+                    // Reproduce the exact comment-attachment the old code used (own leading
+                    // comments + nested distribution) on a throwaway Value, then harvest
+                    // svelte-ignore texts into the map. The statement itself stays TYPED.
+                    if !stmt_leading.is_empty() || !comment_entries.is_empty() {
+                        let mut val = stmt_node.to_value();
+                        if !stmt_leading.is_empty()
+                            && let Value::Object(ref mut obj) = val
+                        {
                             obj.insert("leadingComments".to_string(), Value::Array(stmt_leading));
                         }
-                        body_nodes.push(JsNode::Raw(stmt_value));
-                    } else {
-                        // No leading comments - keep as typed JsNode
-                        body_nodes.push(stmt_node);
+                        distribute_comments_to_node(&mut val, &comment_entries);
+                        harvest_ignore_comments(&val, &mut ignore_comment_map);
                     }
-                }
-            }
 
-            // Post-process: distribute comments to nested statement bodies.
-            // Build a temporary Value body array, run distribution, then extract back.
-            let comment_entries: Vec<CommentEntry> = all_comments
-                .iter()
-                .map(|comment| {
-                    let comment_start = offset + comment.span.start as usize;
-                    let comment_end = offset + comment.span.end as usize;
-                    CommentEntry {
-                        start: comment_start as u32,
-                        end: comment_end as u32,
-                        value: build_comment_value(comment, content, offset),
-                    }
-                })
-                .collect();
-
-            // Distribute comments to nested bodies within each statement.
-            //
-            // A statement only needs the `JsNode::Raw(Value)` representation if it
-            // actually carries comment payload:
-            //   - it already has its own `leadingComments` (already wrapped as Raw above), or
-            //   - distribution attaches `leadingComments` to a nested statement body.
-            // Otherwise we keep the typed `JsNode` so downstream typed walkers don't
-            // have to fall back to a serde_json::Value walk for it.
-            for node in body_nodes.iter_mut() {
-                if matches!(node, JsNode::Raw(_)) {
-                    // Already Raw (had its own leading comments). Run distribution on
-                    // the existing Value in place so nested bodies still get comments.
-                    if let JsNode::Raw(val) = node {
-                        distribute_comments_to_node(val, &comment_entries);
-                    }
-                } else {
-                    // Typed node: distribute onto a throwaway Value and only convert
-                    // to Raw if distribution actually inserted nested comments.
-                    let mut val = node.to_value();
-                    if distribute_comments_to_node(&mut val, &comment_entries) {
-                        *node = JsNode::Raw(val);
-                    }
+                    body_nodes.push(stmt_node);
                 }
             }
 
@@ -6330,6 +6315,7 @@ pub fn parse_program_with_error(
                 source_type: CompactString::from("module"),
                 leading_comments: leading_comments_val,
                 trailing_comments: trailing_comments_val,
+                ignore_comment_map,
             }),
             parse_error,
         )
@@ -6373,6 +6359,49 @@ fn build_comment_value(comment: &oxc_ast::ast::Comment, content: &str, offset: u
         Value::Number((comment_end as i64).into()),
     );
     Value::Object(comment_obj)
+}
+
+/// Walk a comment-annotated statement `Value` (after `distribute_comments_to_node`)
+/// and harvest every `svelte-ignore` leading-comment text into `map`, keyed by the
+/// owning node's absolute `start` offset.
+///
+/// Only `svelte-ignore` comments are kept (the sole Phase-2 consumer of statement-level
+/// `leadingComments`); a comment is a candidate when its value text — after leading
+/// whitespace — begins with `svelte-ignore` (a strict superset of the analyze-side
+/// `^\s*svelte-ignore\s` match, so nothing relevant is dropped and non-matching texts
+/// that survive simply extract to zero codes downstream).
+fn harvest_ignore_comments(node: &Value, map: &mut Vec<(u32, Vec<CompactString>)>) {
+    let Value::Object(obj) = node else {
+        return;
+    };
+
+    if let Some(Value::Array(comments)) = obj.get("leadingComments")
+        && let Some(start) = obj.get("start").and_then(|s| s.as_u64())
+    {
+        let kept: Vec<CompactString> = comments
+            .iter()
+            .filter_map(|c| c.get("value").and_then(|v| v.as_str()))
+            .filter(|v| v.trim_start().starts_with("svelte-ignore"))
+            .map(CompactString::from)
+            .collect();
+        if !kept.is_empty() {
+            map.push((start as u32, kept));
+        }
+    }
+
+    // Recurse into every nested object / array so nested `svelte-ignore` comments
+    // (attached by `distribute_comments_to_node`) are harvested too.
+    for value in obj.values() {
+        match value {
+            Value::Object(_) => harvest_ignore_comments(value, map),
+            Value::Array(items) => {
+                for item in items {
+                    harvest_ignore_comments(item, map);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// A pre-computed comment entry with positions extracted to avoid repeated Value lookups.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -259,6 +259,7 @@ fn get_loose_identifier(
             end: end as u32,
             loc: None,
             name: CompactString::from(""),
+            type_annotation: None,
         }));
     }
     None
@@ -841,6 +842,7 @@ fn try_parse_arrow_function(
                 end: 0,
                 loc: None,
                 name: CompactString::from(p),
+                type_annotation: None,
             });
         }
     }
@@ -1306,6 +1308,7 @@ fn try_parse_ident_or_member(
             end: (offset + seg_end) as u32,
             loc: create_typed_loc(offset + seg_start, offset + seg_end, line_offsets),
             name: CompactString::from(prop_name),
+            type_annotation: None,
         };
 
         result = Expression::from_node(JsNode::MemberExpression {
@@ -1746,6 +1749,7 @@ fn create_invalid_identifier(start: usize, end: usize, _line_offsets: &[usize]) 
         end: end as u32,
         loc: None,
         name: CompactString::from(""),
+        type_annotation: None,
     })
 }
 
@@ -3931,6 +3935,7 @@ fn create_identifier(name: &str, start: usize, end: usize, line_offsets: &[usize
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         name: CompactString::from(name),
+        type_annotation: None,
     })
 }
 
@@ -3961,6 +3966,7 @@ fn create_identifier_for_binding(
         end: end as u32,
         loc: create_typed_loc_for_binding(start, end, line_offsets),
         name: CompactString::from(name),
+        type_annotation: None,
     }
 }
 
@@ -3992,6 +3998,7 @@ fn create_identifier_for_binding_toplevel(
         end: end as u32,
         loc: create_typed_loc_for_binding_identifier(start, end, line_offsets),
         name: CompactString::from(name),
+        type_annotation: None,
     }
 }
 
@@ -4062,6 +4069,7 @@ pub fn create_identifier_with_character(
         end: end as u32,
         loc: create_typed_loc_with_character(start, end, line_offsets),
         name: CompactString::from(name),
+        type_annotation: None,
     })
 }
 
@@ -4073,6 +4081,7 @@ pub fn create_empty_identifier(name: &str, start: usize, end: usize) -> Expressi
         end: end as u32,
         loc: None,
         name: CompactString::from(name),
+        type_annotation: None,
     })
 }
 
@@ -4278,6 +4287,7 @@ fn create_static_member_expression(
             end: prop_end as u32,
             loc: create_typed_loc(prop_start, prop_end, line_offsets),
             name: CompactString::from(member.property.name.as_str()),
+            type_annotation: None,
         }),
         computed: false,
         optional: member.optional,
@@ -5768,65 +5778,16 @@ fn convert_variable_declarator(
     }
 }
 
-/// Convert a binding pattern for variable declarations.
-fn convert_binding_pattern_for_decl(
-    arena: &ParseArena,
-    pattern: &oxc_ast::ast::BindingPattern,
-    offset: usize,
-    line_offsets: &[usize],
-    type_annotation: Option<&oxc_ast::ast::TSTypeAnnotation>,
-) -> Value {
-    match pattern {
-        oxc_ast::ast::BindingPattern::BindingIdentifier(id) => {
-            let start = offset + id.span.start as usize - 1;
-            // If there's a type annotation, extend the end to include it
-            let end = if let Some(type_ann) = type_annotation {
-                offset + type_ann.span.end as usize - 1
-            } else {
-                offset + id.span.end as usize - 1
-            };
-
-            let mut obj = Map::new();
-            obj.insert("type".to_string(), Value::String("Identifier".to_string()));
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
-            obj.insert("name".to_string(), Value::String(id.name.to_string()));
-
-            // OXC v0.107: type annotations are on VariableDeclarator, not BindingIdentifier
-            if let Some(type_ann) = type_annotation {
-                let type_ann_value =
-                    convert_type_annotation_adjusted(type_ann, offset - 1, line_offsets);
-                obj.insert("typeAnnotation".to_string(), type_ann_value);
-            }
-
-            Value::Object(obj)
-        }
-        oxc_ast::ast::BindingPattern::ObjectPattern(obj_pat) => {
-            convert_object_pattern(arena, obj_pat, offset - 1, line_offsets).to_value()
-        }
-        oxc_ast::ast::BindingPattern::ArrayPattern(arr_pat) => {
-            convert_array_pattern(arena, arr_pat, offset - 1, line_offsets).to_value()
-        }
-        oxc_ast::ast::BindingPattern::AssignmentPattern(assign_pat) => {
-            convert_assignment_pattern(arena, assign_pat, offset - 1, line_offsets).to_value()
-        }
-    }
-}
-
-/// Typed sibling of [`convert_binding_pattern_for_decl`].
+/// Convert a binding pattern for a variable declarator id, returning a typed
+/// `JsNode` directly so the id routes through the typed analyze walker instead
+/// of `JsNode::Raw`. The Object / Array / Assignment pattern arms reuse the
+/// already-typed program-path converters (`offset - 1`). A bare
+/// `BindingIdentifier` produces a typed `Identifier`.
 ///
-/// Returns the typed `JsNode` directly so a variable declarator id routes
-/// through the typed analyze walker instead of `JsNode::Raw`. The
-/// Object / Array / Assignment pattern arms reuse the already-typed program-path
-/// converters (`offset - 1`), exactly as the Value form does before its
-/// `.to_value()`. A bare `BindingIdentifier` produces a typed `Identifier`.
-///
-/// A TS-type-annotated `BindingIdentifier` carries a `typeAnnotation` field that
-/// is not representable on the typed `Identifier` node, so that single case
-/// stays `JsNode::Raw` (deferred to a later TS-aware stage).
+/// A TS-type-annotated `BindingIdentifier` carries its `typeAnnotation` as an
+/// opaque, output-only boundary blob on the typed `Identifier` node (analyze
+/// never walks into it), with the extended `end`, recomputed `loc`, and the
+/// `convert_type_annotation_adjusted` blob.
 fn convert_binding_pattern_for_decl_as_node(
     arena: &ParseArena,
     pattern: &oxc_ast::ast::BindingPattern,
@@ -5835,10 +5796,25 @@ fn convert_binding_pattern_for_decl_as_node(
     type_annotation: Option<&oxc_ast::ast::TSTypeAnnotation>,
 ) -> JsNode {
     match pattern {
-        oxc_ast::ast::BindingPattern::BindingIdentifier(id) if type_annotation.is_none() => {
+        oxc_ast::ast::BindingPattern::BindingIdentifier(id) => {
             let start = offset + id.span.start as usize - 1;
-            let end = offset + id.span.end as usize - 1;
-            expr_to_node(create_identifier(&id.name, start, end, line_offsets))
+            if let Some(type_ann) = type_annotation {
+                // TS-annotated: extend `end` over the annotation and carry the
+                // annotation blob verbatim (same as the Value form at
+                // `convert_binding_pattern_for_decl`).
+                let end = offset + type_ann.span.end as usize - 1;
+                let ta_value = convert_type_annotation_adjusted(type_ann, offset - 1, line_offsets);
+                JsNode::Identifier {
+                    start: start as u32,
+                    end: end as u32,
+                    loc: create_typed_loc(start, end, line_offsets),
+                    name: CompactString::from(id.name.as_str()),
+                    type_annotation: Some(Box::new(ta_value)),
+                }
+            } else {
+                let end = offset + id.span.end as usize - 1;
+                expr_to_node(create_identifier(&id.name, start, end, line_offsets))
+            }
         }
         oxc_ast::ast::BindingPattern::ObjectPattern(obj_pat) => {
             convert_object_pattern(arena, obj_pat, offset - 1, line_offsets)
@@ -5849,15 +5825,6 @@ fn convert_binding_pattern_for_decl_as_node(
         oxc_ast::ast::BindingPattern::AssignmentPattern(assign_pat) => {
             convert_assignment_pattern(arena, assign_pat, offset - 1, line_offsets)
         }
-        // TS-annotated `BindingIdentifier` only — keep the Value form (its
-        // `typeAnnotation` field is not yet representable as a typed node).
-        _ => JsNode::Raw(convert_binding_pattern_for_decl(
-            arena,
-            pattern,
-            offset,
-            line_offsets,
-            type_annotation,
-        )),
     }
 }
 
@@ -8126,43 +8093,58 @@ fn convert_variable_declarator_for_program(
     let end = offset + decl.span.end as usize;
     let loc = create_typed_loc(start, end, line_offsets);
 
-    // Convert the id (pattern).
-    // Only use JsNode::Raw when TypeScript type annotation is present,
-    // otherwise keep the typed JsNode so the scope builder's typed path works.
+    // Convert the id (pattern). When a TS type annotation is present, a plain
+    // annotated identifier (`let x: T = …`) routes through the typed walker
+    // carrying the annotation as an opaque boundary blob; an annotated
+    // destructuring pattern (`let { a }: T = …`) keeps the Value (Raw) form
+    // since the annotation hangs off a pattern node.
     let id_pattern = convert_binding_pattern(arena, &decl.id, offset, line_offsets);
     let id_node = if let Some(type_annotation) = &decl.type_annotation {
-        let mut id_value = id_pattern.to_value();
-        if let Value::Object(ref mut id_obj) = id_value {
-            let ts_start = type_annotation.span.start as usize + offset;
-            let ts_end = type_annotation.span.end as usize + offset;
+        let ts_start = type_annotation.span.start as usize + offset;
+        let ts_end = type_annotation.span.end as usize + offset;
 
-            let mut ts_obj = Map::new();
-            ts_obj.insert(
-                "type".to_string(),
-                Value::String("TSTypeAnnotation".to_string()),
-            );
-            ts_obj.insert("start".to_string(), Value::Number((ts_start as i64).into()));
-            ts_obj.insert("end".to_string(), Value::Number((ts_end as i64).into()));
-            if let Some(loc) = create_loc(ts_start, ts_end, line_offsets) {
-                ts_obj.insert("loc".to_string(), loc);
-            }
+        let mut ts_obj = Map::new();
+        ts_obj.insert(
+            "type".to_string(),
+            Value::String("TSTypeAnnotation".to_string()),
+        );
+        ts_obj.insert("start".to_string(), Value::Number((ts_start as i64).into()));
+        ts_obj.insert("end".to_string(), Value::Number((ts_end as i64).into()));
+        if let Some(loc) = create_loc(ts_start, ts_end, line_offsets) {
+            ts_obj.insert("loc".to_string(), loc);
+        }
+        let type_value = convert_ts_type(&type_annotation.type_annotation, offset, line_offsets);
+        ts_obj.insert("typeAnnotation".to_string(), type_value);
+        let ts_value = Value::Object(ts_obj);
 
-            let type_value =
-                convert_ts_type(&type_annotation.type_annotation, offset, line_offsets);
-            ts_obj.insert("typeAnnotation".to_string(), type_value);
-
-            id_obj.insert("typeAnnotation".to_string(), Value::Object(ts_obj));
-
-            id_obj.insert("end".to_string(), Value::Number((ts_end as i64).into()));
-            if let Some(loc) = create_loc(
-                id_obj.get("start").and_then(|v| v.as_i64()).unwrap_or(0) as usize,
-                ts_end,
-                line_offsets,
-            ) {
-                id_obj.insert("loc".to_string(), loc);
+        match id_pattern {
+            JsNode::Identifier {
+                start: id_start,
+                name,
+                ..
+            } => arena.alloc_js_node(JsNode::Identifier {
+                start: id_start,
+                end: ts_end as u32,
+                loc: create_typed_loc(id_start as usize, ts_end, line_offsets),
+                name,
+                type_annotation: Some(Box::new(ts_value)),
+            }),
+            other => {
+                let mut id_value = other.to_value();
+                if let Value::Object(ref mut id_obj) = id_value {
+                    id_obj.insert("typeAnnotation".to_string(), ts_value);
+                    id_obj.insert("end".to_string(), Value::Number((ts_end as i64).into()));
+                    if let Some(loc) = create_loc(
+                        id_obj.get("start").and_then(|v| v.as_i64()).unwrap_or(0) as usize,
+                        ts_end,
+                        line_offsets,
+                    ) {
+                        id_obj.insert("loc".to_string(), loc);
+                    }
+                }
+                arena.alloc_js_node(JsNode::Raw(id_value))
             }
         }
-        arena.alloc_js_node(JsNode::Raw(id_value))
     } else {
         arena.alloc_js_node(id_pattern)
     };
@@ -9482,13 +9464,17 @@ fn convert_function_expression_for_program_as_node(
     if let Some(rest) = &func.params.rest {
         let rest_start = offset + rest.span.start as usize;
         let rest_end = offset + rest.span.end as usize;
-        let argument =
-            convert_binding_pattern_for_param(arena, &rest.rest.argument, offset, line_offsets);
+        let argument = convert_binding_pattern_for_param_as_node(
+            arena,
+            &rest.rest.argument,
+            offset,
+            line_offsets,
+        );
         params.push(JsNode::RestElement {
             start: rest_start as u32,
             end: rest_end as u32,
             loc: create_typed_loc(rest_start, rest_end, line_offsets),
-            argument: arena.alloc_js_node(JsNode::Raw(argument)),
+            argument: arena.alloc_js_node(argument),
         });
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6894,81 +6894,60 @@ fn convert_statement_for_program(
         oxc_ast::ast::Statement::ClassDeclaration(class_decl) => {
             let start = offset + class_decl.span.start as usize;
             let end = offset + class_decl.span.end as usize;
-            let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("ClassDeclaration".to_string()),
-            );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            let loc = create_typed_loc(start, end, line_offsets);
 
             // id
-            if let Some(id) = &class_decl.id {
+            let id = class_decl.id.as_ref().map(|id| {
                 let id_start = offset + id.span.start as usize;
                 let id_end = offset + id.span.end as usize;
                 let id_expr = create_identifier(&id.name, id_start, id_end, line_offsets);
-                obj.insert("id".to_string(), id_expr.as_json().clone());
-            } else {
-                obj.insert("id".to_string(), Value::Null);
-            }
+                arena.alloc_js_node(expr_to_node(id_expr))
+            });
 
             // superClass
-            if let Some(super_class) = &class_decl.super_class {
+            let super_class = class_decl.super_class.as_ref().map(|super_class| {
                 let super_class_value =
                     convert_expression_for_program(arena, super_class, offset, line_offsets);
-                obj.insert(
-                    "superClass".to_string(),
-                    super_class_value.as_json().clone(),
-                );
-            } else {
-                obj.insert("superClass".to_string(), Value::Null);
-            }
+                arena.alloc_js_node(expr_to_node(super_class_value))
+            });
 
-            // body (ClassBody)
+            // body (ClassBody) — kept as a Raw value (mirrors ClassExpression).
             let body_value =
                 convert_class_body_for_program(arena, &class_decl.body, offset, line_offsets);
-            obj.insert("body".to_string(), body_value);
+            let body = arena.alloc_js_node(JsNode::Raw(body_value));
 
-            // TypeScript: declare field
-            if class_decl.declare {
-                obj.insert("declare".to_string(), Value::Bool(true));
-            }
-
-            // TypeScript: abstract field
-            if class_decl.r#abstract {
-                obj.insert("abstract".to_string(), Value::Bool(true));
-            }
-
-            // TypeScript: implements (presence indicates it should be removed by remove_typescript_nodes)
-            if !class_decl.implements.is_empty() {
-                obj.insert("implements".to_string(), Value::Bool(true));
-            }
-
-            // Decorators: include so remove_typescript_nodes can detect them
-            if !class_decl.decorators.is_empty() {
-                let decorators: Vec<Value> = class_decl
+            // Decorators: include so remove_typescript_nodes can detect them.
+            let decorators = if class_decl.decorators.is_empty() {
+                IdRange::empty()
+            } else {
+                let decorator_nodes: Vec<JsNode> = class_decl
                     .decorators
                     .iter()
                     .map(|dec| {
                         let dec_start = offset + dec.span.start as usize;
                         let dec_end = offset + dec.span.end as usize;
-                        let mut dec_obj = Map::new();
-                        dec_obj.insert("type".to_string(), Value::String("Decorator".to_string()));
-                        dec_obj.insert(
-                            "start".to_string(),
-                            Value::Number((dec_start as i64).into()),
-                        );
-                        dec_obj.insert("end".to_string(), Value::Number((dec_end as i64).into()));
-                        Value::Object(dec_obj)
+                        JsNode::Decorator {
+                            start: dec_start as u32,
+                            end: dec_end as u32,
+                            loc: None,
+                        }
                     })
                     .collect();
-                obj.insert("decorators".to_string(), Value::Array(decorators));
-            }
+                arena.alloc_js_children(decorator_nodes)
+            };
 
-            Some(JsNode::Raw(Value::Object(obj)))
+            Some(JsNode::ClassDeclaration {
+                start: start as u32,
+                end: end as u32,
+                loc,
+                id,
+                super_class,
+                body,
+                declare: class_decl.declare,
+                r#abstract: class_decl.r#abstract,
+                implements: !class_decl.implements.is_empty(),
+                decorators,
+            })
         }
         oxc_ast::ast::Statement::ReturnStatement(ret_stmt) => {
             let start = offset + ret_stmt.span.start as usize;

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
@@ -247,6 +247,7 @@ impl Parser<'_> {
                 source_type: CompactString::from("module"),
                 leading_comments: None,
                 trailing_comments: None,
+                ignore_comment_map: Vec::new(),
             });
             Script {
                 node_type: ScriptType::Script,
@@ -292,6 +293,7 @@ impl Parser<'_> {
                     source_type: CompactString::from("module"),
                     leading_comments: None,
                     trailing_comments: None,
+                    ignore_comment_map: Vec::new(),
                 });
                 Script {
                     node_type: ScriptType::Script,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
@@ -389,6 +389,638 @@ fn visit_children(node: &mut JsonValue, path: &[&str]) -> Result<(), ParseError>
     Ok(())
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// Typed transform (arena-based, no serde_json::Value round-trip)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// `remove_typescript_nodes_typed` is the typed sibling of `remove_typescript_nodes`.
+// It mutates the arena-backed `JsNode` tree in place so that a TS `<script>` can
+// stay `Expression::Typed` through Phase-2 analyze without ever building a
+// `serde_json::Value` for the whole program (the expensive `as_json()` round
+// trip the old Value path required).
+//
+// Design notes (see also the parser conversion in `read/expression.rs`):
+//   * The typed conversion is taken ONLY for clean plain-JS shapes. Every
+//     TS-messy construct — `declare`/`abstract`/`accessor`/decorators classes &
+//     members, interfaces, type aliases, declare functions, TS-modifier params,
+//     etc. — falls back to `JsNode::Raw(Value)`. So for any `JsNode::Raw` we
+//     simply delegate to the existing Value mutator, which handles that whole
+//     subtree with the exact same semantics (including errors).
+//   * TS expression wrappers (`as`/`satisfies`/`!`/`<T>`/instantiation) are
+//     already unwrapped at parse time, and the typed enum has no
+//     `returnType`/`accessibility`/`readonly`/… fields, so there is nothing to
+//     strip there.
+//   * The only TS cases that CAN reach a typed node are: type-only
+//     import/export (whole or per-specifier), `declare` variable declarations,
+//     `TSEnumDeclaration`, and `TSModuleDeclaration` (namespace) — handled
+//     structurally below.
+//   * The opaque `type_annotation` blobs on Identifier/ObjectPattern/ArrayPattern
+//     are intentionally NOT cleared: analyze never walks into them and the
+//     stripped program is never serialized as compile output, so leaving them is
+//     byte-identical for the only consumer (analyze).
+//   * The `Program.ignore_comment_map` is preserved automatically: we never
+//     rebuild the `Program` node, only mutate its body entries in place.
+
+use crate::ast::arena::{IdRange, JsNodeId, ParseArena};
+use crate::ast::typed_expr::JsNode;
+
+/// Recurse the typed TS strip into the arena node addressed by `id`.
+///
+/// Centralizes the single documented `unsafe` access used by the recursion.
+#[inline]
+fn recurse_node_id(id: JsNodeId, arena: &ParseArena) -> Result<(), ParseError> {
+    // SAFETY: the parse arena is single-threaded (`!Sync`) and the typed AST is
+    // an acyclic tree, so no two recursion frames address the same node; the
+    // `&mut JsNode` returned here is the only live mutable borrow of that node.
+    // The transform only ever appends to the arena (`alloc_js_*`), and the arena
+    // stores each node in its own `Box` / each child range in its own boxed
+    // slice, so those appends never move data behind references held by
+    // outer recursion frames.
+    let node = unsafe { arena.get_js_node_mut(id) };
+    remove_typescript_nodes_typed(node, arena)
+}
+
+/// Recurse the typed TS strip into every child of `range`.
+#[inline]
+fn recurse_range(range: IdRange, arena: &ParseArena) -> Result<(), ParseError> {
+    if range.is_empty() {
+        return Ok(());
+    }
+    // SAFETY: see `recurse_node_id` — single-threaded, acyclic, append-only.
+    // The returned `&mut [JsNode]` points into a stable boxed slice that the
+    // append-only `alloc_js_*` calls performed during recursion never move.
+    let children = unsafe { arena.get_js_children_mut(range) };
+    for child in children {
+        remove_typescript_nodes_typed(child, arena)?;
+    }
+    Ok(())
+}
+
+/// Build a typed `EmptyStatement` carrying `node`'s span (the span is irrelevant
+/// to analyze, which treats every `EmptyStatement` as a no-op, but we keep it for
+/// faithfulness).
+#[inline]
+fn typed_empty_statement(node: &JsNode) -> JsNode {
+    JsNode::EmptyStatement {
+        start: node.start().unwrap_or(0),
+        end: node.end().unwrap_or(0),
+        loc: None,
+    }
+}
+
+/// Typed entry point. Mirrors [`remove_typescript_nodes`] but operates directly
+/// on the arena-backed typed tree.
+pub fn remove_typescript_nodes_typed(
+    node: &mut JsNode,
+    arena: &ParseArena,
+) -> Result<(), ParseError> {
+    // `JsNode::Raw` carries a full `serde_json::Value` subtree (the TS-messy
+    // fallback). Delegate to the Value mutator, which recurses and strips it
+    // with the canonical semantics — including raising the same errors.
+    if let JsNode::Raw(value) = node {
+        return remove_typescript_nodes(value, &[]);
+    }
+
+    match node.node_type() {
+        // Decorators are not supported.
+        Some("Decorator") => {
+            return Err(ParseError::typescript_invalid_feature(
+                "decorators (related TSC proposal is not stage 4 yet)",
+                (
+                    node.start().unwrap_or(0) as usize,
+                    node.end().unwrap_or(0) as usize,
+                ),
+            ));
+        }
+
+        // Enums are not supported.
+        Some("TSEnumDeclaration") => {
+            return Err(ParseError::typescript_invalid_feature(
+                "enums",
+                (
+                    node.start().unwrap_or(0) as usize,
+                    node.end().unwrap_or(0) as usize,
+                ),
+            ));
+        }
+
+        // Namespaces / modules: error if they contain non-type nodes, else strip.
+        Some("TSModuleDeclaration") => {
+            return strip_ts_module_declaration_typed(node, arena);
+        }
+
+        // Filter out type-only imports.
+        Some("ImportDeclaration") => {
+            return strip_import_declaration_typed(node, arena);
+        }
+
+        // Filter out type-only exports.
+        Some("ExportNamedDeclaration") => {
+            return strip_export_named_declaration_typed(node, arena);
+        }
+
+        // Remove declared variables (`declare const x`).
+        Some("VariableDeclaration") => {
+            if let JsNode::VariableDeclaration { declare: true, .. } = node {
+                *node = typed_empty_statement(node);
+                return Ok(());
+            }
+        }
+
+        // Remove declared classes (`declare class C`). The typed class path is
+        // only taken for non-declare classes, so this is defensive.
+        Some("ClassDeclaration") => {
+            if let JsNode::ClassDeclaration { declare: true, .. } = node {
+                *node = typed_empty_statement(node);
+                return Ok(());
+            }
+        }
+
+        // Remove the leading `this` parameter from functions. (The typed function
+        // path emits only `params.items`, so this is effectively defensive — a
+        // typed function never actually carries a `this` param.)
+        Some("FunctionExpression") | Some("FunctionDeclaration") => {
+            remove_this_param_typed(node, arena);
+        }
+
+        _ => {}
+    }
+
+    // Recurse into children.
+    visit_typed_children(node, arena)
+}
+
+/// Strip a `TSModuleDeclaration` (typed). Mirrors the Value-mutator namespace
+/// logic: error when the body contains non-type nodes, otherwise replace with an
+/// empty statement.
+fn strip_ts_module_declaration_typed(
+    node: &mut JsNode,
+    arena: &ParseArena,
+) -> Result<(), ParseError> {
+    let body_id = match node {
+        JsNode::TSModuleDeclaration { body, .. } => *body,
+        _ => None,
+    };
+
+    if let Some(body_id) = body_id {
+        // Typed module body is a `BlockStatement { body: [...] }` wrapper.
+        let block = arena.get_js_node(body_id);
+        let stmts_range = match block {
+            JsNode::BlockStatement { body, .. } => *body,
+            _ => IdRange::empty(),
+        };
+        let stmts = arena.get_js_children(stmts_range);
+        let has_non_type_nodes = stmts
+            .iter()
+            .any(|entry| !is_type_only_namespace_member(entry));
+        if has_non_type_nodes {
+            return Err(ParseError::typescript_invalid_feature(
+                "namespaces with non-type nodes",
+                (
+                    node.start().unwrap_or(0) as usize,
+                    node.end().unwrap_or(0) as usize,
+                ),
+            ));
+        }
+    }
+
+    *node = typed_empty_statement(node);
+    Ok(())
+}
+
+/// Classify a single namespace-body member as "safe to strip" (type-only).
+/// Mirrors the Value mutator's per-entry predicate (lines for `TSModuleDeclaration`).
+fn is_type_only_namespace_member(entry: &JsNode) -> bool {
+    match entry.node_type() {
+        Some("EmptyStatement")
+        | Some("TSInterfaceDeclaration")
+        | Some("TSTypeAliasDeclaration")
+        | Some("TSEnumDeclaration") => true,
+        Some("ExportNamedDeclaration") => {
+            // `export type ...`
+            if let JsNode::ExportNamedDeclaration { export_kind, .. } = entry
+                && export_kind.as_deref() == Some("type")
+            {
+                return true;
+            }
+            // `export <type-only declaration>`
+            if let JsNode::Raw(v) = entry {
+                if v.get("exportKind").and_then(|k| k.as_str()) == Some("type") {
+                    return true;
+                }
+                if let Some(decl) = v.get("declaration") {
+                    let dt = decl.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    return matches!(
+                        dt,
+                        "TSInterfaceDeclaration" | "TSTypeAliasDeclaration" | "TSEnumDeclaration"
+                    );
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+/// Strip type-only imports (typed). Whole `import type {...}` → empty; otherwise
+/// drop `import { type X }` specifiers, emptying the import if none remain.
+fn strip_import_declaration_typed(node: &mut JsNode, arena: &ParseArena) -> Result<(), ParseError> {
+    let (is_type, spec_range) = match node {
+        JsNode::ImportDeclaration {
+            import_kind,
+            specifiers,
+            ..
+        } => (import_kind.as_deref() == Some("type"), *specifiers),
+        _ => (false, IdRange::empty()),
+    };
+
+    if is_type {
+        *node = typed_empty_statement(node);
+        return Ok(());
+    }
+
+    if !spec_range.is_empty() {
+        let specs = arena.get_js_children(spec_range);
+        let any_type = specs.iter().any(specifier_import_kind_is_type);
+        if any_type {
+            let kept: Vec<JsNode> = specs
+                .iter()
+                .filter(|s| !specifier_import_kind_is_type(s))
+                .cloned()
+                .collect();
+            if kept.is_empty() {
+                *node = typed_empty_statement(node);
+                return Ok(());
+            }
+            let new_range = arena.alloc_js_children(kept);
+            if let JsNode::ImportDeclaration { specifiers, .. } = node {
+                *specifiers = new_range;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Strip type-only named exports (typed).
+fn strip_export_named_declaration_typed(
+    node: &mut JsNode,
+    arena: &ParseArena,
+) -> Result<(), ParseError> {
+    let (is_type, declaration, spec_range) = match node {
+        JsNode::ExportNamedDeclaration {
+            export_kind,
+            declaration,
+            specifiers,
+            ..
+        } => (
+            export_kind.as_deref() == Some("type"),
+            *declaration,
+            *specifiers,
+        ),
+        _ => (false, None, IdRange::empty()),
+    };
+
+    if is_type {
+        *node = typed_empty_statement(node);
+        return Ok(());
+    }
+
+    // If the declaration is already an EmptyStatement, the whole export is empty.
+    if let Some(decl_id) = declaration
+        && arena.get_js_node(decl_id).node_type() == Some("EmptyStatement")
+    {
+        *node = typed_empty_statement(node);
+        return Ok(());
+    }
+
+    // Filter type-only specifiers.
+    if !spec_range.is_empty() {
+        let specs = arena.get_js_children(spec_range);
+        let any_type = specs.iter().any(specifier_export_kind_is_type);
+        if any_type {
+            let kept: Vec<JsNode> = specs
+                .iter()
+                .filter(|s| !specifier_export_kind_is_type(s))
+                .cloned()
+                .collect();
+            if kept.is_empty() {
+                *node = typed_empty_statement(node);
+                return Ok(());
+            }
+            let new_range = arena.alloc_js_children(kept);
+            if let JsNode::ExportNamedDeclaration { specifiers, .. } = node {
+                *specifiers = new_range;
+            }
+        }
+    }
+
+    // Recurse into the declaration (e.g. `export interface Foo` → declaration is a
+    // Raw TSInterfaceDeclaration that the Value mutator turns into EmptyStatement).
+    if let Some(decl_id) = declaration {
+        recurse_node_id(decl_id, arena)?;
+    }
+    Ok(())
+}
+
+#[inline]
+fn specifier_import_kind_is_type(spec: &JsNode) -> bool {
+    match spec {
+        JsNode::ImportSpecifier { import_kind, .. } => import_kind.as_deref() == Some("type"),
+        JsNode::Raw(v) => v.get("importKind").and_then(|k| k.as_str()) == Some("type"),
+        _ => false,
+    }
+}
+
+#[inline]
+fn specifier_export_kind_is_type(spec: &JsNode) -> bool {
+    match spec {
+        JsNode::ExportSpecifier { export_kind, .. } => export_kind.as_deref() == Some("type"),
+        JsNode::Raw(v) => v.get("exportKind").and_then(|k| k.as_str()) == Some("type"),
+        _ => false,
+    }
+}
+
+/// Remove a leading `this` parameter from a typed function node, if present.
+fn remove_this_param_typed(node: &mut JsNode, arena: &ParseArena) {
+    let params = match node {
+        JsNode::FunctionExpression { params, .. } | JsNode::FunctionDeclaration { params, .. } => {
+            *params
+        }
+        _ => return,
+    };
+    if params.is_empty() {
+        return;
+    }
+    let items = arena.get_js_children(params);
+    let first_is_this =
+        matches!(items.first(), Some(JsNode::Identifier { name, .. }) if name == "this");
+    if !first_is_this {
+        return;
+    }
+    let kept: Vec<JsNode> = items.iter().skip(1).cloned().collect();
+    let new_range = arena.alloc_js_children(kept);
+    match node {
+        JsNode::FunctionExpression { params, .. } | JsNode::FunctionDeclaration { params, .. } => {
+            *params = new_range;
+        }
+        _ => {}
+    }
+}
+
+/// Recurse into every JS child of a typed node.
+fn visit_typed_children(node: &mut JsNode, arena: &ParseArena) -> Result<(), ParseError> {
+    // Recurse into a single child by id.
+    macro_rules! rec_id {
+        ($id:expr) => {{
+            recurse_node_id($id, arena)?;
+        }};
+    }
+    macro_rules! rec_opt {
+        ($opt:expr) => {{
+            if let Some(id) = $opt {
+                rec_id!(id);
+            }
+        }};
+    }
+    // Recurse into every child of a range.
+    macro_rules! rec_range {
+        ($range:expr) => {{
+            recurse_range($range, arena)?;
+        }};
+    }
+
+    match node {
+        JsNode::BinaryExpression { left, right, .. }
+        | JsNode::LogicalExpression { left, right, .. }
+        | JsNode::AssignmentExpression { left, right, .. }
+        | JsNode::AssignmentPattern { left, right, .. }
+        | JsNode::ForOfStatement { left, right, .. }
+        | JsNode::ForInStatement { left, right, .. } => {
+            let (l, r) = (*left, *right);
+            rec_id!(l);
+            rec_id!(r);
+        }
+        JsNode::UnaryExpression { argument, .. }
+        | JsNode::UpdateExpression { argument, .. }
+        | JsNode::AwaitExpression { argument, .. }
+        | JsNode::ThrowStatement { argument, .. }
+        | JsNode::SpreadElement { argument, .. }
+        | JsNode::RestElement { argument, .. } => {
+            rec_id!(*argument);
+        }
+        JsNode::YieldExpression { argument, .. } | JsNode::ReturnStatement { argument, .. } => {
+            rec_opt!(*argument);
+        }
+        JsNode::ConditionalExpression {
+            test,
+            consequent,
+            alternate,
+            ..
+        } => {
+            let (t, c, a) = (*test, *consequent, *alternate);
+            rec_id!(t);
+            rec_id!(c);
+            rec_id!(a);
+        }
+        JsNode::IfStatement {
+            test,
+            consequent,
+            alternate,
+            ..
+        } => {
+            let (t, c, a) = (*test, *consequent, *alternate);
+            rec_id!(t);
+            rec_id!(c);
+            rec_opt!(a);
+        }
+        JsNode::CallExpression {
+            callee, arguments, ..
+        }
+        | JsNode::NewExpression {
+            callee, arguments, ..
+        } => {
+            let (c, args) = (*callee, *arguments);
+            rec_id!(c);
+            rec_range!(args);
+        }
+        JsNode::MemberExpression {
+            object, property, ..
+        } => {
+            let (o, p) = (*object, *property);
+            rec_id!(o);
+            rec_id!(p);
+        }
+        JsNode::MetaProperty { meta, property, .. } => {
+            let (m, p) = (*meta, *property);
+            rec_id!(m);
+            rec_id!(p);
+        }
+        JsNode::FunctionExpression {
+            id, params, body, ..
+        }
+        | JsNode::FunctionDeclaration {
+            id, params, body, ..
+        } => {
+            let (i, p, b) = (*id, *params, *body);
+            rec_opt!(i);
+            rec_range!(p);
+            rec_opt!(b);
+        }
+        JsNode::ArrowFunctionExpression {
+            id, params, body, ..
+        } => {
+            let (i, p, b) = (*id, *params, *body);
+            rec_opt!(i);
+            rec_range!(p);
+            rec_id!(b);
+        }
+        JsNode::ClassExpression {
+            id,
+            super_class,
+            body,
+            ..
+        } => {
+            let (i, s, b) = (*id, *super_class, *body);
+            rec_opt!(i);
+            rec_opt!(s);
+            rec_id!(b);
+        }
+        JsNode::ClassDeclaration {
+            id,
+            super_class,
+            body,
+            decorators,
+            ..
+        } => {
+            // `decorators` carries `JsNode::Decorator` entries that must raise the
+            // "decorators not supported" error when present.
+            let (i, s, b, d) = (*id, *super_class, *body, *decorators);
+            rec_opt!(i);
+            rec_opt!(s);
+            rec_id!(b);
+            rec_range!(d);
+        }
+        JsNode::SequenceExpression { expressions, .. } => {
+            rec_range!(*expressions);
+        }
+        JsNode::TemplateLiteral {
+            quasis,
+            expressions,
+            ..
+        } => {
+            let (q, e) = (*quasis, *expressions);
+            rec_range!(q);
+            rec_range!(e);
+        }
+        JsNode::TaggedTemplateExpression { tag, quasi, .. } => {
+            let (t, q) = (*tag, *quasi);
+            rec_id!(t);
+            rec_id!(q);
+        }
+        JsNode::ArrayExpression { elements, .. } | JsNode::ArrayPattern { elements, .. } => {
+            for el in elements.iter_mut().flatten() {
+                remove_typescript_nodes_typed(el, arena)?;
+            }
+        }
+        JsNode::ObjectExpression { properties, .. } | JsNode::ObjectPattern { properties, .. } => {
+            rec_range!(*properties);
+        }
+        JsNode::ImportExpression { source, .. } => {
+            rec_id!(*source);
+        }
+        JsNode::ChainExpression { expression, .. }
+        | JsNode::ExpressionStatement { expression, .. } => {
+            rec_id!(*expression);
+        }
+        JsNode::Property { key, value, .. } | JsNode::MethodDefinition { key, value, .. } => {
+            let (k, v) = (*key, *value);
+            rec_id!(k);
+            rec_id!(v);
+        }
+        JsNode::PropertyDefinition { key, value, .. } => {
+            let (k, v) = (*key, *value);
+            rec_id!(k);
+            rec_opt!(v);
+        }
+        JsNode::Program { body, .. }
+        | JsNode::BlockStatement { body, .. }
+        | JsNode::ClassBody { body, .. }
+        | JsNode::StaticBlock { body, .. } => {
+            rec_range!(*body);
+        }
+        JsNode::VariableDeclaration { declarations, .. } => {
+            rec_range!(*declarations);
+        }
+        JsNode::VariableDeclarator { id, init, .. } => {
+            let (i, n) = (*id, *init);
+            rec_id!(i);
+            rec_opt!(n);
+        }
+        JsNode::ForStatement {
+            init,
+            test,
+            update,
+            body,
+            ..
+        } => {
+            let (i, t, u, b) = (*init, *test, *update, *body);
+            rec_opt!(i);
+            rec_opt!(t);
+            rec_opt!(u);
+            rec_id!(b);
+        }
+        JsNode::WhileStatement { test, body, .. } | JsNode::DoWhileStatement { test, body, .. } => {
+            let (t, b) = (*test, *body);
+            rec_id!(t);
+            rec_id!(b);
+        }
+        JsNode::TryStatement {
+            block,
+            handler,
+            finalizer,
+            ..
+        } => {
+            let (bl, h, f) = (*block, *handler, *finalizer);
+            rec_id!(bl);
+            rec_opt!(h);
+            rec_opt!(f);
+        }
+        JsNode::CatchClause { param, body, .. } => {
+            let (p, b) = (*param, *body);
+            rec_opt!(p);
+            rec_id!(b);
+        }
+        JsNode::SwitchStatement {
+            discriminant,
+            cases,
+            ..
+        } => {
+            let (d, c) = (*discriminant, *cases);
+            rec_id!(d);
+            rec_range!(c);
+        }
+        JsNode::SwitchCase {
+            test, consequent, ..
+        } => {
+            let (t, c) = (*test, *consequent);
+            rec_opt!(t);
+            rec_range!(c);
+        }
+        JsNode::LabeledStatement { label, body, .. } => {
+            let (l, b) = (*label, *body);
+            rec_id!(l);
+            rec_id!(b);
+        }
+        JsNode::ExportDefaultDeclaration { declaration, .. } => {
+            rec_id!(*declaration);
+        }
+        // Childless / type-only / handled-elsewhere variants: nothing to recurse.
+        _ => {}
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/function_declaration.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/function_declaration.rs
@@ -90,20 +90,31 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
             context.scope = scope_idx;
         }
 
-        // Visit function body
+        // Visit function body. Snapshot the Raw-delegation counter so we can tell
+        // whether the typed body walk had to fall back to the Value walker for any
+        // genuinely-`JsNode::Raw` subtree (the typed walker routes `Raw` →
+        // `walk_js_node`, which bumps `raw_walk_count`).
+        let raw_before = context.raw_walk_count;
         let result = if let Some(body_id) = body {
             let body_node = arena.get_js_node(*body_id);
             super::script::walk_js_node_typed(body_node, context)
         } else {
             Ok(())
         };
+        let body_had_raw = context.raw_walk_count > raw_before;
 
         // For function bodies containing arrow functions whose body was serialized
         // as JsNode::Raw(Value) during parsing, the Value may have corrupt nested
         // nodes (JsNodeIds resolved incorrectly during to_value()). The walker above
-        // may miss NewExpression nodes nested inside arrow function bodies.
-        // Scan the source text as a fallback to detect `new ` keyword usage.
+        // may miss NewExpression nodes nested inside such genuinely-`Raw` subtrees.
+        // Scan the source text as a fallback to detect `new ` keyword usage — but
+        // ONLY when the body actually contained a `Raw` subtree. For a fully-typed
+        // body the typed walk already visits every `NewExpression` precisely, so the
+        // text scan is redundant there and would false-positive on the substring
+        // `"new "` inside string literals / comments (e.g. `prompt("Add a new card")`),
+        // spuriously forcing `needs_context` (and an unwanted `$.push`/`$$props`).
         if !context.analysis.needs_context
+            && body_had_raw
             && let Some(body_id) = body
         {
             let body_node = arena.get_js_node(*body_id);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -433,6 +433,14 @@ pub struct VisitorContext<'a> {
     /// Each entry is a set of warning codes that should be ignored at that nesting level.
     /// Corresponds to ignore_stack in Svelte's state.js.
     pub ignore_stack: Vec<rustc_hash::FxHashSet<String>>,
+    /// Map from a script JS node's absolute `start` offset to the raw `svelte-ignore`
+    /// comment value texts attached to it as leading comments. Populated from the typed
+    /// `JsNode::Program`'s `ignore_comment_map` for the duration of a script body walk
+    /// (see `script::visit_script_expr`), and consulted by the typed walker
+    /// (`walk_js_node_typed`) and `variable_declarator::collect_ignore_codes_from_parent`
+    /// in place of reading `leadingComments` off a materialized `JsNode::Raw` Value.
+    /// Empty outside a script walk and whenever the script has no `svelte-ignore` comments.
+    pub script_ignore_comments: rustc_hash::FxHashMap<u32, Vec<compact_str::CompactString>>,
     /// Stack of ancestor element names for node_invalid_placement validation.
     /// This is separate from path because path contains TemplateNode references that are difficult to manage.
     pub element_ancestors: Vec<String>,
@@ -565,6 +573,7 @@ impl<'a> VisitorContext<'a> {
             in_expression_tag: false,
             in_template_function: false,
             ignore_stack: Vec::new(),
+            script_ignore_comments: rustc_hash::FxHashMap::default(),
             element_ancestors: Vec::new(),
             block_depth_at_element: Vec::new(),
             each_block_stack: Vec::new(),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -441,6 +441,12 @@ pub struct VisitorContext<'a> {
     /// in place of reading `leadingComments` off a materialized `JsNode::Raw` Value.
     /// Empty outside a script walk and whenever the script has no `svelte-ignore` comments.
     pub script_ignore_comments: rustc_hash::FxHashMap<u32, Vec<compact_str::CompactString>>,
+    /// Number of times the Value walker (`walk_js_node`) has been entered. The
+    /// typed walker delegates genuinely-`JsNode::Raw` subtrees to it, so a delta
+    /// in this counter across a typed subtree walk reveals whether that subtree
+    /// contained any `Raw` node (used by `function_declaration::visit_typed` to
+    /// gate its `new `-keyword text-scan fallback to Raw-bearing bodies only).
+    pub raw_walk_count: usize,
     /// Stack of ancestor element names for node_invalid_placement validation.
     /// This is separate from path because path contains TemplateNode references that are difficult to manage.
     pub element_ancestors: Vec<String>,
@@ -574,6 +580,7 @@ impl<'a> VisitorContext<'a> {
             in_template_function: false,
             ignore_stack: Vec::new(),
             script_ignore_comments: rustc_hash::FxHashMap::default(),
+            raw_walk_count: 0,
             element_ancestors: Vec::new(),
             block_depth_at_element: Vec::new(),
             each_block_stack: Vec::new(),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
@@ -116,6 +116,12 @@ pub fn visit_script(script_ast: &Value, context: &mut VisitorContext) -> Result<
 /// * `node` - The JavaScript AST node
 /// * `context` - The visitor context
 pub fn walk_js_node(node: &Value, context: &mut VisitorContext) -> Result<(), AnalysisError> {
+    // Count Value-walker entries. The typed walker only reaches here by
+    // delegating a genuinely-`JsNode::Raw` subtree, so a nonzero delta across a
+    // typed subtree walk signals that the subtree contained a `Raw` node (see
+    // `function_declaration::visit_typed`'s `new `-keyword fallback gate).
+    context.raw_walk_count = context.raw_walk_count.saturating_add(1);
+
     // Fast path: skip non-object values (primitives, arrays, nulls)
     let obj = match node {
         Value::Object(obj) => obj,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
@@ -28,29 +28,44 @@ pub fn visit_script_expr(
 ) -> Result<(), AnalysisError> {
     match script_expr {
         Expression::Typed(te) => {
-            if let JsNode::Program { body, .. } = &te.node {
+            if let JsNode::Program {
+                body,
+                ignore_comment_map,
+                ..
+            } = &te.node
+            {
+                // Install this program's svelte-ignore map for the duration of the body
+                // walk, so the typed walker can surface statement-level svelte-ignore
+                // suppression without the nodes being materialized as `JsNode::Raw`.
+                // Save/restore the previous map (module vs instance scripts each set
+                // their own; template walks expect an empty map).
+                let saved_ignores = std::mem::take(&mut context.script_ignore_comments);
+                context.script_ignore_comments = ignore_comment_map.iter().cloned().collect();
+
                 // Fast path: push a lazily-computed Value for js_path, then walk body typed
                 let program_value = te.as_json();
                 context.js_path.push(super::JsPathEntry::new(program_value));
 
                 let arena = context.parse_arena;
+                let mut result = Ok(());
                 for stmt in arena.get_js_children(*body) {
-                    match stmt {
+                    let step = match stmt {
                         // For Raw nodes (statements with leadingComments attached),
                         // use the Value-based walker which handles all node types
                         // via string matching and processes leadingComments properly.
-                        JsNode::Raw(value) => {
-                            walk_js_node(value, context)?;
-                        }
+                        JsNode::Raw(value) => walk_js_node(value, context),
                         // For typed nodes, use the typed walker for direct field access.
-                        _ => {
-                            walk_js_node_typed(stmt, context)?;
-                        }
+                        _ => walk_js_node_typed(stmt, context),
+                    };
+                    if step.is_err() {
+                        result = step;
+                        break;
                     }
                 }
 
                 context.js_path.pop();
-                Ok(())
+                context.script_ignore_comments = saved_ignores;
+                result
             } else {
                 // Not a Program - fall back to JSON path
                 visit_script(script_expr.as_json(), context)
@@ -114,17 +129,34 @@ pub fn walk_js_node(node: &Value, context: &mut VisitorContext) -> Result<(), An
     // which extracts svelte-ignore codes from JS comments and pushes them to the ignore stack.
     // Most nodes don't have leadingComments, so check existence first.
     let mut has_ignores = false;
+    let mut ignores = Vec::new();
     if let Some(comments) = obj.get("leadingComments").and_then(|c| c.as_array()) {
-        let mut ignores = Vec::new();
         for comment in comments {
             if let Some(value) = comment.get("value").and_then(|v| v.as_str()) {
                 ignores.extend(extract_svelte_ignore(value, context.analysis.runes));
             }
         }
-        if !ignores.is_empty() {
-            context.push_ignore(ignores);
-            has_ignores = true;
+    }
+    // Fallback to the harvested svelte-ignore map (keyed by absolute node start).
+    // This covers statements nested inside a genuinely-`JsNode::Raw` subtree — e.g.
+    // a function-expression / block-bodied arrow / class body — which are walked here
+    // via the Value walker and no longer carry `leadingComments` on their Value (the
+    // parser harvests those texts into `script_ignore_comments` instead of wrapping the
+    // whole owning statement as Raw). The map is empty outside a script body walk and
+    // in the pure Value-path analysis, so this is a no-op there.
+    if ignores.is_empty() && !context.script_ignore_comments.is_empty() {
+        let runes = context.analysis.runes;
+        if let Some(start) = obj.get("start").and_then(|s| s.as_u64())
+            && let Some(values) = context.script_ignore_comments.get(&(start as u32))
+        {
+            for value in values {
+                ignores.extend(extract_svelte_ignore(value, runes));
+            }
         }
+    }
+    if !ignores.is_empty() {
+        context.push_ignore(ignores);
+        has_ignores = true;
     }
 
     // Push to JS path
@@ -621,8 +653,26 @@ pub fn walk_js_node_typed(
         return walk_js_node(value, context);
     }
 
-    // leadingComments are not stored in JsNode variants (only in Raw/Value),
-    // so we skip that processing for typed nodes. The Raw fallback handles it.
+    // Process svelte-ignore directives attached to this node as leading comments.
+    // The parser harvests those comment texts into the Program's `ignore_comment_map`
+    // (keyed by absolute node start) instead of materializing the node as `JsNode::Raw`,
+    // so we consult that map here. This mirrors `walk_js_node`'s leadingComments handling:
+    // push the ignore codes before visiting children, pop after.
+    let mut has_ignores = false;
+    if !context.script_ignore_comments.is_empty()
+        && let Some(start) = node.start()
+        && let Some(values) = context.script_ignore_comments.get(&start)
+    {
+        let runes = context.analysis.runes;
+        let mut ignores = Vec::new();
+        for value in values {
+            ignores.extend(extract_svelte_ignore(value, runes));
+        }
+        if !ignores.is_empty() {
+            context.push_ignore(ignores);
+            has_ignores = true;
+        }
+    }
 
     // Push a TypedNode entry onto js_path. The Value will be lazily materialized
     // only if code inspects this entry through Deref (which most entries never need).
@@ -706,6 +756,11 @@ pub fn walk_js_node_typed(
 
     // Pop from JS path
     context.js_path.pop();
+
+    // Pop svelte-ignore codes (after visiting children), mirroring walk_js_node.
+    if has_ignores {
+        context.pop_ignore();
+    }
 
     Ok(())
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -963,10 +963,33 @@ fn collect_ignore_codes_from_parent(context: &VisitorContext) -> Vec<String> {
         return codes;
     }
     for node in context.js_path[..path_len - 1].iter().rev() {
-        let node_type = node.get("type").and_then(|t| t.as_str());
+        let node_type = node.get_type_str();
         match node_type {
             Some("VariableDeclaration") | Some("ExportNamedDeclaration") => {
-                if let Some(comments) = node.get("leadingComments").and_then(|c| c.as_array()) {
+                // Prefer the parser-harvested svelte-ignore map (keyed by the parent's
+                // absolute start). This covers both typed parents and Value-entry parents
+                // that live inside a genuinely-`JsNode::Raw` subtree, without materializing
+                // a typed node into a Value.
+                let before = codes.len();
+                if let Some(start) = node.get_field_u64("start")
+                    && let Some(values) = context.script_ignore_comments.get(&(start as u32))
+                {
+                    for value in values {
+                        codes.extend(
+                            crate::compiler::phases::phase2_analyze::utils::extract_svelte_ignore(
+                                value,
+                                context.analysis.runes,
+                            ),
+                        );
+                    }
+                }
+                // Legacy Value-path fallback: read the materialized `leadingComments`
+                // directly when the map yielded nothing (e.g. pure Value-path analysis,
+                // where `script_ignore_comments` is empty).
+                if codes.len() == before
+                    && node.as_js_node().is_none()
+                    && let Some(comments) = node.get("leadingComments").and_then(|c| c.as_array())
+                {
                     for comment in comments {
                         if let Some(value) = comment.get("value").and_then(|v| v.as_str()) {
                             let extracted =

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -1402,6 +1402,22 @@ fn visit_runes_mode_typed(
                 .or_else(|| context.analysis.root.get_binding(&path.name, context.scope))
                 .or_else(|| context.analysis.root.find_binding_any_scope(&path.name));
             if let Some(binding_idx) = binding_idx {
+                // Guard: a plain (non-rune) `const`/`let`/`var` declarator must
+                // never write `initial` onto a prop binding. In runes mode props
+                // derive `initial` solely from the `$props()` destructuring, so a
+                // same-named binding reached here is always a *different* (e.g.
+                // block-scoped) variable. Without this guard, the typed-path
+                // position lookup — whose `path.start` (global) cannot match the
+                // binding's `declaration_start` (global + script offset, see
+                // scope_builder) — falls back to a scope-insensitive lookup that
+                // resolves to the prop and erases its default (initial → None),
+                // which then mis-emits `$$props.x` instead of the `x()` accessor.
+                if matches!(
+                    context.analysis.root.bindings[binding_idx].kind,
+                    BindingKind::Prop | BindingKind::BindableProp | BindingKind::RestProp
+                ) {
+                    continue;
+                }
                 let binding = &mut context.analysis.root.bindings[binding_idx];
                 binding.initial = extract_literal_string_typed(init);
                 binding.initial_is_defined = is_expression_defined_typed(init, arena);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -1264,8 +1264,44 @@ fn is_expression_defined_typed(node: &JsNode, arena: &crate::ast::arena::ParseAr
                 .map(|last| is_expression_defined_typed(last, arena))
                 .unwrap_or(false)
         }
+        // Mirror the Value-path `CallExpression` arm: upstream `scope.evaluate`
+        // knows the global `Math.*` / `Number` / `String` / `BigInt` functions
+        // return a defined number/string, so a `const x = Math.round(...)`
+        // binding is `is_defined` and a template `${x}` reads bare (no `?? ''`).
+        // Without this arm the typed path falls through to `_ => false`, which
+        // spuriously adds `?? ''` for TS scripts now walked typed.
+        JsNode::CallExpression { callee, .. } => {
+            js_node_member_keypath(arena.get_js_node(*callee), arena)
+                .map(|kp| is_known_defined_global_call(&kp))
+                .unwrap_or(false)
+        }
         JsNode::Raw(value) => is_expression_defined(value),
         _ => false,
+    }
+}
+
+/// Build a dotted keypath for a non-computed identifier member chain on a typed
+/// `JsNode` (`Math.round` → `"Math.round"`, `Number` → `"Number"`). Returns
+/// `None` for any computed access / non-identifier link. Typed mirror of
+/// `json_member_keypath`; falls back to it for genuinely-`Raw` subtrees.
+fn js_node_member_keypath(node: &JsNode, arena: &crate::ast::arena::ParseArena) -> Option<String> {
+    match node {
+        JsNode::Identifier { name, .. } => Some(name.to_string()),
+        JsNode::MemberExpression {
+            object,
+            property,
+            computed: false,
+            ..
+        } => {
+            let object = js_node_member_keypath(arena.get_js_node(*object), arena)?;
+            let prop = match arena.get_js_node(*property) {
+                JsNode::Identifier { name, .. } => name.to_string(),
+                _ => return None,
+            };
+            Some(format!("{object}.{prop}"))
+        }
+        JsNode::Raw(value) => json_member_keypath(value),
+        _ => None,
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -1664,20 +1664,6 @@ mod tests {
         assert_eq!(roundtrip(src), expected, "round-trip mismatch for {src:?}");
     }
 
-    /// Assert that conversion bails (returns `None`) for `src` — used for shapes
-    /// the parse-phase `_for_program` IR stores as opaque `JsNode::Raw` (e.g.
-    /// block-bodied arrows, function expressions, destructuring assignment
-    /// targets, `export` declarations), which the structural printer cannot
-    /// faithfully reconstruct.
-    fn assert_bails(src: &str) {
-        let (arena, program) = parse(src);
-        let allocator = Allocator::default();
-        assert!(
-            jsnode_to_oxc_program(&program, &arena, &allocator).is_none(),
-            "expected conversion to bail for {src:?}"
-        );
-    }
-
     #[test]
     fn identifier_and_member() {
         assert_rt("foo;", "foo;");
@@ -1727,20 +1713,23 @@ mod tests {
         // Expression-bodied arrows are typed and convert faithfully.
         assert_rt("(a, b) => a + b;", "(a, b) => a + b;");
         assert_rt("async (x) => x;", "async (x) => x;");
-        // A block-bodied arrow stores its body as opaque `JsNode::Raw` in the
-        // parse-phase `_for_program` IR, so conversion bails (safe fallback).
-        assert_bails("() => { return 1; };");
+        // Block-bodied arrows are now typed in the parse-phase `_for_program`
+        // IR and round-trip faithfully.
+        assert_rt("() => { return 1; };", "() => {\n\treturn 1;\n};");
     }
 
     #[test]
-    fn function_declaration_converts_but_expression_bails() {
+    fn function_declaration_and_expression_convert() {
         // A top-level `FunctionDeclaration` is fully typed in the IR.
         assert_rt(
             "function add(a, b) { return a + b; }",
             "function add(a, b) {\n\treturn a + b;\n}",
         );
-        // A `FunctionExpression` is stored as opaque `JsNode::Raw`; bail.
-        assert_bails("const f = function* () { yield 1; };");
+        // A `FunctionExpression` initializer is now typed and round-trips.
+        assert_rt(
+            "const f = function* () { yield 1; };",
+            "const f = function* () {\n\tyield 1;\n};",
+        );
     }
 
     #[test]
@@ -1748,9 +1737,12 @@ mod tests {
         assert_rt("({ a: 1, b });", "({ a: 1, b });");
         assert_rt("({ ...rest });", "({ ...rest });");
         assert_rt("({ [k]: v });", "({ [k]: v });");
-        // A getter / method value is a `FunctionExpression` → opaque `Raw`; bail.
-        assert_bails("({ get x() { return 1; } });");
-        assert_bails("({ m() { return 2; } });");
+        // Getter / method values are now typed and round-trip faithfully.
+        assert_rt(
+            "({ get x() { return 1; } });",
+            "({\n\tget x() {\n\t\treturn 1;\n\t}\n});",
+        );
+        assert_rt("({ m() { return 2; } });", "({\n\tm() {\n\t\treturn 2;\n\t}\n});");
     }
 
     #[test]
@@ -1792,10 +1784,10 @@ mod tests {
         assert_rt("a = b;", "a = b;");
         assert_rt("a += 1;", "a += 1;");
         assert_rt("a.b = c;", "a.b = c;");
-        // Destructuring assignment targets (`[a]=` / `{a}=`) are stored as
-        // opaque `JsNode::Raw` in the parse IR, so conversion bails.
-        assert_bails("[a, b] = c;");
-        assert_bails("({ a, b } = c);");
+        // Destructuring assignment targets (`[a]=` / `{a}=`) are now typed in
+        // the parse IR and round-trip faithfully.
+        assert_rt("[a, b] = c;", "[a, b] = c;");
+        assert_rt("({ a, b } = c);", "({ a, b } = c);");
     }
 
     #[test]
@@ -1827,9 +1819,8 @@ mod tests {
         );
         assert_rt("import Foo from 'mod';", "import Foo from 'mod';");
         assert_rt("import * as ns from 'mod';", "import * as ns from 'mod';");
-        // `export` declarations carry a `JsNode::Raw` declaration in the parse
-        // IR, so conversion bails.
-        assert_bails("export const x = 1;");
+        // `export` declarations are now typed in the parse IR and round-trip.
+        assert_rt("export const x = 1;", "export const x = 1;");
     }
 
     #[test]
@@ -1841,13 +1832,13 @@ mod tests {
     }
 
     #[test]
-    fn bails_on_raw_nodes() {
-        // A block-bodied arrow / function expression / destructuring assignment
-        // target are all `JsNode::Raw` in the parse IR; the converter must
-        // return `None` rather than emit guessed code.
-        assert_bails("() => { f(); };");
-        assert_bails("(function () {})();");
-        assert_bails("[a] = b;");
+    fn typed_formerly_raw_nodes() {
+        // Block-bodied arrows, IIFEs, and destructuring assignment targets are
+        // now typed in the parse IR and round-trip faithfully (previously these
+        // were opaque `JsNode::Raw` and the converter bailed).
+        assert_rt("() => { f(); };", "() => {\n\tf();\n};");
+        assert_rt("(function () {})();", "(function () {})();");
+        assert_rt("[a] = b;", "[a] = b;");
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -1742,7 +1742,10 @@ mod tests {
             "({ get x() { return 1; } });",
             "({\n\tget x() {\n\t\treturn 1;\n\t}\n});",
         );
-        assert_rt("({ m() { return 2; } });", "({\n\tm() {\n\t\treturn 2;\n\t}\n});");
+        assert_rt(
+            "({ m() { return 2; } });",
+            "({\n\tm() {\n\t\treturn 2;\n\t}\n});",
+        );
     }
 
     #[test]

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -2261,24 +2261,32 @@ mod tests {
         assert_eq!(buf[root_off], TAG_ROOT);
     }
 
-    /// #908: a typed arrow parameter (`(r: number[]) => …`) is lowered to a
-    /// `JsNode::Raw` JSON sub-tree. That JSON carries byte offsets, which must
+    /// #908: a genuinely-TS construct lowered to a `JsNode::Raw` JSON sub-tree
+    /// (here a constructor parameter property) carries byte offsets, which must
     /// be remapped to UTF-16 like every other span when the source contains
-    /// non-ASCII characters — otherwise the whole arrow (params + body) drifts
-    /// past the preceding multibyte text and `source.slice(start, end)` breaks.
+    /// non-ASCII characters — otherwise the whole sub-tree drifts past the
+    /// preceding multibyte text and `source.slice(start, end)` breaks.
     #[test]
-    fn typed_arrow_raw_json_offsets_are_utf16() {
+    fn raw_json_offsets_are_utf16() {
         use std::collections::HashSet;
 
-        // 4 multibyte chars precede the typed arrow, so a leaked byte offset
-        // would be shifted by +8 (4 chars × 2 extra bytes) versus UTF-16.
+        // A TypeScript constructor *parameter property* (`constructor(public a:
+        // number)`) is a genuinely-TS construct still lowered to a `JsNode::Raw`
+        // JSON sub-tree (the `analyze-value-detax` typing campaign now types the
+        // previously-Raw TS arrow this test originally used). That JSON carries
+        // byte offsets, which must be remapped to UTF-16 like every other span
+        // when the source contains non-ASCII characters — otherwise the whole
+        // class drifts past the preceding multibyte text and
+        // `source.slice(start, end)` breaks (#908).
+        //
+        // 4 multibyte chars precede the class, so a leaked byte offset would be
+        // shifted by +8 (4 chars × 2 extra bytes) versus UTF-16.
         let src = concat!(
             "<script lang=\"ts\">\n",
             "  const \u{30E9}\u{30D9}\u{30EB} = \"\u{3042}\";\n",
-            "  let last = 0;\n",
-            "  const set = (r: number[]) => { last = r.length; };\n",
+            "  class P { constructor(public a: number) { this.a = a; } }\n",
             "</script>\n",
-            "<p>{\u{30E9}\u{30D9}\u{30EB}}{last}{set}</p>",
+            "<p>{\u{30E9}\u{30D9}\u{30EB}}</p>",
         );
         let ast = parse(src, ParseOptions::default()).unwrap();
 

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -1135,6 +1135,43 @@ fn write_root<W: Writer>(w: &mut W, root: &Root) -> std::io::Result<()> {
 // JsNode (estree) — 74-variant dispatcher
 // ---------------------------------------------------------------------------
 
+/// Encode an opaque ESTree JSON sub-tree as a `JS_RAW_JSON` blob, mirroring the
+/// `JsNode::Raw(value)` arm (including UTF-16 offset remapping when active). Used
+/// both for genuine `Raw` nodes and for a TS-annotated `Identifier` whose
+/// `typeAnnotation` boundary blob is re-materialized so the NAPI binary output
+/// stays byte-identical to the pre-typed (`JsNode::Raw`) encoding.
+fn write_raw_json<W: Writer>(w: &mut W, value: &serde_json::Value) -> std::io::Result<()> {
+    write_preamble(w, JS_RAW_JSON, u32::MAX, u32::MAX);
+    let len_slot = w.position();
+    write_u32(w, 0);
+    let p0 = w.position();
+    struct A<'a, W2: Writer>(&'a mut W2);
+    impl<W2: Writer> std::io::Write for A<'_, W2> {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.write_bytes(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut shim = A(w);
+    if offset_remap_active() {
+        let mut json_value = value.clone();
+        OFFSET_CONV.with(|c| {
+            if let Some(conv) = &*c.borrow() {
+                crate::compiler::legacy::convert_positions_to_utf16(&mut json_value, conv);
+            }
+        });
+        serde_json::to_writer(&mut shim, &json_value).map_err(std::io::Error::other)?;
+    } else {
+        serde_json::to_writer(&mut shim, value).map_err(std::io::Error::other)?;
+    }
+    let p1 = shim.0.position();
+    w.patch_u32(len_slot, (p1 - p0) as u32);
+    Ok(())
+}
+
 fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std::io::Result<()> {
     match node {
         JsNode::Identifier {
@@ -1142,7 +1179,37 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             end,
             loc,
             name,
+            type_annotation,
         } => {
+            if let Some(ta) = type_annotation {
+                // Re-materialize the legacy Raw blob shape so the NAPI binary
+                // output stays byte-identical to the pre-typed encoding.
+                let mut obj = serde_json::Map::new();
+                obj.insert(
+                    "type".to_string(),
+                    serde_json::Value::String("Identifier".to_string()),
+                );
+                obj.insert(
+                    "start".to_string(),
+                    serde_json::Value::Number((*start as i64).into()),
+                );
+                obj.insert(
+                    "end".to_string(),
+                    serde_json::Value::Number((*end as i64).into()),
+                );
+                if let Some(l) = loc.as_deref() {
+                    obj.insert(
+                        "loc".to_string(),
+                        serde_json::to_value(l).map_err(std::io::Error::other)?,
+                    );
+                }
+                obj.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(name.to_string()),
+                );
+                obj.insert("typeAnnotation".to_string(), (**ta).clone());
+                return write_raw_json(w, &serde_json::Value::Object(obj));
+            }
             write_preamble(w, JS_IDENTIFIER, *start, *end);
             write_typed_loc(w, loc.as_deref());
             write_str(w, name.as_str());
@@ -2035,41 +2102,12 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
         }
         // `Raw(Value)` and `Null` don't carry positions, so they use
         // dedicated sentinel tags without the usual preamble pair.
+        // A `Raw` sub-tree (e.g. a typed function parameter, or a whole typed
+        // arrow lowered to legacy JSON) carries byte offsets too. `write_raw_json`
+        // remaps them to UTF-16 so the envelope stays consistent with the JSON
+        // `parse` path (#793, #908).
         JsNode::Raw(value) => {
-            write_preamble(w, JS_RAW_JSON, u32::MAX, u32::MAX);
-            let len_slot = w.position();
-            write_u32(w, 0);
-            let p0 = w.position();
-            struct A<'a, W2: Writer>(&'a mut W2);
-            impl<W2: Writer> std::io::Write for A<'_, W2> {
-                fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
-                    self.0.write_bytes(b);
-                    Ok(b.len())
-                }
-                fn flush(&mut self) -> std::io::Result<()> {
-                    Ok(())
-                }
-            }
-            let mut shim = A(w);
-            if offset_remap_active() {
-                // A `Raw` sub-tree (e.g. a typed function parameter, or a whole
-                // typed arrow lowered to legacy JSON) carries byte offsets too.
-                // Remap them to UTF-16 so the envelope stays consistent with the
-                // JSON `parse` path (#793, #908). Without this, every descendant
-                // of a typed-parameter arrow keeps its byte offsets and drifts
-                // past any preceding non-ASCII source.
-                let mut json_value = value.clone();
-                OFFSET_CONV.with(|c| {
-                    if let Some(conv) = &*c.borrow() {
-                        crate::compiler::legacy::convert_positions_to_utf16(&mut json_value, conv);
-                    }
-                });
-                serde_json::to_writer(&mut shim, &json_value).map_err(std::io::Error::other)?;
-            } else {
-                serde_json::to_writer(&mut shim, value).map_err(std::io::Error::other)?;
-            }
-            let p1 = shim.0.position();
-            w.patch_u32(len_slot, (p1 - p0) as u32);
+            write_raw_json(w, value)?;
         }
         JsNode::Null => {
             write_preamble(w, JS_NULL, u32::MAX, u32::MAX);

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -1174,6 +1174,22 @@ fn write_raw_json<W: Writer>(w: &mut W, value: &serde_json::Value) -> std::io::R
 
 fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std::io::Result<()> {
     match node {
+        // Annotated destructuring declarator id (`let { a }: T` / `let [ a ]: T`):
+        // re-materialize the legacy Raw JSON blob (children + `typeAnnotation`) so
+        // the NAPI binary output stays byte-identical to the pre-typed encoding.
+        // The serialize arena is installed for the whole emission (see
+        // `to_typed_raw`), so `serde_json::to_value` can resolve the child IdRange.
+        pat @ (JsNode::ObjectPattern {
+            type_annotation: Some(_),
+            ..
+        }
+        | JsNode::ArrayPattern {
+            type_annotation: Some(_),
+            ..
+        }) => {
+            let value = serde_json::to_value(pat).map_err(std::io::Error::other)?;
+            return write_raw_json(w, &value);
+        }
         JsNode::Identifier {
             start,
             end,
@@ -1561,6 +1577,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             end,
             loc,
             properties,
+            type_annotation: _,
         } => {
             write_preamble(w, JS_OBJECT_PATTERN, *start, *end);
             write_typed_loc(w, loc.as_deref());
@@ -1571,6 +1588,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             end,
             loc,
             elements,
+            type_annotation: _,
         } => {
             write_preamble(w, JS_ARRAY_PATTERN, *start, *end);
             write_typed_loc(w, loc.as_deref());

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -1559,6 +1559,8 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             source_type,
             leading_comments,
             trailing_comments,
+            // Internal analyze-only metadata; not part of the serialized AST.
+            ignore_comment_map: _,
         } => {
             write_preamble(w, JS_PROGRAM, *start, *end);
             write_typed_loc(w, loc.as_deref());

--- a/crates/rsvelte_core/tests/ts_svelte_ignore_suppression.rs
+++ b/crates/rsvelte_core/tests/ts_svelte_ignore_suppression.rs
@@ -1,0 +1,48 @@
+//! Landmine guard for the typed `remove_typescript_nodes` port: a TS component
+//! must still honor a SCRIPT-level `svelte-ignore` comment. That suppression is
+//! driven by `Program.ignore_comment_map`, which the typed strip transform must
+//! preserve. The transform mutates the arena `Program` in place (never rebuilds
+//! it), so the map survives — this test guards against a regression that no
+//! runtime/snapshot test would catch.
+
+use rsvelte_core::{CompileOptions, compile};
+
+fn warning_codes(src: &str) -> Vec<String> {
+    match compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            ..Default::default()
+        },
+    ) {
+        Ok(r) => r.warnings.into_iter().map(|w| w.code).collect(),
+        Err(e) => panic!("compile failed: {e:?}"),
+    }
+}
+
+const CODE: &str = "export_let_unused";
+
+/// Baseline: a TS component with an unused `export let` and no ignore comment
+/// emits `export_let_unused` (proves the warning fires on TS components).
+#[test]
+fn ts_component_emits_export_let_unused_without_ignore() {
+    let codes = warning_codes("<script lang=\"ts\">\n\texport let some: number;\n</script>");
+    assert!(
+        codes.iter().any(|c| c == CODE),
+        "expected {CODE} on TS component, got {codes:?}"
+    );
+}
+
+/// Landmine: the same TS component with a script-level
+/// `// svelte-ignore export_let_unused` must have the warning suppressed
+/// (Program.ignore_comment_map preserved through the typed TS strip).
+#[test]
+fn ts_component_script_svelte_ignore_suppresses_warning() {
+    let codes = warning_codes(
+        "<script lang=\"ts\">\n\t// svelte-ignore export_let_unused\n\texport let some: number;\n</script>",
+    );
+    assert!(
+        !codes.iter().any(|c| c == CODE),
+        "script-level svelte-ignore failed to suppress {CODE} on TS component, got {codes:?}"
+    );
+}


### PR DESCRIPTION
Two byte-identical steps toward eliminating `serde_json::Value` / `JsNode::Raw` from the compiler's internal script AST (groundwork for a unified typed AST). Both are pure representation cleanups — **aggregate compile time is neutral** (the test corpus is comment-light); the value is a more uniformly-typed AST and fewer text-printer fallbacks on comment-bearing real-world scripts.

1. **Keep comment-free statements typed** (`151012c4`): the comment-handling slow path in `parse_program_with_error` re-wrapped *every* top-level statement as `JsNode::Raw` whenever the script had any comment. Now only statements that actually carry comment payload become Raw. Raw top-level statements over the 3854-file corpus: **472 → 198 (−58%)**.
2. **Type ClassDeclaration** (`3408cbee`): was always `JsNode::Raw`; now the existing typed `JsNode::ClassDeclaration` (class body still Raw for byte-identity). Raw ClassDeclaration **85 → 3**; total top-level Raw **198 → 116** (remainder is now entirely comment-driven).

## Verification
Byte-identical across compiler_fixtures / ssr / validator / runtime{runes,legacy} / parser_fixtures / print. A/B (compile_profile, mimalloc) neutral within noise.

## Follow-up (not in this PR)
Remaining Raw is comment-driven. Clearing it (Stage C) requires implementing comment emission in the typed codegen path (`to_oxc`/esrap) so comment-bearing statements can be typed without losing comments — currently they rely on the Raw→text-printer fallback. That's a larger, byte-identical-critical change (and would also fix a latent gap: the **server path currently drops statement comments that the official compiler keeps**). After that, the Value walkers in analyze can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)