### PR TITLE
fix(transform): wrap function-valued private $derived read in callee position (server module)

### DIFF
--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -6,7 +6,6 @@
 	"bits-ui/packages/bits-ui/src/lib/bits/scroll-area/scroll-area.svelte.ts",
 	"bits-ui/packages/bits-ui/src/lib/bits/tooltip/tooltip.svelte.ts",
 	"bits-ui/packages/bits-ui/src/lib/bits/utilities/floating-layer/use-floating-layer.svelte.ts",
-	"bits-ui/packages/bits-ui/src/lib/internal/dom-typeahead.svelte.ts",
 	"cmsaasstarter/src/routes/(marketing)/+page.svelte",
 	"cmsaasstarter/src/routes/(marketing)/blog/(posts)/+layout.svelte",
 	"flowbite-svelte/src/lib/clipboard-manager/ClipboardManager.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -5760,15 +5760,22 @@ fn transform_private_derived_accesses_server(
                 continue;
             }
 
-            let next_non_ws = after_match.chars().find(|c| !c.is_whitespace());
-            let is_already_call = next_non_ws == Some('(');
-
             let is_assignment = {
                 let trimmed_after = after_match.trim_start();
                 trimmed_after.starts_with('=') && !trimmed_after.starts_with("==")
             };
 
-            if is_already_call || is_assignment {
+            // A READ of a private `$derived` field is always rewritten to a call
+            // `this.#field()`, mirroring upstream's `MemberExpression` visitor
+            // (`b.call(member)`), EXCEPT when it is the LHS of an assignment
+            // (`this.#field = …`, lowered to a setter call elsewhere). Crucially,
+            // a following `(` does NOT mean the read is already wrapped: when the
+            // derived holds a FUNCTION (`#fn = $derived.by(() => () => …)`),
+            // user source `this.#fn(args)` calls that function, so the read still
+            // needs wrapping → `this.#fn()(args)`. (The generated getter
+            // delegations `return this.#name();` are written directly and never
+            // pass through this function, so there is no double-wrap risk.)
+            if is_assignment {
                 new_result.push_str(&search_pattern);
             } else {
                 new_result.push_str(&search_pattern);
@@ -7185,6 +7192,39 @@ mod class_field_server_tests {
         assert!(
             !out.contains("set isDisabled("),
             "private #isDisabled must not get a public setter:\n{out}"
+        );
+    }
+
+    /// A `$derived.by` private field that holds a FUNCTION is read AND called in
+    /// user source (`this.#fn(args)`). The READ must still be wrapped to a call,
+    /// yielding `this.#fn()(args)` — a following `(` does not mean the read is
+    /// already wrapped. (Regression: a previous `is_already_call` guard skipped
+    /// the wrap, emitting `this.#fn(args)`.)
+    #[test]
+    fn function_valued_derived_read_in_callee_position_is_wrapped() {
+        let input = r#"class Foo {
+  #opts;
+  #onMatch = $derived.by(() => {
+    return (node) => node.focus();
+  });
+  constructor(opts) {
+    this.#opts = opts;
+  }
+  run(item) {
+    const cur = this.#onMatch;
+    if (item) this.#onMatch(item);
+  }
+}"#;
+        let out = transform_class_fields_server(input);
+        // Bare read → call.
+        assert!(
+            out.contains("const cur = this.#onMatch();"),
+            "bare derived read must be wrapped:\n{out}"
+        );
+        // Call of a function-valued derived → wrap the read, keep the user call.
+        assert!(
+            out.contains("this.#onMatch()(item);"),
+            "function-valued derived call must wrap the read:\n{out}"
         );
     }
 


### PR DESCRIPTION
## What

In the server `.svelte.(js|ts)` module class transform,
`transform_private_derived_accesses_server` rewrites a read of a private
`$derived`/`$derived.by` field `this.#x` to a call `this.#x()` (mirroring
upstream's `MemberExpression` visitor `b.call(member)`). It skipped that wrap
when the member was immediately followed by `(` (an `is_already_call` guard).

That guard is wrong when the derived holds a **function**:

```js
#onMatch = $derived.by(() => (node) => node.focus());
// user source:
this.#onMatch(item);
// expected:
this.#onMatch()(item);   // read the derived, then call the returned function
// rsvelte emitted:
this.#onMatch(item);
```

## Why it's safe

The guard was not needed for double-wrap protection: the generated getter
delegations (`return this.#name();`) are written directly into the output and
**never pass through** this function. Only user source reaches it, and there a
following `(` always means "call the function-valued derived." Drop the
`is_already_call` branch; keep the `is_assignment` (LHS write) skip.

## Result

Corpus known-failures: **187 → 186** (bits-ui `dom-typeahead.svelte.ts`).
Verified green: byte-exact `runtime`/`ssr`/`compiler_fixtures` suites + a new
unit test; no regressions.

> Stacked on #1269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)