### PR TITLE
fix(napi): decode compiler options leniently to match the official compiler

### DIFF
--- a/.changeset/lenient-napi-compile-options.md
+++ b/.changeset/lenient-napi-compile-options.md
@@ -11,8 +11,9 @@ type \`bool\``, `Failed to convert js number to serde_json::Number`, …) on a
 non-boolean or non-finite value.
 
 - `runes` mirrors upstream's `parametric` validator: it accepts any JS value and
-  never rejects it. A truthy value forces runes on, a real `false` forces
-  legacy, and `undefined`/`null`/absent leave the mode auto-detected.
+  never rejects it. A truthy scalar (number/string) forces runes on, a real
+  `false` forces legacy, and `undefined`/`null`/absent — as well as non-scalars
+  like an object or function — leave the mode auto-detected.
 - A genuinely wrong-typed option (e.g. `dev: 1`, `namespace: 2`) is reported as
   `Invalid compiler option: …` using the upstream message.
 

--- a/.changeset/lenient-napi-compile-options.md
+++ b/.changeset/lenient-napi-compile-options.md
@@ -1,0 +1,23 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix(napi): accept lenient compiler options like the official compiler
+
+The N-API `compile`/`compileModule` surface now decodes every option the way
+`svelte/compiler`'s `validate-options.js` does, instead of failing the whole
+call with a raw N-API conversion error (`Failed to convert napi value into rust
+type \`bool\``, `Failed to convert js number to serde_json::Number`, …) on a
+non-boolean or non-finite value.
+
+- `runes` mirrors upstream's `parametric` validator: it accepts any JS value and
+  never rejects it. A truthy value forces runes on, a real `false` forces
+  legacy, and `undefined`/`null`/absent leave the mode auto-detected.
+- A genuinely wrong-typed option (e.g. `dev: 1`, `namespace: 2`) is reported as
+  `Invalid compiler option: …` using the upstream message.
+
+Accepted, N-API-imposed difference from upstream: because the compiler's `runes`
+is `Option<bool>`, a falsy-but-not-`false` value (`0`, `""`, `NaN`) auto-detects
+instead of forcing legacy — only a real `false` maps to `Some(false)`, so it
+can't spuriously trigger the strict `runes === false` paths. A function-valued
+`runes` cannot be invoked from Rust and likewise auto-detects.

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -290,11 +290,12 @@ pub enum LenientScalar {
     Bool(bool),
     Number(f64),
     Str(String),
-    // A plain (non-array) object, keyed by property name. Nested values are
-    // themselves `LenientScalar`, so a non-finite child (`{ async: NaN }`) is
-    // read as `Number` rather than aborting the whole decode like `serde_json`.
-    // `null`/`undefined` children are dropped, matching the top-level `Option`
-    // guard.
+    // A plain (non-array) object, keyed by property name. Direct children are
+    // decoded one level deep (so `{ async: NaN }` reads `async` as `Number`
+    // rather than aborting like `serde_json`), but a grandchild object collapses
+    // to `Other` instead of recursing — that depth cap is what makes a
+    // self-referential object safe to decode. `undefined` children are dropped
+    // (unset); everything the consumers read lives at depth 1.
     Object(Vec<(String, LenientScalar)>),
     // Arrays, functions, symbols and other non-scalars — JS-truthy, but not a
     // value any option can consume.
@@ -323,6 +324,54 @@ impl napi::bindgen_prelude::TypeName for LenientScalar {
     }
 }
 
+// Decode a JS value as a scalar; objects, arrays, functions and every other
+// non-scalar become `Other` with no recursion, so this can never chase a cyclic
+// reference. Used for an object's direct children, capping the decode at depth 1.
+unsafe fn decode_scalar(
+    env: napi::sys::napi_env,
+    napi_val: napi::sys::napi_value,
+) -> napi::Result<LenientScalar> {
+    use napi::bindgen_prelude::FromNapiValue;
+    let mut val_type = 0;
+    // SAFETY: `env`/`napi_val` are valid handles from Node-API; `napi_typeof`
+    // only reads them and writes the type tag.
+    let status = unsafe { napi::sys::napi_typeof(env, napi_val, &mut val_type) };
+    if status != napi::sys::Status::napi_ok {
+        return Err(napi::Error::from_status(napi::Status::from(status)));
+    }
+    // SAFETY: each arm reads the confirmed JS type; the numeric path uses
+    // `napi_get_value_double`, which tolerates non-finite values.
+    unsafe {
+        Ok(match val_type {
+            napi::sys::ValueType::napi_boolean => {
+                LenientScalar::Bool(bool::from_napi_value(env, napi_val)?)
+            }
+            napi::sys::ValueType::napi_number => {
+                LenientScalar::Number(f64::from_napi_value(env, napi_val)?)
+            }
+            napi::sys::ValueType::napi_string => {
+                LenientScalar::Str(String::from_napi_value(env, napi_val)?)
+            }
+            _ => LenientScalar::Other,
+        })
+    }
+}
+
+// Single-level view used only for an object's direct children: its decoder
+// never recurses into further objects, which is what bounds `LenientScalar`
+// decoding at depth 1 and makes a cyclic object graph unreachable.
+struct ScalarLeaf(LenientScalar);
+
+impl napi::bindgen_prelude::FromNapiValue for ScalarLeaf {
+    unsafe fn from_napi_value(
+        env: napi::sys::napi_env,
+        napi_val: napi::sys::napi_value,
+    ) -> napi::Result<Self> {
+        // SAFETY: valid handles from Node-API, forwarded to the scalar decoder.
+        Ok(ScalarLeaf(unsafe { decode_scalar(env, napi_val)? }))
+    }
+}
+
 impl napi::bindgen_prelude::FromNapiValue for LenientScalar {
     unsafe fn from_napi_value(
         env: napi::sys::napi_env,
@@ -335,42 +384,30 @@ impl napi::bindgen_prelude::FromNapiValue for LenientScalar {
         if status != napi::sys::Status::napi_ok {
             return Err(napi::Error::from_status(napi::Status::from(status)));
         }
-        // SAFETY: the value is the confirmed JS type for each arm; the numeric
-        // path uses `napi_get_value_double`, which tolerates non-finite values,
-        // and the object path reads properties through the safe `Object` API.
-        unsafe {
-            Ok(match val_type {
-                napi::sys::ValueType::napi_boolean => {
-                    LenientScalar::Bool(bool::from_napi_value(env, napi_val)?)
-                }
-                napi::sys::ValueType::napi_number => {
-                    LenientScalar::Number(f64::from_napi_value(env, napi_val)?)
-                }
-                napi::sys::ValueType::napi_string => {
-                    LenientScalar::Str(String::from_napi_value(env, napi_val)?)
-                }
-                napi::sys::ValueType::napi_object => {
-                    let mut is_array = false;
-                    let st = napi::sys::napi_is_array(env, napi_val, &mut is_array);
-                    if st != napi::sys::Status::napi_ok {
-                        return Err(napi::Error::from_status(napi::Status::from(st)));
-                    }
-                    if is_array {
-                        LenientScalar::Other
-                    } else {
-                        let obj = napi::bindgen_prelude::Object::from_napi_value(env, napi_val)?;
-                        let mut fields = Vec::new();
-                        for key in napi::bindgen_prelude::Object::keys(&obj)? {
-                            if let Some(child) = obj.get::<LenientScalar>(&key)? {
-                                fields.push((key, child));
-                            }
-                        }
-                        LenientScalar::Object(fields)
-                    }
-                }
-                _ => LenientScalar::Other,
-            })
+        if val_type != napi::sys::ValueType::napi_object {
+            // SAFETY: valid handles; non-object values are decoded directly.
+            return unsafe { decode_scalar(env, napi_val) };
         }
+        let mut is_array = false;
+        // SAFETY: valid handles; `napi_is_array` only reads them and writes the flag.
+        let st = unsafe { napi::sys::napi_is_array(env, napi_val, &mut is_array) };
+        if st != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_status(napi::Status::from(st)));
+        }
+        if is_array {
+            return Ok(LenientScalar::Other);
+        }
+        // SAFETY: confirmed non-array object; properties are read through the
+        // safe `Object` API, and each child is decoded via `ScalarLeaf`, which
+        // does not recurse — so no cycle can drive an unbounded decode.
+        let obj = unsafe { napi::bindgen_prelude::Object::from_napi_value(env, napi_val)? };
+        let mut fields = Vec::new();
+        for key in napi::bindgen_prelude::Object::keys(&obj)? {
+            if let Some(ScalarLeaf(v)) = obj.get::<ScalarLeaf>(&key)? {
+                fields.push((key, v));
+            }
+        }
+        Ok(LenientScalar::Object(fields))
     }
 }
 

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -109,7 +109,7 @@ pub struct NapiParseOptions {
     /// parser (e.g. `svelte-eslint-parser`) can opt in for a smaller
     /// AST and a faster `JSON.parse` (or, when paired with
     /// `parseEnvelope`, a tighter binary buffer).
-    pub skip_expression_loc: Option<bool>,
+    pub skip_expression_loc: Option<LenientScalar>,
     /// Skip emitting the full CSS `StyleSheet` AST — only the outer
     /// `start`/`end` positions are kept. The decoded `css` field
     /// becomes a minimal stub (`{ type: "StyleSheet", start, end,
@@ -118,7 +118,19 @@ pub struct NapiParseOptions {
     /// pipeline re-parses style blocks with its own CSS parser (e.g.
     /// `svelte-eslint-parser` uses postcss). Saves ~5–10 KB of buffer
     /// and the matching JSON-parse cost on the JS side per component.
-    pub skip_css_ast: Option<bool>,
+    pub skip_css_ast: Option<LenientScalar>,
+}
+
+impl NapiParseOptions {
+    /// Read a boolean parse flag, defaulting to `false` when unset and
+    /// rejecting a non-boolean with the same message shape as the compile
+    /// options.
+    fn flag(field: Option<&LenientScalar>, keypath: &str) -> napi::Result<bool> {
+        match field {
+            Some(v) => coerce_bool(keypath, v),
+            None => Ok(false),
+        }
+    }
 }
 
 /// Parse a Svelte component and return the AST as a JSON string.
@@ -134,10 +146,12 @@ pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Re
     use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse as rust_parse};
 
     let parse_options = ParseOptions {
-        skip_expression_loc: options
-            .as_ref()
-            .and_then(|o| o.skip_expression_loc)
-            .unwrap_or(false),
+        skip_expression_loc: NapiParseOptions::flag(
+            options
+                .as_ref()
+                .and_then(|o| o.skip_expression_loc.as_ref()),
+            "skipExpressionLoc",
+        )?,
         // The public AST API mirrors svelte/compiler `parse()`, which keeps
         // `leadingComments`/`trailingComments` on nodes.
         capture_comments: true,
@@ -180,17 +194,19 @@ pub fn napi_parse_envelope(
     use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse as rust_parse};
 
     let parse_options = ParseOptions {
-        skip_expression_loc: options
-            .as_ref()
-            .and_then(|o| o.skip_expression_loc)
-            .unwrap_or(false),
+        skip_expression_loc: NapiParseOptions::flag(
+            options
+                .as_ref()
+                .and_then(|o| o.skip_expression_loc.as_ref()),
+            "skipExpressionLoc",
+        )?,
         ..ParseOptions::default()
     };
     let skip_loc = parse_options.skip_expression_loc;
-    let skip_css = options
-        .as_ref()
-        .and_then(|o| o.skip_css_ast)
-        .unwrap_or(false);
+    let skip_css = NapiParseOptions::flag(
+        options.as_ref().and_then(|o| o.skip_css_ast.as_ref()),
+        "skipCssAst",
+    )?;
     let ast = rust_parse(&source, parse_options)
         .map_err(|e| napi::Error::from_reason(format!("{e:?}")))?;
     // napi-rs's `Vec<u8> → Buffer` conversion is already zero-copy
@@ -210,7 +226,7 @@ pub fn napi_parse_envelope(
 /// matching the official `svelte/compiler` output shape.
 #[napi(js_name = "compile")]
 pub fn napi_compile(source: String, options: Option<NapiCompileOptions>) -> napi::Result<Value> {
-    let opts = options_to_compile(options);
+    let opts = options_to_compile(options)?;
 
     match rust_compile(&source, opts) {
         Ok(result) => {
@@ -262,14 +278,252 @@ pub fn napi_compile(source: String, options: Option<NapiCompileOptions>) -> napi
 // `sourcemap` field accepts either; the callback fields aren't
 // modelled here because the compiler core can't call back into JS.
 
-#[napi(object)]
-pub struct NapiExperimentalOptions {
-    pub r#async: Option<bool>,
+// Each scalar option is decoded straight from its JS value rather than through
+// `serde_json`, whose number conversion aborts on non-finite input (`NaN`,
+// `Infinity`) before any coercion runs. Objects, arrays, functions and other
+// non-scalars collapse to `Other`, so no input type can surface a raw
+// "Failed to convert napi value" error; a wrong-typed option instead reports
+// the same message the upstream `validate-options.js` prints. `undefined`,
+// absent keys and `null` all become `None` via the `#[napi(object)]` `Option`
+// guard, leaving the option at its default.
+pub enum LenientScalar {
+    Bool(bool),
+    Number(f64),
+    Str(String),
+    // A plain (non-array) object, keyed by property name. Nested values are
+    // themselves `LenientScalar`, so a non-finite child (`{ async: NaN }`) is
+    // read as `Number` rather than aborting the whole decode like `serde_json`.
+    // `null`/`undefined` children are dropped, matching the top-level `Option`
+    // guard.
+    Object(Vec<(String, LenientScalar)>),
+    // Arrays, functions, symbols and other non-scalars — JS-truthy, but not a
+    // value any option can consume.
+    Other,
 }
 
-#[napi(object)]
-pub struct NapiCompatibilityOptions {
-    pub component_api: Option<u32>,
+impl LenientScalar {
+    fn is_object(&self) -> bool {
+        matches!(self, LenientScalar::Object(_))
+    }
+
+    fn field(&self, key: &str) -> Option<&LenientScalar> {
+        match self {
+            LenientScalar::Object(fields) => fields.iter().find(|(k, _)| k == key).map(|(_, v)| v),
+            _ => None,
+        }
+    }
+}
+
+impl napi::bindgen_prelude::TypeName for LenientScalar {
+    fn type_name() -> &'static str {
+        "unknown"
+    }
+    fn value_type() -> napi::ValueType {
+        napi::ValueType::Unknown
+    }
+}
+
+impl napi::bindgen_prelude::FromNapiValue for LenientScalar {
+    unsafe fn from_napi_value(
+        env: napi::sys::napi_env,
+        napi_val: napi::sys::napi_value,
+    ) -> napi::Result<Self> {
+        let mut val_type = 0;
+        // SAFETY: `env`/`napi_val` are the valid handles Node-API passed in;
+        // `napi_typeof` only reads them and writes the type tag.
+        let status = unsafe { napi::sys::napi_typeof(env, napi_val, &mut val_type) };
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_status(napi::Status::from(status)));
+        }
+        // SAFETY: the value is the confirmed JS type for each arm; the numeric
+        // path uses `napi_get_value_double`, which tolerates non-finite values,
+        // and the object path reads properties through the safe `Object` API.
+        unsafe {
+            Ok(match val_type {
+                napi::sys::ValueType::napi_boolean => {
+                    LenientScalar::Bool(bool::from_napi_value(env, napi_val)?)
+                }
+                napi::sys::ValueType::napi_number => {
+                    LenientScalar::Number(f64::from_napi_value(env, napi_val)?)
+                }
+                napi::sys::ValueType::napi_string => {
+                    LenientScalar::Str(String::from_napi_value(env, napi_val)?)
+                }
+                napi::sys::ValueType::napi_object => {
+                    let mut is_array = false;
+                    let st = napi::sys::napi_is_array(env, napi_val, &mut is_array);
+                    if st != napi::sys::Status::napi_ok {
+                        return Err(napi::Error::from_status(napi::Status::from(st)));
+                    }
+                    if is_array {
+                        LenientScalar::Other
+                    } else {
+                        let obj = napi::bindgen_prelude::Object::from_napi_value(env, napi_val)?;
+                        let mut fields = Vec::new();
+                        for key in napi::bindgen_prelude::Object::keys(&obj)? {
+                            if let Some(child) = obj.get::<LenientScalar>(&key)? {
+                                fields.push((key, child));
+                            }
+                        }
+                        LenientScalar::Object(fields)
+                    }
+                }
+                _ => LenientScalar::Other,
+            })
+        }
+    }
+}
+
+impl napi::bindgen_prelude::ToNapiValue for LenientScalar {
+    unsafe fn to_napi_value(
+        env: napi::sys::napi_env,
+        val: Self,
+    ) -> napi::Result<napi::sys::napi_value> {
+        // SAFETY: `env` is the valid env Node-API passed in; each branch
+        // delegates to the matching primitive's own `to_napi_value`. Input-only
+        // in practice — this exists so `#[napi(object)]` structs holding the
+        // type satisfy the derived `ToNapiValue` bound.
+        unsafe {
+            match val {
+                LenientScalar::Bool(b) => bool::to_napi_value(env, b),
+                LenientScalar::Number(n) => f64::to_napi_value(env, n),
+                LenientScalar::Str(s) => String::to_napi_value(env, s),
+                LenientScalar::Object(_) | LenientScalar::Other => {
+                    napi::bindgen_prelude::Null::to_napi_value(env, napi::bindgen_prelude::Null)
+                }
+            }
+        }
+    }
+}
+
+fn invalid_option(detail: impl std::fmt::Display) -> napi::Error {
+    napi::Error::from_reason(format!("Invalid compiler option: {detail}"))
+}
+
+fn coerce_bool(keypath: &str, v: &LenientScalar) -> napi::Result<bool> {
+    match v {
+        LenientScalar::Bool(b) => Ok(*b),
+        _ => Err(invalid_option(format!(
+            "{keypath} should be true or false, if specified"
+        ))),
+    }
+}
+
+fn coerce_string(keypath: &str, v: &LenientScalar) -> napi::Result<String> {
+    match v {
+        LenientScalar::Str(s) => Ok(s.clone()),
+        _ => Err(invalid_option(format!(
+            "{keypath} should be a string, if specified"
+        ))),
+    }
+}
+
+// `runes` mirrors upstream's `parametric` validator, which never rejects a
+// value. Only a real `false` becomes `Some(false)`: `Option<bool>` can't encode
+// the other falsy values (`0`/`""`/`NaN`, none of which upstream compares
+// `=== false`), so those — and non-scalars like `null` or the uninvokable
+// `(opts) => boolean` form — auto-detect (`None`) rather than risk misfiring the
+// strict `runes === false` paths a spurious `Some(false)` would trigger.
+fn coerce_runes(v: &LenientScalar) -> Option<bool> {
+    match v {
+        LenientScalar::Bool(b) => Some(*b),
+        LenientScalar::Number(n) if *n != 0.0 && !n.is_nan() => Some(true),
+        LenientScalar::Str(s) if !s.is_empty() => Some(true),
+        _ => None,
+    }
+}
+
+fn coerce_generate(v: &LenientScalar) -> napi::Result<GenerateMode> {
+    let msg = "generate must be \"client\", \"server\" or false";
+    match v {
+        LenientScalar::Bool(false) => Ok(GenerateMode::None),
+        // `dom`/`ssr` are the pre-Svelte-5 spellings of `client`/`server`.
+        LenientScalar::Str(s) => match s.as_str() {
+            "client" | "dom" => Ok(GenerateMode::Client),
+            "server" | "ssr" => Ok(GenerateMode::Server),
+            "false" => Ok(GenerateMode::None),
+            _ => Err(invalid_option(msg)),
+        },
+        _ => Err(invalid_option(msg)),
+    }
+}
+
+fn coerce_namespace(v: &LenientScalar) -> napi::Result<Namespace> {
+    let msg = "namespace should be one of \"html\", \"mathml\" or \"svg\"";
+    match v {
+        LenientScalar::Str(s) => match s.as_str() {
+            "html" => Ok(Namespace::Html),
+            "svg" => Ok(Namespace::Svg),
+            "mathml" => Ok(Namespace::Mathml),
+            _ => Err(invalid_option(msg)),
+        },
+        _ => Err(invalid_option(msg)),
+    }
+}
+
+fn coerce_css(v: &LenientScalar) -> napi::Result<CssMode> {
+    match v {
+        LenientScalar::Bool(_) => Err(invalid_option(
+            "The boolean options have been removed from the css option. Use \"external\" instead of false and \"injected\" instead of true",
+        )),
+        LenientScalar::Str(s) => match s.as_str() {
+            "external" => Ok(CssMode::External),
+            "injected" => Ok(CssMode::Injected),
+            _ => Err(invalid_option(
+                "css should be either \"external\" (default, recommended) or \"injected\"",
+            )),
+        },
+        _ => Err(invalid_option(
+            "css should be either \"external\" (default, recommended) or \"injected\"",
+        )),
+    }
+}
+
+fn coerce_fragments(v: &LenientScalar) -> napi::Result<rsvelte_core::compiler::FragmentMode> {
+    let msg = "fragments should be either \"html\" or \"tree\"";
+    match v {
+        LenientScalar::Str(s) => match s.as_str() {
+            "html" => Ok(rsvelte_core::compiler::FragmentMode::Html),
+            "tree" => Ok(rsvelte_core::compiler::FragmentMode::Tree),
+            _ => Err(invalid_option(msg)),
+        },
+        _ => Err(invalid_option(msg)),
+    }
+}
+
+// Upstream `list([4, 5], 5)` accepts only the numbers 4 and 5 (the string
+// `"4"` is rejected).
+fn coerce_component_api(v: &LenientScalar) -> napi::Result<rsvelte_core::compiler::ComponentApi> {
+    match v {
+        LenientScalar::Number(n) if *n == 4.0 => Ok(rsvelte_core::compiler::ComponentApi::V4),
+        LenientScalar::Number(n) if *n == 5.0 => Ok(rsvelte_core::compiler::ComponentApi::V5),
+        _ => Err(invalid_option(
+            "compatibility.componentApi should be either \"4\" or \"5\"",
+        )),
+    }
+}
+
+// Upstream `experimental: object({ async: boolean(false) })`: a non-object is
+// rejected; a missing/`null`/`undefined` `async` keeps the default.
+fn coerce_experimental(v: &LenientScalar) -> napi::Result<ExperimentalOptions> {
+    if !v.is_object() {
+        return Err(invalid_option("experimental should be an object"));
+    }
+    let mut exp = ExperimentalOptions::default();
+    if let Some(a) = v.field("async") {
+        exp.r#async = coerce_bool("experimental.async", a)?;
+    }
+    Ok(exp)
+}
+
+fn coerce_compatibility(v: &LenientScalar) -> napi::Result<rsvelte_core::compiler::ComponentApi> {
+    if !v.is_object() {
+        return Err(invalid_option("compatibility should be an object"));
+    }
+    match v.field("componentApi") {
+        None => Ok(rsvelte_core::compiler::ComponentApi::default()),
+        Some(c) => coerce_component_api(c),
+    }
 }
 
 /// Typed mirror of `CompileOptions` for the NAPI boundary. Field
@@ -278,98 +532,87 @@ pub struct NapiCompatibilityOptions {
 /// `options` argument (`{ dev, generate, filename, rootDir, … }`).
 #[napi(object)]
 pub struct NapiCompileOptions {
-    pub dev: Option<bool>,
-    pub generate: Option<String>,
-    pub filename: Option<String>,
-    pub root_dir: Option<String>,
-    pub name: Option<String>,
-    pub custom_element: Option<bool>,
-    pub accessors: Option<bool>,
-    pub namespace: Option<String>,
-    pub immutable: Option<bool>,
-    pub css: Option<String>,
-    pub preserve_comments: Option<bool>,
-    pub preserve_whitespace: Option<bool>,
-    pub runes: Option<bool>,
-    pub disclose_version: Option<bool>,
+    pub dev: Option<LenientScalar>,
+    pub generate: Option<LenientScalar>,
+    pub filename: Option<LenientScalar>,
+    pub root_dir: Option<LenientScalar>,
+    pub name: Option<LenientScalar>,
+    pub custom_element: Option<LenientScalar>,
+    pub accessors: Option<LenientScalar>,
+    pub namespace: Option<LenientScalar>,
+    pub immutable: Option<LenientScalar>,
+    pub css: Option<LenientScalar>,
+    pub preserve_comments: Option<LenientScalar>,
+    pub preserve_whitespace: Option<LenientScalar>,
+    pub runes: Option<LenientScalar>,
+    pub disclose_version: Option<LenientScalar>,
     /// SourceMap v3 object **or** its serialized JSON string — both
     /// accepted. Preprocessors pass an object; the test harness
     /// sometimes passes a string. Anything else (number, array,
     /// boolean) is ignored.
     pub sourcemap: Option<Value>,
-    pub output_filename: Option<String>,
-    pub css_output_filename: Option<String>,
-    pub hmr: Option<bool>,
-    pub modern_ast: Option<bool>,
-    pub experimental: Option<NapiExperimentalOptions>,
-    pub compatibility: Option<NapiCompatibilityOptions>,
+    pub output_filename: Option<LenientScalar>,
+    pub css_output_filename: Option<LenientScalar>,
+    pub hmr: Option<LenientScalar>,
+    pub modern_ast: Option<LenientScalar>,
+    pub experimental: Option<LenientScalar>,
+    pub compatibility: Option<LenientScalar>,
     /// Pre-computed deterministic hash for the test harness (the JS
     /// `cssHash` callback can't be called from Rust).
     pub css_hash_override: Option<String>,
-    pub fragments: Option<String>,
+    pub fragments: Option<LenientScalar>,
 }
 
 impl NapiCompileOptions {
-    /// Convert into the compiler's native `CompileOptions`. The
-    /// defaults match `CompileOptions::default()`; only fields the JS
-    /// caller actually set are propagated.
-    fn into_compile_options(self) -> CompileOptions {
+    /// Convert into the compiler's native `CompileOptions`, mirroring the
+    /// upstream `validate-options.js`: an absent field keeps its default and a
+    /// wrong JS type is rejected with the upstream message.
+    fn into_compile_options(self) -> napi::Result<CompileOptions> {
         let mut opts = CompileOptions::default();
-        if let Some(v) = self.dev {
-            opts.dev = v;
+        if let Some(v) = &self.dev {
+            opts.dev = coerce_bool("dev", v)?;
         }
-        if let Some(v) = self.generate.as_deref() {
-            opts.generate = match v {
-                "server" | "ssr" => GenerateMode::Server,
-                "false" => GenerateMode::None,
-                _ => GenerateMode::Client,
-            };
+        if let Some(v) = &self.generate {
+            opts.generate = coerce_generate(v)?;
         }
-        if let Some(v) = self.filename {
-            opts.filename = Some(v);
+        if let Some(v) = &self.filename {
+            opts.filename = Some(coerce_string("filename", v)?);
         }
-        // rootDir defaults to the process's cwd (matches official Svelte)
-        if let Some(v) = self.root_dir {
-            opts.root_dir = Some(v);
+        // rootDir defaults to the process's cwd (matches official Svelte).
+        if let Some(v) = &self.root_dir {
+            opts.root_dir = Some(coerce_string("rootDir", v)?);
         } else if let Ok(cwd) = std::env::current_dir() {
             opts.root_dir = Some(cwd.to_string_lossy().to_string());
         }
-        if let Some(v) = self.name {
-            opts.name = Some(v);
+        if let Some(v) = &self.name {
+            opts.name = Some(coerce_string("name", v)?);
         }
-        if let Some(v) = self.custom_element {
-            opts.custom_element = v;
+        if let Some(v) = &self.custom_element {
+            opts.custom_element = coerce_bool("customElement", v)?;
         }
-        if let Some(v) = self.accessors {
-            opts.accessors = v;
+        if let Some(v) = &self.accessors {
+            opts.accessors = coerce_bool("accessors", v)?;
         }
-        if let Some(v) = self.namespace.as_deref() {
-            opts.namespace = match v {
-                "svg" => Namespace::Svg,
-                "mathml" => Namespace::Mathml,
-                _ => Namespace::Html,
-            };
+        if let Some(v) = &self.namespace {
+            opts.namespace = coerce_namespace(v)?;
         }
-        if let Some(v) = self.immutable {
-            opts.immutable = v;
+        if let Some(v) = &self.immutable {
+            opts.immutable = coerce_bool("immutable", v)?;
         }
-        if let Some(v) = self.css.as_deref() {
-            opts.css = match v {
-                "injected" => CssMode::Injected,
-                _ => CssMode::External,
-            };
+        if let Some(v) = &self.css {
+            opts.css = coerce_css(v)?;
         }
-        if let Some(v) = self.preserve_comments {
-            opts.preserve_comments = v;
+        if let Some(v) = &self.preserve_comments {
+            opts.preserve_comments = coerce_bool("preserveComments", v)?;
         }
-        if let Some(v) = self.preserve_whitespace {
-            opts.preserve_whitespace = v;
+        if let Some(v) = &self.preserve_whitespace {
+            opts.preserve_whitespace = coerce_bool("preserveWhitespace", v)?;
         }
-        if let Some(v) = self.runes {
-            opts.runes = Some(v);
+        if let Some(v) = &self.runes {
+            opts.runes = coerce_runes(v);
         }
-        if let Some(v) = self.disclose_version {
-            opts.disclose_version = v;
+        if let Some(v) = &self.disclose_version {
+            opts.disclose_version = coerce_bool("discloseVersion", v)?;
         }
         if let Some(v) = self.sourcemap {
             // Preprocessors pass the map as an object; the test harness
@@ -384,102 +627,91 @@ impl NapiCompileOptions {
                 opts.sourcemap = serde_json::to_string(&v).ok();
             }
         }
-        if let Some(v) = self.output_filename {
-            opts.output_filename = Some(v);
+        if let Some(v) = &self.output_filename {
+            opts.output_filename = Some(coerce_string("outputFilename", v)?);
         }
-        if let Some(v) = self.css_output_filename {
-            opts.css_output_filename = Some(v);
+        if let Some(v) = &self.css_output_filename {
+            opts.css_output_filename = Some(coerce_string("cssOutputFilename", v)?);
         }
-        if let Some(v) = self.hmr {
-            opts.hmr = v;
+        if let Some(v) = &self.hmr {
+            opts.hmr = coerce_bool("hmr", v)?;
         }
-        if let Some(v) = self.modern_ast {
-            opts.modern_ast = v;
+        if let Some(v) = &self.modern_ast {
+            opts.modern_ast = coerce_bool("modernAst", v)?;
         }
-        if let Some(exp) = self.experimental
-            && let Some(v) = exp.r#async
-        {
-            opts.experimental = ExperimentalOptions { r#async: v };
+        if let Some(v) = &self.experimental {
+            opts.experimental = coerce_experimental(v)?;
         }
-        if let Some(compat) = self.compatibility
-            && let Some(v) = compat.component_api
-        {
-            opts.compatibility.component_api = if v == 4 {
-                rsvelte_core::compiler::ComponentApi::V4
-            } else {
-                rsvelte_core::compiler::ComponentApi::V5
-            };
+        if let Some(v) = &self.compatibility {
+            opts.compatibility.component_api = coerce_compatibility(v)?;
         }
         if let Some(hash_override) = self.css_hash_override {
             opts.css_hash = Some(std::sync::Arc::new(
                 move |_: &rsvelte_core::compiler::CssHashInput| hash_override.clone(),
             ));
         }
-        if let Some(v) = self.fragments.as_deref() {
-            opts.fragments = match v {
-                "tree" => rsvelte_core::compiler::FragmentMode::Tree,
-                _ => rsvelte_core::compiler::FragmentMode::Html,
-            };
+        if let Some(v) = &self.fragments {
+            opts.fragments = coerce_fragments(v)?;
         }
-        opts
+        Ok(opts)
     }
 }
 
 /// Typed mirror of `ModuleCompileOptions`.
 #[napi(object)]
 pub struct NapiModuleCompileOptions {
-    pub dev: Option<bool>,
-    pub generate: Option<String>,
-    pub filename: Option<String>,
-    pub root_dir: Option<String>,
-    pub experimental: Option<NapiExperimentalOptions>,
+    pub dev: Option<LenientScalar>,
+    pub generate: Option<LenientScalar>,
+    pub filename: Option<LenientScalar>,
+    pub root_dir: Option<LenientScalar>,
+    pub experimental: Option<LenientScalar>,
 }
 
 impl NapiModuleCompileOptions {
-    fn into_module_compile_options(self) -> ModuleCompileOptions {
+    fn into_module_compile_options(self) -> napi::Result<ModuleCompileOptions> {
         let mut opts = ModuleCompileOptions::default();
-        if let Some(v) = self.dev {
-            opts.dev = v;
+        if let Some(v) = &self.dev {
+            opts.dev = coerce_bool("dev", v)?;
         }
-        if let Some(v) = self.generate.as_deref() {
-            opts.generate = match v {
-                "server" | "ssr" => GenerateMode::Server,
-                "false" => GenerateMode::None,
-                _ => GenerateMode::Client,
-            };
+        if let Some(v) = &self.generate {
+            opts.generate = coerce_generate(v)?;
         }
-        if let Some(v) = self.filename {
-            opts.filename = Some(v);
+        if let Some(v) = &self.filename {
+            opts.filename = Some(coerce_string("filename", v)?);
         }
-        if let Some(v) = self.root_dir {
-            opts.root_dir = Some(v);
+        if let Some(v) = &self.root_dir {
+            opts.root_dir = Some(coerce_string("rootDir", v)?);
         }
-        if let Some(exp) = self.experimental
-            && let Some(v) = exp.r#async
-        {
-            opts.experimental = ExperimentalOptions { r#async: v };
+        if let Some(v) = &self.experimental {
+            opts.experimental = coerce_experimental(v)?;
         }
-        opts
+        Ok(opts)
     }
 }
 
 /// Compatibility wrapper: convert an Option<NapiCompileOptions> (the
 /// typed surface) into `CompileOptions`. `None` and `Some(empty)`
 /// both produce the defaults.
-fn options_to_compile(opts: Option<NapiCompileOptions>) -> CompileOptions {
-    opts.map(NapiCompileOptions::into_compile_options)
-        .unwrap_or_else(|| {
+fn options_to_compile(opts: Option<NapiCompileOptions>) -> napi::Result<CompileOptions> {
+    match opts {
+        Some(o) => o.into_compile_options(),
+        None => {
             let mut o = CompileOptions::default();
             if let Ok(cwd) = std::env::current_dir() {
                 o.root_dir = Some(cwd.to_string_lossy().to_string());
             }
-            o
-        })
+            Ok(o)
+        }
+    }
 }
 
-fn options_to_module_compile(opts: Option<NapiModuleCompileOptions>) -> ModuleCompileOptions {
-    opts.map(NapiModuleCompileOptions::into_module_compile_options)
-        .unwrap_or_default()
+fn options_to_module_compile(
+    opts: Option<NapiModuleCompileOptions>,
+) -> napi::Result<ModuleCompileOptions> {
+    match opts {
+        Some(o) => o.into_module_compile_options(),
+        None => Ok(ModuleCompileOptions::default()),
+    }
 }
 
 /// Compile a Svelte module (.svelte.js/.svelte.ts).
@@ -488,7 +720,7 @@ pub fn napi_compile_module(
     source: String,
     options: Option<NapiModuleCompileOptions>,
 ) -> napi::Result<Value> {
-    let opts = options_to_module_compile(options);
+    let opts = options_to_module_compile(options)?;
     match rust_compile_module(&source, opts) {
         Ok(result) => {
             let js_obj = serde_json::json!({
@@ -646,7 +878,7 @@ pub fn napi_resolve_id(importer: Option<String>, specifier: String) -> napi::Res
 /// signature `preprocess(source, preprocessors, options?: { filename? })`.
 #[napi(object)]
 pub struct PreprocessOptions {
-    pub filename: Option<String>,
+    pub filename: Option<LenientScalar>,
 }
 
 /// Run rsvelte's preprocessor pipeline, bridging JS preprocessor
@@ -684,7 +916,10 @@ pub fn napi_preprocess(
     // values never cross the await boundary (they're not Send).
     let extracted = preprocess_bridge::extract_groups(groups)?;
     let rust_groups = preprocess_bridge::build_groups(extracted);
-    let filename = options.and_then(|o| o.filename);
+    let filename = match options.as_ref().and_then(|o| o.filename.as_ref()) {
+        Some(v) => Some(coerce_string("filename", v)?),
+        None => None,
+    };
 
     env.execute_tokio_future(
         async move {
@@ -1117,7 +1352,7 @@ pub fn napi_compile_buffers(
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<CompileBuffersResult> {
-    let opts = options_to_compile(options);
+    let opts = options_to_compile(options)?;
     match rust_compile(&source, opts) {
         Ok(result) => Ok(CompileBuffersResult {
             js: CompileBuffersJs {
@@ -1142,7 +1377,7 @@ pub fn napi_compile_module_buffers(
     source: String,
     options: Option<NapiModuleCompileOptions>,
 ) -> napi::Result<CompileBuffersResult> {
-    let opts = options_to_module_compile(options);
+    let opts = options_to_module_compile(options)?;
 
     match rust_compile_module(&source, opts) {
         Ok(result) => Ok(CompileBuffersResult {
@@ -1215,7 +1450,7 @@ pub fn napi_compile_envelope(
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<Buffer> {
-    let opts = options_to_compile(options);
+    let opts = options_to_compile(options)?;
     match rust_compile(&source, opts) {
         Ok(result) => {
             ensure_envelope_size(rsvelte_core::napi_raw::estimate_size(&result))?;
@@ -1328,7 +1563,7 @@ pub fn napi_compile_envelope_zero_copy(
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<JsBuffer> {
-    let opts = options_to_compile(options);
+    let opts = options_to_compile(options)?;
     let result = match rust_compile(&source, opts) {
         Ok(r) => r,
         Err(e) => return Err(napi::Error::from_reason(format!("{e:?}"))),
@@ -1343,7 +1578,7 @@ pub fn napi_compile_module_envelope_zero_copy(
     source: String,
     options: Option<NapiModuleCompileOptions>,
 ) -> napi::Result<JsBuffer> {
-    let opts = options_to_module_compile(options);
+    let opts = options_to_module_compile(options)?;
     let result = match rust_compile_module(&source, opts) {
         Ok(r) => r,
         Err(e) => return Err(napi::Error::from_reason(format!("{e:?}"))),
@@ -1366,7 +1601,7 @@ pub fn napi_compile_module_envelope(
     source: String,
     options: Option<NapiModuleCompileOptions>,
 ) -> napi::Result<Buffer> {
-    let opts = options_to_module_compile(options);
+    let opts = options_to_module_compile(options)?;
     match rust_compile_module(&source, opts) {
         Ok(result) => {
             // Adapt the module result into the same `CompileResult` shape
@@ -1421,8 +1656,8 @@ pub fn napi_compile_batch(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer
     // rayon stage focused on the actual compile.
     let parsed: Vec<(String, rsvelte_core::compiler::CompileOptions)> = inputs
         .into_iter()
-        .map(|item| (item.source, options_to_compile(item.options)))
-        .collect();
+        .map(|item| Ok((item.source, options_to_compile(item.options)?)))
+        .collect::<napi::Result<_>>()?;
 
     // Compile in parallel. `compile_batch` takes `&[(&str, CompileOptions)]`,
     // so we materialise the borrowed view once.
@@ -1514,11 +1749,11 @@ impl Task for CompileEnvelopeTask {
 pub fn napi_compile_envelope_async(
     source: String,
     options: Option<NapiCompileOptions>,
-) -> AsyncTask<CompileEnvelopeTask> {
-    AsyncTask::new(CompileEnvelopeTask {
+) -> napi::Result<AsyncTask<CompileEnvelopeTask>> {
+    Ok(AsyncTask::new(CompileEnvelopeTask {
         source,
-        options: options_to_compile(options),
-    })
+        options: options_to_compile(options)?,
+    }))
 }
 
 /// Async variant of `compileBatch` — same `compile_batch` (rayon
@@ -1565,10 +1800,12 @@ impl Task for CompileBatchTask {
 }
 
 #[napi(js_name = "compileBatchAsync")]
-pub fn napi_compile_batch_async(inputs: Vec<CompileBatchInput>) -> AsyncTask<CompileBatchTask> {
+pub fn napi_compile_batch_async(
+    inputs: Vec<CompileBatchInput>,
+) -> napi::Result<AsyncTask<CompileBatchTask>> {
     let parsed: Vec<(String, CompileOptions)> = inputs
         .into_iter()
-        .map(|item| (item.source, options_to_compile(item.options)))
-        .collect();
-    AsyncTask::new(CompileBatchTask { inputs: parsed })
+        .map(|item| Ok((item.source, options_to_compile(item.options)?)))
+        .collect::<napi::Result<_>>()?;
+    Ok(AsyncTask::new(CompileBatchTask { inputs: parsed }))
 }

--- a/scripts/dev/test-vps-shim.mjs
+++ b/scripts/dev/test-vps-shim.mjs
@@ -124,5 +124,61 @@ assert(
 	`${decodedAst?.type} vs ${parsedAst?.type}`,
 );
 
+// 8. Lenient compiler options — `runes` accepts any JS value (mirroring the
+//    upstream `parametric` validator, so tooling passing `null`/`undefined`/a
+//    number never crashes the compile), and a wrong-typed option is rejected
+//    with the upstream "Invalid compiler option" message rather than a raw
+//    N-API "Failed to convert napi value" error.
+const runesSrc = '<h1>{name}</h1>';
+for (const [runes, expected] of [
+	[true, true],
+	[false, false],
+	[1, true],
+	['true', true],
+	[null, false],
+	[undefined, false],
+]) {
+	let ok = true;
+	let meta;
+	try {
+		meta = r.compile(runesSrc, { filename: 'A.svelte', generate: 'client', runes })?.metadata
+			?.runes;
+	} catch {
+		ok = false;
+	}
+	assert(
+		`compile() accepts runes=${JSON.stringify(runes)} (runes mode ${expected})`,
+		ok && meta === expected,
+		`ok=${ok} meta=${JSON.stringify(meta)}`,
+	);
+}
+
+function compileError(options) {
+	try {
+		r.compile('<h1>x</h1>', { filename: 'A.svelte', generate: 'client', ...options });
+		return null;
+	} catch (e) {
+		return e.message;
+	}
+}
+for (const [label, options, needle] of [
+	['dev', { dev: 1 }, 'dev should be true or false'],
+	['namespace', { namespace: 2 }, 'namespace should be one of'],
+	['css', { css: 3 }, 'css should be either'],
+	['experimental.async', { experimental: { async: 1 } }, 'experimental.async should be true or false'],
+	[
+		'compatibility.componentApi',
+		{ compatibility: { componentApi: '4' } },
+		'componentApi should be either',
+	],
+]) {
+	const msg = compileError(options);
+	assert(
+		`compile() rejects invalid ${label} with the upstream message`,
+		msg != null && msg.startsWith('Invalid compiler option') && msg.includes(needle),
+		msg,
+	);
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail > 0 ? 1 : 0);

--- a/scripts/dev/test-vps-shim.mjs
+++ b/scripts/dev/test-vps-shim.mjs
@@ -137,6 +137,10 @@ for (const [runes, expected] of [
 	['true', true],
 	[null, false],
 	[undefined, false],
+	// Non-finite numbers must not crash the serde bridge: NaN is falsy
+	// (auto-detect -> legacy for this rune-free source), Infinity is truthy.
+	[NaN, false],
+	[Infinity, true],
 ]) {
 	let ok = true;
 	let meta;
@@ -163,6 +167,8 @@ function compileError(options) {
 }
 for (const [label, options, needle] of [
 	['dev', { dev: 1 }, 'dev should be true or false'],
+	['dev (NaN)', { dev: NaN }, 'dev should be true or false'],
+	['name (Infinity)', { name: Infinity }, 'name should be a string'],
 	['namespace', { namespace: 2 }, 'namespace should be one of'],
 	['css', { css: 3 }, 'css should be either'],
 	['experimental.async', { experimental: { async: 1 } }, 'experimental.async should be true or false'],

--- a/scripts/dev/test-vps-shim.mjs
+++ b/scripts/dev/test-vps-shim.mjs
@@ -165,6 +165,30 @@ function compileError(options) {
 		return e.message;
 	}
 }
+
+// A self-referential object must not crash the process while decoding — it is
+// rejected (or ignored) like any other non-scalar, never followed into a cycle.
+const circular = {};
+circular.self = circular;
+// Reaching this line at all proves no fatal crash occurred; throwing a normal
+// error is an acceptable outcome, a process abort is not.
+const survives = (options) => {
+	try {
+		r.compile('<h1>x</h1>', { filename: 'A.svelte', generate: 'client', ...options });
+	} catch {
+		/* a normal thrown error is fine */
+	}
+	return true;
+};
+assert(
+	'compile() rejects a circular object option without crashing',
+	compileError({ dev: circular }) != null,
+);
+assert('compile() survives a circular experimental option', survives({ experimental: circular }));
+assert(
+	'compile() survives a nested circular option',
+	survives({ experimental: { async: circular } }),
+);
 for (const [label, options, needle] of [
 	['dev', { dev: 1 }, 'dev should be true or false'],
 	['dev (NaN)', { dev: NaN }, 'dev should be true or false'],


### PR DESCRIPTION
## Problem

Reported in #1656: under Bun, prebundling a dependency's `.svelte` file through `@rsvelte/vite-plugin-svelte-native` crashed with

```
RolldownError: Failed to convert napi value into rust type `bool` on NapiCompileOptions.runes
```

**Root cause — not a Bun bug.** rsvelte's N-API option decoding was stricter than the official compiler. `svelte/compiler` models `runes` as a `parametric` validator that accepts *any* JS value (`null`, a number, a string, or a `(opts) => boolean` function) and never rejects it. rsvelte typed it as `Option<bool>`, so napi-rs hard-failed on any non-boolean, non-`undefined` value. This reproduces on **both Node and Bun** — e.g. `runes: null` / `runes: 1` / `runes: "true"` all threw the exact error above, while the official compiler accepts them. (Current Bun 1.3.11 handles `undefined` identically to Node; older Bun additionally mishandled explicit `undefined`, cf. oven-sh/bun#26388, which the lenient decode also immunises against.)

The same class of failure affected every typed option field, and non-finite numbers (`NaN`/`Infinity`) additionally aborted with `Failed to convert js number to serde_json::Number`.

## Fix

Every option on the `compile` / `compileModule` / `parse` / `preprocess` surface is now read through a small `LenientScalar` decoder (typeof-based, so non-finite numbers and functions never abort the decode) and coerced exactly the way the upstream `validate-options.js` does:

- **`runes`** accepts any value: truthy → runes on, real `false` → legacy, `undefined`/`null`/absent → auto-detect.
- **Every other option**: an absent/`undefined` value keeps its default; a genuinely wrong-typed value is rejected with the upstream message (`Invalid compiler option: dev should be true or false, if specified`, etc.) instead of a raw N-API conversion error.
- Decoding is **capped at depth 1** (option consumers only read direct children), so a self-referential option object (`o.self = o`) is rejected or ignored like any other non-scalar instead of driving an unbounded decode that would abort the process with a V8 fatal error.

## Behaviour vs. the official compiler (`svelte.compile` 5.56.4)

| input | official | rsvelte (after) |
|---|---|---|
| `runes: null` / `undefined` | OK (auto) | OK (auto) |
| `runes: 1` / `"true"` / `Infinity` | OK (runes on) | OK (runes on) |
| `runes: false` | OK (legacy) | OK (legacy) |
| `runes: NaN` | OK (legacy/auto) | OK (auto) |
| `dev: 1` / `null` / `NaN` | throw | throw (`dev should be true or false, if specified`) |
| `namespace: 2` | throw | throw (`namespace should be one of …`) |
| `css: true` / `3` | throw | throw (removed-boolean / `external`\|`injected`) |
| `experimental: "x"` / `[1]` | throw | throw (`experimental should be an object`) |
| `experimental: { async: NaN }` | throw | throw (`experimental.async should be true or false`) |
| `compatibility: { componentApi: "4" }` | throw | throw; `4` (number) → OK |

Success/throw matches the official compiler on all 29 cross-checked cases, including the exact #1656 prebundle option shape.

## Accepted, N-API-imposed differences

1. **`runes` falsy-but-not-`false`** (`0`/`""`/`NaN`): `Option<bool>` cannot encode "falsy but not `=== false`", so these auto-detect. Only a real `false` maps to `Some(false)`, which is deliberate — it's what mirrors upstream's strict `runes === false` legacy paths without misfiring them for values upstream never compares that way.
2. **Function-valued parametric options** (`runes` / `customElement` / `css`): the Rust core cannot call back into JS, so a function `runes` auto-detects and a function `customElement`/`css` is rejected. (Pre-existing limitation; previously a hard crash.)
3. **`css: "none"`**: reported with the generic `external`/`injected` message rather than upstream's dedicated "none" wording.
4. **`metadata.runes`** is always a real boolean; upstream leaks the raw truthy value (e.g. `1`, `"true"`) — rsvelte's value matches upstream's own declared type.

## Verification

- Node v24.13.1 and Bun 1.3.11: `runes: null/1/"true"/NaN/Infinity` all succeed; every wrong-typed field yields a clean `Invalid compiler option: …`.
- Oracle comparison vs `svelte/compiler` 5.56.4: success/throw parity on all cross-checked cases.
- Circular-reference options (top-level, `experimental`, nested, and mutual `a.b=b; b.a=a` cycles) throw a normal error or are ignored — the process never crashes — on both Node and Bun.
- `scripts/dev/test-vps-shim.mjs`: **33 passed, 0 failed** on both Node and Bun (adds runes coercion + clean-error + `NaN`/`Infinity` + circular-reference cases); `test-envelope-validation.mjs` passes; `cargo clippy --all-targets --all-features -D warnings` clean; `cargo fmt` applied.

Closes #1656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkdyAsXFK8cCX6X3CpAHWd
