### PR TITLE
fix(wasm): wasm-opt で reference-types を有効化し、間欠的な MVP パース失敗を防ぐ

### DIFF
--- a/.changeset/fix-wasm-reference-types.md
+++ b/.changeset/fix-wasm-reference-types.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/lint": patch
+---
+
+fix(wasm): enable reference-types in wasm-opt
+
+Newer rustc/LLVM can emit a second wasm table (a reference-types externref table
+alongside the funcref indirect-call table) for `wasm32-unknown-unknown`, which
+`wasm-opt`'s default MVP feature set rejects with "Only 1 table definition allowed
+in MVP". Whether the extra table appears depends on the rustc version CI resolves
+that day, not on anything in this repo, so the wasm build could break without any
+change here.
+
+Passing `--enable-reference-types` lets wasm-opt parse and optimize it. The
+`rsvelte_fmt_wasm` artifact shrinks ~1% as a result; `rsvelte_lint`'s is byte-identical.

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -214,11 +214,8 @@ harness = false
 name = "compiler"
 harness = false
 
-# wasm-opt (Binaryen) is the single largest WASM size win (≈15–40%). `-Oz`
-# optimizes the produced `.wasm` for size; this only affects the wasm-pack
-# release build shipped as @rsvelte/compiler, not native artifacts.
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-Oz']
+# wasm-pack reads `package.metadata.wasm-pack` only from the crate passed to
+# `wasm-pack build`, so the wasm-opt config lives in rsvelte_lint / rsvelte_fmt_wasm.
 
 [lints]
 workspace = true

--- a/crates/rsvelte_fmt_wasm/Cargo.toml
+++ b/crates/rsvelte_fmt_wasm/Cargo.toml
@@ -22,3 +22,8 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [lints]
 workspace = true
+
+# rustc can emit a second wasm table (reference-types); wasm-opt's default MVP
+# feature set rejects that, so the feature must be enabled explicitly.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-Oz', '--enable-reference-types']

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -85,3 +85,8 @@ serde_yaml = "0.9"
 
 [lints]
 workspace = true
+
+# rustc can emit a second wasm table (reference-types); wasm-opt's default MVP
+# feature set rejects that, so the feature must be enabled explicitly.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-Oz', '--enable-reference-types']


### PR DESCRIPTION
## What

wasm ビルドで `wasm-opt` に `--enable-reference-types` を渡すようにします。**リポジトリを一切変更しなくても、新しい Rust stable がリリースされただけで CI が落ちうる**構造を解消します。

## Why

PR #1612 の `Language server` ジョブが、この変更と無関係な内容にもかかわらず次のエラーで失敗しました(再実行では通過):

```
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[parse exception: Only 1 table definition allowed in MVP (at 0:9858)]
Fatal: error in parsing input
Error: failed to execute `wasm-opt`: exited with exit code: 1
```

新しい rustc / LLVM は `wasm32-unknown-unknown` 向けに **2つ目の wasm テーブル**(funcref の間接呼び出しテーブルに加え、reference-types の externref テーブル)を出力することがあります。一方 `wasm-opt` の既定である MVP フィーチャセットは**テーブルを1つしか受け付けず**、2つ見つけると abort します。

問題は、**2つ目のテーブルが出力されるかどうかがリポジトリの内容に依存しない**ことです。CI は `dtolnay/rust-toolchain@stable` を使っており(`rust-toolchain.toml` は存在しません)、その日 stable が解決する rustc のバージョン次第で挙動が変わります。今回たまたま再実行で通ったのは、ランナーのキャッシュ状態の差と考えられます。

つまりこれは偶発的なフレークではなく、**toolchain と同梱 binaryen のバージョン境界を跨いだときに決定的に発生する**性質のものです。

## What changed

`crates/rsvelte_lint/Cargo.toml` と `crates/rsvelte_fmt_wasm/Cargo.toml` の `[package.metadata.wasm-pack.profile.release]` に `--enable-reference-types` を追加しました。

### なぜこの2クレートなのか

**`wasm-pack` は `wasm-pack build <path>` に渡されたクレート自身の Cargo.toml しか `package.metadata.wasm-pack` を読みません。** リポジトリ内の `wasm-pack build` 呼び出しを洗い出したところ:

| 対象クレート | 呼び出し箇所 |
|---|---:|
| `crates/rsvelte_lint` | 3 |
| `crates/rsvelte_fmt_wasm` | 2 |
| `crates/rsvelte_core` | **0** |

`rsvelte_core` は常に上記2クレートの依存として推移的にビルドされるだけなので、**そこにあった `wasm-opt = ['-Oz']` は一度も適用されていませんでした**。この死んだ設定は削除し、同じ誤解が繰り返されないよう理由を1行残しています。

wasm-pack を呼ぶ CI ジョブは4箇所(`ci.yml` の Language server、`deploy-docs.yml`、`release.yml` の publish、`publish-vscode.yml`)で、いずれもこの2クレート経由です。

## Verification

ローカル(wasm-pack 0.13.1 / binaryen 117 同梱、rustc 1.96.0)で CI と同じコマンドを実行し、両クレートともビルド成功を確認しました。

**wasm サイズへの影響**(`-Oz` はサイズ最適化なので確認しました):

| 成果物 | 変更前 | 変更後 | 差 |
|---|---:|---:|---:|
| `rsvelte_fmt_wasm_bg.wasm` | 3,910,756 B | 3,871,728 B | **-39,028 B(約1%減)** |
| `rsvelte_lint_bg.wasm` | 8,624,450 B | 8,624,450 B | 完全一致 |

`--enable-reference-types` を付けると wasm-opt が reference-types 命令も最適化できるようになるため、`rsvelte_fmt_wasm` はむしろ縮んでいます。`rsvelte_lint` がバイト単位で一致したのは、このクレートの wasm モジュールが今回のビルドでは reference-types 命令を含まなかったためです。**劣化ゼロです。**

なお**ローカルでは修正前でもビルドが通り、CI で見えた失敗は再現しませんでした。** 再現条件が toolchain と binaryen の組み合わせに依存するためで、**この修正の本当の検証環境は CI(4つの wasm ビルドジョブ)です。**

## Not included

`rust-toolchain.toml` による toolchain の固定も検討しましたが、**この PR には含めていません**。

Renovate に `rust-toolchain` マネージャが存在するため「固定すると陳腐化する」という懸念自体は解消できることを確認しましたが、pin の影響範囲は wasm ビルドの4ジョブに留まらず、`release.yml` の複数 triple(Windows / macOS / Linux)向けクロスコンパイル、`cargo test`、clippy を含む11箇所以上に及びます。ローカル(macOS arm64)では他ターゲットの検証ができず、影響を確認しきれません。

今回のバグは `--enable-reference-types` だけで根本解決するため、**toolchain 固定は「別軸の一般的な再現性強化」として、スコープを分けて検討すべき**と判断しました。
