### PR TITLE
fix(formatter): fmt-parity burndown 48 → 46 (`<pre>` space-indent reindent)

### DIFF
--- a/.changeset/fix-fmt-pre-space-indent.md
+++ b/.changeset/fix-fmt-pre-space-indent.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(formatter): keep space indentation inside space-indented `<pre>` bodies
+
+`reformat_pre_inner` regenerated element-direct lines inside `<pre>` with tabs
+unconditionally, but oxfmt preserves `<pre>` bodies verbatim — tabs are only
+correct when the source itself was tab-indented. Block-tag lines (e.g. `{#if}`)
+inside a space-indented `<pre>` now keep spaces, including the closing-tag line.
+Formatter-parity baseline shrinks 48 → 46.

--- a/compat/corpus/fmt-known-failures.json
+++ b/compat/corpus/fmt-known-failures.json
@@ -29,8 +29,6 @@
 	"svar-core/svelte/demos/common/Index.svelte",
 	"svar-core/svelte/src/components/calendar/Panel.svelte",
 	"svelte-calendar/src/lib/components/Popover.svelte",
-	"svelte-calendar/src/lib/docs/Code.svelte",
-	"svelte-calendar/src/lib/docs/JSONEditor.svelte",
 	"svelte-fa/src/routes/components/ui/docs-code.svelte",
 	"svelte-form-builder/src/lib/FormBuilder.svelte",
 	"svelte-maplibre/src/site/components/CodeBlock.svelte",

--- a/compat/corpus/fmt-known-failures.md
+++ b/compat/corpus/fmt-known-failures.md
@@ -5,7 +5,7 @@ The formatter-parity corpus formats every `.svelte` component with both
 Svelte structure + oxc for embedded JS/CSS — rsvelte-fmt's exact layering) and
 requires **byte-identical** output. The ratchet may only shrink.
 
-**Current baseline: 48 entries**, concentrated in real-world corpus repos
+**Current baseline: 46 entries**, concentrated in real-world corpus repos
 (layercake, svelte-ux, layerchart, cmsaasstarter, date-picker-svelte, and a long
 tail). Oracle-bug / invalid-input / migrate cases are NOT here — those are
 permanently excluded in `fmt-oracle-excluded.json` (see `fmt-oracle-excluded.md`).
@@ -106,14 +106,18 @@ fill is genuinely context-dependent and not hand-characterizable without the
 full lookahead algorithm. Fix belongs in rsvelte — the `Fill`/prose layout
 port.
 
-## Cluster 6 — `<pre>` embedded block-tag reindent (2)
+## Cluster 6 — `<pre>` embedded block-tag reindent (0, resolved)
 
 Inside a literal `<pre>` whose body mixes raw text with a Svelte block tag
-(`{#if …}…{/if}` wrapping a `<code>` child), the oracle reindents the block
-tag's own lines (tabs → spaces, depth-normalized) while leaving the literal
-text verbatim; rsvelte's `<pre>` handling emits the source's raw tabs
-unchanged. `reformat_pre_inner` is string surgery with no Doc IR (flagged
-fragile). Fix belongs in rsvelte — rewriting the `<pre>` path on the Doc IR.
+(`{#if …}…{/if}` wrapping a `<code>` child), `reformat_pre_inner` regenerates
+element-direct indentation as **tabs**, on the assumption that oxfmt preserves
+the source's element-direct whitespace as tabs. That assumption only holds when
+the source actually indented with tabs — a space-indented `<pre>` body is kept
+verbatim as spaces by oxfmt, so regenerating its block-tag lines as tabs
+diverged. Fixed by gating tab regeneration on whether the `<pre>` body's source
+indentation uses tabs at all (`pre_uses_tabs`); a space-indented body now stays
+spaces throughout. Cleared `svelte-calendar/…/Code.svelte` and
+`svelte-calendar/…/JSONEditor.svelte`.
 
 ## Cluster 7 — oxc paren / type-annotation divergence (2)
 

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -432,6 +432,12 @@ fn reformat_pre_inner(
     let inner_end = elem.start as usize + close_rel;
     let raw_inner = out.get(inner_start..inner_end)?;
 
+    // Element-direct whitespace inside `<pre>` is preserved verbatim by oxfmt, so
+    // it only becomes tabs when the SOURCE indented with tabs. A `<pre>` whose
+    // body is space-indented keeps spaces throughout (block-tag lines included),
+    // so don't regenerate its element-direct lines as tabs.
+    let pre_uses_tabs = raw_inner.lines().any(|l| l.starts_with('\t'));
+
     let iw = options.js.indent_width.value() as usize;
     let full_width = options.js.line_width.value() as usize;
     // Format the children standalone, but narrowed so a depth-0 layout matches the
@@ -549,7 +555,7 @@ fn reformat_pre_inner(
             if !trimmed.is_empty() {
                 let spaces = line.len() - trimmed.len();
                 let real_depth = spaces / iw + content_depth;
-                if tab_lines.contains(&offset) {
+                if pre_uses_tabs && tab_lines.contains(&offset) {
                     for _ in 0..real_depth {
                         result.push('\t');
                     }
@@ -569,8 +575,14 @@ fn reformat_pre_inner(
     // follows on the same line — no trailing `\n<indent>` needed.
     if !hugged {
         result.push('\n');
-        for _ in 0..content_depth.saturating_sub(1) {
-            result.push('\t');
+        if pre_uses_tabs {
+            for _ in 0..content_depth.saturating_sub(1) {
+                result.push('\t');
+            }
+        } else {
+            for _ in 0..content_depth.saturating_sub(1) * iw {
+                result.push(' ');
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Reduces the formatter-parity corpus ratchet (`compat/corpus/fmt-known-failures.json`) from **48 → 46** by fixing a structural (platform-independent) `<pre>` reindent bug.

## The fix

`reformat_pre_inner` regenerates the indentation of a `<pre>`'s element-direct lines as **tabs**, on the assumption that oxfmt preserves the source's element-direct whitespace as tabs inside `<pre>` (whitespace-sensitive). That assumption only holds when the source actually indented with tabs. oxfmt keeps a **space-indented** `<pre>` body verbatim as spaces, so a Svelte block tag such as `{#if …}` sitting directly inside a space-indented `<pre>` diverged — rsvelte emitted a tab where the oracle kept the source's 2 spaces:

```
  <pre class="language-{language}">
-	{#if highlighted}      ← rsvelte (tab)
+  {#if highlighted}       ← oracle (2 spaces, source-preserved)
    <code>{@html highlighted}</code>
  {/if}
</pre>
```

The fix gates tab regeneration on whether the `<pre>` body's source indentation uses tabs at all (`pre_uses_tabs = raw_inner.lines().any(|l| l.starts_with('\t'))`). A space-indented body now stays spaces throughout, including the close-tag line. This is conservative and cannot regress a passing tab-indented `<pre>` (those are untouched); it only forces spaces where the source had no tabs, which is always what oxfmt emits there.

## Resolves Cluster 6 (both entries)

- `svelte-calendar/src/lib/docs/Code.svelte`
- `svelte-calendar/src/lib/docs/JSONEditor.svelte`

## Validation

Ran the full local fmt-parity corpus (12,657 components) before/after: total failures dropped by exactly 2 (the two Cluster-6 entries) with **zero new regressions**. `cargo test -p rsvelte_formatter -p rsvelte_fmt`, `cargo fmt`, and `cargo clippy -p rsvelte_formatter --all-targets --all-features -- -D warnings` all pass.

> Note: the committed baseline is the Linux-CI failure set; only these two structural fixes are removed. Other local pass/fail deltas (e.g. `SearchBox.svelte`, a few shadcn trailing-comma files) are local-oxfmt-version artifacts, not code changes, and are deliberately left in the baseline for CI to arbitrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EizyABnBLJmcSeQYmGwFi