### PR TITLE
chore(deps): bump oxc git rev to 5762638 across all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1665,7 +1665,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "phf 0.14.0",
  "proc-macro2 1.0.106",
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1687,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1708,12 +1708,12 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 
 [[package]]
 name = "oxc_diagnostics"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1723,7 +1723,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1738,7 +1738,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter"
 version = "0.56.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_core"
 version = "0.56.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_json"
 version = "0.56.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "dragonbox_ecma",
  "oxc_allocator",
@@ -1814,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "oxc_jsdoc"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "itertools 0.15.0",
  "memchr",
@@ -1925,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1939,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=7537c582e090181244450aa4a9797c4264a84180#7537c582e090181244450aa4a9797c4264a84180"
+source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,18 +80,18 @@ type_complexity = "allow"
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -76,7 +76,7 @@ oxc_semantic = "0.137"
 oxc_resolver = "11"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/bin/fmt_benchmark_runner.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -25,9 +25,9 @@ oxc_allocator = "0.137"
 oxc_ast = "0.137"
 oxc_parser = "0.137"
 oxc_span = "0.137"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_formatter_json = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_formatter_json = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
 thiserror = "2.0"
 unicode-width = "0.2"
 

--- a/crates/rsvelte_lint_types/Cargo.toml
+++ b/crates/rsvelte_lint_types/Cargo.toml
@@ -53,18 +53,18 @@ type_complexity = "allow"
 # Mirror the root workspace's oxc unification patch so the path-dep rsvelte
 # crates build with the same oxc rev. MUST match crates/../Cargo.toml.
 [patch.crates-io]
-oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
-oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "7537c582e090181244450aa4a9797c4264a84180" }
+oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }


### PR DESCRIPTION
Renovate opened three separate digest bumps — #1185 (oxc_formatter), #1186 (oxc_formatter_core), #1188 (oxc_formatter_json) — that each move only the formatter crates while `[patch.crates-io]` stays pinned to the old rev `7537c582`. That leaves two copies of `oxc_ast`/`oxc_span`/etc. in the tree, so rsvelte's AST types fail to unify and the individual PRs can never go green.

This bumps **every** oxc git dependency (the `[patch.crates-io]` block plus the formatter crates in `rsvelte_core` / `rsvelte_fmt` / `rsvelte_formatter` / `rsvelte_lint_types`) to a single rev `5762638` so all `oxc_*` unify again.

`cargo build --workspace` and `cargo clippy --workspace --all-targets --all-features` both pass locally.

Supersedes #1185, #1186, #1188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)