### PR TITLE
chore(svelte2tsx): shrink module-wide lint allows, delete dead code, fix doc attribution

### DIFF
--- a/.changeset/chore-svelte2tsx-lint-cleanup.md
+++ b/.changeset/chore-svelte2tsx-lint-cleanup.md
@@ -1,0 +1,20 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+chore(svelte2tsx): shrink module-wide lint allows and fix doc attribution
+
+Remove the blanket `#[allow(dead_code, doc_lazy_continuation,
+if_same_then_else, unnecessary_unwrap, ...)]` module attributes on the
+svelte2tsx submodules — only `module_inception` remains (with its own
+reason), since `svelte2tsx::svelte2tsx` mirrors the upstream package
+layout. Truly dead helpers are deleted (unused JSON rune-global walkers,
+`node_start_pos`/`node_end_pos`, unused structured-bake formatters, unused
+`PropsRuneInfo` fields), `is_some()`-then-`unwrap()` sites become
+let-chains, identical `if`/`else` arms collapse, and doc comments that had
+drifted onto the wrong item (`process_instance_script`,
+`handle_reactive_statement`, `emit_segmented_overwrite`,
+`format_attribute_node_segments`, overlay's `emit_external_shadows` /
+`path_relative`) are reattached. No behavior change — the transform output
+is byte-identical (fixture suite verified).

--- a/crates/rsvelte_core/src/svelte2tsx/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/mod.rs
@@ -3,27 +3,12 @@
     reason = "MagicString::to_string mirrors JS `MagicString.toString()`; the inherent name is the ported public API"
 )]
 pub mod magic_string;
-#[allow(
-    dead_code,
-    clippy::doc_lazy_continuation,
-    clippy::if_same_then_else,
-    reason = "ported svelte2tsx module: retains upstream TS structure (explicit branches / doc layout) and helpers not yet wired into the port; only these specific lints are waived, full rustc + clippy enforcement applies otherwise"
-)]
 pub mod script;
 #[allow(
-    dead_code,
-    clippy::if_same_then_else,
-    clippy::unnecessary_unwrap,
     clippy::module_inception,
-    reason = "ported svelte2tsx module: retains upstream TS structure (explicit branches / doc layout) and helpers not yet wired into the port; only these specific lints are waived, full rustc + clippy enforcement applies otherwise"
+    reason = "svelte2tsx::svelte2tsx mirrors the upstream package layout (svelte2tsx/index.ts); renaming the file would break the 1:1 structural mapping"
 )]
 pub mod svelte2tsx;
-#[allow(
-    dead_code,
-    clippy::doc_lazy_continuation,
-    clippy::doc_overindented_list_items,
-    reason = "ported svelte2tsx module: retains upstream TS structure (explicit branches / doc layout) and helpers not yet wired into the port; only these specific lints are waived, full rustc + clippy enforcement applies otherwise"
-)]
 pub mod template;
 
 pub use svelte2tsx::{

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -936,8 +936,6 @@ struct PropsRuneInfo {
     props_call_end: u32,
     /// Whether the declarator has a TS type annotation
     has_type_annotation: bool,
-    /// Start of the type annotation (after `:`, relative to raw_content)
-    type_annotation_start: Option<u32>,
     /// End of the type annotation (relative to raw_content)
     type_annotation_end: Option<u32>,
     /// Text of the type annotation
@@ -957,9 +955,6 @@ struct PropsRuneInfo {
     /// all other annotated types (TSIndexedAccessType, TSUnionType, etc.) get wrapped
     /// in `$$ComponentProps` — mirrors the official `ts.isTypeReferenceNode` check.
     is_named_type_reference: bool,
-    /// Whether the $props() binding pattern is an identifier (whole-object form),
-    /// e.g. `let props = $props()` rather than a destructuring `let { a } = $props()`.
-    is_identifier_pattern: bool,
     /// Whether the pattern has a rest element (`...rest`)
     has_rest: bool,
     /// Whether the pattern has any non-identifier property keys (mirrors official `withUnknown`).
@@ -987,21 +982,6 @@ struct PropsRuneInfo {
 // Script Processing
 // =============================================================================
 
-/// Process an instance script block (`<script>`).
-///
-/// Extracts:
-/// - Exported variables (props in Svelte 4, or named exports)
-/// - `$props()` usage (Svelte 5 runes)
-/// - Event dispatcher declarations
-/// - Store subscriptions
-///
-/// # Arguments
-///
-/// * `script` - The parsed Script AST node
-/// * `source` - The original source code
-/// * `str` - The MagicString for source manipulation
-/// * `exported_names` - Accumulator for exported names
-/// * `events` - Accumulator for component events
 /// Classify a Svelte component basename for SvelteKit autotype injection.
 ///
 /// Returns:
@@ -1028,6 +1008,13 @@ pub fn classify_kit_route_file(basename: &str) -> Option<bool> {
     }
 }
 
+/// Process an instance script block (`<script>`).
+///
+/// Extracts:
+/// - Exported variables (props in Svelte 4, or named exports)
+/// - `$props()` usage (Svelte 5 runes)
+/// - Event dispatcher declarations
+/// - Store subscriptions
 pub fn process_instance_script(
     script: &Script,
     source: &str,
@@ -3558,17 +3545,6 @@ fn handle_export_named_decl(
     }
 }
 
-/// Handle a reactive labeled statement (`$: ...`).
-///
-/// Transforms reactive declarations and statements according to svelte2tsx conventions:
-///
-/// - `$: x = expr` (new variable) → `let  x = __sveltets_2_invalidate(() => expr)`
-/// - `$: x = expr` (existing var) → `$: x = __sveltets_2_invalidate(() => expr)`
-/// - `$: $store = expr` (store) → `$: $store = __sveltets_2_invalidate(() => expr)`
-/// - `$: ({ a } = expr)` (destructure, new) → `let  { a } = __sveltets_2_invalidate(() => expr)`
-/// - `$: ({ a } = expr)` (destructure, existing) → `$: ({ a } = __sveltets_2_invalidate(() => expr))`
-/// - `$: { ... }` (block) → `;() => {$: { ... }}`
-/// - `$: expr` (expression) → `;() => {$: expr}`
 /// True if a reactive assignment's LHS qualifies for the
 /// `__sveltets_2_invalidate(() => …)` RHS wrap — i.e. it is a plain Identifier,
 /// an object destructuring target, or an array destructuring target. Mirrors
@@ -3584,6 +3560,17 @@ fn is_invalidate_assignment_target(target: &oxc::AssignmentTarget) -> bool {
     )
 }
 
+/// Handle a reactive labeled statement (`$: ...`).
+///
+/// Transforms reactive declarations and statements according to svelte2tsx conventions:
+///
+/// - `$: x = expr` (new variable) → `let  x = __sveltets_2_invalidate(() => expr)`
+/// - `$: x = expr` (existing var) → `$: x = __sveltets_2_invalidate(() => expr)`
+/// - `$: $store = expr` (store) → `$: $store = __sveltets_2_invalidate(() => expr)`
+/// - `$: ({ a } = expr)` (destructure, new) → `let  { a } = __sveltets_2_invalidate(() => expr)`
+/// - `$: ({ a } = expr)` (destructure, existing) → `$: ({ a } = __sveltets_2_invalidate(() => expr))`
+/// - `$: { ... }` (block) → `;() => {$: { ... }}`
+/// - `$: expr` (expression) → `;() => {$: expr}`
 fn handle_reactive_statement(
     labeled: &oxc::LabeledStatement,
     offset: u32,
@@ -4352,20 +4339,8 @@ fn infer_type_from_default(expr: &oxc::Expression, raw_content: &str) -> String 
         oxc::Expression::NumericLiteral(_) => "number".to_string(),
         oxc::Expression::StringLiteral(_) => "string".to_string(),
         oxc::Expression::NullLiteral(_) => "any".to_string(),
-        oxc::Expression::ArrayExpression(arr) => {
-            if arr.elements.is_empty() {
-                "any[]".to_string()
-            } else {
-                "any[]".to_string()
-            }
-        }
-        oxc::Expression::ObjectExpression(obj) => {
-            if obj.properties.is_empty() {
-                "Record<string, any>".to_string()
-            } else {
-                "Record<string, any>".to_string()
-            }
-        }
+        oxc::Expression::ArrayExpression(_) => "any[]".to_string(),
+        oxc::Expression::ObjectExpression(_) => "Record<string, any>".to_string(),
         oxc::Expression::ArrowFunctionExpression(_) | oxc::Expression::FunctionExpression(_) => {
             "Function".to_string()
         }
@@ -4470,7 +4445,6 @@ fn collect_props_rune_info(
     // Also detect if the type is "hoistable" (inline object type vs named type reference)
     let (
         has_type_annotation,
-        type_annotation_start,
         type_annotation_end,
         type_text,
         is_hoistable_type,
@@ -4496,7 +4470,6 @@ fn collect_props_rune_info(
         let colon = ta.span.start;
         (
             true,
-            Some(start),
             Some(end),
             text,
             is_hoistable,
@@ -4504,7 +4477,7 @@ fn collect_props_rune_info(
             Some(colon),
         )
     } else {
-        (false, None, None, None, false, false, None)
+        (false, None, None, false, false, None)
     };
 
     // Detect JSDoc @type comment before the let statement
@@ -4525,7 +4498,6 @@ fn collect_props_rune_info(
     let mut has_unknown_props = false;
     let mut prop_types: Vec<(String, bool, String)> = Vec::new();
     let mut bindable_names: Vec<String> = Vec::new();
-    let is_identifier_pattern = matches!(&declarator.id, oxc::BindingPattern::BindingIdentifier(_));
 
     if let oxc::BindingPattern::ObjectPattern(obj_pat) = &declarator.id {
         has_rest = obj_pat.rest.is_some();
@@ -4601,13 +4573,11 @@ fn collect_props_rune_info(
         destructure_end,
         props_call_end,
         has_type_annotation,
-        type_annotation_start,
         type_annotation_end,
         type_text,
         colon_pos,
         is_hoistable_type,
         is_named_type_reference,
-        is_identifier_pattern,
         jsdoc_type,
         jsdoc_start,
         jsdoc_end,
@@ -4682,88 +4652,6 @@ fn find_matching_brace(text: &str) -> Option<usize> {
         }
     }
     None
-}
-
-/// Extract names from a binding pattern for regular export declarations.
-///
-/// Used for `export let/const` (not $props).
-fn extract_names_from_binding_pattern(
-    pattern: &oxc::BindingPattern,
-    exported_names: &mut ExportedNames,
-    has_default: bool,
-    is_prop: bool,
-) {
-    match pattern {
-        oxc::BindingPattern::BindingIdentifier(id) => {
-            let name = id.name.to_string();
-            exported_names.add(name.clone(), name, has_default, None, is_prop);
-        }
-        oxc::BindingPattern::ObjectPattern(obj_pat) => {
-            for prop in obj_pat.properties.iter() {
-                match &prop.value {
-                    oxc::BindingPattern::AssignmentPattern(assign) => {
-                        extract_names_from_binding_pattern(
-                            &assign.left,
-                            exported_names,
-                            true,
-                            is_prop,
-                        );
-                    }
-                    _ => {
-                        extract_names_from_binding_pattern(
-                            &prop.value,
-                            exported_names,
-                            has_default,
-                            is_prop,
-                        );
-                    }
-                }
-            }
-            // Handle rest element: `{ a, ...rest }` — recurse into `rest`
-            if let Some(rest) = &obj_pat.rest {
-                extract_names_from_binding_pattern(
-                    &rest.argument,
-                    exported_names,
-                    has_default,
-                    is_prop,
-                );
-            }
-        }
-        oxc::BindingPattern::ArrayPattern(arr_pat) => {
-            for el in arr_pat.elements.iter().flatten() {
-                match el {
-                    oxc::BindingPattern::AssignmentPattern(assign) => {
-                        extract_names_from_binding_pattern(
-                            &assign.left,
-                            exported_names,
-                            true,
-                            is_prop,
-                        );
-                    }
-                    _ => {
-                        extract_names_from_binding_pattern(
-                            el,
-                            exported_names,
-                            has_default,
-                            is_prop,
-                        );
-                    }
-                }
-            }
-            // Handle rest element: `[a, ...rest]` — recurse into `rest`
-            if let Some(rest) = &arr_pat.rest {
-                extract_names_from_binding_pattern(
-                    &rest.argument,
-                    exported_names,
-                    has_default,
-                    is_prop,
-                );
-            }
-        }
-        oxc::BindingPattern::AssignmentPattern(assign) => {
-            extract_names_from_binding_pattern(&assign.left, exported_names, true, is_prop);
-        }
-    }
 }
 
 fn extract_names_from_binding_pattern_full(
@@ -4919,25 +4807,6 @@ fn module_export_name_to_string(name: &oxc::ModuleExportName) -> String {
 /// Reserved names that should not be treated as store references.
 const RESERVED_STORE_NAMES: &[&str] = &["$$props", "$$restProps", "$$slots"];
 
-/// Svelte rune names that should not be treated as store references.
-/// When `$state(0)` appears in the source, `state` should NOT be treated as a store.
-const SVELTE_RUNES: &[&str] = &[
-    "$state",
-    "$derived",
-    "$effect",
-    "$props",
-    "$bindable",
-    "$inspect",
-    "$host",
-];
-
-/// Scan the full source for `$identifier` patterns and return the set of
-/// store names (without the `$` prefix).
-///
-/// Excludes:
-/// - Reserved names (`$$props`, `$$restProps`, `$$slots`)
-/// - Member access like `obj.$store` (preceded by `.`)
-/// - String literals like `'$store'` or `"$store"` (preceded by `'` or `"`)
 /// Return the leading `/** … */` JSDoc comment immediately before `before`
 /// (skipping whitespace), or None. Mirrors official `getLastLeadingDoc`.
 fn leading_jsdoc_comment(source: &str, before: usize) -> Option<String> {

--- a/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
@@ -628,21 +628,17 @@ pub fn svelte2tsx(
 
     // Step 7.45: Detect `$state`/`$derived`/`$effect` rune-globals in TEMPLATE expressions.
     //
-    // Official rule (index.ts): `exportedNames.checkGlobalsForRunes(implicitStoreValues.getGlobals())`
-    // — `implicitStoreValues` collects ALL accessed undeclared globals across the entire
-    // component INCLUDING template expressions.  `checkGlobalsForRunes` (ExportedNames.ts
-    // ~line 878–881) sets `hasRunesGlobals = isSvelte5Plus && globals.some(g =>
+    // Official rule: `exportedNames.checkGlobalsForRunes(implicitStoreValues.getGlobals())`
+    // (svelte2tsx/index.ts) — `implicitStoreValues` collects ALL accessed undeclared
+    // globals across the entire component INCLUDING template expressions.
+    // `checkGlobalsForRunes` (svelte2tsx/nodes/ExportedNames.ts ~line 878–881) sets
+    // `hasRunesGlobals = isSvelte5Plus && globals.some(g =>
     // ['$state','$derived','$effect'].includes(g))`.
     //
     // A component with NO `<script>` but with e.g. `aria-current={$state.eager(pathname) === '/'
     // ? 'page' : null}` is therefore RUNES (because `$state` is an undeclared global
     // referenced in the template).  rsvelte's instance-script scanner never runs for
     // template-only components, so we need to walk the template AST here.
-    //
-    // Reference: language-tools/packages/svelte2tsx/src/svelte2tsx/index.ts
-    //   `exportedNames.checkGlobalsForRunes(implicitStoreValues.getGlobals())`
-    // Reference: language-tools/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
-    //   `hasRunesGlobals = isSvelte5Plus && globals.some(g => ['$state','$derived','$effect'].includes(g))`
     if detect_rune_global_in_template(&ast, source, &exported_names.instance_value_names) {
         exported_names.set_uses_runes(true);
     }
@@ -785,7 +781,6 @@ pub fn svelte2tsx(
     }
 
     // Step 8: Blank out <style> tag (CSS is not relevant for TSX type checking)
-    //
     //
     // First blank any style tag the parser captured in ast.css.
     // Then ALWAYS run the fallback scanner to catch style tags the parser
@@ -1403,11 +1398,10 @@ pub fn svelte2tsx(
                 };
 
             let ts_component_props_before_render = if exported_names.has_component_props_typedef
-                && exported_names.props_type_text.is_some()
                 && !exported_names.type_already_inserted
                 && !force_inside_render
+                && let Some(type_text) = exported_names.props_type_text.as_ref()
             {
-                let type_text = exported_names.props_type_text.as_ref().unwrap();
                 format!(";type $$ComponentProps =  {};", type_text)
             } else {
                 String::new()
@@ -1426,10 +1420,9 @@ pub fn svelte2tsx(
                 && exported_names.props_type_text.is_some();
             let ts_component_props_inside_render = if (exported_names.type_already_inserted
                 || force_inside_render)
-                && exported_names.props_type_text.is_some()
                 && !inline_type_at_let
+                && let Some(type_text) = exported_names.props_type_text.as_ref()
             {
-                let type_text = exported_names.props_type_text.as_ref().unwrap();
                 if force_inside_render {
                     format!("\n;type $$ComponentProps =  {};", type_text)
                 } else {
@@ -1647,11 +1640,10 @@ pub fn svelte2tsx(
                 };
 
             let ts_component_props_before_render = if exported_names.has_component_props_typedef
-                && exported_names.props_type_text.is_some()
                 && !exported_names.type_already_inserted
                 && !force_inside_render_no_imports
+                && let Some(type_text) = exported_names.props_type_text.as_ref()
             {
-                let type_text = exported_names.props_type_text.as_ref().unwrap();
                 format!("\n;type $$ComponentProps =  {};", type_text)
             } else {
                 String::new()
@@ -1665,10 +1657,9 @@ pub fn svelte2tsx(
                 && exported_names.props_type_text.is_some();
             let ts_component_props_inside_render = if (exported_names.type_already_inserted
                 || force_inside_render_no_imports)
-                && exported_names.props_type_text.is_some()
                 && !inline_type_at_let
+                && let Some(type_text) = exported_names.props_type_text.as_ref()
             {
-                let type_text = exported_names.props_type_text.as_ref().unwrap();
                 if force_inside_render_no_imports {
                     format!("\n;type $$ComponentProps =  {};", type_text)
                 } else {
@@ -2877,76 +2868,6 @@ fn extract_component_documentation(fragment: &crate::ast::template::Fragment) ->
     }
 
     None
-}
-
-/// Get the start position of a template node.
-fn node_start_pos(node: &crate::ast::template::TemplateNode) -> u32 {
-    use crate::ast::template::TemplateNode;
-    match node {
-        TemplateNode::Text(n) => n.start,
-        TemplateNode::Comment(n) => n.start,
-        TemplateNode::RegularElement(n) => n.start,
-        TemplateNode::Component(n) => n.start,
-        TemplateNode::ExpressionTag(n) => n.start,
-        TemplateNode::IfBlock(n) => n.start,
-        TemplateNode::EachBlock(n) => n.start,
-        TemplateNode::AwaitBlock(n) => n.start,
-        TemplateNode::KeyBlock(n) => n.start,
-        TemplateNode::SnippetBlock(n) => n.start,
-        TemplateNode::HtmlTag(n) => n.start,
-        TemplateNode::ConstTag(n) => n.start,
-        TemplateNode::DeclarationTag(n) => n.start,
-        TemplateNode::DebugTag(n) => n.start,
-        TemplateNode::RenderTag(n) => n.start,
-        TemplateNode::AttachTag(n) => n.start,
-        TemplateNode::TitleElement(n) => n.start,
-        TemplateNode::SlotElement(n) => n.start,
-        TemplateNode::SvelteComponent(n) => n.start,
-        TemplateNode::SvelteElement(n) => n.start,
-        TemplateNode::SvelteBody(n)
-        | TemplateNode::SvelteDocument(n)
-        | TemplateNode::SvelteFragment(n)
-        | TemplateNode::SvelteBoundary(n)
-        | TemplateNode::SvelteHead(n)
-        | TemplateNode::SvelteOptions(n)
-        | TemplateNode::SvelteSelf(n)
-        | TemplateNode::SvelteWindow(n) => n.start,
-    }
-}
-
-/// Get the end position of a template node.
-fn node_end_pos(node: &crate::ast::template::TemplateNode) -> u32 {
-    use crate::ast::template::TemplateNode;
-    match node {
-        TemplateNode::Text(n) => n.end,
-        TemplateNode::Comment(n) => n.end,
-        TemplateNode::RegularElement(n) => n.end,
-        TemplateNode::Component(n) => n.end,
-        TemplateNode::ExpressionTag(n) => n.end,
-        TemplateNode::IfBlock(n) => n.end,
-        TemplateNode::EachBlock(n) => n.end,
-        TemplateNode::AwaitBlock(n) => n.end,
-        TemplateNode::KeyBlock(n) => n.end,
-        TemplateNode::SnippetBlock(n) => n.end,
-        TemplateNode::HtmlTag(n) => n.end,
-        TemplateNode::ConstTag(n) => n.end,
-        TemplateNode::DeclarationTag(n) => n.end,
-        TemplateNode::DebugTag(n) => n.end,
-        TemplateNode::RenderTag(n) => n.end,
-        TemplateNode::AttachTag(n) => n.end,
-        TemplateNode::TitleElement(n) => n.end,
-        TemplateNode::SlotElement(n) => n.end,
-        TemplateNode::SvelteComponent(n) => n.end,
-        TemplateNode::SvelteElement(n) => n.end,
-        TemplateNode::SvelteBody(n)
-        | TemplateNode::SvelteDocument(n)
-        | TemplateNode::SvelteFragment(n)
-        | TemplateNode::SvelteBoundary(n)
-        | TemplateNode::SvelteHead(n)
-        | TemplateNode::SvelteOptions(n)
-        | TemplateNode::SvelteSelf(n)
-        | TemplateNode::SvelteWindow(n) => n.end,
-    }
 }
 
 /// Conservative whole-word substring search. Returns `true` when `needle`
@@ -5059,135 +4980,6 @@ fn js_node_references_rune_global(
         // Bare Identifier (e.g. `{$state}` — store auto-subscription) → NOT a rune call.
         // MemberExpression without being called (e.g. `$state.value` as a bare expr) → NOT a rune call.
         // These are legitimate store/object references, not rune invocations.
-        _ => false,
-    }
-}
-
-/// Check whether a JSON callee node directly IS a rune-global call target.
-/// Mirrors `js_callee_is_rune_global` for the `Expression::Value` path.
-fn json_callee_is_rune_global(callee: &serde_json::Value) -> bool {
-    let ty = callee.get("type").and_then(|t| t.as_str()).unwrap_or("");
-    match ty {
-        // Direct call: `$state(x)` — callee is Identifier "$state"
-        "Identifier" => callee
-            .get("name")
-            .and_then(|n| n.as_str())
-            .is_some_and(is_rune_global_name),
-        // Member call: `$state.eager(x)` — callee is MemberExpression { object: Identifier "$state" }
-        "MemberExpression" => callee
-            .get("object")
-            .and_then(|o| {
-                if o.get("type").and_then(|t| t.as_str()) == Some("Identifier") {
-                    o.get("name").and_then(|n| n.as_str())
-                } else {
-                    None
-                }
-            })
-            .is_some_and(is_rune_global_name),
-        _ => false,
-    }
-}
-
-/// Walk a JSON-encoded expression AST looking for a rune-global CALL.
-///
-/// This covers the `Expression::Value` variant (legacy / fallback AST path).
-/// Only matches when a rune global is actually invoked (called), not when it
-/// appears as a bare store auto-subscription reference like `{$state}`.
-/// Recurse up to a bounded depth to avoid unbounded recursion.
-///
-/// Extended (mirrors `js_node_references_rune_global`) to recurse into:
-/// - ArrowFunctionExpression / FunctionExpression bodies
-/// - BlockStatement statements
-/// - ExpressionStatement inner expression
-/// - ObjectExpression property values
-/// - ArrayExpression elements
-/// - SequenceExpression sub-expressions
-/// - AwaitExpression / UnaryExpression arguments
-/// - AssignmentExpression right-hand side
-fn json_references_rune_global(v: &serde_json::Value, depth: u8) -> bool {
-    if depth > 20 {
-        return false;
-    }
-    let ty = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
-    match ty {
-        // CallExpression: the callee must be a rune-global target.
-        // Also recurse into arguments to catch `foo($state(x))`.
-        "CallExpression" => {
-            v.get("callee").is_some_and(json_callee_is_rune_global)
-                || v.get("arguments")
-                    .and_then(|a| a.as_array())
-                    .is_some_and(|arr| {
-                        arr.iter()
-                            .any(|arg| json_references_rune_global(arg, depth + 1))
-                    })
-        }
-        "ConditionalExpression" => ["test", "consequent", "alternate"].iter().any(|field| {
-            v.get(*field)
-                .is_some_and(|c| json_references_rune_global(c, depth + 1))
-        }),
-        "BinaryExpression" | "LogicalExpression" => {
-            v.get("left")
-                .is_some_and(|c| json_references_rune_global(c, depth + 1))
-                || v.get("right")
-                    .is_some_and(|c| json_references_rune_global(c, depth + 1))
-        }
-        // Arrow/function bodies: recurse into `body`.
-        "ArrowFunctionExpression" | "FunctionExpression" => v
-            .get("body")
-            .is_some_and(|b| json_references_rune_global(b, depth + 1)),
-        // BlockStatement: recurse into each statement in `body`.
-        "BlockStatement" => v
-            .get("body")
-            .and_then(|b| b.as_array())
-            .is_some_and(|stmts| {
-                stmts
-                    .iter()
-                    .any(|s| json_references_rune_global(s, depth + 1))
-            }),
-        // ExpressionStatement: unwrap to expression field.
-        "ExpressionStatement" => v
-            .get("expression")
-            .is_some_and(|e| json_references_rune_global(e, depth + 1)),
-        // ObjectExpression: recurse into property values.
-        "ObjectExpression" => v
-            .get("properties")
-            .and_then(|p| p.as_array())
-            .is_some_and(|props| {
-                props.iter().any(|prop| {
-                    prop.get("value")
-                        .is_some_and(|val| json_references_rune_global(val, depth + 1))
-                })
-            }),
-        // ArrayExpression: recurse into elements (may contain nulls for elisions).
-        "ArrayExpression" => v
-            .get("elements")
-            .and_then(|e| e.as_array())
-            .is_some_and(|elems| {
-                elems
-                    .iter()
-                    .filter(|e| !e.is_null())
-                    .any(|e| json_references_rune_global(e, depth + 1))
-            }),
-        // SequenceExpression: recurse into each sub-expression.
-        "SequenceExpression" => {
-            v.get("expressions")
-                .and_then(|e| e.as_array())
-                .is_some_and(|exprs| {
-                    exprs
-                        .iter()
-                        .any(|e| json_references_rune_global(e, depth + 1))
-                })
-        }
-        // AwaitExpression / UnaryExpression: recurse into argument.
-        "AwaitExpression" | "UnaryExpression" => v
-            .get("argument")
-            .is_some_and(|a| json_references_rune_global(a, depth + 1)),
-        // AssignmentExpression: check right-hand side.
-        "AssignmentExpression" => v
-            .get("right")
-            .is_some_and(|r| json_references_rune_global(r, depth + 1)),
-        // Bare "Identifier" (`{$state}` store ref), "MemberExpression" without call, etc.
-        // → NOT a rune invocation.
         _ => false,
     }
 }

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -325,15 +325,6 @@ fn segs_trim_start(segs: &mut Vec<Seg>) {
     }
 }
 
-/// Apply a list of segments to a MagicString, overwriting `[start, end)`
-/// while preserving every `Seg::Src(s, e)` chunk as an unedited region —
-/// the cornerstone of the structured bake. The unedited chunks survive
-/// MagicString's per-character `generate_mappings` pass intact, so
-/// diagnostics inside `<Component a={x} />` resolve to the exact column.
-///
-/// Invariants on `segments` (debug-asserted):
-///   - `Src(s, e)` ranges appear in strictly increasing order.
-///   - Each `Src(s, e)` lies within `[range_start, range_end]`.
 /// Reorder-safe pre-pass for [`emit_segmented_overwrite`], which requires
 /// `Seg::Src` ranges to appear in ascending source order (a MagicString can
 /// only overwrite left-to-right). When a later segment references an earlier
@@ -363,6 +354,15 @@ fn bake_out_of_order_src(segs: Vec<Seg>, source: &str) -> Vec<Seg> {
     out
 }
 
+/// Apply a list of segments to a MagicString, overwriting `[start, end)`
+/// while preserving every `Seg::Src(s, e)` chunk as an unedited region —
+/// the cornerstone of the structured bake. The unedited chunks survive
+/// MagicString's per-character `generate_mappings` pass intact, so
+/// diagnostics inside `<Component a={x} />` resolve to the exact column.
+///
+/// Invariants on `segments` (debug-asserted):
+/// - `Src(s, e)` ranges appear in strictly increasing order.
+/// - Each `Src(s, e)` lies within `[range_start, range_end]`.
 fn emit_segmented_overwrite(
     str: &mut MagicString,
     range_start: u32,
@@ -5802,14 +5802,6 @@ fn is_js_numeric(data: &str) -> bool {
     t.parse::<f64>().is_ok()
 }
 
-/// Structured-bake variant of [`format_attribute_node`]. Wraps every
-/// expression site in `Seg::Src` so the resulting MagicString chunks
-/// retain per-character source-map fidelity.
-///
-/// Applies the same wrapping rules as `format_attribute_node`:
-/// - `is_element` && `data-*` (not `data-sveltekit-*`) → `__sveltets_2_empty({…})`
-/// - `!is_element` && `--*` → `__sveltets_2_cssProp({…})`
-/// (Mirrors `htmlxtojsx_v2/nodes/Attribute.ts` `addAttribute`.)
 /// SVG attribute names that preserve their original (often camelCase) casing.
 /// Mirrors `htmlxtojsx_v2/svgattributes.ts`.
 const SVG_ATTRIBUTES: &str = "accent-height accumulate additive alignment-baseline allowReorder alphabetic amplitude arabic-form ascent attributeName attributeType autoReverse azimuth baseFrequency baseline-shift baseProfile bbox begin bias by calcMode cap-height class clip clipPathUnits clip-path clip-rule color color-interpolation color-interpolation-filters color-profile color-rendering contentScriptType contentStyleType cursor cx cy d decelerate descent diffuseConstant direction display divisor dominant-baseline dur dx dy edgeMode elevation enable-background end exponent externalResourcesRequired fill fill-opacity fill-rule filter filterRes filterUnits flood-color flood-opacity font-family font-size font-size-adjust font-stretch font-style font-variant font-weight format from fr fx fy g1 g2 glyph-name glyph-orientation-horizontal glyph-orientation-vertical glyphRef gradientTransform gradientUnits hanging height href horiz-adv-x horiz-origin-x id ideographic image-rendering in in2 intercept k k1 k2 k3 k4 kernelMatrix kernelUnitLength kerning keyPoints keySplines keyTimes lang lengthAdjust letter-spacing lighting-color limitingConeAngle local marker-end marker-mid marker-start markerHeight markerUnits markerWidth mask maskContentUnits maskUnits mathematical max media method min mode name numOctaves offset onabort onactivate onbegin onclick onend onerror onfocusin onfocusout onload onmousedown onmousemove onmouseout onmouseover onmouseup onrepeat onresize onscroll onunload opacity operator order orient orientation origin overflow overline-position overline-thickness panose-1 paint-order pathLength patternContentUnits patternTransform patternUnits pointer-events points pointsAtX pointsAtY pointsAtZ preserveAlpha preserveAspectRatio primitiveUnits r radius refX refY rendering-intent repeatCount repeatDur requiredExtensions requiredFeatures restart result rotate rx ry scale seed shape-rendering slope spacing specularConstant specularExponent speed spreadMethod startOffset stdDeviation stemh stemv stitchTiles stop-color stop-opacity strikethrough-position strikethrough-thickness string stroke stroke-dasharray stroke-dashoffset stroke-linecap stroke-linejoin stroke-miterlimit stroke-opacity stroke-width style surfaceScale systemLanguage tabindex tableValues target targetX targetY text-anchor text-decoration text-rendering textLength to transform type u1 u2 underline-position underline-thickness unicode unicode-bidi unicode-range units-per-em v-alphabetic v-hanging v-ideographic v-mathematical values version vert-adv-y vert-origin-x vert-origin-y viewBox viewTarget visibility width widths word-spacing writing-mode x x-height x1 x2 xChannelSelector xlink:actuate xlink:arcrole xlink:href xlink:role xlink:show xlink:title xlink:type xml:base xml:lang xml:space y y1 y2 yChannelSelector z zoomAndPan";
@@ -5897,6 +5889,15 @@ fn leading_attr_comment_segs(attr_start: u32, source: &str) -> Vec<Seg> {
     })
 }
 
+/// Structured-bake variant of [`format_attribute_node`]. Wraps every
+/// expression site in `Seg::Src` so the resulting MagicString chunks
+/// retain per-character source-map fidelity.
+///
+/// Applies the same wrapping rules as `format_attribute_node`:
+/// - `is_element` && `data-*` (not `data-sveltekit-*`) → `__sveltets_2_empty({…})`
+/// - `!is_element` && `--*` → `__sveltets_2_cssProp({…})`
+///
+/// (Mirrors `htmlxtojsx_v2/nodes/Attribute.ts` `addAttribute`.)
 fn format_attribute_node_segments(
     node: &AttributeNode,
     source: &str,
@@ -6360,72 +6361,6 @@ fn class_style_directive_seg(attr: &Attribute, source: &str) -> Option<Vec<Seg>>
     Some(out)
 }
 
-/// Structured-bake variant of [`format_class_directive`].
-fn format_class_directive_segments(class: &ClassDirective, source: &str) -> Vec<Seg> {
-    let mut out = Vec::new();
-    segs_push_lit(&mut out, &format!("\"class:{}\":", class.name));
-    if let Some((s, e)) = get_expression_range(&class.expression) {
-        segs_push_src(&mut out, s, e);
-    } else {
-        segs_push_lit(&mut out, get_expression_text(&class.expression, source));
-    }
-    segs_push_lit(&mut out, ",");
-    out
-}
-
-/// Structured-bake variant of [`format_style_directive`].
-fn format_style_directive_segments(style: &StyleDirective, source: &str) -> Vec<Seg> {
-    let mut out = Vec::new();
-    match &style.value {
-        AttributeValue::True(_) => {
-            // Shorthand `style:color` → `"style:color":color,`. The
-            // implicit `color` reference has no source range we can pin
-            // because it's synthesised from the directive name.
-            segs_push_lit(
-                &mut out,
-                &format!("\"style:{}\":{},", style.name, style.name),
-            );
-        }
-        AttributeValue::Expression(expr) => {
-            segs_push_lit(&mut out, &format!("\"style:{}\":", style.name));
-            if let Some((s, e)) = get_expression_range(&expr.expression) {
-                segs_push_src(&mut out, s, e);
-            } else {
-                segs_push_lit(&mut out, get_expression_text(&expr.expression, source));
-            }
-            segs_push_lit(&mut out, ",");
-        }
-        AttributeValue::Sequence(parts) => {
-            segs_push_lit(&mut out, &format!("\"style:{}\":`", style.name));
-            for part in parts {
-                match part {
-                    AttributeValuePart::Text(text) => {
-                        // Escape backslash first so `\n` / `\t` in raw text
-                        // (e.g. a Windows path) stay literal. H-091.
-                        let escaped = text
-                            .raw
-                            .replace('\\', "\\\\")
-                            .replace('`', "\\`")
-                            .replace('$', "\\$");
-                        segs_push_lit(&mut out, &escaped);
-                    }
-                    AttributeValuePart::ExpressionTag(expr) => {
-                        segs_push_lit(&mut out, "${");
-                        if let Some((s, e)) = get_expression_range(&expr.expression) {
-                            segs_push_src(&mut out, s, e);
-                        } else {
-                            segs_push_lit(&mut out, get_expression_text(&expr.expression, source));
-                        }
-                        segs_push_lit(&mut out, "}");
-                    }
-                }
-            }
-            segs_push_lit(&mut out, "`,");
-        }
-    }
-    out
-}
-
 /// Structured-bake variant of the `@attach` tag's inline emission.
 fn format_attach_tag_segments(attach: &AttachTag, source: &str) -> Vec<Seg> {
     let mut out = Vec::new();
@@ -6437,52 +6372,6 @@ fn format_attach_tag_segments(attach: &AttachTag, source: &str) -> Vec<Seg> {
     }
     segs_push_lit(&mut out, ",");
     out
-}
-
-/// Format a slot prop attribute. Unlike regular attributes, slot props
-/// always use the full "key":value format (no shorthand).
-/// `err={err}` → `"err":err,` (not `err,`)
-fn format_slot_prop_node(node: &AttributeNode, source: &str) -> Option<String> {
-    let name = &node.name;
-
-    match &node.value {
-        AttributeValue::True(_) => Some(format!("\"{}\":true,", name)),
-        AttributeValue::Expression(expr) => {
-            let expr_text = get_expression_text(&expr.expression, source);
-            // Always use full "key":value format for slot props
-            Some(format!("\"{}\":{},", name, expr_text))
-        }
-        AttributeValue::Sequence(parts) => {
-            // Same as format_attribute_node for sequences
-            if parts.len() == 1
-                && let AttributeValuePart::ExpressionTag(expr) = &parts[0]
-            {
-                let expr_text = get_expression_text(&expr.expression, source);
-                return Some(format!("\"{}\":{},", name, expr_text));
-            }
-
-            let mut value_parts = Vec::new();
-            for part in parts {
-                match part {
-                    AttributeValuePart::Text(text) => {
-                        // Escape backslash first so `\n` / `\t` in raw text
-                        // (e.g. a Windows path) stay literal. H-091.
-                        let escaped = text
-                            .raw
-                            .replace('\\', "\\\\")
-                            .replace('`', "\\`")
-                            .replace('$', "\\$");
-                        value_parts.push(escaped);
-                    }
-                    AttributeValuePart::ExpressionTag(expr) => {
-                        let expr_text = get_expression_text(&expr.expression, source);
-                        value_parts.push(format!("${{{}}}", expr_text));
-                    }
-                }
-            }
-            Some(format!("\"{}\":`{}`,", name, value_parts.join("")))
-        }
-    }
 }
 
 /// Format a spread attribute: `{...expr}` → `...expr,`, or `{...expr as T}` → `...(expr as T),`.
@@ -6583,9 +6472,8 @@ fn bind_needs_element_var(name: &str) -> bool {
 /// - one-way (clientWidth, …)  → `<expr>= <element_var>.<attr>;`
 /// - one-way-not-on-element    → `<expr>= /** @type {T} */ (null);` (typed null)
 /// - any other `bind:foo`      → keeps the prop, then appends an
-///                                ignored-comments-wrapped
-///                                `() => <expr> = __sveltets_2_any(null);`
-///                                so TS widens the type.
+///   ignored-comments-wrapped `() => <expr> = __sveltets_2_any(null);` so TS
+///   widens the type.
 fn build_bind_directive_suffix(
     attributes: &[Attribute],
     source: &str,
@@ -7260,22 +7148,6 @@ fn build_let_destructure_string(let_directives: &[&LetDirective], source: &str) 
     parts.join("")
 }
 
-/// Check if a component has meaningful children (non-whitespace content).
-fn has_meaningful_children(fragment: &Fragment) -> bool {
-    for node in &fragment.nodes {
-        match node {
-            TemplateNode::Text(text) => {
-                // Check if text contains non-whitespace
-                if text.start < text.end {
-                    return true;
-                }
-            }
-            _ => return true,
-        }
-    }
-    false
-}
-
 /// Get the static `slot="name"` attribute value from an element's attributes.
 /// Returns None if no `slot` attribute is present, or if its value is a dynamic
 /// expression (`slot={foo}`).
@@ -7309,14 +7181,6 @@ fn get_slot_attr_value(attributes: &[Attribute], _source: &str) -> Option<String
         }
     }
     None
-}
-
-/// Count the number of `let:` directives in an attribute list.
-fn count_let_directives(attributes: &[Attribute]) -> usize {
-    attributes
-        .iter()
-        .filter(|attr| matches!(attr, Attribute::LetDirective(_)))
-        .count()
 }
 
 // =============================================================================

--- a/crates/rsvelte_core/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_core/src/svelte_check/overlay.rs
@@ -428,10 +428,6 @@ fn discover_external_svelte_packages(workspace: &Path, cache_dir: &Path) -> Vec<
     out
 }
 
-/// Emit `.tsx` + `.d.ts` shadows for one external package's `.svelte` files into
-/// its cache mirror, preserving each file's path relative to the package root.
-/// Non-incremental (external packages change rarely and are bounded by the
-/// dependency set).
 /// Symlink `<dst>` → `<src>` (a directory), cross-platform.
 fn symlink_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
@@ -449,6 +445,10 @@ fn symlink_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Emit `.tsx` + `.d.ts` shadows for one external package's `.svelte` files into
+/// its cache mirror, preserving each file's path relative to the package root.
+/// Non-incremental (external packages change rarely and are bounded by the
+/// dependency set).
 fn emit_external_shadows(pkg: &ExternalPackage) -> Result<(), OverlayError> {
     // Mirror the package's own `node_modules` into the shadow dir so the
     // shadow's bare-package imports (`import type { X } from 'sortablejs'`,
@@ -1210,8 +1210,6 @@ fn resolve_root_dirs_abs(tsconfig_path: &Path) -> Vec<PathBuf> {
     Vec::new()
 }
 
-/// POSIX-style relative path from `from_dir` to `to_path` (so the
-/// generated tsconfig is consumable on every platform).
 /// If `abs_source` (`…/Foo.svelte`) has a sibling companion module
 /// (`Foo.svelte.ts` or `Foo.svelte.js`), return a module specifier — relative
 /// to the component shadow's directory and ending in `.js` so TS strips it and
@@ -1438,6 +1436,8 @@ fn lexical_relative_posix(from_dir: &Path, to_path: &Path) -> String {
     }
 }
 
+/// POSIX-style relative path from `from_dir` to `to_path` (so the
+/// generated tsconfig is consumable on every platform).
 fn path_relative(from_dir: &Path, to_path: &Path) -> String {
     use std::path::Component;
     let from_abs = from_dir


### PR DESCRIPTION
## Summary

Review finding PR-G (findings-05): the svelte2tsx submodules carried blanket module-level `#[allow(dead_code, doc_lazy_continuation, doc_overindented_list_items, if_same_then_else, unnecessary_unwrap, module_inception)]` attributes in `svelte2tsx/mod.rs`, hiding real dead code and doc-attribution drift. This PR removes every module-wide waiver except `module_inception` (kept with its own reason: `svelte2tsx::svelte2tsx` mirrors the upstream `svelte2tsx/index.ts` package layout, and renaming the file would break the 1:1 structural mapping).

## Changes

- **dead_code → deleted** (~500 lines): `extract_names_from_binding_pattern` (only self-recursive), `SVELTE_RUNES`, `node_start_pos`/`node_end_pos`, the serde_json rune-global walkers `json_callee_is_rune_global`/`json_references_rune_global` (removes the last `serde_json` use in svelte2tsx.rs), the unused structured-bake formatters (`format_class_directive_segments`, `format_style_directive_segments`, `format_slot_prop_node`), `has_meaningful_children`, `count_let_directives`, and the never-read `PropsRuneInfo` fields `type_annotation_start` / `is_identifier_pattern`.
- **unnecessary_unwrap → let-chains**: the four `props_type_text.is_some()` … `.as_ref().unwrap()` sites.
- **if_same_then_else → collapsed**: `infer_type_from_default`'s Array/Object arms had literally identical branches.
- **doc lints → doc fixes**: reattached doc comments that had drifted onto the wrong item — `process_instance_script`, `handle_reactive_statement`, `emit_segmented_overwrite`, `format_attribute_node_segments`, and overlay.rs's `emit_external_shadows` / `path_relative` (docs were sitting on `symlink_dir` / `companion_reexport_specifier`); unindented the `build_bind_directive_suffix` doc list continuation.
- **comment cleanup**: deduplicated the Step 7.45 upstream references (the trailing `Reference:` block repeated the two citations already in the prose) and dropped a stray empty `//` line in Step 8.
- Changeset for `@rsvelte/svelte2tsx` + `@rsvelte/svelte-check` (directory rule).

## Verification

- `cargo test --release --test svelte2tsx_fixtures`: pass set identical before/after (246/254 locally; the 8 local failures are pre-existing from a dirty local `language-tools` submodule checkout — CI's pinned submodule runs 253/253).
- `cargo +1.97 clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt`: applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj