### PR TITLE
fix(parse): preserve remaining TS assertion forms deferred by #1648

### DIFF
--- a/.changeset/fix-preserve-remaining-ts-assertions.md
+++ b/.changeset/fix-preserve-remaining-ts-assertions.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): preserve the remaining TypeScript assertion forms in parse() output
+
+Follow-up to #1648, which deliberately deferred three forms. `parse()` now also
+keeps `TSTypeAssertion` (`<T>x`) and `TSInstantiationExpression` (`f<T>`) — with
+svelte/compiler-compatible shape (`TSTypeAssertion` serializes `typeAnnotation`
+before `expression`; `TSInstantiationExpression` carries `typeArguments`) — and a
+non-null `!` sitting inside an optional chain (`a!?.b`), matching svelte/compiler.
+As with the other wrappers, `remove_typescript_nodes` erases them before
+analyze/transform, so compiled client/server output is unchanged.

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -158,6 +158,8 @@ const JS_TS_PARAMETER_PROPERTY = 0xcc;
 const JS_TS_AS_EXPRESSION = 0xcd;
 const JS_TS_SATISFIES_EXPRESSION = 0xce;
 const JS_TS_NON_NULL_EXPRESSION = 0xcf;
+const JS_TS_TYPE_ASSERTION = 0xd0;
+const JS_TS_INSTANTIATION_EXPRESSION = 0xd1;
 
 // LiteralValue inner tag (within a JS_LITERAL payload).
 const LV_NULL = 0;
@@ -590,6 +592,10 @@ function readNodeBody(ctx, tag, start, end) {
 			return readJsTSAssertion(ctx, 'TSSatisfiesExpression', start, end, true);
 		case JS_TS_NON_NULL_EXPRESSION:
 			return readJsTSAssertion(ctx, 'TSNonNullExpression', start, end, false);
+		case JS_TS_TYPE_ASSERTION:
+			return readJsTSTypeAssertion(ctx, start, end);
+		case JS_TS_INSTANTIATION_EXPRESSION:
+			return readJsTSInstantiationExpression(ctx, start, end);
 		case JS_COMMENT:
 			return readJsComment_(ctx, start, end);
 
@@ -996,6 +1002,30 @@ function readJsTSAssertion(ctx, typeName, start, end, hasTypeAnnotation) {
 		const typeAnnotation = readOptTypeAnnotation(ctx);
 		if (typeAnnotation !== null) node.typeAnnotation = typeAnnotation;
 	}
+	return node;
+}
+
+function readJsTSTypeAssertion(ctx, start, end) {
+	// Wire order: loc, expression, typeAnnotation — but svelte/compiler emits
+	// `typeAnnotation` before `expression`, so build the object in that order.
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const typeAnnotation = readOptTypeAnnotation(ctx);
+	const node = { type: 'TSTypeAssertion', start, end };
+	if (loc !== null) node.loc = loc;
+	if (typeAnnotation !== null) node.typeAnnotation = typeAnnotation;
+	node.expression = expression;
+	return node;
+}
+
+function readJsTSInstantiationExpression(ctx, start, end) {
+	const loc = readTypedLoc(ctx);
+	const expression = readNode(ctx);
+	const typeArguments = readOptTypeAnnotation(ctx);
+	const node = { type: 'TSInstantiationExpression', start, end };
+	if (loc !== null) node.loc = loc;
+	node.expression = expression;
+	if (typeArguments !== null) node.typeArguments = typeArguments;
 	return node;
 }
 

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -680,6 +680,24 @@ pub enum JsNode {
         loc: Option<Box<Loc>>,
         expression: JsNodeId,
     },
+    // Old-style cast `<T>x`. svelte/compiler serializes `typeAnnotation` BEFORE
+    // `expression` (see the Serialize impl).
+    TSTypeAssertion {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+        type_annotation: Box<Value>,
+    },
+    // Explicit type-argument instantiation `f<T>`. Carries `type_arguments`
+    // (a `TSTypeParameterInstantiation` type node) rather than a single type.
+    TSInstantiationExpression {
+        start: u32,
+        end: u32,
+        loc: Option<Box<Loc>>,
+        expression: JsNodeId,
+        type_arguments: Box<Value>,
+    },
     // Comment (used in Program.comments array, type is "Line" or "Block")
     Comment {
         start: u32,
@@ -2126,6 +2144,41 @@ impl Serialize for JsNode {
                 ser_comments!(map, *start, *end);
                 map.end()
             }
+            JsNode::TSTypeAssertion {
+                start,
+                end,
+                loc,
+                expression,
+                type_annotation,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSTypeAssertion")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                // svelte/compiler emits `typeAnnotation` before `expression` here.
+                map.serialize_entry("typeAnnotation", type_annotation.as_ref())?;
+                ser_node!(map, "expression", expression);
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
+            JsNode::TSInstantiationExpression {
+                start,
+                end,
+                loc,
+                expression,
+                type_arguments,
+            } => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "TSInstantiationExpression")?;
+                map.serialize_entry("start", start)?;
+                map.serialize_entry("end", end)?;
+                ser_loc!(map, loc);
+                ser_node!(map, "expression", expression);
+                map.serialize_entry("typeArguments", type_arguments.as_ref())?;
+                ser_comments!(map, *start, *end);
+                map.end()
+            }
             JsNode::Comment {
                 start,
                 end,
@@ -2859,6 +2912,24 @@ impl JsNode {
                         loc,
                         expression: convert_child(obj, "expression"),
                     },
+                    "TSTypeAssertion" => JsNode::TSTypeAssertion {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                        type_annotation: Box::new(
+                            obj.get("typeAnnotation").cloned().unwrap_or(Value::Null),
+                        ),
+                    },
+                    "TSInstantiationExpression" => JsNode::TSInstantiationExpression {
+                        start,
+                        end,
+                        loc,
+                        expression: convert_child(obj, "expression"),
+                        type_arguments: Box::new(
+                            obj.get("typeArguments").cloned().unwrap_or(Value::Null),
+                        ),
+                    },
                     "Line" | "Block" => JsNode::Comment {
                         start,
                         end,
@@ -2960,6 +3031,8 @@ impl JsNode {
             JsNode::TSAsExpression { .. } => Some("TSAsExpression"),
             JsNode::TSSatisfiesExpression { .. } => Some("TSSatisfiesExpression"),
             JsNode::TSNonNullExpression { .. } => Some("TSNonNullExpression"),
+            JsNode::TSTypeAssertion { .. } => Some("TSTypeAssertion"),
+            JsNode::TSInstantiationExpression { .. } => Some("TSInstantiationExpression"),
             JsNode::Comment { comment_type, .. } => Some(comment_type.as_str()),
             JsNode::Null => None,
         }
@@ -3631,6 +3704,8 @@ impl JsNode {
             | JsNode::TSAsExpression { start, .. }
             | JsNode::TSSatisfiesExpression { start, .. }
             | JsNode::TSNonNullExpression { start, .. }
+            | JsNode::TSTypeAssertion { start, .. }
+            | JsNode::TSInstantiationExpression { start, .. }
             | JsNode::Comment { start, .. } => *start,
             JsNode::Null => 0,
         }
@@ -3715,6 +3790,8 @@ impl JsNode {
             | JsNode::TSAsExpression { end, .. }
             | JsNode::TSSatisfiesExpression { end, .. }
             | JsNode::TSNonNullExpression { end, .. }
+            | JsNode::TSTypeAssertion { end, .. }
+            | JsNode::TSInstantiationExpression { end, .. }
             | JsNode::Comment { end, .. } => *end,
             JsNode::Null => 0,
         }
@@ -3801,6 +3878,8 @@ impl JsNode {
             JsNode::TSAsExpression { .. } => "TSAsExpression",
             JsNode::TSSatisfiesExpression { .. } => "TSSatisfiesExpression",
             JsNode::TSNonNullExpression { .. } => "TSNonNullExpression",
+            JsNode::TSTypeAssertion { .. } => "TSTypeAssertion",
+            JsNode::TSInstantiationExpression { .. } => "TSInstantiationExpression",
             JsNode::Comment { .. } => "Comment",
             JsNode::Null => "Null",
         }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -3806,13 +3806,36 @@ fn convert_expression(
                 expression: arena.alloc_js_node(expr_to_node(inner)),
             })
         }
-        // `<T>x` type assertions and `f<T>` instantiation expressions are still
-        // unwrapped (out of scope; rare in Svelte templates).
         OxcExpression::TSTypeAssertion(ts_assertion) => {
-            convert_expression(arena, &ts_assertion.expression, offset, line_offsets)
+            let start = offset + ts_assertion.span.start as usize - 1;
+            let end = offset + ts_assertion.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_assertion.expression, offset, line_offsets);
+            let type_annotation =
+                convert_ts_type(&ts_assertion.type_annotation, offset - 1, line_offsets);
+            Expression::from_node(JsNode::TSTypeAssertion {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            })
         }
         OxcExpression::TSInstantiationExpression(ts_inst) => {
-            convert_expression(arena, &ts_inst.expression, offset, line_offsets)
+            let start = offset + ts_inst.span.start as usize - 1;
+            let end = offset + ts_inst.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_inst.expression, offset, line_offsets);
+            let type_arguments = convert_ts_type_param_instantiation(
+                &ts_inst.type_arguments,
+                offset - 1,
+                line_offsets,
+            );
+            Expression::from_node(JsNode::TSInstantiationExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_arguments: Box::new(type_arguments),
+            })
         }
         OxcExpression::NewExpression(new_expr) => {
             let start = offset + new_expr.span.start as usize - 1;
@@ -3903,9 +3926,18 @@ fn convert_expression(
                         line_offsets,
                     ))
                 }
-                oxc_ast::ast::ChainElement::TSNonNullExpression(ts_non_null) => expr_to_node(
-                    convert_expression(arena, &ts_non_null.expression, offset, line_offsets),
-                ),
+                oxc_ast::ast::ChainElement::TSNonNullExpression(ts_non_null) => {
+                    let inner_start = offset + ts_non_null.span.start as usize - 1;
+                    let inner_end = offset + ts_non_null.span.end as usize - 1;
+                    let inner =
+                        convert_expression(arena, &ts_non_null.expression, offset, line_offsets);
+                    JsNode::TSNonNullExpression {
+                        start: inner_start as u32,
+                        end: inner_end as u32,
+                        loc: create_typed_loc(inner_start, inner_end, line_offsets),
+                        expression: arena.alloc_js_node(expr_to_node(inner)),
+                    }
+                }
                 oxc_ast::ast::ChainElement::StaticMemberExpression(member) => {
                     let inner_start = offset + member.span.start as usize - 1;
                     let inner_end = offset + member.span.end as usize - 1;
@@ -8997,12 +9029,20 @@ fn convert_expression_for_program(
                     }
                 }
                 oxc_ast::ast::ChainElement::TSNonNullExpression(ts_non_null) => {
-                    expr_to_node(convert_expression_for_program(
+                    let inner_start = offset + ts_non_null.span.start as usize;
+                    let inner_end = offset + ts_non_null.span.end as usize;
+                    let inner = convert_expression_for_program(
                         arena,
                         &ts_non_null.expression,
                         offset,
                         line_offsets,
-                    ))
+                    );
+                    JsNode::TSNonNullExpression {
+                        start: inner_start as u32,
+                        end: inner_end as u32,
+                        loc: create_typed_loc(inner_start, inner_end, line_offsets),
+                        expression: arena.alloc_js_node(expr_to_node(inner)),
+                    }
                 }
                 oxc_ast::ast::ChainElement::StaticMemberExpression(member) => {
                     let inner_start = offset + member.span.start as usize;
@@ -9206,13 +9246,39 @@ fn convert_expression_for_program(
                 expression: arena.alloc_js_node(expr_to_node(inner)),
             })
         }
-        // `<T>x` type assertions and `f<T>` instantiation expressions are still
-        // unwrapped (out of scope; rare in Svelte scripts).
         OxcExpression::TSTypeAssertion(ts_assertion) => {
-            convert_expression_for_program(arena, &ts_assertion.expression, offset, line_offsets)
+            let start = offset + ts_assertion.span.start as usize;
+            let end = offset + ts_assertion.span.end as usize;
+            let inner = convert_expression_for_program(
+                arena,
+                &ts_assertion.expression,
+                offset,
+                line_offsets,
+            );
+            let type_annotation =
+                convert_ts_type(&ts_assertion.type_annotation, offset, line_offsets);
+            Expression::from_node(JsNode::TSTypeAssertion {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            })
         }
         OxcExpression::TSInstantiationExpression(ts_inst) => {
-            convert_expression_for_program(arena, &ts_inst.expression, offset, line_offsets)
+            let start = offset + ts_inst.span.start as usize;
+            let end = offset + ts_inst.span.end as usize;
+            let inner =
+                convert_expression_for_program(arena, &ts_inst.expression, offset, line_offsets);
+            let type_arguments =
+                convert_ts_type_param_instantiation(&ts_inst.type_arguments, offset, line_offsets);
+            Expression::from_node(JsNode::TSInstantiationExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_arguments: Box::new(type_arguments),
+            })
         }
         OxcExpression::MetaProperty(meta) => {
             // `import.meta` / `new.target`. Without this arm the fallback

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
@@ -581,14 +581,20 @@ pub fn remove_typescript_nodes_typed(
             remove_this_param_typed(node, arena);
         }
 
-        // Unwrap TS assertion wrappers (`x as T` / `x satisfies T` / `x!`),
-        // replacing the wrapper with its inner expression and continuing the
-        // strip into it. Mirrors upstream `context.visit(node.expression)`.
-        Some("TSAsExpression") | Some("TSSatisfiesExpression") | Some("TSNonNullExpression") => {
+        // Unwrap TS assertion wrappers (`x as T` / `x satisfies T` / `x!` /
+        // `<T>x` / `x<T>`), replacing the wrapper with its inner expression and
+        // continuing the strip into it. Mirrors upstream `context.visit(node.expression)`.
+        Some("TSAsExpression")
+        | Some("TSSatisfiesExpression")
+        | Some("TSNonNullExpression")
+        | Some("TSTypeAssertion")
+        | Some("TSInstantiationExpression") => {
             let inner_id = match node {
                 JsNode::TSAsExpression { expression, .. }
                 | JsNode::TSSatisfiesExpression { expression, .. }
-                | JsNode::TSNonNullExpression { expression, .. } => *expression,
+                | JsNode::TSNonNullExpression { expression, .. }
+                | JsNode::TSTypeAssertion { expression, .. }
+                | JsNode::TSInstantiationExpression { expression, .. } => *expression,
                 _ => unreachable!("node_type matched a TS assertion variant"),
             };
             *node = arena.get_js_node(inner_id).clone();

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -3525,7 +3525,9 @@ fn js_node_check_features(
         // is opaque and carries no references).
         JsNode::TSAsExpression { expression, .. }
         | JsNode::TSSatisfiesExpression { expression, .. }
-        | JsNode::TSNonNullExpression { expression, .. } => walk_id!(*expression),
+        | JsNode::TSNonNullExpression { expression, .. }
+        | JsNode::TSTypeAssertion { expression, .. }
+        | JsNode::TSInstantiationExpression { expression, .. } => walk_id!(*expression),
     }
 
     shadowed.truncate(shadow_base);
@@ -5470,6 +5472,20 @@ fn collect_identifier_names_in_node(
             end: _,
             loc: _,
             expression,
+        }
+        | JsNode::TSTypeAssertion {
+            start: _,
+            end: _,
+            loc: _,
+            expression,
+            type_annotation: _,
+        }
+        | JsNode::TSInstantiationExpression {
+            start: _,
+            end: _,
+            loc: _,
+            expression,
+            type_arguments: _,
         } => walk(*expression, out),
 
         JsNode::Comment {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -1063,7 +1063,8 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             // ClassBody member variants we do not reproduce here) and any other
             // variant not explicitly handled above (the CRITICAL RULE). The TS
             // assertion wrappers (`TSAsExpression` / `TSSatisfiesExpression` /
-            // `TSNonNullExpression`) are erased by `remove_typescript_nodes`
+            // `TSNonNullExpression` / `TSTypeAssertion` / `TSInstantiationExpression`)
+            // are erased by `remove_typescript_nodes`
             // before transform, so they never reach here; if one somehow did,
             // `None` is the correct, safe answer — it falls back to the text
             // printer rather than emitting wrong code.

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -232,6 +232,8 @@ pub const JS_TS_PARAMETER_PROPERTY: u8 = 0xCC;
 pub const JS_TS_AS_EXPRESSION: u8 = 0xCD;
 pub const JS_TS_SATISFIES_EXPRESSION: u8 = 0xCE;
 pub const JS_TS_NON_NULL_EXPRESSION: u8 = 0xCF;
+pub const JS_TS_TYPE_ASSERTION: u8 = 0xD0;
+pub const JS_TS_INSTANTIATION_EXPRESSION: u8 = 0xD1;
 
 // LiteralValue inner tag (within a JS_LITERAL payload).
 const LV_NULL: u8 = 0;
@@ -2128,6 +2130,30 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             write_preamble(w, JS_TS_NON_NULL_EXPRESSION, *start, *end);
             write_typed_loc(w, loc.as_deref());
             write_js_node(w, arena.get_js_node(*expression), arena)?;
+        }
+        JsNode::TSTypeAssertion {
+            start,
+            end,
+            loc,
+            expression,
+            type_annotation,
+        } => {
+            write_preamble(w, JS_TS_TYPE_ASSERTION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_js_node(w, arena.get_js_node(*expression), arena)?;
+            write_opt_type_annotation(w, Some(type_annotation.as_ref()))?;
+        }
+        JsNode::TSInstantiationExpression {
+            start,
+            end,
+            loc,
+            expression,
+            type_arguments,
+        } => {
+            write_preamble(w, JS_TS_INSTANTIATION_EXPRESSION, *start, *end);
+            write_typed_loc(w, loc.as_deref());
+            write_js_node(w, arena.get_js_node(*expression), arena)?;
+            write_opt_type_annotation(w, Some(type_arguments.as_ref()))?;
         }
         // `Null` doesn't carry positions, so it uses a dedicated sentinel tag
         // without the usual preamble pair.

--- a/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/template/mod.rs
@@ -6235,7 +6235,10 @@ fn get_expression_end_stripping_ts(expr: &crate::ast::js::Expression, source: &s
     let ty = expr.node_type()?;
     if !matches!(
         ty,
-        "TSAsExpression" | "TSSatisfiesExpression" | "TSNonNullExpression"
+        "TSAsExpression"
+            | "TSSatisfiesExpression"
+            | "TSNonNullExpression"
+            | "TSInstantiationExpression"
     ) {
         return Some(end);
     }
@@ -6255,6 +6258,36 @@ fn get_expression_end_stripping_ts(expr: &crate::ast::js::Expression, source: &s
         }
         while i > s && bytes[i - 1].is_ascii_whitespace() {
             i -= 1;
+        }
+        return Some(i as u32);
+    }
+    if ty == "TSInstantiationExpression" {
+        // `f<T>`: strip the trailing `<…>` type-argument list. Scan back from the
+        // closing `>` balancing nested `<…>` to its matching `<`; the inner
+        // expression ends just before it.
+        let mut i = e;
+        while i > s && bytes[i - 1].is_ascii_whitespace() {
+            i -= 1;
+        }
+        if i > s && bytes[i - 1] == b'>' {
+            let mut depth: i32 = 0;
+            while i > s {
+                match bytes[i - 1] {
+                    b'>' => depth += 1,
+                    b'<' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            i -= 1;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+                i -= 1;
+            }
+            while i > s && bytes[i - 1].is_ascii_whitespace() {
+                i -= 1;
+            }
         }
         return Some(i as u32);
     }
@@ -6312,14 +6345,56 @@ fn get_expression_end_stripping_ts(expr: &crate::ast::js::Expression, source: &s
     }
 }
 
-/// Source text of a binding assignment LHS: the expression with any trailing TS
-/// assertion stripped (mirrors `[expr.start, getEnd(expr)]` upstream).
+/// Start offset of an expression, stripping a leading TS `<T>` type-assertion
+/// prefix (`TSTypeAssertion`). For `<T>x` the assignable inner expression begins
+/// after the closing `>`; every other expression keeps its own start.
+fn get_expression_start_stripping_ts(
+    expr: &crate::ast::js::Expression,
+    source: &str,
+) -> Option<u32> {
+    let (start, end) = get_expression_range(expr)?;
+    if expr.node_type()? != "TSTypeAssertion" {
+        return Some(start);
+    }
+    let bytes = source.as_bytes();
+    let (s, e) = (start as usize, end as usize);
+    if e > source.len() || s >= e || bytes[s] != b'<' {
+        return Some(start);
+    }
+    // Balance the leading `<…>` (nested generics included), then skip whitespace.
+    let mut i = s;
+    let mut depth: i32 = 0;
+    while i < e {
+        match bytes[i] {
+            b'<' => depth += 1,
+            b'>' => {
+                depth -= 1;
+                if depth == 0 {
+                    i += 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    while i < e && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    Some(i as u32)
+}
+
+/// Source text of a binding assignment LHS: the expression with any TS assertion
+/// stripped (mirrors `[getStart(expr), getEnd(expr)]` upstream). A trailing
+/// postfix (`as T` / `satisfies T` / `!` / `<T>` type args) is trimmed from the
+/// end and a leading `<T>` type-assertion prefix from the start, so a cast never
+/// lands on the assignment target.
 fn get_binding_lhs_text<'a>(expr: &crate::ast::js::Expression, source: &'a str) -> &'a str {
     match (
-        get_expression_range(expr),
+        get_expression_start_stripping_ts(expr, source),
         get_expression_end_stripping_ts(expr, source),
     ) {
-        (Some((start, _)), Some(ge)) => slice_src(source, start as usize, ge as usize),
+        (Some(start), Some(ge)) if start <= ge => slice_src(source, start as usize, ge as usize),
         _ => get_expression_text(expr, source),
     }
 }

--- a/crates/rsvelte_core/tests/svelte2tsx_binding_ts_assertion.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_binding_ts_assertion.rs
@@ -110,3 +110,39 @@ fn nested_assertion_only_outermost_is_stripped() {
         "only the outermost assertion should be stripped:\n{out}"
     );
 }
+
+// ── follow-up: prefix `<T>x` cast and `f<T>` instantiation binding targets ──
+// Both compile as valid Svelte bindings; the assertion/type-args must be
+// stripped from the setter LHS, not just trailing postfix forms.
+
+#[test]
+fn element_binding_type_assertion_prefix_strips_from_setter() {
+    let out = to_tsx(
+        "<script lang=\"ts\">let x = 0;</script>\
+         <input bind:value={<number>x} />",
+    );
+    assert!(
+        out.contains("() => x = __sveltets_2_any(null)"),
+        "setter should strip the leading `<number>` cast (bare `x`):\n{out}"
+    );
+    assert!(
+        !out.contains("<number>x = __sveltets_2_any(null)"),
+        "prefix cast leaked into the setter LHS:\n{out}"
+    );
+}
+
+#[test]
+fn element_binding_instantiation_strips_from_setter() {
+    let out = to_tsx(
+        "<script lang=\"ts\">let f: any;</script>\
+         <input bind:value={f<number>} />",
+    );
+    assert!(
+        out.contains("() => f = __sveltets_2_any(null)"),
+        "setter should strip the trailing `<number>` type args (bare `f`):\n{out}"
+    );
+    assert!(
+        !out.contains("f<number> = __sveltets_2_any(null)"),
+        "instantiation type args leaked into the setter LHS:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/ts_assertion_expressions_extra.rs
+++ b/crates/rsvelte_core/tests/ts_assertion_expressions_extra.rs
@@ -1,0 +1,186 @@
+//! Follow-up to #1648: the remaining TS assertion forms it deferred —
+//! `TSTypeAssertion` (`<T>x`), `TSInstantiationExpression` (`f<T>`), and a
+//! non-null `!` sitting inside an optional chain — must also be preserved in the
+//! public `parse()` AST (mirroring svelte/compiler) and erased at compile time.
+
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{CompileOptions, GenerateMode, ParseOptions, compile, parse};
+use serde_json::Value;
+
+fn parse_to_value(source: &str) -> Value {
+    let ast = parse(source, ParseOptions::default()).expect("parse should succeed");
+    with_serialize_arena(&ast.arena, || serde_json::to_value(&ast).unwrap())
+}
+
+/// Depth-first search for the first node whose `type` equals `ty`.
+fn find_node<'a>(v: &'a Value, ty: &str) -> Option<&'a Value> {
+    match v {
+        Value::Object(map) => {
+            if map.get("type").and_then(|t| t.as_str()) == Some(ty) {
+                return Some(v);
+            }
+            for (_, child) in map {
+                if let Some(found) = find_node(child, ty) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Array(arr) => arr.iter().find_map(|c| find_node(c, ty)),
+        _ => None,
+    }
+}
+
+/// Ordered keys of an object node (serde_json `preserve_order` is enabled, so
+/// this reflects svelte/compiler's serialization order).
+fn keys_of(node: &Value) -> Vec<&str> {
+    node.as_object()
+        .map(|m| m.keys().map(String::as_str).collect())
+        .unwrap_or_default()
+}
+
+// ── parse-shape: TSTypeAssertion (`<T>x`) ──────────────────────────────────
+
+#[test]
+fn ts_type_assertion_preserves_wrapper_type_annotation_before_expression() {
+    let source = "<script lang=\"ts\">let a = <string>'';</script>";
+    let ast = parse_to_value(source);
+    let node = find_node(&ast, "TSTypeAssertion").expect("TSTypeAssertion must be preserved");
+
+    assert_eq!(
+        node.pointer("/expression/type").and_then(Value::as_str),
+        Some("Literal")
+    );
+    assert_eq!(
+        node.pointer("/typeAnnotation/type").and_then(Value::as_str),
+        Some("TSStringKeyword")
+    );
+    // svelte/compiler emits `typeAnnotation` before `expression`.
+    let keys = keys_of(node);
+    let ta = keys.iter().position(|k| *k == "typeAnnotation").unwrap();
+    let ex = keys.iter().position(|k| *k == "expression").unwrap();
+    assert!(
+        ta < ex,
+        "typeAnnotation must serialize before expression, keys: {keys:?}"
+    );
+}
+
+// ── parse-shape: TSInstantiationExpression (`f<T>`) ────────────────────────
+
+#[test]
+fn ts_instantiation_preserves_wrapper_and_type_arguments() {
+    let source = "<script lang=\"ts\">const e = f<number>;</script>";
+    let ast = parse_to_value(source);
+    let node =
+        find_node(&ast, "TSInstantiationExpression").expect("TSInstantiationExpression preserved");
+
+    assert_eq!(
+        node.pointer("/expression/name").and_then(Value::as_str),
+        Some("f")
+    );
+    assert_eq!(
+        node.pointer("/typeArguments/type").and_then(Value::as_str),
+        Some("TSTypeParameterInstantiation")
+    );
+}
+
+// ── parse-shape: non-null inside an optional chain (`a!?.b`) ────────────────
+
+#[test]
+fn non_null_inside_optional_chain_preserves_wrapper() {
+    let source = "<script lang=\"ts\">let x = a!?.b;</script>";
+    let ast = parse_to_value(source);
+    // The chain's member object is the `a!` non-null assertion.
+    let member = find_node(&ast, "MemberExpression").expect("MemberExpression");
+    assert_eq!(
+        member.pointer("/object/type").and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+    assert_eq!(
+        member
+            .pointer("/object/expression/name")
+            .and_then(Value::as_str),
+        Some("a")
+    );
+}
+
+#[test]
+fn non_null_as_member_object_preserves_wrapper() {
+    // `a!.b` — plain member access whose object is a non-null assertion.
+    let source = "<script lang=\"ts\">let x = a!.b;</script>";
+    let ast = parse_to_value(source);
+    let member = find_node(&ast, "MemberExpression").expect("MemberExpression");
+    assert_eq!(
+        member.pointer("/object/type").and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+}
+
+// ── parse-shape: template expression tag ───────────────────────────────────
+
+#[test]
+fn ts_type_assertion_in_template_expression_tag_preserved() {
+    let source = "<script lang=\"ts\">let d = 0;</script>{<number>d}";
+    let ast = parse_to_value(source);
+    let node = find_node(&ast, "TSTypeAssertion").expect("TSTypeAssertion in template preserved");
+    assert_eq!(
+        node.pointer("/typeAnnotation/type").and_then(Value::as_str),
+        Some("TSNumberKeyword")
+    );
+}
+
+// ── codegen erasure: compile output must not carry the assertions ──────────
+
+fn client_code(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("client compile should succeed")
+    .js
+    .code
+}
+
+fn server_code(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Server,
+            ..Default::default()
+        },
+    )
+    .expect("server compile should succeed")
+    .js
+    .code
+}
+
+#[test]
+fn type_assertion_and_instantiation_erased_from_codegen() {
+    // `<T>x` and `f<T>` used in a template expression must not leak their type
+    // syntax (or an `Unknown:` placeholder) into client or server output.
+    let source = "<script lang=\"ts\">let d = 0; function f<T>(): number { return 0; }</script>{<number>d}{f<number>()}";
+    for code in [client_code(source), server_code(source)] {
+        assert!(
+            !code.contains("Unknown:"),
+            "TS wrapper leaked into codegen:\n{code}"
+        );
+        assert!(
+            !code.contains("<number>"),
+            "type assertion leaked into codegen:\n{code}"
+        );
+    }
+}
+
+#[test]
+fn non_null_in_chain_erased_from_codegen() {
+    let source = "<script lang=\"ts\">let a = { b: 1 };</script>{a!?.b}";
+    for code in [client_code(source), server_code(source)] {
+        assert!(
+            !code.contains("Unknown:"),
+            "TS wrapper leaked into codegen:\n{code}"
+        );
+    }
+}


### PR DESCRIPTION
Refs #1645 (issue already closed by #1648).

## Context

#1648 preserved `TSAsExpression`, `TSSatisfiesExpression`, and `TSNonNullExpression` in `parse()` output, but explicitly deferred three forms as "follow-up issues to come":

> "Deliberately out of scope (pre-existing unwraps, inline-commented): `TSTypeAssertion` (`<T>x`), `TSInstantiationExpression` (`f<T>`), and `!` inside optional chains — follow-up issues to come."

This PR is that follow-up. It extends #1648's established structure to preserve those remaining forms so `parse()` fully matches svelte/compiler.

## Change

Preserves three more forms (unwrapped before, now kept as wrappers):

- **`TSTypeAssertion`** (`<T>x`) — svelte/compiler serializes `typeAnnotation` **before** `expression`; the typed variant's `Serialize` impl mirrors that order.
- **`TSInstantiationExpression`** (`f<T>`) — carries `typeArguments` (a `TSTypeParameterInstantiation` node).
- **Non-null `!` inside an optional chain** (`a!?.b`) — the chain-element `TSNonNullExpression` is kept as the member object instead of being unwrapped.

Each is added following #1648's exact 3-variant pattern across:
- the typed AST (`typed_expr.rs`: variant, `Serialize`, `from_value`, `node_type`/`get_start_inner`/`get_end_inner`/`type_str`)
- both parser conversion paths (`convert_expression`, `convert_expression_for_program`) plus the two chain-element non-null sites
- the typed TS stripper (`remove_typescript_nodes_typed`)
- the analyze walkers (`js_node_check_features`, `collect_identifier_names_in_node`)
- the NAPI binary envelope (`napi_raw_parse.rs` tags `0xD0`/`0xD1` + write arms, and the JS decoder in `parse-envelope.js`)

Like the other wrappers, they are erased by `remove_typescript_nodes` before analyze/transform, so **compiled client/server output is unchanged**. `jsnode_to_oxc`'s `_ => None` fallback already covers them (they never reach transform).

`svelte2tsx` **is** updated: `<number>x` and `f<number>` are valid binding targets in Svelte, and svelte2tsx must strip the cast from the assignment LHS (the same bug class #1648 fixed for postfix forms). `get_expression_end_stripping_ts` now also strips a trailing `<…>` type-argument list (`f<T>`), and a new `get_expression_start_stripping_ts` strips a leading `<T>` type-assertion prefix; both feed `get_binding_lhs_text` so the setter widener uses the bare target (`() => x = __sveltets_2_any(null)`) while the bound value keeps the cast. Regression tests added to `svelte2tsx_binding_ts_assertion`.

The prior PR for this work (#1652) was closed as superseded once #1648 merged; this is the clean split of #1652's unique delta rebuilt on top of #1648's merged structure to avoid mixing two divergent implementations.

## Verification

- New suite `ts_assertion_expressions_extra` (7 tests): parse-shape for `<T>x` (incl. `typeAnnotation`-before-`expression` field order), `f<T>` (`typeArguments`), `a!?.b` and `a!.b` (non-null member object), a template-tag `{<number>d}`, and codegen-erasure checks proving no TS syntax / `Unknown:` placeholder leaks into client **or** server output — all pass.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean; `cargo fmt`: clean.
- The full `cargo test -p rsvelte_core -p rsvelte_lint --release` (byte-exact output gates) was in its final release-compile stage locally; CI runs it in full here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XHPUBHj4ywFM8skv4GwxV
