### PR TITLE
fix(transform): preserve whitespace inside <title> SSR (39→38)

### DIFF
--- a/.changeset/fix-corpus-title-preserve-whitespace.md
+++ b/.changeset/fix-corpus-title-preserve-whitespace.md
@@ -1,0 +1,24 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): preserve whitespace inside `<title>` (SSR), matching upstream
+
+Upstream's server `TitleElement` visitor calls `process_children` directly on the
+raw fragment nodes — it never runs `clean_nodes`, so the title's inner whitespace
+is preserved verbatim:
+
+```svelte
+<svelte:head>
+  <title>
+    {name ? `${name} |` : ''} Smelte the framework
+  </title>
+</svelte:head>
+```
+
+rsvelte's `process_children` cleans whitespace internally, so the leading
+`\n    ` before the expression was trimmed (`<title>${…}` instead of
+`<title>\n    ${…}`). Toggle `preserve_whitespace` around the title body's
+`process_children` so its whitespace is kept verbatim, matching upstream's
+clean_nodes bypass. Clears `smelte/src/routes/components/_layout.svelte`
+(39 → 38).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -18,7 +18,6 @@
 	"powertable/app/src/lib/components/PowerTable.svelte",
 	"shadcn-svelte/docs/src/lib/components/mobile-nav.svelte",
 	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",
-	"smelte/src/routes/components/_layout.svelte",
 	"svelte-form-builder/src/lib/Components/Select.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/title_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/title_element.rs
@@ -37,7 +37,15 @@ pub fn visit_title_element<'a>(node: &TitleElement, state: &mut ServerTransformS
     state
         .template
         .push(TemplateEntry::Literal("<title>".to_string()));
+    // Upstream's `TitleElement` calls `process_children` directly on the raw
+    // fragment nodes WITHOUT running `clean_nodes`, so the title's inner
+    // whitespace is preserved verbatim. rsvelte's `process_children` cleans
+    // internally, so suppress that for the title body by toggling
+    // `preserve_whitespace` (save/restore).
+    let saved_preserve = state.preserve_whitespace;
+    state.preserve_whitespace = true;
     process_children(&node.fragment.nodes, None, "html", state);
+    state.preserve_whitespace = saved_preserve;
     state
         .template
         .push(TemplateEntry::Literal("</title>".to_string()));


### PR DESCRIPTION
## What

Upstream's server `TitleElement` visitor calls `process_children` directly on the raw fragment nodes — it never runs `clean_nodes`, so a title's inner whitespace is preserved verbatim:

```svelte
<svelte:head>
  <title>
    {name ? `${name} |` : ''} Smelte the framework
  </title>
</svelte:head>
```

rsvelte's `process_children` cleans whitespace internally, so the leading `\n    ` before the expression was trimmed (`<title>${…}` instead of `<title>\n    ${…}`).

## Fix

Toggle `preserve_whitespace` around the title body's `process_children` so its whitespace is kept verbatim, matching upstream's `clean_nodes` bypass.

## Impact

`compat/corpus/known-failures.json`: **39 → 38** — clears `smelte/src/routes/components/_layout.svelte`.

> Stacked on #1318. Retarget to `main` once #1318 merges.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5