### PR TITLE
fix(transform): client treats binary/template-literal let inits as defined (no `?? ''`)

### DIFF
--- a/.changeset/fix-client-binary-init-is-defined.md
+++ b/.changeset/fix-client-binary-init-is-defined.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): client text interpolation treats binary/template-literal `let` inits as defined (no `?? ''`)
+
+`is_expression_defined` (the client `?? ''` gate for `{expr}` text
+interpolations) only skipped the fallback for a `const` binding whose
+`initial_is_defined` flag was set. That flag is not populated for legacy
+(non-runes) `let` bindings, so `let key = a.charAt(0) + a.slice(1)` — whose
+value is always a string — was emitted as `${key ?? ''}` instead of `${key}`.
+
+Add a binding-type check that mirrors upstream `scope.evaluate`: a Normal
+binding that is never reassigned and whose initializer is a `BinaryExpression`
+or `TemplateLiteral` is a definite string/number/boolean and therefore
+`is_defined`, so no `?? ''` is appended. Reads the recorded init node type
+directly (independent of the unpopulated flag). Deliberately excludes
+`UpdateExpression` (`x++`), which upstream's `evaluate` has no case for and
+thus treats as UNKNOWN — keeping its `?? ''`. Removes
+`svelte-table/example/example6/ContactButtonComponent.svelte` from
+known-failures.client.json.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -7,7 +7,6 @@
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",
-	"svelte-table/example/example6/ContactButtonComponent.svelte",
 	"svelte-table/src/SvelteTable.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -4401,6 +4401,30 @@ fn is_expression_defined_json(json_value: &serde_json::Value, context: &Componen
                     {
                         return true;
                     }
+
+                    // For a Normal binding (any `let`/`var`/`const`) whose
+                    // initializer is a `BinaryExpression` (`a + b`) or a
+                    // `TemplateLiteral` — the only two non-mutable shapes upstream
+                    // `scope.evaluate` types as a definite STRING/NUMBER (never
+                    // null/undefined), so `is_defined` holds and no `?? ''` is
+                    // added. (Notably NOT `UpdateExpression`: upstream's evaluate
+                    // has no case for it, so `x++` falls through to UNKNOWN and
+                    // keeps its `?? ''`.) A primitive result cannot be turned
+                    // nullish by a later in-place mutation, so only reassignment
+                    // (`!reassigned`) can invalidate it. Uses the recorded init
+                    // node TYPE directly rather than the `initial_is_defined`
+                    // flag, which is not populated for legacy (non-runes) `let`
+                    // bindings. Fixes e.g. `let key = a.charAt(0) + a.slice(1)`
+                    // reading bare.
+                    if matches!(binding.kind, BindingKind::Normal)
+                        && !binding.reassigned
+                        && binding
+                            .initial_node_type
+                            .as_deref()
+                            .is_some_and(|t| matches!(t, "BinaryExpression" | "TemplateLiteral"))
+                    {
+                        return true;
+                    }
                 }
             }
             false


### PR DESCRIPTION
## What

`is_expression_defined` — the client gate deciding whether a `{expr}` text interpolation needs a `?? ''` nullish fallback — only skipped the fallback for a `const` binding whose `initial_is_defined` flag was set. That flag is **not populated for legacy (non-runes) `let` bindings**, so:

```svelte
<script>
  export let col;
  let key = col.key.charAt(0).toUpperCase() + col.key.slice(1);
</script>
{key}
```

emitted `${key ?? ''}` instead of `${key}`, even though a `+` of two strings is always a string.

## How

Add a binding-type check that mirrors upstream `scope.evaluate` (`2-analyze/scope.js`): a `Normal` binding that is never reassigned and whose initializer is a **`BinaryExpression`** or **`TemplateLiteral`** evaluates to a definite string/number/boolean → `is_defined` → no `?? ''`. It reads the recorded init node **type** directly, independent of the unpopulated `initial_is_defined` flag.

Deliberately **excludes `UpdateExpression`** (`x++`): upstream's `evaluate` has no case for it, so it falls through to `UNKNOWN` and keeps its `?? ''`. (Confirmed by the `derived-update-server` / `store-increment-decrement` fixtures — an earlier over-broad whitelist regressed them.)

## Corpus impact

Removes `svelte-table/example/example6/ContactButtonComponent.svelte` from `known-failures.client.json` (client symmetric-difference −1). Full corpus verify: **no regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx7swPDFMah8ExRiZhHArN