### PR TITLE
fix(fmt): preserve script width without indentation

### DIFF
--- a/.changeset/fix-fmt-script-width-no-indent.md
+++ b/.changeset/fix-fmt-script-width-no-indent.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): preserve full print width for `<script>` bodies when `svelteIndentScriptAndStyle` is disabled
+
+`format_script` always narrowed the configured `printWidth` by one indent
+level before formatting the `<script>` body, on the assumption that the body
+would subsequently be re-indented one level under the `<script>` tag. That
+assumption only holds when `svelteIndentScriptAndStyle` (default `true`) is
+enabled; with it disabled the body is spliced back in flush at column 0, so
+narrowing the width was wrong and caused lines that fit the real configured
+width to wrap unnecessarily. The width is now only narrowed when
+`indent_script_and_style` is `true`, matching the already-correct general
+pattern used by `format_nested_script` and the `<style>` formatting paths
+(`format_nested_style` / `collect_style_edit`), which derive the width
+narrowing from the body's actual indent rather than assuming a fixed one
+level.

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -104,18 +104,20 @@ pub(crate) fn format_script(
         )));
     }
 
-    // Format the body one indent level narrower than the configured width.
-    // The body is formatted at indent 0 here but then nested one level under
-    // `<script>` (`reindent_body` below), so a line that is exactly
-    // `printWidth` wide at indent 0 would overflow once indented. oxfmt formats
-    // the body already nested, so narrowing the width here matches its wrap
-    // decisions and keeps `<script>` bodies identical to oxfmt.
+    // When the body is indented, format it one indent level narrower than the
+    // configured width. A line that is exactly `printWidth` wide at indent 0
+    // would otherwise overflow once re-indented below. With
+    // `svelteIndentScriptAndStyle: false`, the body stays flush and retains the
+    // full configured width.
     let mut js = options.js.clone();
-    let nested_width = js
-        .line_width
-        .value()
-        .saturating_sub(js.indent_width.value() as u16);
-    js.line_width = oxc_formatter_core::LineWidth::try_from(nested_width).unwrap_or(js.line_width);
+    if options.indent_script_and_style {
+        let nested_width = js
+            .line_width
+            .value()
+            .saturating_sub(js.indent_width.value() as u16);
+        js.line_width =
+            oxc_formatter_core::LineWidth::try_from(nested_width).unwrap_or(js.line_width);
+    }
     let formatted = format_program(&allocator, &parser_ret.program, js, None)
         .print()
         .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?

--- a/crates/rsvelte_formatter/tests/options.rs
+++ b/crates/rsvelte_formatter/tests/options.rs
@@ -4,7 +4,9 @@
 //! default exactly the way oxfmt (`prettier-plugin-svelte`) does. See issue
 //! #1057.
 
-use rsvelte_formatter::{FormatOptions, SortOrderSpec, format};
+use rsvelte_formatter::{
+    FormatOptions, IndentWidth, JsFormatOptions, LineWidth, SortOrderSpec, format,
+};
 
 fn fmt(src: &str, opts: &FormatOptions) -> String {
     format(src, opts).expect("format ok")
@@ -91,6 +93,35 @@ fn indent_script_and_style_false_flushes_script_body() {
     };
     let out = fmt("<script>\n  const a = 1;\n</script>", &opts);
     assert_eq!(out, "<script>\nconst a = 1;\n</script>\n");
+}
+
+#[test]
+fn indent_script_and_style_false_keeps_full_print_width() {
+    let opts = FormatOptions {
+        js: JsFormatOptions {
+            indent_width: IndentWidth::try_from(4).expect("valid indent width"),
+            line_width: LineWidth::try_from(100).expect("valid line width"),
+            ..JsFormatOptions::default()
+        },
+        indent_script_and_style: false,
+        ..FormatOptions::default()
+    };
+    let src = r#"<script>
+const metrics = $derived.by(() => {
+    return {
+        recurring_amount:
+            overview.recurring_snapshot?.currencies?.[0]?.committed_monthly_equivalent_display ||
+            'No recurring base yet',
+    }
+})
+</script>"#;
+    let out = fmt(src, &opts);
+    assert!(
+        out.contains(
+            "overview.recurring_snapshot?.currencies?.[0]?.committed_monthly_equivalent_display ||"
+        ),
+        "script body should retain the full configured line width:\n{out}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- retain the full configured `printWidth` when `svelteIndentScriptAndStyle` is disabled
- keep the existing one-indent width adjustment when script/style indentation is enabled
- add a regression test using the 100-column, 4-space configuration that exposed the unnecessary wrap

## Validation

- `mise x rust@1.97.0 -- cargo fmt --all -- --check`
- `mise x rust@1.97.0 -- cargo test -p rsvelte_formatter`
- `mise x rust@1.97.0 -- cargo clippy -p rsvelte_formatter --all-targets -- -D warnings`

AI assistance was used to investigate the reproduction and prepare this change. I reviewed the diff and verified the formatter behavior and test results.