### PR TITLE
fix(compiler): lower legacy-reactive component bind writes through $.set (#1228)

### DIFF
--- a/.changeset/fix-1228-legacy-reactive-bind-set.md
+++ b/.changeset/fix-1228-legacy-reactive-bind-set.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): lower legacy-reactive component bind writes through `$.set`
+
+A `bind:` on a component whose target is a legacy reactive (`$:`-declared)
+variable was lowered to a plain `path = $$value` assignment instead of the
+reactive `$.set(path, $$value)`, so writes from the child component no longer
+notified subscribers (reactivity loss). The getter still read the variable via
+`$.get(path)`, producing an inconsistent get/set pair.
+
+`process_bind_directive`'s `is_state_binding` predicate only covered
+`is_state_source || Derived`, so a `LegacyReactive` identifier fell through to
+the final plain-assignment branch. `add_state_transformers` registers a `$.set`
+assign transform for exactly `is_state_source || Derived || LegacyReactive`, so
+`LegacyReactive` is now included here to match.
+
+Fixes #1228 (smelte `_layout.svelte`, svelte-calendar `DayPicker.svelte`).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1486,17 +1486,22 @@ fn process_bind_directive(
     // Check if this is a store member expression (e.g., $store.value)
     let is_store_member = is_store_member_expression(&bind.expression, context);
 
-    // Check if this is a state source or derived binding that needs $.get/$.set
-    // In the official compiler, the transform.assign for both State and Derived
-    // generates $.set(node, value), so both need the same treatment.
+    // Check if this is a state source or derived binding that needs $.get/$.set.
+    // In the official compiler, the transform.assign for state, derived AND legacy
+    // reactive (`$:`-declared) bindings all generate $.set(node, value) — this is
+    // exactly the set `add_state_transformers` registers a `$.set` assign for
+    // (is_state_source || Derived || LegacyReactive). Without LegacyReactive here,
+    // a plain `bind:x={path}` whose `path` comes from `$: path = …` falls through
+    // to a plain `path = $$value` assignment and loses reactivity (issue #1228).
     let is_state_binding = if let JsExpr::Identifier(name) = &raw_expression {
         if let Some(binding) = context.state.get_binding(name) {
+            use crate::compiler::phases::phase2_analyze::scope::BindingKind;
             crate::compiler::phases::phase3_transform::client::utils::is_state_source(
                 binding,
                 context.state.analysis,
             ) || matches!(
                 binding.kind,
-                crate::compiler::phases::phase2_analyze::scope::BindingKind::Derived
+                BindingKind::Derived | BindingKind::LegacyReactive
             )
         } else {
             false

--- a/crates/rsvelte_core/tests/component_bind_getter_setter.rs
+++ b/crates/rsvelte_core/tests/component_bind_getter_setter.rs
@@ -10,6 +10,10 @@
 use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
 fn compile_js(src: &str) -> String {
+    compile_js_with(src, Some(true))
+}
+
+fn compile_js_with(src: &str, runes: Option<bool>) -> String {
     let result = compile(
         src,
         CompileOptions {
@@ -17,7 +21,7 @@ fn compile_js(src: &str) -> String {
             generate: GenerateMode::Client,
             dev: false,
             css: CssMode::External,
-            runes: Some(true),
+            runes,
             ..Default::default()
         },
     )
@@ -44,5 +48,29 @@ fn two_getter_setter_binds_declare_unique_names() {
     assert!(
         out.contains("bind_set_1("),
         "second setter helper should be declared/called as bind_set_1, got:\n{out}"
+    );
+}
+
+/// Regression test for issue #1228: a `bind:` on a component whose target is a
+/// legacy reactive (`$:`-declared) variable must lower the setter write through
+/// `$.set(path, $$value)`, not a plain `path = $$value` assignment — otherwise
+/// the bound state loses reactivity (writes don't notify subscribers).
+#[test]
+fn legacy_reactive_component_bind_setter_uses_set() {
+    let src = r#"<script>
+  export let page;
+  $: path = page.path;
+</script>
+
+<Tabs bind:selected={path} />"#;
+    let out = compile_js_with(src, None);
+
+    assert!(
+        out.contains("$.set(path, $$value)"),
+        "setter for a legacy-reactive bind target must use $.set, got:\n{out}"
+    );
+    assert!(
+        !out.contains("path = $$value"),
+        "setter must not be a plain assignment, got:\n{out}"
     );
 }


### PR DESCRIPTION
Fixes #1228.

## Problem

A `bind:` on a component whose target is a legacy reactive (`$:`-declared) variable was lowered to a plain assignment `path = $$value` instead of the reactive `$.set(path, $$value)`. The bound state therefore lost reactivity — writes from the child component no longer notified subscribers.

```diff
  set selected($$value) {
-   path = $$value;
+   $.set(path, $$value);
  },
```

Repro: smelte `src/routes/_layout.svelte` (`$: path = $page.path` + `<Tabs bind:selected={path} />`) and svelte-calendar `DayPicker.svelte`.

## Root cause

`process_bind_directive` (client component bind codegen) has its own `is_state_binding` predicate that decides whether the getter/setter use `$.get`/`$.set`. It only covered `is_state_source || Derived`, so a `LegacyReactive` identifier (a `$:`-declared variable) fell through to the final plain-assignment branch.

Notably the **getter** still read the variable via `$.get(path)` (through the registered read transform), producing an inconsistent get-uses-`$.get` / set-uses-plain-assignment pair.

`add_state_transformers` registers a `$.set` assign transform for exactly `is_state_source || Derived || LegacyReactive`, so the bind predicate must match that set.

## Fix

Include `BindingKind::LegacyReactive` in `is_state_binding`. Since `LegacyReactive` only exists in legacy (non-runes) mode, `needs_proxy` stays `false`, yielding `$.set(path, $$value)` — byte-identical to the official compiler.

## Verification

- New regression test `legacy_reactive_component_bind_setter_uses_set` in `component_bind_getter_setter.rs`.
- Compared against the official compiler on the repro: output is now byte-identical.
- `runtime` (legacy/runes/browser/hydration), `compiler_fixtures` (snapshot), `ssr`, `validator`, `compiler_errors`, and the bind pin suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)