### PR TITLE
refactor(analyze): ClassBody の書き捨てデッドコード削除 + usize キーの IndexSet を Fx 化

### DIFF
--- a/crates/rsvelte_core/src/ast/template.rs
+++ b/crates/rsvelte_core/src/ast/template.rs
@@ -5,6 +5,9 @@
 
 use compact_str::CompactString;
 use indexmap::IndexSet;
+
+/// Binding-index sets are keyed by `usize`; the default SipHash is needless here.
+pub type BindingIndexSet = IndexSet<usize, rustc_hash::FxBuildHasher>;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -367,7 +370,7 @@ pub struct EachBlockMetadata {
     pub expression: ExpressionMetadata,
     /// Transitive dependencies (for legacy reactivity).
     /// Uses IndexSet to preserve insertion order (matching JavaScript Set behavior).
-    pub transitive_deps: IndexSet<usize>,
+    pub transitive_deps: BindingIndexSet,
     /// Whether the each block is controlled (has explicit key tracking)
     #[serde(default)]
     pub is_controlled: bool,
@@ -1227,10 +1230,10 @@ pub struct ExpressionMetadata {
     /// Bindings that this expression depends on (indices into analysis bindings).
     /// Uses IndexSet to preserve insertion order (matching JavaScript Set behavior),
     /// which determines the order of dependency tracking in invalidate_inner_signals().
-    pub dependencies: IndexSet<usize>,
+    pub dependencies: BindingIndexSet,
     /// Bindings that this expression references (indices into analysis bindings).
     /// Uses IndexSet to preserve insertion order (matching JavaScript Set behavior).
-    pub references: IndexSet<usize>,
+    pub references: BindingIndexSet,
 }
 
 impl ExpressionMetadata {
@@ -1374,9 +1377,9 @@ impl<'de> Deserialize<'de> for ExpressionMetadata {
             #[serde(default)]
             has_assignment: bool,
             #[serde(default)]
-            dependencies: IndexSet<usize>,
+            dependencies: BindingIndexSet,
             #[serde(default)]
-            references: IndexSet<usize>,
+            references: BindingIndexSet,
         }
 
         let helper = ExpressionMetadataHelper::deserialize(deserializer)?;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -1784,10 +1784,6 @@ pub struct ComponentAnalysis {
     /// Whether dev mode is enabled (needed for $inspect.trace handling)
     pub dev: bool,
 
-    /// Class bodies with their state fields (for class body analysis)
-    /// Maps from class body node (JSON) to state fields by name
-    pub classes: FxHashMap<String, FxHashMap<String, StateField>>,
-
     /// Reactive statements ($: statements) in legacy mode
     /// Maps from the labeled statement node (JSON string) to its analysis
     pub reactive_statements: FxHashMap<String, ReactiveStatement>,
@@ -1953,7 +1949,6 @@ impl ComponentAnalysis {
             filename_hash,
             tracing: false,
             dev: options.dev,
-            classes: FxHashMap::default(),
             reactive_statements: FxHashMap::default(),
             reactive_statement_dependencies: Vec::new(),
             immutable: options.immutable,
@@ -2311,14 +2306,8 @@ pub struct EventDirectiveInfo {
 /// A state field in a class (using $state, $state.raw, $derived, $derived.by).
 #[derive(Debug, Clone)]
 pub struct StateField {
-    /// The type of rune used ($state, $state.raw, $derived, $derived.by)
-    pub rune_type: String,
     /// The field node (PropertyDefinition or AssignmentExpression in JS)
     pub node: serde_json::Value,
-    /// The private identifier key
-    pub key: serde_json::Value,
-    /// The call expression value ($state(...), etc.)
-    pub value: serde_json::Value,
 }
 
 /// CSS analysis result.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/class_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/class_body.rs
@@ -5,9 +5,7 @@
 //! Corresponds to Svelte's `2-analyze/visitors/ClassBody.js`.
 
 use rustc_hash::FxHashMap;
-use std::sync::LazyLock;
 
-use regex::Regex;
 use serde_json::Value;
 
 use super::super::errors;
@@ -15,10 +13,6 @@ use super::super::types::StateField;
 use super::VisitorContext;
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
-
-// Cached regex for sanitizing identifier names
-static REGEX_INVALID_IDENTIFIER_CHARS: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(^[^a-zA-Z_$]|[^a-zA-Z0-9_$])").unwrap());
 
 /// Visit a class body.
 ///
@@ -41,24 +35,6 @@ fn visit_impl(
         Some(b) => b,
         None => return Ok(()),
     };
-
-    // Track private identifiers to avoid conflicts when generating deconflicted names
-    let mut private_ids: Vec<String> = Vec::new();
-
-    // Collect private identifiers from methods and properties
-    for prop in body {
-        let prop_type = prop.get("type").and_then(|t| t.as_str());
-
-        if matches!(
-            prop_type,
-            Some("MethodDefinition") | Some("PropertyDefinition")
-        ) && let Some(key) = prop.get("key")
-            && key.get("type").and_then(|t| t.as_str()) == Some("PrivateIdentifier")
-            && let Some(name) = key.get("name").and_then(|n| n.as_str())
-        {
-            private_ids.push(name.to_string());
-        }
-    }
 
     // State fields map (name -> StateField)
     let mut state_fields: FxHashMap<String, StateField> = FxHashMap::default();
@@ -149,7 +125,7 @@ fn visit_impl(
         // Check if the value is a rune call
         let rune = value.and_then(get_rune);
 
-        if let Some(rune_name) = rune {
+        if rune.is_some() {
             // Check for duplicate state fields
             if state_fields.contains_key(&name) {
                 return Err(errors::state_field_duplicate(&name));
@@ -170,26 +146,7 @@ fn visit_impl(
                 }
             }
 
-            // Create the state field
-            // Note: In JS, the key is filled out later for public state
-            // For private identifiers, use the key as-is
-            let key_value = if key.get("type").and_then(|t| t.as_str()) == Some("PrivateIdentifier")
-            {
-                key.clone()
-            } else {
-                // Will be filled with private identifier later
-                Value::Null
-            };
-
-            state_fields.insert(
-                name,
-                StateField {
-                    rune_type: rune_name,
-                    node: node.clone(),
-                    key: key_value,
-                    value: value.unwrap().clone(),
-                },
-            );
+            state_fields.insert(name, StateField { node: node.clone() });
         }
 
         Ok(())
@@ -366,40 +323,6 @@ fn visit_impl(
             }
         }
     }
-
-    // Generate deconflicted private identifiers for public state fields
-    for (name, field) in state_fields.iter_mut() {
-        // Skip private identifiers (already have keys)
-        if name.starts_with('#') {
-            continue;
-        }
-
-        // Replace invalid identifier characters with underscores
-        let mut deconflicted = REGEX_INVALID_IDENTIFIER_CHARS
-            .replace_all(name, "_")
-            .to_string();
-
-        // Ensure it doesn't conflict with existing private identifiers
-        while private_ids.contains(&deconflicted) {
-            deconflicted = format!("_{}", deconflicted);
-        }
-
-        private_ids.push(deconflicted.clone());
-
-        // Create the private identifier
-        field.key = serde_json::json!({
-            "type": "PrivateIdentifier",
-            "name": deconflicted
-        });
-    }
-
-    // Store the state fields in the analysis
-    // Create a unique key for this class body node
-    let node_key = format!("{:?}", node); // Simple key based on the node structure
-    context
-        .analysis
-        .classes
-        .insert(node_key, state_fields.clone());
 
     // Set state_fields on context before visiting children.
     // This corresponds to context.next({ ...context.state, state_fields }) in the official compiler.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
@@ -4,8 +4,6 @@
 //!
 //! Corresponds to Svelte's `2-analyze/visitors/EachBlock.js`.
 
-use indexmap::IndexSet;
-
 use super::super::{AnalysisError, Binding, BindingKind, errors};
 use super::shared::fragment;
 use super::shared::utils::{
@@ -342,7 +340,7 @@ fn walk_expression_children_refs_only(node: &serde_json::Value, context: &mut Vi
 fn collect_transitive_dependencies_impl(
     binding_idx: usize,
     bindings: &[Binding],
-    deps: &mut IndexSet<usize>,
+    deps: &mut crate::ast::template::BindingIndexSet,
 ) {
     if deps.contains(&binding_idx) {
         return;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_body_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_body_ast.rs
@@ -10,7 +10,7 @@
 //! suites + corpus.
 //!
 //! ## Target algorithm (写经 client `ClassBody.js`)
-//! For each `$state` / `$derived` class field in `analysis.classes`:
+//! For each `$state` / `$derived` class field found by the `ClassBody` visitor:
 //! - **PUBLIC** `x = $state(v)` → backing private `#x = $.state(v)` **plus**
 //!   `get x() { return $.get(this.#x); }` and
 //!   `set x(value) { $.set(this.#x, value, should_proxy && true); }`. Reads/writes

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -15,7 +15,6 @@ use crate::compiler::phases::phase3_transform::client::transform_template::Templ
 use crate::compiler::phases::phase3_transform::js_ast::arena::JsArena;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
 use im::{HashMap as ImHashMap, HashSet as ImHashSet};
-use indexmap::IndexSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::{Cell, RefCell};
 use std::fmt::Write as _;
@@ -3299,7 +3298,7 @@ pub struct ExpressionMetadata {
     /// need to be read for dependency tracking (matching the official Svelte
     /// compiler's `metadata.references`).
     /// Uses IndexSet to preserve insertion order (matching JavaScript Set behavior).
-    pub references: IndexSet<usize>,
+    pub references: crate::ast::template::BindingIndexSet,
 }
 
 impl ExpressionMetadata {


### PR DESCRIPTION
## What

`ClassBody` の解析から、**書き込まれるだけで誰にも読まれないデータ**を削除します。**net -88行**(3挿入 / 91削除)。

**性能改善を主張する PR ではありません。** 計測はしましたが効果は閾値未満です(下記)。目的はコードベースの負債解消です。

## Why

`class_body.rs` は解析のたびに次を行っていました:

```rust
let node_key = format!("{:?}", node);   // serde_json::Value のツリー全体を Debug 整形して String 化
context.analysis.classes.insert(node_key, state_fields.clone());  // Value の deep clone を含む
```

**`ComponentAnalysis.classes` にはリポジトリ全体で読み手が存在しません。** `class_body_ast.rs:13` の doc コメントが言及しているだけで、実際に読むコードはありません。つまり Value ツリー全体の Debug 整形も、フィールドごとの deep clone も、すべて捨てられていました。

## What changed

指示された3項目に加え、**それらを消した結果として死ぬものを連鎖的に削除**しています:

- `format!("{:?}")` によるキー生成と `analysis.classes` への insert
- `ComponentAnalysis.classes` フィールド本体(`types.rs`)
- `field.key = json!({...})` — 書かれるだけで読まれない
- **`StateField` の `rune_type` / `key` / `value`** — 実際に読まれるのは `node` の `type` と `start` の2スカラーのみ。特に `value` は `value.unwrap().clone()` と Value を deep clone していました
- **deconflict ループ** — `field.key` を埋めるのが唯一の目的だった
- **`private_ids` の収集ループ** — 上記が消えると消費者ゼロ
- 上記専用だった正規表現 static

部分的に削除すると「`key` を埋めるだけの死んだループ」が残り、次に読む人が存在理由を推測する羽目になります。中途半端な削除は削除しないより悪いと判断しました。

なお `3_transform` 側に同名の `ClassStateField`(`value: String`)があり、これは生きています。リポジトリに `StateField` という名前の型が4つあることが、以前「読まれている」という誤認を生んでいました。

## Measurements — 効果は閾値未満です

CPU時間 + min-of-N(20反復/3ウォームアップ)+ 交互 A/B 3ラウンド:

| タスク | 指標 | base | after | 差 |
|---|---|---:|---:|---:|
| compile-server | CPU | 2.593s | 2.537s | -2.2% |
| compile-server | min wall | 106.15ms | 104.98ms | -1.1% |
| compile-client | min wall | — | — | -0.18%(ノイズ) |
| compile-client | CPU | — | — | **+0.5%**(ノイズ) |

server は3ラウンド × 2指標すべてで方向が一致していますが、**いずれも 3% 未満**です。client は符号すら安定しません。

**効果が小さい理由も計測しました**: この処理が走るのは `class` 宣言かつ `$state`/`$derived` を含むファイルだけで、**ベンチコーパスの 71/3856(1.8%)、実世界コーパスの 7/3855(0.18%)** しかありません。`format!("{:?}")` 自体は高価ですが、走る機会が稀なため全体への寄与が薄まりました。

## Verification

出力ダイジェストの全件比較を両コーパスで実施し、**差分ゼロ**:

- svelte コーパス 3,857 ファイル(client + server、**エラー経路 453 件を含む**)
- 実世界コーパス 3,856 ファイル(client + server)

エラー内容もダイジェストに含めているため、`state_field_duplicate` / `duplicate_class_field` / `state_field_invalid_assignment` の判定が不変であることも担保されています。

## Testing

`RUST_MIN_STACK=33554432 cargo test --release -p rsvelte_core` — **167 スイート / 2,164 テスト / 失敗ゼロ**。`cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` クリーン。

(注: 私の手元の別 worktree では `cargo test --release` が `test_reporter` バイナリのリンク段階で失敗しましたが、これは環境の問題です — main・本ブランチとも `cargo build --release --bin test_reporter` は単体で成功し、同一 target ディレクトリで `cargo build --release`(`panic = "abort"`)と `cargo test --release`(unwind 必須)を混在させたことによる成果物の不整合でした。CI のフルスイートを最終ゲートとしています。)

---

## 追加コミット: `78816d6e` — `usize` キーの IndexSet を FxBuildHasher 化

同じ「設計上の正しさ」の観点で、**`usize` キーに暗号強度ハッシュ(SipHash)を使っている箇所**を `FxBuildHasher` に置き換えます。`BindingIndexSet` という型エイリアスを導入し、4箇所をまとめて変更しました:

- `ExpressionMetadata.dependencies` / `.references` — **識別子を訪問するたびに insert される**、ガード条件のない全コンポーネント共通のパス
- `EachBlockMetadata.transitive_deps`、`each_block.rs` の `deps`、`client/types.rs` の `references`

**文字列キーの IndexSet は対象外**にしています(Fx は文字列で衝突しやすいケースがあるため)。`slot_names` が既に `FxBuildHasher` 化されている前例に倣った形です。3ファイル / 10挿入 / 9削除。

`IndexSet` は設計上 挿入順を保持しますが、依存配列の順序が変われば生成コードが変わるため、**ダイジェスト比較で実測**しています(両コーパス × client/server で差分ゼロ)。

## 計測についての注記 — この PR では性能改善を主張しません

2つの変更をまとめた累積効果(main → 本ブランチ、同一セッション内での交互 A/B):

| タスク | 指標 | 差 |
|---|---|---:|
| compile-server | CPU | **-1.6%** |
| compile-server | min wall | -1.57% |
| compile-client | min wall | -1.16% |
| compile-client | CPU | -0.68% |

**個別に測った値の単純な和にはなりません**(a 単独 server CPU -2.2%、c 単独 -1.7% でしたが、累積は -1.6%)。原因はセッション間のベースラインドリフトで、**同一バイナリの server min がセッションをまたぐと 105〜107ms ↔ 111〜112ms と 5% 動く**ことを確認しています。交互 A/B は同一セッション内のドリフトは打ち消しますが、セッション間の比較には効きません。

**したがってこの計測系の実効分解能は 1〜2% 程度で、上記の数値はいずれもその境界上にあります。** 性能改善の根拠としては採用せず、**同一セッション内で測った累積 -1.6% を参考値として記載するに留めます。** この PR の価値は、書き捨てデータの削除(net -88行)と `usize` キーへの適切なハッシャ選択という、設計上の正しさにあります。
