### PR TITLE
fix(fmt): keep `<T>` arrow type-param without a JSX comma in <script>

### DIFF
--- a/.changeset/fix-fmt-arrow-type-param-comma.md
+++ b/.changeset/fix-fmt-arrow-type-param-comma.md
@@ -1,0 +1,20 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): don't force a JSX-disambiguation comma on a single arrow type parameter in `<script>`
+
+`<script lang="ts">` bodies were formatted with `SourceType::ts()`, whose
+`extension` field is `None`. oxc_formatter forces a trailing
+JSX-disambiguation comma on a single arrow-function type parameter
+(`const f = <T>(…) => …` → `<T,>`) for every source whose extension is not
+`.ts` (i.e. `.tsx`/`.mts`/`.cts`/unknown), so the `None` extension triggered the
+comma. oxfmt formats embedded `.svelte` scripts as `.ts` and emits `<T>`.
+
+Parse `<script>` bodies with `SourceType::from_extension("ts")` (extension
+`Some(Ts)`, otherwise identical to `SourceType::ts()`) so the formatter sees a
+`.ts` extension and leaves `<T>` as `<T>`. The only output-affecting use of
+`source_type.extension()` in oxc_formatter is this arrow type-parameter comma.
+
+Burns down the fmt-parity corpus by 1 (74 known failures; svelte-splitpanes
+Splitpanes.svelte).

--- a/compat/corpus/fmt-known-failures.json
+++ b/compat/corpus/fmt-known-failures.json
@@ -55,7 +55,6 @@
 	"svelte-pivottable/src/routes/+page.svelte",
 	"svelte-sonner/src/components/Hero.svelte",
 	"svelte-splitpanes/src/comp/Button.svelte",
-	"svelte-splitpanes/src/lib/Splitpanes.svelte",
 	"svelte-stepper/src/routes/components/spinner.svelte",
 	"svelte-table/example/example6/ContactButtonComponent.svelte",
 	"svelte-table/src/SvelteTable.svelte",

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -85,9 +85,14 @@ pub(crate) fn format_script(
     //   1. Numeric-looking string keys like `{ '1': 'one' }` are preserved as `"1"`
     //      rather than being unquoted to `1` (see `can_remove_number_quotes_by_file_type`).
     //   2. TypeScript class property declarations keep their quotes.
-    // Both of these match the oracle, so using `SourceType::ts()` unconditionally
-    // aligns rsvelte-fmt with oxfmt's `.svelte` behaviour (#D).
-    let source_type = SourceType::ts();
+    // Both of these match the oracle, so using TypeScript unconditionally aligns
+    // rsvelte-fmt with oxfmt's `.svelte` behaviour (#D). Use `from_extension("ts")`
+    // (not the bare `SourceType::ts()`, whose `extension` field is `None`) so the
+    // formatter sees a `.ts` extension: oxc_formatter forces a JSX-disambiguation
+    // trailing comma on a single arrow-function type parameter (`<T>` → `<T,>`) for
+    // every source whose extension is not `.ts`, but oxfmt formats embedded `.svelte`
+    // scripts as `.ts` (no comma). Matching the extension keeps `<T>` as `<T>`.
+    let source_type = SourceType::from_extension("ts").unwrap_or_else(|_| SourceType::ts());
 
     let parser_ret = Parser::new(&allocator, body, source_type)
         .with_options(formatter_parse_options())
@@ -168,7 +173,9 @@ pub(crate) fn format_nested_script(
     let allocator = Allocator::default();
     // Same reasoning as format_script: always use TS source type so that
     // numeric-looking string property keys are preserved (oracle uses babel-ts).
-    let source_type = SourceType::ts();
+    // `from_extension("ts")` (extension `Some(Ts)`) avoids the forced
+    // `<T>` → `<T,>` arrow type-parameter comma that a `None` extension triggers.
+    let source_type = SourceType::from_extension("ts").unwrap_or_else(|_| SourceType::ts());
     let parser_ret = Parser::new(&allocator, body, source_type)
         .with_options(formatter_parse_options())
         .parse();


### PR DESCRIPTION
## Summary

`<script lang="ts">` bodies were parsed/formatted with `SourceType::ts()`, whose `extension` field is `None`. oxc_formatter forces a trailing JSX-disambiguation comma on a single arrow-function type parameter (`const f = <T>(…) => …` → `<T,>`) for **any** source whose extension is not `.ts` (`.tsx`/`.mts`/`.cts`/unknown). The `None` extension therefore triggered the comma, while oxfmt — which formats embedded `.svelte` scripts as `.ts` — emits `<T>`.

Fix: parse `<script>` bodies with `SourceType::from_extension("ts")` (extension `Some(Ts)`, otherwise identical to `SourceType::ts()`). The arrow type-parameter comma is the **only** output-affecting use of `source_type.extension()` in oxc_formatter, so the change is fully scoped.

## Result

Formatter-parity corpus: **75 → 74** known failures, **0 regressions** (svelte-splitpanes `Splitpanes.svelte` now byte-identical to the oxfmt oracle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)