### PR TITLE
ci(bench): eliminate the Criterion double-compile (one cargo bench step)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,10 +28,9 @@ jobs:
   bench:
     name: Criterion benchmarks
     runs-on: ubuntu-latest
-    # Build (≤30 min, mostly the cold oxc-from-git compile) + Run criterion
-    # (≤40 min: absorbs the local-crate rebuild noted on that step, then the
-    # measurement sweep). Keep the job ceiling above their sum.
-    timeout-minutes: 75
+    # A single `Run criterion` step (≤45 min) does the build + measurement;
+    # the job ceiling sits above it with room for checkout/cache overhead.
+    timeout-minutes: 60
     # Criterion reports absolute wall-clock throughput, which is noisier than
     # CodSpeed's instruction counts and moves slowly — not worth gating every
     # PR on. Always run on push to `main` (and manual dispatch); on PRs run
@@ -63,39 +62,45 @@ jobs:
           # if a later step fails.
           cache-on-failure: true
 
-      - name: Build benchmarks
-        # Compile the bench harnesses up front so a build failure is reported
-        # as its own step (a clear CI signal, separate from a measurement
-        # timeout). On a warm cache this is a quick no-op.
-        #
-        # NOTE: this build is intentionally NOT relied on to make the `Run
-        # criterion` step a pure measurement pass. `rsvelte_core` is a
-        # `cdylib`+`rlib`, and building it for its own benches alongside the
-        # `rsvelte_formatter` bench (which depends on it) produces an "output
-        # filename collision" on `librsvelte_core.{so,rlib}`. That collision
-        # makes the unit's fingerprint ambiguous, so the *next* `cargo bench`
-        # re-links/re-compiles the local crates from scratch (~14 min) instead
-        # of reusing this output. Rather than fight Cargo's fingerprinting, the
-        # measurement step below just absorbs that rebuild and is given a
-        # budget large enough for build + measurement.
-        run: cargo bench --bench parser --bench compiler --bench formatter --no-run
-        timeout-minutes: 30
-
       - name: Run criterion
+        # ONE `cargo bench` invocation that compiles *and* measures.
+        #
+        # A split (`--no-run` build step + a separate run step) double-compiles
+        # the workspace crates: `rsvelte_core` is a `cdylib`+`rlib`, and
+        # building it for its own benches alongside the `rsvelte_formatter`
+        # bench (which depends on it) produces an "output filename collision"
+        # on `librsvelte_core.{so,rlib}`. That collision makes the unit's
+        # fingerprint ambiguous, so a *second* `cargo bench` re-compiles the
+        # local crates from scratch (~13 min) instead of reusing the first
+        # build's output. A single invocation builds once, then runs — paying
+        # that compile only once and roughly halving the job wall-clock.
+        #
         # `--save-baseline pr` saves results so a follow-up job (or the next
         # commit) can diff against this baseline with `--baseline pr`.
         #
-        # Criterion wall-clock throughput is noisier than CodSpeed's
-        # instruction counts and isn't a PR gate (see the job comment), so we
-        # trade a little statistical fidelity for a much shorter, reliable run:
-        # a 1s warm-up + 2s measurement window with 50 samples is plenty to
-        # track coarse regressions while keeping the whole sweep (~100 benches,
-        # plus the ~14 min local rebuild noted above) well inside the budget.
+        # The pinned corpus grew this suite to ~100 benchmarks. Criterion
+        # wall-clock throughput is noisier than CodSpeed's instruction counts
+        # and isn't a PR gate (see the job comment), so trade a little
+        # statistical fidelity for a much shorter, reliable run:
+        #
+        #   --warm-up-time/--measurement-time/--sample-size — a 1s warm-up + 2s
+        #     window at the minimum sample size (10) tracks coarse regressions
+        #     while keeping the whole measurement sweep to ~7 min.
+        #   --noplot — skip per-bench HTML/SVG rendering (with no gnuplot the
+        #     in-process `plotters` backend would render plots for every one of
+        #     the ~100 benchmarks). The raw estimate JSON is still written and
+        #     uploaded, so the saved baseline is unaffected.
+        #
+        # Local `cargo bench` is unaffected — it keeps Criterion's full-accuracy
+        # defaults and renders the HTML reports.
         run: >-
           cargo bench --bench parser --bench compiler --bench formatter --
-          --save-baseline pr
-          --warm-up-time 1 --measurement-time 2 --sample-size 50
-        timeout-minutes: 40
+          --save-baseline pr --noplot
+          --warm-up-time 1 --measurement-time 2 --sample-size 10
+        # Cold-cache flake guard, not an expected duration: oxc-from-git deps
+        # (~15 min) + the one rsvelte_core compile (~13 min) + ~7 min of
+        # measurement. Warm-cache runs are far shorter (~20 min observed).
+        timeout-minutes: 45
 
       - name: Upload criterion reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Context

#1264 already fixed the `main` Benchmark timeout (introduced by #1249's larger corpus suite) by **absorbing** the workspace-crate double-compile under a bigger budget — two steps (`--no-run` build + run), job timeout 75 min, run step 40 min, `--sample-size 50`.

This PR (rebased on top of #1264) **eliminates** the double-compile instead of paying for it.

## Why there was a double-compile

`rsvelte_core` is a `cdylib`+`rlib`. Building it for its own benches alongside the `rsvelte_formatter` bench (which depends on it) triggers an *output filename collision* on `librsvelte_core.{so,rlib}`, which makes Cargo's unit fingerprint ambiguous. So a **second** `cargo bench` invocation recompiles the local crates from scratch instead of reusing the first build's output.

The CI log confirmed it: the separate `Run criterion` step spent **13 min recompiling `rsvelte_core`/`rsvelte_formatter` before the first benchmark**, on top of the `Build benchmarks` step's ~18 min.

## What

- **Collapse build + run into a single `cargo bench` invocation** → the ~13 min `rsvelte_core` compile is paid **once**, not twice. Observed job wall-clock **~38 min → ~21 min**; job ceiling back to 60 min, single step to 45 min (a cold-cache flake guard, not an expected duration).
- **`--noplot`** — no gnuplot on the runner, so Criterion's in-process `plotters` backend would render plots for all ~100 benches; the uploaded estimate JSON is unaffected.
- **`--sample-size 10`** (Criterion minimum) for this explicitly non-gating, noisy wall-clock track.
- Local `cargo bench` is unaffected — full-accuracy defaults + HTML reports.

CodSpeed is unaffected throughout: it runs each bench once under cachegrind and ignores these knobs.

## Verification

Full CI green on this branch (Criterion benchmarks step ~20 min, well under the 45-min cap). The flag combination was also run locally (`Warming up for 1.0000 s` / `Collecting 10 samples in estimated 2.00 s`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)