### PR TITLE
chore(ci): unify workflow naming and drop set-matrix job

### DIFF
--- a/.github/workflows/auto-update-oxfmt.yml
+++ b/.github/workflows/auto-update-oxfmt.yml
@@ -1,4 +1,4 @@
-name: auto-update-oxfmt
+name: Auto-update oxfmt
 
 # Auto-follow new `oxfmt` npm releases. `oxfmt` is the engine rsvelte delegates
 # inline `<style>` CSS (and standalone md/yaml/toml/html) to, pinned with a

--- a/.github/workflows/auto-update-submodules.yml
+++ b/.github/workflows/auto-update-submodules.yml
@@ -1,4 +1,4 @@
-name: auto-update-submodules
+name: Auto-update Submodules
 
 # Weekly bump of the tooling submodules — everything EXCEPT svelte. The svelte
 # submodule is handled separately by `auto-update-svelte.yml` because bumping it

--- a/.github/workflows/auto-update-svelte.yml
+++ b/.github/workflows/auto-update-svelte.yml
@@ -1,4 +1,4 @@
-name: auto-update-svelte
+name: Auto-update Svelte
 
 # Weekly: when a newer stable svelte@X.Y.Z is published than the one pinned by
 # the submodules/svelte gitlink, open a STARTER PR that advances the gitlink to

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,7 @@ on:
       - 'benches/corpus/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - '.github/workflows/bench.yml'
+      - '.github/workflows/benchmark.yml'
   pull_request:
     branches: [main]
     # Default + `labeled` so adding the `bench` label triggers a run; the

--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -1,4 +1,4 @@
-name: rsvelte_capi (C ABI)
+name: C ABI
 
 # Tests the C FFI surface on Linux, macOS, and Windows:
 #  - Build the cdylib + verify the committed include/rsvelte.h matches
@@ -22,7 +22,7 @@ on:
       - 'crates/rsvelte_core/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - '.github/workflows/rsvelte-capi.yml'
+      - '.github/workflows/capi.yml'
   pull_request:
     branches: [main]
     paths:
@@ -30,7 +30,7 @@ on:
       - 'crates/rsvelte_core/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - '.github/workflows/rsvelte-capi.yml'
+      - '.github/workflows/capi.yml'
   workflow_dispatch:
 
 concurrency:
@@ -59,34 +59,22 @@ jobs:
   # still runs on push to `main` and on demand, so a Windows-specific ABI
   # regression is caught before the next release. Mirrors CI dropping macOS from
   # its PR test matrix.
-  set-matrix:
-    name: Set capi matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    outputs:
-      include: ${{ steps.m.outputs.include }}
-    steps:
-      - id: m
-        shell: bash
-        run: |
-          ubuntu='{"os":"ubuntu-latest","lib":"librsvelte_capi.so","exe_ext":""}'
-          macos='{"os":"macos-latest","lib":"librsvelte_capi.dylib","exe_ext":""}'
-          windows='{"os":"windows-latest","lib":"rsvelte_capi.dll","exe_ext":".exe"}'
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "include=[$ubuntu,$macos]" >> "$GITHUB_OUTPUT"
-          else
-            echo "include=[$ubuntu,$macos,$windows]" >> "$GITHUB_OUTPUT"
-          fi
-
   capi:
-    name: capi (${{ matrix.os }})
-    needs: set-matrix
+    name: C ABI (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
+      # The OS list is computed inline via a parse-time conditional rather than
+      # in a separate `set-matrix` job: that job added a full job's queue +
+      # startup (~1 min) to the serial path before any build could begin. This
+      # expression is evaluated at workflow-parse time so the matrix legs start
+      # immediately (mirrors the `test` job in ci.yml). PRs drop Windows (see the
+      # comment above); pushes and manual runs get all three OSes.
       matrix:
-        include: ${{ fromJSON(needs.set-matrix.outputs.include) }}
+        include: ${{ github.event_name == 'pull_request'
+          && fromJSON('[{"os":"ubuntu-latest","lib":"librsvelte_capi.so","exe_ext":""},{"os":"macos-latest","lib":"librsvelte_capi.dylib","exe_ext":""}]')
+          || fromJSON('[{"os":"ubuntu-latest","lib":"librsvelte_capi.so","exe_ext":""},{"os":"macos-latest","lib":"librsvelte_capi.dylib","exe_ext":""},{"os":"windows-latest","lib":"rsvelte_capi.dll","exe_ext":".exe"}]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/check-svelte-release.yml
+++ b/.github/workflows/check-svelte-release.yml
@@ -1,4 +1,4 @@
-name: check-svelte-release
+name: Check Svelte Release
 
 # Daily poll of sveltejs/svelte for new stable releases. When the latest
 # svelte@X.Y.Z release is newer than the version pinned by the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
     # macOS is dropped from the PR matrix to keep PR feedback fast — it
     # consistently runs ~2x slower than Linux for identical work and the
     # platform-specific failure modes (PATH, line endings, dylib loading) are
-    # already covered by `rsvelte_capi` and the `Release` workflow. macOS still
+    # already covered by the `C ABI` and `Release` workflows. macOS still
     # runs on every push to `main` and on demand via the `macos-ci` label, so
     # regressions are caught before the next release.
     #
@@ -789,7 +789,7 @@ jobs:
             }
 
   # `Build` (`cargo build --release` for the main crate) was removed —
-  # release-mode codegen is already exercised by `rsvelte_capi (C ABI)`
+  # release-mode codegen is already exercised by the `C ABI` workflow
   # (Linux/macOS/Windows release builds with the same crate's source) and
   # by the `Release` workflow's `build-svelte-check` / `build-vps-native`
   # matrices, so a standalone PR-time build only repeated work. To restore

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   benchmarks:
-    name: Run CodSpeed benchmarks
+    name: Run benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 45
     # Runs on every PR to `main` (and on push to `main` for the baseline).

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -1,4 +1,4 @@
-name: corpus-compat
+name: Corpus Compat
 
 # Compiles every .svelte / .svelte.(js|ts) source (including markdown code
 # blocks) from every corpus source repository — sveltejs/svelte, sveltejs/
@@ -116,7 +116,7 @@ on:
       - '.github/workflows/corpus-compat.yml'
 
 concurrency:
-  group: corpus-compat-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -135,7 +135,7 @@ env:
 
 jobs:
   corpus:
-    name: Corpus compatibility
+    name: Compiler parity
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -202,7 +202,7 @@ jobs:
           # timeout/failure left the cache cold forever and every later run
           # recompiled from scratch and could time out again. Saving on failure
           # preserves the compiled `target/` and breaks that deadlock (mirrors
-          # the same fix in bench.yml).
+          # the same fix in benchmark.yml).
           cache-on-failure: true
 
       - name: Build rsvelte NAPI binding

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs to GitHub Pages
+name: Deploy Docs
 
 on:
   push:
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -29,7 +30,7 @@ jobs:
       # string into the NAPI cdylib. The other submodules (language-tools,
       # typescript-go — ~534 MB combined, plus the SSH-only vite-plugin-svelte
       # remote) are never touched by the WASM / NAPI / playground build, so a
-      # shallow svelte-only init keeps checkout fast (mirrors rsvelte-capi.yml).
+      # shallow svelte-only init keeps checkout fast (mirrors capi.yml).
       - name: Checkout svelte submodule (shallow)
         run: git submodule update --init --depth 1 submodules/svelte
 
@@ -130,6 +131,7 @@ jobs:
           path: apps/playground/build
 
   deploy:
+    name: Deploy
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release-capi.yml
+++ b/.github/workflows/release-capi.yml
@@ -1,4 +1,4 @@
-name: Release rsvelte_capi
+name: Release C ABI
 
 # Cut a versioned release of the C ABI bindings.
 #
@@ -35,7 +35,7 @@ env:
 
 jobs:
   build:
-    name: build (${{ matrix.triple }})
+    name: Build (${{ matrix.triple }})
     strategy:
       fail-fast: false
       matrix:

--- a/crates/rsvelte_capi/README.md
+++ b/crates/rsvelte_capi/README.md
@@ -21,7 +21,7 @@ shared library + one header that **any** language with a C FFI can call
 | .NET (C# / F#)    | `[DllImport]` / `LibraryImport`          | applicable             | —       |
 | Swift             | bridging header                          | applicable             | —       |
 
-The CI workflow (`.github/workflows/rsvelte-capi.yml`) runs on Linux,
+The CI workflow (`.github/workflows/capi.yml`) runs on Linux,
 macOS, and Windows: the cargo test suite + the C smoke gate every PR that
 touches the C ABI or the compiler, while the other language smokes run on
 push to `main` and manual dispatch (Zig is temporarily out of CI until

--- a/crates/rsvelte_core/benches/compiler.rs
+++ b/crates/rsvelte_core/benches/compiler.rs
@@ -1,7 +1,7 @@
 //! Compiler benchmarks — per-phase and end-to-end compile cost.
 //!
 //! These are the primary inputs to the CodSpeed regression gate and the
-//! Criterion baseline (`bench.yml`). For that signal to mean anything the
+//! Criterion baseline (`benchmark.yml`). For that signal to mean anything the
 //! workload must be **identical** between the base commit and a PR, so every
 //! input here is either:
 //!


### PR DESCRIPTION
## 概要

CI ワークフローの命名がスタイル混在で「ぐちゃっと」していたため、**表示名・ファイル名・ジョブ名を統一**し、あわせて処理の最適化を1件行いました。

## 変更内容

### 1. 表示名 (`name:`) を Title Case に統一
lowercase-kebab / snake / 括弧混在を人間可読な Title Case へ:

| ファイル | 旧 | 新 |
|---|---|---|
| corpus-compat.yml | `corpus-compat` | **Corpus Compat** |
| capi.yml | `rsvelte_capi (C ABI)` | **C ABI** |
| release-capi.yml | `Release rsvelte_capi` | **Release C ABI** |
| auto-update-oxfmt.yml | `auto-update-oxfmt` | **Auto-update oxfmt** |
| auto-update-submodules.yml | `auto-update-submodules` | **Auto-update Submodules** |
| auto-update-svelte.yml | `auto-update-svelte` | **Auto-update Svelte** |
| check-svelte-release.yml | `check-svelte-release` | **Check Svelte Release** |
| deploy-docs.yml | `Deploy Docs to GitHub Pages` | **Deploy Docs** |

### 2. ファイルリネーム (`git mv` で履歴保持)
- `bench.yml` → **`benchmark.yml`**（略語を廃し `site-benchmark.yml` と語形統一）
- `rsvelte-capi.yml` → **`capi.yml`**（`ci.yml` の兄弟。`capi`=CI / `release-capi`=リリース、と役割が一目瞭然に）

### 3. ジョブ名の整備
- `deploy-docs`: 無名だった `build`/`deploy` に **`Build`/`Deploy`** を付与
- `release-capi`: `build (…)` → **`Build (…)`**
- `capi`: `capi (…)` → **`C ABI (…)`**
- スタッター解消: `Corpus compatibility` → **`Compiler parity`**（`Formatter parity`/`Lint parity` と並列化）、`Run CodSpeed benchmarks` → **`Run benchmarks`**

### 4. 処理最適化
- `capi.yml` の **`set-matrix` 独立ジョブを廃止**し、`ci.yml` と同じパースタイム条件式にインライン化。matrix 算出専用ジョブが足していた**約1分のキュー遅延と1ジョブ分のランナー起動を削減**（`needs` 依存も解消）。

### 5. 参照の追従更新
`ci.yml`/`deploy-docs.yml`/`corpus-compat.yml` のコメント、冗長な concurrency group、`crates/rsvelte_capi/README.md`、`crates/rsvelte_core/benches/compiler.rs` の旧名参照をすべて更新。旧名の残存参照ゼロを確認。

## 検証
- 全15ワークフローの YAML パース OK
- `capi.yml` の折り畳み matrix 式が正しい単一行式・JSON ペイロード妥当を確認
- ブランチ保護の必須ステータスチェックは未設定（ルールは deletion / non_fast_forward のみ）のため、リネームによる merge ブロックのリスクなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)