### PR TITLE
fix(client): burn down 4 client known-failures (8 -> 4)

### DIFF
--- a/.changeset/fix-client-svelte-element-events-and-const-prop.md
+++ b/.changeset/fix-client-svelte-element-events-and-const-prop.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(client): emit `svelte:element` `on:` events bare in after_update (no `$.effect` wrap with `use:`), and emit a plain prop init for a function-valued `{@const}` shadowed by an outer same-named binding

--- a/.changeset/fix-reactive-statement-invalidate-inner-signals.md
+++ b/.changeset/fix-reactive-statement-invalidate-inner-signals.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(client): emit `$.invalidate_inner_signals` for prop member mutations inside `$:` reactive statements (legacy `<select bind:value={prop…}>` indirect bindings), matching the instance-script mutation path

--- a/.changeset/fix-root-scope-pollution-instance-first.md
+++ b/.changeset/fix-root-scope-pollution-instance-first.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyze): insert instance-scope declarations into the root-scope name map before module-script inner-function scopes, so a same-named function parameter in the module script no longer shadows an instance `let` (restoring its reactivity)

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -5,6 +5,5 @@
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",
 	"svelte-table/src/SvelteTable.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte"
 ]

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,7 +1,6 @@
 [
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
-	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",
 	"svelte-table/src/SvelteTable.svelte"

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,6 +1,5 @@
 [
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
-	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",
 	"svelte-table/src/SvelteTable.svelte"

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -4,6 +4,5 @@
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/Table/TableColumnSpecific.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
 	"svelte-table/example/Example2.svelte",
-	"svelte-table/src/SvelteTable.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte"
+	"svelte-table/src/SvelteTable.svelte"
 ]

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -14,7 +14,7 @@ compiler-behaviour gap; attempts to fix them are regression-prone against the
 8000+ passing entries (several have been reverted after wide blowups), so they are
 accepted until an upstream-faithful port lands.
 
-## Client (`known-failures.client.json`, 5 entries)
+## Client (`known-failures.client.json`, 4 entries)
 
 - **`melt-ui/.../SpatialMenuNavTest.svelte`** — two causes: (a) a proxy argument in
   `$.set(highlighted, id, true)` where `id` is an inner-scope TemplateLiteral const
@@ -22,9 +22,6 @@ accepted until an upstream-faithful port lands.
   multi-occurrence names); (b) `${cols ?? ''}` — svelte keeps the `?? ''`, rsvelte
   elides it (scope.evaluate treats a prop member as defined where svelte keeps it
   UNKNOWN).
-- **`svelte-form-builder/.../PropertyPanelChoiceCheckboxRadioSpecific.svelte`** —
-  reactive assignment lowered to a SequenceExpression (`(field(...), true), ...`)
-  vs a bare CallExpression (~114-node difference).
 - **`svelte-sonner/.../Toaster.svelte`** — JS now matches; remaining divergence is
   **CSS unused-selector pruning**: svelte prunes selectors like
   `[data-sonner-toast][data-styled='true'] [data-description]` as unused while

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -14,7 +14,7 @@ compiler-behaviour gap; attempts to fix them are regression-prone against the
 8000+ passing entries (several have been reverted after wide blowups), so they are
 accepted until an upstream-faithful port lands.
 
-## Client (`known-failures.client.json`, 8 entries)
+## Client (`known-failures.client.json`, 7 entries)
 
 - **`melt-ui/.../SpatialMenuNavTest.svelte`** — two causes: (a) a proxy argument in
   `$.set(highlighted, id, true)` where `id` is an inner-scope TemplateLiteral const
@@ -40,9 +40,6 @@ accepted until an upstream-faithful port lands.
   `col` missing inside `$.invalidate_inner_signals` (from a `bind:value` key
   `filterSelections()[col.key]`). The exact condition making `col` reactive is
   unresolved.
-- **`svelte-ux/.../Button.svelte`** — an `$.event('click', …)` wrapped in
-  `$.effect(() => $.event(…))` where svelte emits it bare in after_update; spread +
-  action-with-event placement (~25-node difference).
 - **`svelte-ux/.../MultiSelect.svelte`** — a component prop emitted as a getter
   (`get onChange(){ return $.get(onChange); }`) where svelte emits plain
   `onChange: $.get(onChange)`. svelte's rule is `has_state ? getter : init`;

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -14,7 +14,7 @@ compiler-behaviour gap; attempts to fix them are regression-prone against the
 8000+ passing entries (several have been reverted after wide blowups), so they are
 accepted until an upstream-faithful port lands.
 
-## Client (`known-failures.client.json`, 7 entries)
+## Client (`known-failures.client.json`, 6 entries)
 
 - **`melt-ui/.../SpatialMenuNavTest.svelte`** — two causes: (a) a proxy argument in
   `$.set(highlighted, id, true)` where `id` is an inner-scope TemplateLiteral const
@@ -40,10 +40,6 @@ accepted until an upstream-faithful port lands.
   `col` missing inside `$.invalidate_inner_signals` (from a `bind:value` key
   `filterSelections()[col.key]`). The exact condition making `col` reactive is
   unresolved.
-- **`svelte-ux/.../MultiSelect.svelte`** — a component prop emitted as a getter
-  (`get onChange(){ return $.get(onChange); }`) where svelte emits plain
-  `onChange: $.get(onChange)`. svelte's rule is `has_state ? getter : init`;
-  rsvelte's `has_state` is true for a legacy prop where svelte's is false.
 
 ## Server (`known-failures.server.json`, 0 entries)
 
@@ -62,6 +58,5 @@ against the full corpus + byte-exact runtime/ssr/css suites before landing):
 - **each-item reactivity wrapping** (function-depth `has_external_dependencies`
   check) — a prior attempt caused ~498 regressions.
 - **`$derived` currying** (`yScale()(tick)`) — reverted twice; do not retry naively.
-- **legacy prop `has_state` analysis** driving getter-vs-plain component-prop shape.
 - **store/runes name-conflict resolution** — two independent sub-bugs that must land
   together and distinguish getter-vs-user-call by context.

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -14,7 +14,7 @@ compiler-behaviour gap; attempts to fix them are regression-prone against the
 8000+ passing entries (several have been reverted after wide blowups), so they are
 accepted until an upstream-faithful port lands.
 
-## Client (`known-failures.client.json`, 6 entries)
+## Client (`known-failures.client.json`, 5 entries)
 
 - **`melt-ui/.../SpatialMenuNavTest.svelte`** — two causes: (a) a proxy argument in
   `$.set(highlighted, id, true)` where `id` is an inner-scope TemplateLiteral const
@@ -25,8 +25,6 @@ accepted until an upstream-faithful port lands.
 - **`svelte-form-builder/.../PropertyPanelChoiceCheckboxRadioSpecific.svelte`** —
   reactive assignment lowered to a SequenceExpression (`(field(...), true), ...`)
   vs a bare CallExpression (~114-node difference).
-- **`svelte-form-builder/.../Table/TableColumnSpecific.svelte`** — divergence around
-  `let column = $.mutable_source()` (~39-node difference).
 - **`svelte-sonner/.../Toaster.svelte`** — JS now matches; remaining divergence is
   **CSS unused-selector pruning**: svelte prunes selectors like
   `[data-sonner-toast][data-styled='true'] [data-description]` as unused while

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -229,7 +229,16 @@ impl<'a> ScopeBuilder<'a> {
         //
         // Example: let { foo } = (() => { const foo = ...; return { foo }; })();
         // The outer `let foo` should be found, not the inner `const foo`.
-        for i in 1..self.scopes.len() {
+        //
+        // Scope creation order is not depth order: module-script inner-function
+        // scopes are created before the instance scope, so the instance scope's
+        // top-level declarations must be inserted first or a same-named function
+        // parameter in the module script would shadow them.
+        let instance_idx = self.instance_scope_index;
+        let instance_first = std::iter::once(instance_idx)
+            .filter(|&i| i != 0)
+            .chain((1..self.scopes.len()).filter(move |&i| i != instance_idx));
+        for i in instance_first {
             // Split to get simultaneous mutable access to scopes[0] and scopes[i]
             let (first, rest) = self.scopes.split_at_mut(1);
             let root = &mut first[0];

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -4799,6 +4799,7 @@ fn transform_instance_script_for_visitors(
                 &var_state_vars,
                 dep_names,
                 analysis,
+                &prop_invalidate_bodies,
             );
             // Also apply state assignment transformations to the reactive statement body
             // This handles cases like: `$: selected ? component = Sub : component = banana`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -283,6 +283,7 @@ pub(super) fn transform_reactive_statement(
     // text scan is no longer consulted.
     dep_names: &[String],
     _analysis: &ComponentAnalysis,
+    prop_invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
 ) -> String {
     let trimmed = statement.trim();
 
@@ -460,7 +461,7 @@ pub(super) fn transform_reactive_statement(
                 &temp,
                 prop_assignment_transform_vars,
                 &[],
-                &rustc_hash::FxHashMap::default(),
+                prop_invalidate_bodies,
             );
             // Wrap state-var member mutations (`obj.a.b = x`) in `$.mutate(obj, …)`.
             // The keyword branch (a `$: if (cond) X = rhs` reactive statement) was
@@ -500,7 +501,7 @@ pub(super) fn transform_reactive_statement(
                 &temp,
                 prop_assignment_transform_vars,
                 &[],
-                &rustc_hash::FxHashMap::default(),
+                prop_invalidate_bodies,
             );
             let temp = transform_state_member_mutations(&temp, state_vars, non_reactive_state_vars);
             let temp = transform_state_set_in_reactive(&temp, state_vars, non_reactive_state_vars);
@@ -545,7 +546,7 @@ pub(super) fn transform_reactive_statement(
                     &transformed_rhs,
                     prop_assignment_transform_vars,
                     &[],
-                    &rustc_hash::FxHashMap::default(),
+                    prop_invalidate_bodies,
                 );
                 let transformed_rhs = wrap_state_vars_in_expr(
                     &transformed_rhs,
@@ -701,7 +702,7 @@ pub(super) fn transform_reactive_statement(
             &temp,
             prop_assignment_transform_vars,
             &[],
-            &rustc_hash::FxHashMap::default(),
+            prop_invalidate_bodies,
         );
         // Transform state member-expression mutations (e.g., `object[key] = []`)
         // to `$.mutate(object, $.get(object)[key] = [])`. Must run before wrap_state_vars_in_expr

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -265,10 +265,9 @@ impl<'a> ComponentContext<'a> {
         let mut inner_update: Vec<JsStatement> = Vec::new();
         let mut inner_after_update: Vec<JsStatement> = Vec::new();
 
-        // Check if there are use directives (affects how we handle on: directives)
-        let has_use = !use_directives.is_empty();
-
-        // Process OnDirectives
+        // Process OnDirectives.
+        // Unlike RegularElement, SvelteElement.js always emits events bare into
+        // after_update (no `$.effect` wrapping for `use:` directives).
         for on_directive in &on_directives {
             // Save current node and temporarily set to element_id.
             // `mem::replace` returns the old value as we install the new one,
@@ -276,19 +275,7 @@ impl<'a> ComponentContext<'a> {
             let saved_node = std::mem::replace(&mut self.state.node, element_id.clone());
 
             if let TransformResult::Expression(event_call) = self.visit_on_directive(on_directive) {
-                if has_use {
-                    // If there's a use: directive, wrap in $.effect
-                    inner_init.push(b::stmt(
-                        &self.arena,
-                        b::call(
-                            &self.arena,
-                            b::member_path(&self.arena, "$.effect"),
-                            vec![b::thunk(&self.arena, event_call)],
-                        ),
-                    ));
-                } else {
-                    inner_after_update.push(b::stmt(&self.arena, event_call));
-                }
+                inner_after_update.push(b::stmt(&self.arena, event_call));
             }
 
             // Restore node

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -4920,23 +4920,48 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
                 // For Derived bindings, skip this early return and fall through to the
                 // detailed binding kind check below.
                 if let Some(transform) = context.state.transform.get(name) {
+                    use crate::compiler::phases::phase2_analyze::scope::BindingKind;
+
+                    // Resolve the binding this reference actually refers to. `get_binding`
+                    // walks the root-scope-polluted map, which prefers an OUTER same-named
+                    // binding; when an in-scope `{@const}` shadows it, that resolves to the
+                    // outer binding instead of the `{@const}`. `transform_deep_read` marks a
+                    // `{@const}` (Template) whose transform is currently active, so in that
+                    // case re-resolve to the shadowing Template binding to check its kind.
+                    let resolved = {
+                        let direct = context.state.get_binding(name);
+                        let is_shadowed_normal = direct
+                            .is_some_and(|b| matches!(b.kind, BindingKind::Normal))
+                            && context.state.transform_deep_read.contains_key(name);
+                        if is_shadowed_normal {
+                            context
+                                .state
+                                .scope_root
+                                .bindings_by_name
+                                .get(name)
+                                .and_then(|idxs| {
+                                    idxs.iter().rev().find_map(|&i| {
+                                        let b =
+                                            context.state.scope_root.bindings.get(i as usize)?;
+                                        matches!(b.kind, BindingKind::Template).then_some(b)
+                                    })
+                                })
+                                .or(direct)
+                        } else {
+                            direct
+                        }
+                    };
+
                     // Check if this is a Derived binding - if so, skip the early return
                     // and fall through to the detailed binding kind check below.
-                    let is_derived = context.state.get_binding(name).is_some_and(|b| {
-                        matches!(
-                            b.kind,
-                            crate::compiler::phases::phase2_analyze::scope::BindingKind::Derived
-                        )
-                    });
+                    let is_derived =
+                        resolved.is_some_and(|b| matches!(b.kind, BindingKind::Derived));
                     if !is_derived {
                         // For Template bindings (@const), check if the initial value is known
                         // instead of blindly using transform.is_reactive.
                         // This matches the official Svelte compiler's scope.evaluate() behavior.
-                        if let Some(binding) = context.state.get_binding(name)
-                            && matches!(
-                                binding.kind,
-                                crate::compiler::phases::phase2_analyze::scope::BindingKind::Template
-                            )
+                        if let Some(binding) = resolved
+                            && matches!(binding.kind, BindingKind::Template)
                         {
                             // A function-valued `{@const}` (`{@const f = (e) => …}`)
                             // mirrors upstream's `!binding.is_function()` term in


### PR DESCRIPTION
Part of #1234 (awesome-svelte corpus divergences). Burns the client known-failures baseline from 8 to 4; server remains 0.

## Fix 1: `svelte:element` `on:` events (svelte-ux `Button.svelte`)

Upstream `SvelteElement.js` has no `has_use` branch: `on:` directive events are always emitted bare into `after_update`, never wrapped in `$.effect` when a `use:` directive is present. rsvelte had copied the `RegularElement` behaviour into `visit_svelte_element`, diverging in both the effect wrapping and the init-vs-after_update placement.

## Fix 2: plain prop init for function `{@const}` shadowed by an outer binding (svelte-ux `MultiSelect.svelte`)

A component prop reading a function-valued `{@const}` must be a plain `onChange: $.get(onChange)` init, not a getter — upstream drives this via the `!binding.is_function()` term of `has_state` (`Identifier.js`). rsvelte's phase-3 `has_reactive_state_json` resolved the name through the root-scope-polluted `get_binding`, which preferred an outer same-named binding (a module-level `function onChange()`), skipping the Template `is_function()` short-circuit and falling through to a getter. The lookup now re-resolves to the shadowing Template `{@const}` binding when its transform is active, mirroring upstream.

## Fix 3: instance-scope declarations win root-scope name pollution (svelte-form-builder `TableColumnSpecific.svelte`)

The root-scope pollution map is filled in scope-creation order under the assumption that creation order is depth order — but module-script inner-function scopes are created before the instance scope exists. A function parameter in the module script (`cleanColumnTitle(column)`) therefore shadowed the same-named instance `let column` in every phase-3 name-based lookup, dropping its `$.mutable_source` wrapping and its legacy reactive-statement dependency. Instance-scope declarations are now inserted first; all other scopes keep their creation order.

## Fix 4: `$.invalidate_inner_signals` in `$:` reactive statements (svelte-form-builder `PropertyPanelChoiceCheckboxRadioSpecific.svelte`)

Prop member mutations inside `$:` reactive statements were lowered without the `$.invalidate_inner_signals` sequence wrap: the reactive-statement path called `transform_prop_assignments` with an empty `prop_invalidate_bodies` map, while the instance-script path passes the real one. Upstream `AssignmentExpression.js` wraps any mutation of a binding with `legacy_indirect_bindings` (populated by legacy `<select bind:value={prop…}>`) regardless of statement position. The map is now threaded into the reactive-statement transforms.

## Verification (each fix individually)

- `one.mjs` on all four files: client and server divergence gone (fixes 1–3 leave only comment-position noise absorbed by `astEquivalent`; fix 4 is an exact MATCH)
- Byte-exact suites: `compiler_fixtures` 17 / `runtime` 19 / `ssr` 16 — all pass after each fix
- Full corpus (13,189 entries, all submodules) after each fix: target entry flipped to PASS, **zero new failures** (final: match 12,255, error-parity 930, js-mismatch 3, css-mismatch 1 = the 4 remaining baseline entries). Explicitly checked layerchart/layercake for the PR #1598 getter↔plain flip pattern — not reproduced.

The 4 remaining entries (melt-ui `SpatialMenuNavTest`, svelte-sonner `Toaster` CSS pruning, svelte-table `Example2` / `SvelteTable`) are documented dead ends or high-regression-risk deep gaps — see `compatibility/known-failures.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8msqRP7cBMLaNTHnxo69w