### PR TITLE
fix(compiler): publish a stable @rsvelte/compiler/wasm export subpath

### DIFF
--- a/.changeset/fix-compiler-wasm-subpath.md
+++ b/.changeset/fix-compiler-wasm-subpath.md
@@ -1,0 +1,20 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/lint": patch
+---
+
+fix(compiler): add a stable `@rsvelte/compiler/wasm` subpath and fix package metadata
+
+The published package now exposes the WebAssembly binary under a stable
+`@rsvelte/compiler/wasm` export. Previously the only way to reach the `.wasm`
+bytes (e.g. to drive `initSync` on Node) was a deep import that hard-coded the
+internal build crate's filename, so consumers broke whenever that name changed
+(`rsvelte_core_bg.wasm` → `rsvelte_lint_bg.wasm`). Import from
+`@rsvelte/compiler/wasm` instead — it stays stable across releases.
+
+Existing crate-named deep imports keep working (an `exports` passthrough
+preserves them), and the default `import ... from '@rsvelte/compiler'` is
+unchanged.
+
+Also corrects the package `description`, which had been the linter crate's text
+rather than the compiler's.

--- a/apps/npm/compiler/PUBLISHING.md
+++ b/apps/npm/compiler/PUBLISHING.md
@@ -2,7 +2,19 @@
 
 This directory is the **changesets version anchor** for the `@rsvelte/compiler` npm package. It contains no runtime code.
 
-The actual published artifact is built by `wasm-pack` into the repo-root `pkg/` directory. When `pnpm publish` runs against this workspace package, the `publishConfig.directory` field redirects it to pack and upload `pkg/`. Right before publish, `scripts/release/finalize-pkg.mjs` rewrites `pkg/package.json`'s `name` from the Cargo crate name (`rsvelte_lint`) to the scoped npm name (`@rsvelte/compiler`), and copies this directory's `README.md` into `pkg/README.md` so the published package documents the compiler (not the linter crate whose README `wasm-pack` would otherwise copy).
+The actual published artifact is built by `wasm-pack` into the repo-root `pkg/` directory. When `pnpm publish` runs against this workspace package, the `publishConfig.directory` field redirects it to pack and upload `pkg/`. Right before publish, `scripts/release/finalize-pkg.mjs` rewrites `pkg/package.json`'s `name` from the Cargo crate name (`rsvelte_lint`) to the scoped npm name (`@rsvelte/compiler`), overrides the `description` (wasm-pack copies the linter crate's description), synthesises an `exports` map, and copies this directory's `README.md` into `pkg/README.md` so the published package documents the compiler (not the linter crate whose README `wasm-pack` would otherwise copy).
+
+## The stable `./wasm` subpath
+
+wasm-pack names its artifacts after the built crate (`rsvelte_lint.js`, `rsvelte_lint_bg.wasm`). Those filenames are **not** a public contract — the built crate has already changed once (`rsvelte_core_*` → `rsvelte_lint_*`), which broke every consumer that read the wasm bytes via a crate-named deep import (`@rsvelte/compiler/rsvelte_core_bg.wasm`).
+
+`finalize-pkg.mjs` therefore adds an `exports` map with a stable alias:
+
+- `@rsvelte/compiler` — the JS glue (default import), unchanged.
+- **`@rsvelte/compiler/wasm`** — the wasm bytes. Consumers that `initSync` the module (e.g. `svelte-shaker`, this repo's `@rsvelte/oxlint-plugin`) should resolve this path; it is invariant across crate/file renames.
+- `@rsvelte/compiler/*` — a passthrough so the crate-named deep imports that predate the `exports` map keep resolving (adding `exports` otherwise makes them fail).
+
+The script asserts every concrete `exports` target exists in `pkg/`, so a future crate rename fails the release loudly instead of publishing a map that points at missing files.
 
 Why split it this way:
 

--- a/apps/npm/compiler/README.md
+++ b/apps/npm/compiler/README.md
@@ -26,6 +26,24 @@ The package is a `wasm-pack` (`--target web`) module — the WebAssembly binary
 ships with the package, so it runs anywhere WebAssembly does (modern browsers,
 Node.js, Deno, Bun) with no native binaries and no `optionalDependencies`.
 
+If you need the raw `.wasm` bytes yourself (for example to drive the synchronous
+`initSync` on Node), import them from the stable **`@rsvelte/compiler/wasm`**
+subpath rather than the internal artifact filename:
+
+```js
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { initSync } from '@rsvelte/compiler';
+
+const require = createRequire(import.meta.url);
+const bytes = readFileSync(require.resolve('@rsvelte/compiler/wasm'));
+initSync({ module: bytes });
+```
+
+`@rsvelte/compiler/wasm` is the supported path for the wasm binary and stays
+stable across releases; the on-disk filename is an internal build detail and may
+change.
+
 ## Usage
 
 ```js

--- a/apps/npm/oxlint-plugin/src/wasm.js
+++ b/apps/npm/oxlint-plugin/src/wasm.js
@@ -15,14 +15,15 @@ const require = createRequire(import.meta.url);
 
 // Prefer the published `@rsvelte/compiler` dependency; fall back to this repo's
 // in-place wasm build at `/pkg` so the plugin runs from a source checkout (and
-// this repo's own E2E test) without a publish/link step. wasm-pack names the
-// artifacts after the built crate (`rsvelte_lint`); `@rsvelte/compiler` ships
-// them under those names.
+// this repo's own E2E test) without a publish/link step. The wasm bytes come
+// from the package's stable `./wasm` subpath, which never names the internal
+// build crate (wasm-pack names its artifacts `rsvelte_lint_*`, but that is not a
+// contract) — so this keeps resolving across crate renames.
 function resolveCompiler() {
 	try {
 		return {
 			jsUrl: pathToFileURL(require.resolve('@rsvelte/compiler')).href,
-			wasmPath: require.resolve('@rsvelte/compiler/rsvelte_lint_bg.wasm'),
+			wasmPath: require.resolve('@rsvelte/compiler/wasm'),
 		};
 	} catch {
 		return {

--- a/scripts/release/finalize-pkg.mjs
+++ b/scripts/release/finalize-pkg.mjs
@@ -7,6 +7,17 @@
 // crate's README into `pkg/`) here after the wasm build completes and before
 // `pnpm publish` reads it.
 //
+// We also synthesise an `exports` map so consumers get a *stable* subpath to
+// the wasm bytes — `@rsvelte/compiler/wasm` — that does not name the internal
+// Cargo crate. wasm-pack names its artifacts after the built crate
+// (`rsvelte_lint.js`, `rsvelte_lint_bg.wasm`); tools that read the wasm to drive
+// `initSync` (svelte-shaker, this repo's own oxlint-plugin) would otherwise have
+// to hard-code that crate name and break every time the wasm build retargets a
+// different crate (`rsvelte_core_*` → `rsvelte_lint_*` did exactly this and broke
+// deep-import consumers). The `./wasm` alias is the contract; the crate-named
+// files stay reachable via a `"./*"` passthrough so existing deep imports keep
+// resolving.
+//
 // The version is the changeset-managed `apps/npm/compiler/package.json`
 // version — the single source of truth. We force it here rather than trusting
 // whatever wasm-pack derived from the built crate's `Cargo.toml`, because the
@@ -19,12 +30,13 @@
 // `workspace:^` consumers (e.g. `@rsvelte/svelte2tsx`) read when pnpm rewrites
 // their dependency range at publish time.
 
-import { copyFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../..');
+const pkgDir = resolve(repoRoot, 'pkg');
 const pkgJsonPath = resolve(repoRoot, 'pkg/package.json');
 const sourceJsonPath = resolve(repoRoot, 'apps/npm/compiler/package.json');
 const sourceReadmePath = resolve(repoRoot, 'apps/npm/compiler/README.md');
@@ -46,10 +58,58 @@ if (generated.version !== source.version) {
 	);
 }
 generated.version = source.version;
+// wasm-pack copies the built crate's `Cargo.toml` description into
+// `pkg/package.json` — for `rsvelte_lint` that is the *linter* description, which
+// mislabels a package literally named `@rsvelte/compiler`. Override it with the
+// compiler-facing description from the version anchor.
+if (source.description) generated.description = source.description;
 if (source.repository) generated.repository = source.repository;
 if (source.homepage) generated.homepage = source.homepage;
 if (source.bugs) generated.bugs = source.bugs;
 if (source.keywords) generated.keywords = source.keywords;
+
+// Synthesise a stable `exports` map. wasm-pack leaves `exports` unset and points
+// `main`/`module`/`types` at the crate-named glue (`rsvelte_lint.js`), so the
+// only way to reach the wasm today is a deep import that hard-codes the crate
+// name. We derive the real filenames from what wasm-pack emitted (so this keeps
+// working if the built crate is renamed) and expose:
+//   "."             → the JS glue (unchanged default import)
+//   "./wasm"        → the wasm bytes, under a name that never mentions the crate
+//   "./package.json"→ conventional, some tools require it
+//   "./*"           → passthrough so existing crate-named deep imports still work
+// The trailing `./*` is what keeps `exports` from *narrowing* resolution: without
+// it, adding `exports` would make `@rsvelte/compiler/rsvelte_lint_bg.wasm` (used
+// by this repo's oxlint-plugin fallback and by older external consumers) fail.
+const withDot = (p) => (p.startsWith('./') ? p : `./${p}`);
+const jsEntry = generated.main ?? generated.module;
+if (!jsEntry) {
+	throw new Error('finalize-pkg: wasm-pack pkg/package.json has neither "main" nor "module"');
+}
+const wasmFile = (generated.files ?? []).find((f) => f.endsWith('_bg.wasm'));
+if (!wasmFile) {
+	throw new Error('finalize-pkg: no `*_bg.wasm` entry in pkg/package.json "files"');
+}
+const dotExport = generated.types
+	? { types: withDot(generated.types), default: withDot(jsEntry) }
+	: withDot(jsEntry);
+generated.exports = {
+	'.': dotExport,
+	'./wasm': withDot(wasmFile),
+	'./package.json': './package.json',
+	'./*': './*',
+};
+
+// Verify every concrete export target actually shipped in `pkg/`, so a future
+// crate rename or wasm-pack layout change fails the release loudly here rather
+// than publishing an `exports` map that points at missing files. The `./*`
+// passthrough is a wildcard with no single target, so it is not checked.
+const exportTargets = new Set([withDot(jsEntry), withDot(wasmFile), './package.json']);
+if (generated.types) exportTargets.add(withDot(generated.types));
+for (const target of exportTargets) {
+	if (!existsSync(resolve(pkgDir, target))) {
+		throw new Error(`finalize-pkg: exports target ${target} is missing from pkg/`);
+	}
+}
 
 writeFileSync(pkgJsonPath, JSON.stringify(generated, null, 2) + '\n');
 console.log(`Finalized pkg/package.json as ${generated.name}@${generated.version}`);


### PR DESCRIPTION
## Summary

`@rsvelte/compiler` ships wasm-pack artifacts named after the built crate (`rsvelte_lint.js` / `rsvelte_lint_bg.wasm`) with no `exports` map, so the only way for a consumer to reach the wasm bytes (to drive `initSync` on Node) was a deep import hard-coding that internal crate name. The `rsvelte_core_*` → `rsvelte_lint_*` retarget broke every such consumer (e.g. svelte-shaker's `require.resolve('@rsvelte/compiler/rsvelte_core_bg.wasm')`).

`finalize-pkg.mjs` now synthesises an `exports` map at publish time:

- `"./wasm"` → the wasm bytes — the new **stable contract**, never names the internal crate
- `"."` → the JS glue (unchanged default import)
- `"./*"` passthrough so existing crate-named deep imports keep resolving (adding `exports` would otherwise narrow resolution and break them)
- every concrete export target is asserted to exist in `pkg/` before publish, so a future crate rename fails the release loudly instead of shipping dangling exports

It also propagates the `description` from the version anchor — wasm-pack was copying the **linter** crate's description into a package named `compiler`.

The in-repo consumer (`oxlint-plugin`) now resolves via `./wasm`, exercising the new contract.

## Testing

- `finalize-pkg.mjs` run against synthetic wasm-pack `pkg/` fixtures (`main`/`module` variants + missing-file failure paths).
- Verified with Node's real resolver against a simulated installed package: `.`, `./wasm`, legacy `./rsvelte_lint_bg.wasm`, and `./package.json` all resolve.

## Consumer migration

```js
// before (breaks on crate renames)
require.resolve('@rsvelte/compiler/rsvelte_lint_bg.wasm');
// after (stable)
require.resolve('@rsvelte/compiler/wasm');
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDF4vHDn5DPosk4N7Nepah