### PR TITLE
feat(fmt): sort custom Tailwind configs via a Node sidecar

### DIFF
--- a/.changeset/feat-fmt-tailwind-js-sorter.md
+++ b/.changeset/feat-fmt-tailwind-js-sorter.md
@@ -1,0 +1,25 @@
+---
+"@rsvelte/fmt": minor
+---
+
+feat(fmt): sort custom Tailwind configs via a Node sidecar
+
+`sortTailwindcss` previously covered only a stock, zero-config Tailwind v4 setup
+(sorted natively in Rust); a custom `@theme` / `@plugin` / `@utility` /
+`@custom-variant` / `@config` stylesheet or a v3 `tailwind.config.js` warned and
+left classes untouched, because their order depends on the project's compiled
+CSS.
+
+For those custom setups `rsvelte-fmt` now shells out to a one-shot Node sidecar
+(`lib/tailwind-sort.mjs`) running the real `prettier-plugin-tailwindcss` — the
+same plugin and `createSorter` / `sortClassAttributes` API `oxfmt` uses, pinned
+to the same insiders build — so the result is byte-for-byte identical to the
+oxfmt oracle. Every static class string across the run is collected and sorted
+in a single batched sidecar call, and the sidecar never throws: if Node or the
+plugin is unavailable the run warns once and leaves class names unchanged, never
+a wrong reorder. The default zero-config path stays pure-Rust with no subprocess.
+
+Adds an rsvelte-only `sortTailwindcss.strategy` extension (not an oxfmt key):
+`auto` (default — stock native, custom via JS), `native` (always pure-Rust), and
+`js` (always the JS oracle, even for a stock config). With the default `auto` an
+existing oxfmt `sortTailwindcss` config works unchanged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,22 @@ jobs:
           npm i --ignore-scripts "oxfmt@$OXFMT_RANGE" "svelte@$SVELTE_RANGE"
           ./node_modules/.bin/oxfmt --version
 
+      - name: Install Tailwind for the sortTailwindcss JS-parity tests
+        # Provides the `tailwindcss` + `prettier-plugin-tailwindcss` a consumer
+        # project would have, so the gated `sort_tailwindcss_*_via_js` tests in
+        # `--test cli` actually run (they no-op without RSVELTE_FMT_TW_TEST_DIR).
+        # The plugin version is read from `@rsvelte/fmt`'s own dependency — the
+        # same pin the sidecar bundles — so `auto-update-oxfmt` keeps this in
+        # lockstep and any drift is caught here (that is the point of this gate).
+        run: |
+          set -euo pipefail
+          TW_PLUGIN=$(node -p "require('./apps/npm/fmt/package.json').dependencies['prettier-plugin-tailwindcss']")
+          echo "resolving tailwindcss + prettier-plugin-tailwindcss@$TW_PLUGIN"
+          mkdir -p "$RUNNER_TEMP/tw-oracle"
+          cd "$RUNNER_TEMP/tw-oracle"
+          npm init -y >/dev/null
+          npm i --ignore-scripts tailwindcss "prettier-plugin-tailwindcss@$TW_PLUGIN"
+
       - name: Resolve svelte.dev submodule SHA
         id: svelte-dev-sha
         shell: bash
@@ -601,6 +617,16 @@ jobs:
         env:
           RUST_MIN_STACK: '33554432'
           FMT_CORPUS_OXFMT: ${{ runner.temp }}/fmt-oracle/node_modules/.bin/oxfmt
+
+      - name: Run sortTailwindcss JS-parity tests (custom config vs. oxfmt)
+        # Asserts rsvelte-fmt's JS-sorted output is byte-identical to the real
+        # oxfmt oracle for a custom Tailwind config. Guards against drift of the
+        # bundled prettier-plugin-tailwindcss version vs. what oxfmt uses.
+        run: cargo nextest run --profile ci -p rsvelte_fmt --test cli sort_tailwindcss
+        timeout-minutes: 10
+        env:
+          OXFMT_BIN: ${{ runner.temp }}/fmt-oracle/node_modules/.bin/oxfmt
+          RSVELTE_FMT_TW_TEST_DIR: ${{ runner.temp }}/tw-oracle
 
   # Builds the lint wasm (nodejs target) + the native rsvelte-fmt binary, bundles
   # @rsvelte/language-server, and runs its headless LSP smoke tests (formatting

--- a/apps/npm/fmt/README.md
+++ b/apps/npm/fmt/README.md
@@ -132,19 +132,34 @@ The following `.oxfmtrc` keys also drive `.svelte` formatting, matching
 | `svelte.sortOrder` | `options-scripts-markup-styles` | Print order of the top-level sections (any permutation of `options`/`scripts`/`markup`/`styles`, or `none` to keep source order) |
 
 `sortTailwindcss` sorts the classes in static `class` attributes (the value must
-be a plain string — values with `{expr}` interpolation are left untouched). It is
-supported **only for a stock, zero-config Tailwind v4 setup**: a stylesheet that
-is essentially `@import "tailwindcss";` with no `@plugin`, `@utility`,
-`@custom-variant`, `@theme`, or `@config`, and no v3 `tailwind.config.js`. That
-is the one case a pure-Rust sorter reproduces byte-for-byte, because Tailwind's
-order otherwise depends on the project's compiled CSS (which needs the JS engine).
+be a plain string — values with `{expr}` interpolation are left untouched).
 
-`rsvelte-fmt` resolves the stylesheet from `sortTailwindcss.stylesheet` (or a
-conventional entry like `src/app.css`) and inspects it. If it is a default setup,
-classes are sorted natively; otherwise `rsvelte-fmt` prints a warning naming the
-reason and leaves class names unchanged — run `oxfmt` directly for a custom
-Tailwind config. The `attributes` option is honored (default `["class"]`);
-`functions` (e.g. `cn(...)`) are not, since those wrap non-static expressions.
+A **stock, zero-config Tailwind v4 setup** — a stylesheet that is essentially
+`@import "tailwindcss";` with no `@plugin`, `@utility`, `@custom-variant`,
+`@theme`, or `@config`, and no v3 `tailwind.config.js` — is sorted **natively**
+in Rust, byte-for-byte, with no subprocess.
+
+A **custom config** (any of the above) changes the class order in ways that
+depend on the project's compiled CSS, so `rsvelte-fmt` shells out to a one-shot
+Node sidecar running the real `prettier-plugin-tailwindcss` — the same plugin
+(and API) `oxfmt` uses — resolving your project's `tailwindcss` and producing the
+same order `oxfmt` would. This needs a Node interpreter (the one recorded at
+install time) and the bundled plugin; if either is unavailable, `rsvelte-fmt`
+prints a warning and leaves class names unchanged rather than reorder them
+wrongly. The `attributes` option is honored (default `["class"]`); `functions`
+(e.g. `cn(...)`) are not yet supported on either path.
+
+`sortTailwindcss.strategy` (an **rsvelte-only extension**, not an oxfmt key)
+selects the sorter:
+
+| `strategy` | Behavior |
+|---|---|
+| `auto` (default) | Stock config → native Rust; custom config → Node/JS oracle |
+| `native` | Always pure-Rust; a custom config warns and is left unsorted |
+| `js` | Always the Node/JS oracle, even for a stock config (bypasses the native sorter's rare edge cases) |
+
+With the default `auto`, an existing oxfmt `sortTailwindcss` config works
+unchanged.
 
 ## CLI flags
 

--- a/apps/npm/fmt/README.md
+++ b/apps/npm/fmt/README.md
@@ -161,6 +161,17 @@ selects the sorter:
 With the default `auto`, an existing oxfmt `sortTailwindcss` config works
 unchanged.
 
+Notes:
+
+- Under `auto`, the choice between native and JS relies on a heuristic that
+  detects a stock stylesheet. If it ever misclassifies your setup, set
+  `strategy: "js"` to force the exact oxfmt oracle for every file.
+- The Node sidecar path bundles `prettier-plugin-tailwindcss` as a dependency of
+  `@rsvelte/fmt` (a few MB), installed for all users even if they never enable
+  `sortTailwindcss`. Because it is a Prettier plugin, some package managers may
+  print a Prettier peer-dependency warning at install time; it is harmless —
+  `rsvelte-fmt` uses only the plugin's sorter API, not Prettier itself.
+
 ## CLI flags
 
 | Flag | Default | Effect |

--- a/apps/npm/fmt/lib/tailwind-sort.mjs
+++ b/apps/npm/fmt/lib/tailwind-sort.mjs
@@ -1,0 +1,70 @@
+// One-shot Tailwind class sorter for @rsvelte/fmt's `sortTailwindcss` JS path.
+//
+// A default `@import "tailwindcss";` setup sorts natively in Rust, but a custom
+// stylesheet / config (`@theme`, `@plugin`, `@utility`, a v3 `tailwind.config`)
+// changes the class order in ways only the real Tailwind engine knows. This
+// script drives the same `prettier-plugin-tailwindcss` API oxfmt uses, so the
+// result is byte-identical to the oxfmt oracle.
+//
+// Protocol: one JSON request on stdin, one JSON response on stdout.
+//   request : { filepath, stylesheetPath?, configPath?, preserveWhitespace?,
+//               preserveDuplicates?, classes: string[] }
+//   response: { ok: true, sorted: string[] } | { ok: false, error: string }
+//
+// Never rejects or exits non-zero for a sort failure: the Rust side treats a
+// non-`ok` (or absent) response as "leave classes as they are", so a missing
+// plugin or a broken config degrades to unsorted output, never a crash.
+
+function readStdin() {
+	return new Promise((resolve) => {
+		let data = '';
+		process.stdin.setEncoding('utf8');
+		process.stdin.on('data', (chunk) => {
+			data += chunk;
+		});
+		process.stdin.on('end', () => resolve(data));
+		process.stdin.on('error', () => resolve(data));
+	});
+}
+
+async function main() {
+	let req;
+	try {
+		req = JSON.parse(await readStdin());
+	} catch (err) {
+		return { ok: false, error: `invalid request: ${err && err.message}` };
+	}
+
+	const classes = Array.isArray(req.classes) ? req.classes : [];
+	if (classes.length === 0) {
+		return { ok: true, sorted: [] };
+	}
+
+	let createSorter;
+	try {
+		({ createSorter } = await import('prettier-plugin-tailwindcss/sorter'));
+	} catch (err) {
+		return { ok: false, error: `prettier-plugin-tailwindcss not resolvable: ${err && err.message}` };
+	}
+
+	const sorter = await createSorter({
+		filepath: req.filepath,
+		stylesheetPath: req.stylesheetPath,
+		configPath: req.configPath,
+		preserveWhitespace: req.preserveWhitespace,
+		preserveDuplicates: req.preserveDuplicates,
+	});
+	const sorted = sorter.sortClassAttributes(classes);
+	if (!Array.isArray(sorted) || sorted.length !== classes.length) {
+		return { ok: false, error: 'sorter returned an unexpected shape' };
+	}
+	return { ok: true, sorted };
+}
+
+main()
+	.then((result) => {
+		process.stdout.write(JSON.stringify(result));
+	})
+	.catch((err) => {
+		process.stdout.write(JSON.stringify({ ok: false, error: String(err && err.message) }));
+	});

--- a/apps/npm/fmt/lib/tailwind-sort.mjs
+++ b/apps/npm/fmt/lib/tailwind-sort.mjs
@@ -15,6 +15,13 @@
 // non-`ok` (or absent) response as "leave classes as they are", so a missing
 // plugin or a broken config degrades to unsorted output, never a crash.
 
+// Guard the JSON channel: the plugin or `tailwindcss` may print to stdout (a
+// deprecation notice, a debug line), which would corrupt our single-line
+// response. Route all stray stdout to stderr and emit only the final JSON on the
+// real stdout.
+const realStdoutWrite = process.stdout.write.bind(process.stdout);
+process.stdout.write = process.stderr.write.bind(process.stderr);
+
 function readStdin() {
 	return new Promise((resolve) => {
 		let data = '';
@@ -61,10 +68,10 @@ async function main() {
 	return { ok: true, sorted };
 }
 
+function emit(result) {
+	realStdoutWrite(JSON.stringify(result));
+}
+
 main()
-	.then((result) => {
-		process.stdout.write(JSON.stringify(result));
-	})
-	.catch((err) => {
-		process.stdout.write(JSON.stringify({ ok: false, error: String(err && err.message) }));
-	});
+	.then(emit)
+	.catch((err) => emit({ ok: false, error: String(err && err.message) }));

--- a/apps/npm/fmt/package.json
+++ b/apps/npm/fmt/package.json
@@ -31,8 +31,12 @@
     "bin/rsvelte-fmt",
     "install.js",
     "lib/resolve.cjs",
+    "lib/tailwind-sort.mjs",
     "daemon/daemon.mjs"
   ],
+  "dependencies": {
+    "prettier-plugin-tailwindcss": "0.0.0-insiders.2b6f3c2"
+  },
   "optionalDependencies": {
     "@rsvelte/fmt-darwin-arm64": "workspace:^",
     "@rsvelte/fmt-darwin-x64": "workspace:^",

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -330,7 +330,7 @@ fn run() -> Result<ExitCode> {
         .unwrap_or_else(|| cwd.clone());
     let cfg = OxfmtConfig::resolve(cli.config.as_deref(), &config_start).map_err(|e| anyhow!(e))?;
 
-    let (mut options, pending_js) = build_format_options(&cli, &cfg, js_sort_env());
+    let (mut options, pending_js) = build_format_options(&cli, &cfg);
 
     if cli.stdin {
         return run_stdin(&cli, &options, &cfg, pending_js.as_ref());
@@ -544,11 +544,7 @@ fn combine(a: PipelineStatus, b: PipelineStatus, mode: Mode) -> ExitCode {
 /// keys that exist in both places (`--print-width`/`--tab-width`/`--use-tabs`):
 /// CLI flag > `.oxfmtrc` > built-in default. Keys with no CLI equivalent
 /// (`singleQuote`, `semi`, `trailingComma`, …) come straight from `.oxfmtrc`.
-fn build_format_options(
-    cli: &Cli,
-    cfg: &OxfmtConfig,
-    js_env: Option<tailwind_sidecar::SidecarEnv>,
-) -> (FormatOptions, Option<PendingJsSort>) {
+fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> (FormatOptions, Option<PendingJsSort>) {
     let use_tabs = cli.use_tabs || cfg.use_tabs.unwrap_or(false);
     let indent_style = if use_tabs {
         IndentStyle::Tab
@@ -591,7 +587,13 @@ fn build_format_options(
     // stylesheet / config is delegated to a Node sidecar running the real
     // `prettier-plugin-tailwindcss` (see `PendingJsSort`); the sort itself is
     // resolved later, once every class string across the run is collected. With
-    // no Node available we warn and leave classes unchanged.
+    // no Node available we warn and leave classes unchanged. The Node probe runs
+    // only when `sortTailwindcss` is actually configured, never on the hot path.
+    let want_tailwind = matches!(
+        &cfg.sort_tailwindcss,
+        Some(v) if v != &serde_json::Value::Bool(false)
+    );
+    let js_env = want_tailwind.then(js_sort_env).flatten();
     let js_available = js_env.is_some();
     let (class_sorter, class_attributes, pending_js) = match tailwind::decide(
         cfg.sort_tailwindcss.as_ref(),
@@ -705,9 +707,7 @@ fn collect_source_classes(source: &str, options: &FormatOptions) -> HashSet<Stri
     opts.class_sorter = Some(collecting_sorter(sink.clone()));
     opts.style_formatter = None;
     let _ = format(source, &opts);
-    Arc::try_unwrap(sink)
-        .map(|m| m.into_inner().expect("class sink poisoned"))
-        .unwrap_or_else(|arc| arc.lock().expect("class sink poisoned").clone())
+    std::mem::take(&mut *sink.lock().expect("class sink poisoned"))
 }
 
 /// Collect every static class-attribute value across `files` in parallel, for
@@ -722,9 +722,7 @@ fn collect_svelte_classes(files: &[PathBuf], options: &FormatOptions) -> HashSet
             let _ = format(&source, &opts);
         }
     });
-    Arc::try_unwrap(sink)
-        .map(|m| m.into_inner().expect("class sink poisoned"))
-        .unwrap_or_else(|arc| arc.lock().expect("class sink poisoned").clone())
+    std::mem::take(&mut *sink.lock().expect("class sink poisoned"))
 }
 
 /// Resolve the JS class sorter for a batch: collect all class strings, run the
@@ -749,12 +747,26 @@ fn resolve_js_class_sorter(
     }
 }
 
-/// Locate the Tailwind sidecar Node environment. `None` disables the JS sort
-/// path (a custom Tailwind config then warns and skips).
+/// Locate the Tailwind sidecar Node environment, requiring both the script and a
+/// runnable Node. `None` disables the JS sort path (a custom Tailwind config then
+/// warns and skips). Only called when `sortTailwindcss` is configured, so the
+/// Node probe never touches the default path.
 fn js_sort_env() -> Option<tailwind_sidecar::SidecarEnv> {
     let script = tailwind_sidecar_script()?;
     let node = oxfmt_node().unwrap_or_else(|| PathBuf::from("node"));
-    Some(tailwind_sidecar::SidecarEnv { node, script })
+    node_runnable(&node).then_some(tailwind_sidecar::SidecarEnv { node, script })
+}
+
+/// Whether `node --version` runs — so a missing Node yields a Node-specific
+/// warning rather than blaming the plugin.
+fn node_runnable(node: &Path) -> bool {
+    Command::new(node)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 /// The `tailwind-sort.mjs` sidecar: `RSVELTE_FMT_TAILWIND_SIDECAR` when set

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -2,12 +2,13 @@
 //! tree. `.svelte` files go through [`rsvelte_formatter`]; every other file
 //! is delegated to a child `oxfmt` process. Both pipelines run in parallel.
 
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
@@ -17,9 +18,9 @@ use oxc_formatter::JsFormatOptions;
 use oxc_formatter_core::{IndentStyle, IndentWidth, LineWidth};
 use rayon::prelude::*;
 use rsvelte_formatter::{
-    CssFormatOptions, CssSingleQuote, CssTrailingCommas, FormatOptions, JsonFormatOptions,
-    JsonVariant, SortOrderSpec, css_variant_from_lang, format, format_css_source, format_js_source,
-    format_json_source, reindent,
+    ClassSorter, CssFormatOptions, CssSingleQuote, CssTrailingCommas, FormatOptions,
+    JsonFormatOptions, JsonVariant, SortOrderSpec, css_variant_from_lang, format,
+    format_css_source, format_js_source, format_json_source, reindent,
 };
 
 mod config;
@@ -27,6 +28,7 @@ mod daemon;
 mod oxfmt_ignore;
 mod style_cache;
 mod tailwind;
+mod tailwind_sidecar;
 mod ts_config;
 use config::OxfmtConfig;
 use style_cache::StyleCache;
@@ -328,10 +330,10 @@ fn run() -> Result<ExitCode> {
         .unwrap_or_else(|| cwd.clone());
     let cfg = OxfmtConfig::resolve(cli.config.as_deref(), &config_start).map_err(|e| anyhow!(e))?;
 
-    let options = build_format_options(&cli, &cfg);
+    let (mut options, pending_js) = build_format_options(&cli, &cfg, js_sort_env());
 
     if cli.stdin {
-        return run_stdin(&cli, &options, &cfg);
+        return run_stdin(&cli, &options, &cfg, pending_js.as_ref());
     }
 
     // No paths given (and not stdin mode): default to the current directory,
@@ -345,6 +347,15 @@ fn run() -> Result<ExitCode> {
     let ignore = oxfmt_ignore::SvelteIgnore::from_config(&cwd, &cfg)?;
     let (svelte, native, native_json, native_css_files, oxfmt_paths) =
         partition_files(&cli.paths, &ignore, &cwd, native_js, native_css)?;
+
+    // Custom Tailwind config (`SortViaJs`): collect every class string across the
+    // `.svelte` files, sort them in one sidecar call, and install a map-backed
+    // sorter for the real formatting pass below. Only `.svelte` files carry the
+    // class sorter, so nothing else needs the collection pass.
+    if let Some(pending) = &pending_js {
+        let classes = collect_svelte_classes(&svelte, &options);
+        options.class_sorter = resolve_js_class_sorter(pending, classes);
+    }
 
     // Whether every in-process pass (Svelte, native JS/JSON/CSS) found
     // nothing at all. When true, `oxfmt`'s own delegated share is the only
@@ -533,7 +544,11 @@ fn combine(a: PipelineStatus, b: PipelineStatus, mode: Mode) -> ExitCode {
 /// keys that exist in both places (`--print-width`/`--tab-width`/`--use-tabs`):
 /// CLI flag > `.oxfmtrc` > built-in default. Keys with no CLI equivalent
 /// (`singleQuote`, `semi`, `trailingComma`, …) come straight from `.oxfmtrc`.
-fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> FormatOptions {
+fn build_format_options(
+    cli: &Cli,
+    cfg: &OxfmtConfig,
+    js_env: Option<tailwind_sidecar::SidecarEnv>,
+) -> (FormatOptions, Option<PendingJsSort>) {
     let use_tabs = cli.use_tabs || cfg.use_tabs.unwrap_or(false);
     let indent_style = if use_tabs {
         IndentStyle::Tab
@@ -572,23 +587,43 @@ fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> FormatOptions {
     };
 
     // `sortTailwindcss` orders class names by the project's tailwind stylesheet.
-    // We reproduce it natively only for a stock, zero-config Tailwind setup — the
-    // one case a pure-Rust sorter matches byte-for-byte. A custom stylesheet /
-    // config depends on the JS engine, so we warn and leave classes unchanged
-    // (a missing re-sort is invisible in the diff, #1057).
-    let (class_sorter, class_attributes) =
-        match tailwind::decide(cfg.sort_tailwindcss.as_ref(), cfg.path.as_deref()) {
-            tailwind::Decision::Sort { sorter, attributes } => (Some(sorter), attributes),
-            tailwind::Decision::Skip { reason } => {
-                eprintln!(
-                    "rsvelte-fmt: warning: `sortTailwindcss` left unapplied — {reason}. Native \
-                     sorting only covers a default `@import \"tailwindcss\";` setup; run `oxfmt` \
-                     for a custom Tailwind config."
-                );
-                (None, Vec::new())
-            }
-            tailwind::Decision::Off => (None, Vec::new()),
-        };
+    // A stock, zero-config setup sorts natively (byte-for-byte). A custom
+    // stylesheet / config is delegated to a Node sidecar running the real
+    // `prettier-plugin-tailwindcss` (see `PendingJsSort`); the sort itself is
+    // resolved later, once every class string across the run is collected. With
+    // no Node available we warn and leave classes unchanged.
+    let js_available = js_env.is_some();
+    let (class_sorter, class_attributes, pending_js) = match tailwind::decide(
+        cfg.sort_tailwindcss.as_ref(),
+        cfg.path.as_deref(),
+        js_available,
+    ) {
+        tailwind::Decision::Sort { sorter, attributes } => (Some(sorter), attributes, None),
+        tailwind::Decision::SortViaJs {
+            filepath,
+            stylesheet_path,
+            config_path,
+            attributes,
+            preserve_whitespace,
+            preserve_duplicates,
+        } => (
+            None,
+            attributes,
+            Some(PendingJsSort {
+                env: js_env.expect("js_available implies an env"),
+                filepath,
+                stylesheet_path,
+                config_path,
+                preserve_whitespace,
+                preserve_duplicates,
+            }),
+        ),
+        tailwind::Decision::Skip { reason } => {
+            eprintln!("rsvelte-fmt: warning: `sortTailwindcss` left unapplied — {reason}.");
+            (None, Vec::new(), None)
+        }
+        tailwind::Decision::Off => (None, Vec::new(), None),
+    };
 
     // Embedded `<style>` blocks are formatted in-process via `oxc_formatter_css`
     // by default (same engine as `oxfmt`, no subprocess). `--no-native-css`
@@ -599,7 +634,7 @@ fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> FormatOptions {
         rsvelte_formatter::native_style_formatter(build_css_options(cli, cfg))
     };
 
-    FormatOptions {
+    let options = FormatOptions {
         js,
         style_formatter: Some(style_formatter),
         // `format` derives this per-document from `<script lang="ts">`.
@@ -611,7 +646,128 @@ fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> FormatOptions {
         bracket_same_line: cfg.bracket_same_line.unwrap_or(false),
         class_sorter,
         class_attributes,
+    };
+    (options, pending_js)
+}
+
+/// A resolved custom-Tailwind `sortTailwindcss` awaiting its one sidecar call.
+/// Held until every class string across the run is collected, so the Node
+/// sidecar runs exactly once for the whole batch.
+struct PendingJsSort {
+    env: tailwind_sidecar::SidecarEnv,
+    filepath: PathBuf,
+    stylesheet_path: Option<PathBuf>,
+    config_path: Option<PathBuf>,
+    preserve_whitespace: bool,
+    preserve_duplicates: bool,
+}
+
+impl PendingJsSort {
+    /// Sort `classes` (deduped) via the sidecar into an `orig -> sorted` map.
+    /// `None` on any sidecar failure, so the caller leaves classes untouched.
+    fn resolve(&self, classes: Vec<String>) -> Option<HashMap<String, String>> {
+        let req = tailwind_sidecar::SortRequest {
+            filepath: &self.filepath,
+            stylesheet_path: self.stylesheet_path.as_deref(),
+            config_path: self.config_path.as_deref(),
+            preserve_whitespace: self.preserve_whitespace,
+            preserve_duplicates: self.preserve_duplicates,
+            classes: classes.clone(),
+        };
+        let sorted = tailwind_sidecar::sort(&self.env, &req)?;
+        Some(classes.into_iter().zip(sorted).collect())
     }
+}
+
+/// A class sorter that records every value it sees (returning it unchanged), for
+/// the collection pass that gathers all class strings before the sidecar call.
+fn collecting_sorter(sink: Arc<Mutex<HashSet<String>>>) -> ClassSorter {
+    Arc::new(move |s: &str| {
+        sink.lock()
+            .expect("class sink poisoned")
+            .insert(s.to_string());
+        s.to_string()
+    })
+}
+
+/// A class sorter backed by a resolved `orig -> sorted` map; an unseen value
+/// (e.g. a sidecar miss) is returned unchanged.
+fn map_sorter(map: Arc<HashMap<String, String>>) -> ClassSorter {
+    Arc::new(move |s: &str| map.get(s).cloned().unwrap_or_else(|| s.to_string()))
+}
+
+/// Format `source` with a collecting class sorter, returning the set of static
+/// class-attribute values it contains. Style formatting is skipped — only the
+/// class strings matter here.
+fn collect_source_classes(source: &str, options: &FormatOptions) -> HashSet<String> {
+    let sink: Arc<Mutex<HashSet<String>>> = Arc::default();
+    let mut opts = options.clone();
+    opts.class_sorter = Some(collecting_sorter(sink.clone()));
+    opts.style_formatter = None;
+    let _ = format(source, &opts);
+    Arc::try_unwrap(sink)
+        .map(|m| m.into_inner().expect("class sink poisoned"))
+        .unwrap_or_else(|arc| arc.lock().expect("class sink poisoned").clone())
+}
+
+/// Collect every static class-attribute value across `files` in parallel, for
+/// the single batched sidecar sort.
+fn collect_svelte_classes(files: &[PathBuf], options: &FormatOptions) -> HashSet<String> {
+    let sink: Arc<Mutex<HashSet<String>>> = Arc::default();
+    let mut opts = options.clone();
+    opts.class_sorter = Some(collecting_sorter(sink.clone()));
+    opts.style_formatter = None;
+    files.par_iter().for_each(|path| {
+        if let Ok(source) = std::fs::read_to_string(path) {
+            let _ = format(&source, &opts);
+        }
+    });
+    Arc::try_unwrap(sink)
+        .map(|m| m.into_inner().expect("class sink poisoned"))
+        .unwrap_or_else(|arc| arc.lock().expect("class sink poisoned").clone())
+}
+
+/// Resolve the JS class sorter for a batch: collect all class strings, run the
+/// sidecar once, and return a map-backed sorter. On sidecar failure, warns once
+/// and returns `None` so classes are left unsorted (never wrongly reordered).
+fn resolve_js_class_sorter(
+    pending: &PendingJsSort,
+    classes: HashSet<String>,
+) -> Option<ClassSorter> {
+    if classes.is_empty() {
+        return None;
+    }
+    match pending.resolve(classes.into_iter().collect()) {
+        Some(map) => Some(map_sorter(Arc::new(map))),
+        None => {
+            eprintln!(
+                "rsvelte-fmt: warning: `sortTailwindcss` left unapplied — the Node sidecar could \
+                 not sort classes (is prettier-plugin-tailwindcss installed?)."
+            );
+            None
+        }
+    }
+}
+
+/// Locate the Tailwind sidecar Node environment. `None` disables the JS sort
+/// path (a custom Tailwind config then warns and skips).
+fn js_sort_env() -> Option<tailwind_sidecar::SidecarEnv> {
+    let script = tailwind_sidecar_script()?;
+    let node = oxfmt_node().unwrap_or_else(|| PathBuf::from("node"));
+    Some(tailwind_sidecar::SidecarEnv { node, script })
+}
+
+/// The `tailwind-sort.mjs` sidecar: `RSVELTE_FMT_TAILWIND_SIDECAR` when set
+/// (tests / overrides), else `lib/tailwind-sort.mjs` beside the installed
+/// `bin/rsvelte-fmt`.
+fn tailwind_sidecar_script() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("RSVELTE_FMT_TAILWIND_SIDECAR") {
+        let p = PathBuf::from(p);
+        return p.is_file().then_some(p);
+    }
+    let exe = std::env::current_exe().ok()?;
+    let script = exe.parent()?.parent()?.join("lib/tailwind-sort.mjs");
+    script.is_file().then_some(script)
 }
 
 /// The base [`JsonFormatOptions`] for the native-JSON path: width/indent/EOL
@@ -770,7 +926,12 @@ fn make_oxfmt_style_formatter(
 
 // ─── stdin path ─────────────────────────────────────────────────────────
 
-fn run_stdin(cli: &Cli, options: &FormatOptions, cfg: &OxfmtConfig) -> Result<ExitCode> {
+fn run_stdin(
+    cli: &Cli,
+    options: &FormatOptions,
+    cfg: &OxfmtConfig,
+    pending_js: Option<&PendingJsSort>,
+) -> Result<ExitCode> {
     let filepath = cli
         .stdin_filepath
         .as_ref()
@@ -782,6 +943,19 @@ fn run_stdin(cli: &Cli, options: &FormatOptions, cfg: &OxfmtConfig) -> Result<Ex
         .context("failed to read stdin")?;
 
     if is_svelte(filepath) {
+        // Custom Tailwind config: collect this source's class strings, sort them
+        // in one sidecar call, then format with the resolved map-backed sorter.
+        let owned_options;
+        let options = match pending_js {
+            Some(pending) => {
+                let classes = collect_source_classes(&source, options);
+                let mut opts = options.clone();
+                opts.class_sorter = resolve_js_class_sorter(pending, classes);
+                owned_options = opts;
+                &owned_options
+            }
+            None => options,
+        };
         let formatted =
             format(&source, options).map_err(|e| anyhow!("rsvelte_formatter error: {e}"))?;
         if cli.check {

--- a/crates/rsvelte_fmt/src/tailwind.rs
+++ b/crates/rsvelte_fmt/src/tailwind.rs
@@ -1,13 +1,16 @@
-//! `sortTailwindcss` support, scoped to the one case a pure-Rust sorter can
-//! reproduce byte-for-byte: a **stock, zero-config** Tailwind v4 setup.
+//! `sortTailwindcss` support. A **stock, zero-config** Tailwind v4 setup sorts
+//! natively — the one case a pure-Rust sorter reproduces byte-for-byte.
 //!
 //! Tailwind's class order depends on the project's compiled CSS, so a JS
 //! `tailwind.config.js`, a `@plugin`, a custom `@utility` / `@custom-variant`,
-//! or `@theme` tokens all change it. We therefore sort natively only when the
-//! resolved stylesheet is confidently a default `@import "tailwindcss";` with no
-//! such order-affecting directive, and no v3 JS config is present. Anything less
-//! certain falls back to a warning and leaves classes untouched — never a
-//! silently wrong reorder.
+//! or `@theme` tokens all change it. For those custom setups we delegate to a
+//! Node sidecar that runs the real `prettier-plugin-tailwindcss` (the same
+//! plugin `oxfmt` uses), matching the oracle exactly. When Node / the plugin is
+//! unavailable the custom case falls back to a warning that leaves classes
+//! untouched — never a silently wrong reorder.
+//!
+//! The rsvelte-only `strategy` knob (`auto` default / `native` / `js`) picks
+//! between the native and JS sorters; see [`decide`].
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -21,19 +24,60 @@ pub enum Decision {
         sorter: ClassSorter,
         attributes: Vec<String>,
     },
-    /// Configured but not a stock setup — warn and leave classes unsorted, with
+    /// Sort through the Node sidecar (real `prettier-plugin-tailwindcss`). Used
+    /// for a custom config, or for any config under `strategy: "js"`.
+    SortViaJs {
+        /// A representative in-project path, so the plugin resolves the
+        /// consumer's `tailwindcss` from the right `node_modules`.
+        filepath: PathBuf,
+        stylesheet_path: Option<PathBuf>,
+        config_path: Option<PathBuf>,
+        attributes: Vec<String>,
+        preserve_whitespace: bool,
+        preserve_duplicates: bool,
+    },
+    /// Configured but not sortable here — warn and leave classes unsorted, with
     /// the reason for the warning.
     Skip { reason: String },
     /// `sortTailwindcss` is not set.
     Off,
 }
 
+/// rsvelte-only `sortTailwindcss.strategy` (not an oxfmt key).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Strategy {
+    /// Default: stock config native, custom config via JS.
+    Auto,
+    /// Always pure-Rust; a custom config warns and skips.
+    Native,
+    /// Always via the JS oracle (opts a stock config into it too).
+    Js,
+}
+
+/// How the resolved config classifies against a stock setup.
+enum Class {
+    Default {
+        stylesheet: PathBuf,
+    },
+    Custom {
+        stylesheet: Option<PathBuf>,
+        config: Option<PathBuf>,
+        reason: String,
+    },
+    Unresolvable {
+        reason: String,
+    },
+}
+
 /// Decide how to handle `sortTailwindcss` for a config. `config_path` is the
 /// `.oxfmtrc` path, used to resolve relative stylesheet paths and to look for a
-/// sibling v3 JS config.
+/// sibling v3 JS config. `js_available` is whether a Node sidecar can run; when
+/// `false`, cases that need JS fall back to warn+skip (or native for a stock
+/// config under `strategy: "js"`).
 pub fn decide(
     sort_tailwindcss: Option<&serde_json::Value>,
     config_path: Option<&Path>,
+    js_available: bool,
 ) -> Decision {
     let Some(value) = sort_tailwindcss else {
         return Decision::Off;
@@ -47,19 +91,129 @@ pub fn decide(
         .map(Path::to_path_buf)
         .unwrap_or_else(|| PathBuf::from("."));
 
-    // A v3 config file (or a `config` key) means JS-driven ordering we cannot
-    // reproduce.
-    if value
-        .get("config")
-        .and_then(serde_json::Value::as_str)
-        .is_some()
-    {
-        return Decision::Skip {
+    let strategy = parse_strategy(value);
+    let attributes = attribute_names(value);
+    let preserve_whitespace = bool_key(value, "preserveWhitespace");
+    let preserve_duplicates = bool_key(value, "preserveDuplicates");
+    // The plugin resolves `tailwindcss` from this path's directory; any file
+    // inside the project resolves the same install `decide` already picked.
+    let filepath = base_dir.join("__rsvelte-fmt-tailwind__.svelte");
+
+    match (strategy, classify(value, &base_dir)) {
+        (_, Class::Unresolvable { reason }) => Decision::Skip { reason },
+
+        (Strategy::Native, Class::Default { .. }) | (Strategy::Auto, Class::Default { .. }) => {
+            native_sort(attributes)
+        }
+        (Strategy::Native, Class::Custom { reason, .. }) => Decision::Skip {
+            reason: format!(
+                "{reason}; `strategy: \"native\"` cannot sort a custom Tailwind config"
+            ),
+        },
+
+        (
+            Strategy::Auto,
+            Class::Custom {
+                stylesheet,
+                config,
+                reason,
+            },
+        ) => sort_via_js_or_skip(
+            js_available,
+            filepath,
+            stylesheet,
+            config,
+            attributes,
+            preserve_whitespace,
+            preserve_duplicates,
+            reason,
+        ),
+
+        (Strategy::Js, Class::Default { stylesheet }) => {
+            if js_available {
+                Decision::SortViaJs {
+                    filepath,
+                    stylesheet_path: Some(stylesheet),
+                    config_path: None,
+                    attributes,
+                    preserve_whitespace,
+                    preserve_duplicates,
+                }
+            } else {
+                native_sort(attributes)
+            }
+        }
+        (
+            Strategy::Js,
+            Class::Custom {
+                stylesheet,
+                config,
+                reason,
+            },
+        ) => sort_via_js_or_skip(
+            js_available,
+            filepath,
+            stylesheet,
+            config,
+            attributes,
+            preserve_whitespace,
+            preserve_duplicates,
+            reason,
+        ),
+    }
+}
+
+fn native_sort(attributes: Vec<String>) -> Decision {
+    Decision::Sort {
+        sorter: Arc::new(|classes: &str| tailwind_class_order::sort_class_string(classes)),
+        attributes,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sort_via_js_or_skip(
+    js_available: bool,
+    filepath: PathBuf,
+    stylesheet_path: Option<PathBuf>,
+    config_path: Option<PathBuf>,
+    attributes: Vec<String>,
+    preserve_whitespace: bool,
+    preserve_duplicates: bool,
+    detect_reason: String,
+) -> Decision {
+    if js_available {
+        Decision::SortViaJs {
+            filepath,
+            stylesheet_path,
+            config_path,
+            attributes,
+            preserve_whitespace,
+            preserve_duplicates,
+        }
+    } else {
+        Decision::Skip {
+            reason: format!(
+                "{detect_reason}; a Node interpreter with prettier-plugin-tailwindcss is required \
+                 to sort a custom Tailwind config"
+            ),
+        }
+    }
+}
+
+/// Classify the resolved config against a stock `@import "tailwindcss";` setup.
+fn classify(value: &serde_json::Value, base_dir: &Path) -> Class {
+    // A v3 config (explicit `config` key or a sibling file) is JS-driven order.
+    if let Some(cfg) = value.get("config").and_then(serde_json::Value::as_str) {
+        return Class::Custom {
+            stylesheet: None,
+            config: Some(base_dir.join(cfg)),
             reason: "a Tailwind `config` (v3) is set".into(),
         };
     }
-    if let Some(name) = find_v3_config(&base_dir) {
-        return Decision::Skip {
+    if let Some(name) = find_v3_config(base_dir) {
+        return Class::Custom {
+            stylesheet: None,
+            config: Some(base_dir.join(&name)),
             reason: format!("a Tailwind v3 config ({name}) was found"),
         };
     }
@@ -70,29 +224,43 @@ pub fn decide(
         .get("stylesheet")
         .and_then(serde_json::Value::as_str)
         .map(|s| base_dir.join(s))
-        .or_else(|| find_default_stylesheet(&base_dir));
+        .or_else(|| find_default_stylesheet(base_dir));
 
     let Some(stylesheet) = stylesheet else {
-        return Decision::Skip {
+        return Class::Unresolvable {
             reason: "no Tailwind stylesheet could be located to verify a default setup".into(),
         };
     };
 
     match read_resolved(&stylesheet) {
-        Some(css) if is_default_stylesheet(&css) => Decision::Sort {
-            sorter: Arc::new(|classes: &str| tailwind_class_order::sort_class_string(classes)),
-            attributes: attribute_names(value),
-        },
-        Some(_) => Decision::Skip {
+        Some(css) if is_default_stylesheet(&css) => Class::Default { stylesheet },
+        Some(_) => Class::Custom {
             reason: format!(
                 "{} is not a default setup (contains @plugin / @utility / @custom-variant / @theme / @config)",
                 stylesheet.display()
             ),
+            stylesheet: Some(stylesheet),
+            config: None,
         },
-        None => Decision::Skip {
+        None => Class::Unresolvable {
             reason: format!("could not read {}", stylesheet.display()),
         },
     }
+}
+
+fn parse_strategy(value: &serde_json::Value) -> Strategy {
+    match value.get("strategy").and_then(serde_json::Value::as_str) {
+        Some("native") => Strategy::Native,
+        Some("js") => Strategy::Js,
+        _ => Strategy::Auto,
+    }
+}
+
+fn bool_key(value: &serde_json::Value, key: &str) -> bool {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 /// The attribute names to sort (`sortTailwindcss.attributes`, default `class`).

--- a/crates/rsvelte_fmt/src/tailwind_sidecar.rs
+++ b/crates/rsvelte_fmt/src/tailwind_sidecar.rs
@@ -4,9 +4,16 @@
 //! like the oxfmt oracle. Driven by [`crate::main`] only for the `SortViaJs`
 //! decision; the default zero-config path stays pure-Rust.
 
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Upper bound on how long the sidecar may run before it's killed and the run
+/// falls back to unsorted classes — a hung Node / plugin must never block the
+/// whole formatter.
+const TIMEOUT: Duration = Duration::from_secs(30);
+const POLL: Duration = Duration::from_millis(10);
 
 /// Node interpreter + `tailwind-sort.mjs` script. `None` at the call site
 /// disables the JS path, so a custom config falls back to warn+skip.
@@ -53,14 +60,37 @@ pub fn sort(env: &SidecarEnv, req: &SortRequest) -> Option<Vec<String>> {
         .spawn()
         .ok()?;
     // Dropping the moved-out stdin at the end of the statement closes the pipe,
-    // signalling EOF to the sidecar's `readStdin`.
+    // signalling EOF to the sidecar's `readStdin`. The child writes stdout only
+    // after that EOF, so writing here can't deadlock against an unread stdout.
     child.stdin.take()?.write_all(&body).ok()?;
-    let out = child.wait_with_output().ok()?;
-    if !out.status.success() {
+
+    // Drain stdout on a thread while polling `try_wait` with a deadline, so a
+    // hung child is killed instead of blocking forever.
+    let mut stdout = child.stdout.take()?;
+    let reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stdout.read_to_end(&mut buf);
+        buf
+    });
+    let deadline = Instant::now() + TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+            Ok(None) => std::thread::sleep(POLL),
+            Err(_) => break None,
+        }
+    };
+    let stdout = reader.join().ok()?;
+    if !status?.success() {
         return None;
     }
 
-    let resp: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    let resp: serde_json::Value = serde_json::from_slice(&stdout).ok()?;
     if resp.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
         return None;
     }

--- a/crates/rsvelte_fmt/src/tailwind_sidecar.rs
+++ b/crates/rsvelte_fmt/src/tailwind_sidecar.rs
@@ -1,0 +1,75 @@
+//! One-shot Node sidecar that sorts Tailwind classes through the real
+//! `prettier-plugin-tailwindcss` — the same plugin (and API) `oxfmt` uses — so a
+//! custom Tailwind config (`@theme` / `@plugin` / v3 config) sorts byte-for-byte
+//! like the oxfmt oracle. Driven by [`crate::main`] only for the `SortViaJs`
+//! decision; the default zero-config path stays pure-Rust.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Node interpreter + `tailwind-sort.mjs` script. `None` at the call site
+/// disables the JS path, so a custom config falls back to warn+skip.
+pub struct SidecarEnv {
+    pub node: PathBuf,
+    pub script: PathBuf,
+}
+
+/// A single batch sort request; all class strings for one `rsvelte-fmt` run are
+/// deduped and sent together.
+pub struct SortRequest<'a> {
+    pub filepath: &'a Path,
+    pub stylesheet_path: Option<&'a Path>,
+    pub config_path: Option<&'a Path>,
+    pub preserve_whitespace: bool,
+    pub preserve_duplicates: bool,
+    pub classes: Vec<String>,
+}
+
+/// Sort `classes` via the sidecar. Returns the sorted list (same order and
+/// length as the input) on success, or `None` on any failure — no Node, an
+/// unresolvable plugin, a non-`ok` response, or a shape mismatch — so the caller
+/// leaves the classes untouched rather than risking a wrong reorder.
+pub fn sort(env: &SidecarEnv, req: &SortRequest) -> Option<Vec<String>> {
+    if req.classes.is_empty() {
+        return Some(Vec::new());
+    }
+
+    let payload = serde_json::json!({
+        "filepath": req.filepath.to_string_lossy(),
+        "stylesheetPath": req.stylesheet_path.map(|p| p.to_string_lossy()),
+        "configPath": req.config_path.map(|p| p.to_string_lossy()),
+        "preserveWhitespace": req.preserve_whitespace,
+        "preserveDuplicates": req.preserve_duplicates,
+        "classes": &req.classes,
+    });
+    let body = serde_json::to_vec(&payload).ok()?;
+
+    let mut child = Command::new(&env.node)
+        .arg(&env.script)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    // Dropping the moved-out stdin at the end of the statement closes the pipe,
+    // signalling EOF to the sidecar's `readStdin`.
+    child.stdin.take()?.write_all(&body).ok()?;
+    let out = child.wait_with_output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+
+    let resp: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    if resp.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
+        return None;
+    }
+    let sorted: Option<Vec<String>> = resp
+        .get("sorted")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_str().map(str::to_owned))
+        .collect();
+    let sorted = sorted?;
+    (sorted.len() == req.classes.len()).then_some(sorted)
+}

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -2088,3 +2088,284 @@ fn tempdir() -> PathBuf {
     std::fs::create_dir(&dir).unwrap_or_else(|e| panic!("tempdir collision at {dir:?}: {e}"));
     dir
 }
+
+// ─── sortTailwindcss JS sidecar (custom config) ────────────────────────────
+//
+// These gate on a directory that resolves both `tailwindcss` and
+// `prettier-plugin-tailwindcss` — set `RSVELTE_FMT_TW_TEST_DIR` to one (e.g. a
+// throwaway `npm i tailwindcss prettier-plugin-tailwindcss@<insiders>` project),
+// and `OXFMT_BIN` to a real oxfmt. Absent either, they no-op, matching the
+// other real-oxfmt-dependent tests. The oracle is real `oxfmt` sorting the same
+// `.svelte`, so a pass is byte-for-byte parity with the plugin oxfmt bundles.
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn sidecar_script() -> PathBuf {
+    repo_root().join("apps/npm/fmt/lib/tailwind-sort.mjs")
+}
+
+/// A directory whose `node_modules` resolves both Tailwind packages, or `None`.
+fn tw_test_dir() -> Option<PathBuf> {
+    let has = |dir: &Path| {
+        dir.join("node_modules/tailwindcss/package.json").is_file()
+            && dir
+                .join("node_modules/prettier-plugin-tailwindcss/package.json")
+                .is_file()
+    };
+    if let Ok(d) = std::env::var("RSVELTE_FMT_TW_TEST_DIR") {
+        let d = PathBuf::from(d);
+        if has(&d) {
+            return Some(d);
+        }
+    }
+    None
+}
+
+fn node_runnable() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Run `rsvelte-fmt` on `stdin` in `cwd` with extra env, returning
+/// `(stdout, stderr, code)`.
+fn run_stdin_in(
+    stdin: &str,
+    cwd: &Path,
+    env: &[(&str, &Path)],
+    args: &[&str],
+) -> (String, String, i32) {
+    let mut cmd = Command::new(bin());
+    cmd.current_dir(cwd)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("spawn rsvelte-fmt");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    (
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// Build a fixture project (custom v4 stylesheet + `node_modules` symlinked from
+/// the resolved Tailwind env) and return `(dir, sidecar_in_dir, oxfmt)`. The
+/// sidecar is copied into the fixture so Node resolves the plugin from there.
+#[cfg(unix)]
+fn tw_fixture(css: &str) -> Option<(PathBuf, PathBuf, PathBuf)> {
+    let tw_dir = tw_test_dir()?;
+    let oxfmt = real_oxfmt_bin();
+    if !real_oxfmt_runnable(&oxfmt) || !node_runnable() || !sidecar_script().is_file() {
+        return None;
+    }
+    let dir = tempdir();
+    std::os::unix::fs::symlink(tw_dir.join("node_modules"), dir.join("node_modules")).unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/app.css"), css).unwrap();
+    let sidecar = dir.join("tailwind-sort.mjs");
+    std::fs::copy(sidecar_script(), &sidecar).unwrap();
+    Some((dir, sidecar, oxfmt))
+}
+
+/// Format `svelte_src` with the real `oxfmt` (`svelte: true` + `sortTailwindcss`)
+/// and return its output — the parity oracle.
+#[cfg(unix)]
+fn oxfmt_oracle(dir: &Path, oxfmt: &Path, svelte_src: &str) -> String {
+    let file = dir.join("src/Oracle.svelte");
+    std::fs::write(&file, svelte_src).unwrap();
+    let cfg = dir.join("oxfmt.oracle.json");
+    std::fs::write(
+        &cfg,
+        r#"{ "svelte": true, "sortTailwindcss": { "stylesheet": "./src/app.css" } }"#,
+    )
+    .unwrap();
+    let status = Command::new(oxfmt)
+        .current_dir(dir)
+        .args([
+            "--write",
+            "--config",
+            cfg.to_str().unwrap(),
+            file.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "oxfmt oracle failed");
+    std::fs::read_to_string(&file).unwrap()
+}
+
+/// `strategy: "auto"` (the default) sorts a custom `@theme`/`@utility` config
+/// through the JS sidecar, byte-identical to the oxfmt oracle.
+#[cfg(unix)]
+#[test]
+fn sort_tailwindcss_custom_config_matches_oxfmt_via_js() {
+    let css = "@import \"tailwindcss\";\n@theme {\n  --color-brand: #1a2b3c;\n}\n@utility tab-4 {\n  tab-size: 4;\n}\n";
+    let Some((dir, sidecar, oxfmt)) = tw_fixture(css) else {
+        eprintln!("[tw-js] no Tailwind env / oxfmt; skipping.");
+        return;
+    };
+    let svelte_src = "<div class=\"text-brand p-4 tab-4 flex m-2 bg-brand\"></div>\n";
+    let oracle = oxfmt_oracle(&dir, &oxfmt, svelte_src);
+
+    let cfg = dir.join("rsvelte.oxfmtrc.json");
+    std::fs::write(
+        &cfg,
+        r#"{ "sortTailwindcss": { "stylesheet": "./src/app.css" } }"#,
+    )
+    .unwrap();
+    let (stdout, stderr, code) = run_stdin_in(
+        svelte_src,
+        &dir,
+        &[("RSVELTE_FMT_TAILWIND_SIDECAR", sidecar.as_path())],
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            dir.join("src/Foo.svelte").to_str().unwrap(),
+            "--config",
+            cfg.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(!stderr.contains("warning"), "unexpected warning:\n{stderr}");
+    assert_eq!(stdout, oracle, "must match the oxfmt oracle byte-for-byte");
+}
+
+/// `strategy: "js"` opts even a default `@import "tailwindcss";` config into the
+/// JS oracle (so the native sorter's few edge cases can be bypassed).
+#[cfg(unix)]
+#[test]
+fn sort_tailwindcss_strategy_js_forces_oracle_on_default() {
+    let Some((dir, sidecar, oxfmt)) = tw_fixture("@import \"tailwindcss\";\n") else {
+        eprintln!("[tw-js] no Tailwind env / oxfmt; skipping.");
+        return;
+    };
+    let svelte_src = "<div class=\"p-4 m-2 flex\"></div>\n";
+    let oracle = oxfmt_oracle(&dir, &oxfmt, svelte_src);
+
+    let cfg = dir.join("rsvelte.oxfmtrc.json");
+    std::fs::write(
+        &cfg,
+        r#"{ "sortTailwindcss": { "stylesheet": "./src/app.css", "strategy": "js" } }"#,
+    )
+    .unwrap();
+    let (stdout, stderr, code) = run_stdin_in(
+        svelte_src,
+        &dir,
+        &[("RSVELTE_FMT_TAILWIND_SIDECAR", sidecar.as_path())],
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            dir.join("src/Foo.svelte").to_str().unwrap(),
+            "--config",
+            cfg.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, oracle, "strategy:js must match the oxfmt oracle");
+}
+
+/// `strategy: "native"` never uses JS: a custom config warns and leaves classes
+/// unsorted even when a sidecar is available.
+#[test]
+fn sort_tailwindcss_strategy_native_skips_custom() {
+    let dir = tempdir();
+    std::fs::write(
+        dir.join("app.css"),
+        "@import \"tailwindcss\";\n@plugin \"@tailwindcss/typography\";\n",
+    )
+    .unwrap();
+    let cfg = dir.join(".oxfmtrc.json");
+    std::fs::write(
+        &cfg,
+        r#"{ "sortTailwindcss": { "stylesheet": "./app.css", "strategy": "native" } }"#,
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run_stdin_in(
+        "<div class=\"p-4 m-2 flex\"></div>\n",
+        &dir,
+        &[("RSVELTE_FMT_TAILWIND_SIDECAR", sidecar_script().as_path())],
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            dir.join("x.svelte").to_str().unwrap(),
+            "--config",
+            cfg.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("class=\"p-4 m-2 flex\""),
+        "native strategy must not sort a custom config:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("left unapplied") && stderr.contains("native"),
+        "expected a native-strategy skip warning:\n{stderr}"
+    );
+}
+
+/// When a sidecar is present but the plugin can't be resolved from it, the run
+/// warns once and leaves classes unsorted — never a wrong reorder or a crash.
+/// The sidecar is copied into the temp dir (no ancestor `node_modules` with the
+/// plugin), so the import reliably fails.
+#[test]
+fn sort_tailwindcss_js_plugin_unresolvable_falls_back() {
+    if !node_runnable() || !sidecar_script().is_file() {
+        eprintln!("[tw-js] no node / sidecar; skipping.");
+        return;
+    }
+    let dir = tempdir();
+    let sidecar = dir.join("tailwind-sort.mjs");
+    std::fs::copy(sidecar_script(), &sidecar).unwrap();
+    std::fs::write(
+        dir.join("app.css"),
+        "@import \"tailwindcss\";\n@theme {\n  --color-brand: #123;\n}\n",
+    )
+    .unwrap();
+    let cfg = dir.join(".oxfmtrc.json");
+    std::fs::write(
+        &cfg,
+        r#"{ "sortTailwindcss": { "stylesheet": "./app.css" } }"#,
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run_stdin_in(
+        "<div class=\"p-4 m-2 flex\"></div>\n",
+        &dir,
+        &[("RSVELTE_FMT_TAILWIND_SIDECAR", sidecar.as_path())],
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            dir.join("x.svelte").to_str().unwrap(),
+            "--config",
+            cfg.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("class=\"p-4 m-2 flex\""),
+        "classes must be left unsorted on a sidecar failure:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("left unapplied"),
+        "expected a fallback warning:\n{stderr}"
+    );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       oxfmt:
         specifier: '*'
         version: 0.53.0(svelte@5.56.7)
+      prettier-plugin-tailwindcss:
+        specifier: 0.0.0-insiders.2b6f3c2
+        version: 0.0.0-insiders.2b6f3c2(prettier-plugin-svelte@4.1.1(prettier@3.9.5)(svelte@5.56.7))(prettier@3.9.5)
     optionalDependencies:
       '@rsvelte/fmt-darwin-arm64':
         specifier: workspace:^
@@ -1677,6 +1680,61 @@ packages:
       prettier: ^3.0.0
       svelte: ^5.0.0
 
+  prettier-plugin-tailwindcss@0.0.0-insiders.2b6f3c2:
+    resolution: {integrity: sha512-bAwh6xzGCT0NvJUenof34s+JME2Fl7wRvUYUE8fEOGl41QgJGAEHWtjlgWC3p3bbPfx3O2ykNcvN1GFoDTM86g==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -2976,6 +3034,12 @@ snapshots:
     dependencies:
       prettier: 3.9.5
       svelte: 5.56.7
+
+  prettier-plugin-tailwindcss@0.0.0-insiders.2b6f3c2(prettier-plugin-svelte@4.1.1(prettier@3.9.5)(svelte@5.56.7))(prettier@3.9.5):
+    dependencies:
+      prettier: 3.9.5
+    optionalDependencies:
+      prettier-plugin-svelte: 4.1.1(prettier@3.9.5)(svelte@5.56.7)
 
   prettier@2.8.8: {}
 


### PR DESCRIPTION
## What

`rsvelte-fmt`'s `sortTailwindcss` previously covered only a **stock, zero-config Tailwind v4 setup** (sorted natively in Rust). A custom `@theme` / `@plugin` / `@utility` / `@custom-variant` / `@config` stylesheet or a v3 `tailwind.config.js` warned and left classes untouched, because their order depends on the project's compiled CSS — the #1605 incompatibility.

This PR closes that gap by delegating custom configs to a one-shot **Node sidecar** running the real `prettier-plugin-tailwindcss` — the same plugin (and `createSorter` / `sortClassAttributes` API) `oxfmt` uses, pinned to the same insiders build (`0.0.0-insiders.2b6f3c2`). The result is **byte-for-byte identical to the oxfmt oracle**.

- Every static class string across the run is collected and sorted in a **single batched sidecar call** (2-pass: collect → sort → apply an `orig → sorted` map).
- The sidecar **never throws**: a missing Node/plugin or bad config returns `{ ok: false }`, and Rust falls back to the original classes with one warning — never a wrong reorder.
- The **default zero-config path is unchanged** — still pure-Rust, no subprocess, byte-identical output. The fmt-parity gate is unaffected.

## `strategy` (rsvelte-only extension)

`sortTailwindcss.strategy` (not an oxfmt key):

| `strategy` | Behavior |
|---|---|
| `auto` (default) | Stock config → native Rust; custom config → Node/JS oracle |
| `native` | Always pure-Rust; a custom config warns and is left unsorted |
| `js` | Always the Node/JS oracle, even for a stock config (bypasses the native sorter's rare edge cases) |

With the default `auto`, an existing oxfmt `sortTailwindcss` config works unchanged.

## Verification

- **Prerequisite check**: confirmed `prettier-plugin-tailwindcss/sorter`'s `createSorter` / `sortClassAttributes` exist in the pinned insiders build, resolve the consumer's `tailwindcss`, and produce different orderings for custom vs. default config.
- **Byte-parity proven**: real `oxfmt` sorting a `.svelte` with a custom `@theme`/`@utility` config produces `m-2 flex bg-brand p-4 tab-4 text-brand` — exactly what `sortClassAttributes` returns and what `rsvelte-fmt` now emits.
- **Automated E2E** (`crates/rsvelte_fmt/tests/cli.rs`, gated on a Tailwind env + `oxfmt`): custom-config output `== oxfmt` output byte-for-byte; `strategy: "js"` on a default config `== oxfmt`; `strategy: "native"` skips a custom config; sidecar-unresolvable falls back with a warning. Ran green locally with `RSVELTE_FMT_TW_TEST_DIR` + `OXFMT_BIN` set.
- `cargo test -p rsvelte_fmt` (60 + suites), `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings` all green.

## Scope notes

- `sortTailwindcss.functions` (`cn()` etc.) remains out of scope on both paths (follow-up).
- Custom-config parity depends on the pinned insiders plugin version; kept in lockstep with oxfmt via the auto-update-oxfmt path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kjwziVV91nApcWDK48gRA