### PR TITLE
feat(svelte-check): complete upstream CLI flag parity

### DIFF
--- a/.changeset/fix-svelte-check-cli-parity.md
+++ b/.changeset/fix-svelte-check-cli-parity.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/svelte-check": minor
+---
+
+feat(svelte-check): upstream CLI flag parity — `--config`, `--no-tsconfig`, `--threshold`, `--preserveWatchOutput`
+
+- `--config <path>`: use an explicit `svelte.config.*` / `vite.config.*` instead of discovery; a missing path exits with code 2, matching the JS reference.
+- `--no-tsconfig`: check only the Svelte files under the workspace, ignoring any project tsconfig/jsconfig.
+- `--threshold error|warning`: filter which diagnostics are printed; counts and the exit code stay computed from the unfiltered set, matching the JS reference.
+- `--preserveWatchOutput` is now the canonical spelling (the hyphenated `--preserve-watch-output` remains as an alias), and `--tsgo-experimental-api` is accepted as an alias of `--tsgo`. `--color` / `--no-color` are accepted for CLI compatibility (output is un-colorized either way).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npx rsvelte-check --watch --incremental
 npx rsvelte-check --no-type-check # Svelte diagnostics only
 ```
 
-Every upstream flag works (`--output machine`, `--fail-on-warnings`, `--compiler-warnings`, …), plus rsvelte-specific ones — see [`@rsvelte/svelte-check`](apps/npm/svelte-check) or `npx rsvelte-check --help`.
+Every upstream flag is accepted (`--output`, `--fail-on-warnings`, `--compiler-warnings`, `--threshold`, `--no-tsconfig`, `--config`, `--preserveWatchOutput`, …), plus rsvelte-specific ones — see the [upstream flag compatibility table](apps/npm/svelte-check#upstream-flag-compatibility) or `npx rsvelte-check --help`.
 
 ### Format (`rsvelte-fmt`)
 

--- a/apps/npm/svelte-check/README.md
+++ b/apps/npm/svelte-check/README.md
@@ -62,12 +62,38 @@ Add it to your `package.json`:
 | `--tsgo` | Prefer [tsgo](https://github.com/microsoft/typescript-go) over `tsc` as the TypeScript backend (each falls back to the other if missing). |
 | `--no-type-check` | Skip TypeScript entirely — Svelte compiler / A11y / CSS diagnostics only. |
 | `--tsconfig <path>` | Base `tsconfig.json` for the overlay to `extends`. |
+| `--no-tsconfig` | Ignore any project tsconfig/jsconfig (no `--tsconfig` extends, no discovery) — check only the Svelte files. |
+| `--config <path>` | Use a non-standard `svelte.config.*` / `vite.config.*` path for the diagnostic-relevant `compilerOptions` (and `kit.files`) instead of discovering one under the workspace. |
 | `--emit-overlay` | Materialise `.tsx` shadow files + an overlay tsconfig under `<workspace>/.svelte-check/` without running a type-checker. Useful for inspecting what gets handed to TS. |
 | `--compiler-warnings <list>` | Per-code overrides, e.g. `--compiler-warnings css-unused-selector:ignore,a11y-no-noninteractive-element-to-interactive-role:error`. |
 | `--diagnostic-sources <list>` | Restrict output to any subset of `svelte`, `ts` / `js`, `css`. |
+| `--threshold <level>` | Filter the diagnostics that are *printed*: `error` shows only errors, `warning` (default) shows warnings and errors. Counts and exit code are unaffected. |
 | `--incremental` | Reuse `<workspace>/.svelte-check/manifest.json` between runs — unchanged files skip the overlay regeneration step. |
 | `--watch` | Stay alive and re-check on file changes. Composes with `--incremental`. |
-| `--preserve-watch-output` | In watch mode, don't clear the terminal between runs. |
+| `--preserveWatchOutput` | In watch mode, don't clear the terminal between runs. (`--preserve-watch-output` is accepted as an alias.) |
+
+### Upstream flag compatibility
+
+`rsvelte-check` accepts every flag the official `svelte-check` CLI exposes. Names match upstream, with two exceptions noted below.
+
+| Upstream flag | rsvelte-check | Notes |
+|---|---|---|
+| `--workspace` | ✅ | |
+| `--output` | ✅ | Plus the rsvelte-only `github-actions` format. |
+| `--watch` | ✅ | |
+| `--preserveWatchOutput` | ✅ | Canonical name; `--preserve-watch-output` kept as an alias. |
+| `--incremental` | ✅ | |
+| `--tsgo` | ✅ | |
+| `--tsgo-experimental-api` | ✅ (alias) | rsvelte has a single native `tsgo` backend, so this behaves exactly like `--tsgo`. |
+| `--tsconfig` | ✅ | |
+| `--config` | ✅ | Overrides the config source for the diagnostic-relevant `compilerOptions` / `kit.files`. |
+| `--no-tsconfig` | ✅ | |
+| `--ignore` | ✅ | Always active as a walker skip-list (rsvelte does not gate it behind `--no-tsconfig`). |
+| `--fail-on-warnings` | ✅ | |
+| `--compiler-warnings` | ✅ | |
+| `--diagnostic-sources` | ✅ | |
+| `--threshold` | ✅ | |
+| `--color` / `--no-color` | ✅ (no-op) | Accepted for compatibility; rsvelte-check output is not colorized. |
 
 Run `rsvelte-check --help` for the authoritative list.
 

--- a/crates/rsvelte_core/src/bin/svelte_check.rs
+++ b/crates/rsvelte_core/src/bin/svelte_check.rs
@@ -34,7 +34,7 @@ use std::collections::{HashMap, HashSet};
 
 use clap::Parser;
 use rsvelte_core::svelte_check::{
-    OutputFormat, RunOptions, run,
+    OutputFormat, RunOptions, Threshold, run,
     runner::{DiagnosticSource, WarningOverride},
     watch::{WatchOptions, run_watch},
     writers::write_diagnostic,
@@ -78,11 +78,30 @@ struct Cli {
     #[arg(long = "tsconfig")]
     tsconfig: Option<PathBuf>,
 
+    /// Only check the Svelte files under the workspace and ignore any
+    /// project tsconfig/jsconfig (no `--tsconfig` extends, no discovery).
+    /// Mirrors the JS reference's `--no-tsconfig`.
+    #[arg(long = "no-tsconfig", default_value_t = false)]
+    no_tsconfig: bool,
+
+    /// Path to a non-standard `svelte.config.*` / `vite.config.*` whose
+    /// diagnostic-relevant `compilerOptions` (and `kit.files`) should be
+    /// used instead of discovering a config under the workspace. Mirrors
+    /// the JS reference's `--config`.
+    #[arg(long = "config")]
+    config: Option<PathBuf>,
+
     /// Prefer Microsoft's native `tsgo` over the stock `tsc` when
     /// type-checking the overlay. Without this flag type-checking still
     /// runs, using `tsc`. (`tsgo` falls back to `tsc` and vice-versa if
-    /// the preferred binary isn't installed.)
-    #[arg(long = "tsgo", default_value_t = false)]
+    /// the preferred binary isn't installed.) `--tsgo-experimental-api`
+    /// is accepted as an alias — rsvelte has a single native tsgo
+    /// backend, so the experimental in-process API has no separate mode.
+    #[arg(
+        long = "tsgo",
+        alias = "tsgo-experimental-api",
+        default_value_t = false
+    )]
     tsgo: bool,
 
     /// Skip the TypeScript type-checking pass entirely and report only
@@ -117,9 +136,32 @@ struct Cli {
     watch: bool,
 
     /// In `--watch` mode, do NOT clear the terminal between runs.
-    /// Mirrors `--preserveWatchOutput` in the JS reference / tsc.
-    #[arg(long = "preserve-watch-output", default_value_t = false)]
+    /// Mirrors `--preserveWatchOutput` in the JS reference / tsc. The
+    /// hyphenated `--preserve-watch-output` is kept as an alias.
+    #[arg(
+        long = "preserveWatchOutput",
+        alias = "preserve-watch-output",
+        default_value_t = false
+    )]
     preserve_watch_output: bool,
+
+    /// Filter the diagnostics that are printed: `error` shows only
+    /// errors, `warning` (the default) shows warnings and errors. Does
+    /// not affect the error/warning counts or the exit code. Mirrors the
+    /// JS reference's `--threshold`.
+    #[arg(long = "threshold", default_value = "warning")]
+    threshold: String,
+
+    /// Force-enable color output. Accepted for JS-CLI compatibility;
+    /// rsvelte-check does not currently colorize its output, so this is a
+    /// no-op.
+    #[arg(long = "color", default_value_t = false)]
+    color: bool,
+
+    /// Force-disable color output. Accepted for JS-CLI compatibility;
+    /// no-op (rsvelte-check output is already un-colorized).
+    #[arg(long = "no-color", default_value_t = false)]
+    no_color: bool,
 }
 
 fn main() -> ExitCode {
@@ -150,6 +192,40 @@ fn main() -> ExitCode {
         })
         .unwrap_or_default();
 
+    // `--color` / `--no-color` are accepted for JS-CLI compatibility but
+    // have no effect (output is already un-colorized).
+    let _ = (cli.color, cli.no_color);
+
+    let threshold = match Threshold::parse(&cli.threshold) {
+        Some(t) => t,
+        None => {
+            eprintln!(
+                "Invalid threshold \"{}\", using \"warning\" instead",
+                cli.threshold
+            );
+            Threshold::default()
+        }
+    };
+
+    // `--config` names an explicit config file; the JS reference errors
+    // when the path doesn't exist rather than silently discovering one.
+    if let Some(config) = cli.config.as_deref() {
+        let abs = if config.is_absolute() {
+            config.to_path_buf()
+        } else {
+            workspace.join(config)
+        };
+        if !abs.exists() {
+            eprintln!("Could not find config file at {}", config.display());
+            return ExitCode::from(2);
+        }
+    }
+
+    // `--no-tsconfig` means "use no project tsconfig": ignore `--tsconfig`
+    // and never extend/discover one. Mirrors the JS reference, where the
+    // two are mutually exclusive.
+    let tsconfig = if cli.no_tsconfig { None } else { cli.tsconfig };
+
     let compiler_warnings = parse_compiler_warnings(cli.compiler_warnings.as_deref());
     let diagnostic_sources = parse_diagnostic_sources(cli.diagnostic_sources.as_deref());
 
@@ -161,12 +237,13 @@ fn main() -> ExitCode {
         ignore,
         fail_on_warnings: cli.fail_on_warnings,
         emit_overlay: cli.emit_overlay,
-        tsconfig: cli.tsconfig,
+        tsconfig,
         type_check,
         prefer_tsgo: cli.tsgo,
         compiler_warnings,
         diagnostic_sources,
         incremental: cli.incremental,
+        config: cli.config.clone(),
     };
 
     if cli.watch {
@@ -179,7 +256,7 @@ fn main() -> ExitCode {
         // practice: SIGINT). Failure here only happens when the OS
         // notify backend can't be initialised.
         if let Err(err) = run_watch(options, watch_opts, |run_result| {
-            print_run(run_result, &workspace_for_print, format);
+            print_run(run_result, &workspace_for_print, format, threshold);
         }) {
             eprintln!("rsvelte-check: watch mode failed to start: {err}");
             return ExitCode::from(2);
@@ -198,7 +275,7 @@ fn main() -> ExitCode {
                 workspace.display()
             );
         }
-        print_run(&result, &workspace, format);
+        print_run(&result, &workspace, format, threshold);
         ExitCode::from(result.exit_code(cli.fail_on_warnings) as u8)
     }
 }
@@ -207,9 +284,16 @@ fn print_run(
     result: &rsvelte_core::svelte_check::runner::RunResult,
     workspace: &Path,
     format: OutputFormat,
+    threshold: Threshold,
 ) {
     let mut out = String::new();
     for diag in &result.diagnostics {
+        // The threshold filters only what is *printed*; the summary and
+        // exit code are always computed from the full diagnostic set,
+        // matching the JS reference.
+        if !threshold.includes(diag.severity) {
+            continue;
+        }
         write_diagnostic(&mut out, diag, workspace, format);
     }
     if matches!(format, OutputFormat::Human | OutputFormat::HumanVerbose) {

--- a/crates/rsvelte_core/src/svelte_check/config.rs
+++ b/crates/rsvelte_core/src/svelte_check/config.rs
@@ -97,7 +97,45 @@ const VITE_CONFIG_CANDIDATES: &[&str] = &[
 /// `svelte.config.js` entirely, so step 2 is skipped and only the inline
 /// `sveltekit({...})` options apply over the defaults.
 pub fn load_compiler_options(workspace: &Path) -> CompilerOptionsSettings {
+    load_compiler_options_with_config(workspace, None)
+}
+
+/// Like [`load_compiler_options`], but when `config` is `Some` the
+/// diagnostic-relevant `compilerOptions` are read from that exact file
+/// instead of discovering `svelte.config.*` / `vite.config.*` under the
+/// workspace. Mirrors the JS reference's `--config` flag, which points at
+/// a non-standard `svelte.config` / `vite.config` location. The file is
+/// classified by name: a `vite.config.*` is parsed for the inline
+/// `svelte()` / `sveltekit()` plugin options, anything else as a Svelte
+/// config.
+pub fn load_compiler_options_with_config(
+    workspace: &Path,
+    config: Option<&Path>,
+) -> CompilerOptionsSettings {
     let mut settings = CompilerOptionsSettings::default();
+
+    if let Some(path) = config {
+        let Ok(source) = std::fs::read_to_string(path) else {
+            return settings;
+        };
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        let is_ts = name.ends_with(".ts") || name.ends_with(".mts") || name.ends_with(".cts");
+        let source_type = if is_ts {
+            SourceType::ts()
+        } else {
+            SourceType::default()
+        };
+        let kind = if name.starts_with("vite.config") {
+            ConfigKind::Vite
+        } else {
+            ConfigKind::Svelte
+        };
+        parse_config(&source, source_type, kind, &mut settings);
+        return settings;
+    }
 
     // Read the vite.config once: it both decides whether svelte.config is
     // consulted (the `sveltekit()` inline-config case) and may itself

--- a/crates/rsvelte_core/src/svelte_check/kit_file.rs
+++ b/crates/rsvelte_core/src/svelte_check/kit_file.rs
@@ -60,7 +60,34 @@ impl Default for KitFilesSettings {
 /// re-exports) are intentionally unsupported; users with those configs
 /// should rely on defaults.
 pub fn load_kit_files_settings(workspace: &Path) -> KitFilesSettings {
+    load_kit_files_settings_with_config(workspace, None)
+}
+
+/// Like [`load_kit_files_settings`], but when `config` is `Some` the
+/// `kit.files` settings are read from that exact file instead of the
+/// discovered `svelte.config.*`. Mirrors the JS reference's `--config`.
+/// `kit.files` only ever lives in a Svelte config, so a `vite.config.*`
+/// override yields defaults.
+pub fn load_kit_files_settings_with_config(
+    workspace: &Path,
+    config: Option<&Path>,
+) -> KitFilesSettings {
     let mut settings = KitFilesSettings::default();
+
+    if let Some(path) = config {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if name.starts_with("vite.config") {
+            return settings;
+        }
+        if let Ok(source) = std::fs::read_to_string(path) {
+            parse_kit_files_source(&source, &mut settings);
+        }
+        return settings;
+    }
+
     for ext in &["js", "cjs", "mjs"] {
         let candidate = workspace.join(format!("svelte.config.{ext}"));
         if !candidate.is_file() {
@@ -69,16 +96,19 @@ pub fn load_kit_files_settings(workspace: &Path) -> KitFilesSettings {
         let Ok(source) = std::fs::read_to_string(&candidate) else {
             continue;
         };
-        let allocator = Allocator::default();
-        let parser = OxcParser::new(&allocator, &source, SourceType::default());
-        let result = parser.parse();
-        let body = &result.program.body;
-        for stmt in body {
-            extract_kit_files_from_stmt(stmt, &mut settings);
-        }
+        parse_kit_files_source(&source, &mut settings);
         break;
     }
     settings
+}
+
+fn parse_kit_files_source(source: &str, settings: &mut KitFilesSettings) {
+    let allocator = Allocator::default();
+    let parser = OxcParser::new(&allocator, source, SourceType::default());
+    let result = parser.parse();
+    for stmt in &result.program.body {
+        extract_kit_files_from_stmt(stmt, settings);
+    }
 }
 
 fn extract_kit_files_from_stmt(stmt: &oxc::Statement, settings: &mut KitFilesSettings) {

--- a/crates/rsvelte_core/src/svelte_check/mod.rs
+++ b/crates/rsvelte_core/src/svelte_check/mod.rs
@@ -23,4 +23,4 @@ pub mod writers;
 pub use diagnostic::{Diagnostic, DiagnosticSeverity};
 pub use runner::{RunOptions, RunResult, run};
 pub use walker::find_svelte_files;
-pub use writers::OutputFormat;
+pub use writers::{OutputFormat, Threshold};

--- a/crates/rsvelte_core/src/svelte_check/runner.rs
+++ b/crates/rsvelte_core/src/svelte_check/runner.rs
@@ -11,9 +11,9 @@ use std::path::{Path, PathBuf};
 
 use crate::compiler::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
 
-use super::config::{CompilerOptionsSettings, load_compiler_options};
+use super::config::{CompilerOptionsSettings, load_compiler_options_with_config};
 use super::diagnostic::{Diagnostic, DiagnosticSeverity, Position, Range};
-use super::kit_file::load_kit_files_settings;
+use super::kit_file::load_kit_files_settings_with_config;
 use super::manifest::{
     self, CachedDiagnostics, SerializableDiagnostic, WarningCache, current_stats,
 };
@@ -98,6 +98,11 @@ pub struct RunOptions {
     /// source `(mtime_ms, size)` hasn't changed since the previous run.
     /// Mirrors the JS reference's `--incremental` flag.
     pub incremental: bool,
+    /// Explicit `svelte.config.*` / `vite.config.*` path whose
+    /// diagnostic-relevant `compilerOptions` (and `kit.files`) override
+    /// workspace discovery. `None` = discover under the workspace.
+    /// Mirrors the JS reference's `--config`.
+    pub config: Option<PathBuf>,
 }
 
 impl Default for RunOptions {
@@ -113,6 +118,7 @@ impl Default for RunOptions {
             compiler_warnings: HashMap::new(),
             diagnostic_sources: None,
             incremental: false,
+            config: None,
         }
     }
 }
@@ -157,11 +163,13 @@ impl RunResult {
 /// and collect the resulting diagnostics. tsgo / svelte2tsx integration
 /// will plug in here in a follow-up.
 pub fn run(options: &RunOptions) -> RunResult {
-    let kit_settings = load_kit_files_settings(&options.workspace);
+    let kit_settings =
+        load_kit_files_settings_with_config(&options.workspace, options.config.as_deref());
     // `compilerOptions` that influence diagnostics (e.g. `experimental.async`),
     // resolved from both `svelte.config.*` and the `vite.config.*` Svelte
-    // plugin call (issue #1034).
-    let compiler_opts = load_compiler_options(&options.workspace);
+    // plugin call (issue #1034). `--config` overrides that discovery.
+    let compiler_opts =
+        load_compiler_options_with_config(&options.workspace, options.config.as_deref());
     let relevant = find_relevant_files(&options.workspace, &options.ignore, &kit_settings);
     let files = relevant.svelte;
     let kit_files = relevant.kit;

--- a/crates/rsvelte_core/src/svelte_check/writers.rs
+++ b/crates/rsvelte_core/src/svelte_check/writers.rs
@@ -38,6 +38,46 @@ impl OutputFormat {
     }
 }
 
+/// Diagnostic display threshold — mirrors the JS reference's
+/// `--threshold` (`getThreshold` in `options.ts` + `createFilter` in
+/// `index.ts`). It filters which diagnostics are *printed*; it never
+/// changes the error/warning counts or the exit code, which the JS
+/// reference always computes from the unfiltered diagnostic set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Threshold {
+    /// Print warnings and errors (the JS default).
+    #[default]
+    Warning,
+    /// Print errors only.
+    Error,
+}
+
+impl Threshold {
+    /// The JS reference only accepts `warning` / `error`; anything else
+    /// warns and falls back to `warning`. `parse` returns `None` for the
+    /// unknown case so the caller can emit that warning.
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "warning" => Threshold::Warning,
+            "error" => Threshold::Error,
+            _ => return None,
+        })
+    }
+
+    /// Whether a diagnostic of `severity` should be displayed. `error`
+    /// keeps only errors; `warning` keeps errors and warnings (dropping
+    /// info/hint, matching the JS `createFilter`).
+    pub fn includes(self, severity: DiagnosticSeverity) -> bool {
+        match self {
+            Threshold::Error => severity == DiagnosticSeverity::Error,
+            Threshold::Warning => matches!(
+                severity,
+                DiagnosticSeverity::Error | DiagnosticSeverity::Warning
+            ),
+        }
+    }
+}
+
 /// Write a single diagnostic to `out` in the chosen format.
 pub fn write_diagnostic(
     out: &mut String,
@@ -290,6 +330,25 @@ mod tests {
             out.starts_with("::error file=sub%2Cdir/Foo.svelte,line=1,col=2::"),
             "comma in path not escaped: {out}"
         );
+    }
+
+    #[test]
+    fn threshold_parses_and_filters_like_the_js_reference() {
+        assert_eq!(Threshold::parse("warning"), Some(Threshold::Warning));
+        assert_eq!(Threshold::parse("error"), Some(Threshold::Error));
+        assert_eq!(Threshold::parse("hint"), None);
+        assert_eq!(Threshold::default(), Threshold::Warning);
+
+        // `error` keeps only errors.
+        assert!(Threshold::Error.includes(DiagnosticSeverity::Error));
+        assert!(!Threshold::Error.includes(DiagnosticSeverity::Warning));
+        assert!(!Threshold::Error.includes(DiagnosticSeverity::Info));
+
+        // `warning` keeps errors + warnings, drops info/hint.
+        assert!(Threshold::Warning.includes(DiagnosticSeverity::Error));
+        assert!(Threshold::Warning.includes(DiagnosticSeverity::Warning));
+        assert!(!Threshold::Warning.includes(DiagnosticSeverity::Info));
+        assert!(!Threshold::Warning.includes(DiagnosticSeverity::Hint));
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/svelte_check_cli_flags.rs
+++ b/crates/rsvelte_core/tests/svelte_check_cli_flags.rs
@@ -1,0 +1,225 @@
+//! Upstream flag-parity tests for the `rsvelte-check` CLI. Each test
+//! spawns the compiled `svelte_check` binary against a throwaway
+//! workspace and asserts the observable behaviour of the flags that the
+//! JS reference (`submodules/language-tools/packages/svelte-check`)
+//! exposes — `--threshold`, `--no-tsconfig`, `--config`, and the
+//! `--preserveWatchOutput` / `--tsgo-experimental-api` / `--color`
+//! compatibility spellings.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_svelte_check")
+}
+
+fn workspace(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "rsvelte_check_cli_{tag}_{}_{}",
+        std::process::id(),
+        // Keep concurrently-running tests from colliding on the same dir.
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(dir: &Path, name: &str, body: &str) {
+    std::fs::write(dir.join(name), body).unwrap();
+}
+
+fn run(dir: &Path, args: &[&str]) -> Output {
+    Command::new(bin())
+        .arg("--workspace")
+        .arg(dir)
+        .args(args)
+        .output()
+        .expect("failed to spawn svelte_check binary")
+}
+
+/// A `.svelte` file whose only diagnostic is a single css-unused-selector
+/// warning — nothing that would also emit an error.
+const WARN_ONLY: &str = "<div>hello</div>\n<style>\n  .unused { color: red; }\n</style>\n";
+
+/// A `.svelte` file that fails to compile (unterminated `{#if}` block).
+const HAS_ERROR: &str = "{#if}\n<p>oops</p>\n";
+
+#[test]
+fn threshold_default_shows_warnings() {
+    let dir = workspace("thr_default");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+
+    let out = run(&dir, &["--no-type-check"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("Unused CSS selector"),
+        "default threshold should print the warning; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("0 errors and 1 warning"),
+        "summary should count the warning; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn threshold_error_hides_warnings_but_keeps_counts() {
+    let dir = workspace("thr_error");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+
+    let out = run(&dir, &["--no-type-check", "--threshold", "error"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stdout.contains("Unused CSS selector"),
+        "`--threshold error` must not print the warning; got:\n{stdout}"
+    );
+    // The count is computed from the unfiltered set, so it is unchanged.
+    assert!(
+        stdout.contains("0 errors and 1 warning"),
+        "`--threshold error` must not change the summary counts; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn threshold_invalid_warns_and_falls_back() {
+    let dir = workspace("thr_invalid");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+
+    let out = run(&dir, &["--no-type-check", "--threshold", "hint"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stderr.contains("Invalid threshold \"hint\""),
+        "invalid threshold should warn on stderr; got:\n{stderr}"
+    );
+    // Falls back to `warning`, so the warning is still printed.
+    assert!(
+        stdout.contains("Unused CSS selector"),
+        "fallback threshold should behave like `warning`; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn no_tsconfig_still_checks_svelte_files() {
+    let dir = workspace("no_tsconfig");
+    write(&dir, "Bad.svelte", HAS_ERROR);
+
+    // `--no-tsconfig` is accepted and Svelte-side diagnostics still run.
+    // `--no-type-check` keeps the test independent of a TS toolchain.
+    let out = run(&dir, &["--no-tsconfig", "--no-type-check"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("1 error") || stdout.contains("errors"),
+        "no-tsconfig run should still report the Svelte compile error; got:\n{stdout}"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "a compile error should exit non-zero"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn no_tsconfig_ignores_tsconfig_flag() {
+    let dir = workspace("no_tsconfig_ignore");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+
+    // Pointing `--tsconfig` at a non-existent path together with
+    // `--no-tsconfig` must be a no-op (the tsconfig is ignored), not an
+    // error — the run should still complete and report the warning.
+    let out = run(
+        &dir,
+        &[
+            "--no-tsconfig",
+            "--no-type-check",
+            "--tsconfig",
+            "does-not-exist.json",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("0 errors and 1 warning"),
+        "run should complete with the tsconfig ignored; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn config_missing_file_errors() {
+    let dir = workspace("config_missing");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+
+    let out = run(&dir, &["--no-type-check", "--config", "nope.config.js"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "a missing --config file should exit 2"
+    );
+    assert!(
+        stderr.contains("Could not find config file"),
+        "missing config should be reported on stderr; got:\n{stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn config_present_is_accepted() {
+    let dir = workspace("config_present");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+    write(
+        &dir,
+        "custom.svelte.config.js",
+        "export default { compilerOptions: {} };",
+    );
+
+    let out = run(
+        &dir,
+        &["--no-type-check", "--config", "custom.svelte.config.js"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("0 errors and 1 warning"),
+        "a valid --config path should be accepted; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The camelCase upstream spelling, the hyphenated alias, the tsgo
+/// experimental alias, and the color no-ops must all be accepted rather
+/// than rejected as unknown arguments (clap exits 2 with "unexpected
+/// argument" otherwise).
+#[test]
+fn compatibility_spellings_are_accepted() {
+    let dir = workspace("spellings");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+
+    for args in [
+        &["--no-type-check", "--preserveWatchOutput"][..],
+        &["--no-type-check", "--preserve-watch-output"][..],
+        &["--no-type-check", "--color"][..],
+        &["--no-type-check", "--no-color"][..],
+    ] {
+        let out = run(&dir, args);
+        // Only a warning is present, so a clean parse exits 0. A clap
+        // "unknown argument" failure would exit 2 with nothing on stdout.
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "args {args:?} should be accepted; stderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Why

An external review flagged that `rsvelte-check` was missing upstream `svelte-check` flags (`--config`, `--no-tsconfig`, `--threshold`) and that `--preserveWatchOutput` was spelled `--preserve-watch-output`, so the root README's "Every upstream flag works" overclaimed.

I audited every flag in `submodules/language-tools/packages/svelte-check/src/options.ts` against the clap definition and closed the gaps. (`--config` **does** exist upstream — the review was correct.)

## Upstream flag ↔ rsvelte-check

| Upstream flag | Before | After | Notes |
|---|---|---|---|
| `--workspace` | ✅ | ✅ | |
| `--output` | ✅ | ✅ | Plus rsvelte-only `github-actions`. |
| `--watch` | ✅ | ✅ | |
| `--preserveWatchOutput` | ⚠️ only `--preserve-watch-output` | ✅ | camelCase is now canonical; hyphen kept as alias. |
| `--incremental` | ✅ | ✅ | |
| `--tsgo` | ✅ | ✅ | |
| `--tsgo-experimental-api` | ❌ | ✅ (alias of `--tsgo`) | rsvelte has one native tsgo backend, so there is no separate experimental in-process API mode. |
| `--tsconfig` | ✅ | ✅ | |
| `--config` | ❌ | ✅ | Overrides the config source for diagnostic-relevant `compilerOptions` / `kit.files`; errors when the path is missing, like upstream. |
| `--no-tsconfig` | ❌ | ✅ | Ignores any project tsconfig/jsconfig; checks only the Svelte files. |
| `--ignore` | ✅ | ✅ | Kept always-active as a walker skip-list (rsvelte does **not** gate it behind `--no-tsconfig`, an intentional, documented divergence). |
| `--fail-on-warnings` | ✅ | ✅ | |
| `--compiler-warnings` | ✅ | ✅ | |
| `--diagnostic-sources` | ✅ | ✅ | |
| `--threshold` | ❌ | ✅ | `error` prints only errors, `warning` (default) prints warnings + errors. Counts / exit code always come from the unfiltered set (mirrors upstream `createFilter`). Only `warning`/`error` are valid; an invalid value warns and falls back to `warning`. |
| `--color` / `--no-color` | ❌ | ✅ (no-op) | Accepted for compatibility; rsvelte-check output is not colorized. |

### On `--threshold hint`

The review suggested `error|warning|hint`, but upstream `getThreshold` only accepts `warning`/`error` (`thresholds = ['warning', 'error']`). I followed upstream exactly rather than inventing a `hint` level.

### On `--no-tsconfig` / `--ignore`

Upstream errors if `--ignore` is used without `--no-tsconfig` (because a tsconfig is otherwise auto-discovered). rsvelte's `--ignore` has always been an always-active walker filter, so enforcing that gate would break existing behavior. I kept `--ignore` always-active and documented the divergence instead.

## Implementation

- `writers.rs`: new `Threshold` enum (`parse` + `includes`); the bin applies it only to what is printed, never to the summary/exit code.
- `config.rs` / `kit_file.rs`: `*_with_config` variants take an optional explicit config path (old 1-arg fns kept as thin wrappers, so no test churn).
- `runner.rs`: `RunOptions.config` threaded into both loaders.
- `bin/svelte_check.rs`: new args + camelCase canonical names / aliases + missing-`--config` validation.

## Tests

- `crates/rsvelte_core/tests/svelte_check_cli_flags.rs` — 8 binary-spawn tests covering `--threshold` (default shows / `error` hides but counts unchanged / invalid falls back), `--no-tsconfig` (Svelte files still checked, `--tsconfig` ignored), `--config` (missing errors exit 2 / present accepted), and that the compatibility spellings parse.
- `writers.rs` unit test for `Threshold::parse` / `includes`.

```
svelte_check_cli_flags: 8 passed
writers Threshold unit test: 1 passed
svelte_check_compiler_options: 5 passed
svelte_check_golden: 3 passed
cargo clippy --all-targets --all-features -- -D warnings: clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EizyABnBLJmcSeQYmGwFi