### PR TITLE
chore(deps): update oxfmt to 0.59.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -115,7 +115,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -662,7 +662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1172,7 +1172,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1610,9 +1610,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc-css-parser"
-version = "0.0.5"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ad4419eacffd5b924610fae592ebf65e2b5fd77c84d0c0ffd7401435733839"
+checksum = "39176e812faa433a4f046e65844cb7bdbee4ef7708d377d050ddde3ae35d5b4f"
 dependencies = [
  "oxc_allocator",
 ]
@@ -1645,8 +1645,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1658,8 +1658,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "bitflags 2.13.0",
  "oxc_allocator",
@@ -1675,8 +1675,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "phf 0.14.0",
  "proc-macro2 1.0.106",
@@ -1686,8 +1686,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1697,8 +1697,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
@@ -1718,13 +1718,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1733,8 +1733,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1749,8 +1749,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1759,8 +1759,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.58.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.59.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1785,8 +1785,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter_core"
-version = "0.58.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.59.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1799,8 +1799,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter_css"
-version = "0.58.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.59.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "cow-utils",
  "oxc-css-parser",
@@ -1813,8 +1813,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter_json"
-version = "0.58.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.59.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "dragonbox_ecma",
  "oxc_allocator",
@@ -1839,8 +1839,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_jsdoc"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1849,8 +1849,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
@@ -1872,8 +1872,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "bitflags 2.13.0",
  "oxc_allocator",
@@ -1915,8 +1915,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "itertools 0.15.0",
  "memchr",
@@ -1950,8 +1950,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "compact_str 0.9.1",
  "oxc-miette",
@@ -1964,8 +1964,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "compact_str 0.9.1",
  "hashbrown 0.17.1",
@@ -1976,8 +1976,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.138.0"
-source = "git+https://github.com/oxc-project/oxc?rev=39677ba50d908ea09f6d9e58ded328461212f52a#39677ba50d908ea09f6d9e58ded328461212f52a"
+version = "0.139.0"
+source = "git+https://github.com/oxc-project/oxc?rev=2d4e8d20644e0e7446f0a381894b45ea339a0625#2d4e8d20644e0e7446f0a381894b45ea339a0625"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
@@ -2520,7 +2520,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2882,7 +2882,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2892,7 +2892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3280,7 +3280,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,18 +92,18 @@ type_complexity = "allow"
 # rsvelte's AST types unify with oxc_formatter's transitive deps
 # (avoids "two Program<'a> types from different source units" errors).
 [patch.crates-io]
-oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
+oxc_allocator         = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_parser            = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_ast               = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_ast_macros        = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_ast_visit         = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_span              = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_diagnostics       = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_codegen           = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_syntax            = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_semantic          = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_ecmascript        = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_estree            = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_str               = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_data_structures   = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -24,7 +24,7 @@
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.49.2",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
-		"oxfmt": "^0.58.0",
+		"oxfmt": "^0.59.0",
 		"oxlint": "^1.36.0",
 		"svelte": "^5.46.1",
 		"typescript": "^6.0.0",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -60,15 +60,15 @@ smallvec = { version = "1.13", features = ["serde"] }
 rustc-hash = "2.0"
 
 # JavaScript parsing and code generation
-oxc_allocator = "0.138"
-oxc_parser = "0.138"
-oxc_ast = { version = "0.138", features = ["serialize"] }
-oxc_span = "0.138"
-oxc_diagnostics = "0.138"
-oxc_codegen = "0.138"
+oxc_allocator = "0.139"
+oxc_parser = "0.139"
+oxc_ast = { version = "0.139", features = ["serialize"] }
+oxc_span = "0.139"
+oxc_diagnostics = "0.139"
+oxc_codegen = "0.139"
 rsvelte_esrap = { path = "../rsvelte_esrap" }
-oxc_syntax = "0.138"
-oxc_semantic = "0.138"
+oxc_syntax = "0.139"
+oxc_semantic = "0.139"
 
 # Module resolution for the svelte-check overlay: resolves `.svelte` imports
 # (including tsconfig `paths`/`baseUrl` aliases like `$lib/...`) so aliased
@@ -76,7 +76,7 @@ oxc_semantic = "0.138"
 oxc_resolver = "11"
 
 # SPIKE: oxc_formatter is publish=false in oxc; pull via git from main HEAD
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
 
 # Error handling
 thiserror = "2.0"
@@ -129,7 +129,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 getrandom = { version = "0.4", optional = true }
 lazy_static = "1.5.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
-oxc_ast_visit = "0.138"
+oxc_ast_visit = "0.139"
 
 # Better multi-threaded memory allocator (optional, Unix/Mac only)
 [target.'cfg(all(not(windows), not(target_arch = "wasm32")))'.dependencies]

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["svelte", "compiler", "esrap", "printer"]
 crate-type = ["rlib"]
 
 [dependencies]
-oxc_allocator = "0.138"
-oxc_ast = "0.138"
-oxc_span = "0.138"
-oxc_syntax = "0.138"
+oxc_allocator = "0.139"
+oxc_ast = "0.139"
+oxc_span = "0.139"
+oxc_syntax = "0.139"
 
 [dev-dependencies]
-oxc_parser = "0.138"
-oxc_ast_visit = "0.138"
+oxc_parser = "0.139"
+oxc_ast_visit = "0.139"
 
 [lints]
 workspace = true

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/bin/fmt_benchmark_runner.rs"
 
 [dependencies]
 rsvelte_formatter = { path = "../rsvelte_formatter" }
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
 clap = { version = "4.5", features = ["derive"] }
 walkdir = "2.5"
 rayon = "1.10"

--- a/crates/rsvelte_formatter/Cargo.toml
+++ b/crates/rsvelte_formatter/Cargo.toml
@@ -21,14 +21,14 @@ wasm = ["rsvelte_core/wasm-deps"]
 
 [dependencies]
 rsvelte_core = { path = "../rsvelte_core", default-features = false }
-oxc_allocator = "0.138"
-oxc_ast = "0.138"
-oxc_parser = "0.138"
-oxc_span = "0.138"
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_formatter_json = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_formatter_css = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
+oxc_allocator = "0.139"
+oxc_ast = "0.139"
+oxc_parser = "0.139"
+oxc_span = "0.139"
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_formatter_json = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_formatter_css = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
 thiserror = "2.0"
 unicode-width = "0.2"
 

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -52,11 +52,11 @@ rayon = { version = "1.10", optional = true }
 
 # OXC — same git rev as rsvelte_core (unified by the workspace `[patch]`),
 # used only to statically parse `eslint.config.js` for the config importer.
-oxc_allocator = { version = "0.138", optional = true }
-oxc_parser = { version = "0.138", optional = true }
-oxc_ast = { version = "0.138", optional = true }
-oxc_ast_visit = { version = "0.138", optional = true }
-oxc_span = { version = "0.138", optional = true }
+oxc_allocator = { version = "0.139", optional = true }
+oxc_parser = { version = "0.139", optional = true }
+oxc_ast = { version = "0.139", optional = true }
+oxc_ast_visit = { version = "0.139", optional = true }
+oxc_span = { version = "0.139", optional = true }
 
 # wasm-only.
 wasm-bindgen = { version = "0.2", optional = true }

--- a/crates/rsvelte_lint_types/Cargo.toml
+++ b/crates/rsvelte_lint_types/Cargo.toml
@@ -52,18 +52,18 @@ type_complexity = "allow"
 # Mirror the root workspace's oxc unification patch so the path-dep rsvelte
 # crates build with the same oxc rev. MUST match crates/../Cargo.toml.
 [patch.crates-io]
-oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
-oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "39677ba50d908ea09f6d9e58ded328461212f52a" }
+oxc_allocator          = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_parser             = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_ast                = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_ast_macros         = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_ast_visit          = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_span               = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_diagnostics        = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_codegen            = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_syntax             = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_semantic           = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_ecmascript         = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_estree             = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_str                = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }
+oxc_data_structures    = { git = "https://github.com/oxc-project/oxc", rev = "2d4e8d20644e0e7446f0a381894b45ea339a0625" }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"@changesets/cli": "^2.27.10",
 		"acorn": "^8.16.0",
 		"esbuild": "^0.28.0",
-		"oxfmt": "^0.58.0",
+		"oxfmt": "^0.59.0",
 		"prettier": "^3.9.4",
 		"prettier-plugin-svelte": "^4.1.0",
 		"svelte": "^5.56.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.28.0
         version: 0.28.1
       oxfmt:
-        specifier: ^0.58.0
-        version: 0.58.0(svelte@5.56.6)
+        specifier: ^0.59.0
+        version: 0.59.0(svelte@5.56.6)
       prettier:
         specifier: ^3.9.4
         version: 3.9.5
@@ -511,8 +511,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm-eabi@0.58.0':
-    resolution: {integrity: sha512-Uz62sHduGGPftXtILGyxdSW4PX82rUg+rfdNqhsgxe881g4rIoXlIqmZQ6HVKcF4f+F8qMhdD03Bx5u7gmeTdg==}
+  '@oxfmt/binding-android-arm-eabi@0.59.0':
+    resolution: {integrity: sha512-bNTnfbuG7sAwb2PakMNaDukx5kXeW9duXOBeWtTOiLz3fXz3q2DlWguufPZ+c2IHEVrRXHD+M4aUgEWm841LDA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
@@ -523,8 +523,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.58.0':
-    resolution: {integrity: sha512-rD0lRaJp1b+9vw6X4A2dJWKukd6X8yxiicN4JxXcXayolmUypRZxk+lKR+fVOu5q/iYc0fh5fR4bgmfOfVlbaA==}
+  '@oxfmt/binding-android-arm64@0.59.0':
+    resolution: {integrity: sha512-R/Sn7z52QtdAKNqQLLY0EK7hVMjXiz3XUlvoCFCm/60jgIzAnQtiqLKBCFaBkimCQL5rs2ezPMcicpjCsrl54Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -535,8 +535,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-arm64@0.58.0':
-    resolution: {integrity: sha512-uzbPPk7O6M+w2K65vcQ1woga3wgP8zghjL1KOG5b6qJ8dvYHZJ1VShaslg2KOK6yQIwCQtcMCXqLBM6sqXUNTg==}
+  '@oxfmt/binding-darwin-arm64@0.59.0':
+    resolution: {integrity: sha512-vm/ynUqE4HjC0ZIEjmXv1UJu1/GngccQ+T+TJudTMxUxm6r+GQTg1TO3E5jJfI71pBaXxSzs1+vWHIwuilGHhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -547,8 +547,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.58.0':
-    resolution: {integrity: sha512-L0nKYDxU32oxeQqJj21W9SlIMnf81VZEhyah6iDvFhf5q0oynq498Fopth7blErUJVBpVtxQ98RMCfMPqpJX6w==}
+  '@oxfmt/binding-darwin-x64@0.59.0':
+    resolution: {integrity: sha512-uTtYDpLN/obfKVWGpgEc8BqYlLZBQTPz2uYEvLRy3HPZxjZ34wiFzukUBU2bf64JuCYZI//GTV1EOMmWlPjf/w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -559,8 +559,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-freebsd-x64@0.58.0':
-    resolution: {integrity: sha512-woNwfD58dC5PGS9LSLSD5JYfo/EFK5iG9vhDWkcCg3q78ag7KC8bpDqgvPHrMoXpx83OLXxoSOhu6z8FsVTHlg==}
+  '@oxfmt/binding-freebsd-x64@0.59.0':
+    resolution: {integrity: sha512-e2UnxL/ifStSPy8ffBCDbdy595SYsGy+U1pur4G65TuMmWxAMBzYGG7atZo/3mp515p8rZdsflxVD/E1FAdPLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -571,8 +571,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.58.0':
-    resolution: {integrity: sha512-Sqs8nMLxuQpY21NKJ1u4stPDmO5hskBCNNh2E3AdCfI1QqWtf4m+Qn4mGEIUO4KGmuq3SWc/SZ80uy5IiwTCDw==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.59.0':
+    resolution: {integrity: sha512-LtdeZ1l0urxte3VNi3g8cocZwv1xGM1NKHSgF/fJEEVhyQmlgGh7WFWKFd/pNuO7djfvPNtNO1+MS+FEWkgVSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -583,8 +583,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.58.0':
-    resolution: {integrity: sha512-Vd4exzBI5B5hB9m22JiTQzIL23WvHo/Pe+sNXPNeBLXSP9swCBPKCEBRwKpmpQzYhlgYaCgfPcGXPKAJBRIiZQ==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.59.0':
+    resolution: {integrity: sha512-dBTciSsj9GTMl7p+h2gMSI0hoPn2ijfc/dUsbnWsP0RbwgPl2r0C/5zkMb3Pb+gGj17LH7f1o4qLo9aes/pAvA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -596,8 +596,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.58.0':
-    resolution: {integrity: sha512-bUWi5mHV+4Vi56RLHE1h6q/HHfwAIT3XoB9vJAVeRzfu5NriXM8y6eeJu0vlKa0C9kq2rq1sOWRClhdLHPocrg==}
+  '@oxfmt/binding-linux-arm64-gnu@0.59.0':
+    resolution: {integrity: sha512-tXVdJ/JINsNWdponPHN0OuKHtC+HdpyoS9sd6IDPNiiEYsRki8b7tefRZ1iMnRkdbyT4SEbguWsr6o+5awvbPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -610,8 +610,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-arm64-musl@0.58.0':
-    resolution: {integrity: sha512-2ZHxemzgHcjtktAuVUwSoyXmGo/t+aF5tS1ciPpPei4rhSyrz3JOqDosXXrmhN/yLUSzJjtuW7ToTWqfQpCj2w==}
+  '@oxfmt/binding-linux-arm64-musl@0.59.0':
+    resolution: {integrity: sha512-RRTq38i2zT5fnw6XGHjvT6w2mh6x/G3m6AZcAZ56OTDTT/lsOeYnG3SVjwmH40z5kPqF+lf+o35e6m6PpKy9Dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -624,8 +624,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.58.0':
-    resolution: {integrity: sha512-AwKkVwjVmFQ3bcO7j0McGYAqCKH2a326fswfofng/E8VewCT/raeeGQr4huVhY704deK8AWASSTlxzMj0eZc6Q==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.59.0':
+    resolution: {integrity: sha512-lD3k7glAJSaXW0D6xzu8VOZbYbosvy+0ktOVkfLEoQF5HJlMSxTQ2KNW0JO+08ccP/1ElOKktVEMI0fqRbVB4w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -638,8 +638,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.58.0':
-    resolution: {integrity: sha512-xsRpTxfUnJF8D3AUKko/qyWdjw4GZVHlCVFuGlzSCTeewLmykKINW8em1+wx+axsDVtJJcMtvsiaXggXxrlHgw==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.59.0':
+    resolution: {integrity: sha512-WH5ZP1RbuHKBO/yfPRQKpNO/ijHcEDNbnmC4VPf/Bcd3+mbMAZpRiJWRa1PL5bREdIZZHo343mk3sqlc9x7Usw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -652,8 +652,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.58.0':
-    resolution: {integrity: sha512-Z4AYOTcy7nYEIiXwD62PlerimyYRcfJOgUbQAEBjXz098kxKuERBlRntofGy69HHhe9E0TLVNMl1yspVNu+efw==}
+  '@oxfmt/binding-linux-riscv64-musl@0.59.0':
+    resolution: {integrity: sha512-743wOiaI9RZY4QVGkWkfGRavD5ZJUJ6gscFjVrVu1dP8AZh9jM+a6v3NhlR+OIzHdS6DhLM96w+gcVskskz7rw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -666,8 +666,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.58.0':
-    resolution: {integrity: sha512-A3nhhtZPC/TKVWOPj9q/H3p2znJDCcHWYlJBhWL8hGq/bFmBaNBHC8Np6E581yVq1w9Mi3rMDNzDalWvtUfJtQ==}
+  '@oxfmt/binding-linux-s390x-gnu@0.59.0':
+    resolution: {integrity: sha512-xjRXQsRnrRZCcCkIEnbd2lmsQNobtwwkJxdy2bWXhZ1lIN0ouZwsBXRsoovW3yATuziAYwr9HMiQuR/Cc75NIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -680,8 +680,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.58.0':
-    resolution: {integrity: sha512-2g+tVkgwqphw8R4hgo+kF4oz8+P5RwVOtr9+irsC7uwEp0e9j7Crw8kDGKL20uYlLPD7g02DqA61mC/UNYx98A==}
+  '@oxfmt/binding-linux-x64-gnu@0.59.0':
+    resolution: {integrity: sha512-4hNjqq/Rbr9B+StY9zMMAfm72+mtM4v80xYL5Qkb59Qd72g2vJMI0iFlPj3kf6miMsie/yJ7rt4urJT292HBgA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -694,8 +694,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-x64-musl@0.58.0':
-    resolution: {integrity: sha512-rc15P6AbyyB7426aN8AakLd02Trb3a6ML/mmfAQeVHJEfVofWLcWIrBdy6zDEY+DIaL/s8E4GGPboVw+oP3+EA==}
+  '@oxfmt/binding-linux-x64-musl@0.59.0':
+    resolution: {integrity: sha512-NH579iN8EVQYsWowUB8B5vFchcylJtwPVJ7NmUAqEQHNLfhPbDT3K56KrECNAkUN4QpF4qiMgN2vsfZwVvjm7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -707,8 +707,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-openharmony-arm64@0.58.0':
-    resolution: {integrity: sha512-ZWoTM27/HYPOh9iq86DAbhPu9nXb8qKvvGU/h8OfliyVUFAMMNTLDkGsWDKKnDqIkqvZ9+dXlgUOsH1LYO3O7g==}
+  '@oxfmt/binding-openharmony-arm64@0.59.0':
+    resolution: {integrity: sha512-mzZy3Z5Aj1D75Aq9FVlmoRQH5ei8Ga4o/NZmlXkKyeZ5EmPrUXRR7c6BMBteV1ZuZ/356UYDuLRLjAMxTDTiBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -719,8 +719,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.58.0':
-    resolution: {integrity: sha512-LHZnqFXe2dEfkRI4XdZS/57nEOT/I4UCRX5IyM9v4GYW9XwQCjGe1IUK59SuKw3POwvcgWQ4pme2cYXmNqTNPg==}
+  '@oxfmt/binding-win32-arm64-msvc@0.59.0':
+    resolution: {integrity: sha512-0CpDJ1gE3jN1Gk6xms1Ie6LPfPcOtY4FAtoOmVLHQoAf8DvO2wd0DW2dIX2f7YTp5dxrr0ND8JeUEjm3DP3k5g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -731,8 +731,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.58.0':
-    resolution: {integrity: sha512-mZKpg20TpheCJym1rarcZCUJeW1sSruw8zAAaCYWvuVfwIUDN1CXdrPU/JgCWReXTCTrEfCB8Wyo3hh9jSZ2EA==}
+  '@oxfmt/binding-win32-ia32-msvc@0.59.0':
+    resolution: {integrity: sha512-zwdKBu3pt87uW0bRcywZb0oGMS7C6n87qogwRYFUgmk44T90ZzYlPjtlFYXs/DnBFrgNCvlHwCuWKfVWLeE7kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
@@ -743,8 +743,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.58.0':
-    resolution: {integrity: sha512-N/wUU4N5PZ2orBtI+Ko7MnMfYLfE7K91UrGMY/c/pYyHR3lA9kwst1XugkZx+92YcRh/Eo+iv2eTESSWXfiZPA==}
+  '@oxfmt/binding-win32-x64-msvc@0.59.0':
+    resolution: {integrity: sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1324,8 +1324,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxfmt@0.58.0:
-    resolution: {integrity: sha512-8feG/7NVEHDVwc1OUpP6Pks+TnaDFUw2jLLFIMi5bcmmwxAX2wBQvjSzj62RRTYBf2Op1Wt8xbkmagmPTR5ETg==}
+  oxfmt@0.59.0:
+    resolution: {integrity: sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1914,115 +1914,115 @@ snapshots:
   '@oxfmt/binding-android-arm-eabi@0.53.0':
     optional: true
 
-  '@oxfmt/binding-android-arm-eabi@0.58.0':
+  '@oxfmt/binding-android-arm-eabi@0.59.0':
     optional: true
 
   '@oxfmt/binding-android-arm64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.58.0':
+  '@oxfmt/binding-android-arm64@0.59.0':
     optional: true
 
   '@oxfmt/binding-darwin-arm64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.58.0':
+  '@oxfmt/binding-darwin-arm64@0.59.0':
     optional: true
 
   '@oxfmt/binding-darwin-x64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.58.0':
+  '@oxfmt/binding-darwin-x64@0.59.0':
     optional: true
 
   '@oxfmt/binding-freebsd-x64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.58.0':
+  '@oxfmt/binding-freebsd-x64@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-arm-gnueabihf@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.58.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-arm-musleabihf@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.58.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-arm64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.58.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-arm64-musl@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.58.0':
+  '@oxfmt/binding-linux-arm64-musl@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-ppc64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.58.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-riscv64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.58.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-riscv64-musl@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.58.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-s390x-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.58.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-x64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.58.0':
+  '@oxfmt/binding-linux-x64-gnu@0.59.0':
     optional: true
 
   '@oxfmt/binding-linux-x64-musl@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.58.0':
+  '@oxfmt/binding-linux-x64-musl@0.59.0':
     optional: true
 
   '@oxfmt/binding-openharmony-arm64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.58.0':
+  '@oxfmt/binding-openharmony-arm64@0.59.0':
     optional: true
 
   '@oxfmt/binding-win32-arm64-msvc@0.53.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.58.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.59.0':
     optional: true
 
   '@oxfmt/binding-win32-ia32-msvc@0.53.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.58.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.59.0':
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.53.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.58.0':
+  '@oxfmt/binding-win32-x64-msvc@0.59.0':
     optional: true
 
   '@parcel/watcher-android-arm64@2.5.6':
@@ -2494,29 +2494,29 @@ snapshots:
       '@oxfmt/binding-win32-x64-msvc': 0.53.0
       svelte: 5.56.4
 
-  oxfmt@0.58.0(svelte@5.56.6):
+  oxfmt@0.59.0(svelte@5.56.6):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.58.0
-      '@oxfmt/binding-android-arm64': 0.58.0
-      '@oxfmt/binding-darwin-arm64': 0.58.0
-      '@oxfmt/binding-darwin-x64': 0.58.0
-      '@oxfmt/binding-freebsd-x64': 0.58.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.58.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.58.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.58.0
-      '@oxfmt/binding-linux-arm64-musl': 0.58.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.58.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.58.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.58.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.58.0
-      '@oxfmt/binding-linux-x64-gnu': 0.58.0
-      '@oxfmt/binding-linux-x64-musl': 0.58.0
-      '@oxfmt/binding-openharmony-arm64': 0.58.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.58.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.58.0
-      '@oxfmt/binding-win32-x64-msvc': 0.58.0
+      '@oxfmt/binding-android-arm-eabi': 0.59.0
+      '@oxfmt/binding-android-arm64': 0.59.0
+      '@oxfmt/binding-darwin-arm64': 0.59.0
+      '@oxfmt/binding-darwin-x64': 0.59.0
+      '@oxfmt/binding-freebsd-x64': 0.59.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.59.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.59.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.59.0
+      '@oxfmt/binding-linux-arm64-musl': 0.59.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.59.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.59.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.59.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.59.0
+      '@oxfmt/binding-linux-x64-gnu': 0.59.0
+      '@oxfmt/binding-linux-x64-musl': 0.59.0
+      '@oxfmt/binding-openharmony-arm64': 0.59.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.59.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.59.0
+      '@oxfmt/binding-win32-x64-msvc': 0.59.0
       svelte: 5.56.6
 
   p-filter@2.1.0:


### PR DESCRIPTION
Replaces #1526 / #1557. Same coordinated bump (npm `oxfmt` 0.58.0 → 0.59.0 + workspace oxc_* git rev synced to the `oxfmt_v0.59.0` tag `2d4e8d206` + `oxc_* = "0.139"` version-requirement bumps + minimally regenerated Cargo.lock / pnpm-lock), rebuilt as fresh commits on current main because GitHub Actions silently dropped every CI event (push / reopen / PR-open) on the two previous branches while all other branches trigger fine.

Content was previously validated on #1526's earlier head (all jobs green at 68ef8ed0 except the main-wide formatter-parity issue since fixed by #1531): no source/API changes needed; formatter output unchanged incl. `css_native`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)