### PR TITLE
fix(transform): snippet non-hoistable when nested fn closes over instance state

### DIFF
--- a/.changeset/fix-corpus-snippet-hoist-nested-fn.md
+++ b/.changeset/fix-corpus-snippet-hoist-nested-fn.md
@@ -1,0 +1,29 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): a snippet is non-hoistable when a nested function closes over instance state
+
+A root-level `{#snippet}` was hoisted to module scope even when one of its nested
+functions referenced component state, e.g.:
+
+```svelte
+{#snippet MobileLink({ href, content })}
+  <a {href} onclick={() => { open = false; }}>{content}</a>
+{/snippet}
+```
+
+`open` is component state, so upstream keeps `MobileLink` defined *inside* the
+component; rsvelte hoisted it to module top-level. The hoistability walk
+(`can_hoist_snippet`) treated every `ArrowFunctionExpression` /
+`FunctionExpression` as unconditionally hoistable (`=> true`), so references
+inside nested handlers were never inspected.
+
+Now nested functions are walked: their own params and locally-declared names are
+treated as local, and any remaining reference to an instance-level binding blocks
+hoisting — mirroring upstream's `scope.references` walk through nested functions.
+Both the typed and JSON expression checkers route through one shared helper.
+
+Clears `shadcn-svelte/.../mobile-nav.svelte` and
+`flowbite-svelte/.../datepicker/Datepicker.svelte` on both CSR and SSR, with zero
+corpus regressions.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -1,5 +1,4 @@
 [
-	"flowbite-svelte/src/lib/datepicker/Datepicker.svelte",
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/products/+page.svelte",
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/users/+page.svelte",
 	"layercake/src/lib/LayerCake.svelte",
@@ -11,7 +10,6 @@
 	"layerchart/packages/layerchart/src/lib/docs/TilesetField.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"powertable/app/src/lib/components/PowerTable.svelte",
-	"shadcn-svelte/docs/src/lib/components/mobile-nav.svelte",
 	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",
 	"svelte-form-builder/src/lib/Components/Select.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",

--- a/compat/corpus/known-failures.server.json
+++ b/compat/corpus/known-failures.server.json
@@ -1,8 +1,6 @@
 [
-	"flowbite-svelte/src/lib/datepicker/Datepicker.svelte",
 	"flowbite-svelte/src/routes/docs-examples/forms/file-input/Dropzone.svelte",
 	"layerchart/packages/layerchart/src/lib/components/Area.svelte",
-	"shadcn-svelte/docs/src/lib/components/mobile-nav.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte",
 	"svelte/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/input.svelte",
 	"sveltestrap/src/Input/Input.svelte"

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
@@ -373,7 +373,15 @@ fn expression_only_uses_params_node(
             true
         }
 
-        JsNode::ArrowFunctionExpression { .. } | JsNode::FunctionExpression { .. } => true,
+        JsNode::ArrowFunctionExpression { .. } | JsNode::FunctionExpression { .. } => {
+            // A nested function/arrow can close over instance-level state (e.g.
+            // `onclick={() => { open = false }}`), which blocks hoisting. Serialize
+            // it (resolving arena children) and walk its body via the JSON helper.
+            match serde_json::from_str::<serde_json::Value>(&node.to_json_string()) {
+                Ok(v) => arrow_hoistable(&v, param_names, context),
+                Err(_) => true,
+            }
+        }
 
         _ => false,
     }
@@ -1034,6 +1042,127 @@ fn is_identifier_hoistable(
     }
 }
 
