### PR TITLE
fix(transform): use byte offsets when slicing instance-script strings

### DIFF
--- a/.changeset/fix-transform-non-ascii-slices.md
+++ b/.changeset/fix-transform-non-ascii-slices.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): use byte offsets when slicing instance-script strings
+
+Several client instance-script string helpers iterated with
+`chars().enumerate()` (or a collected `Vec<char>`) and then used the resulting
+char index as a byte offset into the original `&str`. Any non-ASCII byte before
+the slice point (a non-ASCII identifier, object key, string/type literal — all
+valid JS/TS/Svelte) pushed the byte offset past a `char` boundary, panicking the
+compiler with `byte index N is not a char boundary`. Because these helpers run
+whenever the client instance-script IR is built, the crash was reachable from
+untrusted `.svelte` input.
+
+Fixed all five sites to work in byte offsets (`char_indices()` /
+peekable-iterator neighbor lookups) so e.g. `let { café, b } = $props()`,
+`let { café: renamed } = $props()`, `let [café = 1] = arr`, and
+`let x: Café = 0` compile instead of panicking:
+
+- `props_transforms.rs`: `split_property_key_value`, `split_destructuring_properties`
+- `destructure_transforms.rs`: `find_top_level_equals` (fixes its 11 byte-slicing callers)
+- `state_transforms.rs`: `body_references_identifier_in_statements`,
+  `transform_legacy_state_declarations`
+
+ASCII input is unaffected (char index equals byte index there), so output is
+byte-for-byte unchanged.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -604,15 +604,17 @@ pub(super) fn find_top_level_colon(s: &str) -> Option<usize> {
 
 /// Find the position of a top-level `=` in a string (not `==` or `===`).
 pub(super) fn find_top_level_equals(s: &str) -> Option<usize> {
-    let chars: Vec<char> = s.chars().collect();
     let mut depth = 0;
     let mut in_string: Option<char> = None;
+    let mut prev: Option<char> = None;
+    let mut iter = s.char_indices().peekable();
 
-    for (i, &c) in chars.iter().enumerate() {
+    while let Some((i, c)) = iter.next() {
         if in_string.is_some() {
             if Some(c) == in_string {
                 in_string = None;
             }
+            prev = Some(c);
             continue;
         }
 
@@ -622,17 +624,20 @@ pub(super) fn find_top_level_equals(s: &str) -> Option<usize> {
             ')' | ']' | '}' => depth -= 1,
             '=' if depth == 0 => {
                 // Make sure it's not == or ===
-                if i + 1 < chars.len() && chars[i + 1] == '=' {
+                if iter.peek().map(|&(_, next)| next) == Some('=') {
+                    prev = Some(c);
                     continue;
                 }
                 // Make sure it's not != or <=, >=
-                if i > 0 && matches!(chars[i - 1], '!' | '<' | '>') {
+                if matches!(prev, Some('!') | Some('<') | Some('>')) {
+                    prev = Some(c);
                     continue;
                 }
                 return Some(i);
             }
             _ => {}
         }
+        prev = Some(c);
     }
 
     None
@@ -1668,4 +1673,26 @@ pub(super) fn transform_member_mutations(
         return rewritten;
     }
     line.to_string()
+}
+
+#[cfg(test)]
+mod non_ascii_tests {
+    use super::find_top_level_equals;
+
+    #[test]
+    fn find_top_level_equals_handles_non_ascii_before_equals() {
+        // `let [café = 1] = arr` — the `=` lands past a multi-byte char, so the
+        // returned index must be a byte offset usable for slicing (no panic).
+        let s = "café = 1";
+        let pos = find_top_level_equals(s).expect("should find top-level =");
+        assert_eq!(&s[..pos], "café ");
+        assert_eq!(s[pos + 1..].trim(), "1");
+    }
+
+    #[test]
+    fn find_top_level_equals_skips_not_equals_after_non_ascii() {
+        // `!=` is not a top-level assignment; the preceding-char check must run
+        // against the correct char even when a multi-byte char sits earlier.
+        assert_eq!(find_top_level_equals("café != x"), None);
+    }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1659,9 +1659,8 @@ pub(super) fn flatten_destructured_let_as_declarators(
 /// Returns None if there's no `:` (simple property like `a` or `a = default`).
 /// Handles nested patterns so `b: { c }` splits into `("b", "{ c }")`.
 pub(super) fn split_property_key_value(prop: &str) -> Option<(&str, &str)> {
-    let chars: Vec<char> = prop.chars().collect();
     let mut depth = 0;
-    for (i, &ch) in chars.iter().enumerate() {
+    for (i, ch) in prop.char_indices() {
         match ch {
             '{' | '[' | '(' => depth += 1,
             '}' | ']' | ')' => depth -= 1,
@@ -1693,14 +1692,13 @@ pub(super) fn split_binding_name_default(s: &str) -> (&str, Option<&str>) {
 
 /// Split destructuring properties/elements by comma, respecting nesting depth.
 pub(super) fn split_destructuring_properties(s: &str) -> Vec<&str> {
-    let chars: Vec<char> = s.chars().collect();
     let mut result = Vec::new();
     let mut depth = 0;
     let mut start = 0;
     let mut in_string = false;
     let mut string_char = ' ';
 
-    for (i, &ch) in chars.iter().enumerate() {
+    for (i, ch) in s.char_indices() {
         if in_string {
             if ch == '\\' {
                 continue;
@@ -3468,8 +3466,29 @@ pub(super) fn split_top_level_args(s: &str) -> Vec<String> {
 #[cfg(test)]
 mod split_declarators_tests {
     use super::{
-        apply_prop_reads_in_prop_default_values, split_declarators, transform_prop_reads_in_expr,
+        apply_prop_reads_in_prop_default_values, split_declarators, split_destructuring_properties,
+        split_property_key_value, transform_prop_reads_in_expr,
     };
+
+    #[test]
+    fn split_property_key_value_handles_non_ascii_key() {
+        // Non-ASCII prop key before the `:` (e.g. `let { café: renamed } = $props()`)
+        // must not panic on a byte/char index mismatch.
+        assert_eq!(
+            split_property_key_value("café: renamed"),
+            Some(("café", "renamed"))
+        );
+        assert_eq!(split_property_key_value("café"), None);
+    }
+
+    #[test]
+    fn split_destructuring_properties_handles_non_ascii() {
+        // `let { café, b } = $props()` — the comma sits past a multi-byte char.
+        assert_eq!(
+            split_destructuring_properties("café, b"),
+            vec!["café", " b"]
+        );
+    }
 
     #[test]
     fn bare_prop_default_stays_a_getter_reference() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -681,10 +681,9 @@ pub(super) fn body_references_identifier_in_statements(
     // Simple approach: scan for statements at depth 0
     let mut depth = 0;
     let mut start = 0;
-    let chars: Vec<char> = content.chars().collect();
 
-    for i in 0..chars.len() {
-        match chars[i] {
+    for (i, c) in content.char_indices() {
+        match c {
             '(' | '[' | '{' => depth += 1,
             ')' | ']' | '}' if depth > 0 => {
                 depth -= 1;
@@ -1676,18 +1675,16 @@ pub(super) fn transform_legacy_state_declarations(
                 if let Some(pos) = result.find(pat.as_str()) {
                     // Find the `=` that ends the type annotation, respecting nested braces/brackets.
                     let type_start = pos + pat.len();
-                    let chars: Vec<char> = result[type_start..].chars().collect();
                     let mut depth = 0i32;
                     let mut eq_pos: Option<usize> = None;
-                    let mut j = 0;
-                    while j < chars.len() {
-                        let c = chars[j];
+                    let mut iter = result[type_start..].char_indices().peekable();
+                    while let Some((j, c)) = iter.next() {
                         match c {
                             '{' | '[' | '(' | '<' => depth += 1,
                             '}' | ']' | ')' | '>' => depth -= 1,
                             '=' if depth == 0 => {
                                 // Make sure it's not `==` or `=>`
-                                let next = chars.get(j + 1).copied();
+                                let next = iter.peek().map(|&(_, ch)| ch);
                                 if !matches!(next, Some('=') | Some('>')) {
                                     eq_pos = Some(j);
                                     break;
@@ -1696,7 +1693,6 @@ pub(super) fn transform_legacy_state_declarations(
                             ';' | '\n' if depth == 0 => break,
                             _ => {}
                         }
-                        j += 1;
                     }
                     if let Some(eq) = eq_pos {
                         let after_eq = type_start + eq + 1;
@@ -1845,4 +1841,27 @@ pub(super) fn transform_legacy_state_declarations(
     }
 
     result
+}
+
+#[cfg(test)]
+mod non_ascii_tests {
+    use super::{body_references_identifier, transform_legacy_state_declarations};
+    use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
+
+    #[test]
+    fn body_references_identifier_handles_non_ascii_statement() {
+        // A non-ASCII token before a `;`/newline statement boundary must not panic
+        // when scanning statements (byte vs char index).
+        assert!(body_references_identifier("café; return count", "count"));
+        assert!(!body_references_identifier("café; return other", "count"));
+    }
+
+    #[test]
+    fn transform_legacy_state_declarations_handles_non_ascii_type() {
+        // `let x: Café = 0` — the `=` sits past a multi-byte char in the type
+        // annotation; slicing must use byte offsets (no panic).
+        let vars = vec![("x".to_string(), None, DeclarationKind::Let)];
+        let out = transform_legacy_state_declarations("let x: Café = 0", &vars, false);
+        assert!(out.contains("$.mutable_source(0)"), "got: {out}");
+    }
 }


### PR DESCRIPTION
## Summary

Five client instance-script string helpers iterated with `chars().enumerate()` (or a collected `Vec<char>`) and then used the resulting **char index as a byte offset** into the original `&str`. Any non-ASCII byte before the slice point (a non-ASCII identifier, object key, or string/type literal — all valid JS/TS/Svelte) pushed the byte offset past a `char` boundary and panicked the compiler with `byte index N is not a char boundary`.

Because these helpers run whenever the client instance-script IR is built, the crash was reachable from **untrusted `.svelte` input** (compiler crash / DoS).

## Fix

Converted all five sites to work in byte offsets (`char_indices()` / peekable-iterator neighbor lookups):

- `props_transforms.rs`: `split_property_key_value`, `split_destructuring_properties`
- `destructure_transforms.rs`: `find_top_level_equals` (fixes its 11 byte-slicing callers)
- `state_transforms.rs`: `body_references_identifier_in_statements`, `transform_legacy_state_declarations`

Inputs that now compile instead of panicking: `let { café, b } = $props()`, `let { café: renamed } = $props()`, `let [café = 1] = arr`, `let x: Café = 0`.

## Output parity

ASCII input is unaffected (char index equals byte index there), so compiler output is byte-for-byte unchanged.

## Tests

- Added 6 regression unit tests covering the five helpers with non-ASCII input.
- `cargo test --release --test runtime -- test_runtime_legacy test_runtime_runes`: identical result to clean `main` (the 7 pre-existing runes mismatches are unrelated to this change and present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj