### PR TITLE
chore(parse): clean up stale docs, merge duplicate match arms, fix a lint disable

### DIFF
--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -862,13 +862,15 @@ pub fn compile_module(
         let (program, parse_error) =
             phases::phase1_parse::read::expression::parse_program_with_error(
                 &arena,
-                source,
-                0, // offset = 0 (source is the entire file)
-                &[],
-                false,        // upstream analyze_module always parses plain JS
-                &[],          // no leading comments
-                0,            // script_tag_start
-                source.len(), // script_tag_end
+                phases::phase1_parse::read::expression::ProgramParseParams {
+                    content: source,
+                    offset: 0, // source is the entire file
+                    line_offsets: &[],
+                    is_typescript: false, // upstream analyze_module always parses plain JS
+                    leading_comments: &[],
+                    script_tag_start: 0,
+                    script_tag_end: source.len(),
+                },
             );
 
         // Mirror upstream acorn's throw-on-error behaviour (js_parse_error).

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
@@ -221,13 +221,15 @@ pub fn parse_module_to_estree(source: &str, is_typescript: bool) -> serde_json::
     crate::ast::arena::with_serialize_arena(&arena, || {
         let (program, _parse_error) = expression::parse_program_with_error(
             &arena,
-            source,
-            0,
-            &line_offsets,
-            is_typescript,
-            &[],
-            0,
-            source.len(),
+            expression::ProgramParseParams {
+                content: source,
+                offset: 0,
+                line_offsets: &line_offsets,
+                is_typescript,
+                leading_comments: &[],
+                script_tag_start: 0,
+                script_tag_end: source.len(),
+            },
         );
         program.as_json().clone()
     })
@@ -243,13 +245,15 @@ pub fn ts_snippet_is_valid(source: &str, is_typescript: bool) -> bool {
     crate::ast::arena::with_serialize_arena(&arena, || {
         let (_program, parse_error) = expression::parse_program_with_error(
             &arena,
-            source,
-            0,
-            &line_offsets,
-            is_typescript,
-            &[],
-            0,
-            source.len(),
+            expression::ProgramParseParams {
+                content: source,
+                offset: 0,
+                line_offsets: &line_offsets,
+                is_typescript,
+                leading_comments: &[],
+                script_tag_start: 0,
+                script_tag_end: source.len(),
+            },
         );
         parse_error.is_none()
     })

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -10,8 +10,9 @@
 //!
 //! - **Parser backend**: Svelte uses [Acorn](https://github.com/acornjs/acorn) for JavaScript
 //!   parsing, while this implementation uses [OXC](https://oxc.rs/) for better performance.
-//! - **AST conversion**: This module converts OXC's AST to a `serde_json::Value` format
-//!   compatible with Svelte's ESTree-based AST output.
+//! - **AST conversion**: This module converts OXC's AST into this crate's typed,
+//!   arena-allocated `JsNode`/`Expression` representation (ESTree-shaped), not a
+//!   `serde_json::Value`.
 //! - **TypeScript support**: OXC provides native TypeScript support, which is used here
 //!   to parse TypeScript expressions without additional configuration.
 //! - **Line/column tracking**: This implementation computes ESTree-style `loc` fields
@@ -6164,6 +6165,22 @@ fn create_typed_loc_for_script(
     }))
 }
 
+/// Parameters for [`parse_program_with_error`], grouped into a struct to keep
+/// the function signature under clippy's argument-count lint.
+pub struct ProgramParseParams<'a> {
+    pub content: &'a str,
+    pub offset: usize,
+    pub line_offsets: &'a [usize],
+    /// Set to true if the script contains TypeScript.
+    pub is_typescript: bool,
+    /// HTML comments that appeared before the script tag.
+    pub leading_comments: &'a [String],
+    /// Positions for loc calculation (Svelte uses locator(start) for
+    /// loc.start and locator(parser.index) for loc.end).
+    pub script_tag_start: usize,
+    pub script_tag_end: usize,
+}
+
 /// Parse a JavaScript program (script content) and return it as an Expression,
 /// surfacing the first JS parse error as a `js_parse_error` `ParseError`
 /// (mirroring upstream `acorn.parse`, which throws `e.js_parse_error` via
@@ -6171,22 +6188,19 @@ fn create_typed_loc_for_script(
 /// acorn.js). The recovered partial program is still returned so lenient
 /// callers (e.g. the profiling binary) can keep operating on a best-effort
 /// AST.
-///
-/// Set `is_typescript` to true if the script contains TypeScript.
-/// `leading_comments` are HTML comments that appeared before the script tag.
-/// `script_tag_start` and `script_tag_end` are positions for loc calculation
-/// (Svelte uses locator(start) for loc.start and locator(parser.index) for loc.end).
-#[allow(clippy::too_many_arguments)]
 pub fn parse_program_with_error(
     arena: &ParseArena,
-    content: &str,
-    offset: usize,
-    line_offsets: &[usize],
-    is_typescript: bool,
-    leading_comments: &[String],
-    script_tag_start: usize,
-    script_tag_end: usize,
+    params: ProgramParseParams,
 ) -> (Expression, Option<crate::error::ParseError>) {
+    let ProgramParseParams {
+        content,
+        offset,
+        line_offsets,
+        is_typescript,
+        leading_comments,
+        script_tag_start,
+        script_tag_end,
+    } = params;
     with_oxc_allocator(|allocator| {
         let source_type = if is_typescript {
             SourceType::ts()

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
@@ -45,13 +45,15 @@ pub fn ensure_script_parsed(
 
     let (program, parse_error) = super::expression::parse_program_with_error(
         arena,
-        &raw,
-        offset,
-        line_offsets,
-        script.is_typescript,
-        &leading_comments,
-        script.start as usize,
-        script.end as usize,
+        super::expression::ProgramParseParams {
+            content: &raw,
+            offset,
+            line_offsets,
+            is_typescript: script.is_typescript,
+            leading_comments: &leading_comments,
+            script_tag_start: script.start as usize,
+            script_tag_end: script.end as usize,
+        },
     );
 
     script.content = program;
@@ -264,13 +266,15 @@ impl Parser<'_> {
             // Eager parsing (default for tests and direct AST comparison)
             let (program, parse_error) = super::super::expression::parse_program_with_error(
                 &self.arena,
-                script_content,
-                content_start,
-                self.expression_line_offsets(),
-                use_typescript,
-                &leading_comments,
-                start,
-                end,
+                super::super::expression::ProgramParseParams {
+                    content: script_content,
+                    offset: content_start,
+                    line_offsets: self.expression_line_offsets(),
+                    is_typescript: use_typescript,
+                    leading_comments: &leading_comments,
+                    script_tag_start: start,
+                    script_tag_end: end,
+                },
             );
             // Upstream acorn throws on the first script parse error, even in
             // loose mode (read/script.js → acorn.js `handle_parse_error`). BUT

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -938,12 +938,7 @@ impl Parser<'_> {
         };
 
         if closes {
-            // Only allocate CompactString when we actually need the result
-            let mut lower = String::with_capacity(next_tag_str.len());
-            for b in next_tag_str.bytes() {
-                lower.push(b.to_ascii_lowercase() as char);
-            }
-            Some(CompactString::from(lower))
+            Some(CompactString::from(next_tag_str.to_ascii_lowercase()))
         } else {
             None
         }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1751,22 +1751,15 @@ impl Parser<'_> {
             // svelte2tsx mode (`script_ts`, set only by `parse_script_ts`).
             if !self.script_ts {
                 let trimmed = params_content.trim();
-                let chars: Vec<char> = trimmed.chars().collect();
                 let mut depth = 0;
-                for i in 0..chars.len() {
-                    let c = chars[i];
+                for (byte_offset, c) in trimmed.char_indices() {
                     if c == '(' || c == '[' || c == '{' {
                         depth += 1;
                     } else if c == ')' || c == ']' || c == '}' {
                         depth -= 1;
-                    } else if depth == 0
-                        && c == '.'
-                        && i + 2 < chars.len()
-                        && chars[i + 1] == '.'
-                        && chars[i + 2] == '.'
-                    {
+                    } else if depth == 0 && c == '.' && trimmed[byte_offset..].starts_with("...") {
                         // Found rest parameter
-                        let rest_start = params_start + i;
+                        let rest_start = params_start + byte_offset;
                         return Err(crate::error::ParseError::svelte(
                             "snippet_invalid_rest_parameter",
                             "Snippets do not support rest parameters; use an array instead",
@@ -2344,16 +2337,9 @@ impl Parser<'_> {
                     metadata: Default::default(),
                 }))))
             }
-            "attach" => {
-                // Skip to closing brace (attach not fully implemented yet)
-                while !self.is_eof() && self.current_char() != '}' {
-                    self.advance();
-                }
-                self.advance(); // consume '}'
-                Ok(None)
-            }
+            // "attach" (not fully implemented yet) and any unknown special tag
+            // are both skipped verbatim up to the closing brace.
             _ => {
-                // Unknown special tag
                 while !self.is_eof() && self.current_char() != '}' {
                     self.advance();
                 }
@@ -2696,6 +2682,11 @@ fn build_empty_loose_declaration(
     }))
 }
 
+/// Strip a TypeScript type annotation from a destructuring/binding pattern,
+/// returning the pattern text up to (but not including) the top-level `:`.
+/// Bracket depth (`{}` / `[]` / `()`) is tracked so a colon nested inside a
+/// type (e.g. `{ a: string }` or `Record<string, number>`) is not mistaken
+/// for the pattern's own annotation.
 fn strip_type_annotation(pattern: &str) -> String {
     let mut depth = 0;
 
@@ -2715,10 +2706,12 @@ fn strip_type_annotation(pattern: &str) -> String {
     pattern.to_string()
 }
 
-/// Build a `VariableDeclaration` node from a pattern expression and init
-/// expression.
-///
-/// This creates the same JSON structure as the official Svelte compiler:
+/// Build a `VariableDeclaration` JSON node with a caller-supplied kind
+/// (`let` / `const` / `var`) from a pattern expression and init expression.
+/// Mirrors `build_const_variable_declaration` (which is locked to `const`)
+/// and powers both `{@const}` and the `{let x = …}` / `{const x = …}`
+/// declaration-tag emit paths. Produces the same JSON structure as the
+/// official Svelte compiler:
 /// ```json
 /// {
 ///   "type": "VariableDeclaration",
@@ -2730,10 +2723,6 @@ fn strip_type_annotation(pattern: &str) -> String {
 ///   }]
 /// }
 /// ```
-/// Build a `VariableDeclaration` JSON node with a caller-supplied kind
-/// (`let` / `const` / `var`). Mirrors `build_const_variable_declaration`
-/// (which is locked to `const`) and powers both `{@const}` and the new
-/// `{let x = …}` / `{const x = …}` declaration-tag emit paths.
 fn build_kind_variable_declaration(
     arena: &crate::ast::arena::ParseArena,
     pattern: &Expression,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -1722,7 +1722,9 @@ fn unary_op(op: &str) -> Option<UnaryOperator> {
 mod tests {
     use super::*;
     use crate::ast::js::Expression as RsExpression;
-    use crate::compiler::phases::phase1_parse::read::expression::parse_program_with_error;
+    use crate::compiler::phases::phase1_parse::read::expression::{
+        ProgramParseParams, parse_program_with_error,
+    };
 
     /// Parse `src` as a JS program with rsvelte's own parser, returning the
     /// `JsNode::Program` and the arena that owns its children.
@@ -1734,8 +1736,18 @@ mod tests {
         // children are resolved via `to_value()` during parsing they need the
         // arena pointer set, mirroring `parse_module_to_estree`.
         let node = crate::ast::arena::with_serialize_arena(&arena, || {
-            let (expr, err) =
-                parse_program_with_error(&arena, src, 0, &line_offsets, false, &[], 0, src.len());
+            let (expr, err) = parse_program_with_error(
+                &arena,
+                ProgramParseParams {
+                    content: src,
+                    offset: 0,
+                    line_offsets: &line_offsets,
+                    is_typescript: false,
+                    leading_comments: &[],
+                    script_tag_start: 0,
+                    script_tag_end: src.len(),
+                },
+            );
             assert!(err.is_none(), "parse error for {src:?}: {err:?}");
             match expr {
                 RsExpression::Typed(te) => te.node,


### PR DESCRIPTION
## Summary
- `read/expression.rs`: fixed the stale module doc claiming OXC's AST is converted to a `serde_json::Value` — it's actually converted into this crate's typed, arena-allocated `JsNode`/`Expression` representation. Also replaced `parse_program_with_error`'s 8 positional parameters (which required `#[allow(clippy::too_many_arguments)]`) with a `ProgramParseParams` struct, updating every call site (`compiler/mod.rs`, `phase1_parse/mod.rs`, `read/script.rs`, and the `jsnode_to_oxc.rs` test helper).
- `state/tag.rs`: gave `strip_type_annotation` its own doc comment (it had none) and folded the two consecutive, partially-duplicated doc comments sitting in front of `build_kind_variable_declaration` into one. Merged the `"attach"` and catch-all arms of `parse_special_tag`'s keyword match — both had identical bodies (skip verbatim to the closing brace).
- `state/element.rs`: replaced the hand-rolled byte-by-byte ASCII-lowercase loop for a closing autoclose tag name with `str::to_ascii_lowercase()`.
- `state/tag.rs`: fixed a char/byte index mix-up in the snippet rest-parameter scan. It built a `Vec<char>` and then used the char *index* directly as a *byte* offset into the original (byte-indexed) source — wrong for any multi-byte character before the `...` rest parameter. Now walks `char_indices()` and reports the real byte offset. Verified against the `snippet-rest-args` compiler-errors fixture (an ASCII parameter name, so the reported error position is unchanged there).

No output changes — verified against the compiler-errors/snapshot/css/parser fixture suites below.

## Test plan
- [x] `cargo test --release --test parser_fixtures` (17/17)
- [x] `cargo test --release --test css` (16/16)
- [x] `cargo test --release --test compiler_errors` (16/16, incl. `snippet-rest-args`)
- [x] `cargo test --release --test compiler_fixtures` (17/17)
- [x] `cargo +1.97 clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt` (no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj