### PR TITLE
fix(analyze): record $$props references so legacy reactive deps deep-read it

### DIFF
--- a/.changeset/fix-legacy-props-deep-read-dep.md
+++ b/.changeset/fix-legacy-props-deep-read-dep.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyze): record `$$props` references so legacy reactive deps deep-read it
+
+A legacy reactive expression reading `$$props.x` (e.g. an `{#if $$props.class || underline || cursor}` test) omitted the `$.deep_read_state($$sanitized_props)` dependency from its `build_expression` sequence, so it read `($.deep_read_state(underline()), …)` instead of `($.deep_read_state($$sanitized_props), $.deep_read_state(underline()), …)`.
+
+The cause was that Phase 2 never declared a `$$props` binding, so `$$props.x` resolved to nothing and no reference was recorded in the expression metadata. Mirror upstream `2-analyze/index.js`, which declares a synthetic `$$props` `rest_prop` binding in the instance scope (non-runes branch) before the walks. The Phase-3 `build_expression` port already deep-reads a `$$props` reference (mapping it to `$$sanitized_props`); it simply never saw one.
+
+Guard `has_prop_bindings` against the synthetic name so a component with no real props (e.g. a static SVG icon) does not gain a spurious `$$props` parameter — mirroring upstream's `binding.node.name !== '$$props'` checks. `$$restProps` is deliberately left undeclared (its plain-read path already works and binding it would mis-route `$$restProps.x`). Removes `svelte-ux/packages/svelte-ux/src/lib/components/Tooltip.svelte` from known-failures.client.json.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -11,6 +11,5 @@
 	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/Tooltip.svelte",
 	"svelthree/src/lib/components/Object3D.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -447,6 +447,40 @@ pub fn analyze_component(
     // it's safe to call here.
     analysis.instance_has_legacy_patterns = instance_has_legacy_patterns(ast);
 
+    // Legacy mode: declare a synthetic `$$props` binding in the instance scope so
+    // template/script references to it (`$$props.class`) are recorded in
+    // expression metadata. Mirrors upstream `2-analyze/index.js`:
+    // `instance.scope.declare(b.id('$$props'), 'rest_prop', 'synthetic')`, done in
+    // the non-runes branch before the AST walks. Without it, a legacy reactive
+    // expression reading `$$props.class` omits the
+    // `$.deep_read_state($$sanitized_props)` dependency in `build_expression`.
+    //
+    // (`$$restProps` is intentionally NOT declared here: it is already handled by
+    // the existing rest-props path, and binding it would re-route a plain
+    // `$$restProps.x` read through the `$$sanitized_props` rewrite.)
+    if !analysis.runes {
+        use crate::compiler::phases::phase2_analyze::scope::{
+            Binding, BindingKind, DeclarationKind,
+        };
+        let instance_scope = analysis.root.instance_scope_index;
+        if analysis
+            .root
+            .get_binding("$$props", instance_scope)
+            .is_none()
+        {
+            let idx = analysis.root.bindings.len();
+            analysis.root.bindings.push(Binding::with_declaration_kind(
+                "$$props".to_string(),
+                BindingKind::RestProp,
+                DeclarationKind::Synthetic,
+                instance_scope,
+            ));
+            if let Some(scope) = analysis.root.all_scopes.get_mut(instance_scope) {
+                scope.declarations.insert("$$props".to_string(), idx);
+            }
+        }
+    }
+
     // Analyze the template using visitors.
     // Take a pointer to the arena to avoid borrow conflict with &mut ast.
     let arena_ptr = &ast.arena as *const crate::ast::arena::ParseArena;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -822,6 +822,12 @@ fn transform_client_with_visitors(
             b.kind,
             BindingKind::Prop | BindingKind::BindableProp | BindingKind::RestProp
         )
+        // The synthetic `$$props` / `$$restProps` bindings (declared in legacy
+        // mode so `$$props.x` references are recorded) are RestProp but must NOT
+        // themselves force a `$$props` parameter — mirrors upstream's
+        // `binding.node.name !== '$$props'` guards.
+        && b.name != "$$props"
+        && b.name != "$$restProps"
     });
 
     let is_legacy_component_api =


### PR DESCRIPTION
## What

A legacy reactive expression reading `$$props.x` — e.g. the test of `{#if $$props.class || underline || cursor}` — omitted the `$.deep_read_state($$sanitized_props)` dependency from its `build_expression` sequence:

```js
// expected
($.deep_read_state($$sanitized_props), $.deep_read_state(underline()), $.deep_read_state(cursor()), $.untrack(() => …))
// actual (missing the first dep)
($.deep_read_state(underline()), $.deep_read_state(cursor()), $.untrack(() => …))
```

## Why

Phase 2 never declared a `$$props` binding, so `$$props.x` resolved to nothing and **no reference was recorded** in the expression metadata that `build_expression` iterates.

## How

Mirror upstream `2-analyze/index.js`, which declares a synthetic `$$props` `rest_prop` binding in the instance scope (non-runes branch) before the AST walks. The Phase-3 `build_expression` port **already** deep-reads a `$$props` reference (mapping it to `$$sanitized_props`) — it just never saw one.

Guard `has_prop_bindings` against the synthetic name so a props-less component (e.g. a static SVG icon) does not gain a spurious `$$props` parameter — mirroring upstream's `binding.node.name !== '$$props'` checks. `$$restProps` is deliberately left undeclared (its plain-read path already works; binding it would mis-route a plain `$$restProps.x`).

## Corpus impact

Removes `svelte-ux/…/Tooltip.svelte` from `known-failures.client.json` (client symmetric-difference −1). Full corpus verify: **no regressions**; `compatibility_report` + `runtime` (legacy) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx7swPDFMah8ExRiZhHArN