### PR TITLE
perf(analyze): Program push・識別子収集を typed AST 化 + store スキャンの再確保除去 (client -16% / server -26%)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4674,8 +4674,780 @@ fn collect_identifier_names_from_expression(
     expr: &crate::ast::js::Expression,
     out: &mut rustc_hash::FxHashSet<String>,
 ) {
+    if let Some(node) = expr.try_as_node_ref()
+        && crate::ast::arena::try_with_current_serialize_arena(|arena| {
+            collect_identifier_names_in_node(node, arena, out);
+        })
+        .is_some()
+    {
+        return;
+    }
     let json = expr.as_json();
     collect_identifier_names_in_json(json, out);
+}
+
+/// Typed equivalent of `collect_identifier_names_in_json`, walking the arena
+/// instead of a materialized `serde_json::Value`.
+///
+/// The JSON walker is generic — it iterates whatever fields serialization
+/// happened to emit — so this one has to name the children itself. To keep that
+/// enumeration honest, the `match` below has **no `_` arm** and **no `..` in any
+/// pattern**: adding a variant, or a field to a variant, is a compile error
+/// rather than a silently missed identifier.
+///
+/// Fields deliberately not descended into, each equivalent to what the JSON
+/// walker does:
+/// - `type_annotation` (`Identifier` / `ObjectPattern` / `ArrayPattern`) and the
+///   whole `TS*` family: serialized as `TSTypeAnnotation` & friends, which the
+///   JSON walker drops on its `starts_with("TS")` guard.
+/// - comments (attached to every node by serialization, plus `Program`'s
+///   `leading_comments` / `trailing_comments`): comment objects carry only
+///   `type` / `start` / `end` / `value`, never an `Identifier`.
+/// - the name slots the JSON walker skips explicitly: specifier
+///   `imported` / `exported`, non-computed `property` / `key`, function and
+///   class `id`, declarator `id`, and statement `label`.
+fn collect_identifier_names_in_node(
+    node: &JsNode,
+    arena: &ParseArena,
+    out: &mut rustc_hash::FxHashSet<String>,
+) {
+    use crate::ast::arena::{IdRange, JsNodeId};
+
+    let walk = |id: JsNodeId, out: &mut rustc_hash::FxHashSet<String>| {
+        collect_identifier_names_in_node(arena.get_js_node(id), arena, out);
+    };
+    let walk_opt = |id: &Option<JsNodeId>, out: &mut rustc_hash::FxHashSet<String>| {
+        if let Some(id) = id {
+            collect_identifier_names_in_node(arena.get_js_node(*id), arena, out);
+        }
+    };
+    let walk_range = |range: IdRange, out: &mut rustc_hash::FxHashSet<String>| {
+        for child in arena.get_js_children(range) {
+            collect_identifier_names_in_node(child, arena, out);
+        }
+    };
+    // `ArrayExpression` / `ArrayPattern` hold their elements inline (holes are
+    // `None`) rather than by arena id.
+    let walk_inline = |elements: &Vec<Option<JsNode>>, out: &mut rustc_hash::FxHashSet<String>| {
+        for element in elements.iter().flatten() {
+            collect_identifier_names_in_node(element, arena, out);
+        }
+    };
+
+    match node {
+        JsNode::Identifier {
+            start: _,
+            end: _,
+            loc: _,
+            name,
+            type_annotation: _,
+        } => {
+            if !out.contains(name.as_str()) {
+                out.insert(name.to_string());
+            }
+        }
+
+        // Not an `Identifier` node, so the JSON walker never collects it.
+        JsNode::PrivateIdentifier {
+            start: _,
+            end: _,
+            loc: _,
+            name: _,
+        } => {}
+
+        JsNode::Literal {
+            start: _,
+            end: _,
+            loc: _,
+            value: _,
+            raw: _,
+            regex: _,
+        } => {}
+
+        JsNode::BinaryExpression {
+            start: _,
+            end: _,
+            loc: _,
+            left,
+            operator: _,
+            right,
+        }
+        | JsNode::LogicalExpression {
+            start: _,
+            end: _,
+            loc: _,
+            left,
+            operator: _,
+            right,
+        }
+        | JsNode::AssignmentPattern {
+            start: _,
+            end: _,
+            loc: _,
+            left,
+            right,
+        } => {
+            walk(*left, out);
+            walk(*right, out);
+        }
+
+        JsNode::AssignmentExpression {
+            start: _,
+            end: _,
+            loc: _,
+            operator: _,
+            left,
+            right,
+        } => {
+            walk(*left, out);
+            walk(*right, out);
+        }
+
+        JsNode::UnaryExpression {
+            start: _,
+            end: _,
+            loc: _,
+            operator: _,
+            prefix: _,
+            argument,
+        }
+        | JsNode::UpdateExpression {
+            start: _,
+            end: _,
+            loc: _,
+            operator: _,
+            prefix: _,
+            argument,
+        } => walk(*argument, out),
+
+        JsNode::ConditionalExpression {
+            start: _,
+            end: _,
+            loc: _,
+            test,
+            consequent,
+            alternate,
+        } => {
+            walk(*test, out);
+            walk(*consequent, out);
+            walk(*alternate, out);
+        }
+
+        JsNode::CallExpression {
+            start: _,
+            end: _,
+            loc: _,
+            callee,
+            arguments,
+            optional: _,
+        } => {
+            walk(*callee, out);
+            walk_range(*arguments, out);
+        }
+
+        JsNode::NewExpression {
+            start: _,
+            end: _,
+            loc: _,
+            callee,
+            arguments,
+        } => {
+            walk(*callee, out);
+            walk_range(*arguments, out);
+        }
+
+        // A non-computed `property` is a name slot, not a reference.
+        JsNode::MemberExpression {
+            start: _,
+            end: _,
+            loc: _,
+            object,
+            property,
+            computed,
+            optional: _,
+        } => {
+            walk(*object, out);
+            if *computed {
+                walk(*property, out);
+            }
+        }
+
+        JsNode::FunctionExpression {
+            start: _,
+            end: _,
+            loc: _,
+            id: _,
+            params,
+            body,
+            generator: _,
+            r#async: _,
+            expression: _,
+        } => {
+            walk_range(*params, out);
+            walk_opt(body, out);
+        }
+
+        JsNode::FunctionDeclaration {
+            start: _,
+            end: _,
+            loc: _,
+            id: _,
+            params,
+            body,
+            generator: _,
+            r#async: _,
+        } => {
+            walk_range(*params, out);
+            walk_opt(body, out);
+        }
+
+        JsNode::ArrowFunctionExpression {
+            start: _,
+            end: _,
+            loc: _,
+            id: _,
+            params,
+            body,
+            expression: _,
+            generator: _,
+            r#async: _,
+        } => {
+            walk_range(*params, out);
+            walk(*body, out);
+        }
+
+        JsNode::ClassExpression {
+            start: _,
+            end: _,
+            loc: _,
+            id: _,
+            super_class,
+            body,
+        } => {
+            walk_opt(super_class, out);
+            walk(*body, out);
+        }
+
+        JsNode::ClassDeclaration {
+            start: _,
+            end: _,
+            loc: _,
+            id: _,
+            super_class,
+            body,
+            declare: _,
+            r#abstract: _,
+            implements: _,
+            decorators,
+        } => {
+            walk_opt(super_class, out);
+            walk(*body, out);
+            walk_range(*decorators, out);
+        }
+
+        JsNode::SequenceExpression {
+            start: _,
+            end: _,
+            loc: _,
+            expressions,
+        } => walk_range(*expressions, out),
+
+        JsNode::ArrayExpression {
+            start: _,
+            end: _,
+            loc: _,
+            elements,
+        } => walk_inline(elements, out),
+
+        JsNode::ObjectExpression {
+            start: _,
+            end: _,
+            loc: _,
+            properties,
+        } => walk_range(*properties, out),
+
+        JsNode::TemplateLiteral {
+            start: _,
+            end: _,
+            loc: _,
+            quasis,
+            expressions,
+        } => {
+            walk_range(*quasis, out);
+            walk_range(*expressions, out);
+        }
+
+        JsNode::TaggedTemplateExpression {
+            start: _,
+            end: _,
+            loc: _,
+            tag,
+            quasi,
+        } => {
+            walk(*tag, out);
+            walk(*quasi, out);
+        }
+
+        JsNode::TemplateElement {
+            start: _,
+            end: _,
+            loc: _,
+            tail: _,
+            value: _,
+        } => {}
+
+        JsNode::ThisExpression {
+            start: _,
+            end: _,
+            loc: _,
+        }
+        | JsNode::Super {
+            start: _,
+            end: _,
+            loc: _,
+        }
+        | JsNode::EmptyStatement {
+            start: _,
+            end: _,
+            loc: _,
+        }
+        | JsNode::DebuggerStatement {
+            start: _,
+            end: _,
+            loc: _,
+        }
+        | JsNode::Decorator {
+            start: _,
+            end: _,
+            loc: _,
+        } => {}
+
+        JsNode::ImportExpression {
+            start: _,
+            end: _,
+            loc: _,
+            source,
+        } => walk(*source, out),
+
+        JsNode::AwaitExpression {
+            start: _,
+            end: _,
+            loc: _,
+            argument,
+        }
+        | JsNode::ThrowStatement {
+            start: _,
+            end: _,
+            loc: _,
+            argument,
+        }
+        | JsNode::SpreadElement {
+            start: _,
+            end: _,
+            loc: _,
+            argument,
+        }
+        | JsNode::RestElement {
+            start: _,
+            end: _,
+            loc: _,
+            argument,
+        } => walk(*argument, out),
+
+        JsNode::YieldExpression {
+            start: _,
+            end: _,
+            loc: _,
+            delegate: _,
+            argument,
+        }
+        | JsNode::ReturnStatement {
+            start: _,
+            end: _,
+            loc: _,
+            argument,
+        } => walk_opt(argument, out),
+
+        JsNode::ChainExpression {
+            start: _,
+            end: _,
+            loc: _,
+            expression,
+        }
+        | JsNode::ExpressionStatement {
+            start: _,
+            end: _,
+            loc: _,
+            expression,
+        } => walk(*expression, out),
+
+        JsNode::MetaProperty {
+            start: _,
+            end: _,
+            loc: _,
+            meta,
+            property,
+        } => {
+            walk(*meta, out);
+            walk(*property, out);
+        }
+
+        JsNode::ObjectPattern {
+            start: _,
+            end: _,
+            loc: _,
+            properties,
+            type_annotation: _,
+        } => walk_range(*properties, out),
+
+        JsNode::ArrayPattern {
+            start: _,
+            end: _,
+            loc: _,
+            elements,
+            type_annotation: _,
+        } => walk_inline(elements, out),
+
+        // A non-computed `key` is a name slot, not a reference.
+        JsNode::Property {
+            start: _,
+            end: _,
+            loc: _,
+            key,
+            value,
+            kind: _,
+            method: _,
+            shorthand: _,
+            computed,
+        } => {
+            if *computed {
+                walk(*key, out);
+            }
+            walk(*value, out);
+        }
+
+        JsNode::MethodDefinition {
+            start: _,
+            end: _,
+            loc: _,
+            key,
+            value,
+            kind: _,
+            r#static: _,
+            computed,
+        } => {
+            if *computed {
+                walk(*key, out);
+            }
+            walk(*value, out);
+        }
+
+        JsNode::PropertyDefinition {
+            start: _,
+            end: _,
+            loc: _,
+            key,
+            value,
+            r#static: _,
+            computed,
+            accessor: _,
+        } => {
+            if *computed {
+                walk(*key, out);
+            }
+            walk_opt(value, out);
+        }
+
+        JsNode::Program {
+            start: _,
+            end: _,
+            loc: _,
+            body,
+            source_type: _,
+            leading_comments: _,
+            trailing_comments: _,
+            ignore_comment_map: _,
+        }
+        | JsNode::BlockStatement {
+            start: _,
+            end: _,
+            loc: _,
+            body,
+        }
+        | JsNode::ClassBody {
+            start: _,
+            end: _,
+            loc: _,
+            body,
+        }
+        | JsNode::StaticBlock {
+            start: _,
+            end: _,
+            loc: _,
+            body,
+        } => walk_range(*body, out),
+
+        JsNode::VariableDeclaration {
+            start: _,
+            end: _,
+            loc: _,
+            declarations,
+            kind: _,
+            declare: _,
+        } => walk_range(*declarations, out),
+
+        JsNode::VariableDeclarator {
+            start: _,
+            end: _,
+            loc: _,
+            id: _,
+            init,
+        } => walk_opt(init, out),
+
+        JsNode::IfStatement {
+            start: _,
+            end: _,
+            loc: _,
+            test,
+            consequent,
+            alternate,
+        } => {
+            walk(*test, out);
+            walk(*consequent, out);
+            walk_opt(alternate, out);
+        }
+
+        JsNode::ForStatement {
+            start: _,
+            end: _,
+            loc: _,
+            init,
+            test,
+            update,
+            body,
+        } => {
+            walk_opt(init, out);
+            walk_opt(test, out);
+            walk_opt(update, out);
+            walk(*body, out);
+        }
+
+        JsNode::ForOfStatement {
+            start: _,
+            end: _,
+            loc: _,
+            r#await: _,
+            left,
+            right,
+            body,
+        } => {
+            walk(*left, out);
+            walk(*right, out);
+            walk(*body, out);
+        }
+
+        JsNode::ForInStatement {
+            start: _,
+            end: _,
+            loc: _,
+            left,
+            right,
+            body,
+        } => {
+            walk(*left, out);
+            walk(*right, out);
+            walk(*body, out);
+        }
+
+        JsNode::WhileStatement {
+            start: _,
+            end: _,
+            loc: _,
+            test,
+            body,
+        }
+        | JsNode::DoWhileStatement {
+            start: _,
+            end: _,
+            loc: _,
+            test,
+            body,
+        } => {
+            walk(*test, out);
+            walk(*body, out);
+        }
+
+        JsNode::TryStatement {
+            start: _,
+            end: _,
+            loc: _,
+            block,
+            handler,
+            finalizer,
+        } => {
+            walk(*block, out);
+            walk_opt(handler, out);
+            walk_opt(finalizer, out);
+        }
+
+        JsNode::CatchClause {
+            start: _,
+            end: _,
+            loc: _,
+            param,
+            body,
+        } => {
+            walk_opt(param, out);
+            walk(*body, out);
+        }
+
+        JsNode::SwitchStatement {
+            start: _,
+            end: _,
+            loc: _,
+            discriminant,
+            cases,
+        } => {
+            walk(*discriminant, out);
+            walk_range(*cases, out);
+        }
+
+        JsNode::SwitchCase {
+            start: _,
+            end: _,
+            loc: _,
+            test,
+            consequent,
+        } => {
+            walk_opt(test, out);
+            walk_range(*consequent, out);
+        }
+
+        // Labels are not identifier references.
+        JsNode::LabeledStatement {
+            start: _,
+            end: _,
+            loc: _,
+            label: _,
+            body,
+        } => walk(*body, out),
+
+        JsNode::BreakStatement {
+            start: _,
+            end: _,
+            loc: _,
+            label: _,
+        }
+        | JsNode::ContinueStatement {
+            start: _,
+            end: _,
+            loc: _,
+            label: _,
+        } => {}
+
+        JsNode::ImportDeclaration {
+            start: _,
+            end: _,
+            loc: _,
+            specifiers,
+            source,
+            import_kind: _,
+            attributes,
+        } => {
+            walk_range(*specifiers, out);
+            walk(*source, out);
+            walk_range(*attributes, out);
+        }
+
+        // `imported` is the name in the exporting module, not a local reference.
+        JsNode::ImportSpecifier {
+            start: _,
+            end: _,
+            loc: _,
+            imported: _,
+            local,
+            import_kind: _,
+        } => walk(*local, out),
+
+        JsNode::ImportDefaultSpecifier {
+            start: _,
+            end: _,
+            loc: _,
+            local,
+        }
+        | JsNode::ImportNamespaceSpecifier {
+            start: _,
+            end: _,
+            loc: _,
+            local,
+        } => walk(*local, out),
+
+        JsNode::ExportNamedDeclaration {
+            start: _,
+            end: _,
+            loc: _,
+            declaration,
+            specifiers,
+            source,
+            export_kind: _,
+            attributes,
+        } => {
+            walk_opt(declaration, out);
+            walk_range(*specifiers, out);
+            walk_opt(source, out);
+            walk_range(*attributes, out);
+        }
+
+        JsNode::ExportDefaultDeclaration {
+            start: _,
+            end: _,
+            loc: _,
+            declaration,
+        } => walk(*declaration, out),
+
+        // `exported` is the name in the importing module, not a local reference.
+        JsNode::ExportSpecifier {
+            start: _,
+            end: _,
+            loc: _,
+            local,
+            exported: _,
+            export_kind: _,
+        } => walk(*local, out),
+
+        // Type-space nodes: dropped by the JSON walker's `starts_with("TS")` guard.
+        JsNode::TSTypeAnnotation {
+            start: _,
+            end: _,
+            loc: _,
+            type_annotation: _,
+        } => {}
+        JsNode::TSEnumDeclaration {
+            start: _,
+            end: _,
+            loc: _,
+        }
+        | JsNode::TSParameterProperty {
+            start: _,
+            end: _,
+            loc: _,
+        } => {}
+        JsNode::TSModuleDeclaration {
+            start: _,
+            end: _,
+            loc: _,
+            body: _,
+        } => {}
+
+        JsNode::Comment {
+            start: _,
+            end: _,
+            comment_type: _,
+            value: _,
+        } => {}
+
+        JsNode::Null => {}
+    }
 }
 
 fn collect_identifier_names_in_json(

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -734,8 +734,26 @@ fn collect_dollar_identifiers_from_js_with_context(
     // space. A param `$x` only suppresses references inside its own arrow body
     // `[start, end)`; a `let/const/var $x` declaration spans the whole script.
     let mut declared: Vec<(String, usize, usize)> = Vec::new();
-    collect_dollar_identifiers_pass(js, base_offset, refs, in_module, true, &mut declared);
-    collect_dollar_identifiers_pass(js, base_offset, refs, in_module, false, &mut declared);
+    // Both passes scan the same text, so decode it once.
+    let chars: Vec<char> = js.chars().collect();
+    collect_dollar_identifiers_pass(
+        js,
+        &chars,
+        base_offset,
+        refs,
+        in_module,
+        true,
+        &mut declared,
+    );
+    collect_dollar_identifiers_pass(
+        js,
+        &chars,
+        base_offset,
+        refs,
+        in_module,
+        false,
+        &mut declared,
+    );
 }
 
 /// One scan over `js`. With `collect_declared` set, only fills `declared`
@@ -743,17 +761,23 @@ fn collect_dollar_identifiers_from_js_with_context(
 /// skipping declared names.
 fn collect_dollar_identifiers_pass(
     js: &str,
+    chars: &[char],
     base_offset: usize,
     refs: &mut Vec<StoreRef>,
     in_module: bool,
     collect_declared: bool,
     declared: &mut Vec<(String, usize, usize)>,
 ) {
-    let chars: Vec<char> = js.chars().collect();
     // Byte offset of each character, so a `StoreRef.position` (consumed
     // downstream as a byte index into the source) stays correct when multi-byte
-    // characters precede the reference (M-005).
-    let char_byte_offsets: Vec<usize> = js.char_indices().map(|(b, _)| b).collect();
+    // characters precede the reference (M-005). Only the reference-collecting
+    // pass reads it, and only a non-ASCII script needs it at all — otherwise a
+    // char index already is the byte offset.
+    let char_byte_offsets: Option<Vec<usize>> = if collect_declared || js.is_ascii() {
+        None
+    } else {
+        Some(js.char_indices().map(|(b, _)| b).collect())
+    };
     let len = chars.len();
     let mut i = 0;
     let mut in_string: Option<char> = None; // track if inside a string literal
@@ -897,8 +921,8 @@ fn collect_dollar_identifiers_pass(
                 // Only add if we have more than just $
                 // (bare $ detection is handled separately via proper AST analysis)
                 if ident.len() > 1 {
-                    let param_range = dollar_param_body_range(&chars, ident_start, i);
-                    let is_var_decl = is_dollar_ident_variable_declaration(&chars, ident_start);
+                    let param_range = dollar_param_body_range(chars, ident_start, i);
+                    let is_var_decl = is_dollar_ident_variable_declaration(chars, ident_start);
                     let is_declaration = param_range.is_some() || is_var_decl;
                     if collect_declared {
                         if let Some((bs, be)) = param_range {
@@ -915,16 +939,18 @@ fn collect_dollar_identifiers_pass(
                         && !declared
                             .iter()
                             .any(|(n, s, e)| n == &ident && ident_start >= *s && ident_start < *e)
-                        && !is_dollar_ident_object_property_key(&chars, ident_start, i)
-                        && !is_dollar_ident_type_declaration(&chars, ident_start)
+                        && !is_dollar_ident_object_property_key(chars, ident_start, i)
+                        && !is_dollar_ident_type_declaration(chars, ident_start)
                     {
+                        let byte_offset = match &char_byte_offsets {
+                            Some(offsets) => offsets.get(ident_start).copied(),
+                            // ASCII: char index == byte index, with the same
+                            // in-bounds condition the offset table would apply.
+                            None => (ident_start < len).then_some(ident_start),
+                        };
                         refs.push(StoreRef {
                             name: ident,
-                            position: base_offset
-                                + char_byte_offsets
-                                    .get(ident_start)
-                                    .copied()
-                                    .unwrap_or(js.len()),
+                            position: base_offset + byte_offset.unwrap_or(js.len()),
                             in_module,
                         });
                     }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
@@ -41,9 +41,17 @@ pub fn visit_script_expr(
                 let saved_ignores = std::mem::take(&mut context.script_ignore_comments);
                 context.script_ignore_comments = ignore_comment_map.iter().cloned().collect();
 
-                // Fast path: push a lazily-computed Value for js_path, then walk body typed
-                let program_value = te.as_json();
-                context.js_path.push(super::JsPathEntry::new(program_value));
+                // Push the Program as a TYPED js_path entry, like every other node
+                // the walker pushes below. `as_json()` here used to materialize the
+                // entire program into a `serde_json::Value` up front, on every script
+                // walk, purely to occupy `js_path[0]` — which consumers only read the
+                // type off of. `JsPathEntry::TypedNode` answers `get_type_str()` from
+                // the `JsNode` directly and falls back to the same `to_value()` lazily
+                // if a consumer really needs the Value, so the observable path is
+                // unchanged.
+                context
+                    .js_path
+                    .push(super::JsPathEntry::new_typed(&te.node));
 
                 let arena = context.parse_arena;
                 let mut result = Ok(());

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -58,7 +58,11 @@ pub(crate) fn validate_template_await(context: &VisitorContext) -> Result<(), An
 /// nodes and checks if their bodies contain a VariableDeclaration with the given name.
 ///
 /// This is used to detect if a component-level constant is being shadowed by a local variable.
-fn has_shadowing_declaration_in_path(js_path: &[super::super::JsPathEntry], name: &str) -> bool {
+fn has_shadowing_declaration_in_path(
+    js_path: &[super::super::JsPathEntry],
+    name: &str,
+    arena: &crate::ast::arena::ParseArena,
+) -> bool {
     // Walk the path from innermost to outermost
     for node in js_path.iter().rev() {
         let node_type = node.get_type_str();
@@ -67,19 +71,23 @@ fn has_shadowing_declaration_in_path(js_path: &[super::super::JsPathEntry], name
             Some("FunctionDeclaration")
             | Some("FunctionExpression")
             | Some("ArrowFunctionExpression") => {
-                // Only a function ancestor is materialized here (its body/params are
-                // needed to detect a shadowing declaration); non-function ancestors
-                // never leave the cheap `get_type_str()` path above, so the common
-                // path (Program / VariableDeclaration / CallExpression …) is not
-                // serialized into a `serde_json::Value` just to read its type.
+                // Non-function ancestors never leave the cheap `get_type_str()`
+                // path above; a function ancestor resolves its body and params
+                // through the arena, so it is not serialized into a
+                // `serde_json::Value` either.
+                if let Some(js_node) = node.as_js_node() {
+                    if function_declares_name_node(js_node, name, arena) {
+                        return true;
+                    }
+                    continue;
+                }
+                // JSON fallback for `Borrowed` / `Owned` entries.
                 let node = node.as_value();
-                // Check if this function declares a variable with the given name
                 if let Some(body) = node.get("body")
                     && has_variable_declaration(body, name)
                 {
                     return true;
                 }
-                // Also check function parameters
                 if let Some(params) = node.get("params").and_then(|p| p.as_array()) {
                     for param in params {
                         if param_declares_name(param, name) {
@@ -92,6 +100,161 @@ fn has_shadowing_declaration_in_path(js_path: &[super::super::JsPathEntry], name
         }
     }
     false
+}
+
+/// Typed mirror of the function-ancestor check above: body first, then params.
+fn function_declares_name_node(
+    func: &JsNode,
+    name: &str,
+    arena: &crate::ast::arena::ParseArena,
+) -> bool {
+    let (params, body) = match func {
+        JsNode::FunctionDeclaration { params, body, .. }
+        | JsNode::FunctionExpression { params, body, .. } => (*params, *body),
+        JsNode::ArrowFunctionExpression { params, body, .. } => (*params, Some(*body)),
+        _ => return false,
+    };
+
+    if let Some(body) = body
+        && has_variable_declaration_node(arena.get_js_node(body), name, arena)
+    {
+        return true;
+    }
+    for param in arena.get_js_children(params) {
+        if pattern_declares_name_node(param, name, arena) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Typed mirror of `has_variable_declaration`: only a block body can declare
+/// anything (an arrow with an expression body cannot).
+fn has_variable_declaration_node(
+    body: &JsNode,
+    name: &str,
+    arena: &crate::ast::arena::ParseArena,
+) -> bool {
+    match body {
+        JsNode::BlockStatement { body, .. } => arena
+            .get_js_children(*body)
+            .iter()
+            .any(|stmt| statement_declares_name_node(stmt, name, arena)),
+        _ => false,
+    }
+}
+
+/// Typed mirror of `statement_declares_name`.
+///
+/// The JSON version reaches only the fields named below, so this one does too —
+/// notably it does NOT look at a `for` statement's `init` or a `for…of`/`for…in`
+/// `left`, which means `for (let x = …)` does not count as a shadowing
+/// declaration. That is existing behaviour and is preserved deliberately.
+fn statement_declares_name_node(
+    stmt: &JsNode,
+    name: &str,
+    arena: &crate::ast::arena::ParseArena,
+) -> bool {
+    let walk = |id: crate::ast::arena::JsNodeId| {
+        statement_declares_name_node(arena.get_js_node(id), name, arena)
+    };
+    let walk_opt = |id: &Option<crate::ast::arena::JsNodeId>| id.is_some_and(&walk);
+
+    match stmt {
+        // Only `let` / `var` shadow; `const` does not.
+        JsNode::VariableDeclaration {
+            declarations, kind, ..
+        } => {
+            (kind.as_str() == "let" || kind.as_str() == "var")
+                && arena.get_js_children(*declarations).iter().any(|decl| {
+                    matches!(decl, JsNode::VariableDeclarator { id, .. }
+                        if pattern_declares_name_node(arena.get_js_node(*id), name, arena))
+                })
+        }
+
+        // A named function declaration binds its own name, but its body is a
+        // different scope and is not descended into.
+        JsNode::FunctionDeclaration { id, .. } => id.is_some_and(|id| {
+            matches!(arena.get_js_node(id), JsNode::Identifier { name: n, .. } if n.as_str() == name)
+        }),
+
+        JsNode::BlockStatement { body, .. } => arena
+            .get_js_children(*body)
+            .iter()
+            .any(|s| statement_declares_name_node(s, name, arena)),
+
+        JsNode::IfStatement {
+            consequent,
+            alternate,
+            ..
+        } => walk(*consequent) || walk_opt(alternate),
+
+        JsNode::ForStatement { body, .. }
+        | JsNode::ForInStatement { body, .. }
+        | JsNode::ForOfStatement { body, .. }
+        | JsNode::WhileStatement { body, .. }
+        | JsNode::DoWhileStatement { body, .. } => walk(*body),
+
+        JsNode::TryStatement {
+            block,
+            handler,
+            finalizer,
+            ..
+        } => {
+            if walk(*block) {
+                return true;
+            }
+            if let Some(handler) = handler
+                && let JsNode::CatchClause { body, .. } = arena.get_js_node(*handler)
+                && walk(*body)
+            {
+                return true;
+            }
+            walk_opt(finalizer)
+        }
+
+        JsNode::SwitchStatement { cases, .. } => {
+            arena.get_js_children(*cases).iter().any(|case| {
+                matches!(case, JsNode::SwitchCase { consequent, .. }
+                    if arena
+                        .get_js_children(*consequent)
+                        .iter()
+                        .any(|s| statement_declares_name_node(s, name, arena)))
+            })
+        }
+
+        _ => false,
+    }
+}
+
+/// Typed mirror of `pattern_declares_name`.
+fn pattern_declares_name_node(
+    pattern: &JsNode,
+    name: &str,
+    arena: &crate::ast::arena::ParseArena,
+) -> bool {
+    match pattern {
+        JsNode::Identifier { name: n, .. } => n.as_str() == name,
+        // Only a `Property`'s value is inspected, matching the JSON version's
+        // `prop.get("value")` (a `{ ...rest }` entry has no `value` key).
+        JsNode::ObjectPattern { properties, .. } => {
+            arena.get_js_children(*properties).iter().any(|prop| {
+                matches!(prop, JsNode::Property { value, .. }
+                    if pattern_declares_name_node(arena.get_js_node(*value), name, arena))
+            })
+        }
+        JsNode::ArrayPattern { elements, .. } => elements
+            .iter()
+            .flatten()
+            .any(|elem| pattern_declares_name_node(elem, name, arena)),
+        JsNode::AssignmentPattern { left, .. } => {
+            pattern_declares_name_node(arena.get_js_node(*left), name, arena)
+        }
+        JsNode::RestElement { argument, .. } => {
+            pattern_declares_name_node(arena.get_js_node(*argument), name, arena)
+        }
+        _ => false,
+    }
 }
 
 /// Check if a function body (BlockStatement or Expression) declares a variable with the given name.
@@ -635,8 +798,11 @@ pub fn validate_no_const_assignment(
                         // by looking for variable declarations in ancestor function bodies.
                         // This handles cases where a const in an outer function is shadowed by
                         // a let/var in a nested loop within the current function.
-                        let has_local_shadowing =
-                            has_shadowing_declaration_in_path(&context.js_path, name);
+                        let has_local_shadowing = has_shadowing_declaration_in_path(
+                            &context.js_path,
+                            name,
+                            context.parse_arena,
+                        );
                         if has_local_shadowing {
                             // Skip validation - there's a local variable that shadows the const
                             return Ok(());
@@ -2642,8 +2808,11 @@ pub fn validate_no_const_assignment_node(
                 }
 
                 if context.function_depth > 1 {
-                    let has_local_shadowing =
-                        has_shadowing_declaration_in_path(&context.js_path, name);
+                    let has_local_shadowing = has_shadowing_declaration_in_path(
+                        &context.js_path,
+                        name,
+                        context.parse_arena,
+                    );
                     if has_local_shadowing {
                         return Ok(());
                     }


### PR DESCRIPTION
## What

Phase-2 analyze に残っていた **`serde_json::Value` の全体実体化を2箇所とも撤去**します。#1582 の続きで、同じ「typed AST を持っているのに JSON へ変換し直している」構造の最後の大物です。出力・診断は不変です。

## Why — 2つは「対」で、片方だけでは効かない

#1582 の後にプロファイルを取り直したところ、`to_value` が依然として **client 19.3% / server 26.1%** を占めており、支払い元は2箇所に集中していました。

まず `visitors/script.rs` の Program push を typed 化した(A-1、`261484e8`)ところ、**その分がそっくり `collect_identifier_names_from_expression` に移動**しました:

| 呼び出し元 | server (A-1前) | server (A-1後) |
|---|---:|---:|
| `visit_script_expr` | 16.5% | **消滅** |
| `collect_identifier_names_from_expression` | — | **13.8%** |
| **to_value 合計** | 26.1% | 25.2% |

A-1 単独の効果が client -1.0% / server -2.4% に留まったのはこのためです。**両方を直して初めて JSON 経済圏そのものが落ちます**:

| | client | server |
|---|---:|---:|
| A-1 単独 | -1.0% | -2.4% |
| **A-1 + A-2** | **-15%** | **-23%** |

## What changed

**A-1 (`261484e8`) — `visitors/script.rs`**

`let program_value = te.as_json(); JsPathEntry::new(program_value)` を `JsPathEntry::new_typed(&te.node)` に置換。コメントは "lazily-computed" と書かれていましたが、`as_json()` は**プログラム全体を即座に実体化**します。同ファイルの他の全ノードは既に `new_typed` を使っており、#1582 で消費者を typed 化した結果、このエントリは実際には型名 "Program" を読むだけになっていました。

**A-2 (`bcc13e96`) — `collect_identifier_names_from_expression`**

コンポーネント名 deconfliction 用の識別子収集を、JSON 総なめから typed AST の直接走査に置換。この経路は `mod.rs` 内 27 箇所から呼ばれ、テンプレート内のほぼ全構造が経由するためガードがなく、常に全体実体化していました。

## 網羅性をどう保証したか

JSON 版は `for (k, v) in obj.iter()` で**フィールドを知らずに総なめする**汎用ウォーカーなので、typed 版は各変種の子を明示列挙せざるを得ません。取りこぼし1つが収集集合を変え、コンポーネント名の deconfliction を壊します。そこで**コンパイラに網羅を強制**しました:

- **`_` catch-all を書かない** — 全 76 変種を明示列挙。変種が追加されたらコンパイルエラー
- **`..` を書かない** — 各アームで全フィールドを明示束縛。子フィールドが追加されたらコンパイルエラー

**この状態でコンパイルが通ること自体が、列挙漏れがないことの証明です。**

加えて一時的な差分検証ハーネスで、両ウォーカーを全コーパス 3,856 ファイルに対し client / server 双方向(`json_only` と `typed_only` の両方)で集合比較し、**差分ゼロ**を確認しました(検証後に撤去)。`loc` / `start` / `end` / コメントを含む実データでの一致です。

不透明な `serde_json::Value` フィールド3種はいずれもスキップして等価であることを確認済みです — `type_annotation` は `TSTypeAnnotation` として serialize され JSON 版が `starts_with("TS")` で即 return する、`leading_comments` / `trailing_comments` は Identifier を含まない、`JsNode::Raw` 変種は存在しない。

## Measurements

**計測手法**: この共有マシンでは wall-clock 中央値が解像しないため、**CPU 時間(user+sys)** と **min-of-N**(20反復/3ウォームアップ)を **交互 A/B**(base→after を3ラウンド)で取得しています。CPU 時間はデスケジュールの影響を受けず、min は競合が緩んだ瞬間の値を拾うため、負荷下でも安定します。

**2人が独立に計測**し、1% 以内で一致しました(コーパス: svelte テストの 3,857 `.svelte` ファイル):

| タスク | 指標 | base (main) | after | 差 | 独立再現 |
|---|---|---:|---:|---:|---:|
| compile-client | CPU | 5.913s | 5.020s | **-15.1%** | -14.9% |
| compile-client | min wall | 249.31ms | 210.52ms | **-15.6%** | -15.5% |
| compile-server | CPU | 3.873s | 2.977s | **-23.1%** | -23.5% |
| compile-server | min wall | 163.50ms | 124.45ms | **-23.9%** | -24.3% |

min wall のレンジは完全分離しています(client base 248.9-249.7 / after 209.1-211.3、server base 162.9-164.2 / after 124.1-124.7)。

#1582 と合わせた累積では、compile-server は **187.7ms → 122.8ms(-35%)** になります。

## Testing

`RUST_MIN_STACK=33554432 cargo test --release -p rsvelte_core` — **166 スイート / 2,153 テスト / 失敗ゼロ**。`cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` クリーン。

(テスト数が #1582 時点の 2,168 から減っているのは、main の `7ef80c03` で `tests/real_world.rs` が削除されたためで、本 PR とは無関係です。)

---

## 追加コミット: `426b4388` — store スキャンの char テーブル再構築を停止

同じ phase-2 analyze のアロケーション削減として、`collect_dollar_identifiers_pass` の無駄な確保を除去しました。#1582 と本 PR の A-1/A-2 で JSON 経済圏を削った結果、この関数がプロファイル上位に浮上したためです。

コードを読むと、想定していた「バイト走査への全面書き換え」は不要でした:

1. **`Vec<char>` を2パスで同じものを2回作っていた** → 呼び出し元で1回だけ作って両パスに貸す
2. **`Vec<usize>`(char→byte オフセット表)は1箇所でしか読まれていなかった** — 参照収集パスのみで、宣言収集パスでは作るだけで一度も参照されていませんでした
3. **ASCII なら char index == byte index** なので、非 ASCII のときだけ表を作れば足ります

結果、ASCII スクリプト(コーパスの約 99%)では **`Vec<usize>` が2本とも消え、`Vec<char>` が1本に半減**します。

**マルチバイト安全性**: 非 ASCII スクリプトは従来経路(オフセット表を作る)のままです。ASCII 分岐は表参照 `get(i)` が `Some` になる条件(`i < chars.len()`)を明示的に再現しているため、境界を含めて等価です。コーパスの約 1% が非 ASCII なので、この経路もテストで実際に踏まれています。

| タスク | 指標 | base (`bcc13e96`) | after | 差 |
|---|---|---:|---:|---:|
| compile-client | CPU | 5.107s | 5.017s | -1.76% |
| compile-client | min wall | 213.92ms | 211.05ms | -1.34% |
| compile-server | CPU | 3.057s | 2.950s | **-3.49%** |
| compile-server | min wall | 126.95ms | 122.69ms | **-3.36%** |

3ラウンド × 2タスク × 2指標の **12回の比較すべてが同方向(改善)** です。差分は 1ファイル 24行追加 / 14行削除。
