### PR TITLE
fix(parse): preserve TypeScript assertion expressions in the parse AST

### DIFF
--- a/.changeset/fix-parse-arrow-param-spans.md
+++ b/.changeset/fix-parse-arrow-param-spans.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): assign real spans to fast-path arrow-function parameters
+
+A top-level mustache/attribute arrow handler (e.g. `onclick={(color, e) => …}`)
+went through a fast-path parser that stamped its parameters with a zero-width
+`Identifier[0,0]` span and no `loc`, diverging from svelte/compiler (which
+assigns each parameter its real source span). The fast path now derives each
+parameter's absolute span from its byte position within the source, matching
+svelte/compiler. Compiled output is unchanged.

--- a/.changeset/fix-parse-preserve-ts-assertions.md
+++ b/.changeset/fix-parse-preserve-ts-assertions.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): preserve TypeScript assertion expressions in the parse AST
+
+`parse()` silently dropped TypeScript assertion wrappers — `x as const`,
+`x as T`, `x satisfies T`, `x!`, `<T>x`, and `x<T>` — returning only the inner
+expression, so consumers that expect the svelte/compiler AST shape (e.g.
+svelte-shaker) saw a different tree than the official compiler.
+
+The parser now keeps `TSAsExpression`, `TSSatisfiesExpression`,
+`TSNonNullExpression`, `TSTypeAssertion`, and `TSInstantiationExpression` (with
+their `typeAnnotation` / `typeArguments`), matching svelte/compiler's `parse()`
+output byte-for-byte. Mirroring the official compiler, `remove_typescript_nodes`
+unwraps these wrappers before analyze/transform, so compiled client/server
+output is unchanged.

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -155,6 +155,11 @@ const JS_NULL = 0xca;
 // 0xcb was the former whole-node JS_RAW_JSON escape (removed — TS type
 // annotations now ride a per-node trailer; see readOptTypeAnnotation).
 const JS_TS_PARAMETER_PROPERTY = 0xcc;
+const JS_TS_AS_EXPRESSION = 0xcd;
+const JS_TS_SATISFIES_EXPRESSION = 0xce;
+const JS_TS_NON_NULL_EXPRESSION = 0xcf;
+const JS_TS_TYPE_ASSERTION = 0xd0;
+const JS_TS_INSTANTIATION_EXPRESSION = 0xd1;
 
 // LiteralValue inner tag (within a JS_LITERAL payload).
 const LV_NULL = 0;
@@ -483,6 +488,16 @@ function readNodeBody(ctx, tag, start, end) {
 			return readJsImportExpression(ctx, start, end);
 		case JS_AWAIT_EXPRESSION:
 			return readJsAwaitExpression(ctx, start, end);
+		case JS_TS_AS_EXPRESSION:
+			return readJsTSAsExpression(ctx, start, end);
+		case JS_TS_SATISFIES_EXPRESSION:
+			return readJsTSSatisfiesExpression(ctx, start, end);
+		case JS_TS_NON_NULL_EXPRESSION:
+			return readJsTSNonNullExpression(ctx, start, end);
+		case JS_TS_TYPE_ASSERTION:
+			return readJsTSTypeAssertion(ctx, start, end);
+		case JS_TS_INSTANTIATION_EXPRESSION:
+			return readJsTSInstantiationExpression(ctx, start, end);
 		case JS_YIELD_EXPRESSION:
 			return readJsYieldExpression(ctx, start, end);
 		case JS_CHAIN_EXPRESSION:
@@ -952,6 +967,60 @@ function readJsAwaitExpression(ctx, start, end) {
 	const node = { type: 'AwaitExpression', start, end };
 	if (loc !== null) node.loc = loc;
 	node.argument = argument;
+	return node;
+}
+
+function readJsTSAsExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const typeAnnotation = readOptTypeAnnotation(ctx);
+	const node = { type: 'TSAsExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.expression = expression;
+	if (typeAnnotation !== null) node.typeAnnotation = typeAnnotation;
+	return node;
+}
+
+function readJsTSSatisfiesExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const typeAnnotation = readOptTypeAnnotation(ctx);
+	const node = { type: 'TSSatisfiesExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.expression = expression;
+	if (typeAnnotation !== null) node.typeAnnotation = typeAnnotation;
+	return node;
+}
+
+function readJsTSNonNullExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const node = { type: 'TSNonNullExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.expression = expression;
+	return node;
+}
+
+function readJsTSTypeAssertion(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const typeAnnotation = readOptTypeAnnotation(ctx);
+	const node = { type: 'TSTypeAssertion', start, end };
+	if (loc !== null) node.loc = loc;
+	// svelte/compiler emits `typeAnnotation` before `expression` here.
+	if (typeAnnotation !== null) node.typeAnnotation = typeAnnotation;
+	node.expression = expression;
+	return node;
+}
+
+function readJsTSInstantiationExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const typeArguments = readOptTypeAnnotation(ctx);
+	const node = { type: 'TSInstantiationExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.expression = expression;
+	if (typeArguments !== null) node.typeArguments = typeArguments;
 	return node;
 }
 

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -655,6 +655,44 @@ pub enum JsNode {
         loc: Option<Box<Loc>>,
         body: Option<JsNodeId>,
     },
+    // TS assertion expression wrappers. The parser keeps them so `parse()` output
+    // matches svelte/compiler; `remove_typescript_nodes` unwraps them to
+    // `expression` before analyze/transform, so compile output is unchanged. The
+    // `type_annotation`/`type_arguments` blobs are opaque, output-only TS types.
+    TSAsExpression {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+        type_annotation: Option<Box<serde_json::Value>>,
+    },
+    TSSatisfiesExpression {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+        type_annotation: Option<Box<serde_json::Value>>,
+    },
+    TSNonNullExpression {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+    },
+    TSTypeAssertion {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+        type_annotation: Option<Box<serde_json::Value>>,
+    },
+    TSInstantiationExpression {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+        type_arguments: Option<Box<serde_json::Value>>,
+    },
     // Comment (used in Program.comments array, type is "Line" or "Block")
     Comment {
         start: u32,
@@ -1189,6 +1227,98 @@ impl Serialize for JsNode {
                 map.serialize_entry("end", end)?;
                 ser_loc!(map, loc);
                 ser_node!(map, "argument", argument);
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
+            JsNode::TSAsExpression {
+                start,
+                end,
+                loc,
+                expression,
+                type_annotation,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSAsExpression")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                ser_node!(map, "expression", expression);
+                if let Some(ta) = type_annotation {
+                    map.serialize_entry("typeAnnotation", ta.as_ref())?;
+                }
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
+            JsNode::TSSatisfiesExpression {
+                start,
+                end,
+                loc,
+                expression,
+                type_annotation,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSSatisfiesExpression")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                ser_node!(map, "expression", expression);
+                if let Some(ta) = type_annotation {
+                    map.serialize_entry("typeAnnotation", ta.as_ref())?;
+                }
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
+            JsNode::TSNonNullExpression {
+                start,
+                end,
+                loc,
+                expression,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSNonNullExpression")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                ser_node!(map, "expression", expression);
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
+            JsNode::TSTypeAssertion {
+                start,
+                end,
+                loc,
+                expression,
+                type_annotation,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSTypeAssertion")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                // svelte/compiler emits `typeAnnotation` before `expression` here.
+                if let Some(ta) = type_annotation {
+                    map.serialize_entry("typeAnnotation", ta.as_ref())?;
+                }
+                ser_node!(map, "expression", expression);
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
+            JsNode::TSInstantiationExpression {
+                start,
+                end,
+                loc,
+                expression,
+                type_arguments,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSInstantiationExpression")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                ser_node!(map, "expression", expression);
+                if let Some(ta) = type_arguments {
+                    map.serialize_entry("typeArguments", ta.as_ref())?;
+                }
                 ser_comments!(map, *start, *end);
                 map.end()
             }
@@ -2409,6 +2539,40 @@ impl JsNode {
                         loc,
                         argument: convert_child(obj, "argument"),
                     },
+                    "TSAsExpression" => JsNode::TSAsExpression {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                        type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
+                    },
+                    "TSSatisfiesExpression" => JsNode::TSSatisfiesExpression {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                        type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
+                    },
+                    "TSNonNullExpression" => JsNode::TSNonNullExpression {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                    },
+                    "TSTypeAssertion" => JsNode::TSTypeAssertion {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                        type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
+                    },
+                    "TSInstantiationExpression" => JsNode::TSInstantiationExpression {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                        type_arguments: obj.get("typeArguments").cloned().map(Box::new),
+                    },
                     "YieldExpression" => JsNode::YieldExpression {
                         start,
                         end,
@@ -2859,6 +3023,11 @@ impl JsNode {
             JsNode::TSParameterProperty { .. } => Some("TSParameterProperty"),
             JsNode::TSEnumDeclaration { .. } => Some("TSEnumDeclaration"),
             JsNode::TSModuleDeclaration { .. } => Some("TSModuleDeclaration"),
+            JsNode::TSAsExpression { .. } => Some("TSAsExpression"),
+            JsNode::TSSatisfiesExpression { .. } => Some("TSSatisfiesExpression"),
+            JsNode::TSNonNullExpression { .. } => Some("TSNonNullExpression"),
+            JsNode::TSTypeAssertion { .. } => Some("TSTypeAssertion"),
+            JsNode::TSInstantiationExpression { .. } => Some("TSInstantiationExpression"),
             JsNode::Comment { comment_type, .. } => Some(comment_type.as_str()),
             JsNode::Null => None,
         }
@@ -3527,6 +3696,11 @@ impl JsNode {
             | JsNode::TSParameterProperty { start, .. }
             | JsNode::TSEnumDeclaration { start, .. }
             | JsNode::TSModuleDeclaration { start, .. }
+            | JsNode::TSAsExpression { start, .. }
+            | JsNode::TSSatisfiesExpression { start, .. }
+            | JsNode::TSNonNullExpression { start, .. }
+            | JsNode::TSTypeAssertion { start, .. }
+            | JsNode::TSInstantiationExpression { start, .. }
             | JsNode::Comment { start, .. } => *start,
             JsNode::Null => 0,
         }
@@ -3608,6 +3782,11 @@ impl JsNode {
             | JsNode::TSParameterProperty { end, .. }
             | JsNode::TSEnumDeclaration { end, .. }
             | JsNode::TSModuleDeclaration { end, .. }
+            | JsNode::TSAsExpression { end, .. }
+            | JsNode::TSSatisfiesExpression { end, .. }
+            | JsNode::TSNonNullExpression { end, .. }
+            | JsNode::TSTypeAssertion { end, .. }
+            | JsNode::TSInstantiationExpression { end, .. }
             | JsNode::Comment { end, .. } => *end,
             JsNode::Null => 0,
         }
@@ -3691,6 +3870,11 @@ impl JsNode {
             JsNode::TSParameterProperty { .. } => "TSParameterProperty",
             JsNode::TSEnumDeclaration { .. } => "TSEnumDeclaration",
             JsNode::TSModuleDeclaration { .. } => "TSModuleDeclaration",
+            JsNode::TSAsExpression { .. } => "TSAsExpression",
+            JsNode::TSSatisfiesExpression { .. } => "TSSatisfiesExpression",
+            JsNode::TSNonNullExpression { .. } => "TSNonNullExpression",
+            JsNode::TSTypeAssertion { .. } => "TSTypeAssertion",
+            JsNode::TSInstantiationExpression { .. } => "TSInstantiationExpression",
             JsNode::Comment { .. } => "Comment",
             JsNode::Null => "Null",
         }

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -1129,7 +1129,11 @@ fn strip_ts_from_expression(
 }
 
 /// Strip TypeScript annotations from all Expression nodes in a Fragment.
-fn strip_ts_from_fragment(
+///
+/// Exposed for svelte2tsx: its template lowering consumes the parse AST and,
+/// like phase-3 transform, expects TS assertion wrappers already removed.
+/// Requires a `SerializeArenaGuard` installed for the fragment's arena.
+pub(crate) fn strip_ts_from_fragment(
     fragment: &mut crate::ast::template::Fragment,
 ) -> Result<(), crate::error::ParseError> {
     for node in &mut fragment.nodes {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -820,12 +820,15 @@ fn try_parse_arrow_function(
             try_parse_update_expression(arena, body_str, body_bytes, body_offset, line_offsets)
         })?;
 
-    // Parse params between ( and )
-    let params_str = content[1..close_paren].trim();
+    // Parse params between ( and ). `content` maps 1:1 to the source at `offset`,
+    // so each identifier's absolute span is derived from its byte position within
+    // the `(...)` region (upstream assigns real spans, not zero-width stubs).
+    let params_region = &content[1..close_paren];
     let mut params_nodes = Vec::new();
 
-    if !params_str.is_empty() {
-        for param in params_str.split(',') {
+    if !params_region.trim().is_empty() {
+        let mut cursor = 0usize; // byte index within `params_region`
+        for param in params_region.split(',') {
             let p = param.trim();
             if p.is_empty() {
                 return None;
@@ -837,13 +840,17 @@ fn try_parse_arrow_function(
             if !p_bytes.iter().all(|&b| is_ident_continue_byte(b)) {
                 return None; // Has type annotations or defaults — too complex
             }
+            let leading_ws = param.len() - param.trim_start().len();
+            let p_start = offset + 1 + cursor + leading_ws;
+            let p_end = p_start + p.len();
             params_nodes.push(JsNode::Identifier {
-                start: 0, // Approximate — exact positions not critical for compilation
-                end: 0,
-                loc: None,
+                start: p_start as u32,
+                end: p_end as u32,
+                loc: create_typed_loc(p_start, p_end, line_offsets),
                 name: CompactString::from(p),
                 type_annotation: None,
             });
+            cursor += param.len() + 1; // +1 for the consumed comma
         }
     }
     let params = arena.alloc_js_children(params_nodes);
@@ -3594,6 +3601,82 @@ fn convert_ts_type_param_instantiation(
     Value::Object(obj)
 }
 
+/// Build a `TSAsExpression`/`TSSatisfiesExpression`/`TSTypeAssertion` typed node
+/// from an already-converted inner expression and TS type blob. The parser keeps
+/// these so `parse()` matches svelte/compiler; `remove_typescript_nodes` unwraps
+/// them before analyze/transform.
+fn build_ts_typed_wrapper(
+    arena: &ParseArena,
+    variant: &str,
+    start: usize,
+    end: usize,
+    line_offsets: &[usize],
+    inner: Expression,
+    type_annotation: Value,
+) -> Expression {
+    let expression = arena.alloc_js_node(expr_to_node(inner));
+    let loc = create_typed_loc(start, end, line_offsets);
+    let type_annotation = Some(Box::new(type_annotation));
+    let node = match variant {
+        "TSSatisfiesExpression" => JsNode::TSSatisfiesExpression {
+            start: start as u32,
+            end: end as u32,
+            loc,
+            expression,
+            type_annotation,
+        },
+        "TSTypeAssertion" => JsNode::TSTypeAssertion {
+            start: start as u32,
+            end: end as u32,
+            loc,
+            expression,
+            type_annotation,
+        },
+        _ => JsNode::TSAsExpression {
+            start: start as u32,
+            end: end as u32,
+            loc,
+            expression,
+            type_annotation,
+        },
+    };
+    Expression::from_node(node)
+}
+
+/// Build a `TSNonNullExpression` typed node (`expr!`).
+fn build_ts_non_null(
+    arena: &ParseArena,
+    start: usize,
+    end: usize,
+    line_offsets: &[usize],
+    inner: Expression,
+) -> Expression {
+    Expression::from_node(JsNode::TSNonNullExpression {
+        start: start as u32,
+        end: end as u32,
+        loc: create_typed_loc(start, end, line_offsets),
+        expression: arena.alloc_js_node(expr_to_node(inner)),
+    })
+}
+
+/// Build a `TSInstantiationExpression` typed node (`expr<T>`).
+fn build_ts_instantiation(
+    arena: &ParseArena,
+    start: usize,
+    end: usize,
+    line_offsets: &[usize],
+    inner: Expression,
+    type_arguments: Value,
+) -> Expression {
+    Expression::from_node(JsNode::TSInstantiationExpression {
+        start: start as u32,
+        end: end as u32,
+        loc: create_typed_loc(start, end, line_offsets),
+        expression: arena.alloc_js_node(expr_to_node(inner)),
+        type_arguments: Some(Box::new(type_arguments)),
+    })
+}
+
 /// Create a TypeScript keyword type node.
 fn create_ts_keyword(type_name: &str, start: usize, end: usize, line_offsets: &[usize]) -> Value {
     let mut obj = Map::new();
@@ -3731,22 +3814,61 @@ fn convert_expression(
             let end = offset + seq.span.end as usize - 1;
             create_sequence_expression(arena, seq, start, end, offset, line_offsets)
         }
-        // TypeScript expression wrappers - unwrap and return the inner expression
-        // This matches Svelte's behavior of removing TypeScript syntax
+        // TypeScript expression wrappers - preserve so `parse()` matches
+        // svelte/compiler; `remove_typescript_nodes` unwraps them in compile.
         OxcExpression::TSAsExpression(ts_as) => {
-            convert_expression(arena, &ts_as.expression, offset, line_offsets)
+            let start = offset + ts_as.span.start as usize - 1;
+            let end = offset + ts_as.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_as.expression, offset, line_offsets);
+            let ty = convert_ts_type(&ts_as.type_annotation, offset - 1, line_offsets);
+            build_ts_typed_wrapper(arena, "TSAsExpression", start, end, line_offsets, inner, ty)
         }
         OxcExpression::TSSatisfiesExpression(ts_satisfies) => {
-            convert_expression(arena, &ts_satisfies.expression, offset, line_offsets)
+            let start = offset + ts_satisfies.span.start as usize - 1;
+            let end = offset + ts_satisfies.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_satisfies.expression, offset, line_offsets);
+            let ty = convert_ts_type(&ts_satisfies.type_annotation, offset - 1, line_offsets);
+            build_ts_typed_wrapper(
+                arena,
+                "TSSatisfiesExpression",
+                start,
+                end,
+                line_offsets,
+                inner,
+                ty,
+            )
         }
         OxcExpression::TSNonNullExpression(ts_non_null) => {
-            convert_expression(arena, &ts_non_null.expression, offset, line_offsets)
+            let start = offset + ts_non_null.span.start as usize - 1;
+            let end = offset + ts_non_null.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_non_null.expression, offset, line_offsets);
+            build_ts_non_null(arena, start, end, line_offsets, inner)
         }
         OxcExpression::TSTypeAssertion(ts_assertion) => {
-            convert_expression(arena, &ts_assertion.expression, offset, line_offsets)
+            let start = offset + ts_assertion.span.start as usize - 1;
+            let end = offset + ts_assertion.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_assertion.expression, offset, line_offsets);
+            let ty = convert_ts_type(&ts_assertion.type_annotation, offset - 1, line_offsets);
+            build_ts_typed_wrapper(
+                arena,
+                "TSTypeAssertion",
+                start,
+                end,
+                line_offsets,
+                inner,
+                ty,
+            )
         }
         OxcExpression::TSInstantiationExpression(ts_inst) => {
-            convert_expression(arena, &ts_inst.expression, offset, line_offsets)
+            let start = offset + ts_inst.span.start as usize - 1;
+            let end = offset + ts_inst.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_inst.expression, offset, line_offsets);
+            let ty = convert_ts_type_param_instantiation(
+                &ts_inst.type_arguments,
+                offset - 1,
+                line_offsets,
+            );
+            build_ts_instantiation(arena, start, end, line_offsets, inner, ty)
         }
         OxcExpression::NewExpression(new_expr) => {
             let start = offset + new_expr.span.start as usize - 1;
@@ -3837,9 +3959,19 @@ fn convert_expression(
                         line_offsets,
                     ))
                 }
-                oxc_ast::ast::ChainElement::TSNonNullExpression(ts_non_null) => expr_to_node(
-                    convert_expression(arena, &ts_non_null.expression, offset, line_offsets),
-                ),
+                oxc_ast::ast::ChainElement::TSNonNullExpression(ts_non_null) => {
+                    let inner_start = offset + ts_non_null.span.start as usize - 1;
+                    let inner_end = offset + ts_non_null.span.end as usize - 1;
+                    let inner =
+                        convert_expression(arena, &ts_non_null.expression, offset, line_offsets);
+                    expr_to_node(build_ts_non_null(
+                        arena,
+                        inner_start,
+                        inner_end,
+                        line_offsets,
+                        inner,
+                    ))
+                }
                 oxc_ast::ast::ChainElement::StaticMemberExpression(member) => {
                     let inner_start = offset + member.span.start as usize - 1;
                     let inner_end = offset + member.span.end as usize - 1;
@@ -8931,11 +9063,20 @@ fn convert_expression_for_program(
                     }
                 }
                 oxc_ast::ast::ChainElement::TSNonNullExpression(ts_non_null) => {
-                    expr_to_node(convert_expression_for_program(
+                    let inner_start = offset + ts_non_null.span.start as usize;
+                    let inner_end = offset + ts_non_null.span.end as usize;
+                    let inner = convert_expression_for_program(
                         arena,
                         &ts_non_null.expression,
                         offset,
                         line_offsets,
+                    );
+                    expr_to_node(build_ts_non_null(
+                        arena,
+                        inner_start,
+                        inner_end,
+                        line_offsets,
+                        inner,
                     ))
                 }
                 oxc_ast::ast::ChainElement::StaticMemberExpression(member) => {
@@ -9088,21 +9229,75 @@ fn convert_expression_for_program(
         OxcExpression::ParenthesizedExpression(paren) => {
             convert_expression_for_program(arena, &paren.expression, offset, line_offsets)
         }
-        // TypeScript expression wrappers - unwrap and return the inner expression
+        // TypeScript expression wrappers - preserve so `parse()` matches
+        // svelte/compiler; `remove_typescript_nodes` unwraps them in compile.
         OxcExpression::TSAsExpression(ts_as) => {
-            convert_expression_for_program(arena, &ts_as.expression, offset, line_offsets)
+            let start = offset + ts_as.span.start as usize;
+            let end = offset + ts_as.span.end as usize;
+            let inner =
+                convert_expression_for_program(arena, &ts_as.expression, offset, line_offsets);
+            let ty = convert_ts_type(&ts_as.type_annotation, offset, line_offsets);
+            build_ts_typed_wrapper(arena, "TSAsExpression", start, end, line_offsets, inner, ty)
         }
         OxcExpression::TSSatisfiesExpression(ts_satisfies) => {
-            convert_expression_for_program(arena, &ts_satisfies.expression, offset, line_offsets)
+            let start = offset + ts_satisfies.span.start as usize;
+            let end = offset + ts_satisfies.span.end as usize;
+            let inner = convert_expression_for_program(
+                arena,
+                &ts_satisfies.expression,
+                offset,
+                line_offsets,
+            );
+            let ty = convert_ts_type(&ts_satisfies.type_annotation, offset, line_offsets);
+            build_ts_typed_wrapper(
+                arena,
+                "TSSatisfiesExpression",
+                start,
+                end,
+                line_offsets,
+                inner,
+                ty,
+            )
         }
         OxcExpression::TSNonNullExpression(ts_non_null) => {
-            convert_expression_for_program(arena, &ts_non_null.expression, offset, line_offsets)
+            let start = offset + ts_non_null.span.start as usize;
+            let end = offset + ts_non_null.span.end as usize;
+            let inner = convert_expression_for_program(
+                arena,
+                &ts_non_null.expression,
+                offset,
+                line_offsets,
+            );
+            build_ts_non_null(arena, start, end, line_offsets, inner)
         }
         OxcExpression::TSTypeAssertion(ts_assertion) => {
-            convert_expression_for_program(arena, &ts_assertion.expression, offset, line_offsets)
+            let start = offset + ts_assertion.span.start as usize;
+            let end = offset + ts_assertion.span.end as usize;
+            let inner = convert_expression_for_program(
+                arena,
+                &ts_assertion.expression,
+                offset,
+                line_offsets,
+            );
+            let ty = convert_ts_type(&ts_assertion.type_annotation, offset, line_offsets);
+            build_ts_typed_wrapper(
+                arena,
+                "TSTypeAssertion",
+                start,
+                end,
+                line_offsets,
+                inner,
+                ty,
+            )
         }
         OxcExpression::TSInstantiationExpression(ts_inst) => {
-            convert_expression_for_program(arena, &ts_inst.expression, offset, line_offsets)
+            let start = offset + ts_inst.span.start as usize;
+            let end = offset + ts_inst.span.end as usize;
+            let inner =
+                convert_expression_for_program(arena, &ts_inst.expression, offset, line_offsets);
+            let ty =
+                convert_ts_type_param_instantiation(&ts_inst.type_arguments, offset, line_offsets);
+            build_ts_instantiation(arena, start, end, line_offsets, inner, ty)
         }
         OxcExpression::MetaProperty(meta) => {
             // `import.meta` / `new.target`. Without this arm the fallback
@@ -10721,7 +10916,9 @@ fn convert_expression_with_adjustment(
                 line_offsets,
             )
         }
-        // TypeScript expression wrappers - unwrap and return the inner expression
+        // TypeScript expression wrappers. This is the JSDoc-adjusted (Value-based)
+        // JS path, which never carries real TS assertions, so unwrapping to the
+        // inner expression is byte-identical to preserving-then-stripping.
         OxcExpression::TSAsExpression(ts_as) => convert_expression_with_adjustment(
             arena,
             &ts_as.expression,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
@@ -842,9 +842,7 @@ fn visit_typed_children(node: &mut JsNode, arena: &ParseArena) -> Result<(), Par
         JsNode::BinaryExpression { left, right, .. }
         | JsNode::LogicalExpression { left, right, .. }
         | JsNode::AssignmentExpression { left, right, .. }
-        | JsNode::AssignmentPattern { left, right, .. }
-        | JsNode::ForOfStatement { left, right, .. }
-        | JsNode::ForInStatement { left, right, .. } => {
+        | JsNode::AssignmentPattern { left, right, .. } => {
             let (l, r) = (*left, *right);
             rec_id!(l);
             rec_id!(r);
@@ -1016,6 +1014,17 @@ fn visit_typed_children(node: &mut JsNode, arena: &ParseArena) -> Result<(), Par
             rec_opt!(i);
             rec_opt!(t);
             rec_opt!(u);
+            rec_id!(b);
+        }
+        JsNode::ForOfStatement {
+            left, right, body, ..
+        }
+        | JsNode::ForInStatement {
+            left, right, body, ..
+        } => {
+            let (l, r, b) = (*left, *right, *body);
+            rec_id!(l);
+            rec_id!(r);
             rec_id!(b);
         }
         JsNode::WhileStatement { test, body, .. } | JsNode::DoWhileStatement { test, body, .. } => {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
@@ -479,6 +479,19 @@ fn typed_empty_statement(node: &JsNode) -> JsNode {
     }
 }
 
+/// Inner `expression` child id of a TS assertion wrapper node.
+#[inline]
+fn ts_wrapper_expression_id(node: &JsNode) -> Option<JsNodeId> {
+    match node {
+        JsNode::TSAsExpression { expression, .. }
+        | JsNode::TSSatisfiesExpression { expression, .. }
+        | JsNode::TSNonNullExpression { expression, .. }
+        | JsNode::TSTypeAssertion { expression, .. }
+        | JsNode::TSInstantiationExpression { expression, .. } => Some(*expression),
+        _ => None,
+    }
+}
+
 /// Typed entry point. Mirrors [`remove_typescript_nodes`] but operates directly
 /// on the arena-backed typed tree.
 pub fn remove_typescript_nodes_typed(
@@ -575,6 +588,23 @@ pub fn remove_typescript_nodes_typed(
         // typed function never actually carries a `this` param.)
         Some("FunctionExpression") | Some("FunctionDeclaration") => {
             remove_this_param_typed(node, arena);
+        }
+
+        // TS assertion wrappers (`as`/`satisfies`/`!`/`<T>`/instantiation): the
+        // parser keeps them for `parse()` fidelity; here we unwrap to the inner
+        // expression (mirrors upstream `remove_typescript_nodes`), then re-run the
+        // strip on the replacement (it may itself be another TS wrapper, e.g.
+        // `x! as const`).
+        Some("TSAsExpression")
+        | Some("TSSatisfiesExpression")
+        | Some("TSNonNullExpression")
+        | Some("TSTypeAssertion")
+        | Some("TSInstantiationExpression") => {
+            let inner_id = ts_wrapper_expression_id(node);
+            if let Some(inner_id) = inner_id {
+                *node = arena.get_js_node(inner_id).clone();
+                return remove_typescript_nodes_typed(node, arena);
+            }
         }
 
         _ => {}

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -3233,6 +3233,16 @@ fn js_node_check_features(
             walk_id!(*argument);
         }
 
+        // TS assertion wrappers are stripped before analyze; walk the inner
+        // expression defensively so a stray wrapper never hides a feature.
+        JsNode::TSAsExpression { expression, .. }
+        | JsNode::TSSatisfiesExpression { expression, .. }
+        | JsNode::TSNonNullExpression { expression, .. }
+        | JsNode::TSTypeAssertion { expression, .. }
+        | JsNode::TSInstantiationExpression { expression, .. } => {
+            walk_id!(*expression);
+        }
+
         JsNode::ConditionalExpression {
             test,
             consequent,
@@ -4819,6 +4829,13 @@ fn collect_identifier_names_in_node(
             prefix: _,
             argument,
         } => walk(*argument, out),
+
+        // TS assertion wrappers: collect identifiers from the inner expression.
+        JsNode::TSAsExpression { expression, .. }
+        | JsNode::TSSatisfiesExpression { expression, .. }
+        | JsNode::TSNonNullExpression { expression, .. }
+        | JsNode::TSTypeAssertion { expression, .. }
+        | JsNode::TSInstantiationExpression { expression, .. } => walk(*expression, out),
 
         JsNode::ConditionalExpression {
             start: _,

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -227,6 +227,11 @@ pub const JS_COMMENT: u8 = 0xC9;
 // `JS_RAW_JSON` escape; type annotations now ride a per-node trailer instead.)
 pub const JS_NULL: u8 = 0xCA;
 pub const JS_TS_PARAMETER_PROPERTY: u8 = 0xCC;
+pub const JS_TS_AS_EXPRESSION: u8 = 0xCD;
+pub const JS_TS_SATISFIES_EXPRESSION: u8 = 0xCE;
+pub const JS_TS_NON_NULL_EXPRESSION: u8 = 0xCF;
+pub const JS_TS_TYPE_ASSERTION: u8 = 0xD0;
+pub const JS_TS_INSTANTIATION_EXPRESSION: u8 = 0xD1;
 
 // LiteralValue inner tag (within a JS_LITERAL payload).
 const LV_NULL: u8 = 0;
@@ -1490,6 +1495,64 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             write_preamble(w, JS_AWAIT_EXPRESSION, *start, *end);
             write_typed_loc(w, loc.as_deref());
             write_node_id(w, *argument, arena)?;
+        }
+        JsNode::TSAsExpression {
+            start,
+            end,
+            loc,
+            expression,
+            type_annotation,
+        } => {
+            write_preamble(w, JS_TS_AS_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *expression, arena)?;
+            write_opt_type_annotation(w, type_annotation.as_deref())?;
+        }
+        JsNode::TSSatisfiesExpression {
+            start,
+            end,
+            loc,
+            expression,
+            type_annotation,
+        } => {
+            write_preamble(w, JS_TS_SATISFIES_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *expression, arena)?;
+            write_opt_type_annotation(w, type_annotation.as_deref())?;
+        }
+        JsNode::TSNonNullExpression {
+            start,
+            end,
+            loc,
+            expression,
+        } => {
+            write_preamble(w, JS_TS_NON_NULL_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *expression, arena)?;
+        }
+        JsNode::TSTypeAssertion {
+            start,
+            end,
+            loc,
+            expression,
+            type_annotation,
+        } => {
+            write_preamble(w, JS_TS_TYPE_ASSERTION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *expression, arena)?;
+            write_opt_type_annotation(w, type_annotation.as_deref())?;
+        }
+        JsNode::TSInstantiationExpression {
+            start,
+            end,
+            loc,
+            expression,
+            type_arguments,
+        } => {
+            write_preamble(w, JS_TS_INSTANTIATION_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_node_id(w, *expression, arena)?;
+            write_opt_type_annotation(w, type_arguments.as_deref())?;
         }
         JsNode::YieldExpression {
             start,

--- a/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/svelte2tsx.rs
@@ -571,7 +571,21 @@ pub fn svelte2tsx(
         skip_non_css_lang_style: false,
         capture_comments: false,
     };
-    let ast = phase1_parse::parse_script_ts(&parse_source, parse_options)?;
+    let mut ast = phase1_parse::parse_script_ts(&parse_source, parse_options)?;
+
+    // Template expressions keep TS assertion wrappers (`x as T`, `x!`,
+    // `x satisfies T`, …) in the parse AST, matching svelte/compiler. The
+    // template lowering below — like phase-3 transform — is written against the
+    // stripped form (e.g. `bind:this={el as T}` relies on the binding
+    // expression's span ending before the cast so the cast moves onto the RHS),
+    // so remove the wrappers from the fragment first. Scripts are re-parsed
+    // TS-aware separately, so only the fragment needs this.
+    {
+        // SAFETY: `ast.arena` lives until the end of this function, outliving the guard.
+        let _arena_guard =
+            unsafe { crate::ast::arena::SerializeArenaGuard::new(&ast.arena as *const _) };
+        crate::compiler::strip_ts_from_fragment(&mut ast.fragment)?;
+    }
 
     // svelte rejects `{@debug expr}` whose arguments are not plain identifiers
     // (`{@debug user.firstname}` / `{@debug a[0]}`) at PARSE time. rsvelte does

--- a/crates/rsvelte_core/tests/each_block_as_const.rs
+++ b/crates/rsvelte_core/tests/each_block_as_const.rs
@@ -37,11 +37,14 @@ fn each_block_with_as_const_alias() {
         out.contains(r#""name":"tab""#),
         "alias should be `tab`, got:\n{out}"
     );
-    // The stray `const` should NOT appear as an identifier — it would mean
-    // the alias was parsed as `const as tab`.
+    // The scanner splits at the RIGHT-most ` as `, so the iterable is
+    // `['a', 'b'] as const` and the alias is `tab` (not `const as tab`). The
+    // trailing `as const` is kept as a `TSAsExpression` — svelte/compiler
+    // preserves TS wrappers in the parse output and strips them only at compile
+    // time — so `const` now appears solely as the cast's type-reference name.
     assert!(
-        !out.contains(r#""name":"const""#),
-        "`const` should not be parsed as an alias identifier:\n{out}"
+        out.contains("TSAsExpression"),
+        "the trailing `as const` cast should be preserved as a TSAsExpression:\n{out}"
     );
 }
 

--- a/crates/rsvelte_core/tests/parse_ts_types.rs
+++ b/crates/rsvelte_core/tests/parse_ts_types.rs
@@ -154,3 +154,172 @@ fn no_typescript_unknown_stub_for_modelled_types() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// #1645: TypeScript assertion expressions must be preserved in the parse AST
+// (svelte/compiler keeps them; the compiler strips them before transform).
+// ---------------------------------------------------------------------------
+
+/// Ordered keys of an object node (serde_json `preserve_order` is enabled, so
+/// this reflects serialization order — i.e. the field order svelte emits).
+fn keys_of(node: &Value) -> Vec<&str> {
+    node.as_object()
+        .map(|m| m.keys().map(String::as_str).collect())
+        .unwrap_or_default()
+}
+
+#[test]
+fn ts_as_const_preserved_in_script_declaration() {
+    let src = "<script lang=\"ts\">const x = 'chips' as const;</script>";
+    let ast = parse_to_json(src);
+    let as_expr = find_node(&ast, "TSAsExpression").expect("TSAsExpression must be preserved");
+
+    // expression is the inner literal `'chips'`.
+    assert_eq!(
+        as_expr.pointer("/expression/type").and_then(Value::as_str),
+        Some("Literal")
+    );
+    assert_eq!(
+        as_expr.pointer("/expression/value").and_then(Value::as_str),
+        Some("chips")
+    );
+    // typeAnnotation is `TSTypeReference` naming `const`.
+    assert_eq!(
+        as_expr
+            .pointer("/typeAnnotation/type")
+            .and_then(Value::as_str),
+        Some("TSTypeReference")
+    );
+    assert_eq!(
+        as_expr
+            .pointer("/typeAnnotation/typeName/name")
+            .and_then(Value::as_str),
+        Some("const")
+    );
+}
+
+#[test]
+fn ts_as_const_preserved_in_inline_expression_tag() {
+    let src = "<script lang=\"ts\"></script><Child p={'chips' as const} />";
+    let ast = parse_to_json(src);
+    let as_expr = find_node(&ast, "TSAsExpression").expect("TSAsExpression must be preserved");
+    assert_eq!(
+        as_expr.pointer("/expression/type").and_then(Value::as_str),
+        Some("Literal")
+    );
+    assert_eq!(
+        as_expr.pointer("/expression/value").and_then(Value::as_str),
+        Some("chips")
+    );
+    assert_eq!(
+        as_expr
+            .pointer("/typeAnnotation/typeName/name")
+            .and_then(Value::as_str),
+        Some("const")
+    );
+}
+
+#[test]
+fn ts_satisfies_expression_preserved() {
+    let src = "<script lang=\"ts\">const z = obj satisfies Foo;</script>";
+    let ast = parse_to_json(src);
+    let n =
+        find_node(&ast, "TSSatisfiesExpression").expect("TSSatisfiesExpression must be preserved");
+    assert_eq!(
+        n.pointer("/expression/name").and_then(Value::as_str),
+        Some("obj")
+    );
+    assert_eq!(
+        n.pointer("/typeAnnotation/typeName/name")
+            .and_then(Value::as_str),
+        Some("Foo")
+    );
+}
+
+#[test]
+fn ts_non_null_expression_preserved_as_member_object() {
+    // `obj!.prop` — the MemberExpression object is a TSNonNullExpression.
+    let src = "<script lang=\"ts\">let v = obj!.prop;</script>";
+    let ast = parse_to_json(src);
+    let member = find_node(&ast, "MemberExpression").expect("MemberExpression");
+    assert_eq!(
+        member.pointer("/object/type").and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+    assert_eq!(
+        member
+            .pointer("/object/expression/name")
+            .and_then(Value::as_str),
+        Some("obj")
+    );
+    // No typeAnnotation on a non-null assertion.
+    let nn = member.get("object").unwrap();
+    assert!(!keys_of(nn).contains(&"typeAnnotation"));
+}
+
+#[test]
+fn ts_type_assertion_emits_type_annotation_before_expression() {
+    // `<Foo>d` — svelte/compiler emits `typeAnnotation` BEFORE `expression`.
+    let src = "<script lang=\"ts\">let c = (<Foo>d);</script>";
+    let ast = parse_to_json(src);
+    let n = find_node(&ast, "TSTypeAssertion").expect("TSTypeAssertion must be preserved");
+    assert_eq!(
+        n.pointer("/expression/name").and_then(Value::as_str),
+        Some("d")
+    );
+    assert_eq!(
+        n.pointer("/typeAnnotation/typeName/name")
+            .and_then(Value::as_str),
+        Some("Foo")
+    );
+    let keys = keys_of(n);
+    let ta = keys
+        .iter()
+        .position(|k| *k == "typeAnnotation")
+        .expect("has typeAnnotation");
+    let ex = keys
+        .iter()
+        .position(|k| *k == "expression")
+        .expect("has expression");
+    assert!(
+        ta < ex,
+        "typeAnnotation must be serialized before expression, keys: {keys:?}"
+    );
+}
+
+#[test]
+fn ts_instantiation_expression_preserved() {
+    let src = "<script lang=\"ts\">const e = f<number>;</script>";
+    let ast = parse_to_json(src);
+    let n = find_node(&ast, "TSInstantiationExpression")
+        .expect("TSInstantiationExpression must be preserved");
+    assert_eq!(
+        n.pointer("/expression/name").and_then(Value::as_str),
+        Some("f")
+    );
+    assert_eq!(
+        n.pointer("/typeArguments/type").and_then(Value::as_str),
+        Some("TSTypeParameterInstantiation")
+    );
+}
+
+#[test]
+fn arrow_handler_parameters_have_real_spans() {
+    // Fast-path mustache/attribute arrow parameters must carry real spans
+    // (svelte/compiler assigns them; rsvelte previously used `Identifier[0,0]`).
+    let src = "<button onclick={(color, e) => handle(color, e)}>x</button>";
+    let ast = parse_to_json(src);
+    let arrow = find_node(&ast, "ArrowFunctionExpression").expect("arrow");
+    let params = arrow
+        .get("params")
+        .and_then(Value::as_array)
+        .expect("params");
+    assert_eq!(params.len(), 2);
+    // `color` occupies columns 18..23, `e` columns 25..26 (matches svelte/compiler).
+    assert_eq!(params[0].get("name").and_then(Value::as_str), Some("color"));
+    assert_eq!(params[0].get("start").and_then(Value::as_u64), Some(18));
+    assert_eq!(params[0].get("end").and_then(Value::as_u64), Some(23));
+    assert_eq!(params[1].get("name").and_then(Value::as_str), Some("e"));
+    assert_eq!(params[1].get("start").and_then(Value::as_u64), Some(25));
+    assert_eq!(params[1].get("end").and_then(Value::as_u64), Some(26));
+}

--- a/crates/rsvelte_core/tests/svelte2tsx_ts_binding_cast.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_ts_binding_cast.rs
@@ -1,0 +1,77 @@
+//! Regression tests for #1645 follow-up: TypeScript assertion wrappers are now
+//! preserved in the parse AST, but svelte2tsx's template lowering expects them
+//! stripped (it moves a binding's trailing cast onto the assignment RHS and uses
+//! the bare target on the reactive-widener shim). svelte2tsx strips TS wrappers
+//! from the fragment before lowering, so a cast must never land on an assignment
+//! LHS. Mirrors the bits-ui / shadcn-svelte corpus failures.
+
+use rsvelte_core::svelte2tsx::{
+    Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion, svelte2tsx,
+};
+
+fn run(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Main.svelte".into(),
+        is_ts_file: true,
+        mode: Svelte2TsxMode::Ts,
+        accessors: false,
+        namespace: Svelte2TsxNamespace::Html,
+        version: SvelteVersion::V5,
+        runes: None,
+        emit_jsdoc: false,
+        rewrite_external_imports: None,
+    };
+    svelte2tsx(src, opts)
+        .expect("svelte2tsx should succeed")
+        .code
+}
+
+#[test]
+fn bind_this_cast_moves_to_rhs() {
+    // `bind:this={el as HTMLElement}` → `el = $$_var as HTMLElement;`, never
+    // `(el as HTMLElement) = $$_var;`.
+    let src = "<script lang=\"ts\">let el;</script><div bind:this={el as HTMLElement}></div>";
+    let out = run(src);
+    assert!(
+        !out.contains("(el as HTMLElement) ="),
+        "cast must not land on the assignment LHS:\n{out}"
+    );
+    assert!(
+        out.contains("el = ") && out.contains("as HTMLElement;"),
+        "cast should move onto the RHS:\n{out}"
+    );
+}
+
+#[test]
+fn bind_value_whole_cast_target_is_bare() {
+    // `bind:value={value as never}` on a component: the reactive widener uses the
+    // bare `value`, while the prop value keeps the cast.
+    let src = "<script lang=\"ts\">let value: string = \"\";</script><Combobox bind:value={value as never} />";
+    let out = run(src);
+    assert!(
+        !out.contains("(value as never) ="),
+        "cast must not land on the assignment LHS:\n{out}"
+    );
+    assert!(
+        out.contains("() => value = __sveltets_2_any(null);"),
+        "reactive widener should use the bare target:\n{out}"
+    );
+    assert!(
+        out.contains("value:value as never"),
+        "the prop value should keep the cast:\n{out}"
+    );
+}
+
+#[test]
+fn bind_value_non_null_target_is_bare() {
+    let src = "<script lang=\"ts\">let binding = null;</script><input type=\"number\" bind:value={binding!} />";
+    let out = run(src);
+    assert!(
+        !out.contains("binding!) = ") && !out.contains("(binding!) ="),
+        "non-null assertion must not land on the assignment LHS:\n{out}"
+    );
+    assert!(
+        out.contains("() => binding = __sveltets_2_any(null);"),
+        "reactive widener should use the bare target:\n{out}"
+    );
+}

--- a/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
+++ b/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
@@ -204,10 +204,25 @@ fn in_function(ancestors: &[&Value]) -> bool {
 }
 
 /// Whether the ancestor chain places the node inside a TS type annotation.
+///
+/// TS *expression* wrappers (`x as T`, `x!`, `<T>x`, `x satisfies T`,
+/// `x<T>`) are values, not type annotations — their `expression` child is
+/// ordinary code — so they must not count here (only their `typeAnnotation` /
+/// `typeArguments` subtrees, which are themselves real `TS…` type nodes, do).
 fn in_type_annotation(ancestors: &[&Value]) -> bool {
-    ancestors
-        .iter()
-        .any(|n| node_type(n).is_some_and(|t| t.starts_with("TS")))
+    ancestors.iter().any(|n| {
+        node_type(n).is_some_and(|t| {
+            t.starts_with("TS")
+                && !matches!(
+                    t,
+                    "TSAsExpression"
+                        | "TSSatisfiesExpression"
+                        | "TSNonNullExpression"
+                        | "TSTypeAssertion"
+                        | "TSInstantiationExpression"
+                )
+        })
+    })
 }
 
 /// Whether all execution paths of a statement end in a jump


### PR DESCRIPTION
Fixes #1645

## Problem

`@rsvelte/compiler`'s `parse()` silently stripped TypeScript assertion wrappers,
returning only the inner expression:

- `pattern={'chips' as const}` → rsvelte emitted `Literal 'chips'` where
  svelte/compiler emits `TSAsExpression { expression: Literal 'chips',
  typeAnnotation: TSTypeReference "const" }`.
- Owner-script declarations (`const X = 'y' as const`) had the same divergence.

Consumers that expect the svelte/compiler AST shape (e.g. svelte-shaker) observed
a different tree depending on which parser ran.

## Root cause

rsvelte parses `<script>` with oxc and converts oxc expressions into its own typed
AST (`JsNode`). The converters (`convert_expression` for template expressions,
`convert_expression_for_program` for script bodies) **unwrapped** the oxc TS
wrapper nodes at parse time, so the wrapper never reached the parse output.

This is the wrong place to strip. The official compiler
(`submodules/svelte/.../1-parse/remove_typescript_nodes.js`, invoked from
`compiler/index.js`) keeps TS nodes in `parse()` and strips them only inside
`compile()` — before analyze/transform — via `remove_typescript_nodes`.

## Change (mirrors the official compiler)

- The parser now **preserves** `TSAsExpression`, `TSSatisfiesExpression`,
  `TSNonNullExpression`, `TSTypeAssertion`, and `TSInstantiationExpression`
  (with their `typeAnnotation` / `typeArguments`) as first-class `JsNode`
  variants, in both script bodies and inline template expressions, including the
  member/optional-chain `a!.b` cases.
- `remove_typescript_nodes` (the typed compile-time pass that already runs before
  analyze/transform) now **unwraps** these wrappers to their inner expression, so
  the AST analyze/transform sees is byte-identical to before — **compiled
  client/server output is unchanged.**
- Serialization is mirrored across all three parse-output surfaces: the serde
  `Serialize` impl (test AST), the NAPI binary envelope (`napi_raw_parse.rs` +
  the JS decoder in `parse-envelope.js`), and `from_value`.

The JSDoc-adjusted (Value-based, non-TS) converter keeps unwrapping — it never
carries real TS assertions, so unwrapping there is byte-identical.

### Secondary fix (zero-width span)

The issue also noted that fast-path mustache/attribute arrow handlers
(`onclick={(color, e) => …}`) returned parameters with a zero-width
`Identifier[0,0]` span and no `loc`. Root cause: a fast-path arrow parser
hardcoded `start: 0, end: 0, loc: None` for parameters ("positions not critical
for compilation"). Parameters now derive their real absolute spans from their byte
position in the source, matching svelte/compiler. Compiled output is unchanged.

## Verification

- The repro (`const x = 'chips' as const`, `<Child p={'chips' as const} />`, plus
  `as T<G>`, `satisfies`, `!`, `f<number>`) now parses to a tree that is
  **byte-identical** to svelte/compiler's `parse({ modern: true })` for every
  declarator init and attribute expression.
- Arrow handler parameters now report real spans (verified against
  svelte/compiler).
- `cargo test -p rsvelte_core --release`: **1602 passed, 0 failed** (includes the
  byte-exact client/server output gates, parser/validator/SSR/hydration/runtime
  suites).
- `cargo fmt` clean; `cargo clippy --all-targets --all-features -- -D warnings`
  clean across the workspace.

## Known issue (pre-existing, out of scope)

rsvelte leniently accepts a TS assertion in a **non**-`lang="ts"` component
(e.g. `{x as const}` with no `<script lang="ts">`), where svelte/compiler
raises a parse error. That lenient acceptance predates this PR; before it the
wrapper was silently stripped, so it was invisible. Now that wrappers are
preserved, the `TSAsExpression` becomes observable in such input. This is an
existing parser-leniency quirk, not introduced here, and is left unchanged.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XHPUBHj4ywFM8skv4GwxV
