### PR TITLE
refactor: split the NAPI cdylib out of rsvelte_core into rsvelte_napi

### DIFF
--- a/.claude/skills/full-code-review/SKILL.md
+++ b/.claude/skills/full-code-review/SKILL.md
@@ -834,8 +834,8 @@ pnpm run compatibility-report
 NAPI 経由の挙動に影響する変更があれば、vitest も実行する:
 
 ```bash
-cargo build --release --features napi --lib
-cp target/release/librsvelte_core.dylib svelte/rsvelte.darwin-arm64.node
+cargo build --release -p rsvelte_napi --lib
+cp target/release/librsvelte_napi.dylib svelte/rsvelte.darwin-arm64.node
 cd svelte
 USE_RSVELTE=true npx vitest run packages/svelte/tests/runtime-runes/test.ts packages/svelte/tests/runtime-legacy/test.ts
 ```

--- a/.claude/skills/perf-loop/SKILL.md
+++ b/.claude/skills/perf-loop/SKILL.md
@@ -367,8 +367,8 @@ ls ~/.cargo/registry/src/*/oxc_ast-*/src/
 ### 7.4 NAPI 経由のエンドツーエンド検証
 
 ```bash
-cargo build --release --features napi --lib
-cp target/release/librsvelte_core.dylib svelte/rsvelte.darwin-arm64.node
+cargo build --release -p rsvelte_napi --lib
+cp target/release/librsvelte_napi.dylib svelte/rsvelte.darwin-arm64.node
 cd svelte && USE_RSVELTE=true npx vitest run \
   packages/svelte/tests/runtime-runes/test.ts \
   packages/svelte/tests/runtime-legacy/test.ts

--- a/.claude/skills/upgrade-svelte/SKILL.md
+++ b/.claude/skills/upgrade-svelte/SKILL.md
@@ -228,8 +228,8 @@ All tests must pass.
 
 ```bash
 # Build NAPI binding
-cargo build --release --features napi --lib
-cp target/release/librsvelte_core.dylib svelte/rsvelte.darwin-arm64.node
+cargo build --release -p rsvelte_napi --lib
+cp target/release/librsvelte_napi.dylib svelte/rsvelte.darwin-arm64.node
 
 # Run official Svelte test suite with rsvelte
 cd svelte
@@ -296,8 +296,8 @@ cargo test --release <test_name> -- --nocapture
 cargo test --release
 
 # NAPI build
-cargo build --release --features napi --lib
-cp target/release/librsvelte_core.dylib svelte/rsvelte.darwin-arm64.node
+cargo build --release -p rsvelte_napi --lib
+cp target/release/librsvelte_napi.dylib svelte/rsvelte.darwin-arm64.node
 
 # Vitest
 cd svelte && USE_RSVELTE=true npx vitest run packages/svelte/tests/runtime-runes/test.ts packages/svelte/tests/runtime-legacy/test.ts

