### PR TITLE
chore(clippy): fix question_mark lints flagged by Rust 1.97 stable

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -1406,16 +1406,15 @@ pub(super) fn parse_state_field(line: &str, rune_type: &str) -> Option<ClassStat
     let value_start = if after_rune.starts_with('(') {
         // Plain form: `$state(`
         rune_start + rune_type.len() + 1
-    } else if let Some(angle_inner) = after_rune.strip_prefix('<') {
+    } else {
         // Generic form: `$state<T>(` — find the matching `>` then expect `(`
+        let angle_inner = after_rune.strip_prefix('<')?;
         let angle_end = find_matching_bracket_angle(angle_inner)?;
         let after_angle = &after_rune[1 + angle_end + 1..]; // skip `<`, inner, `>`
         if !after_angle.starts_with('(') {
             return None;
         }
         rune_start + rune_type.len() + 1 + angle_end + 1 + 1 // `<` + inner + `>` + `(`
-    } else {
-        return None;
     };
 
     // Find matching closing paren

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -4997,10 +4997,7 @@ fn find_module_script_span(source: &str) -> Option<(usize, usize)> {
     while let Some(rel) = source[search..].find("<script") {
         let tag_start = search + rel;
         // Find the end of the opening tag `>`.
-        let gt = match source[tag_start..].find('>') {
-            Some(g) => tag_start + g,
-            None => return None,
-        };
+        let gt = tag_start + source[tag_start..].find('>')?;
         let open_tag = &source[tag_start..gt];
         // `module` either as a bare attribute or `context="module"` / `context='module'`.
         let is_module = open_tag.contains("context=\"module\"")
@@ -5040,10 +5037,7 @@ fn find_instance_script_span(source: &str) -> Option<(usize, usize)> {
     let mut search = 0usize;
     while let Some(rel) = source[search..].find("<script") {
         let tag_start = search + rel;
-        let gt = match source[tag_start..].find('>') {
-            Some(g) => tag_start + g,
-            None => return None,
-        };
+        let gt = tag_start + source[tag_start..].find('>')?;
         let open_tag = &source[tag_start..gt];
         let is_module = open_tag.contains("context=\"module\"")
             || open_tag.contains("context='module'")

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -3559,11 +3559,7 @@ fn try_break_pre_own_attrs(
         return None;
     }
     // Find the open tag end (position right after `>` of the opening tag).
-    let open_end = if let Some(first) = fragment.nodes.first() {
-        node_start(first) as usize
-    } else {
-        return None;
-    };
+    let open_end = node_start(fragment.nodes.first()?) as usize;
     let open = out.get(s..open_end)?;
     // Must be a single-line open tag with at least one attribute.
     if open.contains('\n') || !open.contains(' ') || !open.ends_with('>') {

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -262,13 +262,10 @@ pub(crate) fn format_open_tag(
 fn wrap_script_open_tag(tag: &str, indent_width: usize) -> Option<String> {
     // Strip the leading `<` and trailing `>`.
     let inner = tag.strip_prefix('<')?.strip_suffix('>')?;
-    // Split tag name from attributes. Tag name is everything up to the first space.
-    let (tag_name, rest) = if let Some(sp) = inner.find(' ') {
-        (&inner[..sp], inner[sp + 1..].trim())
-    } else {
-        // No attributes — nothing to wrap.
-        return None;
-    };
+    // Split tag name from attributes. Tag name is everything up to the first
+    // space; without attributes there is nothing to wrap.
+    let sp = inner.find(' ')?;
+    let (tag_name, rest) = (&inner[..sp], inner[sp + 1..].trim());
     // Parse attributes from the flat string. All values are double-quoted after
     // normalize_open_tag, so we scan respecting quoted spans.
     let mut attrs: Vec<String> = Vec::new();


### PR DESCRIPTION
CI's `dtolnay/rust-toolchain@stable` now resolves to Rust 1.97, whose clippy flags three pre-existing `if let`/`match`-on-`Option` blocks under `question_mark` (class_transforms.rs:1409, svelte2tsx/script/mod.rs:5000/5043). Every open Rust PR fails the Clippy job on these until main is fixed.

Rewritten with `?` exactly as clippy suggests; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj