### PR TITLE
fix(transform): invalidate_inner_signals for legacy prop member mutations (50→49)

### DIFF
--- a/.changeset/fix-corpus-invalidate-inner-signals.md
+++ b/.changeset/fix-corpus-invalidate-inner-signals.md
@@ -1,0 +1,25 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): emit `$.invalidate_inner_signals` for legacy prop member mutations
+
+A legacy `<select bind:value={prop.x}>` whose subtree references other variables
+(`<option>` content, the select's own `id`, etc.) records those on the bound
+prop's `legacy_indirect_bindings`; the official compiler wraps every mutation of
+that prop in `(prop(...), $.invalidate_inner_signals(() => { …reads }))` so the
+referenced signals re-read. rsvelte only did this for `bind:` setters, not for
+ordinary prop member mutations (e.g. `field.tooltipAttributes = {}` in `onMount`).
+
+Two fixes:
+- Phase 3: the legacy prop-member-mutation rewrite (`prop_member_mutate_ast`) now
+  wraps the mutation in the `$.invalidate_inner_signals` sequence when the prop
+  carries indirect bindings, using each binding's read form (prop → `name()`,
+  store sub → `name()`, reactive state/derived → `$.get(name)`, else bare).
+- Phase 2: `legacy_indirect_bindings` collection is narrowed to identifiers
+  referenced *within the `<select>` element's own source span* (ordered by source
+  position), mirroring the official `scope.references` iteration. Previously it
+  pulled in every template-referenced binding in the component, so an `id` used on
+  an unrelated sibling element leaked into the invalidation list.
+
+Clears `svelte-form-builder/.../PropertyPanelTooltip.svelte` (50 → 49).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -32,7 +32,6 @@
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelDataAttributes.svelte",
-	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelTooltip.svelte",
 	"svelte-form-builder/src/lib/FormBuilder.svelte",
 	"svelte-maplibre/src/lib/DeckGlLayer.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -1255,7 +1255,15 @@ pub fn visit(
                         // We collect indirect_names first (read-only access to declarations
                         // and bindings), then mutate the target binding separately to avoid
                         // cloning the entire declarations HashMap.
-                        let mut indirect_names: Vec<String> = Vec::new();
+                        // Collect only bindings referenced WITHIN this `<select>`
+                        // element's own source span (its attributes + descendant
+                        // options), mirroring the official compiler which iterates
+                        // the select's scope references — NOT every template
+                        // reference in the component (which would wrongly pull in
+                        // unrelated ids used on sibling elements). Order by the
+                        // first in-span reference position so the emitted
+                        // `$.invalidate_inner_signals` body matches source order.
+                        let mut indirect_with_pos: Vec<(u32, String)> = Vec::new();
                         {
                             let scope_declarations =
                                 if context.analysis.root.all_scopes.len() > scope_idx {
@@ -1270,17 +1278,24 @@ pub fn visit(
                                 }
                                 if let Some(other_binding) =
                                     context.analysis.root.bindings.get(other_idx)
-                                {
-                                    let has_template_ref = other_binding
+                                    && let Some(min_pos) = other_binding
                                         .references
                                         .iter()
-                                        .any(|r| r.is_template_reference);
-                                    if has_template_ref {
-                                        indirect_names.push(name.clone());
-                                    }
+                                        .filter(|r| {
+                                            r.is_template_reference
+                                                && r.start >= element.start
+                                                && r.end <= element.end
+                                        })
+                                        .map(|r| r.start)
+                                        .min()
+                                {
+                                    indirect_with_pos.push((min_pos, name.clone()));
                                 }
                             }
                         }
+                        indirect_with_pos.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+                        let indirect_names: Vec<String> =
+                            indirect_with_pos.into_iter().map(|(_, n)| n).collect();
 
                         let binding = &mut context.analysis.root.bindings[binding_idx];
                         for name in indirect_names {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -4388,6 +4388,61 @@ fn transform_instance_script_for_visitors(
         .map(|b| b.name.clone())
         .collect();
 
+    // For each prop binding that carries `legacy_indirect_bindings` (legacy
+    // `<select bind:value={prop…}>` whose subtree references other variables),
+    // precompute the `$.invalidate_inner_signals(() => { … })` body — the read
+    // form of each indirect binding, one statement per line. This lets the
+    // legacy prop-member-mutation transform wrap `prop(prop().x = v, true)` in a
+    // sequence so those signals re-read, mirroring AssignmentExpression.js. Only
+    // ever non-empty in legacy mode. The read form mirrors `build_getter`:
+    // prop source → `name()`, store sub → `name()`, reactive state/derived →
+    // `$.get(name)`, everything else → bare `name`.
+    let prop_invalidate_bodies: rustc_hash::FxHashMap<String, String> = {
+        use crate::compiler::phases::phase2_analyze::scope::BindingKind as BK;
+        let read_form = |n: &str| -> String {
+            match analysis
+                .root
+                .find_binding_any_scope(n)
+                .and_then(|i| analysis.root.bindings.get(i))
+            {
+                Some(b)
+                    if matches!(b.kind, BK::Prop | BK::BindableProp)
+                        && utils::is_prop_source(b, analysis) =>
+                {
+                    format!("{}()", n)
+                }
+                Some(b) if matches!(b.kind, BK::StoreSub) => format!("{}()", n),
+                Some(b)
+                    if matches!(
+                        b.kind,
+                        BK::State | BK::RawState | BK::Derived | BK::LegacyReactive
+                    ) =>
+                {
+                    format!("$.get({})", n)
+                }
+                _ => n.to_string(),
+            }
+        };
+        analysis
+            .root
+            .bindings
+            .iter()
+            .filter(|b| {
+                matches!(b.kind, BindingKind::Prop | BindingKind::BindableProp)
+                    && !b.legacy_indirect_bindings.is_empty()
+            })
+            .map(|b| {
+                let body = b
+                    .legacy_indirect_bindings
+                    .iter()
+                    .map(|n| format!("{};", read_form(n)))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                (b.name.clone(), body)
+            })
+            .collect()
+    };
+
     // Collect non-bindable prop vars (kind === 'prop', not 'bindable_prop').
     // In runes mode, these should NOT have member mutations wrapped with the prop setter
     // because the official compiler's mutate transform for non-bindable props returns
@@ -5126,6 +5181,7 @@ fn transform_instance_script_for_visitors(
                 &transformed,
                 prop_assignment_transform_vars,
                 &non_bindable_prop_vars,
+                &prop_invalidate_bodies,
             )
         } else {
             transformed

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
@@ -74,6 +74,7 @@ pub fn transform_prop_member_mutate_ast(
     source: &str,
     prop_vars: &[String],
     non_bindable_prop_vars: &[String],
+    prop_invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
 ) -> Option<String> {
     if prop_vars.is_empty() {
         return None;
@@ -99,6 +100,7 @@ pub fn transform_prop_member_mutate_ast(
                     source: src,
                     prop_vars,
                     non_bindable_prop_vars,
+                    prop_invalidate_bodies,
                     replacements: Vec::new(),
                     skip_assignment_spans: Vec::new(),
                 };
@@ -131,6 +133,10 @@ struct PropMemberMutateCollector<'a> {
     source: &'a str,
     prop_vars: &'a [String],
     non_bindable_prop_vars: &'a [String],
+    /// Prop name → precomputed `$.invalidate_inner_signals` body (read forms of
+    /// the prop's `legacy_indirect_bindings`). Empty unless the prop backs a
+    /// legacy `<select bind:value>` referencing other variables.
+    prop_invalidate_bodies: &'a rustc_hash::FxHashMap<String, String>,
     replacements: Vec<Edit>,
     /// Spans of `AssignmentExpression`s that are the first arg of a
     /// `prop(<assignment>, true)` wrap call. Skipping these is what
@@ -236,10 +242,24 @@ impl<'a, 'ast> Visit<'ast> for PropMemberMutateCollector<'a> {
         let rest_and_assignment = &outer_text[local_rest_start..];
 
         // Build the wrapped mutation: `prop(prop()<rest_and_assignment>, true)`
-        let rewrite = format!(
+        let mutation = format!(
             "{}({}(){}, true)",
             root_name, root_name, rest_and_assignment
         );
+
+        // If the prop carries legacy indirect bindings (a `<select bind:value>`
+        // referencing other variables), wrap the mutation in a sequence with
+        // `$.invalidate_inner_signals(() => { … })` so those signals re-read.
+        // Mirrors AssignmentExpression.js / the bind-directive setter path.
+        let rewrite = match self.prop_invalidate_bodies.get(root_name) {
+            Some(body) if !body.is_empty() => {
+                format!(
+                    "({}, $.invalidate_inner_signals(() => {{ {} }}))",
+                    mutation, body
+                )
+            }
+            _ => mutation,
+        };
 
         self.replacements
             .push((expr.span.start, expr.span.end, rewrite));
@@ -254,49 +274,80 @@ mod tests {
         names.iter().map(|s| s.to_string()).collect()
     }
 
+    /// Empty `prop_invalidate_bodies` map for tests that don't exercise the
+    /// `$.invalidate_inner_signals` wrapping.
+    fn nm() -> rustc_hash::FxHashMap<String, String> {
+        rustc_hash::FxHashMap::default()
+    }
+
+    #[test]
+    fn wraps_mutation_with_invalidate_inner_signals() {
+        let mut map = nm();
+        map.insert("field".to_string(), "a; b();".to_string());
+        let out =
+            transform_prop_member_mutate_ast("field.x = {};", &ssv(&["field"]), &[], &map).unwrap();
+        assert_eq!(
+            out,
+            "(field(field().x = {}, true), $.invalidate_inner_signals(() => { a; b(); }));"
+        );
+    }
+
+    #[test]
+    fn no_invalidate_wrap_when_prop_absent_from_map() {
+        let mut map = nm();
+        map.insert("other".to_string(), "a;".to_string());
+        let out =
+            transform_prop_member_mutate_ast("field.x = {};", &ssv(&["field"]), &[], &map).unwrap();
+        assert_eq!(out, "field(field().x = {}, true);");
+    }
+
     #[test]
     fn static_member_assignment() {
-        let out = transform_prop_member_mutate_ast("prop.foo = 5;", &ssv(&["prop"]), &[]).unwrap();
+        let out =
+            transform_prop_member_mutate_ast("prop.foo = 5;", &ssv(&["prop"]), &[], &nm()).unwrap();
         assert_eq!(out, "prop(prop().foo = 5, true);");
     }
 
     #[test]
     fn call_then_static_member_assignment_is_idempotent_shape() {
-        let out =
-            transform_prop_member_mutate_ast("prop().foo = 5;", &ssv(&["prop"]), &[]).unwrap();
+        let out = transform_prop_member_mutate_ast("prop().foo = 5;", &ssv(&["prop"]), &[], &nm())
+            .unwrap();
         assert_eq!(out, "prop(prop().foo = 5, true);");
     }
 
     #[test]
     fn computed_member_assignment() {
-        let out = transform_prop_member_mutate_ast("prop[0] = 5;", &ssv(&["prop"]), &[]).unwrap();
+        let out =
+            transform_prop_member_mutate_ast("prop[0] = 5;", &ssv(&["prop"]), &[], &nm()).unwrap();
         assert_eq!(out, "prop(prop()[0] = 5, true);");
     }
 
     #[test]
     fn compound_addition() {
-        let out = transform_prop_member_mutate_ast("prop.foo += 3;", &ssv(&["prop"]), &[]).unwrap();
+        let out = transform_prop_member_mutate_ast("prop.foo += 3;", &ssv(&["prop"]), &[], &nm())
+            .unwrap();
         assert_eq!(out, "prop(prop().foo += 3, true);");
     }
 
     #[test]
     fn compound_nullish() {
-        let out =
-            transform_prop_member_mutate_ast("prop.foo ??= 5;", &ssv(&["prop"]), &[]).unwrap();
+        let out = transform_prop_member_mutate_ast("prop.foo ??= 5;", &ssv(&["prop"]), &[], &nm())
+            .unwrap();
         assert_eq!(out, "prop(prop().foo ??= 5, true);");
     }
 
     #[test]
     fn chained_member_chain() {
-        let out =
-            transform_prop_member_mutate_ast("prop.a.b.c = 5;", &ssv(&["prop"]), &[]).unwrap();
+        let out = transform_prop_member_mutate_ast("prop.a.b.c = 5;", &ssv(&["prop"]), &[], &nm())
+            .unwrap();
         assert_eq!(out, "prop(prop().a.b.c = 5, true);");
     }
 
     #[test]
     fn mixed_static_and_computed() {
         let out =
-            transform_prop_member_mutate_ast("prop.items[0] = x;", &ssv(&["prop"]), &[]).unwrap();
+            transform_prop_member_mutate_ast("prop.items[0] = x;", &ssv(&["prop"]), &[], &nm())
+                .unwrap();
         assert_eq!(out, "prop(prop().items[0] = x, true);");
     }
 
@@ -304,45 +355,57 @@ mod tests {
     fn non_bindable_prop_left_alone() {
         // prop is in prop_vars but flagged non-bindable → no rewrite
         assert!(
-            transform_prop_member_mutate_ast("prop.foo = 5;", &ssv(&["prop"]), &ssv(&["prop"]))
-                .is_none()
+            transform_prop_member_mutate_ast(
+                "prop.foo = 5;",
+                &ssv(&["prop"]),
+                &ssv(&["prop"]),
+                &nm()
+            )
+            .is_none()
         );
     }
 
     #[test]
     fn non_prop_member_left_alone() {
-        assert!(transform_prop_member_mutate_ast("obj.foo = 5;", &ssv(&["prop"]), &[]).is_none());
+        assert!(
+            transform_prop_member_mutate_ast("obj.foo = 5;", &ssv(&["prop"]), &[], &nm()).is_none()
+        );
     }
 
     #[test]
     fn bare_prop_assignment_left_alone() {
         // `prop = 5` is handled by prop_assign_ast (PR #198)
-        assert!(transform_prop_member_mutate_ast("prop = 5;", &ssv(&["prop"]), &[]).is_none());
+        assert!(
+            transform_prop_member_mutate_ast("prop = 5;", &ssv(&["prop"]), &[], &nm()).is_none()
+        );
     }
 
     #[test]
     fn update_expression_left_alone() {
         // `prop.x++` is NOT this pass's concern.
-        assert!(transform_prop_member_mutate_ast("prop.x++;", &ssv(&["prop"]), &[]).is_none());
+        assert!(
+            transform_prop_member_mutate_ast("prop.x++;", &ssv(&["prop"]), &[], &nm()).is_none()
+        );
     }
 
     #[test]
     fn does_not_rewrite_inside_string_literal() {
         let src = r#"let s = "prop.foo = 5";"#;
-        assert!(transform_prop_member_mutate_ast(src, &ssv(&["prop"]), &[]).is_none());
+        assert!(transform_prop_member_mutate_ast(src, &ssv(&["prop"]), &[], &nm()).is_none());
     }
 
     #[test]
     fn rewrites_inside_template_expression() {
         let src = "let s = `${prop.foo = 5}`;";
-        let out = transform_prop_member_mutate_ast(src, &ssv(&["prop"]), &[]).unwrap();
+        let out = transform_prop_member_mutate_ast(src, &ssv(&["prop"]), &[], &nm()).unwrap();
         assert_eq!(out, "let s = `${prop(prop().foo = 5, true)}`;");
     }
 
     #[test]
     fn multiple_props_in_one_source() {
         let out =
-            transform_prop_member_mutate_ast("a.x = 1; b.y = 2;", &ssv(&["a", "b"]), &[]).unwrap();
+            transform_prop_member_mutate_ast("a.x = 1; b.y = 2;", &ssv(&["a", "b"]), &[], &nm())
+                .unwrap();
         assert_eq!(out, "a(a().x = 1, true); b(b().y = 2, true);");
     }
 
@@ -351,30 +414,41 @@ mod tests {
         // The text version had to specifically skip `=>` (arrow). The
         // AST naturally separates `=` (AssignmentExpression) from `=>`
         // (ArrowFunctionExpression).
-        let out = transform_prop_member_mutate_ast("prop.cb = (x) => x + 1;", &ssv(&["prop"]), &[])
-            .unwrap();
+        let out = transform_prop_member_mutate_ast(
+            "prop.cb = (x) => x + 1;",
+            &ssv(&["prop"]),
+            &[],
+            &nm(),
+        )
+        .unwrap();
         assert_eq!(out, "prop(prop().cb = (x) => x + 1, true);");
     }
 
     #[test]
     fn function_call_on_member_is_not_a_mutation() {
         // `prop.foo()` is a CallExpression, not a mutation.
-        assert!(transform_prop_member_mutate_ast("prop.foo();", &ssv(&["prop"]), &[]).is_none());
+        assert!(
+            transform_prop_member_mutate_ast("prop.foo();", &ssv(&["prop"]), &[], &nm()).is_none()
+        );
     }
 
     #[test]
     fn empty_prop_vars_is_no_op() {
-        assert!(transform_prop_member_mutate_ast("prop.foo = 5;", &[], &[]).is_none());
+        assert!(transform_prop_member_mutate_ast("prop.foo = 5;", &[], &[], &nm()).is_none());
     }
 
     #[test]
     fn parse_error_returns_none() {
-        assert!(transform_prop_member_mutate_ast("prop.foo = (", &ssv(&["prop"]), &[]).is_none());
+        assert!(
+            transform_prop_member_mutate_ast("prop.foo = (", &ssv(&["prop"]), &[], &nm()).is_none()
+        );
     }
 
     #[test]
     fn no_op_without_equals() {
-        assert!(transform_prop_member_mutate_ast("foo(prop);", &ssv(&["prop"]), &[]).is_none());
+        assert!(
+            transform_prop_member_mutate_ast("foo(prop);", &ssv(&["prop"]), &[], &nm()).is_none()
+        );
     }
 
     #[test]
@@ -383,7 +457,7 @@ mod tests {
         // recognises the `prop(<assignment>, true)` shape and skips
         // the inner AssignmentExpression — fixed-point exits cleanly.
         let already = "prop(prop().foo = 5, true);";
-        assert!(transform_prop_member_mutate_ast(already, &ssv(&["prop"]), &[]).is_none());
+        assert!(transform_prop_member_mutate_ast(already, &ssv(&["prop"]), &[], &nm()).is_none());
     }
 
     #[test]
@@ -391,8 +465,8 @@ mod tests {
         // Apply to the same source twice; the second call should
         // be a no-op (returns None).
         let first =
-            transform_prop_member_mutate_ast("prop.foo = 5;", &ssv(&["prop"]), &[]).unwrap();
-        let second = transform_prop_member_mutate_ast(&first, &ssv(&["prop"]), &[]);
+            transform_prop_member_mutate_ast("prop.foo = 5;", &ssv(&["prop"]), &[], &nm()).unwrap();
+        let second = transform_prop_member_mutate_ast(&first, &ssv(&["prop"]), &[], &nm());
         assert!(second.is_none(), "expected None, got: {:?}", second);
     }
 
@@ -402,7 +476,7 @@ mod tests {
         // The inner assignment is wrapped in parens. Verify output
         // matches the text version exactly.
         let src = "console.log((a.b = true));";
-        let out = transform_prop_member_mutate_ast(src, &ssv(&["a"]), &[]).unwrap();
+        let out = transform_prop_member_mutate_ast(src, &ssv(&["a"]), &[], &nm()).unwrap();
         assert_eq!(out, "console.log((a(a().b = true, true)));");
     }
 
@@ -414,7 +488,8 @@ mod tests {
             transform_prop_member_mutate_ast(
                 "prop.foo = 5;",
                 &ssv(&["prop", "other"]),
-                &ssv(&["prop", "other"])
+                &ssv(&["prop", "other"]),
+                &nm()
             )
             .is_none()
         );

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -456,7 +456,12 @@ pub(super) fn transform_reactive_statement(
                 &[],
             )
             .unwrap_or_else(|| transform_prop_reads_in_expr(&temp, prop_assignment_transform_vars));
-            let temp = transform_prop_assignments(&temp, prop_assignment_transform_vars, &[]);
+            let temp = transform_prop_assignments(
+                &temp,
+                prop_assignment_transform_vars,
+                &[],
+                &rustc_hash::FxHashMap::default(),
+            );
             // Wrap state-var member mutations (`obj.a.b = x`) in `$.mutate(obj, …)`.
             // The keyword branch (a `$: if (cond) X = rhs` reactive statement) was
             // missing this pass that both sibling branches have, so a state-var
@@ -491,7 +496,12 @@ pub(super) fn transform_reactive_statement(
             let temp =
                 transform_state_update_expressions(&temp, state_vars, non_reactive_state_vars);
             let temp = transform_prop_reads_in_expr(&temp, prop_assignment_transform_vars);
-            let temp = transform_prop_assignments(&temp, prop_assignment_transform_vars, &[]);
+            let temp = transform_prop_assignments(
+                &temp,
+                prop_assignment_transform_vars,
+                &[],
+                &rustc_hash::FxHashMap::default(),
+            );
             let temp = transform_state_member_mutations(&temp, state_vars, non_reactive_state_vars);
             let temp = transform_state_set_in_reactive(&temp, state_vars, non_reactive_state_vars);
             let temp =
@@ -535,6 +545,7 @@ pub(super) fn transform_reactive_statement(
                     &transformed_rhs,
                     prop_assignment_transform_vars,
                     &[],
+                    &rustc_hash::FxHashMap::default(),
                 );
                 let transformed_rhs = wrap_state_vars_in_expr(
                     &transformed_rhs,
@@ -673,7 +684,12 @@ pub(super) fn transform_reactive_statement(
         // assignment-generated calls like `callback = value` → `callback(value)`.
         let temp = transform_prop_reads_in_expr(&temp, prop_assignment_transform_vars);
         // Then transform prop compound assignments (e.g., `count += 1` → `count(count() + 1)`)
-        let temp = transform_prop_assignments(&temp, prop_assignment_transform_vars, &[]);
+        let temp = transform_prop_assignments(
+            &temp,
+            prop_assignment_transform_vars,
+            &[],
+            &rustc_hash::FxHashMap::default(),
+        );
         // Transform state member-expression mutations (e.g., `object[key] = []`)
         // to `$.mutate(object, $.get(object)[key] = [])`. Must run before wrap_state_vars_in_expr
         // so identifiers are still in their original form.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -1091,6 +1091,7 @@ pub(super) fn transform_prop_assignments(
     line: &str,
     prop_vars: &[String],
     non_bindable_prop_vars: &[String],
+    prop_invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
 ) -> String {
     if prop_vars.is_empty() {
         return line.to_string();
@@ -1125,6 +1126,7 @@ pub(super) fn transform_prop_assignments(
         stage1,
         prop_vars,
         non_bindable_prop_vars,
+        prop_invalidate_bodies,
     )
     .unwrap_or_else(|| stage1.to_string())
 }


### PR DESCRIPTION
## What

A legacy `<select bind:value={prop.x}>` whose subtree references other variables (`<option>` content, the select's own `id`, …) records them on the bound prop's `legacy_indirect_bindings`. The official compiler wraps **every** mutation of that prop in `(prop(...), $.invalidate_inner_signals(() => { …reads }))` so the referenced signals re-read. rsvelte only did this for `bind:` setters — not for ordinary prop member mutations such as `field.tooltipAttributes = {}` inside `onMount`.

## Fix

- **Phase 3** (`prop_member_mutate_ast`): wrap the legacy prop-member mutation in the `$.invalidate_inner_signals` sequence when the prop carries indirect bindings, using each binding's read form (prop → `name()`, store sub → `name()`, reactive state/derived → `$.get(name)`, else bare). Threaded a precomputed `prop → body` map through `transform_prop_assignments`.
- **Phase 2** (`regular_element`): narrow `legacy_indirect_bindings` to identifiers referenced **within the `<select>` element's own source span** (ordered by source position), mirroring the official `scope.references` iteration. Previously it pulled in every template-referenced binding in the component, so an `id` used on an unrelated sibling element leaked into the invalidation list.

## Impact

`compat/corpus/known-failures.json`: **50 → 49** — clears `svelte-form-builder/.../PropertyPanelTooltip.svelte`. (The sibling PropertyPanel/PowerTable files improve too but retain orthogonal reactivity diffs.)

> Stacked on #1304 → main. Retarget to `main` once #1304 merges.

## Verification

- New `prop_member_mutate_ast` unit tests (wrap + no-wrap)
- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5