### PR TITLE
fix(transform): keep PROPS_IS_UPDATED for param-shadowed reassigned prop (41→40)

### DIFF
--- a/.changeset/fix-corpus-prop-shadow-param-updated.md
+++ b/.changeset/fix-corpus-prop-shadow-param-updated.md
@@ -1,0 +1,31 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): keep `PROPS_IS_UPDATED` when a reassigned prop is shadowed by a function parameter
+
+When an `export let` prop shares its name with a function parameter elsewhere in
+the component, the `BindableProp` kind can land on the parameter binding (which is
+never reassigned), while the real prop declaration — which actually carries the
+reassignment — ends up as a separate instance-scope binding:
+
+```svelte
+<script context="module">
+  function setCanvasContext(context) { setContext(key, context); } // param `context`
+</script>
+<script>
+  export let context = undefined;                 // the real prop
+  onMount(() => { context = element?.getContext('2d'); }); // reassigns the prop
+</script>
+```
+
+`calculate_prop_flags` resolved the parameter binding (not reassigned) and emitted
+`$.prop($$props, "context", 8, …)` (BINDABLE) instead of the correct `12`
+(BINDABLE | UPDATED).
+
+When computing `PROPS_IS_UPDATED`, also OR in the reassigned/mutated state of any
+same-named *real* declaration in the instance/module scope (excluding function
+parameters). This is flag-only — it does not change which binding is marked
+`BindableProp`, so var-hoisting (and the previously-fixed `BrushContext` /
+`GeoContext` outputs) are untouched. Clears
+`layerchart/.../layout/Canvas.svelte` (41 → 40).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -13,7 +13,6 @@
 	"layerchart/packages/layerchart/src/lib/components/Points.svelte",
 	"layerchart/packages/layerchart/src/lib/components/charts/AreaChart.svelte",
 	"layerchart/packages/layerchart/src/lib/components/charts/BarChart.svelte",
-	"layerchart/packages/layerchart/src/lib/components/layout/Canvas.svelte",
 	"layerchart/packages/layerchart/src/lib/docs/TilesetField.svelte",
 	"layerchart/packages/layerchart/src/routes/docs/examples/Area/+page.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1760,10 +1760,30 @@ pub(super) fn calculate_prop_flags(
     if analysis.accessors {
         flags |= PROPS_IS_UPDATED;
     } else if let Some(b) = binding {
+        use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
+        // When a prop is shadowed by a same-named function parameter, the
+        // BindableProp kind can land on the parameter binding (which is never
+        // reassigned), while the real `export let`/destructured prop binding —
+        // declared in the instance/module scope — carries the reassignment.
+        // Borrow the real declaration's updated-ness so a reassigned prop still
+        // gets PROPS_IS_UPDATED. (Sort/flag-only — does not change which binding
+        // is marked BindableProp, so var-hoisting is untouched.)
+        let real_reassigned = analysis.root.bindings.iter().any(|x| {
+            x.name == name
+                && x.declaration_kind != DeclarationKind::Param
+                && (x.scope_index == 0 || x.scope_index == analysis.root.instance_scope_index)
+                && x.reassigned
+        });
+        let real_mutated = analysis.root.bindings.iter().any(|x| {
+            x.name == name
+                && x.declaration_kind != DeclarationKind::Param
+                && (x.scope_index == 0 || x.scope_index == analysis.root.instance_scope_index)
+                && x.mutated
+        });
         let is_updated = if analysis.immutable {
-            b.reassigned || (analysis.runes && b.mutated)
+            (b.reassigned || real_reassigned) || (analysis.runes && (b.mutated || real_mutated))
         } else {
-            b.is_updated()
+            b.is_updated() || real_reassigned || real_mutated
         };
         if is_updated {
             flags |= PROPS_IS_UPDATED;


### PR DESCRIPTION
## What

When an `export let` prop shares its name with a function parameter elsewhere in the component, the `BindableProp` kind lands on the **parameter** binding (never reassigned), while the real prop declaration carries the reassignment as a separate instance-scope binding:

```svelte
<script context="module">
  function setCanvasContext(context) { setContext(key, context); } // param `context`
</script>
<script>
  export let context = undefined;                          // the real prop
  onMount(() => { context = element?.getContext('2d'); }); // reassigns the prop
</script>
```

`calculate_prop_flags` resolved the parameter binding (not reassigned) → `$.prop($$props, "context", 8, …)` (BINDABLE) instead of the correct `12` (BINDABLE | UPDATED).

(Debug-traced: `export let context` is declared as `Let` in the instance scope, but the prop-marking lookup — polluted by the root scope — marked the module-script param as `BindableProp`; the real prop, reassigned in `onMount`, was promoted to `State`.)

## Fix

When computing `PROPS_IS_UPDATED`, also OR in the reassigned/mutated state of any same-named **real** declaration in the instance/module scope (excluding function parameters). This is flag-only — it does **not** change which binding is marked `BindableProp`, so var-hoisting is untouched (a prior re-marking attempt regressed `BrushContext`/`GeoContext`; this approach avoids that coupling).

## Impact

`compat/corpus/known-failures.json`: **41 → 40** — clears `layerchart/.../layout/Canvas.svelte`.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions** (incl. BrushContext/GeoContext)
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5