### PR TITLE
fix(formatter): preserve inline control-flow prefixes

### DIFF
--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -1762,7 +1762,8 @@ fn collect_break_block_non_ws_prefix(
                 let line_start = out[..s].rfind('\n').map_or(0, |i| i + 1);
                 let indent = out.get(line_start..s).unwrap_or("");
                 let non_ws = !indent.bytes().all(|b| b == b' ' || b == b'\t');
-                if non_ws && indent.ends_with('>') && is_block_display(e.name.as_str()) {
+                let is_simple_gt_prefix = non_ws && indent.trim_start_matches([' ', '\t']) == ">";
+                if is_simple_gt_prefix && is_block_display(e.name.as_str()) {
                     // Extract the whitespace-only portion of the prefix.
                     let ws_indent: &str = {
                         let trim_pos = indent.rfind([' ', '\t']).map_or(0, |i| i + 1);

--- a/crates/rsvelte_formatter/tests/markup_wrap.rs
+++ b/crates/rsvelte_formatter/tests/markup_wrap.rs
@@ -60,6 +60,16 @@ fn nested_element_uses_deeper_indent_when_wrapped() {
 }
 
 #[test]
+fn inline_else_prefix_is_not_reused_as_indentation() {
+    let src = r#"{#if found}<div>Found</div>{:else}<section class="mx-auto max-w-3xl px-4 py-20 text-center"><h1 class="text-3xl font-bold">Stage not found</h1></section>{/if}"#;
+    let out = fmt_at_width(src, 80);
+
+    rsvelte_core::parse(&out, rsvelte_core::ParseOptions::default())
+        .expect("formatted output should remain valid Svelte");
+    assert_eq!(fmt_at_width(&out, 80), out, "formatting must be idempotent");
+}
+
+#[test]
 fn empty_open_tag_stays_inline_even_with_short_width() {
     // No attributes — never wrap.
     let out = fmt_at_width("<div></div>", 10);


### PR DESCRIPTION
## Summary

- restrict the non-whitespace-prefix collapse pass to its intended `^[\t ]*>$` shape
- prevent inline control-flow and parent markup from being reused as indentation
- add a regression asserting valid, idempotent output for the minimized inline `{:else}` case

## Root cause

`collect_break_block_non_ws_prefix` is intended for block elements immediately following a hugged parent delimiter such as `  >`. Its previous `indent.ends_with('>')` check also accepted arbitrary one-line markup ending in `>`. The whitespace extraction then copied that entire prefix around a nested block element, producing invalid Svelte.

## Validation

- `cargo test -p rsvelte_formatter`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`

## AI usage

Codex was used to help investigate the failure, prepare the fix and regression test, and draft this PR. The submitted changes and test results were reviewed by the contributor.
