### PR TITLE
chore(deps): bump oxc git rev dd5d39e -> 6ca9125 (unified)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1665,7 +1665,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "phf 0.14.0",
  "proc-macro2 1.0.106",
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1687,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1708,12 +1708,12 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 
 [[package]]
 name = "oxc_diagnostics"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1723,7 +1723,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1738,7 +1738,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter"
 version = "0.57.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_core"
 version = "0.57.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "oxc_formatter_json"
 version = "0.57.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "dragonbox_ecma",
  "oxc_allocator",
@@ -1814,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "oxc_jsdoc"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "itertools 0.15.0",
  "memchr",
@@ -1925,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1939,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=dd5d39ec2e5a92a87d12d59e10ca9027f504efd8#dd5d39ec2e5a92a87d12d59e10ca9027f504efd8"
+source = "git+https://github.com/oxc-project/oxc?rev=6ca912513e2b3ef9df173d043c2f501b0532786d#6ca912513e2b3ef9df173d043c2f501b0532786d"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,18 +80,18 @@ type_complexity = "allow"
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -76,7 +76,7 @@ oxc_semantic = "0.138"
 oxc_resolver = "11"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/bin/fmt_benchmark_runner.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -25,9 +25,9 @@ oxc_allocator = "0.138"
 oxc_ast = "0.138"
 oxc_parser = "0.138"
 oxc_span = "0.138"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_formatter_json = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_formatter_json = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
 thiserror = "2.0"
 unicode-width = "0.2"
 

--- a/crates/rsvelte_lint_types/Cargo.toml
+++ b/crates/rsvelte_lint_types/Cargo.toml
@@ -53,18 +53,18 @@ type_complexity = "allow"
 # Mirror the root workspace's oxc unification patch so the path-dep rsvelte
 # crates build with the same oxc rev. MUST match crates/../Cargo.toml.
 [patch.crates-io]
-oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
-oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "dd5d39ec2e5a92a87d12d59e10ca9027f504efd8" }
+oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }
+oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "6ca912513e2b3ef9df173d043c2f501b0532786d" }


### PR DESCRIPTION
Move every `oxc_*` crate (workspace deps, `[patch.crates-io]`, bare per-crate `version` pins) and `oxc_formatter*` from rev `dd5d39ec` to `6ca912513e2b3ef9df173d043c2f501b0532786d`.

Both revs are oxc `0.138.0` — a same-version git-rev bump, so there are no API changes (local `cargo check --workspace --all-targets` and `clippy --all-targets --all-features` both clean under `RUSTFLAGS=-Dwarnings`).

Consolidates the individual Renovate digest PRs, which can never pass CI on their own: a partial bump splits the crate graph between `dd5d39e` and `6ca9125`, and the oxc AST types fail to unify (`[patch.crates-io]` type-unification). Supersedes / closes:
- #1359 `oxc_formatter`, #1360 `oxc_formatter_core`, #1361 `oxc_formatter_json` (all → `6ca9125`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111MCdq64eCjfHMmygaXuPE