### PR TITLE
chore(deps): unify oxc to 0.138 and oxc_formatter to dd5d39e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -115,7 +115,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -648,7 +648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1169,7 +1169,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1634,8 +1634,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1647,8 +1647,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1664,8 +1664,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "phf 0.14.0",
  "proc-macro2 1.0.106",
@@ -1675,8 +1675,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1686,8 +1686,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1707,13 +1707,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1722,8 +1722,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1737,8 +1737,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1747,8 +1747,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.56.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.57.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1773,8 +1773,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter_core"
-version = "0.56.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.57.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1787,8 +1787,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter_json"
-version = "0.56.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.57.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "dragonbox_ecma",
  "oxc_allocator",
@@ -1813,8 +1813,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_jsdoc"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1823,8 +1823,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1846,8 +1846,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1889,8 +1889,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "itertools 0.15.0",
  "memchr",
@@ -1924,8 +1924,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1938,8 +1938,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1950,8 +1950,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.137.0"
-source = "git+https://github.com/oxc-project/oxc?rev=5762638c8ec6981455ef6d7e9482d2ceca757829#5762638c8ec6981455ef6d7e9482d2ceca757829"
+version = "0.138.0"
+source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2499,7 +2499,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2850,7 +2850,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3257,7 +3257,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,18 +80,18 @@ type_complexity = "allow"
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -60,15 +60,15 @@ smallvec = { version = "1.13", features = ["serde"] }
 rustc-hash = "2.0"
 
 # JavaScript parsing and code generation
-oxc_allocator = "0.137"
-oxc_parser = "0.137"
-oxc_ast = { version = "0.137", features = ["serialize"] }
-oxc_span = "0.137"
-oxc_diagnostics = "0.137"
-oxc_codegen = "0.137"
+oxc_allocator = "0.138"
+oxc_parser = "0.138"
+oxc_ast = { version = "0.138", features = ["serialize"] }
+oxc_span = "0.138"
+oxc_diagnostics = "0.138"
+oxc_codegen = "0.138"
 rsvelte_esrap = { path = "../rsvelte_esrap" }
-oxc_syntax = "0.137"
-oxc_semantic = "0.137"
+oxc_syntax = "0.138"
+oxc_semantic = "0.138"
 
 # Module resolution for the svelte-check overlay: resolves `.svelte` imports
 # (including tsconfig `paths`/`baseUrl` aliases like `$lib/...`) so aliased
@@ -76,7 +76,7 @@ oxc_semantic = "0.137"
 oxc_resolver = "11"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
 
 # Error handling
 thiserror = "2.0"
@@ -129,7 +129,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 getrandom = { version = "0.4", optional = true }
 lazy_static = "1.5.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
-oxc_ast_visit = "0.137"
+oxc_ast_visit = "0.138"
 
 # Better multi-threaded memory allocator (optional, Unix/Mac only)
 [target.'cfg(all(not(windows), not(target_arch = "wasm32")))'.dependencies]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
@@ -1,3 +1,8 @@
+// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
+// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
+// deprecation here and defer the mechanical migration to a dedicated follow-up.
+
+#![allow(deprecated)]
 //! Ergonomic oxc-AST builders — the Rust port of upstream Svelte's
 //! `src/compiler/utils/builders.js` (`b.*`).
 //!

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -1,3 +1,8 @@
+// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
+// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
+// deprecation here and defer the mechanical migration to a dedicated follow-up.
+
+#![allow(deprecated)]
 //! Convert the internal `js_ast` IR (`JsProgram`) into an oxc
 //! [`oxc_ast::ast::Program`] so it can be printed by [`rsvelte_esrap`].
 //!

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -1,3 +1,8 @@
+// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
+// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
+// deprecation here and defer the mechanical migration to a dedicated follow-up.
+
+#![allow(deprecated)]
 //! Convert rsvelte's parse-phase `JsNode` AST (the ESTree-shaped representation
 //! of `<script>` blocks and template expressions) into an oxc
 //! [`oxc_ast::ast::Expression`] / [`oxc_ast::ast::Statement`] so Phase-3 can

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -1,3 +1,8 @@
+// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
+// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
+// deprecation here and defer the mechanical migration to a dedicated follow-up.
+
+#![allow(deprecated)]
 //! AST-based server code generation (Phase-3 rewrite).
 //!
 //! This is the additive, in-progress replacement for the string-surgery server

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/read_wrap.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/read_wrap.rs
@@ -1,3 +1,8 @@
+// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
+// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
+// deprecation here and defer the mechanical migration to a dedicated follow-up.
+
+#![allow(deprecated)]
 //! Server READ-WRAPPING single pass (Phase-3 rewrite).
 //!
 //! After `ServerTransformState::visit_expr` produces an oxc [`Expression`],

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -1,3 +1,8 @@
+// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
+// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
+// deprecation here and defer the mechanical migration to a dedicated follow-up.
+
+#![allow(deprecated)]
 //! AST-based server INSTANCE / MODULE script transform (Phase-3 rewrite).
 //!
 //! This is the additive, in-progress port of the server `VariableDeclaration` /

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["svelte", "compiler", "esrap", "printer"]
 crate-type = ["rlib"]
 
 [dependencies]
-oxc_allocator = "0.137"
-oxc_ast = "0.137"
-oxc_span = "0.137"
-oxc_syntax = "0.137"
+oxc_allocator = "0.138"
+oxc_ast = "0.138"
+oxc_span = "0.138"
+oxc_syntax = "0.138"
 
 [dev-dependencies]
-oxc_parser = "0.137"
-oxc_ast_visit = "0.137"
+oxc_parser = "0.138"
+oxc_ast_visit = "0.138"
 
 [lints]
 workspace = true

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/bin/fmt_benchmark_runner.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -21,13 +21,13 @@ wasm = ["rsvelte_core/wasm-deps"]
 
 [dependencies]
 rsvelte_core = { path = "../rsvelte_core", default-features = false }
-oxc_allocator = "0.137"
-oxc_ast = "0.137"
-oxc_parser = "0.137"
-oxc_span = "0.137"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_formatter_json = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_allocator = "0.138"
+oxc_ast = "0.138"
+oxc_parser = "0.138"
+oxc_span = "0.138"
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_formatter_json = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
 thiserror = "2.0"
 unicode-width = "0.2"
 

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -52,11 +52,11 @@ rayon = { version = "1.10", optional = true }
 
 # OXC — same git rev as rsvelte_core (unified by the workspace `[patch]`),
 # used only to statically parse `eslint.config.js` for the config importer.
-oxc_allocator = { version = "0.137", optional = true }
-oxc_parser = { version = "0.137", optional = true }
-oxc_ast = { version = "0.137", optional = true }
-oxc_ast_visit = { version = "0.137", optional = true }
-oxc_span = { version = "0.137", optional = true }
+oxc_allocator = { version = "0.138", optional = true }
+oxc_parser = { version = "0.138", optional = true }
+oxc_ast = { version = "0.138", optional = true }
+oxc_ast_visit = { version = "0.138", optional = true }
+oxc_span = { version = "0.138", optional = true }
 
 # wasm-only.
 wasm-bindgen = { version = "0.2", optional = true }

--- a/crates/rsvelte_lint_types/Cargo.toml
+++ b/crates/rsvelte_lint_types/Cargo.toml
@@ -53,18 +53,18 @@ type_complexity = "allow"
 # Mirror the root workspace's oxc unification patch so the path-dep rsvelte
 # crates build with the same oxc rev. MUST match crates/../Cargo.toml.
 [patch.crates-io]
-oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
-oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "5762638c8ec6981455ef6d7e9482d2ceca757829" }
+oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }


### PR DESCRIPTION
## What

Bump every `oxc_*` crate (workspace deps, `[patch.crates-io]`, and the bare per-crate `version` pins) and `oxc_formatter*` from the 0.137 git rev `5762638c` to the 0.138 rev `dd5d39ec2e5a92a87d12d59e10ca9027f504efd8`.

## Why a single consolidated PR

Per the repo's known constraint, individual Renovate oxc-crate PRs can **never** pass CI: a partial bump leaves two oxc versions in the crate graph and the AST types fail to unify (`[patch.crates-io]` type-unification). Bumping all `oxc_*` + `oxc_formatter*` to one rev together is the only way to keep the graph consistent.

Supersedes / closes:
- #1352 `oxc_allocator`, #1353 `oxc_ast`, #1355 `oxc_ast_visit`, #1356 `oxc_codegen`, #1357 `oxc_diagnostics` (all → 0.138)
- #1283 `oxc_formatter`, #1284 `oxc_formatter_core`, #1287 `oxc_formatter_json` (digest → `dd5d39e`)

## Deprecations

oxc 0.138 deprecates the legacy `AstBuilder` `vec`/`alloc`/`*_static` helpers in favour of the arena APIs ([oxc#23043](https://github.com/oxc-project/oxc/issues/23043)). The old methods behave **identically**, so the six Phase-3 codegen files that use them carry a scoped `#![allow(deprecated)]` to keep output byte-identical. The mechanical migration is deferred to a dedicated follow-up.

## Verification

- `cargo check --workspace --all-targets` with `RUSTFLAGS=-Dwarnings`: clean
- `cargo clippy --workspace --all-targets --all-features` with `-Dwarnings`: clean
- Full CI (corpus byte-parity, runtime, fmt) runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111MCdq64eCjfHMmygaXuPE