### PR TITLE
fix(formatter): include the close tag in the hugged-content width measurement (32 → 31)

### DIFF
--- a/.changeset/fix-fmt-hug-close-in-fits.md
+++ b/.changeset/fix-fmt-hug-close-in-fits.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(formatter): include the close tag in the hugged-content width measurement
+
+When a multi-line open tag's hugged content line (`>{content}</tag`) overflows,
+the Doc-IR reformat printed the body alone, so the printer's fits lookahead never
+saw the close tag's width — an inner self-closing component whose own attributes
+fit, but overflow once `</tag` is appended, never broke. The overflowing hugged
+line is now printed as prettier's `group(['>', body, '</tag'])` with the dangling
+`>` appended after, so the close tag participates in the fits measurement and the
+inner component's attributes wrap exactly where the oracle wraps them.

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -4540,6 +4540,44 @@ fn try_hug_mixed(
             format!("</{tag}\n{ws_indent}>")
         };
         let simple = format!("{onb}\n{inner_indent}>{raw}{close_form}");
+        // When the hugged inner line `>{raw}</{tag}` overflows, break an inner
+        // component's attributes via the Doc IR. The measured group carries the close
+        // tag `</tag` (prettier's `group(['>', body, '</tag'])`) so the printer's fits
+        // lookahead counts its width — otherwise a child whose own attrs fit but
+        // overflow once the close tag is appended never breaks.
+        let inner_line = inner_indent.width() + 1 + raw.width() + 2 + tag.width();
+        if !raw_trail_ws_only
+            && inner_line > line_width
+            && !raw.contains('\n')
+            && let Some(body) = build_children_doc(out, fragment)
+        {
+            let base_level = if options.js.indent_style.is_tab() {
+                inner_indent
+                    .bytes()
+                    .take_while(|&b| b == b' ' || b == b'\t')
+                    .count()
+            } else {
+                inner_indent.width() / indent_width_hm
+            };
+            let measured = crate::doc::Doc::Group(vec![
+                crate::doc::Doc::Text(">".to_string()),
+                body,
+                crate::doc::Doc::Text(format!("</{tag}")),
+            ]);
+            let printed_full = crate::doc::print(
+                measured,
+                line_width,
+                indent_unit_hm.as_str(),
+                base_level,
+                inner_indent.width(),
+            );
+            if printed_full.contains('\n') {
+                let result2 = format!("{onb}\n{inner_indent}{printed_full}\n{ws_indent}>");
+                if result2 != whole {
+                    return Some((start, end, result2));
+                }
+            }
+        }
         if simple != whole {
             return Some((start, end, simple));
         }
@@ -6466,5 +6504,50 @@ mod tests {
         assert!(!is_block_display("span"));
         assert!(!is_block_display("a"));
         assert!(!is_block_display("strong"));
+    }
+
+    #[test]
+    fn hug_close_tag_width_drives_inner_component_break() {
+        use crate::doc::{Doc, print};
+
+        // Mirrors build_self_closing_component_doc's structure for
+        // `<Icon data={TrashIcon} class="text-surface-content/50" />`.
+        let icon = || {
+            Doc::Group(vec![
+                Doc::Text("<Icon".to_string()),
+                Doc::Indent(vec![Doc::Group(vec![
+                    Doc::Line,
+                    Doc::Text("data={TrashIcon}".to_string()),
+                    Doc::Line,
+                    Doc::Text("class=\"text-surface-content/50\"".to_string()),
+                    Doc::Dedent(vec![Doc::Line]),
+                ])]),
+                Doc::Text("/>".to_string()),
+            ])
+        };
+        let body = || Doc::Concat(vec![Doc::Text("Clear ".to_string()), icon()]);
+
+        // Body alone from col 15 ends at 78 <= 80: the Icon must stay flat.
+        let a = print(body(), 80, "  ", 7, 15);
+        assert_eq!(
+            a,
+            "Clear <Icon data={TrashIcon} class=\"text-surface-content/50\" />"
+        );
+
+        // With the close tag inside the measured group (prettier's
+        // group(['>', body, '</tag'])) the same body overflows (86 > 80), so the
+        // fits lookahead must break the Icon's attributes.
+        let measured = Doc::Group(vec![
+            Doc::Text(">".to_string()),
+            body(),
+            Doc::Text("</button".to_string()),
+        ]);
+        let b = print(measured, 80, "  ", 7, 14);
+        let expected = "\
+>Clear <Icon
+                data={TrashIcon}
+                class=\"text-surface-content/50\"
+              /></button";
+        assert_eq!(b, expected);
     }
 }


### PR DESCRIPTION
Part of #1508 (fmt-parity burndown). Clears the Cluster 1 entry "a long
self-closing component tag that should hug-break its attributes but doesn't":
`layerchart/docs/src/routes/docs/playground/+page.svelte`.

## Root cause

When a multi-line open tag's hugged content line (`>{content}</tag`) overflows,
`try_hug_mixed`'s Doc-IR reformat printed the **body alone** and string-glued the
leading `>` and trailing `</tag` afterwards. The doc printer's fits lookahead
therefore never charged the close tag's width: in the failing file the inner
`<Icon data={TrashIcon} class="text-surface-content/50" />` fits on its own
(ends at column 78 ≤ 80) but overflows once `</button` is appended (86 > 80), so
it never broke — while prettier measures `group(['>', body, '</tag'])` with the
close tag inside the group (same structure as our faithful port in
`children.rs`) and breaks the Icon's attributes.

## Fix

For the overflowing hugged line (non-`raw_trail_ws_only`, single-line content),
print `Group([Text(">"), body, Text("</tag")])` from the inner indent column and
append the dangling `\n{ws_indent}>`. The `raw_trail_ws_only` shape keeps the
previous body-only path (its trailing whitespace already provides the break).
Body columns are unchanged (`>` at the same position), so layouts that fit stay
byte-identical; the change only adds break opportunities where the glued line
already overflowed.

A doc-level unit test pins the mechanism: the same body doc stays flat when
printed alone and breaks its attribute group once the close tag joins the
measured group.

## Verification

- Full fmt corpus: 12,657 files, **32 → 31 known failures, zero new failures**
  (confirmed the sole newly-passing id is `docs/playground/+page.svelte`)
- `fmt-one.mjs` on the target id: byte-identical to the oxfmt(`--svelte`) oracle
- `cargo test -p rsvelte_formatter`: 291 passed, 0 failed
- `cargo fmt` / `cargo clippy --all-targets --all-features`: clean

Baseline shrink (`fmt-known-failures.json`) is intentionally **not** in this PR —
per the cross-platform rule it follows from the Linux CI Formatter parity job's
per-id NOTICEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTZTTxLcg1ayEEEkYPkx4a