### PR TITLE
ci: Rust toolchain を 1.96.0 に固定し dtolnay アクションを SHA ピン

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,7 +50,9 @@ jobs:
           submodules: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -91,7 +91,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       # Without this every run recompiles the whole oxc_* dependency graph
       # in release mode from scratch (the bulk of the build time). The

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           components: rustfmt
 
       - name: Check formatting
@@ -98,8 +99,9 @@ jobs:
           submodules: true
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           components: clippy
 
       - name: Cache cargo registry + target
@@ -166,7 +168,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte submodules/language-tools submodules/eslint-plugin-svelte submodules/esrap
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       # mold is a drop-in faster linker. The test build links ~150 separate
       # integration-test binaries (one per tests/*.rs), so link time is a real
@@ -337,7 +341,9 @@ jobs:
           submodules: true
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -428,7 +434,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -474,7 +482,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -515,7 +525,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -593,8 +605,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           targets: wasm32-unknown-unknown
 
       - name: Setup mold linker
@@ -708,7 +721,9 @@ jobs:
           submodules: true
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -836,7 +851,9 @@ jobs:
           submodules: true
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -40,7 +40,9 @@ jobs:
           submodules: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -147,7 +147,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/cmsaasstarter
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -251,7 +253,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/cmsaasstarter
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -325,7 +329,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/eslint-plugin-svelte submodules/svelte-eslint-parser submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,8 +39,9 @@ jobs:
           submodules: true
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           components: llvm-tools-preview
 
       - name: Setup Node.js

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,7 +35,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -70,8 +70,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           targets: wasm32-unknown-unknown
 
       - name: Setup mold linker

--- a/.github/workflows/release-capi.yml
+++ b/.github/workflows/release-capi.yml
@@ -59,8 +59,9 @@ jobs:
           sudo apt-get install -y ${{ matrix.apt }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,8 +107,9 @@ jobs:
           sudo apt-get install -y ${{ matrix.apt }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target
@@ -168,8 +169,9 @@ jobs:
           sudo apt-get install -y ${{ matrix.apt }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target
@@ -230,8 +232,9 @@ jobs:
           sudo apt-get install -y ${{ matrix.apt }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target
@@ -292,8 +295,9 @@ jobs:
           sudo apt-get install -y ${{ matrix.apt }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target
@@ -359,8 +363,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: 1.96.0
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry + target

--- a/.github/workflows/site-benchmark.yml
+++ b/.github/workflows/site-benchmark.yml
@@ -53,7 +53,9 @@ jobs:
         run: git submodule update --init --depth 1 submodules/svelte submodules/language-tools
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.96.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Development environment for rsvelte_core
-FROM rust:1.97-bookworm
+# Pinned Rust toolchain — keep in sync with the CI pin (dtolnay `toolchain:`
+# input in .github/workflows/*.yml). Both are Renovate-managed.
+FROM rust:1.96.0-bookworm
 
 # Install Node.js 22.x and pnpm
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
@@ -11,10 +13,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # Install wasm-pack for WASM builds
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-# Install Rust nightly for edition 2024 support
-# Note: edition 2024 and rust-version 1.90 require nightly as of early 2025
-RUN rustup default nightly \
-    && rustup component add rustfmt clippy
+# Install rustfmt/clippy components and the wasm target for WASM builds.
+# The toolchain version itself is fixed by the base image tag above.
+RUN rustup component add rustfmt clippy \
+    && rustup target add wasm32-unknown-unknown
 
 # Install additional development tools
 RUN apt-get update && apt-get install -y \

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,21 @@
   "extends": [
     "config:recommended"
   ],
+  "customManagers": [
+    {
+      "description": "The Rust toolchain is pinned by an explicit `toolchain: X.Y.Z` input on every dtolnay/rust-toolchain step (see .github/workflows/*.yml). This tracks that single version string across all workflows so Renovate raises one PR to bump them together. The dtolnay action SHA itself is tracked by the standard github-actions manager via the `# master` comment.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "toolchain: (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "rust",
+      "packageNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "packageRules": [
     {
       "description": "The oxc AST/formatter stack is pinned to a single git rev (synced to the oxfmt release tag by the auto-update-oxfmt workflow); per-crate updates can never pass CI. The #1550 explicit matchPackageNames list still did not suppress the PRs (#1563/#1564) because for cargo GIT dependencies Renovate's packageName is the repository URL, not the crate name. Match on depName (crate name) AND on the repo-URL packageName, and disable all update types. oxc_resolver / oxc_sourcemap / oxc-miette / oxc_index stay Renovate-managed (registry deps, deliberately not listed).",


### PR DESCRIPTION
## What

CI 全体の Rust toolchain を **1.96.0 に固定**します。あわせて `dtolnay/rust-toolchain` アクションを `@stable` から SHA ピンに変えます。

**リポジトリを一切変更しなくても、新しい Rust stable がリリースされただけで CI の挙動が変わりうる**構造を解消します(PR #1612 で wasm-opt が間欠的に落ちた根本原因。wasm-opt 自体は #1618 で対処済みですが、toolchain が固定されていない問題は残っていました)。

## Why `dtolnay@stable` + a bare `rust-toolchain.toml` does not work

`dtolnay/rust-toolchain` アクションは **`rust-toolchain.toml` を読みません**。`rustup default <channel>` でチャンネルを選びます。したがって単に `rust-toolchain.toml` を置くと、アクションが入れる `stable-<host>` と、cargo 実行時に rustup が toml から解決する `1.96.0-<host>` が**別 toolchain として二重インストール**され、各ジョブの `components`/`targets` が「stable 側」に付くのに実ビルドは「toml 側」を使う、というズレが起きます(特に release のクロスコンパイルは toml 側に target が無く失敗しうる)。

そこで **各ジョブに `toolchain: 1.96.0` を明示的に渡す**方式にしました。番号で直接指定するため二重インストールは起きず、各ジョブの `components`/`targets` もそのまま効きます。

## What changed

- **`.github/workflows/*.yml`(26箇所)**: `dtolnay/rust-toolchain@stable` → `dtolnay/rust-toolchain@2c7215f… # master` に SHA ピンし、各ステップの `with:` に `toolchain: 1.96.0` を追加。既存の `components`(rustfmt / clippy / llvm-tools-preview)と `targets`(wasm32-unknown-unknown、release の5ターゲット)はすべて維持
- **`renovate.json`**: `toolchain: X.Y.Z` を全ワークフローで単一追跡する customManager を追加(datasource は `github-releases` の `rust-lang/rust`)。26箇所を1つの PR でまとめて更新できます。dtolnay の SHA は標準の github-actions マネージャが `# master` コメント経由で追跡します
- **`Dockerfile`**: `rust:1.97-bookworm` → `rust:1.96.0-bookworm`、`rustup default nightly` を削除(CI は stable のみ使用、nightly は不要)、`rustup target add wasm32-unknown-unknown` を追加、edition 2024 が nightly 必須という**陳腐化したコメントを削除**(edition 2024 は stable 1.85+ で安定)

`rust-toolchain.toml` は**作っていません** — version の情報源を「CI の `toolchain:` 直書き(customManager 管理)」の1系統に保つためです。

## Why 1.96.0 and why not a composite action

- **1.96.0**: 開発環境の active stable(`rustc 1.96.0 (ac68faa20 2026-05-25)`)と一致し、**ローカルで end-to-end 検証できる唯一のバージョン**です。MSRV(1.90)を超え、edition 2024(stable 1.85+)に対応します
- **composite action で toml をパースする案は見送りました**。その方式だと Windows ジョブでシェルによる toml パースが走りますが、macOS arm64 の開発環境では検証できません。version の単一管理は Renovate customManager で達成できるため、検証できない実行経路を増やさない直書き方式を選びました

## Verification

ローカル(macOS arm64)で確認できたこと:
- **26箇所すべてが SHA ピン済み**(`@stable` 残存ゼロ)で、`toolchain: 1.96.0` が26行 — dtolnay の出現数と一致
- **`components`/`targets` が全ファイルで維持**(変更前後のカウントが一致)
- dtolnay SHA `2c7215f132e9ebf062739d9130488b56d53c060c` が確認時点の master と一致(`git ls-remote` + API で GPG 署名検証済みコミットであることを確認)
- 全15ワークフローの **YAML 構文チェック通過**、`renovate.json` は valid JSON
- ローカルの `rustc --version` が 1.96.0 でピン先と一致

**ローカルで検証できないこと**: `release.yml` のクロスコンパイル(Windows / Linux / x86_64 ターゲットでの実ビルド)。これは macOS arm64 では原理的に不可能で、**CI が唯一の検証手段**です。toolchain 選択ロジックは全ジョブ均一なので host で成立すれば論理的には同じく効くはずですが、各ターゲットの実インストール成否は CI に委ねます。
