### PR TITLE
fix(compiler/csr): lower component bind write to legacy `$:` var via $.set

### DIFF
--- a/.changeset/fix-component-bind-legacy-reactive.md
+++ b/.changeset/fix-component-bind-legacy-reactive.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler/csr): lower a component `bind:` write to a legacy `$:` variable via `$.set`
+
+A `bind:` on a component whose target is a legacy `$:` reactive declaration was
+lowered to a plain assignment in the generated setter (`path = $$value`), dropping
+reactivity so subscribers were never notified. The `is_state_binding` predicate
+that selects the `$.get`/`$.set` accessor form omitted the `LegacyReactive`
+binding kind; adding it restores parity with upstream (whose `transform.assign`
+runs for state, `derived`, and `legacy_reactive` bindings) and with the
+element-bind path. Fixes #1228.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1486,17 +1486,21 @@ fn process_bind_directive(
     // Check if this is a store member expression (e.g., $store.value)
     let is_store_member = is_store_member_expression(&bind.expression, context);
 
-    // Check if this is a state source or derived binding that needs $.get/$.set
-    // In the official compiler, the transform.assign for both State and Derived
-    // generates $.set(node, value), so both need the same treatment.
+    // Check if this is a state source, derived, or legacy reactive binding that
+    // needs $.get/$.set. In the official compiler the component bind setter is built
+    // by visiting `expr = $$value` through the normal assignment visitor, which applies
+    // `transform.assign` — installed for state sources, `derived`, AND `legacy_reactive`
+    // bindings (`$:` reactive declarations). All three lower the write to `$.set(...)`,
+    // so missing `LegacyReactive` here silently dropped reactivity on `bind:x={reactiveVar}`.
     let is_state_binding = if let JsExpr::Identifier(name) = &raw_expression {
         if let Some(binding) = context.state.get_binding(name) {
+            use crate::compiler::phases::phase2_analyze::scope::BindingKind;
             crate::compiler::phases::phase3_transform::client::utils::is_state_source(
                 binding,
                 context.state.analysis,
             ) || matches!(
                 binding.kind,
-                crate::compiler::phases::phase2_analyze::scope::BindingKind::Derived
+                BindingKind::Derived | BindingKind::LegacyReactive
             )
         } else {
             false

--- a/crates/rsvelte_core/tests/component_bind_getter_setter.rs
+++ b/crates/rsvelte_core/tests/component_bind_getter_setter.rs
@@ -46,3 +46,47 @@ fn two_getter_setter_binds_declare_unique_names() {
         "second setter helper should be declared/called as bind_set_1, got:\n{out}"
     );
 }
+
+fn compile_js_legacy(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(false),
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+/// Issue #1228: a `bind:` on a component whose target is a legacy `$:` reactive
+/// declaration must lower the write through `$.set(...)`, not a plain assignment
+/// (which would drop reactivity). The getter already used `$.get(...)`; only the
+/// setter was emitting `path = $$value`.
+#[test]
+fn legacy_reactive_component_bind_uses_set() {
+    let src = r#"<script>
+	export let page;
+	$: path = page.path;
+</script>
+<Tabs bind:selected={path} />"#;
+    let out = compile_js_legacy(src);
+
+    assert!(
+        out.contains("$.set(path, $$value)"),
+        "legacy reactive bind setter must use $.set, got:\n{out}"
+    );
+    assert!(
+        !out.contains("path = $$value"),
+        "legacy reactive bind setter must not be a plain assignment, got:\n{out}"
+    );
+    // The getter side must stay reactive too.
+    assert!(
+        out.contains("$.get(path)"),
+        "legacy reactive bind getter must use $.get, got:\n{out}"
+    );
+}


### PR DESCRIPTION
## What

Fixes #1228 — a `bind:` on a **component** whose target is a legacy `$:` reactive declaration was lowered to a **plain assignment** in the setter, dropping reactivity.

```diff
  set selected($$value) {
-   path = $$value;       // ❌ reactivity lost — subscribers never notified
+   $.set(path, $$value); // ✅
  }
```

The getter was already correct (`$.get(path)`).

## Root cause

In `process_bind_directive` (client `shared/component.rs`), the `is_state_binding` predicate that selects the `$.get`/`$.set` accessor form matched only `is_state_source(...) || Derived` and **omitted `LegacyReactive`** (the kind given to `$:` reactive declarations like `$: path = page.path`).

Upstream builds the component-bind setter by visiting `expr = $$value` through the normal assignment visitor, which applies `transform.assign`. That transform is installed for state sources, `derived`, **and `legacy_reactive`** bindings (`add_state_transformers` gates on exactly those three) — all of which lower the write to `$.set(...)`. The getter happened to stay correct because the non-state branch falls back to the read-transformed expression (`$.get(path)`), masking the asymmetry.

The fix adds `LegacyReactive` to the predicate, restoring parity with upstream and with the element-bind path (which already routes through `apply_transforms_to_expression` and handled this correctly).

## Repro

- smelte `src/routes/_layout.svelte` — `<Tabs bind:selected={path} />` with `$: path = $page.path`
- svelte-calendar `DayPicker.svelte` — `bind:index={monthIndex}` with `$: monthIndex = …`

Both now byte-match the official compiler (CSR) via `scripts/compat-corpus/one.mjs`. Element binds and runes-mode `$state` binds were already correct and remain so.

## Tests

- New regression test `legacy_reactive_component_bind_uses_set` in `component_bind_getter_setter.rs`.
- Full `compatibility_report` (15/15) and `runtime` (19/19) suites pass — 0 failures, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)