### PR TITLE
fix(transform): a spread element marks an expression as having a call (legacy reactivity)

### DIFF
--- a/.changeset/fix-corpus-spread-has-call.md
+++ b/.changeset/fix-corpus-spread-has-call.md
@@ -1,0 +1,25 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): a spread element marks an expression as having a call (legacy reactivity)
+
+A legacy component/element attribute value containing a spread —
+
+```svelte
+<Comp scrollIntoView={{ condition: a === b, onlyIfNeeded: c, ...rest }} />
+```
+
+— was emitted without the `(deps, $.untrack(...))` dependency sequence, so its
+reactive dependencies (`c`, `rest`, …) weren't tracked. Upstream's
+`2-analyze/visitors/SpreadElement.js` sets `has_call = true` (and `has_state =
+true`) for any spread ("treat `[...x]` like `[...x.values()]`"), which makes
+`build_expression` wrap the value. rsvelte's metadata walks omitted spreads, so
+`has_call`/`has_member`/`has_assignment` were all false → the value was emitted
+bare.
+
+Both metadata walks now flag a `SpreadElement` as a call: the Phase-2
+`walk_js_expression` (`has_call` + `has_state`) and the Phase-3
+`walk_metadata_flags` used by `build_attribute_value` (`has_call`).
+
+Clears `svelte-ux/.../SelectField.svelte`, zero corpus regressions.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -23,7 +23,6 @@
 	"svelte-ux/packages/svelte-ux/src/lib/components/DateRange.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Duration.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/SelectField.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Tooltip.svelte",
 	"svelthree/src/lib/components/Object3D.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -2165,6 +2165,14 @@ pub fn walk_js_expression(
             }
         }
         Some("SpreadElement") => {
+            // A spread `...x` is treated like `...x.values()` — it may invoke a
+            // getter/iterator — so it counts as both a call and a state reference.
+            // Mirrors upstream `2-analyze/visitors/SpreadElement.js`, which sets
+            // `has_call = true; has_state = true`. This is what makes a legacy
+            // attribute value containing a spread (`{ ...props }`) get wrapped in
+            // the `(deps, $.untrack(...))` dependency sequence by `build_expression`.
+            metadata.set_has_call(true);
+            metadata.set_has_state(true);
             // Visit argument (e.g., ...foo => visit foo)
             if let Some(argument) = expression.get("argument") {
                 walk_js_expression(argument, context, metadata)?;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -375,6 +375,13 @@ fn walk_metadata_flags(
             if let Some(t) = obj.get("type").and_then(|t| t.as_str()) {
                 match t {
                     "CallExpression" => *has_call = true,
+                    // A spread `...x` is treated like `...x.values()` — it may
+                    // invoke a getter/iterator — so it counts as a call. Mirrors
+                    // upstream `2-analyze/visitors/SpreadElement.js`, which sets
+                    // `has_call = true`. This makes a legacy attribute value with a
+                    // spread (`{ ...props }`) get the `(deps, $.untrack(...))`
+                    // dependency wrapping from `build_expression`.
+                    "SpreadElement" => *has_call = true,
                     "MemberExpression" => *has_member = true,
                     "AssignmentExpression" | "UpdateExpression" => *has_assignment = true,
                     "AwaitExpression" => *has_await = true,


### PR DESCRIPTION
## What

A legacy attribute value containing a spread:
```svelte
<Comp scrollIntoView={{ condition: a === b, onlyIfNeeded: c, ...rest }} />
```
was emitted **without** the `(deps, $.untrack(…))` dependency sequence, so its reactive deps (`c`, `rest`, …) weren't tracked.

## Root cause

Upstream's `2-analyze/visitors/SpreadElement.js` sets `has_call = true` (and `has_state = true`) for **any** spread — "treat `[...x]` like `[...x.values()]`" (a spread may invoke a getter/iterator). That makes `build_expression`'s gate (`has_call || has_member || has_assignment`) fire and wrap the value in the deps sequence.

rsvelte's metadata walks didn't flag spreads, so for an all-identifier object with a spread, `has_call`/`has_member`/`has_assignment` were all false → the value was emitted bare.

## Fix

Flag a `SpreadElement` as a call in **both** metadata walks:
- Phase-2 `walk_js_expression` → `has_call` + `has_state`
- Phase-3 `walk_metadata_flags` (used by `build_attribute_value`) → `has_call`

## Impact

`known-failures.client.json`: 27 → 26. Clears `svelte-ux/.../SelectField.svelte`.

## Verification

- `astEquivalent` SelectField both targets = true
- `verify.mjs`: 1 entry now passes, **0 regressions**
- `cargo test --release --lib` + `--test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5