### PR TITLE
fix(fmt): don't double-count indent for multi-line string attribute interpolations

### DIFF
--- a/.changeset/fix-multiline-string-attr-indent.md
+++ b/.changeset/fix-multiline-string-attr-indent.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): don't double-count indent for interpolations in multi-line string attributes
+
+A multi-line quoted attribute value (`style="…\n\tleft: {expr}%;\n…"`) carries
+each interpolation's physical column in the literal text already emitted on its
+own line. The interpolation-width math was *also* subtracting the attribute's
+logical indent, double-counting it — so an expression that actually fits was
+force-broken (and a long member chain wrapped instead of the top-level operator).
+The width now uses the physical column only for multi-line string values, so
+`left: {$xGet(d) + ($xScale.bandwidth ? … : 0)}%;` and similar stay on one line,
+matching the oxfmt / prettier-plugin-svelte oracle.

--- a/compat/corpus/fmt-known-failures.json
+++ b/compat/corpus/fmt-known-failures.json
@@ -11,8 +11,6 @@
 	"layercake/src/_components/AxisRadial.svelte",
 	"layercake/src/_components/AxisY.percent-range.html.svelte",
 	"layercake/src/_components/AxisYRight.percent-range.html.svelte",
-	"layercake/src/_components/Scatter.html.svelte",
-	"layercake/src/_components/SharedTooltip.percent-range.html.svelte",
 	"layercake/src/lib/layouts/ScaledSvg.svelte",
 	"layercake/src/lib/layouts/Svg.svelte",
 	"layercake/src/routes/_components/AxisY.svelte",

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -1950,11 +1950,27 @@ fn render_attribute_value_sequence(
                     // first line ends with `{`/`[` (expanded call-argument block),
                     // keep the wider result to avoid over-constraining inner exprs.
                     let on_line = out.rsplit('\n').next().unwrap_or(&out);
-                    let lead_cols = if out.contains('\n') {
+                    // A multi-line string value (`style="…\n\tleft: {expr}%;\n…"`)
+                    // already carries the interpolation's physical column in the
+                    // emitted leading text on its own line (the source tabs/spaces),
+                    // so `lead_cols` IS the start column — the attribute's logical
+                    // indent must NOT be added on top (that double-counts and
+                    // over-breaks an expression that actually fits). On a single-line
+                    // value the logical indent still applies.
+                    let value_is_multiline = out.contains('\n');
+                    let lead_cols = if value_is_multiline {
                         visual_width(on_line)
                     } else {
                         name_prefix + visual_width(on_line)
                     };
+                    // `format_attribute_value_expression` narrows the print width by
+                    // `attr_depth` indent levels. For a multi-line string value the
+                    // interpolation's physical indent is the literal text already on
+                    // its line (counted in `lead_cols`), NOT the logical attribute
+                    // depth — so pass depth 0 there to avoid subtracting the indent
+                    // twice (which over-breaks: e.g. a member chain wraps instead of
+                    // the top-level `??`).
+                    let effective_attr_depth = if value_is_multiline { 0 } else { attr_depth };
                     // Trailing columns that share the interpolation's closing-`}`
                     // LINE — i.e. literal text up to the next newline only. A
                     // multi-line string value (`style="…\n\twidth: {r * 2}px;\n…"`)
@@ -1984,10 +2000,17 @@ fn render_attribute_value_sequence(
                     let has_trailing_expr = parts[i + 1..]
                         .iter()
                         .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)));
