### PR TITLE
perf(analyze): CSS 解析が見ない属性式のシリアライズを回避 (server -1.7~2.8%)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css/mod.rs
@@ -13,6 +13,7 @@ mod warn;
 pub use analyze::{analyze_css, extract_css_selector_info};
 pub use prune::prune_css;
 pub use utils::{
-    get_parent_rules, get_possible_values, is_global, is_outer_global, is_unscoped_pseudo_class,
+    get_parent_rules, get_possible_values, get_possible_values_expr, is_global, is_outer_global,
+    is_unscoped_pseudo_class,
 };
 pub use warn::warn_unused;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css/utils.rs
@@ -78,6 +78,38 @@ const UNKNOWN_MARKER: &str = "__UNKNOWN__";
 /// Returns `Some(Vec<String>)` if we can determine all possible values.
 ///
 /// This is used for class attribute analysis to determine which classes might be used.
+/// `get_possible_values` for a template expression, skipping the JSON
+/// materialization when the node type alone settles the answer.
+///
+/// `gather_possible_values` only inspects `Literal`, `ConditionalExpression`,
+/// `LogicalExpression`, `BinaryExpression`, `TemplateLiteral`,
+/// `TSAsExpression`, and — for a class attribute only — `ArrayExpression` and
+/// `ObjectExpression`. Everything else falls to its `_` arm, which marks the
+/// value unknown and makes `get_possible_values` return `None`. A bare
+/// `Identifier` (`class={cls}`, the common dynamic case) is in that group, so
+/// serializing the expression first is wasted work.
+pub fn get_possible_values_expr(
+    expr: &crate::ast::js::Expression,
+    is_class: bool,
+) -> Option<Vec<String>> {
+    if let Some(node_type) = expr.node_type() {
+        let inspected = matches!(
+            node_type,
+            "Literal"
+                | "ConditionalExpression"
+                | "LogicalExpression"
+                | "BinaryExpression"
+                | "TemplateLiteral"
+                | "TSAsExpression"
+        ) || (is_class
+            && matches!(node_type, "ArrayExpression" | "ObjectExpression"));
+        if !inspected {
+            return None;
+        }
+    }
+    get_possible_values(expr.as_json(), is_class)
+}
+
 pub fn get_possible_values(chunk: &serde_json::Value, is_class: bool) -> Option<Vec<String>> {
     let mut values = Vec::new();
     let chunk_type = chunk.get("type").and_then(|t| t.as_str());

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -484,10 +484,9 @@ pub fn visit(
                                     }
                                 }
                                 AttributeValuePart::ExpressionTag(expr_tag) => {
-                                    let expr_json = expr_tag.expression.as_json();
-                                    use super::super::css::get_possible_values;
+                                    use super::super::css::get_possible_values_expr;
                                     if let Some(possible_vals) =
-                                        get_possible_values(expr_json, false)
+                                        get_possible_values_expr(&expr_tag.expression, false)
                                     {
                                         if possible_vals.len() > 20 {
                                             // Too many combinations, bail out
@@ -526,9 +525,10 @@ pub fn visit(
                     // Expression or other dynamic value
                     // Try to statically determine the value for CSS attribute selector matching
                     if let AttributeValue::Expression(expr_tag) = &attr_node.value {
-                        let expr_json = expr_tag.expression.as_json();
-                        use super::super::css::get_possible_values;
-                        if let Some(possible_values) = get_possible_values(expr_json, false) {
+                        use super::super::css::get_possible_values_expr;
+                        if let Some(possible_values) =
+                            get_possible_values_expr(&expr_tag.expression, false)
+                        {
                             // We can determine the possible values statically
                             for value in &possible_values {
                                 static_attributes
@@ -562,9 +562,8 @@ pub fn visit(
                                         Some(vec![text.data.to_string()])
                                     }
                                     AttributeValuePart::ExpressionTag(expr_tag) => {
-                                        let expr_json = expr_tag.expression.as_json();
-                                        use super::super::css::get_possible_values;
-                                        get_possible_values(expr_json, true)
+                                        use super::super::css::get_possible_values_expr;
+                                        get_possible_values_expr(&expr_tag.expression, true)
                                     }
                                 };
 
@@ -670,9 +669,10 @@ pub fn visit(
                         AttributeValue::Expression(expr_tag) => {
                             // Expression as attribute value: class={{ ... }}
                             // Use the cached JSON view of the expression to analyze it
-                            let expr_json = expr_tag.expression.as_json();
-                            use super::super::css::get_possible_values;
-                            if let Some(possible_values) = get_possible_values(expr_json, true) {
+                            use super::super::css::get_possible_values_expr;
+                            if let Some(possible_values) =
+                                get_possible_values_expr(&expr_tag.expression, true)
+                            {
                                 // We can statically determine the classes
                                 for value in &possible_values {
                                     for class_name in value.split_whitespace() {


### PR DESCRIPTION
## What

CSS 解析が**見もしない属性式を丸ごとシリアライズしていた**のを、ノード型による短絡でやめます。出力は不変です(両コーパスで出力ダイジェスト差分ゼロ)。

## Why

`get_possible_values` に渡される式は、`gather_possible_values` のトップレベル match で実際に検査されるものだけが意味を持ちます。検査対象は `Literal` / `ConditionalExpression` / `LogicalExpression` / `BinaryExpression` / `TemplateLiteral` / `TSAsExpression` と、**class 属性のときだけ** `ArrayExpression` / `ObjectExpression` の計8種で、それ以外はすべて `_` アームで UNKNOWN → `None` を返します。

つまり **`class={cls}` のような素の `Identifier`(動的クラスの最も一般的な形)は、`None` を返すためだけに式全体を `serde_json::Value` へシリアライズしていました。** ノード型を見れば結論が確定するのにです。

呼び出しは4サイトありますが、いずれも単一関数 `get_possible_values` を経由していたため、修正は1関数に閉じています。`is_class` ガード(`ArrayExpression` / `ObjectExpression` は class 属性のときだけ検査される)もミラーしています。

## Measurements — 正直に言って、client では効果を検出できませんでした

CPU時間 + min-of-N + 交互 A/B を3ラウンド、**2つのコーパス**で測定しました:

| コーパス | タスク | CPU | min wall |
|---|---|---:|---:|
| ベンチ(svelte tests, 0.88MB) | client | ±0.00% | -0.57% |
| ベンチ | **server** | **-1.70%** | **-1.68%** |
| 実世界(shadcn/flowbite/bits-ui/melt/layerchart, 6.85MB) | client | -0.06% | -1.74% |
| 実世界 | **server** | **-2.82%** | -0.46% |

- **client は両コーパスで測定限界**です。CPU がほぼ 0%、min はラウンド別で符号が揺れます(ベンチ: -1.6/-0.6/+0.4)。**改善したとは言えません**
- **server は4指標中3つで -1.7〜-2.8%、ラウンド別の符号も安定**しています(ベンチ CPU: -2.0/-1.2/-1.9、実世界 CPU: -2.1/-4.4/-2.0)

「実世界のほうが動的 class の使用頻度が高いので効果が大きいはず」という仮説を立てて実世界コーパスでも測りましたが、**支持されませんでした**。

**マージする理由**は、測定できた server の一貫した弱い改善と、「型を見れば確定する結論のために全体をシリアライズしない」という理屈上厳密に仕事が減る変更であること、そしてリスクが極めて低いことです。client については効果を主張しません。

## Verification

出力ダイジェストの全件比較を**両コーパス**で実施し、いずれも**差分ゼロ**:

- ベンチコーパス 3,857 ファイル(client + server)
- **実世界コーパス 3,856 ファイル(client + server)** — shadcn-svelte / flowbite-svelte / bits-ui / melt-ui / layerchart の実プロジェクトコード

ベンチコーパスは svelte 自身のテストフィクスチャで式の形が人工的なため、実プロジェクト固有の式でも一致を確認しています。

## Testing

`cargo test -p rsvelte_core` — 164 スイート / 2,150 テスト / 失敗ゼロ。`cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` クリーン。

(注: `cargo test --release` によるローカル最終確認は、測定マシンが他プロセスで負荷 60 に達しており実行できませんでした。CI のフルスイートを最終ゲートとしています。)
