### PR TITLE
fix(fmt): don't CSS-parse non-CSS `<style lang>` blocks (#1233)

### DIFF
--- a/.changeset/fix-1233-scss-style-passthrough.md
+++ b/.changeset/fix-1233-scss-style-passthrough.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): don't CSS-parse non-CSS `<style lang>` blocks
+
+`rsvelte-fmt` hard-failed on `<style lang="scss">` (and other non-CSS dialects):
+the body was run through the internal CSS parser, which choked on SCSS syntax
+(`//` line comments, `$variables`, maps) with `css_expected_identifier` and
+aborted the whole-file format. A non-CSS `lang` block is opaque preprocessor
+input, so the formatter no longer CSS-parses it — its raw body is still handed to
+the embedded style formatter (oxfmt), exactly as before, so output is unchanged
+for already-working blocks while SCSS-syntax blocks stop aborting the format.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -529,6 +529,7 @@ pub fn compile(source: &str, options: CompileOptions) -> Result<CompileResult, C
         defer_script_parse: true,
         force_typescript: false,
         lenient_script: false,
+        skip_non_css_lang_style: false,
     };
     let mut ast = phases::phase1_parse::parse(source, parse_options)?;
 
@@ -640,6 +641,7 @@ pub fn compile_both(
         defer_script_parse: true,
         force_typescript: false,
         lenient_script: false,
+        skip_non_css_lang_style: false,
     };
     let mut ast = phases::phase1_parse::parse(source, parse_options)?;
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
@@ -106,6 +106,16 @@ pub struct ParseOptions {
     /// script error-recovery path only — template expressions and everything
     /// outside `<script>` are unaffected.
     pub lenient_script: bool,
+    /// When true, a top-level `<style lang="...">` whose lang is not plain CSS
+    /// (scss/sass/less/stylus/postcss/…) is NOT parsed as CSS: its body is kept
+    /// verbatim (`children: []`, `content.styles` = raw) instead of being run
+    /// through the CSS parser. The compiler keeps this `false` — it relies on
+    /// preprocessing to turn the body into CSS before it sees it — but the
+    /// *formatter* sets it so a `<style lang="scss">` doesn't abort the
+    /// whole-file parse with `css_expected_identifier`; the formatter then
+    /// leaves such blocks untouched, matching prettier-plugin-svelte. Also
+    /// implied by `lenient_script` (lint mode).
+    pub skip_non_css_lang_style: bool,
 }
 
 /// Extended parse options with filename (separate to keep ParseOptions Copy).

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -140,7 +140,8 @@ impl Parser<'_> {
         // other lint on the file. Plain-CSS `<style>` keeps full strictness, so
         // invalid plain CSS still fails to parse exactly as the official
         // compiler (and the eslint oracle) treats it.
-        let lenient_non_css = self.options.lenient_script && has_non_css_lang(&attributes);
+        let lenient_non_css = (self.options.lenient_script || self.options.skip_non_css_lang_style)
+            && has_non_css_lang(&attributes);
 
         let content_start = self.index;
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -1276,6 +1276,7 @@ mod tests {
             defer_script_parse: true,
             force_typescript: false,
             lenient_script: false,
+            skip_non_css_lang_style: false,
         };
         let mut ast = phase1_parse::parse(source, parse_options).expect("parse");
 
@@ -1327,6 +1328,7 @@ mod tests {
             defer_script_parse: true,
             force_typescript: false,
             lenient_script: false,
+            skip_non_css_lang_style: false,
         };
         let mut ast = phase1_parse::parse(source, parse_options).expect("parse");
         // SAFETY: `ast` (and thus `ast.arena`) outlives `_guard` for the rest of
@@ -3030,6 +3032,7 @@ mod tests {
             defer_script_parse: true,
             force_typescript: false,
             lenient_script: false,
+            skip_non_css_lang_style: false,
         };
         let mut ast = phase1_parse::parse(source, parse_options).expect("parse");
         // SAFETY: `ast` (and thus `ast.arena`) outlives `_guard` for the rest of
@@ -3544,6 +3547,7 @@ mod tests {
             defer_script_parse: true,
             force_typescript: false,
             lenient_script: false,
+            skip_non_css_lang_style: false,
         };
         let mut ast = phase1_parse::parse(source, parse_options).expect("parse");
         // SAFETY: `ast` (and thus `ast.arena`) outlives `_guard` for the rest of
@@ -5049,6 +5053,7 @@ mod tests {
             defer_script_parse: true,
             force_typescript: false,
             lenient_script: false,
+            skip_non_css_lang_style: false,
         };
 
         // Parse into a heap-stable Box so the arena address stays valid for the

--- a/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
@@ -548,6 +548,7 @@ pub fn svelte2tsx(
         defer_script_parse: false,
         force_typescript: false,
         lenient_script: false,
+        skip_non_css_lang_style: false,
     };
     let ast = phase1_parse::parse_script_ts(&parse_source, parse_options)?;
 

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -53,13 +53,22 @@ pub fn format(source: &str, options: &FormatOptions) -> Result<String, FormatErr
     // cannot regress — only previously-erroring TS-in-plain-`<script>` files gain
     // formatting. The TS retry sets `is_typescript` on the scripts, so the
     // dialect detection below threads TS through every template expression too.
