### PR TITLE
fix(transform): legacy invalidate_inner_signals for select bind:value indirect bindings

### DIFF
--- a/.changeset/fix-corpus-scope-references-invalidate.md
+++ b/.changeset/fix-corpus-scope-references-invalidate.md
@@ -1,0 +1,26 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): correct legacy `invalidate_inner_signals` for `<select bind:value>` indirect bindings
+
+Legacy `<select bind:value={prop…}>` must invalidate the OTHER scope variables read
+within the select (e.g. a `guid` prop in the select's `id=` attribute) whenever the
+bound value is mutated. Several gaps are fixed so the invalidation matches upstream:
+
+- **`legacy_indirect_bindings` population** (`2-analyze/RegularElement`): the indirect
+  bindings are now collected from the select's enclosing scope **and its ancestors**
+  (via `binding.scope_index`, not the backward-compat-polluted `scope.declarations`),
+  so an outer-scope prop like `guid` is included while child-scope each-block items are
+  excluded. Store auto-subscriptions (`$label`) are skipped (no real scope binding
+  upstream).
+- **assignment LHS is reactive** (`has_reactive_state` AssignmentExpression): `{(x.value
+  = [])}` now reads `x` on the LHS, so the text is reactive (`$.template_effect`) rather
+  than a static `nodeValue =`.
+- **invalidate wrap on prop member mutations** (template assignment + component
+  `bind:value` setter): a prop member mutation whose prop has `legacy_indirect_bindings`
+  is wrapped in `(<mutation>, $.invalidate_inner_signals(() => { … }))`.
+
+Clears `svelte-form-builder/.../PropertyPanelDataAttributes.svelte`, zero corpus
+regressions (binding-indirect / binding-interop-derived / select-option-store etc. all
+still pass).

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -10,7 +10,6 @@
 	"svelte-form-builder/src/lib/Components/Select.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
-	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelDataAttributes.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",
 	"svelte-table/example/example6/ContactButtonComponent.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -1265,29 +1265,72 @@ pub fn visit(
                         // `$.invalidate_inner_signals` body matches source order.
                         let mut indirect_with_pos: Vec<(u32, String)> = Vec::new();
                         {
-                            let scope_declarations =
-                                if context.analysis.root.all_scopes.len() > scope_idx {
-                                    &context.analysis.root.all_scopes[scope_idx].declarations
-                                } else {
-                                    &context.analysis.root.scope.declarations
-                                };
-
-                            for (name, &other_idx) in scope_declarations {
+                            // Mirror the official `scope.references.keys()`: the
+                            // bindings visible in the select's ENCLOSING scope that
+                            // are referenced within the select. The select's own
+                            // local scope (`scope_idx`) is too narrow — an indirect
+                            // binding usually lives in an OUTER scope (e.g. a prop
+                            // `guid` read in the select's `id=` attribute when the
+                            // select is nested in `{#if}`). So we walk `scope_idx`
+                            // and all its ANCESTOR scopes, collecting their
+                            // declarations. Crucially this EXCLUDES descendant
+                            // (child) scopes — e.g. a `{#each tasks as task}` inside
+                            // the select declares `task` in a child scope, which the
+                            // official's enclosing-scope references never contain, so
+                            // mutating the bound value must not invalidate `task`.
+                            // The in-span template-reference filter keeps this to the
+                            // select element (not unrelated sibling elements).
+                            // The set of scope indices that are `scope_idx` or an
+                            // ancestor of it. A binding is in the select's ENCLOSING
+                            // scope iff its own `scope_index` is in this set; a
+                            // binding declared in a descendant scope (e.g. an
+                            // each-block item inside the select) is NOT. We use
+                            // `binding.scope_index` rather than `scope.declarations`
+                            // because the latter is polluted with child-scope
+                            // declarations for backward compat (see scope.rs).
+                            let mut ancestor_scopes: FxHashSet<usize> = FxHashSet::default();
+                            {
+                                let mut cur = Some(scope_idx);
+                                while let Some(si) = cur {
+                                    ancestor_scopes.insert(si);
+                                    cur = context
+                                        .analysis
+                                        .root
+                                        .all_scopes
+                                        .get(si)
+                                        .and_then(|s| s.parent);
+                                }
+                            }
+                            for other_binding in context.analysis.root.bindings.iter() {
+                                let name = &other_binding.name;
                                 if name == root_name {
                                     continue;
                                 }
-                                if let Some(other_binding) =
-                                    context.analysis.root.bindings.get(other_idx)
-                                    && let Some(min_pos) = other_binding
-                                        .references
-                                        .iter()
-                                        .filter(|r| {
-                                            r.is_template_reference
-                                                && r.start >= element.start
-                                                && r.end <= element.end
-                                        })
-                                        .map(|r| r.start)
-                                        .min()
+                                if !ancestor_scopes.contains(&other_binding.scope_index) {
+                                    continue;
+                                }
+                                // A store auto-subscription (`$label`) is not a real
+                                // scope binding upstream — `scope.get('$label')`
+                                // returns null (the binding is `label`), so the
+                                // official never adds it as an indirect binding.
+                                // rsvelte synthesizes a `$label` StoreSub binding, so
+                                // skip it explicitly to match.
+                                if matches!(
+                                    other_binding.kind,
+                                    crate::compiler::phases::phase2_analyze::scope::BindingKind::StoreSub
+                                ) {
+                                    continue;
+                                }
+                                if let Some(min_pos) = other_binding
+                                    .references
+                                    .iter()
+                                    .filter(|r| {
+                                        r.is_template_reference
+                                            && r.start >= element.start
+                                            && r.end <= element.end
+                                    })
+                                    .map(|r| r.start)
+                                    .min()
                                 {
                                     indirect_with_pos.push((min_pos, name.clone()));
                                 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -4713,10 +4713,70 @@ fn try_transform_assignment(
 
         let result = mutate_fn(&context.arena, b::id(&root_name), mutation_expr);
         let result = apply_store_ref_transform(result, &root_name, context);
+        // If the mutated prop carries `legacy_indirect_bindings` (a legacy
+        // `<select bind:value={prop…}>` whose subtree references other scope
+        // variables), wrap the mutation in a sequence with
+        // `$.invalidate_inner_signals(() => { … })` so those signals re-read.
+        // Mirrors the instance-script prop-member-mutation path
+        // (`prop_member_mutate_ast`) and upstream `AssignmentExpression.js`.
+        let result = wrap_with_legacy_invalidate(result, &root_name, context);
         return Some(result);
     }
 
     None
+}
+
+/// Wrap a prop-member-mutation expression in
+/// `(<mutation>, $.invalidate_inner_signals(() => { <reads> }))` when the
+/// mutated prop binding has `legacy_indirect_bindings`. Returns the input
+/// unchanged otherwise. The read form of each indirect binding mirrors
+/// `build_getter` / the `prop_invalidate_bodies` precompute: prop source →
+/// `name()`, store sub → `name()`, reactive state/derived → `$.get(name)`,
+/// everything else → bare `name`.
+pub(crate) fn wrap_with_legacy_invalidate(
+    result: JsExpr,
+    root_name: &str,
+    context: &ComponentContext,
+) -> JsExpr {
+    use crate::compiler::phases::phase2_analyze::scope::BindingKind as BK;
+    use crate::compiler::phases::phase3_transform::client::utils::is_prop_source;
+    use crate::compiler::phases::phase3_transform::js_ast::builders as b;
+
+    let indirect = match context.state.get_binding(root_name) {
+        Some(binding) if !binding.legacy_indirect_bindings.is_empty() => {
+            binding.legacy_indirect_bindings.clone()
+        }
+        _ => return result,
+    };
+
+    let analysis = context.state.analysis;
+    let read_form = |n: &str| -> String {
+        match context.state.get_binding(n) {
+            Some(b)
+                if matches!(b.kind, BK::Prop | BK::BindableProp) && is_prop_source(b, analysis) =>
+            {
+                format!("{n}()")
+            }
+            Some(b) if matches!(b.kind, BK::StoreSub) => format!("{n}()"),
+            Some(b)
+                if matches!(
+                    b.kind,
+                    BK::State | BK::RawState | BK::Derived | BK::LegacyReactive
+                ) =>
+            {
+                format!("$.get({n})")
+            }
+            _ => n.to_string(),
+        }
+    };
+
+    let body = indirect
+        .iter()
+        .map(|n| format!("{};", read_form(n)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let invalidate = b::raw(format!("$.invalidate_inner_signals(() => {{ {body} }})"));
+    b::sequence(vec![result, invalidate])
 }
 
 /// Get the appropriate $.assign* function name for an operator.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1759,14 +1759,19 @@ fn process_bind_directive(
                     transformed_expression.clone(),
                     b::id("$$value"),
                 );
-                vec![b::stmt(
+                let call = b::call(
                     &context.arena,
-                    b::call(
-                        &context.arena,
-                        b::id(root_name.clone()),
-                        vec![assignment, b::boolean(true)],
-                    ),
-                )]
+                    b::id(root_name.clone()),
+                    vec![assignment, b::boolean(true)],
+                );
+                // Wrap in `(call, $.invalidate_inner_signals(…))` when the prop
+                // carries legacy indirect bindings (a `<select bind:value>`
+                // referencing other scope variables), mirroring the text /
+                // instance-script prop-member-mutation paths.
+                let wrapped = crate::compiler::phases::phase3_transform::client::visitors::expression_converter::wrap_with_legacy_invalidate(
+                    call, &root_name, context,
+                );
+                vec![b::stmt(&context.arena, wrapped)]
             } else if is_state {
                 if context.state.analysis.runes {
                     // In runes mode, replace the root with $.get(root) in the assignment:

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -4695,11 +4695,21 @@ fn analyze_props_json(
                     }
                 }
             }
-            // has_state: check right side
-            if !props.has_state
-                && let Some(right) = obj.get("right")
-            {
-                props.has_state = has_reactive_state_json(right, context);
+            // has_state: check BOTH sides. Upstream's AssignmentExpression
+            // visitor walks `left` and `right`, so the LHS member object is read
+            // too: `dataAttribute.value = []` reads `dataAttribute`, making the
+            // text `{(dataAttribute.value = [])}` reactive (→ `$.template_effect`,
+            // not a static `nodeValue =`) when `dataAttribute` is a reactive
+            // prop/state.
+            if !props.has_state {
+                for field in ["left", "right"] {
+                    if let Some(v) = obj.get(field)
+                        && has_reactive_state_json(v, context)
+                    {
+                        props.has_state = true;
+                        break;
+                    }
+                }
             }
             // has_call: check right side
             if !props.has_call


### PR DESCRIPTION
## What

A legacy `<select bind:value={prop…}>` must invalidate the **other** scope variables read within the select (e.g. a `guid` prop in the select's `id=` attribute) whenever the bound value is mutated. This was the long-standing `Scope.references` gap.

## Fixes

1. **`legacy_indirect_bindings` population** (`2-analyze/RegularElement`): collect indirect bindings from the select's enclosing scope **and its ancestors** using `binding.scope_index` (not the backward-compat-polluted `scope.declarations`). This includes an outer-scope prop like `guid` while excluding child-scope each-block items (the prior all-bindings attempt over-captured them). Store auto-subscriptions (`$label`) are skipped — upstream `scope.get('$label')` returns null.
2. **assignment LHS reactivity** (`has_reactive_state` AssignmentExpression): check the LHS too, so `{(dataAttribute.value = [])}` reads `dataAttribute` and becomes reactive (`$.template_effect`) instead of a static `nodeValue =`.
3. **invalidate wrap on prop member mutations**: wrap `prop(prop().x = v, true)` in `(<mutation>, $.invalidate_inner_signals(() => { … }))` when the prop has `legacy_indirect_bindings` — for both the template assignment path (`expression_converter`) and the component `bind:value` setter (`shared/component`).

## Impact

`known-failures.client.json`: 23 → 22. Clears `svelte-form-builder/.../PropertyPanelDataAttributes.svelte`. (Other invalidate-cluster files — PowerTable/ChartContext/etc. — have additional, separate roots and remain.)

## Verification

- `astEquivalent` PropertyPanelDataAttributes both targets = true
- `verify.mjs`: 1 entry now passes, **0 regressions** (binding-indirect, binding-indirect-computed, binding-interop-derived, select-option-store-implicit-value, PropertyPanelTooltip all still pass)
- `cargo test --release --lib` + `--test runtime --test ssr --test compiler_fixtures`: all pass
- `cargo clippy --all-targets --all-features`: 0 warnings; `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR7m4kcr25YdoYumxipf5