### PR TITLE
fix(parse): harden parser against panic and infinite loops on malformed input

### DIFF
--- a/.changeset/fix-parser-hardening.md
+++ b/.changeset/fix-parser-hardening.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): harden parser against panics and infinite loops on edge-case input
+
+`strip_type_annotation` now slices on byte offsets (`{const café: T = e}` no
+longer panics), the CSS rule loop has a progress guard so `<style>{}</style>`
+reports `css_expected_identifier` like the official compiler instead of hanging,
+and selector identifiers accept code points >= 160 (matching the official
+compiler's treatment of e.g. `×` as a valid type selector).

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -413,17 +413,24 @@ impl<'a> CssParser<'a> {
                 continue;
             }
 
+            let index_before = self.index;
+
             // Check for at-rules
             if self.current_char() == '@' {
                 if let Some(rule) = self.parse_atrule() {
                     rules.push(rule);
                 }
-                continue;
+            } else if let Some(rule) = self.parse_rule() {
+                // Parse regular rule
+                rules.push(rule);
             }
 
-            // Parse regular rule
-            if let Some(rule) = self.parse_rule() {
-                rules.push(rule);
+            // Progress guard: if the sub-parser consumed no input (e.g. an empty
+            // selector at a block start like `{}`, where `parse_rule` records
+            // `css_expected_identifier` and returns `None`), stop instead of
+            // spinning forever.
+            if self.index == index_before {
+                break;
             }
         }
 
@@ -598,6 +605,20 @@ impl<'a> CssParser<'a> {
         let selector_text = &self.source[selector_start..selector_end];
 
         if selector_text.trim().is_empty() {
+            // An empty selector at a block start (e.g. `{}`) mirrors the official
+            // `read_selector` → `read_identifier` path, which raises
+            // `css_expected_identifier` at the block-start position.
+            if !self.is_eof() {
+                let pos = self.offset + self.index;
+                record_first_error(
+                    &self.error,
+                    crate::error::ParseError::svelte(
+                        "css_expected_identifier",
+                        "Expected a valid CSS identifier",
+                        (pos, pos),
+                    ),
+                );
+            }
             return None;
         }
 
@@ -1764,6 +1785,19 @@ impl<'a> SelectorParser<'a> {
                 // `-`, `_`, code points >= 160, and `\`-escapes.
                 if let Some(selector) = self.parse_type_selector() {
                     selectors.push(selector);
+                } else {
+                    // An empty identifier here would leave `self.index`
+                    // unchanged and spin the loop; mirror the official
+                    // `read_identifier` empty-identifier error and stop.
+                    if self.error.is_none() {
+                        let pos = self.offset + self.index;
+                        self.error = Some(crate::error::ParseError::svelte(
+                            "css_expected_identifier",
+                            "Expected a valid CSS identifier",
+                            (pos, pos),
+                        ));
+                    }
+                    break;
                 }
             } else if c.is_ascii_digit() || (c == '.' && self.peek_next_char().is_ascii_digit()) {
                 // Percentage selector (used inside @keyframes blocks): `0%`, `33.3%`, `.5%`.
@@ -2770,7 +2804,12 @@ impl<'a> SelectorParser<'a> {
                     // Escape of a single non-hex character (e.g., \. means literal .)
                     self.advance();
                 }
-            } else if c.is_alphanumeric() || c == '-' || c == '_' {
+            } else if c.is_alphanumeric() || c == '-' || c == '_' || (c as u32) >= 160 {
+                // Mirror the official `read_identifier` valid-character set:
+                // `[a-zA-Z0-9_-]` plus every code point >= 160 (CSS treats those
+                // as identifier characters, e.g. `×` is a valid type-selector
+                // name). Without the `>= 160` branch a non-alphanumeric code
+                // point >= 160 yields an empty identifier and spins the caller.
                 self.advance();
             } else {
                 break;

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -2697,10 +2697,9 @@ fn build_empty_loose_declaration(
 }
 
 fn strip_type_annotation(pattern: &str) -> String {
-    let chars: Vec<char> = pattern.chars().collect();
     let mut depth = 0;
 
-    for (i, &c) in chars.iter().enumerate() {
+    for (i, c) in pattern.char_indices() {
         match c {
             '{' | '[' | '(' => depth += 1,
             '}' | ']' | ')' => depth -= 1,

--- a/crates/rsvelte_core/tests/parser_hardening.rs
+++ b/crates/rsvelte_core/tests/parser_hardening.rs
@@ -1,0 +1,78 @@
+//! Parser hardening regressions: malformed / adversarial input must not panic
+//! or spin forever, and must surface the same error the official Svelte
+//! compiler raises.
+//!
+//! - `strip_type_annotation` sliced a declaration-tag pattern by character
+//!   index instead of byte index, so a multi-byte identifier before the type
+//!   colon (`{const café: T = e}`) panicked on a non-char-boundary slice.
+//! - The `<style>` CSS parser had no progress guard, so an empty selector
+//!   (`<style>{}</style>`) looped forever instead of raising
+//!   `css_expected_identifier` like the official parser.
+//! - A CSS type selector starting with a non-alphanumeric code point >= 160
+//!   (`<style>× {}</style>`) read an empty identifier and spun forever; the
+//!   official `read_identifier` treats every code point >= 160 as a valid
+//!   identifier character, so `×` is a valid type-selector name.
+
+use rsvelte_core::{CompileOptions, GenerateMode, ParseOptions, compile, parse};
+
+fn compile_result(src: &str) -> Result<(), String> {
+    match compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let s = format!("{e:?}");
+            let code = s
+                .split("code: \"")
+                .nth(1)
+                .and_then(|t| t.split('"').next())
+                .unwrap_or(&s)
+                .to_string();
+            Err(code)
+        }
+    }
+}
+
+#[test]
+fn declaration_tag_multibyte_type_annotation_does_not_panic() {
+    // Reaches `strip_type_annotation` with a multi-byte char (`é`, 2 bytes)
+    // sitting before the top-level type colon. A char-index slice would land
+    // mid-`é` and panic; a byte-index slice must succeed.
+    let root = parse(
+        "{#if true}{@const café: T = e}{/if}",
+        ParseOptions::default(),
+    );
+    assert!(
+        root.is_ok(),
+        "multi-byte @const type annotation panicked/failed"
+    );
+}
+
+#[test]
+fn empty_style_selector_reports_css_expected_identifier() {
+    // Official Svelte raises `css_expected_identifier` at the `{`; rsvelte used
+    // to loop forever on the empty selector.
+    assert_eq!(
+        compile_result("<style>{}</style>"),
+        Err("css_expected_identifier".to_string()),
+    );
+}
+
+#[test]
+fn high_codepoint_type_selector_parses() {
+    // `×` (U+00D7, code point 215 >= 160) is a valid CSS type-selector name.
+    // rsvelte used to spin forever reading an empty identifier here.
+    let root = parse("<style>× {}</style>", ParseOptions::default())
+        .expect("high-codepoint type selector failed to parse");
+    let css = serde_json::to_string(&root.css).expect("serialize css");
+    assert!(
+        css.contains("\"TypeSelector\"") && css.contains('×'),
+        "expected a `×` TypeSelector, got: {css}"
+    );
+}


### PR DESCRIPTION
## What

Three parser hardening fixes for adversarial / malformed input that currently panic or hang. Verified against the official Svelte compiler for error-code / behavior parity.

### P1-1 — panic on multi-byte declaration-tag pattern
`strip_type_annotation` (`state/tag.rs`) sliced a declaration-tag pattern by **character** index into a byte-indexed string. A multi-byte identifier before the top-level type colon — `{const café: T = e}` — landed the slice mid-`é` (a non-char-boundary byte) and panicked. Fixed by iterating with `char_indices()` so the slice index is a byte offset.

### P1-2 — infinite loop on empty CSS selector
The `<style>` CSS parser's rule loop had no progress guard, so an empty selector (`<style>{}</style>`) spun forever. Added a progress guard and made `parse_rule` record `css_expected_identifier` for an empty selector at a block start. The official compiler raises `css_expected_identifier` at the `{` for this input (confirmed by running it).

### P1-3 — infinite loop on high-codepoint type selector
A CSS type selector starting with a non-alphanumeric code point ≥ 160 (`<style>× {}</style>`) read an empty identifier and spun forever. The official `read_identifier` accepts **every** code point ≥ 160 as an identifier character, so `×` is a valid type-selector name (confirmed: official parses it to a `TypeSelector`). Mirrored that in the selector `read_identifier`. Existing inputs are unaffected (they only reach ≥ 160 code points that are already alphanumeric, hence already accepted). A defensive `break` on an empty type selector guards against any future dispatch/consume mismatch.

> Note: finding P1-3 suggested erroring on `×`, but the official compiler treats `×` as a **valid** type selector, so the byte-parity-correct fix is to accept code points ≥ 160.

## Tests
New `crates/rsvelte_core/tests/parser_hardening.rs` (3 regressions, all pass). Also verified green: `css` (fixtures), `parser_fixtures`, `compiler_errors`. `cargo fmt` + clippy clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj