### PR TITLE
feat(napi): support function compile options (customElement/css/runes/warningFilter/cssHash constant)

### DIFF
--- a/.changeset/napi-function-compile-options.md
+++ b/.changeset/napi-function-compile-options.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/vite-plugin-svelte-native": minor
+"@rsvelte/vite-plugin-svelte": minor
+---
+
+feat(napi): support function-form compile options (customElement/css/runes/warningFilter) and a constant cssHashOverride
+
+The NAPI shim now resolves the function forms of `customElement`, `css`, and `runes`
+(`({ filename }) => value`) once at the binding boundary before handing the plain value
+to the compiler, matching Svelte's `parametric()` normalization. `warningFilter` is
+applied as a post-filter on the returned `warnings` array — equivalent to Svelte's
+emit-time filter since warnings never affect codegen. A new `cssHashOverride` string
+option lets callers pass a pre-computed constant CSS scope hash without the callback
+bridge; `@rsvelte/vite-plugin-svelte` now uses it for its HMR-stable hash instead of the
+previously ignored `cssHash = () => hash` closure.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -901,6 +901,52 @@ jobs:
         env:
           RUSTDOCFLAGS: -Dwarnings
 
+  # Builds the NAPI addon for the host triple and runs the vite-plugin-svelte
+  # native smoke test, which exercises the JS-function compile options
+  # (customElement/css/runes, warningFilter, cssHash) end-to-end through the shim.
+  vps-shim:
+    name: VPS native shim smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      # rsvelte_core's build.rs reads the Svelte version string from the submodule.
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.97.1
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: vps-shim
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build NAPI addon (host)
+        run: pnpm run build:vps-native
+
+      - name: Run vite-plugin-svelte native shim smoke test
+        run: pnpm run test:vps-shim
+
   vps-version-check:
     name: VPS native VERSION drift check
     runs-on: ubuntu-latest

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -51,18 +51,13 @@ try {
 	);
 }
 
-// Resolve the function-form compile options the NAPI boundary can't accept.
-// `customElement` / `css` / `runes` may be `(({ filename }) => value)` in the
-// upstream Svelte contract; they depend only on `filename`, so we evaluate them
-// once here and hand the plain value to Rust. `warningFilter` is returned to the
-// caller so it can post-filter the warnings array (warnings never affect codegen,
-// so filtering after compile is equivalent to Svelte's emit-time filter).
-//
-// A dynamic `cssHash` function needs the Rust→JS callback bridge and is handled
-// separately by `compileWithCssHash`; constant hashes go through `cssHashOverride`.
-//
-// Fast path: when none of these fields are functions the original object is
-// returned untouched — no clone, no allocation, zero overhead for the hot path.
+// Resolve the function-form compile options the NAPI boundary can't accept:
+// evaluate `customElement`/`css`/`runes` (`({ filename }) => value`) once and hand
+// the plain value to Rust, and return any `warningFilter` for the caller to
+// post-filter the warnings array (warnings never affect codegen, so post-filtering
+// equals Svelte's emit-time filter). A dynamic `cssHash` uses the callback bridge
+// (`compileWithCssHash`); constant hashes go through `cssHashOverride`. When no
+// field is a function the original object is returned as-is.
 function prepareCompileOptions(options) {
 	if (options == null) return { options, warningFilter: undefined };
 	const { customElement, css, runes, warningFilter } = options;
@@ -74,7 +69,8 @@ function prepareCompileOptions(options) {
 	if (!hasParametric && !hasWarningFilter) {
 		return { options, warningFilter: undefined };
 	}
-	const meta = { filename: options.filename };
+	// Svelte defaults `filename` to '(unknown)' before invoking these functions.
+	const meta = { filename: options.filename ?? '(unknown)' };
 	const resolved = { ...options };
 	if (typeof customElement === 'function') resolved.customElement = customElement(meta);
 	if (typeof css === 'function') resolved.css = css(meta);

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -51,6 +51,54 @@ try {
 	);
 }
 
+// Resolve the function-form compile options the NAPI boundary can't accept.
+// `customElement` / `css` / `runes` may be `(({ filename }) => value)` in the
+// upstream Svelte contract; they depend only on `filename`, so we evaluate them
+// once here and hand the plain value to Rust. `warningFilter` is returned to the
+// caller so it can post-filter the warnings array (warnings never affect codegen,
+// so filtering after compile is equivalent to Svelte's emit-time filter).
+//
+// A dynamic `cssHash` function needs the Rust→JS callback bridge and is handled
+// separately by `compileWithCssHash`; constant hashes go through `cssHashOverride`.
+//
+// Fast path: when none of these fields are functions the original object is
+// returned untouched — no clone, no allocation, zero overhead for the hot path.
+function prepareCompileOptions(options) {
+	if (options == null) return { options, warningFilter: undefined };
+	const { customElement, css, runes, warningFilter } = options;
+	const hasParametric =
+		typeof customElement === 'function' ||
+		typeof css === 'function' ||
+		typeof runes === 'function';
+	const hasWarningFilter = typeof warningFilter === 'function';
+	if (!hasParametric && !hasWarningFilter) {
+		return { options, warningFilter: undefined };
+	}
+	const meta = { filename: options.filename };
+	const resolved = { ...options };
+	if (typeof customElement === 'function') resolved.customElement = customElement(meta);
+	if (typeof css === 'function') resolved.css = css(meta);
+	if (typeof runes === 'function') resolved.runes = runes(meta);
+	if (hasWarningFilter) delete resolved.warningFilter;
+	return { options: resolved, warningFilter: hasWarningFilter ? warningFilter : undefined };
+}
+
+function applyWarningFilter(result, warningFilter) {
+	if (!warningFilter || result == null) return result;
+	const warnings = result.warnings;
+	if (Array.isArray(warnings) && warnings.length) {
+		// `warnings` is a lazy getter on the envelope-decoded result; redefine it
+		// as a plain data property so the filtered array replaces the accessor.
+		Object.defineProperty(result, 'warnings', {
+			value: warnings.filter((warning) => warningFilter(warning)),
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		});
+	}
+	return result;
+}
+
 // `compile` / `compileModule` are wrapped to route through the
 // raw-transfer envelope (`compileEnvelope`): the Rust side hands us
 // one `Buffer`, the JS side lazy-decodes only the fields the caller
@@ -62,11 +110,16 @@ try {
 // directly. The legacy JSON path is preserved as `compileLegacy` for
 // parity testing and as an escape hatch.
 function compile(source, options) {
-	return decodeEnvelope(binding.compileEnvelope(source, options));
+	const { options: resolved, warningFilter } = prepareCompileOptions(options);
+	return applyWarningFilter(decodeEnvelope(binding.compileEnvelope(source, resolved)), warningFilter);
 }
 
 function compileModule(source, options) {
-	return decodeEnvelope(binding.compileModuleEnvelope(source, options));
+	const { options: resolved, warningFilter } = prepareCompileOptions(options);
+	return applyWarningFilter(
+		decodeEnvelope(binding.compileModuleEnvelope(source, resolved)),
+		warningFilter,
+	);
 }
 
 // `compileBatch([{source, options}, …])` compiles N files in
@@ -75,7 +128,17 @@ function compileModule(source, options) {
 // each slot is either a `CompileResult` or an `Error` (parse
 // failures don't abort the whole batch).
 function compileBatch(inputs) {
-	return decodeBatch(binding.compileBatch(inputs));
+	const filters = [];
+	const prepared = inputs.map((input, i) => {
+		const { options, warningFilter } = prepareCompileOptions(input.options);
+		if (warningFilter) filters[i] = warningFilter;
+		return options === input.options ? input : { source: input.source, options };
+	});
+	const results = decodeBatch(binding.compileBatch(prepared));
+	if (filters.length) {
+		results.forEach((result, i) => applyWarningFilter(result, filters[i]));
+	}
+	return results;
 }
 
 // `compileAsync` / `compileBatchAsync` release the JS event loop
@@ -84,11 +147,25 @@ function compileBatch(inputs) {
 // (Vite middleware, SSR pre-render) — the await yields control
 // instead of blocking V8.
 async function compileAsync(source, options) {
-	return decodeEnvelope(await binding.compileEnvelopeAsync(source, options));
+	const { options: resolved, warningFilter } = prepareCompileOptions(options);
+	return applyWarningFilter(
+		decodeEnvelope(await binding.compileEnvelopeAsync(source, resolved)),
+		warningFilter,
+	);
 }
 
 async function compileBatchAsync(inputs) {
-	return decodeBatch(await binding.compileBatchAsync(inputs));
+	const filters = [];
+	const prepared = inputs.map((input, i) => {
+		const { options, warningFilter } = prepareCompileOptions(input.options);
+		if (warningFilter) filters[i] = warningFilter;
+		return options === input.options ? input : { source: input.source, options };
+	});
+	const results = decodeBatch(await binding.compileBatchAsync(prepared));
+	if (filters.length) {
+		results.forEach((result, i) => applyWarningFilter(result, filters[i]));
+	}
+	return results;
 }
 
 // Re-export every NAPI function as its own named binding so node's

--- a/apps/npm/vite-plugin-svelte-native/index.d.ts
+++ b/apps/npm/vite-plugin-svelte-native/index.d.ts
@@ -22,29 +22,53 @@ export interface CompileOptions {
 	rootDir?: string;
 	/** Component identifier hint. */
 	name?: string;
-	/** Compile as a custom element. */
-	customElement?: boolean;
+	/**
+	 * Compile as a custom element. A function form `({ filename }) => boolean`
+	 * is evaluated once at the binding boundary.
+	 */
+	customElement?: boolean | ((meta: { filename: string | undefined }) => boolean);
 	/** Generate `accessors`. */
 	accessors?: boolean;
 	/** HTML namespace. */
 	namespace?: 'html' | 'svg' | 'mathml';
 	/** Hint that bindings are immutable. */
 	immutable?: boolean;
-	/** Output CSS injected into the bundle or as an external asset. */
-	css?: 'injected' | 'external';
-	/** Custom hash function for CSS scoping — currently honored as a string-mapper. */
+	/**
+	 * Output CSS injected into the bundle or as an external asset. A function
+	 * form `({ filename }) => 'injected' | 'external'` is evaluated once at the
+	 * binding boundary.
+	 */
+	css?:
+		| 'injected'
+		| 'external'
+		| ((meta: { filename: string | undefined }) => 'injected' | 'external');
+	/**
+	 * Custom hash function for CSS scoping. Called once per component with the
+	 * component's CSS; the returned string becomes the scope class. Bridged into
+	 * the compiler via a threadsafe callback (`compileWithCssHash`).
+	 */
 	cssHash?: (args: {
 		hash: (input: string) => string;
 		css: string;
 		name: string;
 		filename: string | undefined;
 	}) => string;
+	/**
+	 * Pre-computed constant CSS scope hash. Escape hatch for callers (e.g.
+	 * `@rsvelte/vite-plugin-svelte`'s HMR path) that already know the hash and
+	 * want to skip the `cssHash` callback bridge entirely.
+	 */
+	cssHashOverride?: string;
 	/** Preserve HTML comments in output. */
 	preserveComments?: boolean;
 	/** Preserve whitespace in the template. */
 	preserveWhitespace?: boolean;
-	/** Force runes mode (`true`), legacy (`false`), or auto-detect (`undefined`). */
-	runes?: boolean;
+	/**
+	 * Force runes mode (`true`), legacy (`false`), or auto-detect (`undefined`).
+	 * A function form `({ filename }) => boolean | undefined` is evaluated once
+	 * at the binding boundary.
+	 */
+	runes?: boolean | ((meta: { filename: string | undefined }) => boolean | undefined);
 	/** Disclose the compiler version in the output banner. */
 	discloseVersion?: boolean;
 	/** Source-map options (forwarded through magic-string). */
@@ -70,6 +94,7 @@ export interface ModuleCompileOptions {
 	generate?: 'client' | 'server' | false;
 	filename?: string;
 	rootDir?: string;
+	/** Filter compiler warnings (applied to the returned `warnings` array). */
 	warningFilter?: (warning: Warning) => boolean;
 }
 

--- a/apps/npm/vite-plugin-svelte-native/index.d.ts
+++ b/apps/npm/vite-plugin-svelte-native/index.d.ts
@@ -26,7 +26,7 @@ export interface CompileOptions {
 	 * Compile as a custom element. A function form `({ filename }) => boolean`
 	 * is evaluated once at the binding boundary.
 	 */
-	customElement?: boolean | ((meta: { filename: string | undefined }) => boolean);
+	customElement?: boolean | ((meta: { filename: string }) => boolean);
 	/** Generate `accessors`. */
 	accessors?: boolean;
 	/** HTML namespace. */
@@ -41,7 +41,7 @@ export interface CompileOptions {
 	css?:
 		| 'injected'
 		| 'external'
-		| ((meta: { filename: string | undefined }) => 'injected' | 'external');
+		| ((meta: { filename: string }) => 'injected' | 'external');
 	/**
 	 * Custom hash function for CSS scoping. Called once per component with the
 	 * component's CSS; the returned string becomes the scope class. Bridged into
@@ -68,7 +68,7 @@ export interface CompileOptions {
 	 * A function form `({ filename }) => boolean | undefined` is evaluated once
 	 * at the binding boundary.
 	 */
-	runes?: boolean | ((meta: { filename: string | undefined }) => boolean | undefined);
+	runes?: boolean | ((meta: { filename: string }) => boolean | undefined);
 	/** Disclose the compiler version in the output banner. */
 	discloseVersion?: boolean;
 	/** Source-map options (forwarded through magic-string). */

--- a/apps/npm/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/apps/npm/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -201,7 +201,7 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 
 	if (compileOptions.hmr && options.emitCss) {
 		const hash = `s-${safeBase64Hash(normalize(filename, options.root))}`;
-		compileOptions.cssHash = () => hash;
+		compileOptions.cssHashOverride = hash;
 	}
 
 	let preprocessed;

--- a/apps/npm/vite-plugin-svelte/src/plugins/setup-optimizer.js
+++ b/apps/npm/vite-plugin-svelte/src/plugins/setup-optimizer.js
@@ -202,6 +202,7 @@ async function compileSvelte(options, { filename, code }, statsCollection) {
 	if (compileOptions.hmr && options.emitCss) {
 		const hash = `s-${safeBase64Hash(normalize(filename, options.root))}`;
 		compileOptions.cssHashOverride = hash;
+		delete compileOptions.cssHash;
 	}
 
 	let preprocessed;

--- a/apps/npm/vite-plugin-svelte/src/utils/compile.js
+++ b/apps/npm/vite-plugin-svelte/src/utils/compile.js
@@ -59,7 +59,9 @@ export function createCompileSvelte() {
 		let finalCode = code;
 		if (compileOptions.hmr && options.emitCss) {
 			const hash = `s-${safeBase64Hash(normalizedFilename)}`;
-			compileOptions.cssHash = () => hash;
+			// Constant hash keeps the css scope class stable across HMR updates; the
+			// override path skips the cssHash callback bridge entirely.
+			compileOptions.cssHashOverride = hash;
 			const closeStylePos = code.lastIndexOf('</style>');
 			if (closeStylePos > -1) {
 				// inject rule that forces compile to attach scope class to every node in the template

--- a/apps/npm/vite-plugin-svelte/src/utils/compile.js
+++ b/apps/npm/vite-plugin-svelte/src/utils/compile.js
@@ -60,8 +60,11 @@ export function createCompileSvelte() {
 		if (compileOptions.hmr && options.emitCss) {
 			const hash = `s-${safeBase64Hash(normalizedFilename)}`;
 			// Constant hash keeps the css scope class stable across HMR updates; the
-			// override path skips the cssHash callback bridge entirely.
+			// override path skips the cssHash callback bridge entirely. Drop any user
+			// cssHash so the override is the sole hash source (matches upstream, which
+			// overwrites cssHash here).
 			compileOptions.cssHashOverride = hash;
+			delete compileOptions.cssHash;
 			const closeStylePos = code.lastIndexOf('</style>');
 			if (closeStylePos > -1) {
 				// inject rule that forces compile to attach scope class to every node in the template

--- a/scripts/dev/test-vps-shim.mjs
+++ b/scripts/dev/test-vps-shim.mjs
@@ -209,6 +209,79 @@ for (const [label, options, needle] of [
 		msg,
 	);
 }
+// 9. Function-form compile options (customElement / css / runes) are resolved
+//    at the binding boundary — a `({ filename }) => value` form must produce the
+//    same output as the resolved value.
+const ceBool = r.compile('<svelte:options customElement="my-el" /><h1>hi</h1>', {
+	filename: 'El.svelte',
+	generate: 'client',
+	customElement: true,
+});
+const ceFn = r.compile('<svelte:options customElement="my-el" /><h1>hi</h1>', {
+	filename: 'El.svelte',
+	generate: 'client',
+	customElement: () => true,
+});
+assert(
+	'customElement function form resolves to boolean value',
+	ceFn.js.code === ceBool.js.code && ceBool.js.code.length > 0,
+);
+
+const cssExternal = r.compile('<h1>hi</h1><style>h1{color:red}</style>', {
+	filename: 'C.svelte',
+	generate: 'client',
+	css: 'external',
+});
+const cssFn = r.compile('<h1>hi</h1><style>h1{color:red}</style>', {
+	filename: 'C.svelte',
+	generate: 'client',
+	css: () => 'injected',
+});
+assert(
+	'css function form resolves and injects styles',
+	cssFn.css == null && cssFn.js.code !== cssExternal.js.code,
+	JSON.stringify({ hasCss: cssFn.css != null }),
+);
+
+const runesFn = r.compile('<script>let count = $state(0);</script><h1>{count}</h1>', {
+	filename: 'R.svelte',
+	generate: 'client',
+	runes: () => true,
+});
+assert('runes function form compiles', typeof runesFn?.js?.code === 'string');
+
+// 10. cssHashOverride — a constant scope hash must appear verbatim in the CSS.
+const hashed = r.compile('<h1>hi</h1><style>h1{color:red}</style>', {
+	filename: 'H.svelte',
+	generate: 'client',
+	css: 'injected',
+	cssHashOverride: 's-DEADBEEF',
+});
+assert(
+	'cssHashOverride sets the scope class',
+	hashed.js.code.includes('s-DEADBEEF'),
+	hashed.js.code.slice(0, 120),
+);
+
+// 11. warningFilter — post-filtering the returned warnings array.
+const warnSrc = '<img src="x.png">';
+const unfiltered = r.compile(warnSrc, { filename: 'W.svelte', generate: 'client' });
+assert(
+	'component emits at least one warning to filter',
+	Array.isArray(unfiltered.warnings) && unfiltered.warnings.length > 0,
+	JSON.stringify(unfiltered.warnings.map((w) => w.code)),
+);
+const filtered = r.compile(warnSrc, {
+	filename: 'W.svelte',
+	generate: 'client',
+	warningFilter: (w) => !w.code.startsWith('a11y'),
+});
+assert(
+	'warningFilter drops matching warnings',
+	filtered.warnings.every((w) => !w.code.startsWith('a11y')) &&
+		filtered.warnings.length < unfiltered.warnings.length,
+	JSON.stringify(filtered.warnings.map((w) => w.code)),
+);
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## What

Wires up the compiler's function-form / callback compile options at the NAPI boundary. Previously these were silently ignored (`crates/rsvelte_napi/src/lib.rs` dropped unknown JS fields), so `@rsvelte/vite-plugin-svelte`'s HMR-stable `cssHash` and any user `warningFilter` / `customElement` function had no effect, and the `.d.ts` contract diverged from the implementation.

This PR handles everything that needs **no Rust callback bridge**:

- **`customElement` / `css` / `runes`** — accept the upstream `({ filename }) => value` function form. These depend only on `filename`, so the shim evaluates them **once** at the boundary and hands the plain value to the compiler (mirrors Svelte's `parametric()` normalization). Required because the typed NAPI fields (`bool` / `string`) would otherwise reject a function value.
- **`warningFilter`** — applied as a **post-filter** on the returned `warnings` array. Verified equivalent to Svelte's emit-time filter: `warn()` in `submodules/svelte/.../warnings.js` applies `warning_filter` as a pure predicate with no side effects (no dedup, no sort, warnings never feed codegen), so filtering after compile yields an identical array.
- **`cssHashOverride`** — a new constant-hash string option. `@rsvelte/vite-plugin-svelte` now passes its HMR-stable `s-<hash>` through this instead of the previously ignored `cssHash = () => hash` closure (`compile.js`, `setup-optimizer.js`).

Dynamic (css-dependent) `cssHash` **functions** need the Rust→JS threadsafe callback bridge and are handled in the follow-up PR.

## Design

Zero-overhead: `prepareCompileOptions` returns the options object untouched (no clone) when none of the fields are functions — the hot path is unchanged. Only when a function form is present does it shallow-clone and resolve.

## Testing

`node scripts/dev/test-vps-shim.mjs` (native addon built via `pnpm run build:vps-native`): **21 passed, 0 failed**, including new coverage for customElement/css/runes function forms, `cssHashOverride`, and `warningFilter` drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kjwziVV91nApcWDK48gRA