### PR TITLE
fix(formatter): strip ASI guard from template expressions

### DIFF
--- a/.changeset/fix-formatter-semi-false-expressions.md
+++ b/.changeset/fix-formatter-semi-false-expressions.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(formatter): strip ASI guard from template expressions
+
+`oxc_formatter` inserts a leading `;` before an expression statement whose
+formatted text begins with `(`, `[`, `` ` ``, a template literal, or certain
+other tokens, when `semicolons` is set to `"as-needed"` — a defensive ASI
+(automatic semicolon insertion) guard so the line stays safe if concatenated
+after a semicolon-less statement. Every embedded `{expr}` (mustache values,
+attribute/directive values, block headers such as `{#if}`/`{#each}`) is
+internally parsed and printed as a synthetic expression statement so it can
+be run through `oxc_formatter`, so with `semi: false` that guard leaked into
+the output: `onclick={() => doSomething()}` was formatted as the invalid
+`onclick={;() => doSomething()}`.
+
+Template expressions are never in statement position, so the guard is never
+meaningful there — it is now stripped from the formatted text before
+splicing it back into the template. Matches `oxfmt`/`prettier-plugin-svelte`,
+which never emit the guard for embedded expressions.

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -1912,6 +1912,10 @@ fn format_expr_core(
         .into_code();
 
     let s = formatted.trim_end().trim_end_matches(';').trim_end();
+    // With semicolons set to "as needed", OXC prefixes expression statements
+    // such as arrow functions with an ASI guard. Template expressions are not
+    // statement-position code, so carrying that guard into `{...}` is invalid.
+    let s = s.strip_prefix(';').unwrap_or(s);
 
     let result = if use_const_wrapper {
         // Strip the `const _rsvelte_x_ = ` prefix that was added as a wrapper.

--- a/crates/rsvelte_formatter/tests/markup_expressions.rs
+++ b/crates/rsvelte_formatter/tests/markup_expressions.rs
@@ -3,6 +3,7 @@
 //! standalone tag (`@html` / `@render` / `@debug` / `@attach`). Markup,
 //! whitespace, attribute order, etc. all stay verbatim.
 
+use oxc_formatter::Semicolons;
 use rsvelte_formatter::{FormatOptions, format};
 
 fn fmt(src: &str) -> String {
@@ -19,6 +20,20 @@ fn attr_expression_value() {
         out.contains("class={foo + 1}"),
         "expected attribute expr formatted:\n{out}"
     );
+}
+
+#[test]
+fn attr_arrow_expression_without_semicolons() {
+    let mut options = FormatOptions::default();
+    options.js.semicolons = Semicolons::AsNeeded;
+
+    let out = format(
+        "<button onclick={() => (open = true)}>Open</button>",
+        &options,
+    )
+    .expect("format ok");
+
+    assert_eq!(out, "<button onclick={() => (open = true)}>Open</button>\n");
 }
 
 #[test]

--- a/crates/rsvelte_formatter/tests/markup_expressions.rs
+++ b/crates/rsvelte_formatter/tests/markup_expressions.rs
@@ -36,6 +36,48 @@ fn attr_arrow_expression_without_semicolons() {
     assert_eq!(out, "<button onclick={() => (open = true)}>Open</button>\n");
 }
 
+/// Beyond the single attribute-value arrow case, the ASI guard OXC emits
+/// under `semicolons: as-needed` can also be triggered by a mustache-tag
+/// call whose leading argument is an arrow function, a `{#each}`/`{#if}`
+/// block header, and non-arrow expressions such as an array literal or a
+/// unary `-`/`+` (see `expression_statement_needs_semicolon` in
+/// `oxc_formatter`). Every shape below is confirmed against
+/// prettier-plugin-svelte with `semi: false`, which never emits the guard
+/// for embedded expressions (they are never in statement position).
+#[test]
+fn asi_guard_stripped_across_expression_positions() {
+    let mut options = FormatOptions::default();
+    options.js.semicolons = Semicolons::AsNeeded;
+
+    let cases: &[(&str, &str)] = &[
+        (
+            "<div>{onClick(() => foo())}</div>",
+            "<div>{onClick(() => foo())}</div>\n",
+        ),
+        (
+            "{#each items as item}<button onclick={() => remove(item)}>x</button>{/each}",
+            "{#each items as item}<button onclick={() => remove(item)}>x</button>{/each}\n",
+        ),
+        (
+            "<div>{[1,2,3].map((x) => x * 2)}</div>",
+            "<div>{[1, 2, 3].map((x) => x * 2)}</div>\n",
+        ),
+        (
+            "{#if (() => cond())()}yes{/if}",
+            "{#if (() => cond())()}yes{/if}\n",
+        ),
+        (
+            "<div data-x={-count}></div>",
+            "<div data-x={-count}></div>\n",
+        ),
+    ];
+
+    for (src, expected) in cases {
+        let out = format(src, &options).expect("format ok");
+        assert_eq!(&out, expected, "mismatch for input: {src}");
+    }
+}
+
 #[test]
 fn attr_sequence_with_interp() {
     let out = fmt("<div class=\"a{ foo +1 }b\"></div>");


### PR DESCRIPTION
## Summary

- strip Oxc's statement-position ASI guard before embedding formatted JavaScript in a Svelte template expression
- cover arrow-function attribute values with `semi: false`

Without this, `onclick={() => ...}` was formatted as invalid `onclick={;() => ...}`.

## Validation

- `cargo test -p rsvelte_formatter --test markup_expressions`
- `cargo clippy -p rsvelte_formatter --tests -- -D warnings`
- formatted and rechecked a 2,000-line real-world Svelte component with `semi: false`

## AI disclosure

This fix was developed with Codex assistance. I reviewed the resulting code, reproduced the failure independently, and ran the validation listed above.
