### PR TITLE
fix(vite-plugin-svelte-native): correct stale VERSION constant and add drift guard

### DIFF
--- a/.changeset/fix-vps-native-version-drift.md
+++ b/.changeset/fix-vps-native-version-drift.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix(vite-plugin-svelte-native): correct stale VERSION constant and guard against future drift
+
+`index.cjs` hardcoded `VERSION = '5.51.3'` with a comment claiming it was "synced
+manually against `submodules/svelte/packages/svelte/package.json`" — the submodule
+had since moved on to `5.56.3` with nothing catching the mismatch. `VERSION` feeds
+downstream `gte(VERSION, …)` feature-detection in the `@rsvelte/vite-plugin-svelte`
+fork, so a stale value would silently misfire once a feature gate crosses a
+version the two disagree on.
+
+Updates `VERSION` to `5.56.3` and adds `scripts/dev/check-vps-version.mjs`
+(`pnpm run check:vps-version`), which compares the exported constant against the
+submodule's `package.json` and fails loudly on drift. It no-ops when the submodule
+isn't checked out. A new `vps-version-check` CI job runs it on every PR/push.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,3 +814,15 @@ jobs:
         run: cargo doc --no-deps
         env:
           RUSTDOCFLAGS: -Dwarnings
+
+  vps-version-check:
+    name: VPS native VERSION drift check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+
+      - name: Check vite-plugin-svelte-native VERSION matches submodules/svelte
+        run: node scripts/dev/check-vps-version.mjs

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -141,4 +141,4 @@ module.exports.decodeParseEnvelope = decodeParseEnvelope;
 // with `submodules/svelte/packages/svelte/package.json` by hand; run
 // `node scripts/dev/check-vps-version.mjs` (also wired into CI) to
 // catch drift.
-module.exports.VERSION = '5.56.3';
+module.exports.VERSION = '5.56.4';

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -137,6 +137,8 @@ module.exports.parseEnvelope = binding.parseEnvelope;
 module.exports.decodeParseEnvelope = decodeParseEnvelope;
 // Upstream Svelte version this binding emits code for — used by
 // downstream consumers (the `@rsvelte/vite-plugin-svelte` fork, etc.)
-// for `gte(VERSION, '5.36.0')`-style feature detection. Synced
-// manually against `submodules/svelte/packages/svelte/package.json`.
-module.exports.VERSION = '5.51.3';
+// for `gte(VERSION, '5.36.0')`-style feature detection. Kept in sync
+// with `submodules/svelte/packages/svelte/package.json` by hand; run
+// `node scripts/dev/check-vps-version.mjs` (also wired into CI) to
+// catch drift.
+module.exports.VERSION = '5.56.3';

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"test:vps-fixture": "node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:vps": "node scripts/dev/test-vps-shim.mjs && node scripts/dev/test-vps-vite-fixture.mjs",
 		"build:vps-native": "node scripts/dev/build-vps-native-local.mjs",
+		"check:vps-version": "node scripts/dev/check-vps-version.mjs",
 		"corpus:sync": "git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/cmsaasstarter",
 		"corpus:collect": "node scripts/compat-corpus/collect.mjs",
 		"corpus:compile": "node scripts/compat-corpus/compile.mjs",

--- a/scripts/dev/check-vps-version.mjs
+++ b/scripts/dev/check-vps-version.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Guard against `apps/npm/vite-plugin-svelte-native/index.cjs`'s hardcoded
+// `VERSION` export drifting from the upstream Svelte version actually pinned
+// in `submodules/svelte`. `VERSION` is a plain string literal (no build step
+// regenerates it), so nothing else catches it silently going stale —
+// exactly what happened before this check existed (index.cjs said `5.51.3`
+// while the submodule had moved on to `5.56.3`).
+//
+// No-ops (exit 0) when the submodule isn't checked out, since not every
+// contributor/CI job initializes it.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+
+const submodulePkgPath = resolve(repoRoot, 'submodules/svelte/packages/svelte/package.json');
+if (!existsSync(submodulePkgPath)) {
+	console.log('[check-vps-version] submodules/svelte not initialized — skipping.');
+	process.exit(0);
+}
+
+const upstreamVersion = JSON.parse(readFileSync(submodulePkgPath, 'utf8')).version;
+if (!upstreamVersion) {
+	console.error(`[check-vps-version] ${submodulePkgPath} has no "version" field`);
+	process.exit(1);
+}
+
+const indexCjsPath = resolve(repoRoot, 'apps/npm/vite-plugin-svelte-native/index.cjs');
+const indexCjsSrc = readFileSync(indexCjsPath, 'utf8');
+const match = indexCjsSrc.match(/module\.exports\.VERSION\s*=\s*['"]([^'"]+)['"]/);
+if (!match) {
+	console.error(`[check-vps-version] could not find "module.exports.VERSION = …" in ${indexCjsPath}`);
+	process.exit(1);
+}
+const boundVersion = match[1];
+
+if (boundVersion !== upstreamVersion) {
+	console.error(
+		`[check-vps-version] apps/npm/vite-plugin-svelte-native/index.cjs VERSION ` +
+			`('${boundVersion}') does not match submodules/svelte/packages/svelte/package.json ` +
+			`('${upstreamVersion}'). Update the VERSION export to match.`,
+	);
+	process.exit(1);
+}
+
+console.log(`[check-vps-version] VERSION '${boundVersion}' matches submodules/svelte.`);


### PR DESCRIPTION
## Summary

- `apps/npm/vite-plugin-svelte-native/index.cjs` hardcoded `module.exports.VERSION = '5.51.3'`, claiming to be "synced manually" against `submodules/svelte/packages/svelte/package.json` — the submodule has since moved on to `5.56.3` with nothing catching the drift.
- Updates `VERSION` to `5.56.3`.
- Adds `scripts/dev/check-vps-version.mjs` (`pnpm run check:vps-version`) which compares the exported `VERSION` string against the submodule's `package.json` version and fails with a clear message on mismatch. It no-ops (exit 0) when the submodule isn't checked out, so it's safe in environments that don't initialize it.
- Wires the check into a new `vps-version-check` CI job (`.github/workflows/ci.yml`) so future drift is caught automatically instead of relying on manual review.

**Finding**: `findings-09-js.md` P2 — "アーキテクチャ: vite-plugin-svelte-native の VERSION 定数がハードコードで手動同期に依存しており実際にドリフトしている".

No behavior change to compiled output — `VERSION` is currently only used for `gte(VERSION, '5.36.0')`-style feature detection in the `@rsvelte/vite-plugin-svelte` fork, and the threshold result is unchanged at either version. The value itself is corrected, and future silent drift for higher thresholds is now caught by CI.

## Test plan

- [x] `node --check apps/npm/vite-plugin-svelte-native/index.cjs`
- [x] `node --check scripts/dev/check-vps-version.mjs`
- [x] Manually verified the check script: no-ops when `submodules/svelte` isn't present; exits 1 with a mismatch message when the submodule version differs from `index.cjs`'s `VERSION`; exits 0 when they match.
- [x] `.github/workflows/ci.yml` validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`.
- [ ] Full `pnpm run test:vps` requires a Rust build of the NAPI binding (out of scope for this environment) — left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj