### PR TITLE
docs(readme): document plain-Vite and SvelteKit setups for vite-plugin-svelte

### DIFF
--- a/.changeset/docs-vite-plugin-svelte-readme.md
+++ b/.changeset/docs-vite-plugin-svelte-readme.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/vite-plugin-svelte": patch
+---
+
+docs(readme): document both plain-Vite and SvelteKit setups
+
+The README only covered direct `svelte()` import in a plain Vite config, with no
+guidance for SvelteKit — where the Svelte plugin is loaded from inside
+`@sveltejs/kit` and must be swapped via a package-manager override
+(`npm:@rsvelte/vite-plugin-svelte`) rather than added to `vite.config`. Reworked
+into an (A) plain Vite / (B) SvelteKit split with pnpm/npm/yarn override examples
+and a "don't do this" note against registering two Svelte plugins.

--- a/apps/npm/vite-plugin-svelte/README.md
+++ b/apps/npm/vite-plugin-svelte/README.md
@@ -5,13 +5,27 @@ by the Rust [rsvelte](https://github.com/baseballyama/rsvelte) compiler. It is a
 fork of the official [`@sveltejs/vite-plugin-svelte`](https://github.com/sveltejs/vite-plugin-svelte)
 whose compile / preprocess / HMR calls route through the rsvelte compiler (via
 [`@rsvelte/vite-plugin-svelte-native`](https://www.npmjs.com/package/@rsvelte/vite-plugin-svelte-native))
-instead of `svelte/compiler`, so you can build a Vite or SvelteKit app on the
-Rust toolchain with the same plugin surface.
+instead of `svelte/compiler` — a drop-in replacement with the same plugin surface.
 
-> **⚠️ Early stage.** A drop-in replacement for `@sveltejs/vite-plugin-svelte`,
-> but treat it as experimental. Supports Vite 6, 7 and 8.
+> **⚠️ Early stage.** Treat it as experimental.
 
-## Install
+The Rust compiler ships as a native binding via `optionalDependencies` and is
+resolved automatically for your platform.
+
+**Compatibility:** Svelte `^5.0.0`, Vite `6.3+`, `7`, or `8`.
+
+## Which setup are you using?
+
+| Setup | How to wire it up |
+| --- | --- |
+| **Plain Vite + Svelte** — you call `svelte()` yourself in `vite.config` | [(A) Import the plugin directly](#a-plain-vite--svelte) |
+| **SvelteKit** — your `vite.config` only has `sveltekit()` | [(B) Alias it with a package-manager override](#b-sveltekit) |
+
+If you are on SvelteKit, do **not** add `svelte()` to your plugins list — see (B).
+
+## (A) Plain Vite + Svelte
+
+Install the plugin:
 
 ```bash
 npm install -D @rsvelte/vite-plugin-svelte
@@ -19,10 +33,7 @@ npm install -D @rsvelte/vite-plugin-svelte
 # yarn add -D @rsvelte/vite-plugin-svelte
 ```
 
-The Rust compiler is pulled in as a native binding via `optionalDependencies`,
-resolved automatically for your platform.
-
-## Usage
+Add it to your Vite config:
 
 ```js
 // vite.config.js
@@ -38,7 +49,7 @@ export default defineConfig({
 });
 ```
 
-The plugin exposes the same API as the official plugin, including
+The package exposes the same API as the official plugin, including
 `vitePreprocess` and `loadSvelteConfig`:
 
 ```js
@@ -52,6 +63,65 @@ export default {
   ]
 };
 ```
+
+## (B) SvelteKit
+
+In a SvelteKit app your `vite.config` only lists `sveltekit()`, and the Svelte
+plugin is loaded **from inside `@sveltejs/kit`** under the package name
+`@sveltejs/vite-plugin-svelte` — it never appears in your config. So the way to
+swap in rsvelte is to redirect that package's module resolution with a
+package-manager override (alias), not to touch `vite.config` at all.
+
+Add the override to your `package.json`, then reinstall:
+
+```jsonc
+// pnpm
+{
+  "pnpm": {
+    "overrides": {
+      "@sveltejs/vite-plugin-svelte": "npm:@rsvelte/vite-plugin-svelte@^0.4.1"
+    }
+  }
+}
+```
+
+```jsonc
+// npm
+{
+  "overrides": {
+    "@sveltejs/vite-plugin-svelte": "npm:@rsvelte/vite-plugin-svelte@^0.4.1"
+  }
+}
+```
+
+```jsonc
+// yarn (v1 and Berry)
+{
+  "resolutions": {
+    "@sveltejs/vite-plugin-svelte": "npm:@rsvelte/vite-plugin-svelte@^0.4.1"
+  }
+}
+```
+
+Because the override targets the package name, it also redirects the
+`import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'` in your
+`svelte.config.js` to the rsvelte version — no change needed there either.
+
+### Don't do this
+
+```js
+// vite.config.js — ❌ WRONG
+import { sveltekit } from '@sveltejs/kit/vite';
+import { svelte } from '@rsvelte/vite-plugin-svelte';
+
+export default {
+  plugins: [sveltekit(), svelte()] // two Svelte plugins → double compilation
+};
+```
+
+`sveltekit()` already loads the Svelte plugin internally. Adding `svelte()`
+alongside it registers a second one, so every component compiles twice. Use the
+override in (B) instead.
 
 ## Documentation
 


### PR DESCRIPTION
## What

Rewrites `apps/npm/vite-plugin-svelte/README.md` so both supported setups are covered up front.

Previously the README only showed the plain-Vite path (`import { svelte } from '@rsvelte/vite-plugin-svelte'` in `vite.config`), despite the intro claiming you can build a **Vite or SvelteKit** app on the Rust toolchain. SvelteKit users had no guidance — and it's genuinely non-obvious, since in SvelteKit the Svelte plugin is loaded *from inside* `@sveltejs/kit` (under the package name `@sveltejs/vite-plugin-svelte`) and never appears in the user's config. The correct swap is a package-manager override/alias, not adding `svelte()` to the plugins list.

## Changes

- **"Which setup are you using?" quick table** at the top routing to (A) or (B).
- **(A) Plain Vite + Svelte** — the existing direct-import usage, plus `vitePreprocess`.
- **(B) SvelteKit** — explains *why* an override is needed (2–3 sentences), with pnpm `overrides` / npm `overrides` / yarn `resolutions` examples aliasing `@sveltejs/vite-plugin-svelte` → `npm:@rsvelte/vite-plugin-svelte`, a note that this also redirects `vitePreprocess` in `svelte.config.js`, and a **"Don't do this"** block against `plugins: [sveltekit(), svelte()]` (double compilation).
- Compatibility line made explicit (Svelte 5, Vite 6.3+/7/8).
- Kept the fork explanation, early-stage note, upstream docs links, and License.

README is 135 lines. Override examples match the working config in `baseballyama/blog`.

## Changeset

Included a `patch` changeset for `@rsvelte/vite-plugin-svelte`. The npm README only refreshes on publish, so a version bump is needed for the new docs to reach npm — following the precedent of #1196 (README-only change, patch changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)