### PR TITLE
chore(changeset): add changeset for #1437 (inline control-flow prefix fix)

### DIFF
--- a/.changeset/fix-fmt-inline-control-flow-prefix.md
+++ b/.changeset/fix-fmt-inline-control-flow-prefix.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(formatter): preserve inline control-flow prefixes
+
+Follow-up changeset for #1437 (by @mustafa0x, merged with `skip-changeset`).
+The break-block prefix collector treated any prefix ending in `>` as a wrapped
+block-display open-tag eligible to be reused as indentation, which misfired on
+inline control-flow markup such as `{:else}<section …>` — the `>` there closes
+inline content, not a wrapped open tag. Narrowed the guard to fire only when the
+prefix (after trimming leading whitespace) is exactly `>`, so a genuine wrapped
+open-tag continuation is still handled while inline `{:else}<el>` markup is left
+intact and formatting stays idempotent.


### PR DESCRIPTION
Follow-up to #1437 (by @mustafa0x), which was merged with the `skip-changeset` label because a changeset could not be pushed to the external contributor's fork branch.

This adds the missing changeset (`@rsvelte/fmt` patch) so the formatter fix — *preserve inline control-flow prefixes* — is included in the next release's changelog/version bump.

No code change; changeset only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KPMtBi2GSUYvat5rowsPu