### PR TITLE
fix(transform): new-callee parens + title defined-check (87→86)

### DIFF
--- a/.changeset/fix-round9-newexpr-title.md
+++ b/.changeset/fix-round9-newexpr-title.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): parenthesize `new` callees with a call in their spine + multi-node title defined-check
+
+- esrap now wraps a `new` callee in parens when its member-object spine contains a
+  CallExpression (`new ($.get(deckgl).MapboxOverlay)(…)`) or it is a
+  ChainExpression — porting esrap's `has_call_expression` clause so the trailing
+  `(…)` is not mis-parsed as the constructor arguments.
+- A multi-node `<title>` interpolation uses the canonical `is_expression_defined`
+  check, so a conditional with two string branches (`{name ? \`…\` : ""}`) no longer
+  gets a spurious `?? ""` coercion.

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -58,7 +58,6 @@
 	"svelte-maplibre/src/lib/DeckGlLayer.svelte",
 	"svelte-pivottable/src/lib/UI/Draggable.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
-	"svelte-splitpanes/src/routes/+layout.svelte",
 	"svelte-table/example/Example2.svelte",
 	"svelte-table/example/example6/ContactButtonComponent.svelte",
 	"svelte-table/src/SvelteTable.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/title_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/title_element.rs
@@ -11,7 +11,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::expression_conv
 use crate::compiler::phases::phase3_transform::client::visitors::fragment::collect_ids_from_expr;
 use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::{
     apply_transforms_to_expression, expression_has_await, expression_has_reactive_state,
-    get_literal_value,
+    get_literal_value, is_expression_defined,
 };
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
@@ -378,12 +378,12 @@ fn build_title_content(
                         is_async: has_await,
                     });
                     let param_ref = b::id(&param_name);
-                    if !is_known_defined_expr(&expr.expression) {
+                    if !is_expression_defined(&expr.expression, context) {
                         expressions.push(b::nullish(&context.arena, param_ref, b::string("")));
                     } else {
                         expressions.push(param_ref);
                     }
-                } else if !is_known_defined_expr(&expr.expression) {
+                } else if !is_expression_defined(&expr.expression, context) {
                     expressions.push(b::nullish(&context.arena, value, b::string("")));
                 } else {
                     expressions.push(value);

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -174,6 +174,22 @@ fn unparen<'a, 'b>(mut expr: &'a Expression<'b>) -> &'a Expression<'b> {
     expr
 }
 
+/// Faithful port of esrap's `has_call_expression`: walk a callee's member-object
+/// spine and report whether any link is a CallExpression. Used to decide whether
+/// a `new` callee needs wrapping parens.
+fn callee_has_call_expression(expr: &Expression) -> bool {
+    let mut node = unparen(expr);
+    loop {
+        match node {
+            Expression::CallExpression(_) => return true,
+            Expression::StaticMemberExpression(m) => node = unparen(&m.object),
+            Expression::ComputedMemberExpression(m) => node = unparen(&m.object),
+            Expression::PrivateFieldExpression(m) => node = unparen(&m.object),
+            _ => return false,
+        }
+    }
+}
+
 /// esrap's `EXPRESSIONS_PRECEDENCE`, keyed by oxc `Expression` kind. Higher
 /// binds tighter; a child is parenthesised when its precedence is lower than the
 /// position requires.
@@ -2173,7 +2189,21 @@ impl<'opt> Printer<'opt> {
             }
             Expression::NewExpression(n) => {
                 ctx.write("new ");
-                self.child_with_parens(&n.callee, 19, ctx);
+                // `new` binds tighter than a call, so a callee whose member-spine
+                // contains a CallExpression (`$.get(x).Member`) — or a
+                // ChainExpression — must be parenthesized, else `new a().b(c)`
+                // would parse the trailing `(c)` as the `new` arguments. Mirrors
+                // esrap's `has_call_expression` clause.
+                let callee = unparen(&n.callee);
+                if matches!(callee, Expression::ChainExpression(_))
+                    || callee_has_call_expression(callee)
+                {
+                    ctx.write("(");
+                    self.print_expression(&n.callee, ctx);
+                    ctx.write(")");
+                } else {
+                    self.child_with_parens(&n.callee, 19, ctx);
+                }
                 self.call_arguments(&n.arguments, n.span().end, ctx);
             }
             Expression::UpdateExpression(u) => {


### PR DESCRIPTION
Two correctness fixes. Byte-exact `runtime`/`ssr`/`compiler_fixtures` + esrap golden green; clippy clean; **no regressions**.

1. **`new` callee parenthesization** — esrap now wraps a `new` callee in parens when its member-object spine contains a `CallExpression` (`new ($.get(deckgl).MapboxOverlay)(…)`) or it is a `ChainExpression`, porting esrap's `has_call_expression` clause. Without the parens, `new a().b(c)` mis-parses the trailing `(c)` as the constructor arguments. (svelte-maplibre DeckGlLayer — correctness; entry has further diffs)
2. **Multi-node `<title>` defined-check** — uses the canonical `is_expression_defined`, so a conditional interpolation with two string branches (`{name ? \`${name} |\` : ""}`) no longer gets a spurious `?? ""`. (smelte `_layout`)

Two other diagnosed fixes were **dropped** for regressing: the server `$state` store-rune narrow guard (still hit `inspect-derived-2` — the `$state` StoreSub binding exists there too), and the `let`-binding `?? ""` defined-check broadening (regressed 2 `props-default` entries — the template `?? ""` defined-check is genuinely unsafe to broaden via binding kind).

## Result
Corpus known-failures: **87 → 86** (1 entry). No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)