### PR TITLE
fix(esrap): parenthesize an optional-chain callee of a non-optional call

### DIFF
--- a/.changeset/fix-esrap-chain-callee-parens.md
+++ b/.changeset/fix-esrap-chain-callee-parens.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(esrap): parenthesize an optional-chain callee of a non-optional call
+
+`rsvelte_esrap` printed a `CallExpression` whose callee is a `ChainExpression`
+(an optional member) without wrapping parentheses, so a NON-optional call on an
+optional-chain callee — e.g. a dynamic `<svelte:component this={instruct?.dataComponent} />`
+lowering to `(instruct?.dataComponent)($$renderer, …)` — was mis-printed as
+`instruct?.dataComponent($$renderer, …)`. Those differ semantically (the latter
+short-circuits when `instruct` is nullish) and are not AST-equivalent.
+
+The callee-precedence check (`< 19`) could not catch it because a
+`ChainExpression` has the same precedence (19) as a call. Add esrap's explicit
+`callee.type === 'ChainExpression'` wrap rule so the callee is parenthesized.
+Removes `powertable/app/src/lib/components/PowerTable.svelte` from
+known-failures.server.json.

--- a/compat/corpus/known-failures.server.json
+++ b/compat/corpus/known-failures.server.json
@@ -1,4 +1,3 @@
 [
-	"powertable/app/src/lib/components/PowerTable.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte"
 ]

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2471,7 +2471,19 @@ impl<'opt> Printer<'opt> {
     }
 
     fn call_expression(&mut self, node: &CallExpression, ctx: &mut Context) {
-        self.child_with_parens(&node.callee, 19, ctx);
+        // esrap's `CallExpression|NewExpression` wrap rule: parenthesize the
+        // callee when it is a ChainExpression — otherwise a NON-optional call on
+        // an optional-chain callee (`(a?.b)(c)`) would be mis-printed as the
+        // optional-chain call `a?.b(c)`, which short-circuits differently. The
+        // precedence path (`< 19`) does not catch this because a ChainExpression
+        // has the same precedence (19) as a call.
+        if matches!(unparen(&node.callee), Expression::ChainExpression(_)) {
+            ctx.write("(");
+            self.print_expression(unparen(&node.callee), ctx);
+            ctx.write(")");
+        } else {
+            self.child_with_parens(&node.callee, 19, ctx);
+        }
         if node.optional {
             ctx.write("?.");
         }

--- a/crates/rsvelte_esrap/tests/compat.rs
+++ b/crates/rsvelte_esrap/tests/compat.rs
@@ -23,6 +23,20 @@ fn plain_js() {
     assert_eq!(print_src("const x = 1;", false), "const x = 1;");
 }
 
+/// A NON-optional call whose callee is an optional chain must parenthesize the
+/// callee (`(a?.b)(c)`), otherwise it would be mis-printed as the optional-chain
+/// call `a?.b(c)`, which short-circuits differently. Mirrors esrap's explicit
+/// `node.callee.type === 'ChainExpression'` wrap rule.
+#[test]
+fn non_optional_call_on_chain_callee_parenthesizes() {
+    assert_eq!(
+        print_src("(instruct?.dataComponent)($$renderer);", false),
+        "(instruct?.dataComponent)($$renderer);"
+    );
+    // A genuinely optional call keeps `?.(` and is not over-parenthesized.
+    assert_eq!(print_src("snippet?.(x);", false), "snippet?.(x);");
+}
+
 #[test]
 fn ts_type_annotation() {
     assert_eq!(


### PR DESCRIPTION
## What

`rsvelte_esrap` printed a `CallExpression` whose callee is a `ChainExpression` (an optional member) **without** wrapping parentheses. So a NON-optional call on an optional-chain callee — e.g. a dynamic component:

```svelte
<svelte:component this={instruct?.dataComponent} value={…} />
```

which lowers (SSR) to `(instruct?.dataComponent)($$renderer, {…})`, was mis-printed as:

```js
instruct?.dataComponent($$renderer, {…})
```

These differ **semantically** — the latter short-circuits the *call* when `instruct` is nullish, the former evaluates the member then calls it — so they are not AST-equivalent and fail byte-equality.

## How

The callee-precedence path (`< 19`) can't catch this because a `ChainExpression` has the *same* precedence (19) as a call. Port esrap's explicit `CallExpression|NewExpression` wrap rule (`node.callee.type === 'ChainExpression'`) into `rsvelte_esrap::printer::call_expression`: when the callee is a chain, parenthesize it. A genuinely optional call (`snippet?.(x)`) is unaffected. Added a `compat.rs` round-trip test.

## Corpus impact

Removes `powertable/app/src/lib/components/PowerTable.svelte` from `known-failures.server.json` — the **last server-only** symmetric-difference entry. Full corpus verify: **no regressions**; `rsvelte_esrap` (all suites) + `ssr` + `compatibility_report` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx7swPDFMah8ExRiZhHArN