### PR TITLE
fix(transform): deep-read a keyed each block's reactive index in deps

### DIFF
--- a/.changeset/fix-corpus-keyed-each-index-deepread.md
+++ b/.changeset/fix-corpus-keyed-each-index-deepread.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): deep-read a keyed `{#each}` block's reactive index in dependency lists
+
+In a keyed each block (`{#each items as item, i (item.key)}`) the index `i` is
+reactive — upstream gives it binding kind `template`, so a dependency read deep-reads
+it: `$.deep_read_state($.get(i))`. rsvelte emitted a plain `$.get(i)` because the
+each-block visitor unconditionally cleared the index from `transform_deep_read`, and
+the `EachIndex` fallback check in `collect_reactive_references` can miss it when
+`get_binding` resolves a same-named non-index binding (e.g. a `map((d, i) => …)`
+callback param) instead of the keyed index.
+
+The index is now marked in `transform_deep_read` when reactive (keyed), and still
+shadows an outer same-named marker when static (non-keyed).
+
+Clears `layerchart/.../charts/AreaChart.svelte`, zero corpus regressions.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -4,7 +4,6 @@
 	"layercake/src/lib/LayerCake.svelte",
 	"layerchart/packages/layerchart/src/lib/components/ChartContext.svelte",
 	"layerchart/packages/layerchart/src/lib/components/Points.svelte",
-	"layerchart/packages/layerchart/src/lib/components/charts/AreaChart.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"powertable/app/src/lib/components/PowerTable.svelte",
 	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -1004,12 +1004,24 @@ fn build_declarations(
                 replacement_id: None,
             },
         );
-        // Each index is not a template-kind binding in legacy reactivity;
-        // ensure any outer same-named deep_read marker is shadowed.
-        context
-            .state
-            .transform_deep_read
-            .remove(&index_name.to_string());
+        // A keyed each block's index is reactive — upstream gives it kind
+        // 'template', so a dependency read deep-reads it
+        // (`$.deep_read_state($.get(i))`). Mark it so `collect_reactive_references`
+        // wraps it; `get_binding` alone can resolve to a same-named non-index
+        // binding (e.g. a `map((d, i) => …)` callback param) and miss the
+        // EachIndex kind. A non-keyed (static) index instead shadows any outer
+        // same-named deep_read marker.
+        if index_reactive {
+            context
+                .state
+                .transform_deep_read
+                .insert(index_name.to_string(), ());
+        } else {
+            context
+                .state
+                .transform_deep_read
+                .remove(&index_name.to_string());
+        }
     }
 
     // Handle simple identifier context


### PR DESCRIPTION
## What

In a keyed each block (`{#each items as item, i (item.key)}`), the index `i` is reactive — a dependency read must deep-read it:
```js
$.deep_read_state($.get(i))  // ✅
```
rsvelte emitted a plain `$.get(i)` (missing the `deep_read_state` wrap).

## Root cause

Upstream gives a keyed each-index binding kind `template`, so it deep-reads in dependency lists. rsvelte's each-block visitor **unconditionally cleared** the index from `transform_deep_read`, and the `EachIndex && has_read_transform` fallback in `collect_reactive_references` can miss it because `get_binding` may resolve a same-named non-index binding (e.g. a `map((d, i) => …)` callback parameter) instead of the keyed index.

## Fix

Mark the index in `transform_deep_read` when reactive (keyed); still shadow an outer same-named marker when static (non-keyed). (Scoped to the each-block body via the existing save/restore.)

## Impact

`known-failures.client.json`: 24 → 23. Clears `layerchart/.../charts/AreaChart.svelte`. (Points has a separate `let:`/each-item issue and remains.)

## Verification

- `astEquivalent` AreaChart both targets = true
- `verify.mjs`: 1 entry now passes, **0 regressions**
- `cargo test --release --lib` + `--test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5