### PR TITLE
refactor(transform): batch module-script dev-tail rune passes into one parse

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
@@ -71,16 +71,23 @@ pub fn transform_console_calls_dev_ast(source: &str, is_ts: bool) -> Option<Stri
             },
             ParseOptions::default(),
             false,
-            |program| {
-                let mut collector = ConsoleCollector {
-                    source: src,
-                    replacements: Vec::new(),
-                };
-                collector.visit_program(program);
-                collector.replacements
-            },
+            |program| collect_console_edits(program, src),
         )
     })
+}
+
+/// Collect leaf `console.METHOD(args)` wraps (calls whose arguments
+/// hold no unwrapped nested console call) from a single parse. Nested
+/// cases resolve across fixed-point iterations — the standalone
+/// `transform_console_calls_dev_ast` loop and the batched module
+/// dev-tail driver both drive that loop.
+pub(super) fn collect_console_edits(program: &Program<'_>, source: &str) -> Vec<Edit> {
+    let mut collector = ConsoleCollector {
+        source,
+        replacements: Vec::new(),
+    };
+    collector.visit_program(program);
+    collector.replacements
 }
 
 struct ConsoleCollector<'src> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/effect_rune_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/effect_rune_ast.rs
@@ -51,14 +51,19 @@ pub fn apply_effect_rune_transforms_ast(source: &str, is_ts: bool) -> Option<Str
         },
         ParseOptions::default(),
         false,
-        |program| {
-            let mut collector = EffectRuneCollector {
-                replacements: Vec::new(),
-            };
-            collector.visit_program(program);
-            collector.replacements
-        },
+        collect_effect_rune_edits,
     )
+}
+
+/// Collect `$effect.*` call-expression rewrites from a single parse.
+/// The batched module dev-tail driver folds this to a fixed point
+/// alongside the other dev-mode collectors.
+pub(super) fn collect_effect_rune_edits(program: &Program<'_>) -> Vec<Edit> {
+    let mut collector = EffectRuneCollector {
+        replacements: Vec::new(),
+    };
+    collector.visit_program(program);
+    collector.replacements
 }
 
 struct EffectRuneCollector {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -18,6 +18,7 @@ mod expression_utils;
 mod formatting;
 mod legacy_state_member_mutate_ast;
 mod local_assign_ast;
+mod module_dev_tail_ast;
 mod module_state_runes_ast;
 mod private_class_assign_ast;
 mod private_field_assign_ast;
@@ -3707,83 +3708,35 @@ pub(crate) fn transform_module_script_runes(
         .unwrap_or(result);
     }
 
-    // Transform $effect.root(), $effect.pre(), $effect.tracking(), $effect()
-    // These rune calls can appear in module scripts (e.g., inside class constructors).
-    //
-    // AST-based rewrite via `effect_rune_ast::apply_effect_rune_transforms_ast`:
-    // OXC parses the module script, the visitor matches `CallExpression`s whose
-    // callee is `$effect` (bare) or `$effect.<member>`, and swaps the callee for
-    // the runtime equivalent (`$.user_effect`, `$.user_pre_effect`, etc.). The
-    // text-based predecessor blindly rewrote byte patterns regardless of lexical
-    // context, so `let s = "$effect("` would be (incorrectly) rewritten — the
-    // AST visitor descends into none of those positions.
+    // Lower the module script's `$effect` runes and, in dev mode, its
+    // `===`/`!==` → `$.strict_equals(...)`, `console.METHOD(...)` →
+    // `...$.log_if_contains_state(...)` wraps, and `$.state`/`$.derived`/
+    // `$.proxy` declarator `$.tag(...)` wraps — all in a single batched
+    // parse. These passes target lexically disjoint syntax (call callees /
+    // binary operators / console calls / declarator inits), so one parse
+    // feeds every collector instead of re-parsing the whole module script
+    // per pass. The AST visitors descend only into expression positions,
+    // so — unlike the text predecessors — none can be tripped by the same
+    // bytes inside a string / template / regex literal. `dev` gates the
+    // three dev-only collectors exactly as the sequential call sites did.
     {
         let is_ts = analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
-        if let Some(rewritten) = effect_rune_ast::apply_effect_rune_transforms_ast(&result, is_ts) {
-            result = rewritten;
-        }
-    }
-
-    // In dev mode, transform === to $.strict_equals() and !== to !$.strict_equals()
-    // This matches the BinaryExpression visitor from the official Svelte compiler.
-    //
-    // AST-based rewrite via `strict_equals_ast::transform_strict_equals_module_ast`:
-    // OXC parses the module script, the visitor walks every BinaryExpression with
-    // operator `===` / `!==`, and replacements are spliced right-to-left. Replaces
-    // the legacy `transform_strict_equals` text scanner — the text version's
-    // string-literal heuristics (count quotes) were fragile under escaped quotes,
-    // regex literals, line comments, and template-literal interpolation. The AST
-    // path can't make those mistakes because OXC's parser knows the lexical
-    // categories. Falls back to the legacy text version on parse failure (which
-    // shouldn't happen for module scripts that get this far in the pipeline).
-    if dev {
-        let is_ts = analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
-        match strict_equals_ast::transform_strict_equals_module_ast(&result, is_ts) {
-            Some(rewritten) => result = rewritten,
-            None => {
-                // None means either no operators to rewrite or a parse
-                // failure; both leave `result` correct as-is. The legacy
-                // text-based pass is no longer wired in; it stays in
-                // `rune_transforms.rs` for the rolling Phase A migration.
-            }
-        }
-    }
-
-    // In dev mode, wrap console.METHOD() calls with $.log_if_contains_state
-    // to detect when state proxies are logged directly.
-    // Reference: CallExpression.js in the official Svelte compiler.
-    //
-    // AST-based rewrite via `console_dev_ast::transform_console_calls_dev_ast`.
-    // The text predecessor used `is_inside_string_literal` (quote counting)
-    // to skip strings, fragile under escaped quotes / regex literals /
-    // template-literal interpolation. The AST visitor descends only into
-    // call positions so it can't make that class of mistake.
-    if dev {
-        let is_ts = analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
-        if let Some(rewritten) = console_dev_ast::transform_console_calls_dev_ast(&result, is_ts) {
-            result = rewritten;
-        }
-    }
-
-    // In dev mode, wrap $.state(), $.derived(), and $.proxy() declarations with $.tag()/$.tag_proxy()
-    // This tags signals with their variable names for better debugging with $inspect.trace().
-    //
-    // Three passes, chained idempotently (the text version's
-    // already-tagged guard skips both AST emissions cleanly):
-    // 1. `tag_declarator_ast` — `let/const/var X = $.state(...)` declarators
-    // 2. `tag_class_field_ast` — class `#field = ...` declarations and
-    //    `this.field` / `this.#field` assignments (with originally-public
-    //    label heuristic via paired setter detection)
-    // 3. `wrap_state_derived_with_tag` text fallback for any remaining
-    //    non-declarator shapes (no-op in practice after the two AST
-    //    passes for valid inputs).
-    if dev {
-        let is_ts = analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
         if let Some(rewritten) =
-            tag_declarator_ast::wrap_state_derived_with_tag_declarators_ast(&result, is_ts)
+            module_dev_tail_ast::transform_module_dev_tail_ast(&result, dev, is_ts)
         {
             result = rewritten;
         }
+    }
+
+    // In dev mode, wrap class-field `$.state()`/`$.derived()`/`$.proxy()`
+    // declarations with `$.tag()`/`$.tag_proxy()` (class `#field = ...` and
+    // `this.field` / `this.#field` assignments, with an originally-public
+    // label heuristic via paired setter detection), then a text fallback
+    // for any remaining non-declarator shapes (a no-op in practice after
+    // the AST passes for valid inputs). The declarator-level tag pass runs
+    // in the batch above; these two cover the class-field / residual cases
+    // that batch's `tag_declarator` collector intentionally skips.
+    if dev {
         if let Some(rewritten) =
             tag_class_field_ast::wrap_state_derived_with_tag_class_fields_ast(&result)
         {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
@@ -1,0 +1,162 @@
+//! Batched module-script (`.svelte.js` / `.svelte.ts`) rune/dev-mode
+//! tail passes.
+//!
+//! After the `$state*` runes are lowered, the module path ran a run of
+//! consecutive AST passes that each re-parsed the whole script through
+//! `ast_rewrite::rewrite_once`:
+//!
+//!   * `$effect.*(...)` callee lowering (always)
+//!   * `===` / `!==` → `$.strict_equals(...)` (dev)
+//!   * `console.METHOD(...)` → `...$.log_if_contains_state(...)` wrap (dev)
+//!   * `$.state` / `$.derived` / `$.proxy` declarator `$.tag(...)` wrap (dev)
+//!
+//! All four share a source type (`ts().with_module(true)` / `mjs()`) and
+//! `ParseOptions::default()`, and target lexically disjoint syntax
+//! (call callees / binary operators / console calls / declarator inits),
+//! so one parse per fixed-point iteration can feed every collector and a
+//! single innermost-first splice apply the union of their edits.
+//!
+//! The strict-equals and console collectors are "leaf only" (they defer
+//! a node whose operands / arguments still hold an unrewritten inner
+//! occurrence); driving them through the batched fixed point reproduces
+//! their standalone single-pass loops. The (legal but rare) case of one
+//! pass's target nested inside another's — e.g. `console.log(a === b)` or
+//! `let x = $.state(a === b)` — settles exactly as the equivalent
+//! sequential per-pass application did: the inner edit lands first, the
+//! next iteration re-parses and re-collects the settled outer node.
+
+use std::cell::RefCell;
+
+use oxc_allocator::Allocator;
+use oxc_parser::ParseOptions;
+use oxc_span::SourceType;
+
+use super::ast_rewrite;
+
+thread_local! {
+    static MODULE_DEV_TAIL_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+}
+
+/// Lower the module script's `$effect` runes and, in dev mode, its
+/// `strict_equals` / `console` / declarator-`tag` passes in a single
+/// batched parse. `dev` gates the three dev-only collectors exactly as
+/// the sequential call sites did. Returns `None` when nothing matched
+/// (no eligible marker, parse failure, or no edit actually landed), so
+/// the caller keeps its existing `String`.
+pub fn transform_module_dev_tail_ast(source: &str, dev: bool, is_ts: bool) -> Option<String> {
+    let bytes = source.as_bytes();
+
+    // Per-collector fast probes, mirroring each standalone pass's own
+    // early-out. A collector whose marker is absent from the source can
+    // never match — none of the passes introduce another's marker — so
+    // probing the original source is sound across fixed-point iterations.
+    let has_effect = memchr::memmem::find(bytes, b"$effect").is_some();
+    let has_strict = dev
+        && (memchr::memmem::find(bytes, b"===").is_some()
+            || memchr::memmem::find(bytes, b"!==").is_some());
+    let has_console = dev && memchr::memmem::find(bytes, b"console.").is_some();
+    let has_tag = dev
+        && (memchr::memmem::find(bytes, b"$.state").is_some()
+            || memchr::memmem::find(bytes, b"$.derived").is_some()
+            || memchr::memmem::find(bytes, b"$.proxy").is_some());
+
+    if !has_effect && !has_strict && !has_console && !has_tag {
+        return None;
+    }
+
+    let source_type = if is_ts {
+        SourceType::ts().with_module(true)
+    } else {
+        SourceType::mjs()
+    };
+
+    ast_rewrite::rewrite_batched(
+        &MODULE_DEV_TAIL_ALLOC,
+        source,
+        source_type,
+        ParseOptions::default(),
+        |program, src| {
+            let mut edits = Vec::new();
+            if has_effect {
+                edits.extend(super::effect_rune_ast::collect_effect_rune_edits(program));
+            }
+            if has_strict {
+                edits.extend(super::strict_equals_ast::collect_strict_equals_edits(
+                    program, src,
+                ));
+            }
+            if has_console {
+                edits.extend(super::console_dev_ast::collect_console_edits(program, src));
+            }
+            if has_tag {
+                edits.extend(super::tag_declarator_ast::collect_tag_declarator_edits(
+                    program, src,
+                ));
+            }
+            edits
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_marker_is_none() {
+        assert!(transform_module_dev_tail_ast("let x = 1;", true, false).is_none());
+    }
+
+    #[test]
+    fn effect_runs_without_dev() {
+        let out = transform_module_dev_tail_ast("$effect(() => {});", false, false).unwrap();
+        assert_eq!(out, "$.user_effect(() => {});");
+    }
+
+    #[test]
+    fn dev_only_passes_skipped_without_dev() {
+        // `===` / `console.` / `$.state` only rewrite in dev mode.
+        assert!(transform_module_dev_tail_ast("a === b;", false, false).is_none());
+        assert!(transform_module_dev_tail_ast("console.log(x);", false, false).is_none());
+        assert!(transform_module_dev_tail_ast("let x = $.state(0);", false, false).is_none());
+    }
+
+    #[test]
+    fn mixed_disjoint_passes_all_apply_in_one_batch() {
+        let src = "$effect(() => {});\na === b;\nconsole.log(x);\nlet s = $.state(0);";
+        let out = transform_module_dev_tail_ast(src, true, false).unwrap();
+        assert!(out.contains("$.user_effect(() => {});"), "got: {out}");
+        assert!(out.contains("$.strict_equals(a, b);"), "got: {out}");
+        assert!(
+            out.contains("console.log(...$.log_if_contains_state(\"log\", x));"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("let s = $.tag($.state(0), 's');"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn nested_cross_pass_fully_settles() {
+        // strict-equals nested inside a console arg nested inside a state
+        // init: the batch must lower all three exactly as the sequential
+        // per-pass application did.
+        let out = transform_module_dev_tail_ast("let s = $.state(a === b);", true, false).unwrap();
+        assert_eq!(out, "let s = $.tag($.state($.strict_equals(a, b)), 's');");
+    }
+
+    #[test]
+    fn console_wrapping_uses_strict_rewritten_args() {
+        let out = transform_module_dev_tail_ast("console.log(a === b);", true, false).unwrap();
+        assert_eq!(
+            out,
+            "console.log(...$.log_if_contains_state(\"log\", $.strict_equals(a, b)));"
+        );
+    }
+
+    #[test]
+    fn rune_shaped_bytes_in_string_left_alone() {
+        assert!(transform_module_dev_tail_ast(r#"let s = "$effect(x)";"#, true, false).is_none());
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
@@ -15,89 +15,30 @@
 //! and template-literal `${...}` interpolation. The OXC parser knows
 //! about all of those — incorrect rewrites just can't happen.
 
-use std::cell::RefCell;
-
-use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
-use oxc_parser::ParseOptions;
-use oxc_span::{GetSpan, SourceType};
+use oxc_span::GetSpan;
 use oxc_syntax::operator::BinaryOperator;
 
-use super::ast_rewrite::{self, Edit};
-
-thread_local! {
-    /// Reuse one OXC allocator per thread across calls; matches the
-    /// pattern used by `ast_state_transform`. Reset between calls
-    /// (the allocator's drop runs in `transform_strict_equals_module_ast`).
-    static MODULE_STRICT_EQ_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
-}
-
-/// AST-based rewrite of `a === b` → `$.strict_equals(a, b)` and
-/// `a !== b` → `!$.strict_equals(a, b)`. Returns `None` if no rewrite
-/// would happen (no `===` / `!==` in the source, or parse failure) so
-/// the caller can keep its `String` allocation.
-///
-/// Designed for module scripts. For component instance scripts the
-/// rewrite already happens inside `ast_state_transform`.
-pub fn transform_strict_equals_module_ast(source: &str, is_ts: bool) -> Option<String> {
-    // Fast probe: no operators → no rewrite.
-    if !contains_strict_op(source) {
-        return None;
-    }
-
-    // Nested `(a === b) === c` needs the outer rewrite to use the
-    // *already-rewritten* inner operand text. The simplest correct
-    // strategy is fixed-point iteration: each pass only rewrites
-    // "leaf" strict-equals binaries (those whose operands no longer
-    // contain `===` / `!==`), then re-parses the result and repeats.
-    // Each iteration strictly reduces the operator count, so this
-    // terminates in O(max nesting depth) passes — typically 1.
-    let mut current: Option<String> = None;
-    loop {
-        let src = current.as_deref().unwrap_or(source);
-        if !contains_strict_op(src) {
-            break;
-        }
-        match single_pass(src, is_ts) {
-            None => break,
-            Some(rewritten) => current = Some(rewritten),
-        }
-    }
-    current
-}
+use super::ast_rewrite::Edit;
 
 fn contains_strict_op(s: &str) -> bool {
     memchr::memmem::find(s.as_bytes(), b"===").is_some()
         || memchr::memmem::find(s.as_bytes(), b"!==").is_some()
 }
 
-/// One parse + collect + apply cycle. Only rewrites strict-equals
-/// binaries whose operands don't *themselves* contain `===` / `!==`;
-/// outer rewrites are deferred to the next iteration so they see the
-/// rewritten inner text. Returns `None` when nothing changed.
-fn single_pass(source: &str, is_ts: bool) -> Option<String> {
-    let source_type = if is_ts {
-        SourceType::ts().with_module(true)
-    } else {
-        SourceType::mjs()
-    };
-    ast_rewrite::rewrite_once(
-        &MODULE_STRICT_EQ_ALLOC,
+/// Collect leaf strict-equals rewrites (`===` / `!==` whose operands
+/// don't themselves contain a strict operator) from a single parse.
+/// Nested cases resolve across fixed-point iterations — the batched
+/// module dev-tail driver drives that loop.
+pub(super) fn collect_strict_equals_edits(program: &Program<'_>, source: &str) -> Vec<Edit> {
+    let mut collector = StrictEqualsCollector {
         source,
-        source_type,
-        ParseOptions::default(),
-        false,
-        |program| {
-            let mut collector = StrictEqualsCollector {
-                source,
-                replacements: Vec::new(),
-            };
-            collector.visit_program(program);
-            collector.replacements
-        },
-    )
+        replacements: Vec::new(),
+    };
+    collector.visit_program(program);
+    collector.replacements
 }
 
 /// Per-call AST visitor: collects `(start, end, replacement_string)`
@@ -155,7 +96,53 @@ impl<'a, 'src> Visit<'a> for StrictEqualsCollector<'src> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
+    use oxc_allocator::Allocator;
+    use oxc_parser::ParseOptions;
+    use oxc_span::SourceType;
+
+    use super::super::ast_rewrite;
     use super::*;
+
+    thread_local! {
+        static TEST_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+    }
+
+    /// Drives `collect_strict_equals_edits` to a fixed point over its own
+    /// parse — mirrors how the batched module dev-tail driver folds it, but
+    /// for the strict-equals rewrite alone so these assertions stay scoped
+    /// to this pass. Each iteration rewrites only leaf binaries; the loop
+    /// re-parses so an outer `(a === b) === c` sees its rewritten operands.
+    fn transform_strict_equals_module_ast(source: &str, is_ts: bool) -> Option<String> {
+        if !contains_strict_op(source) {
+            return None;
+        }
+        let source_type = if is_ts {
+            SourceType::ts().with_module(true)
+        } else {
+            SourceType::mjs()
+        };
+        let mut current: Option<String> = None;
+        loop {
+            let src = current.as_deref().unwrap_or(source);
+            if !contains_strict_op(src) {
+                break;
+            }
+            match ast_rewrite::rewrite_once(
+                &TEST_ALLOC,
+                src,
+                source_type,
+                ParseOptions::default(),
+                false,
+                |program| collect_strict_equals_edits(program, src),
+            ) {
+                None => break,
+                Some(rewritten) => current = Some(rewritten),
+            }
+        }
+        current
+    }
 
     #[test]
     fn rewrites_strict_equality() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_declarator_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_declarator_ast.rs
@@ -67,14 +67,21 @@ pub fn wrap_state_derived_with_tag_declarators_ast(source: &str, is_ts: bool) ->
         },
         ParseOptions::default(),
         false,
-        |program| {
-            let mut replacements: Vec<Edit> = Vec::new();
-            for stmt in &program.body {
-                walk_statement_for_declarators(stmt, source, &mut replacements);
-            }
-            replacements
-        },
+        |program| collect_tag_declarator_edits(program, source),
     )
+}
+
+/// Collect `$.tag(...)` / `$.tag_proxy(...)` wraps for tag-eligible
+/// declarator initialisers from a single parse. Already-tagged inits
+/// are skipped, so this is idempotent and needs no fixed point of its
+/// own; the batched module dev-tail driver still folds it alongside the
+/// other collectors.
+pub(super) fn collect_tag_declarator_edits(program: &Program<'_>, source: &str) -> Vec<Edit> {
+    let mut replacements: Vec<Edit> = Vec::new();
+    for stmt in &program.body {
+        walk_statement_for_declarators(stmt, source, &mut replacements);
+    }
+    replacements
 }
 
 /// Recursive top-down walk that finds VariableDeclarations anywhere


### PR DESCRIPTION
## What

Stage-C of the client-script "string codegen → AST" cleanup (findings PR-B: `ast_rewrite` batching — next group). **Stacked on #1494 (stage-B)**; this branch merges `refactor/client-script-ast-stage-b`, so until #1494 lands the diff below includes its commit.

The module-script (`.svelte.js` / `.svelte.ts`) path lowered its `$effect` runes and — in dev mode — its `===`/`!==` → `$.strict_equals(...)`, `console.METHOD(...)` wrap, and `$.state`/`$.derived`/`$.proxy` declarator `$.tag(...)` wrap as **four consecutive AST passes**, each re-parsing the whole script through `ast_rewrite::rewrite_once`.

All four share a source type (`ts().with_module(true)` / `mjs()`) and `ParseOptions::default()` and target lexically disjoint syntax (call callees / binary operators / console calls / declarator inits), so one parse per fixed-point iteration now feeds every collector and a single innermost-first splice applies the union of their edits. The strict-equals and console **leaf** collectors, driven through the batched fixed point, reproduce their standalone single-pass loops; the (rare, legal) nested cross-pass shape — `console.log(a === b)`, `let x = $.state(a === b)` — settles exactly as the sequential per-pass application did (inner edit first, outer re-collected after re-parse).

- New `module_dev_tail_ast::transform_module_dev_tail_ast(source, dev, is_ts)` entry point replaces the four consecutive call sites in `transform_module_script_runes` (`client/mod.rs`). `dev` gates the three dev-only collectors exactly as the sequential sites did.
- Each pass keeps a `collect_*_edits` collector as the shared production surface. The `strict_equals` `transform_*` / `single_pass` wrapper had no remaining production caller once its module-path site moved into the batch, so it relocates into `#[cfg(test)]` (mirroring stage-B's snapshot wrapper); the `effect_rune` / `console_dev` / `tag_declarator` wrappers stay — they're still called from the instance / legacy / class paths.
- `tag_class_field_ast` (different `SourceType`/`ParseOptions`) and the residual `wrap_state_derived_with_tag` text fallback stay after the batch, unchanged.

Net effect: **4 parses → 1 parse** on every dev-mode `.svelte.js` compile touching these runes (and 1 parse for `$effect` alone in non-dev), reusing the stage-B batching driver.

## Byte-neutrality

A feature-gated shadow comparator (`shadow_dev_tail`, scaffolding only — removed from the final commit) re-ran the previous four-sequential-pass pipeline alongside the batched one on **every** `transform_module_dev_tail_ast` call and `assert_eq!`-ed equality:

- `runtime` (runes 999 / legacy 1206 / hydration 80 / browser 32): **19/19**
- `ssr`: **16/16**
- `compiler_fixtures` (snapshot): **17/17**
- `compatibility_report`: **15/15**
- synthetic cases (comparator active): mixed disjoint passes, nested cross-pass `$.state(a === b)`, console-wraps-strict-rewritten-args, rune-shaped bytes in string literals

Zero divergences. Full corpus CSR/SSR byte-parity is enforced by CI.

## Verification (final code, comparator removed)

- `cargo test -p rsvelte_core --lib` → 1514 passed, 0 failed
- `cargo +1.97 clippy -p rsvelte_core --all-targets --all-features -- -D warnings` → clean
- `cargo fmt` clean

No changeset (refactor; output unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj