### PR TITLE
refactor(playground): extract shared UI components + remaining P2/P3 review fixes

### DIFF
--- a/apps/playground/src/lib/components/Eyebrow.svelte
+++ b/apps/playground/src/lib/components/Eyebrow.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+		gap?: string;
+		fontSize?: string;
+		letterSpacing?: string;
+		marginBottom?: string;
+		ruleWidth?: string;
+		uppercase?: boolean;
+	}
+
+	let {
+		children,
+		gap = '0.7rem',
+		fontSize = '0.75rem',
+		letterSpacing = '0.08em',
+		marginBottom = '0',
+		ruleWidth = '24px',
+		uppercase = true
+	}: Props = $props();
+</script>
+
+<p
+	class="eyebrow"
+	style="--eyebrow-gap: {gap}; --eyebrow-font-size: {fontSize}; --eyebrow-letter-spacing: {letterSpacing}; --eyebrow-margin-bottom: {marginBottom}; --eyebrow-rule-width: {ruleWidth}; --eyebrow-text-transform: {uppercase
+		? 'uppercase'
+		: 'none'};"
+>
+	<span class="rule"></span>{@render children()}
+</p>
+
+<style>
+	.eyebrow {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--eyebrow-gap);
+		font-family: 'JetBrains Mono', monospace;
+		font-size: var(--eyebrow-font-size);
+		letter-spacing: var(--eyebrow-letter-spacing);
+		text-transform: var(--eyebrow-text-transform);
+		color: var(--rust);
+		margin: 0 0 var(--eyebrow-margin-bottom);
+	}
+
+	.eyebrow .rule {
+		display: inline-block;
+		width: var(--eyebrow-rule-width);
+		height: 1px;
+		background: var(--rust);
+	}
+</style>

--- a/apps/playground/src/lib/components/Guide.svelte
+++ b/apps/playground/src/lib/components/Guide.svelte
@@ -4,6 +4,7 @@
 	import SiteNav from '$lib/components/SiteNav.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 	import CodeBlock from '$lib/components/CodeBlock.svelte';
+	import Eyebrow from '$lib/components/Eyebrow.svelte';
 
 	interface Props {
 		guide: Guide;
@@ -23,7 +24,9 @@
 		</nav>
 
 		<header class="head">
-			<p class="eyebrow"><span class="rule"></span>{guide.pkg}</p>
+			<Eyebrow gap="0.6rem" fontSize="0.72rem" letterSpacing="0.06em" ruleWidth="20px" uppercase={false}
+				>{guide.pkg}</Eyebrow
+			>
 			<h1 class="title">{guide.title}</h1>
 			<p class="dropin">drop-in for <code>{guide.dropInFor}</code></p>
 			<p class="tagline">{guide.tagline}</p>
@@ -143,24 +146,6 @@
 
 	.crumbs .here {
 		color: var(--ink);
-	}
-
-	.eyebrow {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.6rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.72rem;
-		letter-spacing: 0.06em;
-		color: var(--rust);
-		margin: 0;
-	}
-
-	.eyebrow .rule {
-		display: inline-block;
-		width: 20px;
-		height: 1px;
-		background: var(--rust);
 	}
 
 	.title {

--- a/apps/playground/src/lib/components/SectionHead.svelte
+++ b/apps/playground/src/lib/components/SectionHead.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		num: string;
+		children: Snippet;
+		lede?: Snippet;
+		columns?: 2 | 3;
+		padding?: string;
+		marginBottom?: string;
+		fontSize?: string;
+	}
+
+	let {
+		num,
+		children,
+		lede,
+		columns = 2,
+		padding = 'clamp(3.5rem, 8vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2.4rem)',
+		marginBottom = '0',
+		fontSize = 'clamp(1.65rem, 3.2vw, 2.6rem)'
+	}: Props = $props();
+</script>
+
+<div
+	class="section-head"
+	style="--sh-columns: {columns === 3
+		? 'auto 1fr auto'
+		: 'auto 1fr'}; --sh-padding: {padding}; --sh-margin-bottom: {marginBottom}; --sh-font-size: {fontSize};"
+>
+	<span class="num">{num}</span>
+	<h2>{@render children()}</h2>
+	{#if lede}{@render lede()}{/if}
+</div>
+
+<style>
+	.section-head {
+		max-width: 1080px;
+		margin: 0 auto var(--sh-margin-bottom);
+		padding: var(--sh-padding);
+		display: grid;
+		grid-template-columns: var(--sh-columns);
+		gap: 0.4rem 1.4rem;
+		align-items: baseline;
+	}
+
+	.num {
+		grid-row: 1;
+		grid-column: 1;
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.18em;
+		color: var(--rust);
+	}
+
+	h2 {
+		grid-row: 1;
+		grid-column: 2;
+		font-family: 'Hanken Grotesk', sans-serif;
+		font-weight: 700;
+		font-size: var(--sh-font-size);
+		line-height: 1.1;
+		letter-spacing: -0.022em;
+		margin: 0;
+		color: var(--ink);
+	}
+
+	h2 :global(em) {
+		font-style: italic;
+		color: var(--svelte);
+		font-weight: 700;
+	}
+
+	.section-head > :global(.lede) {
+		grid-row: 2;
+		grid-column: 2;
+		margin-top: 0.7rem;
+	}
+
+	.section-head > :global(.clear-filter) {
+		grid-row: 1;
+		grid-column: 3;
+	}
+
+	@media (max-width: 880px) {
+		.section-head {
+			grid-template-columns: auto 1fr;
+		}
+
+		.section-head > :global(.clear-filter) {
+			grid-column: 1 / -1;
+			justify-self: start;
+		}
+	}
+</style>

--- a/apps/playground/src/lib/components/SiteFooter.svelte
+++ b/apps/playground/src/lib/components/SiteFooter.svelte
@@ -1,7 +1,3 @@
-<script lang="ts">
-	// Compact site-wide footer. Kept identical across all pages.
-</script>
-
 <footer class="foot">
 	<div class="inner">
 		<div class="mark">

--- a/apps/playground/src/lib/ecosystem.ts
+++ b/apps/playground/src/lib/ecosystem.ts
@@ -116,20 +116,20 @@ export const shipped: EcoComponent[] = [
 		blurb:
 			'The editor LSP — diagnostics, hover, completion, rename — backed by the rsvelte compiler + svelte2tsx. Ships as the `rsvelte` VS Code extension (Marketplace + Open VSX) and as a standalone package.',
 		note: 'Also published as the `rsvelte` VS Code extension'
+	},
+	{
+		name: 'eslint-plugin-svelte',
+		dropInFor: 'eslint-plugin-svelte',
+		originalUrl: 'https://github.com/sveltejs/eslint-plugin-svelte',
+		status: 'shipped',
+		blurb:
+			'A Rust-native port of the Svelte ESLint rules, driven by the rsvelte AST, verified against a registry-driven compatibility oracle for behaviour + suggestion parity.',
+		note: 'All rules ported · CI-enforced coverage'
 	}
 ];
 
 // ─── Planned / in progress ───────────────────────────────────────────────────
 export const planned: EcoComponent[] = [
-	{
-		name: 'eslint-plugin-svelte',
-		dropInFor: 'eslint-plugin-svelte',
-		originalUrl: 'https://github.com/sveltejs/eslint-plugin-svelte',
-		status: 'planned',
-		blurb:
-			'A Rust-native port of the Svelte ESLint rules, driven by the rsvelte AST. In progress — rules are being ported against a registry-driven compatibility oracle for behaviour + suggestion parity.',
-		note: 'In progress'
-	},
 	{
 		name: 'svelte-preprocess',
 		dropInFor: 'svelte-preprocess',

--- a/apps/playground/src/lib/styles/terminal-code.css
+++ b/apps/playground/src/lib/styles/terminal-code.css
@@ -1,0 +1,15 @@
+/* Token colors for the hand-written terminal-style <pre> snippets
+   (progress / benchmark empty states and the benchmark repro block). */
+.c-cmt {
+	color: var(--ink-faint);
+}
+
+.c-prompt {
+	color: var(--svelte);
+	margin-right: 0.5em;
+}
+
+.c-flag,
+.c-op {
+	color: var(--rust);
+}

--- a/apps/playground/src/routes/+page.svelte
+++ b/apps/playground/src/routes/+page.svelte
@@ -6,6 +6,8 @@
 	import SiteNav from '$lib/components/SiteNav.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 	import EcoCard from '$lib/components/EcoCard.svelte';
+	import Eyebrow from '$lib/components/Eyebrow.svelte';
+	import SectionHead from '$lib/components/SectionHead.svelte';
 	import { shipped, planned, delegated, counts } from '$lib/ecosystem';
 
 	let bench = $state<BenchmarkResults | null>(null);
@@ -131,7 +133,7 @@
 	<header class="hero">
 		<img class="hero-logo" src="{base}/logo.png" alt="rsvelte" width="96" height="96" />
 
-		<p class="eyebrow"><span class="rule"></span>Svelte ecosystem · written in Rust</p>
+		<Eyebrow marginBottom="1.6rem">Svelte ecosystem · written in Rust</Eyebrow>
 
 		<h1 class="title">
 			The Svelte ecosystem,<br />rewritten in <span class="ink-rust">Rust</span>.
@@ -158,15 +160,16 @@
 	</header>
 
 	<section class="perf" id="performance">
-		<div class="section-head">
-			<span class="num">01</span>
-			<h2>Fast across the <em>whole</em> toolchain.</h2>
-			<p class="lede">
-				Speed is the point. Every tool is benchmarked against its official
-				<code>svelte/*</code> counterpart — same machine, same corpus, full pipeline: parse,
-				analyze, codegen.
-			</p>
-		</div>
+		<SectionHead num="01">
+			Fast across the <em>whole</em> toolchain.
+			{#snippet lede()}
+				<p class="lede">
+					Speed is the point. Every tool is benchmarked against its official
+					<code>svelte/*</code> counterpart — same machine, same corpus, full pipeline: parse,
+					analyze, codegen.
+				</p>
+			{/snippet}
+		</SectionHead>
 
 		<div class="perf-grid">
 			<figure class="bars">
@@ -246,16 +249,17 @@
 	</section>
 
 	<section class="eco" id="ecosystem">
-		<div class="section-head">
-			<span class="num">02</span>
-			<h2>Not just a <em>compiler</em>.</h2>
-			<p class="lede">
-				rsvelte ports the hot path of every common Svelte workflow. {counts.shipped} drop-in
-				packages ship today — each a byte-for-byte replacement for its upstream tool — with
-				{counts.planned} more planned and {counts.delegated} deliberately delegated to the wider
-				<a class="link" href="https://oxc.rs/" target="_blank" rel="noopener">OXC</a> toolchain.
-			</p>
-		</div>
+		<SectionHead num="02">
+			Not just a <em>compiler</em>.
+			{#snippet lede()}
+				<p class="lede">
+					rsvelte ports the hot path of every common Svelte workflow. {counts.shipped} drop-in
+					packages ship today — each a byte-for-byte replacement for its upstream tool — with
+					{counts.planned} more planned and {counts.delegated} deliberately delegated to the wider
+					<a class="link" href="https://oxc.rs/" target="_blank" rel="noopener">OXC</a> toolchain.
+				</p>
+			{/snippet}
+		</SectionHead>
 
 		<h3 class="eco-tier">Shipped <span class="eco-tier-n">· usable today</span></h3>
 		<div class="eco-grid">
@@ -284,15 +288,16 @@
 	</section>
 
 	<section class="dropin">
-		<div class="section-head">
-			<span class="num">03</span>
-			<h2>One import. <em>No flags.</em></h2>
-			<p class="lede">
-				No bundler plugin to rewrite, no compiler flag to flip. The same
-				<code>compile()</code>, <code>parse()</code>, <code>preprocess()</code> — or swap the Vite
-				plugin and leave your <code>vite.config.js</code> untouched.
-			</p>
-		</div>
+		<SectionHead num="03">
+			One import. <em>No flags.</em>
+			{#snippet lede()}
+				<p class="lede">
+					No bundler plugin to rewrite, no compiler flag to flip. The same
+					<code>compile()</code>, <code>parse()</code>, <code>preprocess()</code> — or swap the Vite
+					plugin and leave your <code>vite.config.js</code> untouched.
+				</p>
+			{/snippet}
+		</SectionHead>
 
 		<figure class="diff">
 			<figcaption>
@@ -304,20 +309,21 @@
 	</section>
 
 	<section class="compat">
-		<div class="section-head">
-			<span class="num">04</span>
-			<h2>Verified against the <em>official</em> suite.</h2>
-			<p class="lede">
-				{#if compat}
-					<span class="big-pct">{compat.passed.toLocaleString('en-US')} / {compat.inScope.toLocaleString('en-US')}</span>
-					in-scope fixtures from <code>sveltejs/svelte</code> — {compat.pct.toFixed(1)}%. Full
-					breakdown on the <a class="link" href="{base}/progress">compatibility page</a>.
-				{:else}
-					Every category of the official <code>sveltejs/svelte</code> suite, run locally. Full
-					breakdown on the <a class="link" href="{base}/progress">compatibility page</a>.
-				{/if}
-			</p>
-		</div>
+		<SectionHead num="04">
+			Verified against the <em>official</em> suite.
+			{#snippet lede()}
+				<p class="lede">
+					{#if compat}
+						<span class="big-pct">{compat.passed.toLocaleString('en-US')} / {compat.inScope.toLocaleString('en-US')}</span>
+						in-scope fixtures from <code>sveltejs/svelte</code> — {compat.pct.toFixed(1)}%. Full
+						breakdown on the <a class="link" href="{base}/progress">compatibility page</a>.
+					{:else}
+						Every category of the official <code>sveltejs/svelte</code> suite, run locally. Full
+						breakdown on the <a class="link" href="{base}/progress">compatibility page</a>.
+					{/if}
+				</p>
+			{/snippet}
+		</SectionHead>
 
 		<dl class="spec-list">
 			{#each specs as s, i (s.label)}
@@ -340,14 +346,15 @@
 	</section>
 
 	<section class="capi">
-		<div class="section-head">
-			<span class="num">05</span>
-			<h2>Not just <em>Node.js</em>.</h2>
-			<p class="lede">
-				A stable C ABI ships alongside the NAPI build — one shared library, one header, UTF-8 JSON
-				in/out. Drive the same compiler from any language with a C FFI.
-			</p>
-		</div>
+		<SectionHead num="05">
+			Not just <em>Node.js</em>.
+			{#snippet lede()}
+				<p class="lede">
+					A stable C ABI ships alongside the NAPI build — one shared library, one header, UTF-8
+					JSON in/out. Drive the same compiler from any language with a C FFI.
+				</p>
+			{/snippet}
+		</SectionHead>
 
 		<ul class="capi-langs">
 			<li><span class="capi-tag">C / C++</span><span>include <code>rsvelte.h</code></span></li>
@@ -369,10 +376,7 @@
 	</section>
 
 	<section class="why">
-		<div class="section-head">
-			<span class="num">06</span>
-			<h2>Why it's fast.</h2>
-		</div>
+		<SectionHead num="06">Why it's fast.</SectionHead>
 
 		<div class="why-list">
 			{#each why as w (w.h)}
@@ -413,25 +417,6 @@
 		height: auto;
 		margin: 0 0 1.8rem;
 		border-radius: 16px;
-	}
-
-	.eyebrow {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.7rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.75rem;
-		letter-spacing: 0.08em;
-		text-transform: uppercase;
-		color: var(--rust);
-		margin: 0 0 1.6rem;
-	}
-
-	.eyebrow .rule {
-		display: inline-block;
-		width: 24px;
-		height: 1px;
-		background: var(--rust);
 	}
 
 	.title {
@@ -545,49 +530,6 @@
 		border-block: 1px solid var(--rule);
 	}
 
-	.perf .section-head,
-	.eco .section-head,
-	.dropin .section-head,
-	.capi .section-head,
-	.compat .section-head,
-	.why .section-head {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: clamp(3.5rem, 8vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2.4rem);
-		display: grid;
-		grid-template-columns: auto 1fr;
-		gap: 0.4rem 1.4rem;
-		align-items: baseline;
-	}
-
-	.section-head .num {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.7rem;
-		letter-spacing: 0.18em;
-		color: var(--rust);
-		grid-row: 1;
-		grid-column: 1;
-	}
-
-	.section-head h2 {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: clamp(1.65rem, 3.2vw, 2.6rem);
-		line-height: 1.1;
-		letter-spacing: -0.022em;
-		margin: 0;
-		color: var(--ink);
-		grid-row: 1;
-		grid-column: 2;
-	}
-
-	.section-head h2 em {
-		font-style: italic;
-		color: var(--svelte);
-		font-weight: 700;
-	}
-
-	.section-head h2 code,
 	.compat .lede code,
 	.perf .lede code {
 		font-family: 'JetBrains Mono', monospace;
@@ -598,12 +540,6 @@
 		border: 1px solid var(--rule);
 		border-radius: 3px;
 		vertical-align: 0.05em;
-	}
-
-	.section-head .lede {
-		grid-row: 2;
-		grid-column: 2;
-		margin-top: 0.7rem;
 	}
 
 	.perf-grid {

--- a/apps/playground/src/routes/benchmark/+page.svelte
+++ b/apps/playground/src/routes/benchmark/+page.svelte
@@ -6,6 +6,7 @@
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 	import Eyebrow from '$lib/components/Eyebrow.svelte';
 	import SectionHead from '$lib/components/SectionHead.svelte';
+	import '$lib/styles/terminal-code.css';
 
 	let { data }: { data: PageData } = $props();
 
@@ -772,20 +773,6 @@
 		padding: 1rem 1.2rem;
 		font-size: 0.85rem;
 		line-height: 1.7;
-	}
-
-	.c-cmt {
-		color: var(--ink-faint);
-	}
-
-	.c-prompt {
-		color: var(--svelte);
-		margin-right: 0.5em;
-	}
-
-	.c-flag,
-	.c-op {
-		color: var(--rust);
 	}
 
 	/* EMPTY */

--- a/apps/playground/src/routes/benchmark/+page.svelte
+++ b/apps/playground/src/routes/benchmark/+page.svelte
@@ -261,69 +261,68 @@
 
 			<div class="task-groups">
 				{#each tasksByGroup as group (group.key)}
-				<div class="task-group">
-					<div class="task-group-head">
-						<span class="task-group-title">{group.title}</span>
-						<span class="task-group-sub">{group.sub}</span>
-					</div>
-					<div class="task-grid">
-				{#each group.items as task (task.id)}
-					{@const t = task.data}
-					<article class="task-panel">
-						<header class="task-panel-head">
-							<div class="task-panel-meta">
-								<span class="task-panel-label">{task.label}</span>
-								<span class="task-panel-sub">{task.sub}</span>
-							</div>
-							<span class="task-panel-speedup">
-								<span class="task-panel-speedup-k">multi · </span>
-								<span class="task-panel-speedup-n">
-									{t.speedup.multiThreadVsJs.toFixed(1)}<span class="x">×</span>
-								</span>
-								<span class="task-panel-speedup-sep">·</span>
-								<span class="task-panel-speedup-st">
-									single {t.speedup.singleThreadVsJs.toFixed(1)}×
-								</span>
-							</span>
-						</header>
-						<div class="bars">
-							{#each [
-								{ name: task.baseline, sub: 'JavaScript', dur: t.javascript.durationMs, tone: 'js' },
-								{ name: 'rsvelte / single', sub: 'no parallelism', dur: t.rustSingleThread.durationMs, tone: 'rs' },
-								{ name: 'rsvelte / multi', sub: 'rayon fan-out', dur: t.rustMultiThread.durationMs, tone: 'rm' }
-							] as bar (bar.name)}
-								<div class="bar-row">
-									<div class="bar-meta">
-										<span class="bar-name">{bar.name}</span>
-										<span class="bar-sub">{bar.sub}</span>
-									</div>
-									<div class="bar-graph">
-										<span class="bar-track">
-											<span
-												class="bar-fill bar-{bar.tone}"
-												style="width: {getAnimatedWidth(t, bar.dur)}%;"
-											></span>
+					<div class="task-group">
+						<div class="task-group-head">
+							<span class="task-group-title">{group.title}</span>
+							<span class="task-group-sub">{group.sub}</span>
+						</div>
+						<div class="task-grid">
+							{#each group.items as task (task.id)}
+								{@const t = task.data}
+								<article class="task-panel">
+									<header class="task-panel-head">
+										<div class="task-panel-meta">
+											<span class="task-panel-label">{task.label}</span>
+											<span class="task-panel-sub">{task.sub}</span>
+										</div>
+										<span class="task-panel-speedup">
+											<span class="task-panel-speedup-k">multi · </span>
+											<span class="task-panel-speedup-n">
+												{t.speedup.multiThreadVsJs.toFixed(1)}<span class="x">×</span>
+											</span>
+											<span class="task-panel-speedup-sep">·</span>
+											<span class="task-panel-speedup-st">
+												single {t.speedup.singleThreadVsJs.toFixed(1)}×
+											</span>
 										</span>
-										<span class="bar-time">
-											{formatDuration(getAnimatedTime(bar.dur))}
-										</span>
+									</header>
+									<div class="bars">
+										{#each [
+											{ name: task.baseline, sub: 'JavaScript', dur: t.javascript.durationMs, tone: 'js' },
+											{ name: 'rsvelte / single', sub: 'no parallelism', dur: t.rustSingleThread.durationMs, tone: 'rs' },
+											{ name: 'rsvelte / multi', sub: 'rayon fan-out', dur: t.rustMultiThread.durationMs, tone: 'rm' }
+										] as bar (bar.name)}
+											<div class="bar-row">
+												<div class="bar-meta">
+													<span class="bar-name">{bar.name}</span>
+													<span class="bar-sub">{bar.sub}</span>
+												</div>
+												<div class="bar-graph">
+													<span class="bar-track">
+														<span
+															class="bar-fill bar-{bar.tone}"
+															style="width: {getAnimatedWidth(t, bar.dur)}%;"
+														></span>
+													</span>
+													<span class="bar-time">
+														{formatDuration(getAnimatedTime(bar.dur))}
+													</span>
+												</div>
+											</div>
+										{/each}
 									</div>
-								</div>
+								</article>
 							{/each}
 						</div>
-					</article>
-				{/each}
 					</div>
-				</div>
 				{/each}
 			</div>
 		</section>
 
 		<section class="repro">
-			<div class="section-head">
-				<span class="num">02</span>
-				<h2>Reproduce it yourself.</h2>
-			</div>
+			<SectionHead num="02" padding="0" marginBottom="1.6rem" fontSize="clamp(1.6rem, 3vw, 2.4rem)"
+				>Reproduce it yourself.</SectionHead
+			>
 			<figure class="diff">
 				<figcaption>
 					<span class="diff-file">your-shell</span>

--- a/apps/playground/src/routes/benchmark/+page.svelte
+++ b/apps/playground/src/routes/benchmark/+page.svelte
@@ -4,6 +4,8 @@
 	import type { BenchmarkTaskResults } from '$lib/types/benchmark';
 	import SiteNav from '$lib/components/SiteNav.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
+	import Eyebrow from '$lib/components/Eyebrow.svelte';
+	import SectionHead from '$lib/components/SectionHead.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -190,7 +192,7 @@
 
 	{#if data.error}
 		<section class="empty">
-			<p class="eyebrow"><span class="rule"></span>Benchmark · unavailable</p>
+			<Eyebrow marginBottom="1.4rem">Benchmark · unavailable</Eyebrow>
 			<h1>No benchmark data yet.</h1>
 			<p class="lede">{data.error}</p>
 			<pre class="empty-code"><code><span class="c-cmt"># From the repo root</span>
@@ -201,9 +203,9 @@
 		{@const r = data.results}
 
 		<header class="hero">
-			<p class="eyebrow">
-				<span class="rule"></span>Across the Svelte toolchain · multi-threaded vs official JS
-			</p>
+			<Eyebrow marginBottom="1.4rem"
+				>Across the Svelte toolchain · multi-threaded vs official JS</Eyebrow
+			>
 
 			<h1 class="title">
 				Up to <span class="ink-svelte">{maxHeadlineSpeedup.toFixed(0)}×</span> faster across the
@@ -357,25 +359,6 @@
 		max-width: 1080px;
 		margin: 0 auto;
 		padding: clamp(3.5rem, 9vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
-	}
-
-	.eyebrow {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.7rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.75rem;
-		letter-spacing: 0.08em;
-		text-transform: uppercase;
-		color: var(--rust);
-		margin: 0 0 1.4rem;
-	}
-
-	.eyebrow .rule {
-		display: inline-block;
-		width: 24px;
-		height: 1px;
-		background: var(--rust);
 	}
 
 	.title {
@@ -758,31 +741,6 @@
 		max-width: 1080px;
 		margin: 0 auto;
 		padding: clamp(3.5rem, 7vh, 5rem) clamp(1rem, 4vw, 2.5rem) clamp(4rem, 8vh, 6rem);
-	}
-
-	.section-head {
-		display: grid;
-		grid-template-columns: auto 1fr;
-		gap: 0.4rem 1.4rem;
-		margin-bottom: 1.6rem;
-		align-items: baseline;
-	}
-
-	.section-head .num {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.7rem;
-		letter-spacing: 0.18em;
-		color: var(--rust);
-	}
-
-	.section-head h2 {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: clamp(1.6rem, 3vw, 2.4rem);
-		line-height: 1.1;
-		letter-spacing: -0.022em;
-		margin: 0;
-		color: var(--ink);
 	}
 
 	.diff {

--- a/apps/playground/src/routes/docs/+page.svelte
+++ b/apps/playground/src/routes/docs/+page.svelte
@@ -3,6 +3,7 @@
 	import { GUIDES } from '$lib/docs';
 	import SiteNav from '$lib/components/SiteNav.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
+	import Eyebrow from '$lib/components/Eyebrow.svelte';
 </script>
 
 <svelte:head>
@@ -18,7 +19,9 @@
 
 	<main class="wrap">
 		<header class="head">
-			<p class="eyebrow"><span class="rule"></span>Documentation</p>
+			<Eyebrow gap="0.6rem" fontSize="0.72rem" letterSpacing="0.06em" ruleWidth="20px"
+				>Documentation</Eyebrow
+			>
 			<h1 class="title">Guides</h1>
 			<p class="lede">
 				One guide per core package in the rsvelte toolchain — install, API, examples and flags.
@@ -63,25 +66,6 @@
 		max-width: 64rem;
 		margin: 0 auto;
 		padding: clamp(1.6rem, 4vh, 2.6rem) clamp(1rem, 4vw, 2rem) 3rem;
-	}
-
-	.eyebrow {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.6rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.72rem;
-		letter-spacing: 0.06em;
-		text-transform: uppercase;
-		color: var(--rust);
-		margin: 0;
-	}
-
-	.eyebrow .rule {
-		display: inline-block;
-		width: 20px;
-		height: 1px;
-		background: var(--rust);
 	}
 
 	.title {

--- a/apps/playground/src/routes/playground/+page.svelte
+++ b/apps/playground/src/routes/playground/+page.svelte
@@ -25,6 +25,7 @@
 	import AstViewer from '$lib/components/AstViewer.svelte';
 	import CodeBlock from '$lib/components/CodeBlock.svelte';
 	import SiteNav from '$lib/components/SiteNav.svelte';
+	import Eyebrow from '$lib/components/Eyebrow.svelte';
 
 	let tool = $state<ToolId>('compiler');
 	let input = $state(DEFAULT_EXAMPLE);
@@ -313,7 +314,9 @@
 
 	<header class="play-head">
 		<div class="play-head-l">
-			<p class="eyebrow"><span class="rule"></span>Live · WASM-compiled</p>
+			<Eyebrow gap="0.6rem" fontSize="0.7rem" letterSpacing="0.1em" ruleWidth="20px"
+				>Live · WASM-compiled</Eyebrow
+			>
 			<h1 class="title">Playground</h1>
 			{#if version}
 				<span class="version">v{version}</span>
@@ -559,7 +562,9 @@
 		<!-- Non-runnable tools: explain why and link the guide + CLI -->
 		<main class="explainer">
 			<div class="explain-card">
-				<p class="eyebrow"><span class="rule"></span>{currentTool.pkg}</p>
+				<Eyebrow gap="0.6rem" fontSize="0.7rem" letterSpacing="0.1em" ruleWidth="20px"
+					>{currentTool.pkg}</Eyebrow
+				>
 				<h2 class="explain-title">{currentTool.label} can't run in a browser</h2>
 				<p class="explain-body">{currentTool.cantRunReason}</p>
 				<div class="explain-actions">
@@ -603,25 +608,6 @@
 		align-items: baseline;
 		gap: 1rem;
 		flex-wrap: wrap;
-	}
-
-	.eyebrow {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.6rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.7rem;
-		letter-spacing: 0.1em;
-		text-transform: uppercase;
-		color: var(--rust);
-		margin: 0;
-	}
-
-	.eyebrow .rule {
-		display: inline-block;
-		width: 20px;
-		height: 1px;
-		background: var(--rust);
 	}
 
 	.title {

--- a/apps/playground/src/routes/progress/+page.svelte
+++ b/apps/playground/src/routes/progress/+page.svelte
@@ -4,6 +4,8 @@
 	import type { TestCase } from '$lib/types/test-results';
 	import SiteNav from '$lib/components/SiteNav.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
+	import Eyebrow from '$lib/components/Eyebrow.svelte';
+	import SectionHead from '$lib/components/SectionHead.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -76,7 +78,7 @@
 
 	{#if data.error}
 		<section class="empty">
-			<p class="eyebrow"><span class="rule"></span>Compatibility · unavailable</p>
+			<Eyebrow marginBottom="1.4rem">Compatibility · unavailable</Eyebrow>
 			<h1>Test results not generated.</h1>
 			<p class="lede">{data.error}</p>
 			<pre class="empty-code"><code
@@ -90,7 +92,7 @@
 		{@const r = data.results}
 
 		<header class="hero">
-			<p class="eyebrow"><span class="rule"></span>Compatibility · live report</p>
+			<Eyebrow marginBottom="1.4rem">Compatibility · live report</Eyebrow>
 
 			<h1 class="title">
 				<span class="ink-svelte">{Math.round(r.summary.percentage)}%</span> of the official
@@ -135,14 +137,19 @@
 		</header>
 
 		<section class="spec">
-			<div class="section-head">
-				<span class="num">01</span>
-				<h2>Every <em>category</em>, verified.</h2>
-				<p class="lede">
-					Click any row to filter the fixture list below. Numbers reflect the official Svelte test
-					fixtures run locally against <code>{r.commit_sha}</code>.
-				</p>
-			</div>
+			<SectionHead
+				num="01"
+				columns={3}
+				padding="clamp(3rem, 7vh, 4.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2rem)"
+			>
+				Every <em>category</em>, verified.
+				{#snippet lede()}
+					<p class="lede">
+						Click any row to filter the fixture list below. Numbers reflect the official Svelte
+						test fixtures run locally against <code>{r.commit_sha}</code>.
+					</p>
+				{/snippet}
+			</SectionHead>
 
 			<div class="spec-list">
 				{#each r.categories as cat, i (cat.id)}
@@ -186,15 +193,20 @@
 		</section>
 
 		<section class="fixtures">
-			<div class="section-head">
-				<span class="num">02</span>
-				<h2>The <em>full</em> fixture list.</h2>
-				{#if selectedCategoryId}
-					<button class="clear-filter" onclick={() => (selectedCategoryId = null)}>
-						<span aria-hidden="true">←</span> Clear filter
-					</button>
-				{/if}
-			</div>
+			<SectionHead
+				num="02"
+				columns={3}
+				padding="clamp(3rem, 7vh, 4.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2rem)"
+			>
+				The <em>full</em> fixture list.
+				{#snippet lede()}
+					{#if selectedCategoryId}
+						<button class="clear-filter" onclick={() => (selectedCategoryId = null)}>
+							<span aria-hidden="true">←</span> Clear filter
+						</button>
+					{/if}
+				{/snippet}
+			</SectionHead>
 
 			<div class="filters">
 				<label class="search">
@@ -286,25 +298,6 @@
 		padding: clamp(3.5rem, 9vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
 	}
 
-	.eyebrow {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.7rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.75rem;
-		letter-spacing: 0.08em;
-		text-transform: uppercase;
-		color: var(--rust);
-		margin: 0 0 1.4rem;
-	}
-
-	.eyebrow .rule {
-		display: inline-block;
-		width: 24px;
-		height: 1px;
-		background: var(--rust);
-	}
-
 	.title {
 		font-family: 'Hanken Grotesk', sans-serif;
 		font-weight: 800;
@@ -392,52 +385,13 @@
 		margin: 0 auto;
 	}
 
-	.section-head {
-		max-width: 1080px;
-		padding: clamp(3rem, 7vh, 4.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2rem);
-		display: grid;
-		grid-template-columns: auto 1fr auto;
-		gap: 0.4rem 1.4rem;
-		align-items: baseline;
-	}
-
-	.section-head .num {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.7rem;
-		letter-spacing: 0.18em;
-		color: var(--rust);
-		grid-row: 1;
-		grid-column: 1;
-	}
-
-	.section-head h2 {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: clamp(1.65rem, 3.2vw, 2.6rem);
-		line-height: 1.1;
-		letter-spacing: -0.022em;
-		margin: 0;
-		color: var(--ink);
-		grid-row: 1;
-		grid-column: 2;
-	}
-
-	.section-head h2 em {
-		font-style: italic;
-		color: var(--svelte);
-		font-weight: 700;
-	}
-
-	.section-head .lede {
-		grid-row: 2;
-		grid-column: 2;
-		margin-top: 0.7rem;
+	.spec .lede {
 		font-size: clamp(1rem, 1.2vw, 1.1rem);
 		color: var(--ink-soft);
 		max-width: 64ch;
 	}
 
-	.section-head .lede code {
+	.spec .lede code {
 		font-size: 0.88em;
 		padding: 0.06em 0.4em;
 		background: var(--paper);
@@ -594,13 +548,7 @@
 		padding-bottom: clamp(4rem, 8vh, 6rem);
 	}
 
-	.fixtures .section-head h2 em {
-		color: var(--svelte);
-	}
-
 	.clear-filter {
-		grid-row: 1;
-		grid-column: 3;
 		justify-self: end;
 		align-self: center;
 		background: transparent;
@@ -963,13 +911,6 @@
 
 	/* RESPONSIVE */
 	@media (max-width: 880px) {
-		.section-head {
-			grid-template-columns: auto 1fr;
-		}
-		.clear-filter {
-			grid-column: 1 / -1;
-			justify-self: start;
-		}
 		.spec-row {
 			grid-template-columns: 1fr auto;
 			gap: 0.4rem 1rem;

--- a/apps/playground/src/routes/progress/+page.svelte
+++ b/apps/playground/src/routes/progress/+page.svelte
@@ -6,6 +6,7 @@
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 	import Eyebrow from '$lib/components/Eyebrow.svelte';
 	import SectionHead from '$lib/components/SectionHead.svelte';
+	import '$lib/styles/terminal-code.css';
 
 	let { data }: { data: PageData } = $props();
 
@@ -893,20 +894,6 @@
 		color: var(--ink);
 		line-height: 1.7;
 		overflow-x: auto;
-	}
-
-	.c-cmt {
-		color: var(--ink-faint);
-	}
-
-	.c-prompt {
-		color: var(--svelte);
-		margin-right: 0.5em;
-	}
-
-	.c-flag,
-	.c-op {
-		color: var(--rust);
 	}
 
 	/* RESPONSIVE */


### PR DESCRIPTION
## Summary

Follow-up to #1445 covering the remaining P2/P3 findings from the playground review — all mechanical, zero intended visual change.

- **Extract `Eyebrow.svelte`** — the "JetBrains Mono, uppercase, rust rule + label" pattern was re-implemented as copy-pasted CSS in 6 files (home, playground, progress, benchmark, docs index, Guide). Per-page metric differences (gap / font-size / letter-spacing / rule width / margin / uppercase) are passed as props via CSS custom properties so each page keeps its exact previous rendering.
- **Extract `SectionHead.svelte`** — the numbered section-head grid (`num` / `h2` / optional `lede` snippet, 2- or 3-column) duplicated across home, progress and benchmark, including the `h2 em` accent and the ≤880px responsive collapse that progress carried locally.
- **Share the terminal-snippet token CSS** — `.c-cmt` / `.c-prompt` / `.c-flag` / `.c-op` were verbatim duplicates in progress + benchmark; moved to `$lib/styles/terminal-code.css`. (The `<pre>` blocks themselves stay in-page on purpose — routing them through a component's snippet would disturb `<pre>` whitespace.)
- **Content staleness**: `ecosystem.ts` still listed `eslint-plugin-svelte` as "Planned / In progress"; the port is complete, so it moves to *Shipped* with an updated blurb/note.
- **Benchmark markup indentation** — the nested `{#each}` blocks under `.task-groups` had drifted one to three tab stops; whitespace-only fix.
- Drop a self-evident comment from `SiteFooter.svelte`.

The P1 items and the `--fg`/`--accent`/`theme-color` variable fixes from the same review were already merged in #1445 and are not repeated here.

## Verification

- Full `pnpm run build` from the repo root (wasm-pack for `rsvelte_lint` + `rsvelte_fmt_wasm`, then the SvelteKit/vite production build with the rsvelte NAPI compiler shim) — green, prerender + adapter-static complete.
- `svelte/compiler` compile check on every touched `.svelte` file — 0 errors, 0 warnings (no unused-selector leftovers).
- `pnpm run lint` (oxlint) in `apps/playground` — clean.
- No changeset: playground-only (private package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj