### PR TITLE
ci: make apps/playground its own pnpm workspace root so Renovate maintains its lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,29 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  playground-lockfile:
+    name: Playground lockfile
+    # Deploy Docs only runs on pushes to main, so a stale
+    # apps/playground/pnpm-lock.yaml (its own workspace, separate from the
+    # repo-root lockfile) used to surface only after merge. Gate it here so a
+    # package.json bump without a lockfile update goes red on the PR instead.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - name: Check playground lockfile is in sync
+        working-directory: apps/playground
+        run: pnpm install --frozen-lockfile --lockfile-only
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -106,11 +106,11 @@ jobs:
           cache-dependency-path: apps/playground/pnpm-lock.yaml
 
       - name: Install playground dependencies
-        # `--ignore-workspace` because the repo root became a pnpm workspace
-        # (npm/* publishing packages), and without this `pnpm install` walks
-        # up to the workspace root and skips installing the playground's own deps.
+        # apps/playground/pnpm-workspace.yaml marks the playground as its own
+        # workspace root, so pnpm no longer walks up to the repo-root workspace
+        # (and Renovate can maintain the standalone lockfile).
         working-directory: apps/playground
-        run: pnpm install --frozen-lockfile --ignore-workspace
+        run: pnpm install --frozen-lockfile
 
       - name: Build playground
         working-directory: apps/playground

--- a/apps/playground/pnpm-workspace.yaml
+++ b/apps/playground/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# Workspace-root marker: stops pnpm's upward walk to the repo-root workspace
+# so the playground keeps its own standalone pnpm-lock.yaml. Without this,
+# any pnpm invocation here (including Renovate's lockfile updater, which
+# cannot pass --ignore-workspace) resolves to the repo root and leaves this
+# directory's lockfile stale — which is how Deploy Docs broke on #1591.


### PR DESCRIPTION
## Summary

Follow-up to #1637, which fixed the symptom (stale playground lockfile → Deploy Docs red on every `main` push). This fixes the root cause so it cannot recur.

### Root cause

`apps/playground` keeps a standalone `pnpm-lock.yaml` and is installed with `--ignore-workspace`. Renovate's lockfile updater cannot pass that flag, so when it runs pnpm for a playground dep bump, pnpm walks up to the repo-root workspace and never touches the standalone lockfile:

- #1591 (monaco-editor): Renovate's commit changed only `package.json` → Deploy Docs broke after merge.
- #1592 (typescript): needed a manual lockfile-sync commit.

### Fix

1. **`apps/playground/pnpm-workspace.yaml` marker** — makes the playground its own pnpm workspace root, stopping the upward walk. Plain `pnpm install` (Renovate's included) now resolves the standalone lockfile natively. Verified locally: `pnpm install --lockfile-only` and `pnpm install --frozen-lockfile` both work without `--ignore-workspace` and leave the lockfile byte-identical.
2. **Deploy Docs** drops `--ignore-workspace` (now unnecessary).
3. **New cheap CI gate (`Playground lockfile`)** — Deploy Docs only runs on pushes to `main`, so a stale playground lockfile used to surface only after merge. The gate runs `pnpm install --frozen-lockfile --lockfile-only` in `apps/playground` on every PR; verified locally that it passes when synced and fails with `ERR_PNPM_OUTDATED_LOCKFILE` on a mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvYNAm2DQyGEzFegZwfa2q