### PR TITLE
fix(transform): deep infer_namespace for SSR reset-parent fragments

### DIFF
--- a/.changeset/fix-ssr-infer-namespace-deep-check.md
+++ b/.changeset/fix-ssr-infer-namespace-deep-check.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): deep infer_namespace for SSR reset-parent fragments
+
+The server whitespace trimmer decides whether a fragment's inter-node
+whitespace is removable from its inferred namespace (svg/mathml contexts drop
+whitespace-only text; html keeps a single space). rsvelte inferred that
+namespace with a shallow direct-child scan; upstream `infer_namespace`
+deep-walks into `{#if}` / `{#each}` / `{#await}` / `{#key}` block bodies for
+namespace-resetting parents (Root / Fragment / Component / SnippetBlock /
+SlotElement). Porting `check_nodes_for_namespace` fixes two SSR whitespace
+divergences: `<svg>…</svg> {#if}<p>…{/if}` (keep the space — html found inside
+the block) and top-level `{#if}svg{/if} {#if}svg{/if}` (drop the space — all svg).

--- a/compat/corpus/known-failures.server.json
+++ b/compat/corpus/known-failures.server.json
@@ -1,6 +1,4 @@
 [
-	"flowbite-svelte/src/routes/docs-examples/forms/file-input/Dropzone.svelte",
-	"layerchart/packages/layerchart/src/lib/components/Area.svelte",
 	"powertable/app/src/lib/components/PowerTable.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte",
 	"svelte/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/input.svelte"

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -901,7 +901,8 @@ pub fn server_component_ast<'a>(
     // fragment they already sit at the head of `template_body` (ahead of the
     // rendered template, after the instance body), and for block-nested snippets
     // they stay inside their block body. No extra splice is needed here.
-    let template_body = visitors::shared::build_fragment_body(&ast.fragment, true, &mut state);
+    let template_body =
+        visitors::shared::build_fragment_body(&ast.fragment, true, true, &mut state);
 
     // -- component-bindings settle-loop (upstream lines 178-211) ------------
     // If the component binds to a child (`<Child bind:value={v} />`), legacy

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
@@ -572,7 +572,7 @@ fn render_slot_body<'a>(
     };
     let saved_namespace = state.namespace;
     state.namespace = inferred_ns;
-    let body = super::shared::build_fragment_body(&synthetic, is_text_first_parent, state);
+    let body = super::shared::build_fragment_body(&synthetic, is_text_first_parent, true, state);
     state.namespace = saved_namespace;
     body
 }
@@ -714,7 +714,7 @@ fn build_snippet_declaration<'a>(
     }
     state.shadowed_names.push(shadow);
     // SnippetBlock body IS an `is_text_first` parent.
-    let body_block = super::shared::build_fragment_body(&snippet.body, true, state);
+    let body_block = super::shared::build_fragment_body(&snippet.body, true, true, state);
     state.shadowed_names.pop();
     let fn_body = state.b.body(body_block);
     state.b.function_declaration(name, params, fn_body, false)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
@@ -175,7 +175,7 @@ pub fn visit_each_block<'a>(node: &EachBlock, state: &mut ServerTransformState<'
         state.slot_let_shadows.push(each_shadow);
     }
     // EachBlock body IS an `is_text_first` parent (upstream `clean_nodes`).
-    each_body.extend(build_fragment_body(&node.body, true, state));
+    each_body.extend(build_fragment_body(&node.body, true, false, state));
     if pushed_shadow {
         state.slot_let_shadows.pop();
         state.shadowed_names.pop();
@@ -205,7 +205,7 @@ pub fn visit_each_block<'a>(node: &EachBlock, state: &mut ServerTransformState<'
         // EachBlock node, so it IS an `is_text_first` parent (upstream
         // `clean_nodes`: `parent.type === 'EachBlock'`) — a text-first fallback
         // gets a leading `<!---->` anchor, same as the loop body.
-        let mut fallback_body = build_fragment_body(fallback, true, state);
+        let mut fallback_body = build_fragment_body(fallback, true, false, state);
         let b = state.b;
         let open_else_push = b.stmt(b.call("$$renderer.push", vec![b.string(BLOCK_OPEN_ELSE)]));
         fallback_body.insert(0, open_else_push);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
@@ -257,7 +257,7 @@ fn build_branch_block<'a>(
     state: &mut ServerTransformState<'a>,
 ) -> Statement<'a> {
     // IfBlock consequent/alternate is NOT an `is_text_first` parent.
-    let mut body = build_fragment_body(frag, false, state);
+    let mut body = build_fragment_body(frag, false, false, state);
     let marker = marker_push(state.b, marker_index);
     body.insert(0, marker);
     state.b.block(body)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -970,7 +970,7 @@ pub fn build_template<'a>(
 /// / SvelteElement / SvelteFragment / TitleElement bodies.
 /// `reset_namespace` — true when this fragment's parent is a namespace-RESETTING
 /// parent (Root / Component / SnippetBlock / SlotElement). Those run the deep
-/// [`check_nodes_for_namespace`] (svg/html elements nested inside `{#if}` /
+/// `check_nodes_for_namespace` (svg/html elements nested inside `{#if}` /
 /// `{#each}` blocks are visible); block-body fragments (`{#if}` / `{#each}` /
 /// `{#key}` / `{#await}` arms) pass `false` and keep the shallow direct-child
 /// inference — mirroring upstream `infer_namespace`, which only runs the deep
@@ -1785,7 +1785,7 @@ fn check_nodes_for_namespace(nodes: &[TemplateNode]) -> NsCheck {
 
 /// Infer a fragment's namespace for a namespace-RESETTING parent (Root /
 /// Fragment / Component / SnippetBlock / SlotElement). Runs the deep
-/// [`check_nodes_for_namespace`] first (which sees svg/html elements nested
+/// `check_nodes_for_namespace` first (which sees svg/html elements nested
 /// inside `{#if}` / `{#each}` blocks); a definitive verdict wins, otherwise
 /// falls back to the shallow direct-child inference. 写经 upstream
 /// `infer_namespace`'s reset-parent branch + element-loop fall-through.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -968,9 +968,17 @@ pub fn build_template<'a>(
 /// (root), SnippetBlock, EachBlock, Component / SvelteSelf / SvelteComponent,
 /// SvelteBoundary — and `false` for IfBlock / KeyBlock / AwaitBlock / SvelteHead
 /// / SvelteElement / SvelteFragment / TitleElement bodies.
+/// `reset_namespace` — true when this fragment's parent is a namespace-RESETTING
+/// parent (Root / Component / SnippetBlock / SlotElement). Those run the deep
+/// [`check_nodes_for_namespace`] (svg/html elements nested inside `{#if}` /
+/// `{#each}` blocks are visible); block-body fragments (`{#if}` / `{#each}` /
+/// `{#key}` / `{#await}` arms) pass `false` and keep the shallow direct-child
+/// inference — mirroring upstream `infer_namespace`, which only runs the deep
+/// check for the reset-parent kinds.
 pub fn build_fragment_body<'a>(
     fragment: &Fragment,
     is_text_first_parent: bool,
+    reset_namespace: bool,
     state: &mut ServerTransformState<'a>,
 ) -> Vec<Statement<'a>> {
     // Fragment-level bodies (root component, block bodies, `<svelte:head>` /
@@ -1031,7 +1039,11 @@ pub fn build_fragment_body<'a>(
     // whitespace text node, emitting a spurious trailing space in the SSR markup
     // (issue #1227). The root component fragment has `state.namespace == "html"`,
     // so its default is unchanged.
