### PR TITLE
fix(transform): mark <select> with non-option content as rich (SSR is_rich)

### DIFF
--- a/.changeset/fix-corpus-select-is-rich.md
+++ b/.changeset/fix-corpus-select-is-rich.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): mark a `<select>` with non-option content as "rich" (SSR)
+
+A `<select>` whose children include anything other than `<option>`/`<optgroup>`
+elements — e.g. `<select multiple><slot /></select>` — must emit the trailing
+`is_rich = true` flag on the SSR `$$renderer.select(attrs, fn, …rest, true)` call
+so the runtime adds the customizable-select hydration marker.
+
+rsvelte's rich-content scan (`select_special_is_rich`) was narrower than upstream's
+`is_customizable_select_element`: it only treated components / `{@render}` /
+`{@html}` as rich and missed `<slot>` (a `SlotElement`), non-option/optgroup
+regular elements, and text. It now faithfully ports
+`is_customizable_select_element` for the `<select>` owner (mirroring
+`find_descendants`: skip snippet/debug/const/declaration/comment/expression tags,
+recurse if/each/key/await/boundary branches but not element children, and treat a
+non-option/optgroup element, non-whitespace text, or any other node as rich).
+
+Clears `sveltestrap/.../Input/Input.svelte` (SSR), zero corpus regressions.

--- a/compat/corpus/known-failures.server.json
+++ b/compat/corpus/known-failures.server.json
@@ -2,6 +2,5 @@
 	"flowbite-svelte/src/routes/docs-examples/forms/file-input/Dropzone.svelte",
 	"layerchart/packages/layerchart/src/lib/components/Area.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte",
-	"svelte/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/input.svelte",
-	"sveltestrap/src/Input/Input.svelte"
+	"svelte/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/input.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/element.rs
@@ -1451,7 +1451,77 @@ fn is_select_special(node: &RegularElement) -> bool {
 /// RegularElement / text child) — we mirror the `transform_server` oracle
 /// byte-for-byte, which the corpus harness compares against.
 fn select_special_is_rich(nodes: &[TemplateNode]) -> bool {
-    select_body_is_rich(nodes, false, false)
+    is_customizable_select(nodes)
+}
+
+/// Faithful port of upstream `nodes.js::is_customizable_select_element` for a
+/// `<select>` owner, combined with its `find_descendants` walk. A `<select>` is
+/// "rich" (needs the trailing `is_rich = true` flag on `$$renderer.select`) when
+/// any descendant — skipping snippet/debug/const/declaration/comment/expression
+/// tags, and recursing into if/each/key/await/boundary branches but NOT into
+/// element children — is:
+///   - a `RegularElement` whose name is not `option`/`optgroup`, or
+///   - a non-whitespace `Text` node, or
+///   - any other node kind (slot, component, `<svelte:element>`, `{@html}`,
+///     `{@render}`, …).
+fn is_customizable_select(nodes: &[TemplateNode]) -> bool {
+    for node in nodes {
+        match node {
+            // `find_descendants` does not yield these (so they never make a
+            // select rich): see upstream `nodes.js`.
+            TemplateNode::SnippetBlock(_)
+            | TemplateNode::DebugTag(_)
+            | TemplateNode::ConstTag(_)
+            | TemplateNode::DeclarationTag(_)
+            | TemplateNode::Comment(_)
+            | TemplateNode::ExpressionTag(_) => {}
+            // Text is rich only when it has non-whitespace content.
+            TemplateNode::Text(t) if !t.data.trim().is_empty() => return true,
+            TemplateNode::Text(_) => {}
+            // Block branches are recursed into (their contents are descendants).
+            TemplateNode::IfBlock(b)
+                if is_customizable_select(&b.consequent.nodes)
+                    || b.alternate
+                        .as_ref()
+                        .is_some_and(|a| is_customizable_select(&a.nodes)) =>
+            {
+                return true;
+            }
+            TemplateNode::IfBlock(_) => {}
+            TemplateNode::EachBlock(b)
+                if is_customizable_select(&b.body.nodes)
+                    || b.fallback
+                        .as_ref()
+                        .is_some_and(|f| is_customizable_select(&f.nodes)) =>
+            {
+                return true;
+            }
+            TemplateNode::EachBlock(_) => {}
+            TemplateNode::KeyBlock(b) if is_customizable_select(&b.fragment.nodes) => return true,
+            TemplateNode::KeyBlock(_) => {}
+            TemplateNode::AwaitBlock(b)
+                if [&b.pending, &b.then, &b.catch]
+                    .into_iter()
+                    .flatten()
+                    .any(|f| is_customizable_select(&f.nodes)) =>
+            {
+                return true;
+            }
+            TemplateNode::AwaitBlock(_) => {}
+            TemplateNode::SvelteBoundary(b) if is_customizable_select(&b.fragment.nodes) => {
+                return true;
+            }
+            TemplateNode::SvelteBoundary(_) => {}
+            // A bare `<option>` / `<optgroup>` is NOT rich, and its children are
+            // not descendants of the select for this check.
+            TemplateNode::RegularElement(el)
+                if el.name.as_str() == "option" || el.name.as_str() == "optgroup" => {}
+            // Every other node — a non-option/optgroup element, slot, component,
+            // `<svelte:element>`, `{@html}`, `{@render}`, … — makes it rich.
+            _ => return true,
+        }
+    }
+    false
 }
 
 /// Whether an `<option>` body has "rich content" → the `$$renderer.option(...)`


### PR DESCRIPTION
## What

A `<select>` whose children include anything other than `<option>`/`<optgroup>` — e.g. `<select multiple><slot /></select>` — must emit the trailing `is_rich = true` flag:

```js
$$renderer.select(attrs, fn, void 0, void 0, void 0, void 0, true)  // ✅ 7 args
```

rsvelte emitted only `$$renderer.select(attrs, fn)` (missing the rest + `is_rich`).

## Root cause

rsvelte's `select_special_is_rich` was intentionally narrower than upstream's `is_customizable_select_element` — it only treated components / `{@render}` / `{@html}` as rich, missing `<slot>` (a `SlotElement`), non-option/optgroup regular elements, and text.

## Fix

Faithfully port `is_customizable_select_element` for the `<select>` owner, mirroring upstream's `find_descendants`:
- skip snippet/debug/const/declaration/comment/expression tags,
- recurse if/each/key/await/boundary branches (not element children),
- treat a non-option/optgroup element, non-whitespace text, or any other node (slot, component, `<svelte:element>`, …) as rich.

`option_is_rich` is left unchanged.

## Impact

`known-failures.server.json`: 5 → 4. Clears `sveltestrap/.../Input/Input.svelte` (SSR).

## Verification

- `astEquivalent` Input both targets = true
- `verify.mjs`: 1 entry now passes, **0 regressions**
- `cargo test --release --lib` + `--test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5