### PR TITLE
fix: vps HMR の context 誤マッチ + preprocess の clone 遅延

### DIFF
--- a/.changeset/fix-preprocess-merge-tables-clone.md
+++ b/.changeset/fix-preprocess-merge-tables-clone.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(preprocess): defer the sources/names table clone in sourcemap concat until an entry is actually new
+
+`MappedCode::concat`'s `merge_tables` helper unconditionally cloned the entire
+`this_table` slice (`self.map.sources` / `self.map.names`) up front via
+`this_table.to_vec()`, before checking whether any entry from `other_table` was
+actually missing. In the common case — every `other_table` entry already
+present — the caller discards the returned table anyway (it only assigns it
+back when `changed` is `true`), so the clone was wasted work on every
+`concat()` call, which runs once per stitched-together `MappedCode` chunk while
+building a preprocessed file's source map.
+
+`merge_tables` now only materializes the merged table (via
+`Option::get_or_insert_with`) the first time an entry is found missing, and
+returns an empty `Vec` (never read by the caller) when nothing changed. Output
+is unchanged — this only affects the discarded-on-no-op allocation.

--- a/.changeset/fix-vps-hmr-context-boundary.md
+++ b/.changeset/fix-vps-hmr-context-boundary.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix(vite-plugin-svelte-native): require an attribute boundary for legacy `context="module"` detection
+
+`hmr_diff`'s `is_module_script_attrs` decided whether a `<script …>` opening tag
+was the legacy module script with a plain `str::contains("context=\"module\"")`
+(and the `'…'` / unquoted variants). That substring check matched inside any
+attribute whose name merely *ends* in `context` — e.g. `<script
+data-context="module">` — misclassifying an ordinary instance script as the
+module script and corrupting the HMR full-reload/hot-update decision.
+
+The bare `module` attribute form already required a whitespace/`=`/`/`/`>`
+boundary on both sides (H-094); the three `context=...` literal checks now get
+the same treatment via a new `contains_at_attr_boundary` helper, which only
+accepts a match starting at the beginning of the attribute text or right after
+whitespace.

--- a/crates/rsvelte_core/src/compiler/preprocess/replace_in_code.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/replace_in_code.rs
@@ -350,24 +350,31 @@ fn last_line_length(s: &str) -> usize {
 /// Merge two tables (sources or names arrays) and return the merged table,
 /// index mapping, and whether values/indices changed.
 ///
+/// `this_table` is only cloned once an entry from `other_table` is actually
+/// missing from it — the common case (every `other_table` entry already
+/// present) skips the clone entirely. The caller only uses the returned
+/// table when `changed` is `true`, so an empty `Vec` is returned otherwise.
+///
 /// Returns: (new_table, idx_map, changed)
 fn merge_tables<T: Clone + Eq>(this_table: &[T], other_table: &[T]) -> (Vec<T>, Vec<usize>, bool) {
-    let mut new_table = this_table.to_vec();
+    let mut new_table: Option<Vec<T>> = None;
     let mut idx_map = Vec::with_capacity(other_table.len());
-    let mut val_changed = false;
 
     for other_val in other_table {
         if let Some(this_idx) = this_table.iter().position(|v| v == other_val) {
             idx_map.push(this_idx);
         } else {
-            let new_idx = new_table.len();
-            new_table.push(other_val.clone());
+            let table = new_table.get_or_insert_with(|| this_table.to_vec());
+            let new_idx = table.len();
+            table.push(other_val.clone());
             idx_map.push(new_idx);
-            val_changed = true;
         }
     }
 
-    (new_table, idx_map, val_changed)
+    match new_table {
+        Some(table) => (table, idx_map, true),
+        None => (Vec::new(), idx_map, false),
+    }
 }
 
 #[cfg(test)]
@@ -409,6 +416,16 @@ mod tests {
         assert_eq!(merged, vec!["a", "b", "c", "d"]);
         assert_eq!(idx_map, vec![1, 3]); // "b" maps to 1, "d" maps to 3
         assert!(changed);
+    }
+
+    #[test]
+    fn test_merge_tables_no_new_entries() {
+        let t1 = vec!["a", "b", "c"];
+        let t2 = vec!["b", "a"];
+        let (_, idx_map, changed) = merge_tables(&t1, &t2);
+
+        assert_eq!(idx_map, vec![1, 0]);
+        assert!(!changed);
     }
 
     fn mapped(string: &str, sources: Vec<String>, mappings: Vec<Vec<Vec<i64>>>) -> MappedCode {

--- a/crates/rsvelte_core/src/vps/hmr.rs
+++ b/crates/rsvelte_core/src/vps/hmr.rs
@@ -107,13 +107,15 @@ fn extract_script(source: &str, module: bool) -> Option<String> {
 
 /// Decide whether a `<script …>` opening tag's attribute text marks a module
 /// script. Recognises the legacy `context="module"` forms and the Svelte 5
-/// bare `module` attribute (H-094). The bare form is matched as a standalone
-/// token so it isn't confused with `module` appearing inside another
-/// attribute's quoted value.
+/// bare `module` attribute (H-094). Both forms are matched at an attribute
+/// boundary (start-of-string or preceded by whitespace) so a different
+/// attribute name that happens to share the same suffix — e.g.
+/// `data-context="module"` or `module` inside another attribute's quoted
+/// value — isn't mistaken for the real thing.
 fn is_module_script_attrs(tag_attrs: &str) -> bool {
-    if tag_attrs.contains("context=\"module\"")
-        || tag_attrs.contains("context='module'")
-        || tag_attrs.contains("context=module")
+    if contains_at_attr_boundary(tag_attrs, "context=\"module\"")
+        || contains_at_attr_boundary(tag_attrs, "context='module'")
+        || contains_at_attr_boundary(tag_attrs, "context=module")
     {
         return true;
     }
@@ -132,6 +134,21 @@ fn is_module_script_attrs(tag_attrs: &str) -> bool {
             return true;
         }
         from = end;
+    }
+    false
+}
+
+/// Find `needle` in `haystack`, but only accept a match that starts at an
+/// attribute boundary (start-of-string or preceded by whitespace).
+fn contains_at_attr_boundary(haystack: &str, needle: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = haystack[from..].find(needle) {
+        let start = from + rel;
+        if start == 0 || bytes[start - 1].is_ascii_whitespace() {
+            return true;
+        }
+        from = start + 1;
     }
     false
 }
@@ -197,6 +214,18 @@ mod tests {
         assert!(!is_module_script_attrs(""));
         assert!(!is_module_script_attrs(" lang=\"ts\""));
         assert!(!is_module_script_attrs(" generics=\"T extends Module\""));
+    }
+
+    #[test]
+    fn context_attribute_requires_a_boundary() {
+        // A differently-named attribute that merely ends in `context="module"`
+        // must not be mistaken for the legacy module-script marker.
+        assert!(!is_module_script_attrs(" data-context=\"module\""));
+        assert!(!is_module_script_attrs(" data-context='module'"));
+        assert!(!is_module_script_attrs(" data-context=module"));
+        // But the real attribute, at a proper boundary, still matches.
+        assert!(is_module_script_attrs(" context=\"module\""));
+        assert!(is_module_script_attrs(" lang=\"ts\" context=\"module\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `vps/hmr.rs`'s `is_module_script_attrs` matched `context="module"` (and the `'…'`/unquoted variants) via a plain substring check, so an attribute like `data-context="module"` was misclassified as the legacy module-script marker, corrupting the HMR hot-update/full-reload decision. Added `contains_at_attr_boundary`, requiring the match to start at the beginning of the attribute text or right after whitespace — mirroring the boundary check the bare `module` attribute (H-094) already had.
- `preprocess/replace_in_code.rs`'s `merge_tables` (used by `MappedCode::concat` when stitching sourcemap `sources`/`names` tables) unconditionally cloned the whole `this_table` up front via `to_vec()`, even though the caller discards the result whenever nothing actually changed. Now lazily materializes the merged table only once an entry is found missing.

## Test plan
- [x] `cargo test --release --lib -p rsvelte_core vps::hmr::` — 9/9 pass (added `context_attribute_requires_a_boundary` regression test)
- [x] `cargo test --release --lib -p rsvelte_core merge_tables` — 2/2 pass (added `test_merge_tables_no_new_entries`)
- [x] `cargo test --release --test print` — 16/16 pass
- [x] `cargo test --release --test compatibility_report` — pass
- [x] `cargo test --release --test preprocess --test preprocess_attributes --test preprocess_pipeline_pin --test preprocess_vlq_sourcemap` — all pass (run individually; one target hit a known transient worktree build flake on first try, passed on retry)
- [x] `cargo +1.97 clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj