### PR TITLE
fix(transform): each item shadows an outer same-named prop getter

### DIFF
--- a/.changeset/fix-each-item-shadows-prop-getter.md
+++ b/.changeset/fix-each-item-shadows-prop-getter.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): each item shadows an outer same-named prop getter
+
+A non-reactive `{#each}` item that is a simple identifier is bound as the render
+arrow's parameter, so it fully shadows any outer binding of the same name. But
+the client only *inserted* a transform for the item when it was reactive — a
+non-reactive item left a stale outer transform in place. When the shadowed name
+was a runes prop (transform `position → position()`), a body reference or
+`{@const}` wrongly called the prop getter:
+
+```svelte
+{#each positions as position}
+  {@const [y, x] = position.split('-')}   <!-- was position().split('-') -->
+{/each}
+```
+
+Remove any outer transform for the item name in the non-reactive branch too,
+mirroring upstream where the each-item binding shadows the outer scope.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -1047,6 +1047,14 @@ fn build_declarations(
                     replacement_id: None,
                 },
             );
+        } else {
+            // A non-reactive each item is the bare arrow parameter, so it fully
+            // shadows any outer same-named binding. Drop a stale outer transform
+            // (e.g. a runes prop getter `position → position()`) so a body
+            // reference / `{@const}` reads the item bare instead of calling the
+            // shadowed prop. e.g. `{#each positions as position}{@const [y, x] =
+            // position.split('-')}`.
+            context.state.transform.remove(name);
         }
         // Each item is not a template-kind binding in legacy reactivity;
         // ensure any outer same-named deep_read marker is shadowed.


### PR DESCRIPTION
## What

A non-reactive `{#each}` item that is a simple identifier is bound as the render arrow's **parameter**, so it fully shadows any outer binding of the same name. But the client only *inserted* a transform for the item when it was **reactive** — a non-reactive item left a stale outer transform in place. When the shadowed name was a runes prop (transform `position → position()`), a body reference or `{@const}` wrongly called the prop getter:

```svelte
{#each positions as position}
  {@const [y, x] = position.split('-')}   <!-- rsvelte emitted position().split('-') -->
{/each}
```

## How

Remove any outer transform for the item name in the non-reactive branch too (previously only `transform_deep_read` was cleared), mirroring upstream where the each-item binding shadows the outer scope.

## Corpus impact

Fixes the JS output of `svelte-sonner/src/lib/Toaster.svelte` (`position().split(...)` → `position.split(...)`); that entry remains a known-failure on a separate, unrelated CSS unused-selector-pruning divergence, so the baseline is unchanged. Full corpus verify: **no regressions** (js-mismatch 11 → 10); `compatibility_report` + `runtime` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx7swPDFMah8ExRiZhHArN