### PR TITLE
refactor(analyze): share destructuring-pattern identifier walkers

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -21,6 +21,7 @@ pub mod control_flow;
 pub mod css;
 mod css_scoping;
 pub mod errors;
+mod pattern_ids;
 pub mod scope;
 mod scope_builder;
 mod store_subscriptions;
@@ -1432,7 +1433,7 @@ fn process_legacy_exports(ast: &Root, analysis: &mut ComponentAnalysis) {
                     };
                     let mut identifiers: Vec<String> = Vec::new();
                     if let Some(id_id) = id_id {
-                        extract_identifiers_from_pattern_typed(
+                        pattern_ids::collect_pattern_identifiers(
                             arena.get_js_node(id_id),
                             arena,
                             &mut identifiers,
@@ -1515,50 +1516,6 @@ fn apply_specifier_export(local: &str, exported: &str, analysis: &mut ComponentA
 }
 
 /// Extract identifier names from a typed pattern (handles destructuring).
-fn extract_identifiers_from_pattern_typed(
-    pattern: &crate::ast::typed_expr::JsNode,
-    arena: &crate::ast::arena::ParseArena,
-    out: &mut Vec<String>,
-) {
-    use crate::ast::typed_expr::JsNode;
-    match pattern {
-        JsNode::Identifier { name, .. } => out.push(name.to_string()),
-        JsNode::ObjectPattern { properties, .. } => {
-            for prop in arena.get_js_children(*properties) {
-                match prop {
-                    JsNode::Property { value, .. } => {
-                        extract_identifiers_from_pattern_typed(
-                            arena.get_js_node(*value),
-                            arena,
-                            out,
-                        );
-                    }
-                    JsNode::RestElement { argument, .. } => {
-                        extract_identifiers_from_pattern_typed(
-                            arena.get_js_node(*argument),
-                            arena,
-                            out,
-                        );
-                    }
-                    _ => {}
-                }
-            }
-        }
-        JsNode::ArrayPattern { elements, .. } => {
-            for e in elements.iter().flatten() {
-                extract_identifiers_from_pattern_typed(e, arena, out);
-            }
-        }
-        JsNode::RestElement { argument, .. } => {
-            extract_identifiers_from_pattern_typed(arena.get_js_node(*argument), arena, out);
-        }
-        JsNode::AssignmentPattern { left, .. } => {
-            extract_identifiers_from_pattern_typed(arena.get_js_node(*left), arena, out);
-        }
-        _ => {}
-    }
-}
-
 /// Promote store underlying variables to 'state' if reassigned in legacy mode.
 ///
 /// When a store subscription `$foo` exists and the underlying variable `foo`
@@ -1941,7 +1898,7 @@ fn populate_legacy_dependencies(ast: &Root, analysis: &mut ComponentAnalysis) {
                 assigned_names.push(name);
             }
         } else {
-            extract_each_pattern_identifiers(left, &mut assigned_names);
+            pattern_ids::collect_pattern_identifiers_json(left, &mut assigned_names);
         }
 
         // Find which of these are LegacyReactive bindings
@@ -2468,51 +2425,6 @@ fn extract_param_names(param: &serde_json::Value, names: &mut Vec<String>) {
 }
 
 /// Extract identifier names from a destructuring pattern.
-fn extract_each_pattern_identifiers(node: &serde_json::Value, names: &mut Vec<String>) {
-    let node_type = node.get("type").and_then(|t| t.as_str());
-    match node_type {
-        Some("Identifier") => {
-            if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
-                names.push(name.to_string());
-            }
-        }
-        Some("ObjectPattern") => {
-            if let Some(props) = node.get("properties").and_then(|p| p.as_array()) {
-                for prop in props {
-                    let prop_type = prop.get("type").and_then(|t| t.as_str());
-                    if prop_type == Some("RestElement") {
-                        if let Some(arg) = prop.get("argument") {
-                            extract_each_pattern_identifiers(arg, names);
-                        }
-                    } else if let Some(value) = prop.get("value") {
-                        extract_each_pattern_identifiers(value, names);
-                    }
-                }
-            }
-        }
-        Some("ArrayPattern") => {
-            if let Some(elements) = node.get("elements").and_then(|e| e.as_array()) {
-                for elem in elements {
-                    if !elem.is_null() {
-                        extract_each_pattern_identifiers(elem, names);
-                    }
-                }
-            }
-        }
-        Some("AssignmentPattern") => {
-            if let Some(left) = node.get("left") {
-                extract_each_pattern_identifiers(left, names);
-            }
-        }
-        Some("RestElement") => {
-            if let Some(arg) = node.get("argument") {
-                extract_each_pattern_identifiers(arg, names);
-            }
-        }
-        _ => {}
-    }
-}
-
 /// Extract identifier names from a destructuring pattern (JsNode version).
 /// Uses JSON fallback for arena-dependent fields to avoid threading ParseArena.
 fn extract_each_pattern_identifiers_node(node: &JsNode, names: &mut Vec<String>) {
@@ -2526,7 +2438,7 @@ fn extract_each_pattern_identifiers_node(node: &JsNode, names: &mut Vec<String>)
         | JsNode::AssignmentPattern { .. }
         | JsNode::RestElement { .. } => {
             let json = node.to_value();
-            extract_each_pattern_identifiers(&json, names);
+            pattern_ids::collect_pattern_identifiers_json(&json, names);
         }
         _ => {}
     }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/pattern_ids.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/pattern_ids.rs
@@ -1,0 +1,113 @@
+//! Shared walkers for destructuring-pattern identifier collection.
+//!
+//! Consolidates several byte-identical copies that previously lived across
+//! `mod.rs`, `scope_builder.rs`, `visitors/each_block.rs`, and
+//! `visitors/regular_element.rs`. Each walker collects the bound identifier
+//! names from a binding pattern in source order, descending into
+//! `ObjectPattern` / `ArrayPattern` / `AssignmentPattern` / `RestElement`.
+
+use serde_json::Value;
+
+use crate::ast::arena::ParseArena;
+use crate::ast::typed_expr::JsNode;
+
+/// Collect bound identifier names from a destructuring pattern (typed).
+///
+/// For `ObjectPattern`, a `RestElement` property contributes its `argument`
+/// while a `Property` contributes its `value`; array holes are skipped.
+pub(crate) fn collect_pattern_identifiers(
+    node: &JsNode,
+    arena: &ParseArena,
+    out: &mut Vec<String>,
+) {
+    match node {
+        JsNode::Identifier { name, .. } => out.push(name.to_string()),
+        JsNode::ObjectPattern { properties, .. } => {
+            for prop in arena.get_js_children(*properties) {
+                match prop {
+                    JsNode::Property { value, .. } => {
+                        collect_pattern_identifiers(arena.get_js_node(*value), arena, out);
+                    }
+                    JsNode::RestElement { argument, .. } => {
+                        collect_pattern_identifiers(arena.get_js_node(*argument), arena, out);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        JsNode::ArrayPattern { elements, .. } => {
+            for elem in elements.iter().flatten() {
+                collect_pattern_identifiers(elem, arena, out);
+            }
+        }
+        JsNode::RestElement { argument, .. } => {
+            collect_pattern_identifiers(arena.get_js_node(*argument), arena, out);
+        }
+        JsNode::AssignmentPattern { left, .. } => {
+            collect_pattern_identifiers(arena.get_js_node(*left), arena, out);
+        }
+        _ => {}
+    }
+}
+
+/// Collect bound identifier names from a destructuring pattern (JSON).
+///
+/// JSON twin of [`collect_pattern_identifiers`] for call sites that only have
+/// a `serde_json::Value` (template expressions where no `ParseArena` is
+/// threaded). Enumeration order and duplicate handling match the typed walker.
+pub(crate) fn collect_pattern_identifiers_json(node: &Value, names: &mut Vec<String>) {
+    match node.get("type").and_then(|t| t.as_str()) {
+        Some("Identifier") => {
+            if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
+                names.push(name.to_string());
+            }
+        }
+        Some("ObjectPattern") => {
+            if let Some(props) = node.get("properties").and_then(|p| p.as_array()) {
+                for prop in props {
+                    if prop.get("type").and_then(|t| t.as_str()) == Some("RestElement") {
+                        if let Some(arg) = prop.get("argument") {
+                            collect_pattern_identifiers_json(arg, names);
+                        }
+                    } else if let Some(value) = prop.get("value") {
+                        collect_pattern_identifiers_json(value, names);
+                    }
+                }
+            }
+        }
+        Some("ArrayPattern") => {
+            if let Some(elements) = node.get("elements").and_then(|e| e.as_array()) {
+                for elem in elements {
+                    if !elem.is_null() {
+                        collect_pattern_identifiers_json(elem, names);
+                    }
+                }
+            }
+        }
+        Some("AssignmentPattern") => {
+            if let Some(left) = node.get("left") {
+                collect_pattern_identifiers_json(left, names);
+            }
+        }
+        Some("RestElement") => {
+            if let Some(arg) = node.get("argument") {
+                collect_pattern_identifiers_json(arg, names);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Resolve the root identifier name of a binding expression (typed).
+///
+/// For `selected` → `"selected"`, `selected.done` → `"selected"`,
+/// `items[0]` → `"items"`. Corresponds to the official compiler's `object()`.
+pub(crate) fn base_identifier_name(node: &JsNode, arena: &ParseArena) -> Option<String> {
+    match node {
+        JsNode::Identifier { name, .. } => Some(name.to_string()),
+        JsNode::MemberExpression { object, .. } => {
+            base_identifier_name(arena.get_js_node(*object), arena)
+        }
+        _ => None,
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -3,6 +3,7 @@
 //! Walks the AST and creates a scope tree with bindings.
 
 use super::errors;
+use super::pattern_ids::{base_identifier_name, collect_pattern_identifiers};
 use super::scope::{Binding, BindingKind, DeclarationKind, Scope, ScopeRoot};
 use super::visitors::shared::utils::validate_identifier_name;
 use crate::ast::arena::{JsNodeId, ParseArena};
@@ -2928,7 +2929,7 @@ impl<'a> ScopeBuilder<'a> {
             }
             JsNode::MemberExpression { object, .. } => {
                 if let Some(name) =
-                    get_node_base_identifier_name(self.arena.get_js_node(*object), self.arena)
+                    base_identifier_name(self.arena.get_js_node(*object), self.arena)
                 {
                     self.updates.push(Update {
                         name,
@@ -2975,7 +2976,7 @@ impl<'a> ScopeBuilder<'a> {
             }
             JsNode::MemberExpression { object, .. } => {
                 if let Some(name) =
-                    get_node_base_identifier_name(self.arena.get_js_node(*object), self.arena)
+                    base_identifier_name(self.arena.get_js_node(*object), self.arena)
                 {
                     self.updates.push(Update {
                         name,
@@ -3760,13 +3761,13 @@ fn collect_arrow_param_names_node(node: &JsNode, names: &mut Vec<String>, arena:
     match node {
         JsNode::ArrowFunctionExpression { params, body, .. } => {
             for param in arena.get_js_children(*params) {
-                collect_pattern_names_node(param, names, arena);
+                collect_pattern_identifiers(param, arena, names);
             }
             collect_arrow_param_names_node(arena.get_js_node(*body), names, arena);
         }
         JsNode::FunctionExpression { params, body, .. } => {
             for param in arena.get_js_children(*params) {
-                collect_pattern_names_node(param, names, arena);
+                collect_pattern_identifiers(param, arena, names);
             }
             if let Some(body) = body {
                 collect_arrow_param_names_node(arena.get_js_node(*body), names, arena);
@@ -3897,36 +3898,6 @@ fn collect_arrow_param_names_node(node: &JsNode, names: &mut Vec<String>, arena:
     }
 }
 
-/// JsNode version of `collect_pattern_names`.
-fn collect_pattern_names_node(node: &JsNode, names: &mut Vec<String>, arena: &ParseArena) {
-    match node {
-        JsNode::Identifier { name, .. } => {
-            names.push(name.to_string());
-        }
-        JsNode::ObjectPattern { properties, .. } => {
-            for prop in arena.get_js_children(*properties) {
-                if let JsNode::Property { value, .. } = prop {
-                    collect_pattern_names_node(arena.get_js_node(*value), names, arena);
-                } else if let JsNode::RestElement { argument, .. } = prop {
-                    collect_pattern_names_node(arena.get_js_node(*argument), names, arena);
-                }
-            }
-        }
-        JsNode::ArrayPattern { elements, .. } => {
-            for elem in elements.iter().flatten() {
-                collect_pattern_names_node(elem, names, arena);
-            }
-        }
-        JsNode::RestElement { argument, .. } => {
-            collect_pattern_names_node(arena.get_js_node(*argument), names, arena);
-        }
-        JsNode::AssignmentPattern { left, .. } => {
-            collect_pattern_names_node(arena.get_js_node(*left), names, arena);
-        }
-        _ => {}
-    }
-}
-
 /// Get the start position of a JsNode (helper for function_scope_map).
 fn node_start(node: &JsNode) -> Option<u32> {
     match node {
@@ -3949,17 +3920,6 @@ fn node_start(node: &JsNode) -> Option<u32> {
         | JsNode::LogicalExpression { start, .. }
         | JsNode::NewExpression { start, .. }
         | JsNode::TemplateLiteral { start, .. } => Some(*start),
-        _ => None,
-    }
-}
-
-/// Get the base identifier name from a JsNode (walking through member expressions).
-fn get_node_base_identifier_name(node: &JsNode, arena: &ParseArena) -> Option<String> {
-    match node {
-        JsNode::Identifier { name, .. } => Some(name.to_string()),
-        JsNode::MemberExpression { object, .. } => {
-            get_node_base_identifier_name(arena.get_js_node(*object), arena)
-        }
         _ => None,
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
@@ -388,54 +388,6 @@ fn walk_expression_children_refs_only(node: &serde_json::Value, context: &mut Vi
     }
 }
 
-/// Extract identifier names from a destructuring pattern.
-///
-/// Corresponds to `extract_identifiers` in utils/ast.js.
-fn extract_identifiers_from_pattern(node: &serde_json::Value, names: &mut Vec<String>) {
-    let node_type = node.get("type").and_then(|t| t.as_str());
-    match node_type {
-        Some("Identifier") => {
-            if let Some(name) = node.get("name").and_then(|n| n.as_str()) {
-                names.push(name.to_string());
-            }
-        }
-        Some("ObjectPattern") => {
-            if let Some(props) = node.get("properties").and_then(|p| p.as_array()) {
-                for prop in props {
-                    let prop_type = prop.get("type").and_then(|t| t.as_str());
-                    if prop_type == Some("RestElement") {
-                        if let Some(arg) = prop.get("argument") {
-                            extract_identifiers_from_pattern(arg, names);
-                        }
-                    } else if let Some(value) = prop.get("value") {
-                        extract_identifiers_from_pattern(value, names);
-                    }
-                }
-            }
-        }
-        Some("ArrayPattern") => {
-            if let Some(elements) = node.get("elements").and_then(|e| e.as_array()) {
-                for elem in elements {
-                    if !elem.is_null() {
-                        extract_identifiers_from_pattern(elem, names);
-                    }
-                }
-            }
-        }
-        Some("AssignmentPattern") => {
-            if let Some(left) = node.get("left") {
-                extract_identifiers_from_pattern(left, names);
-            }
-        }
-        Some("RestElement") => {
-            if let Some(arg) = node.get("argument") {
-                extract_identifiers_from_pattern(arg, names);
-            }
-        }
-        _ => {}
-    }
-}
-
 /// Collect transitive dependencies for legacy reactivity.
 ///
 /// This function recursively collects all dependencies of a binding,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -6,6 +6,7 @@
 
 use super::super::AnalysisError;
 use super::super::errors;
+use super::super::pattern_ids::base_identifier_name;
 use super::super::warnings;
 use super::VisitorContext;
 use super::attribute;
@@ -1452,23 +1453,7 @@ fn extract_binding_root_identifier(
     arena: &crate::ast::arena::ParseArena,
 ) -> Option<String> {
     let node = expr.as_node();
-    extract_binding_root_identifier_node(&node, arena)
-}
-
-fn extract_binding_root_identifier_node(
-    node: &crate::ast::typed_expr::JsNode,
-    arena: &crate::ast::arena::ParseArena,
-) -> Option<String> {
-    use crate::ast::typed_expr::JsNode;
-    match node {
-        JsNode::Identifier { name, .. } => Some(name.to_string()),
-        JsNode::MemberExpression { object, .. } => {
-            // Recurse through the typed arena instead of materializing the
-            // whole MemberExpression chain into a Value.
-            extract_binding_root_identifier_node(arena.get_js_node(*object), arena)
-        }
-        _ => None,
-    }
+    base_identifier_name(&node, arena)
 }
 
 /// Recursively collect component-tag references within a fragment subtree, in
@@ -1539,15 +1524,4 @@ fn collect_subtree_component_refs(
         }
     }
     walk(&fragment.nodes, out);
-}
-
-fn extract_binding_root_identifier_json(value: &serde_json::Value) -> Option<String> {
-    match value.get("type").and_then(|t| t.as_str())? {
-        "Identifier" => value.get("name").and_then(|n| n.as_str()).map(String::from),
-        "MemberExpression" => {
-            let object = value.get("object")?;
-            extract_binding_root_identifier_json(object)
-        }
-        _ => None,
-    }
 }


### PR DESCRIPTION
## What

Consolidates the analyzer's duplicated "walk a binding pattern → collect bound identifier names" logic (findings-02 P2-2) into a single shared module, `crates/rsvelte_core/src/compiler/phases/2_analyze/pattern_ids.rs`.

### Before

Several byte-identical copies were scattered across the analyze phase (and two were fully dead, hidden by the `visitors/mod.rs` `#![allow(dead_code)]`):

- Typed pattern walker: `extract_identifiers_from_pattern_typed` (mod.rs) and `collect_pattern_names_node` (scope_builder.rs) — identical.
- JSON pattern walker: `extract_each_pattern_identifiers` (mod.rs) and `extract_identifiers_from_pattern` (each_block.rs) — identical; the each_block copy had **no caller** (dead).
- Base-identifier: `extract_binding_root_identifier_node` (regular_element.rs) and `get_node_base_identifier_name` (scope_builder.rs) — identical; plus a **dead** JSON `extract_binding_root_identifier_json`.

### After

Three shared helpers:

- `collect_pattern_identifiers` (typed)
- `collect_pattern_identifiers_json` (JSON twin; the `_node` bridge routes through it)
- `base_identifier_name` (typed)

Enumeration order and duplicate handling are preserved exactly, so compiler output is byte-identical. Net **-89 lines**.

### Deliberately left out of scope

- The JSON pattern walkers in `blockers.rs` / `visitors/shared/fragment.rs` use **different** semantics (no rest-in-object binding; `blockers` additionally handles `MemberExpression` and collects into an `FxHashSet`), so merging them would change behavior — not safe for byte-parity.
- The `build_keypath_parts_node` `to_value()` fallback (findings mention) is left as-is: its whole neighborhood (`extract_all_identifiers_from_node`) relies on the same `to_value` thread-local-arena path and the call sites (`bind.expression.as_node()`) do not thread a `ParseArena`, so a typed-complete rewrite would require plumbing that this PR intentionally avoids. Tracked for the epic.
- `scope_builder`'s `get_base_identifier_name(&self, &oxc_ast::Expression)` operates on a different (OXC borrow-scope) type and is unrelated.

## Testing

- `cargo +1.97 clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt` — clean
- `cargo test`: compatibility_report 15/15, runtime 19/19, ssr 16/16, validator 16/16, css 16/16, print 16/16 — all green, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj