### PR TITLE
fix(transform): remote functions — private-field `??=` and object-destructuring assignment to $state

### DIFF
--- a/.changeset/fix-remote-function-state-assignments.md
+++ b/.changeset/fix-remote-function-state-assignments.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(transform): compile assignments to `$state` that broke SvelteKit remote functions (#1438). A logical compound assignment (`??=`/`||=`/`&&=`) to a private `$state` field inside a method/getter, and an object/nested destructuring assignment to a module-level `$state` variable, were both miscompiled to invalid assignment targets. They now lower to `$.set(...)` matching the official compiler.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -1232,11 +1232,15 @@ fn wrap_arrow_body(body: &str) -> String {
 
 /// Generate an IIFE for a destructure assignment.
 ///
-/// For array patterns: `(($$value) => { var $$array = $.to_array($$value, N); target1 = $$array[0]; ... })(rhs)`
+/// For array patterns: `((<p>) => { var $$array = $.to_array(<p>, N); target1 = $$array[0]; ... })(rhs)`
 /// For object patterns: `(($$value) => { target1 = $$value.key1; ... })(rhs)`
 ///
+/// The IIFE parameter `<p>` is the RHS identifier itself when the RHS is a plain
+/// identifier (upstream `should_cache = value.type !== 'Identifier'` is false);
+/// otherwise the RHS is cached in `$$value`.
+///
 /// When `is_standalone` is false (the destructure is part of a larger expression),
-/// `return $$value;` is appended so the IIFE returns the value.
+/// `return <p>;` is appended so the IIFE returns the value.
 pub(super) fn generate_destructure_iife(
     pattern_type: char, // ']' for array, '}' for object
     pattern_str: &str,
@@ -1271,10 +1275,28 @@ pub(super) fn generate_destructure_iife(
             .map(|p| p.trim().starts_with("..."))
             .unwrap_or(false);
 
-        let to_array_args = if has_rest {
-            "$.to_array($$value)".to_string()
+        // Upstream `visit_assignment_expression`: `should_cache = value.type !==
+        // 'Identifier'`. When the RHS is a plain identifier (and won't be
+        // rewritten into a call — see `force_cache_rhs`), it is used verbatim as
+        // both the IIFE parameter and the `$.to_array(...)` base
+        // (`((array) => { var $$array = $.to_array(array, 2); … })(array)`);
+        // otherwise the value is cached in a `$$value` parameter.
+        let rhs_trimmed = rhs_str.trim();
+        let rhs_is_simple_identifier = !rhs_trimmed.is_empty()
+            && rhs_trimmed
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+            && !rhs_trimmed.starts_with(|c: char| c.is_ascii_digit());
+        let param_name = if rhs_is_simple_identifier && !force_cache_rhs {
+            rhs_trimmed
         } else {
-            format!("$.to_array($$value, {})", parts.len())
+            "$$value"
+        };
+
+        let to_array_args = if has_rest {
+            format!("$.to_array({})", param_name)
+        } else {
+            format!("$.to_array({}, {})", param_name, parts.len())
         };
 
         let mut body_lines = Vec::new();
@@ -1339,17 +1361,20 @@ pub(super) fn generate_destructure_iife(
 
         if !is_standalone {
             body_lines.push(String::new()); // blank line before return
-            body_lines.push("\treturn $$value;".to_string());
+            body_lines.push(format!("\treturn {};", param_name));
         }
 
         let body = body_lines.join("\n");
         // When the IIFE body or RHS contains `await`, the arrow must be async
         // and the whole call must be `await`ed. This matches the official Svelte
-        // compiler which generates `await (async ($$value) => { ... })(rhs)`.
+        // compiler which generates `await (async (<param>) => { ... })(rhs)`.
         if code_contains_await(&body) || code_contains_await(rhs_str) {
-            format!("await (async ($$value) => {{\n{}\n}})({})", body, rhs_str)
+            format!(
+                "await (async ({}) => {{\n{}\n}})({})",
+                param_name, body, rhs_str
+            )
         } else {
-            format!("(($$value) => {{\n{}\n}})({})", body, rhs_str)
+            format!("(({}) => {{\n{}\n}})({})", param_name, body, rhs_str)
         }
     } else {
         // Object destructure

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -243,11 +243,23 @@ pub fn transform_client_module(
 
     // Transform the module source (rune replacements, class fields, etc.)
     let class_transformed = transform_class_fields_client(source);
-    let transformed = transform_module_script_runes(&class_transformed, analysis, options.dev);
 
-    // Transform destructured assignments where LHS contains state variables (client only).
-    // e.g., `[a, b] = array;` where `a` and `b` are $state() variables becomes:
-    //   ((array) => { var $$array = $.to_array(array, 2); $.set(a, $$array[0], true); $.set(b, $$array[1], true); })(array);
+    // Transform destructured assignments whose LHS contains state variables into
+    // IIFE / sequence form (mirrors upstream `visit_assignment_expression` in
+    // `shared/assignments.js`), e.g.
+    //   `({ issues: raw = [], result } = rhs)` becomes
+    //   `(($$value) => { $.set(raw, $.fallback($$value.issues, () => [], true), true);
+    //                    $.set(result, $$value.result, true); })(rhs)`.
+    // This MUST run on the RAW (pre-read-wrap) source — the same ordering the
+    // instance-script pipeline uses (`transform_instance_script_for_visitors`)
+    // — because it decomposes the destructure pattern into individual `$.set`
+    // targets before `transform_module_script_runes` wraps state *reads* in
+    // `$.get(...)`. Running it afterwards would see the pattern's LHS
+    // identifiers already wrapped (`$.get(raw) = []`), which is invalid.
+    // Handles object / array / rest patterns robustly; the previous
+    // line-based `[a, b] = …` handler only matched array destructures at the
+    // start of a line and left object patterns (and mid-line array patterns)
+    // untransformed. See issue #1438.
     let reactive_state_vars: Vec<String> = analysis
         .root
         .bindings
@@ -261,7 +273,21 @@ pub fn transform_client_module(
         })
         .map(|b| b.name.clone())
         .collect();
-    let transformed = transform_destructured_state_assignments(&transformed, &reactive_state_vars);
+    let class_transformed = if reactive_state_vars.is_empty() {
+        class_transformed
+    } else {
+        // Reset the per-compile `$$array` counter (as the instance-script path
+        // does) so `$.to_array(...)` temp names start at `$$array` and are
+        // deterministic across compiles that reuse this thread.
+        SCRIPT_ARRAY_COUNTER.with(|c| c.set(0));
+        destructure_transforms::transform_destructure_assignments(
+            &class_transformed,
+            &reactive_state_vars,
+            &[],
+        )
+    };
+
+    let transformed = transform_module_script_runes(&class_transformed, analysis, options.dev);
 
     // The transformed source includes everything (imports + body).
     // We need to split imports from body to avoid duplicate svelte import.
@@ -3804,117 +3830,6 @@ pub(crate) fn transform_module_script_runes(
         result = wrap_state_derived_with_tag(&result);
     }
 
-    result
-}
-
-/// Transform destructured array assignments where the LHS contains state variables.
-///
-/// Converts `[a, b] = expr;` where `a` or `b` are reactive state variables into:
-/// ```js
-/// ((array) => {
-///     var $$array = $.to_array(array, 2);
-///     $.set(a, $$array[0], true);
-///     $.set(b, $$array[1], true);
-/// })(expr);
-/// ```
-///
-/// Non-state variables in the pattern are assigned normally: `c = $$array[N];`
-fn transform_destructured_state_assignments(
-    script: &str,
-    reactive_state_vars: &[String],
-) -> String {
-    if reactive_state_vars.is_empty() {
-        return script.to_string();
-    }
-
-    let mut result = String::new();
-    for line in script.lines() {
-        let trimmed = line.trim();
-        // Look for lines like `[a, b] = expr;` or `[a, b] = expr`
-        if trimmed.starts_with('[') {
-            // Find the matching `]`
-            let mut depth = 0;
-            let mut bracket_end = None;
-            for (i, c) in trimmed.char_indices() {
-                match c {
-                    '[' => depth += 1,
-                    ']' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            bracket_end = Some(i);
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            if let Some(bracket_end) = bracket_end {
-                let pattern = &trimmed[..bracket_end + 1]; // e.g., "[a, b]"
-                let after_pattern = trimmed[bracket_end + 1..].trim();
-                // Must be followed by `= expr` or `= expr;`
-                if let Some(rhs) = after_pattern.strip_prefix('=') {
-                    let rhs = rhs.trim().trim_end_matches(';').trim();
-                    let inner = &pattern[1..pattern.len() - 1]; // strip [ ]
-                    let parts: Vec<&str> = inner.split(',').map(|s| s.trim()).collect();
-                    // By the time this runs, the rune pipeline has already wrapped
-                    // state reads, so an LHS target `a` appears as `$.get(a)`.
-                    // Unwrap that to recover the underlying state-var name.
-                    let unwrap_get = |p: &str| -> String {
-                        p.strip_prefix("$.get(")
-                            .and_then(|s| s.strip_suffix(')'))
-                            .map(|s| s.trim().to_string())
-                            .unwrap_or_else(|| p.to_string())
-                    };
-                    // Check if any parts are reactive state vars
-                    let has_state_var = parts
-                        .iter()
-                        .any(|p| reactive_state_vars.iter().any(|v| *v == unwrap_get(p)));
-                    if has_state_var {
-                        // Build the IIFE
-                        let indent: String =
-                            line.chars().take_while(|c| c.is_whitespace()).collect();
-                        let inner_indent = format!("{}\t", indent);
-                        let n = parts.len();
-                        let mut body_lines = Vec::new();
-                        body_lines.push(format!(
-                            "{}var $$array = $.to_array(array, {});",
-                            inner_indent, n
-                        ));
-                        body_lines.push(String::new()); // blank line after var
-                        for (idx, part) in parts.iter().enumerate() {
-                            let name = unwrap_get(part);
-                            if reactive_state_vars.contains(&name) {
-                                body_lines.push(format!(
-                                    "{}$.set({}, $$array[{}], true);",
-                                    inner_indent, name, idx
-                                ));
-                            } else {
-                                body_lines
-                                    .push(format!("{}{} = $$array[{}];", inner_indent, part, idx));
-                            }
-                        }
-                        let _ = writeln!(
-                            result,
-                            "{}((array) => {{\n{}\n{}}})({});",
-                            indent,
-                            body_lines.join("\n"),
-                            indent,
-                            rhs
-                        );
-                        // Add blank line after the IIFE
-                        result.push('\n');
-                        continue;
-                    }
-                }
-            }
-        }
-        result.push_str(line);
-        result.push('\n');
-    }
-    // Remove trailing newline to match original
-    if result.ends_with('\n') && !script.ends_with('\n') {
-        result.pop();
-    }
     result
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
@@ -14,13 +14,20 @@
 //! 2. Update expressions (`q++`, `--q`) are also rewritten to
 //!    `$.update(q)` / `$.update_pre(q[, -1])`.
 //!
-//! Mappings (preserved exactly):
+//! Mappings (preserved exactly). Whether the `, true` proxy flag is
+//! emitted follows upstream `AssignmentExpression.js`:
+//! `needs_proxy = field is $state && is_non_coercive_operator(op) &&
+//! should_proxy(value)`. Only `=` and the *logical* compounds
+//! (`||= &&= ??=`) are non-coercive; arithmetic / bitwise / shift
+//! compounds are coercive and never proxy.
 //!
 //! | Source        | Replacement (proxy-needing $state)         | Replacement (otherwise)             |
 //! |---------------|--------------------------------------------|-------------------------------------|
 //! | `q = expr`    | `$.set(q, expr, true)`                     | `$.set(q, expr)`                    |
-//! | `q += expr`   | `$.set(q, $.get(q) + expr, true)`          | `$.set(q, $.get(q) + expr)`         |
-//! | (incl. `-= *= /= %= **=`)                                                                          |
+//! | `q += expr`   | `$.set(q, $.get(q) + expr)`                | `$.set(q, $.get(q) + expr)`         |
+//! | (incl. coercive `-= *= /= %= **= &= |= ^= <<= >>= >>>=` — never proxy)                             |
+//! | `q ??= expr`  | `$.set(q, $.get(q) ?? expr, true)`         | `$.set(q, $.get(q) ?? expr)`        |
+//! | (incl. logical `||= &&=`; the built value is a LogicalExpression → always proxies for `$state`)   |
 //! | `q++`         | `$.update(q)`                              | `$.update(q)`                       |
 //! | `q--`         | `$.update(q, -1)`                          | `$.update(q, -1)`                   |
 //! | `++q`         | `$.update_pre(q)`                          | `$.update_pre(q)`                   |
@@ -288,6 +295,20 @@ enum Match {
     Other,
 }
 
+/// How a compound assignment operator expands into the `$.set` value,
+/// mirroring upstream `build_assignment_value`.
+#[derive(Clone, Copy)]
+enum Compound {
+    /// Plain `=` — value is the RHS verbatim.
+    None,
+    /// Coercive `+= -= *= /= %= **= &= |= ^= <<= >>= >>>=` — value is
+    /// `$.get(q) <op> rhs` (a binary expression); never proxies.
+    Arith(&'static str),
+    /// Non-coercive `||= &&= ??=` — value is `$.get(q) <op> rhs` (a
+    /// logical expression); proxies for `$state` fields.
+    Logic(&'static str),
+}
+
 impl<'a> PrivateClassAssignCollector<'a> {
     fn classify(&self, text: &str) -> Option<Match> {
         if self.state_qualified.iter().any(|q| q.as_str() == text) {
@@ -313,15 +334,28 @@ impl<'a, 'ast> Visit<'ast> for PrivateClassAssignCollector<'a> {
         };
         let qualified = pf_text;
 
-        let op_str = match expr.operator {
-            AssignmentOperator::Assign => None,
-            AssignmentOperator::Addition => Some("+"),
-            AssignmentOperator::Subtraction => Some("-"),
-            AssignmentOperator::Multiplication => Some("*"),
-            AssignmentOperator::Division => Some("/"),
-            AssignmentOperator::Remainder => Some("%"),
-            AssignmentOperator::Exponential => Some("**"),
-            _ => return,
+        // Classify the compound operator, mirroring upstream
+        // `build_assignment_value` (`utils/ast.js`): `=` uses the RHS
+        // verbatim; `||= &&= ??=` expand to a *logical* expression
+        // `left <op> right`; every other compound (`+= -= … & | << …`)
+        // expands to a *binary* expression `left <op> right`.
+        let compound = match expr.operator {
+            AssignmentOperator::Assign => Compound::None,
+            AssignmentOperator::Addition => Compound::Arith("+"),
+            AssignmentOperator::Subtraction => Compound::Arith("-"),
+            AssignmentOperator::Multiplication => Compound::Arith("*"),
+            AssignmentOperator::Division => Compound::Arith("/"),
+            AssignmentOperator::Remainder => Compound::Arith("%"),
+            AssignmentOperator::Exponential => Compound::Arith("**"),
+            AssignmentOperator::BitwiseAnd => Compound::Arith("&"),
+            AssignmentOperator::BitwiseOR => Compound::Arith("|"),
+            AssignmentOperator::BitwiseXOR => Compound::Arith("^"),
+            AssignmentOperator::ShiftLeft => Compound::Arith("<<"),
+            AssignmentOperator::ShiftRight => Compound::Arith(">>"),
+            AssignmentOperator::ShiftRightZeroFill => Compound::Arith(">>>"),
+            AssignmentOperator::LogicalOr => Compound::Logic("||"),
+            AssignmentOperator::LogicalAnd => Compound::Logic("&&"),
+            AssignmentOperator::LogicalNullish => Compound::Logic("??"),
         };
 
         let rhs_span = expr.right.span();
@@ -329,20 +363,35 @@ impl<'a, 'ast> Visit<'ast> for PrivateClassAssignCollector<'a> {
 
         // Proxy logic mirrors upstream `AssignmentExpression.js` private-state
         // branch: `needs_proxy = field.type === '$state' &&
-        // is_non_coercive_operator(operator) && should_proxy(value, scope)`.
-        // The only non-coercive operator this pass handles is `=` (compound
-        // arithmetic `+= -= *= …` is coercive, so it never proxies); the
-        // logical compound ops are excluded earlier. `should_proxy` is the
-        // scope-aware check that traces an identifier RHS to its binding's
-        // initializer.
+        // is_non_coercive_operator(operator) && should_proxy(value, scope)`
+        // where `value` is the built (and visited) assignment value.
+        // The non-coercive operators are `= || && ??`. Compound arithmetic /
+        // bitwise / shift ops are coercive → never proxy. For `= `, `value`
+        // is the RHS, so `should_proxy` traces it. For the logical ops,
+        // `value` is a `LogicalExpression` (`$.get(q) <op> rhs`), which is
+        // never in `should_proxy`'s no-proxy set, so it always proxies for a
+        // `$state` field.
         let needs_proxy = matches!(kind, Match::State)
-            && op_str.is_none()
-            && should_proxy_with_bindings(&expr.right, self.var_proxy, self.reassigned);
+            && match compound {
+                Compound::None => {
+                    should_proxy_with_bindings(&expr.right, self.var_proxy, self.reassigned)
+                }
+                Compound::Logic(_) => true,
+                Compound::Arith(_) => false,
+            };
 
-        let rewrite = match op_str {
-            None if needs_proxy => format!("$.set({}, {}, true)", qualified, rhs_text),
-            None => format!("$.set({}, {})", qualified, rhs_text),
-            Some(op) => format!(
+        let rewrite = match compound {
+            Compound::None if needs_proxy => format!("$.set({}, {}, true)", qualified, rhs_text),
+            Compound::None => format!("$.set({}, {})", qualified, rhs_text),
+            Compound::Arith(op) => format!(
+                "$.set({}, $.get({}) {} {})",
+                qualified, qualified, op, rhs_text
+            ),
+            Compound::Logic(op) if needs_proxy => format!(
+                "$.set({}, $.get({}) {} {}, true)",
+                qualified, qualified, op, rhs_text
+            ),
+            Compound::Logic(op) => format!(
                 "$.set({}, $.get({}) {} {})",
                 qualified, qualified, op, rhs_text
             ),
@@ -589,12 +638,60 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_compound_left_alone() {
-        // ??=, &&=, ||= not in text version's allowlist
-        assert!(
-            transform_private_class_assign_ast("this.#count ??= 5;", &ssv(&["this.#count"]), &[])
-                .is_none()
+    fn nullish_assign_state_proxies() {
+        // `??=` is non-coercive and the built value is a LogicalExpression,
+        // so a `$state` field always proxies (`, true`). Regression test for
+        // issue #1438 (`??=` was previously left un-rewritten, producing the
+        // invalid `$.get(this.#promise) ??= run()`).
+        let out = transform_private_class_assign_ast(
+            "this.#promise ??= run();",
+            &ssv(&["this.#promise"]),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "$.set(this.#promise, $.get(this.#promise) ?? run(), true);"
         );
+    }
+
+    #[test]
+    fn logical_or_assign_state_proxies() {
+        let out =
+            transform_private_class_assign_ast("this.#x ||= y;", &ssv(&["this.#x"]), &[]).unwrap();
+        assert_eq!(out, "$.set(this.#x, $.get(this.#x) || y, true);");
+    }
+
+    #[test]
+    fn logical_and_assign_state_proxies() {
+        let out =
+            transform_private_class_assign_ast("this.#x &&= y;", &ssv(&["this.#x"]), &[]).unwrap();
+        assert_eq!(out, "$.set(this.#x, $.get(this.#x) && y, true);");
+    }
+
+    #[test]
+    fn logical_assign_other_no_proxy() {
+        // `$derived`/etc. (other_qualified) never proxy — no `, true`.
+        let out =
+            transform_private_class_assign_ast("this.#d ??= y;", &[], &ssv(&["this.#d"])).unwrap();
+        assert_eq!(out, "$.set(this.#d, $.get(this.#d) ?? y);");
+    }
+
+    #[test]
+    fn bitwise_compound_state_no_proxy() {
+        // Bitwise compound (`&=`) is coercive → no proxy, binary expansion.
+        let out =
+            transform_private_class_assign_ast("this.#count &= 3;", &ssv(&["this.#count"]), &[])
+                .unwrap();
+        assert_eq!(out, "$.set(this.#count, $.get(this.#count) & 3);");
+    }
+
+    #[test]
+    fn shift_compound_state_no_proxy() {
+        let out =
+            transform_private_class_assign_ast("this.#count <<= 2;", &ssv(&["this.#count"]), &[])
+                .unwrap();
+        assert_eq!(out, "$.set(this.#count, $.get(this.#count) << 2);");
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/client_transforms_pin.rs
+++ b/crates/rsvelte_core/tests/client_transforms_pin.rs
@@ -48,3 +48,30 @@ fn h026_exponentiation_compound_lowers_correctly() {
     // Pin the lowered shape for the `**=` operator path.
     assert!(out.contains("$.set(x, $.get(x) ** 3)"), "got:\n{out}");
 }
+
+/// Regression for issue #1438: a logical compound assignment (`??=`/`||=`/`&&=`)
+/// to a *private* `$state` field inside a regular method/getter was left
+/// un-rewritten, so the read-wrap pass turned the LHS into `$.get(this.#x)`,
+/// producing the invalid `$.get(this.#x) ??= rhs`. It must lower to
+/// `$.set(this.#x, $.get(this.#x) ?? rhs, true)`, matching the official
+/// compiler. (The `class-private-fields-assignment-shorthand` upstream fixture
+/// only exercises the constructor path, which is compiled separately.)
+#[test]
+fn issue_1438_private_field_nullish_compound_in_method() {
+    let out = client(
+        r#"<script>
+          class Query {
+            #promise = $state(null);
+            get() { return this.#promise ??= run(); }
+          }
+          function run() { return Promise.resolve(1); }
+        </script>
+        <p>{new Query().get()}</p>"#,
+    );
+    assert!(
+        out.contains("$.set(this.#promise, $.get(this.#promise) ?? run(), true)"),
+        "got:\n{out}"
+    );
+    // The buggy shape must be gone.
+    assert!(!out.contains("??= run()"), "invalid `??=` remains:\n{out}");
+}

--- a/crates/rsvelte_core/tests/module_destructure_state_assign.rs
+++ b/crates/rsvelte_core/tests/module_destructure_state_assign.rs
@@ -1,0 +1,101 @@
+//! Regression tests for destructuring assignments to `$state` variables in
+//! `compileModule(generate:'client')` — issue baseballyama/rsvelte#1438.
+//!
+//! The module (`.svelte.js`) client path previously handled only line-leading
+//! *array* destructures (`[a, b] = expr`) via a fragile text handler, so an
+//! object-pattern destructure — or an array destructure inside a function body
+//! — was left untransformed. The read-wrap pass then wrapped the pattern's LHS
+//! identifiers as `$.get(name)`, producing invalid targets such as
+//! `({ issues: $.get(raw_issues) = [] } = …)` ("Cannot assign to this
+//! expression"), which broke `vite build` for SvelteKit remote functions
+//! (`@sveltejs/kit`'s `form.svelte.js`).
+//!
+//! The module path now reuses the same AST-faithful
+//! `transform_destructure_assignments` the instance-script path uses (run on
+//! the raw source before read-wrapping), mirroring upstream
+//! `visit_assignment_expression` in `shared/assignments.js`.
+
+use rsvelte_core::GenerateMode;
+use rsvelte_core::compile_module;
+use rsvelte_core::compiler::ModuleCompileOptions;
+
+fn compile_mod_client(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("in.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile_module")
+    .js
+    .code
+}
+
+#[test]
+fn object_pattern_with_default_lowers_to_set() {
+    // Mirrors @sveltejs/kit form.svelte.js.
+    let src = r#"let raw_issues = $state([]);
+let result = $state(undefined);
+export function apply(response) {
+  ({ issues: raw_issues = [], result } = response._ ?? {});
+}
+"#;
+    let out = compile_mod_client(src);
+    assert!(
+        out.contains("$.set(raw_issues, $.fallback($$value.issues, () => [], true), true)"),
+        "object destructure default must lower to $.set + $.fallback. Got:\n{out}"
+    );
+    assert!(
+        out.contains("$.set(result, $$value.result, true)"),
+        "object destructure shorthand must lower to $.set. Got:\n{out}"
+    );
+    // The invalid read-wrapped assignment target must be gone.
+    assert!(
+        !out.contains("$.get(raw_issues) ="),
+        "invalid `$.get(...)` assignment target remains:\n{out}"
+    );
+}
+
+#[test]
+fn array_pattern_inside_function_body_lowers_to_set() {
+    // The old line-leading text handler missed mid-line array destructures.
+    let src = r#"let count = $state(0);
+let obj = $state({ a: 1 });
+export function arr(a) { [count, obj] = a; }
+"#;
+    let out = compile_mod_client(src);
+    assert!(
+        out.contains("$.to_array($$value, 2)"),
+        "array destructure must go through $.to_array. Got:\n{out}"
+    );
+    assert!(
+        out.contains("$.set(count, $$array[0], true)")
+            && out.contains("$.set(obj, $$array[1], true)"),
+        "array destructure targets must lower to $.set. Got:\n{out}"
+    );
+    assert!(
+        !out.contains("[$.get(count)"),
+        "invalid `$.get(...)` array assignment target remains:\n{out}"
+    );
+}
+
+#[test]
+fn array_temp_counter_starts_at_zero() {
+    // `$$array` (not `$$array_1`) for the first array pattern — the per-compile
+    // counter must be reset in the module path too.
+    let src = r#"let b = $state(0);
+export function f(o) { [b] = o; }
+"#;
+    let out = compile_mod_client(src);
+    assert!(
+        out.contains("var $$array = $.to_array"),
+        "first `$$array` temp must not be suffixed. Got:\n{out}"
+    );
+    assert!(
+        !out.contains("$$array_1"),
+        "counter leaked from a prior compile:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/module_destructure_state_assign.rs
+++ b/crates/rsvelte_core/tests/module_destructure_state_assign.rs
@@ -62,14 +62,17 @@ export function apply(response) {
 #[test]
 fn array_pattern_inside_function_body_lowers_to_set() {
     // The old line-leading text handler missed mid-line array destructures.
+    // The RHS is a plain identifier (`a`), so upstream uses it verbatim as the
+    // IIFE parameter / `$.to_array` base (`should_cache = false`) rather than a
+    // cached `$$value`.
     let src = r#"let count = $state(0);
 let obj = $state({ a: 1 });
 export function arr(a) { [count, obj] = a; }
 "#;
     let out = compile_mod_client(src);
     assert!(
-        out.contains("$.to_array($$value, 2)"),
-        "array destructure must go through $.to_array. Got:\n{out}"
+        out.contains("((a) => {") && out.contains("$.to_array(a, 2)"),
+        "identifier RHS must name the IIFE param after the RHS. Got:\n{out}"
     );
     assert!(
         out.contains("$.set(count, $$array[0], true)")
@@ -79,6 +82,20 @@ export function arr(a) { [count, obj] = a; }
     assert!(
         !out.contains("[$.get(count)"),
         "invalid `$.get(...)` array assignment target remains:\n{out}"
+    );
+}
+
+#[test]
+fn non_identifier_rhs_caches_in_dollar_value() {
+    // A non-identifier RHS (`should_cache = true`) is cached in `$$value`.
+    let src = r#"let count = $state(0);
+let obj = $state({ a: 1 });
+export function arr(o) { [count, obj] = o.pair ?? []; }
+"#;
+    let out = compile_mod_client(src);
+    assert!(
+        out.contains("(($$value) => {") && out.contains("$.to_array($$value, 2)"),
+        "non-identifier RHS must cache in `$$value`. Got:\n{out}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #1438 — both compiler bugs that broke `vite build` for a project using SvelteKit remote functions. Both are miscompilations of assignments to `$state` that produced **invalid assignment targets** ("Cannot assign to this expression").

## Bug 1 — logical compound assign to a private `$state` field (`instance.svelte.js`)

`this.#field ??= expr` (and `||=`/`&&=`) inside a regular method/getter compiled to the invalid `$.get(this.#field) ??= expr`.

```js
// input:  get() { return this.#promise ??= run(); }
// BEFORE: return $.get(this.#promise) ??= run();          // invalid
// AFTER:  return $.set(this.#promise, $.get(this.#promise) ?? run(), true);   // == official
```

**Cause:** `private_class_assign_ast.rs` only allow-listed `=` and arithmetic compounds (`+= -= *= /= %= **=`) and bailed (`_ => return`) on everything else, so `??= ||= &&=` (and bitwise/shift) were never lowered; the read-wrap pass then wrapped the bare LHS. **Fix:** mirror upstream `AssignmentExpression.js` + `build_assignment_value` — expand `q <op>= rhs` → `$.set(q, $.get(q) <op> rhs)` (logical operator for `||= &&= ??=`, binary otherwise), with the `, true` proxy flag following `is_non_coercive_operator(op) && should_proxy(value)`.

## Bug 2 — object / nested destructuring assignment to module `$state` (`form.svelte.js`)

```js
// input:  ({ issues: raw_issues = [], result } = response._ ?? {});
// BEFORE: ({ issues: $.get(raw_issues) = [], $.get(result) } = response._ ?? {});   // invalid
// AFTER:  (($$value) => {
//           $.set(raw_issues, $.fallback($$value.issues, () => [], true), true);
//           $.set(result, $$value.result, true);
//         })(response._ ?? {});   // == official
```

**Cause:** the `.svelte.js` module client path handled only *array* destructures at the **start of a line**, via a fragile text handler; object patterns (and mid-line/nested array patterns) were left untransformed, so read-wrap wrapped the pattern's LHS identifiers. **Fix:** route the module path through the same AST-faithful `transform_destructure_assignments` the instance-script path already uses (a port of upstream `visit_assignment_expression`), run on the raw source **before** read-wrapping (matching the instance ordering), with the per-compile `$$array` counter reset. Object / array / nested / rest / default patterns now match the component path byte-for-byte. The dead array-only handler is removed.

## Why these weren't caught

- **Bug 1:** the **constructor** path is a separate branch (`in_constructor`, reads `this.#x.v`) that already handled logical ops; the only upstream fixture pairing a private `$state` field with a logical compound assign (`class-private-fields-assignment-shorthand`) uses a **constructor**, so the method-body path was never exercised. No fixture/corpus entry uses `??=` on a private field in a regular method.
- **Bug 2:** the `.svelte` component (instance-script) path already lowered these correctly — only the separate `.svelte.js` **module** path used the broken text handler, and no corpus entry exercised an object-destructuring assignment to a module `$state`.
- SvelteKit's remote-function runtime files (`instance.svelte.js`, `form.svelte.js`) — where both patterns occur — are not part of the compat corpus.

## Tests

- `private_class_assign_ast.rs`: unit tests for `??= ||= &&=` (proxy) and `&= <<=` (coercive), plus the `$derived` no-proxy case; the old `unsupported_compound_left_alone` test (which codified the bug) is replaced.
- `client_transforms_pin.rs`: component-level regression `issue_1438_private_field_nullish_compound_in_method`.
- New `module_destructure_state_assign.rs`: object-pattern-with-default, mid-line array pattern, and `$$array` counter-reset regressions.
- Verified end-to-end that a SvelteKit-style `.svelte.js` module and the equivalent `.svelte` component now emit output identical to the official compiler for both bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GcVFTcU8ZW1aENnZNp2fr