### PR TITLE
refactor(transform): batch module-script $state rune passes into one parse

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -18,6 +18,7 @@ mod expression_utils;
 mod formatting;
 mod legacy_state_member_mutate_ast;
 mod local_assign_ast;
+mod module_state_runes_ast;
 mod private_class_assign_ast;
 mod private_field_assign_ast;
 mod private_member_mutate_root_ast;
@@ -3438,60 +3439,21 @@ pub(crate) fn transform_module_script_runes(
         .cloned()
         .collect();
 
-    // Transform $state.snapshot(x) to $.snapshot(x).
-    // Module scripts don't need dev-mode handling for state_snapshot_uncloneable.
-    //
-    // AST-based rewrite via `state_snapshot_ast::transform_state_snapshot_ast`.
-    // The text version was `String::replace("$state.snapshot(", "$.snapshot(")`
-    // — rewrites byte patterns regardless of lexical context, so anything inside
-    // a string / template literal got (incorrectly) rewritten too. The AST
-    // visitor descends only into expression positions and can't make that
-    // mistake.
+    // Lower the module script's `$state*` runes in a single batched parse:
+    //   * `$state.snapshot(x)` → `$.snapshot(x)`
+    //   * `$state.raw(x)` / `$state.frozen(x)` → `$.state(x)` or raw value
+    //   * bare `$state(x)`   → `$.state(...)` / `$.proxy(...)` / raw value
+    // These three rewrites target lexically disjoint syntax, so one parse feeds
+    // all three collectors instead of re-parsing the whole module script per
+    // rune. Module scripts don't need dev-mode `state_snapshot_uncloneable`
+    // handling. The AST visitors descend only into expression positions, so —
+    // unlike the text predecessors — none of them can be tripped by the same
+    // bytes inside a string / template / regex literal. On a parse failure the
+    // batch is a no-op and the legacy `$state(` text loop below runs as a
+    // fallback (and, on success, sees no remaining `$state(` and exits).
     {
         let is_ts = analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
-        if let Some(rewritten) = state_snapshot_ast::transform_state_snapshot_ast(&result, is_ts) {
-            result = rewritten;
-        }
-    }
-
-    // Transform $state.raw(x) / $state.frozen(x).
-    // Like $state(), whether we wrap in $.state() depends on whether the variable
-    // is reassigned.  $state.raw/$state.frozen never use $.proxy(), just the raw value
-    // when non-reactive, or $.state(value) when reassigned.
-    //
-    // AST-based rewrite via `state_raw_frozen_ast::transform_state_raw_frozen_ast`.
-    // The text predecessor scanned for `$state.raw(` / `$state.frozen(`, walked
-    // backwards via `extract_var_name_before_rune` to discover the declarator's
-    // identifier, then rewrote in place. That walked-back search was fragile
-    // (any byte pattern matching `$state.raw(` inside a string would trigger it).
-    // The AST visitor knows about strings / templates / regexes and reads the
-    // binding name from the `BindingPattern` directly.
-    {
-        let is_ts = analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
-        if let Some(rewritten) = state_raw_frozen_ast::transform_state_raw_frozen_ast(
-            &result,
-            &module_non_reactive_vars,
-            is_ts,
-        ) {
-            result = rewritten;
-        }
-    }
-
-    // Transform $state(x) - handling both reassigned and non-reassigned cases.
-    // Non-reassigned vars get $.proxy() only, reassigned vars get $.state($.proxy()).
-    //
-    // AST-based rewrite via `state_call_ast::transform_state_call_ast`. The
-    // text predecessor scanned for `$state(`, found the close-paren via a
-    // custom brace tracker, walked backwards via `extract_var_name_before_rune`
-    // to discover the binding name, then dispatched on the reactive /
-    // needs-proxy / empty axes. The OXC parser knows about all of the
-    // lexical concerns (strings, templates, regexes, comments) and the
-    // `BindingPattern` gives us the name directly. After the AST helper
-    // runs, the legacy text loop below sees no remaining `$state(` and
-    // exits immediately — idempotent fallback for parse failures.
-    {
-        let is_ts = analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
-        if let Some(rewritten) = state_call_ast::transform_state_call_ast(
+        if let Some(rewritten) = module_state_runes_ast::transform_module_state_runes_ast(
             &result,
             &module_non_reactive_vars,
             &module_non_proxy_vars,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_state_runes_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_state_runes_ast.rs
@@ -1,0 +1,117 @@
+//! Batched `$state*` rune lowering for module scripts (`.svelte.js` /
+//! `.svelte.ts`).
+//!
+//! The `$state.snapshot(...)`, `$state.raw(...)` / `$state.frozen(...)`, and
+//! bare `$state(...)` rewrites used to run as three sequential AST passes, each
+//! re-parsing the whole module script. Their targets are lexically disjoint
+//! (`$state.snapshot` callee / `$state.raw|frozen` calls / bare `$state(` calls),
+//! so a single parse can feed all three collectors and one splice apply the
+//! union of their edits.
+//!
+//! The batched driver folds to a fixed point with innermost-first splicing, so
+//! the (pathological but legal) case of one rune nested inside another — e.g.
+//! `$state($state.snapshot(x))` — still resolves exactly as the equivalent
+//! sequential per-pass application: the inner edit lands first, the next
+//! iteration re-parses and re-collects the settled outer node.
+
+use std::cell::RefCell;
+
+use oxc_allocator::Allocator;
+use oxc_parser::ParseOptions;
+use oxc_span::SourceType;
+
+use super::ast_rewrite;
+
+thread_local! {
+    static MODULE_STATE_RUNES_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+}
+
+/// Rewrite every `$state*` rune in a module script in a single parse per
+/// fixed-point iteration. `non_reactive_vars` / `non_proxy_vars` are the
+/// caller-computed classification sets consulted by the raw/frozen and bare-call
+/// rewrites. Returns `None` when nothing changed (no rune present, parse
+/// failure, or no matched call actually rewrote).
+pub fn transform_module_state_runes_ast(
+    source: &str,
+    non_reactive_vars: &[String],
+    non_proxy_vars: &[String],
+    is_ts: bool,
+) -> Option<String> {
+    // Fast probe — skip the parse entirely for scripts with no `$state` at all.
+    memchr::memmem::find(source.as_bytes(), b"$state")?;
+
+    let source_type = if is_ts {
+        SourceType::ts().with_module(true)
+    } else {
+        SourceType::mjs()
+    };
+
+    ast_rewrite::rewrite_batched(
+        &MODULE_STATE_RUNES_ALLOC,
+        source,
+        source_type,
+        ParseOptions::default(),
+        |program, src| {
+            let mut edits = super::state_snapshot_ast::collect_snapshot_edits(program);
+            edits.extend(super::state_raw_frozen_ast::collect_raw_frozen_edits(
+                program,
+                src,
+                non_reactive_vars,
+            ));
+            edits.extend(super::state_call_ast::collect_state_call_edits(
+                program,
+                src,
+                non_reactive_vars,
+                non_proxy_vars,
+            ));
+            edits
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mixed_disjoint_runes_all_lower_in_one_pass() {
+        let src = "let a = $state.snapshot(x);\nlet b = $state.raw(0);\nlet c = $state(1);";
+        let out = transform_module_state_runes_ast(src, &[], &[], false).unwrap();
+        assert_eq!(
+            out,
+            "let a = $.snapshot(x);\nlet b = $.state(0);\nlet c = $.state(1);"
+        );
+    }
+
+    #[test]
+    fn no_rune_is_none() {
+        assert!(transform_module_state_runes_ast("let x = 1;", &[], &[], false).is_none());
+    }
+
+    #[test]
+    fn rune_shaped_bytes_in_string_literal_are_left_alone() {
+        // Every rewrite descends only into expression positions, so the same
+        // bytes inside a string literal must not be touched.
+        assert!(
+            transform_module_state_runes_ast(r#"let s = "$state(x)";"#, &[], &[], false).is_none()
+        );
+    }
+
+    #[test]
+    fn nested_cross_rune_fully_lowers() {
+        // Pathological but legal: a snapshot call nested inside a bare `$state(...)`.
+        // The batched fixed point must fully lower both — no rune bytes may remain
+        // and the inner snapshot must have been rewritten — matching what three
+        // sequential passes would have produced.
+        let out = transform_module_state_runes_ast(
+            "let a = $state($state.snapshot(x));",
+            &[],
+            &[],
+            false,
+        )
+        .unwrap();
+        assert!(out.starts_with("let a = $.state("), "got: {out}");
+        assert!(out.contains("$.snapshot(x)"), "got: {out}");
+        assert!(!out.contains("$state"), "rune bytes remained: {out}");
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_call_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_call_ast.rs
@@ -30,56 +30,33 @@
 //! The AST visitor descends only into expression positions and
 //! reads the binding name straight off the `BindingIdentifier`.
 
-use std::cell::RefCell;
-
-use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::ParseOptions;
-use oxc_span::{GetSpan, SourceType};
+use oxc_span::GetSpan;
 
-use super::ast_rewrite::{self, Edit};
+use super::ast_rewrite::Edit;
 use super::expression_utils::{collapse_to_single_line, expression_needs_proxy_with_scope};
 
-thread_local! {
-    static MODULE_STATE_CALL_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
-}
-
-/// AST-based rewrite of `$state(value)`.
-///
-/// `non_reactive_vars` lists module-level bindings that are known
-/// never to be reassigned. Returns `None` when nothing changed.
-pub fn transform_state_call_ast(
+/// Collect the bare `$state(value)` rewrite edits for an already-parsed program.
+/// Shared with the batched module-rune driver so the call rewrite can ride along
+/// on a single parse. `source` must be the exact text `program` was parsed from
+/// (spans index into it).
+pub(super) fn collect_state_call_edits(
+    program: &Program<'_>,
     source: &str,
     non_reactive_vars: &[String],
     non_proxy_vars: &[String],
-    is_ts: bool,
-) -> Option<String> {
-    memchr::memmem::find(source.as_bytes(), b"$state")?;
-
-    ast_rewrite::rewrite_once(
-        &MODULE_STATE_CALL_ALLOC,
+) -> Vec<Edit> {
+    let mut collector = StateCallCollector {
         source,
-        if is_ts {
-            SourceType::ts().with_module(true)
-        } else {
-            SourceType::mjs()
-        },
-        ParseOptions::default(),
-        false,
-        |program| {
-            let mut collector = StateCallCollector {
-                source,
-                non_reactive_vars,
-                non_proxy_vars,
-                current_var: None,
-                replacements: Vec::new(),
-            };
-            collector.visit_program(program);
-            collector.replacements
-        },
-    )
+        non_reactive_vars,
+        non_proxy_vars,
+        current_var: None,
+        replacements: Vec::new(),
+    };
+    collector.visit_program(program);
+    collector.replacements
 }
 
 /// Stateful visitor — `current_var` tracks the binding name being
@@ -150,7 +127,42 @@ impl<'a, 'src, 'ast> Visit<'ast> for StateCallCollector<'a, 'src> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
+    use oxc_allocator::Allocator;
+    use oxc_parser::ParseOptions;
+    use oxc_span::SourceType;
+
+    use super::super::ast_rewrite;
     use super::*;
+
+    thread_local! {
+        static TEST_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+    }
+
+    /// Drives `collect_state_call_edits` in isolation over its own parse —
+    /// mirrors how the batched module-rune driver runs it, but for the bare
+    /// `$state(...)` rewrite alone so these assertions stay scoped to this pass.
+    fn transform_state_call_ast(
+        source: &str,
+        non_reactive_vars: &[String],
+        non_proxy_vars: &[String],
+        is_ts: bool,
+    ) -> Option<String> {
+        memchr::memmem::find(source.as_bytes(), b"$state")?;
+        ast_rewrite::rewrite_once(
+            &TEST_ALLOC,
+            source,
+            if is_ts {
+                SourceType::ts().with_module(true)
+            } else {
+                SourceType::mjs()
+            },
+            ParseOptions::default(),
+            false,
+            |program| collect_state_call_edits(program, source, non_reactive_vars, non_proxy_vars),
+        )
+    }
 
     fn nrv(names: &[&str]) -> Vec<String> {
         names.iter().map(|s| s.to_string()).collect()

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_raw_frozen_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_raw_frozen_ast.rs
@@ -23,63 +23,30 @@
 //! the same-shaped bytes inside a string literal, and `BindingPattern`
 //! gives us the variable name directly.
 
-use std::cell::RefCell;
-
-use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::ParseOptions;
-use oxc_span::{GetSpan, SourceType};
+use oxc_span::GetSpan;
 
-use super::ast_rewrite::{self, Edit};
+use super::ast_rewrite::Edit;
 
-thread_local! {
-    static MODULE_STATE_RAW_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
-}
-
-/// AST-based rewrite of `$state.raw(x)` / `$state.frozen(x)`.
-///
-/// `non_reactive_vars` lists the module-level bindings that are
-/// known to never be reassigned — for those the call collapses to
-/// the raw value. Everything else gets wrapped in `$.state(...)`.
-///
-/// Returns `None` when there's nothing to rewrite (no occurrence in
-/// the source, parse failure, or none of the matched calls actually
-/// changed).
-pub fn transform_state_raw_frozen_ast(
+/// Collect the `$state.raw(x)` / `$state.frozen(x)` rewrite edits for an
+/// already-parsed program. Shared with the batched module-rune driver so the
+/// raw/frozen rewrite can ride along on a single parse. `source` must be the
+/// exact text `program` was parsed from (spans index into it).
+pub(super) fn collect_raw_frozen_edits(
+    program: &Program<'_>,
     source: &str,
     non_reactive_vars: &[String],
-    is_ts: bool,
-) -> Option<String> {
-    // Fast probe.
-    if memchr::memmem::find(source.as_bytes(), b"$state.raw").is_none()
-        && memchr::memmem::find(source.as_bytes(), b"$state.frozen").is_none()
-    {
-        return None;
-    }
-
-    ast_rewrite::rewrite_once(
-        &MODULE_STATE_RAW_ALLOC,
+) -> Vec<Edit> {
+    let mut collector = StateRawFrozenCollector {
         source,
-        if is_ts {
-            SourceType::ts().with_module(true)
-        } else {
-            SourceType::mjs()
-        },
-        ParseOptions::default(),
-        false,
-        |program| {
-            let mut collector = StateRawFrozenCollector {
-                source,
-                non_reactive_vars,
-                current_var: None,
-                replacements: Vec::new(),
-            };
-            collector.visit_program(program);
-            collector.replacements
-        },
-    )
+        non_reactive_vars,
+        current_var: None,
+        replacements: Vec::new(),
+    };
+    collector.visit_program(program);
+    collector.replacements
 }
 
 /// Stateful visitor — `current_var` tracks the binding being
@@ -155,7 +122,45 @@ impl<'a, 'src, 'ast> Visit<'ast> for StateRawFrozenCollector<'a, 'src> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
+    use oxc_allocator::Allocator;
+    use oxc_parser::ParseOptions;
+    use oxc_span::SourceType;
+
+    use super::super::ast_rewrite;
     use super::*;
+
+    thread_local! {
+        static TEST_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+    }
+
+    /// Drives `collect_raw_frozen_edits` in isolation over its own parse —
+    /// mirrors how the batched module-rune driver runs it, but for the
+    /// raw/frozen rewrite alone so these assertions stay scoped to this pass.
+    fn transform_state_raw_frozen_ast(
+        source: &str,
+        non_reactive_vars: &[String],
+        is_ts: bool,
+    ) -> Option<String> {
+        if memchr::memmem::find(source.as_bytes(), b"$state.raw").is_none()
+            && memchr::memmem::find(source.as_bytes(), b"$state.frozen").is_none()
+        {
+            return None;
+        }
+        ast_rewrite::rewrite_once(
+            &TEST_ALLOC,
+            source,
+            if is_ts {
+                SourceType::ts().with_module(true)
+            } else {
+                SourceType::mjs()
+            },
+            ParseOptions::default(),
+            false,
+            |program| collect_raw_frozen_edits(program, source, non_reactive_vars),
+        )
+    }
 
     fn nrv(names: &[&str]) -> Vec<String> {
         names.iter().map(|s| s.to_string()).collect()

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_snapshot_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_snapshot_ast.rs
@@ -14,47 +14,24 @@
 //! between wrapping in `$.state(...)` and emitting the raw value.
 //! That plumbing belongs in a follow-up PR.
 
-use std::cell::RefCell;
-
-use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::ParseOptions;
-use oxc_span::{GetSpan, SourceType};
+use oxc_span::GetSpan;
 
-use super::ast_rewrite::{self, Edit};
+use super::ast_rewrite::Edit;
 
-thread_local! {
-    static MODULE_SNAPSHOT_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
-}
-
-/// AST-based rewrite of `$state.snapshot(x)` → `$.snapshot(x)`.
-/// Returns `None` when nothing changed.
-pub fn transform_state_snapshot_ast(source: &str, is_ts: bool) -> Option<String> {
-    // Fast probe — most module scripts don't reference $state.snapshot.
-    memchr::memmem::find(source.as_bytes(), b"$state.snapshot")?;
-
-    ast_rewrite::rewrite_once(
-        &MODULE_SNAPSHOT_ALLOC,
-        source,
-        if is_ts {
-            SourceType::ts().with_module(true)
-        } else {
-            SourceType::mjs()
-        },
-        ParseOptions::default(),
-        false,
-        |program| {
-            let mut collector = SnapshotCollector { spans: Vec::new() };
-            collector.visit_program(program);
-            collector
-                .spans
-                .into_iter()
-                .map(|(start, end)| (start, end, "$.snapshot".to_string()))
-                .collect::<Vec<Edit>>()
-        },
-    )
+/// Collect the `$state.snapshot` → `$.snapshot` callee-swap edits for an
+/// already-parsed program. Shared with the batched module-rune driver so the
+/// snapshot rewrite can ride along on a single parse.
+pub(super) fn collect_snapshot_edits(program: &Program<'_>) -> Vec<Edit> {
+    let mut collector = SnapshotCollector { spans: Vec::new() };
+    collector.visit_program(program);
+    collector
+        .spans
+        .into_iter()
+        .map(|(start, end)| (start, end, "$.snapshot".to_string()))
+        .collect()
 }
 
 struct SnapshotCollector {
@@ -84,7 +61,37 @@ impl<'a> Visit<'a> for SnapshotCollector {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
+    use oxc_allocator::Allocator;
+    use oxc_parser::ParseOptions;
+    use oxc_span::SourceType;
+
+    use super::super::ast_rewrite;
     use super::*;
+
+    thread_local! {
+        static TEST_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+    }
+
+    /// Drives `collect_snapshot_edits` in isolation over its own parse — mirrors
+    /// how the batched module-rune driver runs it, but for the snapshot rewrite
+    /// alone so these assertions stay scoped to this pass.
+    fn transform_state_snapshot_ast(source: &str, is_ts: bool) -> Option<String> {
+        memchr::memmem::find(source.as_bytes(), b"$state.snapshot")?;
+        ast_rewrite::rewrite_once(
+            &TEST_ALLOC,
+            source,
+            if is_ts {
+                SourceType::ts().with_module(true)
+            } else {
+                SourceType::mjs()
+            },
+            ParseOptions::default(),
+            false,
+            collect_snapshot_edits,
+        )
+    }
 
     #[test]
     fn rewrites_snapshot_call() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/ast_rewrite.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/ast_rewrite.rs
@@ -112,6 +112,32 @@ pub fn rewrite_once(
     })
 }
 
+/// Run several collectors against a *single* parse of `source`, unioning their
+/// edits before one splice, then drive that to a fixed point. This folds a group
+/// of passes that share a source type and parse options — and whose edits target
+/// disjoint syntax — into one parse per iteration instead of one parse per pass.
+///
+/// `collect` receives the parsed program and the exact text it was parsed from
+/// (so span-derived slices stay valid), and returns the union of every grouped
+/// pass's edits. Splicing uses `innermost_only` + the fixed-point loop so the
+/// rare case of one pass's target nested inside another's — which a single flat
+/// splice cannot represent — still resolves exactly as the equivalent sequential
+/// per-pass application would: the inner edit lands this iteration, the next one
+/// re-parses and re-collects the now-settled outer node.
+pub fn rewrite_batched(
+    arena: &'static LocalKey<RefCell<Allocator>>,
+    source: &str,
+    source_type: SourceType,
+    parse_options: ParseOptions,
+    mut collect: impl FnMut(&Program<'_>, &str) -> Vec<Edit>,
+) -> Option<String> {
+    fixed_point(source, |current| {
+        with_program(arena, current, source_type, parse_options, |program| {
+            splice(current, collect(program, current), true)
+        })
+    })
+}
+
 /// Drive `pass` to a fixed point, capped at [`MAX_FIXED_POINT_ITERS`]. Returns
 /// `Some(rewritten)` if at least one pass changed the source, `None` if the
 /// very first pass was already a no-op. Each call to `pass` re-parses the


### PR DESCRIPTION
## What

Stage-B of the client-script "string codegen → AST" cleanup (findings PR-B: `ast_rewrite` batching — first group).

The module-script (`.svelte.js` / `.svelte.ts`) path lowered its `$state*` runes as **three sequential AST passes** — `$state.snapshot(...)`, `$state.raw(...)`/`$state.frozen(...)`, and bare `$state(...)` — each re-parsing the whole script through `ast_rewrite::rewrite_once` (parse → visit → text splice → discard AST).

This PR adds a shared **`ast_rewrite::rewrite_batched`** driver: one parse per fixed-point iteration feeds all grouped collectors, and the union of their edits lands in a single innermost-first splice. Because the three rewrites target lexically disjoint syntax, one iteration suffices for real inputs; the pathological nested cross-rune shape (`$state($state.snapshot(x))`) settles on the next iteration exactly as the sequential per-pass application did (inner edit first, outer re-collected after re-parse).

- `module_state_runes_ast::transform_module_state_runes_ast` is the new single entry point wired into `transform_module_script_runes` (`client/mod.rs`), replacing the three consecutive call sites.
- The per-pass files keep their collectors (`collect_snapshot_edits` / `collect_raw_frozen_edits` / `collect_state_call_edits`) as the shared production surface; their `transform_*` wrappers move into each file's `#[cfg(test)]` module so the existing per-pass assertions keep running unchanged while production carries no dead wrappers.

Net effect: 3 parses → 1 parse on every `.svelte.js` compile that touches `$state`, and the batching driver is in place for the follow-up groups (per-statement legacy-path passes are the next, larger target).

## Byte-neutrality

A feature-gated shadow comparator (`shadow_state_runes_probe`, scaffolding only — removed from the final commit) re-ran the previous three-sequential-pass pipeline alongside the batched one on **every** `transform_module_state_runes_ast` call and `assert!`-ed equality, over:

- `runtime` (runtime-runes 999 / runtime-legacy 1206 / hydration 80 / browser 32): **19/19 pass**
- `compiler_fixtures` (snapshot suite): **17/17 pass**
- `ssr`: **16/16 pass**
- `compatibility_report`: **15/15 pass**
- module-path suites: `module_state_raw_reads` 3/3, `module_class_field_state_codegen` 6/6, `module_compile_ts_strip` 5/5, `compile_module_thread_safety` 1/1
- synthetic cases (comparator active): mixed disjoint runes, rune-shaped bytes inside string literals, nested cross-rune `$state($state.snapshot(x))`

Zero divergences. Full corpus CSR/SSR byte-parity is enforced by CI.

## Verification (final code, comparator removed)

- `cargo test --release --test runtime` → 19/19; `--test ssr` → 16/16; `--test compiler_fixtures` → 17/17; `--test compatibility_report` → 15/15
- lib unit tests for the touched passes + `ast_rewrite` → 54/54
- `cargo fmt` clean; `cargo +1.97 clippy --all-targets --all-features -- -D warnings` clean

No changeset (refactor; output unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj