### PR TITLE
fix(transform): don't collect nested-function local decls as reactive deps

### DIFF
--- a/.changeset/fix-corpus-deps-skip-fn-locals.md
+++ b/.changeset/fix-corpus-deps-skip-fn-locals.md
@@ -1,0 +1,28 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): don't collect a nested function's local declarations as reactive dependencies
+
+A legacy reactive expression whose value contains a nested function with its own
+local declarations —
+
+```svelte
+sum(visibleSeries, (s) => {
+  const seriesTooltipData = s.data ? findRelatedData(s.data, data, x) : data;
+  return valueAccessor(seriesTooltipData);
+})
+```
+
+— wrongly listed the function-local `seriesTooltipData` in the dependency
+sequence (`$.deep_read_state(seriesTooltipData)`). Upstream filters references by
+`function_depth`: a binding declared inside the nested function is a local, never
+an eager dependency (its own deps — `findRelatedData`/`data`/`x` — are tracked
+instead).
+
+The fallback dependency collector (`collect_reactive_references_inner`) already
+shadowed arrow/function *parameters*; it now also shadows top-level
+`const`/`let`/`var` declarations in the function body (scoped via the existing
+seen-set save/restore).
+
+Clears `layerchart/.../charts/BarChart.svelte`, zero corpus regressions.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -5,7 +5,6 @@
 	"layerchart/packages/layerchart/src/lib/components/ChartContext.svelte",
 	"layerchart/packages/layerchart/src/lib/components/Points.svelte",
 	"layerchart/packages/layerchart/src/lib/components/charts/AreaChart.svelte",
-	"layerchart/packages/layerchart/src/lib/components/charts/BarChart.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"powertable/app/src/lib/components/PowerTable.svelte",
 	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -2200,6 +2200,19 @@ fn collect_reactive_references(
 }
 
 /// Inner recursive function for collecting reactive references.
+/// Collect the names bound by top-level `const`/`let`/`var` declarations in a
+/// block body. Used to treat a nested function's local declarations as locals
+/// (not dependencies) during reactive-reference collection.
+fn collect_block_local_decl_names(body: &[JsStatement], out: &mut rustc_hash::FxHashSet<String>) {
+    for stmt in body {
+        if let JsStatement::VariableDeclaration(var_decl) = stmt {
+            for decl in &var_decl.declarations {
+                extract_pattern_names(&decl.id, out);
+            }
+        }
+    }
+}
+
 fn collect_reactive_references_inner(
     expr: &JsExpr,
     context: &ComponentContext,
@@ -2561,14 +2574,26 @@ fn collect_reactive_references_inner(
             // However, arrow parameter names shadow outer reactive references and must be
             // excluded. For example, in `switches.filter(s => !!s.on)`, the `s` parameter
             // shadows the each-block `s` and should NOT be collected as a dependency.
-            let mut param_names = FxHashSet::default();
+            let mut local_names = FxHashSet::default();
             for param in &arrow.params {
-                extract_pattern_names(param, &mut param_names);
+                extract_pattern_names(param, &mut local_names);
             }
-            // Add parameter names to seen set to prevent them from being collected
-            for name in &param_names {
-                seen.insert(name.clone());
+            // Block-local declarations (`const`/`let`/`var`) inside the arrow body
+            // are LOCALS, not external dependencies — the official filters
+            // references by function_depth, so a binding declared inside this
+            // nested function is never an eager dep. Add their names too, so a
+            // later read of e.g. `const seriesTooltipData = …` inside the arrow is
+            // not wrongly collected as `$.deep_read_state(seriesTooltipData)`.
+            if let JsArrowBody::Block(block) = &arrow.body {
+                collect_block_local_decl_names(&block.body, &mut local_names);
             }
+            // Add only the names we actually introduce (so we don't clobber an
+            // outer same-named dependency on restore).
+            let newly_added: Vec<String> = local_names
+                .iter()
+                .filter(|n| seen.insert((*n).clone()))
+                .cloned()
+                .collect();
             match &arrow.body {
                 JsArrowBody::Expression(body_expr) => {
                     collect_reactive_references_inner(
@@ -2584,25 +2609,28 @@ fn collect_reactive_references_inner(
                     }
                 }
             }
-            // Remove parameter names from seen set so they don't affect sibling expressions
-            for name in &param_names {
+            // Restore: only remove the names we introduced.
+            for name in &newly_added {
                 seen.remove(name);
             }
         }
 
         JsExpr::Function(func) => {
-            // Also process function bodies, excluding function parameter names
-            let mut param_names = FxHashSet::default();
+            // Also process function bodies, excluding params AND block-local decls.
+            let mut local_names = FxHashSet::default();
             for param in &func.params {
-                extract_pattern_names(param, &mut param_names);
+                extract_pattern_names(param, &mut local_names);
             }
-            for name in &param_names {
-                seen.insert(name.clone());
-            }
+            collect_block_local_decl_names(&func.body.body, &mut local_names);
+            let newly_added: Vec<String> = local_names
+                .iter()
+                .filter(|n| seen.insert((*n).clone()))
+                .cloned()
+                .collect();
             for stmt in &func.body.body {
                 collect_reactive_references_from_statement(stmt, context, getters, seen);
             }
-            for name in &param_names {
+            for name in &newly_added {
                 seen.remove(name);
             }
         }


### PR DESCRIPTION
## What

A legacy reactive expression whose value contains a nested function with its own local declarations:
```svelte
sum(visibleSeries, (s) => {
  const seriesTooltipData = s.data ? findRelatedData(s.data, data, x) : data;
  return valueAccessor(seriesTooltipData);
})
```
wrongly listed the function-local `seriesTooltipData` in the dependency sequence (`$.deep_read_state(seriesTooltipData)`).

## Root cause

Upstream filters references by `function_depth`: a binding declared **inside** the nested function is a local, never an eager dependency (its own deps — `findRelatedData`/`data`/`x` — are tracked instead). rsvelte's fallback dependency collector (`collect_reactive_references_inner`) shadowed arrow/function **parameters** but not their **body-local declarations**.

## Fix

Also shadow top-level `const`/`let`/`var` declaration names in arrow/function bodies (via a small `collect_block_local_decl_names` helper), scoped with the existing seen-set save/restore.

## Impact

`known-failures.client.json`: 26 → 25. Clears `layerchart/.../charts/BarChart.svelte`. (AreaChart/Points have additional, unrelated deep_read diffs and remain.)

## Verification

- `astEquivalent` BarChart both targets = true
- `verify.mjs`: 1 entry now passes, **0 regressions**
- `cargo test --release --lib` + `--test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5