### PR TITLE
refactor(vite-plugin-svelte-native): share envelope bounds-check logic between envelope.js and parse-envelope.js

### DIFF
--- a/apps/npm/vite-plugin-svelte-native/envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/envelope.js
@@ -12,6 +12,8 @@
 
 'use strict';
 
+const { isWindowOutOfBounds, windowOutOfBoundsMessage } = require('./lib/bounds-check.js');
+
 const MAGIC = 0x31565352; // "RSV1" little-endian
 const VERSION = 1;
 const HEADER_LEN = 60;
@@ -27,10 +29,8 @@ const WARN_HAS_FRAME = 1 << 3;
 
 /**
  * Validate that the byte window `[off, off + len)` lies fully inside a
- * buffer of `bufLen` bytes. The encoder writes offsets/lengths as u32s
- * the decoder otherwise trusts blindly — `buf.toString` / `subarray`
- * silently *clamp* an out-of-range window, so a malformed envelope would
- * decode to truncated data instead of failing loudly. Throw instead (M-012).
+ * buffer of `bufLen` bytes (see `./lib/bounds-check.js` for why this must
+ * throw rather than let `toString`/`subarray` clamp silently — M-012).
  *
  * @param {number} bufLen
  * @param {number} off
@@ -38,11 +38,8 @@ const WARN_HAS_FRAME = 1 << 3;
  * @param {string} label
  */
 function assertWindow(bufLen, off, len, label) {
-	if (off < 0 || len < 0 || off + len > bufLen) {
-		throw new Error(
-			`[rsvelte] envelope ${label} out of bounds ` +
-				`(offset ${off} + length ${len} exceeds buffer of ${bufLen} bytes)`,
-		);
+	if (isWindowOutOfBounds(off, len, bufLen)) {
+		throw new Error(`[rsvelte] envelope ${windowOutOfBoundsMessage(label, off, len, bufLen)}`);
 	}
 }
 

--- a/apps/npm/vite-plugin-svelte-native/lib/bounds-check.js
+++ b/apps/npm/vite-plugin-svelte-native/lib/bounds-check.js
@@ -1,0 +1,38 @@
+// Shared bounds-check primitive for the two raw-transfer envelope decoders
+// (`../envelope.js` for `compileEnvelope`/`compileModuleEnvelope`, and
+// `../parse-envelope.js` for `parseEnvelope`). Both wire formats encode
+// offsets/lengths as u32s that the decoder otherwise trusts blindly —
+// `Buffer.toString` / `Uint8Array.subarray` silently *clamp* an
+// out-of-range window instead of throwing, so a malformed envelope would
+// decode to truncated/misaligned data rather than failing loudly (M-012).
+//
+// Each decoder wraps this in its own `assertWindow` helper so it can throw
+// its own Error subtype with its own message prefix (`[rsvelte] envelope …`
+// vs `parse envelope: …`) while sharing the actual bounds arithmetic and
+// message body.
+
+'use strict';
+
+/**
+ * @param {number} off
+ * @param {number} len
+ * @param {number} bufLen
+ * @returns {boolean} true when the byte window `[off, off + len)` does NOT
+ *   lie fully inside a buffer of `bufLen` bytes.
+ */
+function isWindowOutOfBounds(off, len, bufLen) {
+	return off < 0 || len < 0 || off + len > bufLen;
+}
+
+/**
+ * @param {string} label
+ * @param {number} off
+ * @param {number} len
+ * @param {number} bufLen
+ * @returns {string}
+ */
+function windowOutOfBoundsMessage(label, off, len, bufLen) {
+	return `${label} out of bounds (offset ${off} + length ${len} exceeds buffer of ${bufLen} bytes)`;
+}
+
+module.exports = { isWindowOutOfBounds, windowOutOfBoundsMessage };

--- a/apps/npm/vite-plugin-svelte-native/package.json
+++ b/apps/npm/vite-plugin-svelte-native/package.json
@@ -24,6 +24,7 @@
   "files": [
     "envelope.js",
     "parse-envelope.js",
+    "lib/bounds-check.js",
     "index.cjs",
     "index.d.ts"
   ],

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -12,6 +12,8 @@
 
 'use strict';
 
+const { isWindowOutOfBounds, windowOutOfBoundsMessage } = require('./lib/bounds-check.js');
+
 const MAGIC = 0x3156_5052; // "RPV1" little-endian
 const VERSION = 1;
 const HEADER_LEN = 24;
@@ -258,11 +260,9 @@ function readBool(ctx) {
 
 /**
  * Validate that the byte window `[start, start + len)` lies fully inside
- * `ctx.bytes`. The encoder writes lengths as u32s the decoder otherwise
- * trusts blindly — `Buffer.toString` / `Uint8Array.subarray` silently
- * *clamp* an out-of-range window, so a malformed envelope would decode to
- * truncated/misaligned data instead of failing loudly. Throw instead
- * (mirrors envelope.js's `assertWindow`, M-012).
+ * `ctx.bytes` (see `./lib/bounds-check.js`, shared with `envelope.js`'s
+ * `assertWindow`, for why this must throw rather than let
+ * `Buffer.toString`/`Uint8Array.subarray` clamp silently — M-012).
  *
  * @param {object} ctx
  * @param {number} start
@@ -270,10 +270,9 @@ function readBool(ctx) {
  * @param {string} label
  */
 function assertWindow(ctx, start, len, label) {
-	if (start < 0 || len < 0 || start + len > ctx.bytes.byteLength) {
+	if (isWindowOutOfBounds(start, len, ctx.bytes.byteLength)) {
 		throw new EnvelopeError(
-			`parse envelope: ${label} out of bounds ` +
-				`(offset ${start} + length ${len} exceeds buffer of ${ctx.bytes.byteLength} bytes)`,
+			`parse envelope: ${windowOutOfBoundsMessage(label, start, len, ctx.bytes.byteLength)}`,
 		);
 	}
 }


### PR DESCRIPTION
## Summary

- `envelope.js` and `parse-envelope.js` each grew their own `assertWindow(...)` bounds-check helper — same arithmetic (`off < 0 || len < 0 || off + len > bufLen`) and same error-message body, only the wrapping `Error` subtype (`Error` vs `EnvelopeError`) and message prefix (`[rsvelte] envelope …` vs `parse envelope: …`) differ. `parse-envelope.js`'s helper was added in a previous PR to close a boundary-check gap and its own comment already says it "mirrors envelope.js's `assertWindow`" — this PR removes the resulting double-maintained duplication.
- Extracts the shared bounds check into `apps/npm/vite-plugin-svelte-native/lib/bounds-check.js` (`isWindowOutOfBounds`, `windowOutOfBoundsMessage`). Each decoder keeps its own `assertWindow` wrapper so it still throws its own `Error` subtype with its own message prefix.
- Adds the new file to `package.json`'s `files` allowlist so it ships in the published package.
- **No behavior change**: thrown error messages are byte-identical to before (verified — see test plan).

**Finding**: `findings-09-js.md` P2 — "アーキテクチャ: envelope.js / parse-envelope.js の重複ロジック共通化(P1 修正で入った境界チェックの二重管理を解消)".

## Test plan

- [x] `node --check` on all three touched/new files
- [x] `node scripts/dev/test-envelope-validation.mjs` — all assertions pass
- [x] `node scripts/dev/test-parse-envelope-validation.mjs` — all assertions pass (these hand-craft malformed envelopes and assert on the exact thrown message text, so any message-format drift would have failed them)
- [ ] Full `pnpm run test:vps` requires a Rust build of the NAPI binding (out of scope for this environment) — left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj