### PR TITLE
fix(formatter): block-header single-line + interp-led value continuation indent (27 → 25)

### DIFF
--- a/.changeset/fix-fmt-block-header-single-line.md
+++ b/.changeset/fix-fmt-block-header-single-line.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(formatter): force block-header call expressions onto one line
+
+A block header like `{#if isNodeVisible(node, nodes.find(...))}` whose call oxc
+expands even at unlimited width (a hug-eligible last argument) was spliced into
+the template as a raw multi-line fragment at the wrong indent. prettier-plugin-
+svelte reprints block headers with `removeLines`, which keeps a group's baked
+`shouldBreak` — so such a call joins onto one line with inner spaces
+(`fn( a, b )`) while every other call collapses without them. The flat-args
+expanded form is now folded back the same way: inner-space join for the shapes
+oxc refuses to keep flat, plain single line otherwise.

--- a/.changeset/fix-fmt-interp-led-value-indent.md
+++ b/.changeset/fix-fmt-interp-led-value-indent.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(formatter): don't double-indent interpolation-led attribute value continuations
+
+The whole-value attribute Doc model baked the absolute attribute indent into
+continuation lines, but the open-tag assembly re-indents interpolation-led
+values (`value="{…}"`) a second time — text-led values (`class="text {…}"`) are
+kept verbatim — so a wrapped interpolation's continuation landed at double the
+intended column. The model's base indent now matches that split: absolute for
+text-led (verbatim) values, relative for interpolation-led (re-indented) ones.
+Break-point selection is unchanged.

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -3480,11 +3480,21 @@ fn collapse_expanded_arg_form(multi: &str) -> Option<String> {
 /// `removeLines` then collapses that layout to one line, turning the `line`
 /// separators into spaces and dropping the trailing comma: `callee( a, b )`.
 ///
+/// The gate rests on the empirical MAX-break ⟺ shouldExpandLastArg correlation
+/// (a call reaches this path only when OXC unconditionally expands it); should a
+/// future oxc update break that correlation, the fmt corpus output-equality gate
+/// is the safety net that catches it.
+///
 /// Accepts only the "flat arguments" shape: the first line ends with `(`, the
 /// last line is `)` alone, and every intervening line is one complete top-level
-/// argument (bracket depth returns to 0 at the line boundary). Returns `None`
-/// otherwise (e.g. an argument's own object/array broke across further lines) so
+/// argument (bracket depth returns to the argument-list level at the line
+/// boundary). Returns `None` otherwise (e.g. an argument's own object/array broke
+/// across further lines, or a curried `)(` closes the argument list mid-region) so
 /// the caller keeps the multi-line output unchanged.
+///
+/// Exclusive with [`collapse_expanded_arg_form`], which handles the complementary
+/// shape where the first line does NOT end with `(` (an argument hugged onto the
+/// first line, e.g. `options.filter((opt) =>`).
 fn collapse_block_header_expanded_call(multi: &str) -> Option<String> {
     let lines: Vec<&str> = multi.trim_end_matches(';').trim().lines().collect();
     if lines.len() < 3 {
@@ -3498,7 +3508,13 @@ fn collapse_block_header_expanded_call(multi: &str) -> Option<String> {
         return None;
     }
     let inner = &lines[1..lines.len() - 1];
-    let mut depth: i32 = 0;
+    // depth starts at 1: the first line's trailing `(` opened the argument list.
+    // Each inner line is one complete top-level argument, so depth returns to 1 at
+    // every line boundary. It must never reach 0 mid-region — depth 0 means the
+    // argument list closed early (e.g. a curried `foo(...)(...)` whose inner line
+    // carries a `)(`), which this flat-args fold cannot represent, so bail rather
+    // than emit a corrupted single line.
+    let mut depth: i32 = 1;
     let mut in_string: Option<char> = None;
     let mut prev_escape = false;
     let mut args: Vec<String> = Vec::with_capacity(inner.len());
@@ -3518,12 +3534,17 @@ fn collapse_block_header_expanded_call(multi: &str) -> Option<String> {
             match c {
                 '"' | '\'' | '`' => in_string = Some(c),
                 '(' | '[' | '{' => depth += 1,
-                ')' | ']' | '}' => depth -= 1,
+                ')' | ']' | '}' => {
+                    depth -= 1;
+                    if depth <= 0 {
+                        return None;
+                    }
+                }
                 _ => {}
             }
         }
-        // An argument must be complete on its own line.
-        if in_string.is_some() || depth != 0 {
+        // A complete top-level argument returns to the argument-list level.
+        if in_string.is_some() || depth != 1 {
             return None;
         }
         args.push(t.to_string());
@@ -3841,6 +3862,28 @@ mod tests {
         // `collapse_expanded_arg_form` in the narrowed-width path, not here.
         let multi = "options.filter((opt) =>\n  selectedValues.has(opt.value),\n)";
         assert!(collapse_block_header_expanded_call(multi).is_none());
+    }
+
+    #[test]
+    fn collapse_block_header_expanded_call_bails_curried_call() {
+        // A curried `foo(...)(...)` whose inner line carries a `)(` closes the
+        // argument list mid-region (depth reaches 0). The flat-args fold cannot
+        // represent it, so it must bail (keep the multi-line form) rather than
+        // emit a corrupted single line. (Without the depth<=0 guard the per-line
+        // net-balance check would accept `a)(b` and fold to `outer( a)(b, c )`.)
+        let multi = "outer(\n  a)(b,\n  c,\n)";
+        assert!(collapse_block_header_expanded_call(multi).is_none());
+    }
+
+    #[test]
+    fn collapse_block_header_expanded_call_folds_paren_inside_string() {
+        // A `(` / `)` inside a string literal argument must not corrupt the depth
+        // walk — the flat-args fold still applies.
+        let multi = "foo(\n  \"(\",\n  second,\n)";
+        assert_eq!(
+            collapse_block_header_expanded_call(multi).unwrap(),
+            "foo( \"(\", second )"
+        );
     }
 
     #[test]

--- a/crates/rsvelte_formatter/src/expression.rs
+++ b/crates/rsvelte_formatter/src/expression.rs
@@ -860,20 +860,24 @@ fn push_bare_expression(
     let suffix_len = compute_header_suffix_len(source, end as usize);
     // First format inline (single-line) to get the canonical expression text.
     let formatted = format_inline_expression(slice, options)?;
-    // prettier-plugin-svelte uses `forceSingleLine: true` (internally `removeLines`)
-    // for block-header expressions like `{#each}`, `{#if}`, etc.  This means all
-    // non-hard line breaks in the formatted expression doc are replaced by spaces,
-    // producing a single-line result even for wide array/object literals.
-    //
-    // OXC's formatter (unlike prettier) always breaks arrays/objects of significant
-    // width into multiple lines, even with `Expand::Never` and `LineWidth::MAX`.
-    // When the source expression is an array or object literal with no newlines,
-    // collapse the multi-line OXC output back to a single line to match oracle.
-    let formatted = if formatted.contains('\n')
-        && starts_with_array_or_object_literal(slice)
-        && !slice.contains('\n')
-    {
-        collapse_multiline_to_single_line(&formatted)
+    // prettier-plugin-svelte forces block-header expressions onto one line
+    // (`forceSingleLine`/`removeLines`). OXC breaks some expressions across lines
+    // even at `LineWidth::MAX` — wide array/object literals, and calls whose last
+    // argument is huggable (prettier's shouldExpandLastArg, printed as
+    // `allArgsBrokenOut`). When the source is single-line, collapse OXC's
+    // multi-line result back to one line so a block header is never emitted broken.
+    let formatted = if formatted.contains('\n') && !slice.contains('\n') {
+        if starts_with_array_or_object_literal(slice) {
+            // Array/object literal: prettier keeps it flat with no added spaces.
+            collapse_multiline_to_single_line(&formatted)
+        } else if let Some(collapsed) = collapse_block_header_expanded_call(&formatted) {
+            // A call OXC expanded because its last arg is huggable. prettier's
+            // `removeLines` collapses the `allArgsBrokenOut` layout to one line but
+            // keeps the expanded-arg spacing: `fn( a, b )`.
+            collapsed
+        } else {
+            formatted
+        }
     } else {
         formatted
     };
@@ -3467,6 +3471,72 @@ fn collapse_expanded_arg_form(multi: &str) -> Option<String> {
     Some(result)
 }
 
+/// Collapse OXC's `LineWidth::MAX` "expanded call" layout back to prettier's
+/// single-line block-header form, WITH expanded-arg spacing.
+///
+/// `format_inline_expression` (LineWidth::MAX) only breaks a call across lines
+/// when OXC unconditionally expands it — the same shape prettier bakes as
+/// `allArgsBrokenOut` under shouldExpandLastArg. prettier-plugin-svelte's
+/// `removeLines` then collapses that layout to one line, turning the `line`
+/// separators into spaces and dropping the trailing comma: `callee( a, b )`.
+///
+/// Accepts only the "flat arguments" shape: the first line ends with `(`, the
+/// last line is `)` alone, and every intervening line is one complete top-level
+/// argument (bracket depth returns to 0 at the line boundary). Returns `None`
+/// otherwise (e.g. an argument's own object/array broke across further lines) so
+/// the caller keeps the multi-line output unchanged.
+fn collapse_block_header_expanded_call(multi: &str) -> Option<String> {
+    let lines: Vec<&str> = multi.trim_end_matches(';').trim().lines().collect();
+    if lines.len() < 3 {
+        return None;
+    }
+    let first = lines[0].trim_end();
+    if !first.ends_with('(') {
+        return None;
+    }
+    if lines[lines.len() - 1].trim() != ")" {
+        return None;
+    }
+    let inner = &lines[1..lines.len() - 1];
+    let mut depth: i32 = 0;
+    let mut in_string: Option<char> = None;
+    let mut prev_escape = false;
+    let mut args: Vec<String> = Vec::with_capacity(inner.len());
+    for line in inner {
+        let t = line.trim();
+        for c in t.chars() {
+            if let Some(q) = in_string {
+                if prev_escape {
+                    prev_escape = false;
+                } else if c == '\\' {
+                    prev_escape = true;
+                } else if c == q {
+                    in_string = None;
+                }
+                continue;
+            }
+            match c {
+                '"' | '\'' | '`' => in_string = Some(c),
+                '(' | '[' | '{' => depth += 1,
+                ')' | ']' | '}' => depth -= 1,
+                _ => {}
+            }
+        }
+        // An argument must be complete on its own line.
+        if in_string.is_some() || depth != 0 {
+            return None;
+        }
+        args.push(t.to_string());
+    }
+    // Drop OXC's trailing comma on the last argument (removeLines strips the
+    // `ifBreak(",")`); the commas between args are the real separators.
+    if let Some(last) = args.last_mut() {
+        *last = last.trim_end_matches(',').trim_end().to_string();
+    }
+    let joined = args.join(" ");
+    Some(format!("{first} {joined} )"))
+}
+
 /// Convert OXC's `fn({ k: v, ... })` / `fn({\n  k: v,\n})` form to
 /// prettier-plugin-svelte's "outer-expanded-arg" form:
 /// ```text
@@ -3743,6 +3813,34 @@ mod tests {
         // FIX 4: bail on string literals
         let multi = "fn(\"hello\",\n)";
         assert!(collapse_expanded_arg_form(multi).is_none());
+    }
+
+    #[test]
+    fn collapse_block_header_expanded_call_stacked_zoom() {
+        // OXC MAX-width expansion of `isNodeVisible(node, nodes.find((n) => …))`
+        // (the layerchart stacked-zoom `{#if}` header). removeLines collapses it
+        // to one line WITH expanded-arg spacing and no trailing comma.
+        let multi = "isNodeVisible(\n  node,\n  nodes.find((n) => n.data.name === selected.data.name && n.depth === selected.depth),\n)";
+        assert_eq!(
+            collapse_block_header_expanded_call(multi).unwrap(),
+            "isNodeVisible( node, nodes.find((n) => n.data.name === selected.data.name && n.depth === selected.depth) )"
+        );
+    }
+
+    #[test]
+    fn collapse_block_header_expanded_call_bails_nested_arg() {
+        // An argument whose object broke across further lines is not the flat-args
+        // shape — bail and keep the multi-line output unchanged.
+        let multi = "handle(\n  first,\n  {\n    a: 1,\n  },\n)";
+        assert!(collapse_block_header_expanded_call(multi).is_none());
+    }
+
+    #[test]
+    fn collapse_block_header_expanded_call_bails_first_line_not_open_paren() {
+        // The "arrow hugged then broke" shape (first line ends `=>`) is handled by
+        // `collapse_expanded_arg_form` in the narrowed-width path, not here.
+        let multi = "options.filter((opt) =>\n  selectedValues.has(opt.value),\n)";
+        assert!(collapse_block_header_expanded_call(multi).is_none());
     }
 
     #[test]

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -2147,11 +2147,20 @@ fn render_value_sequence_doc(
     // matching prettier-plugin-svelte.
     let width = line_width.saturating_sub(1);
     let unit = indent_str(1, &options.js);
+    // The open-tag assembly emits a TEXT-led value (`class="text {…}"`,
+    // `is_string_value_attr` true) VERBATIM, but re-indents an INTERPOLATION-led
+    // value (`value="{…}"`) by the attribute column. So bake the absolute indent
+    // into continuation lines only for the verbatim case; emit the interp-led
+    // form RELATIVE (base_indent 0) so the downstream re-indent lands a broken
+    // interpolation's continuation at `attr_indent + 2`, not `2*attr_indent + 2`.
+    // (`fits` ignores indentation, so base_indent never changes a break decision.)
+    let text_led = matches!(parts.first(), Some(AttributeValuePart::Text(t)) if !t.raw.is_empty());
+    let base_indent = if text_led { attr_depth } else { 0 };
     let out = doc_print(
         propagate_breaks(Doc::Concat(docs)),
         width,
         &unit,
-        attr_depth,
+        base_indent,
         start_col,
     );
     Ok(Some(out))

--- a/crates/rsvelte_formatter/tests/attr_width.rs
+++ b/crates/rsvelte_formatter/tests/attr_width.rs
@@ -166,3 +166,27 @@ fn multi_breakable_value_keeps_first_flat_when_later_absorbs() {
     let twice = fmt_w(&out, 60);
     assert_eq!(out, twice, "later-absorbs wrap is not idempotent:\n{out}");
 }
+
+#[test]
+fn interp_led_value_continuation_indents_relative_to_attr_column() {
+    // An INTERPOLATION-led quoted value (`value="{…}"`, not text-led) whose
+    // second interpolation breaks, on a DEEPLY NESTED element. Unlike a text-led
+    // value (emitted verbatim), an interp-led value is re-indented by the open-tag
+    // assembly, so the whole-value Doc model must emit its continuation RELATIVE to
+    // the attribute line. The broken interpolation's continuation must land at
+    // `attr_indent + 2` (10 spaces here), NOT `2*attr_indent + 2`. (layerchart
+    // Treemap/stacked-zoom `value=` shape, Cluster 2.)
+    let src = "<div>\n  <div>\n    <div>\n      <Text longAttributeToForceWrap=\"yes\" value=\"{node.data.name} ({node.children?.length ?? defaultFallbackNumber})\" />\n    </div>\n  </div>\n</div>\n";
+    let out = fmt80(src);
+    assert!(
+        out.contains(
+            "        value=\"{node.data.name} ({node.children?.length ??\n          defaultFallbackNumber})\""
+        ),
+        "interp-led value continuation must indent to attr_indent + 2 (10sp), not doubled:\n{out}"
+    );
+    let twice = fmt80(&out);
+    assert_eq!(
+        out, twice,
+        "interp-led continuation wrap is not idempotent:\n{out}"
+    );
+}


### PR DESCRIPTION
Part of #1508 (fmt-parity burndown). Three fixes on one branch; together they
clear **two** baseline entries (27 → 25):

- `layerchart/docs/src/examples/components/Treemap/stacked-zoom.svelte`
  (dual-cluster: needed both fixes below)
- `svelte-calendar/src/lib/components/Popover.svelte` (cleared by the
  continuation-indent fix alone)

## 1. Block-header call expressions forced onto one line (Cluster 3)

prettier-plugin-svelte reprints block headers with `removeLines`, which keeps a
group's baked `shouldBreak` — so a `shouldExpandLastArg` call (≥2 args,
hug-eligible last arg) joins with inner spaces `isNodeVisible( node, … )`, and
every other call joins without them. rsvelte formatted the header at
`LineWidth::MAX`, but oxc still expands hug-eligible-last-arg calls at MAX
width, and the multi-line result skipped the single-line path entirely — the
raw expansion was spliced in at the wrong indent. A new
`collapse_block_header_expanded_call` folds oxc's flat-args expanded form back
to the inner-space single line. The gate is structural (fires only when oxc
refuses flat at MAX width — a 9-shape probe confirmed this is exactly the
`shouldExpandLastArg` set). Review found and fixed a curried-call hazard: a
`)(` inner line now bails (depth starts at 1, `<= 0` → None) instead of
producing a corrupted join.

## 2. Interpolation-led attribute value continuation double-indent (Cluster 2)

The whole-value Doc model baked the absolute attribute indent into continuation
lines, but open-tag assembly re-indents interpolation-led values
(`value="{…}"`) a second time (text-led values are kept verbatim) → 28 + 26 =
54 spaces. The model's base indent now matches `is_string_value_attr`'s split:
absolute for text-led, relative for interpolation-led. Break-point selection is
unchanged (`fits` is indent-independent here); this cleared Popover.svelte too,
whose diff was the same break-at-the-right-point-wrong-indent symptom.
PowerTable (same symptom, but entangled with Clusters 1/3) remains, as
documented in `fmt-known-failures.md`.

## Verification

- `fmt-one.mjs`: stacked-zoom and Popover byte-identical to the oracle
- Full fmt corpus ×2 (after each commit): 12,657 files, **27 → 25 known
  failures, zero new failures**
- Focused tests: 3 (block-header shapes) + 1 (continuation-indent contract) +
  2 (curried bail, paren-inside-string) — `cargo test -p rsvelte_formatter`
  green; `cargo fmt` / `cargo clippy --all-targets --all-features -D warnings`
  clean
- Reviewed; the single blocker (curried `)(` corruption) is fixed in
  `bf78e442`

Baseline shrink follows separately from Linux CI per the cross-platform rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTZTTxLcg1ayEEEkYPkx4a