### PR TITLE
fix(preprocess): harden sourcemap decoding and offset handling

### DIFF
--- a/.changeset/fix-sourcemap-offset-hardening.md
+++ b/.changeset/fix-sourcemap-offset-hardening.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(preprocess): harden sourcemap decoding and warning offset handling
+
+Malformed VLQ continuation runs no longer overflow-panic the decoder (shift is
+bounded and running state uses wrapping adds), `process_markup` now decodes
+standard VLQ-string v3 maps through `decode_map` instead of silently dropping
+them, and `byte_offset_to_position` rewinds mid-codepoint offsets to the nearest
+char boundary before slicing.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -408,7 +408,12 @@ pub struct Position {
 /// - `column` is 0-indexed (in UTF-16 code units for compatibility with JavaScript)
 /// - `character` is the UTF-16 code unit offset (matching JavaScript's string indexing)
 fn byte_offset_to_position(source: &str, offset: usize) -> Position {
-    let offset = offset.min(source.len());
+    let mut offset = offset.min(source.len());
+    // Slicing at a non-UTF-8-boundary byte panics, so rewind an out-of-range or
+    // mid-codepoint offset to the nearest char boundary at or below it.
+    while offset > 0 && !source.is_char_boundary(offset) {
+        offset -= 1;
+    }
     let before = &source[..offset];
     let line = before.bytes().filter(|&b| b == b'\n').count() + 1;
 
@@ -1456,6 +1461,22 @@ impl std::error::Error for CompileError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_byte_offset_to_position_clamps_to_char_boundary() {
+        // "é" is two UTF-8 bytes (0xC3 0xA9). An offset landing between them
+        // must rewind to the boundary instead of panicking on the slice.
+        let source = "aéb";
+        let pos = byte_offset_to_position(source, 2);
+        // Rewound to offset 1 ("a"): one UTF-16 unit consumed.
+        assert_eq!(pos.character, 1);
+        assert_eq!(pos.column, 1);
+        assert_eq!(pos.line, 1);
+
+        // Past-the-end offset clamps to the string length.
+        let end = byte_offset_to_position(source, 999);
+        assert_eq!(end.character, 3);
+    }
 
     #[test]
     fn test_compile_simple() {

--- a/crates/rsvelte_core/src/compiler/preprocess/decode_sourcemap.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/decode_sourcemap.rs
@@ -88,7 +88,7 @@ fn decode_vlq_mappings(s: &str) -> Vec<Vec<Vec<i64>>> {
             };
             let mut segment = Vec::with_capacity(deltas.len());
             for (i, d) in deltas.into_iter().enumerate().take(5) {
-                last[i] += d;
+                last[i] = last[i].wrapping_add(d);
                 segment.push(last[i]);
             }
             segments.push(segment);
@@ -130,6 +130,12 @@ fn decode_vlq_segment(s: &str) -> Option<Vec<i64>> {
                 return None;
             }
             let digit = digit as i64;
+            // A well-formed VLQ value fits in 32 bits (7 base-64 groups reach
+            // shift 30); anything past that is malformed. Bail before the shift
+            // rather than let `<< shift` overflow-panic in debug builds.
+            if shift >= 32 {
+                return None;
+            }
             value |= (digit & 31) << shift;
             shift += 5;
             if digit & 32 == 0 {
@@ -170,6 +176,39 @@ mod tests {
         let decoded = decoded.unwrap();
         assert_eq!(decoded.version, Some(3));
         assert_eq!(decoded.sources.len(), 1);
+    }
+
+    #[test]
+    fn test_decode_map_from_vlq_string_json() {
+        // Standard Source Map v3: `mappings` is a base64-VLQ string. The first
+        // segment "AAAA" decodes to [0, 0, 0, 0].
+        let json_map = r#"{
+            "version": 3,
+            "sources": ["input.svelte"],
+            "names": [],
+            "mappings": "AAAA"
+        }"#;
+
+        let processed = Processed {
+            code: "test".to_string(),
+            map: Some(SourceMapInput::Json(json_map.to_string())),
+            dependencies: vec![],
+            attributes: None,
+        };
+
+        let decoded = decode_map(&processed).expect("VLQ string map should decode");
+        assert_eq!(decoded.version, Some(3));
+        assert_eq!(decoded.sources, vec!["input.svelte".to_string()]);
+        assert_eq!(decoded.mappings, vec![vec![vec![0, 0, 0, 0]]]);
+    }
+
+    #[test]
+    fn test_decode_vlq_segment_overlong_returns_none() {
+        // A run of continuation bytes (all high-bit set) would push `shift`
+        // past 32 and overflow-panic the `<< shift` in debug builds. The guard
+        // must bail with `None` instead. 'g' = 32 (continuation bit only).
+        let malicious = "gggggggggggggggggggg";
+        assert!(decode_vlq_segment(malicious).is_none());
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/preprocess/mod.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/mod.rs
@@ -433,14 +433,12 @@ async fn process_markup(
     let processed_opt = process(options).await?;
 
     if let Some(processed) = processed_opt {
-        let map = if let Some(map_input) = processed.map {
-            match map_input {
-                SourceMapInput::Json(json) => serde_json::from_str(&json).ok(),
-                SourceMapInput::Decoded(decoded) => Some(decoded),
-            }
-        } else {
-            None
-        };
+        // Route through `decode_map` so a standard Source Map v3 document with a
+        // VLQ-encoded `mappings` string decodes here too, matching the
+        // script/style paths (`processed_content_to_code`). The previous inline
+        // `serde_json::from_str` only accepted the pre-decoded array form and
+        // silently dropped every VLQ string map.
+        let map = decode_map(&processed);
 
         Ok(SourceUpdate {
             string: Some(processed.code),
@@ -582,5 +580,40 @@ mod tests {
         let result = PreprocessResult::new("test".to_string(), Some("test.svelte".to_string()));
         assert_eq!(result.source, "test");
         assert_eq!(result.file_basename, "test.svelte");
+    }
+
+    #[test]
+    fn test_process_markup_decodes_vlq_string_map() {
+        // A markup preprocessor returning a standard Source Map v3 document
+        // (VLQ-encoded `mappings` string) must have its map decoded, not
+        // silently dropped — matching the script/style paths.
+        let process: MarkupPreprocessorFn = Box::new(|_opts: MarkupPreprocessorOptions| {
+            Box::pin(async {
+                Ok(Some(Processed {
+                    code: "<p>hi</p>".to_string(),
+                    map: Some(SourceMapInput::Json(
+                        r#"{"version":3,"sources":["input.svelte"],"names":[],"mappings":"AAAA"}"#
+                            .to_string(),
+                    )),
+                    dependencies: vec![],
+                    attributes: None,
+                }))
+            })
+        });
+
+        let source = Source {
+            source: "<p>hi</p>".to_string(),
+            get_location: std::sync::Arc::new(|_| Location { line: 0, column: 0 }),
+            file_basename: "input.svelte".to_string(),
+            filename: Some("input.svelte".to_string()),
+        };
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let update = runtime.block_on(process_markup(&process, &source)).unwrap();
+        let map = update.map.expect("VLQ string markup map should decode");
+        assert_eq!(map.mappings, vec![vec![vec![0, 0, 0, 0]]]);
     }
 }


### PR DESCRIPTION
## Summary

Defensive hardening of the preprocess sourcemap path and byte-offset conversion (from findings-08 infra review, P1-1/P1-2/P1-3). No normal-path output changes — these only affect malformed input and previously-dropped VLQ string maps.

- **P1-1** `preprocess/decode_sourcemap.rs`: guard the VLQ shift (`shift >= 32 → None`) so a malformed run of continuation bytes no longer overflow-panics `<< shift` in debug builds; make the running-state accumulation `wrapping_add` instead of `+=`.
- **P1-2** `preprocess/mod.rs` `process_markup`: route the markup preprocessor's map through `decode_map` so a standard Source Map v3 document with a VLQ-encoded `mappings` string decodes here too (it was silently dropped via `serde_json::from_str(..).ok()`), matching the script/style paths (`processed_content_to_code`).
- **P1-3** `compiler/mod.rs` `byte_offset_to_position`: rewind an out-of-range or mid-codepoint byte offset to the nearest char boundary before slicing, avoiding a slice panic.

## Tests

Added regression unit tests:
- crafted overlong VLQ segment returns `None` (no panic),
- standard VLQ string map decodes (both at the `decode_map` level and end-to-end through `process_markup`),
- multibyte-boundary / past-the-end offset clamps instead of panicking.

Verified: `cargo build -p rsvelte_core`, `cargo test -p rsvelte_core --lib preprocess:: / byte_offset_to_position` (all green). The fixture-driven `--test preprocess` needs the svelte submodule + generated fixtures (not present in this worktree) — left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj