### PR TITLE
chore: satisfy stricter clippy::question_mark lint (Rust 1.97)

### DIFF
--- a/.changeset/chore-clippy-question-mark-1.97.md
+++ b/.changeset/chore-clippy-question-mark-1.97.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+"@rsvelte/fmt": patch
+---
+
+chore: satisfy the stricter `clippy::question_mark` lint on Rust 1.97
+
+Rust 1.97's clippy widened the `question_mark` lint, flagging five pre-existing
+`match`/`if let` blocks that hand-propagate `None` as rewritable with `?`. Applied
+clippy's autofix in `class_transforms.rs`, `svelte2tsx/script/mod.rs`,
+`collapse.rs`, and `script.rs`. The rewrites are semantically identical (they all
+return `Option` and `?` propagates `None` exactly as the original early-returns
+did); compiler output is unchanged. Unblocks CI clippy, which runs on stable
+(now 1.97).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -1406,7 +1406,8 @@ pub(super) fn parse_state_field(line: &str, rune_type: &str) -> Option<ClassStat
     let value_start = if after_rune.starts_with('(') {
         // Plain form: `$state(`
         rune_start + rune_type.len() + 1
-    } else if let Some(angle_inner) = after_rune.strip_prefix('<') {
+    } else {
+        let angle_inner = after_rune.strip_prefix('<')?;
         // Generic form: `$state<T>(` — find the matching `>` then expect `(`
         let angle_end = find_matching_bracket_angle(angle_inner)?;
         let after_angle = &after_rune[1 + angle_end + 1..]; // skip `<`, inner, `>`
@@ -1414,8 +1415,6 @@ pub(super) fn parse_state_field(line: &str, rune_type: &str) -> Option<ClassStat
             return None;
         }
         rune_start + rune_type.len() + 1 + angle_end + 1 + 1 // `<` + inner + `>` + `(`
-    } else {
-        return None;
     };
 
     // Find matching closing paren

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -4997,9 +4997,9 @@ fn find_module_script_span(source: &str) -> Option<(usize, usize)> {
     while let Some(rel) = source[search..].find("<script") {
         let tag_start = search + rel;
         // Find the end of the opening tag `>`.
-        let gt = match source[tag_start..].find('>') {
-            Some(g) => tag_start + g,
-            None => return None,
+        let gt = {
+            let g = source[tag_start..].find('>')?;
+            tag_start + g
         };
         let open_tag = &source[tag_start..gt];
         // `module` either as a bare attribute or `context="module"` / `context='module'`.
@@ -5040,9 +5040,9 @@ fn find_instance_script_span(source: &str) -> Option<(usize, usize)> {
     let mut search = 0usize;
     while let Some(rel) = source[search..].find("<script") {
         let tag_start = search + rel;
-        let gt = match source[tag_start..].find('>') {
-            Some(g) => tag_start + g,
-            None => return None,
+        let gt = {
+            let g = source[tag_start..].find('>')?;
+            tag_start + g
         };
         let open_tag = &source[tag_start..gt];
         let is_module = open_tag.contains("context=\"module\"")

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -3559,10 +3559,9 @@ fn try_break_pre_own_attrs(
         return None;
     }
     // Find the open tag end (position right after `>` of the opening tag).
-    let open_end = if let Some(first) = fragment.nodes.first() {
+    let open_end = {
+        let first = fragment.nodes.first()?;
         node_start(first) as usize
-    } else {
-        return None;
     };
     let open = out.get(s..open_end)?;
     // Must be a single-line open tag with at least one attribute.

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -263,11 +263,9 @@ fn wrap_script_open_tag(tag: &str, indent_width: usize) -> Option<String> {
     // Strip the leading `<` and trailing `>`.
     let inner = tag.strip_prefix('<')?.strip_suffix('>')?;
     // Split tag name from attributes. Tag name is everything up to the first space.
-    let (tag_name, rest) = if let Some(sp) = inner.find(' ') {
+    let (tag_name, rest) = {
+        let sp = inner.find(' ')?;
         (&inner[..sp], inner[sp + 1..].trim())
-    } else {
-        // No attributes — nothing to wrap.
-        return None;
     };
     // Parse attributes from the flat string. All values are double-quoted after
     // normalize_open_tag, so we scan respecting quoted spans.


### PR DESCRIPTION
CI runs clippy on stable, which advanced to **Rust 1.97**. 1.97's clippy widened the `question_mark` lint and now flags five pre-existing `match` / `if let` blocks that hand-propagate `None`, breaking the `Clippy` job on **every** open PR (not just the one where it first surfaced):

- `crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs`
- `crates/rsvelte_core/src/svelte2tsx/script/mod.rs` (×2)
- `crates/rsvelte_formatter/src/collapse.rs`
- `crates/rsvelte_formatter/src/script.rs`

Applied clippy's own autofix. The rewrites are semantically identical — each function returns `Option`, and `?` propagates `None` exactly as the original early-returns did — so compiler/formatter output is unchanged. Verified `cargo clippy --all-targets --all-features -- -D warnings` is clean under 1.97.

This is a prerequisite for the rest of the open PR fleet to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KPMtBi2GSUYvat5rowsPu