### PR TITLE
fix(parse): scan special-tag bodies with find_matching_bracket

### DIFF
--- a/.changeset/fix-parse-special-tag-bracket-scan.md
+++ b/.changeset/fix-parse-special-tag-bracket-scan.md
@@ -1,0 +1,31 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): scan `{@html/@render/@const/@debug}` bodies with find_matching_bracket
+
+The `{@html}`, `{@render}`, `{@const}` and `{@debug}` special tags each carried
+their own bespoke brace-depth loop to locate the closing `}`. Those loops
+handled some JavaScript lexical contexts but not all — none skipped comments or
+regex literals, and `{@debug}` skipped nothing at all — so a `}` inside a
+comment or regex (and, for `{@debug}`, a string) terminated the tag early and
+mis-parsed the rest of the template. All four now route through the shared
+`find_matching_bracket`, which skips strings, template literals, comments, and
+regex literals exactly like upstream's `read_expression`. This brings several
+cases into line with the official compiler:
+
+- `{@html x /* } */ + y}` — brace in a block comment
+- `{@render foo(/}/g)}` — brace in a regex literal
+- `{@const re = /}/}` — brace in a regex literal
+- `{@debug foo /* } */}` — brace in a block comment
+
+The `{@const}` sequence-expression guard (`{@const a = b, c = d}` is rejected,
+`{@const a = (b, c)}` is allowed) is now derived from the parsed initializer's
+node type, mirroring upstream's `init.type === 'SequenceExpression'` check,
+instead of a top-level comma byte-scan. This stops a comma inside a regex,
+string, or comment (e.g. `{@const x = /a,b/.test(y)}`) from being mistaken for a
+sequence separator and wrongly rejected.
+
+No change to the output of any existing fixture; the parser now additionally
+accepts the inputs the official compiler accepts. Net ~160 fewer lines in
+`state/tag.rs`.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1892,129 +1892,15 @@ impl Parser<'_> {
 
         match keyword.as_str() {
             "html" => {
+                // Locate the closing `}` with the JS-lexical-aware scanner so
+                // braces inside strings, template literals, comments, and regex
+                // literals (e.g. `{@html x /* } */ + y}`) do not terminate the
+                // tag early. Mirrors upstream `read_expression`, which parses
+                // with acorn and skips over the same lexical contexts.
                 let expr_start = self.index;
-
-                // Track bracket depth to handle nested braces in expressions
-                // e.g., {@html `foo: ${foo}`} - need to skip the inner `}` in template literal
-                let mut depth: u32 = 1; // We're already inside the opening `{` of the tag
-                while self.index < self.bytes.len() {
-                    let ch = self.bytes[self.index];
-                    match ch {
-                        b'{' => {
-                            depth += 1;
-                            self.index += 1;
-                        }
-                        b'}' => {
-                            depth -= 1;
-                            if depth == 0 {
-                                break;
-                            }
-                            self.index += 1;
-                        }
-                        // Skip string literals to avoid counting braces inside strings
-                        b'"' | b'\'' => {
-                            let quote = ch;
-                            self.index += 1;
-                            while self.index < self.bytes.len() {
-                                let c = self.bytes[self.index];
-                                if c == b'\\' {
-                                    self.index += 2; // skip escape sequence
-                                } else if c == quote {
-                                    break;
-                                } else if c < 0x80 {
-                                    self.index += 1;
-                                } else {
-                                    self.advance();
-                                }
-                            }
-                            if self.index < self.bytes.len() {
-                                self.index += 1; // consume closing quote
-                            }
-                        }
-                        // Skip template literals - they can contain ${...}
-                        b'`' => {
-                            self.index += 1; // consume opening backtick
-                            let mut escaped = false;
-                            while self.index < self.bytes.len() {
-                                let c = self.bytes[self.index];
-                                if escaped {
-                                    escaped = false;
-                                    self.advance();
-                                } else if c == b'\\' {
-                                    escaped = true;
-                                    self.index += 1;
-                                } else if c == b'$'
-                                    && self.index + 1 < self.bytes.len()
-                                    && self.bytes[self.index + 1] == b'{'
-                                {
-                                    // Template literal expression ${...}
-                                    self.index += 2; // consume '${'
-                                    let mut template_depth: u32 = 1;
-                                    while self.index < self.bytes.len() && template_depth > 0 {
-                                        match self.bytes[self.index] {
-                                            b'{' => {
-                                                template_depth += 1;
-                                                self.index += 1;
-                                            }
-                                            b'}' => {
-                                                template_depth -= 1;
-                                                self.index += 1;
-                                            }
-                                            b'`' => {
-                                                // Nested template literal - skip it
-                                                self.index += 1;
-                                                while self.index < self.bytes.len() {
-                                                    let nc = self.bytes[self.index];
-                                                    if nc == b'\\' {
-                                                        self.index += 2;
-                                                    } else if nc == b'`' {
-                                                        self.index += 1;
-                                                        break;
-                                                    } else if nc < 0x80 {
-                                                        self.index += 1;
-                                                    } else {
-                                                        self.advance();
-                                                    }
-                                                }
-                                            }
-                                            b'"' | b'\'' => {
-                                                // Skip strings inside template expression
-                                                let q = self.bytes[self.index];
-                                                self.index += 1;
-                                                while self.index < self.bytes.len() {
-                                                    let sc = self.bytes[self.index];
-                                                    if sc == b'\\' {
-                                                        self.index += 2;
-                                                    } else if sc == q {
-                                                        self.index += 1;
-                                                        break;
-                                                    } else if sc < 0x80 {
-                                                        self.index += 1;
-                                                    } else {
-                                                        self.advance();
-                                                    }
-                                                }
-                                            }
-                                            b if b < 0x80 => self.index += 1,
-                                            _ => self.advance(),
-                                        }
-                                    }
-                                } else if c == b'`' {
-                                    break;
-                                } else if c < 0x80 {
-                                    self.index += 1;
-                                } else {
-                                    self.advance();
-                                }
-                            }
-                            if self.index < self.bytes.len() {
-                                self.index += 1; // consume closing backtick
-                            }
-                        }
-                        b if b < 0x80 => self.index += 1,
-                        _ => self.advance(),
-                    }
-                }
+                let end = find_matching_bracket(self.source, expr_start, '{')
+                    .unwrap_or(self.source.len());
+                self.index = end;
                 let expr_content = &self.source[expr_start..self.index];
                 self.advance(); // consume '}'
 
@@ -2030,43 +1916,14 @@ impl Parser<'_> {
             }
             "render" => {
                 // {@render snippet(...)}
+                // Locate the closing `}` with the JS-lexical-aware scanner so
+                // braces inside strings, comments, and regex literals (e.g.
+                // `{@render foo(/}/g)}`) do not terminate the tag early. Mirrors
+                // upstream `read_expression`.
                 let expr_start = self.index;
-
-                // Track bracket depth to handle nested braces in expressions
-                // e.g., {@render foo({ count })} - need to skip the inner `}` of the object
-                let mut depth = 1; // We're already inside the opening `{` of the tag
-                while !self.is_eof() {
-                    let ch = self.current_char();
-                    match ch {
-                        '{' => depth += 1,
-                        '}' => {
-                            depth -= 1;
-                            if depth == 0 {
-                                break;
-                            }
-                        }
-                        // Skip string literals to avoid counting braces inside strings
-                        '"' | '\'' | '`' => {
-                            let quote = ch;
-                            self.advance();
-                            let mut escaped = false;
-                            while !self.is_eof() {
-                                let c = self.current_char();
-                                if escaped {
-                                    escaped = false;
-                                } else if c == '\\' {
-                                    escaped = true;
-                                } else if c == quote {
-                                    break;
-                                }
-                                self.advance();
-                            }
-                        }
-                        _ => {}
-                    }
-                    self.advance();
-                }
-
+                let end = find_matching_bracket(self.source, expr_start, '{')
+                    .unwrap_or(self.source.len());
+                self.index = end;
                 let expr_content = &self.source[expr_start..self.index];
                 self.advance(); // consume '}'
 
@@ -2089,61 +1946,29 @@ impl Parser<'_> {
             }
             "const" => {
                 // {@const foo = bar}
-                // Note: Must track brace depth for destructuring patterns like { handler } = obj
+                // Locate the closing `}` with the JS-lexical-aware scanner so
+                // braces inside strings, comments, and regex literals (e.g.
+                // `{@const re = /}/}`) do not terminate the tag early, and
+                // destructuring patterns like `{ handler } = obj` nest correctly.
                 self.skip_whitespace();
                 let expr_start = self.index;
-                let mut brace_depth = 0;
-                let mut in_string = false;
-                let mut string_char = '\0';
-                let mut prev_char = '\0';
-
-                while !self.is_eof() {
-                    let c = self.current_char();
-
-                    if in_string {
-                        // Handle escape sequences - backslash escapes the next char
-                        if c == string_char && prev_char != '\\' {
-                            in_string = false;
-                        }
-                        prev_char = c;
-                        self.advance();
-                        continue;
-                    }
-
-                    if c == '"' || c == '\'' || c == '`' {
-                        in_string = true;
-                        string_char = c;
-                        prev_char = c;
-                        self.advance();
-                        continue;
-                    }
-
-                    if c == '{' {
-                        brace_depth += 1;
-                    } else if c == '}' {
-                        if brace_depth == 0 {
-                            // Found the closing brace of the @const tag
-                            break;
-                        }
-                        brace_depth -= 1;
-                    }
-                    prev_char = c;
-                    self.advance();
-                }
+                let end = find_matching_bracket(self.source, expr_start, '{')
+                    .unwrap_or(self.source.len());
+                self.index = end;
                 let expr_content = &self.source[expr_start..self.index];
                 let expr_end = self.index;
                 self.advance(); // consume '}'
 
-                // Check for sequence expression (multiple declarations with comma)
-                // Parse the expression and check if it's a sequence expression
+                // Locate the top-level assignment `=` that splits the pattern
+                // from the initializer. Scan bytes (not a `Vec<char>`):
+                // `first_equals` is later used as a byte index to slice
+                // `trimmed`, so a character index would corrupt a `{@const}`
+                // whose LHS has a multi-byte character (H-131). Every token
+                // examined here is ASCII. A `=` can only appear before the
+                // assignment operator inside a bracketed destructuring default
+                // (depth > 0) or a string, both of which are skipped here, so
+                // the first depth-0 `=` is the assignment.
                 let trimmed = expr_content.trim();
-
-                // Simple check: if there's a comma at top level (outside parentheses/brackets),
-                // and not part of a single assignment, it's invalid
-                // Scan bytes (not a `Vec<char>`): `first_equals` is later used as
-                // a byte index to slice `trimmed`, so a character index would
-                // corrupt a `{@const}` whose LHS has a multi-byte character
-                // (H-131). Every token examined here is ASCII.
                 let mut depth = 0i32;
                 let mut in_string = false;
                 let mut string_char = 0u8;
@@ -2172,7 +1997,7 @@ impl Parser<'_> {
                         depth += 1;
                     } else if c == b')' || c == b']' || c == b'}' {
                         depth -= 1;
-                    } else if c == b'=' && first_equals.is_none() && depth == 0 {
+                    } else if c == b'=' && depth == 0 {
                         // Check it's not ==, ===, !=, !==, <=, >=, =>
                         let next = bytes.get(i + 1).copied().unwrap_or(0);
                         let prev = if i > 0 { bytes[i - 1] } else { 0 };
@@ -2183,15 +2008,7 @@ impl Parser<'_> {
                             && prev != b'>'
                         {
                             first_equals = Some(i);
-                        }
-                    } else if c == b',' && depth == 0 {
-                        // Found top-level comma after the first assignment - this is a sequence expression
-                        if first_equals.is_some() {
-                            return Err(crate::error::ParseError::svelte(
-                                "const_tag_invalid_expression",
-                                "{@const ...} must consist of a single variable declaration",
-                                (expr_start, expr_end),
-                            ));
+                            break;
                         }
                     }
                     i += 1;
@@ -2241,6 +2058,32 @@ impl Parser<'_> {
                         + (trimmed[eq_idx + 1..].len() - trimmed[eq_idx + 1..].trim_start().len());
                     let init_expr = self.parse_js_expression(init_str, init_offset);
 
+                    // Reject a sequence-expression initializer, mirroring
+                    // upstream: `{@const a = (b, c)}` is allowed but
+                    // `{@const a = b, c = d}` is not. A parenthesized sequence
+                    // is permitted, detected (as upstream does) by a `(`
+                    // between the `=` and the parsed initializer's start.
+                    // Deriving this from the parsed `init` — rather than a
+                    // top-level comma byte-scan — keeps commas inside strings,
+                    // comments, and regex literals (e.g. `/a,b/`) from being
+                    // mistaken for a sequence separator.
+                    if init_expr.node_type() == Some("SequenceExpression") {
+                        let paren_before = init_expr
+                            .start()
+                            .map(|s| self.source[init_offset..s as usize].contains('('))
+                            .unwrap_or(false);
+                        if !paren_before {
+                            let err_start =
+                                init_expr.start().map(|s| s as usize).unwrap_or(init_offset);
+                            let err_end = init_expr.end().map(|e| e as usize).unwrap_or(expr_end);
+                            return Err(crate::error::ParseError::svelte(
+                                "const_tag_invalid_expression",
+                                "{@const ...} must consist of a single variable declaration",
+                                (err_start, err_end),
+                            ));
+                        }
+                    }
+
                     // Position just past the initializer text (including any
                     // wrapping parens) but before trailing whitespace — mirrors
                     // upstream's `declarator_end = parser.index` captured right
@@ -2281,22 +2124,16 @@ impl Parser<'_> {
                     // {@debug} - no identifiers (debug all)
                     Vec::new()
                 } else {
-                    // Read expression content up to closing brace
+                    // Read expression content up to the closing brace with the
+                    // JS-lexical-aware scanner so braces inside strings,
+                    // comments, and regex literals (e.g. `{@debug obj["}"]}`)
+                    // do not terminate the tag early. Mirrors upstream
+                    // `read_expression`.
                     let expr_start = self.index;
-                    let mut depth = 1;
-                    while !self.is_eof() && depth > 0 {
-                        let ch = self.current_char();
-                        match ch {
-                            '{' => depth += 1,
-                            '}' => depth -= 1,
-                            _ => {}
-                        }
-                        if depth > 0 {
-                            self.advance();
-                        }
-                    }
-                    let expr_end = self.index;
-                    let expr_content = self.source[expr_start..expr_end].trim();
+                    let end = find_matching_bracket(self.source, expr_start, '{')
+                        .unwrap_or(self.source.len());
+                    self.index = end;
+                    let expr_content = self.source[expr_start..end].trim();
 
                     if expr_content.is_empty() {
                         Vec::new()

--- a/crates/rsvelte_core/tests/special_tag_bracket_scan.rs
+++ b/crates/rsvelte_core/tests/special_tag_bracket_scan.rs
@@ -1,0 +1,136 @@
+//! Regression tests for the `{@html}` / `{@render}` / `{@const}` / `{@debug}`
+//! special-tag scanners.
+//!
+//! These tags used bespoke brace-depth loops to locate their closing `}`. The
+//! loops handled some, but not all, JavaScript lexical contexts, so a brace
+//! inside a comment or a regex literal terminated the tag early. They are now
+//! routed through the shared `find_matching_bracket`, which skips strings,
+//! template literals, comments, and regex literals exactly like upstream's
+//! `read_expression`. Each case below is cross-checked against the official
+//! Svelte compiler.
+
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{ParseOptions, parse};
+
+fn ast_json(src: &str) -> serde_json::Value {
+    let ast = parse(src, ParseOptions::default()).expect("parse should succeed");
+    let s = with_serialize_arena(&ast.arena, || serde_json::to_string(&ast).unwrap());
+    serde_json::from_str(&s).unwrap()
+}
+
+/// Find the first node with `type == ty` and return its `end` offset.
+fn find_node_end(value: &serde_json::Value, ty: &str) -> Option<u64> {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.get("type").and_then(|t| t.as_str()) == Some(ty) {
+                return map.get("end").and_then(|e| e.as_u64());
+            }
+            map.values().find_map(|v| find_node_end(v, ty))
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(|it| find_node_end(it, ty)),
+        _ => None,
+    }
+}
+
+fn assert_tag_spans_whole(src: &str, ty: &str) {
+    let json = ast_json(src);
+    let end =
+        find_node_end(&json, ty).unwrap_or_else(|| panic!("no {ty} node parsed from {src:?}"));
+    assert_eq!(
+        end as usize,
+        src.len(),
+        "{ty} should end at the trailing `}}` (src {src:?})"
+    );
+}
+
+#[test]
+fn html_tag_comment_with_brace() {
+    // The `}` inside the block comment must not close the tag early.
+    assert_tag_spans_whole("{@html x /* } */ + y}", "HtmlTag");
+}
+
+#[test]
+fn html_tag_string_with_brace() {
+    assert_tag_spans_whole(r#"{@html obj["}"]}"#, "HtmlTag");
+}
+
+#[test]
+fn render_tag_regex_with_brace() {
+    // `/}/g` is a regex literal, not a division, so its `}` is not the closer.
+    assert_tag_spans_whole("{@render foo(/}/g)}", "RenderTag");
+}
+
+#[test]
+fn render_tag_string_with_brace() {
+    assert_tag_spans_whole(r#"{@render foo(obj["}"])}"#, "RenderTag");
+}
+
+#[test]
+fn const_tag_regex_with_brace() {
+    assert_tag_spans_whole("{@const re = /}/}", "ConstTag");
+}
+
+#[test]
+fn const_tag_comment_with_brace() {
+    assert_tag_spans_whole("{@const x = a /* } */}", "ConstTag");
+}
+
+#[test]
+fn debug_tag_comment_with_brace() {
+    // Official accepts this: `foo` is an identifier and the comment is dropped.
+    assert_tag_spans_whole("{@debug foo /* } */}", "DebugTag");
+}
+
+#[test]
+fn debug_tag_string_stops_at_real_close() {
+    // The `}` inside the string must not close the tag; the trailing `X` stays a
+    // separate text node, so the DebugTag ends before it.
+    let src = r#"{@debug a["}"]}X"#;
+    let json = ast_json(src);
+    let end = find_node_end(&json, "DebugTag").expect("DebugTag");
+    assert_eq!(end as usize, src.len() - 1, "DebugTag must end before `X`");
+}
+
+// ---- {@const} sequence-expression detection ---------------------------------
+// A comma at the top level of the initializer means a sequence expression, which
+// upstream rejects — unless the whole thing is wrapped in parentheses. Detecting
+// this from the parsed initializer (rather than a byte-level comma scan) keeps
+// commas inside regex / string / comment literals from being mistaken for a
+// sequence separator.
+
+fn parse_ok(src: &str) -> bool {
+    parse(src, ParseOptions::default()).is_ok()
+}
+
+fn parse_err_code(src: &str) -> Option<String> {
+    match parse(src, ParseOptions::default()) {
+        Ok(_) => None,
+        Err(e) => Some(format!("{e:?}")),
+    }
+}
+
+#[test]
+fn const_tag_regex_comma_is_not_a_sequence() {
+    // `/a,b/` contains a comma but is a single regex literal — must not error.
+    assert!(
+        parse_ok("{@const x = /a,b/.test(y)}"),
+        "regex comma wrongly treated as a sequence separator"
+    );
+}
+
+#[test]
+fn const_tag_parenthesized_sequence_is_allowed() {
+    assert!(
+        parse_ok("{@const a = (b, c)}"),
+        "parenthesized sequence should be allowed"
+    );
+}
+
+#[test]
+fn const_tag_bare_sequence_is_rejected() {
+    let code = parse_err_code("{@const a = b, c = d}").expect("bare sequence must error");
+    assert!(
+        code.contains("const_tag_invalid_expression"),
+        "expected const_tag_invalid_expression, got {code}"
+    );
+}


### PR DESCRIPTION
## What

The `{@html}`, `{@render}`, `{@const}` and `{@debug}` special tags each carried their own ~200-line bespoke brace-depth loop to locate the closing `}`. Those loops handled some JavaScript lexical contexts but not all — none skipped comments or regex literals, and `{@debug}` skipped nothing at all. A `}` inside a comment or regex (and, for `{@debug}`, a string) therefore terminated the tag early and mis-parsed the rest of the template.

All four now route through the shared `find_matching_bracket`, which skips strings, template literals, comments, and regex literals exactly like upstream's `read_expression` — the same helper the `ExpressionTag` / `{#if}` / `{#each}` / `{#key}` paths in this file already use.

The `{@const}` sequence-expression guard (`{@const a = b, c = d}` rejected, `{@const a = (b, c)}` allowed) is now derived from the parsed initializer's node type — mirroring upstream's `init.type === 'SequenceExpression'` check — instead of a top-level comma byte-scan, so a comma inside a regex/string/comment is no longer mistaken for a sequence separator.

## Behavior brought into line with official Svelte

Each case below was cross-checked against `submodules/svelte`:

- `{@html x /* } */ + y}` — brace in a block comment
- `{@render foo(/}/g)}` — brace in a regex literal
- `{@const re = /}/}` — brace in a regex literal
- `{@const x = /a,b/.test(y)}` — comma in a regex (previously wrongly rejected)
- `{@debug foo /* } */}` — brace in a block comment

No existing fixture output changes; the parser now additionally accepts the inputs the official compiler accepts. Net ~160 fewer lines in `state/tag.rs`.

## Tests

- New `crates/rsvelte_core/tests/special_tag_bracket_scan.rs` (11 cases, each cross-checked against the official compiler).
- `cargo nextest run -p rsvelte_core --test parser_fixtures --test compiler_errors --test compiler_fixtures --test runtime --test ssr --test special_tag_bracket_scan` → 96/96 pass.
- `cargo +1.97 clippy -p rsvelte_core --all-targets --all-features -- -D warnings` clean; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsxpnJUC4u4YN3PwB98cj