### PR TITLE
fix(parse): preserve TSFunctionType in convert_ts_type unions

### DIFF
--- a/.changeset/fix-ts-function-type-in-union.md
+++ b/.changeset/fix-ts-function-type-in-union.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): preserve `TSFunctionType` / `TSConstructorType` in `convert_ts_type` instead of collapsing them to a `TSUnknownKeyword` stub (e.g. inside a union like `string | (() => void)`)

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -2579,8 +2579,12 @@ fn convert_formal_parameter_inner(
                 obj.insert("name".to_string(), Value::String(name.to_string()));
 
                 // Convert type annotation
-                let type_ann_obj =
-                    convert_type_annotation_adjusted(type_ann, adjusted_offset, line_offsets);
+                let type_ann_obj = convert_type_annotation_adjusted(
+                    arena,
+                    type_ann,
+                    adjusted_offset,
+                    line_offsets,
+                );
                 obj.insert("typeAnnotation".to_string(), type_ann_obj);
 
                 Expression::from_json(Value::Object(obj))
@@ -2601,11 +2605,11 @@ fn convert_formal_parameter_inner(
             // parameter's source by this span — without it the explicit type and
             // its optionality are lost and the member is inferred as `any` /
             // required (#912).
-            attach_param_type_annotation(expr, param, adjusted_offset, line_offsets)
+            attach_param_type_annotation(arena, expr, param, adjusted_offset, line_offsets)
         }
         BindingPattern::ArrayPattern(arr_pat) => {
             let expr = convert_array_pattern_to_expr(arena, arr_pat, adjusted_offset, line_offsets);
-            attach_param_type_annotation(expr, param, adjusted_offset, line_offsets)
+            attach_param_type_annotation(arena, expr, param, adjusted_offset, line_offsets)
         }
         BindingPattern::AssignmentPattern(assign_pat) => {
             convert_assignment_pattern_to_expr(arena, assign_pat, adjusted_offset, line_offsets)
@@ -2640,6 +2644,7 @@ fn convert_formal_parameter_inner(
 /// spans use the same base, so callers needing original-source positions
 /// (e.g. the optional-marker remap path) still remap the top-level `end`.
 fn attach_param_type_annotation(
+    arena: &ParseArena,
     expr: Expression,
     param: &oxc_ast::ast::FormalParameter,
     adjusted_offset: usize,
@@ -2657,7 +2662,7 @@ fn attach_param_type_annotation(
             obj.insert("loc".to_string(), loc);
         }
         let type_ann_obj =
-            convert_type_annotation_adjusted(type_ann, adjusted_offset, line_offsets);
+            convert_type_annotation_adjusted(arena, type_ann, adjusted_offset, line_offsets);
         obj.insert("typeAnnotation".to_string(), type_ann_obj);
     }
     Expression::from_json(json)
@@ -3066,6 +3071,7 @@ fn convert_binding_pattern_for_param_as_node(
 
 /// Convert type annotation with pre-adjusted offset.
 fn convert_type_annotation_adjusted(
+    arena: &ParseArena,
     type_ann: &oxc_ast::ast::TSTypeAnnotation,
     adjusted_offset: usize,
     line_offsets: &[usize],
@@ -3085,8 +3091,12 @@ fn convert_type_annotation_adjusted(
     }
 
     // Convert the inner type
-    let inner_type =
-        convert_ts_type_adjusted(&type_ann.type_annotation, adjusted_offset, line_offsets);
+    let inner_type = convert_ts_type_adjusted(
+        arena,
+        &type_ann.type_annotation,
+        adjusted_offset,
+        line_offsets,
+    );
     obj.insert("typeAnnotation".to_string(), inner_type);
 
     Value::Object(obj)
@@ -3124,11 +3134,12 @@ fn ts_assertion_value(
 /// avoids churning the FunctionParameter / declarator call sites that already
 /// pass an `adjusted_offset`.
 fn convert_ts_type_adjusted(
+    arena: &ParseArena,
     ts_type: &oxc_ast::ast::TSType,
     adjusted_offset: usize,
     line_offsets: &[usize],
 ) -> Value {
-    convert_ts_type(ts_type, adjusted_offset, line_offsets)
+    convert_ts_type(arena, ts_type, adjusted_offset, line_offsets)
 }
 
 /// Convert TSTypeName with pre-adjusted offset.
@@ -3214,7 +3225,12 @@ fn convert_ts_type_name_adjusted(
 /// (`$props()` destructuring annotations) and the FunctionParameter / pattern
 /// path route through here so inline annotations no longer collapse to a
 /// members-less `TSUnknownKeyword` stub (#791).
-fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: &[usize]) -> Value {
+fn convert_ts_type(
+    arena: &ParseArena,
+    ts_type: &oxc_ast::ast::TSType,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Value {
     use oxc_ast::ast::TSType;
 
     let span = ts_type.span();
@@ -3278,7 +3294,7 @@ fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: 
             if let Some(args) = &type_ref.type_arguments {
                 obj.insert(
                     "typeArguments".to_string(),
-                    convert_ts_type_param_instantiation(args, offset, line_offsets),
+                    convert_ts_type_param_instantiation(arena, args, offset, line_offsets),
                 );
             }
             Value::Object(obj)
@@ -3290,7 +3306,7 @@ fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: 
             let members: Vec<Value> = lit
                 .members
                 .iter()
-                .map(|m| convert_ts_signature(m, offset, line_offsets))
+                .map(|m| convert_ts_signature(arena, m, offset, line_offsets))
                 .collect();
             obj.insert("members".to_string(), Value::Array(members));
             Value::Object(obj)
@@ -3302,7 +3318,7 @@ fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: 
             let types: Vec<Value> = u
                 .types
                 .iter()
-                .map(|t| convert_ts_type(t, offset, line_offsets))
+                .map(|t| convert_ts_type(arena, t, offset, line_offsets))
                 .collect();
             obj.insert("types".to_string(), Value::Array(types));
             Value::Object(obj)
@@ -3312,7 +3328,7 @@ fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: 
             let types: Vec<Value> = i
                 .types
                 .iter()
-                .map(|t| convert_ts_type(t, offset, line_offsets))
+                .map(|t| convert_ts_type(arena, t, offset, line_offsets))
                 .collect();
             obj.insert("types".to_string(), Value::Array(types));
             Value::Object(obj)
@@ -3323,7 +3339,7 @@ fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: 
             let mut obj = base("TSArrayType");
             obj.insert(
                 "elementType".to_string(),
-                convert_ts_type(&a.element_type, offset, line_offsets),
+                convert_ts_type(arena, &a.element_type, offset, line_offsets),
             );
             Value::Object(obj)
         }
@@ -3342,7 +3358,7 @@ fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: 
             let mut obj = base("TSParenthesizedType");
             obj.insert(
                 "typeAnnotation".to_string(),
-                convert_ts_type(&p.type_annotation, offset, line_offsets),
+                convert_ts_type(arena, &p.type_annotation, offset, line_offsets),
             );
             Value::Object(obj)
         }
@@ -3358,7 +3374,7 @@ fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: 
             obj.insert("operator".to_string(), Value::String(operator.to_string()));
             obj.insert(
                 "typeAnnotation".to_string(),
-                convert_ts_type(&op.type_annotation, offset, line_offsets),
+                convert_ts_type(arena, &op.type_annotation, offset, line_offsets),
             );
             Value::Object(obj)
         }
@@ -3366,11 +3382,79 @@ fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: 
             let mut obj = base("TSIndexedAccessType");
             obj.insert(
                 "objectType".to_string(),
-                convert_ts_type(&ia.object_type, offset, line_offsets),
+                convert_ts_type(arena, &ia.object_type, offset, line_offsets),
             );
             obj.insert(
                 "indexType".to_string(),
-                convert_ts_type(&ia.index_type, offset, line_offsets),
+                convert_ts_type(arena, &ia.index_type, offset, line_offsets),
+            );
+            Value::Object(obj)
+        }
+
+        // ---- function / constructor signature types -------------------------
+        // `(a: string) => void` / `new (a: string) => Foo`. Both share the same
+        // shape (generic type parameters, a flat `parameters` array with any
+        // `this` parameter prepended as a plain Identifier, and a `typeAnnotation`
+        // wrapping the return type) — svelte/compiler (acorn-typescript) keeps
+        // these as real nodes rather than collapsing them to `TSUnknownKeyword` (#1660).
+        TSType::TSFunctionType(f) => {
+            let mut obj = base("TSFunctionType");
+            if let Some(type_parameters) = &f.type_parameters {
+                obj.insert(
+                    "typeParameters".to_string(),
+                    convert_ts_type_parameter_declaration(
+                        arena,
+                        type_parameters,
+                        offset,
+                        line_offsets,
+                    ),
+                );
+            }
+            obj.insert(
+                "parameters".to_string(),
+                Value::Array(convert_ts_function_like_params(
+                    arena,
+                    f.this_param.as_deref(),
+                    &f.params,
+                    offset,
+                    line_offsets,
+                )),
+            );
+            obj.insert(
+                "typeAnnotation".to_string(),
+                convert_type_annotation_adjusted(arena, &f.return_type, offset, line_offsets),
+            );
+            Value::Object(obj)
+        }
+        TSType::TSConstructorType(c) => {
+            let mut obj = base("TSConstructorType");
+            // svelte/compiler always emits `abstract` (unlike `optional` / `readonly`
+            // elsewhere, which are omitted when false).
+            obj.insert("abstract".to_string(), Value::Bool(c.r#abstract));
+            if let Some(type_parameters) = &c.type_parameters {
+                obj.insert(
+                    "typeParameters".to_string(),
+                    convert_ts_type_parameter_declaration(
+                        arena,
+                        type_parameters,
+                        offset,
+                        line_offsets,
+                    ),
+                );
+            }
+            obj.insert(
+                "parameters".to_string(),
+                Value::Array(convert_ts_function_like_params(
+                    arena,
+                    None,
+                    &c.params,
+                    offset,
+                    line_offsets,
+                )),
+            );
+            obj.insert(
+                "typeAnnotation".to_string(),
+                convert_type_annotation_adjusted(arena, &c.return_type, offset, line_offsets),
             );
             Value::Object(obj)
         }
@@ -3382,10 +3466,149 @@ fn convert_ts_type(ts_type: &oxc_ast::ast::TSType, offset: usize, line_offsets: 
     }
 }
 
+/// Convert a `TSTypeParameterDeclaration` (`<T, U extends V = W>`) into
+/// svelte/compiler's shape: `{ type: 'TSTypeParameterDeclaration', params }`,
+/// each param `{ type: 'TSTypeParameter', name: <string>, constraint?, default? }`.
+/// acorn-typescript stores `name` as a plain string (not an `Identifier` node)
+/// and omits `constraint`/`default` when absent.
+fn convert_ts_type_parameter_declaration(
+    arena: &ParseArena,
+    decl: &oxc_ast::ast::TSTypeParameterDeclaration,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Value {
+    let start = offset + decl.span.start as usize;
+    let end = offset + decl.span.end as usize;
+    let mut obj = Map::new();
+    obj.insert(
+        "type".to_string(),
+        Value::String("TSTypeParameterDeclaration".to_string()),
+    );
+    obj.insert("start".to_string(), Value::Number((start as i64).into()));
+    obj.insert("end".to_string(), Value::Number((end as i64).into()));
+    if let Some(loc) = create_loc(start, end, line_offsets) {
+        obj.insert("loc".to_string(), loc);
+    }
+    let params: Vec<Value> = decl
+        .params
+        .iter()
+        .map(|p| convert_ts_type_parameter(arena, p, offset, line_offsets))
+        .collect();
+    obj.insert("params".to_string(), Value::Array(params));
+    Value::Object(obj)
+}
+
+/// Convert a single `TSTypeParameter` (`T extends U = V`).
+fn convert_ts_type_parameter(
+    arena: &ParseArena,
+    param: &oxc_ast::ast::TSTypeParameter,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Value {
+    let start = offset + param.span.start as usize;
+    let end = offset + param.span.end as usize;
+    let mut obj = Map::new();
+    obj.insert(
+        "type".to_string(),
+        Value::String("TSTypeParameter".to_string()),
+    );
+    obj.insert("start".to_string(), Value::Number((start as i64).into()));
+    obj.insert("end".to_string(), Value::Number((end as i64).into()));
+    if let Some(loc) = create_loc(start, end, line_offsets) {
+        obj.insert("loc".to_string(), loc);
+    }
+    obj.insert(
+        "name".to_string(),
+        Value::String(param.name.name.to_string()),
+    );
+    if let Some(constraint) = &param.constraint {
+        obj.insert(
+            "constraint".to_string(),
+            convert_ts_type(arena, constraint, offset, line_offsets),
+        );
+    }
+    if let Some(default) = &param.default {
+        obj.insert(
+            "default".to_string(),
+            convert_ts_type(arena, default, offset, line_offsets),
+        );
+    }
+    Value::Object(obj)
+}
+
+/// Convert a `TSFunctionType` / `TSConstructorType` parameter list into
+/// svelte/compiler's flat `parameters` array. acorn-typescript parses `this: T`
+/// as an ordinary parameter pattern (not a distinct node), so a `this` param is
+/// prepended as a plain `Identifier` named `"this"`.
+fn convert_ts_function_like_params(
+    arena: &ParseArena,
+    this_param: Option<&oxc_ast::ast::TSThisParameter>,
+    params: &oxc_ast::ast::FormalParameters,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Vec<Value> {
+    let mut out = Vec::with_capacity(
+        this_param.is_some() as usize + params.items.len() + params.rest.is_some() as usize,
+    );
+
+    if let Some(this_param) = this_param {
+        let start = offset + this_param.span.start as usize;
+        let end = offset + this_param.span.end as usize;
+        let mut obj = Map::new();
+        obj.insert("type".to_string(), Value::String("Identifier".to_string()));
+        obj.insert("start".to_string(), Value::Number((start as i64).into()));
+        obj.insert("end".to_string(), Value::Number((end as i64).into()));
+        if let Some(loc) = create_loc(start, end, line_offsets) {
+            obj.insert("loc".to_string(), loc);
+        }
+        obj.insert("name".to_string(), Value::String("this".to_string()));
+        if let Some(type_ann) = &this_param.type_annotation {
+            obj.insert(
+                "typeAnnotation".to_string(),
+                convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
+            );
+        }
+        out.push(Value::Object(obj));
+    }
+
+    for param in &params.items {
+        out.push(
+            convert_formal_parameter(arena, param, offset, line_offsets)
+                .as_json()
+                .clone(),
+        );
+    }
+
+    if let Some(rest) = &params.rest {
+        let start = offset + rest.span.start as usize;
+        let end = offset + rest.span.end as usize;
+        let argument =
+            convert_binding_pattern_for_param(arena, &rest.rest.argument, offset, line_offsets);
+        let mut obj = Map::new();
+        obj.insert("type".to_string(), Value::String("RestElement".to_string()));
+        obj.insert("start".to_string(), Value::Number((start as i64).into()));
+        obj.insert("end".to_string(), Value::Number((end as i64).into()));
+        if let Some(loc) = create_loc(start, end, line_offsets) {
+            obj.insert("loc".to_string(), loc);
+        }
+        obj.insert("argument".to_string(), argument);
+        if let Some(type_ann) = &rest.type_annotation {
+            obj.insert(
+                "typeAnnotation".to_string(),
+                convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
+            );
+        }
+        out.push(Value::Object(obj));
+    }
+
+    out
+}
+
 /// Convert a member of a `TSTypeLiteral` / interface body. Currently models
 /// `TSPropertySignature` exactly (the common inline-props case); other
 /// signature kinds degrade to a span-bearing node.
 fn convert_ts_signature(
+    arena: &ParseArena,
     sig: &oxc_ast::ast::TSSignature,
     offset: usize,
     line_offsets: &[usize],
@@ -3422,7 +3645,7 @@ fn convert_ts_signature(
             if let Some(type_ann) = &prop.type_annotation {
                 obj.insert(
                     "typeAnnotation".to_string(),
-                    convert_type_annotation_adjusted(type_ann, offset, line_offsets),
+                    convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
                 );
             }
             Value::Object(obj)
@@ -3602,6 +3825,7 @@ fn number_value(v: f64) -> Value {
 /// Convert a `TSTypeParameterInstantiation` (`<A, B>`) into svelte/compiler's
 /// shape: `{ type: 'TSTypeParameterInstantiation', start, end, loc, params }`.
 fn convert_ts_type_param_instantiation(
+    arena: &ParseArena,
     args: &oxc_ast::ast::TSTypeParameterInstantiation,
     offset: usize,
     line_offsets: &[usize],
@@ -3621,7 +3845,7 @@ fn convert_ts_type_param_instantiation(
     let params: Vec<Value> = args
         .params
         .iter()
-        .map(|t| convert_ts_type(t, offset, line_offsets))
+        .map(|t| convert_ts_type(arena, t, offset, line_offsets))
         .collect();
     obj.insert("params".to_string(), Value::Array(params));
     Value::Object(obj)
@@ -3772,7 +3996,8 @@ fn convert_expression(
             let start = offset + ts_as.span.start as usize - 1;
             let end = offset + ts_as.span.end as usize - 1;
             let inner = convert_expression(arena, &ts_as.expression, offset, line_offsets);
-            let type_annotation = convert_ts_type(&ts_as.type_annotation, offset - 1, line_offsets);
+            let type_annotation =
+                convert_ts_type(arena, &ts_as.type_annotation, offset - 1, line_offsets);
             Expression::from_node(JsNode::TSAsExpression {
                 start: start as u32,
                 end: end as u32,
@@ -3785,8 +4010,12 @@ fn convert_expression(
             let start = offset + ts_satisfies.span.start as usize - 1;
             let end = offset + ts_satisfies.span.end as usize - 1;
             let inner = convert_expression(arena, &ts_satisfies.expression, offset, line_offsets);
-            let type_annotation =
-                convert_ts_type(&ts_satisfies.type_annotation, offset - 1, line_offsets);
+            let type_annotation = convert_ts_type(
+                arena,
+                &ts_satisfies.type_annotation,
+                offset - 1,
+                line_offsets,
+            );
             Expression::from_node(JsNode::TSSatisfiesExpression {
                 start: start as u32,
                 end: end as u32,
@@ -3810,8 +4039,12 @@ fn convert_expression(
             let start = offset + ts_assertion.span.start as usize - 1;
             let end = offset + ts_assertion.span.end as usize - 1;
             let inner = convert_expression(arena, &ts_assertion.expression, offset, line_offsets);
-            let type_annotation =
-                convert_ts_type(&ts_assertion.type_annotation, offset - 1, line_offsets);
+            let type_annotation = convert_ts_type(
+                arena,
+                &ts_assertion.type_annotation,
+                offset - 1,
+                line_offsets,
+            );
             Expression::from_node(JsNode::TSTypeAssertion {
                 start: start as u32,
                 end: end as u32,
@@ -3825,6 +4058,7 @@ fn convert_expression(
             let end = offset + ts_inst.span.end as usize - 1;
             let inner = convert_expression(arena, &ts_inst.expression, offset, line_offsets);
             let type_arguments = convert_ts_type_param_instantiation(
+                arena,
                 &ts_inst.type_arguments,
                 offset - 1,
                 line_offsets,
@@ -5916,7 +6150,8 @@ fn convert_binding_pattern_for_decl_as_node(
                 // annotation blob verbatim (same as the Value form at
                 // `convert_binding_pattern_for_decl`).
                 let end = offset + type_ann.span.end as usize - 1;
-                let ta_value = convert_type_annotation_adjusted(type_ann, offset - 1, line_offsets);
+                let ta_value =
+                    convert_type_annotation_adjusted(arena, type_ann, offset - 1, line_offsets);
                 JsNode::Identifier {
                     start: start as u32,
                     end: end as u32,
@@ -8252,7 +8487,12 @@ fn convert_variable_declarator_for_program(
         if let Some(loc) = create_loc(ts_start, ts_end, line_offsets) {
             ts_obj.insert("loc".to_string(), loc);
         }
-        let type_value = convert_ts_type(&type_annotation.type_annotation, offset, line_offsets);
+        let type_value = convert_ts_type(
+            arena,
+            &type_annotation.type_annotation,
+            offset,
+            line_offsets,
+        );
         ts_obj.insert("typeAnnotation".to_string(), type_value);
         let ts_value = Value::Object(ts_obj);
 
@@ -9202,7 +9442,8 @@ fn convert_expression_for_program(
             let end = offset + ts_as.span.end as usize;
             let inner =
                 convert_expression_for_program(arena, &ts_as.expression, offset, line_offsets);
-            let type_annotation = convert_ts_type(&ts_as.type_annotation, offset, line_offsets);
+            let type_annotation =
+                convert_ts_type(arena, &ts_as.type_annotation, offset, line_offsets);
             Expression::from_node(JsNode::TSAsExpression {
                 start: start as u32,
                 end: end as u32,
@@ -9221,7 +9462,7 @@ fn convert_expression_for_program(
                 line_offsets,
             );
             let type_annotation =
-                convert_ts_type(&ts_satisfies.type_annotation, offset, line_offsets);
+                convert_ts_type(arena, &ts_satisfies.type_annotation, offset, line_offsets);
             Expression::from_node(JsNode::TSSatisfiesExpression {
                 start: start as u32,
                 end: end as u32,
@@ -9256,7 +9497,7 @@ fn convert_expression_for_program(
                 line_offsets,
             );
             let type_annotation =
-                convert_ts_type(&ts_assertion.type_annotation, offset, line_offsets);
+                convert_ts_type(arena, &ts_assertion.type_annotation, offset, line_offsets);
             Expression::from_node(JsNode::TSTypeAssertion {
                 start: start as u32,
                 end: end as u32,
@@ -9270,8 +9511,12 @@ fn convert_expression_for_program(
             let end = offset + ts_inst.span.end as usize;
             let inner =
                 convert_expression_for_program(arena, &ts_inst.expression, offset, line_offsets);
-            let type_arguments =
-                convert_ts_type_param_instantiation(&ts_inst.type_arguments, offset, line_offsets);
+            let type_arguments = convert_ts_type_param_instantiation(
+                arena,
+                &ts_inst.type_arguments,
+                offset,
+                line_offsets,
+            );
             Expression::from_node(JsNode::TSInstantiationExpression {
                 start: start as u32,
                 end: end as u32,
@@ -10913,6 +11158,7 @@ fn convert_expression_with_adjustment(
                 line_offsets,
             );
             let type_annotation = convert_ts_type(
+                arena,
                 &ts_as.type_annotation,
                 doc_offset - prefix_len,
                 line_offsets,
@@ -10937,6 +11183,7 @@ fn convert_expression_with_adjustment(
                 line_offsets,
             );
             let type_annotation = convert_ts_type(
+                arena,
                 &ts_satisfies.type_annotation,
                 doc_offset - prefix_len,
                 line_offsets,

--- a/crates/rsvelte_core/tests/parse_ts_types.rs
+++ b/crates/rsvelte_core/tests/parse_ts_types.rs
@@ -146,6 +146,10 @@ fn no_typescript_unknown_stub_for_modelled_types() {
         "<script lang=\"ts\">\n  let x: { a: number } = y;\n</script>",
         "<script lang=\"ts\">\n  let x: string | number = y;\n</script>",
         "<script lang=\"ts\">\n  let x: string[] = y;\n</script>",
+        "<script lang=\"ts\">\n  let x: string | (() => void);\n</script>",
+        "<script lang=\"ts\">\n  let x: string & (() => void);\n</script>",
+        "<script lang=\"ts\">\n  let x: new (a: string) => Foo;\n</script>",
+        "<script lang=\"ts\">\n  let x = 1 as (() => void);\n</script>",
     ] {
         let ast = parse_to_json(src);
         assert!(
@@ -153,4 +157,191 @@ fn no_typescript_unknown_stub_for_modelled_types() {
             "no TSUnknownKeyword stub expected for: {src}"
         );
     }
+}
+
+// ---- #1660: TSFunctionType / TSConstructorType inside a type annotation ---
+
+#[test]
+fn function_type_inside_union_is_preserved() {
+    // The exact repro from #1660: a TSFunctionType member of a union used to
+    // collapse to a members-less `TSUnknownKeyword` stub.
+    let src = "<script lang=\"ts\">\n  let x: string | (() => void);\n</script>";
+    let ast = parse_to_json(src);
+    let union = find_node(&ast, "TSUnionType").expect("TSUnionType must be present");
+    let types = union
+        .get("types")
+        .and_then(|t| t.as_array())
+        .expect("union must have a types array");
+    assert_eq!(types.len(), 2);
+    assert_eq!(type_of(&types[0]), Some("TSStringKeyword"));
+
+    let paren = &types[1];
+    assert_eq!(type_of(paren), Some("TSParenthesizedType"));
+    let func = paren
+        .get("typeAnnotation")
+        .expect("TSParenthesizedType must carry typeAnnotation");
+    assert_eq!(type_of(func), Some("TSFunctionType"));
+    assert_eq!(
+        func.get("parameters").and_then(|p| p.as_array()),
+        Some(&vec![])
+    );
+    assert_eq!(
+        func.pointer("/typeAnnotation/typeAnnotation/type")
+            .and_then(|v| v.as_str()),
+        Some("TSVoidKeyword")
+    );
+}
+
+#[test]
+fn function_type_inside_intersection_is_preserved() {
+    let src = "<script lang=\"ts\">\n  let x: string & (() => void);\n</script>";
+    let ast = parse_to_json(src);
+    let inter = find_node(&ast, "TSIntersectionType").expect("TSIntersectionType must be present");
+    let types = inter
+        .get("types")
+        .and_then(|t| t.as_array())
+        .expect("intersection must have a types array");
+    assert_eq!(
+        types[1]
+            .pointer("/typeAnnotation/type")
+            .and_then(|v| v.as_str()),
+        Some("TSFunctionType")
+    );
+}
+
+#[test]
+fn function_type_via_as_assertion_is_preserved() {
+    // #1648 started preserving the `TSAsExpression` wrapper; its `typeAnnotation`
+    // routes through the same `convert_ts_type` this fix touches.
+    let src = "<script lang=\"ts\">\n  let x = 1 as (() => void);\n</script>";
+    let ast = parse_to_json(src);
+    let as_expr = find_node(&ast, "TSAsExpression").expect("TSAsExpression must be present");
+    assert_eq!(
+        as_expr
+            .pointer("/typeAnnotation/typeAnnotation/type")
+            .and_then(|v| v.as_str()),
+        Some("TSFunctionType")
+    );
+}
+
+#[test]
+fn function_type_parameters_and_return_type() {
+    let src = "<script lang=\"ts\">\n  let y: (a: string, b?: number) => void;\n</script>";
+    let ast = parse_to_json(src);
+    let func = find_node(&ast, "TSFunctionType").expect("TSFunctionType must be present");
+
+    let params = func
+        .get("parameters")
+        .and_then(|p| p.as_array())
+        .expect("parameters array must be present");
+    assert_eq!(params.len(), 2);
+
+    let a = &params[0];
+    assert_eq!(a.pointer("/name").and_then(|v| v.as_str()), Some("a"));
+    assert!(a.get("optional").is_none());
+    assert_eq!(
+        a.pointer("/typeAnnotation/typeAnnotation/type")
+            .and_then(|v| v.as_str()),
+        Some("TSStringKeyword")
+    );
+
+    let b = &params[1];
+    assert_eq!(b.pointer("/name").and_then(|v| v.as_str()), Some("b"));
+    // NOTE: svelte/compiler emits `optional: true` here (the `?` marker), but
+    // rsvelte currently drops it for *every* function/arrow parameter — not
+    // specific to TSFunctionType — because `JsNode::Identifier` has no
+    // `optional` field to round-trip it through the typed AST. Out of scope
+    // for #1660; tracked separately.
+    assert!(b.get("optional").is_none());
+    assert_eq!(
+        b.pointer("/typeAnnotation/typeAnnotation/type")
+            .and_then(|v| v.as_str()),
+        Some("TSNumberKeyword")
+    );
+
+    assert_eq!(
+        func.pointer("/typeAnnotation/typeAnnotation/type")
+            .and_then(|v| v.as_str()),
+        Some("TSVoidKeyword")
+    );
+}
+
+#[test]
+fn function_type_generics_and_rest_parameter() {
+    let src = "<script lang=\"ts\">\n  let f: <T>(a: T, ...rest: T[]) => T;\n</script>";
+    let ast = parse_to_json(src);
+    let func = find_node(&ast, "TSFunctionType").expect("TSFunctionType must be present");
+
+    assert_eq!(
+        func.pointer("/typeParameters/type")
+            .and_then(|v| v.as_str()),
+        Some("TSTypeParameterDeclaration")
+    );
+    assert_eq!(
+        func.pointer("/typeParameters/params/0/name")
+            .and_then(|v| v.as_str()),
+        Some("T")
+    );
+
+    let params = func
+        .get("parameters")
+        .and_then(|p| p.as_array())
+        .expect("parameters array must be present");
+    assert_eq!(params.len(), 2);
+    assert_eq!(type_of(&params[0]), Some("Identifier"));
+
+    let rest = &params[1];
+    assert_eq!(type_of(rest), Some("RestElement"));
+    assert_eq!(
+        rest.pointer("/argument/name").and_then(|v| v.as_str()),
+        Some("rest")
+    );
+    assert_eq!(
+        rest.pointer("/typeAnnotation/typeAnnotation/type")
+            .and_then(|v| v.as_str()),
+        Some("TSArrayType")
+    );
+}
+
+#[test]
+fn function_type_this_parameter_is_prepended() {
+    let src = "<script lang=\"ts\">\n  let h: (this: Foo, a: number) => void;\n</script>";
+    let ast = parse_to_json(src);
+    let func = find_node(&ast, "TSFunctionType").expect("TSFunctionType must be present");
+    let params = func
+        .get("parameters")
+        .and_then(|p| p.as_array())
+        .expect("parameters array must be present");
+    assert_eq!(params.len(), 2);
+    assert_eq!(
+        params[0].pointer("/name").and_then(|v| v.as_str()),
+        Some("this")
+    );
+    assert_eq!(
+        params[0]
+            .pointer("/typeAnnotation/typeAnnotation/typeName/name")
+            .and_then(|v| v.as_str()),
+        Some("Foo")
+    );
+    assert_eq!(
+        params[1].pointer("/name").and_then(|v| v.as_str()),
+        Some("a")
+    );
+}
+
+#[test]
+fn constructor_type_is_preserved() {
+    let src = "<script lang=\"ts\">\n  let z: new (a: string) => Foo;\n</script>";
+    let ast = parse_to_json(src);
+    let ctor = find_node(&ast, "TSConstructorType").expect("TSConstructorType must be present");
+    assert_eq!(ctor.get("abstract"), Some(&Value::Bool(false)));
+    assert_eq!(
+        ctor.pointer("/parameters/0/name").and_then(|v| v.as_str()),
+        Some("a")
+    );
+    assert_eq!(
+        ctor.pointer("/typeAnnotation/typeAnnotation/typeName/name")
+            .and_then(|v| v.as_str()),
+        Some("Foo")
+    );
 }


### PR DESCRIPTION
## Summary

- `convert_ts_type` (the oxc TS-type AST → estree-ts JSON converter, `crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs`) had no match arm for `TSType::TSFunctionType` / `TSType::TSConstructorType`, so both fell through to the catch-all `TSUnknownKeyword` stub arm. Most visible as a union member (`let x: string | (() => void)`), but the same fallback hit intersections, `ParenthesizedType`-wrapped standalone function types, `as`/`satisfies`/type-assertion wrappers, and `TSTypeParameterInstantiation` — none of that is specific to unions.
- svelte/compiler (acorn-typescript) keeps these as full nodes: `typeParameters` (generic type params, omitted when absent), a flat `parameters` array (any `this` parameter prepended as a plain `Identifier` named `"this"`, matching acorn-typescript's parse), and a `typeAnnotation`-wrapped return type. `TSConstructorType` additionally always emits `abstract` (never omitted, unlike `optional`/`readonly` elsewhere).
- Added `convert_ts_type_parameter_declaration` / `convert_ts_type_parameter` (`<T extends U = V>`) and `convert_ts_function_like_params` (this-param + regular params via the existing `convert_formal_parameter` + rest element), and threaded a `&ParseArena` through the whole `convert_ts_type` call graph (unions, intersections, arrays, wrappers, `TSTypeParameterInstantiation`, and every TS assertion/instantiation expression call site) since building the parameters array needs it.
- Verified expected shapes against the real `svelte` 5.56.7 compiler (`node_modules/svelte/compiler`, acorn-typescript-based) for unions, intersections, `as`-assertions, generics + rest params, `this` params, and `TSConstructorType`.

**Found but out of scope** (documented in the new test with a `NOTE`): `b?: number`-style optional function/arrow parameters lose their `optional: true` marker for *every* function, not just `TSFunctionType` — `JsNode::Identifier` (and the other pattern variants) have no `optional` field to round-trip through the typed AST (`Expression::from_json` → `JsNode::from_value` → `to_value()` drops unmodelled keys). Fixing it means adding a field to a very widely-constructed enum variant across the codebase; flagged for a separate, larger PR rather than folded in here.

## Root cause

`convert_ts_type`'s `match` over `oxc_ast::ast::TSType` never had arms for `TSFunctionType`/`TSConstructorType`, so they hit the `_ => Value::Object(base("TSUnknownKeyword"))` fallback — a bug that predates #1648 but became more visible once #1648 started preserving the `TSAsExpression`/etc. wrapper nodes (whose `typeAnnotation` routes through `convert_ts_type`).

## Test plan

- [x] New regression tests in `crates/rsvelte_core/tests/parse_ts_types.rs`: function type inside union/intersection, via `as`-assertion, standalone with params + optional marker + return type, generics + rest parameter, `this` parameter prepending, and `TSConstructorType`.
- [x] `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core` — full suite (171 test binaries incl. `parser_fixtures`, `svelte2tsx` (1538 tests), `parse_ts_types`) — all pass, 0 failures.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGrjrA4zeTQR75pPThFQFT