### PR TITLE
fix(formatter): restore collapse child-breaking passes retired as dead in #1505

### DIFF
--- a/.changeset/fix-fmt-restore-collapse-child-breaking-passes.md
+++ b/.changeset/fix-fmt-restore-collapse-child-breaking-passes.md
@@ -1,0 +1,36 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(formatter): restore the collapse child-breaking passes retired as "dead" in #1505
+
+#1505 removed collapse passes 1.6–1.95 and the final children-port sweep on the
+premise that they were dead code. They were not: every one of those passes is
+load-bearing for real corpus components, so their removal regressed the
+formatter-parity corpus — 11 components that had matched the `oxfmt(svelte: true)`
+oracle byte-for-byte began diverging, all in the same family of "the element
+should break its children / open tag onto their own lines but rsvelte keeps them
+inline" (e.g. `<button …> Add Day </button>` staying on one line, a `<Span>` open
+tag not breaking on an overflowing prose line, an SVG `<clipPath>`/`<rect>` pair
+not hugging, a Component block child `<div>` not breaking, a `<script></script>`
+sibling of an `{@html}` not breaking).
+
+Each retired pass is required by at least one of those regressions:
+
+- 1.6 `try_collapse` sweep — inline pure-text elements revealed by pass-1
+  restructuring (card-air / calendar-test / ListGroup).
+- 1.7 `hug_mixed` non-ws-prefix sweep — SVG child hug (flowbite Microsoft icon).
+- 1.8 block-break non-ws-prefix — Component block child (svelte print `formatting`).
+- 1.9 break-inline-open-tag — overflowing inline/component open tags
+  (TextDecoration / Underline / html-tag-script-2).
+- final children-port sweep — faithful prettier-plugin-svelte layout for its
+  gated shapes (svelte-maplibre radio labels).
+
+Restoring `collapse.rs` to its pre-#1505 state returns the formatter to the last
+green parity state and re-fixes all 11 regressions. This intentionally reverts
+#1505 in full: the passes cannot be separated at whole-pass granularity (each is
+needed by a regression), so a partial keep would either leave regressions or
+require new per-shape guards that belong to a dedicated formatter-layout change,
+not a regression fix.
+
+No compiler-output change; formatter output only.

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -76,6 +76,85 @@ pub(crate) fn collapse_pure_text_elements(
         tree = t;
     }
 
+    // 1.6-th pass: run a targeted `try_collapse` sweep on inline pure-text
+    // elements that were revealed by pass 1's block restructuring. Example: a
+    // `<li><a href="…"\n  class="…">text</a\n></li>` whose `<a>` was not visited
+    // in pass 1 because `try_break_block_multiline_content` owned the `<li>` edit.
+    // After the `<li>` is re-broken, the `<a>` may need its multi-line open tag
+    // hugged (`>text</a\n>` → `\n  >text</a\n>`).
+    let mut edits1c: Vec<(u32, u32, String)> = Vec::new();
+    collect_try_collapse_only(&result, &tree.fragment, line_width, options, &mut edits1c);
+    if !edits1c.is_empty() {
+        result = apply_edits(&result, edits1c);
+        let Ok(t) = parse(&result, parse_opts) else {
+            return Ok(result);
+        };
+        tree = t;
+    }
+
+    // 1.7-th pass: targeted `try_hug_mixed` sweep for elements whose `indent`
+    // now ends with `>` (non-ws prefix). Pass 1 may have hugged a container
+    // element (e.g. `<defs\n    >`), causing a child element (e.g. `<clipPath>`)
+    // to gain a `    >` prefix. That child's hug was blocked by the parent-edit
+    // ownership in pass 1; this targeted pass applies it without re-running the
+    // full layout suite (which would disturb already-correct prose wrapping).
+    let mut edits1d: Vec<(u32, u32, String)> = Vec::new();
+    collect_hug_mixed_non_ws_prefix(&result, &tree.fragment, line_width, options, &mut edits1d);
+    if !edits1d.is_empty() {
+        result = apply_edits(&result, edits1d);
+        let Ok(t) = parse(&result, parse_opts) else {
+            return Ok(result);
+        };
+        tree = t;
+    }
+
+    // 1.8-th pass: break block-display elements that land at a non-ws `>` prefix.
+    // Pass 1 may produce a Component hug like `<Component\n  ><div>…</div>…`
+    // where the `<div>` is now at a `  >` prefix and overflows the line width.
+    // `try_break_block_overflow` normally requires a pure-whitespace indent, so
+    // this targeted sweep extracts the ws portion from `  >` and re-applies the
+    // block-break logic.
+    let mut edits1e: Vec<(u32, u32, String)> = Vec::new();
+    collect_break_block_non_ws_prefix(&result, &tree.fragment, line_width, &mut edits1e);
+    if !edits1e.is_empty() {
+        result = apply_edits(&result, edits1e);
+        let Ok(t) = parse(&result, parse_opts) else {
+            return Ok(result);
+        };
+        tree = t;
+    }
+
+    // 1.9-th pass: break the open tag of inline/component elements that appear on
+    // an overflowing line with non-whitespace text before them. Example:
+    //   `      Explore … of <span class="font-medium …">`  (>80 cols)
+    // → `      Explore … of <span\n        class="font-medium …"\n      >`
+    // Only fires for elements whose open tag is currently single-line and whose
+    // content has leading whitespace (hug_start=false), to avoid disturbing the
+    // already-correct hug layouts from earlier passes.
+    let mut edits1f: Vec<(u32, u32, String)> = Vec::new();
+    collect_break_inline_open_tag(&result, &tree.fragment, line_width, &mut edits1f);
+    if !edits1f.is_empty() {
+        result = apply_edits(&result, edits1f);
+        let Ok(t) = parse(&result, parse_opts) else {
+            return Ok(result);
+        };
+        tree = t;
+    }
+
+    // 1.95-th pass: re-collapse broken open tags whose single-line form now fits
+    // at their current column. Undoes incorrect pass-1 breaks that were caused
+    // by a long preceding line; after pass 1.9 has broken inline elements to
+    // shorten those lines, the previously-broken sibling open tag may now fit.
+    let mut edits1g: Vec<(u32, u32, String)> = Vec::new();
+    collect_recollapse_open_tag(&result, &tree.fragment, line_width, &mut edits1g);
+    if !edits1g.is_empty() {
+        result = apply_edits(&result, edits1g);
+        let Ok(t) = parse(&result, parse_opts) else {
+            return Ok(result);
+        };
+        tree = t;
+    }
+
     // Second pass: the hug/break edits above may leave a long expression mustache
     // on an overflowing line (a hugged element's trailing `{a.b().c()}`).
     // Member-chain-break those in place — this can't run in the first pass
@@ -85,6 +164,28 @@ pub(crate) fn collapse_pure_text_elements(
     collect_content_tag_breaks(&result, &tree.fragment, line_width, options, &mut edits2);
     if !edits2.is_empty() {
         result = apply_edits(&result, edits2);
+    }
+
+    // Final children-port pass: re-assert the faithful prettier-plugin-svelte
+    // layout (`children.rs`) for its gated shapes. The earlier breaking passes
+    // (1.6–2) operate on the re-parsed output without knowing which elements the
+    // children port owns, so they can re-break an already-correct (intentionally
+    // overflowing) prose line — e.g. break an inline `<a>`'s open tag on a 93-col
+    // line that the port deliberately keeps whole. Running the port LAST gives it
+    // the final word: it re-parses, rebuilds the element from the AST, and emits a
+    // corrected edit (or a no-op when the layout is already right).
+    if let Ok(root_cp) = parse(&result, parse_opts) {
+        let mut edits_cp: Vec<(u32, u32, String)> = Vec::new();
+        collect_children_port_only(
+            &result,
+            &root_cp.fragment,
+            line_width,
+            options,
+            &mut edits_cp,
+        );
+        if !edits_cp.is_empty() {
+            result = apply_edits(&result, edits_cp);
+        }
     }
 
     // Third pass: `<pre>` / `<textarea>` whose content contains a block. rsvelte
@@ -1398,6 +1499,770 @@ fn try_fill_run(
         return None;
     }
     (printed != whole).then_some((s as u32, e as u32, printed))
+}
+
+/// Pass 1.7: targeted `try_hug_mixed` sweep for elements that have a
+/// non-whitespace prefix (indent ending with `>`). This can occur when pass 1
+/// hugs a container element — e.g. `<defs>` becomes `<defs\n    >` — so a
+/// child element (`<clipPath>`) that was previously at a whitespace indent now
+/// immediately follows the parent's closing `>` on the same line. Pass 1 did
+/// not process the child independently (the parent edit owned the range), so
+/// this pass applies the hug-mixed transform specifically for those cases.
+fn collect_hug_mixed_non_ws_prefix(
+    out: &str,
+    fragment: &Fragment,
+    line_width: usize,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) {
+    for node in &fragment.nodes {
+        let children = match node {
+            TemplateNode::RegularElement(e) => {
+                if is_whitespace_preserving(e.name.as_str()) {
+                    continue;
+                }
+                // Check if this element has a non-ws-prefix indent that is exactly
+                // `{spaces}>` — a parent's hugged closing `>` immediately before this
+                // element.  We intentionally reject longer non-ws indents (e.g. the
+                // element follows a sibling's close-tag `</span>`) because those
+                // produce incorrect `ws_indent` values in `try_hug_mixed`.
+                let s = e.start as usize;
+                let line_start = out[..s].rfind('\n').map_or(0, |i| i + 1);
+                let indent = out.get(line_start..s).unwrap_or("");
+                let non_ws = !indent.bytes().all(|b| b == b' ' || b == b'\t');
+                let is_simple_gt_prefix = non_ws && indent.trim_start_matches([' ', '\t']) == ">";
+                if is_simple_gt_prefix
+                    && let Some(edit) = try_hug_mixed(
+                        out,
+                        e.name.as_str(),
+                        e.start,
+                        e.end,
+                        &e.fragment,
+                        line_width,
+                        options,
+                    )
+                {
+                    edits.push(edit);
+                    continue; // edit owns this element, don't recurse
+                }
+                vec![&e.fragment]
+            }
+            TemplateNode::Component(c) => {
+                let s = c.start as usize;
+                let line_start = out[..s].rfind('\n').map_or(0, |i| i + 1);
+                let indent = out.get(line_start..s).unwrap_or("");
+                let non_ws = !indent.bytes().all(|b| b == b' ' || b == b'\t');
+                let is_simple_gt_prefix = non_ws && indent.trim_start_matches([' ', '\t']) == ">";
+                if is_simple_gt_prefix
+                    && let Some(edit) = try_hug_mixed(
+                        out,
+                        c.name.as_str(),
+                        c.start,
+                        c.end,
+                        &c.fragment,
+                        line_width,
+                        options,
+                    )
+                {
+                    edits.push(edit);
+                    continue;
+                }
+                vec![&c.fragment]
+            }
+            TemplateNode::SlotElement(s) => {
+                let ss = s.start as usize;
+                let line_start = out[..ss].rfind('\n').map_or(0, |i| i + 1);
+                let indent = out.get(line_start..ss).unwrap_or("");
+                let non_ws = !indent.bytes().all(|b| b == b' ' || b == b'\t');
+                let is_simple_gt_prefix = non_ws && indent.trim_start_matches([' ', '\t']) == ">";
+                if is_simple_gt_prefix
+                    && let Some(edit) = try_hug_mixed(
+                        out,
+                        s.name.as_str(),
+                        s.start,
+                        s.end,
+                        &s.fragment,
+                        line_width,
+                        options,
+                    )
+                {
+                    edits.push(edit);
+                    continue;
+                }
+                vec![&s.fragment]
+            }
+            _ => {
+                for child in child_fragments(node) {
+                    collect_hug_mixed_non_ws_prefix(out, child, line_width, options, edits);
+                }
+                continue;
+            }
+        };
+        for child in children {
+            collect_hug_mixed_non_ws_prefix(out, child, line_width, options, edits);
+        }
+    }
+}
+
+/// Pass 1.8: break block-display elements that land at a non-ws `>` prefix.
+///
+/// When pass 1 hugs a Component (`<Component\n  ><div>…</div></Component\n>`),
+/// the `<div>` is placed immediately after the hugged `>` — its "indent" is
+/// `  >` (non-whitespace).  `try_break_block_overflow` normally requires a
+/// pure-whitespace indent, so pass 1 can't handle this.  This targeted pass
+/// extracts the whitespace portion (`  `) from the `  >` prefix and applies
+/// the block-break logic manually.
+fn collect_break_block_non_ws_prefix(
+    out: &str,
+    fragment: &Fragment,
+    line_width: usize,
+    edits: &mut Vec<(u32, u32, String)>,
+) {
+    for node in &fragment.nodes {
+        match node {
+            TemplateNode::RegularElement(e) => {
+                if is_whitespace_preserving(e.name.as_str()) {
+                    continue;
+                }
+                let s = e.start as usize;
+                let end = e.end as usize;
+                let line_start = out[..s].rfind('\n').map_or(0, |i| i + 1);
+                let indent = out.get(line_start..s).unwrap_or("");
+                let non_ws = !indent.bytes().all(|b| b == b' ' || b == b'\t');
+                let is_simple_gt_prefix = non_ws && indent.trim_start_matches([' ', '\t']) == ">";
+                if is_simple_gt_prefix && is_block_display(e.name.as_str()) {
+                    // Extract the whitespace-only portion of the prefix.
+                    let ws_indent: &str = {
+                        let trim_pos = indent.rfind([' ', '\t']).map_or(0, |i| i + 1);
+                        &indent[..trim_pos]
+                    };
+                    // Only act when the whole element is on one line and overflows.
+                    let whole = out.get(s..end).unwrap_or("");
+                    let column = indent.width() + 1; // +1 for the `>` char
+                    if !whole.contains('\n') && column + whole.width() > line_width {
+                        // Find first and last non-whitespace children.
+                        if let (Some(first_child), Some(last_child)) = (
+                            e.fragment.nodes.iter().find(
+                                |n| !matches!(n, TemplateNode::Text(t) if crate::is_blank_text(t.data.as_str())),
+                            ),
+                            e.fragment.nodes.iter().rfind(
+                                |n| !matches!(n, TemplateNode::Text(t) if crate::is_blank_text(t.data.as_str())),
+                            ),
+                        ) {
+                            let first_start = node_start(first_child) as usize;
+                            let last_end = node_end(last_child) as usize;
+                            let open = out.get(s..first_start).unwrap_or("");
+                            let close = out.get(last_end..end).unwrap_or("");
+                            let content = out.get(first_start..last_end).unwrap_or("");
+                            if open.ends_with('>') && !content.is_empty() {
+                                let inner_indent = format!("{ws_indent}  ");
+                                let broken =
+                                    format!("{open}\n{inner_indent}{content}\n{ws_indent}{close}");
+                                if broken != whole {
+                                    edits.push((e.start, e.end, broken));
+                                    continue; // edit owns this element
+                                }
+                            }
+                        }
+                    }
+                }
+                collect_break_block_non_ws_prefix(out, &e.fragment, line_width, edits);
+            }
+            _ => {
+                for child in child_fragments(node) {
+                    collect_break_block_non_ws_prefix(out, child, line_width, edits);
+                }
+            }
+        }
+    }
+}
+
+/// Pass 1.9: break the open tag of inline/component elements that land on an
+/// overflowing line with non-whitespace text before them.
+///
+/// Pattern:
+///   `      Explore … of <span class="font-medium …">`  (>80 cols)
+/// becomes:
+///   `      Explore … of <span\n        class="font-medium …"\n      >`
+///
+/// Only fires when:
+/// - The element has at least one attribute.
+/// - The element's open tag is currently single-line.
+/// - The line containing the element's open `<` overflows the print width.
+/// - There is non-whitespace text before the element on the same line.
+/// - The element's content starts with whitespace (`hug_start=false`).
+///
+/// The broken form uses the line's leading-whitespace as `indent` and
+/// `indent + "  "` as `inner_indent` for attributes.
+fn collect_break_inline_open_tag(
+    out: &str,
+    fragment: &Fragment,
+    line_width: usize,
+    edits: &mut Vec<(u32, u32, String)>,
+) {
+    for node in &fragment.nodes {
+        match node {
+            TemplateNode::RegularElement(e) => {
+                // For block/whitespace-preserving elements that are EMPTY (no
+                // children, no attributes), break the open tag when the whole
+                // line overflows and there is inline content after the element.
+                // Example: `  <script></script>{@html ...}` (86 chars) →
+                //          `  <script\n  ></script>{@html ...}`.
+                let elem_fragment_empty = e.fragment.nodes.iter().all(
+                    |n| matches!(n, TemplateNode::Text(t) if crate::is_blank_text(t.data.as_str())),
+                );
+                if (is_block_display(e.name.as_str()) || is_whitespace_preserving(e.name.as_str()))
+                    && e.attributes.is_empty()
+                    && elem_fragment_empty
+                    && let Some(edit) = try_break_empty_block_open_tag(
+                        out,
+                        e.name.as_str(),
+                        e.start,
+                        e.end,
+                        line_width,
+                    )
+                {
+                    edits.push(edit);
+                    continue;
+                }
+                if is_whitespace_preserving(e.name.as_str()) {
+                    continue;
+                }
+                // Only inline (non-block) regular elements.
+                if !is_block_display(e.name.as_str())
+                    && let Some(edit) = try_break_inline_open_tag(
+                        out,
+                        e.name.as_str(),
+                        &e.attributes,
+                        e.start,
+                        e.end,
+                        &e.fragment,
+                        line_width,
+                    )
+                {
+                    // A whole-element edit (`edit.1 == e.end`) rewrites the tag
+                    // *and its children* in one span, so a child edit collected
+                    // below would apply against now-stale offsets inside that
+                    // span — corrupting the output or panicking `apply_edits`.
+                    // Skip recursion in that case. An open-tag-only edit
+                    // (`edit.1 < e.end`) leaves the children untouched, so
+                    // recursion into them is still safe.
+                    let whole_element = edit.1 == e.end;
+                    edits.push(edit);
+                    if whole_element {
+                        continue;
+                    }
+                }
+                collect_break_inline_open_tag(out, &e.fragment, line_width, edits);
+            }
+            TemplateNode::Component(c) => {
+                let mut whole_element = false;
+                if let Some(edit) = try_break_inline_open_tag(
+                    out,
+                    c.name.as_str(),
+                    &c.attributes,
+                    c.start,
+                    c.end,
+                    &c.fragment,
+                    line_width,
+                ) {
+                    whole_element = edit.1 == c.end;
+                    edits.push(edit);
+                }
+                if !whole_element {
+                    collect_break_inline_open_tag(out, &c.fragment, line_width, edits);
+                }
+            }
+            _ => {
+                for child in child_fragments(node) {
+                    collect_break_inline_open_tag(out, child, line_width, edits);
+                }
+            }
+        }
+    }
+}
+
+/// Try to break the open tag of an inline/component element whose line overflows
+/// and has non-whitespace text before it. Returns `None` when the conditions
+/// are not met or the element is already correctly broken.
+fn try_break_inline_open_tag(
+    out: &str,
+    tag: &str,
+    attrs: &[rsvelte_core::ast::template::Attribute],
+    elem_start: u32,
+    elem_end: u32,
+    fragment: &Fragment,
+    line_width: usize,
+) -> Option<(u32, u32, String)> {
+    // Must have attributes to break. Zero-attribute elements in hug_start=true
+    // contexts can't be broken safely without tree-level indent information.
+    if attrs.is_empty() {
+        return None;
+    }
+    // Must have at least one child so we can locate the end of the open tag
+    // (the `>` is immediately followed by the first child's start position).
+    let first = fragment.nodes.first()?;
+    let open_tag_end = node_start(first) as usize;
+
+    // Get the open tag text (from `<` to just after `>`).
+    let open_tag = out.get(elem_start as usize..open_tag_end)?;
+
+    // Open tag must be single-line (not already broken) and end with `>`.
+    if open_tag.contains('\n') || !open_tag.ends_with('>') {
+        return None;
+    }
+
+    // Check the line containing the element's opening `<`.
+    let elem_start_usize = elem_start as usize;
+    let line_start = out[..elem_start_usize].rfind('\n').map_or(0, |i| i + 1);
+    // Line end: find the next `\n` starting from after the open tag.
+    let line_end = out[open_tag_end..]
+        .find('\n')
+        .map_or(out.len(), |i| open_tag_end + i);
+    let line = out.get(line_start..line_end)?;
+
+    // Line must overflow.
+    if line.width() <= line_width {
+        return None;
+    }
+
+    // There must be non-whitespace text before the element on this line.
+    let before = out.get(line_start..elem_start_usize)?;
+    if before.is_empty() || before.bytes().all(|b| b == b' ' || b == b'\t') {
+        return None; // element is at line start — not our target
+    }
+
+    // Extract leading whitespace of the line as the base indent for the tag.
+    let ws_end = before
+        .char_indices()
+        .find(|(_, c)| !c.is_whitespace())
+        .map_or(before.len(), |(i, _)| i);
+    let indent = &before[..ws_end];
+    let inner_indent = format!("{indent}  ");
+
+    // Collect attribute texts; bail on any multi-line attribute.
+    let mut attr_texts: Vec<&str> = Vec::with_capacity(attrs.len());
+    for attr in attrs {
+        let (as_, ae) = attribute_span(attr);
+        let atext = out.get(as_ as usize..ae as usize)?;
+        if atext.contains('\n') {
+            return None;
+        }
+        attr_texts.push(atext);
+    }
+
+    // Check whether content starts with whitespace (hug_start=false) or directly
+    // after `>` (hug_start=true).
+    let first_child_text = out.get(open_tag_end..node_end(first) as usize)?;
+    let hug_start = !first_child_text.starts_with([' ', '\t', '\r', '\n']);
+
+    if !hug_start {
+        // hug_start=false: build broken open tag with `>` on its own line.
+        //   <tag
+        //     attr1
+        //     attr2
+        //   >
+        let mut broken = format!("<{tag}");
+        for atext in &attr_texts {
+            broken.push('\n');
+            broken.push_str(&inner_indent);
+            broken.push_str(atext);
+        }
+        broken.push('\n');
+        broken.push_str(indent);
+        broken.push('>');
+
+        // Only emit if different from the current open tag.
+        (broken != open_tag).then_some((elem_start, open_tag_end as u32, broken))
+    } else {
+        // hug_start=true: the element's content starts directly after `>` with no
+        // whitespace. We need to break the open tag so that `>content</tag` stays
+        // glued, and the close tag's `>` goes on its own line at the base indent.
+        //
+        // Only apply when the element has at least 2 attributes. Single-attribute
+        // elements are left inline even if the line overflows, matching prettier's
+        // behavior of not breaking short inline elements that can't be meaningfully
+        // split without disrupting reading flow.
+        if attr_texts.len() < 2 {
+            return None;
+        }
+
+        // The whole element text: `<tag attrs>content</tag>`
+        // We replace it with one of two patterns depending on whether
+        // `{before}<tag attrs_without_close_angle` fits in line_width:
+        //
+        // Option A (attrs need full break):
+        //   <tag
+        //     attr1
+        //     attrN>content</tag
+        //   >
+        //
+        // Option B (only close-angle needs to break):
+        //   <tag attr1 attrN
+        //     >content</tag
+        //   >
+
+        let elem_end_usize = elem_end as usize;
+        // The whole element text must be single-line (no internal newlines except
+        // possibly in content — skip if element is already multi-line).
+        let whole = out.get(elem_start_usize..elem_end_usize)?;
+        if whole.contains('\n') {
+            return None;
+        }
+
+        // Find the close tag: `</tag>` is the suffix.
+        // We locate `</tag` working backwards from elem_end.
+        let close_pat = format!("</{tag}");
+        let close_rel = whole.rfind(close_pat.as_str())?;
+        let content = whole.get(open_tag.len()..close_rel)?; // text between open `>` and `</tag`
+        // The close tag `>` is the last character.
+        if !whole.ends_with('>') {
+            return None;
+        }
+        // close_tag_text = `</tag>` (everything from close_rel to end)
+        let close_tag_text = whole.get(close_rel..)?;
+        // Strip trailing `>` to get `</tag`, then we'll append `\n{indent}>`.
+        let close_tag_without_angle = close_tag_text.strip_suffix('>')?;
+
+        // Check if Option B fits: `{before}<tag attr1 attrN` (no `>`) ≤ line_width.
+        // We use the open_tag minus the trailing `>` character.
+        let open_tag_without_angle = open_tag.strip_suffix('>')?;
+        let option_b_prefix_len = before.width() + open_tag_without_angle.width();
+
+        let broken = if option_b_prefix_len <= line_width {
+            // Option B: keep `<tag attrs` on the current line, break at `>`.
+            //   <tag attr1 attrN
+            //     >content</tag
+            //   >
+            format!(
+                "{open_tag_without_angle}\n{inner_indent}>{content}{close_tag_without_angle}\n{indent}>"
+            )
+        } else {
+            // Option A: break each attr onto its own line.
+            //   <tag
+            //     attr1
+            //     attrN>content</tag
+            //   >
+            let mut broken = format!("<{tag}");
+            for (i, atext) in attr_texts.iter().enumerate() {
+                broken.push('\n');
+                broken.push_str(&inner_indent);
+                broken.push_str(atext);
+                // Last attr: close angle `>` and content stay on the same line.
+                if i == attr_texts.len() - 1 {
+                    broken.push('>');
+                    broken.push_str(content);
+                    broken.push_str(close_tag_without_angle);
+                    broken.push('\n');
+                    broken.push_str(indent);
+                    broken.push('>');
+                }
+            }
+            broken
+        };
+
+        if broken == whole {
+            return None;
+        }
+        Some((elem_start, elem_end, broken))
+    }
+}
+
+/// Try to break the open tag of an EMPTY block/whitespace-preserving element
+/// (no attributes, no children) that sits at line-start on a line that overflows
+/// because of following inline content.
+///
+/// Example (`html-tag-script-2`):
+///   `  <script></script>{@html `...`}` (86 chars, overflows 80)
+/// → `  <script\n  ></script>{@html `...`}`
+///
+/// Prettier-plugin-svelte breaks the `<tagname>` open tag to `<tagname\n{indent}>`
+/// when the full line (element + following sibling content) would overflow. This
+/// gives prettier a break point even though the element itself has nothing to split.
+fn try_break_empty_block_open_tag(
+    out: &str,
+    tag: &str,
+    elem_start: u32,
+    elem_end: u32,
+    line_width: usize,
+) -> Option<(u32, u32, String)> {
+    let s = elem_start as usize;
+
+    // The expected open tag is `<tagname>` with no attributes.
+    let expected_open = format!("<{tag}>");
+    let open_len = expected_open.len();
+    let open_tag = out.get(s..s + open_len)?;
+    if open_tag != expected_open {
+        return None; // has attributes or not this form
+    }
+    let open_tag_end = s + open_len;
+
+    // Check the line containing the element.
+    let line_start = out[..s].rfind('\n').map_or(0, |i| i + 1);
+    let line_end = out[elem_end as usize..]
+        .find('\n')
+        .map_or(out.len(), |i| elem_end as usize + i);
+    let line = out.get(line_start..line_end)?;
+
+    // Line must overflow.
+    if line.width() <= line_width {
+        return None;
+    }
+
+    // There must be non-whitespace content AFTER the element's close tag on this
+    // line. If the element itself is the only thing on the line, this pass is not
+    // needed (another pass handles that case).
+    let after_elem = out.get(elem_end as usize..line_end)?;
+    if after_elem.bytes().all(|b| b.is_ascii_whitespace()) {
+        return None;
+    }
+
+    // The element must start at a pure-whitespace line prefix (it's at the indent
+    // column, not following other inline content on the same line).
+    let before = out.get(line_start..s)?;
+    if !before.bytes().all(|b| b == b' ' || b == b'\t') {
+        return None;
+    }
+    let indent = before;
+
+    // Break: `<tagname\n{indent}>`
+    let broken = format!("<{tag}\n{indent}>");
+    Some((elem_start, open_tag_end as u32, broken))
+}
+
+/// Pass 1.95: re-collapse broken open tags whose single-line form now fits at
+/// their current column. This undoes incorrect breaks from pass 1 that were
+/// caused by a long preceding line; after pass 1.9 has broken inline elements
+/// to shorten those lines, the previously-broken element may now sit at a
+/// shorter column and fit on one line.
+///
+/// Example (TextDecoration.svelte): pass 1 broke the red `<Span>` open tag
+/// because it was on the same 199-char line as the green `<Span>`. After pass
+/// 1.9 broke the green `<Span>`, the red `<Span>` moved to a line starting
+/// with `  >, ` (column 5). Its single-line form (74 chars) now fits: 5+74=79.
+fn collect_recollapse_open_tag(
+    out: &str,
+    fragment: &Fragment,
+    line_width: usize,
+    edits: &mut Vec<(u32, u32, String)>,
+) {
+    for node in &fragment.nodes {
+        match node {
+            TemplateNode::RegularElement(e) => {
+                if is_whitespace_preserving(e.name.as_str()) {
+                    continue;
+                }
+                if let Some(edit) = try_recollapse_open_tag(
+                    out,
+                    e.name.as_str(),
+                    &e.attributes,
+                    e.start,
+                    &e.fragment,
+                    line_width,
+                ) {
+                    edits.push(edit);
+                }
+                collect_recollapse_open_tag(out, &e.fragment, line_width, edits);
+            }
+            TemplateNode::Component(c) => {
+                if let Some(edit) = try_recollapse_open_tag(
+                    out,
+                    c.name.as_str(),
+                    &c.attributes,
+                    c.start,
+                    &c.fragment,
+                    line_width,
+                ) {
+                    edits.push(edit);
+                }
+                collect_recollapse_open_tag(out, &c.fragment, line_width, edits);
+            }
+            _ => {
+                for child in child_fragments(node) {
+                    collect_recollapse_open_tag(out, child, line_width, edits);
+                }
+            }
+        }
+    }
+}
+
+fn try_recollapse_open_tag(
+    out: &str,
+    tag: &str,
+    attrs: &[rsvelte_core::ast::template::Attribute],
+    elem_start: u32,
+    fragment: &Fragment,
+    line_width: usize,
+) -> Option<(u32, u32, String)> {
+    if attrs.is_empty() {
+        return None;
+    }
+    let first = fragment.nodes.first()?;
+    let open_tag_end = node_start(first) as usize;
+    let open_tag = out.get(elem_start as usize..open_tag_end)?;
+
+    // Open tag must be multi-line (contains `\n`) to be worth recollapsing.
+    if !open_tag.contains('\n') {
+        return None;
+    }
+    // Open tag must end with `>`.
+    if !open_tag.ends_with('>') {
+        return None;
+    }
+
+    // The element must have non-whitespace text before it on the same line.
+    // Elements at line start were broken by pass 1 for their own reasons (e.g.,
+    // a long attribute list) — we only recollapse elements that were broken
+    // because of the long PRECEDING CONTEXT, which is reflected by having
+    // non-whitespace content before them on the same line.
+    let elem_start_usize = elem_start as usize;
+    let line_start = out[..elem_start_usize].rfind('\n').map_or(0, |i| i + 1);
+    let before = out.get(line_start..elem_start_usize)?;
+    if before.is_empty() || before.bytes().all(|b| b == b' ' || b == b'\t') {
+        return None; // element is at line start — don't recollapse
+    }
+
+    // Only recollapse when the content after `>` starts with whitespace
+    // (hug_start=false). For hug_start=true elements, the multi-line open tag
+    // is part of the hug break pattern and must not be collapsed back to a
+    // single-line form — collapsing would inline the content and break the
+    // close-tag `>` structure.
+    let first_child_text = out.get(open_tag_end..node_end(first) as usize)?;
+    if !first_child_text.starts_with([' ', '\t', '\r', '\n']) {
+        return None; // hug_start=true — don't recollapse
+    }
+
+    // Build the single-line form: `<tag attr1 attr2>`.
+    let mut single_line = format!("<{tag}");
+    for attr in attrs {
+        let (as_, ae) = attribute_span(attr);
+        let atext = out.get(as_ as usize..ae as usize)?;
+        // If any attribute is multi-line, can't collapse to single line.
+        if atext.contains('\n') {
+            return None;
+        }
+        single_line.push(' ');
+        single_line.push_str(atext);
+    }
+    single_line.push('>');
+
+    // Check if single-line form fits at the element's current column.
+    let col = before.width();
+    if col + single_line.width() > line_width {
+        return None;
+    }
+
+    // Only emit if the forms differ.
+    (single_line != open_tag).then_some((elem_start, open_tag_end as u32, single_line))
+}
+
+/// Pass 1.6: targeted `try_collapse` sweep on inline/component pure-text
+/// elements. Runs after pass 1 so that block restructuring (e.g.
+/// `try_break_block_multiline_content` on `<li>`) exposes inline children
+/// (`<a>`, `<A>`) that need their multi-line open tags hugged.
+/// Only visits non-block elements; block elements were already handled in
+/// pass 1 and their layout must not be disturbed.
+fn collect_try_collapse_only(
+    out: &str,
+    fragment: &Fragment,
+    line_width: usize,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) {
+    for node in &fragment.nodes {
+        match node {
+            TemplateNode::RegularElement(elem) => {
+                if is_whitespace_preserving(elem.name.as_str()) {
+                    continue;
+                }
+                // Apply try_collapse to non-block elements only.
+                if !is_block_display(elem.name.as_str())
+                    && let Some(edit) = try_collapse(
+                        out,
+                        elem.name.as_str(),
+                        elem.start,
+                        elem.end,
+                        &elem.fragment,
+                        line_width,
+                        options,
+                        Some(node),
+                    )
+                {
+                    edits.push(edit);
+                    continue; // edit owns this element, don't recurse
+                }
+                collect_try_collapse_only(out, &elem.fragment, line_width, options, edits);
+            }
+            TemplateNode::Component(c) => {
+                if let Some(edit) = try_collapse(
+                    out,
+                    c.name.as_str(),
+                    c.start,
+                    c.end,
+                    &c.fragment,
+                    line_width,
+                    options,
+                    None,
+                ) {
+                    edits.push(edit);
+                    continue;
+                }
+                collect_try_collapse_only(out, &c.fragment, line_width, options, edits);
+            }
+            TemplateNode::TitleElement(t) => {
+                collect_try_collapse_only(out, &t.fragment, line_width, options, edits);
+            }
+            TemplateNode::SvelteBody(s)
+            | TemplateNode::SvelteDocument(s)
+            | TemplateNode::SvelteFragment(s)
+            | TemplateNode::SvelteBoundary(s)
+            | TemplateNode::SvelteHead(s)
+            | TemplateNode::SvelteOptions(s)
+            | TemplateNode::SvelteSelf(s)
+            | TemplateNode::SvelteWindow(s) => {
+                collect_try_collapse_only(out, &s.fragment, line_width, options, edits);
+            }
+            TemplateNode::SvelteComponent(c) => {
+                collect_try_collapse_only(out, &c.fragment, line_width, options, edits);
+            }
+            TemplateNode::SvelteElement(e) => {
+                collect_try_collapse_only(out, &e.fragment, line_width, options, edits);
+            }
+            TemplateNode::IfBlock(blk) => {
+                collect_try_collapse_only(out, &blk.consequent, line_width, options, edits);
+                if let Some(alt) = &blk.alternate {
+                    collect_try_collapse_only(out, alt, line_width, options, edits);
+                }
+            }
+            TemplateNode::EachBlock(blk) => {
+                collect_try_collapse_only(out, &blk.body, line_width, options, edits);
+                if let Some(fb) = &blk.fallback {
+                    collect_try_collapse_only(out, fb, line_width, options, edits);
+                }
+            }
+            TemplateNode::AwaitBlock(blk) => {
+                if let Some(f) = &blk.pending {
+                    collect_try_collapse_only(out, f, line_width, options, edits);
+                }
+                if let Some(f) = &blk.then {
+                    collect_try_collapse_only(out, f, line_width, options, edits);
+                }
+                if let Some(f) = &blk.catch {
+                    collect_try_collapse_only(out, f, line_width, options, edits);
+                }
+            }
+            TemplateNode::KeyBlock(blk) => {
+                collect_try_collapse_only(out, &blk.fragment, line_width, options, edits);
+            }
+            TemplateNode::SnippetBlock(blk) => {
+                collect_try_collapse_only(out, &blk.body, line_width, options, edits);
+            }
+            TemplateNode::SlotElement(s) => {
+                collect_try_collapse_only(out, &s.fragment, line_width, options, edits);
+            }
+            _ => {}
+        }
+    }
 }
 
 fn collect(
@@ -3682,6 +4547,42 @@ fn try_hug_mixed(
     };
     let printed = crate::doc::print(elem_doc, line_width, indent_unit_hm.as_str(), level, column);
     (printed != whole).then_some((start, end, printed))
+}
+
+/// Recurse the tree running ONLY `try_children_port` on each `RegularElement`.
+/// Used as the final collapse pass so the faithful children port has the last
+/// word over the earlier breaking passes. When the port claims an element
+/// (`Some(_)`), its layout is authoritative — apply any edit and don't recurse
+/// into it; otherwise recurse into the node's child fragments.
+fn collect_children_port_only(
+    out: &str,
+    fragment: &Fragment,
+    line_width: usize,
+    options: &FormatOptions,
+    edits: &mut Vec<(u32, u32, String)>,
+) {
+    for node in &fragment.nodes {
+        // Never descend into whitespace-preserving subtrees (`<pre>`,
+        // `<textarea>`, `<script>`, `<style>`) — their content is verbatim, so a
+        // pure-text inline element inside (`<pre>…<span>C\nD</span>…`) must NOT be
+        // collapsed (mirrors prettier's `isPreTagContent` ancestor guard).
+        if let TemplateNode::RegularElement(e) = node
+            && is_whitespace_preserving(e.name.as_str())
+        {
+            continue;
+        }
+        if matches!(node, TemplateNode::RegularElement(_))
+            && let Some(maybe_edit) = try_children_port(out, node, line_width, options)
+        {
+            if let Some(edit) = maybe_edit {
+                edits.push(edit);
+            }
+            continue;
+        }
+        for f in child_fragments(node) {
+            collect_children_port_only(out, f, line_width, options, edits);
+        }
+    }
 }
 
 /// Recursively convert a template node into a `children::Child`, building any


### PR DESCRIPTION
## Problem

The CI **Formatter parity** gate (`fmt-parity` in `corpus-compat.yml`) has been red on every PR since #1505 (`56724fd1`, "refactor(formatter): retire dead collapse passes 1.6-1.95 + children-port sweep") landed. #1503/#1504 were green — #1505 is the only formatter change since, and it merged while the parity gate was already failing.

`node scripts/compat-corpus/fmt-verify.mjs` reported **11 NEW failures (not in baseline)** → exit 1.

## Root cause

#1505 deleted collapse passes 1.6, 1.7, 1.8, 1.9, 1.95 and the final children-port sweep on the premise they were dead code. **They were not dead** — each is load-bearing for real corpus components. Removing them regressed 11 components that had matched the `oxfmt(svelte: true)` oracle byte-for-byte, all in the same family: *the element should break its children / open tag onto their own lines, but rsvelte kept them inline*.

Bisecting the restored passes against the 11 regressions (env-gating each pass individually) shows every pass is required by at least one regression:

| pass | regressions it fixes |
|------|----------------------|
| 1.6 `try_collapse` sweep | card-air, calendar-test, ListGroup |
| 1.7 `hug_mixed` non-ws-prefix | flowbite Microsoft SVG icon (`<clipPath>`/`<rect>` hug) |
| 1.8 block-break non-ws-prefix | svelte print `formatting` (Component block child `<div>`) |
| 1.9 break-inline-open-tag | TextDecoration, Underline, html-tag-script-2 |
| children-port sweep | svelte-maplibre radio labels ×2 |
| (combined) | shadcn docs-sidebar |

