### PR TITLE
perf(lint): share one parse across a Svelte file's rule passes

### DIFF
--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -7,6 +7,7 @@
 use std::path::Path;
 
 use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::ast::template::Root;
 use rsvelte_core::{ParseOptions, parse};
 use serde_json::Value;
 
@@ -18,11 +19,45 @@ use crate::rule::{RuleMeta, Severity};
 use crate::script::{ScriptKind, ScriptRule};
 use crate::visitor::{EnabledRule, LintVisitor};
 
+/// The lenient parse options every lint pass uses. `lenient_script: true` keeps
+/// a `<script lang="…">` / invalid-TS block from aborting the parse so the rules
+/// still see the template. Every consumer of a shared [`Root`] MUST parse with
+/// these exact options (the block-lang fallback's success probe depends on it).
+pub(crate) fn lint_parse_options() -> ParseOptions {
+    ParseOptions {
+        lenient_script: true,
+        ..Default::default()
+    }
+}
+
 /// Run every enabled native rule over `source`, returning raw findings. `path`
 /// is the file being linted when known (`None` for in-memory / wasm linting);
 /// filesystem-aware rules (e.g. `svelte/no-companion-module-shadow`) use it and
 /// no-op when it is `None`.
 pub fn run_native_rules(
+    source: &str,
+    filename: &str,
+    config: &LintConfig,
+    path: Option<&Path>,
+) -> Vec<LintDiagnostic> {
+    // Skip the parse entirely when every native rule is off.
+    if all_rules()
+        .iter()
+        .all(|r| config.severity_for(r.meta()) == Severity::Off)
+    {
+        return Vec::new();
+    }
+    let Ok(root) = parse(source, lint_parse_options()) else {
+        return Vec::new();
+    };
+    run_native_rules_on_root(&root, source, filename, config, path)
+}
+
+/// Like [`run_native_rules`] but reuses an already-parsed [`Root`] instead of
+/// parsing again — lets `lint_source` share one parse across the native walk,
+/// the script walk, and the block-lang fallback.
+pub(crate) fn run_native_rules_on_root(
+    root: &Root,
     source: &str,
     filename: &str,
     config: &LintConfig,
@@ -48,21 +83,12 @@ pub fn run_native_rules(
     if enabled.is_empty() {
         return Vec::new();
     }
-    let Ok(root) = parse(
-        source,
-        ParseOptions {
-            lenient_script: true,
-            ..Default::default()
-        },
-    ) else {
-        return Vec::new();
-    };
     let mut ctx = LintContext::new(config, source, filename).with_path(path);
     // Re-install the arena pointer so that `Expression::Typed::as_json()` can
     // resolve arena-indexed children while the visitor walks the template.
     // The pointer was cleared when `parse()` dropped its `SerializeArenaGuard`.
     with_serialize_arena(&root.arena, || {
-        LintVisitor::new(enabled).visit_root(&mut ctx, &root);
+        LintVisitor::new(enabled).visit_root(&mut ctx, root);
     });
     ctx.into_diagnostics()
 }
@@ -155,20 +181,31 @@ pub fn run_script_rules_with_path(
     if enabled.is_empty() {
         return Vec::new();
     }
-    let Ok(root) = parse(
-        source,
-        ParseOptions {
-            lenient_script: true,
-            ..Default::default()
-        },
-    ) else {
+    let Ok(root) = parse(source, lint_parse_options()) else {
         return Vec::new();
     };
+    run_script_rules_on_root(&root, source, filename, config, path)
+}
+
+/// Like [`run_script_rules_with_path`] but reuses an already-parsed [`Root`]
+/// instead of parsing again (shared-parse fast path in `lint_source`).
+pub(crate) fn run_script_rules_on_root(
+    root: &Root,
+    source: &str,
+    filename: &str,
+    config: &LintConfig,
+    path: Option<&Path>,
+) -> Vec<LintDiagnostic> {
+    let rules = all_script_rules();
+    let enabled = enabled_script_rules(&rules, config);
+    if enabled.is_empty() {
+        return Vec::new();
+    }
 
     // Materialise each script program to an owned ESTree JSON value. The
     // serialization MUST run inside the arena scope (the program body resolves
     // arena-indexed children) and BEFORE any out-of-scope `as_json` would cache
-    // an empty body — so we parse fresh here and serialize immediately.
+    // an empty body — so we serialize immediately inside the arena guard.
     let programs: Vec<(ScriptKind, Value)> = with_serialize_arena(&root.arena, || {
         let mut out = Vec::new();
         if let Some(s) = root.instance.as_ref() {

--- a/crates/rsvelte_lint/src/rules/block_lang.rs
+++ b/crates/rsvelte_lint/src/rules/block_lang.rs
@@ -488,6 +488,7 @@ pub fn block_lang_source_scan_diagnostics(
     source: &str,
     file: &Path,
     config: &LintConfig,
+    parse_ok: bool,
 ) -> Vec<Diagnostic> {
     let severity = config.resolve_code(META.name, META.default_severity);
     if severity == Severity::Off {
@@ -495,17 +496,12 @@ pub fn block_lang_source_scan_diagnostics(
     }
 
     // Only run when the AST path was skipped — `BlockLang::check_root` already
-    // covers every file the lint engine could parse. The engine parses in
-    // LENIENT mode (`lenient_script: true`), so this guard MUST use the same
-    // mode: a `<style lang="scss">` / `<script lang="…">` block parses leniently
-    // (so `check_root` fires) while a strict `ParseOptions::default()` parse
-    // would fail here — running the source scan on top of `check_root` would
-    // then double-report. Mirror the engine's options exactly.
-    let lenient = rsvelte_core::ParseOptions {
-        lenient_script: true,
-        ..Default::default()
-    };
-    if rsvelte_core::parse(source, lenient).is_ok() {
+    // covers every file the lint engine could parse. `parse_ok` is the result of
+    // the caller's single LENIENT parse (`lenient_script: true`): a
+    // `<style lang="scss">` / `<script lang="…">` block parses leniently (so
+    // `check_root` fires) and running the source scan on top would double-report,
+    // so bail out when the shared parse succeeded.
+    if parse_ok {
         return Vec::new();
     }
 

--- a/crates/rsvelte_lint/src/runner.rs
+++ b/crates/rsvelte_lint/src/runner.rs
@@ -8,7 +8,10 @@ use rsvelte_core::svelte_check::diagnostic::Diagnostic;
 
 use crate::config::LintConfig;
 use crate::diagnostic::{LintDiagnostic, TextEdit};
-use crate::engine::{run_native_rules, run_script_rules, run_script_rules_with_path};
+use crate::engine::{
+    lint_parse_options, run_native_rules, run_native_rules_on_root, run_script_rules,
+    run_script_rules_on_root,
+};
 use crate::line_index::LineIndex;
 use crate::suppression::Suppressions;
 
@@ -44,19 +47,28 @@ pub fn lint_source(
             diags
         }
         crate::engine::SourceKind::Svelte => {
+            // Parse the source ONCE (lenient) and share the `Root` across the
+            // native-template walk, the script-AST walk, and the block-lang
+            // fallback's success probe — instead of re-parsing in each. The
+            // validator wrap below still compiles independently (it needs a full
+            // analyze pass), so it keeps its own parse.
+            let parsed = rsvelte_core::parse(source, lint_parse_options()).ok();
+
             // 1. Validator wrap — compiler warnings/errors/a11y (config applied inside).
             let mut diags = crate::validator::validator_diagnostics(source, file, options, config);
 
-            // 2. Native rule engine — single shared DFS over the template AST.
-            for d in run_native_rules(source, &filename, config, Some(file)) {
-                diags.push(d.to_output(file, &line_index));
-            }
+            if let Some(root) = &parsed {
+                // 2. Native rule engine — single shared DFS over the template AST.
+                for d in run_native_rules_on_root(root, source, &filename, config, Some(file)) {
+                    diags.push(d.to_output(file, &line_index));
+                }
 
-            // 2a. Script-AST rules — walk the `<script>` ESTree program(s).
-            // Thread the full path so path-gated rules (e.g. SvelteKit route
-            // file detection) can check whether the file lives under src/routes.
-            for d in run_script_rules_with_path(source, &filename, config, Some(file)) {
-                diags.push(d.to_output(file, &line_index));
+                // 2a. Script-AST rules — walk the `<script>` ESTree program(s).
+                // Thread the full path so path-gated rules (e.g. SvelteKit route
+                // file detection) can check whether the file lives under src/routes.
+                for d in run_script_rules_on_root(root, source, &filename, config, Some(file)) {
+                    diags.push(d.to_output(file, &line_index));
+                }
             }
 
             // 2b. Scope-based rules (Wave 2). No-op until scope rules ship; this
@@ -86,7 +98,12 @@ pub fn lint_source(
             // the normal `check_root` path is skipped. Run a source-scan instead
             // to catch `<script lang="…">` / `<style lang="…">` violations.
             diags.extend(
-                crate::rules::block_lang::block_lang_source_scan_diagnostics(source, file, config),
+                crate::rules::block_lang::block_lang_source_scan_diagnostics(
+                    source,
+                    file,
+                    config,
+                    parsed.is_some(),
+                ),
             );
 
             // 2e. Cross-cutting (template + script) source-scan meta-rules.
@@ -193,13 +210,22 @@ pub fn lint_source_raw(source: &str, file: &Path, config: &LintConfig) -> Vec<Li
             crate::engine::run_script_rules_module(source, &filename, ts, config)
         }
         crate::engine::SourceKind::Svelte => {
-            let mut d = run_native_rules(source, &filename, config, Some(file));
-            d.extend(run_script_rules_with_path(
-                source,
-                &filename,
-                config,
-                Some(file),
-            ));
+            // Share one lenient parse across the native + script walks.
+            let mut d = match rsvelte_core::parse(source, lint_parse_options()) {
+                Ok(root) => {
+                    let mut d =
+                        run_native_rules_on_root(&root, source, &filename, config, Some(file));
+                    d.extend(run_script_rules_on_root(
+                        &root,
+                        source,
+                        &filename,
+                        config,
+                        Some(file),
+                    ));
+                    d
+                }
+                Err(_) => Vec::new(),
+            };
             d.extend(crate::scope::scope_diagnostics(source, config));
             d
         }


### PR DESCRIPTION
## Problem

For a typical `.svelte` file under the recommended preset, `lint_source` parses the same source **up to 4 times**:

1. `validator::validator_diagnostics` → `compile()` (full parse + analyze, `GenerateMode::None`)
2. `engine::run_native_rules` → `parse(lenient_script: true)`
3. `engine::run_script_rules_with_path` → `parse(lenient_script: true)` — same options
4. `rules::block_lang::block_lang_source_scan_diagnostics` → `parse(lenient_script: true)` used **only** to check `.is_ok()` and decide whether the AST path (`BlockLang::check_root`, run inside #2) had already covered the file

Over the ~12k-file compat corpus — and every CLI / CI / playground(wasm) run — that 3–4× parse/analyze cost is a real multiplier.

## Fix

Parse the template **once** (lenient) at the top of the `Svelte` arm and share the `Root` across passes #2–#4:

- **`engine`**: add `run_native_rules_on_root` / `run_script_rules_on_root` that take a pre-parsed `&Root`. The public `run_native_rules` / `run_script_rules_with_path` become thin wrappers (parse → delegate), so external callers — `fix_source`, the wasm entry, the `no_companion_module` tests — are untouched. A shared `lint_parse_options()` guarantees every consumer parses with the identical `lenient_script: true` options (the block-lang probe's correctness depends on that).
- **`runner::lint_source`**: reuse the one `Root` for the native + script walks, and pass `parsed.is_some()` to the block-lang fallback instead of making it re-parse. `lint_source_raw` (the compat-oracle path) shares its parse too.
- **`block_lang_source_scan_diagnostics`**: takes a `parse_ok: bool` and drops its internal `parse()`.

The validator wrap keeps its own `compile()` — it needs a full analyze pass that the lint parse doesn't run, so it's a separate code path (the finding noted full sharing there is out of scope).

### Parse-count reduction

| Path | Before | After |
|---|---|---|
| `lint_source` (per `.svelte`) | 4 | 2 |
| `lint_source_raw` (oracle) | 2 | 1 |

Diagnostic content and ordering are unchanged.

## Verification

- `cargo test -p rsvelte_lint --no-default-features --features native --test eslint_plugin_oracle` → `oracle_strict_parity ... ok` (byte-level diagnostic + fix/suggestion parity with real eslint-plugin-svelte).
- All 224 `rsvelte_lint` lib unit tests pass, including `block_lang_non_css_lang_reports_once`, which specifically exercises the new `parse_ok` guard (the double-report regression test).
- `cargo fmt` and `cargo clippy` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj