### PR TITLE
fix(analyze): record template expression references

### DIFF
--- a/.changeset/fix-template-reference-analysis.md
+++ b/.changeset/fix-template-reference-analysis.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyze): record references from Svelte boundary handlers and snippet parameter defaults

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
@@ -11,7 +11,7 @@ use super::shared::fragment;
 use super::shared::snippets::validate_snippet;
 use super::shared::utils::validate_block_not_empty;
 use crate::ast::js::Expression;
-use crate::ast::template::{SnippetBlock, TemplateNode};
+use crate::ast::template::{ExpressionMetadata, SnippetBlock, TemplateNode};
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
 
@@ -62,6 +62,16 @@ pub fn visit(block: &mut SnippetBlock, context: &mut VisitorContext) -> Result<(
     let old_scope = context.scope;
     if let Some(&snippet_scope_idx) = context.analysis.root.template_scope_map.get(&block.start) {
         context.scope = snippet_scope_idx;
+    }
+
+    let mut parameter_metadata = ExpressionMetadata::default();
+    for parameter in &block.parameters {
+        match parameter {
+            Expression::Typed(expression) => {
+                visit_parameter_expressions(&expression.node, context, &mut parameter_metadata)?
+            }
+            Expression::Lazy { .. } => panic!("Expression::Lazy must be resolved before analysis"),
+        }
     }
 
     // Direct children of the snippet body are direct children of a SnippetBlock,
@@ -129,6 +139,54 @@ pub fn visit(block: &mut SnippetBlock, context: &mut VisitorContext) -> Result<(
         context.analysis.template.hoisted_snippets.insert(name);
     }
 
+    Ok(())
+}
+
+fn visit_parameter_expressions(
+    node: &JsNode,
+    context: &mut VisitorContext,
+    metadata: &mut ExpressionMetadata,
+) -> Result<(), AnalysisError> {
+    let arena = context.parse_arena;
+    match node {
+        JsNode::AssignmentPattern { left, right, .. } => {
+            super::shared::utils::walk_js_expression_node(
+                arena.get_js_node(*right),
+                context,
+                metadata,
+            )?;
+            visit_parameter_expressions(arena.get_js_node(*left), context, metadata)?;
+        }
+        JsNode::ObjectPattern { properties, .. } => {
+            for property in arena.get_js_children(*properties) {
+                visit_parameter_expressions(property, context, metadata)?;
+            }
+        }
+        JsNode::ArrayPattern { elements, .. } => {
+            for element in elements.iter().flatten() {
+                visit_parameter_expressions(element, context, metadata)?;
+            }
+        }
+        JsNode::Property {
+            key,
+            value,
+            computed,
+            ..
+        } => {
+            if *computed {
+                super::shared::utils::walk_js_expression_node(
+                    arena.get_js_node(*key),
+                    context,
+                    metadata,
+                )?;
+            }
+            visit_parameter_expressions(arena.get_js_node(*value), context, metadata)?;
+        }
+        JsNode::RestElement { argument, .. } => {
+            visit_parameter_expressions(arena.get_js_node(*argument), context, metadata)?;
+        }
+        _ => {}
+    }
     Ok(())
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_boundary.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_boundary.rs
@@ -7,13 +7,19 @@
 use super::super::AnalysisError;
 use super::VisitorContext;
 use super::shared::fragment;
-use crate::ast::template::SvelteElement;
+use crate::ast::template::{Attribute, SvelteElement};
 
 /// Visit a svelte:boundary.
 pub fn visit(
     boundary: &mut SvelteElement,
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
+    for attribute in &mut boundary.attributes {
+        if let Attribute::Attribute(attribute) = attribute {
+            super::attribute::visit(attribute, context)?;
+        }
+    }
+
     // Push fragment owner type for const_tag placement validation
     context
         .fragment_owner_stack

--- a/crates/rsvelte_core/tests/template_reference_analysis.rs
+++ b/crates/rsvelte_core/tests/template_reference_analysis.rs
@@ -1,0 +1,91 @@
+use rsvelte_core::{
+    CompileOptions, ParseOptions, ast::arena::SerializeArenaGuard,
+    compiler::phases::analyze_component, parse,
+};
+
+fn assert_template_reference(source: &str, binding_name: &str, reference_start: usize) {
+    let mut root = parse(source, ParseOptions::default()).expect("parse");
+    // SAFETY: `root.arena` outlives the guard and the analysis below.
+    let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
+    let analysis =
+        analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze");
+    let binding = analysis
+        .root
+        .bindings
+        .iter()
+        .find(|binding| binding.name == binding_name)
+        .expect("binding");
+
+    assert!(
+        binding.references.iter().any(|reference| {
+            reference.start == u32::try_from(reference_start).unwrap()
+                && reference.is_template_reference
+        }),
+        "missing template reference for {binding_name}: {:?}",
+        binding.references
+    );
+}
+
+fn assert_has_template_reference(source: &str, binding_name: &str) {
+    let mut root = parse(source, ParseOptions::default()).expect("parse");
+    // SAFETY: `root.arena` outlives the guard and the analysis below.
+    let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
+    let analysis =
+        analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze");
+    let binding = analysis
+        .root
+        .bindings
+        .iter()
+        .find(|binding| binding.name == binding_name)
+        .expect("binding");
+
+    assert!(
+        binding
+            .references
+            .iter()
+            .any(|reference| reference.is_template_reference),
+        "missing template reference for {binding_name}: {:?}",
+        binding.references
+    );
+}
+
+#[test]
+fn boundary_handler_is_a_template_reference() {
+    let source = r#"<svelte:boundary onerror={handle_error}>
+  <p>content</p>
+</svelte:boundary>
+<script>
+function handle_error(error) {
+  console.error(error);
+}
+</script>"#;
+
+    assert_template_reference(source, "handle_error", source.find("handle_error").unwrap());
+}
+
+#[test]
+fn snippet_default_is_a_template_reference() {
+    let source = r#"{#snippet card(value = file_id)}
+  <p>{value}</p>
+{/snippet}
+<script>
+let file_id = 1;
+</script>"#;
+
+    assert_template_reference(source, "file_id", source.find("file_id").unwrap());
+}
+
+#[test]
+fn nested_snippet_defaults_are_template_references() {
+    let source = r#"{#snippet card({ value = fallback } = source)}
+  <p>{value}</p>
+{/snippet}
+<script>
+let fallback = 1;
+let source = {};
+</script>"#;
+
+    for name in ["fallback", "source"] {
+        assert_has_template_reference(source, name);
+    }
+}


### PR DESCRIPTION
## Summary

- analyze `<svelte:boundary>` attribute expressions before entering its child scope
- record references from snippet parameter defaults, including nested destructuring defaults
- add focused binding-reference regression tests

This fixes downstream lint integrations incorrectly reporting boundary handlers and values used only by snippet defaults as unused.

## Validation

- `cargo fmt --all --check`
- `cargo test -p rsvelte_core --test template_reference_analysis`
- `cargo test -p rsvelte_core --test snippet_default_transform --test snippet_param_destructuring`
- `cargo clippy --all-targets --all-features -- -D warnings`

## AI disclosure

AI assistance was used to investigate the downstream reproductions, implement the focused fix, and draft tests. I reviewed the changes and validation results.