### PR TITLE
refactor(3-transform): migrate off deprecated oxc AstBuilder helpers

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
@@ -1,8 +1,3 @@
-// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
-// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
-// deprecation here and defer the mechanical migration to a dedicated follow-up.
-
-#![allow(deprecated)]
 //! Ergonomic oxc-AST builders — the Rust port of upstream Svelte's
 //! `src/compiler/utils/builders.js` (`b.*`).
 //!
@@ -20,14 +15,9 @@
 //! Spans are always the dummy [`oxc_span::SPAN`]: esrap formats structurally,
 //! so spans do not affect comment-free output.
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
 use oxc_ast::AstBuilder;
-use oxc_ast::ast::{
-    Argument, ArrayExpressionElement, BindingPattern, BindingRestElement, Expression,
-    FormalParameterKind, FormalParameters, FunctionBody, FunctionType, IdentifierName,
-    ImportOrExportKind, MemberExpression, ObjectPropertyKind, PropertyKey, PropertyKind, Statement,
-    TemplateElementValue, VariableDeclarationKind,
-};
+use oxc_ast::ast::*;
 use oxc_span::{SPAN, Span};
 pub use oxc_syntax::number::NumberBase;
 pub use oxc_syntax::operator::{
@@ -90,59 +80,61 @@ impl<'a> B<'a> {
     /// dotted "identifiers" like `"$.derived"` are valid (matching upstream).
     #[inline]
     pub fn id(self, name: &str) -> Expression<'a> {
-        self.ab.expression_identifier(SPAN, self.str(name))
+        Expression::new_identifier(SPAN, self.str(name), &self.ab)
     }
 
     /// An [`IdentifierName`] (for static member property / meta-property keys).
     #[inline]
     pub fn id_name(self, name: &str) -> IdentifierName<'a> {
-        self.ab.identifier_name(SPAN, self.str(name))
+        IdentifierName::new(SPAN, self.str(name), &self.ab)
     }
 
     /// A string literal expression with the default (printer-chosen) quoting.
     #[inline]
     pub fn string(self, value: &str) -> Expression<'a> {
-        self.ab
-            .expression_string_literal(SPAN, self.str(value), None)
+        Expression::new_string_literal(SPAN, self.str(value), None, &self.ab)
     }
 
     /// A numeric literal expression (decimal).
     #[inline]
     pub fn number(self, value: f64) -> Expression<'a> {
-        self.ab
-            .expression_numeric_literal(SPAN, value, None, NumberBase::Decimal)
+        Expression::new_numeric_literal(SPAN, value, None, NumberBase::Decimal, &self.ab)
     }
 
     /// A boolean literal expression.
     #[inline]
     pub fn bool(self, value: bool) -> Expression<'a> {
-        self.ab.expression_boolean_literal(SPAN, value)
+        Expression::new_boolean_literal(SPAN, value, &self.ab)
     }
 
     /// `null`.
     #[inline]
     pub fn null(self) -> Expression<'a> {
-        self.ab.expression_null_literal(SPAN)
+        Expression::new_null_literal(SPAN, &self.ab)
     }
 
     /// `this`.
     #[inline]
     pub fn this(self) -> Expression<'a> {
-        self.ab.expression_this(SPAN)
+        Expression::ThisExpression(ThisExpression::boxed(SPAN, &self.ab))
     }
 
     /// `void 0`.
     #[inline]
     pub fn void0(self) -> Expression<'a> {
-        self.ab
-            .expression_unary(SPAN, UnaryOperator::Void, self.number(0.0))
+        Expression::UnaryExpression(UnaryExpression::boxed(
+            SPAN,
+            UnaryOperator::Void,
+            self.number(0.0),
+            &self.ab,
+        ))
     }
 
     /// A property key: a bare identifier when `name` is a valid identifier,
     /// otherwise a string-literal key (upstream `b.key`).
     pub fn key(self, name: &str) -> PropertyKey<'a> {
         if is_valid_identifier(name) {
-            self.ab.property_key_static_identifier(SPAN, self.str(name))
+            PropertyKey::new_static_identifier(SPAN, self.str(name), &self.ab)
         } else {
             PropertyKey::from(self.string(name))
         }
@@ -155,10 +147,9 @@ impl<'a> B<'a> {
     pub fn member(self, object: impl IntoExpr<'a>, property: &str) -> Expression<'a> {
         let object = object.into_expr(self);
         let property = self.id_name(property);
-        Expression::from(
-            self.ab
-                .member_expression_static(SPAN, object, property, false),
-        )
+        Expression::from(MemberExpression::StaticMemberExpression(
+            StaticMemberExpression::boxed(SPAN, object, property, false, &self.ab),
+        ))
     }
 
     /// `object[property]` (computed, non-optional).
@@ -168,10 +159,9 @@ impl<'a> B<'a> {
         object: Expression<'a>,
         property: Expression<'a>,
     ) -> Expression<'a> {
-        Expression::from(
-            self.ab
-                .member_expression_computed(SPAN, object, property, false),
-        )
+        Expression::from(MemberExpression::ComputedMemberExpression(
+            ComputedMemberExpression::boxed(SPAN, object, property, false, &self.ab),
+        ))
     }
 
     /// Build a static [`MemberExpression`] node (not wrapped as `Expression`),
@@ -179,8 +169,9 @@ impl<'a> B<'a> {
     #[inline]
     pub fn member_node(self, object: Expression<'a>, property: &str) -> MemberExpression<'a> {
         let property = self.id_name(property);
-        self.ab
-            .member_expression_static(SPAN, object, property, false)
+        MemberExpression::StaticMemberExpression(StaticMemberExpression::boxed(
+            SPAN, object, property, false, &self.ab,
+        ))
     }
 
     /// `a.b.c` from a dotted path (upstream `b.member_id`).
@@ -199,8 +190,14 @@ impl<'a> B<'a> {
     pub fn call(self, callee: impl IntoExpr<'a>, args: Vec<Expression<'a>>) -> Expression<'a> {
         let callee = callee.into_expr(self);
         let args = self.args(args);
-        self.ab
-            .expression_call(SPAN, callee, oxc_ast::NONE, args, false)
+        Expression::CallExpression(CallExpression::boxed(
+            SPAN,
+            callee,
+            oxc_ast::NONE,
+            args,
+            false,
+            &self.ab,
+        ))
     }
 
     /// `callee(args…)` taking pre-built [`Argument`]s (for spreads).
@@ -210,8 +207,14 @@ impl<'a> B<'a> {
         args: ArenaVec<'a, Argument<'a>>,
     ) -> Expression<'a> {
         let callee = callee.into_expr(self);
-        self.ab
-            .expression_call(SPAN, callee, oxc_ast::NONE, args, false)
+        Expression::CallExpression(CallExpression::boxed(
+            SPAN,
+            callee,
+            oxc_ast::NONE,
+            args,
+            false,
+            &self.ab,
+        ))
     }
 
     /// Upstream `b.call(callee, ...args)` semantics with optional arguments:
@@ -241,24 +244,31 @@ impl<'a> B<'a> {
         use oxc_ast::ast::ChainElement;
         let callee = callee.into_expr(self);
         let args = self.args(args);
-        let call = self
-            .ab
-            .alloc_call_expression(SPAN, callee, oxc_ast::NONE, args, true);
+        let call = CallExpression::boxed(SPAN, callee, oxc_ast::NONE, args, true, &self.ab);
         // Wrap in a ChainExpression so esrap prints the `?.()` chain form.
-        self.ab
-            .expression_chain(SPAN, ChainElement::CallExpression(call))
+        Expression::ChainExpression(ChainExpression::boxed(
+            SPAN,
+            ChainElement::CallExpression(call),
+            &self.ab,
+        ))
     }
 
     /// `new callee(args…)`.
     pub fn new_expr(self, callee: impl IntoExpr<'a>, args: Vec<Expression<'a>>) -> Expression<'a> {
         let callee = callee.into_expr(self);
         let args = self.args(args);
-        self.ab.expression_new(SPAN, callee, oxc_ast::NONE, args)
+        Expression::NewExpression(NewExpression::boxed(
+            SPAN,
+            callee,
+            oxc_ast::NONE,
+            args,
+            &self.ab,
+        ))
     }
 
     /// Convert a `Vec<Expression>` into an arena `Vec<Argument>`.
     pub fn args(self, exprs: Vec<Expression<'a>>) -> ArenaVec<'a, Argument<'a>> {
-        let mut out = self.ab.vec_with_capacity(exprs.len());
+        let mut out = ArenaVec::with_capacity_in(exprs.len(), &self.ab);
         for e in exprs {
             out.push(Argument::from(e));
         }
@@ -268,7 +278,7 @@ impl<'a> B<'a> {
     /// A spread argument `...expr` (for use with [`B::call_args`]).
     #[inline]
     pub fn spread_arg(self, expr: Expression<'a>) -> Argument<'a> {
-        self.ab.argument_spread_element(SPAN, expr)
+        Argument::new_spread_element(SPAN, expr, &self.ab)
     }
 
     // -- operators ----------------------------------------------------------
@@ -280,7 +290,7 @@ impl<'a> B<'a> {
         left: Expression<'a>,
         right: Expression<'a>,
     ) -> Expression<'a> {
-        self.ab.expression_binary(SPAN, left, op, right)
+        Expression::BinaryExpression(BinaryExpression::boxed(SPAN, left, op, right, &self.ab))
     }
 
     #[inline]
@@ -290,12 +300,12 @@ impl<'a> B<'a> {
         left: Expression<'a>,
         right: Expression<'a>,
     ) -> Expression<'a> {
-        self.ab.expression_logical(SPAN, left, op, right)
+        Expression::LogicalExpression(LogicalExpression::boxed(SPAN, left, op, right, &self.ab))
     }
 
     #[inline]
     pub fn unary(self, op: UnaryOperator, argument: Expression<'a>) -> Expression<'a> {
-        self.ab.expression_unary(SPAN, op, argument)
+        Expression::UnaryExpression(UnaryExpression::boxed(SPAN, op, argument, &self.ab))
     }
 
     #[inline]
@@ -305,50 +315,51 @@ impl<'a> B<'a> {
         consequent: Expression<'a>,
         alternate: Expression<'a>,
     ) -> Expression<'a> {
-        self.ab
-            .expression_conditional(SPAN, test, consequent, alternate)
+        Expression::ConditionalExpression(ConditionalExpression::boxed(
+            SPAN, test, consequent, alternate, &self.ab,
+        ))
     }
 
     #[inline]
     pub fn await_expr(self, argument: Expression<'a>) -> Expression<'a> {
-        self.ab.expression_await(SPAN, argument)
+        Expression::AwaitExpression(AwaitExpression::boxed(SPAN, argument, &self.ab))
     }
 
     pub fn sequence(self, expressions: Vec<Expression<'a>>) -> Expression<'a> {
-        let mut out = self.ab.vec_with_capacity(expressions.len());
+        let mut out = ArenaVec::with_capacity_in(expressions.len(), &self.ab);
         for e in expressions {
             out.push(e);
         }
-        self.ab.expression_sequence(SPAN, out)
+        Expression::SequenceExpression(SequenceExpression::boxed(SPAN, out, &self.ab))
     }
 
     // -- array & object -----------------------------------------------------
 
     /// `[elements…]`. `None` entries become elisions (holes).
     pub fn array(self, elements: Vec<Option<Expression<'a>>>) -> Expression<'a> {
-        let mut out = self.ab.vec_with_capacity(elements.len());
+        let mut out = ArenaVec::with_capacity_in(elements.len(), &self.ab);
         for el in elements {
             match el {
-                None => out.push(self.ab.array_expression_element_elision(SPAN)),
+                None => out.push(ArrayExpressionElement::new_elision(SPAN, &self.ab)),
                 Some(e) => out.push(ArrayExpressionElement::from(e)),
             }
         }
-        self.ab.expression_array(SPAN, out)
+        Expression::ArrayExpression(ArrayExpression::boxed(SPAN, out, &self.ab))
     }
 
     /// `{ properties… }`.
     pub fn object(self, properties: Vec<ObjectPropertyKind<'a>>) -> Expression<'a> {
-        let mut out = self.ab.vec_with_capacity(properties.len());
+        let mut out = ArenaVec::with_capacity_in(properties.len(), &self.ab);
         for p in properties {
             out.push(p);
         }
-        self.ab.expression_object(SPAN, out)
+        Expression::ObjectExpression(ObjectExpression::boxed(SPAN, out, &self.ab))
     }
 
     /// `name: value` object property (upstream `b.init`).
     pub fn init(self, name: &str, value: Expression<'a>) -> ObjectPropertyKind<'a> {
         let key = self.key(name);
-        ObjectPropertyKind::ObjectProperty(self.ab.alloc_object_property(
+        ObjectPropertyKind::ObjectProperty(ObjectProperty::boxed(
             SPAN,
             PropertyKind::Init,
             key,
@@ -356,6 +367,7 @@ impl<'a> B<'a> {
             false,
             false,
             false,
+            &self.ab,
         ))
     }
 
@@ -370,22 +382,21 @@ impl<'a> B<'a> {
         shorthand: bool,
         computed: bool,
     ) -> ObjectPropertyKind<'a> {
-        ObjectPropertyKind::ObjectProperty(
-            self.ab
-                .alloc_object_property(SPAN, kind, key, value, method, shorthand, computed),
-        )
+        ObjectPropertyKind::ObjectProperty(ObjectProperty::boxed(
+            SPAN, kind, key, value, method, shorthand, computed, &self.ab,
+        ))
     }
 
     /// `...expr` spread property.
     pub fn spread(self, argument: Expression<'a>) -> ObjectPropertyKind<'a> {
-        ObjectPropertyKind::SpreadProperty(self.ab.alloc_spread_element(SPAN, argument))
+        ObjectPropertyKind::SpreadProperty(SpreadElement::boxed(SPAN, argument, &self.ab))
     }
 
     /// `get name() { body }` (upstream `b.get`).
     pub fn get(self, name: &str, body: Vec<Statement<'a>>) -> ObjectPropertyKind<'a> {
         let key = self.key(name);
         let value = self.function_expr(None, self.empty_params(), self.body(body), false);
-        ObjectPropertyKind::ObjectProperty(self.ab.alloc_object_property(
+        ObjectPropertyKind::ObjectProperty(ObjectProperty::boxed(
             SPAN,
             PropertyKind::Get,
             key,
@@ -393,6 +404,7 @@ impl<'a> B<'a> {
             false,
             false,
             false,
+            &self.ab,
         ))
     }
 
@@ -401,7 +413,7 @@ impl<'a> B<'a> {
         let key = self.key(name);
         let params = self.params(vec![self.id_pat("$$value")], None);
         let value = self.function_expr(None, params, self.body(body), false);
-        ObjectPropertyKind::ObjectProperty(self.ab.alloc_object_property(
+        ObjectPropertyKind::ObjectProperty(ObjectProperty::boxed(
             SPAN,
             PropertyKind::Set,
             key,
@@ -409,6 +421,7 @@ impl<'a> B<'a> {
             false,
             false,
             false,
+            &self.ab,
         ))
     }
 
@@ -417,8 +430,7 @@ impl<'a> B<'a> {
     /// A simple identifier binding pattern.
     #[inline]
     pub fn id_pat(self, name: &str) -> BindingPattern<'a> {
-        self.ab
-            .binding_pattern_binding_identifier(SPAN, self.str(name))
+        BindingPattern::new_binding_identifier(SPAN, self.str(name), &self.ab)
     }
 
     /// `{ name: value }` — a single-property object **binding pattern**
@@ -428,11 +440,9 @@ impl<'a> B<'a> {
         self,
         properties: Vec<(String, BindingPattern<'a>)>,
     ) -> BindingPattern<'a> {
-        let mut props = self.ab.vec_with_capacity(properties.len());
+        let mut props = ArenaVec::with_capacity_in(properties.len(), &self.ab);
         for (name, value) in properties {
-            let key = self
-                .ab
-                .property_key_static_identifier(SPAN, self.str(&name));
+            let key = PropertyKey::new_static_identifier(SPAN, self.str(&name), &self.ab);
             // `shorthand` is purely cosmetic for esrap output; mark it true when
             // the value is the same identifier as the key so `{ x }` prints
             // shorthand rather than `{ x: x }`.
@@ -440,10 +450,11 @@ impl<'a> B<'a> {
                 &value,
                 BindingPattern::BindingIdentifier(id) if id.name.as_str() == name
             );
-            props.push(self.ab.binding_property(SPAN, key, value, shorthand, false));
+            props.push(BindingProperty::new(
+                SPAN, key, value, shorthand, false, &self.ab,
+            ));
         }
-        self.ab
-            .binding_pattern_object_pattern(SPAN, props, oxc_ast::NONE)
+        BindingPattern::new_object_pattern(SPAN, props, oxc_ast::NONE, &self.ab)
     }
 
     /// Reinterpret an `Expression` as a `BindingPattern`, mirroring upstream's
@@ -461,7 +472,7 @@ impl<'a> B<'a> {
             Expression::Identifier(id) => self.id_pat(id.name.as_str()),
             Expression::ObjectExpression(obj) => {
                 let props_vec = obj.unbox().properties;
-                let mut props = self.ab.vec_with_capacity(props_vec.len());
+                let mut props = ArenaVec::with_capacity_in(props_vec.len(), &self.ab);
                 let mut rest = None;
                 for member in props_vec {
                     match member {
@@ -472,29 +483,28 @@ impl<'a> B<'a> {
                             let key = p.key;
                             let value = self.expr_to_pattern(p.value, "undefined");
                             let shorthand = p.shorthand;
-                            props.push(
-                                self.ab
-                                    .binding_property(SPAN, key, value, shorthand, p.computed),
-                            );
+                            props.push(BindingProperty::new(
+                                SPAN, key, value, shorthand, p.computed, &self.ab,
+                            ));
                         }
                         OPK::SpreadProperty(s) => {
                             let inner = self.expr_to_pattern(s.unbox().argument, "undefined");
-                            rest = Some(self.ab.alloc_binding_rest_element(SPAN, inner));
+                            rest = Some(BindingRestElement::boxed(SPAN, inner, &self.ab));
                         }
                     }
                 }
-                self.ab.binding_pattern_object_pattern(SPAN, props, rest)
+                BindingPattern::new_object_pattern(SPAN, props, rest, &self.ab)
             }
             Expression::ArrayExpression(arr) => {
                 let elements = arr.unbox().elements;
-                let mut out = self.ab.vec_with_capacity(elements.len());
+                let mut out = ArenaVec::with_capacity_in(elements.len(), &self.ab);
                 let mut rest = None;
                 for el in elements {
                     match el {
                         ArrayExpressionElement::Elision(_) => out.push(None),
                         ArrayExpressionElement::SpreadElement(s) => {
                             let inner = self.expr_to_pattern(s.unbox().argument, "undefined");
-                            rest = Some(self.ab.alloc_binding_rest_element(SPAN, inner));
+                            rest = Some(BindingRestElement::boxed(SPAN, inner, &self.ab));
                         }
                         other => {
                             let e = Expression::try_from(other)
@@ -503,7 +513,7 @@ impl<'a> B<'a> {
                         }
                     }
                 }
-                self.ab.binding_pattern_array_pattern(SPAN, out, rest)
+                BindingPattern::new_array_pattern(SPAN, out, rest, &self.ab)
             }
             Expression::AssignmentExpression(_) => self.id_pat(default_name),
             _ => self.id_pat(default_name),
@@ -522,11 +532,11 @@ impl<'a> B<'a> {
         patterns: Vec<BindingPattern<'a>>,
         rest: Option<BindingPattern<'a>>,
     ) -> FormalParameters<'a> {
-        let mut items = self.ab.vec_with_capacity(patterns.len());
+        let mut items = ArenaVec::with_capacity_in(patterns.len(), &self.ab);
         for pat in patterns {
-            items.push(self.ab.formal_parameter(
+            items.push(FormalParameter::new(
                 SPAN,
-                self.ab.vec(),
+                ArenaVec::new_in(&self.ab),
                 pat,
                 oxc_ast::NONE,
                 oxc_ast::NONE,
@@ -534,26 +544,33 @@ impl<'a> B<'a> {
                 None,
                 false,
                 false,
+                &self.ab,
             ));
         }
         let rest: Option<oxc_allocator::Box<'a, oxc_ast::ast::FormalParameterRest<'a>>> =
             rest.map(|pat| {
-                let rest_el: BindingRestElement<'a> = self.ab.binding_rest_element(SPAN, pat);
-                self.ab
-                    .alloc_formal_parameter_rest(SPAN, self.ab.vec(), rest_el, oxc_ast::NONE)
+                let rest_el: BindingRestElement<'a> = BindingRestElement::new(SPAN, pat, &self.ab);
+                FormalParameterRest::boxed(
+                    SPAN,
+                    ArenaVec::new_in(&self.ab),
+                    rest_el,
+                    oxc_ast::NONE,
+                    &self.ab,
+                )
             });
-        self.ab.formal_parameters(
+        FormalParameters::new(
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
             items,
             rest,
+            &self.ab,
         )
     }
 
     /// Build a [`FunctionBody`] from a list of statements.
     pub fn body(self, statements: Vec<Statement<'a>>) -> FunctionBody<'a> {
-        let stmts = self.ab.vec_from_iter(statements);
-        self.ab.function_body(SPAN, self.ab.vec(), stmts)
+        let stmts = ArenaVec::from_iter_in(statements, &self.ab);
+        FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab)
     }
 
     /// `(params) => body` / `async (params) => body`. `body_is_expression`
@@ -565,7 +582,7 @@ impl<'a> B<'a> {
         body_is_expression: bool,
         is_async: bool,
     ) -> Expression<'a> {
-        self.ab.expression_arrow_function(
+        Expression::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
             SPAN,
             body_is_expression,
             is_async,
@@ -573,7 +590,8 @@ impl<'a> B<'a> {
             params,
             oxc_ast::NONE,
             body,
-        )
+            &self.ab,
+        ))
     }
 
     /// `(params) => expr` — concise-body arrow.
@@ -583,7 +601,7 @@ impl<'a> B<'a> {
         expr: Expression<'a>,
         is_async: bool,
     ) -> Expression<'a> {
-        let stmt = self.ab.statement_expression(SPAN, expr);
+        let stmt = Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, expr, &self.ab));
         let body = self.body(vec![stmt]);
         self.arrow(params, body, true, is_async)
     }
@@ -617,8 +635,8 @@ impl<'a> B<'a> {
         body: FunctionBody<'a>,
         is_async: bool,
     ) -> Expression<'a> {
-        let id = id.map(|n| self.ab.binding_identifier(SPAN, self.str(n)));
-        let func = self.ab.alloc_function(
+        let id = id.map(|n| BindingIdentifier::new(SPAN, self.str(n), &self.ab));
+        let func = Function::boxed(
             SPAN,
             FunctionType::FunctionExpression,
             id,
@@ -630,6 +648,7 @@ impl<'a> B<'a> {
             params,
             oxc_ast::NONE,
             Some(body),
+            &self.ab,
         );
         Expression::FunctionExpression(func)
     }
@@ -642,8 +661,8 @@ impl<'a> B<'a> {
         body: FunctionBody<'a>,
         is_async: bool,
     ) -> Statement<'a> {
-        let id = Some(self.ab.binding_identifier(SPAN, self.str(name)));
-        let func = self.ab.alloc_function(
+        let id = Some(BindingIdentifier::new(SPAN, self.str(name), &self.ab));
+        let func = Function::boxed(
             SPAN,
             FunctionType::FunctionDeclaration,
             id,
@@ -655,6 +674,7 @@ impl<'a> B<'a> {
             params,
             oxc_ast::NONE,
             Some(body),
+            &self.ab,
         );
         Statement::from(oxc_ast::ast::Declaration::FunctionDeclaration(func))
     }
@@ -708,20 +728,19 @@ impl<'a> B<'a> {
         kind: VariableDeclarationKind,
         pairs: Vec<(BindingPattern<'a>, Option<Expression<'a>>)>,
     ) -> Statement<'a> {
-        let mut declarators = self.ab.vec_with_capacity(pairs.len());
+        let mut declarators = ArenaVec::with_capacity_in(pairs.len(), &self.ab);
         for (pat, init) in pairs {
-            declarators.push(self.ab.variable_declarator(
+            declarators.push(VariableDeclarator::new(
                 SPAN,
                 kind,
                 pat,
                 oxc_ast::NONE,
                 init,
                 false,
+                &self.ab,
             ));
         }
-        let decl = self
-            .ab
-            .alloc_variable_declaration(SPAN, kind, declarators, false);
+        let decl = VariableDeclaration::boxed(SPAN, kind, declarators, false, &self.ab);
         Statement::VariableDeclaration(decl)
     }
 
@@ -748,10 +767,9 @@ impl<'a> B<'a> {
         init: Option<Expression<'a>>,
     ) -> Statement<'a> {
         let declarator =
-            self.ab
-                .variable_declarator(SPAN, kind, pattern, oxc_ast::NONE, init, false);
-        let decls = self.ab.vec1(declarator);
-        let decl = self.ab.alloc_variable_declaration(SPAN, kind, decls, false);
+            VariableDeclarator::new(SPAN, kind, pattern, oxc_ast::NONE, init, false, &self.ab);
+        let decls = ArenaVec::from_value_in(declarator, &self.ab);
+        let decl = VariableDeclaration::boxed(SPAN, kind, decls, false, &self.ab);
         Statement::VariableDeclaration(decl)
     }
 
@@ -760,19 +778,19 @@ impl<'a> B<'a> {
     /// `expr;` — expression statement.
     #[inline]
     pub fn stmt(self, expr: Expression<'a>) -> Statement<'a> {
-        self.ab.statement_expression(SPAN, expr)
+        Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, expr, &self.ab))
     }
 
     /// `return expr;` / `return;`.
     #[inline]
     pub fn return_stmt(self, argument: Option<Expression<'a>>) -> Statement<'a> {
-        self.ab.statement_return(SPAN, argument)
+        Statement::ReturnStatement(ReturnStatement::boxed(SPAN, argument, &self.ab))
     }
 
     /// `{ body }` block statement.
     pub fn block(self, body: Vec<Statement<'a>>) -> Statement<'a> {
-        let stmts = self.ab.vec_from_iter(body);
-        self.ab.statement_block(SPAN, stmts)
+        let stmts = ArenaVec::from_iter_in(body, &self.ab);
+        Statement::BlockStatement(BlockStatement::boxed(SPAN, stmts, &self.ab))
     }
 
     /// `if (test) consequent else alternate`.
@@ -782,12 +800,14 @@ impl<'a> B<'a> {
         consequent: Statement<'a>,
         alternate: Option<Statement<'a>>,
     ) -> Statement<'a> {
-        self.ab.statement_if(SPAN, test, consequent, alternate)
+        Statement::IfStatement(IfStatement::boxed(
+            SPAN, test, consequent, alternate, &self.ab,
+        ))
     }
 
     /// `do body while (test);` (upstream `b.do_while`).
     pub fn do_while(self, test: Expression<'a>, body: Statement<'a>) -> Statement<'a> {
-        self.ab.statement_do_while(SPAN, body, test)
+        Statement::DoWhileStatement(DoWhileStatement::boxed(SPAN, body, test, &self.ab))
     }
 
     /// `!argument` — logical-NOT unary (upstream `b.unary('!', ...)`).
@@ -799,7 +819,7 @@ impl<'a> B<'a> {
     /// `;` empty statement.
     #[inline]
     pub fn empty(self) -> Statement<'a> {
-        self.ab.statement_empty(SPAN)
+        Statement::EmptyStatement(EmptyStatement::boxed(SPAN, &self.ab))
     }
 
     /// A *kept* `;` empty statement — one the esrap printer must NOT elide.
@@ -819,13 +839,13 @@ impl<'a> B<'a> {
     /// body-sequence comment-resync logic treats them as separate nodes.
     #[inline]
     pub fn empty_kept(self, start: u32) -> Statement<'a> {
-        self.ab.statement_empty(Span::new(start, u32::MAX))
+        Statement::EmptyStatement(EmptyStatement::boxed(Span::new(start, u32::MAX), &self.ab))
     }
 
     /// `debugger;` statement (upstream `b.debugger`).
     #[inline]
     pub fn debugger(self) -> Statement<'a> {
-        self.ab.statement_debugger(SPAN)
+        Statement::DebuggerStatement(DebuggerStatement::boxed(SPAN, &self.ab))
     }
 
     /// `target++` / `target--` / `++target` / `--target` (upstream `b.update`).
@@ -837,18 +857,17 @@ impl<'a> B<'a> {
     ) -> Expression<'a> {
         use oxc_ast::ast::SimpleAssignmentTarget;
         let st: SimpleAssignmentTarget<'a> = match target {
-            Expression::Identifier(id) => self
-                .ab
-                .simple_assignment_target_assignment_target_identifier(
-                    SPAN,
-                    self.str(id.name.as_str()),
-                ),
+            Expression::Identifier(id) => SimpleAssignmentTarget::new_assignment_target_identifier(
+                SPAN,
+                self.str(id.name.as_str()),
+                &self.ab,
+            ),
             other => match MemberExpression::try_from(other) {
                 Ok(member) => SimpleAssignmentTarget::from(member),
                 Err(_) => panic!("update target must be an identifier or member expression"),
             },
         };
-        self.ab.expression_update(SPAN, op, prefix, st)
+        Expression::UpdateExpression(UpdateExpression::boxed(SPAN, op, prefix, st, &self.ab))
     }
 
     /// A multi-declarator variable declaration node (the boxed form, suitable as
@@ -858,20 +877,20 @@ impl<'a> B<'a> {
         kind: VariableDeclarationKind,
         decls: Vec<(&str, Option<Expression<'a>>)>,
     ) -> oxc_allocator::Box<'a, oxc_ast::ast::VariableDeclaration<'a>> {
-        let mut declarators = self.ab.vec_with_capacity(decls.len());
+        let mut declarators = ArenaVec::with_capacity_in(decls.len(), &self.ab);
         for (name, init) in decls {
             let pat = self.id_pat(name);
-            declarators.push(self.ab.variable_declarator(
+            declarators.push(VariableDeclarator::new(
                 SPAN,
                 kind,
                 pat,
                 oxc_ast::NONE,
                 init,
                 false,
+                &self.ab,
             ));
         }
-        self.ab
-            .alloc_variable_declaration(SPAN, kind, declarators, false)
+        VariableDeclaration::boxed(SPAN, kind, declarators, false, &self.ab)
     }
 
     /// `for (init; test; update) body` (upstream `b.for`).
@@ -884,13 +903,15 @@ impl<'a> B<'a> {
     ) -> Statement<'a> {
         use oxc_ast::ast::ForStatementInit;
         let init = init.map(ForStatementInit::VariableDeclaration);
-        self.ab.statement_for(SPAN, init, test, update, body)
+        Statement::ForStatement(ForStatement::boxed(
+            SPAN, init, test, update, body, &self.ab,
+        ))
     }
 
     /// `throw new Error("…")` (upstream `b.throw_error`).
     pub fn throw_error(self, message: &str) -> Statement<'a> {
         let err = self.new_expr("Error", vec![self.string(message)]);
-        self.ab.statement_throw(SPAN, err)
+        Statement::ThrowStatement(ThrowStatement::boxed(SPAN, err, &self.ab))
     }
 
     // -- imports & exports --------------------------------------------------
@@ -901,19 +922,19 @@ impl<'a> B<'a> {
     /// escaping), matching the established `module_source` convention so esrap
     /// reproduces `'svelte/internal/server'` byte-for-byte.
     pub fn import_all(self, as_name: &str, source: &str) -> Statement<'a> {
-        let local = self.ab.binding_identifier(SPAN, self.str(as_name));
-        let mut specs = self.ab.vec_with_capacity(1);
-        specs.push(
-            self.ab
-                .import_declaration_specifier_import_namespace_specifier(SPAN, local),
-        );
-        let decl = self.ab.module_declaration_import_declaration(
+        let local = BindingIdentifier::new(SPAN, self.str(as_name), &self.ab);
+        let mut specs = ArenaVec::with_capacity_in(1, &self.ab);
+        specs.push(ImportDeclarationSpecifier::new_import_namespace_specifier(
+            SPAN, local, &self.ab,
+        ));
+        let decl = ModuleDeclaration::new_import_declaration(
             SPAN,
             Some(specs),
             self.module_source(source),
             None,
             oxc_ast::NONE,
             ImportOrExportKind::Value,
+            &self.ab,
         );
         Statement::from(decl)
     }
@@ -926,26 +947,28 @@ impl<'a> B<'a> {
         let specifiers = if parts.is_empty() {
             None
         } else {
-            let mut specs = self.ab.vec_with_capacity(parts.len());
+            let mut specs = ArenaVec::with_capacity_in(parts.len(), &self.ab);
             for (imported, local) in parts {
                 let imported_name = self.module_export_name(imported);
-                let local_id = self.ab.binding_identifier(SPAN, self.str(local));
-                specs.push(self.ab.import_declaration_specifier_import_specifier(
+                let local_id = BindingIdentifier::new(SPAN, self.str(local), &self.ab);
+                specs.push(ImportDeclarationSpecifier::new_import_specifier(
                     SPAN,
                     imported_name,
                     local_id,
                     ImportOrExportKind::Value,
+                    &self.ab,
                 ));
             }
             Some(specs)
         };
-        let decl = self.ab.module_declaration_import_declaration(
+        let decl = ModuleDeclaration::new_import_declaration(
             SPAN,
             specifiers,
             self.module_source(source),
             None,
             oxc_ast::NONE,
             ImportOrExportKind::Value,
+            &self.ab,
         );
         Statement::from(decl)
     }
@@ -968,18 +991,14 @@ impl<'a> B<'a> {
                 return other;
             }
         };
-        let decl = self
-            .ab
-            .module_declaration_export_default_declaration(SPAN, kind);
+        let decl = ModuleDeclaration::new_export_default_declaration(SPAN, kind, &self.ab);
         Statement::from(decl)
     }
 
     /// `export default <expr>;` (upstream `b.export_default` of an expression).
     pub fn export_default_expr(self, expr: Expression<'a>) -> Statement<'a> {
         let kind = oxc_ast::ast::ExportDefaultDeclarationKind::from(expr);
-        let decl = self
-            .ab
-            .module_declaration_export_default_declaration(SPAN, kind);
+        let decl = ModuleDeclaration::new_export_default_declaration(SPAN, kind, &self.ab);
         Statement::from(decl)
     }
 
@@ -987,14 +1006,12 @@ impl<'a> B<'a> {
     /// quotes (mirrors `to_oxc.rs::module_source`).
     fn module_source(self, source: &str) -> oxc_ast::ast::StringLiteral<'a> {
         let raw = self.str(&format!("'{source}'"));
-        self.ab
-            .string_literal(SPAN, self.str(source), Some(raw.into()))
+        StringLiteral::new(SPAN, self.str(source), Some(raw.into()), &self.ab)
     }
 
     /// Build a `ModuleExportName::IdentifierName` from a plain name.
     fn module_export_name(self, name: &str) -> oxc_ast::ast::ModuleExportName<'a> {
-        self.ab
-            .module_export_name_identifier_name(SPAN, self.str(name))
+        ModuleExportName::new_identifier_name(SPAN, self.str(name), &self.ab)
     }
 
     /// `target <op> value` assignment expression (upstream `b.assignment`).
@@ -1009,33 +1026,36 @@ impl<'a> B<'a> {
     ) -> Expression<'a> {
         use oxc_ast::ast::AssignmentTarget;
         let lhs: AssignmentTarget<'a> = match target {
-            Expression::Identifier(id) => AssignmentTarget::from(
-                self.ab
-                    .simple_assignment_target_assignment_target_identifier(
-                        SPAN,
-                        self.str(id.name.as_str()),
-                    ),
-            ),
+            Expression::Identifier(id) => {
+                AssignmentTarget::from(SimpleAssignmentTarget::new_assignment_target_identifier(
+                    SPAN,
+                    self.str(id.name.as_str()),
+                    &self.ab,
+                ))
+            }
             other => match MemberExpression::try_from(other) {
                 Ok(member) => AssignmentTarget::from(member),
                 Err(_) => panic!("assignment target must be an identifier or member expression"),
             },
         };
-        self.ab.expression_assignment(SPAN, op, lhs, value)
+        Expression::AssignmentExpression(AssignmentExpression::boxed(
+            SPAN, op, lhs, value, &self.ab,
+        ))
     }
 
     /// Assemble a module [`Program`](oxc_ast::ast::Program) from top-level
     /// statements, ready for [`rsvelte_esrap::print`].
     pub fn program(self, body: Vec<Statement<'a>>) -> oxc_ast::ast::Program<'a> {
-        let body = self.ab.vec_from_iter(body);
-        self.ab.program(
+        let body = ArenaVec::from_iter_in(body, &self.ab);
+        Program::new(
             SPAN,
             oxc_span::SourceType::mjs(),
             "",
-            self.ab.vec(),
+            ArenaVec::new_in(&self.ab),
             None,
-            self.ab.vec(),
+            ArenaVec::new_in(&self.ab),
             body,
+            &self.ab,
         )
     }
 
@@ -1045,20 +1065,23 @@ impl<'a> B<'a> {
     /// expressions. `quasis.len()` must be `expressions.len() + 1`.
     pub fn template(self, quasis: Vec<&str>, expressions: Vec<Expression<'a>>) -> Expression<'a> {
         let n = quasis.len();
-        let mut q = self.ab.vec_with_capacity(n);
+        let mut q = ArenaVec::with_capacity_in(n, &self.ab);
         for (i, cooked) in quasis.iter().enumerate() {
             let raw = sanitize_template_string(cooked);
             let value = TemplateElementValue {
                 raw: self.str(&raw).into(),
                 cooked: Some(self.str(cooked).into()),
             };
-            q.push(self.ab.template_element(SPAN, value, i == n - 1));
+            q.push(TemplateElement::new(SPAN, value, i == n - 1, &self.ab));
         }
-        let mut e = self.ab.vec_with_capacity(expressions.len());
+        let mut e = ArenaVec::with_capacity_in(expressions.len(), &self.ab);
         for expr in expressions {
             e.push(expr);
         }
-        Expression::TemplateLiteral(self.ab.alloc(self.ab.template_literal(SPAN, q, e)))
+        Expression::TemplateLiteral(ArenaBox::new_in(
+            TemplateLiteral::new(SPAN, q, e, &self.ab),
+            &self.ab,
+        ))
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
@@ -1043,7 +1043,7 @@ impl<'a> B<'a> {
         ))
     }
 
-    /// Assemble a module [`Program`](oxc_ast::ast::Program) from top-level
+    /// Assemble a module [`Program`] from top-level
     /// statements, ready for [`rsvelte_esrap::print`].
     pub fn program(self, body: Vec<Statement<'a>>) -> oxc_ast::ast::Program<'a> {
         let body = ArenaVec::from_iter_in(body, &self.ab);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -1,8 +1,3 @@
-// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
-// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
-// deprecation here and defer the mechanical migration to a dedicated follow-up.
-
-#![allow(deprecated)]
 //! Convert the internal `js_ast` IR (`JsProgram`) into an oxc
 //! [`oxc_ast::ast::Program`] so it can be printed by [`rsvelte_esrap`].
 //!
@@ -32,13 +27,9 @@
 
 use super::arena::{ExprId, JsArena};
 use super::nodes::*;
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
 use oxc_ast::AstBuilder;
-use oxc_ast::ast::{
-    Argument, ArrayExpressionElement, ChainElement, Expression, ForStatementInit, ForStatementLeft,
-    FormalParameterKind, FunctionType, ImportOrExportKind, ObjectPropertyKind, PropertyKey,
-    PropertyKind, RegExp, RegExpFlags, RegExpPattern, Statement, VariableDeclarationKind,
-};
+use oxc_ast::ast::*;
 use oxc_span::{GetSpanMut, SPAN, Span};
 use oxc_syntax::number::{BigintBase, NumberBase};
 use oxc_syntax::operator::{
@@ -65,15 +56,16 @@ pub fn program_to_oxc<'a>(
         body.extend(cx.expand_stmt(s)?);
     }
 
-    let body = ab.vec_from_iter(body);
-    Some(ab.program(
+    let body = ArenaVec::from_iter_in(body, &ab);
+    Some(Program::new(
         SPAN,
         oxc_span::SourceType::mjs(),
         "",
-        ab.vec(),
+        ArenaVec::new_in(&ab),
         None,
-        ab.vec(),
+        ArenaVec::new_in(&ab),
         body,
+        &ab,
     ))
 }
 
@@ -105,33 +97,49 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         match stmt {
             JsStatement::Expression(e) => {
                 let expr = self.expr_id(e.expression)?;
-                Some(self.ab.statement_expression(SPAN, expr))
+                Some(Statement::ExpressionStatement(ExpressionStatement::boxed(
+                    SPAN, expr, &self.ab,
+                )))
             }
             JsStatement::Return(r) => {
                 let arg = match r.argument {
                     Some(id) => Some(self.expr_id(id)?),
                     None => None,
                 };
-                Some(self.ab.statement_return(SPAN, arg))
+                Some(Statement::ReturnStatement(ReturnStatement::boxed(
+                    SPAN, arg, &self.ab,
+                )))
             }
             JsStatement::VariableDeclaration(decl) => self.variable_declaration(decl),
             JsStatement::Block(b) => {
                 let stmts = self.statements(&b.body)?;
-                Some(self.ab.statement_block(SPAN, stmts))
+                Some(Statement::BlockStatement(BlockStatement::boxed(
+                    SPAN, stmts, &self.ab,
+                )))
             }
-            JsStatement::Empty => Some(self.ab.statement_empty(SPAN)),
-            JsStatement::Debugger => Some(self.ab.statement_debugger(SPAN)),
+            JsStatement::Empty => Some(Statement::EmptyStatement(EmptyStatement::boxed(
+                SPAN, &self.ab,
+            ))),
+            JsStatement::Debugger => Some(Statement::DebuggerStatement(DebuggerStatement::boxed(
+                SPAN, &self.ab,
+            ))),
             JsStatement::Throw(id) => {
                 let arg = self.expr_id(*id)?;
-                Some(self.ab.statement_throw(SPAN, arg))
+                Some(Statement::ThrowStatement(ThrowStatement::boxed(
+                    SPAN, arg, &self.ab,
+                )))
             }
             JsStatement::Break(label) => {
                 let label = self.label(label.as_deref());
-                Some(self.ab.statement_break(SPAN, label))
+                Some(Statement::BreakStatement(BreakStatement::boxed(
+                    SPAN, label, &self.ab,
+                )))
             }
             JsStatement::Continue(label) => {
                 let label = self.label(label.as_deref());
-                Some(self.ab.statement_continue(SPAN, label))
+                Some(Statement::ContinueStatement(ContinueStatement::boxed(
+                    SPAN, label, &self.ab,
+                )))
             }
             JsStatement::If(if_stmt) => {
                 let test = self.expr_id(if_stmt.test)?;
@@ -140,7 +148,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     Some(id) => Some(self.stmt(self.arena.get_stmt(id))?),
                     None => None,
                 };
-                Some(self.ab.statement_if(SPAN, test, consequent, alternate))
+                Some(Statement::IfStatement(IfStatement::boxed(
+                    SPAN, test, consequent, alternate, &self.ab,
+                )))
             }
             JsStatement::Import(import) => self.import_declaration(import),
             JsStatement::ExportNamed(export) => self.export_named(export),
@@ -155,18 +165,24 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             JsStatement::While(w) => {
                 let test = self.expr_id(w.test)?;
                 let body = self.stmt(self.arena.get_stmt(w.body))?;
-                Some(self.ab.statement_while(SPAN, test, body))
+                Some(Statement::WhileStatement(WhileStatement::boxed(
+                    SPAN, test, body, &self.ab,
+                )))
             }
             JsStatement::DoWhile(d) => {
                 let body = self.stmt(self.arena.get_stmt(d.body))?;
                 let test = self.expr_id(d.test)?;
-                Some(self.ab.statement_do_while(SPAN, body, test))
+                Some(Statement::DoWhileStatement(DoWhileStatement::boxed(
+                    SPAN, body, test, &self.ab,
+                )))
             }
             JsStatement::Switch(s) => self.switch_statement(s),
             JsStatement::Labeled(l) => {
-                let label = self.ab.label_identifier(SPAN, self.str(&l.label));
+                let label = LabelIdentifier::new(SPAN, self.str(&l.label), &self.ab);
                 let body = self.stmt(self.arena.get_stmt(l.body))?;
-                Some(self.ab.statement_labeled(SPAN, label, body))
+                Some(Statement::LabeledStatement(LabeledStatement::boxed(
+                    SPAN, label, body, &self.ab,
+                )))
             }
             JsStatement::Try(t) => self.try_statement(t),
             // `Raw`/`RawMapped` at a SINGLE-statement site (if / while / for
@@ -185,7 +201,11 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         if stmts.len() == 1 {
             stmts.into_iter().next()
         } else {
-            Some(self.ab.statement_block(SPAN, self.ab.vec_from_iter(stmts)))
+            Some(Statement::BlockStatement(BlockStatement::boxed(
+                SPAN,
+                ArenaVec::from_iter_in(stmts, &self.ab),
+                &self.ab,
+            )))
         }
     }
 
@@ -212,7 +232,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             None => None,
         };
         let body = self.stmt(self.arena.get_stmt(for_stmt.body))?;
-        Some(self.ab.statement_for(SPAN, init, test, update, body))
+        Some(Statement::ForStatement(ForStatement::boxed(
+            SPAN, init, test, update, body, &self.ab,
+        )))
     }
 
     /// Build a `for (left of right)` / `for await (left of right)` statement,
@@ -236,12 +258,13 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 // representable; reuse the assignment-target helper which bails
                 // on anything else.
                 let target = match pattern {
-                    JsPattern::Identifier(name) => self
-                        .ab
-                        .simple_assignment_target_assignment_target_identifier(
+                    JsPattern::Identifier(name) => {
+                        SimpleAssignmentTarget::new_assignment_target_identifier(
                             SPAN,
                             self.str(name),
-                        ),
+                            &self.ab,
+                        )
+                    }
                     _ => return None,
                 };
                 let assignment_target = oxc_ast::ast::AssignmentTarget::from(target);
@@ -255,35 +278,46 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             if for_of.is_await {
                 return None;
             }
-            Some(self.ab.statement_for_in(SPAN, left, right, body))
+            Some(Statement::ForInStatement(ForInStatement::boxed(
+                SPAN, left, right, body, &self.ab,
+            )))
         } else {
-            Some(
-                self.ab
-                    .statement_for_of(SPAN, for_of.is_await, left, right, body),
-            )
+            Some(Statement::ForOfStatement(ForOfStatement::boxed(
+                SPAN,
+                for_of.is_await,
+                left,
+                right,
+                body,
+                &self.ab,
+            )))
         }
     }
 
     /// Build a `switch (disc) { case … }` statement.
     fn switch_statement(&self, s: &JsSwitchStatement) -> Option<Statement<'a>> {
         let discriminant = self.expr_id(s.discriminant)?;
-        let mut cases = self.ab.vec_with_capacity(s.cases.len());
+        let mut cases = ArenaVec::with_capacity_in(s.cases.len(), &self.ab);
         for case in &s.cases {
             let test = match case.test {
                 Some(id) => Some(self.expr_id(id)?),
                 None => None,
             };
             let consequent = self.statements(&case.consequent)?;
-            cases.push(self.ab.switch_case(SPAN, test, consequent));
+            cases.push(SwitchCase::new(SPAN, test, consequent, &self.ab));
         }
-        Some(self.ab.statement_switch(SPAN, discriminant, cases))
+        Some(Statement::SwitchStatement(SwitchStatement::boxed(
+            SPAN,
+            discriminant,
+            cases,
+            &self.ab,
+        )))
     }
 
     /// Build a `try { } catch (e) { } finally { }` statement. Bails on a
     /// destructuring catch parameter.
     fn try_statement(&self, t: &JsTryStatement) -> Option<Statement<'a>> {
         let block_stmts = self.statements(&t.block.body)?;
-        let block = self.ab.alloc_block_statement(SPAN, block_stmts);
+        let block = BlockStatement::boxed(SPAN, block_stmts, &self.ab);
 
         let handler = match &t.handler {
             None => None,
@@ -292,12 +326,12 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     None => None,
                     Some(pat) => {
                         let pattern = self.binding_pattern(pat)?;
-                        Some(self.ab.catch_parameter(SPAN, pattern, oxc_ast::NONE))
+                        Some(CatchParameter::new(SPAN, pattern, oxc_ast::NONE, &self.ab))
                     }
                 };
                 let body_stmts = self.statements(&catch.body.body)?;
-                let body = self.ab.alloc_block_statement(SPAN, body_stmts);
-                Some(self.ab.catch_clause(SPAN, param, body))
+                let body = BlockStatement::boxed(SPAN, body_stmts, &self.ab);
+                Some(CatchClause::new(SPAN, param, body, &self.ab))
             }
         };
 
@@ -305,11 +339,13 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             None => None,
             Some(block) => {
                 let stmts = self.statements(&block.body)?;
-                Some(self.ab.alloc_block_statement(SPAN, stmts))
+                Some(BlockStatement::boxed(SPAN, stmts, &self.ab))
             }
         };
 
-        Some(self.ab.statement_try(SPAN, block, handler, finalizer))
+        Some(Statement::TryStatement(TryStatement::boxed(
+            SPAN, block, handler, finalizer, &self.ab,
+        )))
     }
 
     /// Build a module-source `StringLiteral`. Codegen emits the source verbatim
@@ -318,14 +354,12 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// make esrap reproduce it byte-for-byte regardless of quote options.
     fn module_source(&self, source: &str) -> oxc_ast::ast::StringLiteral<'a> {
         let raw = self.str(&format!("'{source}'"));
-        self.ab
-            .string_literal(SPAN, self.str(source), Some(raw.into()))
+        StringLiteral::new(SPAN, self.str(source), Some(raw.into()), &self.ab)
     }
 
     /// Build a `ModuleExportName::IdentifierName` from a plain name.
     fn module_export_name(&self, name: &str) -> oxc_ast::ast::ModuleExportName<'a> {
-        self.ab
-            .module_export_name_identifier_name(SPAN, self.str(name))
+        ModuleExportName::new_identifier_name(SPAN, self.str(name), &self.ab)
     }
 
     fn import_declaration(&self, import: &JsImportDeclaration) -> Option<Statement<'a>> {
@@ -336,33 +370,30 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             && !matches!(import.specifiers[0], JsImportSpecifier::SideEffect);
 
         let specifiers = if has_specifiers {
-            let mut specs = self.ab.vec_with_capacity(import.specifiers.len());
+            let mut specs = ArenaVec::with_capacity_in(import.specifiers.len(), &self.ab);
             for spec in &import.specifiers {
                 match spec {
                     JsImportSpecifier::Default(name) => {
-                        let local = self.ab.binding_identifier(SPAN, self.str(name));
-                        specs.push(
-                            self.ab
-                                .import_declaration_specifier_import_default_specifier(SPAN, local),
-                        );
+                        let local = BindingIdentifier::new(SPAN, self.str(name), &self.ab);
+                        specs.push(ImportDeclarationSpecifier::new_import_default_specifier(
+                            SPAN, local, &self.ab,
+                        ));
                     }
                     JsImportSpecifier::Namespace(name) => {
-                        let local = self.ab.binding_identifier(SPAN, self.str(name));
-                        specs.push(
-                            self.ab
-                                .import_declaration_specifier_import_namespace_specifier(
-                                    SPAN, local,
-                                ),
-                        );
+                        let local = BindingIdentifier::new(SPAN, self.str(name), &self.ab);
+                        specs.push(ImportDeclarationSpecifier::new_import_namespace_specifier(
+                            SPAN, local, &self.ab,
+                        ));
                     }
                     JsImportSpecifier::Named { imported, local } => {
                         let imported = self.module_export_name(imported);
-                        let local = self.ab.binding_identifier(SPAN, self.str(local));
-                        specs.push(self.ab.import_declaration_specifier_import_specifier(
+                        let local = BindingIdentifier::new(SPAN, self.str(local), &self.ab);
+                        specs.push(ImportDeclarationSpecifier::new_import_specifier(
                             SPAN,
                             imported,
                             local,
                             ImportOrExportKind::Value,
+                            &self.ab,
                         ));
                     }
                     // A `SideEffect` specifier alongside real ones would mean
@@ -377,13 +408,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         };
 
         let source = self.module_source(&import.source);
-        let decl = self.ab.module_declaration_import_declaration(
+        let decl = ModuleDeclaration::new_import_declaration(
             SPAN,
             specifiers,
             source,
             None,
             oxc_ast::NONE,
             ImportOrExportKind::Value,
+            &self.ab,
         );
         Some(Statement::from(decl))
     }
@@ -395,30 +427,32 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let (declaration, specifiers) = if let Some(decl) = &export.declaration {
             let var_decl = self.variable_declaration_node(decl)?;
             let declaration = oxc_ast::ast::Declaration::VariableDeclaration(var_decl);
-            (Some(declaration), self.ab.vec())
+            (Some(declaration), ArenaVec::new_in(&self.ab))
         } else {
-            let mut specs = self.ab.vec_with_capacity(export.specifiers.len());
+            let mut specs = ArenaVec::with_capacity_in(export.specifiers.len(), &self.ab);
             for spec in &export.specifiers {
                 let local = self.module_export_name(&spec.local);
                 let exported = self.module_export_name(&spec.exported);
-                specs.push(self.ab.export_specifier(
+                specs.push(ExportSpecifier::new(
                     SPAN,
                     local,
                     exported,
                     ImportOrExportKind::Value,
+                    &self.ab,
                 ));
             }
             (None, specs)
         };
 
         // The IR has no re-export source (`export { x } from 'y'`); always None.
-        let decl = self.ab.module_declaration_export_named_declaration(
+        let decl = ModuleDeclaration::new_export_named_declaration(
             SPAN,
             declaration,
             specifiers,
             None,
             ImportOrExportKind::Value,
             oxc_ast::NONE,
+            &self.ab,
         );
         Some(Statement::from(decl))
     }
@@ -434,9 +468,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 oxc_ast::ast::ExportDefaultDeclarationKind::from(expr)
             }
         };
-        let decl = self
-            .ab
-            .module_declaration_export_default_declaration(SPAN, kind);
+        let decl = ModuleDeclaration::new_export_default_declaration(SPAN, kind, &self.ab);
         Some(Statement::from(decl))
     }
 
@@ -452,11 +484,11 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let id = func
             .id
             .as_ref()
-            .map(|name| self.ab.binding_identifier(SPAN, self.str(name)));
+            .map(|name| BindingIdentifier::new(SPAN, self.str(name), &self.ab));
         let params = self.formal_params(&func.params)?;
         let stmts = self.statements(&func.body.body)?;
-        let body = self.ab.function_body(SPAN, self.ab.vec(), stmts);
-        Some(self.ab.alloc_function(
+        let body = FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab);
+        Some(Function::boxed(
             SPAN,
             func_type,
             id,
@@ -468,6 +500,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             params,
             oxc_ast::NONE,
             Some(body),
+            &self.ab,
         ))
     }
 
@@ -478,12 +511,12 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         for s in body {
             v.extend(self.expand_stmt(s)?);
         }
-        Some(self.ab.vec_from_iter(v))
+        Some(ArenaVec::from_iter_in(v, &self.ab))
     }
 
     /// Build an optional `LabelIdentifier` for `break`/`continue` labels.
     fn label(&self, name: Option<&str>) -> Option<oxc_ast::ast::LabelIdentifier<'a>> {
-        name.map(|n| self.ab.label_identifier(SPAN, self.str(n)))
+        name.map(|n| LabelIdentifier::new(SPAN, self.str(n), &self.ab))
     }
 
     fn variable_declaration(&self, decl: &JsVariableDeclaration) -> Option<Statement<'a>> {
@@ -505,7 +538,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             JsVariableKind::Const => VariableDeclarationKind::Const,
         };
 
-        let mut declarators = self.ab.vec_with_capacity(decl.declarations.len());
+        let mut declarators = ArenaVec::with_capacity_in(decl.declarations.len(), &self.ab);
         for d in &decl.declarations {
             // Identifier or destructuring binding pattern; `binding_pattern`
             // bails on anything it cannot faithfully reproduce.
@@ -514,20 +547,24 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 Some(id) => Some(self.expr_id(id)?),
                 None => None,
             };
-            declarators.push(self.ab.variable_declarator(
+            declarators.push(VariableDeclarator::new(
                 SPAN,
                 kind,
                 binding,
                 oxc_ast::NONE,
                 init,
                 false,
+                &self.ab,
             ));
         }
 
-        Some(
-            self.ab
-                .alloc_variable_declaration(SPAN, kind, declarators, false),
-        )
+        Some(VariableDeclaration::boxed(
+            SPAN,
+            kind,
+            declarators,
+            false,
+            &self.ab,
+        ))
     }
 
     // -- binding patterns ---------------------------------------------------
@@ -541,12 +578,13 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// structurally).
     fn binding_pattern(&self, pat: &JsPattern) -> Option<oxc_ast::ast::BindingPattern<'a>> {
         match pat {
-            JsPattern::Identifier(name) => Some(
-                self.ab
-                    .binding_pattern_binding_identifier(SPAN, self.str(name)),
-            ),
+            JsPattern::Identifier(name) => Some(BindingPattern::new_binding_identifier(
+                SPAN,
+                self.str(name),
+                &self.ab,
+            )),
             JsPattern::Object(obj) => {
-                let mut props = self.ab.vec_with_capacity(obj.properties.len());
+                let mut props = ArenaVec::with_capacity_in(obj.properties.len(), &self.ab);
                 let mut rest: Option<oxc_allocator::Box<'a, oxc_ast::ast::BindingRestElement<'a>>> =
                     None;
                 let last = obj.properties.len().saturating_sub(1);
@@ -572,10 +610,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                                 self.property_key(key)?
                             };
                             let value = self.binding_pattern(value)?;
-                            props.push(
-                                self.ab
-                                    .binding_property(SPAN, key, value, *shorthand, *computed),
-                            );
+                            props.push(BindingProperty::new(
+                                SPAN, key, value, *shorthand, *computed, &self.ab,
+                            ));
                         }
                         JsObjectPatternProperty::Rest(inner) => {
                             // A rest property must be the last entry.
@@ -583,14 +620,16 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                                 return None;
                             }
                             let inner = self.binding_pattern(inner)?;
-                            rest = Some(self.ab.alloc_binding_rest_element(SPAN, inner));
+                            rest = Some(BindingRestElement::boxed(SPAN, inner, &self.ab));
                         }
                     }
                 }
-                Some(self.ab.binding_pattern_object_pattern(SPAN, props, rest))
+                Some(BindingPattern::new_object_pattern(
+                    SPAN, props, rest, &self.ab,
+                ))
             }
             JsPattern::Array(arr) => {
-                let mut elements = self.ab.vec_with_capacity(arr.elements.len());
+                let mut elements = ArenaVec::with_capacity_in(arr.elements.len(), &self.ab);
                 let mut rest: Option<oxc_allocator::Box<'a, oxc_ast::ast::BindingRestElement<'a>>> =
                     None;
                 let last = arr.elements.len().saturating_sub(1);
@@ -603,20 +642,21 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                                 return None;
                             }
                             let inner = self.binding_pattern(inner)?;
-                            rest = Some(self.ab.alloc_binding_rest_element(SPAN, inner));
+                            rest = Some(BindingRestElement::boxed(SPAN, inner, &self.ab));
                         }
                         Some(el) => elements.push(Some(self.binding_pattern(el)?)),
                     }
                 }
-                Some(self.ab.binding_pattern_array_pattern(SPAN, elements, rest))
+                Some(BindingPattern::new_array_pattern(
+                    SPAN, elements, rest, &self.ab,
+                ))
             }
             JsPattern::Assignment(JsAssignmentPattern { left, right }) => {
                 let left = self.binding_pattern(left)?;
                 let right = self.expr_id(*right)?;
-                Some(
-                    self.ab
-                        .binding_pattern_assignment_pattern(SPAN, left, right),
-                )
+                Some(BindingPattern::new_assignment_pattern(
+                    SPAN, left, right, &self.ab,
+                ))
             }
             // A bare `Rest` only ever appears nested inside an object / array
             // pattern (handled above) or as the last function parameter (handled
@@ -629,85 +669,115 @@ impl<'a, 'arena> Cx<'a, 'arena> {
 
     fn expr(&self, expr: &JsExpr) -> Option<Expression<'a>> {
         match expr {
-            JsExpr::Identifier(name) => Some(self.ab.expression_identifier(SPAN, self.str(name))),
+            JsExpr::Identifier(name) => {
+                Some(Expression::new_identifier(SPAN, self.str(name), &self.ab))
+            }
             JsExpr::OpaqueIdentifier(name) => {
-                Some(self.ab.expression_identifier(SPAN, self.str(name)))
+                Some(Expression::new_identifier(SPAN, self.str(name), &self.ab))
             }
             JsExpr::Literal(lit) => self.literal(lit),
-            JsExpr::This => Some(self.ab.expression_this(SPAN)),
-            JsExpr::Super => Some(Expression::Super(self.ab.alloc_super(SPAN))),
+            JsExpr::This => Some(Expression::ThisExpression(ThisExpression::boxed(
+                SPAN, &self.ab,
+            ))),
+            JsExpr::Super => Some(Expression::Super(Super::boxed(SPAN, &self.ab))),
             JsExpr::MetaProperty(meta, property) => {
-                let meta = self.ab.identifier_name(SPAN, self.str(meta));
-                let property = self.ab.identifier_name(SPAN, self.str(property));
-                Some(self.ab.expression_meta_property(SPAN, meta, property))
+                let meta = IdentifierName::new(SPAN, self.str(meta), &self.ab);
+                let property = IdentifierName::new(SPAN, self.str(property), &self.ab);
+                Some(Expression::new_meta_property(
+                    SPAN, meta, property, &self.ab,
+                ))
             }
             JsExpr::Member(m) => self.member(m),
             JsExpr::Call(c) => {
                 let callee = self.expr_id(c.callee)?;
                 let args = self.arguments(&c.arguments)?;
-                Some(
-                    self.ab
-                        .expression_call(SPAN, callee, oxc_ast::NONE, args, c.optional),
-                )
+                Some(Expression::CallExpression(CallExpression::boxed(
+                    SPAN,
+                    callee,
+                    oxc_ast::NONE,
+                    args,
+                    c.optional,
+                    &self.ab,
+                )))
             }
             JsExpr::New(n) => {
                 let callee = self.expr_id(n.callee)?;
                 let args = self.arguments(&n.arguments)?;
-                Some(self.ab.expression_new(SPAN, callee, oxc_ast::NONE, args))
+                Some(Expression::NewExpression(NewExpression::boxed(
+                    SPAN,
+                    callee,
+                    oxc_ast::NONE,
+                    args,
+                    &self.ab,
+                )))
             }
             JsExpr::Binary(b) => {
                 let left = self.expr_id(b.left)?;
                 let right = self.expr_id(b.right)?;
-                Some(
-                    self.ab
-                        .expression_binary(SPAN, left, binary_op(b.operator), right),
-                )
+                Some(Expression::BinaryExpression(BinaryExpression::boxed(
+                    SPAN,
+                    left,
+                    binary_op(b.operator),
+                    right,
+                    &self.ab,
+                )))
             }
             JsExpr::Logical(l) => {
                 let left = self.expr_id(l.left)?;
                 let right = self.expr_id(l.right)?;
-                Some(
-                    self.ab
-                        .expression_logical(SPAN, left, logical_op(l.operator), right),
-                )
+                Some(Expression::LogicalExpression(LogicalExpression::boxed(
+                    SPAN,
+                    left,
+                    logical_op(l.operator),
+                    right,
+                    &self.ab,
+                )))
             }
             JsExpr::Unary(u) => {
                 let arg = self.expr_id(u.argument)?;
-                Some(self.ab.expression_unary(SPAN, unary_op(u.operator), arg))
+                Some(Expression::UnaryExpression(UnaryExpression::boxed(
+                    SPAN,
+                    unary_op(u.operator),
+                    arg,
+                    &self.ab,
+                )))
             }
             JsExpr::Conditional(c) => {
                 let test = self.expr_id(c.test)?;
                 let consequent = self.expr_id(c.consequent)?;
                 let alternate = self.expr_id(c.alternate)?;
-                Some(
-                    self.ab
-                        .expression_conditional(SPAN, test, consequent, alternate),
-                )
+                Some(Expression::ConditionalExpression(
+                    ConditionalExpression::boxed(SPAN, test, consequent, alternate, &self.ab),
+                ))
             }
             JsExpr::Sequence(s) => {
-                let mut exprs = self.ab.vec_with_capacity(s.expressions.len());
+                let mut exprs = ArenaVec::with_capacity_in(s.expressions.len(), &self.ab);
                 for e in &s.expressions {
                     exprs.push(self.expr(e)?);
                 }
-                Some(self.ab.expression_sequence(SPAN, exprs))
+                Some(Expression::SequenceExpression(SequenceExpression::boxed(
+                    SPAN, exprs, &self.ab,
+                )))
             }
             JsExpr::Array(a) => {
-                let mut elements = self.ab.vec_with_capacity(a.elements.len());
+                let mut elements = ArenaVec::with_capacity_in(a.elements.len(), &self.ab);
                 for el in &a.elements {
                     let element = match el {
-                        None => self.ab.array_expression_element_elision(SPAN),
+                        None => ArrayExpressionElement::new_elision(SPAN, &self.ab),
                         Some(JsExpr::Spread(inner)) => {
                             // `[...x]` — spread element inside an array.
                             let inner = self.expr_id(*inner)?;
-                            ArrayExpressionElement::SpreadElement(
-                                self.ab.alloc_spread_element(SPAN, inner),
-                            )
+                            ArrayExpressionElement::SpreadElement(SpreadElement::boxed(
+                                SPAN, inner, &self.ab,
+                            ))
                         }
                         Some(e) => ArrayExpressionElement::from(self.expr(e)?),
                     };
                     elements.push(element);
                 }
-                Some(self.ab.expression_array(SPAN, elements))
+                Some(Expression::ArrayExpression(ArrayExpression::boxed(
+                    SPAN, elements, &self.ab,
+                )))
             }
             JsExpr::Object(o) => self.object(o),
             JsExpr::Spread(inner) => {
@@ -719,39 +789,53 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             }
             JsExpr::Await(id) => {
                 let arg = self.expr_id(*id)?;
-                Some(self.ab.expression_await(SPAN, arg))
+                Some(Expression::AwaitExpression(AwaitExpression::boxed(
+                    SPAN, arg, &self.ab,
+                )))
             }
             JsExpr::Void(id) => {
                 let arg = self.expr_id(*id)?;
-                Some(self.ab.expression_unary(SPAN, UnaryOperator::Void, arg))
+                Some(Expression::UnaryExpression(UnaryExpression::boxed(
+                    SPAN,
+                    UnaryOperator::Void,
+                    arg,
+                    &self.ab,
+                )))
             }
             JsExpr::Arrow(arrow) => self.arrow(arrow),
             JsExpr::TemplateLiteral(tpl) => {
                 let tpl = self.template_literal(tpl)?;
-                Some(Expression::TemplateLiteral(self.ab.alloc(tpl)))
+                Some(Expression::TemplateLiteral(ArenaBox::new_in(tpl, &self.ab)))
             }
             JsExpr::TaggedTemplate(t) => {
                 let tag = self.expr_id(t.tag)?;
                 let quasi = self.template_literal(&t.quasi)?;
-                Some(
-                    self.ab
-                        .expression_tagged_template(SPAN, tag, oxc_ast::NONE, quasi),
-                )
+                Some(Expression::TaggedTemplateExpression(
+                    TaggedTemplateExpression::boxed(SPAN, tag, oxc_ast::NONE, quasi, &self.ab),
+                ))
             }
             JsExpr::Assignment(a) => {
                 let left = self.assignment_target(self.arena.get_expr(a.left))?;
                 let right = self.expr_id(a.right)?;
-                Some(
-                    self.ab
-                        .expression_assignment(SPAN, assignment_op(a.operator), left, right),
-                )
+                Some(Expression::AssignmentExpression(
+                    AssignmentExpression::boxed(
+                        SPAN,
+                        assignment_op(a.operator),
+                        left,
+                        right,
+                        &self.ab,
+                    ),
+                ))
             }
             JsExpr::Update(u) => {
                 let target = self.simple_assignment_target(self.arena.get_expr(u.argument))?;
-                Some(
-                    self.ab
-                        .expression_update(SPAN, update_op(u.operator), u.prefix, target),
-                )
+                Some(Expression::UpdateExpression(UpdateExpression::boxed(
+                    SPAN,
+                    update_op(u.operator),
+                    u.prefix,
+                    target,
+                    &self.ab,
+                )))
             }
             JsExpr::Chain(chain) => self.chain(chain),
             JsExpr::ImportExpression { source, options } => {
@@ -762,7 +846,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 };
                 // `phase` (`import.defer` / `import.source`) is not represented
                 // in the IR; pass `None`.
-                Some(self.ab.expression_import(SPAN, source, options, None))
+                Some(Expression::ImportExpression(ImportExpression::boxed(
+                    SPAN, source, options, None, &self.ab,
+                )))
             }
             JsExpr::Function(func) => self.function(func),
             JsExpr::Yield(y) => {
@@ -770,7 +856,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     Some(id) => Some(self.expr_id(id)?),
                     None => None,
                 };
-                Some(self.ab.expression_yield(SPAN, y.delegate, argument))
+                Some(Expression::YieldExpression(YieldExpression::boxed(
+                    SPAN, y.delegate, argument, &self.ab,
+                )))
             }
             JsExpr::Class(class) => self.class(class),
             // `Spanned` wraps a real inner expression with the original-source
@@ -875,14 +963,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let id = class
             .id
             .as_ref()
-            .map(|name| self.ab.binding_identifier(SPAN, self.str(name)));
+            .map(|name| BindingIdentifier::new(SPAN, self.str(name), &self.ab));
 
         let super_class = match class.super_class {
             Some(id) => Some(self.expr_id(id)?),
             None => None,
         };
 
-        let mut elements = self.ab.vec_with_capacity(class.body.body.len());
+        let mut elements = ArenaVec::with_capacity_in(class.body.body.len(), &self.ab);
         for member in &class.body.body {
             match member {
                 JsClassMember::Method(method) => {
@@ -897,10 +985,10 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     // a boxed `Function` with `FunctionType::FunctionExpression`,
                     // bailing on any param / body shape that cannot be reproduced.
                     let value = self.method_function(&method.value)?;
-                    elements.push(self.ab.class_element_method_definition(
+                    elements.push(ClassElement::new_method_definition(
                         SPAN,
                         MethodDefinitionType::MethodDefinition,
-                        self.ab.vec(),
+                        ArenaVec::new_in(&self.ab),
                         key,
                         value,
                         kind,
@@ -909,6 +997,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                         false,
                         false,
                         None,
+                        &self.ab,
                     ));
                 }
                 JsClassMember::Property(prop) => {
@@ -917,10 +1006,10 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                         Some(id) => Some(self.expr_id(id)?),
                         None => None,
                     };
-                    elements.push(self.ab.class_element_property_definition(
+                    elements.push(ClassElement::new_property_definition(
                         SPAN,
                         PropertyDefinitionType::PropertyDefinition,
-                        self.ab.vec(),
+                        ArenaVec::new_in(&self.ab),
                         key,
                         oxc_ast::NONE,
                         value,
@@ -932,6 +1021,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                         false,
                         false,
                         None,
+                        &self.ab,
                     ));
                 }
                 // Static blocks (and any future member kind) are not reproducible
@@ -940,20 +1030,21 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             }
         }
 
-        let body = self.ab.class_body(SPAN, elements);
-        Some(self.ab.expression_class(
+        let body = ClassBody::new(SPAN, elements, &self.ab);
+        Some(Expression::ClassExpression(Class::boxed(
             SPAN,
             ClassType::ClassExpression,
-            self.ab.vec(),
+            ArenaVec::new_in(&self.ab),
             id,
             oxc_ast::NONE,
             super_class,
             oxc_ast::NONE,
-            self.ab.vec(),
+            ArenaVec::new_in(&self.ab),
             body,
             false,
             false,
-        ))
+            &self.ab,
+        )))
     }
 
     /// Build a class member's [`PropertyKey`]. A computed key holds an arbitrary
@@ -985,11 +1076,11 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let id = func
             .id
             .as_ref()
-            .map(|name| self.ab.binding_identifier(SPAN, self.str(name)));
+            .map(|name| BindingIdentifier::new(SPAN, self.str(name), &self.ab));
         let params = self.formal_params(&func.params)?;
         let stmts = self.statements(&func.body.body)?;
-        let body = self.ab.function_body(SPAN, self.ab.vec(), stmts);
-        Some(self.ab.alloc_function(
+        let body = FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab);
+        Some(Function::boxed(
             SPAN,
             FunctionType::FunctionExpression,
             id,
@@ -1001,30 +1092,37 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             params,
             oxc_ast::NONE,
             Some(body),
+            &self.ab,
         ))
     }
 
     fn literal(&self, lit: &JsLiteral) -> Option<Expression<'a>> {
         match lit {
-            JsLiteral::String(s) => {
-                Some(self.ab.expression_string_literal(SPAN, self.str(s), None))
-            }
-            JsLiteral::Number(n) => {
-                Some(
-                    self.ab
-                        .expression_numeric_literal(SPAN, *n, None, NumberBase::Decimal),
-                )
-            }
-            JsLiteral::RawString { value, raw } => Some(self.ab.expression_string_literal(
+            JsLiteral::String(s) => Some(Expression::new_string_literal(
+                SPAN,
+                self.str(s),
+                None,
+                &self.ab,
+            )),
+            JsLiteral::Number(n) => Some(Expression::new_numeric_literal(
+                SPAN,
+                *n,
+                None,
+                NumberBase::Decimal,
+                &self.ab,
+            )),
+            JsLiteral::RawString { value, raw } => Some(Expression::new_string_literal(
                 SPAN,
                 self.str(value),
                 Some(self.str(raw).into()),
+                &self.ab,
             )),
-            JsLiteral::RawNumber { value, raw } => Some(self.ab.expression_numeric_literal(
+            JsLiteral::RawNumber { value, raw } => Some(Expression::new_numeric_literal(
                 SPAN,
                 *value,
                 Some(self.str(raw).into()),
                 NumberBase::Decimal,
+                &self.ab,
             )),
             JsLiteral::BigInt(raw) => {
                 // The IR stores the raw source spelling including the trailing
@@ -1032,16 +1130,17 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 // builder's `value` field expects base-10 digits with no
                 // suffix; strip the trailing `n` for the value.
                 let value = raw.strip_suffix('n').unwrap_or(raw);
-                Some(self.ab.expression_big_int_literal(
+                Some(Expression::new_big_int_literal(
                     SPAN,
                     self.str(value),
                     None,
                     BigintBase::Decimal,
+                    &self.ab,
                 ))
             }
-            JsLiteral::Boolean(b) => Some(self.ab.expression_boolean_literal(SPAN, *b)),
-            JsLiteral::Null => Some(self.ab.expression_null_literal(SPAN)),
-            JsLiteral::Undefined => Some(self.ab.expression_identifier(SPAN, "undefined")),
+            JsLiteral::Boolean(b) => Some(Expression::new_boolean_literal(SPAN, *b, &self.ab)),
+            JsLiteral::Null => Some(Expression::new_null_literal(SPAN, &self.ab)),
+            JsLiteral::Undefined => Some(Expression::new_identifier(SPAN, "undefined", &self.ab)),
             JsLiteral::Regex { pattern, flags } => {
                 // Build the flags bitset faithfully from the source spelling;
                 // bail on any unrecognised flag character so we never guess.
@@ -1059,10 +1158,12 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 // esrap prints `raw` verbatim when present, so emit the exact
                 // `/pattern/flags` source spelling.
                 let raw = self.str(&format!("/{pattern}/{flags}"));
-                Some(
-                    self.ab
-                        .expression_reg_exp_literal(SPAN, regex, Some(raw.into())),
-                )
+                Some(Expression::new_reg_exp_literal(
+                    SPAN,
+                    regex,
+                    Some(raw.into()),
+                    &self.ab,
+                ))
             }
         }
     }
@@ -1077,22 +1178,25 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let object = self.expr_id(m.object)?;
         let member = match &m.property {
             JsMemberProperty::Identifier(name) => {
-                let property = self.ab.identifier_name(SPAN, self.str(name));
-                self.ab
-                    .member_expression_static(SPAN, object, property, m.optional)
+                let property = IdentifierName::new(SPAN, self.str(name), &self.ab);
+                MemberExpression::StaticMemberExpression(StaticMemberExpression::boxed(
+                    SPAN, object, property, m.optional, &self.ab,
+                ))
             }
             JsMemberProperty::Expression(id) => {
                 let property = self.expr_id(*id)?;
-                self.ab
-                    .member_expression_computed(SPAN, object, property, m.optional)
+                MemberExpression::ComputedMemberExpression(ComputedMemberExpression::boxed(
+                    SPAN, object, property, m.optional, &self.ab,
+                ))
             }
             JsMemberProperty::PrivateIdentifier(name) => {
                 // The IR stores the bare name (no leading `#`, matching the
                 // ESTree `PrivateIdentifier.name` convention); codegen and the
                 // esrap printer both add the `#`, so pass the name verbatim.
-                let field = self.ab.private_identifier(SPAN, self.str(name));
-                self.ab
-                    .member_expression_private_field_expression(SPAN, object, field, m.optional)
+                let field = PrivateIdentifier::new(SPAN, self.str(name), &self.ab);
+                MemberExpression::new_private_field_expression(
+                    SPAN, object, field, m.optional, &self.ab,
+                )
             }
         };
         Some(member)
@@ -1104,19 +1208,19 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         &self,
         tpl: &JsTemplateLiteral,
     ) -> Option<oxc_ast::ast::TemplateLiteral<'a>> {
-        let mut quasis = self.ab.vec_with_capacity(tpl.quasis.len());
+        let mut quasis = ArenaVec::with_capacity_in(tpl.quasis.len(), &self.ab);
         for q in &tpl.quasis {
             let value = oxc_ast::ast::TemplateElementValue {
                 raw: self.str(&q.raw).into(),
                 cooked: Some(self.str(&q.cooked).into()),
             };
-            quasis.push(self.ab.template_element(SPAN, value, q.tail));
+            quasis.push(TemplateElement::new(SPAN, value, q.tail, &self.ab));
         }
-        let mut expressions = self.ab.vec_with_capacity(tpl.expressions.len());
+        let mut expressions = ArenaVec::with_capacity_in(tpl.expressions.len(), &self.ab);
         for e in &tpl.expressions {
             expressions.push(self.expr(e)?);
         }
-        Some(self.ab.template_literal(SPAN, quasis, expressions))
+        Some(TemplateLiteral::new(SPAN, quasis, expressions, &self.ab))
     }
 
     /// Build a [`SimpleAssignmentTarget`] from an IR expression used as an
@@ -1127,10 +1231,13 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         expr: &JsExpr,
     ) -> Option<oxc_ast::ast::SimpleAssignmentTarget<'a>> {
         match expr {
-            JsExpr::Identifier(name) => Some(
-                self.ab
-                    .simple_assignment_target_assignment_target_identifier(SPAN, self.str(name)),
-            ),
+            JsExpr::Identifier(name) => {
+                Some(SimpleAssignmentTarget::new_assignment_target_identifier(
+                    SPAN,
+                    self.str(name),
+                    &self.ab,
+                ))
+            }
             JsExpr::Member(m) if !m.optional => {
                 let member = self.member_expr(m)?;
                 Some(oxc_ast::ast::SimpleAssignmentTarget::from(member))
@@ -1156,7 +1263,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     fn assignment_target(&self, expr: &JsExpr) -> Option<oxc_ast::ast::AssignmentTarget<'a>> {
         match expr {
             JsExpr::Array(arr) => {
-                let mut elements = self.ab.vec_with_capacity(arr.elements.len());
+                let mut elements = ArenaVec::with_capacity_in(arr.elements.len(), &self.ab);
                 let mut rest: Option<
                     oxc_allocator::Box<'a, oxc_ast::ast::AssignmentTargetRest<'a>>,
                 > = None;
@@ -1170,16 +1277,16 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                                 return None;
                             }
                             let target = self.assignment_target(self.arena.get_expr(*inner))?;
-                            rest = Some(self.ab.alloc_assignment_target_rest(SPAN, target));
+                            rest = Some(AssignmentTargetRest::boxed(SPAN, target, &self.ab));
                         }
                         Some(e) => elements.push(Some(self.assignment_target_maybe_default(e)?)),
                     }
                 }
-                let array = self.ab.alloc_array_assignment_target(SPAN, elements, rest);
+                let array = ArrayAssignmentTarget::boxed(SPAN, elements, rest, &self.ab);
                 Some(oxc_ast::ast::AssignmentTarget::ArrayAssignmentTarget(array))
             }
             JsExpr::Object(obj) => {
-                let mut props = self.ab.vec_with_capacity(obj.properties.len());
+                let mut props = ArenaVec::with_capacity_in(obj.properties.len(), &self.ab);
                 let mut rest: Option<
                     oxc_allocator::Box<'a, oxc_ast::ast::AssignmentTargetRest<'a>>,
                 > = None;
@@ -1192,7 +1299,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                                 return None;
                             }
                             let target = self.assignment_target(self.arena.get_expr(*id))?;
-                            rest = Some(self.ab.alloc_assignment_target_rest(SPAN, target));
+                            rest = Some(AssignmentTargetRest::boxed(SPAN, target, &self.ab));
                         }
                         JsObjectMember::Property(p) => {
                             // Only plain `key: value` / shorthand `{ key }` /
@@ -1206,7 +1313,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                         }
                     }
                 }
-                let object = self.ab.alloc_object_assignment_target(SPAN, props, rest);
+                let object = ObjectAssignmentTarget::boxed(SPAN, props, rest, &self.ab);
                 Some(oxc_ast::ast::AssignmentTarget::ObjectAssignmentTarget(
                     object,
                 ))
@@ -1232,10 +1339,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             let binding = self.assignment_target(self.arena.get_expr(a.left))?;
             let init = self.expr_id(a.right)?;
             return Some(
-                self.ab
-                    .assignment_target_maybe_default_assignment_target_with_default(
-                        SPAN, binding, init,
-                    ),
+                AssignmentTargetMaybeDefault::new_assignment_target_with_default(
+                    SPAN, binding, init, &self.ab,
+                ),
             );
         }
         let target = self.assignment_target(expr)?;
@@ -1265,11 +1371,10 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 }
                 _ => return None,
             };
-            let binding = self.ab.identifier_reference(SPAN, self.str(name));
+            let binding = IdentifierReference::new(SPAN, self.str(name), &self.ab);
             return Some(
                 oxc_ast::ast::AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(
-                    self.ab
-                        .alloc_assignment_target_property_identifier(SPAN, binding, init),
+                    AssignmentTargetPropertyIdentifier::boxed(SPAN, binding, init, &self.ab),
                 ),
             );
         }
@@ -1279,21 +1384,20 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let binding = self.assignment_target_maybe_default(self.arena.get_expr(p.value))?;
         Some(
             oxc_ast::ast::AssignmentTargetProperty::AssignmentTargetPropertyProperty(
-                self.ab
-                    .alloc_assignment_target_property_property(SPAN, key, binding, p.computed),
+                AssignmentTargetPropertyProperty::boxed(SPAN, key, binding, p.computed, &self.ab),
             ),
         )
     }
 
     fn object(&self, o: &JsObjectExpression) -> Option<Expression<'a>> {
-        let mut props = self.ab.vec_with_capacity(o.properties.len());
+        let mut props = ArenaVec::with_capacity_in(o.properties.len(), &self.ab);
         for member in &o.properties {
             match member {
                 JsObjectMember::SpreadElement(id) => {
                     let arg = self.expr_id(*id)?;
-                    props.push(ObjectPropertyKind::SpreadProperty(
-                        self.ab.alloc_spread_element(SPAN, arg),
-                    ));
+                    props.push(ObjectPropertyKind::SpreadProperty(SpreadElement::boxed(
+                        SPAN, arg, &self.ab,
+                    )));
                 }
                 JsObjectMember::Property(p) => {
                     let prop = self.object_property(p)?;
@@ -1301,7 +1405,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 }
             }
         }
-        Some(self.ab.expression_object(SPAN, props))
+        Some(Expression::ObjectExpression(ObjectExpression::boxed(
+            SPAN, props, &self.ab,
+        )))
     }
 
     /// Build a boxed [`ObjectProperty`] from an IR [`JsProperty`].
@@ -1350,7 +1456,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 // A computed key that is structurally an identifier or literal
                 // (`[name]: …` / `[0]: …`): build the key from that expression.
                 JsPropertyKey::Identifier(name) => {
-                    let expr = self.ab.expression_identifier(SPAN, self.str(name));
+                    let expr = Expression::new_identifier(SPAN, self.str(name), &self.ab);
                     PropertyKey::from(expr)
                 }
                 JsPropertyKey::Literal(lit) => {
@@ -1364,17 +1470,25 @@ impl<'a, 'arena> Cx<'a, 'arena> {
 
         let value = self.expr_id(p.value)?;
 
-        Some(
-            self.ab
-                .alloc_object_property(SPAN, kind, key, value, method, p.shorthand, p.computed),
-        )
+        Some(ObjectProperty::boxed(
+            SPAN,
+            kind,
+            key,
+            value,
+            method,
+            p.shorthand,
+            p.computed,
+            &self.ab,
+        ))
     }
 
     fn property_key(&self, key: &JsPropertyKey) -> Option<PropertyKey<'a>> {
         match key {
-            JsPropertyKey::Identifier(name) => {
-                Some(self.ab.property_key_static_identifier(SPAN, self.str(name)))
-            }
+            JsPropertyKey::Identifier(name) => Some(PropertyKey::new_static_identifier(
+                SPAN,
+                self.str(name),
+                &self.ab,
+            )),
             JsPropertyKey::Literal(lit) => {
                 // A literal key is the literal expression in key position.
                 let expr = self.literal(lit)?;
@@ -1394,24 +1508,35 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 // Expression-bodied arrow: the function body is a single
                 // implicit-return expression statement.
                 let expr = self.expr_id(*id)?;
-                let stmt = self.ab.statement_expression(SPAN, expr);
-                let stmts = self.ab.vec1(stmt);
-                (true, self.ab.function_body(SPAN, self.ab.vec(), stmts))
+                let stmt = Statement::ExpressionStatement(ExpressionStatement::boxed(
+                    SPAN, expr, &self.ab,
+                ));
+                let stmts = ArenaVec::from_value_in(stmt, &self.ab);
+                (
+                    true,
+                    FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab),
+                )
             }
             JsArrowBody::Block(block) => {
                 let stmts = self.statements(&block.body)?;
-                (false, self.ab.function_body(SPAN, self.ab.vec(), stmts))
+                (
+                    false,
+                    FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab),
+                )
             }
         };
 
-        Some(self.ab.expression_arrow_function(
-            SPAN,
-            is_expr,
-            arrow.is_async,
-            oxc_ast::NONE,
-            params,
-            oxc_ast::NONE,
-            body,
+        Some(Expression::ArrowFunctionExpression(
+            ArrowFunctionExpression::boxed(
+                SPAN,
+                is_expr,
+                arrow.is_async,
+                oxc_ast::NONE,
+                params,
+                oxc_ast::NONE,
+                body,
+                &self.ab,
+            ),
         ))
     }
 
@@ -1429,13 +1554,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 let callee = self.expr_id(c.callee)?;
                 let args = self.arguments(&c.arguments)?;
                 let call =
-                    self.ab
-                        .alloc_call_expression(SPAN, callee, oxc_ast::NONE, args, c.optional);
+                    CallExpression::boxed(SPAN, callee, oxc_ast::NONE, args, c.optional, &self.ab);
                 ChainElement::CallExpression(call)
             }
             _ => return None,
         };
-        Some(self.ab.expression_chain(SPAN, element))
+        Some(Expression::ChainExpression(ChainExpression::boxed(
+            SPAN, element, &self.ab,
+        )))
     }
 
     /// Build a function expression. Reuses [`formal_params`] (which bails on
@@ -1444,11 +1570,11 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let id = func
             .id
             .as_ref()
-            .map(|name| self.ab.binding_identifier(SPAN, self.str(name)));
+            .map(|name| BindingIdentifier::new(SPAN, self.str(name), &self.ab));
         let params = self.formal_params(&func.params)?;
         let stmts = self.statements(&func.body.body)?;
-        let body = self.ab.function_body(SPAN, self.ab.vec(), stmts);
-        Some(self.ab.expression_function(
+        let body = FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab);
+        Some(Expression::FunctionExpression(Function::boxed(
             SPAN,
             FunctionType::FunctionExpression,
             id,
@@ -1460,7 +1586,8 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             params,
             oxc_ast::NONE,
             Some(body),
-        ))
+            &self.ab,
+        )))
     }
 
     /// Convert function parameters, handling destructuring patterns and a
@@ -1468,7 +1595,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// pattern that cannot be faithfully reproduced, or on a rest param that is
     /// not the last parameter.
     fn formal_params(&self, params: &[JsPattern]) -> Option<oxc_ast::ast::FormalParameters<'a>> {
-        let mut items = self.ab.vec_with_capacity(params.len());
+        let mut items = ArenaVec::with_capacity_in(params.len(), &self.ab);
         let mut rest: Option<oxc_allocator::Box<'a, oxc_ast::ast::FormalParameterRest<'a>>> = None;
         let last = params.len().saturating_sub(1);
         for (i, p) in params.iter().enumerate() {
@@ -1479,19 +1606,20 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     return None;
                 }
                 let pattern = self.binding_pattern(inner)?;
-                let rest_el = self.ab.binding_rest_element(SPAN, pattern);
-                rest = Some(self.ab.alloc_formal_parameter_rest(
+                let rest_el = BindingRestElement::new(SPAN, pattern, &self.ab);
+                rest = Some(FormalParameterRest::boxed(
                     SPAN,
-                    self.ab.vec(),
+                    ArenaVec::new_in(&self.ab),
                     rest_el,
                     oxc_ast::NONE,
+                    &self.ab,
                 ));
                 continue;
             }
             let pattern = self.binding_pattern(p)?;
-            items.push(self.ab.formal_parameter(
+            items.push(FormalParameter::new(
                 SPAN,
-                self.ab.vec(),
+                ArenaVec::new_in(&self.ab),
                 pattern,
                 oxc_ast::NONE,
                 oxc_ast::NONE,
@@ -1499,24 +1627,26 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 None,
                 false,
                 false,
+                &self.ab,
             ));
         }
-        Some(self.ab.formal_parameters(
+        Some(FormalParameters::new(
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
             items,
             rest,
+            &self.ab,
         ))
     }
 
     /// Convert call/new arguments, supporting spread arguments (`f(...x)`).
     fn arguments(&self, args: &[JsExpr]) -> Option<ArenaVec<'a, Argument<'a>>> {
-        let mut out = self.ab.vec_with_capacity(args.len());
+        let mut out = ArenaVec::with_capacity_in(args.len(), &self.ab);
         for arg in args {
             let argument = match arg {
                 JsExpr::Spread(inner) => {
                     let inner = self.expr_id(*inner)?;
-                    self.ab.argument_spread_element(SPAN, inner)
+                    Argument::new_spread_element(SPAN, inner, &self.ab)
                 }
                 other => Argument::from(self.expr(other)?),
             };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -1,8 +1,3 @@
-// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
-// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
-// deprecation here and defer the mechanical migration to a dedicated follow-up.
-
-#![allow(deprecated)]
 //! Convert rsvelte's parse-phase `JsNode` AST (the ESTree-shaped representation
 //! of `<script>` blocks and template expressions) into an oxc
 //! [`oxc_ast::ast::Expression`] / [`oxc_ast::ast::Statement`] so Phase-3 can
@@ -32,13 +27,9 @@
 
 use crate::ast::arena::{IdRange, JsNodeId, ParseArena};
 use crate::ast::typed_expr::{JsNode, LiteralValue};
-use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, Box as ArenaBox, Vec as ArenaVec};
 use oxc_ast::AstBuilder;
-use oxc_ast::ast::{
-    Argument, ArrayExpressionElement, ChainElement, Expression, ForStatementInit, ForStatementLeft,
-    FormalParameterKind, FunctionType, ImportOrExportKind, ObjectPropertyKind, PropertyKey,
-    PropertyKind, RegExp, RegExpFlags, RegExpPattern, Statement, VariableDeclarationKind,
-};
+use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_syntax::number::NumberBase;
 use oxc_syntax::operator::{
@@ -76,14 +67,15 @@ pub fn jsnode_to_oxc_program<'a>(
         arena,
     };
     let stmts = cx.statements(*body)?;
-    Some(cx.ab.program(
+    Some(Program::new(
         SPAN,
         oxc_span::SourceType::mjs(),
         "",
-        cx.ab.vec(),
+        ArenaVec::new_in(&cx.ab),
         None,
-        cx.ab.vec(),
+        ArenaVec::new_in(&cx.ab),
         stmts,
+        &cx.ab,
     ))
 }
 
@@ -102,15 +94,16 @@ pub fn jsnode_stmts_to_oxc_program<'a>(
         .iter()
         .map(|s| cx.stmt(s))
         .collect::<Option<Vec<_>>>()?;
-    let body = cx.ab.vec_from_iter(body);
-    Some(cx.ab.program(
+    let body = ArenaVec::from_iter_in(body, &cx.ab);
+    Some(Program::new(
         SPAN,
         oxc_span::SourceType::mjs(),
         "",
-        cx.ab.vec(),
+        ArenaVec::new_in(&cx.ab),
         None,
-        cx.ab.vec(),
+        ArenaVec::new_in(&cx.ab),
         body,
+        &cx.ab,
     ))
 }
 
@@ -146,14 +139,18 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         match node {
             JsNode::ExpressionStatement { expression, .. } => {
                 let expr = self.expr_id(*expression)?;
-                Some(self.ab.statement_expression(SPAN, expr))
+                Some(Statement::ExpressionStatement(ExpressionStatement::boxed(
+                    SPAN, expr, &self.ab,
+                )))
             }
             JsNode::ReturnStatement { argument, .. } => {
                 let arg = match argument {
                     Some(id) => Some(self.expr_id(*id)?),
                     None => None,
                 };
-                Some(self.ab.statement_return(SPAN, arg))
+                Some(Statement::ReturnStatement(ReturnStatement::boxed(
+                    SPAN, arg, &self.ab,
+                )))
             }
             JsNode::VariableDeclaration { .. } => {
                 let decl = self.variable_declaration_node(node)?;
@@ -161,21 +158,33 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             }
             JsNode::BlockStatement { body, .. } => {
                 let stmts = self.statements(*body)?;
-                Some(self.ab.statement_block(SPAN, stmts))
+                Some(Statement::BlockStatement(BlockStatement::boxed(
+                    SPAN, stmts, &self.ab,
+                )))
             }
-            JsNode::EmptyStatement { .. } => Some(self.ab.statement_empty(SPAN)),
-            JsNode::DebuggerStatement { .. } => Some(self.ab.statement_debugger(SPAN)),
+            JsNode::EmptyStatement { .. } => Some(Statement::EmptyStatement(
+                EmptyStatement::boxed(SPAN, &self.ab),
+            )),
+            JsNode::DebuggerStatement { .. } => Some(Statement::DebuggerStatement(
+                DebuggerStatement::boxed(SPAN, &self.ab),
+            )),
             JsNode::ThrowStatement { argument, .. } => {
                 let arg = self.expr_id(*argument)?;
-                Some(self.ab.statement_throw(SPAN, arg))
+                Some(Statement::ThrowStatement(ThrowStatement::boxed(
+                    SPAN, arg, &self.ab,
+                )))
             }
             JsNode::BreakStatement { label, .. } => {
                 let label = self.opt_label(label)?;
-                Some(self.ab.statement_break(SPAN, label))
+                Some(Statement::BreakStatement(BreakStatement::boxed(
+                    SPAN, label, &self.ab,
+                )))
             }
             JsNode::ContinueStatement { label, .. } => {
                 let label = self.opt_label(label)?;
-                Some(self.ab.statement_continue(SPAN, label))
+                Some(Statement::ContinueStatement(ContinueStatement::boxed(
+                    SPAN, label, &self.ab,
+                )))
             }
             JsNode::IfStatement {
                 test,
@@ -189,7 +198,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     Some(id) => Some(self.stmt_id(*id)?),
                     None => None,
                 };
-                Some(self.ab.statement_if(SPAN, test, consequent, alternate))
+                Some(Statement::IfStatement(IfStatement::boxed(
+                    SPAN, test, consequent, alternate, &self.ab,
+                )))
             }
             JsNode::ImportDeclaration { .. } => self.import_declaration(node),
             JsNode::ExportNamedDeclaration { .. } => self.export_named(node),
@@ -207,19 +218,25 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             JsNode::WhileStatement { test, body, .. } => {
                 let test = self.expr_id(*test)?;
                 let body = self.stmt_id(*body)?;
-                Some(self.ab.statement_while(SPAN, test, body))
+                Some(Statement::WhileStatement(WhileStatement::boxed(
+                    SPAN, test, body, &self.ab,
+                )))
             }
             JsNode::DoWhileStatement { test, body, .. } => {
                 let body = self.stmt_id(*body)?;
                 let test = self.expr_id(*test)?;
-                Some(self.ab.statement_do_while(SPAN, body, test))
+                Some(Statement::DoWhileStatement(DoWhileStatement::boxed(
+                    SPAN, body, test, &self.ab,
+                )))
             }
             JsNode::SwitchStatement { .. } => self.switch_statement(node),
             JsNode::LabeledStatement { label, body, .. } => {
                 let name = self.identifier_name_of(*label)?;
-                let label = self.ab.label_identifier(SPAN, self.str(&name));
+                let label = LabelIdentifier::new(SPAN, self.str(&name), &self.ab);
                 let body = self.stmt_id(*body)?;
-                Some(self.ab.statement_labeled(SPAN, label, body))
+                Some(Statement::LabeledStatement(LabeledStatement::boxed(
+                    SPAN, label, body, &self.ab,
+                )))
             }
             JsNode::TryStatement { .. } => self.try_statement(node),
             // Bail on opaque Raw / Null / TypeScript-only / decorators and any
@@ -237,7 +254,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             None => Some(None),
             Some(id) => {
                 let name = self.identifier_name_of(*id)?;
-                Some(Some(self.ab.label_identifier(SPAN, self.str(&name))))
+                Some(Some(LabelIdentifier::new(SPAN, self.str(&name), &self.ab)))
             }
         }
     }
@@ -284,7 +301,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             None => None,
         };
         let body = self.stmt_id(*body)?;
-        Some(self.ab.statement_for(SPAN, init, test, update, body))
+        Some(Statement::ForStatement(ForStatement::boxed(
+            SPAN, init, test, update, body, &self.ab,
+        )))
     }
 
     /// Build `for (left of right)` / `for await (left of right)` /
@@ -323,9 +342,13 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             if is_await {
                 return None;
             }
-            Some(self.ab.statement_for_in(SPAN, left, right, body))
+            Some(Statement::ForInStatement(ForInStatement::boxed(
+                SPAN, left, right, body, &self.ab,
+            )))
         } else {
-            Some(self.ab.statement_for_of(SPAN, is_await, left, right, body))
+            Some(Statement::ForOfStatement(ForOfStatement::boxed(
+                SPAN, is_await, left, right, body, &self.ab,
+            )))
         }
     }
 
@@ -340,7 +363,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         };
         let discriminant = self.expr_id(*discriminant)?;
         let case_nodes = self.arena.get_js_children(*cases);
-        let mut out = self.ab.vec_with_capacity(case_nodes.len());
+        let mut out = ArenaVec::with_capacity_in(case_nodes.len(), &self.ab);
         for case in case_nodes {
             let JsNode::SwitchCase {
                 test, consequent, ..
@@ -353,9 +376,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 None => None,
             };
             let consequent = self.statements(*consequent)?;
-            out.push(self.ab.switch_case(SPAN, test, consequent));
+            out.push(SwitchCase::new(SPAN, test, consequent, &self.ab));
         }
-        Some(self.ab.statement_switch(SPAN, discriminant, out))
+        Some(Statement::SwitchStatement(SwitchStatement::boxed(
+            SPAN,
+            discriminant,
+            out,
+            &self.ab,
+        )))
     }
 
     fn try_statement(&self, node: &JsNode) -> Option<Statement<'a>> {
@@ -381,11 +409,11 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     None => None,
                     Some(p) => {
                         let pattern = self.binding_pattern(self.arena.get_js_node(*p))?;
-                        Some(self.ab.catch_parameter(SPAN, pattern, oxc_ast::NONE))
+                        Some(CatchParameter::new(SPAN, pattern, oxc_ast::NONE, &self.ab))
                     }
                 };
                 let body = self.block_statement_box(*body)?;
-                Some(self.ab.catch_clause(SPAN, catch_param, body))
+                Some(CatchClause::new(SPAN, catch_param, body, &self.ab))
             }
         };
 
@@ -394,7 +422,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             Some(id) => Some(self.block_statement_box(*id)?),
         };
 
-        Some(self.ab.statement_try(SPAN, block, handler, finalizer))
+        Some(Statement::TryStatement(TryStatement::boxed(
+            SPAN, block, handler, finalizer, &self.ab,
+        )))
     }
 
     /// Resolve a `BlockStatement` node behind `id` into a boxed oxc block.
@@ -406,7 +436,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             return None;
         };
         let stmts = self.statements(*body)?;
-        Some(self.ab.alloc_block_statement(SPAN, stmts))
+        Some(BlockStatement::boxed(SPAN, stmts, &self.ab))
     }
 
     /// Build a module-source `StringLiteral`, preserving the raw `'source'` /
@@ -420,10 +450,12 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         else {
             return None;
         };
-        Some(
-            self.ab
-                .string_literal(SPAN, self.str(s), Some(self.str(raw).into())),
-        )
+        Some(StringLiteral::new(
+            SPAN,
+            self.str(s),
+            Some(self.str(raw).into()),
+            &self.ab,
+        ))
     }
 
     fn import_declaration(&self, node: &JsNode) -> Option<Statement<'a>> {
@@ -445,26 +477,22 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let specifiers = if spec_nodes.is_empty() {
             None
         } else {
-            let mut specs = self.ab.vec_with_capacity(spec_nodes.len());
+            let mut specs = ArenaVec::with_capacity_in(spec_nodes.len(), &self.ab);
             for spec in spec_nodes {
                 match spec {
                     JsNode::ImportDefaultSpecifier { local, .. } => {
                         let name = self.identifier_name_of(*local)?;
-                        let local = self.ab.binding_identifier(SPAN, self.str(&name));
-                        specs.push(
-                            self.ab
-                                .import_declaration_specifier_import_default_specifier(SPAN, local),
-                        );
+                        let local = BindingIdentifier::new(SPAN, self.str(&name), &self.ab);
+                        specs.push(ImportDeclarationSpecifier::new_import_default_specifier(
+                            SPAN, local, &self.ab,
+                        ));
                     }
                     JsNode::ImportNamespaceSpecifier { local, .. } => {
                         let name = self.identifier_name_of(*local)?;
-                        let local = self.ab.binding_identifier(SPAN, self.str(&name));
-                        specs.push(
-                            self.ab
-                                .import_declaration_specifier_import_namespace_specifier(
-                                    SPAN, local,
-                                ),
-                        );
+                        let local = BindingIdentifier::new(SPAN, self.str(&name), &self.ab);
+                        specs.push(ImportDeclarationSpecifier::new_import_namespace_specifier(
+                            SPAN, local, &self.ab,
+                        ));
                     }
                     JsNode::ImportSpecifier {
                         imported,
@@ -477,12 +505,13 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                         }
                         let imported = self.module_export_name(*imported)?;
                         let local_name = self.identifier_name_of(*local)?;
-                        let local = self.ab.binding_identifier(SPAN, self.str(&local_name));
-                        specs.push(self.ab.import_declaration_specifier_import_specifier(
+                        let local = BindingIdentifier::new(SPAN, self.str(&local_name), &self.ab);
+                        specs.push(ImportDeclarationSpecifier::new_import_specifier(
                             SPAN,
                             imported,
                             local,
                             ImportOrExportKind::Value,
+                            &self.ab,
                         ));
                     }
                     _ => return None,
@@ -492,13 +521,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         };
 
         let source = self.module_source_node(*source)?;
-        let decl = self.ab.module_declaration_import_declaration(
+        let decl = ModuleDeclaration::new_import_declaration(
             SPAN,
             specifiers,
             source,
             None,
             oxc_ast::NONE,
             ImportOrExportKind::Value,
+            &self.ab,
         );
         Some(Statement::from(decl))
     }
@@ -507,15 +537,16 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// imported/exported name node.
     fn module_export_name(&self, id: JsNodeId) -> Option<oxc_ast::ast::ModuleExportName<'a>> {
         match self.arena.get_js_node(id) {
-            JsNode::Identifier { name, .. } => Some(
-                self.ab
-                    .module_export_name_identifier_name(SPAN, self.str(name)),
-            ),
+            JsNode::Identifier { name, .. } => Some(ModuleExportName::new_identifier_name(
+                SPAN,
+                self.str(name),
+                &self.ab,
+            )),
             JsNode::Literal {
                 value: LiteralValue::String(s),
                 ..
             } => {
-                let lit = self.ab.string_literal(SPAN, self.str(s), None);
+                let lit = StringLiteral::new(SPAN, self.str(s), None, &self.ab);
                 Some(oxc_ast::ast::ModuleExportName::StringLiteral(lit))
             }
             _ => None,
@@ -554,10 +585,10 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 }
                 _ => return None,
             };
-            (Some(declaration), self.ab.vec())
+            (Some(declaration), ArenaVec::new_in(&self.ab))
         } else {
             let spec_nodes = self.arena.get_js_children(*specifiers);
-            let mut out = self.ab.vec_with_capacity(spec_nodes.len());
+            let mut out = ArenaVec::with_capacity_in(spec_nodes.len(), &self.ab);
             for spec in spec_nodes {
                 let JsNode::ExportSpecifier {
                     local,
@@ -573,23 +604,25 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 }
                 let local = self.module_export_name(*local)?;
                 let exported = self.module_export_name(*exported)?;
-                out.push(self.ab.export_specifier(
+                out.push(ExportSpecifier::new(
                     SPAN,
                     local,
                     exported,
                     ImportOrExportKind::Value,
+                    &self.ab,
                 ));
             }
             (None, out)
         };
 
-        let decl = self.ab.module_declaration_export_named_declaration(
+        let decl = ModuleDeclaration::new_export_named_declaration(
             SPAN,
             declaration,
             specs,
             None,
             ImportOrExportKind::Value,
             oxc_ast::NONE,
+            &self.ab,
         );
         Some(Statement::from(decl))
     }
@@ -607,9 +640,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 oxc_ast::ast::ExportDefaultDeclarationKind::from(expr)
             }
         };
-        let decl = self
-            .ab
-            .module_declaration_export_default_declaration(SPAN, kind);
+        let decl = ModuleDeclaration::new_export_default_declaration(SPAN, kind, &self.ab);
         Some(Statement::from(decl))
     }
 
@@ -648,8 +679,8 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         // A declared-but-bodyless function (TS overload) is not reproducible.
         let body_id = (*body)?;
         let stmts = self.block_body_statements(body_id)?;
-        let body = self.ab.function_body(SPAN, self.ab.vec(), stmts);
-        Some(self.ab.alloc_function(
+        let body = FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab);
+        Some(Function::boxed(
             SPAN,
             func_type,
             id,
@@ -661,13 +692,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             params,
             oxc_ast::NONE,
             Some(body),
+            &self.ab,
         ))
     }
 
     /// Build a `BindingIdentifier` from an `Identifier` node behind `id`.
     fn binding_identifier_of(&self, id: JsNodeId) -> Option<oxc_ast::ast::BindingIdentifier<'a>> {
         let name = self.identifier_name_of(id)?;
-        Some(self.ab.binding_identifier(SPAN, self.str(&name)))
+        Some(BindingIdentifier::new(SPAN, self.str(&name), &self.ab))
     }
 
     /// Resolve a `BlockStatement` node behind `id` and convert its body.
@@ -685,7 +717,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             .iter()
             .map(|s| self.stmt(s))
             .collect::<Option<Vec<_>>>()?;
-        Some(self.ab.vec_from_iter(v))
+        Some(ArenaVec::from_iter_in(v, &self.ab))
     }
 
     /// Build a boxed `VariableDeclaration` from a `VariableDeclaration` node.
@@ -715,7 +747,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         };
 
         let decl_nodes = self.arena.get_js_children(*declarations);
-        let mut declarators = self.ab.vec_with_capacity(decl_nodes.len());
+        let mut declarators = ArenaVec::with_capacity_in(decl_nodes.len(), &self.ab);
         for d in decl_nodes {
             let JsNode::VariableDeclarator { id, init, .. } = d else {
                 return None;
@@ -725,19 +757,23 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 Some(id) => Some(self.expr_id(*id)?),
                 None => None,
             };
-            declarators.push(self.ab.variable_declarator(
+            declarators.push(VariableDeclarator::new(
                 SPAN,
                 kind,
                 binding,
                 oxc_ast::NONE,
                 init,
                 false,
+                &self.ab,
             ));
         }
-        Some(
-            self.ab
-                .alloc_variable_declaration(SPAN, kind, declarators, false),
-        )
+        Some(VariableDeclaration::boxed(
+            SPAN,
+            kind,
+            declarators,
+            false,
+            &self.ab,
+        ))
     }
 
     // -- binding patterns ---------------------------------------------------
@@ -748,13 +784,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// pattern that itself bails.
     fn binding_pattern(&self, pat: &JsNode) -> Option<oxc_ast::ast::BindingPattern<'a>> {
         match pat {
-            JsNode::Identifier { name, .. } => Some(
-                self.ab
-                    .binding_pattern_binding_identifier(SPAN, self.str(name)),
-            ),
+            JsNode::Identifier { name, .. } => Some(BindingPattern::new_binding_identifier(
+                SPAN,
+                self.str(name),
+                &self.ab,
+            )),
             JsNode::ObjectPattern { properties, .. } => {
                 let prop_nodes = self.arena.get_js_children(*properties);
-                let mut props = self.ab.vec_with_capacity(prop_nodes.len());
+                let mut props = ArenaVec::with_capacity_in(prop_nodes.len(), &self.ab);
                 let mut rest = None;
                 let last = prop_nodes.len().saturating_sub(1);
                 for (i, member) in prop_nodes.iter().enumerate() {
@@ -768,25 +805,26 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                         } => {
                             let key = self.binding_property_key(*key, *computed)?;
                             let value = self.binding_pattern(self.arena.get_js_node(*value))?;
-                            props.push(
-                                self.ab
-                                    .binding_property(SPAN, key, value, *shorthand, *computed),
-                            );
+                            props.push(BindingProperty::new(
+                                SPAN, key, value, *shorthand, *computed, &self.ab,
+                            ));
                         }
                         JsNode::RestElement { argument, .. } => {
                             if i != last {
                                 return None;
                             }
                             let inner = self.binding_pattern(self.arena.get_js_node(*argument))?;
-                            rest = Some(self.ab.alloc_binding_rest_element(SPAN, inner));
+                            rest = Some(BindingRestElement::boxed(SPAN, inner, &self.ab));
                         }
                         _ => return None,
                     }
                 }
-                Some(self.ab.binding_pattern_object_pattern(SPAN, props, rest))
+                Some(BindingPattern::new_object_pattern(
+                    SPAN, props, rest, &self.ab,
+                ))
             }
             JsNode::ArrayPattern { elements, .. } => {
-                let mut out = self.ab.vec_with_capacity(elements.len());
+                let mut out = ArenaVec::with_capacity_in(elements.len(), &self.ab);
                 let mut rest = None;
                 let last = elements.len().saturating_sub(1);
                 for (i, el) in elements.iter().enumerate() {
@@ -797,20 +835,19 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                                 return None;
                             }
                             let inner = self.binding_pattern(self.arena.get_js_node(*argument))?;
-                            rest = Some(self.ab.alloc_binding_rest_element(SPAN, inner));
+                            rest = Some(BindingRestElement::boxed(SPAN, inner, &self.ab));
                         }
                         Some(el) => out.push(Some(self.binding_pattern(el)?)),
                     }
                 }
-                Some(self.ab.binding_pattern_array_pattern(SPAN, out, rest))
+                Some(BindingPattern::new_array_pattern(SPAN, out, rest, &self.ab))
             }
             JsNode::AssignmentPattern { left, right, .. } => {
                 let left = self.binding_pattern(self.arena.get_js_node(*left))?;
                 let right = self.expr_id(*right)?;
-                Some(
-                    self.ab
-                        .binding_pattern_assignment_pattern(SPAN, left, right),
-                )
+                Some(BindingPattern::new_assignment_pattern(
+                    SPAN, left, right, &self.ab,
+                ))
             }
             _ => None,
         }
@@ -832,17 +869,21 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     fn expr(&self, node: &JsNode) -> Option<Expression<'a>> {
         match node {
             JsNode::Identifier { name, .. } => {
-                Some(self.ab.expression_identifier(SPAN, self.str(name)))
+                Some(Expression::new_identifier(SPAN, self.str(name), &self.ab))
             }
             JsNode::Literal { .. } => self.literal(node),
-            JsNode::ThisExpression { .. } => Some(self.ab.expression_this(SPAN)),
-            JsNode::Super { .. } => Some(Expression::Super(self.ab.alloc_super(SPAN))),
+            JsNode::ThisExpression { .. } => Some(Expression::ThisExpression(
+                ThisExpression::boxed(SPAN, &self.ab),
+            )),
+            JsNode::Super { .. } => Some(Expression::Super(Super::boxed(SPAN, &self.ab))),
             JsNode::MetaProperty { meta, property, .. } => {
                 let meta = self.identifier_name_of(*meta)?;
                 let property = self.identifier_name_of(*property)?;
-                let meta = self.ab.identifier_name(SPAN, self.str(&meta));
-                let property = self.ab.identifier_name(SPAN, self.str(&property));
-                Some(self.ab.expression_meta_property(SPAN, meta, property))
+                let meta = IdentifierName::new(SPAN, self.str(&meta), &self.ab);
+                let property = IdentifierName::new(SPAN, self.str(&property), &self.ab);
+                Some(Expression::new_meta_property(
+                    SPAN, meta, property, &self.ab,
+                ))
             }
             JsNode::MemberExpression { .. } => Some(Expression::from(self.member_expr(node)?)),
             JsNode::CallExpression {
@@ -853,17 +894,27 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             } => {
                 let callee = self.expr_id(*callee)?;
                 let args = self.arguments(*arguments)?;
-                Some(
-                    self.ab
-                        .expression_call(SPAN, callee, oxc_ast::NONE, args, *optional),
-                )
+                Some(Expression::CallExpression(CallExpression::boxed(
+                    SPAN,
+                    callee,
+                    oxc_ast::NONE,
+                    args,
+                    *optional,
+                    &self.ab,
+                )))
             }
             JsNode::NewExpression {
                 callee, arguments, ..
             } => {
                 let callee = self.expr_id(*callee)?;
                 let args = self.arguments(*arguments)?;
-                Some(self.ab.expression_new(SPAN, callee, oxc_ast::NONE, args))
+                Some(Expression::NewExpression(NewExpression::boxed(
+                    SPAN,
+                    callee,
+                    oxc_ast::NONE,
+                    args,
+                    &self.ab,
+                )))
             }
             JsNode::BinaryExpression {
                 left,
@@ -874,7 +925,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 let op = binary_op(operator)?;
                 let left = self.expr_id(*left)?;
                 let right = self.expr_id(*right)?;
-                Some(self.ab.expression_binary(SPAN, left, op, right))
+                Some(Expression::BinaryExpression(BinaryExpression::boxed(
+                    SPAN, left, op, right, &self.ab,
+                )))
             }
             JsNode::LogicalExpression {
                 left,
@@ -885,14 +938,18 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 let op = logical_op(operator)?;
                 let left = self.expr_id(*left)?;
                 let right = self.expr_id(*right)?;
-                Some(self.ab.expression_logical(SPAN, left, op, right))
+                Some(Expression::LogicalExpression(LogicalExpression::boxed(
+                    SPAN, left, op, right, &self.ab,
+                )))
             }
             JsNode::UnaryExpression {
                 operator, argument, ..
             } => {
                 let op = unary_op(operator)?;
                 let arg = self.expr_id(*argument)?;
-                Some(self.ab.expression_unary(SPAN, op, arg))
+                Some(Expression::UnaryExpression(UnaryExpression::boxed(
+                    SPAN, op, arg, &self.ab,
+                )))
             }
             JsNode::ConditionalExpression {
                 test,
@@ -903,40 +960,45 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 let test = self.expr_id(*test)?;
                 let consequent = self.expr_id(*consequent)?;
                 let alternate = self.expr_id(*alternate)?;
-                Some(
-                    self.ab
-                        .expression_conditional(SPAN, test, consequent, alternate),
-                )
+                Some(Expression::ConditionalExpression(
+                    ConditionalExpression::boxed(SPAN, test, consequent, alternate, &self.ab),
+                ))
             }
             JsNode::SequenceExpression { expressions, .. } => {
                 let nodes = self.arena.get_js_children(*expressions);
-                let mut exprs = self.ab.vec_with_capacity(nodes.len());
+                let mut exprs = ArenaVec::with_capacity_in(nodes.len(), &self.ab);
                 for e in nodes {
                     exprs.push(self.expr(e)?);
                 }
-                Some(self.ab.expression_sequence(SPAN, exprs))
+                Some(Expression::SequenceExpression(SequenceExpression::boxed(
+                    SPAN, exprs, &self.ab,
+                )))
             }
             JsNode::ArrayExpression { elements, .. } => {
-                let mut out = self.ab.vec_with_capacity(elements.len());
+                let mut out = ArenaVec::with_capacity_in(elements.len(), &self.ab);
                 for el in elements {
                     let element = match el {
-                        None => self.ab.array_expression_element_elision(SPAN),
+                        None => ArrayExpressionElement::new_elision(SPAN, &self.ab),
                         Some(JsNode::SpreadElement { argument, .. }) => {
                             let inner = self.expr_id(*argument)?;
-                            ArrayExpressionElement::SpreadElement(
-                                self.ab.alloc_spread_element(SPAN, inner),
-                            )
+                            ArrayExpressionElement::SpreadElement(SpreadElement::boxed(
+                                SPAN, inner, &self.ab,
+                            ))
                         }
                         Some(e) => ArrayExpressionElement::from(self.expr(e)?),
                     };
                     out.push(element);
                 }
-                Some(self.ab.expression_array(SPAN, out))
+                Some(Expression::ArrayExpression(ArrayExpression::boxed(
+                    SPAN, out, &self.ab,
+                )))
             }
             JsNode::ObjectExpression { .. } => self.object(node),
             JsNode::AwaitExpression { argument, .. } => {
                 let arg = self.expr_id(*argument)?;
-                Some(self.ab.expression_await(SPAN, arg))
+                Some(Expression::AwaitExpression(AwaitExpression::boxed(
+                    SPAN, arg, &self.ab,
+                )))
             }
             JsNode::ArrowFunctionExpression { .. } => self.arrow(node),
             JsNode::FunctionExpression { .. } => {
@@ -945,15 +1007,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             }
             JsNode::TemplateLiteral { .. } => {
                 let tpl = self.template_literal(node)?;
-                Some(Expression::TemplateLiteral(self.ab.alloc(tpl)))
+                Some(Expression::TemplateLiteral(ArenaBox::new_in(tpl, &self.ab)))
             }
             JsNode::TaggedTemplateExpression { tag, quasi, .. } => {
                 let tag = self.expr_id(*tag)?;
                 let quasi = self.template_literal(self.arena.get_js_node(*quasi))?;
-                Some(
-                    self.ab
-                        .expression_tagged_template(SPAN, tag, oxc_ast::NONE, quasi),
-                )
+                Some(Expression::TaggedTemplateExpression(
+                    TaggedTemplateExpression::boxed(SPAN, tag, oxc_ast::NONE, quasi, &self.ab),
+                ))
             }
             JsNode::AssignmentExpression {
                 operator,
@@ -964,7 +1025,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 let op = assignment_op(operator)?;
                 let left = self.assignment_target(self.arena.get_js_node(*left))?;
                 let right = self.expr_id(*right)?;
-                Some(self.ab.expression_assignment(SPAN, op, left, right))
+                Some(Expression::AssignmentExpression(
+                    AssignmentExpression::boxed(SPAN, op, left, right, &self.ab),
+                ))
             }
             JsNode::UpdateExpression {
                 operator,
@@ -974,12 +1037,16 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             } => {
                 let op = update_op(operator)?;
                 let target = self.simple_assignment_target(self.arena.get_js_node(*argument))?;
-                Some(self.ab.expression_update(SPAN, op, *prefix, target))
+                Some(Expression::UpdateExpression(UpdateExpression::boxed(
+                    SPAN, op, *prefix, target, &self.ab,
+                )))
             }
             JsNode::ChainExpression { expression, .. } => self.chain(*expression),
             JsNode::ImportExpression { source, .. } => {
                 let source = self.expr_id(*source)?;
-                Some(self.ab.expression_import(SPAN, source, None, None))
+                Some(Expression::ImportExpression(ImportExpression::boxed(
+                    SPAN, source, None, None, &self.ab,
+                )))
             }
             JsNode::YieldExpression {
                 delegate, argument, ..
@@ -988,7 +1055,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     Some(id) => Some(self.expr_id(*id)?),
                     None => None,
                 };
-                Some(self.ab.expression_yield(SPAN, *delegate, argument))
+                Some(Expression::YieldExpression(YieldExpression::boxed(
+                    SPAN, *delegate, argument, &self.ab,
+                )))
             }
             // Bail on opaque Raw / Null / ClassExpression (bodies use separate
             // ClassBody member variants we do not reproduce here) and any other
@@ -1018,27 +1087,30 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 },
                 flags: flag_bits,
             };
-            return Some(self.ab.expression_reg_exp_literal(
+            return Some(Expression::new_reg_exp_literal(
                 SPAN,
                 regexp,
                 Some(self.str(raw).into()),
+                &self.ab,
             ));
         }
 
         match value {
-            LiteralValue::String(s) => Some(self.ab.expression_string_literal(
+            LiteralValue::String(s) => Some(Expression::new_string_literal(
                 SPAN,
                 self.str(s),
                 Some(self.str(raw).into()),
+                &self.ab,
             )),
-            LiteralValue::Number(n) => Some(self.ab.expression_numeric_literal(
+            LiteralValue::Number(n) => Some(Expression::new_numeric_literal(
                 SPAN,
                 *n,
                 Some(self.str(raw).into()),
                 NumberBase::Decimal,
+                &self.ab,
             )),
-            LiteralValue::Bool(b) => Some(self.ab.expression_boolean_literal(SPAN, *b)),
-            LiteralValue::Null => Some(self.ab.expression_null_literal(SPAN)),
+            LiteralValue::Bool(b) => Some(Expression::new_boolean_literal(SPAN, *b, &self.ab)),
+            LiteralValue::Null => Some(Expression::new_null_literal(SPAN, &self.ab)),
             // Regex handled above; reaching here would be a `Regex` value with
             // no `regex` field, which is malformed — bail.
             LiteralValue::Regex(_) => None,
@@ -1062,21 +1134,24 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let prop_node = self.arena.get_js_node(*property);
         let member = if *computed {
             let property = self.expr(prop_node)?;
-            self.ab
-                .member_expression_computed(SPAN, object, property, *optional)
+            MemberExpression::ComputedMemberExpression(ComputedMemberExpression::boxed(
+                SPAN, object, property, *optional, &self.ab,
+            ))
         } else {
             match prop_node {
                 JsNode::Identifier { name, .. } => {
-                    let property = self.ab.identifier_name(SPAN, self.str(name));
-                    self.ab
-                        .member_expression_static(SPAN, object, property, *optional)
+                    let property = IdentifierName::new(SPAN, self.str(name), &self.ab);
+                    MemberExpression::StaticMemberExpression(StaticMemberExpression::boxed(
+                        SPAN, object, property, *optional, &self.ab,
+                    ))
                 }
                 JsNode::PrivateIdentifier { name, .. } => {
                     // The IR stores the bare name (no leading `#`); esrap adds
                     // the `#`, so pass the name verbatim.
-                    let field = self.ab.private_identifier(SPAN, self.str(name));
-                    self.ab
-                        .member_expression_private_field_expression(SPAN, object, field, *optional)
+                    let field = PrivateIdentifier::new(SPAN, self.str(name), &self.ab);
+                    MemberExpression::new_private_field_expression(
+                        SPAN, object, field, *optional, &self.ab,
+                    )
                 }
                 _ => return None,
             }
@@ -1094,7 +1169,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             return None;
         };
         let quasi_nodes = self.arena.get_js_children(*quasis);
-        let mut quasis_out = self.ab.vec_with_capacity(quasi_nodes.len());
+        let mut quasis_out = ArenaVec::with_capacity_in(quasi_nodes.len(), &self.ab);
         for q in quasi_nodes {
             let JsNode::TemplateElement { tail, value, .. } = q else {
                 return None;
@@ -1103,14 +1178,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 raw: self.str(&value.raw).into(),
                 cooked: value.cooked.as_ref().map(|c| self.str(c).into()),
             };
-            quasis_out.push(self.ab.template_element(SPAN, val, *tail));
+            quasis_out.push(TemplateElement::new(SPAN, val, *tail, &self.ab));
         }
         let expr_nodes = self.arena.get_js_children(*expressions);
-        let mut exprs = self.ab.vec_with_capacity(expr_nodes.len());
+        let mut exprs = ArenaVec::with_capacity_in(expr_nodes.len(), &self.ab);
         for e in expr_nodes {
             exprs.push(self.expr(e)?);
         }
-        Some(self.ab.template_literal(SPAN, quasis_out, exprs))
+        Some(TemplateLiteral::new(SPAN, quasis_out, exprs, &self.ab))
     }
 
     /// Build a `SimpleAssignmentTarget` from an identifier / simple member node.
@@ -1119,10 +1194,13 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         node: &JsNode,
     ) -> Option<oxc_ast::ast::SimpleAssignmentTarget<'a>> {
         match node {
-            JsNode::Identifier { name, .. } => Some(
-                self.ab
-                    .simple_assignment_target_assignment_target_identifier(SPAN, self.str(name)),
-            ),
+            JsNode::Identifier { name, .. } => {
+                Some(SimpleAssignmentTarget::new_assignment_target_identifier(
+                    SPAN,
+                    self.str(name),
+                    &self.ab,
+                ))
+            }
             JsNode::MemberExpression { optional, .. } if !*optional => {
                 let member = self.member_expr(node)?;
                 Some(oxc_ast::ast::SimpleAssignmentTarget::from(member))
@@ -1168,7 +1246,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         I: ExactSizeIterator<Item = Option<&'n JsNode>>,
     {
         let len = elements.len();
-        let mut out = self.ab.vec_with_capacity(len);
+        let mut out = ArenaVec::with_capacity_in(len, &self.ab);
         let mut rest = None;
         let last = len.saturating_sub(1);
         for (i, el) in elements.enumerate() {
@@ -1180,12 +1258,12 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                         return None;
                     }
                     let target = self.assignment_target(self.arena.get_js_node(*argument))?;
-                    rest = Some(self.ab.alloc_assignment_target_rest(SPAN, target));
+                    rest = Some(AssignmentTargetRest::boxed(SPAN, target, &self.ab));
                 }
                 Some(e) => out.push(Some(self.assignment_target_maybe_default(e)?)),
             }
         }
-        let array = self.ab.alloc_array_assignment_target(SPAN, out, rest);
+        let array = ArrayAssignmentTarget::boxed(SPAN, out, rest, &self.ab);
         Some(oxc_ast::ast::AssignmentTarget::ArrayAssignmentTarget(array))
     }
 
@@ -1193,7 +1271,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         &self,
         members: &[JsNode],
     ) -> Option<oxc_ast::ast::AssignmentTarget<'a>> {
-        let mut props = self.ab.vec_with_capacity(members.len());
+        let mut props = ArenaVec::with_capacity_in(members.len(), &self.ab);
         let mut rest = None;
         let last = members.len().saturating_sub(1);
         for (i, member) in members.iter().enumerate() {
@@ -1203,7 +1281,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                         return None;
                     }
                     let target = self.assignment_target(self.arena.get_js_node(*argument))?;
-                    rest = Some(self.ab.alloc_assignment_target_rest(SPAN, target));
+                    rest = Some(AssignmentTargetRest::boxed(SPAN, target, &self.ab));
                 }
                 JsNode::Property {
                     key,
@@ -1224,7 +1302,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 _ => return None,
             }
         }
-        let object = self.ab.alloc_object_assignment_target(SPAN, props, rest);
+        let object = ObjectAssignmentTarget::boxed(SPAN, props, rest, &self.ab);
         Some(oxc_ast::ast::AssignmentTarget::ObjectAssignmentTarget(
             object,
         ))
@@ -1241,10 +1319,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             let binding = self.assignment_target(self.arena.get_js_node(*left))?;
             let init = self.expr_id(*right)?;
             return Some(
-                self.ab
-                    .assignment_target_maybe_default_assignment_target_with_default(
-                        SPAN, binding, init,
-                    ),
+                AssignmentTargetMaybeDefault::new_assignment_target_with_default(
+                    SPAN, binding, init, &self.ab,
+                ),
             );
         }
         if let JsNode::AssignmentExpression {
@@ -1258,10 +1335,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             let binding = self.assignment_target(self.arena.get_js_node(*left))?;
             let init = self.expr_id(*right)?;
             return Some(
-                self.ab
-                    .assignment_target_maybe_default_assignment_target_with_default(
-                        SPAN, binding, init,
-                    ),
+                AssignmentTargetMaybeDefault::new_assignment_target_with_default(
+                    SPAN, binding, init, &self.ab,
+                ),
             );
         }
         let target = self.assignment_target(node)?;
@@ -1302,11 +1378,10 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 },
                 _ => return None,
             };
-            let binding = self.ab.identifier_reference(SPAN, self.str(&name));
+            let binding = IdentifierReference::new(SPAN, self.str(&name), &self.ab);
             return Some(
                 oxc_ast::ast::AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(
-                    self.ab
-                        .alloc_assignment_target_property_identifier(SPAN, binding, init),
+                    AssignmentTargetPropertyIdentifier::boxed(SPAN, binding, init, &self.ab),
                 ),
             );
         }
@@ -1315,8 +1390,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let binding = self.assignment_target_maybe_default(self.arena.get_js_node(value))?;
         Some(
             oxc_ast::ast::AssignmentTargetProperty::AssignmentTargetPropertyProperty(
-                self.ab
-                    .alloc_assignment_target_property_property(SPAN, key, binding, computed),
+                AssignmentTargetPropertyProperty::boxed(SPAN, key, binding, computed, &self.ab),
             ),
         )
     }
@@ -1326,14 +1400,14 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             return None;
         };
         let prop_nodes = self.arena.get_js_children(*properties);
-        let mut props = self.ab.vec_with_capacity(prop_nodes.len());
+        let mut props = ArenaVec::with_capacity_in(prop_nodes.len(), &self.ab);
         for member in prop_nodes {
             match member {
                 JsNode::SpreadElement { argument, .. } => {
                     let arg = self.expr_id(*argument)?;
-                    props.push(ObjectPropertyKind::SpreadProperty(
-                        self.ab.alloc_spread_element(SPAN, arg),
-                    ));
+                    props.push(ObjectPropertyKind::SpreadProperty(SpreadElement::boxed(
+                        SPAN, arg, &self.ab,
+                    )));
                 }
                 JsNode::Property { .. } => {
                     let prop = self.object_property(member)?;
@@ -1342,7 +1416,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 _ => return None,
             }
         }
-        Some(self.ab.expression_object(SPAN, props))
+        Some(Expression::ObjectExpression(ObjectExpression::boxed(
+            SPAN, props, &self.ab,
+        )))
     }
 
     /// Build a boxed `ObjectProperty`. Handles plain `key: value`, computed
@@ -1392,21 +1468,24 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         };
 
         let value = self.expr_id(*value)?;
-        Some(
-            self.ab
-                .alloc_object_property(SPAN, prop_kind, key, value, method, *shorthand, *computed),
-        )
+        Some(ObjectProperty::boxed(
+            SPAN, prop_kind, key, value, method, *shorthand, *computed, &self.ab,
+        ))
     }
 
     /// Build a non-computed `PropertyKey` from an identifier / literal node.
     fn property_key(&self, node: &JsNode) -> Option<PropertyKey<'a>> {
         match node {
-            JsNode::Identifier { name, .. } => {
-                Some(self.ab.property_key_static_identifier(SPAN, self.str(name)))
-            }
+            JsNode::Identifier { name, .. } => Some(PropertyKey::new_static_identifier(
+                SPAN,
+                self.str(name),
+                &self.ab,
+            )),
             JsNode::PrivateIdentifier { name, .. } => {
-                let field = self.ab.private_identifier(SPAN, self.str(name));
-                Some(PropertyKey::PrivateIdentifier(self.ab.alloc(field)))
+                let field = PrivateIdentifier::new(SPAN, self.str(name), &self.ab);
+                Some(PropertyKey::PrivateIdentifier(ArenaBox::new_in(
+                    field, &self.ab,
+                )))
             }
             JsNode::Literal { .. } => {
                 let expr = self.literal(node)?;
@@ -1432,24 +1511,34 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let (is_expr, fn_body) = if *expression {
             // Concise-body arrow: a single implicit-return expression.
             let expr = self.expr(body_node)?;
-            let stmt = self.ab.statement_expression(SPAN, expr);
-            let stmts = self.ab.vec1(stmt);
-            (true, self.ab.function_body(SPAN, self.ab.vec(), stmts))
+            let stmt =
+                Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, expr, &self.ab));
+            let stmts = ArenaVec::from_value_in(stmt, &self.ab);
+            (
+                true,
+                FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab),
+            )
         } else {
             let JsNode::BlockStatement { body, .. } = body_node else {
                 return None;
             };
             let stmts = self.statements(*body)?;
-            (false, self.ab.function_body(SPAN, self.ab.vec(), stmts))
+            (
+                false,
+                FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab),
+            )
         };
-        Some(self.ab.expression_arrow_function(
-            SPAN,
-            is_expr,
-            *r#async,
-            oxc_ast::NONE,
-            params,
-            oxc_ast::NONE,
-            fn_body,
+        Some(Expression::ArrowFunctionExpression(
+            ArrowFunctionExpression::boxed(
+                SPAN,
+                is_expr,
+                *r#async,
+                oxc_ast::NONE,
+                params,
+                oxc_ast::NONE,
+                fn_body,
+                &self.ab,
+            ),
         ))
     }
 
@@ -1470,20 +1559,21 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 let callee = self.expr_id(*callee)?;
                 let args = self.arguments(*arguments)?;
                 let call =
-                    self.ab
-                        .alloc_call_expression(SPAN, callee, oxc_ast::NONE, args, *optional);
+                    CallExpression::boxed(SPAN, callee, oxc_ast::NONE, args, *optional, &self.ab);
                 ChainElement::CallExpression(call)
             }
             _ => return None,
         };
-        Some(self.ab.expression_chain(SPAN, element))
+        Some(Expression::ChainExpression(ChainExpression::boxed(
+            SPAN, element, &self.ab,
+        )))
     }
 
     /// Convert function parameters (a child range of pattern nodes), handling a
     /// trailing `...rest`. Bails on a non-last rest or any unhandled pattern.
     fn formal_params(&self, params: IdRange) -> Option<oxc_ast::ast::FormalParameters<'a>> {
         let nodes = self.arena.get_js_children(params);
-        let mut items = self.ab.vec_with_capacity(nodes.len());
+        let mut items = ArenaVec::with_capacity_in(nodes.len(), &self.ab);
         let mut rest = None;
         let last = nodes.len().saturating_sub(1);
         for (i, p) in nodes.iter().enumerate() {
@@ -1492,19 +1582,20 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     return None;
                 }
                 let pattern = self.binding_pattern(self.arena.get_js_node(*argument))?;
-                let rest_el = self.ab.binding_rest_element(SPAN, pattern);
-                rest = Some(self.ab.alloc_formal_parameter_rest(
+                let rest_el = BindingRestElement::new(SPAN, pattern, &self.ab);
+                rest = Some(FormalParameterRest::boxed(
                     SPAN,
-                    self.ab.vec(),
+                    ArenaVec::new_in(&self.ab),
                     rest_el,
                     oxc_ast::NONE,
+                    &self.ab,
                 ));
                 continue;
             }
             let pattern = self.binding_pattern(p)?;
-            items.push(self.ab.formal_parameter(
+            items.push(FormalParameter::new(
                 SPAN,
-                self.ab.vec(),
+                ArenaVec::new_in(&self.ab),
                 pattern,
                 oxc_ast::NONE,
                 oxc_ast::NONE,
@@ -1512,25 +1603,27 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 None,
                 false,
                 false,
+                &self.ab,
             ));
         }
-        Some(self.ab.formal_parameters(
+        Some(FormalParameters::new(
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
             items,
             rest,
+            &self.ab,
         ))
     }
 
     /// Convert call / new arguments (a child range), supporting spreads.
     fn arguments(&self, args: IdRange) -> Option<ArenaVec<'a, Argument<'a>>> {
         let nodes = self.arena.get_js_children(args);
-        let mut out = self.ab.vec_with_capacity(nodes.len());
+        let mut out = ArenaVec::with_capacity_in(nodes.len(), &self.ab);
         for arg in nodes {
             let argument = match arg {
                 JsNode::SpreadElement { argument, .. } => {
                     let inner = self.expr_id(*argument)?;
-                    self.ab.argument_spread_element(SPAN, inner)
+                    Argument::new_spread_element(SPAN, inner, &self.ab)
                 }
                 other => Argument::from(self.expr(other)?),
             };
@@ -1863,15 +1956,16 @@ mod tests {
         let oxc_expr = jsnode_to_oxc_expr(expr_node, &arena, &allocator).expect("convert expr");
         // Wrap in a trivial program to print it.
         let ab = AstBuilder::new(&allocator);
-        let stmt = ab.statement_expression(SPAN, oxc_expr);
-        let program = ab.program(
+        let stmt = Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, oxc_expr, &ab));
+        let program = Program::new(
             SPAN,
             oxc_span::SourceType::mjs(),
             "",
-            ab.vec(),
+            ArenaVec::new_in(&ab),
             None,
-            ab.vec(),
-            ab.vec1(stmt),
+            ArenaVec::new_in(&ab),
+            ArenaVec::from_value_in(stmt, &ab),
+            &ab,
         );
         assert_eq!(rsvelte_esrap::print(&program, "").trim(), "a + b;");
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -1,8 +1,3 @@
-// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
-// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
-// deprecation here and defer the mechanical migration to a dedicated follow-up.
-
-#![allow(deprecated)]
 //! AST-based server code generation (Phase-3 rewrite).
 //!
 //! This is the additive, in-progress replacement for the string-surgery server
@@ -745,7 +740,8 @@ fn strip_ts_expression_wrappers<'a>(expr: &mut OxcExpression<'a>, allocator: &'a
                 if !is_wrapper {
                     break;
                 }
-                let placeholder = self.ab.expression_boolean_literal(SPAN, false);
+                let placeholder =
+                    oxc_ast::ast::Expression::new_boolean_literal(SPAN, false, &self.ab);
                 let taken = std::mem::replace(expr, placeholder);
                 *expr = match taken {
                     OxcExpression::TSAsExpression(e) => e.unbox().expression,
@@ -1223,12 +1219,16 @@ pub fn server_component_ast<'a>(
         let render_target = b.member(b.id(component_name), "render");
         let render_params = b.params(vec![b.id_pat("$$props"), b.id_pat("$$opts")], None);
         // $$opts?.context — optional member chaining.
-        let opts_context = oxc_ast::ast::Expression::from(b.ab.member_expression_static(
-            SPAN,
-            b.id("$$opts"),
-            b.id_name("context"),
-            true,
-        ));
+        let opts_context =
+            oxc_ast::ast::Expression::from(oxc_ast::ast::MemberExpression::StaticMemberExpression(
+                oxc_ast::ast::StaticMemberExpression::boxed(
+                    SPAN,
+                    b.id("$$opts"),
+                    b.id_name("context"),
+                    true,
+                    &b.ab,
+                ),
+            ));
         let render_obj = b.object(vec![
             b.init("props", b.id("$$props")),
             b.init("context", opts_context),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/read_wrap.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/read_wrap.rs
@@ -1,8 +1,3 @@
-// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
-// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
-// deprecation here and defer the mechanical migration to a dedicated follow-up.
-
-#![allow(deprecated)]
 //! Server READ-WRAPPING single pass (Phase-3 rewrite).
 //!
 //! After `ServerTransformState::visit_expr` produces an oxc [`Expression`],
@@ -504,7 +499,9 @@ impl<'a, 'b> ReadWrap<'a, 'b> {
         // `if (!changed) return null`, but we must keep the already-visited node.
         if !changed {
             taken.right = rhs;
-            return Some(Expression::AssignmentExpression(b.ab.alloc(taken)));
+            return Some(Expression::AssignmentExpression(
+                oxc_allocator::ArenaBox::new_in(taken, &b.ab),
+            ));
         }
 
         let assignments: Vec<Expression<'a>> = leaves

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -1,8 +1,3 @@
-// oxc 0.138 deprecated the legacy `AstBuilder` vec/alloc/*_static helpers in favour
-// of the arena APIs (oxc#23043); the old methods behave identically, so suppress the
-// deprecation here and defer the mechanical migration to a dedicated follow-up.
-
-#![allow(deprecated)]
 //! AST-based server INSTANCE / MODULE script transform (Phase-3 rewrite).
 //!
 //! This is the additive, in-progress port of the server `VariableDeclaration` /
@@ -1143,12 +1138,19 @@ impl<'a, 'b> ClassFieldRuneLower<'a, 'b> {
                 let retarget =
                     !is_private && matches!(rune, DeclRune::Derived | DeclRune::DerivedBy);
                 if retarget && let Some(backing_name) = backing.get(&name) {
-                    assign.left = AT::from(b.ab.member_expression_private_field_expression(
-                        oxc_span::SPAN,
-                        b.this(),
-                        b.ab.private_identifier(oxc_span::SPAN, b.str(backing_name)),
-                        false,
-                    ));
+                    assign.left = AT::from(
+                        oxc_ast::ast::MemberExpression::new_private_field_expression(
+                            oxc_span::SPAN,
+                            b.this(),
+                            oxc_ast::ast::PrivateIdentifier::new(
+                                oxc_span::SPAN,
+                                b.str(backing_name),
+                                &b.ab,
+                            ),
+                            false,
+                            &b.ab,
+                        ),
+                    );
                 }
             }
         }
@@ -1171,7 +1173,7 @@ impl<'a, 'b> ClassFieldRuneLower<'a, 'b> {
             let call = b.call(member, vec![]);
             b.body(vec![b.return_stmt(Some(call))])
         };
-        let getter_fn = b.ab.alloc_function(
+        let getter_fn = oxc_ast::ast::Function::boxed(
             oxc_span::SPAN,
             oxc_ast::ast::FunctionType::FunctionExpression,
             None,
@@ -1183,11 +1185,12 @@ impl<'a, 'b> ClassFieldRuneLower<'a, 'b> {
             b.empty_params(),
             oxc_ast::NONE,
             Some(getter_body),
+            &b.ab,
         );
-        new_body.push(b.ab.class_element_method_definition(
+        new_body.push(oxc_ast::ast::ClassElement::new_method_definition(
             oxc_span::SPAN,
             oxc_ast::ast::MethodDefinitionType::MethodDefinition,
-            b.ab.vec(),
+            oxc_allocator::ArenaVec::new_in(&b.ab),
             b.key(public_name),
             getter_fn,
             MethodDefinitionKind::Get,
@@ -1196,6 +1199,7 @@ impl<'a, 'b> ClassFieldRuneLower<'a, 'b> {
             false,
             false,
             None,
+            &b.ab,
         ));
 
         let setter_body = {
@@ -1204,7 +1208,7 @@ impl<'a, 'b> ClassFieldRuneLower<'a, 'b> {
             b.body(vec![b.return_stmt(Some(call))])
         };
         let setter_params = b.params(vec![b.id_pat("$$value")], None);
-        let setter_fn = b.ab.alloc_function(
+        let setter_fn = oxc_ast::ast::Function::boxed(
             oxc_span::SPAN,
             oxc_ast::ast::FunctionType::FunctionExpression,
             None,
@@ -1216,11 +1220,12 @@ impl<'a, 'b> ClassFieldRuneLower<'a, 'b> {
             setter_params,
             oxc_ast::NONE,
             Some(setter_body),
+            &b.ab,
         );
-        new_body.push(b.ab.class_element_method_definition(
+        new_body.push(oxc_ast::ast::ClassElement::new_method_definition(
             oxc_span::SPAN,
             oxc_ast::ast::MethodDefinitionType::MethodDefinition,
-            b.ab.vec(),
+            oxc_allocator::ArenaVec::new_in(&b.ab),
             b.key(public_name),
             setter_fn,
             MethodDefinitionKind::Set,
@@ -1229,6 +1234,7 @@ impl<'a, 'b> ClassFieldRuneLower<'a, 'b> {
             false,
             false,
             None,
+            &b.ab,
         ));
     }
 }
@@ -1359,8 +1365,10 @@ impl<'a, 'b> VisitMut<'a> for ClassFieldRuneLower<'a, 'b> {
         }
 
         // Take ownership of the existing body and rebuild it element-by-element.
-        let old_body = std::mem::replace(&mut class.body.body, b.ab.vec());
-        let mut new_body: oxc_allocator::Vec<'a, ClassElement<'a>> = b.ab.vec();
+        let old_body =
+            std::mem::replace(&mut class.body.body, oxc_allocator::ArenaVec::new_in(&b.ab));
+        let mut new_body: oxc_allocator::Vec<'a, ClassElement<'a>> =
+            oxc_allocator::ArenaVec::new_in(&b.ab);
 
         // Insert backing fields + get/set accessors for constructor-declared PUBLIC
         // `$derived` / `$derived.by` fields, at the TOP of the body (写经 server
@@ -1372,12 +1380,15 @@ impl<'a, 'b> VisitMut<'a> for ClassFieldRuneLower<'a, 'b> {
             }
             let backing_name = backing.get(&cf.name).cloned().unwrap_or_default();
             // `#<backing>;` (bare backing field — value set in the constructor)
-            let private_key =
-                b.ab.property_key_private_identifier(oxc_span::SPAN, b.str(&backing_name));
-            new_body.push(b.ab.class_element_property_definition(
+            let private_key = oxc_ast::ast::PropertyKey::new_private_identifier(
+                oxc_span::SPAN,
+                b.str(&backing_name),
+                &b.ab,
+            );
+            new_body.push(oxc_ast::ast::ClassElement::new_property_definition(
                 oxc_span::SPAN,
                 oxc_ast::ast::PropertyDefinitionType::PropertyDefinition,
-                b.ab.vec(),
+                oxc_allocator::ArenaVec::new_in(&b.ab),
                 private_key,
                 oxc_ast::NONE,
                 None,
@@ -1389,6 +1400,7 @@ impl<'a, 'b> VisitMut<'a> for ClassFieldRuneLower<'a, 'b> {
                 false,
                 false,
                 None,
+                &b.ab,
             ));
             self.push_accessors(&mut new_body, &cf.name, &backing_name);
         }
@@ -1458,8 +1470,11 @@ impl<'a, 'b> VisitMut<'a> for ClassFieldRuneLower<'a, 'b> {
             // Move the lowered `$.derived(...)` value onto the private backing
             // field, keeping the original `PropertyDefinition` node (and its now
             // private key).
-            let private_key =
-                b.ab.property_key_private_identifier(oxc_span::SPAN, b.str(&deconflicted));
+            let private_key = oxc_ast::ast::PropertyKey::new_private_identifier(
+                oxc_span::SPAN,
+                b.str(&deconflicted),
+                &b.ab,
+            );
             prop_box.key = private_key;
             new_body.push(ClassElement::PropertyDefinition(prop_box));
 
@@ -2220,9 +2235,9 @@ fn expand_props_pattern<'a>(
     // mirrors esrap/estree printing: `{ $$slots }` when key == value, but
     // `{ $$slots: $$slots_ }` when they differ (the `uses_slots` deconfliction).
     let make_prop = |key: &str, value: &str| -> oxc_ast::ast::BindingProperty<'a> {
-        let k = ab.property_key_static_identifier(SPAN, b.str(key));
-        let v = ab.binding_pattern_binding_identifier(SPAN, b.str(value));
-        ab.binding_property(SPAN, k, v, key == value, false)
+        let k = oxc_ast::ast::PropertyKey::new_static_identifier(SPAN, b.str(key), &ab);
+        let v = oxc_ast::ast::BindingPattern::new_binding_identifier(SPAN, b.str(value), &ab);
+        oxc_ast::ast::BindingProperty::new(SPAN, k, v, key == value, false, &ab)
     };
 
     match pat {
@@ -2232,16 +2247,16 @@ fn expand_props_pattern<'a>(
             // END of `properties` keeps them before the (separately-printed) rest.
             obj.properties.push(make_prop("$$slots", slots_name));
             obj.properties.push(make_prop("$$events", "$$events"));
-            BindingPattern::ObjectPattern(ab.alloc(obj))
+            BindingPattern::ObjectPattern(oxc_allocator::ArenaBox::new_in(obj, &ab))
         }
         BindingPattern::BindingIdentifier(id) => {
             let name = b.str(id.name.as_str());
-            let mut props = ab.vec_with_capacity(2);
+            let mut props = oxc_allocator::ArenaVec::with_capacity_in(2, &ab);
             props.push(make_prop("$$slots", slots_name));
             props.push(make_prop("$$events", "$$events"));
-            let rest_inner = ab.binding_pattern_binding_identifier(SPAN, name);
-            let rest = ab.alloc_binding_rest_element(SPAN, rest_inner);
-            ab.binding_pattern_object_pattern(SPAN, props, Some(rest))
+            let rest_inner = oxc_ast::ast::BindingPattern::new_binding_identifier(SPAN, name, &ab);
+            let rest = oxc_ast::ast::BindingRestElement::boxed(SPAN, rest_inner, &ab);
+            oxc_ast::ast::BindingPattern::new_object_pattern(SPAN, props, Some(rest), &ab)
         }
         // Object pattern WITHOUT rest, or array pattern → verbatim.
         other => other,


### PR DESCRIPTION
## What

Follow-up to #1358. That PR bumped oxc to 0.138, which deprecated the **entire** legacy `AstBuilder` builder surface — the `vec`/`alloc`/`*_static` helpers **plus** every `self.ab.<node>()` / `self.ab.alloc_<node>()` / `self.ab.<enum>_<variant>()` convenience method ([oxc#23043](https://github.com/oxc-project/oxc/issues/23043)) — and parked a scoped `#![allow(deprecated)]` on the six Phase-3 codegen files, deferring the mechanical migration to a dedicated follow-up.

[@overlookmotel pointed at the upstream codemod](https://github.com/baseballyama/rsvelte/pull/1358#issuecomment-4852787044) in a review comment. This PR does that migration and removes the `#![allow(deprecated)]` shims.

## How

All ~370 call sites across the six files move to the new arena-native interface:

| deprecated | new |
|---|---|
| `ab.vec()` | `ArenaVec::new_in(&ab)` |
| `ab.vec_with_capacity(n)` | `ArenaVec::with_capacity_in(n, &ab)` |
| `ab.vec1(x)` | `ArenaVec::from_value_in(x, &ab)` |
| `ab.vec_from_iter(i)` | `ArenaVec::from_iter_in(i, &ab)` |
| `ab.alloc(x)` | `ArenaBox::new_in(x, &ab)` |
| `ab.<node>(a)` | `<Node>::new(a, &ab)` |
| `ab.alloc_<node>(a)` | `<Node>::boxed(a, &ab)` |
| `ab.<enum>_<variant>(a)` | `<Enum>::new_<variant>(a, &ab)`, or the explicit `<Enum>::<Variant>(<Box>::boxed(a, &ab))` the deprecated helper expanded to when the new interface generates no `new_<variant>` |

The new constructors build byte-identical AST nodes, so **compiler output is unchanged**. Import housekeeping:

- The three heavy converters (`jsnode_to_oxc.rs`, `js_ast/to_oxc.rs`, `builders.rs`) now reference many more node types directly, so their explicit `oxc_ast::ast::{…}` lists become a `use oxc_ast::ast::*;` glob (+ `Box as ArenaBox`).
- The three server files alias `oxc_ast::ast::Expression` (to avoid clashing with `crate::ast::js::Expression`), so their rewrites use fully-qualified `oxc_ast::ast::` / `oxc_allocator::` paths to stay conflict-free.

`crates/rsvelte_core/src/napi.rs` keeps its own `#![allow(deprecated)]` — that one is unrelated (napi 3 `compat-mode`, not the oxc AstBuilder deprecation) and out of scope.

## Verification

- `cargo build -p rsvelte_core`: clean, **0 deprecation warnings** (was 437)
- `cargo clippy --all-targets --all-features`: clean
- Byte-parity suites green: **snapshot** (client.js + server.js) 17/17, **ssr** 16/16, **print** 16/16, **runtime** legacy/runes/browser/hydration 19/19

🤖 Generated with [Claude Code](https://claude.com/claude-code)