### PR TITLE
fix(transform): Math/Number constant members are compile-time known (45→44)

### DIFF
--- a/.changeset/fix-corpus-known-global-member.md
+++ b/.changeset/fix-corpus-known-global-member.md
@@ -1,0 +1,23 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): treat `Math`/`Number` constant members as compile-time known
+
+A `$derived` whose initializer is constant arithmetic over a global constant —
+
+```svelte
+const circumference = $derived(2 * Math.PI * 42.5);
+```
+
+— was treated as reactive, so an attribute that only reads it (e.g.
+`style="stroke-dasharray: {circumference} {circumference};"`) was emitted inside a
+`$.template_effect(...)` instead of as a one-time `$.set_style(...)`. The
+reactive-state evaluator's `is_expression_known_json` returned `false` for every
+`MemberExpression`, so `Math.PI` made the whole derived "unknown → reactive".
+
+Treat a non-computed member of a pure global namespace (`Math.*`, `Number.*`,
+when not locally shadowed) as a known compile-time constant — mirroring the
+globals table in upstream `scope.evaluate`. `Math.random()` etc. stay reactive
+(they're `CallExpression`s, handled separately). Clears
+`shadcn-svelte/.../circular-gauge.svelte` (45 → 44).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -20,7 +20,6 @@
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"powertable/app/src/lib/components/PowerTable.svelte",
 	"shadcn-svelte/docs/src/lib/components/mobile-nav.svelte",
-	"shadcn-svelte/docs/src/lib/registry/examples/create/vercel/circular-gauge.svelte",
 	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",
 	"smelte/src/routes/components/_layout.svelte",
 	"svar-core/svelte/src/components/calendar/Month.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -6218,8 +6218,28 @@ fn is_expression_known_json(json_value: &serde_json::Value, context: &ComponentC
         // Arrow/function expressions are "known" (they evaluate to a function)
         "ArrowFunctionExpression" | "FunctionExpression" => true,
 
-        // Member expressions are generally not known
-        "MemberExpression" => false,
+        // Member expressions are generally not known, EXCEPT a non-computed
+        // member of a pure global namespace whose members are compile-time
+        // constants — `Math.PI`, `Math.E`, `Number.MAX_VALUE`, etc. (mirrors the
+        // globals table in upstream `scope.evaluate`). This lets a derived like
+        // `$derived(2 * Math.PI * r)` fold to a known constant (no reactive deps).
+        "MemberExpression" => {
+            if obj.get("computed").and_then(|c| c.as_bool()) == Some(true) {
+                return false;
+            }
+            let Some(object) = obj.get("object") else {
+                return false;
+            };
+            if object.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
+                return false;
+            }
+            object
+                .get("name")
+                .and_then(|n| n.as_str())
+                .is_some_and(|name| {
+                    matches!(name, "Math" | "Number") && context.state.get_binding(name).is_none()
+                })
+        }
 
         // Default: not known
         _ => false,


### PR DESCRIPTION
## What

A `$derived` of constant arithmetic over a global constant —

```svelte
const circumference = $derived(2 * Math.PI * 42.5);
```

— was treated as reactive, so an attribute that only reads it (`style="stroke-dasharray: {circumference} {circumference};"`) was emitted inside `$.template_effect(...)` instead of a one-time `$.set_style(...)`. `is_expression_known_json` returned `false` for **every** `MemberExpression`, so `Math.PI` made the whole derived "unknown → reactive".

## Fix

Treat a non-computed member of a pure global namespace (`Math.*`, `Number.*`, when not locally shadowed) as a known compile-time constant — mirroring the globals table in upstream `scope.evaluate`. `Math.random()` etc. remain reactive (they're `CallExpression`s, handled separately).

## Impact

`compat/corpus/known-failures.json`: **45 → 44** — clears `shadcn-svelte/.../circular-gauge.svelte`.

> Stacked on #1311 (base = `fix/corpus-template-literal-const-known`). Retarget to `main` once #1311 merges.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions** (10,982 match)
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5