### PR TITLE
fix(transform): propagate inferred namespace into nested component slots

### DIFF
--- a/.changeset/fix-client-slot-namespace-cascade.md
+++ b/.changeset/fix-client-slot-namespace-cascade.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): propagate inferred namespace into nested component slots
+
+When lowering a component's slot content, the client computed the slot fragment's inferred namespace (used for whitespace trimming) but never stored it on the child state's `metadata.namespace`. So a namespace inferred from an `<svg>` deep in one component's slot did not cascade to a nested component's slot whose own children are namespace-inconclusive (only text + components).
+
+For `<Card>…<svg/></Card>` with a `<CardDescription>418.2K Visitors <Badge/></CardDescription>` inside, upstream infers `svg` for the `Card` slot and inherits it down (`infer_namespace`'s `new_namespace ?? namespace` fallback) so the `CardDescription` fragment is also `svg`. rsvelte kept `html`, building `$.from_html` with untrimmed SVG whitespace and mismatched `$.sibling` offsets.
+
+Set `state.metadata.namespace` to the inferred namespace while visiting slot children (save/restore around it), mirroring upstream `Fragment.js`, which puts the inferred `namespace` on the new child `state.metadata`. Removes `shadcn-svelte/…/cards/analytics-card.svelte` from known-failures.client.json.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -2,7 +2,6 @@
 	"layercake/src/lib/LayerCake.svelte",
 	"layerchart/packages/layerchart/src/lib/components/Points.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
-	"shadcn-svelte/docs/src/routes/(app)/(layout)/(root)/cards/analytics-card.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -2291,6 +2291,18 @@ fn visit_slot_children(
         );
     let saved_memoizer = std::mem::replace(&mut context.state.memoizer, new_memoizer);
 
+    // Propagate the slot fragment's inferred namespace to the child state so a
+    // NESTED component slot (whose own children are namespace-inconclusive, e.g.
+    // only text + components) inherits it via `infer_namespace`'s
+    // `new_namespace ?? namespace` fallback. Mirrors upstream `Fragment.js`,
+    // which puts the inferred `namespace` on the new child `state.metadata`.
+    // Without this an `<svg>` sibling deep inside one component's slot never
+    // cascades down to a nested component's slot (e.g. `<Card>…<svg/></Card>`
+    // making a `<CardDescription>` fragment `svg`), so it wrongly built a
+    // `$.from_html` template with untrimmed SVG whitespace.
+    let saved_namespace = context.state.metadata.namespace.clone();
+    context.state.metadata.namespace = inferred_ns.to_string();
+
     // Reset template for slot content
     context.state.template =
         crate::compiler::phases::phase3_transform::client::transform_template::Template::new();
@@ -2783,6 +2795,7 @@ fn visit_slot_children(
     context.state.template = saved_template;
     context.state.node = saved_node;
     context.state.is_standalone = saved_is_standalone;
+    context.state.metadata.namespace = saved_namespace;
 
     result
 }


### PR DESCRIPTION
## What

When lowering a component's slot content, the client computed the slot fragment's inferred namespace (used for whitespace trimming) but **never stored it on the child state's `metadata.namespace`**. So a namespace inferred from an `<svg>` deep in one component's slot did not cascade to a **nested** component's slot whose own children are namespace-inconclusive (only text + components).

```svelte
<Card>
  <CardHeader>
    <CardDescription>418.2K Visitors <Badge>+10%</Badge></CardDescription>
  </CardHeader>
  <svg …>…</svg>   <!-- direct child of Card -->
</Card>
```

Upstream infers `svg` for the `Card` slot (its `<svg>` child) and inherits it down (`infer_namespace`'s `new_namespace ?? namespace` fallback), so the `CardDescription` fragment is also `svg`. rsvelte kept `html` → built `$.from_html` with **untrimmed** SVG whitespace (`<!> <!> <!>` vs `<!><!><!>`) and mismatched `$.sibling(node, 2)` offsets.

## How

Set `state.metadata.namespace` to the inferred namespace while visiting slot children (save/restore around it), mirroring upstream `Fragment.js`, which puts the inferred `namespace` on the new child `state.metadata`.

## Corpus impact

Removes `shadcn-svelte/…/cards/analytics-card.svelte` from `known-failures.client.json` (client symmetric-difference −1). Full corpus verify: **no regressions**; `ssr` + `compatibility_report` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx7swPDFMah8ExRiZhHArN