-    let root = match parse(source, ParseOptions::default()) {
+    // A `<style lang="scss|less|postcss|…">` body is not plain CSS, so parsing it
+    // as CSS would abort the whole-file parse (`css_expected_identifier` on `//`
+    // comments, `$variables`, maps, …). prettier-plugin-svelte treats these as
+    // opaque preprocessor input and leaves them untouched; mirror that by skipping
+    // the CSS parse for non-CSS `lang` blocks (the body is left verbatim below).
+    let parse_options = ParseOptions {
+        skip_non_css_lang_style: true,
+        ..ParseOptions::default()
+    };
+    let root = match parse(source, parse_options) {
         Ok(root) => root,
         Err(_) => parse(
             source,
             ParseOptions {
                 force_typescript: true,
-                ..ParseOptions::default()
+                ..parse_options
             },
         )
         .map_err(FormatError::from_parse)?,

--- a/crates/rsvelte_formatter/tests/style.rs
+++ b/crates/rsvelte_formatter/tests/style.rs
@@ -59,12 +59,47 @@ fn callback_receives_scss_lang_attribute() {
         style_formatter: Some(cb),
         ..FormatOptions::default()
     };
-    // Use CSS-valid body but declare lang="scss" — rsvelte's CSS
-    // parser still walks the body, so syntactic CSS keeps the test
-    // hermetic.
+    // CSS-valid body declared `lang="scss"`. The body is no longer CSS-parsed
+    // (it's opaque preprocessor input), but it is still handed to the embedded
+    // formatter callback with the declared lang so an scss-capable engine can
+    // format it — matching the oxfmt-based oracle.
     let _out = fmt("<style lang=\"scss\">p { color: red; }</style>", &opts);
 
     assert_eq!(captured.lock().unwrap().as_deref(), Some("scss"));
+}
+
+#[test]
+fn scss_syntax_body_does_not_abort_parse() {
+    // SCSS-only syntax (`//` line comments, `$variables`, maps) would make the
+    // CSS parser raise `css_expected_identifier` and abort the whole-file format
+    // (#1233). The body must no longer be CSS-parsed: the file formats, the
+    // callback receives the raw scss body verbatim, and lang is "scss".
+    let captured: Arc<Mutex<Option<(String, String)>>> = Arc::new(Mutex::new(None));
+    let captured_clone = captured.clone();
+    // Identity formatter (an scss-aware engine would reformat; here we only assert
+    // the body reaches the callback untouched and the file no longer errors).
+    let cb: StyleFormatter = Arc::new(move |body, lang, _width| {
+        *captured_clone.lock().unwrap() = Some((body.to_string(), lang.to_string()));
+        Ok(body.to_string())
+    });
+
+    let opts = FormatOptions {
+        style_formatter: Some(cb),
+        ..FormatOptions::default()
+    };
+    let src = "<script>let x=1+2</script>\n<style lang=\"scss\">\n  // Disable default zoom\n  $light_root: (a: 1, b: 2);\n  .foo {\n    color: $light_root;\n  }\n</style>";
+    let out = fmt(src, &opts);
+
+    assert!(
+        out.contains("let x = 1 + 2;"),
+        "rest of file formatted:\n{out}"
+    );
+    let (body, lang) = captured.lock().unwrap().clone().expect("callback ran");
+    assert_eq!(lang, "scss");
+    assert!(
+        body.contains("// Disable default zoom") && body.contains("$light_root: (a: 1, b: 2)"),
+        "scss body reached the callback verbatim:\n{body}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #1233.

## Problem
`rsvelte-fmt` hard-failed when a component had a `<style lang="scss">` (or any non-CSS dialect) block. The body was run through the internal CSS parser, which choked on SCSS syntax (`//` line comments, `$variables`, maps) with `css_expected_identifier` and aborted the entire format — leaving the whole file untouched.

Repro files from the awesome-svelte compat corpus (PR #1219): `svelte-splitpanes/src/lib/Splitpanes.svelte`, `powertable/.../example5/+page.svelte`.

## Fix
A non-CSS `lang` block is opaque preprocessor input, not CSS, so it must not drive CSS-AST construction.

- Add `ParseOptions::skip_non_css_lang_style`. When set, a top-level `<style lang="…">` whose lang is not plain CSS is **not** CSS-parsed; its raw body is still captured in `content.styles`. The compiler keeps it `false` (it relies on preprocessing); lint mode's `lenient_script` already implied this behavior and still does.
- The formatter (`rsvelte_formatter::format`) sets the flag on both parse attempts. The raw body is still handed to the embedded style formatter (oxfmt) with its declared lang, so output is **byte-identical for already-working blocks** while SCSS-syntax blocks stop aborting the format.

This is deliberately minimal: the formatter's `<style>` formatting path is unchanged (`crates/rsvelte_formatter/src/style.rs` has no net diff). The only behavioral change is skipping the internal CSS parse that used to abort.

## Tests
`crates/rsvelte_formatter/tests/style.rs`:
- `callback_receives_scss_lang_attribute` — the embedded formatter callback still receives an scss block (with lang `"scss"`).
- `scss_syntax_body_does_not_abort_parse` — an scss body with `//` comments + a `$map` no longer aborts the format; the rest of the file formats and the raw body reaches the callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My1fKCr3PPL969reH75HAo