### PR TITLE
fix(svelte-check): UTF-8-safe JSONC strip, path-escape guard, OsStr tsconfig arg

### DIFF
--- a/.changeset/fix-svelte-check-robustness.md
+++ b/.changeset/fix-svelte-check-robustness.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): preserve non-ASCII tsconfig content, contain overlay emit paths, accept non-UTF-8 tsconfig paths
+
+`strip_jsonc_comments` rebuilt retained bytes with `out.push(c as char)`, mangling
+multi-byte UTF-8 in tsconfig values. It now accumulates raw bytes and converts once
+at the end. Overlay emit-path joins are routed through a `safe_relative()` helper so
+a source outside the workspace can no longer produce an absolute join target outside
+the cache dir, and `run_tsgo` passes the tsconfig path as `OsStr` instead of
+panicking on non-UTF-8 paths.

--- a/crates/rsvelte_core/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_core/src/svelte_check/overlay.rs
@@ -182,10 +182,7 @@ pub fn materialize_overlay_with(
 
     let mut entries = Vec::with_capacity(files.len());
     for abs_source in &abs_files {
-        let rel = abs_source
-            .strip_prefix(workspace)
-            .unwrap_or(abs_source)
-            .to_path_buf();
+        let rel = safe_relative(abs_source, workspace);
         let tsx_rel = append_extension(&rel, ".tsx");
         let dts_rel = append_extension(&rel, ".d.ts");
         let tsx_path = emit_dir.join(&tsx_rel);
@@ -469,9 +466,9 @@ fn emit_external_shadows(pkg: &ExternalPackage) -> Result<(), OverlayError> {
         let _ = symlink_dir(&real_nm, &mirror_nm);
     }
     for abs_source in &pkg.svelte_files {
-        let rel = abs_source.strip_prefix(&pkg.real_dir).unwrap_or(abs_source);
-        let tsx_path = pkg.mirror_dir.join(append_extension(rel, ".tsx"));
-        let dts_path = pkg.mirror_dir.join(append_extension(rel, ".d.ts"));
+        let rel = safe_relative(abs_source, &pkg.real_dir);
+        let tsx_path = pkg.mirror_dir.join(append_extension(&rel, ".tsx"));
+        let dts_path = pkg.mirror_dir.join(append_extension(&rel, ".d.ts"));
         if let Some(parent) = tsx_path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -530,7 +527,7 @@ fn materialize_kit_files(
         } else {
             workspace.join(source)
         };
-        let rel = abs.strip_prefix(workspace).unwrap_or(&abs).to_path_buf();
+        let rel = safe_relative(&abs, workspace);
         let out_path = emit_dir.join(&rel);
         if let Some(parent) = out_path.parent() {
             fs::create_dir_all(parent)?;
@@ -690,6 +687,32 @@ fn append_extension(rel: &Path, extra: &str) -> PathBuf {
     let mut s = rel.as_os_str().to_owned();
     s.push(extra);
     PathBuf::from(s)
+}
+
+/// Rebase `abs` under `base` for use as an emit path, guaranteeing the
+/// result can never escape a subsequent `emit_dir.join(..)`. A plain
+/// `strip_prefix(base).unwrap_or(abs)` returns the *absolute* input when
+/// `abs` is not under `base`, and `Path::join` discards its left operand
+/// on an absolute right operand — so the overlay would write outside its
+/// cache directory. Here we fall back to the bare file name (always
+/// contained) and reject any `..` / root component that survived.
+fn safe_relative(abs: &Path, base: &Path) -> PathBuf {
+    if let Ok(rel) = abs.strip_prefix(base) {
+        let escapes = rel.components().any(|c| {
+            matches!(
+                c,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        });
+        if !rel.as_os_str().is_empty() && !escapes {
+            return rel.to_path_buf();
+        }
+    }
+    abs.file_name()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("__unnamed"))
 }
 
 /// Quick lexical sniff for `<script lang="ts">` so the v0.2 overlay can
@@ -1077,7 +1100,11 @@ fn relative_lexical(from_dir: &Path, to_path: &Path) -> String {
 /// canonically JSONC, but `serde_json` only accepts strict JSON.
 /// Tracks string state so that `"// not a comment"` survives.
 fn strip_jsonc_comments(src: &str) -> String {
-    let mut out = String::with_capacity(src.len());
+    // Scan raw bytes but copy them through verbatim (never `c as char`,
+    // which would mangle any multi-byte UTF-8 sequence). Comment markers
+    // are all ASCII, so byte-level detection is exact; non-ASCII bytes only
+    // ever appear inside string literals or values and pass through intact.
+    let mut out: Vec<u8> = Vec::with_capacity(src.len());
     let bytes = src.as_bytes();
     let mut i = 0;
     let mut in_string = false;
@@ -1085,7 +1112,7 @@ fn strip_jsonc_comments(src: &str) -> String {
     while i < bytes.len() {
         let c = bytes[i];
         if in_string {
-            out.push(c as char);
+            out.push(c);
             if escape {
                 escape = false;
             } else if c == b'\\' {
@@ -1098,7 +1125,7 @@ fn strip_jsonc_comments(src: &str) -> String {
         }
         if c == b'"' {
             in_string = true;
-            out.push(c as char);
+            out.push(c);
             i += 1;
             continue;
         }
@@ -1123,10 +1150,12 @@ fn strip_jsonc_comments(src: &str) -> String {
                 _ => {}
             }
         }
-        out.push(c as char);
+        out.push(c);
         i += 1;
     }
-    out
+    // Every retained byte came unaltered from a valid UTF-8 `&str`, and we
+    // only ever drop whole ASCII comment spans, so the result stays UTF-8.
+    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
 
 /// Resolve a tsconfig's effective `rootDirs` to absolute paths, following
@@ -1448,6 +1477,30 @@ mod tests {
     use super::*;
     use std::fs;
     use std::io::Write;
+
+    #[test]
+    fn strip_jsonc_comments_preserves_non_ascii() {
+        // A tsconfig with a multi-byte UTF-8 comment and a multi-byte value.
+        // The comment is dropped whole; the string value survives verbatim.
+        let src = "{\n  // コメント — dropped\n  \"paths\": { \"@app/*\": [\"./ソース/*\"] } /* ブロック */\n}\n";
+        let out = strip_jsonc_comments(src);
+        assert!(out.is_char_boundary(out.len()));
+        assert!(
+            out.contains("./ソース/*"),
+            "non-ASCII string value must survive intact: {out}"
+        );
+        assert!(
+            !out.contains("コメント"),
+            "line comment must be stripped: {out}"
+        );
+        assert!(
+            !out.contains("ブロック"),
+            "block comment must be stripped: {out}"
+        );
+        // Result must be valid JSON once comments are gone.
+        let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid JSON after strip");
+        assert_eq!(parsed["paths"]["@app/*"][0], "./ソース/*");
+    }
 
     #[test]
     fn rewrites_kit_types_route_imports_to_colocated_mirror() {

--- a/crates/rsvelte_core/src/svelte_check/tsgo.rs
+++ b/crates/rsvelte_core/src/svelte_check/tsgo.rs
@@ -146,15 +146,11 @@ pub fn run_tsgo(
 ) -> Result<Vec<RawTsDiagnostic>, TsgoError> {
     let mut cmd = Command::new(&binary.program);
     cmd.args(&binary.args_prefix);
-    cmd.args([
-        "-p",
-        tsconfig_path
-            .to_str()
-            .expect("overlay tsconfig path must be UTF-8"),
-        "--pretty",
-        "false",
-        "--noErrorTruncation",
-    ]);
+    // Pass the tsconfig path as an `OsStr` so a non-UTF-8 path survives
+    // verbatim instead of panicking in `to_str().expect(..)`.
+    cmd.arg("-p");
+    cmd.arg(tsconfig_path);
+    cmd.args(["--pretty", "false", "--noErrorTruncation"]);
     cmd.current_dir(cwd);
     let output = cmd.output().map_err(TsgoError::Spawn)?;
     let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Summary

Correctness/robustness fixes in the `svelte-check` overlay + tsgo driver (from findings-05 review). No compiler/svelte2tsx output changes.

- **P1-1** — `strip_jsonc_comments` (overlay.rs) scanned raw bytes but wrote them back with `out.push(c as char)`, corrupting any multi-byte UTF-8 sequence in a tsconfig's comments/values. It now accumulates raw bytes and rebuilds a `String`, dropping only whole ASCII comment spans. Added a non-ASCII round-trip unit test (`strip_jsonc_comments_preserves_non_ascii`).
- **P2-1** — Three overlay emit-path joins used `strip_prefix(base).unwrap_or(abs)`, which returns the *absolute* input when a source is outside the base; `Path::join` then discards `emit_dir`, letting the overlay write outside its cache dir. Added `safe_relative()` (falls back to the bare file name, rejects `..`/root components) and routed all three sites through it.
- **P3-1** — `run_tsgo` passed the overlay tsconfig path via `to_str().expect(..)`, panicking on a non-UTF-8 path. It's now passed as an `OsStr` (`cmd.arg(tsconfig_path)`).

## Testing

- `cargo test -p rsvelte_core --lib svelte_check` — 77 passed (incl. the new test).
- `cargo build -p rsvelte_core`, `cargo fmt --check` clean. Own files are clippy-clean (a pre-existing unrelated `collapsible_if` lint in `server/ast/visitors/shared.rs`, identical on main, is left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj