### PR TITLE
ci: update playground lockfile for monaco-editor ^0.56.0 to fix Deploy Docs

### DIFF
--- a/apps/playground/pnpm-lock.yaml
+++ b/apps/playground/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
       monaco-editor:
-        specifier: ^0.55.1
-        version: 0.55.1
+        specifier: ^0.56.0
+        version: 0.56.0
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
@@ -611,8 +611,8 @@ packages:
   devalue@5.6.3:
     resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
@@ -726,8 +726,8 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
-  monaco-editor@0.55.1:
-    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+  monaco-editor@0.56.0:
+    resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -1209,7 +1209,7 @@ snapshots:
 
   devalue@5.6.3: {}
 
-  dompurify@3.2.7:
+  dompurify@3.4.8:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -1289,9 +1289,9 @@ snapshots:
 
   marked@14.0.0: {}
 
-  monaco-editor@0.55.1:
+  monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.8
       marked: 14.0.0
 
   mrmime@2.0.1: {}


### PR DESCRIPTION
## Summary

Deploy Docs has been failing on every `main` push since #1591.

- #1591 (Renovate) bumped `monaco-editor` to `^0.56.0` in `apps/playground/package.json`, but the playground's standalone lockfile (installed with `--ignore-workspace`) was left at `^0.55.1`.
- The Deploy Docs workflow's "Install playground dependencies" step (`pnpm install --frozen-lockfile --ignore-workspace`) therefore fails with `ERR_PNPM_OUTDATED_LOCKFILE`.

This PR regenerates `apps/playground/pnpm-lock.yaml` (`pnpm install --ignore-workspace --lockfile-only`). The diff is only monaco-editor 0.55.1 → 0.56.0 and its transitive dompurify 3.2.7 → 3.4.8.

## Verification

`pnpm install --frozen-lockfile --ignore-workspace` now succeeds in `apps/playground` (previously reproduced the CI failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvYNAm2DQyGEzFegZwfa2q