### PR TITLE
fix(transform): prop default referencing legacy $: reactive var is lazy

### DIFF
--- a/.changeset/fix-corpus-prop-lazy-legacy-reactive.md
+++ b/.changeset/fix-corpus-prop-lazy-legacy-reactive.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): a prop default referencing a legacy `$:` reactive variable is lazy
+
+```svelte
+<script>
+  $: defaultServiceUrl = services['mapbox v1']['streets-v11'];
+  export let serviceUrl = defaultServiceUrl;
+</script>
+```
+
+`serviceUrl`'s default references `defaultServiceUrl`, a legacy `$:` reactive
+variable (`BindingKind::LegacyReactive`). Upstream applies the read transform
+first — `defaultServiceUrl` → `$.get(defaultServiceUrl)` — so `is_simple_expression`
+sees a (non-simple) `CallExpression` and emits a lazy thunk with
+`PROPS_IS_LAZY_INITIAL`: `$.prop($$props, 'serviceUrl', 28, () => $.get(defaultServiceUrl))`.
+
+rsvelte's prop-flag reactivity check only recognised
+`bindable_prop`/`prop`/`state`/`raw_state`/`derived` identifiers as non-simple, so
+a `LegacyReactive` reference was treated as simple → emitted eagerly
+(`…, 12, $.get(defaultServiceUrl)`). Add `LegacyReactive` to both prop-default
+paths; unlike a prop ref it transforms to a member call (`$.get(...)`), so it is
+thunked rather than unwrapped to a bare callee.
+
+Clears `layerchart/.../docs/TilesetField.svelte`, zero corpus regressions.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -7,7 +7,6 @@
 	"layerchart/packages/layerchart/src/lib/components/Points.svelte",
 	"layerchart/packages/layerchart/src/lib/components/charts/AreaChart.svelte",
 	"layerchart/packages/layerchart/src/lib/components/charts/BarChart.svelte",
-	"layerchart/packages/layerchart/src/lib/docs/TilesetField.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"powertable/app/src/lib/components/PowerTable.svelte",
 	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -528,6 +528,25 @@ pub(super) fn transform_let_with_reexported_props(
                     is_simple = false;
                     is_prop_ref = true;
                 }
+                // A bare legacy `$:` reactive variable (`BindingKind::LegacyReactive`)
+                // becomes `$.get(name)` after transform — a MEMBER call, not a
+                // no-arg identifier getter — so it is non-simple and must be
+                // THUNKED (`() => $.get(name)`), not unwrapped to a bare callee
+                // like a prop ref. Mirrors upstream applying the transform before
+                // `is_simple_expression` (the visited CallExpression is non-simple,
+                // and its callee `$.get` is a MemberExpression so it falls through
+                // to `b.thunk(initial)`).
+                if is_simple
+                    && is_identifier_str(val)
+                    && analysis
+                        .root
+                        .find_binding_any_scope(val)
+                        .and_then(|idx| analysis.root.bindings.get(idx))
+                        .is_some_and(|b| matches!(b.kind, BindingKind::LegacyReactive))
+                {
+                    is_simple = false;
+                    // is_prop_ref stays false → thunk path
+                }
                 let flags = calculate_prop_flags(name, analysis, !is_simple);
                 if is_simple {
                     results.push(format!(
@@ -1050,6 +1069,22 @@ pub(super) fn transform_export_let(line: &str, analysis: &ComponentAnalysis) -> 
                 {
                     is_simple = false;
                     is_prop_ref = true;
+                }
+                // A bare legacy `$:` reactive variable becomes `$.get(name)` after
+                // transform — a MEMBER call, not a no-arg identifier getter — so it
+                // is non-simple and must be THUNKED (`() => $.get(name)`), not
+                // unwrapped to a bare callee. Mirrors upstream applying the
+                // transform before `is_simple_expression`.
+                if is_simple
+                    && is_identifier_str(value)
+                    && analysis
+                        .root
+                        .find_binding_any_scope(value)
+                        .and_then(|idx| analysis.root.bindings.get(idx))
+                        .is_some_and(|b| matches!(b.kind, BindingKind::LegacyReactive))
+                {
+                    is_simple = false;
+                    // is_prop_ref stays false → thunk path
                 }
 
                 // Calculate flags: PROPS_IS_BINDABLE + PROPS_IS_UPDATED + PROPS_IS_LAZY_INITIAL


### PR DESCRIPTION
## What

```svelte
<script>
  $: defaultServiceUrl = services['mapbox v1']['streets-v11'];
  export let serviceUrl = defaultServiceUrl;
</script>
```

`serviceUrl`'s default references `defaultServiceUrl`, a legacy `$:` reactive variable. Upstream applies the read transform first (`defaultServiceUrl` → `$.get(defaultServiceUrl)`), so `is_simple_expression` sees a non-simple `CallExpression` and emits a **lazy** thunk:

```js
$.prop($$props, 'serviceUrl', 28, () => $.get(defaultServiceUrl))   // ✅ 28 = LAZY|BINDABLE|UPDATED
```

rsvelte emitted it **eagerly**:

```js
$.prop($$props, 'serviceUrl', 12, $.get(defaultServiceUrl))          // ❌ missing PROPS_IS_LAZY_INITIAL
```

## Root cause

rsvelte's prop-flag reactivity check only treated `bindable_prop`/`prop`/`state`/`raw_state`/`derived` identifier defaults as non-simple (→ lazy). A `BindingKind::LegacyReactive` reference (`$:` variable) was missing, so it stayed "simple" → eager.

## Fix

Add `LegacyReactive` to both prop-default code paths. Unlike a prop ref (which transforms to a no-arg getter `name()` and is unwrapped to its callee), a `$:` variable transforms to a **member call** `$.get(name)`, so it takes the **thunk** branch (`() => $.get(name)`), matching upstream's `b.thunk(initial)`.

## Impact

`known-failures.client.json`: 29 → 28. Clears `layerchart/.../docs/TilesetField.svelte`.

## Verification

- `astEquivalent` TilesetField both targets = true
- `verify.mjs`: 1 entry now passes, **0 regressions**
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5