--- a/.claude/skills/verify-svelte-compat/SKILL.md
+++ b/.claude/skills/verify-svelte-compat/SKILL.md
@@ -331,7 +331,7 @@ cargo build --release --bin canonicalize_js
 ```
 
 `build-rsvelte.sh` の挙動:
-- `cargo build --release --features napi --lib`
+- `cargo build --release -p rsvelte_napi --lib`
 - プラットフォームに応じた `.node` ファイル名を計算
 - `svelte/${NODE_NAME}` と `${TARGET_PATH}/.rsvelte/${NODE_NAME}` の両方にコピー
 

--- a/.claude/skills/verify-svelte-compat/scripts/build-rsvelte.sh
+++ b/.claude/skills/verify-svelte-compat/scripts/build-rsvelte.sh
@@ -25,10 +25,10 @@ esac
 
 cd "$ROOT"
 
-echo "[build-rsvelte] cargo build --release --features napi --lib"
-cargo build --release --features napi --lib
+echo "[build-rsvelte] cargo build --release -p rsvelte_napi --lib"
+cargo build --release -p rsvelte_napi --lib
 
-SRC="target/release/librsvelte_core.${EXT}"
+SRC="target/release/librsvelte_napi.${EXT}"
 if [ ! -f "$SRC" ]; then
   echo "[build-rsvelte] ERROR: build output not found: $SRC" >&2
   exit 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,15 +65,11 @@ jobs:
       - name: Run criterion
         # ONE `cargo bench` invocation that compiles *and* measures.
         #
-        # A split (`--no-run` build step + a separate run step) double-compiles
-        # the workspace crates: `rsvelte_core` is a `cdylib`+`rlib`, and
-        # building it for its own benches alongside the `rsvelte_formatter`
-        # bench (which depends on it) produces an "output filename collision"
-        # on `librsvelte_core.{so,rlib}`. That collision makes the unit's
-        # fingerprint ambiguous, so a *second* `cargo bench` re-compiles the
-        # local crates from scratch (~13 min) instead of reusing the first
-        # build's output. A single invocation builds once, then runs — paying
-        # that compile only once and roughly halving the job wall-clock.
+        # A split (`--no-run` build step + a separate run step) re-resolves the
+        # unit graph twice, which has historically re-compiled the local crates
+        # from scratch (~13 min) rather than reusing the first build's output.
+        # A single invocation builds once, then runs — paying that compile only
+        # once and roughly halving the job wall-clock.
         #
         # `--save-baseline pr` saves results so a follow-up job (or the next
         # commit) can diff against this baseline with `--baseline pr`.

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -207,9 +207,9 @@ jobs:
 
       - name: Build rsvelte NAPI binding
         run: |
-          cargo build --release --features napi --lib
+          cargo build --release -p rsvelte_napi --lib
           mkdir -p .corpus-cache
-          cp target/release/librsvelte_core.so .corpus-cache/rsvelte.node
+          cp target/release/librsvelte_napi.so .corpus-cache/rsvelte.node
 
       - name: Collect corpus
         run: node scripts/compat-corpus/collect.mjs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -87,13 +87,13 @@ jobs:
         # apps/playground/rsvelte-shim/compiler.mjs loads
         # apps/npm/vite-plugin-svelte-native-<triple>/rsvelte.node at build time so
         # vite-plugin-svelte compiles every .svelte through rsvelte. Ubuntu CI
-        # is linux-x64-gnu; the cdylib is named librsvelte_core.so.
-        run: cargo build --release --features napi --lib
+        # is linux-x64-gnu; the cdylib is named librsvelte_napi.so.
+        run: cargo build --release -p rsvelte_napi --lib
 
       - name: Stage NAPI binding
         run: |
           mkdir -p apps/npm/vite-plugin-svelte-native-linux-x64-gnu
-          cp target/release/librsvelte_core.so \
+          cp target/release/librsvelte_napi.so \
              apps/npm/vite-plugin-svelte-native-linux-x64-gnu/rsvelte.node
 
       - name: Setup pnpm cache for playground

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,11 +151,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, dylib: librsvelte_core.dylib }
-          - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, dylib: librsvelte_core.dylib }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, dylib: librsvelte_core.so }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, dylib: librsvelte_core.so, apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, dylib: rsvelte_core.dll }
+          - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, dylib: librsvelte_napi.dylib }
+          - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, dylib: librsvelte_napi.dylib }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, dylib: librsvelte_napi.so }
+          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, dylib: librsvelte_napi.so, apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, dylib: rsvelte_napi.dll }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -187,7 +187,7 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
           CC_aarch64_unknown_linux_gnu: ${{ matrix.linker }}
-        run: cargo build --profile dist --features napi --lib --target ${{ matrix.target }}
+        run: cargo build --profile dist -p rsvelte_napi --lib --target ${{ matrix.target }}
 
       - name: Stage .node binary
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,9 +2376,6 @@ dependencies = [
  "memchr",
  "miette",
  "mimalloc",
- "napi",
- "napi-build",
- "napi-derive",
  "notify",
  "oxc_allocator",
  "oxc_ast",
@@ -2491,6 +2488,21 @@ dependencies = [
  "serde_yaml",
  "walkdir",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "rsvelte_napi"
+version = "0.8.0"
+dependencies = [
+ "bumpalo",
+ "mimalloc",
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "rsvelte_core",
+ "rustc-hash",
+ "serde_json",
+ "tikv-jemallocator",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/rsvelte_fmt_wasm",
     "crates/rsvelte_formatter",
     "crates/rsvelte_lint",
+    "crates/rsvelte_napi",
     "crates/rsvelte_preprocess",
     "crates/tailwind_class_order",
 ]

--- a/apps/playground/rsvelte-shim/compiler.mjs
+++ b/apps/playground/rsvelte-shim/compiler.mjs
@@ -61,7 +61,7 @@ try {
 } catch (err) {
 	throw new Error(
 		`[rsvelte-compiler shim] Failed to load NAPI binding at ${nodePath}.\n` +
-			`Make sure the binary is built (cargo build --release --features napi --lib).\n\n` +
+			`Make sure the binary is built (cargo build --release -p rsvelte_napi --lib).\n\n` +
 			`Original error: ${err.message}`
 	);
 }

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -10,24 +10,20 @@ homepage = "https://github.com/baseballyama/rsvelte"
 keywords = ["svelte", "compiler", "wasm"]
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+# rlib only. Emitting a cdylib here too would write unhashed
+# `deps/librsvelte_core.{so,rlib}`, letting cargo's two profile variants clobber
+# each other and letting this crate's bins link the cdylib instead of the rlib
+# (rust-lang/cargo#6313). The NAPI cdylib lives in `rsvelte_napi`.
+crate-type = ["rlib"]
 
 [features]
 default = ["native"]
-# `mimalloc-alloc` is included so the NAPI cdylib + profiling bins default to
-# mimalloc, which A/B-measured ~11% faster than jemalloc on the compile workload
-# (mold itself links mimalloc for the same allocation-bound reason). jemalloc is
-# kept available for comparison.
+# `mimalloc-alloc` is included so the profiling bins default to mimalloc, which
+# A/B-measured ~11% faster than jemalloc on the compile workload (mold itself
+# links mimalloc for the same allocation-bound reason). jemalloc is kept
+# available for comparison.
 native = ["rayon", "miette/fancy", "jemalloc", "mimalloc-alloc"]
 trace-fastpath = []
-# `napi` opts the cdylib into the NAPI build. When the cdylib gets
-# dlopen'd by Node (post-program-start), jemalloc's default
-# initial-exec TLS model can exhaust the static TLS reserve on Linux —
-# producing "cannot allocate memory in static TLS block" at load time.
-# Pull in the `disable_initial_exec_tls` feature transitively so the
-# NAPI build is always dlopen-safe. The `?` makes it a no-op when
-# jemalloc is disabled (e.g. `--no-default-features --features napi`).
-napi = ["dep:napi", "dep:napi-derive", "dep:napi-build", "tikv-jemallocator?/disable_initial_exec_tls"]
 jemalloc = ["dep:tikv-jemallocator"]
 # Profiling-only: use mimalloc instead of jemalloc in the profiling bins (A/B).
 mimalloc-alloc = ["dep:mimalloc"]
@@ -119,9 +115,6 @@ clap = { version = "4.5", features = ["derive"] }
 # Time
 chrono = "0.4"
 
-# N-API support (optional)
-napi = { version = "3", default-features = false, features = ["napi9", "serde-json", "async", "tokio_rt", "compat-mode"], optional = true }
-napi-derive = { version = "3", optional = true }
 
 # WASM support (optional)
 wasm-bindgen = { version = "0.2", optional = true }
@@ -134,16 +127,9 @@ oxc_ast_visit = "0.139"
 # Better multi-threaded memory allocator (optional, Unix/Mac only)
 [target.'cfg(all(not(windows), not(target_arch = "wasm32")))'.dependencies]
 tikv-jemallocator = { version = "0.7", optional = true }
-# mimalloc: production allocator (mold itself links mimalloc). `local_dynamic_tls`
-# builds mimalloc with the local-dynamic TLS model instead of the default
-# initial-exec one — required so the NAPI cdylib can be `dlopen`'d by Node on
-# Linux without "cannot allocate memory in static TLS block" (the same class of
-# issue jemalloc's `disable_initial_exec_tls` solved).
+# mimalloc: production allocator (mold itself links mimalloc).
 mimalloc = { version = "0.1", optional = true, features = ["local_dynamic_tls"] }
 pprof = { version = "0.15", default-features = false, optional = true }
-
-[build-dependencies]
-napi-build = { version = "2", optional = true }
 
 [dev-dependencies]
 # Testing

--- a/crates/rsvelte_core/benches/compiler.rs
+++ b/crates/rsvelte_core/benches/compiler.rs
@@ -23,12 +23,8 @@
 // faster than jemalloc on this allocation-bound workload (mold links mimalloc
 // for the same reason); the previous bench used the system allocator and so
 // understated neither — it simply measured a different allocator than ships.
-// `not(feature = "napi")` mirrors the bin entry points: under `--all-features`
-// (CI clippy) the `napi` feature compiles napi.rs's `#[global_allocator]` into the
-// rlib this bench links, so the bench must not register a second one.
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/build.rs
+++ b/crates/rsvelte_core/build.rs
@@ -1,8 +1,4 @@
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(feature, values(\"napi\"))");
-    #[cfg(feature = "napi")]
-    napi_build::setup();
-
     // Read the Svelte version from the submodule's package.json
     // so that the generated code can include the correct version string.
     // The submodule lives at the workspace root (two levels above this

--- a/crates/rsvelte_core/src/bin/benchmark_runner.rs
+++ b/crates/rsvelte_core/src/bin/benchmark_runner.rs
@@ -10,7 +10,6 @@
 // rust-lang/cargo#6313.
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/canon_dump.rs
+++ b/crates/rsvelte_core/src/bin/canon_dump.rs
@@ -1,14 +1,10 @@
 //! Canonicalize a JS file using OXC and print to stdout.
 //! Usage: canon_dump `<file>`
 
-// Use jemalloc as the global allocator for better multi-threaded
-// performance. Defined per-bin rather than once in the lib because the lib
-// is built as both rlib and cdylib, and a lib-level `#[global_allocator]`
-// is duplicated across both outputs at link time — cargo issue
-// rust-lang/cargo#6313.
+// Defined per-bin rather than once in the lib so that linking the `rsvelte_core`
+// rlib never imposes an allocator on the consumer.
 #[cfg(all(
     feature = "jemalloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/canonicalize_and_compare.rs
+++ b/crates/rsvelte_core/src/bin/canonicalize_and_compare.rs
@@ -2,14 +2,10 @@
 //! Usage: canonicalize_and_compare `<file1>` `<file2>`
 //! Exits 0 if semantically equal, 1 if different, prints first diff.
 
-// Use jemalloc as the global allocator for better multi-threaded
-// performance. Defined per-bin rather than once in the lib because the lib
-// is built as both rlib and cdylib, and a lib-level `#[global_allocator]`
-// is duplicated across both outputs at link time — cargo issue
-// rust-lang/cargo#6313.
+// Defined per-bin rather than once in the lib so that linking the `rsvelte_core`
+// rlib never imposes an allocator on the consumer.
 #[cfg(all(
     feature = "jemalloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/canonicalize_js.rs
+++ b/crates/rsvelte_core/src/bin/canonicalize_js.rs
@@ -5,14 +5,10 @@
 //!
 //! Usage: cat input.js | canonicalize_js > canonical.js
 
-// Use jemalloc as the global allocator for better multi-threaded
-// performance. Defined per-bin rather than once in the lib because the lib
-// is built as both rlib and cdylib, and a lib-level `#[global_allocator]`
-// is duplicated across both outputs at link time — cargo issue
-// rust-lang/cargo#6313.
+// Defined per-bin rather than once in the lib so that linking the `rsvelte_core`
+// rlib never imposes an allocator on the consumer.
 #[cfg(all(
     feature = "jemalloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/compile_hot.rs
+++ b/crates/rsvelte_core/src/bin/compile_hot.rs
@@ -6,7 +6,6 @@
 
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]
@@ -16,7 +15,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     feature = "jemalloc",
     not(feature = "mimalloc-alloc"),
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/compile_profile.rs
+++ b/crates/rsvelte_core/src/bin/compile_profile.rs
@@ -1,13 +1,9 @@
 //! Profile compile phases: parse, analyze, transform
 
-// Use jemalloc as the global allocator for better multi-threaded
-// performance. Defined per-bin rather than once in the lib because the lib
-// is built as both rlib and cdylib, and a lib-level `#[global_allocator]`
-// is duplicated across both outputs at link time — cargo issue
-// rust-lang/cargo#6313.
+// Defined per-bin rather than once in the lib so that linking the `rsvelte_core`
+// rlib never imposes an allocator on the consumer.
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]
@@ -17,7 +13,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     feature = "jemalloc",
     not(feature = "mimalloc-alloc"),
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/fastpath_coverage.rs
+++ b/crates/rsvelte_core/src/bin/fastpath_coverage.rs
@@ -8,7 +8,6 @@
 // rust-lang/cargo#6313.
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/min_parse_cost.rs
+++ b/crates/rsvelte_core/src/bin/min_parse_cost.rs
@@ -5,7 +5,6 @@
 // rust-lang/cargo#6313.
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/oxc_call_counter.rs
+++ b/crates/rsvelte_core/src/bin/oxc_call_counter.rs
@@ -7,7 +7,6 @@
 // rust-lang/cargo#6313.
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/parse_bottleneck.rs
+++ b/crates/rsvelte_core/src/bin/parse_bottleneck.rs
@@ -8,7 +8,6 @@
 // rust-lang/cargo#6313.
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/parse_profile.rs
+++ b/crates/rsvelte_core/src/bin/parse_profile.rs
@@ -10,7 +10,6 @@
 use std::fmt::Write as _;
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/profiler.rs
+++ b/crates/rsvelte_core/src/bin/profiler.rs
@@ -23,7 +23,6 @@
 use std::fmt::Write as _;
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/samply_target.rs
+++ b/crates/rsvelte_core/src/bin/samply_target.rs
@@ -7,7 +7,6 @@
 // rust-lang/cargo#6313.
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/svelte_check.rs
+++ b/crates/rsvelte_core/src/bin/svelte_check.rs
@@ -3,14 +3,10 @@
 //! TypeScript type errors. Type-checking runs by default via `tsc`
 //! (or `tsgo` with `--tsgo`); pass `--no-type-check` for Svelte-only.
 
-// Use jemalloc as the global allocator for better multi-threaded
-// performance. Defined per-bin rather than once in the lib because the lib
-// is built as both rlib and cdylib, and a lib-level `#[global_allocator]`
-// is duplicated across both outputs at link time — cargo issue
-// rust-lang/cargo#6313.
+// Defined per-bin rather than once in the lib so that linking the `rsvelte_core`
+// rlib never imposes an allocator on the consumer.
 #[cfg(all(
     feature = "mimalloc-alloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]
@@ -20,7 +16,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     feature = "jemalloc",
     not(feature = "mimalloc-alloc"),
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/bin/test_reporter.rs
+++ b/crates/rsvelte_core/src/bin/test_reporter.rs
@@ -5,14 +5,10 @@
 //! Usage:
 //!   cargo run --bin test_reporter -- --output apps/playground/static/test-results.json
 
-// Use jemalloc as the global allocator for better multi-threaded
-// performance. Defined per-bin rather than once in the lib because the lib
-// is built as both rlib and cdylib, and a lib-level `#[global_allocator]`
-// is duplicated across both outputs at link time — cargo issue
-// rust-lang/cargo#6313.
+// Defined per-bin rather than once in the lib so that linking the `rsvelte_core`
+// rlib never imposes an allocator on the consumer.
 #[cfg(all(
     feature = "jemalloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_core/src/compiler/legacy.rs
+++ b/crates/rsvelte_core/src/compiler/legacy.rs
@@ -39,11 +39,11 @@ static REGEX_NOT_WHITESPACE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[^ 
 
 /// Converter from UTF-8 byte positions to UTF-16 code unit positions.
 ///
-/// `pub(crate)` so the modern parse output paths (`wasm::parse_svelte`,
-/// `napi::parse`, and the raw-transfer envelope encoder) can reuse the same
-/// remap the legacy path already applies, keeping every public AST surface on
-/// svelte/compiler's UTF-16 offsets (#793).
-pub(crate) struct Utf8ToUtf16 {
+/// Public so the modern parse output paths (`wasm::parse_svelte`, the
+/// `rsvelte_napi` bindings, and the raw-transfer envelope encoder) can reuse
+/// the same remap the legacy path already applies, keeping every public AST
+/// surface on svelte/compiler's UTF-16 offsets.
+pub struct Utf8ToUtf16 {
     /// One UTF-16 offset per source byte (plus a trailing entry). `u32` rather
     /// than `usize` because source positions are u32-bounded across the compiler
     /// — this halves the per-byte table on 64-bit targets.
@@ -54,7 +54,7 @@ pub(crate) struct Utf8ToUtf16 {
 }
 
 impl Utf8ToUtf16 {
-    pub(crate) fn new(source: &str) -> Self {
+    pub fn new(source: &str) -> Self {
         let mut utf16_pos = Vec::with_capacity(source.len() + 1);
         let mut utf16_idx = 0usize;
         let mut line_starts_byte = vec![0];
@@ -127,7 +127,7 @@ impl Utf8ToUtf16 {
 }
 
 /// Recursively convert positions in JSON from UTF-8 to UTF-16.
-pub(crate) fn convert_positions_to_utf16(value: &mut Value, pos_conv: &Utf8ToUtf16) {
+pub fn convert_positions_to_utf16(value: &mut Value, pos_conv: &Utf8ToUtf16) {
     match value {
         Value::Object(map) => {
             if let Some(Value::Number(n)) = map.get("start")

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -17,14 +17,11 @@
 //! ```
 
 // `#[global_allocator]` deliberately lives in each binary entry point
-// (src/main.rs, src/bin/*.rs) and in the napi cdylib root (src/napi.rs)
-// rather than here. Defining it in the lib root causes a duplicate
-// `#[global_allocator]` symbol when the lib is built with both `cdylib`
-// and `rlib` crate-types and a downstream bin links against both copies —
-// cargo issue rust-lang/cargo#6313. The system-allocator fallback for the
-// rlib path is intentional; everything that actually runs in production
-// (the napi/cdylib, the bins) installs its own allocator (mimalloc,
-// preferred; jemalloc as a fallback — see napi.rs).
+// (src/main.rs, src/bin/*.rs) and in the `rsvelte_napi` cdylib root rather
+// than here, so that linking this rlib never imposes an allocator on the
+// consumer. The system-allocator fallback for the rlib path is intentional;
+// everything that runs in production installs its own allocator (mimalloc
+// preferred, jemalloc as a fallback).
 
 pub mod ast;
 pub mod compiler;
@@ -35,11 +32,9 @@ pub mod svelte2tsx;
 pub mod svelte_check;
 pub mod vps;
 
-#[cfg(feature = "napi")]
-pub mod napi;
-// The raw-transfer envelope is needed regardless of the `napi` feature so
-// that unit tests and any future non-NAPI consumers (the WASM build, for
-// example) can exercise the encoder.
+// The raw-transfer envelope stays in this crate (rather than in `rsvelte_napi`)
+// so unit tests and non-NAPI consumers such as the WASM build can exercise the
+// encoder.
 pub mod napi_raw;
 pub mod napi_raw_parse;
 

--- a/crates/rsvelte_core/src/main.rs
+++ b/crates/rsvelte_core/src/main.rs
@@ -1,13 +1,9 @@
 //! CLI for the Svelte Rust compiler.
 
-// Use jemalloc as the global allocator for better multi-threaded
-// performance. Defined per-bin rather than once in the lib because the lib
-// is built as both rlib and cdylib, and a lib-level `#[global_allocator]`
-// is duplicated across both outputs at link time — cargo issue
-// rust-lang/cargo#6313.
+// Defined per-bin rather than once in the lib so that linking the `rsvelte_core`
+// rlib never imposes an allocator on the consumer.
 #[cfg(all(
     feature = "jemalloc",
-    not(feature = "napi"),
     not(target_arch = "wasm32"),
     not(target_os = "windows")
 ))]

--- a/crates/rsvelte_napi/Cargo.toml
+++ b/crates/rsvelte_napi/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "rsvelte_napi"
+version = "0.8.0"
+edition = "2024"
+rust-version = "1.90"
+description = "Node.js N-API bindings for the rsvelte Svelte compiler"
+license = "MIT"
+repository = "https://github.com/baseballyama/rsvelte"
+homepage = "https://github.com/baseballyama/rsvelte"
+publish = false
+
+[lib]
+# cdylib only: this crate exists so that `rsvelte_core` can stay a pure rlib.
+# A package that emits both a cdylib and an rlib writes both artifacts to
+# unhashed `deps/lib<name>.{so,rlib}` paths, so the two profile variants cargo
+# builds (`panic = "abort"` for bins, forced unwind for test/bench units)
+# clobber each other — cargo issue rust-lang/cargo#6313.
+crate-type = ["cdylib"]
+# A test/doc harness for this crate would be an executable, and the `napi_*`
+# symbols it imports only resolve when Node dlopen's the addon — so a
+# workspace-wide `cargo test` would fail to link it.
+test = false
+doctest = false
+bench = false
+
+[features]
+default = ["mimalloc-alloc"]
+# jemalloc's default initial-exec TLS model exhausts Linux's static TLS reserve
+# when Node dlopen's this addon after program start.
+jemalloc = ["dep:tikv-jemallocator", "tikv-jemallocator?/disable_initial_exec_tls"]
+mimalloc-alloc = ["dep:mimalloc"]
+
+[dependencies]
+rsvelte_core = { path = "../rsvelte_core", default-features = false, features = ["native"] }
+napi = { version = "3", default-features = false, features = ["napi9", "serde-json", "async", "tokio_rt", "compat-mode"] }
+napi-derive = "3"
+serde_json = { version = "1.0", features = ["preserve_order"] }
+rustc-hash = "2.0"
+bumpalo = { version = "3.16", features = ["collections"] }
+
+[target.'cfg(all(not(windows), not(target_arch = "wasm32")))'.dependencies]
+tikv-jemallocator = { version = "0.7", optional = true }
+# `local_dynamic_tls` builds mimalloc with the local-dynamic TLS model, required
+# so Node can dlopen this addon on Linux.
+mimalloc = { version = "0.1", optional = true, features = ["local_dynamic_tls"] }
+
+[build-dependencies]
+napi-build = "2"
+
+[lints]
+workspace = true

--- a/crates/rsvelte_napi/build.rs
+++ b/crates/rsvelte_napi/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -49,11 +49,11 @@ use napi::{Env, JsBuffer};
 use napi_derive::napi;
 use serde_json::Value;
 
-use crate::compiler::{
+use rsvelte_core::compiler::{
     CompileOptions, CssMode, ExperimentalOptions, GenerateMode, ModuleCompileOptions, Namespace,
     compile as rust_compile, compile_module as rust_compile_module,
 };
-use crate::svelte2tsx::{
+use rsvelte_core::svelte2tsx::{
     Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion,
     svelte2tsx as rust_svelte2tsx,
 };
@@ -62,7 +62,7 @@ use crate::svelte2tsx::{
 /// Serialise compiler warnings into the JSON shape the official
 /// `svelte/compiler` output uses (`code`, `message`, `filename`, `start`, `end`,
 /// `position`, `frame`).
-fn warnings_to_json(warnings: &[crate::compiler::Warning]) -> Vec<Value> {
+fn warnings_to_json(warnings: &[rsvelte_core::compiler::Warning]) -> Vec<Value> {
     warnings
         .iter()
         .map(|w| {
@@ -131,7 +131,7 @@ pub struct NapiParseOptions {
 /// and the matching `decodeParseEnvelope` JS decoder.
 #[napi(js_name = "parse")]
 pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Result<String> {
-    use crate::compiler::phases::phase1_parse::{ParseOptions, parse as rust_parse};
+    use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse as rust_parse};
 
     let parse_options = ParseOptions {
         skip_expression_loc: options
@@ -147,7 +147,7 @@ pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Re
         Ok(ast) => {
             // Serialize within the AST's arena so `JsNodeId`s in the
             // Serialize impls resolve (mirrors `wasm::parse_svelte`).
-            crate::ast::arena::with_serialize_arena(&ast.arena, || {
+            rsvelte_core::ast::arena::with_serialize_arena(&ast.arena, || {
                 // Spans are UTF-16 code-unit offsets to match svelte/compiler
                 // (#793). ASCII source needs no remap — keep the fast path.
                 if source.is_ascii() {
@@ -156,8 +156,8 @@ pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Re
                 }
                 let mut value = serde_json::to_value(&ast)
                     .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}")))?;
-                let conv = crate::compiler::legacy::Utf8ToUtf16::new(&source);
-                crate::compiler::legacy::convert_positions_to_utf16(&mut value, &conv);
+                let conv = rsvelte_core::compiler::legacy::Utf8ToUtf16::new(&source);
+                rsvelte_core::compiler::legacy::convert_positions_to_utf16(&mut value, &conv);
                 serde_json::to_string(&value)
                     .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}")))
             })
@@ -177,7 +177,7 @@ pub fn napi_parse_envelope(
     source: String,
     options: Option<NapiParseOptions>,
 ) -> napi::Result<Buffer> {
-    use crate::compiler::phases::phase1_parse::{ParseOptions, parse as rust_parse};
+    use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse as rust_parse};
 
     let parse_options = ParseOptions {
         skip_expression_loc: options
@@ -199,8 +199,9 @@ pub fn napi_parse_envelope(
     // pre-sized arena + finalizer plumbing outweighs the saved
     // `Vec::reserve` calls for envelopes that fit in a single growth
     // step.
-    let buf =
-        crate::napi_raw_parse::encode_root_to_vec_with_flags(&ast, &source, skip_loc, skip_css);
+    let buf = rsvelte_core::napi_raw_parse::encode_root_to_vec_with_flags(
+        &ast, &source, skip_loc, skip_css,
+    );
     Ok(buf.into())
 }
 
@@ -404,20 +405,20 @@ impl NapiCompileOptions {
             && let Some(v) = compat.component_api
         {
             opts.compatibility.component_api = if v == 4 {
-                crate::compiler::ComponentApi::V4
+                rsvelte_core::compiler::ComponentApi::V4
             } else {
-                crate::compiler::ComponentApi::V5
+                rsvelte_core::compiler::ComponentApi::V5
             };
         }
         if let Some(hash_override) = self.css_hash_override {
             opts.css_hash = Some(std::sync::Arc::new(
-                move |_: &crate::compiler::CssHashInput| hash_override.clone(),
+                move |_: &rsvelte_core::compiler::CssHashInput| hash_override.clone(),
             ));
         }
         if let Some(v) = self.fragments.as_deref() {
             opts.fragments = match v {
-                "tree" => crate::compiler::FragmentMode::Tree,
-                _ => crate::compiler::FragmentMode::Html,
+                "tree" => rsvelte_core::compiler::FragmentMode::Tree,
+                _ => rsvelte_core::compiler::FragmentMode::Html,
             };
         }
         opts
@@ -604,7 +605,7 @@ fn parse_svelte2tsx_options(options: &Value) -> Svelte2TsxOptions {
 // vite-plugin-svelte (Wave 3) NAPI surface
 // =============================================================================
 
-use crate::vps::{ResolveOptions, hmr_diff as rust_hmr_diff, resolve_id as rust_resolve_id};
+use rsvelte_core::vps::{ResolveOptions, hmr_diff as rust_hmr_diff, resolve_id as rust_resolve_id};
 
 /// Diff two `.svelte` source versions. Returns `{ change, instanceChanged,
 /// moduleChanged }` so the JS shim can decide between Vite's hot-update
@@ -614,9 +615,9 @@ use crate::vps::{ResolveOptions, hmr_diff as rust_hmr_diff, resolve_id as rust_r
 pub fn napi_hmr_diff(prev: String, curr: String) -> napi::Result<Value> {
     let diff = rust_hmr_diff(&prev, &curr);
     let kind = match diff.change {
-        crate::vps::HmrChange::HotUpdate => "hot-update",
-        crate::vps::HmrChange::FullReload => "full-reload",
-        crate::vps::HmrChange::Unchanged => "unchanged",
+        rsvelte_core::vps::HmrChange::HotUpdate => "hot-update",
+        rsvelte_core::vps::HmrChange::FullReload => "full-reload",
+        rsvelte_core::vps::HmrChange::Unchanged => "unchanged",
     };
     Ok(serde_json::json!({
         "change": kind,
@@ -687,7 +688,7 @@ pub fn napi_preprocess(
 
     env.execute_tokio_future(
         async move {
-            crate::compiler::preprocess::preprocess(source, rust_groups, filename)
+            rsvelte_core::compiler::preprocess::preprocess(source, rust_groups, filename)
                 .await
                 .map_err(|e| napi::Error::from_reason(format!("{e}")))
         },
@@ -696,14 +697,14 @@ pub fn napi_preprocess(
 }
 
 mod preprocess_bridge {
-    use crate::compiler::preprocess::types::{
+    use napi::Status;
+    use napi::bindgen_prelude::{FromNapiValue, Object, Promise};
+    use napi::threadsafe_function::ThreadsafeFunction;
+    use rsvelte_core::compiler::preprocess::types::{
         AttributeValue as RsAttrValue, MarkupPreprocessorFn, MarkupPreprocessorOptions,
         PreprocessError, PreprocessorFn, PreprocessorGroup, PreprocessorOptions,
         PreprocessorResult, Processed, SimpleDecodedMap, SourceMapInput,
     };
-    use napi::Status;
-    use napi::bindgen_prelude::{FromNapiValue, Object, Promise};
-    use napi::threadsafe_function::ThreadsafeFunction;
     use rustc_hash::FxHashMap;
     use serde_json::Value;
 
@@ -1157,7 +1158,7 @@ pub fn napi_compile_module_buffers(
     }
 }
 
-fn warning_to_napi(w: crate::compiler::Warning) -> NapiWarning {
+fn warning_to_napi(w: rsvelte_core::compiler::Warning) -> NapiWarning {
     NapiWarning {
         code: w.code,
         message: w.message,
@@ -1168,7 +1169,7 @@ fn warning_to_napi(w: crate::compiler::Warning) -> NapiWarning {
     }
 }
 
-fn position_to_napi(p: crate::compiler::Position) -> NapiPosition {
+fn position_to_napi(p: rsvelte_core::compiler::Position) -> NapiPosition {
     NapiPosition {
         line: p.line as u32,
         column: p.column as u32,
@@ -1181,7 +1182,7 @@ fn position_to_napi(p: crate::compiler::Position) -> NapiPosition {
 // =============================================================================
 //
 // `compileEnvelope` packs the entire `CompileResult` into one
-// fixed-layout byte buffer (`crate::napi_raw`) and hands it to V8 as
+// fixed-layout byte buffer (`rsvelte_core::napi_raw`) and hands it to V8 as
 // a single `Buffer`. The JS shim's `decodeEnvelope` slices fields
 // out on demand — no `serde_json` on the boundary, no V8 object tree
 // construction for the warning array unless the caller actually
@@ -1198,17 +1199,17 @@ fn position_to_napi(p: crate::compiler::Position) -> NapiPosition {
 /// buffer (M-012).
 #[inline]
 fn ensure_envelope_size(size: usize) -> napi::Result<()> {
-    crate::napi_raw::check_envelope_size(size).map_err(|size| {
+    rsvelte_core::napi_raw::check_envelope_size(size).map_err(|size| {
         napi::Error::from_reason(format!(
             "rsvelte: compiled output is {size} bytes, exceeding the \
              {max}-byte envelope limit (header offsets are u32)",
-            max = crate::napi_raw::MAX_ENVELOPE_SIZE
+            max = rsvelte_core::napi_raw::MAX_ENVELOPE_SIZE
         ))
     })
 }
 
 /// `compile()` returning a single packed envelope buffer.
-/// See `crate::napi_raw` for the byte-level format.
+/// See `rsvelte_core::napi_raw` for the byte-level format.
 #[napi(js_name = "compileEnvelope")]
 pub fn napi_compile_envelope(
     source: String,
@@ -1217,8 +1218,8 @@ pub fn napi_compile_envelope(
     let opts = options_to_compile(options);
     match rust_compile(&source, opts) {
         Ok(result) => {
-            ensure_envelope_size(crate::napi_raw::estimate_size(&result))?;
-            Ok(Buffer::from(crate::napi_raw::encode_to_vec(&result)))
+            ensure_envelope_size(rsvelte_core::napi_raw::estimate_size(&result))?;
+            Ok(Buffer::from(rsvelte_core::napi_raw::encode_to_vec(&result)))
         }
         Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
     }
@@ -1264,9 +1265,9 @@ pub fn napi_compile_envelope(
 /// with the buffer. No Rust code retains the pointer after this returns.
 fn create_zero_copy_envelope(
     env: &Env,
-    result: &crate::compiler::CompileResult,
+    result: &rsvelte_core::compiler::CompileResult,
 ) -> napi::Result<JsBuffer> {
-    let size = crate::napi_raw::estimate_size(result);
+    let size = rsvelte_core::napi_raw::estimate_size(result);
     ensure_envelope_size(size)?;
     let bump = Box::new(bumpalo::Bump::with_capacity(size));
     let bump_ptr: *mut bumpalo::Bump = Box::into_raw(bump);
@@ -1291,7 +1292,7 @@ fn create_zero_copy_envelope(
     // aliased; we re-acquire ownership via Box::from_raw inside the
     // finalizer below.
     let bump_ref: &bumpalo::Bump = unsafe { &*bump_ptr };
-    let slice = crate::napi_raw::encode_into_bump(bump_ref, result);
+    let slice = rsvelte_core::napi_raw::encode_into_bump(bump_ref, result);
     let ptr = slice.as_mut_ptr();
     let len = slice.len();
 
@@ -1347,11 +1348,11 @@ pub fn napi_compile_module_envelope_zero_copy(
         Ok(r) => r,
         Err(e) => return Err(napi::Error::from_reason(format!("{e:?}"))),
     };
-    let cr = crate::compiler::CompileResult {
+    let cr = rsvelte_core::compiler::CompileResult {
         js: result.js,
         css: None,
         warnings: Vec::new(),
-        metadata: crate::compiler::CompileMetadata { runes: true },
+        metadata: rsvelte_core::compiler::CompileMetadata { runes: true },
         ast: None,
     };
     create_zero_copy_envelope(&env, &cr)
@@ -1372,15 +1373,15 @@ pub fn napi_compile_module_envelope(
             // the envelope encoder expects. Module compiles never produce
             // CSS or warnings, and runes mode is always on, so the
             // resulting envelope is the minimal js-only form.
-            let cr = crate::compiler::CompileResult {
+            let cr = rsvelte_core::compiler::CompileResult {
                 js: result.js,
                 css: None,
                 warnings: Vec::new(),
-                metadata: crate::compiler::CompileMetadata { runes: true },
+                metadata: rsvelte_core::compiler::CompileMetadata { runes: true },
                 ast: None,
             };
-            ensure_envelope_size(crate::napi_raw::estimate_size(&cr))?;
-            Ok(Buffer::from(crate::napi_raw::encode_to_vec(&cr)))
+            ensure_envelope_size(rsvelte_core::napi_raw::estimate_size(&cr))?;
+            Ok(Buffer::from(rsvelte_core::napi_raw::encode_to_vec(&cr)))
         }
         Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
     }
@@ -1391,9 +1392,9 @@ pub fn napi_compile_module_envelope(
 // =============================================================================
 //
 // `compileBatch([{source, options}, …])` hands the whole worklist to
-// `crate::compiler::compile_batch`, which uses rayon to compile in
+// `rsvelte_core::compiler::compile_batch`, which uses rayon to compile in
 // parallel, and packs the resulting `Result<CompileResult, _>`s into
-// one batch envelope (`crate::napi_raw::encode_batch_to_vec`). One
+// one batch envelope (`rsvelte_core::napi_raw::encode_batch_to_vec`). One
 // `napi_create_external_buffer` per call regardless of N — the
 // per-file boundary cost goes from O(N) to O(1).
 //
@@ -1418,18 +1419,18 @@ pub fn napi_compile_batch(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer
     // pure (no NAPI touchpoint) so it could in principle run in
     // parallel, but the per-call work is trivial and this keeps the
     // rayon stage focused on the actual compile.
-    let parsed: Vec<(String, crate::compiler::CompileOptions)> = inputs
+    let parsed: Vec<(String, rsvelte_core::compiler::CompileOptions)> = inputs
         .into_iter()
         .map(|item| (item.source, options_to_compile(item.options)))
         .collect();
 
     // Compile in parallel. `compile_batch` takes `&[(&str, CompileOptions)]`,
     // so we materialise the borrowed view once.
-    let borrowed: Vec<(&str, crate::compiler::CompileOptions)> = parsed
+    let borrowed: Vec<(&str, rsvelte_core::compiler::CompileOptions)> = parsed
         .iter()
         .map(|(s, o)| (s.as_str(), o.clone()))
         .collect();
-    let results = crate::compiler::compile_batch(&borrowed);
+    let results = rsvelte_core::compiler::compile_batch(&borrowed);
 
     // Build the BatchEntry view over the results so the encoder can
     // walk them without taking ownership. Error messages format
@@ -1442,17 +1443,21 @@ pub fn napi_compile_batch(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer
         })
         .collect();
 
-    let entries: Vec<crate::napi_raw::BatchEntry<'_>> = results
+    let entries: Vec<rsvelte_core::napi_raw::BatchEntry<'_>> = results
         .iter()
         .zip(err_strings.iter())
         .map(|(r, e)| match r {
-            Ok(cr) => crate::napi_raw::BatchEntry::Ok(cr),
-            Err(_) => crate::napi_raw::BatchEntry::Err(e.as_deref().unwrap_or("unknown error")),
+            Ok(cr) => rsvelte_core::napi_raw::BatchEntry::Ok(cr),
+            Err(_) => {
+                rsvelte_core::napi_raw::BatchEntry::Err(e.as_deref().unwrap_or("unknown error"))
+            }
         })
         .collect();
 
-    ensure_envelope_size(crate::napi_raw::estimate_batch_size(&entries))?;
-    Ok(Buffer::from(crate::napi_raw::encode_batch_to_vec(&entries)))
+    ensure_envelope_size(rsvelte_core::napi_raw::estimate_batch_size(&entries))?;
+    Ok(Buffer::from(rsvelte_core::napi_raw::encode_batch_to_vec(
+        &entries,
+    )))
 }
 
 // =============================================================================
@@ -1493,8 +1498,8 @@ impl Task for CompileEnvelopeTask {
         // small and we only pay it once per call.
         let result = rust_compile(&self.source, self.options.clone())
             .map_err(|e| napi::Error::from_reason(format!("{e:?}")))?;
-        ensure_envelope_size(crate::napi_raw::estimate_size(&result))?;
-        Ok(crate::napi_raw::encode_to_vec(&result))
+        ensure_envelope_size(rsvelte_core::napi_raw::estimate_size(&result))?;
+        Ok(rsvelte_core::napi_raw::encode_to_vec(&result))
     }
 
     fn resolve(&mut self, _env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
@@ -1532,7 +1537,7 @@ impl Task for CompileBatchTask {
             .iter()
             .map(|(s, o)| (s.as_str(), o.clone()))
             .collect();
-        let results = crate::compiler::compile_batch(&borrowed);
+        let results = rsvelte_core::compiler::compile_batch(&borrowed);
         let err_strings: Vec<Option<String>> = results
             .iter()
             .map(|r| match r {
@@ -1540,16 +1545,18 @@ impl Task for CompileBatchTask {
                 Err(e) => Some(format!("{e:?}")),
             })
             .collect();
-        let entries: Vec<crate::napi_raw::BatchEntry<'_>> = results
+        let entries: Vec<rsvelte_core::napi_raw::BatchEntry<'_>> = results
             .iter()
             .zip(err_strings.iter())
             .map(|(r, e)| match r {
-                Ok(cr) => crate::napi_raw::BatchEntry::Ok(cr),
-                Err(_) => crate::napi_raw::BatchEntry::Err(e.as_deref().unwrap_or("unknown error")),
+                Ok(cr) => rsvelte_core::napi_raw::BatchEntry::Ok(cr),
+                Err(_) => {
+                    rsvelte_core::napi_raw::BatchEntry::Err(e.as_deref().unwrap_or("unknown error"))
+                }
             })
             .collect();
-        ensure_envelope_size(crate::napi_raw::estimate_batch_size(&entries))?;
-        Ok(crate::napi_raw::encode_batch_to_vec(&entries))
+        ensure_envelope_size(rsvelte_core::napi_raw::estimate_batch_size(&entries))?;
+        Ok(rsvelte_core::napi_raw::encode_batch_to_vec(&entries))
     }
 
     fn resolve(&mut self, _env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -115,8 +115,8 @@ itself never spends cycles on cosmetic output massaging (rsvelte targets
 pnpm run corpus:sync        # init/update every corpus source submodule
 
 # build + stage the rsvelte NAPI binding
-cargo build --release --features napi --lib
-cp target/release/librsvelte_core.dylib .corpus-cache/rsvelte.node   # .so on Linux
+cargo build --release -p rsvelte_napi --lib
+cp target/release/librsvelte_napi.dylib .corpus-cache/rsvelte.node   # .so on Linux
 
 pnpm run corpus             # sync + collect + compile + verify
 ```

--- a/scripts/compat-corpus/compile.mjs
+++ b/scripts/compat-corpus/compile.mjs
@@ -147,7 +147,7 @@ if (args.includes('--worker')) {
 
 if (!fs.existsSync(BINDING)) {
 	console.error(`[compile] rsvelte NAPI binding missing at ${BINDING}`);
-	console.error('  build: cargo build --release --features napi --lib');
+	console.error('  build: cargo build --release -p rsvelte_napi --lib');
 	console.error('  stage: cp target/release/librsvelte_core.{dylib,so} .corpus-cache/rsvelte.node');
 	process.exit(1);
 }

--- a/scripts/compat-corpus/one.mjs
+++ b/scripts/compat-corpus/one.mjs
@@ -10,8 +10,8 @@
  *   svelte.dev/apps/svelte.dev/content/docs/svelte/02-runes/04-$effect.md/1.svelte
  *
  * --raw skips oxfmt normalization. Requires a staged NAPI binding at
- * .corpus-cache/rsvelte.node (cargo build --release --features napi --lib,
- * then cp target/release/librsvelte_core.dylib .corpus-cache/rsvelte.node).
+ * .corpus-cache/rsvelte.node (cargo build --release -p rsvelte_napi --lib,
+ * then cp target/release/librsvelte_napi.dylib .corpus-cache/rsvelte.node).
  */
 
 import fs from 'node:fs';

--- a/scripts/compat-corpus/svelte2tsx-compile.mjs
+++ b/scripts/compat-corpus/svelte2tsx-compile.mjs
@@ -137,7 +137,7 @@ if (args.includes('--worker')) {
 // Parent mode.
 if (!fs.existsSync(BINDING)) {
 	console.error(`[s2t-compile] rsvelte NAPI binding missing at ${BINDING}`);
-	console.error('  build: cargo build --release --features napi --lib');
+	console.error('  build: cargo build --release -p rsvelte_napi --lib');
 	console.error('  stage: cp target/release/librsvelte_core.{dylib,so} .corpus-cache/rsvelte.node');
 	process.exit(1);
 }

--- a/scripts/dev/build-vps-native-local.mjs
+++ b/scripts/dev/build-vps-native-local.mjs
@@ -18,26 +18,26 @@ let triple;
 let dylib;
 if (platform === 'darwin' && arch === 'arm64') {
 	triple = 'darwin-arm64';
-	dylib = 'librsvelte_core.dylib';
+	dylib = 'librsvelte_napi.dylib';
 } else if (platform === 'darwin' && arch === 'x64') {
 	triple = 'darwin-x64';
-	dylib = 'librsvelte_core.dylib';
+	dylib = 'librsvelte_napi.dylib';
 } else if (platform === 'linux' && arch === 'x64') {
 	triple = 'linux-x64-gnu';
-	dylib = 'librsvelte_core.so';
+	dylib = 'librsvelte_napi.so';
 } else if (platform === 'linux' && arch === 'arm64') {
 	triple = 'linux-arm64-gnu';
-	dylib = 'librsvelte_core.so';
+	dylib = 'librsvelte_napi.so';
 } else if (platform === 'win32' && arch === 'x64') {
 	triple = 'win32-x64-msvc';
-	dylib = 'rsvelte_core.dll';
+	dylib = 'rsvelte_napi.dll';
 } else {
 	console.error(`[build-vps-native] unsupported platform ${platform}/${arch}`);
 	process.exit(2);
 }
 
 console.log(`[build-vps-native] building NAPI cdylib for ${triple}…`);
-execSync('cargo build --release --features napi --lib', {
+execSync('cargo build --release -p rsvelte_napi --lib', {
 	cwd: repoRoot,
 	stdio: 'inherit',
 });

--- a/scripts/dev/test-vps-shim.mjs
+++ b/scripts/dev/test-vps-shim.mjs
@@ -7,7 +7,7 @@
 // guard that runs in CI by exercising the NAPI surface directly.
 //
 // Run: `node scripts/dev/test-vps-shim.mjs` (after `cargo build --release
-// --features napi --lib` and `cp target/release/librsvelte_core.dylib
+// --features napi --lib` and `cp target/release/librsvelte_napi.dylib
 // apps/npm/vite-plugin-svelte-native-<triple>/rsvelte.node`).
 
 import { createRequire } from 'node:module';

--- a/scripts/release/publish-all-local.sh
+++ b/scripts/release/publish-all-local.sh
@@ -212,7 +212,7 @@ log "═════════════════════════
 build_for_target() {
   local triple="$1"   # e.g. "darwin-arm64"
   local target="$2"   # e.g. "aarch64-apple-darwin"
-  local crate_args=("${@:3}")  # remaining args: --bin svelte_check OR --lib --features napi
+  local crate_args=("${@:3}")  # remaining args: --bin svelte_check OR --lib -p rsvelte_napi
 
   case "$target" in
     *-apple-darwin)
@@ -253,9 +253,9 @@ sc_dest_for() {
 dylib_for() {
   local target="$1"
   case "$target" in
-    *-apple-darwin)    echo "librsvelte_core.dylib" ;;
-    *-unknown-linux-*) echo "librsvelte_core.so" ;;
-    *-pc-windows-msvc) echo "rsvelte_core.dll" ;;
+    *-apple-darwin)    echo "librsvelte_napi.dylib" ;;
+    *-unknown-linux-*) echo "librsvelte_napi.so" ;;
+    *-pc-windows-msvc) echo "rsvelte_napi.dll" ;;
   esac
 }
 
@@ -307,7 +307,7 @@ for entry in "${TRIPLES[@]}"; do
     log "  ↻ @rsvelte/vite-plugin-svelte-native-$triple already published; skipping napi build"
   else
     step "  napi cdylib ($triple)" \
-      build_for_target "$triple" "$target" --lib --features napi
+      build_for_target "$triple" "$target" --lib -p rsvelte_napi
     vps_dylib="$(dylib_for "$target")"
     vps_dest="$vps_dir/rsvelte.node"
     cp "target/$target/release/$vps_dylib" "$vps_dest"


### PR DESCRIPTION
## なぜ出力名衝突がリンク事故になるのか

`rsvelte_core` は `crate-type = ["cdylib", "rlib"]` を宣言していた。cdylib を出す
パッケージは `target/<profile>/deps/` 配下の成果物名に metadata ハッシュが付かない。
一方 cargo はこの lib を **2 ユニット** ビルドする:

- `[profile.release]` の `panic = "abort"` を使う通常ビルド（bin 用）
- test / bench ターゲットが要求する強制 unwind 版

この 2 つが両方とも `librsvelte_core.so` **および** `librsvelte_core.rlib` という
同じパスに書き込み、互いを上書きする。cargo はこれを警告する:

```
warning: output filename collision at target/release/deps/librsvelte_core.so
warning: output filename collision at target/release/deps/librsvelte_core.rlib
note: this may become a hard error in the future; see rust-lang/cargo#6313
```

壊れるのは **rlib が上書きされる** 点。CI の部分キャッシュ復元（`Cargo.lock` 変更で
完全キーが外れ restore-key で部分ヒット）と重なると、bin ターゲットが `rsvelte_core`
を rlib ではなく cdylib に解決してしまう。cdylib は Rust の crate metadata を持たない
ため、リンク時にこうなる:

```
rust-lld: error: undefined symbol: rsvelte_core::compiler::compile
rust-lld: error: undefined symbol: rsvelte_core::compiler::phases::phase1_parse::parse
```

### 実例

- **#1600** / **#1613** — 同日に 2 回、`compile_profile` / `benchmark_runner` の
  リンクで CI が落ちた。
- `benchmark.yml` には既にこの衝突による被害が回避策コメントとして記録されていた
  （ビルド成果物が再利用されず ~13 分の再コンパイルが発生する）。本 PR で根本原因が
  消えたのでコメントを更新した。

## 採った解法

NAPI バインディング（`src/napi.rs`, 32 個の `#[napi]` 項目）を **cdylib 専用の
新クレート `crates/rsvelte_napi`** へ切り出し、`rsvelte_core` を `crate-type = ["rlib"]`
のみにした。

### 代替案を退けた根拠

- **bin を別クレートへ移す** — 効かない。衝突しているのは `.so` だけでなく
  **`librsvelte_core.rlib` 自身**であり（上の警告参照）、パッケージから cdylib を
  取り除かない限り rlib は上書きされ続ける。
- **cdylib を feature gate する** — cargo は `crate-type` を feature で条件分岐できない。
- **wasm のために cdylib を残す必要があるか** → 不要だった。`wasm-pack` は
  `rsvelte_core` を直接ターゲットせず、`rsvelte_lint` と `rsvelte_fmt_wasm` を
  ビルドする。`rsvelte_core` の `#[wasm_bindgen]` シンボルは rlib 経由でそれらの
  cdylib に取り込まれるので、rlib 化しても wasm ビルドは影響を受けない。

Rust 側の移動はきれいだった。`napi.rs` が使う内部 API のうち `pub` でなかったのは
`Utf8ToUtf16` と `convert_positions_to_utf16` の 2 つだけで、それらを `pub` にした。
アロケータ設定（mimalloc `local_dynamic_tls` / jemalloc `disable_initial_exec_tls`、
Node が Linux で dlopen する際の static-TLS 対策）は挙動を変えずそのまま移設した。

`rsvelte_napi` には `test = false` / `doctest = false` を設定している。cdylib 専用
クレートのテストハーネスは実行可能ファイルになり、`napi_*` シンボルは Node が
dlopen したときにしか解決しないため、workspace 全体の `cargo test` がリンクに失敗する。

## 追随させた箇所

成果物名が `librsvelte_core.{so,dylib}` / `rsvelte_core.dll` → `librsvelte_napi.*` に、
ビルドコマンドが `--features napi --lib` → `-p rsvelte_napi --lib` に変わるため:

- `.github/workflows/`: `release.yml`（マトリクスの `dylib:` 5 件 + ビルド + cp）、
  `corpus-compat.yml`、`deploy-docs.yml`、`benchmark.yml`（コメント）
- `scripts/`: `release/publish-all-local.sh`、`dev/build-vps-native-local.mjs`、
  `dev/test-vps-shim.mjs`、`compat-corpus/{compile,svelte2tsx-compile,one}.mjs` + README
- `apps/playground/rsvelte-shim/compiler.mjs`
- `.claude/skills/` 配下の手順書 4 件

`rsvelte_lint` 側の `--features napi -p rsvelte_lint` 系は別クレートなので変更なし。

## ローカル検証

| 項目 | 結果 |
|---|---|
| `cargo fmt --all` | OK |
| `cargo build --release --all-targets` の衝突警告 | **`librsvelte_core.*` が消滅**（下記参照） |
| `cargo build --release -p rsvelte_napi --lib` | OK（`librsvelte_napi.dylib` 生成） |
| Node からの `require()` | 17 エクスポート登録を確認 |
| アドオン経由の `compile()` | 正しい client 出力を生成 |
| `cargo clippy --all-targets -- -D warnings` | クリーン |
| `cargo test --release -p rsvelte_core` | exit 0 / 167 スイート / 0 failure |
| `cargo test -p rsvelte_capi` | 35 passed |

衝突警告の before / after:

```
before: librsvelte_capi.*  librsvelte_core.dylib  librsvelte_core.rlib  librsvelte_lint.*
after:  librsvelte_capi.*                                               librsvelte_lint.*
```

## 残るリスク / フォローアップ

- `rsvelte_capi` と `rsvelte_lint` は依然 `cdylib` + `rlib` で衝突が残る。とくに
  `rsvelte_lint` は同一パッケージに bin (`rsvelte-lint`) を持つため、**同じクラスの
  リンク事故が起こりうる**。本 PR のスコープ外だが、同じ手法で解消できる。
- Linux の dlopen / static-TLS 挙動は macOS では検証できない。アロケータ設定は
  そのまま移設しただけだが、実証は Linux CI 頼み。
- クロスコンパイルのリリースマトリクス（zigbuild / xwin）はタグ push 時にしか
  動かない。ただし `corpus-compat.yml` と `deploy-docs.yml` が PR CI で同じ
  `-p rsvelte_napi --lib` ビルドと成果物名を通るので、取り違えがあれば検知される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxUqvhaXY1UciaoW4VhRKu