### PR TITLE
chore: use oxc_allocator's ArenaBox/ArenaVec aliases directly

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
@@ -15,7 +15,7 @@
 //! Spans are always the dummy [`oxc_span::SPAN`]: esrap formats structurally,
 //! so spans do not affect comment-free output.
 
-use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::AstBuilder;
 use oxc_ast::ast::*;
 use oxc_span::{SPAN, Span};

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -27,7 +27,7 @@
 
 use super::arena::{ExprId, JsArena};
 use super::nodes::*;
-use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::AstBuilder;
 use oxc_ast::ast::*;
 use oxc_span::{GetSpanMut, SPAN, Span};

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -27,7 +27,7 @@
 
 use crate::ast::arena::{IdRange, JsNodeId, ParseArena};
 use crate::ast::typed_expr::{JsNode, LiteralValue};
-use oxc_allocator::{Allocator, Box as ArenaBox, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec};
 use oxc_ast::AstBuilder;
 use oxc_ast::ast::*;
 use oxc_span::SPAN;


### PR DESCRIPTION
## Summary

Follow-up to a review comment on #1388 by @overlookmotel:
https://github.com/baseballyama/rsvelte/pull/1388#discussion_r3577980185

`oxc_allocator` now exports `Box` / `Vec` under the `ArenaBox` and `ArenaVec` aliases (available at our pinned rev `39677ba`), so import the aliases directly instead of renaming locally:

```diff
-use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec};
```

Applied to all three occurrences in the codebase:
- `crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs`
- `crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs`
- `crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs`

Import-only change, no behavior change. `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eUPMbwYpKzBH11AzDNC2L