### PR TITLE
fix(svelte2tsx): bind a component child's legacy `let:` from its own slot_def (#1232)

### DIFF
--- a/.changeset/fix-1232-component-child-slot-let.md
+++ b/.changeset/fix-1232-component-child-slot-let.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+fix(svelte2tsx): bind a component child's legacy `let:` from its own slot_def (#1232)
+
+A legacy `let:` directive on a *component* child of another component (`<Preview><State let:value let:set>…</State></Preview>`) binds from the child's OWN `$$slot_def.default` — its own `handle_component` already emits that destructure. rsvelte additionally treated the component child as a "default-slot-let child" of the enclosing component, so it gave the parent a spurious instance const and emitted a duplicate `$$_parent.$$slot_def.default` destructure that bound the child's `let:` props onto the parent instance, mistyping the slot props. Only non-component slot content (`<div let:x>` / `<svelte:fragment let:x>` / `<svelte:element let:x>`) forwards its `let:` bindings to the enclosing component's slot_def; `Component`/`SvelteComponent`/`SvelteSelf` children are now excluded from both the parent-instance trigger and the parent-side destructure emission, mirroring official svelte2tsx.

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -3356,13 +3356,18 @@ fn has_component_slot_children(fragment: &Fragment, source: &str) -> bool {
 /// this does not recurse.
 fn has_default_slot_let_children(fragment: &Fragment, _source: &str) -> bool {
     fragment.nodes.iter().any(|node| {
+        // Only NON-component default-slot children forward their `let:` bindings
+        // to the enclosing component's `$$slot_def.default`. A component child
+        // (`<Child let:x>` / `<svelte:component let:x>` / `<svelte:self let:x>`)
+        // binds `let:x` from its OWN `$$slot_def.default` — its own
+        // `handle_component` emits that destructure — so it must not mark the
+        // parent as needing an instance var. Mirrors official svelte2tsx, where
+        // only `Element`/`SlotElement`/`InlineComponent` *slot content* (not the
+        // inline component's own lets) routes through the parent slot.
         let attrs = match node {
             TemplateNode::RegularElement(el) => &el.attributes,
-            TemplateNode::Component(c) => &c.attributes,
             TemplateNode::SvelteFragment(f) => &f.attributes,
             TemplateNode::SvelteElement(e) => &e.attributes,
-            TemplateNode::SvelteComponent(sc) => &sc.attributes,
-            TemplateNode::SvelteSelf(s) => &s.attributes,
             _ => return false,
         };
         !get_let_directives(attrs).is_empty()
@@ -3581,12 +3586,18 @@ fn process_component_children_with_slots(
                 str.append_left(node.start(), &block_open);
                 default_slot_opened = true;
             }
-            // A default-slot child (`<svelte:fragment let:foo>`, `<div let:foo>`,
-            // `<Child let:foo>`) with no `slot=` but its OWN `let:` directives
-            // needs a `$$slot_def.default` destructure block — JS reference's
-            // Element.performTransformation emits one whenever the default-slot
-            // child has `let:` directives. Wrap the child so the `let:` bindings
-            // are scoped to its body.
+            // A default-slot child (`<svelte:fragment let:foo>`, `<div let:foo>`)
+            // with no `slot=` but its OWN `let:` directives needs a
+            // `$$slot_def.default` destructure block referencing the ENCLOSING
+            // component — JS reference's Element.performTransformation emits one
+            // whenever the default-slot child has `let:` directives. Wrap the
+            // child so the `let:` bindings are scoped to its body.
+            //
+            // A COMPONENT child (`<Child let:foo>`) is excluded: its `let:foo`
+            // binds from `Child`'s OWN `$$slot_def.default`, which its own
+            // `handle_component` already emits. Routing it through the parent
+            // here would wrongly duplicate the destructure onto the parent
+            // instance (#1232).
             let fragment_lets: Option<Vec<&LetDirective>> = match node {
                 TemplateNode::SvelteFragment(el) => {
                     let lets = get_let_directives(&el.attributes);
@@ -3594,10 +3605,6 @@ fn process_component_children_with_slots(
                 }
                 TemplateNode::RegularElement(el) => {
                     let lets = get_let_directives(&el.attributes);
-                    if lets.is_empty() { None } else { Some(lets) }
-                }
-                TemplateNode::Component(c) => {
-                    let lets = get_let_directives(&c.attributes);
                     if lets.is_empty() { None } else { Some(lets) }
                 }
                 _ => None,

--- a/crates/rsvelte_core/tests/svelte2tsx_slot_let_1232.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_slot_let_1232.rs
@@ -1,0 +1,67 @@
+//! Regression tests for #1232: a legacy `let:` binding on a COMPONENT child of
+//! another component must destructure from the *child's own* `$$slot_def.default`
+//! (emitted by the child's own `handle_component`), NOT be re-forwarded onto the
+//! enclosing component's instance.
+//!
+//! Before the fix, `<Preview><State let:value let:set>…</State></Preview>` marked
+//! `Preview` as a "default-slot-let child" carrier, so rsvelte (a) gave `Preview`
+//! a spurious instance const and (b) emitted a duplicate
+//! `$$_preview.$$slot_def.default` destructure binding `State`'s `let:` props onto
+//! `Preview`. Official svelte2tsx only routes a component's *own* lets through its
+//! own slot_def — a non-component slot-content child (`<div let:x>` /
+//! `<svelte:fragment let:x>`) is what forwards to the parent.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Comp.svelte".to_string(),
+        is_ts_file: false,
+        emit_jsdoc: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+/// A component child with its own `let:` directives destructures from its own
+/// instance, and the enclosing component is a bare `new` (no instance const, no
+/// duplicated destructure).
+#[test]
+fn component_child_let_binds_from_own_slot_def() {
+    let src = "<script>\n  import Preview from './Preview.svelte';\n  import State from './State.svelte';\n</script>\n\n<Preview>\n  <State let:value={xDomain} let:set>\n    {xDomain}\n  </State>\n</Preview>\n";
+    let code = convert(src);
+
+    // State (reversed `etatS`) gets its own instance const + destructure.
+    assert!(
+        code.contains("$$_etatS1.$$slot_def.default"),
+        "expected State to destructure from its own slot_def, got:\n{code}"
+    );
+    // Preview (reversed `weiverP`) must NOT carry a slot_def destructure — the
+    // `let:` props belong to State.
+    assert!(
+        !code.contains("$$_weiverP0.$$slot_def.default"),
+        "Preview must not duplicate State's let: bindings, got:\n{code}"
+    );
+    // Preview is a bare `new` (no `const $$_weiverP0 =` instance var).
+    assert!(
+        !code.contains("const $$_weiverP0 ="),
+        "Preview must not get a spurious instance const, got:\n{code}"
+    );
+}
+
+/// A NON-component default-slot child (`<div let:x>`) still forwards its `let:`
+/// bindings to the enclosing component's `$$slot_def.default` (unchanged
+/// behavior — this is the case that legitimately needs the parent instance).
+#[test]
+fn element_child_let_still_forwards_to_parent() {
+    let src = "<script>\n  import Preview from './Preview.svelte';\n</script>\n\n<Preview>\n  <div let:value={v} let:set>\n    {v}\n  </div>\n</Preview>\n";
+    let code = convert(src);
+    assert!(
+        code.contains("$$_weiverP0.$$slot_def.default"),
+        "element child let: must forward to the parent component's slot_def, got:\n{code}"
+    );
+    assert!(
+        code.contains("const $$_weiverP0 ="),
+        "parent must get an instance const for the element-child let forward, got:\n{code}"
+    );
+}


### PR DESCRIPTION
Fixes #1232.

## Problem

A legacy `let:` directive on a **component** child of another component was lowered incorrectly. For

```svelte
<Preview>
  <State initial={[null, null]} let:value={xDomain} let:set>
    <div class="h-[40px]">{xDomain}</div>
  </State>
</Preview>
```

rsvelte treated `State` (a component child carrying its own `let:`) as a *default-slot-let child* of `Preview`, so it:

1. gave `Preview` a spurious instance const (`const $$_weiverP0 = new …`), and
2. emitted a **duplicate** `$$_weiverP0.$$slot_def.default` destructure that bound `State`'s `let:value`/`let:set` onto the `Preview` instance — mistyping the slot props.

`State`'s `let:` bindings actually come from `State`'s own `$$slot_def.default`, which `handle_component(State)` already emits.

## Fix

Only **non-component** slot content (`<div let:x>` / `<svelte:fragment let:x>` / `<svelte:element let:x>`) forwards its `let:` bindings to the enclosing component's `$$slot_def.default`. A component child (`Component` / `SvelteComponent` / `SvelteSelf`) binds from its **own** slot_def, mirroring official svelte2tsx.

Excluded the component-like node types from both:
- `has_default_slot_let_children` (the parent-instance-const trigger), and
- the `fragment_lets` parent-side destructure emission.

## Verification

- Byte-identical (after oxfmt normalization, the corpus comparison contract) to official svelte2tsx on the repro `layerchart/.../docs/components/BrushContext/+page.svelte`.
- New regression test `svelte2tsx_slot_let_1232.rs` (component-child binds from own slot_def; element-child still forwards to parent).
- Full svelte2tsx fixture set: no regressions (the 7 unrelated failures are a pre-existing submodule-version artifact, identical with/without this change).
- `cargo fmt` + `cargo clippy --all-targets --all-features -D warnings` clean.

This is the largest remaining svelte2tsx structural corpus cluster (~57 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AHBcuRsyu6K8kWTZVno1j