### PR TITLE
fix(transform): treat a line ending in `?` as continuation (53→52)

### DIFF
--- a/.changeset/fix-corpus-ternary-continuation.md
+++ b/.changeset/fix-corpus-ternary-continuation.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): treat a line ending in `?` as a statement continuation
+
+The text-based instance-script accumulator decides a multi-line statement is
+complete when a line looks balanced and isn't followed by an obvious
+continuation. A line ending in a bare ternary `?` was not recognised as a
+continuation, so a legacy `$:` (or `$derived`) assignment whose `?` and
+consequent were separated by a `// comment` —
+
+```js
+$: isSelectedStart =
+  selected instanceof Object
+    ? // @ts-expect-error
+      isSame(date, selected.from ?? selected.to)
+    : false;
+```
+
+— was split after the (comment-stripped) `?` line, orphaning
+`isSame(…) : false;` as bogus top-level statements and emitting invalid JS.
+
+Add `?` to the trailing-operator continuation set (a superset of the existing
+`??` case). Valid JS never ends a statement with a bare `?`, so this only
+rescues the dangling-ternary case. Clears
+`svelte-ux/.../components/DateButton.svelte` from the corpus baseline (53 → 52).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -41,7 +41,6 @@
 	"svelte-table/src/SvelteTable.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/DateButton.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/DateRange.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Duration.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5377,7 +5377,16 @@ fn transform_instance_script_for_visitors(
                     && !t.ends_with("=>"))
                     || t.ends_with("&&")
                     || t.ends_with("||")
-                    || t.ends_with("??")
+                    // Ternary `?` (and nullish `??`, a superset) continuation:
+                    // a line ending with a bare `?` is always a dangling ternary
+                    // operator whose consequent follows on the next line. This
+                    // happens when a `// comment` between `?` and the consequent
+                    // is stripped (legacy mode), e.g.
+                    //   ? // @ts-expect-error
+                    //     isSame(date, selected.from ?? selected.to)
+                    // becomes a line ending in `?`. Valid JS never ends a
+                    // statement with a bare `?`, so this is safe.
+                    || t.ends_with('?')
                     // Binary `+` continuation: line ends with `+ ` (i.e., `+` not as part of `++`)
                     || (t.ends_with('+') && !t.ends_with("++"))
             };


### PR DESCRIPTION
## What

The text-based instance-script accumulator decides a multi-line statement is complete when a line looks balanced and isn't followed by an obvious continuation. A line ending in a bare ternary `?` wasn't recognised, so a legacy `$:` assignment whose `?` and consequent were separated by a `// comment`:

```js
$: isSelectedStart =
  selected instanceof Object
    ? // @ts-expect-error
      isSame(date, selected.from ?? selected.to)
    : false;
```

was split after the (comment-stripped) `?` line — orphaning `isSame(…) : false;` as bogus top-level statements and emitting **invalid JS**.

## Fix

Add `?` to the trailing-operator continuation set (a superset of the existing `??`). Valid JS never ends a statement with a bare `?`, so this only rescues the dangling-ternary case.

## Impact

`compat/corpus/known-failures.json`: **53 → 52** — clears `svelte-ux/.../components/DateButton.svelte`.

> Stacked on #1300 → #1299 → (#1298 merged). Retarget to `main` as parents merge.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5