### PR TITLE
fix(transform): parenthesized sub-expr is simple in SSR prop fallback (38→37)

### DIFF
--- a/.changeset/fix-corpus-fallback-paren-simple.md
+++ b/.changeset/fix-corpus-fallback-paren-simple.md
@@ -1,0 +1,25 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): treat a parenthesized sub-expression as "simple" in prop fallbacks (SSR)
+
+A legacy prop whose default is a simple arithmetic expression containing
+parentheses was emitted with a needless lazy thunk:
+
+```svelte
+<script>
+  export let value = max < min ? min : min + (max - min) / 2;
+</script>
+```
+
+produced `$.fallback($$props["value"], () => (max < min ? …), true)` instead of
+the eager `$.fallback($$props["value"], max < min ? …)`.
+
+Upstream parses with `preserveParens: false`, so `is_simple_expression` never
+sees a parenthesized node. OXC preserves `(max - min)` as a
+`ParenthesizedExpression`, which `is_simple_default`'s catch-all treated as
+non-simple — making the whole default complex → lazy. Unwrap
+`ParenthesizedExpression` (recurse on the inner expression) so a parenthesized
+simple expression stays simple/eager, matching upstream. Clears
+`attractions/.../slider/slider.svelte` (38 → 37).

--- a/compat/corpus/known-failures.json
+++ b/compat/corpus/known-failures.json
@@ -1,5 +1,4 @@
 [
-	"attractions/attractions/slider/slider.svelte",
 	"flowbite-svelte/src/lib/datepicker/Datepicker.svelte",
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/products/+page.svelte",
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/users/+page.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -3047,6 +3047,12 @@ fn is_simple_default(init: &OxcExpression) -> bool {
         }
         E::BinaryExpression(bin) => is_simple_default(&bin.left) && is_simple_default(&bin.right),
         E::LogicalExpression(l) => is_simple_default(&l.left) && is_simple_default(&l.right),
+        // Upstream parses with `preserveParens: false`, so a parenthesized
+        // sub-expression like `(max - min)` is an implicit/transparent node there.
+        // OXC preserves it as a `ParenthesizedExpression`, so unwrap it to match —
+        // otherwise an otherwise-simple default (e.g. `min + (max - min) / 2`) is
+        // wrongly treated as complex and emitted as a lazy `$.fallback(…, () => …, true)`.
+        E::ParenthesizedExpression(p) => is_simple_default(&p.expression),
         _ => false,
     }
 }


### PR DESCRIPTION
## What

A legacy prop whose default is a simple arithmetic expression containing parentheses was emitted with a needless lazy thunk:

```svelte
<script>
  export let value = max < min ? min : min + (max - min) / 2;
</script>
```

produced `$.fallback($$props["value"], () => (max < min ? …), true)` instead of the eager `$.fallback($$props["value"], max < min ? …)`.

## Root cause

Upstream parses with `preserveParens: false`, so `is_simple_expression` never sees a parenthesized node. OXC preserves `(max - min)` as a `ParenthesizedExpression`, which `is_simple_default`'s catch-all (`_ => false`) treated as non-simple — so the whole default became "complex" → lazy.

## Fix

Unwrap `ParenthesizedExpression` (recurse on the inner expression) in `is_simple_default`, matching upstream's paren-transparent AST.

## Impact

`compat/corpus/known-failures.json`: **38 → 37** — clears `attractions/.../slider/slider.svelte`.

## Verification

- `compile.mjs` + `verify.mjs`: 1 known failure now passes, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5