### PR TITLE
fix(analyze): enter block scopes in visitor so block-local shadows resolve (42→41)

### DIFF
--- a/.changeset/fix-corpus-block-scope-mutation.md
+++ b/.changeset/fix-corpus-block-scope-mutation.md
@@ -1,0 +1,32 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): resolve block-scoped local shadowing a prop in mutation tracking
+
+A block-local `let` that shadows a prop of the same name was mis-attributed to
+the prop, inflating its `$.prop(...)` flags with `PROPS_IS_UPDATED`:
+
+```svelte
+<script>
+  let { css = "" } = $props();
+  const days = $derived.by(() => {
+    for (…) {
+      let css = "";        // block-local, shadows the prop
+      css += " wx-selected"; // mutates the LOCAL, not the prop
+    }
+  });
+</script>
+```
+
+The Phase-2 scope builder created a lexical scope for each `BlockStatement` (so
+the local `css` lived there), but it didn't register that scope anywhere the
+later visitor pass could find it, and the visitor's `BlockStatement` walk never
+entered block scopes. So `css += …` resolved up to the prop binding and marked it
+reassigned → `$.prop($$props, "css", 7, "")` instead of `3`.
+
+Register each (non-function) block's scope in `function_scope_map` keyed by the
+block start, and have the typed visitor walk enter that scope for `BlockStatement`
+nodes (mirroring how function bodies are already handled). Block-local mutations
+now resolve to the correct local binding. Clears
+`svar-core/svelte/src/components/calendar/Month.svelte` (42 → 41).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -21,7 +21,6 @@
 	"shadcn-svelte/docs/src/lib/components/mobile-nav.svelte",
 	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",
 	"smelte/src/routes/components/_layout.svelte",
-	"svar-core/svelte/src/components/calendar/Month.svelte",
 	"svelte-form-builder/src/lib/Components/Select.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -758,6 +758,14 @@ impl<'a> ScopeBuilder<'a> {
             JsNode::BlockStatement { body, .. } => {
                 let body = *body;
                 let old_scope = self.push_scope();
+                // Register this (non-function) block's scope so the Phase-2 visitor
+                // can enter it too — otherwise block-local `let`s (e.g. a `let css`
+                // inside a `for` body that shadows a `css` prop) are invisible to the
+                // visitor's mutation/reference resolution, which then mis-attributes
+                // the mutation to the outer (prop) binding. Keyed by block start.
+                if let Some(bstart) = node.start() {
+                    self.function_scope_map.insert(bstart, self.current_scope);
+                }
                 for stmt in self.arena.get_js_children(body) {
                     self.process_statement_typed(stmt);
                 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
@@ -798,10 +798,24 @@ fn visit_children_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(
         | JsNode::ExportNamedDeclaration { .. }
         | JsNode::ImportDeclaration { .. } => Ok(()),
 
-        // Block-like with body array (IdRange)
-        JsNode::BlockStatement { body, .. }
-        | JsNode::Program { body, .. }
-        | JsNode::StaticBlock { body, .. } => {
+        // Block-like with body array (IdRange). For a BlockStatement, enter the
+        // block's lexical scope (registered by scope_builder) so block-local `let`s
+        // shadow outer bindings of the same name during mutation/reference
+        // resolution — mirroring scope_builder. Program/StaticBlock keep the scope.
+        JsNode::BlockStatement { body, .. } => {
+            let saved_scope = context.scope;
+            if let Some(start) = node.start()
+                && let Some(&scope_idx) = context.analysis.root.function_scope_map.get(&start)
+            {
+                context.scope = scope_idx;
+            }
+            for child in arena.get_js_children(*body) {
+                walk_js_node_typed(child, context)?;
+            }
+            context.scope = saved_scope;
+            Ok(())
+        }
+        JsNode::Program { body, .. } | JsNode::StaticBlock { body, .. } => {
             for child in arena.get_js_children(*body) {
                 walk_js_node_typed(child, context)?;
             }


### PR DESCRIPTION
## What

A block-local `let` that shadows a prop of the same name was mis-attributed to the prop, inflating its `$.prop(...)` flags with `PROPS_IS_UPDATED`:

```svelte
<script>
  let { css = "" } = $props();
  const days = $derived.by(() => {
    for (…) {
      let css = "";          // block-local, shadows the prop
      css += " wx-selected"; // mutates the LOCAL, not the prop
    }
  });
</script>
```

Output was `$.prop($$props, "css", 7, "")` (flags `IMMUTABLE|RUNES|UPDATED`) instead of the correct `3` (`IMMUTABLE|RUNES`).

## Root cause

The Phase-2 scope builder creates a lexical scope for each `BlockStatement` (so the local `css` lives there), but it **didn't register that scope** anywhere the later visitor pass could find it, and the visitor's `BlockStatement` walk **never entered block scopes**. So `css += …` resolved up the chain to the prop binding and marked it reassigned.

(Verified by debug: scope_builder's own `updates` pass correctly marked the *local* binding; only the visitor's `mark_binding_mutation` path, running with the outer `context.scope`, mis-marked the prop.)

## Fix

- Register each (non-function) block's scope in `function_scope_map`, keyed by block start (function bodies were already registered).
- Have the typed visitor walk enter that scope for `BlockStatement` nodes (save/set/restore `context.scope`), mirroring how function bodies are handled.

Block-local mutations and references now resolve to the correct local binding.

## Impact

`compat/corpus/known-failures.json`: **42 → 41** — clears `svar-core/.../calendar/Month.svelte` (the named "Month block-scope" 難所).

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions** (10,985 match)
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5