### PR TITLE
chore(fmt): add Doc::RawExpr IR primitive for the layout-engine port

### DIFF
--- a/crates/rsvelte_formatter/src/doc.rs
+++ b/crates/rsvelte_formatter/src/doc.rs
@@ -39,6 +39,19 @@ pub(crate) enum Doc {
     /// Alternating `[content, sep, content, sep, …]` greedily packed.
     Fill(Vec<Doc>),
     Concat(Vec<Doc>),
+    /// A pre-formatted embedded expression (`{expr}`) whose JS was formatted by
+    /// the external engine (oxc) into a string, not a Doc. In `Flat` mode it
+    /// prints `flat`; in `Break` mode it prints `broken` — the multi-line form,
+    /// one entry per line, the first line bare and each continuation carrying its
+    /// own relative indent (as produced at column 0) plus the current indent
+    /// level. This lets an oxc-formatted interpolation participate in a `Fill`:
+    /// the fill keeps it on one line when its `flat` form fits at the current
+    /// column, else places it broken with continuation lines indented under the
+    /// attribute. `fits` measures it by `flat` width (it never forces a break).
+    RawExpr {
+        flat: String,
+        broken: Vec<String>,
+    },
     /// Sentinel: forces the nearest enclosing group to break. Consumed by
     /// [`propagate_breaks`]; prints as nothing.
     BreakParent,
@@ -109,6 +122,26 @@ pub(crate) fn print(
                 trim_trailing_blanks(&mut out);
                 out.push('\n');
                 pos = 0;
+            }
+            Doc::RawExpr { flat, broken } => {
+                if mode == Mode::Flat || broken.len() <= 1 {
+                    pos += flat.width();
+                    out.push_str(&flat);
+                } else {
+                    let pad = unit.repeat(ind);
+                    let mut lines = broken.into_iter();
+                    if let Some(first) = lines.next() {
+                        pos += first.width();
+                        out.push_str(&first);
+                    }
+                    for line in lines {
+                        trim_trailing_blanks(&mut out);
+                        out.push('\n');
+                        out.push_str(&pad);
+                        out.push_str(&line);
+                        pos = pad.width() + line.width();
+                    }
+                }
             }
             Doc::BreakParent => {} // consumed by propagate_breaks; prints nothing
             Doc::Group(ps) => {
@@ -217,6 +250,18 @@ fn fits(mut remaining: isize, rest_stack: &[(usize, Mode, Doc)], next: &[Doc]) -
                     remaining -= s.width() as isize;
                 }
             }
+            // A pre-formatted interpolation is measured by its flat width: the
+            // fill decides whether to keep it inline (flat) or break it based on
+            // whether that flat form fits at the current column.
+            Doc::RawExpr { flat, .. } => {
+                if !flat.is_empty() {
+                    if has_pending_space {
+                        remaining -= 1;
+                        has_pending_space = false;
+                    }
+                    remaining -= flat.width() as isize;
+                }
+            }
             Doc::Concat(ps)
             | Doc::Indent(ps)
             | Doc::Dedent(ps)
@@ -283,6 +328,9 @@ pub(crate) fn propagate_breaks(doc: Doc) -> Doc {
         }
         match doc {
             Doc::Text(_) | Doc::Line | Doc::Softline => (doc, false),
+            // A RawExpr has a flat form, so it never forces the enclosing group
+            // to break (the fill/group decides per-position).
+            Doc::RawExpr { .. } => (doc, false),
             Doc::Hardline | Doc::Literalline | Doc::BreakParent => (doc, true),
             Doc::Concat(ps) => {
                 let (ps, f) = map_children(ps);
@@ -335,6 +383,43 @@ mod tests {
             Doc::Dedent(vec![Doc::Hardline, Doc::Text("b".into())]),
         ])]);
         assert_eq!(p(doc, 80), "\n  a\nb");
+    }
+
+    #[test]
+    fn raw_expr_flat_when_it_fits() {
+        // A pre-formatted interpolation prints its flat form inline when the
+        // enclosing group fits flat.
+        let doc = Doc::Group(vec![
+            Doc::Text("x: ".into()),
+            Doc::RawExpr {
+                flat: "{a + b}".into(),
+                broken: vec!["{a +".into(), "  b}".into()],
+            },
+        ]);
+        assert_eq!(p(doc, 80), "x: {a + b}");
+    }
+
+    #[test]
+    fn raw_expr_breaks_in_a_fill_when_too_wide() {
+        // In a fill, a RawExpr that does not fit at the current column prints its
+        // broken form, with continuation lines indented to the fill's level.
+        let doc = propagate_breaks(Doc::Fill(vec![
+            Doc::Text("lead".into()),
+            Doc::Line,
+            Doc::RawExpr {
+                flat: "{averylongidentifier + anotherlongidentifier}".into(),
+                broken: vec![
+                    "{averylongidentifier +".into(),
+                    "  anotherlongidentifier}".into(),
+                ],
+            },
+        ]));
+        // width 20 forces the fill's Line to break before the wide RawExpr, then
+        // the RawExpr itself prints broken with its continuation at indent 0.
+        assert_eq!(
+            print(doc, 20, "  ", 0, 0),
+            "lead\n{averylongidentifier +\n  anotherlongidentifier}"
+        );
     }
 
     #[test]

--- a/docs/fmt-layout-port-plan.md
+++ b/docs/fmt-layout-port-plan.md
@@ -30,7 +30,15 @@ Doc primitives the layout relies on: `group`, `indent`, `dedent`, `softline`,
 0. **Extend `doc.rs`** — add `Dedent`, `BreakParent`, `Literalline`, `ForcedGroup`
    variants; `fits()` arms (`BreakParent`/`Literalline` → not-fit, `Dedent` →
    indent-1); a `propagate_breaks` pre-pass (Group containing `BreakParent` →
-   `ForcedGroup`). Unit-tested.
+   `ForcedGroup`). Unit-tested. **DONE.** Also landed (2026-06-28):
+   `Doc::RawExpr { flat, broken }` — embeds an oxc-formatted interpolation
+   (`{expr}`) into a measured Doc: `flat` (single-line) in `Flat` mode, the
+   pre-broken `broken` lines (continuation reindented to the current level) in
+   `Break` mode; `fits` measures it by `flat` width and it never forces a break.
+   This is the primitive that lets an oxc-string expression participate in a
+   `Fill`/`Group` (rsvelte formats embedded JS with oxc, not as a Doc, so the
+   expression can't otherwise be measured in-place by the outer layout). Unit-tested
+   (`raw_expr_*`). NOT yet wired into markup (see the style-value finding below).
 1. **New `children.rs`** — faithful port of `printChildren` + the 4-case element
    assembly; `should_hug_start/end`, canonical `is_block_element` (the 33-name
    oracle list, replacing the two divergent lists in markup.rs/collapse.rs),
@@ -47,6 +55,28 @@ Doc primitives the layout relies on: `group`, `indent`, `dedent`, `softline`,
    sibling forces the parent group to break (`forceBreakContent`).
 6. **`Doc::Literalline` for `<pre>`/`<textarea>`** — verbatim path via
    `in_pre_context`.
+
+## Finding (2026-06-28): style-value cases are CSS-aware, not a markup fill
+
+The remaining `style:transform="translate({a}px, calc(-50% + {b}px))"` failures
+(AxisY/AxisYRight) are NOT solvable with a generic whitespace-`fill` over the
+attribute value. Traced from the raw source + oracle:
+
+- The oracle breaks after `…px,` — the `translate(a, b)` **argument comma** — and
+  keeps `calc(-50% + {b…}` together on the next line, with `{b}` breaking
+  internally (oxc). A naive whitespace fill would instead break before `{b}`
+  (the `+ {b}` separator), which is wrong.
+- So oxfmt formats a `style` value **CSS-structure-aware** (it knows `translate`
+  takes comma-separated args and `calc(...)` is one unit), interleaving the
+  embedded `{expr}` mustaches. That is a CSS-value-with-interpolations formatter,
+  a distinct subsystem from `printChildren`/markup fill — and likely needs the
+  embedded JS as `Doc::RawExpr` atoms placed by a CSS-aware layout.
+
+Implication for the port: target **prose / mixed text+element content fill**
+(Cluster A, `printChildren`) first — that IS the generic whitespace fill the
+milestones describe. The CSS-aware style-value path is a separate, later effort;
+`Doc::RawExpr` is the right primitive for both, but the style path additionally
+needs a CSS value tokenizer (split at CSS punctuation, not whitespace).
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Starts the Doc-IR fill port (`docs/fmt-layout-port-plan.md`, milestone 0). rsvelte formats embedded JS with **oxc**, which produces a *string*, not a Doc — so an interpolation can't be measured in-place by an enclosing fill/group the way prettier-plugin-svelte measures its embedded-JS Doc. `Doc::RawExpr { flat, broken }` bridges that gap:

- `Flat` mode → prints `flat` (oxc single-line).
- `Break` mode → prints the pre-broken `broken` lines, continuation reindented to the current level.
- `fits` measures it by `flat` width; it never forces a break.

This is the primitive a markup/attribute fill needs to place oxc-formatted interpolations in a column-aware layout. Unit-tested (`raw_expr_flat_when_it_fits`, `raw_expr_breaks_in_a_fill_when_too_wide`).

**No behavior change** — `RawExpr` is not yet wired into markup; the full 11,478-component corpus is byte-identical (90 known failures, 0 regressions).

## Findings recorded in the port plan

- `RawExpr` landed under milestone 0.
- **Key:** the `style:transform="translate({a}px, calc(-50% + {b}px))"` cases (AxisY/AxisYRight) are **CSS-structure-aware**, not a generic whitespace fill — the oracle breaks at the `translate(a, b)` argument comma and keeps `calc(-50% + {b}` together, breaking `{b}` internally. So the port's first wiring target is prose / mixed text+element fill (`printChildren`, Cluster A); the CSS-value-with-interpolations path is a separate later subsystem (also built on `RawExpr`, plus a CSS value tokenizer). This redirects the port design before any risky markup wiring.

## Test plan

- `cargo test -p rsvelte_formatter` (doc IR unit tests incl. the two new ones) green; `cargo clippy` clean.
- `fmt.mjs --actual && fmt-verify.mjs`: 90 failed, 0 regressions, output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)