### PR TITLE
fix(fmt): default to cwd when no paths given, matching oxfmt (#1432)

### DIFF
--- a/.changeset/fix-fmt-default-cwd.md
+++ b/.changeset/fix-fmt-default-cwd.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): default to the current working directory when no paths are given, matching `oxfmt`
+
+`rsvelte-fmt` (no arguments) now formats the current directory in place, and
+`rsvelte-fmt --check` checks it, exactly like `oxfmt`. Previously the path
+argument was required and the no-path invocation exited with an error.
+`--stdin` mode is unaffected.

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ One Rust CLI that formats `.svelte` in-process and routes `.js` / `.ts` / `.css`
 
 ```bash
 npm install -D @rsvelte/fmt oxfmt
-npx rsvelte-fmt src/          # format in place
-npx rsvelte-fmt --check src/  # CI gate: exit 1 if anything would change
+npx rsvelte-fmt             # format the current directory in place (no path = cwd)
+npx rsvelte-fmt src/        # format a specific path in place
+npx rsvelte-fmt --check     # CI gate: exit 1 if anything would change
 ```
 
 See [`@rsvelte/fmt`](apps/npm/fmt) for all flags, stdin/editor integration, and configuration.

--- a/apps/npm/fmt/README.md
+++ b/apps/npm/fmt/README.md
@@ -74,15 +74,21 @@ npm install -D oxfmt
 ## Usage
 
 ```bash
+# Format the current directory in place (no path = cwd, like `oxfmt`)
+npx rsvelte-fmt
+
 # Format everything under src/ in place
 npx rsvelte-fmt src/
 
 # Check mode — exits non-zero if anything would change (CI gate)
-npx rsvelte-fmt --check src/
+npx rsvelte-fmt --check
 
 # Editor / stdin mode
 cat App.svelte | npx rsvelte-fmt --stdin --stdin-filepath App.svelte
 ```
+
+When no path is given, `rsvelte-fmt` formats the current directory — matching
+`oxfmt`, where the path argument is optional and defaults to the cwd.
 
 Add it to your `package.json`:
 

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -38,7 +38,8 @@ struct Cli {
     /// process; every other path is delegated to `oxfmt`, so directories cover
     /// the full oxfmt-supported set (`.ts`/`.js`/`.css`/`.json` and also
     /// `.md`/`.yaml`/`.toml`/`.html`, etc.) — the same files `oxfmt .` would
-    /// format. See #694.
+    /// format. When omitted, the current directory is formatted (matching
+    /// `oxfmt`). See #694.
     paths: Vec<PathBuf>,
 
     /// Write formatted output back to source files. Default when paths
@@ -332,10 +333,10 @@ fn run() -> Result<ExitCode> {
         return run_stdin(&cli, &options, &cfg);
     }
 
+    // No paths given (and not stdin mode): default to the current directory,
+    // matching `oxfmt`, which formats the cwd when no PATH is provided.
     if cli.paths.is_empty() {
-        return Err(anyhow!(
-            "no paths given — pass files/directories or use --stdin --stdin-filepath PATH"
-        ));
+        cli.paths.push(PathBuf::from("."));
     }
 
     let native_js = !cli.no_native_js;

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -121,16 +121,89 @@ fn write_mode_updates_svelte_file_on_disk() {
     assert!(after.contains("let x = 1 + 2;"), "{after}");
 }
 
+/// With no path argument, `rsvelte-fmt` formats the current directory in place
+/// (write is the default), matching `oxfmt`'s "if not provided, current working
+/// directory is used" behavior (#1432).
 #[test]
-fn no_paths_errors_helpfully() {
+fn no_paths_defaults_to_cwd_and_writes() {
+    let dir = tempdir();
+    let file = dir.join("App.svelte");
+    std::fs::write(&file, "<script>let x=1+2</script>").unwrap();
+
     let out = Command::new(bin())
-        .stderr(Stdio::piped())
+        .current_dir(&dir)
+        .args(["--oxfmt-bin", "true"])
         .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .output()
         .unwrap();
-    assert_ne!(out.status.code(), Some(0));
-    let stderr = String::from_utf8(out.stderr).unwrap();
-    assert!(stderr.contains("no paths given"), "stderr:\n{stderr}");
+    assert_eq!(out.status.code(), Some(0), "should default to cwd + write");
+
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert!(after.contains("let x = 1 + 2;"), "{after}");
+}
+
+/// `--check` with no path checks the current directory and never writes, exiting
+/// non-zero when a file would be reformatted — same as `oxfmt --check`.
+#[test]
+fn no_paths_check_does_not_write() {
+    let dir = tempdir();
+    let file = dir.join("App.svelte");
+    std::fs::write(&file, "<script>let x=1+2</script>").unwrap();
+
+    let out = Command::new(bin())
+        .current_dir(&dir)
+        .args(["--check", "--oxfmt-bin", "true"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "unformatted cwd must fail --check"
+    );
+
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        after, "<script>let x=1+2</script>",
+        "--check must not write"
+    );
+}
+
+/// The cwd default applies only to the file-walk path: `--stdin` still reads
+/// stdin and leaves on-disk files untouched even with no path argument.
+#[test]
+fn stdin_ignores_cwd_default() {
+    let dir = tempdir();
+    let file = dir.join("App.svelte");
+    std::fs::write(&file, "<script>let x=1+2</script>").unwrap();
+
+    let mut child = Command::new(bin())
+        .current_dir(&dir)
+        .args(["--stdin", "--stdin-filepath", "In.svelte"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"<script>let y=3+4</script>\n<p>{ y }</p>")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(0));
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("let y = 3 + 4;"), "stdout:\n{stdout}");
+    // The on-disk file must be left untouched — stdin mode doesn't walk the cwd.
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        after, "<script>let x=1+2</script>",
+        "stdin must not touch cwd"
+    );
 }
 
 /// Batched `<style>` delegation: every `.svelte` file's `<style>` body is


### PR DESCRIPTION
## 概要

`rsvelte-fmt` は `oxfmt` の drop-in replacement を謳っているが、パス引数を必須としていた。一方 `oxfmt` はパス省略時にカレントディレクトリを既定対象にする(`rsvelte-fmt .` と書かずに済む、という #1432 の要望)。

file-walk パスで `paths` が空のとき `.` を既定に補うようにし、`rsvelte-fmt` / `rsvelte-fmt --check` が `oxfmt` / `oxfmt --check` と一致するようにした。`--stdin` モードは従来どおり(cwd 既定を適用しない)。

## 実測した oxfmt の仕様 (v0.56.0)

空の temp ディレクトリで実測:

- パス省略・フラグなし: カレントディレクトリを対象に in-place write(write が既定)、exit 0。
- パス省略 + `--check`: cwd をチェック、未フォーマットがあれば exit 1・ファイル不変。フォーマット済みなら exit 0。

ヘルプにも `PATH ... If not provided, current working directory is used` / `--write ... (default)` と明記されている。

## 変更内容

- `crates/rsvelte_fmt/src/main.rs`: `run()` で `cli.paths.is_empty()` のとき、従来のエラー bail をやめ `cli.paths.push(PathBuf::from("."))` に変更(stdin モードは手前で return するため非影響)。`paths` の clap doc コメントに「省略時は cwd」を追記。
- `crates/rsvelte_fmt/tests/cli.rs`: 既存の `no_paths_errors_helpfully` を削除し、テスト3件を追加。
- `apps/npm/fmt/README.md` / ルート `README.md`: パスなし(=cwd)の使用例と説明を追記。

## 追加テスト (3件)

temp dir + `--oxfmt-bin true` で実 oxfmt に依存しない:

- `no_paths_defaults_to_cwd_and_writes` — パスなしで cwd を write、exit 0。
- `no_paths_check_does_not_write` — パスなし `--check` で exit 1・ファイル不変。
- `stdin_ignores_cwd_default` — `--stdin` は cwd を歩かず on-disk ファイルを触らない。

`cargo test -p rsvelte_fmt` の cli スイート 39 passed、`cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings` クリーン。

## 既知の残差分

空ディレクトリでパス省略時の exit code(oxfmt=2 / rsvelte-fmt=0)は既存ギャップの継承であり、本 PR の範囲外。フォローアップ issue で対応予定。

Closes #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZ6GV2yZMgo1nrq4siYM8S