### PR TITLE
ci: pin wasm-pack version to avoid silent v0.9.1 fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,8 @@ jobs:
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+        with:
+          version: 'v0.15.0'
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+        with:
+          version: 'v0.15.0'
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,7 +371,7 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
         with:
-          version: latest
+          version: 'v0.15.0'
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
## Problem

All three `jetli/wasm-pack-action` steps resolved wasm-pack via `version: latest` (explicit in `release.yml`, implicit — the action's default — in `ci.yml` and `publish-vscode.yml`).

`latest` is resolved at runtime through the GitHub Releases API. When that call fails (rate limit / transient error), the action does **not** fail the step — it **silently falls back to v0.9.1**. The binaryen bundled with v0.9.1 predates reference-types and multi-table support, so `wasm-opt` cannot parse the wasm that current `wasm-bindgen` emits and the build dies with:

```
[parse exception: Only 1 table definition allowed in MVP]
```

This is not hypothetical: it flaked the wasm build in #1606.

## Fix

Pin all three call sites to an explicit tag:

| Workflow | Before | After |
|---|---|---|
| `.github/workflows/ci.yml` | (no `with:` → implicit `latest`) | `version: 'v0.15.0'` |
| `.github/workflows/release.yml` | `version: latest` | `version: 'v0.15.0'` |
| `.github/workflows/publish-vscode.yml` | (no `with:` → implicit `latest`) | `version: 'v0.15.0'` |

A `grep` over `.github/` confirms these are the only three usages of the action.

## Why v0.15.0

`v0.15.0` (published 2026-05-15) is both the version with a proven success record in this repo's CI and — verified via `gh api repos/rustwasm/wasm-pack/releases/latest` — the current latest release upstream. So pinning costs no freshness here; it only removes the silent-downgrade failure mode.

Resolution failures now surface as a hard error instead of a confusing `wasm-opt` parse exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxUqvhaXY1UciaoW4VhRKu