### PR TITLE
perf(parse): skip per-statement JSON conversion when no svelte-ignore comments

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6256,6 +6256,18 @@ pub fn parse_program_with_error(
         let all_comments: Vec<_> = result.program.comments.iter().collect();
         let has_comments = !all_comments.is_empty();
 
+        // The per-statement `to_value()` + comment-distribution + harvest pass
+        // below exists solely to populate `ignore_comment_map` from
+        // `svelte-ignore` leading comments. A comment that never contains the
+        // literal `svelte-ignore` can never match, so gate the whole (expensive,
+        // full-tree) slow path on the presence of at least one such comment and
+        // keep every other comment-bearing script on the typed fast path.
+        let has_ignore = all_comments.iter().any(|comment| {
+            let end = (comment.span.end as usize).min(content.len());
+            let start = comment.span.start as usize;
+            start <= end && content[start..end].contains("svelte-ignore")
+        });
+
         // Mirror upstream `parser.root.comments`: forward every comment seen
         // by the script parser so it lands in `Root.comments`.
         for comment in all_comments.iter() {
@@ -6298,7 +6310,7 @@ pub fn parse_program_with_error(
         // above, and codegen re-parses script text, so dropping the Raw wrapping changes no
         // output.
         let mut ignore_comment_map: Vec<(u32, Vec<CompactString>)> = Vec::new();
-        let body: Vec<JsNode> = if has_comments {
+        let body: Vec<JsNode> = if has_comments && has_ignore {
             let mut comment_idx = 0;
             let mut body_nodes: Vec<JsNode> = Vec::with_capacity(program.body.len());
 
@@ -6361,7 +6373,8 @@ pub fn parse_program_with_error(
 
             body_nodes
         } else {
-            // No comments at all - fast path: keep everything as typed JsNode
+            // No comments, or comments but no `svelte-ignore` — fast path: keep
+            // everything as typed JsNode (the harvest pass would find nothing).
             program
                 .body
                 .iter()


### PR DESCRIPTION
## What

A comment-bearing `<script>` currently runs a full-tree `to_value()` + comment-distribution + `harvest_ignore_comments` pass on **every** statement, purely to populate `ignore_comment_map` from `svelte-ignore` leading comments (`read/expression.rs`).

The problem: the guard was `has_comments`, but *any* comment (a plain `// foo`, a license header, JSDoc, …) triggered the whole expensive slow path — even though only `svelte-ignore` comments can ever contribute to the map.

## Fix

Compute `has_ignore` once (does any comment text contain the literal `svelte-ignore`?) and gate the slow path on `has_comments && has_ignore`. Every other comment-bearing script stays on the typed fast path.

## Why output is unchanged (byte-parity)

- `ignore_comment_map` is consumed **only** by Phase-2 `svelte-ignore` warning suppression, and is empty whenever no `svelte-ignore` comment exists — so gating changes nothing for those scripts.
- `Root.comments` and trailing comments are populated by a **separate** loop that still runs for all comments.
- The typed body `JsNode`s are byte-identical between the two branches (same `convert_statement_for_program`); only the harvest side-effect differs.

## Tests
Verified green: `svelte_ignore_pin`, `svelte_ignore_routing`, `ts_svelte_ignore_suppression`, `warning_filter` (suppression still works), plus byte-exact fixture suites `parser_fixtures`, `compiler_fixtures`, `validator`, `css`, `ssr`. `cargo fmt` + clippy clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj