### PR TITLE
fix(compiler): don't false-positive store_invalid_scoped_subscription with a module-script function (#1225)

### DIFF
--- a/.changeset/fix-scoped-subscription-module-fn.md
+++ b/.changeset/fix-scoped-subscription-module-fn.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): don't false-positive `store_invalid_scoped_subscription` when a `<script context="module">` declares a function
+
+A function declaration in `<script context="module">` pushes its own function
+scope, so the instance scope index is no longer always `1`. The scoped-store
+guard in `walk_js_expression` / `walk_js_expression_node` hardcoded `1` as the
+instance scope, so an instance-scope store (e.g. an imported store) referenced
+inside a template arrow function was wrongly rejected with
+`store_invalid_scoped_subscription`. The guard now compares against the real
+`instance_scope_index`, mirroring upstream's `owner !== instance.scope` check.
+Genuine scoped subscriptions (a store shadowed by an each-item binding or an
+arrow parameter) still error. Fixes #1225 (svelte-form-builder `PropertyPanel`).

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -1294,4 +1294,65 @@ mod tests {
             .any(|b| b.name == "$items" && matches!(b.kind, BindingKind::StoreSub));
         assert!(has_items_store, "Should have a StoreSub binding for $items");
     }
+
+    /// Regression test for #1225: a function declaration in
+    /// `<script context="module">` pushes its own function scope, which shifts
+    /// the instance scope index past 1. The scoped-subscription guard must
+    /// compare against the real `instance_scope_index` (mirroring upstream's
+    /// `owner !== instance.scope` check), not a hardcoded `1`, otherwise an
+    /// instance-scope store referenced inside a template arrow function is
+    /// wrongly rejected with `store_invalid_scoped_subscription`.
+    #[test]
+    fn test_module_function_does_not_cause_false_scoped_subscription() {
+        use crate::ast::arena::{clear_serialize_arena, set_serialize_arena};
+        use crate::compiler::CompileOptions;
+        use crate::compiler::phases::phase1_parse::{ParseOptions, parse};
+        use crate::compiler::phases::phase2_analyze::analyze_component;
+
+        let options = CompileOptions::default();
+
+        let analyze = |source: &str| {
+            let mut ast = parse(source, ParseOptions::default()).unwrap();
+            // SAFETY: `ast` (and thus `ast.arena`) outlives the
+            // `analyze_component` call; `clear_serialize_arena()` runs before
+            // `ast` is dropped, so the installed pointer never dangles.
+            unsafe { set_serialize_arena(&ast.arena as *const _) };
+            let result = analyze_component(&mut ast, source, &options).map(|_| ());
+            clear_serialize_arena();
+            result
+        };
+
+        // Valid: the module script declares a function (which shifts the
+        // instance scope index), and `$opts` (an instance-scope import) is
+        // referenced inside a template arrow. Official Svelte accepts this.
+        let valid = r#"<script context="module">
+    export function f() {}
+</script>
+<script>
+    import { opts } from './store';
+</script>
+<button on:click={() => ($opts = false)}>x</button>
+"#;
+        assert!(
+            analyze(valid).is_ok(),
+            "module-script function must not trigger a false-positive store_invalid_scoped_subscription"
+        );
+
+        // Still invalid: an arrow PARAMETER shadows the store, so the `$store`
+        // reference is a genuinely scoped subscription — must keep erroring even
+        // when a module-script function shifts the instance scope index.
+        let invalid = r#"<script context="module">
+    export function g() {}
+</script>
+<script>
+    import { writable } from 'svelte/store';
+    const store = writable();
+</script>
+<button on:click={(store) => { $store = Math.random(); }} />
+"#;
+        assert!(
+            analyze(invalid).is_err(),
+            "a store shadowed by an arrow parameter must still error even with a module-script function"
+        );
+    }
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -1714,18 +1714,27 @@ pub fn walk_js_expression(
                             context.analysis.root.scope.declarations.get(store_name)
                         {
                             let binding = &context.analysis.root.bindings[binding_idx];
-                            // If the binding's scope_index is > 1 (deeper than instance scope),
-                            // AND we're inside that nested scope, it's a shadowing error
-                            // Scope 0 = module, Scope 1 = instance, Scope 2+ = nested
+                            // If the binding's scope_index is deeper than the instance
+                            // scope, AND we're inside that nested scope, it's a shadowing
+                            // error. The instance scope is NOT always index 1: a function
+                            // declaration in `<script context="module">` pushes its own
+                            // function scope, so the instance scope index shifts. We must
+                            // compare against the real `instance_scope_index` (mirroring
+                            // upstream's `owner !== instance.scope` check) instead of a
+                            // hardcoded `1`, otherwise an instance-scope store binding is
+                            // wrongly treated as nested (false-positive
+                            // `store_invalid_scoped_subscription`).
                             //
                             // We need to check if we're actually inside the scope where this
                             // binding is declared. function_depth gives us an approximation:
                             // - In template: function_depth = 0
                             // - In event handler (first level function): function_depth = 1
                             // - In nested function: function_depth >= 2
-                            // Only error if scope_index > 1 AND we're deep enough to be in that scope
-                            if binding.scope_index > 1
-                                && binding.scope_index <= context.function_depth + 1
+                            // Only error if the binding is deeper than the instance scope
+                            // AND we're deep enough to be in that scope.
+                            let instance_scope = context.analysis.root.instance_scope_index;
+                            if binding.scope_index > instance_scope
+                                && binding.scope_index <= context.function_depth + instance_scope
                             {
                                 return Err(
                                     super::super::super::errors::store_invalid_scoped_subscription(
@@ -3008,7 +3017,16 @@ pub fn walk_js_expression_node(
                         context.analysis.root.scope.declarations.get(store_name)
                 {
                     let binding = &context.analysis.root.bindings[binding_idx];
-                    if binding.scope_index > 1 && binding.scope_index <= context.function_depth + 1
+                    // Compare against the real instance scope index, not a hardcoded `1`:
+                    // a function declaration in `<script context="module">` shifts the
+                    // instance scope deeper, so a hardcoded `1` would treat an
+                    // instance-scope store as nested (false-positive
+                    // `store_invalid_scoped_subscription`). Mirrors upstream's
+                    // `owner !== instance.scope` check. See the matching guard in
+                    // `walk_js_expression`.
+                    let instance_scope = context.analysis.root.instance_scope_index;
+                    if binding.scope_index > instance_scope
+                        && binding.scope_index <= context.function_depth + instance_scope
                     {
                         return Err(
                             super::super::super::errors::store_invalid_scoped_subscription(),


### PR DESCRIPTION
## What

Fixes #1225 — rsvelte rejected a store subscription that official `svelte@5.56.3` accepts, emitting a false-positive `store_invalid_scoped_subscription` for `svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanel.svelte`.

## Root cause

A function declaration in `<script context="module">` (here, `export function addAndSelectExternalTab`) pushes its own function scope during scope building, so the **instance scope index is no longer `1`** — it shifts to `2`. The scoped-store guards in `walk_js_expression` / `walk_js_expression_node` hardcoded `1` as the instance scope:

```rust
if binding.scope_index > 1 && binding.scope_index <= context.function_depth + 1 { ... }
```

So an instance-scope store (e.g. an imported `opts`) referenced inside a **template arrow function** (`on:click={() => ($opts = false)}`) was treated as a nested/shadowed binding and wrongly rejected.

The minimal trigger is a module-script **function** (a module `let`/`var` doesn't shift the index) + a `$store` reference inside a template arrow whose store is imported into the instance scope.

## Fix

Both guards now compare against the real `instance_scope_index`, mirroring upstream's `owner !== module.scope && owner !== instance.scope` check in `2-analyze/index.js`:

```rust
let instance_scope = context.analysis.root.instance_scope_index;
if binding.scope_index > instance_scope
    && binding.scope_index <= context.function_depth + instance_scope { ... }
```

Genuine scoped subscriptions (a store shadowed by an each-item binding or an arrow parameter) still error — verified to still error even when a module-script function shifts the instance scope index.

## Verification

- New regression test `test_module_function_does_not_cause_false_scoped_subscription` in `store_subscriptions.rs` (valid case compiles cleanly; arrow-param-shadowed case still errors).
- The real `PropertyPanel.svelte` now compiles cleanly for both CSR and SSR (was: `ERROR store_invalid_scoped_subscription`).
- `compiler_errors` (incl. `store-shadow-scope*`, `store-contextual`, `store-template-expression-scope`), `validator`, `store_subscription_pin`, `store_member_mutate_binding_kind`, `store_ref_multibyte`, and `compatibility_report` suites all pass.

Note: `PropertyPanel.svelte` and the other svelte-form-builder entries remain in `compat/corpus/known-failures.json` — they still diverge on **other** axes (comment handling / output codegen) tracked by the PR #1219 epic, so this change is scoped to the analyze-phase false positive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)