### PR TITLE
fix(lint): make rsvelte-lint per-file panic isolation effective in release builds

### DIFF
--- a/.changeset/fix-lint-panic-isolation.md
+++ b/.changeset/fix-lint-panic-isolation.md
@@ -1,0 +1,22 @@
+---
+---
+
+fix(lint): make the `rsvelte-lint` per-file panic isolation effective under distribution builds
+
+`rsvelte-lint`'s CLI wraps each file in `catch_unwind` so that a compiler panic
+on one pathological file is turned into a single `lint-internal-error`
+diagnostic instead of aborting the whole run. That guarantee was silently void
+in the shipped binary: the shared `[profile.release]` (and the `dist` profile
+that inherits it) set `panic = "abort"`, which makes a panic call `abort()`
+immediately — `catch_unwind` never gets to run, so the process dies with
+`SIGABRT` (exit 134) and every file's output is lost. `cargo test` always
+unwinds, so unit tests could not catch the regression.
+
+Add a dedicated `dist-lint` cargo profile (`inherits = "dist"` + `panic =
+"unwind"`) and build the CLI with `--profile dist-lint`, so the per-file
+isolation actually holds while keeping dist's optimization and symbol stripping.
+The corpus-compat lint job — which runs the CLI over ~12k files, exactly the
+scenario the isolation protects — now builds with this profile. The misleading
+"must not abort the whole run" comments now state the profile requirement.
+
+No published-package code changes (`rsvelte_lint` is `publish = false`).

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -335,7 +335,11 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build rsvelte-lint
-        run: cargo build --release --bin rsvelte-lint
+        # `--profile dist-lint` (release optimization + `panic = "unwind"`) so the
+        # CLI's per-file `catch_unwind` isolation actually holds when a single
+        # corpus file makes the compiler panic — the shared release/dist profiles
+        # use `panic = "abort"`, which would SIGABRT the whole ~12k-file run.
+        run: cargo build --profile dist-lint --bin rsvelte-lint
 
       # The oracle is the pinned real eslint-plugin-svelte; deps install into an
       # isolated package so the comparison never drifts from what users run.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,18 @@ panic = "abort"
 inherits = "release"
 strip = "symbols"
 
+# Distribution profile for the `rsvelte-lint` CLI. It isolates a per-file
+# compiler panic via `catch_unwind` (see `crates/rsvelte_lint/src/main.rs`), a
+# guarantee that only holds when the binary UNWINDS — the shared `release`/`dist`
+# profiles set `panic = "abort"` (smaller/faster), which turns that isolation
+# into an immediate `SIGABRT` for the whole run. This profile keeps dist's
+# optimization + symbol stripping but restores unwinding, so one pathological
+# file can be skipped instead of aborting the entire lint pass. Build the CLI
+# with `--profile dist-lint`.
+[profile.dist-lint]
+inherits = "dist"
+panic = "unwind"
+
 [profile.profiling]
 inherits = "release"
 lto = "thin"          # thin LTO keeps profiling builds within the dev box's RAM

--- a/crates/rsvelte_lint/src/main.rs
+++ b/crates/rsvelte_lint/src/main.rs
@@ -179,7 +179,11 @@ fn main() -> ExitCode {
     }
 
     // Lint files in parallel; each file is independent. A panic in the compiler
-    // on one pathological file must not abort the whole run — isolate per file.
+    // on one pathological file is isolated per file by `lint_file_safe` — but
+    // `catch_unwind` only recovers when the binary UNWINDS. The shared
+    // release/dist profiles set `panic = "abort"`, so distribution builds must
+    // use `--profile dist-lint` (release + `panic = "unwind"`) for this
+    // isolation to hold; under an aborting build a panic still ends the run.
     let per_file: Vec<Vec<Diagnostic>> = files
         .par_iter()
         .map(|f| lint_file_safe(f, &config))
@@ -206,7 +210,9 @@ fn main() -> ExitCode {
 }
 
 /// Lint a file, isolating any panic so a single pathological file can't abort
-/// the whole run; the panic surfaces as a diagnostic instead.
+/// the whole run; the panic surfaces as a diagnostic instead. Effective only in
+/// an unwinding build (see `--profile dist-lint`); a `panic = "abort"` build
+/// cannot recover here.
 fn lint_file_safe(file: &Path, config: &LintConfig) -> Vec<Diagnostic> {
     use std::panic::{AssertUnwindSafe, catch_unwind};
     match catch_unwind(AssertUnwindSafe(|| lint_file(file, config))) {

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -279,7 +279,7 @@ against each fixture's expected `*-errors.yaml`; this corpus track is the
 ```bash
 pnpm run lint-corpus:sync             # init eslint-plugin-svelte + svelte-eslint-parser submodules
 pnpm run lint-corpus:oracle-install   # install the pinned real eslint-plugin-svelte (oracle)
-cargo build --release --bin rsvelte-lint
+cargo build --profile dist-lint --bin rsvelte-lint   # `panic = "unwind"` → per-file panic isolation holds
 pnpm run lint-corpus:collect          # gather .svelte sources -> compat/lint-corpus/sources/
 pnpm run lint-corpus:verify           # diff oracle vs rsvelte-lint, ratchet known-failures.json
 # or, all of the above:

--- a/scripts/compat-corpus/lint-verify.mjs
+++ b/scripts/compat-corpus/lint-verify.mjs
@@ -108,7 +108,7 @@ const MANUAL_EXCLUSIONS = new Set([
 ]);
 
 function findBinary() {
-	for (const profile of ['release', 'debug']) {
+	for (const profile of ['dist-lint', 'release', 'debug']) {
 		const p = path.join(ROOT, 'target', profile, 'rsvelte-lint');
 		if (fs.existsSync(p)) return p;
 	}


### PR DESCRIPTION
## Problem

`rsvelte-lint`'s CLI wraps each file in `catch_unwind` (`crates/rsvelte_lint/src/main.rs` — `lint_file_safe` / `fix_one`) with an explicit design comment: *"A panic in the compiler on one pathological file must not abort the whole run — isolate per file."*

That guarantee is **silently void in every optimized build**. The workspace `[profile.release]` (`Cargo.toml`) sets `panic = "abort"`, and the `dist` profile inherits it. Under `panic = "abort"`, a panic calls `abort()` immediately — it never unwinds, so `catch_unwind` cannot catch it. The process dies with `SIGABRT` (exit 134). Worse, `main.rs` collects every file's diagnostics with `par_iter().map(...).collect()` and prints once at the end, so a single unexpected panic drops **all** output, not just the offending file's.

`cargo test` always unwinds (Cargo ignores `panic` for test/bench), so unit tests exercise the recovery path and pass — the release regression is invisible to the suite.

### Reproduction (before/after)

A minimal `catch_unwind` harness:

- `rustc -C panic=abort` (mirrors `[profile.release]`): `thread panicked … / exit=134`, the `Err` branch never runs.
- `rustc -C panic=unwind` (mirrors the new profile): `RECOVERED-ERR (isolation works) / continued after per-file panic / exit=0`.

## Fix

Chosen approach: **restore unwinding for the CLI via a dedicated profile**, rather than abandoning `catch_unwind`. Rationale:

- It restores the exact documented guarantee with **zero change to code, output, or diagnostic ordering** — `catch_unwind` starts working again as written.
- Cargo cannot set `panic` per-package, and flipping the shared `release`/`dist` profiles to unwind would enlarge/deoptimize every artifact (NAPI `.node`, `svelte_check`, `rsvelte-fmt`) for a property only the lint CLI relies on. A dedicated profile scopes the cost to the one binary.
- The lint CLI is not perf-critical and is not npm-distributed, so the marginal unwind cost is irrelevant.
- The alternative (panic hook + per-file flush before abort) cannot truly continue after an abort, and per-file flushing conflicts with `render()`'s aggregate summary/SARIF output — it would change output.

Changes:
- `Cargo.toml`: new `[profile.dist-lint]` (`inherits = "dist"`, `panic = "unwind"`) — keeps dist's optimization + symbol stripping, restores unwinding.
- `.github/workflows/corpus-compat.yml`: build the CLI with `--profile dist-lint` (the ~12k-file corpus run is exactly the scenario the isolation protects).
- `scripts/compat-corpus/lint-verify.mjs`: look in `target/dist-lint/` first when locating the binary.
- `scripts/compat-corpus/README.md`: documented build command updated.
- `main.rs`: the misleading isolation comments now state the profile requirement.

## Verification

- Minimal harness confirms abort→exit 134 vs unwind→recovery (above).
- `cargo build --profile dist-lint --bin rsvelte-lint` succeeds; the resulting binary contains unwinding machinery (`_Unwind_Resume` / `rust_eh_personality` — absent in a `panic=abort` binary) and lints normally.

`rsvelte_lint` is `publish = false`; no published-package code changes (changeset has empty frontmatter per project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj