### PR TITLE
fix(transform): order $.bind_props correctly under param-shadowed prop (44→43)

### DIFF
--- a/.changeset/fix-corpus-bind-props-param-shadow-order.md
+++ b/.changeset/fix-corpus-bind-props-param-shadow-order.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): order `$.bind_props` props correctly when a prop is shadowed by a function parameter
+
+When an `export let` prop shares its name with a function parameter elsewhere in
+the script —
+
+```svelte
+<script>
+  function setTooltipContext(tooltip) { setContext(key, tooltip); }
+  export let tooltip = writable({ … });   // line 116
+  export let hideDelay = 0;               // line 127
+</script>
+```
+
+— the `BindableProp` kind can land on the parameter binding (which has no
+`declaration_start`), so the server `$.bind_props($$props, { … })` trailer sorted
+that prop to the end (`{ …, hideDelay, tooltip }`) instead of its true source
+position (`{ …, tooltip, hideDelay }`).
+
+Fix the bind_props sort to borrow the real `let`/`var` declaration's
+`declaration_start` when the marked binding lacks one. This is sort-only: it does
+not change which binding is marked `BindableProp`, so the var-hoisting order (and
+the previously-fixed `BrushContext`/`GeoContext` outputs) are untouched. Clears
+`layerchart/.../tooltip/TooltipContext.svelte` (44 → 43).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -14,7 +14,6 @@
 	"layerchart/packages/layerchart/src/lib/components/charts/AreaChart.svelte",
 	"layerchart/packages/layerchart/src/lib/components/charts/BarChart.svelte",
 	"layerchart/packages/layerchart/src/lib/components/layout/Canvas.svelte",
-	"layerchart/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte",
 	"layerchart/packages/layerchart/src/lib/docs/TilesetField.svelte",
 	"layerchart/packages/layerchart/src/routes/docs/examples/Area/+page.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -999,7 +999,32 @@ pub fn server_component_ast<'a>(
             matches!(binding.kind, BindingKind::BindableProp) && !binding.name.starts_with("$$")
         })
         .collect();
-    bindable.sort_by_key(|binding| binding.declaration_start.unwrap_or(u32::MAX));
+    // Sort by source-declaration position. A bindable prop that is shadowed by a
+    // same-named function parameter can have its BindableProp kind on the param
+    // binding (no `declaration_start`); borrow the real `let/var` declaration's
+    // position so the prop sorts at its true source location instead of last.
+    // Sort-only — does not change which binding is marked (so var-hoisting is
+    // untouched).
+    let decl_pos = |binding: &crate::compiler::phases::phase2_analyze::scope::Binding| -> u32 {
+        if let Some(start) = binding.declaration_start {
+            return start;
+        }
+        use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
+        analysis
+            .root
+            .bindings
+            .iter()
+            .filter(|b| {
+                b.name == binding.name
+                    && matches!(
+                        b.declaration_kind,
+                        DeclarationKind::Let | DeclarationKind::Var
+                    )
+            })
+            .find_map(|b| b.declaration_start)
+            .unwrap_or(u32::MAX)
+    };
+    bindable.sort_by_key(|binding| decl_pos(binding));
     let mut bind_props: Vec<oxc_ast::ast::ObjectPropertyKind<'a>> = Vec::new();
     for binding in bindable {
         let key = binding.prop_alias.as_deref().unwrap_or(&binding.name);


### PR DESCRIPTION
## What

When an `export let` prop shares its name with a function parameter elsewhere in the script:

```svelte
<script>
  function setTooltipContext(tooltip) { setContext(key, tooltip); }
  export let tooltip = writable({ … });   // line 116
  export let hideDelay = 0;               // line 127
</script>
```

the `BindableProp` kind can land on the **parameter** binding (which has no `declaration_start`), so the server `$.bind_props($$props, { … })` trailer sorted that prop to the end — `{ …, hideDelay, tooltip }` — instead of its true source position `{ …, tooltip, hideDelay }`.

## Fix

The bind_props sort borrows the real `let`/`var` declaration's `declaration_start` when the marked binding lacks one. **Sort-only** — it does *not* change which binding is marked `BindableProp`, so var-hoisting order is untouched.

A prior attempt that re-marked the binding regressed `BrushContext`/`GeoContext` (their var-hoisting is coupled to the marked binding); this sort-only approach avoids that coupling entirely.

## Impact

`compat/corpus/known-failures.json`: **44 → 43** — clears `layerchart/.../tooltip/TooltipContext.svelte`.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions** (incl. BrushContext/GeoContext)
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5