### PR TITLE
fix(svelte2tsx): widen renamed legacy prop with a typed default (#1231)

### DIFF
--- a/.changeset/fix-1231-renamed-prop-widen.md
+++ b/.changeset/fix-1231-renamed-prop-widen.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+fix(svelte2tsx): widen renamed legacy prop with a typed default (#1231)
+
+A renamed legacy prop with a default and a type — most commonly a JSDoc `/** @type {T} */` (the sveltestrap shape), e.g. `let className = ""; export { className as class }` — must still receive official svelte2tsx's `__sveltets_2_any` coercion bounded by `/*Ωignore_startΩ*/ … /*Ωignore_endΩ*/` markers. The `export { x as y }` widening predicate only fired on `!has_init || has_type_annotation`, so any renamed prop with a default dropped the coercion (and the Ω-ignore markers the language server relies on) even with a JSDoc `@type` or a boolean default. It now mirrors official `propTypeAssertToUserDefined`: widen on no-init OR a type (TS annotation or JSDoc `@type`) OR a boolean-literal initializer; a plain untyped string default is still left untouched.

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -157,6 +157,10 @@ struct PossibleExport {
     is_let: bool,
     has_init: bool,
     has_type_annotation: bool,
+    /// Initializer is a boolean literal (`let x = false`). Like official's
+    /// `propTypeAssertToUserDefined`, this still forces the `__sveltets_2_any`
+    /// widen (TS would otherwise narrow `x` to the `false`/`true` literal type).
+    has_boolean_init: bool,
     decl_end: u32,
     type_annotation_text: Option<String>,
     /// Leading JSDoc `/** @type {…} */` on the declaration, for
@@ -987,6 +991,7 @@ pub fn process_instance_script(
                                     is_let,
                                     has_init: declarator.init.is_some(),
                                     has_type_annotation: declarator.type_annotation.is_some(),
+                                    has_boolean_init: declarator_has_boolean_init(declarator),
                                     decl_end: declarator.span.end,
                                     type_annotation_text: ta_text,
                                     doc: leading_jsdoc_comment(
@@ -1008,6 +1013,7 @@ pub fn process_instance_script(
                                         is_let,
                                         has_init: declarator.init.is_some(),
                                         has_type_annotation: false,
+                                        has_boolean_init: false,
                                         decl_end: declarator.span.end,
                                         type_annotation_text: None,
                                         doc: None,
@@ -1124,6 +1130,9 @@ pub fn process_instance_script(
                                                 has_type_annotation: declarator
                                                     .type_annotation
                                                     .is_some(),
+                                                has_boolean_init: declarator_has_boolean_init(
+                                                    declarator,
+                                                ),
                                                 decl_end: declarator.span.end,
                                                 type_annotation_text: ta_text,
                                                 doc: leading_jsdoc_comment(
@@ -3383,12 +3392,24 @@ fn handle_export_named_decl(
             if let Some(doc) = doc {
                 exported_names.set_doc(&exported, doc);
             }
-            // Inject __sveltets_2_any for exported variables that either:
-            // 1. Have no initializer (export { x } where x has no default)
-            // 2. Have a type annotation (export { x } where x: Type = value)
+            // Inject __sveltets_2_any for exported variables. Mirrors official
+            // `propTypeAssertToUserDefined` (called from `addExport` when the
+            // re-exported local is a `let`): widen when the declaration has
+            //   1. no initializer (`export { x }` where `x` has no default), OR
+            //   2. a type — a TS annotation (`let x: T = …`) OR a JSDoc
+            //      `/** @type {T} */` (the doc lives on the `let x` declaration), OR
+            //   3. a boolean-literal initializer (`let x = false`), which TS would
+            //      otherwise narrow to the `false`/`true` literal type.
+            // Cases 2 and 3 cover renamed legacy props like
+            // `let className = ""; export { className as class }` with a JSDoc
+            // `@type` (e.g. sveltestrap) that previously lost the widen.
             if is_instance && is_let {
                 let has_ta = possible.map(|p| p.has_type_annotation).unwrap_or(false);
-                if (!has_init || has_ta)
+                let has_jsdoc_type = possible
+                    .and_then(|p| p.doc.as_deref())
+                    .is_some_and(|d| d.contains("@type"));
+                let has_bool_init = possible.map(|p| p.has_boolean_init).unwrap_or(false);
+                if (!has_init || has_ta || has_jsdoc_type || has_bool_init)
                     && let Some(pe) = possible
                 {
                     let inject = format!(
@@ -4715,6 +4736,17 @@ fn binding_pattern_simple_name(pattern: &oxc::BindingPattern) -> Option<String> 
         oxc::BindingPattern::BindingIdentifier(id) => Some(id.name.to_string()),
         _ => None,
     }
+}
+
+/// Whether a declarator's initializer is a boolean literal (`let x = false`).
+/// Mirrors official `propTypeAssertToUserDefined`'s `True/FalseKeyword` check —
+/// such an init still forces the `__sveltets_2_any` widen (TS would otherwise
+/// narrow `x` to the `false`/`true` literal type).
+fn declarator_has_boolean_init(declarator: &oxc::VariableDeclarator) -> bool {
+    declarator
+        .init
+        .as_ref()
+        .is_some_and(|init| matches!(init, oxc::Expression::BooleanLiteral(_)))
 }
 
 /// Convert a PropertyKey to a string name.

--- a/crates/rsvelte_core/tests/svelte2tsx_renamed_prop_widen_1231.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_renamed_prop_widen_1231.rs
@@ -1,0 +1,58 @@
+//! Regression tests for #1231: a renamed legacy prop with a default
+//! (`let className = ""; export { className as class }`) must still get the
+//! `__sveltets_2_any` coercion + `/*Ωignore_*Ω*/` markers when the declaration
+//! carries a type — either a JSDoc `/** @type {T} */` (the common sveltestrap
+//! shape) or a boolean-literal initializer. This mirrors official svelte2tsx's
+//! `propTypeAssertToUserDefined`, which `addExport` invokes when the re-exported
+//! local is a `let`. Without the widen, `let foo: string | undefined = undefined`
+//! is narrowed to `undefined` and TS reports spurious "possibly undefined"
+//! errors in the language server.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Comp.svelte".to_string(),
+        is_ts_file: false,
+        emit_jsdoc: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+/// JSDoc `@type` on a renamed legacy prop with a string default → widen.
+#[test]
+fn jsdoc_typed_renamed_prop_with_default_is_widened() {
+    let src = "<script>\n  /** @type {string} */\n  let className = \"\";\n  export { className as class };\n</script>\n";
+    let code = convert(src);
+    assert!(
+        code.contains(
+            "let className = \"\"/*\u{03A9}ignore_start\u{03A9}*/;className = __sveltets_2_any(className);/*\u{03A9}ignore_end\u{03A9}*/"
+        ),
+        "expected __sveltets_2_any widen with ignore markers, got:\n{code}"
+    );
+}
+
+/// Boolean-literal default on a renamed legacy prop → widen (TS would otherwise
+/// narrow to the `false` literal type).
+#[test]
+fn boolean_default_renamed_prop_is_widened() {
+    let src = "<script>\n  let open = false;\n  export { open as isOpen };\n</script>\n";
+    let code = convert(src);
+    assert!(
+        code.contains("open = __sveltets_2_any(open)"),
+        "expected boolean-init renamed prop to be widened, got:\n{code}"
+    );
+}
+
+/// A plain (untyped) string default on a renamed prop must NOT be widened —
+/// official leaves `let className = ""` untouched here.
+#[test]
+fn plain_string_default_renamed_prop_is_not_widened() {
+    let src = "<script>\n  let className = \"\";\n  export { className as class };\n</script>\n";
+    let code = convert(src);
+    assert!(
+        !code.contains("__sveltets_2_any(className)"),
+        "plain string default must not be widened, got:\n{code}"
+    );
+}


### PR DESCRIPTION
Fixes #1231.

## Problem
For a renamed legacy prop with a default and a type — most commonly a JSDoc `/** @type {T} */` (the sveltestrap shape):

```svelte
<script>
  /** @type {string} */
  let className = "";
  export { className as class };
</script>
```

official svelte2tsx wraps the declaration with an `__sveltets_2_any` coercion bounded by `/*Ωignore_startΩ*/ … /*Ωignore_endΩ*/` markers (functional markers the language server relies on). rsvelte omitted both:

```diff
-  let className = "" /*Ωignore_startΩ*/;
-  className = __sveltets_2_any(className);
-  /*Ωignore_endΩ*/ /**
+  let className = "";
+
+  /**
```

## Root cause
rsvelte's `export { x as y }` (Case 2) widening predicate in `script/mod.rs` only fired on `!has_init || has_type_annotation`, so any renamed prop **with a default** dropped the coercion — even when the `let` declaration carried a JSDoc `@type` or a boolean-literal default.

Official `propTypeAssertToUserDefined` (invoked from `addExport` when the re-exported local is a `let`) widens when the declaration has **no initializer OR a type (TS annotation _or_ JSDoc `@type`) OR a boolean-literal initializer**.

## Fix
Mirror the official predicate in the Case 2 path: widen on `!has_init || has_type_annotation || has_jsdoc_type || has_boolean_init`. Adds a `has_boolean_init` field to `PossibleExport` and a `declarator_has_boolean_init` helper. A plain untyped string default (`let className = ""` with no `@type`) is still left untouched — verified against official.

## Tests
New `svelte2tsx_renamed_prop_widen_1231.rs` covers the JSDoc-typed, boolean-default, and plain-string (no-widen) cases. All existing `svelte2tsx_*`, `svelte2tsx_fixtures`, and `svelte_check_golden` suites stay green; `cargo fmt` + `clippy` clean.

## Corpus baseline
This is the largest svelte2tsx cluster in the awesome-svelte compat corpus (~51 entries). The corpus job runs on push-to-main only (not PRs); after merge it will report these entries now pass, and `compat/corpus/svelte2tsx-known-failures.json` can be shrunk via a corpus refresh in CI's (Linux) environment — intentionally not regenerated here to avoid a noisy cross-platform baseline diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)