### PR TITLE
perf(analyze): undo declaration shadows via a diff log instead of full-map clone

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -486,6 +486,13 @@ pub struct VisitorContext<'a> {
     /// Used to prevent `identifier::visit` from setting `has_direct_template_read`
     /// for bind:this references, since bind:this has special non_reactive_update logic.
     pub in_bind_this: bool,
+    /// Undo log of temporary shadowing inserts into `analysis.root.scope.declarations`
+    /// made while walking a function/arrow body. Each entry is `(name, previous)` where
+    /// `previous` is the binding index the name mapped to before the insert (or `None` if
+    /// the name was absent). The function-body walker records a length marker on entry and,
+    /// on exit, pops entries back to that marker in LIFO order to reverse exactly the
+    /// declarations added during that scope — replacing a full clone/restore of the map.
+    pub decl_undo_log: Vec<(String, Option<usize>)>,
 }
 
 /// Type of ancestor that can "own" a slot attribute.
@@ -590,6 +597,7 @@ impl<'a> VisitorContext<'a> {
             current_template_scope: 0,
             in_const_tag: false,
             in_bind_this: false,
+            decl_undo_log: Vec::new(),
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -2034,12 +2034,13 @@ pub fn walk_js_expression(
             // This is important for detecting scoped store subscriptions
             context.function_depth += 1;
 
-            // Save a snapshot of the declarations map before entering the function scope.
-            // This ensures that both parameter shadowing AND local variable declarations
-            // inside the function body are properly scoped and restored when we exit.
-            // Without this, `const bar = baz` inside a callback would permanently
-            // shadow the outer `bar` binding in the declarations map.
-            let saved_declarations = context.analysis.root.scope.declarations.clone();
+            // Mark the current length of the declarations undo log before entering the
+            // function scope. Parameter shadows and local variable declarations added
+            // inside the body each append a `(name, previous)` entry; on exit we pop
+            // back to this mark to reverse exactly those inserts. Without this cleanup,
+            // `const bar = baz` inside a callback would permanently shadow the outer
+            // `bar` binding in the declarations map.
+            let decl_undo_mark = context.decl_undo_log.len();
 
             // Create a temporary scope in all_scopes for the function parameters.
             // This ensures that parameter names properly shadow bindings from outer
@@ -2086,12 +2087,13 @@ pub fn walk_js_expression(
 
                         // Also add to the root scope declarations for backward compatibility
                         // with $store scoped subscription checks
-                        context
+                        let prev = context
                             .analysis
                             .root
                             .scope
                             .declarations
                             .insert(param_name.clone(), temp_binding_idx);
+                        context.decl_undo_log.push((param_name, prev));
                     }
                 }
             }
@@ -2144,8 +2146,18 @@ pub fn walk_js_expression(
 
             // Restore the declarations map to the state before entering this function scope.
             // This undoes both parameter shadows and any local variable declarations
-            // that were registered inside the function body.
-            context.analysis.root.scope.declarations = saved_declarations;
+            // that were registered inside the function body, in LIFO order.
+            while context.decl_undo_log.len() > decl_undo_mark {
+                let (name, prev) = context.decl_undo_log.pop().unwrap();
+                match prev {
+                    Some(idx) => {
+                        context.analysis.root.scope.declarations.insert(name, idx);
+                    }
+                    None => {
+                        context.analysis.root.scope.declarations.remove(&name);
+                    }
+                }
+            }
 
             // Restore function depth
             context.function_depth -= 1;
@@ -2300,12 +2312,13 @@ pub fn walk_js_statement(
                             }
 
                             // Also add to root scope declarations for backward compatibility
-                            context
+                            let prev = context
                                 .analysis
                                 .root
                                 .scope
                                 .declarations
-                                .insert(name, temp_binding_idx);
+                                .insert(name.clone(), temp_binding_idx);
+                            context.decl_undo_log.push((name, prev));
                         }
                     }
                 }
@@ -3260,7 +3273,7 @@ pub fn walk_js_expression_node(
         } => {
             context.function_depth += 1;
 
-            let saved_declarations = context.analysis.root.scope.declarations.clone();
+            let decl_undo_mark = context.decl_undo_log.len();
 
             let saved_scope = context.scope;
             let temp_scope_idx = context.analysis.root.all_scopes.len();
@@ -3289,12 +3302,13 @@ pub fn walk_js_expression_node(
                         .declarations
                         .insert(param_name.clone(), temp_binding_idx);
 
-                    context
+                    let prev = context
                         .analysis
                         .root
                         .scope
                         .declarations
                         .insert(param_name.clone(), temp_binding_idx);
+                    context.decl_undo_log.push((param_name, prev));
                 }
             }
 
@@ -3333,7 +3347,17 @@ pub fn walk_js_expression_node(
             context.in_template_function = saved_in_template_function;
             context.expression = saved_expression;
             context.scope = saved_scope;
-            context.analysis.root.scope.declarations = saved_declarations;
+            while context.decl_undo_log.len() > decl_undo_mark {
+                let (name, prev) = context.decl_undo_log.pop().unwrap();
+                match prev {
+                    Some(idx) => {
+                        context.analysis.root.scope.declarations.insert(name, idx);
+                    }
+                    None => {
+                        context.analysis.root.scope.declarations.remove(&name);
+                    }
+                }
+            }
             context.function_depth -= 1;
         }
         JsNode::FunctionExpression { body: None, .. }
@@ -3468,12 +3492,13 @@ pub fn walk_js_statement_node(
                             scope.declarations.insert(name.clone(), temp_binding_idx);
                         }
 
-                        context
+                        let prev = context
                             .analysis
                             .root
                             .scope
                             .declarations
-                            .insert(name, temp_binding_idx);
+                            .insert(name.clone(), temp_binding_idx);
+                        context.decl_undo_log.push((name, prev));
                     }
                 }
             }


### PR DESCRIPTION
## What

The template-expression JS walkers (`walk_js_expression` / `walk_js_expression_node` in `2_analyze/visitors/shared/utils.rs`) cloned the **entire** `analysis.root.scope.declarations` map on entry to **every** nested function / arrow body, and restored that clone on exit. The clone exists only to scope-away the parameter and local-variable shadows registered while walking the body — but it costs O(map size) per nested function regardless of how few names the function actually shadows. Component scripts with many top-level bindings and many callbacks pay this repeatedly.

## How

Record only the mutations instead of snapshotting the whole map:

- New field `VisitorContext::decl_undo_log: Vec<(String, Option<usize>)>`.
- Each shadowing insert into `root.scope.declarations` (function params + body-local `let`/`const`/`var`, in both the JSON and typed walker paths) now captures the previous value (`HashMap::insert`'s return) and appends `(name, previous)` to the log.
- Each function body records `decl_undo_log.len()` on entry and, on exit, pops back to that mark in **LIFO** order — re-inserting the shadowed binding (`Some`) or removing an added one (`None`).

Per-frame length markers + LIFO guarantee the map is **byte-identical** to the old clone/restore at every observable point: a nested frame undoes only its own entries (appended after its marker) before the outer frame exits, so the outer frame reverses only its own params/locals. Same-name-shadowed-twice is handled correctly because each undo restores the exact pre-insert value. Cost drops from O(map size) to O(shadowed names) per function.

## Verification

- `cargo build` + `cargo clippy` clean (the one remaining clippy error is a pre-existing newer-clippy `collapsible_match` lint at `utils.rs`-unrelated `mod.rs:1711`, present on `main`).
- `cargo test --release --test runtime test_runtime_legacy` → **1206/1206 pass**. runtime-legacy is the heaviest exercise of this exact code path (legacy `$store` scoped-subscription detection, reactive dependency collection, and callback-parameter shadowing of each-block items).
- `cargo test --release --test runtime test_runtime_runes` → **no new failures** vs. baseline (7 pre-existing snippet/derived MISMATCHes are environmental to this local macOS + symlinked-fixtures setup and unrelated to this change; the set is identical before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj