### PR TITLE
perf(parse): gate from_value comment capture behind a thread-local

### DIFF
--- a/crates/rsvelte_core/src/ast/arena.rs
+++ b/crates/rsvelte_core/src/ast/arena.rs
@@ -90,18 +90,14 @@ pub struct ParseArena {
     /// place to allocate from.
     bump: Bump,
     /// Side table of `leadingComments`/`trailingComments` keyed by a node's
-    /// `(start, end)` span. Populated by `JsNode::from_value` when
-    /// `capture_comments` is set (the `parse()` path), and read back by
-    /// `JsNode`'s `Serialize` impl so AST output stays comment-lossless without
-    /// storing comments on every node. The key includes `end` because a node and
-    /// its first child can share a `start` (e.g. a `SequenceExpression` and its
-    /// first element) — keying on `start` alone would leak the comment onto the
-    /// inner node too.
+    /// `(start, end)` span. Populated by `JsNode::from_value` when comment
+    /// capture is active (see [`comment_capture_active`] — the `parse()` path),
+    /// and read back by `JsNode`'s `Serialize` impl so AST output stays
+    /// comment-lossless without storing comments on every node. The key includes
+    /// `end` because a node and its first child can share a `start` (e.g. a
+    /// `SequenceExpression` and its first element) — keying on `start` alone
+    /// would leak the comment onto the inner node too.
     node_comments: RefCell<FxHashMap<(u32, u32), NodeComments>>,
-    /// When `true`, `from_value` records node comments into `node_comments`.
-    /// Off by default (compile path) so the hot codegen path never builds the
-    /// table; `parse()` turns it on.
-    capture_comments: Cell<bool>,
 }
 
 // ParseArena is explicitly NOT Sync - it's single-threaded only.
@@ -127,27 +123,14 @@ impl ParseArena {
             next_js_child_start: UnsafeCell::new(0),
             bump: Bump::new(),
             node_comments: RefCell::new(FxHashMap::default()),
-            capture_comments: Cell::new(false),
         }
     }
 
     // -- Node comment side table (parse-only) --------------------------------
 
-    /// Enable/disable recording of node `leadingComments`/`trailingComments`
-    /// into the side table. `parse()` enables it; the compile path leaves it off.
-    #[inline]
-    pub fn set_capture_comments(&self, on: bool) {
-        self.capture_comments.set(on);
-    }
-
-    /// Whether comment capture is currently enabled.
-    #[inline]
-    pub fn capture_comments(&self) -> bool {
-        self.capture_comments.get()
-    }
-
-    /// Record the comments attached to the node at `(start, end)` (no-op when
-    /// capture is disabled or both arrays are absent).
+    /// Record the comments attached to the node at `(start, end)`. Callers gate
+    /// this behind [`comment_capture_active`] (the parse path); it is never
+    /// reached on the compile path, so there is no per-call flag check here.
     #[inline]
     pub fn record_node_comments(
         &self,
@@ -156,7 +139,7 @@ impl ParseArena {
         leading: Option<Vec<serde_json::Value>>,
         trailing: Option<Vec<serde_json::Value>>,
     ) {
-        if !self.capture_comments.get() || (leading.is_none() && trailing.is_none()) {
+        if leading.is_none() && trailing.is_none() {
             return;
         }
         self.node_comments
@@ -364,7 +347,6 @@ impl Clone for ParseArena {
                 next_js_child_start: UnsafeCell::new(*self.next_js_child_start.get()),
                 bump: Bump::new(),
                 node_comments: RefCell::new(self.node_comments.borrow().clone()),
-                capture_comments: Cell::new(self.capture_comments.get()),
             }
         }
     }
@@ -440,6 +422,46 @@ mod tests {
 
 thread_local! {
     static SERIALIZE_ARENA: Cell<Option<*const ParseArena>> = const { Cell::new(None) };
+    /// Whether `JsNode::from_value` should record node comments into the current
+    /// serialize arena's side table. A thread-local so the per-node check in the
+    /// hot `from_value` path is a single `Cell` read; `parse()` flips it on via
+    /// [`CommentCaptureGuard`], the compile path leaves it off.
+    static COMMENT_CAPTURE: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Whether node-comment capture is currently active (the `parse()` AST path).
+#[inline(always)]
+pub fn comment_capture_active() -> bool {
+    COMMENT_CAPTURE.with(|c| c.get())
+}
+
+/// RAII guard that enables [`comment_capture_active`] for its lifetime,
+/// restoring the previous value on drop (so a comment-capturing `parse()`
+/// nested under a non-capturing one — or vice versa — leaves no residue).
+pub struct CommentCaptureGuard {
+    prev: bool,
+}
+
+impl CommentCaptureGuard {
+    #[inline]
+    pub fn new() -> Self {
+        let prev = COMMENT_CAPTURE.with(|c| c.replace(true));
+        CommentCaptureGuard { prev }
+    }
+}
+
+impl Default for CommentCaptureGuard {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for CommentCaptureGuard {
+    #[inline]
+    fn drop(&mut self) {
+        COMMENT_CAPTURE.with(|c| c.set(self.prev));
+    }
 }
 
 /// RAII guard that installs an arena pointer in `SERIALIZE_ARENA` for

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -2187,9 +2187,9 @@ impl JsNode {
                 // Preserve any `leadingComments`/`trailingComments` on this node
                 // into the arena side table (parse path only — `Program` keeps
                 // its own; every other node would otherwise drop them on the
-                // typed round-trip). No-ops when comment capture is off, so the
-                // compile path pays only one `Cell<bool>` read per node.
-                if with_deser_arena(|a| a.capture_comments()) && type_str != "Program" {
+                // typed round-trip). The gate is a single thread-local `Cell`
+                // read, so the compile path (capture off) pays almost nothing.
+                if type_str != "Program" && crate::ast::arena::comment_capture_active() {
                     let leading = obj
                         .get("leadingComments")
                         .and_then(|v| v.as_array().cloned());
@@ -3939,7 +3939,7 @@ mod tests {
             }
         });
         let arena = crate::ast::arena::ParseArena::new();
-        arena.set_capture_comments(true);
+        let _capture = crate::ast::arena::CommentCaptureGuard::new();
         let back = crate::ast::arena::with_serialize_arena(&arena, || {
             JsNode::from_value(json.clone()).to_value()
         });

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
@@ -140,9 +140,11 @@ pub fn parse(source: &str, options: ParseOptions) -> ParseResult<Root> {
     // when this parse() is invoked from within a `compile()` that has
     // already installed its own arena.
     //
-    if options.capture_comments {
-        parser.arena.set_capture_comments(true);
-    }
+    // Enable node-comment capture (thread-local; restored on drop) only for the
+    // AST-output path — the compiler leaves `capture_comments` false.
+    let _capture = options
+        .capture_comments
+        .then(crate::ast::arena::CommentCaptureGuard::new);
     // SAFETY: `parser.arena` lives until `parser` is dropped, which
     // happens after `_guard`.
     let _guard = unsafe { crate::ast::arena::SerializeArenaGuard::new(&parser.arena as *const _) };
@@ -159,9 +161,9 @@ pub fn parse(source: &str, options: ParseOptions) -> ParseResult<Root> {
 pub fn parse_script_ts(source: &str, options: ParseOptions) -> ParseResult<Root> {
     let mut parser = Parser::new(source, options);
     parser.script_ts = true;
-    if options.capture_comments {
-        parser.arena.set_capture_comments(true);
-    }
+    let _capture = options
+        .capture_comments
+        .then(crate::ast::arena::CommentCaptureGuard::new);
     // SAFETY: see `parse`.
     let _guard = unsafe { crate::ast::arena::SerializeArenaGuard::new(&parser.arena as *const _) };
     parser.parse()
@@ -175,9 +177,9 @@ pub fn parse_reuse<'a>(
     options: ParseOptions,
 ) -> ParseResult<Root> {
     parser.reset(source, options);
-    if options.capture_comments {
-        parser.arena.set_capture_comments(true);
-    }
+    let _capture = options
+        .capture_comments
+        .then(crate::ast::arena::CommentCaptureGuard::new);
     // SAFETY: `parser.arena` lives until the caller drops `parser`,
     // which can only happen after this function returns.
     let _guard = unsafe { crate::ast::arena::SerializeArenaGuard::new(&parser.arena as *const _) };


### PR DESCRIPTION
## Summary

Follow-up to #1326 (the Raw / `Expression::Value` eradication). That change made `JsNode::from_value` run for every expression at parse time, and each call probed comment-capture via `with_deser_arena(|a| a.capture_comments())` — two thread-local reads + a pointer deref + an arena `Cell` read, on the hot per-node path even when capture is off (the compile path).

This replaces the per-arena capture flag with a thread-local gate (`comment_capture_active()` = a single `Cell` read), flipped on for the `parse()` AST path via an RAII `CommentCaptureGuard`. The comment data still lives in the per-arena side table; only the gate moved.

Recovers part of the snippet-heavy `parse[07-snippets]` regression #1326 introduced. The remainder is the inherent `OXC → serde_json → JsNode` conversion now done eagerly at parse (a larger, separate refactor — parsing OXC directly into `JsNode` — would be needed to remove it).

## Verification
- comment round-trip unit test + `parser_fixtures` 26/26 (incl. the `comment-before-function-binding` / `parens` / `tag-type-identifier-probe-comment` fixtures) pass.
- corpus parity unchanged (no regressions, `error-mismatch 0`).
- fmt + clippy clean.

Watch CodSpeed on this PR for the parse delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)