### PR TITLE
fix(analyze): don't flag a $-prefixed destructured callback param as global_reference_invalid (#1222)

### DIFF
--- a/.changeset/fix-global-ref-destructure-param.md
+++ b/.changeset/fix-global-ref-destructure-param.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyze): don't report `global_reference_invalid` for a `$`-prefixed destructured callback parameter
+
+A `$`-prefixed identifier bound by an array/object destructuring parameter — e.g. `derived([box_d], ([$box]) => $box.width)` — was wrongly treated as a store subscription and rejected with `global_reference_invalid` (`box` has no store binding). The lexical `$`-identifier scan only recognised `($x)` / `let $x` declaration forms and missed destructuring patterns. Before erroring, the unprefixed-name lookup now also checks whether the full `$name` is itself a real (non-synthetic) scope binding and, if so, treats it as a local reference. The guard sits at the error path so a genuine store whose name also appears as a nested callback parameter (e.g. `page` used as `$page` in the template and as `($page) => …` in `.subscribe()`) still subscribes correctly.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -439,6 +439,24 @@ pub fn detect_store_subscriptions(
             // Corresponds to Svelte's L398-400 in 2-analyze/index.js
             if !store_name.is_empty() && store_name.chars().next().is_some_and(|c| c.is_lowercase())
             {
+                // Before erroring, check whether `$name` is itself a real declared
+                // binding — e.g. a destructured callback parameter
+                // `derived([box_d], ([$box]) => $box.width)`, where `$box` is the
+                // array-pattern param, not a store ref. The lexical `declared`
+                // scan in `collect_dollar_identifiers_*` only recognises `($x)` /
+                // `let $x` forms and misses array/object destructuring, so it
+                // collected `$box` as a ref. Upstream resolves it through the scope
+                // chain to the local binding; mirror that here. This guard lives at
+                // the error path (not the loop top) so a genuine store whose name
+                // also appears as a nested callback param — e.g. `page` used both as
+                // `$page` in the template and as `($page) => …` in `.subscribe()` —
+                // still creates its StoreSub (it never reaches this branch because
+                // the unprefixed `page` binding exists).
+                if analysis.root.bindings.iter().any(|b| {
+                    &b.name == ref_name && b.declaration_kind != DeclarationKind::Synthetic
+                }) {
+                    continue;
+                }
                 return Err(errors::global_reference_invalid(ref_name));
             }
         }


### PR DESCRIPTION
Fixes #1222.

## Problem
rsvelte raised a false-positive `global_reference_invalid` on `$`-prefixed identifiers that are actually **destructured callback parameters**, rejecting components the official compiler accepts:

```js
// layercake/src/lib/LayerCake.svelte
const width_d = derived([box_d], ([$box]) => $box.width);
```
Here `$box` is the array-pattern parameter of the `derived` callback, not a store reference — but rsvelte reported ``$box` is an illegal variable name``. Affected `layercake/src/lib/LayerCake.svelte` and `svelte-calendar`'s `InlineCalendar.svelte` / `generic/InfiniteGrid.svelte`.

## Root cause
Store-subscription detection scans the script lexically for `$xxx` identifiers and skips declaration sites via string heuristics (`is_dollar_ident_parameter` etc.), but those only recognise `($x)` and `let $x` — they miss array/object destructuring patterns (`[$box]`, `{$box}`), so `$box` was collected as a store ref. With no `box` store binding it then hit the `global_reference_invalid` error branch.

## Fix
At the error branch, before reporting, check whether the full `$name` resolves to a real (non-synthetic) scope binding — the destructuring parameter creates a `$box` binding in the scope tree. If so, treat it as a local reference (mirroring upstream's scope-chain resolution) instead of erroring.

The guard is placed at the **error path**, not the loop top, so a genuine store whose name *also* appears as a nested callback parameter still subscribes. e.g. svelte-ux's layout uses `page` (a `$app/stores` store) both as `$page` in the template and as `($page) => …` in `page.subscribe(...)`: because the unprefixed `page` binding exists, `$page` never reaches the error branch and its `StoreSub` is created as before.

## Verification
- LayerCake / InlineCalendar / InfiniteGrid now compile (client + server) with no error, matching official `svelte@5.56.3`.
- awesome-svelte corpus (CSR+SSR): 0 regressions (the svelte-ux `$page` store-order regression from the first attempt is gone after moving the guard to the error path).
- Full `rsvelte_core` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
