### PR TITLE
fix(transform): read store dependency via $name() in attr/derived deps (43→42)

### DIFF
--- a/.changeset/fix-corpus-store-dependency-getter.md
+++ b/.changeset/fix-corpus-store-dependency-getter.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): read a store dependency via `$name()` in attribute/derived dependency lists
+
+A reactive expression that depends on a store value (`$view`, or a store that is
+also written via `$.store_set(view, …)`) must collect that dependency as the
+store's subscribed value — `$view()` — not `$.deep_read_state(view)` (which would
+deep-read the store object instead of subscribing to its value).
+
+The `$:` reactive-statement dependency builder already handled stores, but the
+two attribute/derived dependency builders
+(`collect_reactive_references_from_metadata` and the tree-walking fallback
+`collect_reactive_references`) classified a store-backed binding as a
+prop/import and wrapped it in `$.deep_read_state(name)`. Detect a store
+dependency by the presence of the synthesized `$name` `StoreSub` binding and emit
+the `$name()` getter instead. Clears
+`svelte-form-builder/src/lib/FormBuilder.svelte` (43 → 42).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -26,7 +26,6 @@
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelDataAttributes.svelte",
-	"svelte-form-builder/src/lib/FormBuilder.svelte",
 	"svelte-maplibre/src/lib/DeckGlLayer.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -2057,6 +2057,27 @@ fn collect_reactive_references_from_metadata(
 
         let name = &binding.name;
 
+        // Store dependency: a reactive expression that references a store value
+        // (e.g. `$view`, or a `$.store_set(view, …)` write) depends on the store's
+        // subscribed value, read via the generated `$name()` getter — NOT
+        // `$.deep_read_state(name)` (which would deep-read the store object). The
+        // `$:` dependency builder already does this (reactive_transforms.rs); mirror
+        // it here for attribute/derived dependency lists. Detected by the presence
+        // of a synthesized `$name` StoreSub binding.
+        if binding.kind != BindingKind::StoreSub {
+            let store_getter = format!("${name}");
+            let is_store = context
+                .state
+                .scope_root
+                .bindings
+                .iter()
+                .any(|b| b.kind == BindingKind::StoreSub && b.name == store_getter);
+            if is_store {
+                getters.push(b::call(&context.arena, b::id(&store_getter), vec![]));
+                continue;
+            }
+        }
+
         // For reassigned each-block items in legacy mode, the dependency getter
         // should use collection[$$index] instead of $.get(item).
         if !context.state.analysis.runes
@@ -2228,6 +2249,26 @@ fn collect_reactive_references_inner(
             }
 
             seen.insert(name.to_string());
+
+            // Store dependency: a referenced store value depends on the store's
+            // subscribed value, read via the generated `$name()` getter — not
+            // `$.deep_read_state(name)`. Mirrors the metadata-based builder and the
+            // `$:` dependency builder. Detected by a synthesized `$name` StoreSub
+            // binding.
+            {
+                use crate::compiler::phases::phase2_analyze::scope::BindingKind;
+                let store_getter = format!("${name}");
+                let is_store = context
+                    .state
+                    .scope_root
+                    .bindings
+                    .iter()
+                    .any(|b| b.kind == BindingKind::StoreSub && b.name == store_getter);
+                if is_store {
+                    getters.push(b::call(&context.arena, b::id(&store_getter), vec![]));
+                    return;
+                }
+            }
 
             // For reassigned each-block items in legacy mode, the dependency getter
             // should use collection[$$index] instead of $.get(item).


### PR DESCRIPTION
## What

A reactive expression that depends on a store value — `$view`, or a store also written via `$.store_set(view, …)` — must collect that dependency as the store's **subscribed value** `$view()`, not `$.deep_read_state(view)` (which deep-reads the store object instead of subscribing to its value):

```js
// expected
() => ($view(), $.get(tmpDefinition), $showPropertyPanel(), …, $.untrack(() => …))
// actual (before)
() => ($.deep_read_state(view), $.get(tmpDefinition), $.deep_read_state(showPropertyPanel), …)
```

## Fix

The `$:` reactive-statement dependency builder already handled stores, but the two attribute/derived dependency builders — `collect_reactive_references_from_metadata` and the tree-walking fallback `collect_reactive_references` — classified a store-backed binding as a prop/import and wrapped it in `$.deep_read_state(name)`. Detect a store dependency by the presence of the synthesized `$name` `StoreSub` binding and emit the `$name()` getter instead.

## Impact

`compat/corpus/known-failures.json`: **43 → 42** — clears `svelte-form-builder/src/lib/FormBuilder.svelte` (the named "store-write 参照" 難所).

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5