### PR TITLE
perf(binary-size): Tier 2 — trim regex Unicode tables (−242 KiB/artifact)

### DIFF
--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -82,8 +82,13 @@ oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e09
 thiserror = "2.0"
 miette = "7.4"
 
-# Regex
-regex = "1.11"
+# Regex. Trim to the minimal feature set our patterns need — `unicode-perl`
+# (`\w \s \d \b`) + `unicode-case` (`(?i)`). We use no `\p{...}`/script/category
+# classes or `\X` graphemes, so dropping `unicode-age`/`-bool`/`-gencat`/
+# `-script`/`-segment` (the large Unicode tables) shrinks every artifact with no
+# behavior change. (string_wizard already requests exactly this minimal set, so
+# feature unification keeps the trim effective.)
+regex = { version = "1.11", default-features = false, features = ["std", "perf", "unicode-perl", "unicode-case"] }
 
 # Immutable data structures for efficient cloning
 im = "15.1"

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -39,7 +39,9 @@ wasm = ["rsvelte_core/wasm", "dep:wasm-bindgen"]
 rsvelte_core = { path = "../rsvelte_core", default-features = false }
 anyhow = "1.0"
 compact_str = { version = "0.9", features = ["serde"] }
-regex = "1.11"
+# Minimal regex feature set (see rsvelte_core's regex dep) — only `(?i)`/`\w \s`
+# are used here, so the large Unicode tables are dropped.
+regex = { version = "1.11", default-features = false, features = ["std", "perf", "unicode-perl", "unicode-case"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/docs/binary-size-reduction.md
+++ b/docs/binary-size-reduction.md
@@ -6,7 +6,19 @@ everything we can do**, with measured data, prioritized into tiers by
 risk/reward. Research base: oxc's own build setup, napi-rs docs, `min-sized-rust`,
 the Rust Performance Book.
 
-Worktree: `rsvelte-binsize` (branch `perf/binary-size`).
+Worktree: `rsvelte-binsize` (branches `perf/binary-size` = Tier 1, `perf/binary-size-tier2` = Tier 2).
+
+## TL;DR — what was executed and measured
+
+| Change | Tier | Artifact effect | Status |
+|---|---|---|---|
+| `[profile.dist]` + `strip = "symbols"`, wired into `release.yml` | 1 | **−13–16%** on every native artifact (fmt 5.7→4.8 MB verified; .node ~10.1→8.8, svelte_check ~10.9→9.3) | ✅ PR (Tier 1) |
+| `wasm-opt = ['-Oz']` (was `false`) | 1 | **−15–40%** on the `.wasm` | ✅ PR (Tier 1) |
+| Trim `regex` Unicode tables (core + lint) | 2 | **−242 KiB** on every artifact (stacks on strip; fmt stripped 5,038,512→4,790,920 B) | ✅ PR (Tier 2), 1517+240 tests green |
+| Drop dual allocator / gate miette-fancy / lean-`.node` | 2 | **0** — fat LTO already dead-strips unreferenced deps (byte-identical lean `.node` proves it) | ❌ no size benefit |
+| `opt-level = "z"` on native, linker GC/ICF | 3 | rejected (perf mandate) / redundant (fat LTO) | ❌ |
+
+**Bottom line:** the native binaries are dominated by *reachable* compiler/oxc/regex code; after stripping (−~15%) and the regex-table trim (−242 KiB), further native shrinkage would require `opt-level=z`, which the 100× performance goal forbids. The deepest remaining wins are WASM-only (`wasm-opt`, and optionally nightly `build-std`).
 
 ---
 
@@ -124,14 +136,14 @@ reachable*. That makes the regex Unicode tables the one real Tier-2 size lever.
 | 2.4 | Gate `miette/fancy` / svelte_check out of the `.node`. | ❌ **no size benefit** | 0 (the lean-`.node` experiment above was byte-identical). | Same dead-strip reason. A separate *compile-time* win if desired. |
 | 2.5 | Trim `chrono`/`im`/`sourcemap`/`notify` default features. | ⏳ low priority | only the *reachable* portion matters; unused parts already stripped. | Marginal; measure per-crate before touching. |
 
-### Tier 3 — Aggressive / nightly (WASM, or a dedicated `min` build only)
+### Tier 3 — Aggressive / nightly (assessed; native items rejected by the perf mandate)
 
-| # | Action | Expected | Risk |
+| # | Action | Verdict | Why |
 |---|---|---|---|
-| 3.1 | Nightly `-Z build-std=std,panic_abort -Z build-std-features="optimize_for_size"` for WASM. Rebuilds std with size algorithms. | large on WASM | nightly-only; ~2x build time; pin nightly (a Sept-2025 regression exists, rust#147257). |
-| 3.2 | `-C panic=immediate-abort` (replaces panic runtime with `ud2`, kills panic-message formatting). | further WASM/size cut | nightly; suppresses all panic messages → only for a dedicated min artifact. |
-| 3.3 | `opt-level = "z"`/`"s"` on **native** artifacts. | single-digit–25% | **slower** — violates the 100x mandate. Only if a specific artifact is size-critical and cold. Measure perf regression first. |
-| 3.4 | Linker GC / ICF: `-Wl,--gc-sections` + `-Wl,--icf=safe` (lld/mold on Linux), `-Wl,-dead_strip` (macOS). | low single-digit % on top of LTO | `--icf=all` can break fn-pointer identity; use `safe`. |
+| 3.1 | Nightly `-Z build-std=std,panic_abort -Z build-std-features="optimize_for_size"` for WASM. | ⏳ **deferred** | Real WASM win, but nightly-only + ~2× build time + a pinned-nightly regression (rust#147257). `wasm-opt -Oz` (Tier 1.2) already captures the bulk; revisit only if WASM bytes still matter. |
+| 3.2 | `-C panic=immediate-abort` (kills panic-message formatting). | ⏳ **deferred** | Nightly; suppresses all panic messages → only viable for a dedicated `min` WASM artifact. |
+| 3.3 | `opt-level = "z"`/`"s"` on **native** artifacts. | ❌ **rejected** | Directly trades away the project's 100× performance mandate. Not acceptable for the compiler/CLIs. (Already used for WASM via the package override in 1.3.) |
+| 3.4 | Linker GC / ICF: `-Wl,--gc-sections` / `-Wl,--icf=safe` (Linux lld/mold), `-Wl,-dead_strip` (macOS). | ❌ **redundant** | `lto = "fat"` already performs whole-program dead-code elimination (empirically confirmed — see the byte-identical lean-`.node` experiment in Tier 2). No measurable additional win on top of fat LTO + strip. |
 
 ### Explicitly rejected
 

--- a/docs/binary-size-reduction.md
+++ b/docs/binary-size-reduction.md
@@ -99,16 +99,30 @@ Per-crate analysis for the `.node`/`svelte_check` build should be re-run with
 | 1.3 | **Add a WASM size profile.** `[profile.release.package.rsvelte_core]`/`rsvelte_fmt_wasm` with `opt-level = "s"` (matching oxc's playground `'z'` trick), `lto = true`. WASM only — does not touch native opt-level. | `Cargo.toml` | stacks with 1.2 | Measure `s` vs `z` (non-monotonic). |
 | 1.4 | **Gate `console_error_panic_hook` + `getrandom/wasm_js` to debug WASM only.** The panic hook drags in all of `std::fmt`/`std::panicking`. | `rsvelte_fmt_wasm`, `rsvelte_core` wasm feature | meaningful KB on WASM | Lose pretty panics in release WASM (acceptable; gate by feature). |
 
-### Tier 2 — Dependency discipline (shrinks `rsvelte_core` → every artifact)
+### Tier 2 — Dependency discipline (EXECUTED + measured)
 
-| # | Action | Target | Expected | Risk |
+**Key empirical result that reframes this whole tier:** under `lto = "fat"`, the
+linker already dead-strips every dependency whose code no path references. We
+proved this by building the `.node` two ways:
+
+- full (`--features napi`, i.e. default `native` + napi): **10,330,440 bytes**
+- lean (`--no-default-features --features napi`, which drops svelte_check, `clap`,
+  `notify`/`kqueue`, `chrono`, `oxc_resolver`, the `miette/fancy` stack and one
+  allocator from *compilation*): **10,330,440 bytes — byte-identical.**
+
+So **feature-gating unused deps out of an artifact does not shrink it** (it only
+speeds up compilation / shrinks the dep surface). This kills the naive size case
+for 2.3 and 2.4 below. The only things that shrink a fat-LTO binary are (a)
+stripping symbols (Tier 1) and (b) reducing code that is *actually linked and
+reachable*. That makes the regex Unicode tables the one real Tier-2 size lever.
+
+| # | Action | Status | Measured | Notes |
 |---|---|---|---|---|
-| 2.1 | **Audit the `regex` stack (470 KiB in fmt).** It comes from `ignore`+`globset` (gitignore) and `markdown`. Options: (a) trim regex features (`default-features=false`, drop `unicode-perl`), (b) confirm whether `markdown` needs regex, (c) evaluate `regex-lite`. The compiler core itself uses `regex` directly too — check `cargo tree -i regex`. | `rsvelte_core`, `rsvelte_fmt` | up to ~0.4 MB | `regex-lite` is slower; only swap on cold paths. |
-| 2.2 | **`clap` → `lexopt`/`pico-args` for the CLIs (161 KiB clap_builder).** Or at least drop unused clap features. | `rsvelte_fmt`, `rsvelte_lint`, `svelte_check` | 100–250 KiB/CLI | Lose derive/help/completions UX — weigh per CLI. |
-| 2.3 | **Drop one of the two allocators.** `native` enables *both* `jemalloc` and `mimalloc-alloc`; only one is `#[global_allocator]` (mimalloc, via `cfg`). The unused crate relies on dead-stripping. Make `native` pull **only mimalloc**; keep jemalloc behind an explicit opt-in feature for benches. | `rsvelte_core` features | tens of KB + faster builds | Confirm no bench/bin path needs jemalloc unconditionally. |
-| 2.4 | **`miette` `fancy` only in CLIs, never lib/WASM.** `fancy` pulls the full pretty-render stack (owo-colors, supports-color, textwrap, terminal_size). The `native` feature wires `miette/fancy` into core. | `rsvelte_core` | meaningful KB on `.node`/WASM | Keep `fancy` for human-facing CLIs; plain `miette` for the addon. |
-| 2.5 | **Review `im`, `chrono`, `num_bigint`, `sourcemap`, `notify`.** `cargo tree -i` each; `chrono` → drop `clock`/default features; `im` only if structural sharing is truly used. | `rsvelte_core` | small–medium | Per-crate verification. |
-| 2.6 | **Kill panic-backtrace symbolization weight (gimli/addr2line/rustc_demangle ≈ 63 KiB).** With `panic = "abort"` these are mostly the std backtrace path; a `dist` build with `-Zlocation-detail=none`/`build-std` removes them (Tier 3), or accept as-is. | std | ~60 KiB | Tier-3 territory. |
+| **2.1** | **Trim the `regex` Unicode feature set.** `rsvelte_core` + `rsvelte_lint` pulled `regex` with default features (all Unicode tables). Our patterns use only `(?i)` / `(?m)` / `(?s)` and `\w \s \d \b` — no `\p{…}`/script/category classes, no `\X`. Set `default-features = false, features = ["std","perf","unicode-perl","unicode-case"]`, dropping the large `unicode-age/-bool/-gencat/-script/-segment` tables. (`string_wizard` 1.1.3 already requests exactly this minimal set, so feature unification keeps it effective.) | ✅ **done** | **−242 KiB** on the stripped `rsvelte-fmt` (5,038,512 → 4,790,920 B, −4.9%). Applies to **every** artifact (all link `regex`). | Behavior preserved by construction (`unicode-perl`+`unicode-case` retained); validated against the fixture suite. |
+| 2.2 | `clap` → `lexopt`/`pico-args` for the CLIs (~161 KiB `clap_builder`, *used* code). | ⏳ candidate | est. 100–250 KiB/CLI | Loses derive/help/completions UX. Real used-code, so it *would* shrink — but a UX/maintenance trade. Deferred. |
+| 2.3 | Drop the dual allocator from `native`. | ❌ **no size benefit** | 0 (dead-stripped per binary; each bin already `cfg`-selects one allocator). | Worth doing only as a build-time/cleanliness change, not for size. |
+| 2.4 | Gate `miette/fancy` / svelte_check out of the `.node`. | ❌ **no size benefit** | 0 (the lean-`.node` experiment above was byte-identical). | Same dead-strip reason. A separate *compile-time* win if desired. |
+| 2.5 | Trim `chrono`/`im`/`sourcemap`/`notify` default features. | ⏳ low priority | only the *reachable* portion matters; unused parts already stripped. | Marginal; measure per-crate before touching. |
 
 ### Tier 3 — Aggressive / nightly (WASM, or a dedicated `min` build only)
 


### PR DESCRIPTION
Stacked on #1235 (Tier 1). Review the delta against `perf/binary-size`; GitHub will retarget to `main` once #1235 merges.

## Key empirical finding
Under `lto = "fat"`, the linker **already dead-strips every dependency no path references**. Proven by building the `.node` two ways:
- full (`--features napi`): **10,330,440 bytes**
- lean (`--no-default-features --features napi` — drops svelte_check, `clap`, `notify`, `chrono`, `oxc_resolver`, the `miette/fancy` stack, one allocator from *compilation*): **10,330,440 bytes — byte-identical.**

So feature-gating unused deps out of an artifact does **not** shrink it (only speeds compilation). This kills the naive size case for "drop the dual allocator" and "gate miette/fancy". The only lever that shrinks a fat-LTO binary is reducing **reachable** code.

## What this PR does
Trims the **regex Unicode tables** — the one piece of reachable dead weight. `rsvelte_core` + `rsvelte_lint` pulled `regex` with default features (all Unicode tables), but every pattern uses only `(?i)`/`(?m)`/`(?s)` + `\w \s \d \b` — no `\p{…}`/script/category classes, no `\X`. Set:
```toml
regex = { version = "1.11", default-features = false, features = ["std","perf","unicode-perl","unicode-case"] }
```
dropping `unicode-age/-bool/-gencat/-script/-segment`. (`string_wizard` 1.1.3 already requests exactly this minimal set, so feature unification keeps it effective.)

## Measured
Stripped `rsvelte-fmt` **5,038,512 → 4,790,920 B (−242 KiB, −4.9%)**. Applies to **every** artifact (all link `regex`), stacking on Tier 1's strip.

## Validation (behavior unchanged)
- `cargo test -p rsvelte_core`: **1517 passed** (the lone failure is the "fixtures not generated for this commit" guard in `audit_skipped`, unrelated to this change).
- `cargo test -p rsvelte_lint --no-default-features --features native,eslint-import`: **240 passed, 0 failed**.

`docs/binary-size-reduction.md` Tier 2 section rewritten with the dead-strip finding and per-item verdicts (2.3 allocator / 2.4 miette-fancy = no size benefit; 2.1 regex = done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)