### PR TITLE
fix(fmt): measure attribute-value fit by visual width; formatter cleanup

### DIFF
--- a/.changeset/fix-fmt-attr-value-visual-width.md
+++ b/.changeset/fix-fmt-attr-value-visual-width.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): measure attribute-value fit by visual width, not byte length
+
+When deciding whether a wide single-line attribute value fits with its
+trailing literal on the same line, the width check used the value's byte
+length instead of its display width. For CJK (and other multi-byte) content
+the byte count overcounts columns, so the check reported an overflow that
+does not exist and the value was broken across lines unnecessarily. Use
+`visual_width` for the value, matching the sibling force-break path.

--- a/crates/rsvelte_formatter/src/children.rs
+++ b/crates/rsvelte_formatter/src/children.rs
@@ -16,15 +16,6 @@
 
 use crate::doc::Doc;
 
-/// Whether `name` is an HTML block-level element (prettier-plugin-svelte's
-/// `blockElements` list — the 33 names) under the default
-/// `htmlWhitespaceSensitivity: 'css'`. Delegates to the single canonical list in
-/// [`crate::markup::is_html_block_display_element`] so there is one source of
-/// truth (the markup open-tag layout uses the same set).
-pub(crate) fn is_block_element_name(name: &str) -> bool {
-    crate::markup::is_html_block_display_element(name)
-}
-
 // ── HTML-collapse-whitespace text predicates (port of the `*_RE` helpers) ──
 
 fn is_html_ws(c: char) -> bool {
@@ -156,6 +147,10 @@ fn split_on_ws_runs(text: &str) -> Vec<&str> {
 #[derive(Clone)]
 pub(crate) enum Child {
     Text(String),
+    // Part of prettier's faithful classification and handled throughout
+    // `print_children`, but the current caller (`collapse::node_to_child`)
+    // never emits a block child, so it is only exercised by unit tests.
+    #[allow(dead_code)]
     Block(Doc),
     Inline(Doc),
     Other(Doc),
@@ -606,16 +601,6 @@ mod tests {
     /// `group` wraps (NOT a fill); text children are fills inside it.
     fn render_children(docs: Vec<Doc>, width: usize) -> String {
         print(propagate_breaks(Doc::Group(docs)), width, "  ", 0, 0)
-    }
-
-    #[test]
-    fn block_classification_matches_canonical_list() {
-        assert!(is_block_element_name("div"));
-        assert!(is_block_element_name("p"));
-        assert!(is_block_element_name("ul"));
-        assert!(!is_block_element_name("span"));
-        assert!(!is_block_element_name("a"));
-        assert!(!is_block_element_name("strong"));
     }
 
     #[test]

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -466,20 +466,6 @@ fn reformat_pre_inner(
     // still correct output) whereas under-narrowing leaves space lines too wide,
     // causing incorrect single-line output for lines that overflow at the real column.
     // Use `content_depth * iw` (correct for space lines) as the primary narrowing.
-    // Format the children standalone, but narrowed so a depth-0 layout matches the
-    // breaks at the real `content_depth`.
-    //
-    // Element-direct children of `<pre>` are re-indented with TABS (1 char each)
-    // rather than spaces (`iw` chars each).  The sub-format sees space indentation,
-    // so a line at sub-depth D appears as `D*iw` chars, but in the final output the
-    // tab-indented prefix uses only `D + content_depth` chars (one per tab level).
-    // Using `content_depth * iw` as the narrowing over-narrows for tab lines,
-    // causing hug-overflow on elements that would fit when tab-indented.
-    //
-    // The saving per sub-depth level is `iw - 1` chars (tab = 1 vs space = iw).
-    // We add one level's saving (`iw - 1`) to account for the typical case where
-    // grandchildren at sub-depth 1 (e.g. `<span>` inside `<code>` inside `<pre>`)
-    // are tab-lines in the final output.
     let narrowed = full_width
         .saturating_sub(content_depth)
         .saturating_add(iw - 1)
@@ -1343,8 +1329,7 @@ fn try_fill_run(
                 // normal word-first after the hardlines — don't apply inverted logic.
                 None
             } else {
-                let starts_with_newline = d.starts_with('\n');
-                Some(starts_with_newline)
+                Some(d.starts_with('\n'))
             }
         } else {
             None
@@ -1356,7 +1341,6 @@ fn try_fill_run(
     // edit region by moving s back by 1. This ensures the fill output (which starts
     // with a space from the inverted leading Line) replaces the space rather than
     // doubling it. Only include ONE space (the char immediately before s).
-    let s_before_case_a_adjust = s;
     if matches!(first_text_leading_ws_kind, Some(false)) {
         // Move s back by 1 to include the single leading space in the edit range.
         // This keeps the indent computation correct (the space is already counted
@@ -1365,7 +1349,6 @@ fn try_fill_run(
             s -= 1;
         }
     }
-    let _ = s_before_case_a_adjust; // suppress unused-variable warning
 
     let mut e = node_end(last) as usize;
     if let TemplateNode::Text(t) = last {
@@ -1659,7 +1642,7 @@ fn collect_hug_mixed_non_ws_prefix(
     edits: &mut Vec<(u32, u32, String)>,
 ) {
     for node in &fragment.nodes {
-        let (start, end, children) = match node {
+        let children = match node {
             TemplateNode::RegularElement(e) => {
                 if is_whitespace_preserving(e.name.as_str()) {
                     continue;
@@ -1688,7 +1671,7 @@ fn collect_hug_mixed_non_ws_prefix(
                     edits.push(edit);
                     continue; // edit owns this element, don't recurse
                 }
-                (e.start, e.end, vec![&e.fragment])
+                vec![&e.fragment]
             }
             TemplateNode::Component(c) => {
                 let s = c.start as usize;
@@ -1710,7 +1693,7 @@ fn collect_hug_mixed_non_ws_prefix(
                     edits.push(edit);
                     continue;
                 }
-                (c.start, c.end, vec![&c.fragment])
+                vec![&c.fragment]
             }
             TemplateNode::SlotElement(s) => {
                 let ss = s.start as usize;
@@ -1732,7 +1715,7 @@ fn collect_hug_mixed_non_ws_prefix(
                     edits.push(edit);
                     continue;
                 }
-                (s.start, s.end, vec![&s.fragment])
+                vec![&s.fragment]
             }
             _ => {
                 for child in child_fragments(node) {
@@ -1741,7 +1724,6 @@ fn collect_hug_mixed_non_ws_prefix(
                 continue;
             }
         };
-        let _ = (start, end); // suppress unused warnings
         for child in children {
             collect_hug_mixed_non_ws_prefix(out, child, line_width, options, edits);
         }
@@ -5164,8 +5146,6 @@ fn try_fill_mixed(
     (broken != whole).then_some((start, end, broken))
 }
 
-/// Port of prettier-plugin-svelte's `printChildren` for inline (prose) content:
-/// a `Concat` of each text node's `fill(splitTextToDocs)` and each inline
 /// Prepend `leading` (a `Doc::Line` or `Doc::Hardline`) to the outermost
 /// `Doc::Fill` within `doc`. This produces prettier's "inverted" fill
 /// structure `[Line/Hardline, word, Line, word, ...]` for text nodes that

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -5,16 +5,11 @@
 //!
 //! - `<script>` / `<script context="module">`: re-parse the body with
 //!   `oxc_parser` and format via `oxc_formatter::Formatter`.
-//! - `<style>`: TODO (verbatim for now).
-//! - markup + `{expr}`: TODO (verbatim for now).
-//!
-//! The current skeleton only handles `<script>` bodies; the rest of the
-//! source is passed through unchanged. Subsequent iterations will add
-//! CSS formatting and markup Doc IR composition.
+//! - `<style>`: formatted via the `oxc_formatter_css` engine (see
+//!   `options::StyleFormatter`).
+//! - markup + `{expr}`: normalized by the `markup` / `expression` passes and
+//!   the `collapse` child-layout pass.
 
-// Milestone-1 `printChildren` port: built and unit-tested, wired into the markup
-// printer in a follow-up (docs/fmt-layout-port-plan.md), so its API is unused for now.
-#[allow(dead_code)]
 mod children;
 mod collapse;
 mod doc;

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -587,7 +587,10 @@ fn render_this_attr(
     // than `this={expr}`. Preserve the string form (`this="value"`) rather
     // than converting to the brace form, which would turn `this="div"` into
     // `this={div}` (an identifier reference, not a string literal).
-    let prev_byte = source.as_bytes().get(expr_start as usize - 1).copied();
+    let prev_byte = (expr_start as usize)
+        .checked_sub(1)
+        .and_then(|i| source.as_bytes().get(i))
+        .copied();
     let this_attr = if matches!(prev_byte, Some(b'"') | Some(b'\'')) {
         let raw = source
             .get(expr_start as usize..expr_end as usize)
@@ -966,13 +969,12 @@ fn open_tag_name_end(source: &str, element_start: u32) -> usize {
     i
 }
 
-/// HTML void elements — they never have a closing tag and are emitted in the
-/// self-closing ` />` form (matching prettier-plugin-svelte's default).
-/// prettier-plugin-svelte's `blockElements` list (its `isBlockElement`). These
+/// Canonical list of HTML block-display elements (prettier-plugin-svelte's
+/// `blockElements` / `isBlockElement`), shared with the collapse pass. These
 /// elements never hug their start/end (`shouldHugStart` / `shouldHugEnd` return
 /// false), so when their open tag wraps the closing `>` always breaks onto its
 /// own line — even when text content sits directly after it.
-/// Canonical list of HTML block-display elements shared with the collapse pass.
+///
 /// Does NOT include `script` / `style` — those are whitespace-preserving in the
 /// collapse pass (handled by `is_whitespace_preserving`) but count as block
 /// elements here for open-tag layout purposes.
@@ -1021,6 +1023,8 @@ fn is_block_element(tag_name: &str) -> bool {
     is_html_block_display_element(tag_name) || matches!(tag_name, "script" | "style")
 }
 
+/// HTML void elements — they never have a closing tag and are emitted in the
+/// self-closing ` />` form (matching prettier-plugin-svelte's default).
 fn is_void_element(tag_name: &str) -> bool {
     matches!(
         tag_name,
@@ -1756,7 +1760,9 @@ fn render_attribute_node(
         AttributeValue::Sequence(parts)
             if matches!(parts.as_slice(), [AttributeValuePart::ExpressionTag(_)]) =>
         {
-            let AttributeValuePart::ExpressionTag(tag) = &parts[0] else {
+            // The guard already established the single-`ExpressionTag` shape;
+            // re-bind through the same slice pattern so the two stay in sync.
+            let [AttributeValuePart::ExpressionTag(tag)] = parts.as_slice() else {
                 unreachable!()
             };
             let inner_src = expression_tag_inner(tag, source).trim();
@@ -2020,7 +2026,7 @@ fn render_attribute_value_sequence(
                             let total = effective_indent
                                 + lead_cols
                                 + 1
-                                + first_pass.len()
+                                + visual_width(first_pass.as_str())
                                 + 1
                                 + trailing_cols
                                 + 1;


### PR DESCRIPTION
## What

**P2-7 — the fix.** In `markup.rs`, the check that decides whether a wide single-line attribute value fits with its trailing literal on the same line used the value's *byte* length (`first_pass.len()`) rather than its display width. For CJK / other multi-byte content the byte count overcounts columns, so the check reported a non-existent overflow and broke the value across lines unnecessarily. It now uses `visual_width`, matching the sibling force-break path a few lines below.

**P2-3 + P3 — cleanup** (no behavior change):
- Drop the module-wide `#[allow(dead_code)]` on `children` (the module is in use) plus its stale "unused for now" note; narrow the allow to the single faithful-port `Child::Block` variant the current caller never emits, and delete the truly-dead `is_block_element_name` wrapper and its test.
- Refresh the stale crate-level doc in `lib.rs`.
- Move the misplaced void-element doc paragraph onto `is_void_element`, leaving `is_html_block_display_element` with only its own block-element doc.
- Harden the two `expr_start - 1` byte look-ups with `checked_sub` (avoids a debug-build subtract-overflow if a span starts at offset 0).
- Bind the single-`ExpressionTag` attribute value through the same slice pattern as its match guard; remove two dead `let _ = …` warning-suppressors and a redundant intermediate binding; drop a duplicated comment block in the `<pre>`-narrowing path and an orphaned doc fragment on `prepend_leading_to_fill`.

Skipped from the findings' P3 list: the `expression.rs:1668-1676 / 2493-2510` "doc fragmentation" references — post the already-merged P2-4 change those line ranges point at ordinary code and a valid doc, with no defect to fix.

## Verify

- `cargo test -p rsvelte_formatter -p rsvelte_fmt` — all pass.
- `cargo +1.97 clippy -p rsvelte_formatter --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt`.
- Output byte-parity enforced by the fmt-corpus in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj