### PR TITLE
perf(analyze): phase-2 のホットパスから serde_json::Value の実体化を排除 (client -9.1% / server -12.5%)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4191,23 +4191,95 @@ fn extract_all_identifiers_from_expr(expr: &serde_json::Value, ids: &mut Vec<Str
 
 /// Extract ALL identifier names from a JsNode expression.
 /// JsNode version of `extract_all_identifiers_from_expr`.
-/// Uses JSON fallback for complex nodes with arena-dependent fields.
+///
+/// Walks the typed tree directly through the thread-local parse arena
+/// (installed for the duration of analysis via `SerializeArenaGuard`), so the
+/// common `{#each}` / `bind:group` expression shapes no longer serialize the
+/// whole subtree into a `serde_json::Value` just to collect names. Falls back
+/// to the JSON walk only when no arena is active (e.g. isolated unit tests),
+/// which keeps the result byte-identical.
 fn extract_all_identifiers_from_node(node: &JsNode, ids: &mut Vec<String>) {
+    // Identifier is the base case and needs no arena.
+    if let JsNode::Identifier { name, .. } = node {
+        let name_str = name.as_str();
+        if !ids.iter().any(|i| i == name_str) {
+            ids.push(name_str.to_string());
+        }
+        return;
+    }
+
+    let walked = crate::ast::arena::try_with_current_serialize_arena(|arena| {
+        extract_all_identifiers_from_node_arena(node, arena, ids);
+    });
+
+    if walked.is_none() {
+        // No arena in scope — fall back to the JSON walk for compound nodes.
+        match node {
+            JsNode::MemberExpression { .. }
+            | JsNode::CallExpression { .. }
+            | JsNode::BinaryExpression { .. }
+            | JsNode::LogicalExpression { .. }
+            | JsNode::ConditionalExpression { .. } => {
+                let json = node.to_value();
+                extract_all_identifiers_from_expr(&json, ids);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Arena-backed recursion for `extract_all_identifiers_from_node`. Mirrors the
+/// field-by-field traversal of `extract_all_identifiers_from_expr` exactly:
+/// only MemberExpression (object always; property only when computed),
+/// CallExpression (callee + arguments), Binary/LogicalExpression (left + right)
+/// and ConditionalExpression (test + consequent + alternate) descend; every
+/// other node type is a no-op, matching the JSON walker's `_ => {}`.
+fn extract_all_identifiers_from_node_arena(
+    node: &JsNode,
+    arena: &ParseArena,
+    ids: &mut Vec<String>,
+) {
     match node {
         JsNode::Identifier { name, .. } => {
-            let name_str = name.to_string();
-            if !ids.contains(&name_str) {
-                ids.push(name_str);
+            let name_str = name.as_str();
+            if !ids.iter().any(|i| i == name_str) {
+                ids.push(name_str.to_string());
             }
         }
-        // For nodes with JsNodeId/IdRange children, fall back to JSON
-        JsNode::MemberExpression { .. }
-        | JsNode::CallExpression { .. }
-        | JsNode::BinaryExpression { .. }
-        | JsNode::LogicalExpression { .. }
-        | JsNode::ConditionalExpression { .. } => {
-            let json = node.to_value();
-            extract_all_identifiers_from_expr(&json, ids);
+        JsNode::MemberExpression {
+            object,
+            property,
+            computed,
+            ..
+        } => {
+            extract_all_identifiers_from_node_arena(arena.get_js_node(*object), arena, ids);
+            // Only extract computed property identifiers (e.g., [index] in arr[index])
+            if *computed {
+                extract_all_identifiers_from_node_arena(arena.get_js_node(*property), arena, ids);
+            }
+        }
+        JsNode::CallExpression {
+            callee, arguments, ..
+        } => {
+            extract_all_identifiers_from_node_arena(arena.get_js_node(*callee), arena, ids);
+            for arg in arena.get_js_children(*arguments) {
+                extract_all_identifiers_from_node_arena(arg, arena, ids);
+            }
+        }
+        JsNode::BinaryExpression { left, right, .. }
+        | JsNode::LogicalExpression { left, right, .. } => {
+            extract_all_identifiers_from_node_arena(arena.get_js_node(*left), arena, ids);
+            extract_all_identifiers_from_node_arena(arena.get_js_node(*right), arena, ids);
+        }
+        JsNode::ConditionalExpression {
+            test,
+            consequent,
+            alternate,
+            ..
+        } => {
+            extract_all_identifiers_from_node_arena(arena.get_js_node(*test), arena, ids);
+            extract_all_identifiers_from_node_arena(arena.get_js_node(*consequent), arena, ids);
+            extract_all_identifiers_from_node_arena(arena.get_js_node(*alternate), arena, ids);
         }
         _ => {}
     }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/call_expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/call_expression.rs
@@ -120,9 +120,9 @@ fn get_global_keypath(node: &Value, context: &VisitorContext) -> Option<String> 
 /// // get_parent(context, 2) returns Program
 /// // get_parent(context, 3) returns None
 /// ```
-fn get_parent<'a>(context: &'a VisitorContext, offset: usize) -> Option<&'a Value> {
+fn get_parent<'a>(context: &'a VisitorContext, offset: usize) -> Option<&'a super::JsPathEntry> {
     let index = context.js_path.len().checked_sub(offset + 1)?;
-    context.js_path.get(index).map(|entry| &**entry)
+    context.js_path.get(index)
 }
 
 /// Check if $bindable is in a valid placement.
@@ -152,7 +152,7 @@ fn is_bindable_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    if parent.get("type").and_then(|t| t.as_str()) != Some("AssignmentPattern") {
+    if parent.get_type_str() != Some("AssignmentPattern") {
         return false;
     }
 
@@ -163,7 +163,7 @@ fn is_bindable_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    let gp_type = grandparent.get("type").and_then(|t| t.as_str());
+    let gp_type = grandparent.get_type_str();
 
     // If grandparent is Property, skip it and look at the next ancestor
     if gp_type == Some("Property") {
@@ -172,7 +172,7 @@ fn is_bindable_valid_placement(context: &VisitorContext) -> bool {
             Some(p) => p,
             None => return false,
         };
-        let next_type = next_ancestor.get("type").and_then(|t| t.as_str());
+        let next_type = next_ancestor.get_type_str();
         if !matches!(next_type, Some("ObjectPattern") | Some("ArrayPattern")) {
             return false;
         }
@@ -187,12 +187,12 @@ fn is_bindable_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    if var_declarator.get("type").and_then(|t| t.as_str()) != Some("VariableDeclarator") {
+    if var_declarator.get_type_str() != Some("VariableDeclarator") {
         return false;
     }
 
     // Check that VariableDeclarator init is $props()
-    if let Some(init) = var_declarator.get("init") {
+    if let Some(init) = var_declarator.as_value().get("init") {
         let rune = get_rune(init, context);
         return rune.as_deref() == Some("$props");
     }
@@ -227,7 +227,7 @@ fn is_props_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    if parent.get("type").and_then(|t| t.as_str()) != Some("VariableDeclarator") {
+    if parent.get_type_str() != Some("VariableDeclarator") {
         return false;
     }
 
@@ -243,7 +243,7 @@ fn is_props_valid_placement(context: &VisitorContext) -> bool {
             None => return false,
         };
 
-        let ancestor_type = ancestor.get("type").and_then(|t| t.as_str());
+        let ancestor_type = ancestor.get_type_str();
 
         match ancestor_type {
             Some("Program") => {
@@ -303,12 +303,12 @@ fn is_props_id_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    if parent.get("type").and_then(|t| t.as_str()) != Some("VariableDeclarator") {
+    if parent.get_type_str() != Some("VariableDeclarator") {
         return false;
     }
 
     // The id field of VariableDeclarator must be an Identifier (not ObjectPattern or ArrayPattern)
-    if let Some(id) = parent.get("id") {
+    if let Some(id) = parent.as_value().get("id") {
         let id_type = id.get("type").and_then(|t| t.as_str());
         if id_type != Some("Identifier") {
             return false;
@@ -325,7 +325,7 @@ fn is_props_id_valid_placement(context: &VisitorContext) -> bool {
             None => return false,
         };
 
-        let ancestor_type = ancestor.get("type").and_then(|t| t.as_str());
+        let ancestor_type = ancestor.get_type_str();
 
         match ancestor_type {
             Some("Program") => {
@@ -397,7 +397,7 @@ fn is_state_or_derived_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    let parent_type = parent.get("type").and_then(|t| t.as_str());
+    let parent_type = parent.get_type_str();
 
     match parent_type {
         Some("VariableDeclarator") => {
@@ -417,20 +417,14 @@ fn is_state_or_derived_valid_placement(context: &VisitorContext) -> bool {
 
         Some("PropertyDefinition") => {
             // Must be non-static and non-computed
-            let is_static = parent
-                .get("static")
-                .and_then(|s| s.as_bool())
-                .unwrap_or(false);
-            let is_computed = parent
-                .get("computed")
-                .and_then(|c| c.as_bool())
-                .unwrap_or(false);
+            let is_static = parent.get_field_bool("static").unwrap_or(false);
+            let is_computed = parent.get_field_bool("computed").unwrap_or(false);
             !is_static && !is_computed
         }
 
         Some("AssignmentExpression") => {
             // Check if this is a valid class property assignment at constructor root
-            is_class_property_assignment_at_constructor_root(parent, context)
+            is_class_property_assignment_at_constructor_root(parent.as_value(), context)
         }
 
         _ => false,
@@ -463,11 +457,11 @@ fn is_class_property_assignment_at_constructor_root(
         None => return false,
     };
 
-    if parent_5.get("type").and_then(|t| t.as_str()) != Some("MethodDefinition") {
+    if parent_5.get_type_str() != Some("MethodDefinition") {
         return false;
     }
 
-    if parent_5.get("kind").and_then(|k| k.as_str()) != Some("constructor") {
+    if parent_5.get_field_str("kind") != Some("constructor") {
         return false;
     }
 
@@ -527,7 +521,7 @@ fn is_effect_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    parent.get("type").and_then(|t| t.as_str()) == Some("ExpressionStatement")
+    parent.get_type_str() == Some("ExpressionStatement")
 }
 
 /// Check if $inspect.trace is in a valid placement.
@@ -556,7 +550,7 @@ fn is_inspect_trace_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    if parent.get("type").and_then(|t| t.as_str()) != Some("ExpressionStatement") {
+    if parent.get_type_str() != Some("ExpressionStatement") {
         return false;
     }
 
@@ -566,7 +560,7 @@ fn is_inspect_trace_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    if grandparent.get("type").and_then(|t| t.as_str()) != Some("BlockStatement") {
+    if grandparent.get_type_str() != Some("BlockStatement") {
         return false;
     }
 
@@ -576,7 +570,7 @@ fn is_inspect_trace_valid_placement(context: &VisitorContext) -> bool {
         None => return false,
     };
 
-    let fn_type = fn_node.get("type").and_then(|t| t.as_str());
+    let fn_type = fn_node.get_type_str();
     if !matches!(
         fn_type,
         Some("FunctionDeclaration") | Some("FunctionExpression") | Some("ArrowFunctionExpression")
@@ -586,11 +580,14 @@ fn is_inspect_trace_valid_placement(context: &VisitorContext) -> bool {
 
     // Check it's the first statement in the block by comparing source positions:
     // distinct AST nodes have distinct `start` offsets within a single parse.
-    if let Some(body) = grandparent.get("body").and_then(|b| b.as_array())
+    if let Some(body) = grandparent
+        .as_value()
+        .get("body")
+        .and_then(|b| b.as_array())
         && let Some(first) = body.first()
     {
         let first_start = first.get("start").and_then(|s| s.as_u64());
-        let parent_start = parent.get("start").and_then(|s| s.as_u64());
+        let parent_start = parent.get_field_u64("start");
         return first_start.is_some() && first_start == parent_start;
     }
 
@@ -709,6 +706,7 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
             // Get parent VariableDeclarator to extract id name
             if let Some(parent) = get_parent(context, 1)
                 && let Some(id_name) = parent
+                    .as_value()
                     .get("id")
                     .and_then(|id| id.get("name"))
                     .and_then(|n| n.as_str())

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -61,12 +61,18 @@ pub(crate) fn validate_template_await(context: &VisitorContext) -> Result<(), An
 fn has_shadowing_declaration_in_path(js_path: &[super::super::JsPathEntry], name: &str) -> bool {
     // Walk the path from innermost to outermost
     for node in js_path.iter().rev() {
-        let node_type = node.get("type").and_then(|t| t.as_str());
+        let node_type = node.get_type_str();
 
         match node_type {
             Some("FunctionDeclaration")
             | Some("FunctionExpression")
             | Some("ArrowFunctionExpression") => {
+                // Only a function ancestor is materialized here (its body/params are
+                // needed to detect a shadowing declaration); non-function ancestors
+                // never leave the cheap `get_type_str()` path above, so the common
+                // path (Program / VariableDeclaration / CallExpression …) is not
+                // serialized into a `serde_json::Value` just to read its type.
+                let node = node.as_value();
                 // Check if this function declares a variable with the given name
                 if let Some(body) = node.get("body")
                     && has_variable_declaration(body, name)
@@ -304,7 +310,7 @@ fn get_name(node: &Value) -> Option<String> {
 /// # Returns
 ///
 /// The parent node at the given index, skipping TypeScript wrapper nodes
-fn get_parent(path: &[super::super::JsPathEntry], at: isize) -> Option<&Value> {
+fn get_parent(path: &[super::super::JsPathEntry], at: isize) -> Option<&super::super::JsPathEntry> {
     let len = path.len() as isize;
     let index = if at < 0 { len + at } else { at };
 
@@ -315,7 +321,7 @@ fn get_parent(path: &[super::super::JsPathEntry], at: isize) -> Option<&Value> {
     let node = &path[index as usize];
 
     // Skip TypeScript wrapper nodes
-    match node.get("type").and_then(|t| t.as_str()) {
+    match node.get_type_str() {
         Some("TSNonNullExpression") | Some("TSAsExpression") => {
             // Get the next node in the appropriate direction
             let next_index = if at < 0 { at - 1 } else { at + 1 };
@@ -504,7 +510,7 @@ pub fn validate_assignment(
             while i > 0 {
                 i -= 1;
                 let parent = &context.js_path[i];
-                let parent_type = parent.get("type").and_then(|t| t.as_str());
+                let parent_type = parent.get_type_str();
 
                 if matches!(
                     parent_type,
@@ -514,9 +520,8 @@ pub fn validate_assignment(
                 ) {
                     // Get the grandparent
                     if let Some(grandparent) = get_parent(&context.js_path, (i as isize) - 1)
-                        && grandparent.get("type").and_then(|t| t.as_str())
-                            == Some("MethodDefinition")
-                        && grandparent.get("kind").and_then(|k| k.as_str()) == Some("constructor")
+                        && grandparent.get_type_str() == Some("MethodDefinition")
+                        && grandparent.get_field_str("kind") == Some("constructor")
                     {
                         // We're in a constructor - check if assignment is before field declaration
                         let node_start = argument.get("start").and_then(|s| s.as_u64());
@@ -2741,7 +2746,7 @@ pub fn validate_assignment_node(
             while i > 0 {
                 i -= 1;
                 let parent = &context.js_path[i];
-                let parent_type = parent.get("type").and_then(|t| t.as_str());
+                let parent_type = parent.get_type_str();
 
                 if matches!(
                     parent_type,
@@ -2750,9 +2755,8 @@ pub fn validate_assignment_node(
                         | Some("ArrowFunctionExpression")
                 ) {
                     if let Some(grandparent) = get_parent(&context.js_path, (i as isize) - 1)
-                        && grandparent.get("type").and_then(|t| t.as_str())
-                            == Some("MethodDefinition")
-                        && grandparent.get("kind").and_then(|k| k.as_str()) == Some("constructor")
+                        && grandparent.get_type_str() == Some("MethodDefinition")
+                        && grandparent.get_field_str("kind") == Some("constructor")
                     {
                         let node_start = argument.start();
                         let field_start = field


### PR DESCRIPTION
## What

Phase-2 analyze の**ホットパスから `serde_json::Value` の実体化を排除**する性能改善です。出力・診断は完全に不変で、変更は内部の走査方法のみです。

## Why

コンパイルパイプラインをプロファイル(macOS `sample`、compile-client シングルスレッド、19,485 サンプル)したところ、self-time の内訳が以下でした:

| 領域 | self-time |
|---|---:|
| **JSON Value 経済圏**(serde 7.4% + indexmap 9.3% + SipHash 4.7%) | **21.4%** |
| mimalloc | 10.7% |
| memmove | 7.5% |
| oxc_parser 合計 | 3.3% |

パース済み JS は既に typed AST(`JsNode` + `ParseArena`)で保持されているにもかかわらず、phase-2 の visitor ユーティリティが `JsPathEntry` の暗黙 `Deref` 経由で `JsNode::to_value()` を発火させ、祖先ノードのサブツリーを丸ごと JSON へシリアライズしていました。`_node` サフィックスの typed 版関数自体が、内部の祖先検証や複合式の識別子抽出で JSON 経路へ「後退」していた形です。

## What changed

**1. 祖先チェーン検証を typed アクセサ経由に(`6c54fbcc`)**

`call_expression.rs::get_parent` の戻り値を `Option<&Value>` → `Option<&JsPathEntry>` に変更し、`&**entry` による実体化を除去。呼び出し元(12箇所以上、offset 5 まで遡るものを含む)を既存の `get_type_str` / `get_field_str` / `get_field_bool` / `get_field_u64` に置き換えました。`utils.rs` の `get_parent` / `has_shadowing_declaration_in_path` / `validate_no_const_assignment` / `validate_assignment_node` も同様です。

`has_shadowing_declaration_in_path` では、関数祖先のみ body/params のために実体化し、Program / VariableDeclaration / CallExpression といった大多数の非関数祖先は型文字列を読むだけで済むようになりました。

**2. 識別子抽出を arena 直走査に(`dd84e441`)**

`extract_all_identifiers_from_node` は Identifier のみ typed で、MemberExpression / CallExpression / Binary / Logical / Conditional は `to_value()` で全体を実体化していました。これらは `{#each items.filter(...)}` や `bind:value={obj.prop}` といった**主流のテンプレート形**であり、フォールバックが常用経路になっていました。thread-local の parse arena を直接走査する実装に置き換えています。

新しい walker は JSON 版 `extract_all_identifiers_from_expr` をフィールド単位で厳密にミラーします — MemberExpression は object を常に辿り property は `computed` のときのみ、CallExpression は callee + arguments、Binary/Logical は left/right、Conditional は test/consequent/alternate、その他は no-op。arena 不在時(単体テスト等)は従来の JSON 経路にフォールバックするため、収集集合は不変です。

## Measurements

同一マシン・同一コーパス(svelte テストの 3,857 `.svelte` ファイル)で、base と本ブランチの両バイナリをビルドし **A/B/A/B 交互実行**(2ラウンド × 10反復、warmup 3)。中央値:

| タスク | base (852f80e2) | 本ブランチ | 改善 |
|---|---:|---:|---:|
| compile-client (single) | 275.67 ms | 250.48 ms | **-9.1%** |
| compile-server (single) | 187.69 ms | 164.25 ms | **-12.5%** |

分布は完全に分離しています(client: base 最小 266.78ms > 本ブランチ最大 258.20ms)。ノイズではありません。マルチスレッドは分散が大きく判定不能だったため、**改善なしとして扱います**。

## Testing

`RUST_MIN_STACK=33554432 cargo test --release -p rsvelte_core` — **167 スイート / 2,168 テスト / 失敗ゼロ**。`cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` クリーン。

## Equivalence review

出力を変えうる箇所を重点的に確認しました:

- **TS ラッパーのスキップ**: `get_parent` は `TSNonNullExpression` / `TSAsExpression` を読み飛ばしますが、`JsNode` enum にこれらのバリアントは存在しません(TS は `types.rs:892` で JsNode 化前に剥がされる)。typed エントリでこの分岐が発火することは変更前からなく、JSON 生まれのエントリは従来どおり `as_value()` にフォールスルーするため、スキップが効いていた経路は無傷です。
- **`kind` / `type` フィールド**: `get_field_str("kind")` は MethodDefinition を正しく処理し、`type_str()` は `to_value()` の `"type"` と一致するため、constructor 判定は等価です。
- **識別子の収集集合**: 上記のとおり JSON 版とフィールド単位で対照済み。JSON 版が辿らないノード(UnaryExpression 等)を新実装が誤って辿ることもありません。

## Not included (measured and rejected)

同じイテレーションで冗長な OXC パースの削除も検討しましたが、計装して実測した結果**却下**しました(コード変更なし)。`normalize_js_with_oxc` の slow path は 2,457 呼び出し中わずか 30 回(1.2%)、TS の冗長 strip は 63 回(コーパスの 0.97%)で、いずれもノイズ床を大きく下回ります。記録として残します。
