### PR TITLE
fix(parse): emit FunctionDeclaration.expression like acorn

### DIFF
--- a/.changeset/fix-function-declaration-expression-field.md
+++ b/.changeset/fix-function-declaration-expression-field.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): emit `FunctionDeclaration.expression` (always `false`) to match acorn's key order (`id`, `expression`, `generator`, `async`, `params`, `body`)

--- a/.changeset/fix-function-declaration-expression-field.md
+++ b/.changeset/fix-function-declaration-expression-field.md
@@ -1,5 +1,12 @@
 ---
 "@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
 ---
 
 fix(parse): emit `FunctionDeclaration.expression` (always `false`) to match acorn's key order (`id`, `expression`, `generator`, `async`, `params`, `body`)
+
+The binary NAPI raw-parse envelope (`napi_raw_parse.rs`'s writer, consumed only
+by `@rsvelte/vite-plugin-svelte-native`'s `parse-envelope.js` decoder) carries
+the same field, so both packages need this release. The envelope's `VERSION`
+is bumped to 2 alongside the wire-format change (one extra bool byte on
+`FunctionDeclaration` payloads).

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -1170,6 +1170,7 @@ function readJsVariableDeclarator(ctx, start, end) {
 function readJsFunctionDeclaration(ctx, start, end) {
 	const loc = readTypedLoc(ctx);
 	const id = readOptNode(ctx);
+	const expression = readBool(ctx);
 	const generator = readBool(ctx);
 	const asyncFlag = readBool(ctx);
 	const params = readChildArray(ctx);
@@ -1177,6 +1178,7 @@ function readJsFunctionDeclaration(ctx, start, end) {
 	const node = { type: 'FunctionDeclaration', start, end };
 	if (loc !== null) node.loc = loc;
 	node.id = id;
+	node.expression = expression;
 	node.generator = generator;
 	node.async = asyncFlag;
 	node.params = params;

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -15,7 +15,9 @@
 const { isWindowOutOfBounds, windowOutOfBoundsMessage } = require('./lib/bounds-check.js');
 
 const MAGIC = 0x3156_5052; // "RPV1" little-endian
-const VERSION = 1;
+// Bumped for the `FunctionDeclaration.expression` bool byte added to the wire
+// format; keep in lockstep with `napi_raw_parse.rs`'s `VERSION`.
+const VERSION = 2;
 const HEADER_LEN = 24;
 
 // Tags — must mirror napi_raw_parse.rs.

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -403,6 +403,9 @@ pub enum JsNode {
         body: Option<JsNodeId>,
         generator: bool,
         r#async: bool,
+        // Always `false`: acorn only ever sets `expression: true` on arrow function
+        // bodies without a block; declarations always have a block body.
+        expression: bool,
     },
     ClassDeclaration {
         start: u32,
@@ -1497,6 +1500,7 @@ impl Serialize for JsNode {
                 body,
                 generator,
                 r#async,
+                expression,
             } => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "FunctionDeclaration")?;
@@ -1504,6 +1508,7 @@ impl Serialize for JsNode {
                 map.serialize_entry("end", end)?;
                 ser_loc!(map, loc);
                 ser_opt_node!(map, "id", id);
+                map.serialize_entry("expression", expression)?;
                 map.serialize_entry("generator", generator)?;
                 map.serialize_entry("async", r#async)?;
                 ser_children!(map, "params", params);
@@ -2653,6 +2658,7 @@ impl JsNode {
                         body: convert_optional_child(obj, "body"),
                         generator: get_bool(obj, "generator"),
                         r#async: get_bool(obj, "async"),
+                        expression: get_bool(obj, "expression"),
                     },
                     "ClassDeclaration" => JsNode::ClassDeclaration {
                         start,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -5808,6 +5808,7 @@ fn convert_statement(
                 body,
                 generator: func_decl.generator,
                 r#async: func_decl.r#async,
+                expression: false,
             })
         }
         // Fallback to the program-context converter for other statement types
@@ -6947,6 +6948,7 @@ fn convert_statement_for_program(
                         body: body_node,
                         generator: func_decl.generator,
                         r#async: func_decl.r#async,
+                        expression: false,
                     }
                 }
                 oxc_ast::ast::ExportDefaultDeclarationKind::ClassDeclaration(class_decl)
@@ -7711,6 +7713,7 @@ fn convert_function_declaration_as_node(
         body: body_node,
         generator: func_decl.generator,
         r#async: func_decl.r#async,
+        expression: false,
     })
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4905,6 +4905,7 @@ fn collect_identifier_names_in_node(
             body,
             generator: _,
             r#async: _,
+            expression: _,
         } => {
             walk_range(*params, out);
             walk_opt(body, out);

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -57,7 +57,9 @@ use crate::ast::template::*;
 use crate::ast::typed_expr::{JsNode, LiteralValue, Loc, RegexValue, TemplateElementValue};
 
 pub const MAGIC: u32 = 0x3156_5052; // "RPV1" little-endian
-pub const VERSION: u32 = 1;
+// Bumped for the `FunctionDeclaration.expression` bool byte added to the wire
+// format; keep in lockstep with `parse-envelope.js`'s `VERSION`.
+pub const VERSION: u32 = 2;
 pub const HEADER_LEN: usize = 24;
 
 // Header `flags` word (offset 20):

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -1681,10 +1681,12 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             body,
             generator,
             r#async,
+            expression,
         } => {
             write_preamble(w, JS_FUNCTION_DECLARATION, *start, *end);
             write_typed_loc(w, loc.as_deref());
             write_opt_node_id(w, *id, arena)?;
+            write_bool(w, *expression);
             write_bool(w, *generator);
             write_bool(w, *r#async);
             write_id_range(w, *params, arena)?;

--- a/scripts/dev/test-parse-envelope-validation.mjs
+++ b/scripts/dev/test-parse-envelope-validation.mjs
@@ -17,7 +17,7 @@ const { decodeParseEnvelope } = await import(
 ).then((m) => m.default ?? m);
 
 const MAGIC = 0x3156_5052; // "RPV1"
-const VERSION = 1;
+const VERSION = 2;
 const HEADER_LEN = 24;
 const TAG_JSON = 0x00;
 const JS_IDENTIFIER = 0x80;


### PR DESCRIPTION
## Summary
- `parse()` output for `FunctionDeclaration` nodes was missing the `expression` field that acorn (used by `svelte/compiler`) always emits as `false`. Verified against svelte/compiler 5.56.7 that the correct key order is `id, expression, generator, async, params, body` (acorn's `initFunction` sets `expression` right after `id`, before `generator`/`async`) — not simply appended at the end.
- Added the field to the `JsNode::FunctionDeclaration` variant and updated every place that serializes/constructs it: the serde `Serialize` impl (JSON parse output), the JSON round-trip deserializer, the binary NAPI raw-parse envelope writer (`napi_raw_parse.rs`), and its JS-side decoder (`parse-envelope.js`).
- Scope check requested by the issue: `FunctionExpression`/`ArrowFunctionExpression` already carry an `expression` field, but `FunctionExpression`'s current field order (`generator, async, expression`) doesn't match acorn's real order (`expression, generator, async` — same `initFunction` logic applies to it too). That's a pre-existing, separate divergence; not fixed here per the issue's requested scope (structural equality is unaffected since JSON comparisons in this repo's test suites are value-based, not key-order-based, but flagging it for a follow-up).

## Verification
- Manually parsed `function f() {}` with both svelte/compiler 5.56.7 (via the `submodules/svelte` checkout) and rsvelte; the `FunctionDeclaration` node now matches byte-for-byte (key set, order, and values).
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core --test parser_fixtures` — 17 passed, 0 failed.
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core --test compiler_fixtures --test compiler_errors --test svelte2tsx_fixtures --test compatibility_report` — all passed.
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core` (full crate suite) — 0 failed across all binaries.
- `cargo fmt` — no changes needed.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.

No existing fixture in `fixtures/eae50dfd1c22/{parser-modern,parser-legacy}` exercises a raw `FunctionDeclaration`/`FunctionExpression` node outside the `javascript-comments` fixture (which is skipped for an unrelated comment-attachment reason), which is why this shape gap wasn't caught by the existing suite — consistent with the issue being found via an external structural diff.

Fixes #1659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGrjrA4zeTQR75pPThFQFT