### PR TITLE
fix(analyze): preserve binding locations and references

### DIFF
--- a/.changeset/fix-analyzer-binding-metadata.md
+++ b/.changeset/fix-analyzer-binding-metadata.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyze): preserve component-relative declaration spans and component tag references in binding metadata

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4738,7 +4738,70 @@ fn collect_identifier_names_in_json(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::arena::SerializeArenaGuard;
+    use crate::compiler::phases::phase1_parse::{ParseOptions, parse};
     use rustc_hash::{FxHashMap, FxHashSet};
+
+    fn analyze(source: &str) -> ComponentAnalysis {
+        let mut ast = parse(
+            source,
+            ParseOptions {
+                defer_script_parse: true,
+                ..ParseOptions::default()
+            },
+        )
+        .unwrap();
+        // SAFETY: `ast` outlives the guard and analysis call.
+        let _guard = unsafe { SerializeArenaGuard::new(&ast.arena as *const _) };
+        analyze_component(&mut ast, source, &CompileOptions::default()).unwrap()
+    }
+
+    #[test]
+    fn binding_declaration_positions_are_component_relative() {
+        let source = r#"<script context="module">
+    const from_module = 1;
+</script>
+<script>
+    import Widget, { named as Alias } from './Widget.svelte';
+    import * as Namespace from './namespace';
+    let count = 0;
+</script>
+<Widget />
+"#;
+        let analysis = analyze(source);
+
+        for name in ["from_module", "Widget", "Alias", "Namespace", "count"] {
+            let binding = analysis
+                .root
+                .bindings
+                .iter()
+                .find(|binding| binding.name == name)
+                .unwrap_or_else(|| panic!("missing binding {name}"));
+            assert_eq!(
+                binding.declaration_start,
+                Some(source.find(name).unwrap() as u32)
+            );
+        }
+    }
+
+    #[test]
+    fn component_tag_is_a_template_binding_reference() {
+        let source = "<script>import Widget from './Widget.svelte';</script>\n<Widget />";
+        let analysis = analyze(source);
+        let binding = analysis
+            .root
+            .bindings
+            .iter()
+            .find(|binding| binding.name == "Widget")
+            .expect("missing Widget binding");
+        let start = source.rfind("Widget").unwrap() as u32;
+
+        assert!(binding.references.iter().any(|reference| {
+            reference.start == start
+                && reference.end == start + "Widget".len() as u32
+                && reference.is_template_reference
+        }));
+    }
 
     #[test]
     fn test_order_reactive_statements_simple() {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -1075,10 +1075,8 @@ impl<'a> ScopeBuilder<'a> {
                 };
                 let idx = self.declare_binding(name.to_string(), kind, decl_kind);
                 // Store declaration position for var hoisting analysis.
-                // Add current_script_offset so positions align with the JSON AST
-                // positions used by the visitor phase.
-                self.bindings[idx].declaration_start =
-                    Some(*start + self.current_script_offset as u32);
+                // Typed JsNode positions are already relative to the full component.
+                self.bindings[idx].declaration_start = Some(*start);
                 // Check if initializer is a function expression
                 if let Some(init_id) = init {
                     let init_node = self.arena.get_js_node(init_id);
@@ -1150,7 +1148,7 @@ impl<'a> ScopeBuilder<'a> {
 
     /// Process an import specifier from a typed JsNode.
     fn process_import_specifier_typed(&mut self, node: &JsNode, source_val: &str) {
-        let (name, specifier_type) = match node {
+        let (name, start, specifier_type) = match node {
             JsNode::ImportSpecifier {
                 local, import_kind, ..
             } => {
@@ -1159,24 +1157,24 @@ impl<'a> ScopeBuilder<'a> {
                     return;
                 }
                 let local_node = self.arena.get_js_node(*local);
-                if let JsNode::Identifier { name, .. } = local_node {
-                    (name.to_string(), "ImportSpecifier")
+                if let JsNode::Identifier { name, start, .. } = local_node {
+                    (name.to_string(), *start, "ImportSpecifier")
                 } else {
                     return;
                 }
             }
             JsNode::ImportDefaultSpecifier { local, .. } => {
                 let local_node = self.arena.get_js_node(*local);
-                if let JsNode::Identifier { name, .. } = local_node {
-                    (name.to_string(), "ImportDefaultSpecifier")
+                if let JsNode::Identifier { name, start, .. } = local_node {
+                    (name.to_string(), *start, "ImportDefaultSpecifier")
                 } else {
                     return;
                 }
             }
             JsNode::ImportNamespaceSpecifier { local, .. } => {
                 let local_node = self.arena.get_js_node(*local);
-                if let JsNode::Identifier { name, .. } = local_node {
-                    (name.to_string(), "ImportNamespaceSpecifier")
+                if let JsNode::Identifier { name, start, .. } = local_node {
+                    (name.to_string(), *start, "ImportNamespaceSpecifier")
                 } else {
                     return;
                 }
@@ -1185,6 +1183,7 @@ impl<'a> ScopeBuilder<'a> {
         };
         let binding_idx =
             self.declare_binding(name.clone(), BindingKind::Normal, DeclarationKind::Import);
+        self.bindings[binding_idx].declaration_start = Some(start);
         // Store the ImportDeclaration as a JSON string on binding.initial,
         // matching the official Svelte compiler where binding.initial is the
         // ImportDeclaration AST node.
@@ -2340,26 +2339,36 @@ impl<'a> ScopeBuilder<'a> {
         let source_val = import_decl.source.value.as_str();
         if let Some(specifiers) = &import_decl.specifiers {
             for specifier in specifiers {
-                let (name, specifier_type) = match specifier {
+                let (name, start, specifier_type) = match specifier {
                     oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(spec) => {
                         // Skip per-specifier type imports: `import { type Foo, Bar }`
                         if spec.import_kind == oxc_ast::ast::ImportOrExportKind::Type {
                             continue;
                         }
-                        (spec.local.name.to_string(), "ImportSpecifier")
+                        (
+                            spec.local.name.to_string(),
+                            spec.local.span.start,
+                            "ImportSpecifier",
+                        )
                     }
-                    oxc_ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
-                        (spec.local.name.to_string(), "ImportDefaultSpecifier")
-                    }
-                    oxc_ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
-                        (spec.local.name.to_string(), "ImportNamespaceSpecifier")
-                    }
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => (
+                        spec.local.name.to_string(),
+                        spec.local.span.start,
+                        "ImportDefaultSpecifier",
+                    ),
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => (
+                        spec.local.name.to_string(),
+                        spec.local.span.start,
+                        "ImportNamespaceSpecifier",
+                    ),
                 };
                 let binding_idx = self.declare_binding(
                     name.clone(),
                     BindingKind::Normal,
                     DeclarationKind::Import,
                 );
+                self.bindings[binding_idx].declaration_start =
+                    Some(start + self.current_script_offset as u32);
                 // Store the ImportDeclaration as a JSON string on binding.initial,
                 // matching the official Svelte compiler where binding.initial is the
                 // ImportDeclaration AST node. This allows ExpressionStatement visitor

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/component.rs
@@ -52,7 +52,7 @@ pub fn visit(component: &mut Component, context: &mut VisitorContext) -> Result<
     component.metadata.dynamic = is_dynamic;
 
     if let Some(binding_idx) = binding_idx_opt {
-        let binding = &context.analysis.root.bindings[binding_idx];
+        let binding = &mut context.analysis.root.bindings[binding_idx];
 
         // Update expression metadata
         component.metadata.expression.set_has_state(is_dynamic);
@@ -62,6 +62,15 @@ pub fn visit(component: &mut Component, context: &mut VisitorContext) -> Result<
             .dependencies
             .insert(binding_idx);
         component.metadata.expression.references.insert(binding_idx);
+
+        let reference_start = component.start + 1;
+        binding.add_reference(
+            reference_start,
+            reference_start + base_name.len() as u32,
+            true,
+            false,
+            false,
+        );
 
         // Check if the binding contains state
         if matches!(


### PR DESCRIPTION
## Summary

- keep typed script declaration positions relative to the full Svelte component instead of applying the script offset twice
- record declaration positions for default, named, and namespace imports in both analyzer paths
- add component tag usages to the resolved binding's template references

## Why

Analyzer consumers need stable declaration and reference spans to build whole-component semantic information. Typed `JsNode` spans are already offset during parsing, so adding `current_script_offset` produced incorrect declaration locations. Component tags were present in expression metadata but absent from `Binding::references`, unlike references collected during Svelte's scope-building phase.

## Tests

- `RUST_MIN_STACK=16777216 cargo test -p rsvelte_core`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

The larger test-thread stack is needed for the existing `ast_matches_oracle_effect_rune_cluster` debug test on this machine.

## AI disclosure

AI assistance was used to investigate the analyzer metadata, implement the focused changes, and draft tests and this PR description. I reviewed the resulting diff and ran the test and lint commands above.
