### PR TITLE
fix(analyze): allow slot="…" on a direct child of a {#snippet} block (#1223)

### DIFF
--- a/.changeset/fix-slot-attribute-in-snippet.md
+++ b/.changeset/fix-slot-attribute-in-snippet.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyze): allow `slot="…"` on a direct child of a `{#snippet}` block
+
+A `slot="name"` text attribute on an element whose immediate parent is a
+`{#snippet}` body — e.g. `{#snippet active()}<span slot="active">…</span>{/snippet}` —
+was wrongly rejected with `slot_attribute_invalid_placement`. Upstream's
+`validate_slot_attribute` returns early when `context.path.at(-2)` is a
+`SnippetBlock`. A new `is_direct_child_of_snippet` context flag (set while
+analyzing a snippet body, reset on entering any nested element/block, mirroring
+`is_direct_child_of_component`) reproduces that early return. Non-text `slot={…}`
+values are still rejected by the separate `is_text_attribute` check.

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -129,7 +129,6 @@
 	"smelte/src/components/Tooltip/Tooltip.svelte",
 	"smelte/src/routes/_layout.svelte",
 	"smelte/src/routes/components/_layout.svelte",
-	"svar-core/svelte/demos/cases/TwoState.svelte",
 	"svar-core/svelte/demos/common/Link.svelte",
 	"svar-core/svelte/src/components/Segmented.svelte",
 	"svar-core/svelte/src/components/Tabs.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_block.rs
@@ -154,7 +154,9 @@ pub fn visit(block: &mut AwaitBlock, context: &mut VisitorContext) -> Result<(),
     // Clear is_direct_child_of_component since children of control flow blocks
     // are not direct children of a component
     let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_snippet = context.is_direct_child_of_snippet;
     context.is_direct_child_of_component = false;
+    context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
     context
@@ -209,6 +211,7 @@ pub fn visit(block: &mut AwaitBlock, context: &mut VisitorContext) -> Result<(),
 
     // Restore is_direct_child_of_component
     context.is_direct_child_of_component = was_direct_child;
+    context.is_direct_child_of_snippet = was_direct_snippet;
 
     // Decrement block depth
     context.block_depth -= 1;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
@@ -119,7 +119,9 @@ pub fn visit(block: &mut EachBlock, context: &mut VisitorContext) -> Result<(), 
     // Clear is_direct_child_of_component since children of control flow blocks
     // are not direct children of a component
     let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_snippet = context.is_direct_child_of_snippet;
     context.is_direct_child_of_component = false;
+    context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
     context
@@ -165,6 +167,7 @@ pub fn visit(block: &mut EachBlock, context: &mut VisitorContext) -> Result<(), 
 
     // Restore is_direct_child_of_component
     context.is_direct_child_of_component = was_direct_child;
+    context.is_direct_child_of_snippet = was_direct_snippet;
 
     // Visit the key expression if present
     // IMPORTANT: Use a separate metadata for the key expression, NOT block.metadata.expression.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/if_block.rs
@@ -69,7 +69,9 @@ pub fn visit(block: &mut IfBlock, context: &mut VisitorContext) -> Result<(), An
     // Clear is_direct_child_of_component since children of control flow blocks
     // are not direct children of a component
     let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_snippet = context.is_direct_child_of_snippet;
     context.is_direct_child_of_component = false;
+    context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
     context
@@ -89,6 +91,7 @@ pub fn visit(block: &mut IfBlock, context: &mut VisitorContext) -> Result<(), An
 
     // Restore is_direct_child_of_component
     context.is_direct_child_of_component = was_direct_child;
+    context.is_direct_child_of_snippet = was_direct_snippet;
 
     // Decrement block depth
     context.block_depth -= 1;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/key_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/key_block.rs
@@ -57,7 +57,9 @@ pub fn visit(block: &mut KeyBlock, context: &mut VisitorContext) -> Result<(), A
     // Clear is_direct_child_of_component since children of control flow blocks
     // are not direct children of a component
     let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_snippet = context.is_direct_child_of_snippet;
     context.is_direct_child_of_component = false;
+    context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
     context
@@ -72,6 +74,7 @@ pub fn visit(block: &mut KeyBlock, context: &mut VisitorContext) -> Result<(), A
 
     // Restore is_direct_child_of_component
     context.is_direct_child_of_component = was_direct_child;
+    context.is_direct_child_of_snippet = was_direct_snippet;
 
     Ok(())
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -450,6 +450,12 @@ pub struct VisitorContext<'a> {
     /// This is set to true when entering a Component/SvelteComponent, and reset to false
     /// when entering any other element type.
     pub is_direct_child_of_component: bool,
+    /// True while analyzing the *direct* children of a `{#snippet}` body. Mirrors
+    /// upstream's `context.path.at(-2)?.type === 'SnippetBlock'` check in
+    /// `validate_slot_attribute`: a `slot="…"` text attribute on an element whose
+    /// immediate parent is a snippet block is allowed (not a placement error).
+    /// Reset to false whenever a nested element/block is entered.
+    pub is_direct_child_of_snippet: bool,
     /// Stack of slot owner types (Component or CustomElement).
     /// When entering a component, push SlotOwnerType::Component.
     /// When entering a custom element (RegularElement with '-' in name), push SlotOwnerType::CustomElement.
@@ -569,6 +575,7 @@ impl<'a> VisitorContext<'a> {
             block_depth_at_element: Vec::new(),
             each_block_stack: Vec::new(),
             is_direct_child_of_component: false,
+            is_direct_child_of_snippet: false,
             slot_owner_ancestors: Vec::new(),
             fragment_owner_stack: vec![FragmentOwnerType::Root],
             current_template_scope: 0,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -1192,7 +1192,9 @@ pub fn visit(
 
     // Clear is_direct_child_of_component since we're now inside an element
     let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_snippet = context.is_direct_child_of_snippet;
     context.is_direct_child_of_component = false;
+    context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
     // Elements with a slot attribute allow {@const} tags (like components)
@@ -1298,6 +1300,7 @@ pub fn visit(
 
     // Restore is_direct_child_of_component
     context.is_direct_child_of_component = was_direct_child;
+    context.is_direct_child_of_snippet = was_direct_snippet;
 
     // Pop from each_block_stack
     context.each_block_stack.pop();

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/attribute.rs
@@ -99,6 +99,15 @@ pub fn validate_slot_attribute(
         return Ok(());
     }
 
+    // A `slot="…"` on an element whose immediate parent is a `{#snippet}` body is
+    // allowed — upstream `validate_slot_attribute` returns early when
+    // `context.path.at(-2)?.type === 'SnippetBlock'`. (A non-text `slot={…}` value
+    // is still rejected by the separate `is_text_attribute` check in the attribute
+    // visitor, mirroring upstream's `slot_attribute_invalid` there.)
+    if context.is_direct_child_of_snippet {
+        return Ok(());
+    }
+
     // Find the nearest slot owner (last item in the stack)
     if let Some(nearest_owner) = context.slot_owner_ancestors.last() {
         match nearest_owner {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -253,7 +253,9 @@ pub fn visit_component(
     // For now, just visit the fragment normally
     // Set is_direct_child_of_component for svelte:fragment validation
     let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_snippet = context.is_direct_child_of_snippet;
     context.is_direct_child_of_component = true;
+    context.is_direct_child_of_snippet = false;
     // Track component depth for slot attribute validation
     context.component_depth += 1;
     // Track that this is a component for slot owner resolution
@@ -292,6 +294,7 @@ pub fn visit_component(
     context.slot_owner_ancestors.pop();
     context.component_depth -= 1;
     context.is_direct_child_of_component = was_direct_child;
+    context.is_direct_child_of_snippet = was_direct_snippet;
 
     Ok(())
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
@@ -64,8 +64,16 @@ pub fn visit(block: &mut SnippetBlock, context: &mut VisitorContext) -> Result<(
         context.scope = snippet_scope_idx;
     }
 
+    // Direct children of the snippet body are direct children of a SnippetBlock,
+    // which `validate_slot_attribute` treats specially (a `slot="…"` text attribute
+    // there is allowed). Nested elements/blocks reset this flag.
+    let was_direct_snippet = context.is_direct_child_of_snippet;
+    context.is_direct_child_of_snippet = true;
+
     // Analyze the body
     fragment::analyze(&mut block.body, context)?;
+
+    context.is_direct_child_of_snippet = was_direct_snippet;
 
     // Restore parent_element and scope
     context.parent_element = old_parent_element;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
@@ -87,7 +87,9 @@ pub fn visit(
     // Set up component context for slot attribute validation
     // svelte:component is a component, so children with slot attributes should be valid
     let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_snippet = context.is_direct_child_of_snippet;
     context.is_direct_child_of_component = true;
+    context.is_direct_child_of_snippet = false;
     context.component_depth += 1;
     context
         .slot_owner_ancestors
@@ -111,6 +113,7 @@ pub fn visit(
     context.slot_owner_ancestors.pop();
     context.component_depth -= 1;
     context.is_direct_child_of_component = was_direct_child;
+    context.is_direct_child_of_snippet = was_direct_snippet;
 
     Ok(())
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -268,7 +268,9 @@ pub fn visit(
     // so children with slot attributes should be allowed (they may be valid at runtime).
     // This matches how <svelte:component> allows slot attributes on its children.
     let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_snippet = context.is_direct_child_of_snippet;
     context.is_direct_child_of_component = true;
+    context.is_direct_child_of_snippet = false;
     context
         .slot_owner_ancestors
         .push(super::SlotOwnerType::Component);
@@ -336,6 +338,7 @@ pub fn visit(
     context.fragment_owner_stack.pop();
     context.slot_owner_ancestors.pop();
     context.is_direct_child_of_component = was_direct_child;
+    context.is_direct_child_of_snippet = was_direct_snippet;
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #1223.

## Problem
rsvelte rejected a `slot="…"` attribute on a direct child of a `{#snippet}` block with `slot_attribute_invalid_placement`, even though the official compiler accepts it:

```svelte
{#snippet active()}
  <span slot="active">Working...</span>
{/snippet}
<TwoState {active}>Click Me</TwoState>
```
(`svar-core/svelte/demos/cases/TwoState.svelte`)

## Root cause
Upstream's `validate_slot_attribute` short-circuits when the element's immediate parent is a `SnippetBlock`:
```js
const parent = context.path.at(-2);
if (parent?.type === 'SnippetBlock') {
  if (!is_text_attribute(attribute)) e.slot_attribute_invalid(attribute);
  return; // no placement error
}
```
rsvelte's port tracks placement via context flags rather than a path and had no equivalent of the `SnippetBlock` parent check, so a snippet-direct `slot="…"` fell through to the "no slot owner" error.

## Fix
Add an `is_direct_child_of_snippet` context flag, set true while analyzing a `{#snippet}` body and reset to false on entering any nested element/block (component, svelte:element, regular element, if/each/await/key blocks) — exactly mirroring the existing `is_direct_child_of_component` flag. `validate_slot_attribute` returns `Ok` when the flag is set. A non-text `slot={…}` value is still rejected by the separate `is_text_attribute` check in the attribute visitor, matching upstream's `slot_attribute_invalid`.

## Verification
- `TwoState.svelte` now compiles (client + server) with no error, matching official `svelte@5.56.3`.
- awesome-svelte corpus (CSR+SSR): 0 regressions.
- Full `rsvelte_core` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
