### PR TITLE
fix(analyze): track directive and declaration metadata

### DIFF
--- a/.changeset/fix-analyzer-directive-metadata.md
+++ b/.changeset/fix-analyzer-directive-metadata.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyze): preserve function, class, rest-prop, and directive binding metadata

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4711,12 +4711,24 @@ mod tests {
     import Widget, { named as Alias } from './Widget.svelte';
     import * as Namespace from './namespace';
     let count = 0;
+    let { ...rest } = $props();
+    function handle_click() {}
+    class Controller {}
 </script>
 <Widget />
 "#;
         let analysis = analyze(source);
 
-        for name in ["from_module", "Widget", "Alias", "Namespace", "count"] {
+        for name in [
+            "from_module",
+            "Widget",
+            "Alias",
+            "Namespace",
+            "count",
+            "rest",
+            "handle_click",
+            "Controller",
+        ] {
             let binding = analysis
                 .root
                 .bindings
@@ -4726,6 +4738,41 @@ mod tests {
             assert_eq!(
                 binding.declaration_start,
                 Some(source.find(name).unwrap() as u32)
+            );
+        }
+    }
+
+    #[test]
+    fn directive_names_and_spreads_are_template_references() {
+        let source = r#"<script>
+    import { slide } from 'svelte/transition';
+    import { flip } from 'svelte/animate';
+    import action from './action';
+    let { ...rest } = $props();
+</script>
+<div use:action transition:slide {...rest}></div>
+{#each [1] as item (item)}
+    <div animate:flip>{item}</div>
+{/each}
+"#;
+        let analysis = analyze(source);
+
+        for name in ["action", "slide", "rest", "flip"] {
+            let binding = analysis
+                .root
+                .bindings
+                .iter()
+                .find(|binding| binding.name == name)
+                .unwrap_or_else(|| panic!("missing binding {name}"));
+            let start = source.rfind(name).unwrap() as u32;
+            assert!(
+                binding.references.iter().any(|reference| {
+                    reference.start == start
+                        && reference.end == start + name.len() as u32
+                        && reference.is_template_reference
+                }),
+                "missing template reference for {name}: {:?}",
+                binding.references
             );
         }
     }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4778,6 +4778,77 @@ mod tests {
     }
 
     #[test]
+    fn transition_directive_with_modifier_reference_span_is_the_name_only() {
+        // Regression: `name_loc` on Transition/In/Out/Animate directives spans the
+        // *whole* raw attribute token (keyword + name + `|modifier`s), so the
+        // reference span must be derived from `name_loc.start + prefix_len`, not
+        // from `name_loc.end` (which would land inside a trailing modifier).
+        let source = r#"<script>
+    import { fade } from 'svelte/transition';
+</script>
+<div transition:fade|local></div>
+"#;
+        let analysis = analyze(source);
+        let binding = analysis
+            .root
+            .bindings
+            .iter()
+            .find(|binding| binding.name == "fade")
+            .unwrap();
+        let expected_start = source.rfind("fade").unwrap() as u32;
+        assert!(
+            binding.references.iter().any(|reference| {
+                reference.start == expected_start
+                    && reference.end == expected_start + "fade".len() as u32
+                    && reference.is_template_reference
+            }),
+            "expected a template reference exactly spanning 'fade', got: {:?}",
+            binding.references
+        );
+    }
+
+    #[test]
+    fn directive_name_is_referenced_even_without_expression_loc() {
+        // Regression: the real `compile()` entry point (`parse_component` in
+        // compiler/mod.rs) always parses with `skip_expression_loc: true`, so
+        // directive-name reference tracking must not be gated on `name_loc`
+        // being `Some` — otherwise `use:`/`transition:`/`animate:`-only usages
+        // are invisible to `non_reactive_update` / unused-`export let` checks
+        // in production compiles.
+        let source = r#"<script>
+    let count = $state(0);
+</script>
+<div use:count></div>
+"#;
+        let mut ast = parse(
+            source,
+            ParseOptions {
+                defer_script_parse: true,
+                skip_expression_loc: true,
+                ..ParseOptions::default()
+            },
+        )
+        .unwrap();
+        let _guard = unsafe { SerializeArenaGuard::new(&ast.arena as *const _) };
+        let analysis = analyze_component(&mut ast, source, &CompileOptions::default()).unwrap();
+        let binding = analysis
+            .root
+            .bindings
+            .iter()
+            .find(|binding| binding.name == "count")
+            .unwrap();
+        assert!(binding.has_direct_template_read);
+        assert!(
+            binding
+                .references
+                .iter()
+                .any(|reference| reference.is_template_reference),
+            "expected a template reference for `use:count`, got: {:?}",
+            binding.references
+        );
+    }
+
+    #[test]
     fn component_tag_is_a_template_binding_reference() {
         let source = "<script>import Widget from './Widget.svelte';</script>\n<Widget />";
         let analysis = analyze(source);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4829,6 +4829,8 @@ mod tests {
             },
         )
         .unwrap();
+        // SAFETY: `ast.arena` lives until the end of this function, which
+        // outlives `_guard`.
         let _guard = unsafe { SerializeArenaGuard::new(&ast.arena as *const _) };
         let analysis = analyze_component(&mut ast, source, &CompileOptions::default()).unwrap();
         let binding = analysis

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -2591,17 +2591,45 @@ impl<'a> ScopeBuilder<'a> {
                     self.process_template_expression(&attach_tag.expression);
                 }
                 Attribute::UseDirective(use_dir) => {
-                    self.reference_directive_name(&use_dir.name, use_dir.name_loc);
+                    // "use:".len() == 4
+                    self.reference_directive_name(
+                        &use_dir.name,
+                        use_dir.name_loc,
+                        4,
+                        use_dir.start,
+                        use_dir.end,
+                    );
                     // Process use: directive expression
                     if let Some(ref expression) = use_dir.expression {
                         self.process_template_expression(expression);
                     }
                 }
                 Attribute::TransitionDirective(transition_dir) => {
-                    self.reference_directive_name(&transition_dir.name, transition_dir.name_loc);
+                    // The written keyword ("transition:" / "in:" / "out:") isn't kept
+                    // verbatim on the node, but intro/outro uniquely identify it:
+                    // transition: => (true, true), in: => (true, false), out: => (false, true).
+                    let prefix_len = match (transition_dir.intro, transition_dir.outro) {
+                        (true, true) => 11, // "transition:"
+                        (true, false) => 3, // "in:"
+                        _ => 4,             // "out:"
+                    };
+                    self.reference_directive_name(
+                        &transition_dir.name,
+                        transition_dir.name_loc,
+                        prefix_len,
+                        transition_dir.start,
+                        transition_dir.end,
+                    );
                 }
                 Attribute::AnimateDirective(animate_dir) => {
-                    self.reference_directive_name(&animate_dir.name, animate_dir.name_loc);
+                    // "animate:".len() == 8
+                    self.reference_directive_name(
+                        &animate_dir.name,
+                        animate_dir.name_loc,
+                        8,
+                        animate_dir.start,
+                        animate_dir.end,
+                    );
                 }
                 Attribute::SpreadAttribute(spread) => {
                     // Process spread attribute expression
@@ -2612,20 +2640,46 @@ impl<'a> ScopeBuilder<'a> {
         }
     }
 
+    /// Register a `use:` / `transition:` / `in:` / `out:` / `animate:` directive
+    /// name as a template reference of the binding it resolves to.
+    ///
+    /// Corresponds to the `SvelteDirective` visitor in Svelte's `scope.js`
+    /// (`state.scope.reference(b.id(node.name.split('.')[0]), path)`), which
+    /// runs unconditionally — the reference must be recorded even when we
+    /// can't compute an exact source span for it (`name_loc` is `None` under
+    /// `skip_expression_loc`, the mode the real `compile()` entry point always
+    /// uses), otherwise `non_reactive_update` / unused-`export let` detection
+    /// silently stop seeing directive-only usages in production compiles.
+    ///
+    /// `prefix_len` is the byte length of the directive keyword the parser
+    /// stripped before `name` (`"use:"` / `"in:"` / `"out:"` / `"transition:"` /
+    /// `"animate:"`) — `name_loc` spans the *whole* raw attribute token
+    /// (keyword + name + any `|modifier`s), so the name's own start is
+    /// `name_loc.start + prefix_len`, not something derived from
+    /// `name_loc.end` (which would land inside a trailing modifier).
     fn reference_directive_name(
         &mut self,
         name: &str,
         name_loc: Option<crate::ast::span::SourceLocation>,
+        prefix_len: u32,
+        fallback_start: u32,
+        fallback_end: u32,
     ) {
         let root_name = name.split('.').next().unwrap_or(name);
         let Some(binding_idx) = self.find_binding_in_scope_chain(root_name) else {
             return;
         };
-        let Some(name_loc) = name_loc else {
-            return;
+        let (start, end) = match name_loc {
+            Some(name_loc) => {
+                let start = name_loc.start.character + prefix_len;
+                (start, start + root_name.len() as u32)
+            }
+            // No location info available (e.g. `skip_expression_loc`): fall back
+            // to the directive's own span rather than dropping the reference —
+            // the exact position only matters for diagnostics/tooling, but the
+            // reference's mere existence drives warning suppression.
+            None => (fallback_start, fallback_end),
         };
-        let start = name_loc.end.character.saturating_sub(name.len() as u32);
-        let end = start + root_name.len() as u32;
         let binding = &mut self.bindings[binding_idx];
         binding.add_reference(start, end, true, false, false);
         binding.has_direct_template_read = true;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -691,13 +691,14 @@ impl<'a> ScopeBuilder<'a> {
             } => {
                 if let Some(id_ref) = id {
                     let id_node = self.arena.get_js_node(*id_ref);
-                    if let JsNode::Identifier { name, .. } = id_node {
+                    if let JsNode::Identifier { name, start, .. } = id_node {
                         let idx = self.declare_binding(
                             name.to_string(),
                             BindingKind::Normal,
                             DeclarationKind::Function,
                         );
                         self.bindings[idx].initial_is_function = true;
+                        self.bindings[idx].declaration_start = Some(*start);
                     }
                 }
                 let params = *params;
@@ -733,12 +734,13 @@ impl<'a> ScopeBuilder<'a> {
             JsNode::ClassDeclaration { id, body, .. } => {
                 if let Some(id_ref) = id {
                     let id_node = self.arena.get_js_node(*id_ref);
-                    if let JsNode::Identifier { name, .. } = id_node {
-                        self.declare_binding(
+                    if let JsNode::Identifier { name, start, .. } = id_node {
+                        let idx = self.declare_binding(
                             name.to_string(),
                             BindingKind::Normal,
                             DeclarationKind::Let,
                         );
+                        self.bindings[idx].declaration_start = Some(*start);
                     }
                 }
                 // Process class body to find assignments in methods, getters, setters, etc.
@@ -1122,12 +1124,13 @@ impl<'a> ScopeBuilder<'a> {
                             if is_props_init {
                                 // For `let { ...rest } = $props()`, the rest binding must be RestProp
                                 let arg_node = self.arena.get_js_node(*argument);
-                                if let JsNode::Identifier { name, .. } = arg_node {
-                                    self.declare_binding(
+                                if let JsNode::Identifier { name, start, .. } = arg_node {
+                                    let idx = self.declare_binding(
                                         name.to_string(),
                                         BindingKind::RestProp,
                                         decl_kind,
                                     );
+                                    self.bindings[idx].declaration_start = Some(*start);
                                 } else {
                                     self.process_binding_pattern_typed(arg_node, None, decl_kind);
                                 }
@@ -1408,6 +1411,8 @@ impl<'a> ScopeBuilder<'a> {
                         self.declare_binding(name, BindingKind::Normal, DeclarationKind::Function);
                     // Mark as a true JS function (not a snippet block)
                     self.bindings[idx].initial_is_function = true;
+                    self.bindings[idx].declaration_start =
+                        Some(id.span.start + self.current_script_offset as u32);
                 }
                 // Create a new scope for the function body (non-porous: function_depth + 1)
                 let old_scope = self.push_function_scope();
@@ -1437,7 +1442,9 @@ impl<'a> ScopeBuilder<'a> {
                     // Class declarations use 'let' (not 'const') because class names
                     // are mutable bindings. This matches the official Svelte compiler:
                     // scope.declare(node.id, 'normal', 'let', node)
-                    self.declare_binding(name, BindingKind::Normal, DeclarationKind::Let);
+                    let idx = self.declare_binding(name, BindingKind::Normal, DeclarationKind::Let);
+                    self.bindings[idx].declaration_start =
+                        Some(id.span.start + self.current_script_offset as u32);
                 }
                 // Process class body to find assignments in methods, getters, setters, etc.
                 self.process_class_body(&class_decl.body);
@@ -2262,11 +2269,13 @@ impl<'a> ScopeBuilder<'a> {
                         // so that detect_store_subscriptions correctly identifies $props as
                         // a rune (not a store subscription).
                         if let BindingPattern::BindingIdentifier(ident) = &rest.argument {
-                            self.declare_binding(
+                            let idx = self.declare_binding(
                                 ident.name.to_string(),
                                 BindingKind::RestProp,
                                 decl_kind,
                             );
+                            self.bindings[idx].declaration_start =
+                                Some(ident.span.start + self.current_script_offset as u32);
                         } else {
                             self.process_binding_pattern(&rest.argument, &None, decl_kind);
                         }
@@ -2582,10 +2591,17 @@ impl<'a> ScopeBuilder<'a> {
                     self.process_template_expression(&attach_tag.expression);
                 }
                 Attribute::UseDirective(use_dir) => {
+                    self.reference_directive_name(&use_dir.name, use_dir.name_loc);
                     // Process use: directive expression
                     if let Some(ref expression) = use_dir.expression {
                         self.process_template_expression(expression);
                     }
+                }
+                Attribute::TransitionDirective(transition_dir) => {
+                    self.reference_directive_name(&transition_dir.name, transition_dir.name_loc);
+                }
+                Attribute::AnimateDirective(animate_dir) => {
+                    self.reference_directive_name(&animate_dir.name, animate_dir.name_loc);
                 }
                 Attribute::SpreadAttribute(spread) => {
                     // Process spread attribute expression
@@ -2594,6 +2610,25 @@ impl<'a> ScopeBuilder<'a> {
                 _ => {}
             }
         }
+    }
+
+    fn reference_directive_name(
+        &mut self,
+        name: &str,
+        name_loc: Option<crate::ast::span::SourceLocation>,
+    ) {
+        let root_name = name.split('.').next().unwrap_or(name);
+        let Some(binding_idx) = self.find_binding_in_scope_chain(root_name) else {
+            return;
+        };
+        let Some(name_loc) = name_loc else {
+            return;
+        };
+        let start = name_loc.end.character.saturating_sub(name.len() as u32);
+        let end = start + root_name.len() as u32;
+        let binding = &mut self.bindings[binding_idx];
+        binding.add_reference(start, end, true, false, false);
+        binding.has_direct_template_read = true;
     }
 
     /// Process a template expression (from attributes, event handlers, etc.) to track updates.


### PR DESCRIPTION
## Summary
- preserve component-relative declaration spans for function, class, and `$props()` rest bindings
- register `use:`, `transition:`, and `animate:` directive names as template references during scope creation
- cover declaration positions and directive/spread references with analyzer tests

## Validation
- `cargo fmt --all -- --check`
- `RUST_MIN_STACK=16777216 mise x rust@1.97.0 -- cargo test -p rsvelte_core --lib` (1520 passed, 1 ignored)
- `mise x rust@1.97.0 -- cargo clippy -p rsvelte_core --lib -- -D warnings`

AI tools were used to investigate, implement, and test this change. I reviewed the resulting code and verified it against the upstream Svelte scope implementation.