### PR TITLE
fix(svelte2tsx): carry renamed-export JSDoc onto the prop (#1230)

### DIFF
--- a/.changeset/fix-renamed-export-jsdoc.md
+++ b/.changeset/fix-renamed-export-jsdoc.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(svelte2tsx): carry renamed-export JSDoc onto the prop
+
+`getDoc(target)` in official svelte2tsx resolves a prop's `/** @type {...} */`
+from the `let x` declaration first, then — when none is there — from the
+`export { x as y }` statement itself (`exportExpr`). rsvelte only captured the
+doc on the `let` declaration, so the common shape
+
+```svelte
+let _class = null;
+/** @type {string | false | null} */
+export { _class as class };
+```
+
+dropped the type from the generated `render({...})` destructure, losing the
+prop's declared type in the language server. The export-specifier handler now
+falls back to the export statement's leading JSDoc, mirroring official's
+`getDoc`.

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -3367,7 +3367,16 @@ fn handle_export_named_decl(
             let is_let = possible.map(|p| p.is_let).unwrap_or(false);
             let has_init = possible.map(|p| p.has_init).unwrap_or(true);
             let type_ann = possible.and_then(|p| p.type_annotation_text.clone());
-            let doc = possible.and_then(|p| p.doc.clone());
+            // Mirror official `getDoc(target)`: the doc is taken from the `let x`
+            // declaration first, then — if none there — from the `export { … }`
+            // statement itself (`exportExpr`). So
+            //   let _class = null;
+            //   /** @type {string | false | null} */
+            //   export { _class as class };
+            // carries the `@type` onto the prop in the render destructure.
+            let doc = possible
+                .and_then(|p| p.doc.clone())
+                .or_else(|| leading_jsdoc_comment(raw_content, export.span.start as usize));
             let is_prop = is_instance && is_let;
             exported_names.add_full(
                 exported.clone(),

--- a/crates/rsvelte_core/tests/svelte2tsx_renamed_export_jsdoc.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_renamed_export_jsdoc.rs
@@ -1,0 +1,64 @@
+//! Regression test for issue #1230.
+//!
+//! Official svelte2tsx attaches a `/** @type {...} */` JSDoc to a prop in the
+//! generated `render({...})` destructure. The doc is resolved via `getDoc`,
+//! which looks first at the `let x` declaration, then — when none is there — at
+//! the `export { x as y }` statement itself (`exportExpr`). The common
+//! real-world shape (e.g. `attractions/accordion/accordion-section.svelte`)
+//! puts the doc on the renamed-export statement:
+//!
+//! ```svelte
+//! let _class = null;
+//! /** @type {string | false | null} */
+//! export { _class as class };
+//! ```
+//!
+//! Without the `exportExpr` fallback the prop lost its declared type in the
+//! language server. This guards that the doc round-trips onto the prop.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "T.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+#[test]
+fn jsdoc_on_renamed_export_statement_round_trips_onto_prop() {
+    let out = to_tsx(concat!(
+        "<script>\n",
+        "  let _class = null;\n",
+        "  /** @type {string | false | null} */\n",
+        "  export { _class as class };\n",
+        "</script>\n",
+        "<li class={_class}></li>",
+    ));
+
+    assert!(
+        out.contains("/** @type {string | false | null} */ class: _class"),
+        "renamed-export JSDoc missing from props destructure:\n{out}"
+    );
+}
+
+#[test]
+fn jsdoc_on_let_declaration_still_takes_precedence() {
+    // When the doc is on the `let x` declaration, that one wins (it is checked
+    // first in `getDoc`), and the export statement has no comment of its own.
+    let out = to_tsx(concat!(
+        "<script>\n",
+        "  /** @type {number} */\n",
+        "  let _value = 0;\n",
+        "  export { _value as value };\n",
+        "</script>\n",
+        "<span>{_value}</span>",
+    ));
+
+    assert!(
+        out.contains("/** @type {number} */ value: _value"),
+        "let-declaration JSDoc missing from props destructure:\n{out}"
+    );
+}


### PR DESCRIPTION
## What

Fixes #1230 — rsvelte's svelte2tsx omitted the `/** @type {...} */` JSDoc on **destructured / renamed props** in the generated `render({...})` signature, losing the prop's declared type in the language server (~35 awesome-svelte corpus entries).

## Root cause

Official svelte2tsx resolves a prop's doc via `getDoc(target)`, which checks two places in order:

1. the `let x` declaration (`variableDeclaration`), then
2. the `export { x as y }` statement itself (`exportExpr`) when (1) has none.

rsvelte's export-specifier handler only captured the doc on the `let` declaration (`possible_exports[local].doc`), so the common real-world shape

```svelte
let _class = null;
/** @type {string | false | null} */
export { _class as class };
```

dropped the type:

```diff
-      /** @type {string | false | null} */ class: _class,
+      class: _class,
```

## Fix

Add the `exportExpr` fallback in `handle_export_named_decl` (Case 2, export specifiers), mirroring official's `getDoc`:

```rust
let doc = possible
    .and_then(|p| p.doc.clone())
    .or_else(|| leading_jsdoc_comment(raw_content, export.span.start as usize));
```

The let-declaration doc still wins when present (checked first), matching official precedence.

## Tests

- New `crates/rsvelte_core/tests/svelte2tsx_renamed_export_jsdoc.rs` (doc on the renamed-export statement; doc on the let declaration takes precedence).
- Existing svelte2tsx suite still 253/253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Wfnq2Ju9nQoDcPBbxDsTP