### PR TITLE
fix(transform): ignore comments when splitting $props() declarators (56→54)

### DIFF
--- a/.changeset/fix-corpus-comment-in-props-destructure.md
+++ b/.changeset/fix-corpus-comment-in-props-destructure.md
@@ -1,0 +1,29 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): ignore comments when splitting `$props()` destructuring declarators
+
+`split_declarators` (used to parse the names in a `let { … } = $props()`
+destructuring for the `$.rest_props(…)` exclusion list) split on every top-level
+comma, including commas inside `//` and `/* … */` comments. A comment such as
+
+```js
+let {
+  class: className,
+  // we add name, color, and stroke for compatibility with different icon libraries props
+  name,
+  ...restProps
+} = $props();
+```
+
+was split on its internal commas, so the comment fragments leaked into the
+emitted `new Set([…])` exclusion list as bogus prop names — producing an
+unterminated-string / invalid-JS output. The same shape with a trailing
+`// comment, with commas` after a real prop corrupted the following names.
+
+Make `split_declarators` comment-aware (skip `//` to end-of-line and `/* … */`,
+respecting string literals and not self-closing a `/*/`). The comment text stays
+with the declarator and is stripped per-declarator by the existing caller logic.
+Clears `flowbite-svelte/.../ClipboardManager.svelte` and
+`shadcn-svelte/.../spinner/spinner.svelte` from the corpus baseline (56 → 54).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -1,7 +1,6 @@
 [
 	"attractions/attractions/date-picker/date-picker.svelte",
 	"attractions/attractions/slider/slider.svelte",
-	"flowbite-svelte/src/lib/clipboard-manager/ClipboardManager.svelte",
 	"flowbite-svelte/src/lib/datepicker/Datepicker.svelte",
 	"flowbite-svelte/src/routes/+page.svelte",
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/products/+page.svelte",
@@ -27,7 +26,6 @@
 	"powertable/app/src/lib/components/PowerTable.svelte",
 	"shadcn-svelte/docs/src/lib/components/mobile-nav.svelte",
 	"shadcn-svelte/docs/src/lib/registry/examples/create/vercel/circular-gauge.svelte",
-	"shadcn-svelte/docs/src/lib/registry/ui/spinner/spinner.svelte",
 	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",
 	"smelte/src/routes/components/_layout.svelte",
 	"svar-core/svelte/src/components/calendar/Month.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -2106,8 +2106,31 @@ pub(super) fn split_declarators(s: &str) -> Vec<&str> {
     // declarator anyway.
     let mut string_char: Option<char> = None;
     let mut escaped = false;
+    // Track comment state so commas inside `// …` / `/* … */` comments — which
+    // can legitimately appear between prop names in a `$props()` destructuring,
+    // e.g. `// we add name, color, and stroke …` — are not treated as
+    // declarator separators. The comment text itself stays inside the declarator
+    // and is stripped per-declarator by the caller.
+    let mut in_line_comment = false;
+    // Byte index just past the `/*` opener, or `usize::MAX` when not in a block
+    // comment. The close `*/` must occur at or after this index so a `/*/` does
+    // not self-close on the opener's own `*`.
+    let mut block_comment_body_start = usize::MAX;
+    let bytes = s.as_bytes();
 
     for (i, c) in s.char_indices() {
+        if in_line_comment {
+            if c == '\n' {
+                in_line_comment = false;
+            }
+            continue;
+        }
+        if block_comment_body_start != usize::MAX {
+            if c == '/' && i >= block_comment_body_start && i > 0 && bytes[i - 1] == b'*' {
+                block_comment_body_start = usize::MAX;
+            }
+            continue;
+        }
         if let Some(quote) = string_char {
             if escaped {
                 escaped = false;
@@ -2116,6 +2139,15 @@ pub(super) fn split_declarators(s: &str) -> Vec<&str> {
             } else if c == quote {
                 string_char = None;
             }
+            continue;
+        }
+        // Comment start (only outside strings). Peek the next byte.
+        if c == '/' && bytes.get(i + 1) == Some(&b'/') {
+            in_line_comment = true;
+            continue;
+        }
+        if c == '/' && bytes.get(i + 1) == Some(&b'*') {
+            block_comment_body_start = i + 3;
             continue;
         }
         match c {
@@ -3418,6 +3450,40 @@ mod split_declarators_tests {
         assert_eq!(
             split_declarators("a = `x,${y},z`, b"),
             vec!["a = `x,${y},z`", " b"]
+        );
+    }
+
+    #[test]
+    fn ignores_commas_inside_comments() {
+        // A `//` comment between prop names can contain commas; they must not
+        // split the declarator list (the comment travels with the next name and
+        // is stripped per-declarator by the caller).
+        assert_eq!(
+            split_declarators("a,\n// we add b, c, and d for compat\nb, c"),
+            vec!["a", "\n// we add b, c, and d for compat\nb", " c"]
+        );
+        // Trailing line comment after a comma (commas inside it preserved).
+        assert_eq!(
+            split_declarators("open = void 0, // If undefined, renders inline; else modal\nclose"),
+            vec![
+                "open = void 0",
+                " // If undefined, renders inline; else modal\nclose"
+            ]
+        );
+        // Block comment with commas.
+        assert_eq!(
+            split_declarators("a /* x, y, z */, b"),
+            vec!["a /* x, y, z */", " b"]
+        );
+        // `/*/` must not self-close on the opener's own star.
+        assert_eq!(
+            split_declarators("a = b /*/, c */ , d"),
+            vec!["a = b /*/, c */ ", " d"]
+        );
+        // `//` inside a string is still a string, not a comment.
+        assert_eq!(
+            split_declarators(r#"a = "http://x,y", b"#),
+            vec![r#"a = "http://x,y""#, " b"]
         );
     }
 


### PR DESCRIPTION
## What

`split_declarators` parses the prop names in a `let { … } = $props()` destructuring to build the `$.rest_props(…)` exclusion list. It split on **every** top-level comma — including commas inside `//` and `/* … */` comments:

```js
let {
  class: className,
  // we add name, color, and stroke for compatibility with different icon libraries props
  name,
  ...restProps
} = $props();
```

The comment was split on its internal commas, leaking fragments into the emitted `new Set([…])` exclusion list as bogus prop names — producing **invalid JS** (unterminated string). A trailing `// comment, with commas` after a real prop corrupted the following names the same way.

## Fix

Make `split_declarators` comment-aware: skip `//` to end-of-line and `/* … */` block comments, respecting string literals, and don't let a `/*/` self-close on the opener's own `*`. The comment text travels with the declarator and is stripped per-declarator by the existing caller logic.

## Impact

`compat/corpus/known-failures.json`: **56 → 54** — clears `flowbite-svelte/.../ClipboardManager.svelte` and `shadcn-svelte/.../spinner/spinner.svelte`.

> Stacked on #1298 (base = `fix/corpus-import-in-template-literal`); retarget to `main` once #1298 merges.

## Verification

- New `split_declarators` unit test (comments with commas, block comments, `/*/`, `//` in strings)
- `compile.mjs` + `verify.mjs`: 2 known failures now pass, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5