### PR TITLE
fix(analyze): false-positive each_item_invalid_assignment for $derived.by for-loop var (#1224)

### DIFF
--- a/.changeset/fix-each-item-derived-by-scope.md
+++ b/.changeset/fix-each-item-derived-by-scope.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): don't misresolve a `$derived.by` for-loop variable to an `{#each}` item
+
+A `for`-loop variable inside a `$derived.by(() => { ... })` callback that shared
+a name with an `{#each ... as name}` template item triggered a false-positive
+`each_item_invalid_assignment` error, rejecting code the official compiler
+accepts. The runes-mode each-item check resolved the assignment target with a
+scope walk that reaches the pollution-seeded root scope, so it matched the
+template each item even though the `{#each}` block is not a lexical ancestor of
+the script callback. The error now only fires when the each-item binding's
+declaring scope is actually an ancestor of the assignment site.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -472,8 +472,24 @@ pub fn validate_assignment(
             }
 
             // Check for each block item assignment (only in runes mode)
-            // In legacy mode, binding to each items is allowed
-            if context.analysis.runes && binding.kind == BindingKind::EachItem {
+            // In legacy mode, binding to each items is allowed.
+            //
+            // Guard against false positives caused by root-scope pollution: the
+            // root scope (index 0) is intentionally seeded with every child
+            // scope's declarations, so a `get_binding` walk that reaches the root
+            // can resolve to an each-item binding that is NOT lexically visible
+            // from the assignment site (e.g. a same-named `for`-loop variable
+            // inside a `$derived.by(() => { ... })` callback). Only treat the
+            // binding as an each item when its declaring scope is an ancestor of
+            // the current scope. Upstream resolves this naturally via
+            // `scope.get(name)` walking only the real lexical chain.
+            if context.analysis.runes
+                && binding.kind == BindingKind::EachItem
+                && context
+                    .analysis
+                    .root
+                    .is_scope_ancestor_of(binding.scope_index, context.scope)
+            {
                 return Err(errors::each_item_invalid_assignment());
             }
 
@@ -2718,7 +2734,18 @@ pub fn validate_assignment_node(
                 return Err(errors::constant_assignment("$props.id()"));
             }
 
-            if context.analysis.runes && binding.kind == BindingKind::EachItem {
+            // See the matching guard in `validate_assignment`: only fire the
+            // each-item error when the binding is lexically visible from the
+            // assignment site, so root-scope pollution can't misresolve a
+            // same-named local (e.g. a `for`-loop variable inside a
+            // `$derived.by` callback) to a template each item.
+            if context.analysis.runes
+                && binding.kind == BindingKind::EachItem
+                && context
+                    .analysis
+                    .root
+                    .is_scope_ancestor_of(binding.scope_index, context.scope)
+            {
                 return Err(errors::each_item_invalid_assignment());
             }
 

--- a/crates/rsvelte_core/tests/each_item_derived_by_scope.rs
+++ b/crates/rsvelte_core/tests/each_item_derived_by_scope.rs
@@ -1,0 +1,125 @@
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn try_compile(src: &str) -> Result<(), String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|_| ())
+    .map_err(|e| format!("{e:?}"))
+}
+
+/// Regression for #1224: a `for`-loop variable inside a `$derived.by` callback
+/// that shares its name with an `{#each}` item must NOT trip the runes-mode
+/// `each_item_invalid_assignment` validation. Official svelte@5.56.3 compiles
+/// this cleanly.
+#[test]
+fn each_item_shadowed_by_for_loop_in_derived_by() {
+    let src = r#"<script>
+  let { rows } = $props();
+
+  const grid = $derived.by(() => {
+    const result = [];
+    for (let day = 1; day <= 31; day++) {
+      day = day + 1;
+      result.push(day);
+    }
+    return result;
+  });
+</script>
+
+{#each rows as day}
+  <span>{day}</span>
+{/each}
+"#;
+    assert!(
+        try_compile(src).is_ok(),
+        "should compile cleanly: {:?}",
+        try_compile(src)
+    );
+}
+
+/// Same shape but with a plain function declaration in the instance script.
+#[test]
+fn each_item_shadowed_by_for_loop_in_function() {
+    let src = r#"<script>
+  let { rows } = $props();
+  function build() {
+    for (let day = 0; day < 10; day++) {
+      day = day + 2;
+    }
+  }
+</script>
+{#each rows as day}<span>{day}</span>{/each}
+"#;
+    assert!(try_compile(src).is_ok(), "{:?}", try_compile(src));
+}
+
+/// Guard must NOT suppress the real error: directly reassigning an each item in
+/// runes mode is still invalid.
+#[test]
+fn real_each_item_reassignment_still_errors() {
+    let src = r#"<script>
+  let { rows } = $props();
+</script>
+{#each rows as day}
+  <button onclick={() => day = day + 1}>{day}</button>
+{/each}
+"#;
+    let err = try_compile(src).expect_err("each-item reassignment must still error");
+    assert!(
+        err.contains("each_item_invalid_assignment"),
+        "expected each_item_invalid_assignment, got: {err}"
+    );
+}
+
+/// The three official `compiler-errors` fixtures that must keep erroring:
+/// `bind:value` on an each item, a `+=` mutation of an each item inside a
+/// handler, and `bind:this` on a destructured each item.
+#[test]
+fn official_each_item_error_fixtures_still_error() {
+    let bind_value = r#"<script>
+	let arr = $state([1,2,3]);
+</script>
+
+{#each arr as value}
+	<input bind:value>
+{/each}
+"#;
+    let mutation = r#"<script>
+	let arr = $state([1,2,3]);
+</script>
+
+{#each arr as value}
+	<button onclick={() => value += 1}>click</button>
+{/each}
+"#;
+    let bind_this = r#"<script lang="ts">
+	let array: Array<{ id: number; element: HTMLElement | null }> = $state([
+		{ id: 1, element: null }
+	]);
+</script>
+
+{#each array as { id, element } (id)}
+	<input bind:this={element} />
+{/each}
+"#;
+    for (name, src) in [
+        ("bind:value", bind_value),
+        ("mutation", mutation),
+        ("bind:this destructured", bind_this),
+    ] {
+        let err = try_compile(src)
+            .err()
+            .unwrap_or_else(|| panic!("{name}: expected each_item_invalid_assignment"));
+        assert!(
+            err.contains("each_item_invalid_assignment"),
+            "{name}: expected each_item_invalid_assignment, got: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## What

Fixes #1224 — a false-positive `each_item_invalid_assignment` compile error.

rsvelte rejected an assignment to a `for`-loop variable inside a
`$derived.by(() => { ... })` callback when that variable happened to share a
name with an `{#each ... as name}` template item. Official `svelte@5.56.3`
compiles this cleanly (surfaced by `svar-core` `Duodecade.svelte` in the
awesome-svelte compat corpus, PR #1219).

## Root cause

The runes-mode each-item validation resolved the assignment target with
`get_binding`, which walks the scope chain up to the **root** scope. The root
scope (index 0) is intentionally seeded with every child scope's declarations
("pollution"), so the walk could resolve to the template's each-item binding
even though the `{#each}` block is **not** a lexical ancestor of the script
callback. Upstream avoids this naturally — its `scope.get(name)` walks only the
real lexical chain.

Concretely:

```svelte
<script>
  let { rows } = $props();
  const grid = $derived.by(() => {
    for (let day = 1; day <= 31; day++) {
      day = day + 1;   // ← local for-loop var, wrongly seen as the each item
    }
  });
</script>
{#each rows as day}<span>{day}</span>{/each}
```

## Fix

Guard the each-item error with
`is_scope_ancestor_of(binding.scope_index, context.scope)` so it only fires
when the each-item binding is actually lexically visible from the assignment
site. Applied to both `validate_assignment` (Value) and
`validate_assignment_node` (JsNode). Validation-only — no codegen change.

## Tests

`crates/rsvelte_core/tests/each_item_derived_by_scope.rs`:
- the `$derived.by` + `function` false-positive shapes now compile cleanly
- a real each-item reassignment in a handler still errors
- the three official `runes-invalid-each-*` fixtures (`bind:value`, `+=`
  mutation, destructured `bind:this`) still error

Local: `compiler_errors` (145) and `validator` (333) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My1fKCr3PPL969reH75HAo