### PR TITLE
test(fmt): fix flaky cli tests (tempdir collision)

### DIFF
--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -1852,15 +1852,25 @@ fn sort_tailwindcss_custom_config_warns_and_skips() {
 }
 
 fn tempdir() -> PathBuf {
+    // PID + timestamp alone can collide: libtest runs this file's tests on a
+    // shared thread pool, so many threads call this within the same PID at
+    // near-identical instants, and some hosts' clocks don't resolve down to a
+    // true unique nanosecond under that load. `create_dir_all` masks a
+    // collision (it happily "succeeds" on an existing dir), so two tests would
+    // silently share one directory and stomp each other's files. The atomic
+    // counter makes each call unique regardless of clock resolution.
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let mut dir = std::env::temp_dir();
     dir.push(format!(
-        "rsvelte_fmt_test_{}_{}",
+        "rsvelte_fmt_test_{}_{}_{}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos(),
+        seq,
     ));
-    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::create_dir(&dir).unwrap_or_else(|e| panic!("tempdir collision at {dir:?}: {e}"));
     dir
 }


### PR DESCRIPTION
Fixes #1638

## Root cause

The shared `tempdir()` helper in `crates/rsvelte_fmt/tests/cli.rs` derived
uniqueness only from PID + a nanosecond timestamp, with no counter or
randomness. All tests in this integration binary share one PID, and libtest
runs them concurrently on a thread pool — so on hosts with coarser clock
resolution (or under load), two threads can call `tempdir()` at the same
observed nanosecond.

`create_dir_all()` made this silent: it "succeeds" even when the directory
already exists, so two colliding tests quietly shared one temp directory and
raced on each other's files (writing/reading `.svelte` files, the fake
`oxfmt` package, `.oxfmtrc.json`, etc.). That explains why the visibly flaky
tests were the ones doing the most multi-file/directory-walk work —
`daemon_formats_inline_style` and `check_excludes_svelte_via_oxfmtrc_ignore_patterns`
— though in principle any test using `tempdir()` was exposed to the same race.

## Fix

- Add a process-wide `AtomicU64` counter mixed into the generated path, so
  each `tempdir()` call is unique regardless of clock resolution.
- Switch `create_dir_all()` → `create_dir()` so any future collision panics
  loudly instead of silently reusing a shared directory.

The daemon socket-connect logic (`crates/rsvelte_fmt/src/daemon.rs`) was
reviewed too: its socket path is a hash of the oxfmt fingerprint (which
includes the oxfmt binary's path under the test's tempdir), so a tempdir
collision was also capable of causing two concurrent test processes to
target the same daemon socket. With `tempdir()` now collision-proof, this
is no longer reachable; the existing spawn/connect/poll logic (5s timeout,
10ms poll, EADDRINUSE handling) needed no changes.

Test-infra only — no changeset added.

## Verification

- `cargo fmt` / `cargo clippy -p rsvelte_fmt --all-targets --all-features -- -D warnings`: clean
- `cargo test -p rsvelte_fmt --test cli`: 10 consecutive runs, all green (48/48 each run)
- `cargo test -p rsvelte_fmt` (whole crate, all test binaries): 10 consecutive runs, all green
- Stress test: 4 concurrent `cli` test binary processes, each running
  `daemon_formats_inline_style` + `check_excludes_svelte_via_oxfmtrc_ignore_patterns`
  with `--test-threads=8`, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XHPUBHj4ywFM8skv4GwxV