### PR TITLE
fix(transform): ignore trailing line comments in continuation check (52→51)

### DIFF
--- a/.changeset/fix-corpus-trailing-comment-operator.md
+++ b/.changeset/fix-corpus-trailing-comment-operator.md
@@ -1,0 +1,23 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): don't treat a trailing line comment's text as a continuation operator
+
+The text-based instance-script statement accumulator decides whether a statement
+continues onto the next line by inspecting the last line's trailing character.
+It ran this check on the raw line *including* a trailing `//` comment, so a
+declaration whose comment happened to end in an operator-looking character —
+
+```js
+export let screenWidth = 768; // md+
+export let menuProps = undefined;
+```
+
+(the comment ends in `+`) was misread as a dangling binary `+`, merging the next
+`export let` into the same statement and emitting invalid JS. Comments are only
+pre-stripped here when the legacy script carries a `$`-token, so this path must
+be comment-robust on its own. Strip a trailing line comment (respecting string
+literals) before the trailing-operator / trailing-comma checks. Clears
+`svelte-ux/.../components/ResponsiveMenu.svelte` from the corpus baseline
+(52 → 51).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -44,7 +44,6 @@
 	"svelte-ux/packages/svelte-ux/src/lib/components/DateRange.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Duration.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/ResponsiveMenu.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/SelectField.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Tooltip.svelte",
 	"svelte/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/input.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5360,6 +5360,16 @@ fn transform_instance_script_for_visitors(
                 || first_trimmed_line.starts_with("var ");
             // The current line (trimmed) is always the last accumulated line,
             // so checking its trailing char is equivalent to checking the full text's trailing char.
+            // Strip a trailing line comment first: its text can end in an
+            // operator-looking char (e.g. `export let w = 768; // md+` ends in
+            // `+`), which would otherwise be misread as a continuation operator
+            // and merge the next statement. Comments are not always stripped
+            // upstream (only when the legacy script carries a `$`-token), so this
+            // path must be comment-robust on its own. Strings are respected.
+            let trimmed = match props_transforms::find_line_comment_position(trimmed) {
+                Some(pos) => trimmed[..pos].trim_end(),
+                None => trimmed,
+            };
             let trailing_comma = is_var_decl && trimmed.ends_with(',');
 
             // Check if the current trimmed line ends with a binary/assignment operator,


### PR DESCRIPTION
## What

The text-based instance-script statement accumulator decides whether a statement continues onto the next line by inspecting the last line's trailing character. It ran this on the raw line *including* a trailing `//` comment, so a declaration whose comment ended in an operator-looking character:

```js
export let screenWidth = 768; // md+
export let menuProps = undefined;
```

(comment ends in `+`) was misread as a dangling binary `+` — merging the next `export let` into the same statement and emitting **invalid JS**.

## Fix

Strip a trailing line comment (via `find_line_comment_position`, respecting string literals) before the trailing-operator / trailing-comma checks. Comments are only pre-stripped on this path when the legacy script carries a `$`-token, so it must be comment-robust on its own.

## Impact

`compat/corpus/known-failures.json`: **52 → 51** — clears `svelte-ux/.../components/ResponsiveMenu.svelte`.

> Stacked on #1302 → #1300 → #1299 → (#1298 merged). Retarget to `main` as parents merge.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5