### PR TITLE
fix(transform): continue multi-line initializer starting with ( [ or backtick (40→39)

### DIFF
--- a/.changeset/fix-corpus-multiline-init-asi.md
+++ b/.changeset/fix-corpus-multiline-init-asi.md
@@ -1,0 +1,26 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): don't truncate a multi-line initializer whose continuation starts with `(`/`[`/backtick
+
+A legacy state declaration whose initializer continues on the next line starting
+with `(` was wrapped incorrectly:
+
+```svelte
+<script>
+  let shownCalendar =
+    (range && value != null ? value.start : value) || new Date();
+</script>
+```
+
+produced `let shownCalendar = $.mutable_source()(range … ) || new Date()` — an
+empty `$.mutable_source()` followed by the un-wrapped initializer — instead of
+`$.mutable_source((range … ) || new Date())`.
+
+`find_statement_end_client` treated the newline after `=` as a statement end
+because the next non-whitespace char (`(`) was not in its continuation set, so the
+extracted initializer was empty. Per JavaScript ASI, a line break followed by `(`,
+`[`, or a backtick continues the previous expression (`foo\n(bar)` is `foo(bar)`,
+`a\n[i]` is `a[i]`). Add those to the continuation set. Clears
+`attractions/.../date-picker/date-picker.svelte` (40 → 39).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -1,5 +1,4 @@
 [
-	"attractions/attractions/date-picker/date-picker.svelte",
 	"attractions/attractions/slider/slider.svelte",
 	"flowbite-svelte/src/lib/datepicker/Datepicker.svelte",
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/products/+page.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -305,6 +305,15 @@ pub(super) fn find_statement_end_client(s: &str) -> usize {
                             | '>'
                             | '='
                             | ','
+                            // `(`, `[`, and a backtick after a newline continue the
+                            // expression per JS ASI rules (`foo\n(bar)` is `foo(bar)`,
+                            // `a\n[i]` is `a[i]`). Without these, a multi-line
+                            // initializer whose continuation line starts with `(`
+                            // (e.g. `let x =\n  (cond ? a : b) || c`) is truncated to
+                            // an empty expression.
+                            | '('
+                            | '['
+                            | '`'
                     ) {
                         // continuation; keep scanning
                     } else {


### PR DESCRIPTION
## What

A legacy state declaration whose initializer continues on the next line starting with `(`:

```svelte
<script>
  let shownCalendar =
    (range && value != null ? value.start : value) || new Date();
</script>
```

produced `let shownCalendar = $.mutable_source()(range … ) || new Date()` — an empty `$.mutable_source()` followed by the un-wrapped initializer — instead of `$.mutable_source((range … ) || new Date())`.

## Root cause

`find_statement_end_client` walks the joined declaration text to find the end of the initializer. When it hit the newline after `=` (at paren depth 0), it checked the next non-whitespace char; `(` was **not** in its continuation set, so it treated the newline as a statement end → the extracted initializer was empty.

Per JavaScript ASI, a line break followed by `(`, `[`, or a backtick continues the previous expression (`foo\n(bar)` → `foo(bar)`, `a\n[i]` → `a[i]`). These were missing from the continuation set (which had ternary/member/binary operators).

## Fix

Add `(`, `[`, and backtick to the newline-continuation set in `find_statement_end_client`.

## Impact

`compat/corpus/known-failures.json`: **40 → 39** — clears `attractions/.../date-picker/date-picker.svelte`.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions** (10,987 match)
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5