### PR TITLE
fix(transform): treat an each-item shadowing an outer binding as reactive

### DIFF
--- a/.changeset/fix-each-item-shadow-reactivity.md
+++ b/.changeset/fix-each-item-shadow-reactivity.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): treat an each-item that shadows an outer binding as reactive
+
+A text/attribute interpolation whose expression is an `{#each … as item}` loop
+variable is reactive, so the client codegen must emit a
+`$.template_effect(() => $.set_text(…))` rather than a one-time `nodeValue`
+assignment. When the loop variable shadowed a same-named outer binding
+(`const title = '…'; {#each rows as title}{title}{/each}`),
+`expression_has_reactive_state` resolved the name to the outer (non-reactive)
+constant — the transform-side scope is not switched to the each scope during the
+body walk — and wrongly baked the interpolation as static. Mirror the existing
+`get_literal_value` each-shadow guard: a name matching an enclosing each ITEM is
+always reactive, an each INDEX uses its analyzer-computed reactivity. Fixes the
+flowbite-svelte admin-dashboard CRUD `+page` components (client SSR/CSR).

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -1,6 +1,4 @@
 [
-	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/products/+page.svelte",
-	"flowbite-svelte/src/routes/admin-dashboard/(sidebar)/crud/users/+page.svelte",
 	"layercake/src/lib/LayerCake.svelte",
 	"layerchart/packages/layerchart/src/lib/components/Points.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -4869,6 +4869,24 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
         "Identifier" => {
             // Check if identifier is a reactive binding
             if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+                // An enclosing `{#each … as <item>[, <index>]}` loop variable shadows
+                // any outer binding of the same name; inside the block it is the loop
+                // variable, not the outer constant. `get_binding` below walks
+                // `self.scope`, which is NOT switched to the each scope during the body
+                // transform, so a shadowed name would resolve to the outer (possibly
+                // non-reactive) binding and wrongly report the text as static. Mirror the
+                // `get_literal_value` each-shadow guard: an each ITEM is always reactive
+                // (matching the `BindingKind::EachItem` rule below); an each INDEX uses
+                // its analyzer-computed reactivity. Innermost context wins (rev()).
+                for c in context.state.each_binding_context.iter().rev() {
+                    if c.item_name == name {
+                        return true;
+                    }
+                    if !c.index_name.is_empty() && c.index_name == name {
+                        return c.index_reactive;
+                    }
+                }
+
                 // Check if identifier has a transform registered (e.g., @const, snippet parameter)
                 // Identifiers with transforms are derived values that need reactive tracking,
                 // BUT only if the transform has is_reactive=true.


### PR DESCRIPTION
## What

A text/attribute interpolation whose expression is an `{#each … as item}` loop variable is reactive — the client codegen must emit `$.template_effect(() => $.set_text(…))`, not a one-time `nodeValue` assignment.

When the loop variable **shadowed a same-named outer binding** —
`const title = '…'; {#each rows as title}{title}{/each}` —
`expression_has_reactive_state` resolved the name to the outer (non-reactive) constant (the transform-side scope is not switched to the each scope during the body walk) and wrongly baked the interpolation as static.

## How

Mirror the existing `get_literal_value` each-shadow guard in `has_reactive_state_json`: a name matching an enclosing each **ITEM** is always reactive (matching the `BindingKind::EachItem` rule), an each **INDEX** uses its analyzer-computed reactivity, innermost context winning.

## Verification

- Corpus: flowbite-svelte admin-dashboard CRUD `products` / `users` `+page` components now byte-match; **known-failures.client shrinks by 2**, 8073 match, **0 regressions**.
- `cargo test -p rsvelte_core --test compiler_fixtures --test runtime --test ssr` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx7swPDFMah8ExRiZhHArN