### PR TITLE
fix: NAPI envelope bounds checks + svelte-check signal exit

### DIFF
--- a/.changeset/fix-npm-envelope-and-signal.md
+++ b/.changeset/fix-npm-envelope-and-signal.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix: add NAPI envelope bounds checks and propagate signal death as non-zero exit
+
+`parse-envelope.js` now applies the same window bounds checks as `envelope.js`
+(M-012), so a malformed or version-skewed envelope throws instead of silently
+decoding a truncated AST. The svelte-check launcher now maps a signal-killed
+native binary to a non-zero exit code (128 + signal) instead of reporting 0,
+matching the fmt launcher.

--- a/apps/npm/svelte-check/bin/svelte-check.cjs
+++ b/apps/npm/svelte-check/bin/svelte-check.cjs
@@ -82,4 +82,14 @@ if (result.error) {
 	console.error(`[@rsvelte/svelte-check] Failed to exec ${binPath}: ${result.error.message}`);
 	process.exit(1);
 }
+
+// If the native binary was killed by a signal (e.g. SIGABRT from a Rust
+// panic), `result.status` is null and `result.signal` holds the signal name.
+// Returning `status ?? 0` would mask the crash as a clean exit 0; propagate
+// signal terminations as the conventional 128 + signal-number exit code.
+if (result.signal) {
+	const signum = require('node:os').constants.signals[result.signal];
+	console.error(`[@rsvelte/svelte-check] ${binPath} was terminated by ${result.signal}.`);
+	process.exit(typeof signum === 'number' ? 128 + signum : 1);
+}
 process.exit(result.status ?? 0);

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -255,10 +255,34 @@ function readU32(ctx) {
 function readBool(ctx) {
 	return readU8(ctx) !== 0;
 }
+
+/**
+ * Validate that the byte window `[start, start + len)` lies fully inside
+ * `ctx.bytes`. The encoder writes lengths as u32s the decoder otherwise
+ * trusts blindly — `Buffer.toString` / `Uint8Array.subarray` silently
+ * *clamp* an out-of-range window, so a malformed envelope would decode to
+ * truncated/misaligned data instead of failing loudly. Throw instead
+ * (mirrors envelope.js's `assertWindow`, M-012).
+ *
+ * @param {object} ctx
+ * @param {number} start
+ * @param {number} len
+ * @param {string} label
+ */
+function assertWindow(ctx, start, len, label) {
+	if (start < 0 || len < 0 || start + len > ctx.bytes.byteLength) {
+		throw new EnvelopeError(
+			`parse envelope: ${label} out of bounds ` +
+				`(offset ${start} + length ${len} exceeds buffer of ${ctx.bytes.byteLength} bytes)`,
+		);
+	}
+}
+
 function readStr(ctx) {
 	const len = readU32(ctx);
 	const start = ctx.pos;
 	const end = start + len;
+	assertWindow(ctx, start, len, 'string');
 	ctx.pos = end;
 	// Branch is monomorphic per envelope: V8 specialises after warmup.
 	return ctx.isBuffer
@@ -289,6 +313,7 @@ function readInlineJson(ctx) {
 	const len = readU32(ctx);
 	const start = ctx.pos;
 	const end = start + len;
+	assertWindow(ctx, start, len, 'inline JSON');
 	ctx.pos = end;
 	if (len === 0) return null;
 	return JSON.parse(

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"stage-vps-native": "node scripts/release/stage-vps-binaries.mjs",
 		"publish-platform-binaries": "node scripts/release/publish-platform-binaries.mjs",
 		"test:envelope": "node scripts/dev/test-envelope-validation.mjs",
+		"test:parse-envelope": "node scripts/dev/test-parse-envelope-validation.mjs",
 		"test:vps-shim": "node scripts/dev/test-vps-shim.mjs",
 		"test:vps-fixture": "node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:vps": "node scripts/dev/test-vps-shim.mjs && node scripts/dev/test-vps-vite-fixture.mjs",

--- a/scripts/dev/test-parse-envelope-validation.mjs
+++ b/scripts/dev/test-parse-envelope-validation.mjs
@@ -1,0 +1,186 @@
+// Regression test for the parse-envelope decoder's bounds validation
+// (M-012, same class of check as scripts/dev/test-envelope-validation.mjs
+// for the compile envelope).
+//
+// Hand-crafts a minimal valid parse envelope (a single TAG_JSON root node,
+// see `napi_raw_parse.rs` for the wire format) plus deliberately-corrupted
+// variants, and asserts that `decodeParseEnvelope` throws on out-of-range
+// string/JSON windows instead of silently truncating.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '../..');
+const { decodeParseEnvelope } = await import(
+	`file://${join(repoRoot, 'apps/npm/vite-plugin-svelte-native/parse-envelope.js')}`
+).then((m) => m.default ?? m);
+
+const MAGIC = 0x3156_5052; // "RPV1"
+const VERSION = 1;
+const HEADER_LEN = 24;
+const TAG_JSON = 0x00;
+const JS_IDENTIFIER = 0x80;
+const FLAG_JSNODE_NO_LOC = 1 << 0;
+
+let failures = 0;
+function ok(label) {
+	console.log(`  ✓ ${label}`);
+}
+function fail(label, detail) {
+	failures++;
+	console.error(`  ✗ ${label}${detail ? ` — ${detail}` : ''}`);
+}
+function expectThrow(label, fn, matcher) {
+	let threw = null;
+	try {
+		fn();
+	} catch (e) {
+		threw = e;
+	}
+	if (!threw) return fail(label, 'expected a throw, got none');
+	if (matcher && !matcher.test(threw.message)) {
+		return fail(label, `message ${JSON.stringify(threw.message)} !~ ${matcher}`);
+	}
+	ok(label);
+}
+function expectNoThrow(label, fn) {
+	try {
+		const v = fn();
+		ok(label);
+		return v;
+	} catch (e) {
+		fail(label, e.message);
+		return null;
+	}
+}
+function assertEq(label, a, b) {
+	if (a === b) ok(label);
+	else fail(label, `${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+}
+
+// Build a minimal v1 parse envelope: header + one TAG_JSON root node whose
+// payload is a length-prefixed JSON string. `over` scribbles raw values over
+// (otherwise-correct) byte offsets to simulate corruption.
+function buildParseEnvelope(json, over = {}) {
+	const jsonBytes = Buffer.from(json, 'utf8');
+	const rootOffset = HEADER_LEN;
+	// root node: tag(1) + start(4) + end(4) + jsonLen(4) + jsonBytes
+	const nodeLen = 1 + 4 + 4 + 4 + jsonBytes.length;
+	const total = HEADER_LEN + nodeLen;
+
+	const buf = Buffer.alloc(total);
+	buf.writeUInt32LE(MAGIC, 0);
+	buf.writeUInt32LE(VERSION, 4);
+	buf.writeUInt32LE(total, 8);
+	buf.writeUInt32LE(rootOffset, 12);
+	buf.writeUInt32LE(0, 16); // source_len — unused by the decoder
+	buf.writeUInt32LE(0, 20); // flags
+
+	let p = rootOffset;
+	buf.writeUInt8(TAG_JSON, p);
+	p += 1;
+	buf.writeUInt32LE(0, p); // start
+	p += 4;
+	buf.writeUInt32LE(0, p); // end
+	p += 4;
+	buf.writeUInt32LE(jsonBytes.length, p); // json len
+	p += 4;
+	jsonBytes.copy(buf, p);
+
+	for (const [offset, value] of Object.entries(over)) {
+		buf.writeUInt32LE(value >>> 0, Number(offset));
+	}
+	return buf;
+}
+
+// Build a minimal v1 envelope whose root is a JS_IDENTIFIER node (exercises
+// `readStr`, as opposed to `buildParseEnvelope`'s TAG_JSON which exercises
+// `readInlineJson`). `FLAG_JSNODE_NO_LOC` is set so `readTypedLoc` is a no-op.
+function buildIdentifierEnvelope(name, over = {}) {
+	const nameBytes = Buffer.from(name, 'utf8');
+	const rootOffset = HEADER_LEN;
+	// node: tag(1) + start(4) + end(4) + nameLen(4) + nameBytes + typeAnnotationFlag(1)
+	const nodeLen = 1 + 4 + 4 + 4 + nameBytes.length + 1;
+	const total = HEADER_LEN + nodeLen;
+
+	const buf = Buffer.alloc(total);
+	buf.writeUInt32LE(MAGIC, 0);
+	buf.writeUInt32LE(VERSION, 4);
+	buf.writeUInt32LE(total, 8);
+	buf.writeUInt32LE(rootOffset, 12);
+	buf.writeUInt32LE(0, 16); // source_len
+	buf.writeUInt32LE(FLAG_JSNODE_NO_LOC, 20);
+
+	let p = rootOffset;
+	buf.writeUInt8(JS_IDENTIFIER, p);
+	p += 1;
+	buf.writeUInt32LE(0, p); // start
+	p += 4;
+	buf.writeUInt32LE(0, p); // end
+	p += 4;
+	buf.writeUInt32LE(nameBytes.length, p); // name len
+	p += 4;
+	nameBytes.copy(buf, p);
+	p += nameBytes.length;
+	buf.writeUInt8(0, p); // no typeAnnotation
+
+	for (const [offset, value] of Object.entries(over)) {
+		buf.writeUInt32LE(value >>> 0, Number(offset));
+	}
+	return buf;
+}
+
+console.log('=== parse-envelope decoder bounds validation (M-012) ===\n');
+
+console.log('valid envelopes still decode:');
+const good = expectNoThrow('minimal JSON-root envelope decodes', () =>
+	decodeParseEnvelope(buildParseEnvelope('{"type":"Foo","value":1}')),
+);
+if (good) assertEq('root round-trips', good.type, 'Foo');
+
+const goodId = expectNoThrow('minimal identifier-root envelope decodes', () =>
+	decodeParseEnvelope(buildIdentifierEnvelope('foo')),
+);
+if (goodId) assertEq('identifier name round-trips', goodId.name, 'foo');
+
+console.log('\nmalformed envelopes throw:');
+// The inline-JSON length field sits right after the node preamble
+// (HEADER_LEN + 1 tag byte + 4 start + 4 end = offset 33).
+const jsonLenOffset = HEADER_LEN + 1 + 4 + 4;
+expectThrow(
+	'oversized inline JSON length throws',
+	() => decodeParseEnvelope(buildParseEnvelope('{"type":"Foo"}', { [jsonLenOffset]: 0xffffff })),
+	/inline JSON out of bounds/,
+);
+// The identifier name-length field sits at the same relative offset.
+const nameLenOffset = HEADER_LEN + 1 + 4 + 4;
+expectThrow(
+	'oversized string length throws',
+	() => decodeParseEnvelope(buildIdentifierEnvelope('foo', { [nameLenOffset]: 0xffffff })),
+	/string out of bounds/,
+);
+// too small to even hold a header.
+expectThrow(
+	'sub-header buffer throws',
+	() => decodeParseEnvelope(Buffer.alloc(HEADER_LEN - 1)),
+	/buffer too small/,
+);
+// bad magic.
+expectThrow(
+	'bad magic throws',
+	() => {
+		const buf = buildParseEnvelope('{"type":"Foo"}');
+		buf.writeUInt32LE(0, 0);
+		decodeParseEnvelope(buf);
+	},
+	/bad magic/,
+);
+
+console.log('');
+if (failures) {
+	console.error(`❌ ${failures} assertion(s) failed`);
+	process.exit(1);
+} else {
+	console.log('✅ all parse-envelope-validation assertions passed');
+}


### PR DESCRIPTION
## Summary
- `parse-envelope.js` decoded the `readStr`/`readInlineJson` byte windows without validating them against the buffer, unlike `envelope.js`'s `assertWindow` guard (M-012). A malformed envelope (encoder bug, or wire-format version skew between a Rust NAPI build and its JS decoder) would silently produce a truncated/misaligned AST instead of throwing — a silent-corruption path into the byte-parity-sensitive AST consumers (svelte2tsx, lint). Added an `assertWindow` check mirroring `envelope.js`, plus a regression test (`scripts/dev/test-parse-envelope-validation.mjs`, wired as `pnpm test:parse-envelope`) analogous to the existing `test-envelope-validation.mjs`.
- `svelte-check.cjs` computed the exit code as `result.status ?? 0`, which silently reports exit code 0 when the native binary is killed by a signal (e.g. SIGABRT from a Rust panic) — `spawnSync` sets `status: null` and `signal: 'SIGABRT'` in that case. `apps/npm/fmt/bin/rsvelte-fmt` already handles this correctly; ported the same signal → `128 + signum` propagation to `svelte-check.cjs` so a crashing type-check binary can't be reported as a passing CI gate.

## Test plan
- [x] `node --check` on both modified `.js`/`.cjs` files
- [x] `node scripts/dev/test-parse-envelope-validation.mjs` (new, all assertions pass)
- [x] `node scripts/dev/test-envelope-validation.mjs` (existing envelope.js test, unaffected, still passes)
- [x] Manual repro: simulated a SIGABRT-killed child process and confirmed the new svelte-check.cjs logic now exits 134 instead of 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj