### PR TITLE
chore(ci): disable all Renovate updates for the pinned oxc stack

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,29 @@
   ],
   "packageRules": [
     {
-      "description": "The oxc_* crates are redirected through [patch.crates-io] to a single pinned git rev so rsvelte's AST types unify with oxc_formatter's transitive deps. Renovate's per-crate git-digest PRs can never pass CI on their own: bumping one crate's rev leaves the lockfile with two distinct oxc revs and the Program<'a> types fail to unify. The whole stack must be moved together as a manual unified bump. Disable digest (git-rev) auto-updates for the oxc crates so these unmergeable PRs stop being opened; version updates (e.g. 0.137 -> 0.138) are still surfaced.",
+      "description": "The oxc AST/formatter stack is pinned to a single git rev (synced to the oxfmt release tag by the auto-update-oxfmt workflow) so rsvelte's AST types unify with oxc_formatter's transitive deps. Any per-crate Renovate update — digest OR version — can never pass CI on its own: moving one crate leaves the lockfile with two distinct oxc revs and the Program<'a> types fail to unify (proven by #1497-#1499/#1506-#1507, #1532-#1535, #1539-#1543). The previous digest-only rule with a /^oxc/ regex did not suppress these PRs, so this rule lists the pinned crates explicitly and disables ALL update types for them. The whole stack moves together via the auto-update-oxfmt PR. oxc_resolver is intentionally NOT listed — it is a normal crates.io dep and Renovate should keep updating it.",
       "matchManagers": ["cargo"],
-      "matchPackageNames": ["/^oxc/"],
-      "matchUpdateTypes": ["digest"],
+      "matchPackageNames": [
+        "oxc_allocator",
+        "oxc_ast",
+        "oxc_ast_macros",
+        "oxc_ast_visit",
+        "oxc_codegen",
+        "oxc_data_structures",
+        "oxc_diagnostics",
+        "oxc_ecmascript",
+        "oxc_estree",
+        "oxc_formatter",
+        "oxc_formatter_core",
+        "oxc_formatter_css",
+        "oxc_formatter_json",
+        "oxc_parser",
+        "oxc_regular_expression",
+        "oxc_semantic",
+        "oxc_span",
+        "oxc_str",
+        "oxc_syntax"
+      ],
       "enabled": false
     }
   ]


### PR DESCRIPTION
The digest-only `/^oxc/` rule from #1183 has not stopped Renovate from opening per-crate oxc PRs — three whole quartets (#1498/#1499/#1506/#1507, #1532–#1535, #1539–#1543) plus a version bump (#1497) were opened after it landed, and none of them can ever pass CI: the workspace pins every oxc crate to one git rev, so moving one crate alone always breaks type unification.

This lists the pinned crates explicitly (robust against regex/updateType classification differences) and disables **all** update types for them. The stack moves together via the `auto-update-oxfmt` workflow (e.g. #1526). `oxc_resolver` is deliberately not listed — it is a normal crates.io dependency and stays Renovate-managed (#1492 merged fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)