### PR TITLE
chore(compat-corpus): dedupe readIf/firstDiffLine across verify/cluster scripts

### DIFF
--- a/scripts/compat-corpus/cluster.mjs
+++ b/scripts/compat-corpus/cluster.mjs
@@ -9,7 +9,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { stripBlankLines } from './normalize.mjs';
+import { stripBlankLines, readIf } from './normalize.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -19,10 +19,6 @@ const args = process.argv.slice(2);
 const SHOW = args.includes('--show') ? args[args.indexOf('--show') + 1] : null;
 
 const report = JSON.parse(fs.readFileSync(path.join(CORPUS, 'report.json'), 'utf8'));
-
-function readIf(p) {
-	return fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null;
-}
 
 // First differing hunk after blank-line normalization; normalized to a signature.
 function diffSignature(exp, act) {

--- a/scripts/compat-corpus/fmt-verify.mjs
+++ b/scripts/compat-corpus/fmt-verify.mjs
@@ -28,6 +28,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { readIf, firstDiffLine } from "./normalize.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "../..");
@@ -57,25 +58,6 @@ const STRICT = args.includes("--strict");
 function fail(msg) {
   console.error(`[fmt-verify] ${msg}`);
   process.exit(1);
-}
-
-function readIf(p) {
-  return fs.existsSync(p) ? fs.readFileSync(p, "utf8") : null;
-}
-
-function firstDiffLine(a, b) {
-  const al = a.split("\n");
-  const bl = b.split("\n");
-  for (let i = 0; i < Math.max(al.length, bl.length); i++) {
-    if (al[i] !== bl[i]) {
-      return {
-        line: i + 1,
-        expected: (al[i] ?? "<EOF>").slice(0, 120),
-        actual: (bl[i] ?? "<EOF>").slice(0, 120),
-      };
-    }
-  }
-  return null;
 }
 
 if (!fs.existsSync(META_PATH)) {

--- a/scripts/compat-corpus/normalize.mjs
+++ b/scripts/compat-corpus/normalize.mjs
@@ -13,6 +13,7 @@
  * ${} nesting) / comment state, and only lines whose newline is outside
  * any multi-line token are eligible for removal.
  */
+import fs from 'node:fs';
 import { parse } from 'acorn';
 
 /**
@@ -267,4 +268,29 @@ export function stripBlankLines(src) {
 		}
 	}
 	return out.join('\n');
+}
+
+/**
+ * Read a file if it exists, else `null`. Shared by every verify/cluster
+ * script that reads optional per-entry output files (`error.json`,
+ * `client.js`, `index.tsx`, …).
+ */
+export function readIf(p) {
+	return fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null;
+}
+
+/**
+ * Locate the first line at which two texts diverge, truncated for display.
+ * Returns `null` when the texts are identical. Shared by every verify
+ * script's failure-detail reporting.
+ */
+export function firstDiffLine(a, b) {
+	const al = a.split('\n');
+	const bl = b.split('\n');
+	for (let i = 0; i < Math.max(al.length, bl.length); i++) {
+		if (al[i] !== bl[i]) {
+			return { line: i + 1, expected: (al[i] ?? '<EOF>').slice(0, 120), actual: (bl[i] ?? '<EOF>').slice(0, 120) };
+		}
+	}
+	return null;
 }

--- a/scripts/compat-corpus/svelte2tsx-cluster.mjs
+++ b/scripts/compat-corpus/svelte2tsx-cluster.mjs
@@ -9,7 +9,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { stripBlankLines } from './normalize.mjs';
+import { stripBlankLines, readIf } from './normalize.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -19,10 +19,6 @@ const args = process.argv.slice(2);
 const SHOW = args.includes('--show') ? args[args.indexOf('--show') + 1] : null;
 
 const report = JSON.parse(fs.readFileSync(path.join(CORPUS, 'report-s2t.json'), 'utf8'));
-
-function readIf(p) {
-	return fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null;
-}
 
 // First differing hunk after blank-line normalization; normalized to a signature.
 function diffSignature(exp, act) {

--- a/scripts/compat-corpus/svelte2tsx-verify.mjs
+++ b/scripts/compat-corpus/svelte2tsx-verify.mjs
@@ -31,7 +31,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { stripBlankLines } from './normalize.mjs';
+import { stripBlankLines, readIf, firstDiffLine } from './normalize.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -81,21 +81,6 @@ if (!NO_FMT) {
 const manifest = JSON.parse(fs.readFileSync(path.join(CORPUS, 'manifest.json'), 'utf8')).filter(
 	(e) => e.kind === 'component'
 );
-
-function readIf(p) {
-	return fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null;
-}
-
-function firstDiffLine(a, b) {
-	const al = a.split('\n');
-	const bl = b.split('\n');
-	for (let i = 0; i < Math.max(al.length, bl.length); i++) {
-		if (al[i] !== bl[i]) {
-			return { line: i + 1, expected: (al[i] ?? '<EOF>').slice(0, 120), actual: (bl[i] ?? '<EOF>').slice(0, 120) };
-		}
-	}
-	return null;
-}
 
 const counts = { match: 0, 'error-parity': 0, 'oracle-invalid': 0, 'ts-mismatch': 0, 'error-mismatch': 0, missing: 0 };
 const failures = [];

--- a/scripts/compat-corpus/verify.mjs
+++ b/scripts/compat-corpus/verify.mjs
@@ -31,7 +31,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { flattenTemplateHoles, stripBlankLines, astEquivalent } from './normalize.mjs';
+import { flattenTemplateHoles, stripBlankLines, astEquivalent, readIf, firstDiffLine } from './normalize.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -100,21 +100,6 @@ if (!NO_FMT) {
 // ---- comparison --------------------------------------------------------------
 
 const manifest = JSON.parse(fs.readFileSync(path.join(CORPUS, 'manifest.json'), 'utf8'));
-
-function readIf(p) {
-	return fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null;
-}
-
-function firstDiffLine(a, b) {
-	const al = a.split('\n');
-	const bl = b.split('\n');
-	for (let i = 0; i < Math.max(al.length, bl.length); i++) {
-		if (al[i] !== bl[i]) {
-			return { line: i + 1, expected: (al[i] ?? '<EOF>').slice(0, 120), actual: (bl[i] ?? '<EOF>').slice(0, 120) };
-		}
-	}
-	return null;
-}
 
 const counts = { match: 0, 'error-parity': 0, 'js-mismatch': 0, 'css-mismatch': 0, 'error-mismatch': 0 };
 const failures = [];


### PR DESCRIPTION
## Summary

- `readIf` (existsSync-then-readFileSync-or-null) and `firstDiffLine` (first differing line between two texts, truncated to 120 chars for display) were byte-for-byte reimplemented in `verify.mjs`, `svelte2tsx-verify.mjs`, and `fmt-verify.mjs`; `readIf` alone was also duplicated in `cluster.mjs` and `svelte2tsx-cluster.mjs` (5 call sites total).
- Moves both into `normalize.mjs` (already the shared module the corpus scripts import `stripBlankLines`/`flattenTemplateHoles`/`astEquivalent` from) and switches all five scripts to import from there.
- Purely mechanical — no logic changes. `fmt-verify.mjs` uses a different code style (2-space/double-quote vs the others' tab/single-quote) from an earlier pass; only its `import` line was added in its own style, the rest of the file is untouched.

Deliberately **out of scope** (kept narrow per review guidance — the corpus pipeline is a CI gate, so anything riskier than a mechanical extraction needs a full corpus run to validate, which isn't available in this environment): the deeper ratchet/regression-computation blocks in the three verify scripts, and `diffSignature`/`add` in the two cluster scripts (their `add()` helpers have small real differences — `ids` cap and `sample` — that make unification less trivially safe).

**Finding**: `findings-09-js.md` P2 — "verify.mjs / svelte2tsx-verify.mjs / fmt-verify.mjs でラチェット判定・firstDiffLine・readIf が三重に重複" (readIf/firstDiffLine portion) and the `readIf` part of "cluster.mjs と svelte2tsx-cluster.mjs の diffSignature / クラスタ集計ロジックが完全重複".

## Test plan

- [x] `node --check` on all 6 touched files
- [x] Built a synthetic `compat/corpus/{manifest.json,expected,actual,expected-s2t,actual-s2t}` fixture (match / mismatch / error-parity / ts-mismatch / missing cases) and ran `verify.mjs --no-fmt --strict`, `svelte2tsx-verify.mjs --no-fmt --strict`, `cluster.mjs`, and `svelte2tsx-cluster.mjs` against it both before and after the refactor (via `git stash`) — stdout and `report{,-s2t}.json` are byte-identical aside from the `generatedAt` timestamp.
- [ ] A real `pnpm run corpus:verify` / `corpus:s2t:verify` run needs the corpus submodules synced and compiled, which is heavy for this environment — left to CI (this PR doesn't touch any comparison logic, only where the two helper functions live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj