### PR TITLE
fix(transform): preserve import/export lines inside template literals (59→56)

### DIFF
--- a/.changeset/fix-corpus-import-in-template-literal.md
+++ b/.changeset/fix-corpus-import-in-template-literal.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): don't drop `import`/`export` lines inside multi-line template literals
+
+The legacy text-based instance-script transform walks the script line by line,
+skipping lines that begin with `import `, `export { … }`, or a `$props.id()`
+declaration (they are hoisted / handled elsewhere). That skip fired
+unconditionally — even when the line actually lived *inside* a multi-line
+template literal being accumulated, e.g. a code-sample string:
+
+```js
+const code = `<script>
+  import { LayerCake, Svg } from 'layercake';
+</script>`;
+```
+
+The `import …` line was silently dropped from the emitted template literal,
+corrupting the string. (The line-by-line `$`-token heuristic routed these
+scripts into the text transform because `${…}` interpolations contain `$`.)
+
+Gate the three statement-boundary skips on `accumulated_lines.is_empty()`, which
+is true only at a clean statement boundary (the accumulator is cleared on
+completion), so lines inside a mid-statement template literal are preserved
+verbatim. Shrinks `compat/corpus/known-failures.json` by 3 entries (59 → 56),
+including the large `flowbite-svelte/.../builder/badge/+page.svelte` divergence.

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -7,10 +7,8 @@
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/products/+page.svelte",
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/users/+page.svelte",
 	"flowbite-svelte/src/routes/blocks/+page.svelte",
-	"flowbite-svelte/src/routes/builder/badge/+page.svelte",
 	"flowbite-svelte/src/routes/docs-examples/forms/file-input/Dropzone.svelte",
 	"layercake/src/lib/LayerCake.svelte",
-	"layercake/src/routes/+page.svelte",
 	"layerchart/packages/layerchart/src/lib/components/Area.svelte",
 	"layerchart/packages/layerchart/src/lib/components/BrushContext.svelte",
 	"layerchart/packages/layerchart/src/lib/components/ChartContext.svelte",
@@ -55,7 +53,6 @@
 	"svelte-ux/packages/svelte-ux/src/lib/components/Tooltip.svelte",
 	"svelte/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/input.svelte",
 	"sveltestrap/src/Input/Input.svelte",
-	"sveltestrap/src/Nav/Nav.stories.svelte",
 	"svelthree/src/lib/components/Object3D.svelte",
 	"svelthree/src/lib/components/WebGLRenderer.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5275,14 +5275,24 @@ fn transform_instance_script_for_visitors(
             continue;
         }
 
+        // The statement-boundary skips below (imports, export specifiers,
+        // `$props.id()` declarations) may only fire when we are NOT in the
+        // middle of accumulating a multi-line statement. Otherwise a line that
+        // merely *looks* like `import …` / `export { … }` while it actually
+        // lives inside a multi-line template literal (e.g. a code-sample string
+        // `const code = \`<script>import … from '…';</script>\``) would be
+        // dropped mid-string. `accumulated_lines.is_empty()` is true only at a
+        // clean statement boundary (the accumulator is cleared on completion).
+        let at_statement_boundary = accumulated_lines.is_empty();
+
         // Skip import statements (already extracted)
-        if trimmed.starts_with("import ") {
+        if at_statement_boundary && trimmed.starts_with("import ") {
             line_idx += 1;
             continue;
         }
 
         // Skip export { ... } statements (will be handled via $$exports object)
-        if starts_export_specifier(trimmed) {
+        if at_statement_boundary && starts_export_specifier(trimmed) {
             in_export_block = !trimmed.contains('}');
             line_idx += 1;
             continue;
@@ -5300,9 +5310,10 @@ fn transform_instance_script_for_visitors(
         // `$props.id()` / `$.props_id()` (whitespace-tolerant) rather than the
         // literal `= $props.id()` substring, so `let id=$props.id()` (no spaces)
         // is also skipped instead of surviving alongside the generated const. H-060.
-        if (trimmed.starts_with("let ")
-            || trimmed.starts_with("const ")
-            || trimmed.starts_with("var "))
+        if at_statement_boundary
+            && (trimmed.starts_with("let ")
+                || trimmed.starts_with("const ")
+                || trimmed.starts_with("var "))
             && trimmed
                 .find('=')
                 .map(|eq| trimmed[eq + 1..].trim().trim_end_matches(';').trim())


### PR DESCRIPTION
## What

The legacy text-based instance-script transform walks the instance `<script>` line by line, skipping lines that begin with `import `, `export { … }`, or a `$props.id()` declaration (they are hoisted / handled elsewhere). That skip fired **unconditionally** — even when the line actually lived *inside a multi-line template literal* being accumulated, e.g. a code-sample string:

```js
const code = `<script>
  import { LayerCake, Svg } from 'layercake';
</script>`;
```

The `import …` line was silently dropped from the emitted template literal, corrupting the string. (Scripts with `${…}` interpolations get routed into the text transform because the `$`-token heuristic sees the `$`.)

## Fix

Gate the three statement-boundary skips on `accumulated_lines.is_empty()`, which is true only at a clean statement boundary (the accumulator is cleared on statement completion). Lines inside a mid-statement template literal are now preserved verbatim.

## Impact

`compat/corpus/known-failures.json`: **59 → 56** (3 entries cleared), including the large `flowbite-svelte/.../builder/badge/+page.svelte` (829-line) divergence, plus `layercake/src/routes/+page.svelte` and `sveltestrap/src/Nav/Nav.stories.svelte`.

## Verification

- `compile.mjs` + `verify.mjs`: 3 known failures now pass, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings
- `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5