### PR TITLE
perf(svelte-check): cache kit source bodies + hoist per-call regexes

### DIFF
--- a/.changeset/perf-svelte-check-mapping-cache.md
+++ b/.changeset/perf-svelte-check-mapping-cache.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+perf(svelte-check): cache kit source bodies during diagnostic mapping
+
+Kit diagnostics re-read and re-scanned the kit source file once per diagnostic.
+The mapper now caches source bodies per run (mirroring the existing tsx cache),
+and the two per-call regex compilations are hoisted into `LazyLock` statics.

--- a/crates/rsvelte_core/src/svelte_check/mapper.rs
+++ b/crates/rsvelte_core/src/svelte_check/mapper.rs
@@ -211,6 +211,10 @@ pub fn map_tsgo_diagnostics(
     // Generated `.tsx` text per shadow, read on demand to test whether a
     // diagnostic falls inside a svelte2tsx `Ωignore` region.
     let mut tsx_texts: HashMap<PathBuf, String> = HashMap::new();
+    // Original kit-source text per source path, read on demand and reused
+    // across every diagnostic on the same file (kit files often produce
+    // many diagnostics — re-reading + re-scanning each was O(n) per diag).
+    let mut kit_texts: HashMap<PathBuf, String> = HashMap::new();
     let mut out: Vec<Diagnostic> = Vec::with_capacity(raw.len());
     // `.svelte` sources whose generated overlay produced a TS1xxx syntax
     // diagnostic, in first-seen order (deduped). Recorded regardless of
@@ -243,7 +247,10 @@ pub fn map_tsgo_diagnostics(
             .or_else(|| by_kit.get(&absolute).copied())
             .or_else(|| by_kit.get(&diag.file).copied());
         if let Some(entry) = kit_match {
-            out.push(map_kit_diagnostic(diag, entry));
+            let original = kit_texts
+                .entry(entry.source_path.clone())
+                .or_insert_with(|| std::fs::read_to_string(&entry.source_path).unwrap_or_default());
+            out.push(map_kit_diagnostic(diag, entry, original));
             continue;
         }
         let entry_match = by_tsx
@@ -347,12 +354,15 @@ pub fn map_tsgo_diagnostics(
 /// same source line". For multi-line insertions (none of which the
 /// current addedCode emits, but the JS reference's `kitType` JSDoc
 /// blocks could) the line table walk keeps things correct.
-fn map_kit_diagnostic(diag: &RawTsDiagnostic, entry: &KitOverlayEntry) -> Diagnostic {
-    let original = std::fs::read_to_string(&entry.source_path).unwrap_or_default();
+fn map_kit_diagnostic(
+    diag: &RawTsDiagnostic,
+    entry: &KitOverlayEntry,
+    original: &str,
+) -> Diagnostic {
     let (orig_line, orig_col) = remap_kit_position(
         diag.line.saturating_sub(1),
         diag.column.saturating_sub(1),
-        &original,
+        original,
         &entry.added_code,
     )
     .unwrap_or((diag.line.saturating_sub(1), diag.column.saturating_sub(1)));

--- a/crates/rsvelte_core/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_core/src/svelte_check/overlay.rs
@@ -666,11 +666,13 @@ fn materialize_kit_types(
 /// basename-keyed rewrite is unambiguous.
 fn rewrite_kit_types_route_imports(text: &str, mirror_dir: &Path) -> String {
     // `import( <q> <maybe-path>/ +layout .js <q> )` → capture quote + basename.
-    let re = regex::Regex::new(
-        r#"import\((['"])(?:[^'"]*/)?(\+(?:layout|page)(?:\.server)?)\.js(['"])\)"#,
-    )
-    .expect("static kit-$types import regex");
-    re.replace_all(text, |caps: &regex::Captures| {
+    static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(
+            r#"import\((['"])(?:[^'"]*/)?(\+(?:layout|page)(?:\.server)?)\.js(['"])\)"#,
+        )
+        .expect("static kit-$types import regex")
+    });
+    RE.replace_all(text, |caps: &regex::Captures| {
         let quote = &caps[1];
         let base = &caps[2];
         if mirror_dir.join(format!("{base}.ts")).is_file() {

--- a/crates/rsvelte_core/src/svelte_check/tsgo.rs
+++ b/crates/rsvelte_core/src/svelte_check/tsgo.rs
@@ -167,13 +167,15 @@ pub fn run_tsgo(
 /// (and tsgo, which is wire-compatible). Lines look like:
 ///   `path/to/file.ts(line,col): error TSxxxx: message`
 fn parse_diagnostics(output: &str) -> Vec<RawTsDiagnostic> {
-    let re = regex::Regex::new(
-        r"^(?P<file>.+?)\((?P<line>\d+),(?P<col>\d+)\):\s+(?P<sev>error|warning|info)\s+(?P<code>TS\d+):\s+(?P<msg>.*)$",
-    )
-    .expect("static regex compiles");
+    static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(
+            r"^(?P<file>.+?)\((?P<line>\d+),(?P<col>\d+)\):\s+(?P<sev>error|warning|info)\s+(?P<code>TS\d+):\s+(?P<msg>.*)$",
+        )
+        .expect("static regex compiles")
+    });
     let mut diags = Vec::new();
     for line in output.lines() {
-        if let Some(caps) = re.captures(line) {
+        if let Some(caps) = RE.captures(line) {
             let line_no: u32 = caps["line"].parse().unwrap_or(1);
             let col: u32 = caps["col"].parse().unwrap_or(1);
             diags.push(RawTsDiagnostic {


### PR DESCRIPTION
## Summary

Performance cleanups in the `svelte-check` diagnostic mapper + drivers (from findings-05 review). No behavior/output changes.

- **P1-2** — `map_kit_diagnostic` did `fs::read_to_string(entry.source_path)` **plus** an O(n) linear rescan for **every** diagnostic on a kit file, while the `.tsx` side already caches bodies in `tsx_texts`. Added a symmetric `kit_texts` per-run `HashMap` cache and threaded the borrowed source into `map_kit_diagnostic`, so a file with N kit diagnostics reads it once.
- **P3-2** — Two `Regex::new(...)` calls sat inside hot-ish functions (`tsgo::parse_diagnostics`, one per compiler run; `overlay::rewrite_kit_types_route_imports`, one per kit `$types.d.ts`). Both are now `std::sync::LazyLock` statics, compiling once for the process.

## Testing

- `cargo test -p rsvelte_core --lib svelte_check` — 76 passed.
- `cargo build -p rsvelte_core`, `cargo fmt --check` clean. Own files are clippy-clean (a pre-existing unrelated `collapsible_if` lint in `server/ast/visitors/shared.rs`, identical on main, is left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj