### PR TITLE
fix(esrap,napi): defensive printer fixes + shared zero-copy envelope guard

### DIFF
--- a/.changeset/fix-esrap-napi-hardening.md
+++ b/.changeset/fix-esrap-napi-hardening.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix(esrap/napi): defensive printer fixes and compileModule arena leak
+
+esrap's `Dedent` no longer underflows on unbalanced command streams and template
+quasis are indexed defensively. The `compileModule` zero-copy NAPI path now uses
+the same leak-safe `BumpGuard` envelope helper as the component path, so a buffer
+creation error no longer leaks the bump arena.

--- a/crates/rsvelte_core/src/napi.rs
+++ b/crates/rsvelte_core/src/napi.rs
@@ -1251,30 +1251,22 @@ pub fn napi_compile_envelope(
 //      Step 3 collapses to one Box<Bump> drop. Negligible per call,
 //      but it grows linearly with batch size.
 
-/// Zero-copy variant of {@link napi_compile_envelope}. Allocates the
-/// envelope bytes inside a `bumpalo::Bump`, hands V8 a Buffer view
-/// over the arena, and drops the arena from a finalizer when V8
-/// finalises the Buffer.
+/// Allocate `result`'s packed envelope into a fresh `bumpalo::Bump` and hand V8
+/// a Buffer that borrows the arena, freeing the arena from the Buffer's
+/// finalizer. Shared by both zero-copy entry points so the leak-safe ownership
+/// dance (RAII guard until V8 takes ownership) lives in one place.
 ///
 /// # Safety
 ///
-/// We pass a raw pointer into the bump arena to napi via
-/// `create_buffer_with_borrowed_data`. The arena is leaked via
-/// `Box::into_raw` and only freed inside the finalizer callback,
-/// after V8 has agreed it's done with the buffer. No Rust code
-/// retains the pointer after the call returns.
-#[napi(js_name = "compileEnvelopeZeroCopy")]
-pub fn napi_compile_envelope_zero_copy(
-    env: Env,
-    source: String,
-    options: Option<NapiCompileOptions>,
+/// A raw pointer into the bump arena is passed to napi via
+/// `create_buffer_with_borrowed_data`. The arena is leaked via `Box::into_raw`
+/// and only freed inside the finalizer callback, after V8 has agreed it's done
+/// with the buffer. No Rust code retains the pointer after this returns.
+fn create_zero_copy_envelope(
+    env: &Env,
+    result: &crate::compiler::CompileResult,
 ) -> napi::Result<JsBuffer> {
-    let opts = options_to_compile(options);
-    let result = match rust_compile(&source, opts) {
-        Ok(r) => r,
-        Err(e) => return Err(napi::Error::from_reason(format!("{e:?}"))),
-    };
-    let size = crate::napi_raw::estimate_size(&result);
+    let size = crate::napi_raw::estimate_size(result);
     ensure_envelope_size(size)?;
     let bump = Box::new(bumpalo::Bump::with_capacity(size));
     let bump_ptr: *mut bumpalo::Bump = Box::into_raw(bump);
@@ -1299,7 +1291,7 @@ pub fn napi_compile_envelope_zero_copy(
     // aliased; we re-acquire ownership via Box::from_raw inside the
     // finalizer below.
     let bump_ref: &bumpalo::Bump = unsafe { &*bump_ptr };
-    let slice = crate::napi_raw::encode_into_bump(bump_ref, &result);
+    let slice = crate::napi_raw::encode_into_bump(bump_ref, result);
     let ptr = slice.as_mut_ptr();
     let len = slice.len();
 
@@ -1325,6 +1317,24 @@ pub fn napi_compile_envelope_zero_copy(
     Ok(js_buf_value.into_raw())
 }
 
+/// Zero-copy variant of {@link napi_compile_envelope}. Allocates the
+/// envelope bytes inside a `bumpalo::Bump`, hands V8 a Buffer view
+/// over the arena, and drops the arena from a finalizer when V8
+/// finalises the Buffer.
+#[napi(js_name = "compileEnvelopeZeroCopy")]
+pub fn napi_compile_envelope_zero_copy(
+    env: Env,
+    source: String,
+    options: Option<NapiCompileOptions>,
+) -> napi::Result<JsBuffer> {
+    let opts = options_to_compile(options);
+    let result = match rust_compile(&source, opts) {
+        Ok(r) => r,
+        Err(e) => return Err(napi::Error::from_reason(format!("{e:?}"))),
+    };
+    create_zero_copy_envelope(&env, &result)
+}
+
 /// `compileModule` counterpart of `compileEnvelopeZeroCopy`.
 #[napi(js_name = "compileModuleEnvelopeZeroCopy")]
 pub fn napi_compile_module_envelope_zero_copy(
@@ -1344,30 +1354,7 @@ pub fn napi_compile_module_envelope_zero_copy(
         metadata: crate::compiler::CompileMetadata { runes: true },
         ast: None,
     };
-    let size = crate::napi_raw::estimate_size(&cr);
-    ensure_envelope_size(size)?;
-    let bump = Box::new(bumpalo::Bump::with_capacity(size));
-    let bump_ptr: *mut bumpalo::Bump = Box::into_raw(bump);
-    // SAFETY: `bump_ptr` is freshly leaked from `Box::into_raw` and not aliased;
-    // ownership is re-acquired via `Box::from_raw` in the finalizer below.
-    let bump_ref: &bumpalo::Bump = unsafe { &*bump_ptr };
-    let slice = crate::napi_raw::encode_into_bump(bump_ref, &cr);
-    let ptr = slice.as_mut_ptr();
-    let len = slice.len();
-    // SAFETY: `ptr`/`len` describe a valid slice inside `*bump_ptr`; V8 invokes the
-    // finalizer exactly once on GC, which drops the Box and frees the arena bytes.
-    let js_buf_value = unsafe {
-        env.create_buffer_with_borrowed_data(
-            ptr,
-            len,
-            bump_ptr,
-            |_env, bump_ptr: *mut bumpalo::Bump| {
-                // SAFETY: same pointer as Box::into_raw above, fired once.
-                let _bump: Box<bumpalo::Bump> = Box::from_raw(bump_ptr);
-            },
-        )?
-    };
-    Ok(js_buf_value.into_raw())
+    create_zero_copy_envelope(&env, &cr)
 }
 
 /// `compileModule()` returning the same packed envelope. The envelope

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -114,7 +114,7 @@ impl Driver<'_> {
             Command::Space => self.needs_space = true,
             Command::Indent => self.current_newline.push_str(self.indent),
             Command::Dedent => {
-                let len = self.current_newline.len() - self.indent.len();
+                let len = self.current_newline.len().saturating_sub(self.indent.len());
                 self.current_newline.truncate(len);
             }
             Command::Str(s) => {
@@ -269,6 +269,21 @@ mod tests {
                 Command::Str(")".into()),
             ]),
             "(x y)"
+        );
+    }
+
+    #[test]
+    fn unbalanced_dedent_does_not_panic() {
+        // A Dedent with no matching Indent (unbalanced buffer) must floor the
+        // newline prefix at 0 rather than underflow-panic on the subtraction.
+        // The prefix (including the leading "\n") collapses to empty.
+        assert_eq!(
+            cmds(vec![
+                Command::Dedent,
+                Command::Newline,
+                Command::Str("x".into()),
+            ]),
+            "x"
         );
     }
 

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1206,7 +1206,11 @@ impl<'opt> Printer<'opt> {
     fn template_literal(&mut self, node: &TemplateLiteral, ctx: &mut Context) {
         ctx.write("`");
         for (i, expr) in node.expressions.iter().enumerate() {
-            let raw = node.quasis[i].value.raw.as_str();
+            let raw = node
+                .quasis
+                .get(i)
+                .map(|q| q.value.raw.as_str())
+                .unwrap_or("");
             ctx.write(format!("{raw}${{"));
             self.print_expression(expr, ctx);
             ctx.write("}");
@@ -3144,7 +3148,7 @@ impl<'opt> Printer<'opt> {
             TSType::TSTemplateLiteralType(t) => {
                 ctx.write("`");
                 for (i, inner) in t.types.iter().enumerate() {
-                    let raw = t.quasis[i].value.raw.as_str();
+                    let raw = t.quasis.get(i).map(|q| q.value.raw.as_str()).unwrap_or("");
                     ctx.write(format!("{raw}${{"));
                     self.print_type(inner, ctx);
                     ctx.write("}");


### PR DESCRIPTION
## Summary

Defensive hardening of the esrap printer and the NAPI zero-copy envelope path (from findings-08 infra review, P1-6 and P2-1). No normal-path output changes — the esrap fixes only affect malformed/unbalanced input, and the napi change is a pure refactor plus a missing error-path guard.

- **P1-6** `rsvelte_esrap/src/command.rs`: floor the `Dedent` prefix subtraction with `saturating_sub` so an unbalanced command buffer can't underflow-panic in debug builds.
- **P1-6** `rsvelte_esrap/src/printer.rs`: index template quasis via `.get(i)` with an empty-string fallback in both the template-literal and TS template-literal-type printers, so a malformed quasi/expression count mismatch can't index-panic.
- **P2-1** `rsvelte_core/src/napi.rs`: extract the zero-copy envelope path (`estimate → ensure_size → bump → encode → create_buffer(+guard)`) into a shared `create_zero_copy_envelope` helper. The `compileModuleEnvelopeZeroCopy` path previously lacked the `BumpGuard`, so an error from `create_buffer_with_borrowed_data` leaked the bump arena; both entry points now route through the guarded helper.

## Tests

- Added an esrap regression test for the unbalanced-`Dedent` case (no panic).
- `cargo test -p rsvelte_esrap` — all green (39 + others).
- `cargo build -p rsvelte_core --features napi --lib` — compiles cleanly (the standalone profiling bins don't link napi symbols by design; the cdylib/lib is the napi build surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj