### PR TITLE
feat(svelte2tsx): upstream-compatible result object (map/exportedNames/events)

### DIFF
--- a/.changeset/feat-svelte2tsx-result-shape.md
+++ b/.changeset/feat-svelte2tsx-result-shape.md
@@ -1,0 +1,24 @@
+---
+"@rsvelte/svelte2tsx": minor
+"@rsvelte/compiler": patch
+---
+
+feat(svelte2tsx): result object matches upstream (`map` SourceMap, `exportedNames.has`, `events.getAll`)
+
+The `svelte2tsx()` result now mirrors the official
+[`svelte2tsx`](https://github.com/sveltejs/language-tools/tree/master/packages/svelte2tsx)
+`SvelteCompiledToTsx` shape:
+
+- **`map`** is now a magic-string-style `SourceMap` **object** (`version`,
+  `sources`, `sourcesContent`, `names`, `mappings`, plus `toString()` /
+  `toUrl()`) instead of a JSON string. In `dts` mode it stays `null`.
+- **`exportedNames`** now exposes `has(name): boolean` (upstream
+  `IExportedNames`). The existing `props` / `all` arrays are kept as a
+  backward-compatible rsvelte extension.
+- **`events`** now exposes `getAll(): { name, type, doc? }[]` (upstream
+  `ComponentEvents`, which is `@deprecated`) instead of a plain record. Types
+  are approximated as `CustomEvent<detail>` / `CustomEvent<any>`; the optional
+  `doc` (JSDoc) field is not populated.
+
+The `map` string → object change folds into the same unreleased `0.2.0` as the
+synchronous-API change, so it stays a single minor bump.

--- a/apps/npm/svelte2tsx/README.md
+++ b/apps/npm/svelte2tsx/README.md
@@ -35,11 +35,15 @@ const result = svelte2tsx(source, {
   version: '5',
 });
 
-console.log(result.code);          // TSX source
-console.log(result.map);           // source map (string | null)
-console.log(result.exportedNames); // { props: ['name'], all: [...] }
-console.log(result.events);        // { eventName: type, ... }
+console.log(result.code);                 // TSX source
+console.log(result.map.mappings);         // source map (magic-string SourceMap object | null)
+console.log(result.exportedNames.has('name')); // true
+console.log(result.events.getAll());      // [{ name, type }, ...]
 ```
+
+The result object matches the upstream `svelte2tsx` surface: `map` is a
+magic-string-style `SourceMap` object, `exportedNames` exposes `has(name)`, and
+`events` exposes `getAll()`.
 
 ## API
 
@@ -67,14 +71,44 @@ interface Svelte2TsxOptions {
 interface Svelte2TsxResult {
   /** Generated TSX source. */
   code: string;
-  /** Source map (v3 JSON, as a string), or `null` if not produced. */
-  map: string | null;
-  /** Names exported by the component — `props` is the prop list, `all` is everything. */
-  exportedNames: { props: string[]; all: string[] };
-  /** Inferred event-handler types — `{ eventName: type }`. */
-  events: Record<string, unknown>;
+  /** magic-string-style v3 source map (with `toString()` / `toUrl()`), or `null` in `dts` mode. */
+  map: SourceMap | null;
+  /** Exported names. `has(name)` matches upstream; `props`/`all` are an rsvelte extension. */
+  exportedNames: IExportedNames;
+  /** @deprecated Component events — `getAll()` returns `{ name, type, doc? }[]`. */
+  events: ComponentEvents;
+}
+
+interface SourceMap {
+  version: number;
+  file?: string;
+  sources: string[];
+  sourcesContent?: (string | null)[];
+  names: string[];
+  mappings: string;
+  toString(): string;
+  toUrl(): string;
+}
+
+interface IExportedNames {
+  has(name: string): boolean;
+  props: string[]; // rsvelte extension
+  all: string[];   // rsvelte extension
+}
+
+interface ComponentEvents {
+  getAll(): { name: string; type: string; doc?: string }[];
 }
 ```
+
+> **Note on `events`.** Like upstream, `events` is deprecated — prefer TypeScript's
+> `TypeChecker` for event types. `getAll()` returns entries sorted by name with
+> `type` approximated as `CustomEvent<detail>` (`CustomEvent<any>` when the detail
+> type is unknown); the optional `doc` (JSDoc) field is not populated. It covers
+> events dispatched via an **untyped** `createEventDispatcher()` and forwarded
+> events; the individual event names of a **typed** dispatcher
+> (`createEventDispatcher<{ … }>()`) are passed through as a TS type expression
+> in the generated code rather than enumerated, so they are not listed here.
 
 `svelte2tsx()` is **synchronous**, matching the upstream package — a drop-in call. On Node the WebAssembly module self-initialises (via `initSync` + `fs.readFileSync`) on the first call; subsequent calls have no init cost. Existing `await svelte2tsx(...)` code keeps working unchanged, since awaiting a plain value returns it.
 

--- a/apps/npm/svelte2tsx/index.d.ts
+++ b/apps/npm/svelte2tsx/index.d.ts
@@ -7,14 +7,58 @@ export interface Svelte2TsxOptions {
 	version?: '4' | '5';
 }
 
+/**
+ * The source map returned alongside the generated code. Mirrors the object
+ * produced by magic-string's `SourceMap` (the shape upstream `svelte2tsx`
+ * returns): the standard v3 fields plus `toString()` / `toUrl()`.
+ */
+export interface SourceMap {
+	version: number;
+	file?: string;
+	sources: string[];
+	sourcesContent?: (string | null)[];
+	names: string[];
+	/** VLQ-encoded mappings string. */
+	mappings: string;
+	toString(): string;
+	toUrl(): string;
+}
+
+/**
+ * Names exported from the component. Upstream exposes only `has(name)`; the
+ * `props` / `all` arrays are a backward-compatible rsvelte extension.
+ */
+export interface IExportedNames {
+	has(name: string): boolean;
+	/** rsvelte extension: exported names that are component props, sorted. */
+	props: string[];
+	/** rsvelte extension: every exported name, sorted. */
+	all: string[];
+}
+
+export interface ComponentEvent {
+	name: string;
+	type: string;
+	doc?: string;
+}
+
+/**
+ * @deprecated Use TypeScript's `TypeChecker` to get the type information
+ * instead. This only covers literal typings.
+ */
+export interface ComponentEvents {
+	getAll(): ComponentEvent[];
+}
+
 export interface Svelte2TsxResult {
 	code: string;
-	map: string | null;
-	exportedNames: {
-		props: string[];
-		all: string[];
-	};
-	events: Record<string, unknown>;
+	map: SourceMap | null;
+	exportedNames: IExportedNames;
+	/**
+	 * @deprecated Use TypeScript's `TypeChecker` to get the type information
+	 * instead. This only covers literal typings.
+	 */
+	events: ComponentEvents;
 }
 
 /**

--- a/apps/npm/svelte2tsx/index.js
+++ b/apps/npm/svelte2tsx/index.js
@@ -65,6 +65,62 @@ export async function initialize(input) {
 	ensureReadySync();
 }
 
+// Base64-encode a string, mirroring magic-string's `SourceMap` (prefers
+// `btoa`, falls back to Node's `Buffer`) so `map.toUrl()` works in browsers.
+function toBase64(str) {
+	if (typeof globalThis !== 'undefined' && typeof globalThis.btoa === 'function') {
+		return globalThis.btoa(unescape(encodeURIComponent(str)));
+	}
+	return Buffer.from(str, 'utf-8').toString('base64');
+}
+
+// Mirror of magic-string's `SourceMap`: the shape `str.generateMap()` returns
+// upstream. Field layout (`version`/`sources`/`names`/`mappings`, plus the
+// optional `file`/`sourcesContent`) matches the object magic-string emits, and
+// `toString()`/`toUrl()` reproduce its methods so tooling that inlines the map
+// keeps working.
+class SourceMap {
+	constructor(props) {
+		this.version = props.version ?? 3;
+		this.file = props.file ?? undefined;
+		this.sources = props.sources ?? [];
+		this.sourcesContent = props.sourcesContent ?? undefined;
+		this.names = props.names ?? [];
+		this.mappings = props.mappings ?? '';
+	}
+
+	toString() {
+		return JSON.stringify(this);
+	}
+
+	toUrl() {
+		return 'data:application/json;charset=utf-8;base64,' + toBase64(this.toString());
+	}
+}
+
+// Wrap the wasm `exportedNames` payload in the upstream `IExportedNames` shape
+// (a `has(name)` predicate over every exported name). The `props`/`all` arrays
+// are retained as a backward-compatible rsvelte extension.
+function wrapExportedNames(exportedNames) {
+	const all = Array.isArray(exportedNames?.all) ? exportedNames.all : [];
+	const props = Array.isArray(exportedNames?.props) ? exportedNames.props : [];
+	const set = new Set(all);
+	return {
+		has: (name) => set.has(name),
+		props,
+		all,
+	};
+}
+
+// Wrap the wasm `events` payload in the upstream `ComponentEvents` shape
+// (`getAll()` returning `{ name, type, doc? }[]`).
+function wrapEvents(events) {
+	const entries = Array.isArray(events) ? events : [];
+	return {
+		getAll: () => entries,
+	};
+}
+
 /**
  * Convert a Svelte component to TypeScript/TSX.
  *
@@ -81,12 +137,7 @@ export async function initialize(input) {
  *   namespace?: 'html' | 'svg' | 'mathml',
  *   version?: '4' | '5',
  * }} [options]
- * @returns {{
- *   code: string,
- *   map: string | null,
- *   exportedNames: { props: string[], all: string[] },
- *   events: Record<string, unknown>,
- * }}
+ * @returns {import('./index.d.ts').Svelte2TsxResult}
  */
 export function svelte2tsx(source, options = {}) {
 	ensureReadySync();
@@ -95,11 +146,16 @@ export function svelte2tsx(source, options = {}) {
 	if (parsed.success === false) {
 		throw new Error(parsed.error || 'svelte2tsx failed');
 	}
+	// `map` crosses the wasm boundary as a JSON string (or null in `dts` mode).
+	let map = null;
+	if (parsed.map != null) {
+		map = new SourceMap(typeof parsed.map === 'string' ? JSON.parse(parsed.map) : parsed.map);
+	}
 	return {
 		code: parsed.code,
-		map: parsed.map ?? null,
-		exportedNames: parsed.exportedNames,
-		events: parsed.events ?? {},
+		map,
+		exportedNames: wrapExportedNames(parsed.exportedNames),
+		events: wrapEvents(parsed.events),
 	};
 }
 

--- a/apps/npm/svelte2tsx/test/result-shape.test.mjs
+++ b/apps/npm/svelte2tsx/test/result-shape.test.mjs
@@ -1,0 +1,64 @@
+// Asserts the result object matches the upstream `svelte2tsx` surface:
+// `map` is a magic-string-style SourceMap object, `exportedNames.has(name)`,
+// and `events.getAll()`.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { svelte2tsx } from '../index.js';
+
+const source = `
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  export let name: string;
+  export const version = '1';
+  const dispatch = createEventDispatcher();
+  function greet() { dispatch('greet', name); }
+</script>
+
+<h1 on:click={greet}>Hello, {name}!</h1>
+`;
+const opts = { filename: 'Hello.svelte', isTsFile: true, version: '5' };
+
+test('map is a SourceMap-like object (not a JSON string)', () => {
+	const { map } = svelte2tsx(source, opts);
+	assert.equal(typeof map, 'object');
+	assert.notEqual(map, null);
+	assert.equal(map.version, 3);
+	assert.equal(typeof map.mappings, 'string', 'map.mappings is the encoded VLQ string');
+	assert.ok(Array.isArray(map.sources), 'map.sources is an array');
+	assert.ok(Array.isArray(map.names), 'map.names is an array');
+});
+
+test('map.toString() is valid JSON and toUrl() is a data URI', () => {
+	const { map } = svelte2tsx(source, opts);
+	const roundTripped = JSON.parse(map.toString());
+	assert.equal(roundTripped.version, 3);
+	assert.equal(roundTripped.mappings, map.mappings);
+	assert.ok(map.toUrl().startsWith('data:application/json;charset=utf-8;base64,'));
+});
+
+test('exportedNames.has(name) reflects every exported name', () => {
+	const { exportedNames } = svelte2tsx(source, opts);
+	assert.equal(typeof exportedNames.has, 'function');
+	assert.equal(exportedNames.has('name'), true);
+	assert.equal(exportedNames.has('version'), true);
+	assert.equal(exportedNames.has('doesNotExist'), false);
+	// Backward-compatible rsvelte extension.
+	assert.ok(Array.isArray(exportedNames.props));
+	assert.ok(exportedNames.props.includes('name'));
+});
+
+test('events.getAll() returns { name, type }[]', () => {
+	const { events } = svelte2tsx(source, opts);
+	assert.equal(typeof events.getAll, 'function');
+	const all = events.getAll();
+	assert.ok(Array.isArray(all), 'getAll() returns an array');
+	const greet = all.find((e) => e.name === 'greet');
+	assert.ok(greet, 'the dispatched "greet" event is present');
+	assert.equal(typeof greet.type, 'string');
+});
+
+test('events.getAll() is an empty array for a component with no events', () => {
+	const { events } = svelte2tsx('<p>hi</p>', {});
+	assert.deepEqual(events.getAll(), []);
+});

--- a/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/mod.rs
@@ -922,6 +922,26 @@ impl ComponentEvents {
             .map(|name| (name.clone(), "__sveltets_2_customEvent".to_string()))
             .collect()
     }
+
+    /// Entries for the public `events.getAll()` API surface: `(name, type)`
+    /// where `type` mirrors upstream's `CustomEvent<detail>` (or
+    /// `CustomEvent<any>` when the detail type is unknown). Sorted by name for
+    /// determinism; the deprecated `doc` field is not tracked.
+    pub fn get_api_entries(&self) -> Vec<(String, String)> {
+        let mut entries: Vec<(String, String)> = self
+            .events
+            .iter()
+            .map(|(name, info)| {
+                let ty = match &info.detail_type {
+                    Some(detail) => format!("CustomEvent<{detail}>"),
+                    None => "CustomEvent<any>".to_string(),
+                };
+                (name.clone(), ty)
+            })
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
 }
 
 /// Position info for $props() typedef generation, collected during OXC walk.

--- a/crates/rsvelte_core/src/wasm.rs
+++ b/crates/rsvelte_core/src/wasm.rs
@@ -193,12 +193,18 @@ pub fn svelte2tsx(source: &str, options_json: &str) -> String {
                 .iter()
                 .map(|n: &&str| serde_json::Value::String((*n).to_string()))
                 .collect();
+            let events: Vec<serde_json::Value> = result
+                .events
+                .get_api_entries()
+                .into_iter()
+                .map(|(name, ty)| serde_json::json!({ "name": name, "type": ty }))
+                .collect();
             let output = serde_json::json!({
                 "success": true,
                 "code": result.code,
                 "map": result.map,
                 "exportedNames": { "props": props, "all": all },
-                "events": {},
+                "events": events,
             });
             output.to_string()
         }


### PR DESCRIPTION
## What

Makes the `@rsvelte/svelte2tsx` result object mirror upstream's `SvelteCompiledToTsx` shape (following #1595, which landed the synchronous API). This is the last remaining API-surface divergence.

| Field | Before | After (upstream-compatible) |
|---|---|---|
| `map` | JSON `string \| null` | magic-string `SourceMap` object (v3 fields + `toString()`/`toUrl()`), `null` in `dts` mode |
| `exportedNames` | `{ props, all }` | `has(name): boolean` (upstream `IExportedNames`) + `props`/`all` kept as a backward-compatible extension |
| `events` | `Record<string, unknown>` (always `{}`) | `getAll(): { name, type, doc? }[]` (upstream `ComponentEvents`, `@deprecated`) |

## How

- **JS glue** (`apps/npm/svelte2tsx/index.js`): parse the wasm `map` JSON into a `SourceMap` class (with `toString`/`toUrl`, `btoa`/`Buffer` fallback like magic-string); wrap `exportedNames` with a `has()` predicate over `all`; wrap `events` with `getAll()`.
- **Wasm** (`crates/rsvelte_core/src/wasm.rs` + `ComponentEvents::get_api_entries`): surface dispatched/forwarded events as `{ name, type }` (previously `events: {}`). `type` is approximated as `CustomEvent<detail>` / `CustomEvent<any>`.
- **Types** (`index.d.ts`) and **README** updated to the new shape.

## Known limitations (documented in README)

`events` is deprecated upstream too. `getAll()` covers untyped `createEventDispatcher()` dispatched events and forwarded events; the individual event names of a **typed** dispatcher (`createEventDispatcher<{…}>()`) are passed through as a TS type expression in the generated code rather than enumerated, and the optional `doc` (JSDoc) field is not populated.

## Consumers

No repo consumer relies on the old shape: `@rsvelte/svelte-check` uses the Rust API directly, and the playground reads the raw wasm JSON (ignoring `events`). Existing package tests keep passing.

## Semver

`@rsvelte/svelte2tsx` **minor** (folds into the same unreleased `0.2.0` as #1595's sync-API change; `map` string→object) + `@rsvelte/compiler` **patch** (events in wasm output).

## Tests

- New `apps/npm/svelte2tsx/test/result-shape.test.mjs` (map object/`toString`/`toUrl`, `exportedNames.has`, `events.getAll`) — 5 new, all pass; existing 6 sync-API tests still pass (11/11).
- `cargo fmt` + `cargo clippy --all-targets --all-features -D warnings` clean.
- svelte2tsx fixture suite: 253/253, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EizyABnBLJmcSeQYmGwFi