### PR TITLE
chore(fmt): harden Tailwind JS sidecar (probe deferral, wait, protocol tests)

### DIFF
--- a/apps/npm/fmt/lib/tailwind-sort.mjs
+++ b/apps/npm/fmt/lib/tailwind-sort.mjs
@@ -16,11 +16,16 @@
 // plugin or a broken config degrades to unsorted output, never a crash.
 
 // Guard the JSON channel: the plugin or `tailwindcss` may print to stdout (a
-// deprecation notice, a debug line), which would corrupt our single-line
-// response. Route all stray stdout to stderr and emit only the final JSON on the
-// real stdout.
+// deprecation notice, a debug line), which would corrupt our response. Route all
+// stray stdout to stderr and emit only the framed JSON on the real stdout.
 const realStdoutWrite = process.stdout.write.bind(process.stdout);
 process.stdout.write = process.stderr.write.bind(process.stderr);
+
+// A native addon (e.g. the Tailwind v4 oxide binary) can write straight to fd 1,
+// bypassing the patch above. Framing the response between markers lets the Rust
+// side extract only the payload and discard such stray bytes. Kept byte-identical
+// to `RESP_MARKER` in `tailwind_sidecar.rs`.
+const RESP_MARKER = '\x00<<rsvelte-tw-sort>>\x00';
 
 function readStdin() {
 	return new Promise((resolve) => {
@@ -69,7 +74,7 @@ async function main() {
 }
 
 function emit(result) {
-	realStdoutWrite(JSON.stringify(result));
+	realStdoutWrite(RESP_MARKER + JSON.stringify(result) + RESP_MARKER);
 }
 
 main()

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -750,7 +750,11 @@ fn resolve_js_class_sorter(
 fn js_sort_env() -> Option<tailwind_sidecar::SidecarEnv> {
     let script = tailwind_sidecar_script()?;
     let node = oxfmt_node().unwrap_or_else(|| PathBuf::from("node"));
-    node_runnable(&node).then_some(tailwind_sidecar::SidecarEnv { node, script })
+    node_runnable(&node).then_some(tailwind_sidecar::SidecarEnv {
+        node,
+        script,
+        timeout: tailwind_sidecar::DEFAULT_TIMEOUT,
+    })
 }
 
 /// Whether `node --version` runs — so a missing Node yields a Node-specific

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -588,18 +588,14 @@ fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> (FormatOptions, Option<
     // `prettier-plugin-tailwindcss` (see `PendingJsSort`); the sort itself is
     // resolved later, once every class string across the run is collected. With
     // no Node available we warn and leave classes unchanged. The Node probe runs
-    // only when `sortTailwindcss` is actually configured, never on the hot path.
-    let want_tailwind = matches!(
-        &cfg.sort_tailwindcss,
-        Some(v) if v != &serde_json::Value::Bool(false)
-    );
-    let js_env = want_tailwind.then(js_sort_env).flatten();
-    let js_available = js_env.is_some();
-    let (class_sorter, class_attributes, pending_js) = match tailwind::decide(
-        cfg.sort_tailwindcss.as_ref(),
-        cfg.path.as_deref(),
-        js_available,
-    ) {
+    // lazily — only if `decide` reaches a JS branch — so a stock config never
+    // spawns `node --version`; the probed env is captured for the `SortViaJs` arm.
+    let mut js_env: Option<tailwind_sidecar::SidecarEnv> = None;
+    let decision = tailwind::decide(cfg.sort_tailwindcss.as_ref(), cfg.path.as_deref(), || {
+        js_env = js_sort_env();
+        js_env.is_some()
+    });
+    let (class_sorter, class_attributes, pending_js) = match decision {
         tailwind::Decision::Sort { sorter, attributes } => (Some(sorter), attributes, None),
         tailwind::Decision::SortViaJs {
             filepath,
@@ -612,7 +608,7 @@ fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> (FormatOptions, Option<
             None,
             attributes,
             Some(PendingJsSort {
-                env: js_env.expect("js_available implies an env"),
+                env: js_env.expect("the js probe set an env when it returned SortViaJs"),
                 filepath,
                 stylesheet_path,
                 config_path,

--- a/crates/rsvelte_fmt/src/tailwind.rs
+++ b/crates/rsvelte_fmt/src/tailwind.rs
@@ -71,13 +71,14 @@ enum Class {
 
 /// Decide how to handle `sortTailwindcss` for a config. `config_path` is the
 /// `.oxfmtrc` path, used to resolve relative stylesheet paths and to look for a
-/// sibling v3 JS config. `js_available` is whether a Node sidecar can run; when
-/// `false`, cases that need JS fall back to warn+skip (or native for a stock
-/// config under `strategy: "js"`).
+/// sibling v3 JS config. `js_available` probes whether a Node sidecar can run;
+/// it is called *only* when a branch actually needs JS, so a stock config never
+/// pays for the Node probe. When it reports `false`, cases that need JS fall
+/// back to warn+skip (or native for a stock config under `strategy: "js"`).
 pub fn decide(
     sort_tailwindcss: Option<&serde_json::Value>,
     config_path: Option<&Path>,
-    js_available: bool,
+    js_available: impl FnOnce() -> bool,
 ) -> Decision {
     let Some(value) = sort_tailwindcss else {
         return Decision::Off;
@@ -130,7 +131,7 @@ pub fn decide(
         ),
 
         (Strategy::Js, Class::Default { stylesheet }) => {
-            if js_available {
+            if js_available() {
                 Decision::SortViaJs {
                     filepath,
                     stylesheet_path: Some(stylesheet),
@@ -172,7 +173,7 @@ fn native_sort(attributes: Vec<String>) -> Decision {
 
 #[allow(clippy::too_many_arguments)]
 fn sort_via_js_or_skip(
-    js_available: bool,
+    js_available: impl FnOnce() -> bool,
     filepath: PathBuf,
     stylesheet_path: Option<PathBuf>,
     config_path: Option<PathBuf>,
@@ -181,7 +182,7 @@ fn sort_via_js_or_skip(
     preserve_duplicates: bool,
     detect_reason: String,
 ) -> Decision {
-    if js_available {
+    if js_available() {
         Decision::SortViaJs {
             filepath,
             stylesheet_path,

--- a/crates/rsvelte_fmt/src/tailwind_sidecar.rs
+++ b/crates/rsvelte_fmt/src/tailwind_sidecar.rs
@@ -12,14 +12,23 @@ use std::time::{Duration, Instant};
 /// Upper bound on how long the sidecar may run before it's killed and the run
 /// falls back to unsorted classes — a hung Node / plugin must never block the
 /// whole formatter.
-const TIMEOUT: Duration = Duration::from_secs(30);
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL: Duration = Duration::from_millis(10);
+
+/// The sidecar frames its JSON response between these markers, so a native addon
+/// (e.g. the Tailwind v4 oxide binary) writing straight to fd 1 — bypassing the
+/// script's `process.stdout.write` guard — can't corrupt the channel: the Rust
+/// side extracts only the framed payload and discards any stray bytes. Kept
+/// byte-identical to the `RESP_MARKER` in `tailwind-sort.mjs`.
+const RESP_MARKER: &[u8] = b"\x00<<rsvelte-tw-sort>>\x00";
 
 /// Node interpreter + `tailwind-sort.mjs` script. `None` at the call site
 /// disables the JS path, so a custom config falls back to warn+skip.
 pub struct SidecarEnv {
     pub node: PathBuf,
     pub script: PathBuf,
+    /// Overridable so tests can exercise the timeout path without a 30s wait.
+    pub timeout: Duration,
 }
 
 /// A single batch sort request; all class strings for one `rsvelte-fmt` run are
@@ -59,22 +68,33 @@ pub fn sort(env: &SidecarEnv, req: &SortRequest) -> Option<Vec<String>> {
         .stderr(Stdio::null())
         .spawn()
         .ok()?;
-    // Dropping the moved-out stdin at the end of the statement closes the pipe,
-    // signalling EOF to the sidecar's `readStdin`. The child writes stdout only
-    // after that EOF, so writing here can't deadlock against an unread stdout.
-    child.stdin.take()?.write_all(&body).ok()?;
 
-    // Drain stdout on a thread while polling `try_wait` with a deadline, so a
-    // hung child is killed instead of blocking forever.
-    let mut stdout = child.stdout.take()?;
+    // Any early exit past this point must reap the child, so a broken pipe or a
+    // missing pipe handle never leaves a zombie behind.
+    let (Some(mut stdin), Some(mut stdout)) = (child.stdin.take(), child.stdout.take()) else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return None;
+    };
+
+    // Feed stdin on its own thread and drain stdout on another, concurrently, so
+    // a child that writes a large burst to stdout before reading all of stdin
+    // (e.g. a native addon printing straight to fd 1) can't deadlock our write.
+    // Dropping the stdin handle at the end of the closure closes the pipe,
+    // signalling EOF to the sidecar's `readStdin`.
+    let writer = std::thread::spawn(move || {
+        let _ = stdin.write_all(&body);
+    });
     let reader = std::thread::spawn(move || {
         let mut buf = Vec::new();
         let _ = stdout.read_to_end(&mut buf);
         buf
     });
-    let deadline = Instant::now() + TIMEOUT;
+
+    let deadline = Instant::now() + env.timeout;
     let status = loop {
         match child.try_wait() {
+            // `try_wait`/`wait` reap the child, so no explicit reap is needed here.
             Ok(Some(status)) => break Some(status),
             Ok(None) if Instant::now() >= deadline => {
                 let _ = child.kill();
@@ -82,15 +102,21 @@ pub fn sort(env: &SidecarEnv, req: &SortRequest) -> Option<Vec<String>> {
                 break None;
             }
             Ok(None) => std::thread::sleep(POLL),
-            Err(_) => break None,
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
         }
     };
-    let stdout = reader.join().ok()?;
+    let _ = writer.join();
+    let stdout = reader.join().unwrap_or_default();
     if !status?.success() {
         return None;
     }
 
-    let resp: serde_json::Value = serde_json::from_slice(&stdout).ok()?;
+    let payload = extract_framed(&stdout)?;
+    let resp: serde_json::Value = serde_json::from_slice(payload).ok()?;
     if resp.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
         return None;
     }
@@ -102,4 +128,19 @@ pub fn sort(env: &SidecarEnv, req: &SortRequest) -> Option<Vec<String>> {
         .collect();
     let sorted = sorted?;
     (sorted.len() == req.classes.len()).then_some(sorted)
+}
+
+/// Extract the JSON payload framed by [`RESP_MARKER`] from the sidecar's raw
+/// stdout, discarding any stray bytes before, after, or (defensively) around it.
+/// `None` when the frame is absent, so a truncated / corrupt response falls back
+/// like any other sidecar miss.
+fn extract_framed(buf: &[u8]) -> Option<&[u8]> {
+    let start = find_subslice(buf, RESP_MARKER)? + RESP_MARKER.len();
+    let rest = &buf[start..];
+    let end = find_subslice(rest, RESP_MARKER)?;
+    Some(&rest[..end])
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
 }

--- a/crates/rsvelte_fmt/src/tailwind_sidecar.rs
+++ b/crates/rsvelte_fmt/src/tailwind_sidecar.rs
@@ -144,3 +144,169 @@ fn extract_framed(buf: &[u8]) -> Option<&[u8]> {
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack.windows(needle.len()).position(|w| w == needle)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[test]
+    fn extract_framed_picks_payload_out_of_noise() {
+        let mut buf = b"stray oxide banner\n".to_vec();
+        buf.extend_from_slice(RESP_MARKER);
+        buf.extend_from_slice(br#"{"ok":true}"#);
+        buf.extend_from_slice(RESP_MARKER);
+        buf.extend_from_slice(b"trailing junk");
+        assert_eq!(extract_framed(&buf), Some(&br#"{"ok":true}"#[..]));
+    }
+
+    #[test]
+    fn extract_framed_absent_marker_is_none() {
+        assert_eq!(extract_framed(b"no markers here"), None);
+        assert_eq!(extract_framed(RESP_MARKER), None); // only one marker
+    }
+
+    fn node() -> Option<PathBuf> {
+        let node = PathBuf::from("node");
+        Command::new(&node)
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+            .then_some(node)
+    }
+
+    /// Write `body` to a unique temp `.mjs` and build a `SidecarEnv` around it.
+    fn env_with_script(node: PathBuf, body: &str, timeout: Duration) -> (SidecarEnv, PathBuf) {
+        static N: AtomicU32 = AtomicU32::new(0);
+        let script = std::env::temp_dir().join(format!(
+            "rsvelte-tw-sidecar-test-{}-{}.mjs",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&script, body).unwrap();
+        (
+            SidecarEnv {
+                node,
+                script: script.clone(),
+                timeout,
+            },
+            script,
+        )
+    }
+
+    fn req(classes: &[&str]) -> Vec<String> {
+        classes.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Run `sort` against a fake sidecar `script_body`. `None` return means "no
+    /// Node — test skipped"; `Some(result)` is the actual `sort` outcome.
+    fn run(script_body: &str, timeout: Duration, classes: &[&str]) -> Option<Option<Vec<String>>> {
+        let node = node()?;
+        let (env, path) = env_with_script(node, script_body, timeout);
+        let request = SortRequest {
+            filepath: Path::new("/tmp/x.svelte"),
+            stylesheet_path: None,
+            config_path: None,
+            preserve_whitespace: false,
+            preserve_duplicates: false,
+            classes: req(classes),
+        };
+        let out = sort(&env, &request);
+        let _ = std::fs::remove_file(path);
+        Some(out)
+    }
+
+    /// Skip the enclosing test (via `return`) when Node is unavailable.
+    macro_rules! run_or_skip {
+        ($($arg:tt)*) => {
+            match run($($arg)*) {
+                Some(out) => out,
+                None => {
+                    eprintln!("[tw-sidecar] no node; skipping.");
+                    return;
+                }
+            }
+        };
+    }
+
+    const M: &str = "\x00<<rsvelte-tw-sort>>\x00";
+
+    fn responder(response_expr: &str) -> String {
+        format!(
+            "let d='';process.stdin.setEncoding('utf8');\
+             process.stdin.on('data',c=>d+=c);\
+             process.stdin.on('end',()=>{{const req=JSON.parse(d);\
+             process.stdout.write({response_expr});}});"
+        )
+    }
+
+    #[test]
+    fn ok_response_round_trips() {
+        // Echo the classes back framed — proves the framed happy path parses.
+        let body = responder(&format!(
+            "'{M}'+JSON.stringify({{ok:true,sorted:req.classes}})+'{M}'"
+        ));
+        let out = run_or_skip!(&body, DEFAULT_TIMEOUT, &["p-4", "m-2"]);
+        assert_eq!(out, Some(req(&["p-4", "m-2"])));
+    }
+
+    #[test]
+    fn stray_fd1_output_before_frame_is_tolerated() {
+        // A native addon printing straight to fd 1 must not corrupt the channel.
+        let body = responder(&format!(
+            "'oxide deprecation notice\\n'+'{M}'+JSON.stringify({{ok:true,sorted:req.classes}})+'{M}'"
+        ));
+        let out = run_or_skip!(&body, DEFAULT_TIMEOUT, &["flex", "p-4"]);
+        assert_eq!(out, Some(req(&["flex", "p-4"])));
+    }
+
+    #[test]
+    fn non_ok_response_falls_back() {
+        let body = responder(&format!(
+            "'{M}'+JSON.stringify({{ok:false,error:'boom'}})+'{M}'"
+        ));
+        let out = run_or_skip!(&body, DEFAULT_TIMEOUT, &["p-4"]);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn malformed_response_falls_back() {
+        // Framed but not JSON.
+        let framed_garbage = responder(&format!("'{M}'+'not json at all'+'{M}'"));
+        let out = run_or_skip!(&framed_garbage, DEFAULT_TIMEOUT, &["p-4"]);
+        assert_eq!(out, None);
+        // No frame markers at all.
+        let unframed = responder("'plain stdout, no markers'");
+        let out = run_or_skip!(&unframed, DEFAULT_TIMEOUT, &["p-4"]);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn length_mismatch_falls_back() {
+        let body = responder(&format!(
+            "'{M}'+JSON.stringify({{ok:true,sorted:['only-one']}})+'{M}'"
+        ));
+        let out = run_or_skip!(&body, DEFAULT_TIMEOUT, &["p-4", "m-2"]);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn hung_sidecar_times_out_and_falls_back() {
+        // Never reads stdin, never exits; the injected short timeout must kill it.
+        let start = Instant::now();
+        let out = run_or_skip!(
+            "setInterval(()=>{},100000);",
+            Duration::from_millis(300),
+            &["p-4", "m-2"]
+        );
+        assert_eq!(out, None);
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "timeout should fire promptly, took {:?}",
+            start.elapsed()
+        );
+    }
+}


### PR DESCRIPTION
## What

Non-blocking follow-ups from the #1668 review, hardening the `sortTailwindcss` Node sidecar without changing its output. Four items, one commit each.

### 1. perf — defer the Node probe until a JS sort is actually chosen
`sortTailwindcss` ran `node --version` (plus a sidecar stat) eagerly whenever the option was configured, so the common **stock-config** case — which sorts natively in Rust — paid that cost only for `decide` to fall back to the native sorter. `tailwind::decide` now takes `js_available` as a lazy `FnOnce`, invoked only when a branch truly needs the sidecar. A stock config never spawns Node; the probed env is captured for the `SortViaJs` arm.

### 2. robustness — decouple the JSON channel from the JS stdout monkey-patch
A native addon (e.g. the Tailwind v4 oxide binary) can write straight to fd 1, bypassing the script's `process.stdout.write` guard and corrupting the response. The sidecar now **frames** its JSON between markers and the Rust side extracts only the framed payload, discarding stray bytes. The stdout drain also no longer runs after the stdin write: stdin is fed on its own thread while stdout drains concurrently, so a large direct write can't deadlock `write_all`.

### 3. correctness — early returns now reap the child
Early exits in `sort()` (a missing pipe handle, a `try_wait` error) now `kill()` + `wait()` the child, so a broken pipe never leaves a zombie until the CLI exits.

### 4. test — timeout and protocol-corruption fallbacks
The sidecar timeout is now an injectable `SidecarEnv` field (default 30s). New unit tests drive `sort()` against fake Node scripts (skipped when Node is absent): a hung sidecar killed by a short injected timeout, malformed / framed-but-non-JSON / non-`ok` / length-mismatch responses, stray fd-1 output before the frame being tolerated, and pure-Rust `extract_framed` marker handling — no 30s waits.

## Verification
- `cargo test -p rsvelte_fmt -p rsvelte_formatter` green (one unrelated pre-existing daemon flake under parallel load, passes in isolation).
- New `tailwind_sidecar::tests` (8) all pass; real `tailwind-sort.mjs` verified to emit the framed response.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

Fixes #1683

🤖 Generated with [Claude Code](https://claude.com/claude-code)