### PR TITLE
perf(transform): 定数畳み込みの Value 往復変換を除去 (client -6.7%)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3646,10 +3646,23 @@ pub(crate) fn get_literal_value(
     expr: &crate::ast::js::Expression,
     context: &ComponentContext,
 ) -> Option<Option<String>> {
-    use crate::ast::typed_expr::LiteralValue;
+    get_literal_value_json(expr.as_json(), context)
+}
 
+/// Constant-folding evaluator, working on the already-materialized JSON for the
+/// expression.
+///
+/// Recursion stays on `&Value` deliberately: the caller always has the child's
+/// JSON in hand, so descending does not clone the subtree, rebuild a typed
+/// `Expression` from it, and then serialize that copy again on the next level —
+/// which is what the previous `serde_json::from_value::<Expression>(x.clone())`
+/// hops did, once per nesting level.
+fn get_literal_value_json(
+    jv: &serde_json::Value,
+    context: &ComponentContext,
+) -> Option<Option<String>> {
     {
-        let expr_type = expr.node_type()?;
+        let expr_type = jv.get("type").and_then(|t| t.as_str())?;
 
         // Upstream `build_template_chunk` memoizes the expression FIRST
         // (`memoizer.add` replaces any `has_call` / `has_await` chunk with an
@@ -3672,35 +3685,37 @@ pub(crate) fn get_literal_value(
                 | "MemberExpression"
                 | "SequenceExpression"
                 | "ChainExpression"
-        ) {
-            let jv = expr.as_json();
-            if has_call_json(jv, context) {
-                return None;
-            }
+        ) && has_call_json(jv, context)
+        {
+            return None;
         }
 
         match expr_type {
             "Literal" => {
-                let node = expr.as_node();
-                match &*node {
-                    crate::ast::typed_expr::JsNode::Literal { value, .. } => match value {
-                        LiteralValue::String(s) => Some(Some(s.to_string())),
-                        LiteralValue::Number(n) => {
-                            if n.fract() == 0.0 {
-                                Some(Some(format!("{}", *n as i64)))
-                            } else {
-                                Some(Some(n.to_string()))
-                            }
+                // A regex literal serializes its `value` as `{}`, so the pattern
+                // and flags have to come from the `regex` entry.
+                if let Some(regex) = jv.get("regex") {
+                    let pattern = regex.get("pattern").and_then(|p| p.as_str())?;
+                    let flags = regex.get("flags").and_then(|f| f.as_str())?;
+                    return Some(Some(format!("/{}/{}", pattern, flags)));
+                }
+                match jv.get("value")? {
+                    serde_json::Value::String(s) => Some(Some(s.clone())),
+                    serde_json::Value::Number(n) => {
+                        let n = n.as_f64()?;
+                        if n.fract() == 0.0 {
+                            Some(Some(format!("{}", n as i64)))
+                        } else {
+                            Some(Some(n.to_string()))
                         }
-                        LiteralValue::Bool(b_val) => Some(Some(b_val.to_string())),
-                        LiteralValue::Null => Some(None),
-                        LiteralValue::Regex(r) => Some(Some(format!("/{}/{}", r.pattern, r.flags))),
-                    },
+                    }
+                    serde_json::Value::Bool(b_val) => Some(Some(b_val.to_string())),
+                    serde_json::Value::Null => Some(None),
                     _ => None,
                 }
             }
             "Identifier" => {
-                let name = expr.name()?;
+                let name = jv.get("name").and_then(|n| n.as_str())?;
                 if name == "undefined" {
                     return Some(None);
                 }
@@ -3884,7 +3899,7 @@ pub(crate) fn get_literal_value(
                                 && let Ok(parsed_expr) =
                                     serde_json::from_str::<crate::ast::js::Expression>(init)
                             {
-                                return get_literal_value(&parsed_expr, context);
+                                return get_literal_value_json(parsed_expr.as_json(), context);
                             }
                         }
                         None
@@ -3896,16 +3911,13 @@ pub(crate) fn get_literal_value(
             | "BinaryExpression"
             | "UnaryExpression"
             | "ConditionalExpression" => {
-                // These complex branches need JSON access for deep traversal
-                let json_value = expr.as_json();
-                let obj = json_value.as_object()?;
+                let obj = jv.as_object()?;
                 get_literal_value_complex(expr_type, obj, context)
             }
             "TemplateLiteral" => {
                 // Template literal with no expressions -> plain string
                 // Template literal with expressions -> try to fold each expression
-                let json_value = expr.as_json();
-                let obj = json_value.as_object()?;
+                let obj = jv.as_object()?;
                 let quasis = obj.get("quasis").and_then(|q| q.as_array())?;
                 let expressions = obj.get("expressions").and_then(|e| e.as_array())?;
 
@@ -3956,8 +3968,6 @@ fn get_literal_value_complex(
     obj: &serde_json::Map<String, serde_json::Value>,
     context: &ComponentContext,
 ) -> Option<Option<String>> {
-    use crate::ast::js::Expression;
-
     match expr_type {
         "LogicalExpression" => {
             // Handle ?? (nullish coalescing) operator
@@ -3967,9 +3977,8 @@ fn get_literal_value_complex(
             }
 
             let left = obj.get("left")?;
-            let left_expr = serde_json::from_value::<Expression>(left.clone()).ok()?;
 
-            match get_literal_value(&left_expr, context) {
+            match get_literal_value_json(left, context) {
                 Some(Some(val)) => {
                     // Left side has non-null value, return it
                     Some(Some(val))
@@ -3977,8 +3986,7 @@ fn get_literal_value_complex(
                 Some(None) => {
                     // Left side is null/undefined, evaluate right side
                     let right = obj.get("right")?;
-                    let right_expr = serde_json::from_value::<Expression>(right.clone()).ok()?;
-                    get_literal_value(&right_expr, context)
+                    get_literal_value_json(right, context)
                 }
                 None => {
                     // Left side cannot be evaluated at compile time
@@ -4012,8 +4020,7 @@ fn get_literal_value_complex(
                     // Evaluate all arguments
                     let mut arg_values: Vec<f64> = Vec::new();
                     for arg in args {
-                        let arg_expr = serde_json::from_value::<Expression>(arg.clone()).ok()?;
-                        let arg_val = get_literal_value(&arg_expr, context)??;
+                        let arg_val = get_literal_value_json(arg, context)??;
                         let num = arg_val.parse::<f64>().ok()?;
                         arg_values.push(num);
                     }
@@ -4046,10 +4053,8 @@ fn get_literal_value_complex(
                     let args = obj.get("arguments").and_then(|a| a.as_array());
                     if let Some(args) = args
                         && let Some(first_arg) = args.first()
-                        && let Ok(arg_expr) =
-                            serde_json::from_value::<Expression>(first_arg.clone())
                     {
-                        return get_literal_value(&arg_expr, context);
+                        return get_literal_value_json(first_arg, context);
                     }
                     return Some(None); // no arg → undefined
                 }
@@ -4065,10 +4070,8 @@ fn get_literal_value_complex(
                     let args = obj.get("arguments").and_then(|a| a.as_array());
                     if let Some(args) = args
                         && let Some(first_arg) = args.first()
-                        && let Ok(arg_expr) =
-                            serde_json::from_value::<Expression>(first_arg.clone())
                     {
-                        return get_literal_value(&arg_expr, context);
+                        return get_literal_value_json(first_arg, context);
                     }
                     return Some(None); // no arg → undefined
                 }
@@ -4079,11 +4082,9 @@ fn get_literal_value_complex(
             let operator = obj.get("operator").and_then(|v| v.as_str())?;
             let left = obj.get("left")?;
             let right = obj.get("right")?;
-            let left_expr = serde_json::from_value::<Expression>(left.clone()).ok()?;
-            let right_expr = serde_json::from_value::<Expression>(right.clone()).ok()?;
 
-            let left_val = get_literal_value(&left_expr, context)?;
-            let right_val = get_literal_value(&right_expr, context)?;
+            let left_val = get_literal_value_json(left, context)?;
+            let right_val = get_literal_value_json(right, context)?;
 
             // Try numeric comparison first
             let left_num = left_val.as_ref().and_then(|s| s.parse::<f64>().ok());
@@ -4137,8 +4138,7 @@ fn get_literal_value_complex(
         "UnaryExpression" => {
             let operator = obj.get("operator").and_then(|v| v.as_str())?;
             let argument = obj.get("argument")?;
-            let arg_expr = serde_json::from_value::<Expression>(argument.clone()).ok()?;
-            let arg_val = get_literal_value(&arg_expr, context)?;
+            let arg_val = get_literal_value_json(argument, context)?;
 
             match operator {
                 "!" => {
@@ -4197,8 +4197,7 @@ fn get_literal_value_complex(
             // only the chosen branch (upstream scope.js `ConditionalExpression`
             // case: evaluate the test; if known, use the matching branch).
             let test = obj.get("test")?;
-            let test_expr = serde_json::from_value::<Expression>(test.clone()).ok()?;
-            let test_val = get_literal_value(&test_expr, context)?;
+            let test_val = get_literal_value_json(test, context)?;
             let truthy = match test_val.as_deref() {
                 None => false, // null / undefined
                 Some("") | Some("false") => false,
@@ -4212,8 +4211,7 @@ fn get_literal_value_complex(
             } else {
                 obj.get("alternate")?
             };
-            let branch_expr = serde_json::from_value::<Expression>(branch.clone()).ok()?;
-            get_literal_value(&branch_expr, context)
+            get_literal_value_json(branch, context)
         }
         _ => None,
     }
@@ -6212,10 +6210,7 @@ fn is_expression_known_json(json_value: &serde_json::Value, context: &ComponentC
                 return false;
             };
             // Try to fold the test to a constant via get_literal_value.
-            use crate::ast::js::Expression;
-            let test_known = serde_json::from_value::<Expression>(test.clone())
-                .ok()
-                .and_then(|test_expr| get_literal_value(&test_expr, context));
+            let test_known = get_literal_value_json(test, context);
             match test_known {
                 Some(test_val) => {
                     // Test is a known constant — only the taken branch needs to be known.
@@ -6237,12 +6232,8 @@ fn is_expression_known_json(json_value: &serde_json::Value, context: &ComponentC
                     // Test is unknown — result is known only if both branches yield the
                     // SAME single compile-time value (mirrors upstream values.size === 1
                     // after adding both branches' values to the set).
-                    let c_val = serde_json::from_value::<Expression>(consequent.clone())
-                        .ok()
-                        .and_then(|e| get_literal_value(&e, context));
-                    let a_val = serde_json::from_value::<Expression>(alternate.clone())
-                        .ok()
-                        .and_then(|e| get_literal_value(&e, context));
+                    let c_val = get_literal_value_json(consequent, context);
+                    let a_val = get_literal_value_json(alternate, context);
                     match (c_val, a_val) {
                         (Some(c), Some(a)) => c == a,
                         _ => false,


### PR DESCRIPTION
## What

定数畳み込み(`get_literal_value`)から **`serde_json::Value` ↔ typed の往復変換を除去**します。#1582 / #1586 と同じ「typed AST を持っているのに JSON へ変換し直している」構造の、client 側に残っていた分です。**出力は完全に不変**(下記の検証参照)。

## Why

#1586 の後にプロファイルを取り直したところ、client 側で `get_literal_value` が **inclusive 7.0%** を占めていました。中身は計算ではなく**配管の無駄**です:

```
親は obj.get("left") で子の Value を既に持っている
  → なのに left.clone() して from_value で Expression を再構築
  → その Expression で get_literal_value を再帰呼び出し
  → 中で as_json() → 新しい OnceCell なので to_value が全部走る
```

`a ?? b` や `cond ? x : y` のような式で、**ネストの深さぶん to_value → clone → from_value → to_value が繰り返されます**。プロファイル上 `from_value` は 5.5%、加えて memmove/allocator 帰属で 4.5% を占めていました。

## What changed

本体を `get_literal_value_json(&Value, …)` に移し、`get_literal_value(&Expression, …)` は1行のラッパとして残置。**降下する13箇所すべて**を「既に手元にある子の Value をそのまま渡す」形に変更し、`from_value(x.clone())` を全廃しました。

**`has_call_json` / `is_pure_json` には一切触れていません。** プロファイルが指摘したのは配管であって計算そのものではなく、これらの本体が遅いという証拠は出ていないためです。差分は `utils.rs` 1ファイル、**53行追加 / 62行削除**。

### 実装上の落とし穴: `Literal` は `regex` を先に見る必要がある

`JsNode::Literal` の Serialize は **Regex の `value` を空オブジェクト `{}` として出力**し、pattern / flags は `regex` エントリにしか現れません。したがって:

- JSON から `Literal` を読む箇所では `regex` を先に確認する必要があります(コード内にコメントを残しています)
- より一般に、**「typed を捨てて Value に寄せる」方向のリファクタは、正規表現リテラルを復元できない一点で原理的に成立しません**。変換は常に Value → typed の一方向でなければなりません

## Verification — 出力ダイジェストの全件比較

この変更は**定数畳み込みの可否を変えうる = 出力が変わりうる**ため、中間表現の比較ではなく**最終成果物そのもの**を検証しました。

一時的な検証用バイナリで **全 3,857 ファイルを client + server の両方でコンパイルし、出力のダイジェストを base / after で比較 → 差分ゼロ**。検証用バイナリは撤去済みです。

upstream の memoize 順序をミラーしている `has_call` ガードも、`has_call_json` 自体に手を入れていないうえ、この出力一致で実証されています。

## Measurements

**2人が独立に計測**(コーパス: svelte テストの 3,857 `.svelte` ファイル、CPU時間 + min-of-N + 交互 A/B 3ラウンド):

| タスク | 指標 | base (`08370ce2`) | after | 差 | 独立再現 |
|---|---|---:|---:|---:|---:|
| compile-client | CPU | 4.873s | 4.547s | **-6.70%** | -6.3% |
| compile-client | min wall | 202.17ms | 189.95ms | **-6.04%** | -6.2% |
| compile-server | CPU | 2.800s | 2.823s | +0.83% | +0.4% |
| compile-server | min wall | 116.47ms | 116.60ms | +0.11% | +0.9% |

client はラウンド別も -6.8/-5.8/-7.5%(CPU)と安定し、レンジは完全分離しています。**server は変化なし** — この経路は client 専用なので想定どおりです。

#1582 / #1586 と合わせた累積: **compile-client 275.7ms → 189.9ms(-31%)、compile-server 187.7ms → 116.5ms(-38%)**。

## Testing

`RUST_MIN_STACK=33554432 cargo test --release -p rsvelte_core` — **166 スイート / 2,153 テスト / 失敗ゼロ**。`cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` クリーン。