+/// Collect names bound *locally* inside a function/arrow body — `var`/`let`/
+/// `const` declarators, nested function/arrow params + names, class names and
+/// `catch` params — so that later references to them are treated as local
+/// (hoistable). Mirrors the official scope-reference walk, which skips bindings
+/// whose `function_depth >= scope.function_depth` (i.e. declared inside the
+/// snippet's own nested functions).
+fn collect_local_bindings(val: &serde_json::Value, out: &mut FxHashSet<String>) {
+    match val {
+        serde_json::Value::Array(a) => {
+            for v in a {
+                collect_local_bindings(v, out);
+            }
+        }
+        serde_json::Value::Object(o) => {
+            let ty = o.get("type").and_then(|t| t.as_str());
+            match ty {
+                Some("VariableDeclarator")
+                | Some("FunctionDeclaration")
+                | Some("ClassDeclaration") => {
+                    if let Some(id) = o.get("id")
+                        && let Some(names) = extract_pattern_names(id)
+                    {
+                        for n in names {
+                            out.insert(n);
+                        }
+                    }
+                }
+                _ => {}
+            }
+            if matches!(
+                ty,
+                Some("FunctionDeclaration")
+                    | Some("FunctionExpression")
+                    | Some("ArrowFunctionExpression")
+            ) && let Some(params) = o.get("params").and_then(|p| p.as_array())
+            {
+                for p in params {
+                    if let Some(names) = extract_pattern_names(p) {
+                        for n in names {
+                            out.insert(n);
+                        }
+                    }
+                }
+            }
+            if ty == Some("CatchClause")
+                && let Some(param) = o.get("param")
+                && let Some(names) = extract_pattern_names(param)
+            {
+                for n in names {
+                    out.insert(n);
+                }
+            }
+            for (_, v) in o {
+                collect_local_bindings(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Walk any node (statement or expression) JSON, returning `false` if it
+/// references a non-hoistable (instance-level) identifier. Skips identifiers in
+/// non-reference position (non-computed member properties and object keys).
+fn refs_hoistable(
+    val: &serde_json::Value,
+    params: &FxHashSet<String>,
+    context: &VisitorContext,
+) -> bool {
+    match val {
+        serde_json::Value::Array(a) => a.iter().all(|v| refs_hoistable(v, params, context)),
+        serde_json::Value::Object(o) => match o.get("type").and_then(|t| t.as_str()) {
+            Some("Identifier") => o
+                .get("name")
+                .and_then(|n| n.as_str())
+                .is_none_or(|n| is_identifier_hoistable(n, params, context)),
+            Some("MemberExpression") => {
+                if let Some(obj) = o.get("object")
+                    && !refs_hoistable(obj, params, context)
+                {
+                    return false;
+                }
+                if o.get("computed").and_then(|c| c.as_bool()).unwrap_or(false)
+                    && let Some(prop) = o.get("property")
+                    && !refs_hoistable(prop, params, context)
+                {
+                    return false;
+                }
+                true
+            }
+            Some("Property") => {
+                if o.get("computed").and_then(|c| c.as_bool()).unwrap_or(false)
+                    && let Some(key) = o.get("key")
+                    && !refs_hoistable(key, params, context)
+                {
+                    return false;
+                }
+                o.get("value")
+                    .is_none_or(|v| refs_hoistable(v, params, context))
+            }
+            _ => o
+                .iter()
+                .all(|(k, v)| k == "type" || refs_hoistable(v, params, context)),
+        },
+        _ => true,
+    }
+}
+
+/// Determine whether a nested function / arrow (as JSON) only references
+/// hoistable identifiers — its own params and any names it declares locally are
+/// treated as local, mirroring upstream's reference walk through nested
+/// functions (which the blanket `=> true` arms previously skipped entirely).
+fn arrow_hoistable(
+    arrow_json: &serde_json::Value,
+    outer_params: &FxHashSet<String>,
+    context: &VisitorContext,
+) -> bool {
+    let mut locals = outer_params.clone();
+    collect_local_bindings(arrow_json, &mut locals);
+    refs_hoistable(arrow_json, &locals, context)
+}
+
 /// Check if an expression only uses hoistable identifiers - JSON version.
 fn expression_only_uses_params(
     val: &serde_json::Value,
@@ -1203,7 +1332,13 @@ fn expression_only_uses_params(
                 true
             }
 
-            Some("ArrowFunctionExpression") | Some("FunctionExpression") => true,
+            // A nested function/arrow can still close over instance-level state
+            // (e.g. an event handler `onclick={() => { open = false }}`), which
+            // blocks hoisting. Walk its body (treating its own params + local
+            // declarations as local) instead of the old blanket `=> true`.
+            Some("ArrowFunctionExpression") | Some("FunctionExpression") => {
+                arrow_hoistable(val, param_names, context)
+            }
 
             _ => false,
         }


### PR DESCRIPTION
## What

A root-level `{#snippet}` was hoisted to module scope even when one of its nested functions closed over component state:

```svelte
{#snippet MobileLink({ href, content })}
  <a {href} onclick={() => { open = false; }}>{content}</a>
{/snippet}
```

`open` is component state → upstream keeps `MobileLink` **inside** the component function; rsvelte hoisted it to module top-level (`export default function` vs a nested `function`).

## Root cause

`can_hoist_snippet`'s reference walk treated every nested `ArrowFunctionExpression` / `FunctionExpression` as unconditionally hoistable (`=> true`) — so references inside event handlers / callbacks were never inspected. Upstream walks `scope.references`, which includes references inside nested functions.

## Fix

Walk nested functions instead of short-circuiting: their own params and locally-declared names (`var`/`let`/`const`, nested params, `catch` params) are treated as local; any remaining reference to an instance-level binding blocks hoisting. One shared JSON helper (`arrow_hoistable` → `collect_local_bindings` + `refs_hoistable`) serves both the typed (`JsNode`, via `to_json_string`) and JSON expression checkers.

## Impact

- `known-failures.client.json`: 31 → 29
- `known-failures.server.json`: 7 → 5

Clears `shadcn-svelte/.../mobile-nav.svelte` and `flowbite-svelte/.../datepicker/Datepicker.svelte` on **both CSR and SSR** (the hoistability metadata is shared by both generators).

## Verification

- `astEquivalent` both files, both targets = true
- `verify.mjs`: 4 entries now pass, **0 regressions**, baseline accurate after prune
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5