### PR TITLE
fix: burn down the last 3 client known-failures — corpus baseline now zero

### DIFF
--- a/.changeset/fix-css-structural-descendant-prune.md
+++ b/.changeset/fix-css-structural-descendant-prune.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(css): prune descendant/child selector chains whose subject or ancestor links cannot match the component's own element tree (attribute/class/id compounds included), and preserve source whitespace after a pruned leading selector-list item

--- a/.changeset/fix-site-aware-proxy-and-nullish-defined.md
+++ b/.changeset/fix-site-aware-proxy-and-nullish-defined.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(client): per-site proxy decision for bare-identifier assignment RHS resolved to a function-local declaration, and upstream-faithful `is_defined` for `unknown ?? b` initializers (no narrowing when the left side is not statically known)

--- a/.changeset/fix-template-chunk-identifier-is-defined.md
+++ b/.changeset/fix-template-chunk-identifier-is-defined.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(client): resolve bare identifiers via scope in template-chunk `is_defined`, so e.g. a legacy `let iconAsc = "↑"` inside `${cond ? iconAsc : iconDesc}` reads bare without a spurious `?? ''`

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,5 +1,4 @@
 [
 	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
-	"svelte-sonner/src/lib/Toaster.svelte",
-	"svelte-table/example/Example2.svelte"
+	"svelte-sonner/src/lib/Toaster.svelte"
 ]

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,3 +1,1 @@
-[
-	"svelte-sonner/src/lib/Toaster.svelte"
-]
+[]

--- a/compatibility/known-failures.client.json
+++ b/compatibility/known-failures.client.json
@@ -1,4 +1,3 @@
 [
-	"melt-ui/packages/melt/src/lib/builders/tests/SpatialMenuNavTest.svelte",
 	"svelte-sonner/src/lib/Toaster.svelte"
 ]

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -14,14 +14,8 @@ compiler-behaviour gap; attempts to fix them are regression-prone against the
 8000+ passing entries (several have been reverted after wide blowups), so they are
 accepted until an upstream-faithful port lands.
 
-## Client (`known-failures.client.json`, 2 entries)
+## Client (`known-failures.client.json`, 1 entry)
 
-- **`melt-ui/.../SpatialMenuNavTest.svelte`** — two causes: (a) a proxy argument in
-  `$.set(highlighted, id, true)` where `id` is an inner-scope TemplateLiteral const
-  not admitted to `non_proxy_vars` (the `name_occurrences==1` heuristic bails on
-  multi-occurrence names); (b) `${cols ?? ''}` — svelte keeps the `?? ''`, rsvelte
-  elides it (scope.evaluate treats a prop member as defined where svelte keeps it
-  UNKNOWN).
 - **`svelte-sonner/.../Toaster.svelte`** — JS now matches; remaining divergence is
   **CSS unused-selector pruning**: svelte prunes selectors like
   `[data-sonner-toast][data-styled='true'] [data-description]` as unused while

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -14,7 +14,7 @@ compiler-behaviour gap; attempts to fix them are regression-prone against the
 8000+ passing entries (several have been reverted after wide blowups), so they are
 accepted until an upstream-faithful port lands.
 
-## Client (`known-failures.client.json`, 3 entries)
+## Client (`known-failures.client.json`, 2 entries)
 
 - **`melt-ui/.../SpatialMenuNavTest.svelte`** — two causes: (a) a proxy argument in
   `$.set(highlighted, id, true)` where `id` is an inner-scope TemplateLiteral const
@@ -28,9 +28,6 @@ accepted until an upstream-faithful port lands.
   rsvelte keeps them. Caused by child-component elements + `{...restProps}` spread
   over-matching (`attribute_matches` returns true on any spread). High CSS-fixture
   regression risk.
-- **`svelte-table/example/Example2.svelte`** — `?? ''` wrongly added to a
-  `${cond ? … : ""}` whose branches are all strings; a legacy `let iconAsc = "↑"`
-  (string-literal init) is not treated as defined.
 
 ## Server (`known-failures.server.json`, 0 entries)
 

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -4,41 +4,38 @@ The output-equality corpus compiles every source with both the official Svelte
 compiler and rsvelte (CSR + SSR) and requires byte-identical output after
 comparison-side normalization. The comparison is **AST-structural**
 (`normalize.astEquivalent` via acorn): comment position, `${}` line-wrapping,
-redundant parens, and quote style are already absorbed, so every entry below is a
+redundant parens, and quote style are already absorbed, so any entry here is a
 **genuine structural (AST-distinct) divergence** in the generated code, not a
 cosmetic one.
 
 The ratchet (`corpus-compat.yml`) fails only on an `(id, target)` pair not in the
-baseline — the lists may only shrink, never grow. Each entry is an isolated, deep
-compiler-behaviour gap; attempts to fix them are regression-prone against the
-8000+ passing entries (several have been reverted after wide blowups), so they are
-accepted until an upstream-faithful port lands.
+baseline — the lists may only shrink, never grow. Each accepted entry must be
+justified in this file.
 
-## Client (`known-failures.client.json`, 1 entry)
+## Client (`known-failures.client.json`, 0 entries)
 
-- **`svelte-sonner/.../Toaster.svelte`** — JS now matches; remaining divergence is
-  **CSS unused-selector pruning**: svelte prunes selectors like
-  `[data-sonner-toast][data-styled='true'] [data-description]` as unused while
-  rsvelte keeps them. Caused by child-component elements + `{...restProps}` spread
-  over-matching (`attribute_matches` returns true on any spread). High CSS-fixture
-  regression risk.
+No accepted client-side divergences remain.
 
 ## Server (`known-failures.server.json`, 0 entries)
 
 No accepted server-side divergences remain.
 
-## General hard-cluster root causes (why fixes are deferred)
+## Hard-cluster warnings for future work
 
-Recurring deep clusters behind these entries (mirror upstream exactly; verify
-against the full corpus + byte-exact runtime/ssr/css suites before landing):
+Deep areas where past fixes caused wide regressions (mirror upstream exactly;
+verify against the full corpus + byte-exact runtime/ssr/css suites before
+landing):
 
 - **scope.evaluate `is_defined` / `should_proxy` lattice** — widening it to drop a
   spurious `?? ''` or proxy regresses real props that need `?? ''`. svelte resolves
-  via scope; rsvelte's text/heuristic approximation is looser.
-- **CSS over-scoping / unused-selector pruning** with `{...spread}` and child
-  components — regression-prone against the 181 CSS fixtures.
+  via scope; a name-keyed approximation cannot represent per-site outcomes — use
+  per-site (Semantic / scope-chain) resolution.
 - **each-item reactivity wrapping** (function-depth `has_external_dependencies`
   check) — a prior attempt caused ~498 regressions.
 - **`$derived` currying** (`yScale()(tick)`) — reverted twice; do not retry naively.
 - **store/runes name-conflict resolution** — two independent sub-bugs that must land
   together and distinguish getter-vs-user-call by context.
+- **CSS structural prune** (`is_structural_descendant_chain_unused`) bails on
+  snippet-declared elements, `<selectedcontent>`, `:host`/`:root`/`:global`,
+  functional pseudo-classes, and escaped identifiers — extend only with the
+  matching upstream semantics.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -2457,6 +2457,9 @@ pub struct CssDomElement {
     /// Whether this element has a dynamic tag name (svelte:element)
     /// When true, any type selector matches this element
     pub is_dynamic_tag: bool,
+    /// Whether this element sits inside a `{#snippet}` declaration — its real
+    /// DOM ancestors are the render sites, not its lexical `parent_idx`.
+    pub in_snippet: bool,
     /// Whether this element can be immediately preceded by an opaque boundary
     /// (slot, render tag, component) - used for :global(X) + Y detection
     pub prev_is_opaque_boundary: bool,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -1010,6 +1010,10 @@ pub fn visit(
         has_content: !element.fragment.nodes.is_empty(),
         has_opaque_content,
         is_dynamic_tag: false,
+        in_snippet: context
+            .fragment_owner_stack
+            .iter()
+            .any(|o| matches!(o, super::FragmentOwnerType::SnippetBlock(..))),
         prev_is_opaque_boundary: false,
         prev_has_opaque_boundary: false,
     };

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -120,6 +120,10 @@ pub fn visit(
         has_content: !element.fragment.nodes.is_empty(),
         has_opaque_content: false, // Dynamic element, conservatively handled via is_dynamic_tag
         is_dynamic_tag: true,
+        in_snippet: context
+            .fragment_owner_stack
+            .iter()
+            .any(|o| matches!(o, super::FragmentOwnerType::SnippetBlock(..))),
         prev_is_opaque_boundary: false,
         prev_has_opaque_boundary: false,
     };

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -256,9 +256,31 @@ fn is_expression_defined_typed(node: &JsNode, arena: &crate::ast::arena::ParseAr
                 "==" | "!=" | "===" | "!==" | "<" | ">" | "<=" | ">=" | "instanceof" | "in"
             )
         }
+        // Upstream evaluate does NOT refine `unknown ?? b` to defined: when the
+        // left side is not statically known, the union of both sides' values
+        // still contains UNKNOWN, so is_defined stays false (scope.js
+        // LogicalExpression). Only a provably-defined left (result is the left)
+        // or a provably-nullish left literal (result is the right) narrows.
         JsNode::LogicalExpression {
-            operator, right, ..
-        } if operator == "??" => is_expression_defined_typed(arena.get_js_node(*right), arena),
+            operator,
+            left,
+            right,
+            ..
+        } if operator == "??" => {
+            let left_node = arena.get_js_node(*left);
+            let left_is_nullish_literal = match left_node {
+                JsNode::Literal { value, .. } => {
+                    matches!(value, crate::ast::typed_expr::LiteralValue::Null)
+                }
+                JsNode::Identifier { name, .. } => name == "undefined",
+                _ => false,
+            };
+            if left_is_nullish_literal {
+                is_expression_defined_typed(arena.get_js_node(*right), arena)
+            } else {
+                is_expression_defined_typed(left_node, arena)
+            }
+        }
         JsNode::UnaryExpression { operator, .. } => operator != "void",
         JsNode::ConditionalExpression {
             consequent,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -243,9 +243,26 @@ struct StateVarCollector<'a, 's> {
     /// component-function body (depth 1), so we trigger the `$.save(...)`
     /// wrap when our `function_depth >= 1`.
     function_depth: u32,
+
+    /// Semantic for the parsed script, set after construction. Enables
+    /// per-site resolution of a bare-identifier assignment RHS (upstream
+    /// `should_proxy` consults the scope at the assignment; the name-list
+    /// cannot distinguish two same-named inner bindings).
+    semantic: Option<&'a oxc_semantic::Semantic<'a>>,
 }
 
 impl<'a, 's> StateVarCollector<'a, 's> {
+    /// Per-site proxy decision for a bare-identifier assignment RHS that
+    /// resolves to a function-local declaration (see
+    /// `state_assigns_combined_ast::ident_rhs_needs_proxy`). `None` defers
+    /// to the name-list `should_proxy_ast` fallback.
+    fn ident_rhs_site_decision(&self, rhs: &Expression<'_>) -> Option<bool> {
+        let Expression::Identifier(rhs_id) = rhs.get_inner_expression() else {
+            return None;
+        };
+        super::state_assigns_combined_ast::ident_rhs_needs_proxy(self.semantic?, rhs_id)
+    }
+
     fn new(
         source: &'s str,
         state_vars: &'a FxHashSet<&'a str>,
@@ -309,6 +326,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             exported_names,
             prop_source_vars_slice: prop_source_vars,
             function_depth: 0,
+            semantic: None,
         }
     }
 
@@ -2604,7 +2622,11 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
                         let needs_proxy = self.is_runes
                             && !is_raw
                             && !is_derived
-                            && should_proxy_ast(&expr.right, self.reassign_non_proxy_vars);
+                            && self
+                                .ident_rhs_site_decision(&expr.right)
+                                .unwrap_or_else(|| {
+                                    should_proxy_ast(&expr.right, self.reassign_non_proxy_vars)
+                                });
 
                         let replacement = if needs_proxy {
                             format!("$.set({}, {}, true)", name, rhs_text)
@@ -2643,7 +2665,11 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
                             && self.is_runes
                             && !is_raw
                             && !is_derived
-                            && should_proxy_ast(&expr.right, self.reassign_non_proxy_vars);
+                            && self
+                                .ident_rhs_site_decision(&expr.right)
+                                .unwrap_or_else(|| {
+                                    should_proxy_ast(&expr.right, self.reassign_non_proxy_vars)
+                                });
 
                         let replacement = if needs_proxy {
                             format!(
@@ -3850,6 +3876,11 @@ pub(super) fn transform_state_vars_ast(
             return None;
         }
 
+        let semantic_ret = oxc_semantic::SemanticBuilder::new()
+            .with_build_nodes(true)
+            .build(&parsed.program);
+        let semantic = &semantic_ret.semantic;
+
         let mut collector = StateVarCollector::new(
             script,
             &var_set,
@@ -3871,6 +3902,7 @@ pub(super) fn transform_state_vars_ast(
             config.analysis,
             config.exported_names,
         );
+        collector.semantic = Some(semantic);
         collector.visit_program(&parsed.program);
 
         if collector.replacements.is_empty() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
@@ -171,9 +171,19 @@ impl<'a, 'sem, 'ast> Visit<'ast> for CombinedCollector<'a, 'sem> {
             AssignmentOperator::Assign => {
                 // Simple assignment.
                 let is_raw_state = self.raw_state_vars.iter().any(|s| s.as_str() == name);
+                // A bare-identifier RHS declared inside this statement resolves
+                // per-site (upstream should_proxy consults the scope at the
+                // assignment); the name-list fallback cannot distinguish two
+                // same-named inner bindings with different proxy-ness.
+                let site_decision = match expr.right.get_inner_expression() {
+                    Expression::Identifier(rhs_id) => ident_rhs_needs_proxy(self.semantic, rhs_id),
+                    _ => None,
+                };
                 let needs_proxy = self.is_runes
                     && !is_raw_state
-                    && expression_needs_proxy_with_scope(rhs_text.trim(), self.non_proxy_vars);
+                    && site_decision.unwrap_or_else(|| {
+                        expression_needs_proxy_with_scope(rhs_text.trim(), self.non_proxy_vars)
+                    });
                 let rewrite = if needs_proxy {
                     format!("$.set({}, {}, true)", name, rhs_text)
                 } else {
@@ -243,6 +253,66 @@ impl<'a, 'sem, 'ast> Visit<'ast> for CombinedCollector<'a, 'sem> {
         self.replacements
             .push((expr.span.start, expr.span.end, rewrite));
     }
+}
+
+/// Mirror upstream `should_proxy(Identifier, scope)` for a bare-identifier
+/// RHS that resolves to a declaration inside the parsed statement: a
+/// non-reassigned `VariableDeclarator` whose init is one of the non-proxy
+/// node types is not proxied; a parameter, reassigned binding, or
+/// initializer-less/other declaration falls through to proxy (upstream's
+/// `return true`). Returns `None` when the identifier does not resolve
+/// within this statement (declared at script level) so the caller can use
+/// the name-list fallback.
+pub(super) fn ident_rhs_needs_proxy(
+    semantic: &Semantic,
+    ident: &IdentifierReference,
+) -> Option<bool> {
+    use oxc_ast::AstKind;
+
+    if ident.name == "undefined" {
+        return Some(false);
+    }
+    let reference_id = ident.reference_id.get()?;
+    let scoping = semantic.scoping();
+    let symbol_id = scoping.get_reference(reference_id).symbol_id()?;
+
+    // Only decide for function-local declarations — the gap the name list
+    // cannot express. Root-scope (script top-level) bindings keep the
+    // name-list decision, which already accounts for binding kinds and
+    // partially-transformed prop declarations.
+    if scoping.symbol_scope_id(symbol_id) == scoping.root_scope_id() {
+        return None;
+    }
+
+    let decl_id = scoping.symbol_declaration(symbol_id);
+    let AstKind::VariableDeclarator(decl) = semantic.nodes().get_node(decl_id).kind() else {
+        return Some(true);
+    };
+    let reassigned = scoping
+        .get_resolved_references(symbol_id)
+        .any(|r| r.is_write());
+    if reassigned {
+        return Some(true);
+    }
+    let Some(init) = &decl.init else {
+        return Some(true);
+    };
+    let non_proxy = match init.get_inner_expression() {
+        Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::TemplateLiteral(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::FunctionExpression(_)
+        | Expression::UnaryExpression(_)
+        | Expression::BinaryExpression(_) => true,
+        Expression::Identifier(id) => id.name == "undefined",
+        _ => false,
+    };
+    Some(!non_proxy)
 }
 
 #[cfg(test)]
@@ -371,5 +441,35 @@ mod tests {
     #[test]
     fn empty_state_vars_returns_none() {
         assert!(transform_state_assigns_ast("x = 5;", &[], &[], false, &[]).is_none());
+    }
+}
+
+#[cfg(test)]
+mod site_proxy_tests {
+    use super::*;
+
+    #[test]
+    fn inner_template_literal_const_rhs_is_not_proxied() {
+        let src = r#"initial.forEach((row, rowIndex) => {
+	const cols = row.split(" ");
+	cols.forEach((col, colIndex) => {
+		const id = `${rowIndex}-${colIndex}`;
+		if (col === "h") {
+			highlighted = id;
+		}
+	});
+});"#;
+        let out =
+            transform_state_assigns_ast(src, &["highlighted".to_string()], &[], true, &[]).unwrap();
+        assert!(out.contains("$.set(highlighted, id)"));
+        assert!(!out.contains("$.set(highlighted, id, true)"));
+    }
+
+    #[test]
+    fn param_rhs_stays_proxied() {
+        let src = "const menu = { onHighlightChange: (id) => { highlighted = id; } };";
+        let out =
+            transform_state_assigns_ast(src, &["highlighted".to_string()], &[], true, &[]).unwrap();
+        assert!(out.contains("$.set(highlighted, id, true)"));
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
@@ -278,9 +278,24 @@ impl<'a, 'sem, 'ast> Visit<'ast> for PipelineVisitor<'a, 'sem> {
         match expr.operator {
             AssignmentOperator::Assign => {
                 let is_raw_state = self.raw_state_vars.iter().any(|s| s.as_str() == name);
+                // A bare-identifier RHS declared inside this statement resolves
+                // per-site (upstream should_proxy consults the scope at the
+                // assignment); the name-list fallback cannot distinguish two
+                // same-named inner bindings with different proxy-ness.
+                let site_decision = match expr.right.get_inner_expression() {
+                    Expression::Identifier(rhs_id) => {
+                        super::state_assigns_combined_ast::ident_rhs_needs_proxy(
+                            self.semantic,
+                            rhs_id,
+                        )
+                    }
+                    _ => None,
+                };
                 let needs_proxy = self.is_runes
                     && !is_raw_state
-                    && expression_needs_proxy_with_scope(rhs_text.trim(), self.non_proxy_vars);
+                    && site_decision.unwrap_or_else(|| {
+                        expression_needs_proxy_with_scope(rhs_text.trim(), self.non_proxy_vars)
+                    });
                 let rewrite = if needs_proxy {
                     format!("$.set({}, {}, true)", name, rhs_text)
                 } else {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -254,7 +254,7 @@ where
                         super::utils::is_expression_defined(&expr_tag.expression, context)
                     }
                 } else {
-                    super::utils::is_js_expr_defined(&memoized, &context.arena)
+                    super::utils::is_js_expr_defined(&memoized, &context.arena, context)
                 };
                 let final_value = if is_defined {
                     memoized
@@ -1299,7 +1299,7 @@ fn build_style_attribute_value_with_memoization(
                         } else if let JsExpr::Identifier(_) = &value {
                             super::utils::is_expression_defined(&expr_tag.expression, context)
                         } else {
-                            super::utils::is_js_expr_defined(&value, &context.arena)
+                            super::utils::is_js_expr_defined(&value, &context.arena, context)
                         };
                         let final_value = if is_defined {
                             value

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3476,7 +3476,7 @@ pub fn build_template_chunk(
                         }
                     } else {
                         // Value was transformed. Check the built expression.
-                        is_js_expr_defined(&value, &context.arena)
+                        is_js_expr_defined(&value, &context.arena, context)
                     };
 
                     // Add ?? '' where necessary (only if not guaranteed to be defined)
@@ -4261,13 +4261,20 @@ fn is_known_defined_global_call(keypath: &str) -> bool {
 pub(crate) fn is_js_expr_defined(
     expr: &JsExpr,
     arena: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena,
+    context: &ComponentContext,
 ) -> bool {
     match expr {
         JsExpr::Literal(lit) => match lit {
             JsLiteral::Null | JsLiteral::Undefined => false,
             _ => true, // String, Number, Boolean are always defined
         },
-        JsExpr::Identifier(_) => false, // Could be undefined
+        // Upstream `scope.evaluate` resolves identifiers through the scope even
+        // on the built (transformed) AST: a non-reactive binding that survives
+        // transformation as a bare identifier (reactive reads become `$.get(x)`
+        // CallExpressions instead) still resolves to its binding's evaluation.
+        // Mirror that so e.g. `cond ? iconAsc : iconDesc` (legacy string lets)
+        // reads bare. Synthetic memo ids (`$0`) have no binding → false.
+        JsExpr::Identifier(name) => identifier_is_defined(name, context),
         JsExpr::Call(call) => {
             // Upstream `scope.evaluate` knows the global `Math.*` / `Number` /
             // `Number.*` / `String` / `String.from*` / `BigInt` functions return
@@ -4284,12 +4291,12 @@ pub(crate) fn is_js_expr_defined(
         JsExpr::Unary(u) => !matches!(u.operator, JsUnaryOp::Void),
         JsExpr::Logical(log) => {
             // Check both sides
-            is_js_expr_defined(arena.get_expr(log.left), arena)
-                && is_js_expr_defined(arena.get_expr(log.right), arena)
+            is_js_expr_defined(arena.get_expr(log.left), arena, context)
+                && is_js_expr_defined(arena.get_expr(log.right), arena, context)
         }
         JsExpr::Conditional(cond) => {
-            is_js_expr_defined(arena.get_expr(cond.consequent), arena)
-                && is_js_expr_defined(arena.get_expr(cond.alternate), arena)
+            is_js_expr_defined(arena.get_expr(cond.consequent), arena, context)
+                && is_js_expr_defined(arena.get_expr(cond.alternate), arena, context)
         }
         JsExpr::Raw(s) => {
             // Raw expressions that are string/number literals are defined.
@@ -4305,10 +4312,123 @@ pub(crate) fn is_js_expr_defined(
             // A sequence expression evaluates to its last element
             seq.expressions
                 .last()
-                .is_some_and(|e| is_js_expr_defined(e, arena))
+                .is_some_and(|e| is_js_expr_defined(e, arena, context))
         }
         _ => false,
     }
+}
+
+/// Resolve a bare identifier to its binding and decide whether upstream's
+/// `scope.evaluate(<identifier>).is_defined` would hold. Shared by the
+/// original-expression path (`is_expression_defined_json`) and the
+/// transformed-value path (`is_js_expr_defined`): upstream's `scope.evaluate`
+/// resolves identifiers through the scope in BOTH cases, so a non-reactive
+/// binding that survives transformation as a bare identifier (e.g. a legacy
+/// `let iconAsc = "↑"` inside a `cond ? iconAsc : iconDesc`) must resolve the
+/// same way whether it appears at the top level or nested in a built expression.
+fn identifier_is_defined(name: &str, context: &ComponentContext) -> bool {
+    use crate::compiler::phases::phase2_analyze::scope::BindingKind;
+
+    // Special identifiers
+    if name == "undefined" {
+        return false;
+    }
+
+    // First, check if there's a transform with is_defined flag
+    // This is how we track EachIndex within each block scope
+    if let Some(transform) = context.state.transform.get(name)
+        && transform.is_defined
+    {
+        return true;
+    }
+
+    // `const uid = $props.id()` always evaluates to a string.
+    // Upstream's scope.evaluate resolves the const binding's initial
+    // `$props.id()` to STRING (scope.js `case '$props.id'`), so
+    // `is_defined` is true and no `?? ''` is appended.
+    if context.state.analysis.props_id.as_deref() == Some(name) {
+        return true;
+    }
+
+    // Check the binding
+    if let Some(binding) = context.state.get_binding(name) {
+        // EachIndex is always a number, never null/undefined
+        if matches!(binding.kind, BindingKind::EachIndex) {
+            return true;
+        }
+        // A template-scoped DeclarationTag / ConstTag binding
+        // (`{const after_async = number + 1}`) is defined when its
+        // initializer is a statically-non-nullish shape. Upstream's
+        // `is_defined` walks `binding.initial`; mirror that with the
+        // recorded `initial_node_type` so e.g. `after_async`
+        // (BinaryExpression) reads bare while `number`
+        // (AwaitExpression) keeps `?? ''`.
+        if matches!(binding.kind, BindingKind::Template)
+            && binding.initial_is_defined
+            && let Some(ref ity) = binding.initial_node_type
+            && matches!(
+                ity.as_str(),
+                "BinaryExpression"
+                    | "UpdateExpression"
+                    | "ArrayExpression"
+                    | "ObjectExpression"
+                    | "TemplateLiteral"
+            )
+        {
+            return true;
+        }
+        // For Normal const bindings with defined initial value
+        if matches!(binding.kind, BindingKind::Normal)
+            && !binding.reassigned
+            && matches!(
+                binding.declaration_kind,
+                crate::compiler::phases::phase2_analyze::scope::DeclarationKind::Const
+            )
+            && binding.initial_is_defined
+        {
+            return true;
+        }
+
+        // For a Normal binding (any `let`/`var`/`const`) whose
+        // initializer is a `BinaryExpression` (`a + b`) or a
+        // `TemplateLiteral` — the only two non-mutable shapes upstream
+        // `scope.evaluate` types as a definite STRING/NUMBER (never
+        // null/undefined), so `is_defined` holds and no `?? ''` is
+        // added. (Notably NOT `UpdateExpression`: upstream's evaluate
+        // has no case for it, so `x++` falls through to UNKNOWN and
+        // keeps its `?? ''`.) A primitive result cannot be turned
+        // nullish by a later in-place mutation, so only reassignment
+        // (`!reassigned`) can invalidate it. Uses the recorded init
+        // node TYPE directly rather than the `initial_is_defined`
+        // flag, which is not populated for legacy (non-runes) `let`
+        // bindings. Fixes e.g. `let key = a.charAt(0) + a.slice(1)`
+        // reading bare.
+        if matches!(binding.kind, BindingKind::Normal)
+            && !binding.reassigned
+            && binding
+                .initial_node_type
+                .as_deref()
+                .is_some_and(|t| matches!(t, "BinaryExpression" | "TemplateLiteral"))
+        {
+            return true;
+        }
+
+        // A non-updated `let`/`var`/`const x = <primitive literal>`
+        // (e.g. legacy `let iconAsc = "↑"`): upstream's scope.evaluate
+        // resolves the binding's Literal initial to a defined primitive
+        // (`!binding.updated && binding.initial !== null && !is_prop`),
+        // so a template `${x}` reads bare. Only a `null` literal is
+        // undefined (`undefined` is an Identifier, handled above).
+        if matches!(binding.kind, BindingKind::Normal)
+            && !binding.is_updated()
+            && binding.initial_node_type.as_deref() == Some("Literal")
+            && binding.initial.as_deref() != Some("null")
+            && binding.initial.is_some()
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Check if an expression is guaranteed to be defined (non-null/undefined).
@@ -4328,8 +4448,6 @@ pub(crate) fn is_expression_defined(
 
 /// Internal helper for checking if a JSON expression is defined.
 fn is_expression_defined_json(json_value: &serde_json::Value, context: &ComponentContext) -> bool {
-    use crate::compiler::phases::phase2_analyze::scope::BindingKind;
-
     let Some(obj) = json_value.as_object() else {
         return false;
     };
@@ -4338,95 +4456,10 @@ fn is_expression_defined_json(json_value: &serde_json::Value, context: &Componen
     };
 
     match expr_type {
-        "Identifier" => {
-            if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
-                // Special identifiers
-                if name == "undefined" {
-                    return false;
-                }
-
-                // First, check if there's a transform with is_defined flag
-                // This is how we track EachIndex within each block scope
-                if let Some(transform) = context.state.transform.get(name)
-                    && transform.is_defined
-                {
-                    return true;
-                }
-
-                // `const uid = $props.id()` always evaluates to a string.
-                // Upstream's scope.evaluate resolves the const binding's initial
-                // `$props.id()` to STRING (scope.js `case '$props.id'`), so
-                // `is_defined` is true and no `?? ''` is appended.
-                if context.state.analysis.props_id.as_deref() == Some(name) {
-                    return true;
-                }
-
-                // Check the binding
-                if let Some(binding) = context.state.get_binding(name) {
-                    // EachIndex is always a number, never null/undefined
-                    if matches!(binding.kind, BindingKind::EachIndex) {
-                        return true;
-                    }
-                    // A template-scoped DeclarationTag / ConstTag binding
-                    // (`{const after_async = number + 1}`) is defined when its
-                    // initializer is a statically-non-nullish shape. Upstream's
-                    // `is_defined` walks `binding.initial`; mirror that with the
-                    // recorded `initial_node_type` so e.g. `after_async`
-                    // (BinaryExpression) reads bare while `number`
-                    // (AwaitExpression) keeps `?? ''`.
-                    if matches!(binding.kind, BindingKind::Template)
-                        && binding.initial_is_defined
-                        && let Some(ref ity) = binding.initial_node_type
-                        && matches!(
-                            ity.as_str(),
-                            "BinaryExpression"
-                                | "UpdateExpression"
-                                | "ArrayExpression"
-                                | "ObjectExpression"
-                                | "TemplateLiteral"
-                        )
-                    {
-                        return true;
-                    }
-                    // For Normal const bindings with defined initial value
-                    if matches!(binding.kind, BindingKind::Normal)
-                        && !binding.reassigned
-                        && matches!(
-                            binding.declaration_kind,
-                            crate::compiler::phases::phase2_analyze::scope::DeclarationKind::Const
-                        )
-                        && binding.initial_is_defined
-                    {
-                        return true;
-                    }
-
-                    // For a Normal binding (any `let`/`var`/`const`) whose
-                    // initializer is a `BinaryExpression` (`a + b`) or a
-                    // `TemplateLiteral` — the only two non-mutable shapes upstream
-                    // `scope.evaluate` types as a definite STRING/NUMBER (never
-                    // null/undefined), so `is_defined` holds and no `?? ''` is
-                    // added. (Notably NOT `UpdateExpression`: upstream's evaluate
-                    // has no case for it, so `x++` falls through to UNKNOWN and
-                    // keeps its `?? ''`.) A primitive result cannot be turned
-                    // nullish by a later in-place mutation, so only reassignment
-                    // (`!reassigned`) can invalidate it. Uses the recorded init
-                    // node TYPE directly rather than the `initial_is_defined`
-                    // flag, which is not populated for legacy (non-runes) `let`
-                    // bindings. Fixes e.g. `let key = a.charAt(0) + a.slice(1)`
-                    // reading bare.
-                    if matches!(binding.kind, BindingKind::Normal)
-                        && !binding.reassigned
-                        && binding
-                            .initial_node_type
-                            .as_deref()
-                            .is_some_and(|t| matches!(t, "BinaryExpression" | "TemplateLiteral"))
-                    {
-                        return true;
-                    }
-                }
-            }
-            false
-        }
+        "Identifier" => obj
+            .get("name")
+            .and_then(|v| v.as_str())
+            .is_some_and(|name| identifier_is_defined(name, context)),
         "Literal" => {
             // Literals are defined unless they're null/undefined
             if let Some(value) = obj.get("value") {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -1479,6 +1479,13 @@ fn is_complex_selector_unused_impl(complex: &Value, ctx: &CssContext) -> bool {
             return true;
         }
 
+        // Structural walk for general descendant/child chains (attribute /
+        // class / id compounds included), mirroring upstream css-prune's
+        // BACKWARD apply_selector over the component's own element tree.
+        if is_structural_descendant_chain_unused(rel_selectors, ctx) {
+            return true;
+        }
+
         // :has() unused detection - check if :has() arguments can match within the subject element's subtree
         // This is guarded inside is_has_selector_unused by has_opaque_sibling_boundaries check
         if is_has_selector_unused(rel_selectors, ctx) {
@@ -3025,6 +3032,236 @@ fn collect_chain_candidates(
             }
         }
     }
+}
+
+/// Structural unused-check for descendant/child chains whose links may be any
+/// compound of type / universal / class / id / attribute / bare pseudo
+/// selectors. Mirrors upstream css-prune's BACKWARD `apply_selector` +
+/// `apply_combinator` over the component's own element tree: the selector is
+/// used only if some element matches the subject AND its ancestor chain
+/// satisfies every remaining link. Conservative: bails (keeps the selector)
+/// on sibling combinators, `:global`, functional pseudo-classes, nesting
+/// selectors, or any shape it cannot evaluate against `CssDomElement`.
+fn is_structural_descendant_chain_unused(rel_selectors: &[Value], ctx: &CssContext) -> bool {
+    if rel_selectors.len() < 2 || ctx.dom_structure.elements.is_empty() {
+        return false;
+    }
+    if ctx.has_dynamic_elements {
+        return false;
+    }
+    // A snippet-declared element's real ancestors are its render sites, and
+    // `<selectedcontent>` mirrors the selected option's subtree — the lexical
+    // parent walk cannot model either, so stay conservative.
+    if ctx
+        .dom_structure
+        .elements
+        .iter()
+        .any(|el| el.in_snippet || el.tag_name.eq_ignore_ascii_case("selectedcontent"))
+    {
+        return false;
+    }
+    for rel in rel_selectors.iter().skip(1) {
+        let combinator = rel
+            .get("combinator")
+            .and_then(|c| c.get("name"))
+            .and_then(|n| n.as_str())
+            .unwrap_or(" ");
+        if combinator != " " && combinator != ">" {
+            return false;
+        }
+    }
+    for rel in rel_selectors {
+        let Some(sels) = rel.get("selectors").and_then(|s| s.as_array()) else {
+            return false;
+        };
+        if sels.is_empty() || !sels.iter().all(structural_simple_selector_is_evaluable) {
+            return false;
+        }
+    }
+
+    let subject = &rel_selectors[rel_selectors.len() - 1];
+    for (idx, el) in ctx.dom_structure.elements.iter().enumerate() {
+        if structural_element_matches_compound(el, subject)
+            && structural_ancestors_satisfy_links(rel_selectors, rel_selectors.len() - 1, idx, ctx)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn structural_ancestors_satisfy_links(
+    rels: &[Value],
+    link_idx: usize,
+    el_idx: usize,
+    ctx: &CssContext,
+) -> bool {
+    if link_idx == 0 {
+        return true;
+    }
+    let combinator = rels[link_idx]
+        .get("combinator")
+        .and_then(|c| c.get("name"))
+        .and_then(|n| n.as_str())
+        .unwrap_or(" ");
+    let prev = &rels[link_idx - 1];
+    let elements = &ctx.dom_structure.elements;
+    if combinator == ">" {
+        let Some(p) = elements[el_idx].parent_idx else {
+            return false;
+        };
+        structural_element_matches_compound(&elements[p], prev)
+            && structural_ancestors_satisfy_links(rels, link_idx - 1, p, ctx)
+    } else {
+        let mut parent = elements[el_idx].parent_idx;
+        while let Some(p) = parent {
+            if structural_element_matches_compound(&elements[p], prev)
+                && structural_ancestors_satisfy_links(rels, link_idx - 1, p, ctx)
+            {
+                return true;
+            }
+            parent = elements[p].parent_idx;
+        }
+        false
+    }
+}
+
+fn structural_simple_selector_is_evaluable(sel: &Value) -> bool {
+    match sel.get("type").and_then(|t| t.as_str()) {
+        // Escape sequences (`#\31 `) are compared un-decoded — bail on them.
+        Some("TypeSelector") | Some("ClassSelector") | Some("IdSelector") => sel
+            .get("name")
+            .and_then(|n| n.as_str())
+            .is_some_and(|n| !n.contains('\\')),
+        Some("AttributeSelector") => {
+            // Only the parsed shape (separate name/matcher/value); the legacy
+            // raw shape stuffs the whole content into `name`.
+            let name = sel.get("name").and_then(|n| n.as_str()).unwrap_or("");
+            !name.is_empty()
+                && !name.contains('=')
+                && !name.contains('[')
+                && !name.contains('\\')
+                && !sel
+                    .get("value")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|v| v.contains('\\'))
+        }
+        Some("PseudoClassSelector") => {
+            let name = sel.get("name").and_then(|n| n.as_str()).unwrap_or("");
+            // `:global` scoping and the global-like `:host`/`:root` (which
+            // match outside the component tree) are not evaluable here.
+            !matches!(name, "global" | "host" | "root")
+                && sel.get("args").map(|a| a.is_null()).unwrap_or(true)
+        }
+        Some("PseudoElementSelector") => true,
+        _ => false,
+    }
+}
+
+fn structural_element_matches_compound(
+    el: &crate::compiler::phases::phase2_analyze::types::CssDomElement,
+    rel: &Value,
+) -> bool {
+    let Some(sels) = rel.get("selectors").and_then(|s| s.as_array()) else {
+        return false;
+    };
+    sels.iter().all(|sel| {
+        let name = sel.get("name").and_then(|n| n.as_str()).unwrap_or("");
+        match sel.get("type").and_then(|t| t.as_str()) {
+            Some("TypeSelector") => {
+                name == "*" || el.is_dynamic_tag || el.tag_name.eq_ignore_ascii_case(name)
+            }
+            Some("ClassSelector") => {
+                el.has_spread
+                    || el
+                        .dynamic_attribute_names
+                        .iter()
+                        .any(|n| n.eq_ignore_ascii_case("class"))
+                    || el.has_class_directive && el.class_directive_names.contains(name)
+                    || el.classes.contains(name)
+            }
+            Some("IdSelector") => {
+                el.has_spread
+                    || el
+                        .dynamic_attribute_names
+                        .iter()
+                        .any(|n| n.eq_ignore_ascii_case("id"))
+                    || el.id.as_deref() == Some(name)
+            }
+            Some("AttributeSelector") => {
+                let matcher = sel
+                    .get("matcher")
+                    .and_then(|m| if m.is_null() { None } else { m.as_str() });
+                let value = sel
+                    .get("value")
+                    .and_then(|v| if v.is_null() { None } else { v.as_str() });
+                let flags = sel
+                    .get("flags")
+                    .and_then(|f| if f.is_null() { None } else { f.as_str() });
+                structural_element_matches_attribute(el, name, matcher, value, flags)
+            }
+            // Bare pseudo-classes (:hover, :first-of-type, …) and
+            // pseudo-elements never constrain prune matching upstream.
+            Some("PseudoClassSelector") | Some("PseudoElementSelector") => true,
+            _ => false,
+        }
+    })
+}
+
+fn structural_element_matches_attribute(
+    el: &crate::compiler::phases::phase2_analyze::types::CssDomElement,
+    attr_name: &str,
+    matcher: Option<&str>,
+    value: Option<&str>,
+    flags: Option<&str>,
+) -> bool {
+    if el.has_spread || el.is_dynamic_tag {
+        return true;
+    }
+    if is_whitelisted_attribute(&el.tag_name, attr_name) {
+        return true;
+    }
+    if el
+        .dynamic_attribute_names
+        .iter()
+        .any(|n| n.eq_ignore_ascii_case(attr_name))
+    {
+        return true;
+    }
+    if attr_name.eq_ignore_ascii_case("class") && el.has_class_directive {
+        return true;
+    }
+    if attr_name.eq_ignore_ascii_case("style") && el.has_style_directive {
+        return true;
+    }
+
+    let operator = matcher.unwrap_or("");
+    let expected_value = value.map(unquote_css_value);
+    let has_explicit_case_flag: i8 = match flags {
+        Some(f) if f.contains('i') || f.contains('I') => 1,
+        Some(f) if f.contains('s') || f.contains('S') => -1,
+        _ => 0,
+    };
+
+    for (name, attr_val) in &el.static_attributes {
+        if name.eq_ignore_ascii_case(attr_name) {
+            if operator.is_empty() {
+                return true;
+            }
+            let case_insensitive = if has_explicit_case_flag != 0 {
+                has_explicit_case_flag == 1
+            } else {
+                is_html_case_insensitive_attribute(attr_name)
+            };
+            let actual = attr_val.as_deref().unwrap_or("");
+            if let Some(ref expected) = expected_value
+                && test_attribute_value(operator, expected, actual, case_insensitive)
+            {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Get the type selector name from a relative selector
@@ -5062,10 +5299,31 @@ fn transform_selector_list(
                             result.push_str(separator);
                         }
                     } else {
-                        // Before first used selector: /* (unused) <selectors>,*/ <used>
+                        // Before first used selector: /* (unused) <selectors>,*/ <used>.
+                        // The comma moves inside the comment; the original
+                        // whitespace after it (e.g. a newline + indent) is kept.
                         result.push_str("/* (unused) ");
                         result.push_str(&unused_buffer);
-                        result.push_str(",*/ ");
+                        result.push_str(",*/");
+                        let mut wrote_between = false;
+                        if let Some(unused_end) = last_unused_end {
+                            let between_start = unused_end.saturating_sub(css_start);
+                            let between_end = sel_start.saturating_sub(css_start);
+                            if between_end <= css_source.len() && between_start < between_end {
+                                let between = &css_source[between_start..between_end];
+                                let after_comma = match between.find(',') {
+                                    Some(i) => &between[i + 1..],
+                                    None => between,
+                                };
+                                if !after_comma.is_empty() {
+                                    result.push_str(after_comma);
+                                    wrote_between = true;
+                                }
+                            }
+                        }
+                        if !wrote_between {
+                            result.push(' ');
+                        }
                     }
                     unused_buffer.clear();
                     last_unused_end = None;


### PR DESCRIPTION
Part of #1234. Empties `known-failures.client.json` (3 → 0; server stays 0): the full output-equality corpus — **13,189 entries across all 30 source repos — now has zero accepted divergences on both targets** (`verify.mjs`: "all corpus outputs identical after normalization").

## Fix 1: template-chunk `is_defined` resolves bare identifiers via scope (svelte-table `Example2.svelte`)

Re-lands the approach of PR #1598 (closed after a layerchart full-corpus regression). That regression is now root-caused: the #1598 branch also flipped `is_expression_known_json`'s Arrow/Function arm to "known" and dropped the function-`{@const}` `is_function()` short-circuits — unrelated semantic changes that flipped function-valued derived props from getter to plain init. This PR keeps those protections and lands only the identifier-resolution change: a non-reactive binding surviving as a bare identifier inside a built `${cond ? iconAsc : iconDesc}` now evaluates through its binding's initial, dropping the spurious `?? ''`.

## Fix 2: per-site proxy + faithful nullish `is_defined` (melt-ui `SpatialMenuNavTest.svelte`)

- `highlighted = id` where `id` is an inner-scope template-literal const was proxied because the name-keyed `non_proxy_vars` list cannot represent two same-named inner bindings with different proxy-ness (a sibling arrow takes an `id` parameter). The runes script pass and statement-level assign passes now resolve a bare-identifier RHS through oxc Semantic at the assignment site, mirroring upstream `should_proxy` for function-local declarations (root-scope names keep the name-list fallback).
- `${cols}` lost its `?? ''`: `is_expression_defined_typed` narrowed `unknown ?? 0` to defined via the right side, but upstream's evaluate keeps the union of both sides, so UNKNOWN survives.

## Fix 3: CSS structural prune for descendant chains (svelte-sonner `Toaster.svelte`)

svelte prunes a descendant/child selector when no element in the component's own tree matches the subject with a satisfying ancestor chain. rsvelte's transform-side heuristics only walked type-selector chains, so attribute/class/id chains were kept (`[data-sonner-toast][data-styled='true'] [data-description]` subject spread-matches `<ol {...restProps}>` but no ancestor matches). Ports the upstream BACKWARD `apply_selector` walk over `CssDomElement`, bailing conservatively on sibling combinators, `:global`/`:host`/`:root`, functional pseudo-classes, escaped identifiers, `<selectedcontent>`, and snippet-declared elements (new `CssDomElement.in_snippet` flag — their real ancestors are render sites). Also preserves source whitespace after a pruned leading selector-list item.

## Verification (after each fix)

- Byte-exact suites: `compiler_fixtures` 17 / `runtime` 19 / `ssr` 16 — all pass
- Full corpus (13,189 entries): target entries flipped to PASS with **zero new failures**; intermediate over-prunes surfaced by the corpus (snippets render-site ancestry, `<selectedcontent>` mirroring, `:host`/`:root` globals, escaped identifiers) were each turned into explicit conservative bails and re-verified
- Final state: match 12,259 / error-parity 930 / js-mismatch 0 / css-mismatch 0 / error-mismatch 0

`known-failures.md` now documents the remaining hard-cluster warnings for future work instead of accepted entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8msqRP7cBMLaNTHnxo69w