### PR TITLE
fix(transform): strip comments when collapsing multi-line imports (54→53)

### DIFF
--- a/.changeset/fix-corpus-comment-in-import-specifiers.md
+++ b/.changeset/fix-corpus-comment-in-import-specifiers.md
@@ -1,0 +1,22 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): strip comments when collapsing multi-line import specifiers
+
+`cleanup_import_line` joins a hoisted multi-line `import { … }` onto a single
+line with spaces. A `//` comment between specifiers —
+
+```js
+import {
+  AppBar, AppLayout, Button, ThemeSelect,
+  // ThemeSwitch,
+  Tooltip, settings
+} from 'svelte-ux';
+```
+
+— was folded inline, commenting out the rest of the statement (including
+`} from '…'`) and producing invalid JS. Strip `//` and `/* … */` comments (via
+`strip_js_comments`, which respects the module-specifier string) before the
+line-join, mirroring esrap which drops these comments. Clears
+`layerchart/.../routes/+layout.svelte` from the corpus baseline (54 → 53).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -20,7 +20,6 @@
 	"layerchart/packages/layerchart/src/lib/components/layout/Canvas.svelte",
 	"layerchart/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte",
 	"layerchart/packages/layerchart/src/lib/docs/TilesetField.svelte",
-	"layerchart/packages/layerchart/src/routes/+layout.svelte",
 	"layerchart/packages/layerchart/src/routes/docs/examples/Area/+page.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"powertable/app/src/lib/components/PowerTable.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2779,6 +2779,13 @@ fn starts_export_specifier(trimmed: &str) -> bool {
 /// type-only specifier removal. Normalizes `import { A,  , C,  } from 'x'` to
 /// `import { A, C } from 'x'`.
 fn cleanup_import_line(import: &str) -> String {
+    // Strip comments first. A multi-line `import { … }` may carry `//` / `/* */`
+    // comments between specifiers (e.g. `ThemeSelect,\n// ThemeSwitch,\nTooltip`);
+    // collapsing the import onto one line below would otherwise fold a `//`
+    // comment inline and comment out the rest of the statement (including
+    // `} from '…'`), emitting invalid JS. esrap drops these comments — mirror
+    // that. String literals (the module specifier) are respected.
+    let import = props_transforms::strip_js_comments(import);
     // Normalize whitespace (join multi-line imports into a single line)
     let single_line = import
         .lines()


### PR DESCRIPTION
## What

`cleanup_import_line` joins a hoisted multi-line `import { … }` onto a single line with spaces. A `//` comment between specifiers:

```js
import {
  AppBar, AppLayout, Button, ThemeSelect,
  // ThemeSwitch,
  Tooltip, settings
} from 'svelte-ux';
```

was folded inline, commenting out the rest of the statement (`Tooltip, settings } from 'svelte-ux';`) — producing **invalid JS**.

## Fix

Strip `//` and `/* … */` comments (via the existing `strip_js_comments`, which respects the module-specifier string) before the line-join. esrap drops these comments; this mirrors that.

## Impact

`compat/corpus/known-failures.json`: **54 → 53** — clears `layerchart/.../routes/+layout.svelte`.

> Stacked on #1299 → #1298. Retarget to `main` once the parents merge.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5