### PR TITLE
fix(compiler): store-getter classification/ordering (LayerCake, svelte-ux AppLayout)

### DIFF
--- a/.changeset/fix-store-getter-classification-ordering.md
+++ b/.changeset/fix-store-getter-classification-ordering.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): faithful `$`-store auto-subscription classification for two edge cases
+
+Two lexical-scope heuristics in the store-subscription detector diverged from
+upstream's scope analysis:
+
+- Destructured arrow parameters spanning multiple lines
+  (`([\n  $a,\n  $b\n]) => …`, e.g. LayerCake's `derived` callbacks) were not
+  recognized as local bindings because the param-detection whitespace scan
+  stopped at the newline before the delimiter. Those names were wrongly emitted
+  as store getters (`const $a = () => $.store_get(a(), …)`) and reordered the
+  emitted getter block.
+- A store reference in a ternary consequent behind a unary operator
+  (`cond ? !$store : x`) was misclassified as an object property key, so no
+  store getter was emitted at all.
+
+Both now match the official compiler; the LayerCake and svelte-ux `AppLayout`
+corpus entries compile byte-identically for CSR and SSR.

--- a/compat/corpus/known-failures.client.json
+++ b/compat/corpus/known-failures.client.json
@@ -1,12 +1,10 @@
 [
-	"layercake/src/lib/LayerCake.svelte",
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",
 	"svelte-table/src/SvelteTable.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte"
 ]

--- a/compat/corpus/known-failures.md
+++ b/compat/corpus/known-failures.md
@@ -14,12 +14,8 @@ compiler-behaviour gap; attempts to fix them are regression-prone against the
 8000+ passing entries (several have been reverted after wide blowups), so they are
 accepted until an upstream-faithful port lands.
 
-## Client (`known-failures.client.json`, 10 entries)
+## Client (`known-failures.client.json`, 8 entries)
 
-- **`layercake/.../LayerCake.svelte`** — store-getter declaration **ordering**
-  (`const $X = () => $.store_get(...)`) differs, plus a derived store called as
-  `flatData()` where svelte emits a bare `box_d`. Store subscription
-  ordering/classification.
 - **`melt-ui/.../SpatialMenuNavTest.svelte`** — two causes: (a) a proxy argument in
   `$.set(highlighted, id, true)` where `id` is an inner-scope TemplateLiteral const
   not admitted to `non_proxy_vars` (the `name_occurrences==1` heuristic bails on
@@ -44,8 +40,6 @@ accepted until an upstream-faithful port lands.
   `col` missing inside `$.invalidate_inner_signals` (from a `bind:value` key
   `filterSelections()[col.key]`). The exact condition making `col` reactive is
   unresolved.
-- **`svelte-ux/.../AppLayout.svelte`** — same store-getter ordering/classification
-  class as LayerCake (this id is also the sole server entry).
 - **`svelte-ux/.../Button.svelte`** — an `$.event('click', …)` wrapped in
   `$.effect(() => $.event(…))` where svelte emits it bare in after_update; spread +
   action-with-event placement (~25-node difference).
@@ -54,11 +48,9 @@ accepted until an upstream-faithful port lands.
   `onChange: $.get(onChange)`. svelte's rule is `has_state ? getter : init`;
   rsvelte's `has_state` is true for a legacy prop where svelte's is false.
 
-## Server (`known-failures.server.json`, 1 entry)
+## Server (`known-failures.server.json`, 0 entries)
 
-- **`svelte-ux/.../AppLayout.svelte`** — the SSR half of the same store-getter
-  ordering/classification divergence (it is in both baselines, so it is the
-  client/server intersection).
+No accepted server-side divergences remain.
 
 ## General hard-cluster root causes (why fixes are deferred)
 

--- a/compat/corpus/known-failures.server.json
+++ b/compat/corpus/known-failures.server.json
@@ -1,3 +1,1 @@
-[
-	"svelte-ux/packages/svelte-ux/src/lib/components/AppLayout.svelte"
-]
+[]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -534,6 +534,10 @@ fn arrow_body_range(chars: &[char], from: usize) -> (usize, usize) {
     (s, m)
 }
 
+fn is_js_whitespace(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\n' | '\r')
+}
+
 /// If the `$xxx` ident at `[ident_start, ident_end)` is a function/arrow
 /// parameter (including inside array/object destructuring), return the char-index
 /// range `[start, end)` of that arrow's BODY — the lexical scope in which the
@@ -547,9 +551,10 @@ fn dollar_param_body_range(
 ) -> Option<(usize, usize)> {
     let len = chars.len();
 
-    // Skip whitespace after the ident.
+    // Skip whitespace after the ident. Newlines count: a destructured param list
+    // often spans multiple lines (`([\n\t$a,\n\t$b\n]) => …`).
     let mut j = ident_end;
-    while j < len && (chars[j] == ' ' || chars[j] == '\t') {
+    while j < len && is_js_whitespace(chars[j]) {
         j += 1;
     }
 
@@ -563,7 +568,7 @@ fn dollar_param_body_range(
     // by one of `) , ] }`, and the enclosing `(...)` is followed by `=>`.
     if ident_start > 0 {
         let mut k = ident_start as isize - 1;
-        while k >= 0 && (chars[k as usize] == ' ' || chars[k as usize] == '\t') {
+        while k >= 0 && is_js_whitespace(chars[k as usize]) {
             k -= 1;
         }
         let preceded_ok = k >= 0 && matches!(chars[k as usize], '(' | ',' | '[' | '{');
@@ -579,7 +584,7 @@ fn dollar_param_body_range(
                     ')' => {
                         if paren_depth == 0 {
                             let mut n = m + 1;
-                            while n < len && (chars[n] == ' ' || chars[n] == '\t') {
+                            while n < len && is_js_whitespace(chars[n]) {
                                 n += 1;
                             }
                             if n + 1 < len && chars[n] == '=' && chars[n + 1] == '>' {
@@ -627,11 +632,14 @@ fn is_dollar_ident_object_property_key(
             return false;
         }
         // Exclude a ternary consequent: `cond ? $x : y`. Walk back over
-        // whitespace (incl. newlines, for multi-line ternaries) from the
+        // whitespace (incl. newlines, for multi-line ternaries) and any leading
+        // unary-only prefix operators (`!`/`~`, e.g. `cond ? !$x : y`) from the
         // identifier; a leading `?` means this is the `then` branch of a
         // conditional expression, not a property key.
         let mut k = ident_start as isize - 1;
-        while k >= 0 && chars[k as usize].is_whitespace() {
+        while k >= 0
+            && (chars[k as usize].is_whitespace() || matches!(chars[k as usize], '!' | '~'))
+        {
             k -= 1;
         }
         if k >= 0 && chars[k as usize] == '?' {
@@ -1476,6 +1484,61 @@ mod tests {
                 "$y".to_string(),
                 "$x".to_string(),
             ],
+        );
+    }
+
+    /// A `$name` destructuring parameter spread across multiple lines
+    /// (`derived([...], ([\n  $a,\n  $b\n]) => …)`) is a local binding, not a
+    /// store subscription — the same as the single-line `([$a]) =>` case. The
+    /// param whitespace scan must skip newlines to recognize it (LayerCake's
+    /// `extents_d` derived). The param name (and body references that resolve to
+    /// it) must never surface as a top-level subscription.
+    #[test]
+    fn test_multiline_destructure_params_not_store_subs() {
+        let source = r#"<script>
+    import { derived, writable } from 'svelte/store';
+    export let flatData = [];
+    export let xDomain = undefined;
+    const _a = writable(1);
+    const extents_d = derived(
+        [_a],
+        ([
+            $flatData,
+            $xDomain
+        ]) => {
+            return [$flatData, $xDomain];
+        }
+    );
+</script>
+<p>{$extents_d}</p>
+"#;
+        let order = store_sub_order(source);
+        assert!(
+            !order.contains(&"$flatData".to_string()),
+            "`$flatData` is only a multi-line destructuring param: {order:?}"
+        );
+        assert!(
+            !order.contains(&"$xDomain".to_string()),
+            "`$xDomain` is only a multi-line destructuring param: {order:?}"
+        );
+        assert!(order.contains(&"$extents_d".to_string()));
+    }
+
+    /// A store in a ternary consequent behind a unary operator
+    /// (`cond ? !$store : y`) must be detected — the `!` must not stop the
+    /// ternary-consequent exclusion so that `$store :` is misread as a property
+    /// key (svelte-ux `AppLayout`: `$: x = BROWSER ? !$mdScreen : false`).
+    #[test]
+    fn test_ternary_consequent_unary_store_subscription_detected() {
+        let source = r#"<script>
+    import { mdScreen } from 'x';
+    $: temporaryDrawer = true ? !$mdScreen : false;
+</script>
+<p>{temporaryDrawer}</p>
+"#;
+        assert!(
+            store_sub_order(source).contains(&"$mdScreen".to_string()),
+            "ternary consequent `? !$mdScreen :` should be detected as a store"
         );
     }
 


### PR DESCRIPTION
## What

Resolves the **store-getter ordering / classification** known-failures cluster in the compiler output-equality corpus. Two `$`-store auto-subscription heuristics in `2_analyze/store_subscriptions.rs` diverged from upstream's scope analysis; both are now upstream-faithful.

### Bug 1 — multi-line destructuring params emitted as spurious store getters

LayerCake's `extents_d` derived callback destructures its inputs across many lines:

```js
const extents_d = derived([ … ], ([
    $flatData,
    $xDomain,
    …
]) => { … });
```

Upstream declares `$`-prefixed destructuring params as local bindings, so `$flatData`/`$xDomain`/… inside the arrow are never store subscriptions. rsvelte's `dollar_param_body_range` only skipped spaces/tabs when scanning for the enclosing `(`/`,`/`[`/`{` delimiter, so a param sitting on its own indented line (preceded by a newline) was not recognized. Those names were wrongly emitted as `const $flatData = () => $.store_get(flatData(), …)` and, because they were collected from the script rather than the template, reordered the whole getter block. Fix: skip newlines (`\n`/`\r`) in the three whitespace scans.

### Bug 2 — store in a unary ternary consequent dropped entirely

svelte-ux `AppLayout` has `$: temporaryDrawer = BROWSER ? !$mdScreen : false`. The ternary-consequent exclusion in `is_dollar_ident_object_property_key` only looked for a `?` immediately before the identifier, so the `!` in `? !$mdScreen :` made `$mdScreen` look like an object property key (`{ $mdScreen: … }`) and no store getter was emitted. Fix: skip unary-only prefix operators (`!`/`~`) when walking back to the `?`.

## Result

`layercake/src/lib/LayerCake.svelte` and `svelte-ux/.../AppLayout.svelte` now compile byte-identically (astEquivalent) for **both** CSR and SSR. Removed from the client ratchet (10 → 8) and the server ratchet (1 → 0, now empty). `known-failures.md` updated.

## Verification

- `compiler_fixtures`, `runtime`, `ssr`, `css` byte-exact suites: all pass
- `validator`, `compiler_errors`, `parser_fixtures`: all pass
- `store_subscriptions` unit tests (+2 new regression tests): 8/8
- 188 store-using `.svelte` files across layercake + svelte-ux checked via astEquivalent — no new regressions (the 2 remaining failures, `MultiSelect`/`Button`, are pre-existing unrelated known-failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EizyABnBLJmcSeQYmGwFi