-                    let first_pass =
-                        format_attribute_value_expression(inner_src, &opts, attr_depth, 0)?;
+                    let first_pass = format_attribute_value_expression(
+                        inner_src,
+                        &opts,
+                        effective_attr_depth,
+                        0,
+                    )?;
                     let formatted = if narrow_value && is_shallow_value(inner_src) {
                         let indent_cols = attr_depth * opts.js.indent_width.value() as usize;
+                        // For a multi-line string value the physical indent is already
+                        // in `lead_cols`; don't add the logical attribute indent again.
+                        let effective_indent = if value_is_multiline { 0 } else { indent_cols };
                         let line_width_val = opts.js.line_width.value() as usize;
                         // Narrowing strategy: narrow only by the expression's START
                         // column (indent + prefix + `{`). When the expression wraps to
@@ -1999,7 +2022,7 @@ fn render_attribute_value_sequence(
                         // force the MINIMAL break below (`force_extra`) so only the
                         // expression's top-level operator wraps, matching the oracle.
                         let extra_start = lead_cols + 1; // chars before `{`
-                        if indent_cols + extra_start >= line_width_val {
+                        if effective_indent + extra_start >= line_width_val {
                             // Expression starts at or past the print width.
                             // OXC formatted at indent-only width. When there are no
                             // trailing interpolations, apply the prettier-style
@@ -2033,7 +2056,7 @@ fn render_attribute_value_sequence(
                         } else if !first_pass.contains('\n') {
                             // Wide first-pass produced a single-line result.
                             // Check if it fits with trailing on the same line.
-                            let total = indent_cols
+                            let total = effective_indent
                                 + lead_cols
                                 + 1
                                 + first_pass.len()
@@ -2056,7 +2079,7 @@ fn render_attribute_value_sequence(
                                 let start_result = format_attribute_value_expression(
                                     inner_src,
                                     &opts,
-                                    attr_depth,
+                                    effective_attr_depth,
                                     extra_start,
                                 )?;
                                 if start_result.contains('\n') {
@@ -2073,13 +2096,14 @@ fn render_attribute_value_sequence(
                                     // itself (e.g. ternary at `?`/`:` or comparison at `===`),
                                     // accepting that the trailing text may overflow on the last
                                     // continuation line.
-                                    let base_width = line_width_val.saturating_sub(indent_cols);
+                                    let base_width =
+                                        line_width_val.saturating_sub(effective_indent);
                                     let expr_len = visual_width(first_pass.as_str());
                                     let force_extra = base_width.saturating_sub(expr_len) + 1;
                                     let forced = format_attribute_value_expression(
                                         inner_src,
                                         &opts,
-                                        attr_depth,
+                                        effective_attr_depth,
                                         force_extra,
                                     )?;
                                     if forced.contains('\n') {
@@ -2133,7 +2157,7 @@ fn render_attribute_value_sequence(
                                 format_attribute_value_expression(
                                     inner_src,
                                     &opts,
-                                    attr_depth,
+                                    effective_attr_depth,
                                     extra_start,
                                 )?
                             }


### PR DESCRIPTION
## Summary

Continuation of the Cluster B burndown. A multi-line quoted attribute value (`style="…\n\tleft: {expr}%;\n…"`) already carries each interpolation's physical column in the literal text emitted on its own line. `render_attribute_value_sequence` was *also* subtracting the attribute's logical indent (`attr_depth` levels) in both the overflow check and the width handed to `format_attribute_value_expression` — double-counting it. So an expression that actually fits was force-broken, and a long optional-member chain wrapped instead of the top-level `??`.

For a multi-line value the interpolation now uses its physical column only: `value_is_multiline` drives `effective_attr_depth = 0` (passed to every `format_attribute_value_expression` call in the block) and `effective_indent = 0` (used in the overflow / `force_extra` math). Single-line values are unchanged.

## Impact

Local fmt-corpus parity (macOS oxfmt 0.56.0): **92 → 90 known failures, 0 regressions** (layercake Scatter, SharedTooltip.percent-range, MapPoints).

The genuine single-line multi-interpolation **fill** case (`style:transform="translate({a}px, calc(-50% + {b}px))"`, AxisY) is *not* addressed here: it needs the literal text broken at whitespace with interpolations breaking internally — a unified Doc-IR `fill` over the attribute value, which the current oxc-delegation (independent per-interpolation formatting) can't express byte-exactly. Documented in `docs/corpus-fmt-remaining-work.md` for the dedicated fill-port effort. (FormBuilder remains a 1-col tab-measurement edge case.)

## Test plan

- `cargo test -p rsvelte_formatter` (lib + markup/attr/wrap suites) green; `cargo clippy` clean.
- Baseline shrink (92 → 90) follows from the authoritative Linux `corpus-compat.yml` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)