### PR TITLE
fix(formatter): break a prose expression/render tag's call arguments in place (27 → 25)

### DIFF
--- a/.changeset/fix-fmt-breakable-content-tags.md
+++ b/.changeset/fix-fmt-breakable-content-tags.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(formatter): break a prose expression/render tag's call arguments in place
+
+A long call inside an expression or render tag in prose (`… LineChart. {format(
+chartData.length,
+)} data points`) was treated as an atomic fill word, so rsvelte wrapped at the
+word boundary before it instead of breaking the call's arguments in place and
+gluing the following word to the `)}` line. Prettier builds such a paragraph as
+fill + expression-tag concat + fill — the tag sits outside the fill with its own
+call-arguments group — so the tag breaks internally while its neighbors stay
+glued. Element-body prose now represents multi-line content tags as a breakable
+flat/broken doc inside the run, reproducing that layout; all other call sites
+keep the previous atomic behavior.

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -1440,7 +1440,8 @@ fn try_fill_run(
     // correctly breaks at the first word that doesn't fit, so multi-line
     // sources get the right reflowed layout.
     let use_word_first = whole.contains('\n');
-    let content_doc = build_children_doc_nodes(out, run, allow_elem_expr_collapse, use_word_first)?;
+    let content_doc =
+        build_children_doc_nodes(out, run, allow_elem_expr_collapse, use_word_first, None)?;
     // Prepend a leading Line/Hardline to the fill doc to produce prettier's
     // "inverted" fill structure when the first text node had leading whitespace.
     // This matches prettier-plugin-svelte's `splitTextToDocs` which places a `line`
@@ -5224,8 +5225,10 @@ fn try_fill_mixed(
     // Build the prettier content doc (a Concat of per-text-node fills with the
     // inline elements as hug groups in between — a port of prettier-plugin-svelte's
     // `printChildren`) and print it. This reproduces the prose fill + in-place
-    // inline-element hug-break exactly.
-    let content_doc = build_children_doc(out, fragment)?;
+    // inline-element hug-break exactly. Options are threaded so a breakable
+    // content/render tag (`{call(…)}`) participates in the fill as a
+    // `group([RawExpr])` and glues the following word to its closing `)}`.
+    let content_doc = build_children_doc_nodes(out, &fragment.nodes, false, false, Some(options))?;
     let base_level = if options.js.indent_style.is_tab() {
         inner_indent
             .bytes()
@@ -5444,7 +5447,70 @@ fn text_preceded_by_close_tag(out: &str, text_start: usize) -> bool {
 /// fresh line (a `hardline`). The first child's leading and last child's trailing
 /// whitespace are dropped (the element wrapper owns that newline).
 fn build_children_doc(out: &str, fragment: &Fragment) -> Option<crate::doc::Doc> {
-    build_children_doc_nodes(out, &fragment.nodes, false, false)
+    build_children_doc_nodes(out, &fragment.nodes, false, false, None)
+}
+
+/// Build a breakable `group([RawExpr{flat, broken}])` for a content-level tag
+/// (`{expr}` / `{@render …}`) so it participates in a prose fill exactly like
+/// prettier-plugin-svelte: the tag's own group decides flat-vs-broken via `fits`,
+/// and a trailing prose word glues to the closing `)}` (through the following
+/// fill's leading `line`) instead of dropping to a fresh line. Returns `None`
+/// when the tag can't be flattened or doesn't break into an argument block — the
+/// caller then keeps the atomic-text path.
+fn content_tag_breakable_doc(
+    out: &str,
+    node: &TemplateNode,
+    options: &FormatOptions,
+) -> Option<crate::doc::Doc> {
+    use crate::doc::Doc;
+    let span = out.get(node_start(node) as usize..node_end(node) as usize)?;
+    let (prefix, expr_src): (&str, &str) = match node {
+        TemplateNode::ExpressionTag(_) => ("", span.strip_prefix('{')?.strip_suffix('}')?.trim()),
+        TemplateNode::RenderTag(t) => {
+            let (Some(s), Some(e)) = (t.expression.start(), t.expression.end()) else {
+                return None;
+            };
+            ("@render ", out.get(s as usize..e as usize)?.trim())
+        }
+        _ => return None,
+    };
+    if expr_src.is_empty() {
+        return None;
+    }
+    // Canonical flat inner (one line). Bail if it can't be flattened.
+    let flat_inner =
+        crate::expression::reformat_content_at_width(expr_src, options, u16::MAX as usize, 0)
+            .ok()?;
+    if flat_inner.contains('\n') {
+        return None;
+    }
+    // Keep the flat form byte-verbatim when the tag is already single-line in the
+    // formatted output (no drift); reconstruct it only for an already-broken tag.
+    let flat = if span.contains('\n') {
+        format!("{{{prefix}{flat_inner}}}")
+    } else {
+        span.to_string()
+    };
+    // Broken shape: force just the outermost break (one column under the flat
+    // inner width, mirroring `try_break_inline_content_tag`); continuation lines
+    // carry oxc's own relative indent measured from column 0, which the `RawExpr`
+    // printer offsets by the current indent level.
+    let width = UnicodeWidthStr::width(flat_inner.as_str())
+        .saturating_sub(1)
+        .max(1);
+    let broken_inner =
+        crate::expression::reformat_content_at_width(expr_src, options, width, 0).ok()?;
+    if !broken_inner.contains('\n') {
+        return None;
+    }
+    let mut lines: Vec<String> = broken_inner.split('\n').map(str::to_string).collect();
+    let last = lines.len() - 1;
+    lines[0] = format!("{{{prefix}{}", lines[0]);
+    lines[last] = format!("{}}}", lines[last]);
+    Some(Doc::Group(vec![Doc::RawExpr {
+        flat,
+        broken: lines,
+    }]))
 }
 
 // `use_word_first`: when true, a trailing text node that follows a non-void
@@ -5455,6 +5521,7 @@ fn build_children_doc_nodes(
     nodes: &[TemplateNode],
     allow_elem_expr_collapse: bool,
     use_word_first: bool,
+    options: Option<&FormatOptions>,
 ) -> Option<crate::doc::Doc> {
     use crate::doc::Doc;
     let n = nodes.len();
@@ -5652,6 +5719,28 @@ fn build_children_doc_nodes(
                 ws_prev = false;
             }
             other => {
+                // A content/render tag (`{expr}` / `{@render …}`) whose expression
+                // is a breakable call becomes a `group([RawExpr])` so the fill can
+                // keep it flat when it fits and break its argument block otherwise,
+                // gluing the following prose word to the closing `)}` — matching
+                // prettier-plugin-svelte's `fill + tag-group + fill` shape. Only
+                // when the caller (`try_fill_mixed`) supplied options; the other
+                // callers keep the atomic path.
+                if let Some(opts) = options
+                    && matches!(
+                        other,
+                        TemplateNode::ExpressionTag(_) | TemplateNode::RenderTag(_)
+                    )
+                    && let Some(doc) = content_tag_breakable_doc(out, other, opts)
+                {
+                    if ws_prev {
+                        docs.push(Doc::Group(vec![Doc::Line, doc]));
+                    } else {
+                        docs.push(doc);
+                    }
+                    ws_prev = false;
+                    continue;
+                }
                 // Expression tag / html tag / component / … : verbatim atom.
                 // For Components with text content (`<A href="/">text</A>`), try
                 // the same hug-doc treatment as RegularElement so the open tag can

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -5719,13 +5719,8 @@ fn build_children_doc_nodes(
                 ws_prev = false;
             }
             other => {
-                // A content/render tag (`{expr}` / `{@render …}`) whose expression
-                // is a breakable call becomes a `group([RawExpr])` so the fill can
-                // keep it flat when it fits and break its argument block otherwise,
-                // gluing the following prose word to the closing `)}` — matching
-                // prettier-plugin-svelte's `fill + tag-group + fill` shape. Only
-                // when the caller (`try_fill_mixed`) supplied options; the other
-                // callers keep the atomic path.
+                // A breakable content/render tag joins the fill as `group([RawExpr])`
+                // (prettier's fill+tag+fill); gated on a caller threading options.
                 if let Some(opts) = options
                     && matches!(
                         other,
@@ -5733,11 +5728,9 @@ fn build_children_doc_nodes(
                     )
                     && let Some(doc) = content_tag_breakable_doc(out, other, opts)
                 {
-                    if ws_prev {
-                        docs.push(Doc::Group(vec![Doc::Line, doc]));
-                    } else {
-                        docs.push(doc);
-                    }
+                    // `ws_prev` is only raised before an inline *element*, never
+                    // before a content tag, so the tag is always pushed bare.
+                    docs.push(doc);
                     ws_prev = false;
                     continue;
                 }

--- a/crates/rsvelte_formatter/tests/fill_content_tag.rs
+++ b/crates/rsvelte_formatter/tests/fill_content_tag.rs
@@ -1,0 +1,41 @@
+//! Prose-fill parity for a breakable content/render tag: when a `{call(…)}` /
+//! `{@render call(…)}` in element text overflows, it breaks its own argument
+//! block while the following prose word stays glued to the closing `)}` — a
+//! `group([RawExpr])` participating in the fill, matching prettier-plugin-svelte's
+//! `fill + tag-group + fill` shape (issue #1508).
+
+use rsvelte_formatter::{FormatOptions, JsFormatOptions, LineWidth, format};
+
+fn fmt(src: &str) -> String {
+    let opts = FormatOptions {
+        js: JsFormatOptions {
+            line_width: LineWidth::try_from(80u16).expect("valid line width"),
+            ..JsFormatOptions::new()
+        },
+        ..FormatOptions::default()
+    };
+    let out = format(src, &opts).expect("format ok");
+    out.strip_suffix('\n').map(str::to_string).unwrap_or(out)
+}
+
+#[test]
+fn expression_tag_breaks_and_glues_trailing_word() {
+    let src = "<Blockquote>\n\tWide data (property per series). Pre-processed before passed to LineChart. {format(chartData.length)} data points\n</Blockquote>";
+    let out = fmt(src);
+    assert_eq!(
+        out,
+        "<Blockquote>\n  Wide data (property per series). Pre-processed before passed to LineChart. {format(\n    chartData.length,\n  )} data points\n</Blockquote>",
+        "got:\n{out}"
+    );
+}
+
+#[test]
+fn render_tag_breaks_and_glues_trailing_word() {
+    let src = "<div class=\"text-sm text-surface-content/50 mb-10\">\n\tBrowse {@render scrollingValue(totalVisibleExamples)} examples across {@render scrollingValue(visibleExamples.length)} components\n</div>";
+    let out = fmt(src);
+    assert_eq!(
+        out,
+        "<div class=\"text-sm text-surface-content/50 mb-10\">\n  Browse {@render scrollingValue(totalVisibleExamples)} examples across {@render scrollingValue(\n    visibleExamples.length,\n  )} components\n</div>",
+        "got:\n{out}"
+    );
+}

--- a/crates/rsvelte_formatter/tests/fill_content_tag.rs
+++ b/crates/rsvelte_formatter/tests/fill_content_tag.rs
@@ -39,3 +39,17 @@ fn render_tag_breaks_and_glues_trailing_word() {
         "got:\n{out}"
     );
 }
+
+#[test]
+fn content_tag_breaks_before_a_following_element() {
+    // The breakable path fires for the content tag regardless of what follows —
+    // here a `<span>` element, not a prose word. The tag still breaks its args and
+    // the element glues to the closing `)}` (no space in the source).
+    let src = "<Blockquote>\n\tWide data (property per series). Pre-processed before passed to LineChart. {format(chartData.length)}<span>x</span>\n</Blockquote>";
+    let out = fmt(src);
+    assert_eq!(
+        out,
+        "<Blockquote>\n  Wide data (property per series). Pre-processed before passed to LineChart. {format(\n    chartData.length,\n  )}<span>x</span>\n</Blockquote>",
+        "got:\n{out}"
+    );
+}


### PR DESCRIPTION
Part of #1508 (fmt-parity burndown). Clears the two remaining fill-adjacent
layerchart entries:

- `layerchart/docs/src/examples/components/LineChart/perf-wide-data-processed.svelte`
- `layerchart/docs/src/routes/docs/examples/+page.svelte`

## Root cause

Both files have a long call inside an expression/render tag in prose. The oracle
keeps the tag on the current line — past the print width — and breaks the call's
arguments internally, gluing the following word to the `)}` line. A
`prettier.__debug.printToDoc` dump showed why: prettier-plugin-svelte does NOT
build the paragraph as a single fill. It emits **fill + expression-tag concat +
fill** — the tag sits outside the fill with its own call-arguments group, and the
adjacent whitespace lives inside each fill as a trailing/leading `line`. The fill
never measures the tag at all, so the preceding word's separator stays flat and
the tag's group breaks on its own.

rsvelte's faithful children path bailed on all three routes for a multi-line
content-tag span, dropping the paragraph to a legacy layout that wraps at the
word boundary instead.

## Fix

`try_fill_mixed`'s element-body prose now passes options through to
`build_children_doc_nodes`, whose content-tag branch builds a
`group([RawExpr{flat, broken}])` via a new `content_tag_breakable_doc` (broken
form reuses `reformat_content_at_width`). The resulting
`Concat([Fill(words + trailing line), RawExpr, Fill(leading line + words)])` is
structurally identical to prettier's doc, and the existing Fill printer
reproduces the glue. Every other call site passes `None` and keeps the previous
atomic behavior — no fill/`pair_fits` semantics were touched (the proven
net-negative territory).

An initial variant also made RenderTag a run member; it regressed two snippet
docs (a standalone `{@render countdown(n-1)}` glued to a neighbor) and was
withdrawn after opening the regression against the oracle.

## Verification

- Full fmt corpus: 12,657 files, **27 → 25 known failures, zero new failures**
  (the two newly-passing ids are exactly the targets)
- `fmt-one.mjs` on both ids: byte-identical to the oxfmt(`--svelte`) oracle
- `cargo test -p rsvelte_formatter` green (+2 focused tests in
  `tests/fill_content_tag.rs`)
- `cargo fmt` / `cargo clippy --all-targets --all-features -D warnings` clean

Baseline shrink follows separately from Linux CI per the cross-platform rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTZTTxLcg1ayEEEkYPkx4a