### PR TITLE
fix(transform): parenthesize new callee when a state read introduces a call

### DIFF
--- a/.changeset/fix-corpus-new-callee-state-parens.md
+++ b/.changeset/fix-corpus-new-callee-state-parens.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): parenthesize a `new` callee when a state read makes its member-spine contain a call
+
+`new deckgl.MapboxOverlay(...)` where `deckgl` is `$state()` rewrites to
+`new ($.get(deckgl).MapboxOverlay)(...)` upstream — the callee's member-spine now
+contains a `CallExpression` (`$.get(deckgl)`), so `new` requires parentheses or the
+trailing `(...)` would parse as the `new` arguments. esrap/codegen apply this for
+proper AST `new` nodes, but the legacy `$.get(...)` text-rewrite path
+(`ast_state_transform`) emitted the `new` as raw text and skipped it. A
+`visit_new_expression` now inserts the parens when the callee's leftmost member-spine
+identifier is a state variable.
+
+Clears `svelte-maplibre/.../DeckGlLayer.svelte`, zero corpus regressions.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -12,7 +12,6 @@
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelDataAttributes.svelte",
-	"svelte-maplibre/src/lib/DeckGlLayer.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",
 	"svelte-table/example/example6/ContactButtonComponent.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -2954,6 +2954,33 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         // Walk normally
         walk::walk_static_member_expression(self, expr);
     }
+
+    fn visit_new_expression(&mut self, expr: &NewExpression<'ast>) {
+        // A `new X.Y(args)` whose callee member-spine bottoms out in a state var
+        // (rewritten to `$.get(name)`) gains a CallExpression in the callee after
+        // transformation, so it must be parenthesised — `new ($.get(x).Y)(args)` —
+        // else `(args)` parses as the `new` arguments. esrap/codegen apply this
+        // for proper AST `new` nodes, but this Raw-text state path can't, so we
+        // insert the parens here. The inserts are added AFTER the walk so the
+        // inner `name -> $.get(name)` replacement (which shares the callee start
+        // offset) is applied first; the right-to-left, stable-sorted apply then
+        // places `(` immediately before the rewritten callee.
+        let mut leftmost = &expr.callee;
+        let wrap = loop {
+            match leftmost {
+                Expression::StaticMemberExpression(m) => leftmost = &m.object,
+                Expression::ComputedMemberExpression(m) => leftmost = &m.object,
+                Expression::Identifier(id) => break self.is_active_state_var(id.name.as_str()),
+                _ => break false,
+            }
+        };
+        walk::walk_new_expression(self, expr);
+        if wrap {
+            let s = expr.callee.span();
+            self.add_replacement(s.start, s.start, "(".to_string());
+            self.add_replacement(s.end, s.end, ")".to_string());
+        }
+    }
 }
 
 impl<'a, 's> StateVarCollector<'a, 's> {


### PR DESCRIPTION
## What

`new deckgl.MapboxOverlay(...)` where `deckgl` is `$state()` must compile to:
```js
new ($.get(deckgl).MapboxOverlay)(...)  // ✅ callee parenthesized
```
rsvelte emitted `new $.get(deckgl).MapboxOverlay(...)` — without parens the trailing `(...)` parses as the `new` arguments.

## Root cause

After the `deckgl → $.get(deckgl)` rewrite, the callee's member-spine contains a `CallExpression`, so `new` requires the callee to be parenthesized. esrap and the text-printer's `emit_new_expression` already do this for proper AST `new` nodes — but this component falls back to the text printer (it's comment-bearing) and the `new` is produced as **raw text** by the `$.get(...)` state rewrite (`ast_state_transform`), which had no `new`-precedence awareness.

## Fix

Added `visit_new_expression` to `ast_state_transform`: when the callee's leftmost member-spine identifier is a state variable (so it will be wrapped in `$.get(...)`), insert `(`/`)` around the callee. The inserts are added **after** the walk so the inner `$.get(...)` replacement — which shares the callee's start offset — is applied first by the right-to-left, stable-sorted edit pass.

## Impact

`known-failures.client.json`: 25 → 24. Clears `svelte-maplibre/.../DeckGlLayer.svelte`.

## Verification

- `astEquivalent` DeckGlLayer both targets = true
- `verify.mjs`: 1 entry now passes, **0 regressions**
- `cargo test --release --lib` + `--test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5