### PR TITLE
fix(transform): don't rewrite $store reads inside string literals (51→50)

### DIFF
--- a/.changeset/fix-corpus-store-read-in-string.md
+++ b/.changeset/fix-corpus-store-read-in-string.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): don't rewrite a `$store` reference inside a string literal
+
+`transform_store_reads_client` appends `()` to legacy store-subscription reads
+(`$store` → `$store()`). Its guard against rewriting inside a string only checked
+whether the *immediately preceding* character was a quote, so it caught
+`'$store'` but not a store name appearing mid-string, e.g. a log message:
+
+```js
+foo("[TODO] -> if ($canvas_dim) :", { w: $canvas_dim.w });
+```
+
+The `$canvas_dim` inside the string was rewritten to `$canvas_dim()`, changing
+the string's content. Replace the preceding-char heuristic with
+`is_inside_string_literal`, which scans from the start tracking string and
+template `${ }` state (a `$store` inside a `${ }` interpolation is code and is
+still rewritten). Clears `svelthree/.../WebGLRenderer.svelte` from the corpus
+baseline (51 → 50).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -48,6 +48,5 @@
 	"svelte-ux/packages/svelte-ux/src/lib/components/Tooltip.svelte",
 	"svelte/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/input.svelte",
 	"sveltestrap/src/Input/Input.svelte",
-	"svelthree/src/lib/components/Object3D.svelte",
-	"svelthree/src/lib/components/WebGLRenderer.svelte"
+	"svelthree/src/lib/components/Object3D.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -372,11 +372,12 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
 
         while i < chars.len() {
             // Check if we're at the start of the identifier
-            let remaining = &result[result
+            let byte_i = result
                 .char_indices()
                 .nth(i)
                 .map(|(idx, _)| idx)
-                .unwrap_or(i)..];
+                .unwrap_or(i);
+            let remaining = &result[byte_i..];
             if remaining.starts_with(store_sub) {
                 // Check character before (must be non-identifier char or start of string)
                 // Also exclude `.` - a dot before means this is a property access like `obj.$value`.
@@ -448,13 +449,14 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
                     }
                 };
 
-                // Check if this is inside a string literal (e.g., '$foo' in $.store_unsub(..., '$foo', ...))
-                let is_inside_string = if i > 0 {
-                    let prev_char = chars[i - 1];
-                    prev_char == '\'' || prev_char == '"'
-                } else {
-                    false
-                };
+                // Check if this is inside a string literal. A store-sub name can
+                // appear mid-string (a log/message argument like
+                // `"… if ($canvas_dim) :"`), not only right after the opening
+                // quote, so scan from the start tracking string + template `${}`
+                // state rather than only inspecting the preceding char. A `$x`
+                // inside a `${ }` interpolation is code and is still transformed.
+                let is_inside_string =
+                    super::state_transforms::is_inside_string_literal(&result, byte_i);
 
                 if before_ok && after_ok {
                     if is_inside_string {


### PR DESCRIPTION
## What

`transform_store_reads_client` appends `()` to legacy store-subscription reads (`$store` → `$store()`). Its guard against rewriting inside a string only checked whether the **immediately preceding** character was a quote, so it caught `'$store'` but not a store name appearing mid-string, e.g. a log message:

```js
foo("[TODO] -> if ($canvas_dim) :", { w: $canvas_dim.w });
```

The `$canvas_dim` inside the string was rewritten to `$canvas_dim()`, corrupting the string content.

## Fix

Replace the preceding-char heuristic with `is_inside_string_literal`, which scans from the start tracking string + template `${ }` state. A `$store` inside a `${ }` interpolation is code and is still rewritten.

## Impact

`compat/corpus/known-failures.json`: **51 → 50** — clears `svelthree/.../WebGLRenderer.svelte`.

> Stacked on #1303 → #1302 → (#1298/#1299/#1300 merged). Retarget to `main` as parents merge.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5