### PR TITLE
style: fmt state_transforms.rs after dead-code removal

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -16,7 +16,6 @@ use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
 // Identifier reference detection (lines 7653-8602 of mod.rs)
 // ---------------------------------------------------------------------------
 
-
 /// Check if a body references an identifier as a read (not only as an assignment target).
 ///
 /// This is used to determine dependencies for `$.legacy_pre_effect()` calls.


### PR DESCRIPTION
One-line `cargo fmt` fixup for the dead-code removal in #1290 (the text-membership helpers were deleted via script, leaving a stray blank line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)