### PR TITLE
fix(analyzer): visit special events and parameter defaults

### DIFF
--- a/.changeset/fix-analyze-special-events-and-param-defaults.md
+++ b/.changeset/fix-analyze-special-events-and-param-defaults.md
@@ -1,0 +1,26 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyzer): visit special events and parameter defaults
+
+Two analyzer gaps left references unrecorded, which could feed incorrect
+warnings/eliminations downstream:
+
+- **`on:` directives on `<svelte:window>` / `<svelte:document>` / `<svelte:body>`**
+  were parsed but never walked, so an expression like
+  `<svelte:window on:keydown={handle_keydown} />` never recorded a reference to
+  `handle_keydown`. These special elements now route their `on:` directives
+  through the same `on_directive` visitor regular elements use, matching the
+  official compiler's generic `context.next()` walk in `SvelteWindow.js` /
+  `SvelteDocument.js` / `SvelteBody.js`.
+- **Function/arrow parameter patterns** (`function f(a, {b} = c, [...d]) {}`)
+  were never visited at all, so identifiers referenced only in a default value
+  — e.g. a store subscription in `function goto_page(page = $search_params.page) {}`
+  — were invisible to the analyzer. `FunctionDeclaration` / `FunctionExpression`
+  / `ArrowFunctionExpression` now walk `params` through the existing generic
+  typed walker (`walk_js_node_typed`) before the body, mirroring upstream's
+  `context.next()` over the whole function node. This also restores the
+  self-reference every other declaration site already gets (see
+  `variable_declarator.rs`), which `export_let_unused`'s "more than one
+  reference" heuristic depends on for other binding kinds.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4750,6 +4750,46 @@ mod tests {
     }
 
     #[test]
+    fn legacy_special_element_event_is_a_template_binding_reference() {
+        let source = "<svelte:window on:keydown={handle_keydown} />\n<script>function handle_keydown() {}</script>";
+        let analysis = analyze(source);
+        let binding = analysis
+            .root
+            .bindings
+            .iter()
+            .find(|binding| binding.name == "handle_keydown")
+            .expect("missing handler binding");
+        let start = source.find("handle_keydown").unwrap() as u32;
+
+        assert!(binding.references.iter().any(|reference| {
+            reference.start == start
+                && reference.end == start + "handle_keydown".len() as u32
+                && reference.is_template_reference
+        }));
+    }
+
+    #[test]
+    fn function_parameter_default_records_store_subscription_reference() {
+        let source = r"<script>
+import { writable } from 'svelte/store';
+const search_params = writable({ page: 1 });
+function goto_page(page = $search_params.page) {}
+</script>";
+        let analysis = analyze(source);
+        let binding = analysis
+            .root
+            .bindings
+            .iter()
+            .find(|binding| binding.name == "$search_params")
+            .expect("missing store subscription binding");
+        let start = source.find("$search_params").unwrap() as u32;
+
+        assert!(binding.references.iter().any(|reference| {
+            reference.start == start && reference.end == start + "$search_params".len() as u32
+        }));
+    }
+
+    #[test]
     fn test_order_reactive_statements_simple() {
         // Test case: $: b = a + 1; $: a = 1;
         // Expected order: a first, then b

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4790,6 +4790,39 @@ function goto_page(page = $search_params.page) {}
     }
 
     #[test]
+    fn function_parameter_bindings_record_declaration_self_reference() {
+        // Every declared binding (VariableDeclarator ids, import specifiers, ...)
+        // gets a reference recorded at its own declaration site — see
+        // `variable_declarator.rs`'s `walk_js_node_typed(id_node, ...)` calls and the
+        // `export_let_unused` "more than 1 reference means used beyond the
+        // declaration" heuristic in this file, which depends on that self-reference
+        // always being present. Function/arrow parameters (bare, destructured object,
+        // destructured array) must get the same self-reference, matching the official
+        // compiler's `context.next()` walk over `node.params` in
+        // `2-analyze/visitors/{FunctionDeclaration,FunctionExpression,ArrowFunctionExpression}.js`.
+        let source = "<script>\nfunction f(aa, {bb}, [cc]) {}\n</script>";
+        let analysis = analyze(source);
+
+        for name in ["aa", "bb", "cc"] {
+            let binding = analysis
+                .root
+                .bindings
+                .iter()
+                .find(|binding| binding.name == name)
+                .unwrap_or_else(|| panic!("missing binding {name}"));
+            let start = source.find(name).unwrap() as u32;
+            assert!(
+                binding
+                    .references
+                    .iter()
+                    .any(|reference| reference.start == start),
+                "expected a self-reference at the declaration site of `{name}`, got {:?}",
+                binding.references
+            );
+        }
+    }
+
+    #[test]
     fn test_order_reactive_statements_simple() {
         // Test case: $: b = a + 1; $: a = 1;
         // Expected order: a first, then b

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/function_declaration.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/function_declaration.rs
@@ -5,13 +5,17 @@
 //! Corresponds to Svelte's `2-analyze/visitors/FunctionDeclaration.js`.
 
 use super::VisitorContext;
+use super::shared::function::visit_parameter_defaults;
 use super::shared::utils::validate_identifier_name;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
 
 /// Visit a function declaration (typed JsNode path).
 pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), AnalysisError> {
-    if let JsNode::FunctionDeclaration { id, body, .. } = node {
+    if let JsNode::FunctionDeclaration {
+        id, params, body, ..
+    } = node
+    {
         let arena = context.parse_arena;
 
         // In runes mode, validate the function name
@@ -36,13 +40,14 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
             context.scope = scope_idx;
         }
 
-        // Visit function body.
-        let result = if let Some(body_id) = body {
+        // Parameter defaults execute in the function scope before the body.
+        let mut result = visit_parameter_defaults(*params, context);
+        if result.is_ok()
+            && let Some(body_id) = body
+        {
             let body_node = arena.get_js_node(*body_id);
-            super::script::walk_js_node_typed(body_node, context)
-        } else {
-            Ok(())
-        };
+            result = super::script::walk_js_node_typed(body_node, context);
+        }
 
         // Decrement function depth and restore scope
         context.function_depth -= 1;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/function_expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/function_expression.rs
@@ -5,7 +5,7 @@
 //! Corresponds to Svelte's `2-analyze/visitors/FunctionExpression.js`.
 
 use super::VisitorContext;
-use super::shared::function::visit_function;
+use super::shared::function::{visit_function, visit_parameter_defaults};
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
 
@@ -14,9 +14,9 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
     let arena = context.parse_arena;
 
     // Get body start for scope lookup
-    let body_id = match node {
-        JsNode::FunctionExpression { body, .. } => *body,
-        JsNode::ArrowFunctionExpression { body, .. } => Some(*body),
+    let (params, body_id) = match node {
+        JsNode::FunctionExpression { params, body, .. } => (*params, *body),
+        JsNode::ArrowFunctionExpression { params, body, .. } => (*params, Some(*body)),
         _ => return Ok(()),
     };
 
@@ -30,6 +30,10 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
 
     let mut result = Ok(());
     visit_function(context, |ctx| {
+        if let Err(error) = visit_parameter_defaults(params, ctx) {
+            result = Err(error);
+            return;
+        }
         // Visit function body
         if let Some(body_id) = body_id
             && let Err(e) = super::script::walk_js_node_typed(arena.get_js_node(body_id), ctx)

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/function.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/function.rs
@@ -5,6 +5,61 @@
 //! Corresponds to Svelte's `2-analyze/visitors/shared/function.js`.
 
 use super::super::VisitorContext;
+use crate::ast::arena::IdRange;
+use crate::ast::typed_expr::JsNode;
+use crate::compiler::phases::phase2_analyze::AnalysisError;
+
+/// Visit expressions evaluated while binding function parameters without treating
+/// the parameter declarations themselves as references.
+pub fn visit_parameter_defaults(
+    params: IdRange,
+    context: &mut VisitorContext,
+) -> Result<(), AnalysisError> {
+    for param in context.parse_arena.get_js_children(params) {
+        visit_parameter_pattern(param, context)?;
+    }
+    Ok(())
+}
+
+fn visit_parameter_pattern(
+    node: &JsNode,
+    context: &mut VisitorContext,
+) -> Result<(), AnalysisError> {
+    let arena = context.parse_arena;
+    match node {
+        JsNode::AssignmentPattern { left, right, .. } => {
+            visit_parameter_pattern(arena.get_js_node(*left), context)?;
+            super::super::script::walk_js_node_typed(arena.get_js_node(*right), context)
+        }
+        JsNode::ObjectPattern { properties, .. } => {
+            for property in arena.get_js_children(*properties) {
+                visit_parameter_pattern(property, context)?;
+            }
+            Ok(())
+        }
+        JsNode::ArrayPattern { elements, .. } => {
+            for element in elements.iter().flatten() {
+                visit_parameter_pattern(element, context)?;
+            }
+            Ok(())
+        }
+        JsNode::Property {
+            key,
+            value,
+            computed,
+            ..
+        } => {
+            if *computed {
+                super::super::script::walk_js_node_typed(arena.get_js_node(*key), context)?;
+            }
+            visit_parameter_pattern(arena.get_js_node(*value), context)
+        }
+        JsNode::RestElement { argument, .. } => {
+            visit_parameter_pattern(arena.get_js_node(*argument), context)
+        }
+        _ => Ok(()),
+    }
+}
 
 /// Visit a function node (ArrowFunctionExpression, FunctionExpression, or FunctionDeclaration).
 ///

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/function.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/function.rs
@@ -6,59 +6,37 @@
 
 use super::super::VisitorContext;
 use crate::ast::arena::IdRange;
-use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
 
-/// Visit expressions evaluated while binding function parameters without treating
-/// the parameter declarations themselves as references.
+/// Visit function parameters — both the binding patterns (`{a, b}`, `[c]`, `...d`)
+/// and any default-value expressions (`x = expr`) — through the same generic typed
+/// walker used for everything else.
+///
+/// Corresponds to the official compiler's `context.next()` in `FunctionDeclaration.js` /
+/// `FunctionExpression.js` / `ArrowFunctionExpression.js` (via `shared/function.js`'s
+/// `visit_function`), which — unlike our hand-written visitors — automatically visits
+/// every child of the function node, including `params`. `walk_js_node_typed` already
+/// has generic recursion for `AssignmentPattern`, `ObjectPattern`, `ArrayPattern`,
+/// `Property`, and `RestElement` (see `script.rs`), and `Identifier`'s `is_reference`
+/// check (mirroring the `is-reference` npm package upstream uses) already returns
+/// `true` — i.e. "this is a reference" — for a parameter's own declaration identifier
+/// (its immediate parent is `FunctionDeclaration`/`FunctionExpression`/
+/// `ArrowFunctionExpression`/`AssignmentPattern`/`ObjectPattern`/`ArrayPattern`, none of
+/// which `is_reference_for_identifier_typed` special-cases as "not a reference"). So a
+/// plain walk here — with no bespoke pattern traversal — reproduces upstream's behavior
+/// of recording a self-reference for every parameter binding (the same self-reference
+/// `VariableDeclarator` bindings already get via `variable_declarator.rs`'s direct
+/// `walk_js_node_typed(id_node, ...)` calls), which existing checks such as
+/// `export_let_unused`'s "more than 1 reference means used beyond the declaration"
+/// heuristic rely on for other binding kinds.
 pub fn visit_parameter_defaults(
     params: IdRange,
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
     for param in context.parse_arena.get_js_children(params) {
-        visit_parameter_pattern(param, context)?;
+        super::super::script::walk_js_node_typed(param, context)?;
     }
     Ok(())
-}
-
-fn visit_parameter_pattern(
-    node: &JsNode,
-    context: &mut VisitorContext,
-) -> Result<(), AnalysisError> {
-    let arena = context.parse_arena;
-    match node {
-        JsNode::AssignmentPattern { left, right, .. } => {
-            visit_parameter_pattern(arena.get_js_node(*left), context)?;
-            super::super::script::walk_js_node_typed(arena.get_js_node(*right), context)
-        }
-        JsNode::ObjectPattern { properties, .. } => {
-            for property in arena.get_js_children(*properties) {
-                visit_parameter_pattern(property, context)?;
-            }
-            Ok(())
-        }
-        JsNode::ArrayPattern { elements, .. } => {
-            for element in elements.iter().flatten() {
-                visit_parameter_pattern(element, context)?;
-            }
-            Ok(())
-        }
-        JsNode::Property {
-            key,
-            value,
-            computed,
-            ..
-        } => {
-            if *computed {
-                super::super::script::walk_js_node_typed(arena.get_js_node(*key), context)?;
-            }
-            visit_parameter_pattern(arena.get_js_node(*value), context)
-        }
-        JsNode::RestElement { argument, .. } => {
-            visit_parameter_pattern(arena.get_js_node(*argument), context)
-        }
-        _ => Ok(()),
-    }
 }
 
 /// Visit a function node (ArrowFunctionExpression, FunctionExpression, or FunctionDeclaration).

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_body.rs
@@ -7,7 +7,8 @@
 use super::super::AnalysisError;
 use super::super::errors;
 use super::VisitorContext;
-use crate::ast::template::SvelteElement;
+use super::on_directive;
+use crate::ast::template::{Attribute, SvelteElement};
 
 /// Visit a svelte:body.
 pub fn visit(body: &mut SvelteElement, context: &mut VisitorContext) -> Result<(), AnalysisError> {
@@ -30,11 +31,14 @@ pub fn visit(body: &mut SvelteElement, context: &mut VisitorContext) -> Result<(
         ));
     }
 
-    // Regular-attribute handler expressions drive `needs_context` (see
-    // svelte_window for the rationale).
+    // Event expressions on special elements participate in normal reference analysis.
     for attr in &mut body.attributes {
-        if let crate::ast::template::Attribute::Attribute(a) = attr {
-            super::attribute::visit_attribute_value_expressions(&mut a.value, context)?;
+        match attr {
+            Attribute::OnDirective(on) => on_directive::visit(on, context)?,
+            Attribute::Attribute(attribute) => {
+                super::attribute::visit_attribute_value_expressions(&mut attribute.value, context)?;
+            }
+            _ => {}
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_document.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_document.rs
@@ -8,6 +8,7 @@ use super::super::AnalysisError;
 use super::super::errors;
 use super::VisitorContext;
 use super::bind_directive;
+use super::on_directive;
 use crate::ast::template::{Attribute, SvelteElement};
 
 /// Visit a svelte:document.
@@ -40,8 +41,8 @@ pub fn visit(
             Attribute::BindDirective(bind) => {
                 bind_directive::visit_with_svelte_element(bind, "svelte:document", context)?;
             }
-            Attribute::OnDirective(_) => {
-                // on: directives are allowed
+            Attribute::OnDirective(on) => {
+                on_directive::visit(on, context)?;
             }
             Attribute::LetDirective(_) => {
                 // let: directives are NOT allowed on svelte:document

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_window.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_window.rs
@@ -8,6 +8,7 @@ use super::super::AnalysisError;
 use super::super::errors;
 use super::VisitorContext;
 use super::bind_directive;
+use super::on_directive;
 use crate::ast::template::{Attribute, SvelteElement};
 
 /// Visit a svelte:window.
@@ -40,8 +41,8 @@ pub fn visit(
             Attribute::BindDirective(bind) => {
                 bind_directive::visit_with_svelte_element(bind, "svelte:window", context)?;
             }
-            Attribute::OnDirective(_) => {
-                // on: directives are allowed
+            Attribute::OnDirective(on) => {
+                on_directive::visit(on, context)?;
             }
             Attribute::LetDirective(_) => {
                 // let: directives are NOT allowed on svelte:window


### PR DESCRIPTION
## Summary

- analyze legacy `on:` directive expressions on `<svelte:window>`, `<svelte:document>`, and `<svelte:body>`
- analyze executable default expressions in function parameters after entering the function scope
- preserve declaration patterns while recording references from nested defaults

This fixes missing analyzer references for markup-only handlers such as `<svelte:window on:keydown={handle}>` and store subscriptions used in defaults such as `function go(page = $search_params.page)`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p rsvelte_core --lib -- -D warnings`
- `cargo test -p rsvelte_core --lib phase2_analyze::tests`
- `cargo test -p rsvelte_core --test special_element_capture_events --test store_subscription_pin --test class_method_default_param_local_derived`

Tests used Rust 1.97 because current `oxc_resolver@11.24.2` requires Rust 1.95+, while the checked-in mise configuration still selects 1.94.1.

## AI assistance

Codex assisted with reproducing the analyzer gaps, implementing the patch, and running validation. I reviewed the resulting changes and remain responsible for the contribution.