Because every pass is needed at whole-pass granularity, the passes cannot be partially kept without leaving regressions. This restores `collapse.rs` verbatim to its pre-#1505 state (`56724fd1~1`), returning the formatter to the last green parity state.

## The 11 regressions (all now fixed)

- `bits-ui/docs/.../homepage/card-air.svelte`
- `bits-ui/tests/.../calendar/calendar-test.svelte`
- `flowbite-svelte/.../icons/Microsoft.svelte`
- `flowbite-svelte/.../forms/radio/ListGroup.svelte`
- `flowbite-svelte/.../typography/text/TextDecoration.svelte`
- `flowbite-svelte/.../typography/text/Underline.svelte`
- `shadcn-svelte/docs/.../docs-sidebar.svelte`
- `svelte-maplibre/.../examples/3d_terrain/+page.svelte`
- `svelte-maplibre/.../examples/overlapping_layer_events/+page.svelte`
- `svelte/.../tests/print/samples/formatting/input.svelte`
- `svelte/.../tests/runtime-browser/samples/html-tag-script-2/main.svelte`

## Baseline

The 5 known-failures that #1505's deletion had incidentally *fixed* (layercake, layerchart, 3× svelte-ux) revert to being known failures — they were a genuine over-break tradeoff of the removed passes (3+ distinct over-break root causes), not separable from the regression fix without new per-shape guards that belong to a dedicated formatter-layout change. The ratchet baseline therefore stays at its checked-in 59; **no baseline shrink, and the gate is honestly green (not padded).**

## Verification

- `node scripts/compat-corpus/fmt-verify.mjs` → **11480 included, 11399 matched, 59 known failures, 0 regressions, exit 0** (reproduces the last-green formatter state exactly across the full corpus).
- `cargo test -p rsvelte_formatter --release` and `cargo test -p rsvelte_fmt --release` green.
- `cargo fmt` (no diff) + `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Xs5NonZj1k1pcuamEfj7