### PR TITLE
feat(svelte2tsx): synchronous API matching upstream (drop-in `svelte2tsx()`)

### DIFF
--- a/.changeset/feat-svelte2tsx-sync-api.md
+++ b/.changeset/feat-svelte2tsx-sync-api.md
@@ -1,0 +1,22 @@
+---
+"@rsvelte/svelte2tsx": minor
+---
+
+feat(svelte2tsx): synchronous API matching upstream (drop-in `svelte2tsx()`)
+
+`svelte2tsx()` is now **synchronous**, exactly like the official
+[`svelte2tsx`](https://github.com/sveltejs/language-tools/tree/master/packages/svelte2tsx)
+— it returns the result object directly instead of a `Promise`. The previous
+async signature existed only to lazily initialise the WebAssembly module; the
+`@rsvelte/compiler` wasm bundle already exports `initSync`, so on Node the module
+now self-initialises synchronously (`initSync` + `fs.readFileSync`) on the first
+call, with no init cost thereafter.
+
+Existing `const r = await svelte2tsx(...)` code keeps working unchanged (awaiting
+a plain value returns it); only code that chained `.then()`/`.catch()` on the
+result needs updating — hence a minor bump.
+
+For browsers or bundlers without a synchronous `node:fs`, a new
+`initialize(input?)` async export pre-loads the wasm (pass the bytes or a
+compiled `WebAssembly.Module`); after `await initialize(...)`, `svelte2tsx()` can
+be called synchronously.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,6 +628,12 @@ jobs:
       - name: Build core wasm (web target) for oxlint-plugin
         run: pnpm run build:wasm:core
 
+      # @rsvelte/svelte2tsx wraps the same web-target wasm (pkg/). Its test's
+      # `pretest` links @rsvelte/compiler at pkg/, then asserts the public
+      # `svelte2tsx()` is synchronous (matching upstream).
+      - name: Run @rsvelte/svelte2tsx tests (sync API)
+        run: pnpm --filter @rsvelte/svelte2tsx run test
+
       - name: Generate oxlint-plugin recommended config
         run: pnpm run build:oxlint-plugin
 

--- a/apps/npm/svelte2tsx/README.md
+++ b/apps/npm/svelte2tsx/README.md
@@ -29,7 +29,7 @@ const source = `
 <h1>Hello, {name}!</h1>
 `;
 
-const result = await svelte2tsx(source, {
+const result = svelte2tsx(source, {
   filename: 'Hello.svelte',
   isTsFile: true,
   version: '5',
@@ -47,7 +47,7 @@ console.log(result.events);        // { eventName: type, ... }
 function svelte2tsx(
   source: string,
   options?: Svelte2TsxOptions
-): Promise<Svelte2TsxResult>;
+): Svelte2TsxResult;
 
 interface Svelte2TsxOptions {
   /** Source filename used in the generated TSX `// @filename:` directive and source maps. */
@@ -76,7 +76,20 @@ interface Svelte2TsxResult {
 }
 ```
 
-The async signature differs slightly from the upstream package, which is synchronous. The async-ness exists purely so we can lazily initialise the WebAssembly module on first call. On subsequent calls it resolves immediately.
+`svelte2tsx()` is **synchronous**, matching the upstream package — a drop-in call. On Node the WebAssembly module self-initialises (via `initSync` + `fs.readFileSync`) on the first call; subsequent calls have no init cost. Existing `await svelte2tsx(...)` code keeps working unchanged, since awaiting a plain value returns it.
+
+### Browsers / bundlers without `node:fs`
+
+The synchronous self-init reads the `.wasm` from disk, which needs Node. Where that isn't available, initialise the module once up front and then call `svelte2tsx()` synchronously:
+
+```js
+import { svelte2tsx, initialize } from '@rsvelte/svelte2tsx';
+
+// Provide the wasm bytes or a compiled WebAssembly.Module for your environment.
+await initialize({ module_or_path: wasmBytes });
+
+const result = svelte2tsx(source, { version: '5' });
+```
 
 ## When to use this
 

--- a/apps/npm/svelte2tsx/index.d.ts
+++ b/apps/npm/svelte2tsx/index.d.ts
@@ -17,6 +17,24 @@ export interface Svelte2TsxResult {
 	events: Record<string, unknown>;
 }
 
-export function svelte2tsx(source: string, options?: Svelte2TsxOptions): Promise<Svelte2TsxResult>;
+/**
+ * Convert a Svelte component to TypeScript/TSX.
+ *
+ * Synchronous, matching the upstream `svelte2tsx` signature. On Node the
+ * WebAssembly module self-initialises on first call. In environments without a
+ * synchronous filesystem (browsers, bundlers), call `await initialize()` once
+ * beforehand.
+ */
+export function svelte2tsx(source: string, options?: Svelte2TsxOptions): Svelte2TsxResult;
+
+/**
+ * Pre-load and initialise the WebAssembly module.
+ *
+ * Optional on Node (`svelte2tsx()` self-initialises there). For browsers or
+ * bundlers without `node:fs`, `await initialize(input)` once — passing the wasm
+ * bytes or a compiled `WebAssembly.Module` — after which `svelte2tsx()` can be
+ * called synchronously.
+ */
+export function initialize(input?: unknown): Promise<void>;
 
 export default svelte2tsx;

--- a/apps/npm/svelte2tsx/index.js
+++ b/apps/npm/svelte2tsx/index.js
@@ -4,32 +4,73 @@
 // custom wasm_bindgen struct per field), so this module's only real work is
 // initialising the wasm module on first use and JSON-parsing the result.
 //
-// The @rsvelte/compiler wasm bundle is wasm-pack --target web, so its default
-// init uses `fetch(new URL(...))`. That works in browsers but fails on Node's
-// `file://` URLs. We load the wasm bytes via fs and hand them to init so Node
-// (the primary consumer here) works without a global fetch shim.
+// The @rsvelte/compiler wasm bundle is wasm-pack --target web. Its default
+// async init uses `fetch(new URL(...))`, but the bundle also exports `initSync`,
+// which compiles the module synchronously. On Node we read the `.wasm` bytes
+// with `fs.readFileSync` and hand them to `initSync`, so the public
+// `svelte2tsx()` is synchronous and matches the upstream signature exactly.
 
-import { readFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 
-import initWasm, { svelte2tsx as wasmSvelte2tsx } from '@rsvelte/compiler';
+import initWasm, { initSync, svelte2tsx as wasmSvelte2tsx } from '@rsvelte/compiler';
 
-const require = createRequire(import.meta.url);
+let ready = false;
 
-let initPromise;
-async function ensureReady() {
-	if (!initPromise) {
-		initPromise = (async () => {
-			const wasmPath = require.resolve('@rsvelte/compiler/rsvelte_core_bg.wasm');
-			const bytes = await readFile(wasmPath);
-			await initWasm({ module_or_path: bytes });
-		})();
+// Synchronous, Node-only wasm init. Reads the bundled `.wasm` and compiles it
+// with `initSync` (no `fetch`, no `await`). Idempotent.
+function ensureReadySync() {
+	if (ready) return;
+	let bytes;
+	try {
+		const require = createRequire(import.meta.url);
+		// wasm-pack ships the glue as `<crate>.js` and the module as
+		// `<crate>_bg.wasm`; derive the wasm path from the resolved entry so this
+		// keeps working across crate renames (rsvelte_core -> rsvelte_lint).
+		const entry = require.resolve('@rsvelte/compiler');
+		const wasmPath = entry.replace(/\.js$/, '_bg.wasm');
+		bytes = readFileSync(wasmPath);
+	} catch (cause) {
+		throw new Error(
+			'svelte2tsx: synchronous wasm initialisation requires a Node.js filesystem. ' +
+				'In a browser or bundler without `node:fs`, call `await initialize()` once before ' +
+				'calling `svelte2tsx()`.',
+			{ cause },
+		);
 	}
-	await initPromise;
+	initSync({ module: bytes });
+	ready = true;
+}
+
+/**
+ * Pre-load and initialise the WebAssembly module.
+ *
+ * `svelte2tsx()` is synchronous and self-initialises on Node, so calling this is
+ * optional there. It exists for environments without a synchronous filesystem
+ * (browsers, bundlers): `await initialize()` once, after which `svelte2tsx()`
+ * can be called synchronously.
+ *
+ * @param {any} [input] — Optional `initSync`/`init` input forwarded to the wasm
+ *   bundle (e.g. `{ module_or_path }` with wasm bytes or a compiled
+ *   `WebAssembly.Module`). Omit on Node to load the bundled `.wasm` from disk.
+ * @returns {Promise<void>}
+ */
+export async function initialize(input) {
+	if (ready) return;
+	if (input !== undefined) {
+		await initWasm(input);
+		ready = true;
+		return;
+	}
+	ensureReadySync();
 }
 
 /**
  * Convert a Svelte component to TypeScript/TSX.
+ *
+ * Synchronous, matching the upstream `svelte2tsx` signature. On Node the wasm
+ * module self-initialises on first call; elsewhere call `await initialize()`
+ * first.
  *
  * @param {string} source — Svelte component source code
  * @param {{
@@ -40,15 +81,15 @@ async function ensureReady() {
  *   namespace?: 'html' | 'svg' | 'mathml',
  *   version?: '4' | '5',
  * }} [options]
- * @returns {Promise<{
+ * @returns {{
  *   code: string,
  *   map: string | null,
  *   exportedNames: { props: string[], all: string[] },
  *   events: Record<string, unknown>,
- * }>}
+ * }}
  */
-export async function svelte2tsx(source, options = {}) {
-	await ensureReady();
+export function svelte2tsx(source, options = {}) {
+	ensureReadySync();
 	const json = wasmSvelte2tsx(source, JSON.stringify(options));
 	const parsed = JSON.parse(json);
 	if (parsed.success === false) {

--- a/apps/npm/svelte2tsx/package.json
+++ b/apps/npm/svelte2tsx/package.json
@@ -20,6 +20,10 @@
     "wasm"
   ],
   "type": "module",
+  "scripts": {
+    "pretest": "node test/link-compiler.mjs",
+    "test": "node --test \"test/*.test.mjs\""
+  },
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {

--- a/apps/npm/svelte2tsx/test/link-compiler.mjs
+++ b/apps/npm/svelte2tsx/test/link-compiler.mjs
@@ -1,0 +1,28 @@
+// Dev/CI setup: point `@rsvelte/compiler` at the repo's in-place wasm build
+// (`/pkg`, the same directory publishConfig redirects the published package to).
+//
+// pnpm links the `@rsvelte/compiler` workspace dependency to `apps/npm/compiler`,
+// which carries only version/metadata — the wasm glue lives in `/pkg` after
+// `pnpm run build:wasm:core`. A real `npm i @rsvelte/svelte2tsx` gets the full
+// pkg contents under `node_modules/@rsvelte/compiler`; this reproduces that for
+// the source checkout so the sync-API test resolves the same way consumers do.
+
+import { existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = resolve(here, '../../../../pkg');
+const link = resolve(here, '../node_modules/@rsvelte/compiler');
+
+if (!existsSync(resolve(pkgDir, 'rsvelte_lint.js'))) {
+	console.error(
+		'link-compiler: /pkg is not built. Run `pnpm run build:wasm:core` first.',
+	);
+	process.exit(1);
+}
+
+mkdirSync(dirname(link), { recursive: true });
+rmSync(link, { force: true, recursive: true });
+symlinkSync(pkgDir, link, 'dir');
+console.log('link-compiler: @rsvelte/compiler -> /pkg');

--- a/apps/npm/svelte2tsx/test/sync-api.test.mjs
+++ b/apps/npm/svelte2tsx/test/sync-api.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { svelte2tsx, initialize } from '../index.js';
+
+const source = `
+<script lang="ts">
+  let { name }: { name: string } = $props();
+</script>
+
+<h1>Hello, {name}!</h1>
+`;
+const opts = { filename: 'Hello.svelte', isTsFile: true, version: '5' };
+
+test('svelte2tsx() is synchronous and returns a plain result (not a Promise)', () => {
+	const result = svelte2tsx(source, opts);
+	assert.ok(!(result instanceof Promise), 'result must not be a Promise');
+	assert.equal(typeof result, 'object');
+	assert.equal(typeof result.code, 'string');
+	assert.ok(result.code.length > 0, 'code is non-empty');
+	assert.ok('map' in result, 'has map field');
+	assert.ok(Array.isArray(result.exportedNames.props), 'exportedNames.props is an array');
+	assert.deepEqual(result.exportedNames.props, ['name']);
+	assert.equal(typeof result.events, 'object');
+});
+
+test('await svelte2tsx() keeps working (awaiting a plain value)', async () => {
+	const sync = svelte2tsx(source, opts);
+	const awaited = await svelte2tsx(source, opts);
+	assert.equal(awaited.code, sync.code);
+});
+
+test('repeated calls reuse the initialised module', () => {
+	const a = svelte2tsx('<p>a</p>', {});
+	const b = svelte2tsx('<p>b</p>', {});
+	assert.ok(a.code.length > 0 && b.code.length > 0);
+});
+
+test('initialize() returns a Promise and is a no-op once ready', async () => {
+	const p = initialize();
+	assert.ok(p instanceof Promise);
+	await p;
+});
+
+test('default export is the named svelte2tsx', async () => {
+	const mod = await import('../index.js');
+	assert.equal(mod.default, mod.svelte2tsx);
+});
+
+test('options is optional and defaults are applied synchronously', () => {
+	const result = svelte2tsx('<p>hi</p>');
+	assert.ok(!(result instanceof Promise));
+	assert.equal(typeof result.code, 'string');
+});


### PR DESCRIPTION
## Why

External review flagged that `@rsvelte/svelte2tsx` returns a `Promise` (for lazy
wasm init), whereas the official
[`svelte2tsx`](https://github.com/sveltejs/language-tools/tree/master/packages/svelte2tsx)
is **synchronous** — so it was output-compatible but not a drop-in.

## What

- **`svelte2tsx()` is now synchronous**, returning the result object directly.
  The `@rsvelte/compiler` wasm bundle (`wasm-pack --target web`) already exports
  `initSync`; on Node the module self-initialises synchronously (`initSync` +
  `fs.readFileSync`) on the first call, matching the upstream signature.
- **Backward compatible for the common pattern.** `const r = await svelte2tsx(...)`
  keeps working (awaiting a plain value returns it). Only code chaining
  `.then()`/`.catch()` on the result needs updating → **minor** changeset.
- **Browser / bundler escape hatch preserved.** New async `initialize(input?)`
  export pre-loads the wasm where a synchronous `node:fs` isn't available; after
  `await initialize(...)`, `svelte2tsx()` can be called synchronously.
- **Fixes a latent stale reference.** The old code resolved
  `@rsvelte/compiler/rsvelte_core_bg.wasm`, but the wasm has been `rsvelte_lint_bg.wasm`
  since the `rsvelte_core → rsvelte_lint` build-crate switch (#724). The wasm path
  is now derived from the resolved `@rsvelte/compiler` entry, surviving crate
  renames.
- **Tests + CI.** Adds a `node:test` sync-API suite
  (`apps/npm/svelte2tsx/test/sync-api.test.mjs`) with a `pretest` that links
  `@rsvelte/compiler` at the in-repo `pkg/` (mirroring a real install), wired into
  the ecosystem CI job after `build:wasm:core`.
- Updates `index.d.ts` and the README (removes the "async differs from upstream"
  note).

## API compatibility

The **call signature** now matches upstream exactly: `svelte2tsx(source, options?)`
returns synchronously. The result **shape** keeps rsvelte's existing documented
form (`map: string | null`, `exportedNames: { props, all }`, `events: Record`),
which is what `@rsvelte/svelte-check` and the 253/253 fixture suite consume —
unchanged by this PR.

## Test

`pnpm --filter @rsvelte/svelte2tsx run test` → 6/6 pass (sync return, `await`
back-compat, repeated calls, `initialize()`, default export, optional options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)