-    let fragment_namespace = infer_namespace_from_nodes_owned(&fragment.nodes, state.namespace);
+    let fragment_namespace = if reset_namespace {
+        infer_namespace_reset(&fragment.nodes, state.namespace)
+    } else {
+        infer_namespace_from_nodes_owned(&fragment.nodes, state.namespace)
+    };
     process_children_inner(
         &fragment.nodes,
         None,
@@ -1188,7 +1200,10 @@ pub fn build_fragment_block<'a>(
     is_text_first_parent: bool,
     state: &mut ServerTransformState<'a>,
 ) -> Statement<'a> {
-    let body = build_fragment_body(fragment, is_text_first_parent, state);
+    // Block visitors (IfBlock / EachBlock / KeyBlock / AwaitBlock) are NOT
+    // namespace-resetting parents upstream, so they keep the shallow direct-child
+    // inference (`reset_namespace = false`).
+    let body = build_fragment_body(fragment, is_text_first_parent, false, state);
     state.b.block(body)
 }
 
@@ -1641,6 +1656,150 @@ pub(crate) fn locate_in_source(source: &str, offset: usize) -> (usize, usize) {
 /// html-context fragment to svg — that mirrors upstream, where `infer_namespace`
 /// only runs `check_nodes_for_namespace` when the parent is a
 /// Fragment/Component/SnippetBlock, not an `{#if}` / `{#each}` block.
+/// Deep namespace check — port of upstream `check_nodes_for_namespace`
+/// (utils.js). Walks INTO block bodies (`{#if}` / `{#each}` / `{#await}` /
+/// `{#key}` fragments) but NOT into element children, checking each
+/// `RegularElement` / `SvelteElement`'s static namespace. Runs ONLY for
+/// namespace-resetting parents (Root / Fragment / Component / SnippetBlock /
+/// SlotElement) — mirroring upstream `infer_namespace`, which invokes it just
+/// for those parent kinds, not for `{#if}` / `{#each}` block-body fragments
+/// (those keep the shallow direct-child inference; see #1227).
+///
+/// Returns a definitive `svg`/`mathml`/`html` when the walk resolves one, or
+/// `None` (upstream's `'keep'` / `'maybe_html'`) so the caller falls back to the
+/// shallow direct-child inference (`infer_namespace_from_nodes_owned`), exactly
+/// as upstream falls through to its element loop.
+#[derive(Clone, Copy, PartialEq)]
+enum NsCheck {
+    Keep,
+    MaybeHtml,
+    Svg,
+    Mathml,
+    Html,
+}
+
+fn check_ns_element(svg: bool, mathml: bool, ns: &mut NsCheck) {
+    // 写经 upstream `RegularElement` handler in `check_nodes_for_namespace`.
+    if !svg && !mathml {
+        *ns = NsCheck::Html;
+    } else if *ns == NsCheck::Keep {
+        *ns = if svg { NsCheck::Svg } else { NsCheck::Mathml };
+    }
+}
+
+fn check_ns_walk(node: &TemplateNode, ns: &mut NsCheck) {
+    if *ns == NsCheck::Html {
+        return;
+    }
+    match node {
+        TemplateNode::RegularElement(el) => {
+            // Element metadata carries the analysis-resolved namespace; do NOT
+            // recurse into its children (upstream's RegularElement handler never
+            // calls `next()`).
+            check_ns_element(el.metadata.svg, el.metadata.mathml, ns);
+        }
+        // `<svelte:element>` has no statically-resolved svg/mathml metadata in
+        // rsvelte (upstream reads `node.metadata.svg`, which we cannot recover
+        // here). Treat it as INCONCLUSIVE rather than forcing `html`: forcing
+        // html would wrongly flip a fragment whose namespace comes from
+        // `<svelte:options namespace="svg">` (e.g. `<svelte:element this="svg">`
+        // siblings of a real `<svg>`), keeping whitespace upstream removes. A
+        // real `<svg>` / `<div>` RegularElement sibling still drives the verdict;
+        // absent one, the shallow direct-child fallback inherits the parent
+        // namespace — matching upstream's element loop, which skips SvelteElement.
+        TemplateNode::SvelteElement(_) => {}
+        TemplateNode::Text(t) => {
+            // 写经 upstream Text handler: any non-whitespace text is inconclusive
+            // (`maybe_html`), deferring to the shallow direct-child inference.
+            if !is_svelte_whitespace_only(&t.data) {
+                *ns = NsCheck::MaybeHtml;
+            }
+        }
+        TemplateNode::IfBlock(b) => {
+            for n in &b.consequent.nodes {
+                check_ns_walk(n, ns);
+                if *ns == NsCheck::Html {
+                    return;
+                }
+            }
+            if let Some(alt) = &b.alternate {
+                for n in &alt.nodes {
+                    check_ns_walk(n, ns);
+                    if *ns == NsCheck::Html {
+                        return;
+                    }
+                }
+            }
+        }
+        TemplateNode::EachBlock(b) => {
+            for n in &b.body.nodes {
+                check_ns_walk(n, ns);
+                if *ns == NsCheck::Html {
+                    return;
+                }
+            }
+            if let Some(fallback) = &b.fallback {
+                for n in &fallback.nodes {
+                    check_ns_walk(n, ns);
+                    if *ns == NsCheck::Html {
+                        return;
+                    }
+                }
+            }
+        }
+        TemplateNode::AwaitBlock(b) => {
+            for frag in [b.pending.as_ref(), b.then.as_ref(), b.catch.as_ref()]
+                .into_iter()
+                .flatten()
+            {
+                for n in &frag.nodes {
+                    check_ns_walk(n, ns);
+                    if *ns == NsCheck::Html {
+                        return;
+                    }
+                }
+            }
+        }
+        TemplateNode::KeyBlock(b) => {
+            for n in &b.fragment.nodes {
+                check_ns_walk(n, ns);
+                if *ns == NsCheck::Html {
+                    return;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn check_nodes_for_namespace(nodes: &[TemplateNode]) -> NsCheck {
+    let mut ns = NsCheck::Keep;
+    for node in nodes {
+        check_ns_walk(node, &mut ns);
+        if ns == NsCheck::Html {
+            return ns;
+        }
+    }
+    ns
+}
+
+/// Infer a fragment's namespace for a namespace-RESETTING parent (Root /
+/// Fragment / Component / SnippetBlock / SlotElement). Runs the deep
+/// [`check_nodes_for_namespace`] first (which sees svg/html elements nested
+/// inside `{#if}` / `{#each}` blocks); a definitive verdict wins, otherwise
+/// falls back to the shallow direct-child inference. 写经 upstream
+/// `infer_namespace`'s reset-parent branch + element-loop fall-through.
+pub(crate) fn infer_namespace_reset(nodes: &[TemplateNode], parent_namespace: &str) -> String {
+    match check_nodes_for_namespace(nodes) {
+        NsCheck::Svg => "svg".to_string(),
+        NsCheck::Mathml => "mathml".to_string(),
+        NsCheck::Html => "html".to_string(),
+        NsCheck::Keep | NsCheck::MaybeHtml => {
+            infer_namespace_from_nodes_owned(nodes, parent_namespace)
+        }
+    }
+}
+
 pub(crate) fn infer_namespace_from_nodes_owned(
     nodes: &[TemplateNode],
     parent_namespace: &str,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/slot_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/slot_element.rs
@@ -117,7 +117,7 @@ pub fn visit_slot_element<'a>(node: &SlotElement, state: &mut ServerTransformSta
         // SnippetBlock / EachBlock / SvelteComponent / SvelteBoundary / Component /
         // SvelteSelf only), so leading text does NOT get a `<!---->` anchor.
         // `b.thunk(BlockStatement)` → `() => { <body> }`.
-        let body = build_fragment_body(&node.fragment, false, state);
+        let body = build_fragment_body(&node.fragment, false, true, state);
         let params = state.b.params(vec![], None);
         state.b.arrow(params, state.b.body(body), false, false)
     };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
@@ -78,7 +78,7 @@ pub fn visit_snippet_block<'a>(node: &SnippetBlock, state: &mut ServerTransformS
     // Body: render the fragment as a `{ ... }` block, then reuse its statements
     // as the function body.
     // SnippetBlock body IS an `is_text_first` parent (upstream `clean_nodes`).
-    let body_block = super::shared::build_fragment_body(&node.body, true, state);
+    let body_block = super::shared::build_fragment_body(&node.body, true, true, state);
     let fn_body = b.body(body_block);
 
     state.shadowed_names.pop();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_boundary.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_boundary.rs
@@ -245,7 +245,7 @@ fn build_boundary_snippet<'a>(
     }
     let params = b.params(patterns, None);
     // SnippetBlock body IS an `is_text_first` parent.
-    let body_block = super::shared::build_fragment_body(&snippet.body, true, state);
+    let body_block = super::shared::build_fragment_body(&snippet.body, true, true, state);
     let fn_body = state.b.body(body_block);
     state.b.function_declaration(name, params, fn_body, false)
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_element.rs
@@ -128,7 +128,7 @@ pub fn visit_svelte_element<'a>(node: &SvelteDynamicElement, state: &mut ServerT
 
     // -- children -----------------------------------------------------------
     // SvelteElement children are NOT an `is_text_first` parent.
-    let children_body = build_fragment_body(&node.fragment, false, state);
+    let children_body = build_fragment_body(&node.fragment, false, false, state);
     let b = state.b;
     let children_thunk = if children_body.is_empty() {
         None

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_head.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_head.rs
@@ -36,7 +36,7 @@ pub fn visit_svelte_head<'a>(node: &SvelteElement, state: &mut ServerTransformSt
     // visited `b.block([...])` directly as the arrow body, so we splice the
     // fragment statements straight in — no extra `{ }` nesting).
     // SvelteHead body is NOT an `is_text_first` parent.
-    let body_stmts = build_fragment_body(&node.fragment, false, state);
+    let body_stmts = build_fragment_body(&node.fragment, false, false, state);
 
     // `($$renderer) => { <body> }`
     let params = b.params(vec![b.id_pat("$$renderer")], None);


### PR DESCRIPTION
## What

The server whitespace trimmer decides whether a fragment's inter-node whitespace is removable from its inferred namespace (svg/mathml drop whitespace-only text; html keeps a single space). rsvelte inferred that namespace with a **shallow** direct-child scan — only a fragment's immediate `RegularElement` children.

Upstream `infer_namespace` (utils.js), for namespace-resetting parents (Root / Fragment / Component / SnippetBlock / SlotElement), first runs `check_nodes_for_namespace`, which **deep-walks** into `{#if}` / `{#each}` / `{#await}` / `{#key}` block bodies (but not into element children).

## Divergences fixed

- `<svg>…</svg> {#if …}<p>…</p>{/if}` — deep walk finds the `<p>` (html) inside the if → html → trailing space **kept**. Shallow scan saw only `<svg>` → svg → dropped it. (**flowbite-svelte Dropzone**, SSR)
- top-level `{#if}…svg…{/if} {#if}…svg…{/if}` — deep walk finds only svg → svg → inter-block whitespace **removed**. Shallow scan saw no direct element child → inherited html → kept a spurious space. (**layerchart Area**, SSR)

## How

Port `check_nodes_for_namespace`; gate it behind a new `reset_namespace` flag on `build_fragment_body`, true only for reset-parent call sites, false for block bodies / `<svelte:head>` / `<svelte:element>` (upstream keeps those shallow, #1227). `<svelte:element>` is inconclusive in the deep walk (no resolved svg metadata), so `<svelte:options namespace="svg">` + `<svelte:element this="svg">` still resolves svg — guarded by `runtime-runes/svg-attribute-case`.

## Verification

- Corpus: Dropzone + Area SSR now byte-match; **known-failures.server shrinks by 2**, 8071 match, **0 regressions**.
- `cargo test -p rsvelte_core --test ssr --test compiler_fixtures` pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx7swPDFMah8ExRiZhHArN