### PR TITLE
fix(transform): parenthesize new-callee with a call in member spine (text printer)

### DIFF
--- a/.changeset/fix-corpus-new-precedence-text-printer.md
+++ b/.changeset/fix-corpus-new-precedence-text-printer.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): parenthesize a `new` callee whose member spine contains a call (text printer)
+
+`new $.get(deckgl).MapboxOverlay({ … })` was emitted by the text-printer fallback
+without parenthesizing the callee, so it parses as
+`(new $.get(deckgl)).MapboxOverlay({ … })`. The AST printer (esrap) already
+guards this via `callee_has_call_expression`; the text printer's
+`emit_new_expression` only parenthesized low-precedence callees (conditional,
+await, …), not a member chain containing a `CallExpression`. Mirror esrap: walk
+the callee's `Member`/`Call` spine and parenthesize when a call is found, emitting
+`new ($.get(deckgl).MapboxOverlay)({ … })`.
+
+Clears the SSR (server) output for `svelte-maplibre/.../DeckGlLayer.svelte`
+(server known-failures 35 → 34). Its CSR output still differs on an orthogonal
+axis (the client builds the effect body as a raw string, bypassing the AST
+printer), so the client entry remains.

--- a/compat/corpus/known-failures.server.json
+++ b/compat/corpus/known-failures.server.json
@@ -19,7 +19,6 @@
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelDataAttributes.svelte",
-	"svelte-maplibre/src/lib/DeckGlLayer.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",
 	"svelte-table/example/example6/ContactButtonComponent.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -1312,8 +1312,12 @@ impl<'a> JsCodegen<'a> {
                 | JsExpr::Await(_)
                 | JsExpr::Assignment(_)
                 | JsExpr::Sequence(_)
-                | JsExpr::Yield(_)
-        );
+                | JsExpr::Yield(_) // `new` binds tighter than a call, so a callee whose member spine
+                                   // contains a CallExpression (`new $.get(x).Member(args)`) — or a chain —
+                                   // must be parenthesised, else the trailing `(args)` would be parsed as
+                                   // the `new` arguments. Mirrors esrap's `callee_has_call_expression`.
+        ) || matches!(callee, JsExpr::Chain(_))
+            || self.callee_has_call_expression(callee);
         if needs_parens {
             self.output.push('(');
         }
@@ -1324,6 +1328,20 @@ impl<'a> JsCodegen<'a> {
         self.output.push('(');
         self.emit_call_args(&new_expr.arguments);
         self.output.push(')');
+    }
+
+    /// True when a `new` callee's member spine contains a `CallExpression`
+    /// (`$.get(x).Member`), which forces the callee to be parenthesised so the
+    /// `new` arguments aren't mis-parsed as a call. Mirrors esrap.
+    fn callee_has_call_expression(&self, expr: &JsExpr) -> bool {
+        let mut node = expr;
+        loop {
+            match node {
+                JsExpr::Call(_) => return true,
+                JsExpr::Member(m) => node = self.arena.get_expr(m.object),
+                _ => return false,
+            }
+        }
     }
 
     #[inline]


### PR DESCRIPTION
## What

The text-printer fallback emitted:
```js
new $.get(deckgl).MapboxOverlay({ … })   // ❌ parses as (new $.get(deckgl)).MapboxOverlay(…)
```
instead of upstream's:
```js
new ($.get(deckgl).MapboxOverlay)({ … })  // ✅
```

## Root cause

`new` binds tighter than a call, so a callee whose member spine contains a `CallExpression` (`$.get(x).Member`) must be parenthesized. The AST printer (esrap) already guards this via `callee_has_call_expression`, but the text-printer fallback's `emit_new_expression` only parenthesized low-precedence callees (conditional, await, sequence, …) — not a member chain with a call.

## Fix

Mirror esrap in `codegen.rs::emit_new_expression`: walk the callee's `Member`/`Call` spine and parenthesize when a call is found. Parenthesizing is always semantically safe; this narrows it to the call case to match upstream byte-for-byte.

## Impact

Clears the **SSR (server)** output for `svelte-maplibre/.../DeckGlLayer.svelte` — **server known-failures 35 → 34**.

Its **CSR (client)** output still differs on an orthogonal axis: the client builds the effect body as a raw string that bypasses the AST printer entirely, so the client entry remains (tracked separately).

## Verification

- `astEquivalent` DeckGlLayer **server = true** (was false), client unchanged
- `verify.mjs`: **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5