### PR TITLE
fix: vscode extension resolves language server at dist/server.mjs

### DIFF
--- a/apps/npm/vscode/src/extension.ts
+++ b/apps/npm/vscode/src/extension.ts
@@ -30,10 +30,10 @@ const DOCUMENT_SELECTOR = [
 ];
 
 export function activate(context: ExtensionContext): void {
-  // The bundled server lives at dist/server.js, copied next to the extension
+  // The bundled server lives at dist/server.mjs, copied next to the extension
   // bundle by the build (see build.mjs).
   const serverModule = context.asAbsolutePath(
-    path.join("dist", "server.js"),
+    path.join("dist", "server.mjs"),
   );
 
   const serverOptions: ServerOptions = {


### PR DESCRIPTION
## Summary
- `apps/npm/vscode/src/extension.ts` pointed `activate()` at `dist/server.js`, but `build.mjs` (and `language-server/package.json`'s `bin`/`files`) actually stage the bundle at `dist/server.mjs` — no `server.js` is ever produced by any build step. `vscode-languageclient`'s stdio transport spawns whatever path it's given, so on every real install the extension silently failed to start the language server (no formatting, no diagnostics), with no error surfaced to the user.
- `apps/npm/language-server/test/server.test.mjs` doesn't catch this because it spawns `dist/server.mjs` directly, bypassing `extension.ts`'s path resolution entirely.

## Test plan
- [x] `pnpm --dir apps/npm/vscode run typecheck` (clean)
- [x] Built the pipeline locally (`node apps/npm/language-server/build.mjs` then `node apps/npm/vscode/build.mjs`, with a stub `vendor/` dir standing in for the wasm-pack output since this environment has no Rust toolchain) and confirmed the bundled `dist/extension.js` now resolves `path.join("dist", "server.mjs")`, matching the file `vscode/build.mjs` actually copies next to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj