### PR TITLE
fix(parser): preserve TS assertion expressions in parse() output

### DIFF
--- a/.changeset/fix-preserve-ts-assertion-nodes.md
+++ b/.changeset/fix-preserve-ts-assertion-nodes.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix(parser): preserve TS assertion expressions in `parse()` output and fix zero-width arrow-param spans
+
+`parse()` now keeps `TSAsExpression`, `TSSatisfiesExpression`, and
+`TSNonNullExpression` wrapper nodes in the public AST — matching
+svelte/compiler, which parses TS via acorn-typescript and returns the assertion
+nodes. rsvelte previously unwrapped them at parse time, returning the bare inner
+expression and diverging from the reference AST shape (it broke downstream
+consumers that rely on parser parity). The wrappers are still erased at compile
+time by `remove_typescript_nodes` exactly as before, so client/server codegen is
+unchanged (`x as const` is stripped from the generated JS). The binary
+`parseEnvelope` encoder/decoder gains matching entries for the three node types.
+
+Also fixes a latent bug where untyped arrow-function parameters inside template
+expressions (event handlers such as `onclick={(color, e) => …}`) came back with
+zero-width spans (`start == end == 0`); the fast-path template arrow parser now
+assigns each parameter its real source span, matching svelte/compiler.

--- a/.changeset/fix-preserve-ts-assertion-nodes.md
+++ b/.changeset/fix-preserve-ts-assertion-nodes.md
@@ -1,6 +1,8 @@
 ---
 "@rsvelte/compiler": patch
 "@rsvelte/vite-plugin-svelte-native": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
 ---
 
 fix(parser): preserve TS assertion expressions in `parse()` output and fix zero-width arrow-param spans
@@ -19,3 +21,8 @@ Also fixes a latent bug where untyped arrow-function parameters inside template
 expressions (event handlers such as `onclick={(color, e) => …}`) came back with
 zero-width spans (`start == end == 0`); the fast-path template arrow parser now
 assigns each parameter its real source span, matching svelte/compiler.
+
+In svelte2tsx (`@rsvelte/svelte2tsx` and the svelte-check overlay), a `bind:`
+expression carrying a TS assertion (`bind:value={value as never}`) now strips the
+assertion from the generated assignment LHS while keeping it on the bound-value
+side — mirroring upstream svelte2tsx's `getEnd(attr.expression)`.

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -155,6 +155,9 @@ const JS_NULL = 0xca;
 // 0xcb was the former whole-node JS_RAW_JSON escape (removed — TS type
 // annotations now ride a per-node trailer; see readOptTypeAnnotation).
 const JS_TS_PARAMETER_PROPERTY = 0xcc;
+const JS_TS_AS_EXPRESSION = 0xcd;
+const JS_TS_SATISFIES_EXPRESSION = 0xce;
+const JS_TS_NON_NULL_EXPRESSION = 0xcf;
 
 // LiteralValue inner tag (within a JS_LITERAL payload).
 const LV_NULL = 0;
@@ -581,6 +584,12 @@ function readNodeBody(ctx, tag, start, end) {
 			return readJsBareExpr(ctx, 'TSParameterProperty', start, end);
 		case JS_TS_MODULE_DECLARATION:
 			return readJsTSModuleDeclaration(ctx, start, end);
+		case JS_TS_AS_EXPRESSION:
+			return readJsTSAssertion(ctx, 'TSAsExpression', start, end, true);
+		case JS_TS_SATISFIES_EXPRESSION:
+			return readJsTSAssertion(ctx, 'TSSatisfiesExpression', start, end, true);
+		case JS_TS_NON_NULL_EXPRESSION:
+			return readJsTSAssertion(ctx, 'TSNonNullExpression', start, end, false);
 		case JS_COMMENT:
 			return readJsComment_(ctx, start, end);
 
@@ -972,6 +981,21 @@ function readJsChainExpression(ctx, start, end) {
 	const node = { type: 'ChainExpression', start, end };
 	if (loc !== null) node.loc = loc;
 	node.expression = expression;
+	return node;
+}
+
+// TS assertion wrappers (`x as T` / `x satisfies T` / `x!`). As/Satisfies carry
+// a `typeAnnotation` trailer; NonNull does not (`hasTypeAnnotation` is false).
+function readJsTSAssertion(ctx, typeName, start, end, hasTypeAnnotation) {
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const node = { type: typeName, start, end };
+	if (loc !== null) node.loc = loc;
+	node.expression = expression;
+	if (hasTypeAnnotation) {
+		const typeAnnotation = readOptTypeAnnotation(ctx);
+		if (typeAnnotation !== null) node.typeAnnotation = typeAnnotation;
+	}
 	return node;
 }
 

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -655,6 +655,31 @@ pub enum JsNode {
         loc: Option<Box<Loc>>,
         body: Option<JsNodeId>,
     },
+    // TS assertion expression wrappers. Preserved at parse time to mirror
+    // svelte/compiler's public `parse()` AST (acorn-typescript keeps them);
+    // `remove_typescript_nodes` erases them at compile time. `type_annotation`
+    // is the opaque, output-only type node (e.g. `TSTypeReference` for
+    // `as const`), serialized verbatim — analyze never walks into it.
+    TSAsExpression {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+        type_annotation: Box<Value>,
+    },
+    TSSatisfiesExpression {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+        type_annotation: Box<Value>,
+    },
+    TSNonNullExpression {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+    },
     // Comment (used in Program.comments array, type is "Line" or "Block")
     Comment {
         start: u32,
@@ -2052,6 +2077,55 @@ impl Serialize for JsNode {
                 ser_comments!(map, *start, *end);
                 map.end()
             }
+            JsNode::TSAsExpression {
+                start,
+                end,
+                loc,
+                expression,
+                type_annotation,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSAsExpression")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                ser_node!(map, "expression", expression);
+                map.serialize_entry("typeAnnotation", type_annotation.as_ref())?;
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
+            JsNode::TSSatisfiesExpression {
+                start,
+                end,
+                loc,
+                expression,
+                type_annotation,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSSatisfiesExpression")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                ser_node!(map, "expression", expression);
+                map.serialize_entry("typeAnnotation", type_annotation.as_ref())?;
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
+            JsNode::TSNonNullExpression {
+                start,
+                end,
+                loc,
+                expression,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSNonNullExpression")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                ser_node!(map, "expression", expression);
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
             JsNode::Comment {
                 start,
                 end,
@@ -2761,6 +2835,30 @@ impl JsNode {
                         loc,
                         body: convert_optional_child(obj, "body"),
                     },
+                    "TSAsExpression" => JsNode::TSAsExpression {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                        type_annotation: Box::new(
+                            obj.get("typeAnnotation").cloned().unwrap_or(Value::Null),
+                        ),
+                    },
+                    "TSSatisfiesExpression" => JsNode::TSSatisfiesExpression {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                        type_annotation: Box::new(
+                            obj.get("typeAnnotation").cloned().unwrap_or(Value::Null),
+                        ),
+                    },
+                    "TSNonNullExpression" => JsNode::TSNonNullExpression {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                    },
                     "Line" | "Block" => JsNode::Comment {
                         start,
                         end,
@@ -2859,6 +2957,9 @@ impl JsNode {
             JsNode::TSParameterProperty { .. } => Some("TSParameterProperty"),
             JsNode::TSEnumDeclaration { .. } => Some("TSEnumDeclaration"),
             JsNode::TSModuleDeclaration { .. } => Some("TSModuleDeclaration"),
+            JsNode::TSAsExpression { .. } => Some("TSAsExpression"),
+            JsNode::TSSatisfiesExpression { .. } => Some("TSSatisfiesExpression"),
+            JsNode::TSNonNullExpression { .. } => Some("TSNonNullExpression"),
             JsNode::Comment { comment_type, .. } => Some(comment_type.as_str()),
             JsNode::Null => None,
         }
@@ -3527,6 +3628,9 @@ impl JsNode {
             | JsNode::TSParameterProperty { start, .. }
             | JsNode::TSEnumDeclaration { start, .. }
             | JsNode::TSModuleDeclaration { start, .. }
+            | JsNode::TSAsExpression { start, .. }
+            | JsNode::TSSatisfiesExpression { start, .. }
+            | JsNode::TSNonNullExpression { start, .. }
             | JsNode::Comment { start, .. } => *start,
             JsNode::Null => 0,
         }
@@ -3608,6 +3712,9 @@ impl JsNode {
             | JsNode::TSParameterProperty { end, .. }
             | JsNode::TSEnumDeclaration { end, .. }
             | JsNode::TSModuleDeclaration { end, .. }
+            | JsNode::TSAsExpression { end, .. }
+            | JsNode::TSSatisfiesExpression { end, .. }
+            | JsNode::TSNonNullExpression { end, .. }
             | JsNode::Comment { end, .. } => *end,
             JsNode::Null => 0,
         }
@@ -3691,6 +3798,9 @@ impl JsNode {
             JsNode::TSParameterProperty { .. } => "TSParameterProperty",
             JsNode::TSEnumDeclaration { .. } => "TSEnumDeclaration",
             JsNode::TSModuleDeclaration { .. } => "TSModuleDeclaration",
+            JsNode::TSAsExpression { .. } => "TSAsExpression",
+            JsNode::TSSatisfiesExpression { .. } => "TSSatisfiesExpression",
+            JsNode::TSNonNullExpression { .. } => "TSNonNullExpression",
             JsNode::Comment { .. } => "Comment",
             JsNode::Null => "Null",
         }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -820,13 +820,18 @@ fn try_parse_arrow_function(
             try_parse_update_expression(arena, body_str, body_bytes, body_offset, line_offsets)
         })?;
 
-    // Parse params between ( and )
-    let params_str = content[1..close_paren].trim();
+    // Parse params between ( and ). Walk the raw `(...)` region (rather than the
+    // trimmed string) so each identifier keeps its real source span — the public
+    // `parse()` AST must match svelte/compiler, which assigns real param spans.
+    let region = &content[1..close_paren];
+    let region_base = offset + 1; // absolute position of `content[1]`
     let mut params_nodes = Vec::new();
 
-    if !params_str.is_empty() {
-        for param in params_str.split(',') {
-            let p = param.trim();
+    if !region.trim().is_empty() {
+        let mut cursor = 0usize; // byte index within `region`
+        for chunk in region.split(',') {
+            let lead_ws = chunk.len() - chunk.trim_start().len();
+            let p = chunk.trim();
             if p.is_empty() {
                 return None;
             }
@@ -837,13 +842,16 @@ fn try_parse_arrow_function(
             if !p_bytes.iter().all(|&b| is_ident_continue_byte(b)) {
                 return None; // Has type annotations or defaults — too complex
             }
+            let p_start = region_base + cursor + lead_ws;
+            let p_end = p_start + p.len();
             params_nodes.push(JsNode::Identifier {
-                start: 0, // Approximate — exact positions not critical for compilation
-                end: 0,
-                loc: None,
+                start: p_start as u32,
+                end: p_end as u32,
+                loc: create_typed_loc(p_start, p_end, line_offsets),
                 name: CompactString::from(p),
                 type_annotation: None,
             });
+            cursor += chunk.len() + 1; // +1 for the consumed comma
         }
     }
     let params = arena.alloc_js_children(params_nodes);
@@ -3084,6 +3092,31 @@ fn convert_type_annotation_adjusted(
     Value::Object(obj)
 }
 
+/// Build a TS assertion wrapper (`TSAsExpression` / `TSSatisfiesExpression` /
+/// `TSNonNullExpression`) as a serde_json `Value` in svelte/compiler's shape.
+/// `type_annotation` is `None` for `TSNonNullExpression` (which has no type).
+fn ts_assertion_value(
+    type_name: &str,
+    start: usize,
+    end: usize,
+    expression: Value,
+    type_annotation: Option<Value>,
+    line_offsets: &[usize],
+) -> Value {
+    let mut obj = Map::new();
+    obj.insert("type".to_string(), Value::String(type_name.to_string()));
+    obj.insert("start".to_string(), Value::Number((start as i64).into()));
+    obj.insert("end".to_string(), Value::Number((end as i64).into()));
+    if let Some(loc) = create_loc(start, end, line_offsets) {
+        obj.insert("loc".to_string(), loc);
+    }
+    obj.insert("expression".to_string(), expression);
+    if let Some(ta) = type_annotation {
+        obj.insert("typeAnnotation".to_string(), ta);
+    }
+    Value::Object(obj)
+}
+
 /// Convert TSType with pre-adjusted offset.
 ///
 /// This is a thin alias for [`convert_ts_type`]: both take an absolute base
@@ -3731,17 +3764,50 @@ fn convert_expression(
             let end = offset + seq.span.end as usize - 1;
             create_sequence_expression(arena, seq, start, end, offset, line_offsets)
         }
-        // TypeScript expression wrappers - unwrap and return the inner expression
-        // This matches Svelte's behavior of removing TypeScript syntax
+        // TypeScript assertion wrappers - preserve the wrapper node so the public
+        // `parse()` AST mirrors svelte/compiler (which keeps them); the TS stripper
+        // erases them at compile time. Template-path spans carry the `-1` synthetic
+        // paren adjustment, so the type-annotation blob uses base `offset - 1`.
         OxcExpression::TSAsExpression(ts_as) => {
-            convert_expression(arena, &ts_as.expression, offset, line_offsets)
+            let start = offset + ts_as.span.start as usize - 1;
+            let end = offset + ts_as.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_as.expression, offset, line_offsets);
+            let type_annotation = convert_ts_type(&ts_as.type_annotation, offset - 1, line_offsets);
+            Expression::from_node(JsNode::TSAsExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            })
         }
         OxcExpression::TSSatisfiesExpression(ts_satisfies) => {
-            convert_expression(arena, &ts_satisfies.expression, offset, line_offsets)
+            let start = offset + ts_satisfies.span.start as usize - 1;
+            let end = offset + ts_satisfies.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_satisfies.expression, offset, line_offsets);
+            let type_annotation =
+                convert_ts_type(&ts_satisfies.type_annotation, offset - 1, line_offsets);
+            Expression::from_node(JsNode::TSSatisfiesExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            })
         }
         OxcExpression::TSNonNullExpression(ts_non_null) => {
-            convert_expression(arena, &ts_non_null.expression, offset, line_offsets)
+            let start = offset + ts_non_null.span.start as usize - 1;
+            let end = offset + ts_non_null.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_non_null.expression, offset, line_offsets);
+            Expression::from_node(JsNode::TSNonNullExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+            })
         }
+        // `<T>x` type assertions and `f<T>` instantiation expressions are still
+        // unwrapped (out of scope; rare in Svelte templates).
         OxcExpression::TSTypeAssertion(ts_assertion) => {
             convert_expression(arena, &ts_assertion.expression, offset, line_offsets)
         }
@@ -9088,16 +9154,60 @@ fn convert_expression_for_program(
         OxcExpression::ParenthesizedExpression(paren) => {
             convert_expression_for_program(arena, &paren.expression, offset, line_offsets)
         }
-        // TypeScript expression wrappers - unwrap and return the inner expression
+        // TypeScript assertion wrappers - preserve the wrapper node so the public
+        // `parse()` AST mirrors svelte/compiler; the TS stripper erases them at
+        // compile time. Program-path spans use the raw `offset` (no paren shift).
         OxcExpression::TSAsExpression(ts_as) => {
-            convert_expression_for_program(arena, &ts_as.expression, offset, line_offsets)
+            let start = offset + ts_as.span.start as usize;
+            let end = offset + ts_as.span.end as usize;
+            let inner =
+                convert_expression_for_program(arena, &ts_as.expression, offset, line_offsets);
+            let type_annotation = convert_ts_type(&ts_as.type_annotation, offset, line_offsets);
+            Expression::from_node(JsNode::TSAsExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            })
         }
         OxcExpression::TSSatisfiesExpression(ts_satisfies) => {
-            convert_expression_for_program(arena, &ts_satisfies.expression, offset, line_offsets)
+            let start = offset + ts_satisfies.span.start as usize;
+            let end = offset + ts_satisfies.span.end as usize;
+            let inner = convert_expression_for_program(
+                arena,
+                &ts_satisfies.expression,
+                offset,
+                line_offsets,
+            );
+            let type_annotation =
+                convert_ts_type(&ts_satisfies.type_annotation, offset, line_offsets);
+            Expression::from_node(JsNode::TSSatisfiesExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            })
         }
         OxcExpression::TSNonNullExpression(ts_non_null) => {
-            convert_expression_for_program(arena, &ts_non_null.expression, offset, line_offsets)
+            let start = offset + ts_non_null.span.start as usize;
+            let end = offset + ts_non_null.span.end as usize;
+            let inner = convert_expression_for_program(
+                arena,
+                &ts_non_null.expression,
+                offset,
+                line_offsets,
+            );
+            Expression::from_node(JsNode::TSNonNullExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+            })
         }
+        // `<T>x` type assertions and `f<T>` instantiation expressions are still
+        // unwrapped (out of scope; rare in Svelte scripts).
         OxcExpression::TSTypeAssertion(ts_assertion) => {
             convert_expression_for_program(arena, &ts_assertion.expression, offset, line_offsets)
         }
@@ -10721,28 +10831,71 @@ fn convert_expression_with_adjustment(
                 line_offsets,
             )
         }
-        // TypeScript expression wrappers - unwrap and return the inner expression
-        OxcExpression::TSAsExpression(ts_as) => convert_expression_with_adjustment(
-            arena,
-            &ts_as.expression,
-            doc_offset,
-            prefix_len,
-            line_offsets,
-        ),
-        OxcExpression::TSSatisfiesExpression(ts_satisfies) => convert_expression_with_adjustment(
-            arena,
-            &ts_satisfies.expression,
-            doc_offset,
-            prefix_len,
-            line_offsets,
-        ),
-        OxcExpression::TSNonNullExpression(ts_non_null) => convert_expression_with_adjustment(
-            arena,
-            &ts_non_null.expression,
-            doc_offset,
-            prefix_len,
-            line_offsets,
-        ),
+        // TypeScript assertion wrappers - preserve the wrapper (Value shape) so
+        // binding-pattern defaults (`let { x = y as const } = …`) mirror
+        // svelte/compiler; the TS stripper erases them at compile time. The
+        // type-annotation base is `doc_offset - prefix_len` (same as the span math
+        // below), so `base + type_span = doc_offset + type_span - prefix_len`.
+        OxcExpression::TSAsExpression(ts_as) => {
+            let start = doc_offset + ts_as.span.start as usize - prefix_len;
+            let end = doc_offset + ts_as.span.end as usize - prefix_len;
+            let inner = convert_expression_with_adjustment(
+                arena,
+                &ts_as.expression,
+                doc_offset,
+                prefix_len,
+                line_offsets,
+            );
+            let type_annotation = convert_ts_type(
+                &ts_as.type_annotation,
+                doc_offset - prefix_len,
+                line_offsets,
+            );
+            ts_assertion_value(
+                "TSAsExpression",
+                start,
+                end,
+                inner,
+                Some(type_annotation),
+                line_offsets,
+            )
+        }
+        OxcExpression::TSSatisfiesExpression(ts_satisfies) => {
+            let start = doc_offset + ts_satisfies.span.start as usize - prefix_len;
+            let end = doc_offset + ts_satisfies.span.end as usize - prefix_len;
+            let inner = convert_expression_with_adjustment(
+                arena,
+                &ts_satisfies.expression,
+                doc_offset,
+                prefix_len,
+                line_offsets,
+            );
+            let type_annotation = convert_ts_type(
+                &ts_satisfies.type_annotation,
+                doc_offset - prefix_len,
+                line_offsets,
+            );
+            ts_assertion_value(
+                "TSSatisfiesExpression",
+                start,
+                end,
+                inner,
+                Some(type_annotation),
+                line_offsets,
+            )
+        }
+        OxcExpression::TSNonNullExpression(ts_non_null) => {
+            let start = doc_offset + ts_non_null.span.start as usize - prefix_len;
+            let end = doc_offset + ts_non_null.span.end as usize - prefix_len;
+            let inner = convert_expression_with_adjustment(
+                arena,
+                &ts_non_null.expression,
+                doc_offset,
+                prefix_len,
+                line_offsets,
+            );
+            ts_assertion_value("TSNonNullExpression", start, end, inner, None, line_offsets)
+        }
         OxcExpression::TSTypeAssertion(ts_assertion) => convert_expression_with_adjustment(
             arena,
             &ts_assertion.expression,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
@@ -417,11 +417,15 @@ fn visit_children(node: &mut JsonValue, path: &[&str]) -> Result<(), ParseError>
 //     etc. — falls back to `JsNode::Raw(Value)`. So for any `JsNode::Raw` we
 //     simply delegate to the existing Value mutator, which handles that whole
 //     subtree with the exact same semantics (including errors).
-//   * TS expression wrappers (`as`/`satisfies`/`!`/`<T>`/instantiation) are
-//     already unwrapped at parse time, and the typed enum has no
-//     `returnType`/`accessibility`/`readonly`/… fields, so there is nothing to
-//     strip there.
-//   * The only TS cases that CAN reach a typed node are: type-only
+//   * The `as`/`satisfies`/`!` assertion wrappers are PRESERVED at parse time
+//     (so `parse()` output mirrors svelte/compiler) and unwrapped here — the
+//     `TSAsExpression`/`TSSatisfiesExpression`/`TSNonNullExpression` arm below
+//     replaces each wrapper with its inner expression, mirroring upstream's
+//     `context.visit(node.expression)`. (`<T>x` type assertions and `f<T>`
+//     instantiation expressions are still unwrapped at parse time, so they never
+//     reach here.) The typed enum has no `returnType`/`accessibility`/`readonly`/…
+//     fields, so there is nothing else to strip.
+//   * The other TS cases that CAN reach a typed node are: type-only
 //     import/export (whole or per-specifier), `declare` variable declarations,
 //     `TSEnumDeclaration`, and `TSModuleDeclaration` (namespace) — handled
 //     structurally below.
@@ -577,6 +581,23 @@ pub fn remove_typescript_nodes_typed(
             remove_this_param_typed(node, arena);
         }
 
+        // Unwrap TS assertion wrappers (`x as T` / `x satisfies T` / `x!`),
+        // replacing the wrapper with its inner expression and continuing the
+        // strip into it. Mirrors upstream `context.visit(node.expression)`.
+        Some("TSAsExpression") | Some("TSSatisfiesExpression") | Some("TSNonNullExpression") => {
+            let inner_id = match node {
+                JsNode::TSAsExpression { expression, .. }
+                | JsNode::TSSatisfiesExpression { expression, .. }
+                | JsNode::TSNonNullExpression { expression, .. } => *expression,
+                _ => unreachable!("node_type matched a TS assertion variant"),
+            };
+            *node = arena.get_js_node(inner_id).clone();
+            return remove_typescript_nodes_typed(node, arena);
+        }
+
+        // Every node needing structural rewriting is handled above; the rest just
+        // recurse. The TS assertion wrappers can never fall through here — the
+        // arm above returns early for them.
         _ => {}
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
@@ -833,12 +833,24 @@ fn visit_typed_children(node: &mut JsNode, arena: &ParseArena) -> Result<(), Par
         JsNode::BinaryExpression { left, right, .. }
         | JsNode::LogicalExpression { left, right, .. }
         | JsNode::AssignmentExpression { left, right, .. }
-        | JsNode::AssignmentPattern { left, right, .. }
-        | JsNode::ForOfStatement { left, right, .. }
-        | JsNode::ForInStatement { left, right, .. } => {
+        | JsNode::AssignmentPattern { left, right, .. } => {
             let (l, r) = (*left, *right);
             rec_id!(l);
             rec_id!(r);
+        }
+        // `for (… of/in …) <body>` — the `body` MUST be recursed too, or a TS
+        // assertion in the loop body (e.g. `(x as T).p = …`) would leak past the
+        // strip into codegen.
+        JsNode::ForOfStatement {
+            left, right, body, ..
+        }
+        | JsNode::ForInStatement {
+            left, right, body, ..
+        } => {
+            let (l, r, b) = (*left, *right, *body);
+            rec_id!(l);
+            rec_id!(r);
+            rec_id!(b);
         }
         JsNode::UnaryExpression { argument, .. }
         | JsNode::UpdateExpression { argument, .. }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -3519,6 +3519,13 @@ fn js_node_check_features(
             type_annotation, ..
         } => walk_id!(*type_annotation),
         JsNode::TSModuleDeclaration { body, .. } => walk_opt_id!(body),
+        // Defensive: `remove_typescript_from_ast` unwraps these assertion
+        // wrappers before analyze runs, so they are never actually reached here.
+        // If one ever did, walk the inner expression (the `typeAnnotation` blob
+        // is opaque and carries no references).
+        JsNode::TSAsExpression { expression, .. }
+        | JsNode::TSSatisfiesExpression { expression, .. }
+        | JsNode::TSNonNullExpression { expression, .. } => walk_id!(*expression),
     }
 
     shadowed.truncate(shadow_base);
@@ -5438,6 +5445,32 @@ fn collect_identifier_names_in_node(
             loc: _,
             body: _,
         } => {}
+
+        // Defensive: `remove_typescript_from_ast` unwraps these assertion
+        // wrappers before analyze runs, so they are never actually reached here.
+        // If one ever did, the inner `expression` carries real identifier
+        // references, so walk it (the `typeAnnotation` blob is type-space and
+        // dropped).
+        JsNode::TSAsExpression {
+            start: _,
+            end: _,
+            loc: _,
+            expression,
+            type_annotation: _,
+        }
+        | JsNode::TSSatisfiesExpression {
+            start: _,
+            end: _,
+            loc: _,
+            expression,
+            type_annotation: _,
+        }
+        | JsNode::TSNonNullExpression {
+            start: _,
+            end: _,
+            loc: _,
+            expression,
+        } => walk(*expression, out),
 
         JsNode::Comment {
             start: _,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -1061,7 +1061,12 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             }
             // Bail on opaque Raw / Null / ClassExpression (bodies use separate
             // ClassBody member variants we do not reproduce here) and any other
-            // variant not explicitly handled above (the CRITICAL RULE).
+            // variant not explicitly handled above (the CRITICAL RULE). The TS
+            // assertion wrappers (`TSAsExpression` / `TSSatisfiesExpression` /
+            // `TSNonNullExpression`) are erased by `remove_typescript_nodes`
+            // before transform, so they never reach here; if one somehow did,
+            // `None` is the correct, safe answer — it falls back to the text
+            // printer rather than emitting wrong code.
             _ => None,
         }
     }

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -227,6 +227,11 @@ pub const JS_COMMENT: u8 = 0xC9;
 // `JS_RAW_JSON` escape; type annotations now ride a per-node trailer instead.)
 pub const JS_NULL: u8 = 0xCA;
 pub const JS_TS_PARAMETER_PROPERTY: u8 = 0xCC;
+// TS assertion wrappers preserved in the public `parse()` AST. As/Satisfies
+// carry a `typeAnnotation` trailer; NonNull does not.
+pub const JS_TS_AS_EXPRESSION: u8 = 0xCD;
+pub const JS_TS_SATISFIES_EXPRESSION: u8 = 0xCE;
+pub const JS_TS_NON_NULL_EXPRESSION: u8 = 0xCF;
 
 // LiteralValue inner tag (within a JS_LITERAL payload).
 const LV_NULL: u8 = 0;
@@ -2087,6 +2092,42 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             write_preamble(w, JS_COMMENT, *start, *end);
             write_str(w, comment_type.as_str());
             write_str(w, value.as_str());
+        }
+        // TS assertion wrappers. `expression` is a child node; As/Satisfies also
+        // carry a `typeAnnotation` JSON trailer (NonNull has none).
+        JsNode::TSAsExpression {
+            start,
+            end,
+            loc,
+            expression,
+            type_annotation,
+        } => {
+            write_preamble(w, JS_TS_AS_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_js_node(w, arena.get_js_node(*expression), arena)?;
+            write_opt_type_annotation(w, Some(type_annotation.as_ref()))?;
+        }
+        JsNode::TSSatisfiesExpression {
+            start,
+            end,
+            loc,
+            expression,
+            type_annotation,
+        } => {
+            write_preamble(w, JS_TS_SATISFIES_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_js_node(w, arena.get_js_node(*expression), arena)?;
+            write_opt_type_annotation(w, Some(type_annotation.as_ref()))?;
+        }
+        JsNode::TSNonNullExpression {
+            start,
+            end,
+            loc,
+            expression,
+        } => {
+            write_preamble(w, JS_TS_NON_NULL_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_js_node(w, arena.get_js_node(*expression), arena)?;
         }
         // `Null` doesn't carry positions, so it uses a dedicated sentinel tag
         // without the usual preamble pair.

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -3430,16 +3430,19 @@ fn handle_component(
                             inst_var
                         );
                     } else {
-                        let expr_text = get_expression_text(&bind.expression, source);
-                        // A trailing TS postfix on the bind expression
-                        // (`bind:this={consolePane as Pane}`) moves onto the RHS
-                        // instance var: `consolePane = $$_inst as Pane;` — same as
-                        // the element `bind:this` path (mirrors Binding.ts
-                        // appending `[end, expression.end]` after the assignment).
+                        // The assignment LHS strips a trailing TS assertion
+                        // (`getEnd`); a `bind:this={consolePane as Pane}` postfix
+                        // moves onto the RHS instance var:
+                        // `consolePane = $$_inst as Pane;` — same as the element
+                        // `bind:this` path (mirrors Binding.ts appending
+                        // `[getEnd, expression.end]` after the assignment).
+                        let expr_text = get_binding_lhs_text(&bind.expression, source);
                         let postfix = get_expression_range(&bind.expression)
                             .map(|(_, e)| {
+                                let ge = get_expression_end_stripping_ts(&bind.expression, source)
+                                    .unwrap_or(e);
                                 let ee = extend_expr_end_with_ts_postfix(source, e, bind.end);
-                                slice_src(source, e as usize, ee as usize)
+                                slice_src(source, ge as usize, ee as usize)
                             })
                             .unwrap_or("");
                         let _ = write!(out, "{} = {}{};", expr_text, inst_var, postfix);
@@ -3457,7 +3460,8 @@ fn handle_component(
                     let _ = write!(out, "{}.$$bindings = '{}';", inst_var, bind.name);
                     continue;
                 }
-                let expr_text = get_expression_text(&bind.expression, source);
+                // Setter type-widener: LHS strips a trailing TS assertion.
+                let expr_text = get_binding_lhs_text(&bind.expression, source);
                 let _ = write!(
                     out,
                     "/*\u{03A9}ignore_start\u{03A9}*/() => {} = __sveltets_2_any(null);/*\u{03A9}ignore_end\u{03A9}*/{}.$$bindings = '{}';",
@@ -4343,15 +4347,26 @@ fn handle_svelte_component(
         for attr in &comp.attributes {
             if let Attribute::BindDirective(bind) = attr {
                 if bind.name == "this" {
-                    let bexpr = get_expression_text(&bind.expression, source);
-                    let _ = write!(out, "{} = {};", bexpr, inst_var);
+                    // LHS strips a trailing TS assertion; a postfix moves onto the
+                    // RHS instance var (mirrors Binding.ts / the element path).
+                    let bexpr = get_binding_lhs_text(&bind.expression, source);
+                    let postfix = get_expression_range(&bind.expression)
+                        .map(|(_, e)| {
+                            let ge = get_expression_end_stripping_ts(&bind.expression, source)
+                                .unwrap_or(e);
+                            let ee = extend_expr_end_with_ts_postfix(source, e, bind.end);
+                            slice_src(source, ge as usize, ee as usize)
+                        })
+                        .unwrap_or("");
+                    let _ = write!(out, "{} = {}{};", bexpr, inst_var, postfix);
                     continue;
                 }
                 if get_set_binding_ranges(&bind.expression, source).is_some() {
                     let _ = write!(out, "{}.$$bindings = '{}';", inst_var, bind.name);
                     continue;
                 }
-                let bexpr = get_expression_text(&bind.expression, source);
+                // Setter type-widener: LHS strips a trailing TS assertion.
+                let bexpr = get_binding_lhs_text(&bind.expression, source);
                 let _ = write!(
                     out,
                     "/*\u{03A9}ignore_start\u{03A9}*/() => {} = __sveltets_2_any(null);/*\u{03A9}ignore_end\u{03A9}*/{}.$$bindings = '{}';",
@@ -6205,6 +6220,110 @@ fn format_spread_attribute_segments(spread: &SpreadAttribute, source: &str) -> O
     Some(out)
 }
 
+/// Mirror upstream svelte2tsx `getEnd` (`htmlxtojsx_v2/utils/node-utils.ts`):
+/// for a TS assertion expression (`x as T` / `x satisfies T` / `x!`) return the
+/// end offset of the INNER expression (stripping the assertion); otherwise the
+/// expression's own end. Used for binding assignment LHSs, which must not carry
+/// the assertion (`() => (value as never) = …` → `() => (value = …)`).
+///
+/// The parser now preserves the assertion wrapper in the binding expression, but
+/// the svelte2tsx parse path does not resolve arena children (`as_json()` is
+/// empty), so — like [`extend_expr_end_with_ts_postfix`] — the inner end is
+/// found by scanning the expression's source span rather than the arena.
+fn get_expression_end_stripping_ts(expr: &crate::ast::js::Expression, source: &str) -> Option<u32> {
+    let (start, end) = get_expression_range(expr)?;
+    let ty = expr.node_type()?;
+    if !matches!(
+        ty,
+        "TSAsExpression" | "TSSatisfiesExpression" | "TSNonNullExpression"
+    ) {
+        return Some(end);
+    }
+    let bytes = source.as_bytes();
+    let (s, e) = (start as usize, end as usize);
+    if e > source.len() || s >= e {
+        return Some(end);
+    }
+    if ty == "TSNonNullExpression" {
+        // Strip the trailing `!` (and any surrounding whitespace).
+        let mut i = e;
+        while i > s && bytes[i - 1].is_ascii_whitespace() {
+            i -= 1;
+        }
+        if i > s && bytes[i - 1] == b'!' {
+            i -= 1;
+        }
+        while i > s && bytes[i - 1].is_ascii_whitespace() {
+            i -= 1;
+        }
+        return Some(i as u32);
+    }
+    // `x as T` / `x satisfies T`: find the outermost (last top-level) ` as ` /
+    // ` satisfies ` keyword; the inner expression ends just before it.
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'$';
+    let mut depth: i32 = 0;
+    let mut string: Option<u8> = None;
+    let mut op_ws: Option<usize> = None; // index of the whitespace preceding the keyword
+    let mut i = s;
+    while i < e {
+        let c = bytes[i];
+        if let Some(q) = string {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == q {
+                string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\'' | b'"' | b'`' => string = Some(c),
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            _ if depth == 0 && c.is_ascii_whitespace() => {
+                let mut j = i;
+                while j < e && bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                for (kw, kwlen) in [("as", 2usize), ("satisfies", 9usize)] {
+                    if j + kwlen <= e
+                        && &source[j..j + kwlen] == kw
+                        && (j + kwlen == e || !is_ident(bytes[j + kwlen]))
+                    {
+                        op_ws = Some(i);
+                    }
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    match op_ws {
+        Some(p) => {
+            let mut ie = p;
+            while ie > s && bytes[ie - 1].is_ascii_whitespace() {
+                ie -= 1;
+            }
+            Some(ie as u32)
+        }
+        None => Some(end),
+    }
+}
+
+/// Source text of a binding assignment LHS: the expression with any trailing TS
+/// assertion stripped (mirrors `[expr.start, getEnd(expr)]` upstream).
+fn get_binding_lhs_text<'a>(expr: &crate::ast::js::Expression, source: &'a str) -> &'a str {
+    match (
+        get_expression_range(expr),
+        get_expression_end_stripping_ts(expr, source),
+    ) {
+        (Some((start, _)), Some(ge)) => slice_src(source, start as usize, ge as usize),
+        _ => get_expression_text(expr, source),
+    }
+}
+
 /// Extend an expression's end to cover a trailing TS postfix (`as T`,
 /// `satisfies T`, `!`) that the parser narrowed out of the expression span.
 /// `scan_end` is the enclosing `{…}` directive/attribute end; the closing `}`
@@ -6557,17 +6676,21 @@ fn bind_directive_suffix_seg(
             }
             return out;
         }
-        let expr_text = get_expression_text(&bind.expression, source);
+        // Every branch here emits `expr` as an assignment LHS, so a trailing TS
+        // assertion must be stripped (mirrors upstream `getEnd(attr.expression)`).
+        let expr_text = get_binding_lhs_text(&bind.expression, source);
         if bind.name == "this" {
             if let Some(var) = element_var {
                 // A trailing TS postfix on the bind expression
                 // (`bind:this={el as HTMLElement}`) moves onto the RHS var:
                 // `el = $$_var as HTMLElement;` (mirrors Binding.ts appending
-                // `[end, expression.end]` after the assignment).
+                // `[getEnd, expression.end]` after the assignment).
                 let postfix = get_expression_range(&bind.expression)
                     .map(|(_, e)| {
+                        let ge =
+                            get_expression_end_stripping_ts(&bind.expression, source).unwrap_or(e);
                         let ee = extend_expr_end_with_ts_postfix(source, e, bind.end);
-                        slice_src(source, e as usize, ee as usize)
+                        slice_src(source, ge as usize, ee as usize)
                     })
                     .unwrap_or("");
                 let _ = write!(out, "{} = {}{};", expr_text, var, postfix);

--- a/crates/rsvelte_core/tests/arrow_param_spans.rs
+++ b/crates/rsvelte_core/tests/arrow_param_spans.rs
@@ -1,0 +1,66 @@
+//! Arrow-function parameters inside template expressions (event handlers) must
+//! carry their real source spans in the public `parse()` AST, matching
+//! svelte/compiler. The fast-path template arrow parser previously stubbed them
+//! to `start == end == 0`.
+
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{ParseOptions, parse};
+use serde_json::Value;
+
+fn first_arrow_params(source: &str) -> Vec<Value> {
+    let ast = parse(source, ParseOptions::default()).expect("parse should succeed");
+    let value = with_serialize_arena(&ast.arena, || serde_json::to_value(&ast).unwrap());
+
+    fn find(v: &Value) -> Option<&Value> {
+        match v {
+            Value::Object(m) => {
+                if m.get("type").and_then(|t| t.as_str()) == Some("ArrowFunctionExpression") {
+                    return Some(v);
+                }
+                m.values().find_map(find)
+            }
+            Value::Array(a) => a.iter().find_map(find),
+            _ => None,
+        }
+    }
+    let arrow = find(&value).expect("arrow function present");
+    arrow
+        .get("params")
+        .and_then(|p| p.as_array())
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn assert_span(source: &str, node: &Value, expected: &str) {
+    let start = node.get("start").and_then(|s| s.as_u64()).unwrap() as usize;
+    let end = node.get("end").and_then(|e| e.as_u64()).unwrap() as usize;
+    assert!(start < end, "expected non-empty span, got {start}..{end}");
+    assert_eq!(&source[start..end], expected);
+    assert!(node.get("loc").is_some(), "param should carry a loc");
+}
+
+#[test]
+fn multi_param_event_handler_spans() {
+    let source = "<button onclick={(color, e) => handle(color, e)}>x</button>";
+    let params = first_arrow_params(source);
+    assert_eq!(params.len(), 2);
+    assert_span(source, &params[0], "color");
+    assert_span(source, &params[1], "e");
+}
+
+#[test]
+fn single_param_event_handler_span() {
+    let source = "<button onclick={(a) => a}>x</button>";
+    let params = first_arrow_params(source);
+    assert_eq!(params.len(), 1);
+    assert_span(source, &params[0], "a");
+}
+
+#[test]
+fn on_directive_event_handler_spans() {
+    let source = "<button on:click={(color, e) => handle(color, e)}>x</button>";
+    let params = first_arrow_params(source);
+    assert_eq!(params.len(), 2);
+    assert_span(source, &params[0], "color");
+    assert_span(source, &params[1], "e");
+}

--- a/crates/rsvelte_core/tests/each_block_as_const.rs
+++ b/crates/rsvelte_core/tests/each_block_as_const.rs
@@ -30,18 +30,41 @@ fn each_block_with_as_const_alias() {
     // The TypeScript `as const` is part of the iterable expression; the alias
     // is `tab`. Prior to the fix the parser split at the first ` as ` and
     // produced `context = (const as tab)`.
+    //
+    // The iterable `['a', 'b'] as const` is now preserved as a `TSAsExpression`
+    // (mirroring svelte/compiler's parse AST), so its `typeAnnotation` carries a
+    // `TSTypeReference` to `const` — i.e. `"name":"const"` legitimately appears
+    // inside the iterable and can no longer be used as a proxy. Assert the
+    // each-block CONTEXT (the alias) directly instead.
     let src = r#"{#each ['a', 'b'] as const as tab (tab)}<span>{tab}</span>{/each}"#;
     let out = compile_each_alias(src);
-    // Alias appears as `"name":"tab"` in the AST output.
-    assert!(
-        out.contains(r#""name":"tab""#),
-        "alias should be `tab`, got:\n{out}"
+    let value: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+
+    fn find_each(v: &serde_json::Value) -> Option<&serde_json::Value> {
+        match v {
+            serde_json::Value::Object(m) => {
+                if m.get("type").and_then(|t| t.as_str()) == Some("EachBlock") {
+                    return Some(v);
+                }
+                m.values().find_map(find_each)
+            }
+            serde_json::Value::Array(a) => a.iter().find_map(find_each),
+            _ => None,
+        }
+    }
+    let each = find_each(&value).expect("EachBlock present");
+    // The alias (`context`) is the identifier `tab`, not `const`.
+    assert_eq!(
+        each.pointer("/context/name").and_then(|n| n.as_str()),
+        Some("tab"),
+        "each-block alias should be `tab`:\n{out}"
     );
-    // The stray `const` should NOT appear as an identifier — it would mean
-    // the alias was parsed as `const as tab`.
-    assert!(
-        !out.contains(r#""name":"const""#),
-        "`const` should not be parsed as an alias identifier:\n{out}"
+    // The iterable expression is preserved as a `TSAsExpression` (greedy parse
+    // to the right-most ` as `).
+    assert_eq!(
+        each.pointer("/expression/type").and_then(|t| t.as_str()),
+        Some("TSAsExpression"),
+        "iterable should be preserved as TSAsExpression:\n{out}"
     );
 }
 

--- a/crates/rsvelte_core/tests/svelte2tsx_binding_ts_assertion.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_binding_ts_assertion.rs
@@ -1,0 +1,112 @@
+//! Regression: a `bind:` expression carrying a TS assertion (`bind:value={value
+//! as never}`, `bind:this={el as HTMLElement}`, `bind:value={x!}`) must strip the
+//! assertion from the generated assignment LHS — mirroring upstream svelte2tsx's
+//! `getEnd(attr.expression)` — while KEEPING it on the prop/attribute value side.
+//!
+//! The parser now preserves the assertion wrapper in the binding expression
+//! (it used to unwrap it at parse time), so the svelte2tsx port must reproduce
+//! upstream's split explicitly.
+
+use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "T.svelte".to_string(),
+        is_ts_file: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+#[test]
+fn element_binding_as_expression_strips_assertion_from_setter() {
+    let out = to_tsx(
+        "<script lang=\"ts\">let value: string[] = [];</script>\
+         <input bind:value={value as never} />",
+    );
+    // Setter type-widener uses the inner expression (assertion stripped).
+    assert!(
+        out.contains("() => value = __sveltets_2_any(null)"),
+        "setter should strip the `as never`:\n{out}"
+    );
+    assert!(
+        !out.contains("() => value as never = __sveltets_2_any(null)"),
+        "assertion leaked into the setter LHS:\n{out}"
+    );
+    // The bound value side KEEPS the assertion (for type-checking).
+    assert!(
+        out.contains("\"bind:value\":value as never"),
+        "value side should keep the `as never`:\n{out}"
+    );
+}
+
+#[test]
+fn component_binding_as_expression_strips_assertion_from_setter() {
+    let out = to_tsx(
+        "<script lang=\"ts\">import C from './C.svelte'; let value = '';</script>\
+         <C bind:value={value as never} />",
+    );
+    assert!(
+        out.contains("() => value = __sveltets_2_any(null)"),
+        "component setter should strip the `as never`:\n{out}"
+    );
+    assert!(
+        out.contains("value:value as never"),
+        "component prop value should keep the `as never`:\n{out}"
+    );
+}
+
+#[test]
+fn bind_this_as_expression_moves_assertion_to_rhs() {
+    let out = to_tsx(
+        "<script lang=\"ts\">let el;</script>\
+         <div bind:this={el as HTMLDivElement}></div>",
+    );
+    // Upstream: `el = $$_var as HTMLDivElement;` — LHS stripped, cast on the RHS.
+    assert!(
+        out.contains(" as HTMLDivElement;"),
+        "bind:this cast should move onto the RHS:\n{out}"
+    );
+    assert!(
+        !out.contains("el as HTMLDivElement ="),
+        "bind:this LHS must not carry the cast:\n{out}"
+    );
+}
+
+#[test]
+fn binding_non_null_and_satisfies_strip_from_setter() {
+    let non_null =
+        to_tsx("<script lang=\"ts\">let value = 0;</script><input bind:value={value!} />");
+    assert!(
+        non_null.contains("() => value = __sveltets_2_any(null)"),
+        "`!` should be stripped from the setter:\n{non_null}"
+    );
+    assert!(
+        non_null.contains("\"bind:value\":value!"),
+        "`!` should be kept on the value side:\n{non_null}"
+    );
+
+    let satisfies = to_tsx(
+        "<script lang=\"ts\">let value = 0;</script>\
+         <input bind:value={value satisfies number} />",
+    );
+    assert!(
+        satisfies.contains("() => value = __sveltets_2_any(null)"),
+        "`satisfies` should be stripped from the setter:\n{satisfies}"
+    );
+}
+
+#[test]
+fn nested_assertion_only_outermost_is_stripped() {
+    // `(without as { foo: number }).foo as number`: the outer `as number` is
+    // stripped from the setter LHS; the inner `as { foo: number }` (inside the
+    // member object) stays.
+    let out = to_tsx(
+        "<script lang=\"ts\">let without = { foo: 2 };</script>\
+         <input bind:value={(without as { foo: number }).foo as number} />",
+    );
+    assert!(
+        out.contains("() => (without as { foo: number }).foo = __sveltets_2_any(null)"),
+        "only the outermost assertion should be stripped:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/ts_assertion_expressions.rs
+++ b/crates/rsvelte_core/tests/ts_assertion_expressions.rs
@@ -181,3 +181,30 @@ fn satisfies_and_non_null_are_erased_at_codegen() {
         );
     }
 }
+
+/// Regression: a TS assertion nested in a `for…of` / `for…in` loop body (a child
+/// position `visit_typed_children` previously did not recurse into) must still be
+/// stripped — otherwise codegen emits an `/* Unknown: TSAsExpression */` stub.
+#[test]
+fn as_cast_inside_for_of_body_is_erased() {
+    let source = "<script lang=\"ts\"></script>\
+        <button onclick={(e) => {\n\
+        \tfor (const el of document.querySelectorAll('x')) {\n\
+        \t\t(el as HTMLDetailsElement).open = false;\n\
+        \t}\n\
+        \tfor (const k in e) {\n\
+        \t\tconsole.log((k as string).length);\n\
+        \t}\n\
+        }}>x</button>";
+
+    for code in [ssr_code(source), client_code(source)] {
+        assert!(
+            !code.contains("Unknown: TS"),
+            "TS assertion leaked into codegen output:\n{code}"
+        );
+        assert!(
+            !code.contains(" as HTMLDetailsElement"),
+            "`as` cast leaked into codegen output:\n{code}"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/ts_assertion_expressions.rs
+++ b/crates/rsvelte_core/tests/ts_assertion_expressions.rs
@@ -1,0 +1,183 @@
+//! TS assertion expression wrappers (`x as T`, `x satisfies T`, `x!`) must be
+//! preserved in the public `parse()` AST (mirroring svelte/compiler, which keeps
+//! them), and erased at compile time so codegen is unaffected.
+//!
+//! There is no upstream Svelte fixture that exercises these in `parse()` output,
+//! so these are direct shape/span assertions rather than fixture comparisons.
+
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{CompileOptions, GenerateMode, ParseOptions, compile, parse};
+use serde_json::Value;
+
+fn parse_to_value(source: &str) -> Value {
+    let ast = parse(source, ParseOptions::default()).expect("parse should succeed");
+    with_serialize_arena(&ast.arena, || serde_json::to_value(&ast).unwrap())
+}
+
+/// Depth-first search for the first node whose `type` equals `ty`.
+fn find_node<'a>(v: &'a Value, ty: &str) -> Option<&'a Value> {
+    match v {
+        Value::Object(map) => {
+            if map.get("type").and_then(|t| t.as_str()) == Some(ty) {
+                return Some(v);
+            }
+            for (_, child) in map {
+                if let Some(found) = find_node(child, ty) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Array(arr) => arr.iter().find_map(|c| find_node(c, ty)),
+        _ => None,
+    }
+}
+
+fn span_text<'a>(source: &'a str, node: &Value) -> &'a str {
+    let start = node.get("start").and_then(|s| s.as_u64()).unwrap() as usize;
+    let end = node.get("end").and_then(|e| e.as_u64()).unwrap() as usize;
+    &source[start..end]
+}
+
+// ── parse-shape: script declarator init ────────────────────────────────────
+
+#[test]
+fn as_const_in_script_declarator_init_preserves_wrapper() {
+    let source = "<script lang=\"ts\">const x = 'chips' as const;</script>";
+    let value = parse_to_value(source);
+
+    let as_expr = find_node(&value, "TSAsExpression").expect("TSAsExpression preserved in script");
+    // The inner `expression` is the string literal.
+    let inner = as_expr.get("expression").expect("expression child");
+    assert_eq!(inner.get("type").and_then(|t| t.as_str()), Some("Literal"));
+    assert_eq!(inner.get("value").and_then(|v| v.as_str()), Some("chips"));
+    // Wrapper span covers the whole `'chips' as const`.
+    assert_eq!(span_text(source, as_expr), "'chips' as const");
+    // typeAnnotation is the type node directly (not wrapped in TSTypeAnnotation).
+    let ta = as_expr
+        .get("typeAnnotation")
+        .expect("typeAnnotation present");
+    assert_eq!(
+        ta.get("type").and_then(|t| t.as_str()),
+        Some("TSTypeReference")
+    );
+    assert_eq!(span_text(source, ta), "const");
+}
+
+// ── parse-shape: template expression tag ───────────────────────────────────
+
+#[test]
+fn as_const_in_template_expression_tag_preserves_wrapper() {
+    let source = "<script lang=\"ts\"></script>{'chips' as const}";
+    let value = parse_to_value(source);
+
+    let as_expr =
+        find_node(&value, "TSAsExpression").expect("TSAsExpression preserved in template");
+    assert_eq!(span_text(source, as_expr), "'chips' as const");
+    let inner = as_expr.get("expression").expect("expression child");
+    assert_eq!(inner.get("value").and_then(|v| v.as_str()), Some("chips"));
+    // Inner literal span is correct within the template (no synthetic-paren drift).
+    assert_eq!(span_text(source, inner), "'chips'");
+}
+
+// ── parse-shape: attribute value ───────────────────────────────────────────
+
+#[test]
+fn as_const_in_attribute_value_preserves_wrapper() {
+    let source = "<script lang=\"ts\"></script><input value={'chips' as const} />";
+    let value = parse_to_value(source);
+
+    let as_expr =
+        find_node(&value, "TSAsExpression").expect("TSAsExpression preserved in attribute");
+    assert_eq!(span_text(source, as_expr), "'chips' as const");
+}
+
+// ── parse-shape: satisfies + non-null ──────────────────────────────────────
+
+#[test]
+fn satisfies_expression_preserves_wrapper() {
+    let source = "<script lang=\"ts\">const x = foo satisfies Bar;</script>";
+    let value = parse_to_value(source);
+
+    let node = find_node(&value, "TSSatisfiesExpression").expect("TSSatisfiesExpression preserved");
+    assert_eq!(span_text(source, node), "foo satisfies Bar");
+    let inner = node.get("expression").expect("expression child");
+    assert_eq!(
+        inner.get("type").and_then(|t| t.as_str()),
+        Some("Identifier")
+    );
+    assert_eq!(inner.get("name").and_then(|n| n.as_str()), Some("foo"));
+    let ta = node.get("typeAnnotation").expect("typeAnnotation present");
+    assert_eq!(span_text(source, ta), "Bar");
+}
+
+#[test]
+fn non_null_expression_preserves_wrapper_without_type_annotation() {
+    let source = "<script lang=\"ts\">const x = foo!;</script>";
+    let value = parse_to_value(source);
+
+    let node = find_node(&value, "TSNonNullExpression").expect("TSNonNullExpression preserved");
+    assert_eq!(span_text(source, node), "foo!");
+    let inner = node.get("expression").expect("expression child");
+    assert_eq!(inner.get("name").and_then(|n| n.as_str()), Some("foo"));
+    // NonNull has no typeAnnotation.
+    assert!(node.get("typeAnnotation").is_none());
+}
+
+// ── codegen erasure: SSR + client output must compile and erase the assertion ─
+
+fn ssr_code(source: &str) -> String {
+    let opts = CompileOptions {
+        generate: GenerateMode::Server,
+        ..CompileOptions::default()
+    };
+    compile(source, opts)
+        .expect("SSR compile should succeed")
+        .js
+        .code
+}
+
+fn client_code(source: &str) -> String {
+    let opts = CompileOptions {
+        generate: GenerateMode::Client,
+        ..CompileOptions::default()
+    };
+    compile(source, opts)
+        .expect("client compile should succeed")
+        .js
+        .code
+}
+
+#[test]
+fn as_const_is_erased_at_codegen() {
+    let source = "<script lang=\"ts\">const x = 'chips' as const;</script>{x} {'fish' as const}";
+
+    for code in [ssr_code(source), client_code(source)] {
+        // The assertion keyword must not survive into generated JS.
+        assert!(
+            !code.contains(" as const"),
+            "`as const` leaked into codegen output:\n{code}"
+        );
+        // The runtime values still appear.
+        assert!(
+            code.contains("chips"),
+            "value 'chips' missing from output:\n{code}"
+        );
+        assert!(
+            code.contains("fish"),
+            "value 'fish' missing from output:\n{code}"
+        );
+    }
+}
+
+#[test]
+fn satisfies_and_non_null_are_erased_at_codegen() {
+    let source = "<script lang=\"ts\">let a = 1; const b = (a satisfies number) + a!;</script>{b}";
+
+    for code in [ssr_code(source), client_code(source)] {
+        assert!(
+            !code.contains("satisfies"),
+            "`satisfies` leaked into codegen output:\n{code}"
+        );
+    }
+}

--- a/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
+++ b/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
@@ -203,11 +203,24 @@ fn in_function(ancestors: &[&Value]) -> bool {
     })
 }
 
-/// Whether the ancestor chain places the node inside a TS type annotation.
+/// Whether the ancestor chain places the node inside a TS *type* annotation.
+///
+/// `TSAsExpression` / `TSSatisfiesExpression` / `TSNonNullExpression` are
+/// value-space assertion wrappers (`x as T`, `x satisfies T`, `x!`) whose
+/// `expression` child is a real value reference — they must NOT count as a type
+/// annotation, or a browser global like the `window` in `(window as any)` would
+/// be silently skipped. Only genuine type-space `TS*` nodes (the `typeAnnotation`
+/// side, e.g. `TSTypeReference`) do.
 fn in_type_annotation(ancestors: &[&Value]) -> bool {
-    ancestors
-        .iter()
-        .any(|n| node_type(n).is_some_and(|t| t.starts_with("TS")))
+    ancestors.iter().any(|n| {
+        node_type(n).is_some_and(|t| {
+            t.starts_with("TS")
+                && !matches!(
+                    t,
+                    "TSAsExpression" | "TSSatisfiesExpression" | "TSNonNullExpression"
+                )
+        })
+    })
 }
 
 /// Whether all execution paths of a statement end in a jump

--- a/crates/rsvelte_lint/tests/browser_globals_ts_assertion.rs
+++ b/crates/rsvelte_lint/tests/browser_globals_ts_assertion.rs
@@ -1,0 +1,68 @@
+//! Regression: `svelte/no-top-level-browser-globals` must still flag a browser
+//! global that is wrapped in a TS assertion expression (`(window as any)`,
+//! `document.dir as X`). Preserving those wrappers in `parse()` output made the
+//! rule's `in_type_annotation` guard (a blanket `startsWith("TS")`) skip the
+//! value-space operand; the guard now excludes the assertion wrappers.
+
+use rsvelte_lint::line_index::LineIndex;
+use rsvelte_lint::{LintConfig, Severity, lint_source_raw};
+use std::path::Path;
+
+const RULE: &str = "svelte/no-top-level-browser-globals";
+
+/// Return `(line, column1based)` for every finding of the rule.
+fn findings(source: &str) -> Vec<(u32, u32)> {
+    let cfg = LintConfig::empty().with_override(RULE, Severity::Warn);
+    let li = LineIndex::new(source);
+    let mut out: Vec<(u32, u32)> = lint_source_raw(source, Path::new("Comp.svelte"), &cfg)
+        .into_iter()
+        .filter(|d| d.rule == RULE)
+        .map(|d| {
+            let (line, col) = li.position(d.start);
+            (line, col + 1)
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn window_wrapped_in_as_and_non_null_is_flagged() {
+    // Mirrors eslint-plugin-svelte no-add-event-listener/invalid/typescript01.
+    let src = "<script lang=\"ts\">\n\
+        \tconst handler = (ev: Event) => {\n\
+        \t\tconsole.log(ev);\n\
+        \t};\n\
+        \n\
+        \t(window as any).addEventListener('message', handler);\n\
+        \t(window.addEventListener as any)('message', handler);\n\
+        </script>\n\
+        \n\
+        <div>Hello</div>";
+    // Upstream reports `window` at 6:3 and 7:3.
+    assert_eq!(findings(src), vec![(6, 3), (7, 3)]);
+}
+
+#[test]
+fn document_wrapped_in_as_is_flagged() {
+    // Mirrors flowbite-svelte ExampleRTL.svelte: `document.dir as X`.
+    let src = "<script lang=\"ts\">\n\
+        \ttype Dir = \"ltr\" | \"rtl\";\n\
+        \tlet dir: Dir = \"ltr\";\n\
+        \tif (document.dir) {\n\
+        \t\tdir = document.dir as Dir;\n\
+        \t}\n\
+        </script>";
+    // Both `document` reads flagged: the plain one (4:6) and the `as`-wrapped one (5:9).
+    assert_eq!(findings(src), vec![(4, 6), (5, 9)]);
+}
+
+#[test]
+fn identifier_inside_a_real_type_annotation_is_still_skipped() {
+    // A browser-global *name* used as a type (not a value) must stay unflagged —
+    // the `in_type_annotation` guard still fires for genuine `TS*` type nodes.
+    let src = "<script lang=\"ts\">\n\
+        \tlet x: window.Foo;\n\
+        </script>";
+    assert_eq!(findings(src), Vec::<(u32, u32)>::new());
+}


### PR DESCRIPTION
## What

Fixes #1645. `parse()` now preserves `TSAsExpression`, `TSSatisfiesExpression`, and `TSNonNullExpression` nodes with svelte/compiler-compatible shape (node type, `expression` / `typeAnnotation` children, real spans), in all three conversion contexts (script declarators, template expression tags, pattern defaults). `compile()` behavior is unchanged: the wrappers are erased by `remove_typescript_nodes` before analyze/transform, exactly like upstream (which strips only inside `compile()`, never in `parse()`).

Also fixes zero-width spans (`start:0,end:0`) on untyped arrow-function parameters from the fast-path template arrow parser — real spans are now assigned, matching svelte/compiler; non-trivial parameter shapes (defaults, destructuring, rest) already fell back to the slow path and keep doing so.

## Why

The parse-time unwrap made `parse()` output diverge from svelte/compiler and broke downstream AST consumers: svelte-shaker's parser-parity contract (svelte-shaker#150) produced different shake results depending on the parser backend.

## Verification

- Parse output structurally identical to installed svelte 5.56 for the three node types across script/template/attribute contexts, including nested `('a' as const)!` and `fn!()` (checked independently in review with an order-independent structural differ, matching the repo's own fixture-comparison semantics)
- Codegen erasure proven by test: `as const` / `satisfies` / `!` never leak into SSR or client output while runtime values survive; a 4-deep nested chain erases fully
- Binary envelope round-trip (Rust encode → JS decode) verified for all three node types; new tags 0xCD/0xCE/0xCF collision-checked against the full tag table
- New suites: `ts_assertion_expressions` (7), `arrow_param_spans` (3); `each_block_as_const` updated with a structural assertion (svelte itself rejects `as const` in each headers — the test pins rsvelte's intentional lenient parse)
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the parser/ssr/compiler/svelte2tsx fixture suites all clean; full workspace run clean apart from a pre-existing debug-profile stack-size artifact in the legacy runtime suite (passes with `RUST_MIN_STACK`, unrelated to this diff)

Deliberately out of scope (pre-existing unwraps, inline-commented): `TSTypeAssertion` (`<T>x`), `TSInstantiationExpression` (`f<T>`), and `!` inside optional chains — follow-up issues to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZP7b71mxqFV7uqAxV2ca1