### PR TITLE
fix(analyze): resolve select indirect bindings from the select's scope (client known-failures 4 -> 3)

### DIFF
--- a/.changeset/fix-select-indirect-bindings-select-scope.md
+++ b/.changeset/fix-select-indirect-bindings-select-scope.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyze): resolve legacy `<select bind:value>` indirect bindings from the select's containing scope, so an each-item wrapping the select (e.g. `{#each columns as col}<select bind:value={sel[col.key]}>`) is invalidated on mutation; a `$store` bind root is skipped like upstream

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,6 +1,5 @@
 [
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte",
-	"svelte-table/example/Example2.svelte",
-	"svelte-table/src/SvelteTable.svelte"
+	"svelte-table/example/Example2.svelte"
 ]

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -14,7 +14,7 @@ compiler-behaviour gap; attempts to fix them are regression-prone against the
 8000+ passing entries (several have been reverted after wide blowups), so they are
 accepted until an upstream-faithful port lands.
 
-## Client (`known-failures.client.json`, 4 entries)
+## Client (`known-failures.client.json`, 3 entries)
 
 - **`melt-ui/.../SpatialMenuNavTest.svelte`** — two causes: (a) a proxy argument in
   `$.set(highlighted, id, true)` where `id` is an inner-scope TemplateLiteral const
@@ -31,10 +31,6 @@ accepted until an upstream-faithful port lands.
 - **`svelte-table/example/Example2.svelte`** — `?? ''` wrongly added to a
   `${cond ? … : ""}` whose branches are all strings; a legacy `let iconAsc = "↑"`
   (string-literal init) is not treated as defined.
-- **`svelte-table/src/SvelteTable.svelte`** — two `$.get(col)` reads for each-item
-  `col` missing inside `$.invalidate_inner_signals` (from a `bind:value` key
-  `filterSelections()[col.key]`). The exact condition making `col` reactive is
-  unresolved.
 
 ## Server (`known-failures.server.json`, 0 entries)
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -1211,9 +1211,27 @@ pub fn visit(
                 let root_id =
                     extract_binding_root_identifier(&bind.expression, context.parse_arena);
                 if let Some(ref root_name) = root_id {
-                    // Get the binding for this identifier using the instance scope
-                    let scope_idx = context.analysis.root.instance_scope_index;
-                    let binding_idx = context.analysis.root.get_binding(root_name, scope_idx);
+                    // Resolve from the scope containing the select (upstream's
+                    // `context.state.scope`), not the instance scope: an each-item
+                    // declared in a block scope wrapping the select (e.g.
+                    // `{#each columns as col}<select bind:value={sel[col.key]}>`)
+                    // is a valid indirect binding upstream and must be reachable
+                    // through the ancestor chain.
+                    let scope_idx = context.scope;
+                    // Upstream `scope.get('$store')` returns null (a store
+                    // auto-subscription is not a real scope binding), so a
+                    // `bind:value={$store}` root never gets indirect bindings;
+                    // rsvelte synthesizes a StoreSub binding, so skip it here.
+                    let binding_idx = context
+                        .analysis
+                        .root
+                        .get_binding(root_name, scope_idx)
+                        .filter(|&i| {
+                            !matches!(
+                                context.analysis.root.bindings[i].kind,
+                                crate::compiler::phases::phase2_analyze::scope::BindingKind::StoreSub
+                            )
+                        });
 
                     if let Some(binding_idx) = binding_idx {
                         // Collect scope references that have template references.


### PR DESCRIPTION
Part of #1234. Burns the client known-failures baseline from 4 to 3 (svelte-table `SvelteTable.svelte`); server remains 0.

## Root cause

Legacy `<select bind:value>` indirect-binding collection (`regular_element.rs`) resolved bindings from the **instance scope's** ancestor chain. An each-item declared in a block scope wrapping the select — `{#each columns as col}<select bind:value={filterSelections[col.key]}>` — therefore never qualified as an indirect binding, and its `$.get(col)` read was missing from the `$.invalidate_inner_signals` body emitted in the bind setter. Upstream (`RegularElement.js`) resolves from `context.state.scope` — the scope containing the select — whose chain includes such block scopes.

The first attempt surfaced one interop regression (`binding-interop-derived`): with the wider scope, a `bind:value={$myStore}` root now resolved to rsvelte's synthesized `StoreSub` binding and collected indirect bindings, while upstream's `scope.get('$myStore')` returns null (store auto-subscriptions are not real scope bindings). The root lookup now skips `StoreSub` explicitly — the same justification already applied on the indirect-binding side.

## Verification

- `one.mjs` SvelteTable: both `$.get(col)` reads restored; remaining diff is comment-position noise absorbed by `astEquivalent` (server unchanged, was already passing)
- Byte-exact suites: `compiler_fixtures` 17 / `runtime` 19 / `ssr` 16 — all pass (including `binding-interop-derived` after the StoreSub guard)
- Full corpus (13,189 entries): SvelteTable flipped to PASS, **zero new failures** (match 12,256, error-parity 930, js-mismatch 2, css-mismatch 1 = the 3 remaining baseline entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8msqRP7cBMLaNTHnxo69w