### PR TITLE
fix(transform): wrap store reads in a ternary inside a function body

### DIFF
--- a/.changeset/fix-store-read-ternary-in-function-body.md
+++ b/.changeset/fix-store-read-ternary-in-function-body.md
@@ -1,0 +1,20 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): wrap store reads in a ternary inside a function body
+
+The legacy text-based store-subscription read transform skipped any `$store`
+whose following `:` made it look like an object property key (`{ $store: … }`).
+Its object-literal guard only counted unmatched `{` in the emitted prefix, so a
+function body's own block brace counted as an object literal — making a ternary
+`cond ? $store : x` *inside any function body* match the property-key heuristic
+and leave `$store` un-called.
+
+A real property key is always immediately preceded (skipping whitespace) by `{`
+(first entry) or `,` (later entry), whereas a ternary consequent is preceded by
+`?`. The property-key check now also requires that preceding separator, so the
+ternary `$store` is correctly lowered to `$store()`.
+
+Fixes the corpus entry
+`svelte-ux/packages/svelte-ux/src/lib/components/Duration.svelte`.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -16,7 +16,6 @@
 	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/DateRange.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/Duration.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Tooltip.svelte",
 	"svelthree/src/lib/components/Object3D.svelte"

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -434,9 +434,23 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
                         && chars[k] == ':'
                         && (k + 1 >= chars.len() || chars[k + 1] != ':');
 
-                    // Only treat as property key if followed by `:` AND we're inside an object literal
-                    // (i.e., there is an unmatched `{` before this position in `new_result`)
-                    has_colon && {
+                    // A real property key is ALWAYS immediately preceded (skipping
+                    // whitespace/newlines) by `{` (first entry) or `,` (later entry).
+                    // A ternary consequent `cond ? $store : x` is instead preceded by
+                    // `?`. This distinguishes the two even inside a function body,
+                    // whose block `{` would otherwise make the brace-depth check below
+                    // a false positive for any ternary `$store :` in the body.
+                    let prev_is_obj_sep = {
+                        let mut j = i;
+                        while j > 0 && chars[j - 1].is_whitespace() {
+                            j -= 1;
+                        }
+                        j > 0 && (chars[j - 1] == '{' || chars[j - 1] == ',')
+                    };
+
+                    // Only treat as property key if followed by `:`, preceded by an
+                    // object-entry separator, AND we're inside an unmatched `{`.
+                    has_colon && prev_is_obj_sep && {
                         let mut brace_depth: i32 = 0;
                         for ch in new_result.chars() {
                             match ch {


### PR DESCRIPTION
## What

The legacy text-based store-subscription read transform left a `$store` un-called (`$store` instead of `$store()`) when it appeared as a ternary consequent **inside a function body**, e.g.:

```js
const endTime = end() ?? (useTimer ? $timer : null); // should be $timer()
```

## Root cause

`transform_store_reads_client`'s property-key guard (which correctly skips `{ $store: … }` keys) decided "object literal context" by counting unmatched `{` in the emitted prefix. A function body's own block `{` counts as an open brace, so a ternary `cond ? $store : x` anywhere in a function body satisfied `has_colon && brace_depth > 0` and was misclassified as a property key.

## Fix

A real property key is always immediately preceded (skipping whitespace) by `{` (first entry) or `,` (later entry); a ternary consequent is preceded by `?`. The property-key check now also requires that preceding object-entry separator, which cleanly distinguishes the two without an AST.

## Result

- Clears corpus entry `svelte-ux/packages/svelte-ux/src/lib/components/Duration.svelte`.
- Corpus verify: no regressions.
- `cargo test --release --test runtime --test ssr --test compiler_fixtures` + lib store unit tests: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)