### PR TITLE
fix(fmt): hug-start `>` for pure-text wrapped-open elements (corpus 80→79)

### DIFF
--- a/.changeset/fix-fmt-puretext-hug-start.md
+++ b/.changeset/fix-fmt-puretext-hug-start.md
@@ -1,0 +1,26 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): move the open `>` to its own line for a hug-start pure-text element with a wrapped open tag
+
+A pure-text element/component with a wrapped (multi-line) open tag whose body
+hugs the open tag (shouldHugStart) but ends with whitespace before the close tag
+(shouldHugEnd = false) is handled by `try_collapse`. It kept the open `>` glued to
+the last attribute (`disabled>Disabled button`) instead of dropping it onto its own
+indented line:
+
+```
+<Button
+  disabledClasses="…"
+  disabled
+  >Disabled button
+</Button>
+```
+
+`try_collapse`'s `had_trail` branch now reconstructs the open `>` on its own
+attribute-indented line, mirroring `build_element_doc`'s hug_start assembly (whose
+`indent([softline, group(['>', body])])` softline breaks once the open tag wrapped)
+— the pure-text counterpart of the `try_hug_mixed` hug-start fix.
+
+Burns down the fmt-parity corpus by 1 (79 known failures; smelte).

--- a/compat/corpus/fmt-known-failures.json
+++ b/compat/corpus/fmt-known-failures.json
@@ -32,7 +32,6 @@
 	"powertable/app/src/routes/examples/+layout.svelte",
 	"powertable/app/src/routes/examples/example4/+page.svelte",
 	"smelte/src/components/Ripple/Ripple.svelte",
-	"smelte/src/routes/components/index.svelte",
 	"smelte/src/routes/index.svelte",
 	"svar-core/svelte/demos/common/Index.svelte",
 	"svar-core/svelte/src/components/RichSelect.svelte",

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -2931,7 +2931,17 @@ fn try_collapse(
                 let line_start_inner = out[..s].rfind('\n').map_or(0, |i| i + 1);
                 let elem_indent = out.get(line_start_inner..s).unwrap_or("");
                 if elem_indent.bytes().all(|b| b == b' ' || b == b'\t') {
-                    let result = format!("{open}{collapsed}\n{elem_indent}</{tag}>");
+                    // shouldHugStart (we are in the `!had_lead` block) + multi-line
+                    // open tag: the open `>` hugs the content on its own indented
+                    // line (at the attribute indent), and the close tag
+                    // (shouldHugEnd=false) sits on its own line at the element
+                    // indent. This mirrors `build_element_doc`'s hug_start case
+                    // (`indent([softline, group(['>', body])])`), whose softline
+                    // breaks once the open tag wrapped. Previously the `>` was left
+                    // glued to the last attribute (`disabled>Disabled button`).
+                    let attr_indent = format!("{elem_indent}{indent_unit_tc}");
+                    let onb = open[..open.len() - 1].trim_end();
+                    let result = format!("{onb}\n{attr_indent}>{collapsed}\n{elem_indent}</{tag}>");
                     if result != whole {
                         return Some((start, end, result));
                     }


### PR DESCRIPTION
Third increment of the **milestone-2 layout-engine alignment** — the pure-text counterpart of #1333.

## What

A pure-text element/component with a wrapped (multi-line) open tag whose body hugs the open tag (shouldHugStart) but ends with whitespace before the close tag (shouldHugEnd = false) is handled by `try_collapse` (not `try_hug_mixed`, which requires non-text children). Its `had_trail` branch left the open `>` glued to the last attribute:

```
<Button
  disabledClasses="…"
  disabled>Disabled button     ← should be `disabled\n  >Disabled button`
</Button>
```

It now drops the `>` onto its own attribute-indented line, mirroring `build_element_doc`'s hug_start assembly (`indent([softline, group(['>', body])])`, whose softline breaks once the open tag wrapped). Since that assembly always puts `>` on its own line when the open tag wraps, the previous glued form was always wrong for this shape.

## Verification

- `fmt.mjs --actual && fmt-verify.mjs` → **79 known failures, 0 regressions** (was 80). Newly passing: smelte.
- `cargo clippy` + `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)