### PR TITLE
fix(svelte-check): re-release for stale core + guard cross-package drift

### DIFF
--- a/.changeset/fix-svelte-check-pick-up-svelte2tsx-core.md
+++ b/.changeset/fix-svelte-check-pick-up-svelte2tsx-core.md
@@ -1,0 +1,24 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): re-release to pick up post-0.3.7 svelte2tsx overlay fixes
+
+`@rsvelte/svelte-check` builds the TSX overlay it type-checks by calling the
+same `rsvelte_core` svelte2tsx code that ships in `@rsvelte/svelte2tsx`, but it
+is a self-contained native binary with no npm dependency edge to
+`@rsvelte/svelte2tsx` (or `@rsvelte/compiler`). Because of that, changesets
+never cascades a core/svelte2tsx change into svelte-check — it only bumps when a
+changeset names it explicitly.
+
+`@rsvelte/svelte-check@0.3.7` was cut on 2026-06-26, *before* several svelte2tsx
+overlay fixes landed, and those fixes were only released through
+`@rsvelte/svelte2tsx@0.1.20` (2026-07-03) — svelte-check was left stale. This
+re-release rebuilds the binary against the current core so svelte-check's
+type-checking diagnostics reflect the same overlay as the standalone tool.
+Included behaviors that were missing from 0.3.7:
+
+- carry a renamed-export's JSDoc onto the prop (#1230)
+- widen a renamed legacy prop with a typed default via `__sveltets_2_any` (#1231)
+- bind a component child's legacy `let:` from its own `$$slot_def` (#1232)
+- drive svelte2tsx corpus output-parity to zero — 254 → 0 (#1295)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,17 @@ jobs:
           echo "Found changeset(s):"
           echo "$added"
 
+      - name: Require consumer changesets for shared-core changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
+        shell: bash
+        # A single Rust crate (rsvelte_core) is compiled into several separate
+        # npm artifacts (compiler, svelte-check, vite-plugin-svelte-native, …).
+        # Some share no npm dependency edge, so Changesets can't cascade a core
+        # change between them — each must be named explicitly or it ships stale.
+        run: node scripts/release/check-core-consumer-changesets.mjs
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,57 @@
+# Releasing
+
+rsvelte ships several npm packages that are all compiled from the **one**
+`rsvelte_core` Rust crate. Changesets versions packages by their **npm**
+dependency graph, which is blind to the shared Rust crate — so a core change can
+be released into one package while leaving another, built from the same code,
+stale.
+
+## The hazard
+
+`@rsvelte/svelte2tsx` is a thin JS wrapper around the wasm `svelte2tsx` export in
+`@rsvelte/compiler`. `@rsvelte/svelte-check` embeds the **same** `rsvelte_core`
+svelte2tsx code, but as a self-contained native binary with **no** npm
+dependency on `@rsvelte/compiler` or `@rsvelte/svelte2tsx`. There is no edge for
+Changesets to cascade along, so svelte-check only bumps when a changeset **names
+it**.
+
+This actually shipped: the 254→0 svelte2tsx corpus-parity fix (#1295) named only
+`@rsvelte/svelte2tsx`. `@rsvelte/compiler` was rebuilt (it's named on nearly
+every PR) and picked the fix up for free, so `@rsvelte/svelte2tsx@0.1.20` got it
+— but `@rsvelte/svelte-check` was never named, stayed on its `0.3.7` build from
+before the fix, and shipped different diagnostics for weeks.
+
+## Which packages are "islanded"
+
+Islanded = separately-compiled artifact of `rsvelte_core` whose `package.json`
+has **no** `@rsvelte/*` dependency that Changesets could cascade a bump along.
+These must be named explicitly whenever the core code they embed changes:
+
+| Package | Embeds | Cascade in? |
+|---|---|---|
+| `@rsvelte/compiler` | full core (wasm compile + svelte2tsx) | ❌ islanded — but named on almost every PR, so rarely drifts |
+| `@rsvelte/svelte-check` | core svelte2tsx overlay + parse/analyze | ❌ islanded — **drifts**, this is the one that bit us |
+| `@rsvelte/vite-plugin-svelte-native` | core compile / hmr / preprocess NAPI | ❌ islanded |
+| `@rsvelte/language-server` | `rsvelte_lint` → core | ❌ islanded |
+
+Packages that **do** cascade (no need to name for a core change, though naming
+is harmless): `@rsvelte/svelte2tsx` → `@rsvelte/compiler`;
+`@rsvelte/vite-plugin-svelte` → `@rsvelte/vite-plugin-svelte-native`.
+
+## The rule
+
+When you change shared core code, add the affected islanded consumers to your
+changeset (a `patch` bump is enough to trigger a rebuild + republish). The most
+common miss is: **a `crates/rsvelte_core/src/svelte2tsx/**` change must name
+`@rsvelte/svelte-check` as well as `@rsvelte/svelte2tsx`.**
+
+## The guard
+
+`scripts/release/check-core-consumer-changesets.mjs` enforces the proven edges in
+CI (the `Changeset` job in `.github/workflows/ci.yml`). It maps changed core
+source directories to the consumer packages that must be named, and fails the PR
+if the pending changesets don't cover them. It is intentionally narrow — only
+edges observed to drift — so routine compiler PRs aren't forced into
+multi-package changesets. Extend the `RULES` table in that script as new
+islanded consumers or shared-source directories appear. Bypass a one-off with
+the `skip-changeset` label.

--- a/scripts/release/check-core-consumer-changesets.mjs
+++ b/scripts/release/check-core-consumer-changesets.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Guard: a single Rust crate (`rsvelte_core`) is compiled into several
+// *separate* npm artifacts. Some of them share no npm dependency edge, so
+// Changesets cannot cascade a core change from one to another — each must be
+// named in a changeset explicitly or it silently ships stale.
+//
+// Concretely, `@rsvelte/svelte-check` embeds the same `rsvelte_core` svelte2tsx
+// code that `@rsvelte/svelte2tsx` (via the `@rsvelte/compiler` wasm) exposes,
+// but svelte-check is a self-contained native binary with no dependency on
+// either package. In the 5.56.x cycle this bit us: the 254→0 svelte2tsx
+// corpus-parity fix (#1295) named only `@rsvelte/svelte2tsx`, so the tool was
+// republished with the fix while `@rsvelte/svelte-check` stayed on its stale
+// 0.3.7 build and shipped different diagnostics.
+//
+// This script maps changed core source directories to the set of npm packages
+// that embed them WITHOUT a cascade edge, and fails if the pending changesets
+// don't collectively name every required package. It is intentionally narrow:
+// only edges that are proven to drift are enforced, to avoid forcing a
+// multi-package changeset on every routine compiler PR.
+//
+// Bypass with the `skip-changeset` label (same as the sibling changeset guard),
+// which sets SKIP=true.
+
+import { execSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// Source-directory prefix → npm packages that embed it but do NOT receive a
+// Changesets cascade for it. List EVERY package that must bump, including ones
+// that are usually named anyway; naming the obvious one is cheap and keeps the
+// rule self-documenting.
+//
+// To extend: add a prefix and its islanded consumers. Islanded = its
+// package.json has no `@rsvelte/*` dependency that would cascade the bump
+// (today: @rsvelte/compiler, @rsvelte/svelte-check, @rsvelte/vite-plugin-svelte-native,
+// @rsvelte/language-server). Packages that DO cascade (@rsvelte/svelte2tsx →
+// @rsvelte/compiler, @rsvelte/vite-plugin-svelte → …-native) don't need listing
+// unless you want them named directly.
+const RULES = [
+  {
+    prefix: 'crates/rsvelte_core/src/svelte2tsx/',
+    // svelte2tsx code ships two ways: the wasm export consumed by
+    // @rsvelte/svelte2tsx, and the overlay generator inside the svelte-check
+    // binary. The latter has no cascade edge, so it must be named too.
+    requires: ['@rsvelte/svelte2tsx', '@rsvelte/svelte-check'],
+  },
+  {
+    prefix: 'crates/rsvelte_core/src/svelte_check/',
+    requires: ['@rsvelte/svelte-check'],
+  },
+];
+
+function sh(cmd) {
+  return execSync(cmd, { cwd: repoRoot, encoding: 'utf8' }).trim();
+}
+
+function resolveBase() {
+  if (process.env.BASE_SHA) return process.env.BASE_SHA;
+  try {
+    return sh('git merge-base HEAD origin/main');
+  } catch {
+    return sh('git merge-base HEAD main');
+  }
+}
+
+function changedFiles(base) {
+  const out = sh(`git diff --name-only ${base}...HEAD`);
+  return out ? out.split('\n').filter(Boolean) : [];
+}
+
+// Names in the frontmatter of every pending changeset (working-tree state — the
+// set the Release workflow will consume), not just ones added in this PR.
+function namedPackages() {
+  const dir = path.join(repoRoot, '.changeset');
+  const named = new Set();
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.md') || file === 'README.md') continue;
+    const text = readFileSync(path.join(dir, file), 'utf8');
+    const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!m) continue;
+    for (const line of m[1].split('\n')) {
+      const pkg = line.match(/^\s*["']?(@[^"':]+)["']?\s*:/);
+      if (pkg) named.add(pkg[1]);
+    }
+  }
+  return named;
+}
+
+function main() {
+  if (process.env.SKIP === 'true') {
+    console.log('skip-changeset label present — skipping core-consumer changeset check.');
+    return;
+  }
+
+  const base = resolveBase();
+  const files = changedFiles(base);
+
+  const required = new Map(); // package → the prefix that required it
+  for (const rule of RULES) {
+    if (files.some((f) => f.startsWith(rule.prefix))) {
+      for (const pkg of rule.requires) {
+        if (!required.has(pkg)) required.set(pkg, rule.prefix);
+      }
+    }
+  }
+
+  if (required.size === 0) {
+    console.log('No shared-core source touched that needs an explicit consumer changeset.');
+    return;
+  }
+
+  const named = namedPackages();
+  const missing = [...required].filter(([pkg]) => !named.has(pkg));
+
+  console.log('Shared-core changes require these packages to be named in a changeset:');
+  for (const [pkg, prefix] of required) {
+    console.log(`  ${named.has(pkg) ? '✓' : '✗'} ${pkg}  (touched: ${prefix})`);
+  }
+
+  if (missing.length > 0) {
+    const list = missing.map(([pkg]) => pkg).join(', ');
+    console.error(
+      `::error::These packages embed the changed core code but are missing from the ` +
+        `pending changesets: ${list}. They are separately-compiled artifacts of ` +
+        `rsvelte_core with no cascade edge, so a core change won't reach them unless ` +
+        `named. Add them to a changeset (bump: patch) or apply the 'skip-changeset' label.`,
+    );
+    process.exit(1);
+  }
+
+  console.log('All required consumer packages are named. ✓');
+}
+
+main();


### PR DESCRIPTION
## Why

`@rsvelte/svelte-check` embeds the **same** `rsvelte_core` svelte2tsx code that `@rsvelte/svelte2tsx` exposes (via the `@rsvelte/compiler` wasm), but it is a self-contained native binary with **no** npm dependency on either package. Changesets versions by the npm graph, so it can **never cascade a core change into svelte-check** — svelte-check only bumps when a changeset names it.

That shipped a real drift: the 254→0 svelte2tsx corpus-parity fix (#1295) named only `@rsvelte/svelte2tsx`. `@rsvelte/compiler` was rebuilt (it's named on nearly every PR) so `@rsvelte/svelte2tsx@0.1.20` got the fix — but `@rsvelte/svelte-check` was never named and stayed on its `0.3.7` build from **2026-06-26**, before the fix landed (06-28). Downstream consumers pinning `@rsvelte/svelte-check` (e.g. flyle-nexus) got stale diagnostics for weeks.

Timeline:
| date | event |
|---|---|
| 06-26 | `@rsvelte/svelte-check@0.3.7` cut |
| 06-28 | 254→0 svelte2tsx core fix lands (#1295) |
| 07-03 | `@rsvelte/svelte2tsx@0.1.20` / `@rsvelte/compiler@0.7.16` published **with** the fix |
| — | `@rsvelte/svelte-check` never re-released → stale |

## What

1. **Immediate** — changeset patch-bumps `@rsvelte/svelte-check` so it is rebuilt against current core (picks up the post-0.3.7 svelte2tsx overlay fixes #1230/#1231/#1232/#1295).
2. **Guard** — `scripts/release/check-core-consumer-changesets.mjs`, wired into the CI `Changeset` job, fails a PR that touches shared-core source without naming the **islanded** consumer packages that embed it. Seeded with the proven `crates/rsvelte_core/src/svelte2tsx/**` → `@rsvelte/svelte-check` edge; extensible `RULES` table. Bypass with the `skip-changeset` label.
3. **Docs** — `docs/releasing.md` documents the one-crate → many-npm-packages hazard, the islanded-package table, and the rule.

Note: `linked`/`fixed` changeset groups do **not** solve this (linked only aligns version numbers when both already bump; fixed would force all packages to one shared version). A source→consumer guard is the mechanism that actually catches the drift.

## Verification

- Guard is a no-op on this PR (no core source touched). ✓
- Simulated the #1295 scenario (touch `svelte2tsx/` core + changeset naming only `@rsvelte/svelte2tsx`): guard reports `✗ @rsvelte/svelte-check` and exits 1. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)