### PR TITLE
fix(transform): include all imports in legacy $: dependency thunks regardless of scope

### DIFF
--- a/.changeset/fix-legacy-reactive-deps-all-imports.md
+++ b/.changeset/fix-legacy-reactive-deps-all-imports.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): include all imports in legacy `$:` dependency thunks regardless of scope
+
+A legacy `$:` reactive statement compiles to `$.legacy_pre_effect(() => (deps…), …)`.
+Upstream `LabeledStatement.js` adds a dependency for every referenced binding that
+is not `kind === 'normal' && declaration_kind !== 'import'` — i.e. **all** imports
+qualify, regardless of which scope they were declared in.
+
+rsvelte built the import-membership list with a `scope_index == instance_scope`
+filter. In some TypeScript components the first imports are assigned scope 0 while
+later imports land in the instance scope, so a `$:` block calling an early-imported
+helper (e.g. `createScale(...)`) dropped that helper from the deps thunk. The
+filter now includes every `Import`-kind binding, matching upstream.
+
+Fixes the corpus entry
+`layerchart/packages/layerchart/src/lib/components/ChartContext.svelte`.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -2,7 +2,6 @@
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/products/+page.svelte",
 	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/users/+page.svelte",
 	"layercake/src/lib/LayerCake.svelte",
-	"layerchart/packages/layerchart/src/lib/components/ChartContext.svelte",
 	"layerchart/packages/layerchart/src/lib/components/Points.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -4328,15 +4328,20 @@ fn transform_instance_script_for_visitors(
     // appear in reactive statement bodies.
     // Reference: LabeledStatement.js line 37 - `if (binding.kind === 'normal' && binding.declaration_kind !== 'import') continue;`
     let import_names: Vec<String> = if !analysis.runes {
-        let instance_scope_index = analysis.root.instance_scope_index;
+        // Every import binding — used to decide which legacy `$:` dependency names
+        // are emitted in the `$.legacy_pre_effect` deps thunk. Upstream
+        // `LabeledStatement.js` includes a dependency whenever its binding is NOT
+        // `kind === 'normal' && declaration_kind !== 'import'`, i.e. ALL imports
+        // qualify regardless of which scope they were declared in. We must NOT
+        // restrict to the instance scope: a TS component whose first imports are
+        // assigned scope 0 (vs later imports at the instance scope) would
+        // otherwise drop those imports from the deps thunk (e.g. an imported
+        // helper `createScale(...)` called inside a `$:` block).
         analysis
             .root
             .bindings
             .iter()
-            .filter(|b| {
-                b.declaration_kind == DeclarationKind::Import
-                    && b.scope_index == instance_scope_index
-            })
+            .filter(|b| b.declaration_kind == DeclarationKind::Import)
             .map(|b| b.name.clone())
             .collect()
     } else {


### PR DESCRIPTION
## What

A legacy `$:` reactive statement compiles to `$.legacy_pre_effect(() => (deps…), () => {body})`. The deps thunk must list every binding the effect reads.

`ChartContext.svelte` has `$:` blocks calling an imported helper:
```js
import { createScale, type AnyScale } from '../utils/scales.js';
$: $_x1Scale = x1Scale && x1Range ? createScale(...) : null;
```
rsvelte dropped `createScale` from the deps thunk (7 deps → 6).

## Root cause

Upstream `LabeledStatement.js` includes a dependency for every referenced binding that is **not** `kind === 'normal' && declaration_kind !== 'import'` — i.e. all imports qualify, regardless of declaring scope.

rsvelte built the import-membership list with a `scope_index == instance_scope` filter. In this TS component the early imports (lines 3–7) are assigned scope 0 while later imports land in the instance scope (3), so `createScale` was filtered out. The filter now includes every `Import`-kind binding.

## Result

- Clears corpus entry `layerchart/.../ChartContext.svelte` (known-failures 22 → 21).
- Corpus verify: no regressions.
- `cargo test --release --test runtime --test ssr --test compiler_fixtures`: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)