### PR TITLE
fix(fmt): exit code mismatch with oxfmt when no files match

### DIFF
--- a/.changeset/fix-fmt-no-match-exit-code.md
+++ b/.changeset/fix-fmt-no-match-exit-code.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): exit 2 with oxfmt's own message when no files match, instead of a false success
+
+`rsvelte-fmt` (e.g. run against an empty directory) now exits 2 with
+`Expected at least one target file. All matched files may have been excluded
+by ignore rules.` — the same exit code and message `oxfmt` gives when it
+finds nothing to format. Previously it printed a different message and
+exited 0, silently reporting success. `--check` behaves the same way.

--- a/.changeset/fix-fmt-no-match-exit-code.md
+++ b/.changeset/fix-fmt-no-match-exit-code.md
@@ -4,8 +4,10 @@
 
 fix(fmt): exit 2 with oxfmt's own message when no files match, instead of a false success
 
-`rsvelte-fmt` (e.g. run against an empty directory) now exits 2 with
-`Expected at least one target file. All matched files may have been excluded
-by ignore rules.` — the same exit code and message `oxfmt` gives when it
-finds nothing to format. Previously it printed a different message and
-exited 0, silently reporting success. `--check` behaves the same way.
+`rsvelte-fmt` now exits 2 with `Expected at least one target file. All
+matched files may have been excluded by ignore rules.` — the same exit code
+and message `oxfmt` gives when it finds nothing to format. This covers a
+genuinely empty directory as well as a tree whose only files are excluded by
+`.gitignore`/`.prettierignore` or don't match any supported extension.
+Previously these cases printed a different message and exited 0, silently
+reporting success. `--check` behaves the same way.

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -343,8 +343,21 @@ fn run() -> Result<ExitCode> {
     let native_js = !cli.no_native_js;
     let native_css = !cli.no_native_css;
     let ignore = oxfmt_ignore::SvelteIgnore::from_config(&cwd, &cfg)?;
-    let (svelte, native, native_json, native_css_files, oxfmt_paths) =
+    let (svelte, native, native_json, native_css_files, oxfmt_paths, saw_any_file) =
         partition_files(&cli.paths, &ignore, &cwd, native_js, native_css)?;
+
+    // Nothing exists under any given path — not even for `oxfmt`'s own
+    // delegated share, so there is nothing to run. Match oxfmt's own
+    // unsuppressed "no target file" error/exit code instead of running
+    // `oxfmt` with our always-on `--no-error-on-unmatched-pattern` (needed so
+    // a Svelte-only or CSS-only tree is a legitimate no-op for it) and
+    // reporting a false success (#1636).
+    if !saw_any_file {
+        eprintln!(
+            "Expected at least one target file. All matched files may have been excluded by ignore rules."
+        );
+        return Ok(ExitCode::from(2));
+    }
 
     let mode = if cli.check { Mode::Check } else { Mode::Write };
 
@@ -861,12 +874,18 @@ fn partition_files(
     Vec<PathBuf>,
     Vec<PathBuf>,
     Vec<PathBuf>,
+    bool,
 )> {
     let mut svelte = Vec::new();
     let mut native = Vec::new();
     let mut native_json = Vec::new();
     let mut native_css_files = Vec::new();
     let mut oxfmt_paths = Vec::new();
+    // Whether any real file was found under `roots` at all, independent of
+    // extension/category or ignore filtering — a directory that walks to zero
+    // file entries can never yield a target for `oxfmt` either, however it's
+    // invoked (see the no-match check in `run`, #1636).
+    let mut saw_any_file = false;
     for root in roots {
         let meta = std::fs::metadata(root)
             .with_context(|| format!("reading {} — no such file or directory", root.display()))?;
@@ -902,6 +921,7 @@ fn partition_files(
                 if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                     continue;
                 }
+                saw_any_file = true;
                 if is_svelte(path) && !ignore.is_ignored(path, false) {
                     svelte.push(entry.into_path());
                 } else if native_js && is_native_js(path) && !ignore.is_ignored(path, false) {
@@ -917,51 +937,63 @@ fn partition_files(
                 }
             }
             oxfmt_paths.push(root.clone());
-        } else if is_svelte(root) {
-            // Single explicit `.svelte` file — apply the same ignore rules.
-            let abs = if root.is_absolute() {
-                root.clone()
-            } else {
-                cwd.join(root)
-            };
-            if !ignore.is_ignored(&abs, false) {
-                svelte.push(root.clone());
-            }
-        } else if native_js && is_native_js(root) {
-            // Single explicit `.ts`/`.js` file — native pass (same ignore rules).
-            let abs = if root.is_absolute() {
-                root.clone()
-            } else {
-                cwd.join(root)
-            };
-            if !ignore.is_ignored(&abs, false) {
-                native.push(root.clone());
-            }
-        } else if native_js && is_native_json(root) {
-            // Single explicit `.json`/`.jsonc` file — native-JSON pass.
-            let abs = if root.is_absolute() {
-                root.clone()
-            } else {
-                cwd.join(root)
-            };
-            if !ignore.is_ignored(&abs, false) {
-                native_json.push(root.clone());
-            }
-        } else if native_css && is_native_css(root) {
-            // Single explicit `.css`/`.scss`/`.less` file — native-CSS pass.
-            let abs = if root.is_absolute() {
-                root.clone()
-            } else {
-                cwd.join(root)
-            };
-            if !ignore.is_ignored(&abs, false) {
-                native_css_files.push(root.clone());
-            }
         } else {
-            oxfmt_paths.push(root.clone());
+            // A single explicit path only reaches here once `metadata` above
+            // has confirmed it exists as a file.
+            saw_any_file = true;
+            if is_svelte(root) {
+                // Single explicit `.svelte` file — apply the same ignore rules.
+                let abs = if root.is_absolute() {
+                    root.clone()
+                } else {
+                    cwd.join(root)
+                };
+                if !ignore.is_ignored(&abs, false) {
+                    svelte.push(root.clone());
+                }
+            } else if native_js && is_native_js(root) {
+                // Single explicit `.ts`/`.js` file — native pass (same ignore rules).
+                let abs = if root.is_absolute() {
+                    root.clone()
+                } else {
+                    cwd.join(root)
+                };
+                if !ignore.is_ignored(&abs, false) {
+                    native.push(root.clone());
+                }
+            } else if native_js && is_native_json(root) {
+                // Single explicit `.json`/`.jsonc` file — native-JSON pass.
+                let abs = if root.is_absolute() {
+                    root.clone()
+                } else {
+                    cwd.join(root)
+                };
+                if !ignore.is_ignored(&abs, false) {
+                    native_json.push(root.clone());
+                }
+            } else if native_css && is_native_css(root) {
+                // Single explicit `.css`/`.scss`/`.less` file — native-CSS pass.
+                let abs = if root.is_absolute() {
+                    root.clone()
+                } else {
+                    cwd.join(root)
+                };
+                if !ignore.is_ignored(&abs, false) {
+                    native_css_files.push(root.clone());
+                }
+            } else {
+                oxfmt_paths.push(root.clone());
+            }
         }
     }
-    Ok((svelte, native, native_json, native_css_files, oxfmt_paths))
+    Ok((
+        svelte,
+        native,
+        native_json,
+        native_css_files,
+        oxfmt_paths,
+        saw_any_file,
+    ))
 }
 
 fn is_svelte(p: &Path) -> bool {

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -343,16 +343,25 @@ fn run() -> Result<ExitCode> {
     let native_js = !cli.no_native_js;
     let native_css = !cli.no_native_css;
     let ignore = oxfmt_ignore::SvelteIgnore::from_config(&cwd, &cfg)?;
-    let (svelte, native, native_json, native_css_files, oxfmt_paths, saw_any_file) =
+    let (svelte, native, native_json, native_css_files, oxfmt_paths) =
         partition_files(&cli.paths, &ignore, &cwd, native_js, native_css)?;
 
-    // Nothing exists under any given path — not even for `oxfmt`'s own
-    // delegated share, so there is nothing to run. Match oxfmt's own
-    // unsuppressed "no target file" error/exit code instead of running
-    // `oxfmt` with our always-on `--no-error-on-unmatched-pattern` (needed so
-    // a Svelte-only or CSS-only tree is a legitimate no-op for it) and
-    // reporting a false success (#1636).
-    if !saw_any_file {
+    // Whether every in-process pass (Svelte, native JS/JSON/CSS) found
+    // nothing at all. When true, `oxfmt`'s own delegated share is the only
+    // remaining source of truth for whether anything exists to format, so it
+    // must be allowed to error for real instead of being unconditionally
+    // suppressed (see `run_oxfmt`'s `suppress_unmatched`) — replicating
+    // oxfmt's own ignore + extension matching here would be a fragile
+    // duplication of logic that already lives in the `oxfmt` binary itself.
+    let in_process_empty = svelte.is_empty()
+        && native.is_empty()
+        && native_json.is_empty()
+        && native_css_files.is_empty();
+
+    // Nothing was even handed to `oxfmt` (every path was an explicit file
+    // that turned out to be ignored), so no subprocess will run to report the
+    // error itself — report it the same way oxfmt would.
+    if in_process_empty && oxfmt_paths.is_empty() {
         eprintln!(
             "Expected at least one target file. All matched files may have been excluded by ignore rules."
         );
@@ -434,6 +443,13 @@ fn run() -> Result<ExitCode> {
                 exclude_native,
                 exclude_native_json,
                 exclude_native_css,
+                // A Svelte-only or CSS-only tree legitimately leaves oxfmt's
+                // own share empty, so suppress its unmatched-pattern error —
+                // but not when every in-process pass is *also* empty: oxfmt
+                // is then the only thing that can tell (via its own ignore
+                // rules and supported-extension set) whether anything really
+                // exists to format, so it must be allowed to error for real.
+                !in_process_empty,
             )
         },
     );
@@ -447,6 +463,14 @@ fn run() -> Result<ExitCode> {
         .merge(native_status)
         .merge(json_status)
         .merge(css_status);
+
+    // oxfmt ran unsuppressed above and genuinely found nothing — its own
+    // "no target file" message already went to stderr (inherited), so don't
+    // also print our summary line; just propagate the error exit code.
+    if in_process_empty && oxfmt_status.had_errors {
+        return Ok(combine(combined, oxfmt_status, mode));
+    }
+
     print_summary(&combined, &oxfmt_status, mode);
     Ok(combine(combined, oxfmt_status, mode))
 }
@@ -874,18 +898,12 @@ fn partition_files(
     Vec<PathBuf>,
     Vec<PathBuf>,
     Vec<PathBuf>,
-    bool,
 )> {
     let mut svelte = Vec::new();
     let mut native = Vec::new();
     let mut native_json = Vec::new();
     let mut native_css_files = Vec::new();
     let mut oxfmt_paths = Vec::new();
-    // Whether any real file was found under `roots` at all, independent of
-    // extension/category or ignore filtering — a directory that walks to zero
-    // file entries can never yield a target for `oxfmt` either, however it's
-    // invoked (see the no-match check in `run`, #1636).
-    let mut saw_any_file = false;
     for root in roots {
         let meta = std::fs::metadata(root)
             .with_context(|| format!("reading {} — no such file or directory", root.display()))?;
@@ -921,7 +939,6 @@ fn partition_files(
                 if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                     continue;
                 }
-                saw_any_file = true;
                 if is_svelte(path) && !ignore.is_ignored(path, false) {
                     svelte.push(entry.into_path());
                 } else if native_js && is_native_js(path) && !ignore.is_ignored(path, false) {
@@ -937,63 +954,51 @@ fn partition_files(
                 }
             }
             oxfmt_paths.push(root.clone());
-        } else {
-            // A single explicit path only reaches here once `metadata` above
-            // has confirmed it exists as a file.
-            saw_any_file = true;
-            if is_svelte(root) {
-                // Single explicit `.svelte` file — apply the same ignore rules.
-                let abs = if root.is_absolute() {
-                    root.clone()
-                } else {
-                    cwd.join(root)
-                };
-                if !ignore.is_ignored(&abs, false) {
-                    svelte.push(root.clone());
-                }
-            } else if native_js && is_native_js(root) {
-                // Single explicit `.ts`/`.js` file — native pass (same ignore rules).
-                let abs = if root.is_absolute() {
-                    root.clone()
-                } else {
-                    cwd.join(root)
-                };
-                if !ignore.is_ignored(&abs, false) {
-                    native.push(root.clone());
-                }
-            } else if native_js && is_native_json(root) {
-                // Single explicit `.json`/`.jsonc` file — native-JSON pass.
-                let abs = if root.is_absolute() {
-                    root.clone()
-                } else {
-                    cwd.join(root)
-                };
-                if !ignore.is_ignored(&abs, false) {
-                    native_json.push(root.clone());
-                }
-            } else if native_css && is_native_css(root) {
-                // Single explicit `.css`/`.scss`/`.less` file — native-CSS pass.
-                let abs = if root.is_absolute() {
-                    root.clone()
-                } else {
-                    cwd.join(root)
-                };
-                if !ignore.is_ignored(&abs, false) {
-                    native_css_files.push(root.clone());
-                }
+        } else if is_svelte(root) {
+            // Single explicit `.svelte` file — apply the same ignore rules.
+            let abs = if root.is_absolute() {
+                root.clone()
             } else {
-                oxfmt_paths.push(root.clone());
+                cwd.join(root)
+            };
+            if !ignore.is_ignored(&abs, false) {
+                svelte.push(root.clone());
             }
+        } else if native_js && is_native_js(root) {
+            // Single explicit `.ts`/`.js` file — native pass (same ignore rules).
+            let abs = if root.is_absolute() {
+                root.clone()
+            } else {
+                cwd.join(root)
+            };
+            if !ignore.is_ignored(&abs, false) {
+                native.push(root.clone());
+            }
+        } else if native_js && is_native_json(root) {
+            // Single explicit `.json`/`.jsonc` file — native-JSON pass.
+            let abs = if root.is_absolute() {
+                root.clone()
+            } else {
+                cwd.join(root)
+            };
+            if !ignore.is_ignored(&abs, false) {
+                native_json.push(root.clone());
+            }
+        } else if native_css && is_native_css(root) {
+            // Single explicit `.css`/`.scss`/`.less` file — native-CSS pass.
+            let abs = if root.is_absolute() {
+                root.clone()
+            } else {
+                cwd.join(root)
+            };
+            if !ignore.is_ignored(&abs, false) {
+                native_css_files.push(root.clone());
+            }
+        } else {
+            oxfmt_paths.push(root.clone());
         }
     }
-    Ok((
-        svelte,
-        native,
-        native_json,
-        native_css_files,
-        oxfmt_paths,
-        saw_any_file,
-    ))
+    Ok((svelte, native, native_json, native_css_files, oxfmt_paths))
 }
 
 fn is_svelte(p: &Path) -> bool {
@@ -1725,7 +1730,7 @@ fn run_native_js(
     // counted in `files_total`; a parse-error file the fallback also can't
     // handle surfaces oxfmt's own diagnostics.
     if !fallback.is_empty() {
-        let fb = run_oxfmt(&fallback, oxfmt, mode, false, false, false)?;
+        let fb = run_oxfmt(&fallback, oxfmt, mode, false, false, false, true)?;
         status.files_changed += fb.files_changed;
         status.had_errors |= fb.had_errors;
     }
@@ -1872,7 +1877,7 @@ fn run_native_json(
     // Explicit paths with no native excludes, so oxfmt formats exactly these
     // (and applies `sortPackageJson` to any `package.json`).
     if !fallback.is_empty() {
-        let fb = run_oxfmt(&fallback, oxfmt, mode, false, false, false)?;
+        let fb = run_oxfmt(&fallback, oxfmt, mode, false, false, false, true)?;
         status.files_changed += fb.files_changed;
         status.had_errors |= fb.had_errors;
     }
@@ -2013,7 +2018,7 @@ fn run_native_css(
     // oxfmt fallback for override-matched + parse-error files. Explicit paths
     // with no native excludes, so oxfmt formats exactly these.
     if !fallback.is_empty() {
-        let fb = run_oxfmt(&fallback, oxfmt, mode, false, false, false)?;
+        let fb = run_oxfmt(&fallback, oxfmt, mode, false, false, false, true)?;
         status.files_changed += fb.files_changed;
         status.had_errors |= fb.had_errors;
     }
@@ -2026,9 +2031,13 @@ fn run_native_css(
 /// Delegate every non-`.svelte` path to a single `oxfmt` invocation.
 ///
 /// `paths` are the user's directory / file inputs verbatim; a `!**/*.svelte`
-/// exclude keeps Svelte files for the in-process pass, and
-/// `--no-error-on-unmatched-pattern` makes a tree with only `.svelte` files a
-/// clean no-op rather than an error. oxfmt's informational summary
+/// exclude keeps Svelte files for the in-process pass. `suppress_unmatched`
+/// adds `--no-error-on-unmatched-pattern`, which makes a tree with only
+/// `.svelte` files (or whichever set an in-process pass already handled) a
+/// clean no-op rather than an error; callers pass `false` when oxfmt's own
+/// share is the last remaining source of truth for whether anything exists to
+/// format at all, so it must be allowed to error for real (see the
+/// `in_process_empty` check in `run`). oxfmt's informational summary
 /// ("Finished … on N files", "Format issues found in above N files") goes to
 /// stdout; we capture it to recover file counts for our own summary, then
 /// forward it. Warnings/errors on stderr stay inherited.
@@ -2039,6 +2048,7 @@ fn run_oxfmt(
     exclude_native: bool,
     exclude_native_json: bool,
     exclude_native_css: bool,
+    suppress_unmatched: bool,
 ) -> Result<PipelineStatus> {
     if paths.is_empty() {
         return Ok(PipelineStatus::default());
@@ -2051,7 +2061,9 @@ fn run_oxfmt(
             cmd.arg("--check");
         }
     }
-    cmd.arg("--no-error-on-unmatched-pattern");
+    if suppress_unmatched {
+        cmd.arg("--no-error-on-unmatched-pattern");
+    }
     cmd.arg(OXFMT_EXCLUDE_SVELTE);
     // When the native `.ts`/`.js` path handled those files in-process, keep
     // oxfmt from re-formatting them in directory walks.

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -6,7 +6,7 @@
 //! scripts/compat-corpus/README.md).
 
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 fn bin() -> PathBuf {
@@ -1851,20 +1851,39 @@ fn sort_tailwindcss_custom_config_warns_and_skips() {
     );
 }
 
-/// #1636: an empty directory (no files at all, so not even `oxfmt`'s own
-/// delegated share has a target) must exit like real `oxfmt` does when it
-/// hits "no target file" unsuppressed — exit 2 with its exact message — not a
-/// false success. `--oxfmt-bin true` proves the fix never even reaches the
-/// `oxfmt` subprocess: `true` would report nothing either way, but if it were
-/// invoked at all the point of the fix (short-circuiting before the pipelines
-/// run) would be defeated.
+/// A stand-in `oxfmt` that mirrors just the one behavior this file's no-match
+/// tests need: real oxfmt only reports "Expected at least one target file…"
+/// (exit 2) when `--no-error-on-unmatched-pattern` is *not* on its argv. Since
+/// `rsvelte-fmt` always used to pass that flag unconditionally (masking a
+/// genuinely empty tree as a false success), whether the flag is present is
+/// exactly what proves the fix: it must be omitted once every in-process pass
+/// (Svelte, native JS/JSON/CSS) also found nothing.
+const NO_MATCH_ECHO_OXFMT: &str = r#"const argv = process.argv.slice(2);
+if (!argv.includes('--no-error-on-unmatched-pattern')) {
+  process.stderr.write('Expected at least one target file. All matched files may have been excluded by ignore rules.\n');
+  process.exit(2);
+}
+"#;
+
+/// An empty directory (no files at all, so not even `oxfmt`'s own delegated
+/// share has a target) must exit like real `oxfmt` does when it hits "no
+/// target file" unsuppressed — exit 2 with its exact message — not a false
+/// success from the `--no-error-on-unmatched-pattern` flag `rsvelte-fmt`
+/// always used to pass.
 #[test]
 fn empty_directory_exits_two_with_oxfmt_message() {
-    let dir = tempdir();
+    // The fake oxfmt script lives next to (not inside) the target directory —
+    // it's a `.cjs` file, so placing it inside would make the tree not
+    // actually empty (the native-JS pass would pick it up as a real target).
+    let holder = tempdir();
+    let fake = holder.join("fake-oxfmt.cjs");
+    std::fs::write(&fake, NO_MATCH_ECHO_OXFMT).unwrap();
+    let dir = holder.join("empty");
+    std::fs::create_dir(&dir).unwrap();
 
     let out = Command::new(bin())
         .current_dir(&dir)
-        .args(["--oxfmt-bin", "true"])
+        .args(["--oxfmt-bin", fake.to_str().unwrap()])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -1883,11 +1902,15 @@ fn empty_directory_exits_two_with_oxfmt_message() {
 /// exit-1 convention, matching oxfmt (which also exits 2, not 1, here).
 #[test]
 fn empty_directory_check_exits_two_with_oxfmt_message() {
-    let dir = tempdir();
+    let holder = tempdir();
+    let fake = holder.join("fake-oxfmt.cjs");
+    std::fs::write(&fake, NO_MATCH_ECHO_OXFMT).unwrap();
+    let dir = holder.join("empty");
+    std::fs::create_dir(&dir).unwrap();
 
     let out = Command::new(bin())
         .current_dir(&dir)
-        .args(["--check", "--oxfmt-bin", "true"])
+        .args(["--check", "--oxfmt-bin", fake.to_str().unwrap()])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -1903,6 +1926,143 @@ fn empty_directory_check_exits_two_with_oxfmt_message() {
         String::from_utf8(out.stderr).unwrap(),
         "Expected at least one target file. All matched files may have been excluded by ignore rules.\n",
     );
+}
+
+/// A directory containing only a `.svelte` file legitimately leaves oxfmt's
+/// own delegated share empty — that must stay a clean no-op (the
+/// `--no-error-on-unmatched-pattern` flag still applied), not the no-match
+/// error above. Regression guard for the `in_process_empty` gate added
+/// alongside `empty_directory_exits_two_with_oxfmt_message`.
+#[test]
+fn svelte_only_directory_is_not_treated_as_no_match() {
+    let dir = tempdir();
+    let fake = dir.join("fake-oxfmt.cjs");
+    std::fs::write(&fake, NO_MATCH_ECHO_OXFMT).unwrap();
+    std::fs::write(dir.join("App.svelte"), "<script>let x=1+2</script>").unwrap();
+
+    let out = Command::new(bin())
+        .current_dir(&dir)
+        .args(["--oxfmt-bin", fake.to_str().unwrap()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "svelte-only tree must still succeed: exit {:?}, stderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ─── real-oxfmt no-match parity (#1636) ──────────────────────────────────
+//
+// The tests above exercise `rsvelte-fmt`'s own decision logic against a fake
+// oxfmt; the tests below replay the same scenarios end-to-end against the
+// real vendored `oxfmt` binary, since the whole point of this fix is exact
+// exit-code/message parity with it. No-op (with a notice) when that binary
+// isn't present/runnable, matching this crate's other real-oxfmt-dependent
+// tests (see `svelte_dev_markdown.rs`).
+
+fn real_oxfmt_bin() -> PathBuf {
+    if let Ok(p) = std::env::var("OXFMT_BIN") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../node_modules/.bin/oxfmt")
+}
+
+fn real_oxfmt_runnable(oxfmt: &Path) -> bool {
+    Command::new(oxfmt)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Runs `rsvelte-fmt <dir>` against the real `oxfmt` binary and asserts both
+/// exit 2 and oxfmt's exact "no target file" message — the scenario is set up
+/// by `setup` beforehand.
+fn assert_real_oxfmt_no_match(setup: impl FnOnce(&Path)) {
+    let oxfmt = real_oxfmt_bin();
+    if !real_oxfmt_runnable(&oxfmt) {
+        eprintln!(
+            "[fmt-no-match] real oxfmt not runnable at {} (set OXFMT_BIN); skipping.",
+            oxfmt.display()
+        );
+        return;
+    }
+
+    let dir = tempdir();
+    setup(&dir);
+
+    let out = Command::new(bin())
+        .current_dir(&dir)
+        .args(["--oxfmt-bin", oxfmt.to_str().unwrap()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit 2 against real oxfmt; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(out.stderr).unwrap(),
+        "Expected at least one target file. All matched files may have been excluded by ignore rules.\n",
+    );
+}
+
+/// Case A: a fully empty directory.
+#[test]
+fn real_oxfmt_empty_directory_is_no_match() {
+    assert_real_oxfmt_no_match(|_dir| {});
+}
+
+/// Case E: an empty subdirectory only — no files anywhere in the tree.
+#[test]
+fn real_oxfmt_empty_subdirectory_only_is_no_match() {
+    assert_real_oxfmt_no_match(|dir| {
+        std::fs::create_dir(dir.join("sub")).unwrap();
+    });
+}
+
+/// Case B: a `.js` file exists but is excluded via `.gitignore`.
+#[test]
+fn real_oxfmt_gitignored_js_is_no_match() {
+    assert_real_oxfmt_no_match(|dir| {
+        let status = Command::new("git")
+            .arg("init")
+            .arg("-q")
+            .arg(dir)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git init failed");
+        std::fs::write(dir.join(".gitignore"), "a.js\n").unwrap();
+        std::fs::write(dir.join("a.js"), "const x=1\n").unwrap();
+    });
+}
+
+/// Case C: a `.js` file exists but is excluded via `.prettierignore`.
+#[test]
+fn real_oxfmt_prettierignored_js_is_no_match() {
+    assert_real_oxfmt_no_match(|dir| {
+        std::fs::write(dir.join(".prettierignore"), "a.js\n").unwrap();
+        std::fs::write(dir.join("a.js"), "const x=1\n").unwrap();
+    });
+}
+
+/// Case D: only a `.txt` file, which no pass (native or oxfmt) formats.
+#[test]
+fn real_oxfmt_unsupported_extension_only_is_no_match() {
+    assert_real_oxfmt_no_match(|dir| {
+        std::fs::write(dir.join("note.txt"), "hello\n").unwrap();
+    });
 }
 
 fn tempdir() -> PathBuf {

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -1851,6 +1851,60 @@ fn sort_tailwindcss_custom_config_warns_and_skips() {
     );
 }
 
+/// #1636: an empty directory (no files at all, so not even `oxfmt`'s own
+/// delegated share has a target) must exit like real `oxfmt` does when it
+/// hits "no target file" unsuppressed — exit 2 with its exact message — not a
+/// false success. `--oxfmt-bin true` proves the fix never even reaches the
+/// `oxfmt` subprocess: `true` would report nothing either way, but if it were
+/// invoked at all the point of the fix (short-circuiting before the pipelines
+/// run) would be defeated.
+#[test]
+fn empty_directory_exits_two_with_oxfmt_message() {
+    let dir = tempdir();
+
+    let out = Command::new(bin())
+        .current_dir(&dir)
+        .args(["--oxfmt-bin", "true"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(2), "empty directory must exit 2");
+    assert!(out.stdout.is_empty(), "stdout:\n{:?}", out.stdout);
+    assert_eq!(
+        String::from_utf8(out.stderr).unwrap(),
+        "Expected at least one target file. All matched files may have been excluded by ignore rules.\n",
+    );
+}
+
+/// Same as `empty_directory_exits_two_with_oxfmt_message`, but with `--check`
+/// — the no-match error takes priority over `--check`'s own "would reformat"
+/// exit-1 convention, matching oxfmt (which also exits 2, not 1, here).
+#[test]
+fn empty_directory_check_exits_two_with_oxfmt_message() {
+    let dir = tempdir();
+
+    let out = Command::new(bin())
+        .current_dir(&dir)
+        .args(["--check", "--oxfmt-bin", "true"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "empty directory must exit 2 even under --check"
+    );
+    assert!(out.stdout.is_empty(), "stdout:\n{:?}", out.stdout);
+    assert_eq!(
+        String::from_utf8(out.stderr).unwrap(),
+        "Expected at least one target file. All matched files may have been excluded by ignore rules.\n",
+    );
+}
+
 fn tempdir() -> PathBuf {
     let mut dir = std::env::temp_dir();
     dir.push(format!(


### PR DESCRIPTION
## Summary

Fixes #1636

When `rsvelte-fmt` is run where nothing matches, it previously exited **0** with the message `No files found matching the given patterns.`, while real `oxfmt` exits **2** with `Expected at least one target file. All matched files may have been excluded by ignore rules.`.

Root cause: `rsvelte-fmt` always passes `--no-error-on-unmatched-pattern` to the delegated `oxfmt` subprocess (needed so a Svelte-only or CSS-only tree — where `oxfmt` itself legitimately has nothing to do — is a clean no-op rather than an error). That same flag suppresses `oxfmt`'s "no target file" error even in the genuinely-empty case, so `rsvelte-fmt` reported false success.

### Revision after code-owner review

An initial version of this fix only detected a **literally empty directory** via `rsvelte-fmt`'s own directory walk. A code-owner review caught that this missed real-world cases where files exist but are excluded by `.gitignore`/`.prettierignore`, or don't match any supported extension — oxfmt still reports "no target file" for those (exit 2), but the walk-based signal can't know that without re-implementing oxfmt's own ignore/extension matching (fragile duplication).

**Fixed approach:** only suppress oxfmt's `--no-error-on-unmatched-pattern` when at least one in-process pass (Svelte, native JS/JSON/CSS) already found something. When every in-process pass is empty, oxfmt's own delegated share is the *only* remaining source of truth, so it's allowed to run **unsuppressed** and decide for real — its own ignore rules and extension matching produce the exact right answer, and its stderr (already inherited) carries the exact right message. No duplication of oxfmt's extension set or ignore logic needed.

### oxfmt real-machine verification

Checked against the vendored `oxfmt` binary (`node_modules/.bin/oxfmt`, **version 0.56.0** — matches the issue's v0.56 reference, no drift), covering the full review matrix:

| Case | rsvelte-fmt | oxfmt | Match |
|---|---|---|---|
| A: fully empty directory | exit 2 | exit 2 | ✅ |
| B: `.js` present but excluded via `.gitignore` | exit 2 | exit 2 | ✅ |
| C: `.js` present but excluded via `.prettierignore` | exit 2 | exit 2 | ✅ |
| D: only a `.txt` (unsupported extension) | exit 2 | exit 2 | ✅ |
| E: empty subdirectory only | exit 2 | exit 2 | ✅ |

All five now match byte-for-byte on both exit code and stderr message (`Expected at least one target file. All matched files may have been excluded by ignore rules.\n`). Also re-verified the legitimate no-op cases (Svelte-only directory, mixed Svelte+Markdown tree) still succeed exactly as before.

## Changes

- `crates/rsvelte_fmt/src/main.rs`:
  - `run_oxfmt` gains a `suppress_unmatched: bool` parameter controlling whether `--no-error-on-unmatched-pattern` is added.
  - `run()` computes `in_process_empty` (Svelte + native JS/JSON/CSS all empty) and passes `!in_process_empty` as `suppress_unmatched` for the top-level directory delegation. When oxfmt then runs unsuppressed and genuinely errors, the exit code propagates and the extra `rsvelte-fmt: ...` summary line is skipped (oxfmt's own message, already inherited to stderr, is left as the sole output).
  - A small direct check handles the narrow edge case where nothing is even handed to `oxfmt` at all (every path was an explicit file that turned out to be ignored, so no subprocess runs to report the error itself).
  - The 3 existing per-file `oxfmt` fallback call sites (native JS/JSON/CSS parse-error delegation) keep `suppress_unmatched: true` unconditionally — they always have ≥1 real file, so the flag never changes their behavior.
- `crates/rsvelte_fmt/tests/cli.rs`:
  - 2 tests against a fake `oxfmt` stand-in that proves `rsvelte-fmt`'s own decision logic (whether the suppression flag is passed) is correct, independent of any real binary.
  - 1 regression guard confirming a Svelte-only directory still succeeds (not mistaken for no-match).
  - 5 new tests running the **real** vendored `oxfmt` end-to-end for cases A/B/C/D/E above (skips gracefully with a notice if `oxfmt` isn't runnable, matching this crate's existing real-oxfmt-dependent test convention).
- `.changeset/fix-fmt-no-match-exit-code.md`: patch changeset for `@rsvelte/fmt`, updated to describe the full scope (ignore-excluded and unsupported-extension trees, not just an empty directory).

## Test plan

- [x] `cargo test -p rsvelte_fmt` — 56/56 `cli.rs` tests pass (incl. all 8 new), full crate suite green in both debug and `--release`
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean (whole workspace)
- [x] Manually verified all 5 review-matrix cases (A/B/C/D/E) against the real `oxfmt` binary — exit code and message match exactly
- [x] Manually verified legitimate no-op cases (Svelte-only directory, mixed Svelte+Markdown tree) still format correctly and exit 0/1 as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XHPUBHj4ywFM8skv4GwxV