### PR TITLE
fix(transform): keep a brace-less control-flow body with its $: header

### DIFF
--- a/.changeset/fix-braceless-control-header-split.md
+++ b/.changeset/fix-braceless-control-header-split.md
@@ -1,0 +1,26 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): keep a brace-less control-flow body with its `$:` header
+
+The legacy instance-script statement splitter treated a depth-0 newline after a
+brace-less control-flow header (`$: if (cond)`, `else`, `for (...)`, `while (...)`,
+`do`) as a statement boundary. So
+
+```svelte
+$: if (object3d)
+	if$_instance_change(object3d, …)
+```
+
+split the body off as a separate top-level statement: rsvelte emitted the call
+eagerly and unguarded at component setup, and lowered the header to an empty
+reactive effect (`if (object3d());`) instead of
+`$.legacy_pre_effect(…, () => { if (object3d()) if$_instance_change(…); })`.
+
+Treat a statement whose accumulated text ends with a brace-less control header as
+incomplete (like a trailing binary operator), so its following body statement is
+accumulated with it. Add `ends_with_braceless_control_header` (word-boundary
+keyword match + backward paren match) to `expression_utils`, applied in both the
+line-accumulation boundary check and `find_statement_end_client`. Removes
+`svelthree/src/lib/components/Object3D.svelte` from known-failures.client.json.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -9,6 +9,5 @@
 	"svelte-table/src/SvelteTable.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
-	"svelthree/src/lib/components/Object3D.svelte"
+	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte"
 ]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -239,6 +239,65 @@ pub(super) fn needs_compound_assignment_parens(expr: &str, _op: &str) -> bool {
 }
 
 /// Find the end of a statement value for client-side transformations.
+/// True if `s` ends with the identifier `kw` on a word boundary (the char before
+/// `kw` is not an identifier char), so `else`/`if` match but `notif` / `myelse`
+/// do not.
+fn ends_with_keyword(s: &str, kw: &str) -> bool {
+    let Some(before) = s.strip_suffix(kw) else {
+        return false;
+    };
+    match before.chars().next_back() {
+        Some(c) => !(c.is_alphanumeric() || c == '_' || c == '$'),
+        None => true,
+    }
+}
+
+/// Given text ending in `)`, return the byte index of the matching `(` (scanning
+/// backward, string-unaware — adequate for the control-header check where the
+/// header parens contain no unbalanced-paren string literals in practice).
+fn matching_open_paren(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    if bytes.last() != Some(&b')') {
+        return None;
+    }
+    let mut depth = 0i32;
+    let mut i = bytes.len();
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b')' => depth += 1,
+            b'(' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// True if `prefix` ends with a brace-less control-flow header whose body is the
+/// following statement — `if (cond)`, `for (...)`, `while (...)`, `switch (...)`,
+/// `catch (...)`, or the bare keywords `else` / `do`. Used so a depth-0 newline
+/// after such a header does not prematurely end the statement.
+pub(super) fn ends_with_braceless_control_header(prefix: &str) -> bool {
+    let t = prefix.trim_end();
+    if ends_with_keyword(t, "else") || ends_with_keyword(t, "do") {
+        return true;
+    }
+    if t.ends_with(')')
+        && let Some(open) = matching_open_paren(t)
+    {
+        let before = t[..open].trim_end();
+        return ["if", "for", "while", "switch", "catch"]
+            .iter()
+            .any(|kw| ends_with_keyword(before, kw));
+    }
+    false
+}
+
 pub(super) fn find_statement_end_client(s: &str) -> usize {
     let mut depth = 0;
     let mut in_string = false;
@@ -316,6 +375,13 @@ pub(super) fn find_statement_end_client(s: &str) -> usize {
                             | '`'
                     ) {
                         // continuation; keep scanning
+                    } else if ends_with_braceless_control_header(&s[..byte_pos]) {
+                        // A brace-less control-flow header (`if (cond)`, `else`,
+                        // `for (...)`, `while (...)`, `do`) takes the following
+                        // statement as its body — JS does not insert a semicolon
+                        // after it. Keep scanning so `$: if (cond)\n  stmt` stays a
+                        // single statement rather than splitting `stmt` off into a
+                        // separate top-level (unguarded) statement.
                     } else {
                         return byte_pos;
                     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5483,7 +5483,21 @@ fn transform_instance_script_for_visitors(
                     || (t.ends_with('+') && !t.ends_with("++"))
             };
 
-            if !trailing_comma && !trailing_operator {
+            // A brace-less control-flow header (`$: if (cond)`, `else`, `for(...)`,
+            // `while(...)`, `do`) whose body is on the FOLLOWING line is not yet a
+            // complete statement — its body statement must be accumulated with it.
+            // Otherwise `$: if (cond)\n\tstmt` splits `stmt` off as a separate
+            // top-level statement, dropping the guard and the reactive wrapper.
+            let ends_with_control_header = {
+                let mut acc = accumulated_lines[..accumulated_lines.len() - 1].join("\n");
+                if !acc.is_empty() {
+                    acc.push('\n');
+                }
+                acc.push_str(trimmed);
+                expression_utils::ends_with_braceless_control_header(&acc)
+            };
+
+            if !trailing_comma && !trailing_operator && !ends_with_control_header {
                 // Before processing, check if the next non-empty line starts with a
                 // continuation token (`.` for method chains, `?`, `:`, `&&`, `||`,
                 // `??` for ternary/logical continuation). Example:


### PR DESCRIPTION
## What

The legacy instance-script statement splitter treated a depth-0 newline after a **brace-less** control-flow header (`$: if (cond)`, `else`, `for (...)`, `while (...)`, `do`) as a statement boundary. So:

```svelte
$: if (object3d)
	if$_instance_change(object3d, …)
```

split the body off as a **separate top-level statement** — rsvelte emitted the call eagerly and **unguarded** at component setup, and lowered the header to an empty reactive effect (`if (object3d());`) instead of:

```js
$.legacy_pre_effect(…, () => {
	if (object3d()) if$_instance_change(object3d(), …);
});
```

## How

Treat a statement whose accumulated text ends with a brace-less control header as **incomplete** (like a trailing binary operator), so its following body statement is accumulated with it. Add `ends_with_braceless_control_header` (word-boundary keyword match + backward paren match) to `expression_utils`, applied in both the line-accumulation boundary check and `find_statement_end_client`.

## Corpus impact

Removes `svelthree/src/lib/components/Object3D.svelte` from `known-failures.client.json` (client symmetric-difference −1). Full corpus verify: **no regressions**; `compatibility_report` + `runtime` (legacy) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx7swPDFMah8ExRiZhHArN