### PR TITLE
feat(wasm): support function compile options (css/customElement/runes/warningFilter/cssHash)

### DIFF
--- a/.changeset/feat-wasm-function-compile-options.md
+++ b/.changeset/feat-wasm-function-compile-options.md
@@ -1,0 +1,23 @@
+---
+"@rsvelte/compiler": minor
+---
+
+feat(wasm): support function compile options via a new `compile(source, options)` entry
+
+The wasm compiler now exposes `compile(source, options)`, which accepts the full
+compile-options object and resolves the function-form options that the primitive
+`compile_client`/`compile_server` entries can't — matching the NAPI shim's
+support (PRs #1666/#1667):
+
+- the `parametric` function forms of `customElement`, `css`, and `runes`
+  (`({ filename }) => value`), evaluated once at the boundary;
+- a `warningFilter` callback, applied natively by the compiler;
+- a constant `cssHashOverride` string; and
+- a dynamic `cssHash` callback bridged through `js_sys::Function` (wasm compile
+  is single-threaded, so the callback runs inline with no threadsafe-function
+  marshalling). A callback that throws surfaces as a compile error; a non-string
+  return falls back to the default hash.
+
+The result is returned as a JSON string (`{ js, css, warnings, metadata }`);
+callbacks are input-only. The existing `compile_client`/`compile_server` entries
+are unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,7 @@ dependencies = [
  "indexmap",
  "insta",
  "itoa",
+ "js-sys",
  "lazy_static",
  "memchr",
  "miette",

--- a/apps/npm/compiler/README.md
+++ b/apps/npm/compiler/README.md
@@ -49,6 +49,7 @@ change.
 ```js
 import init, {
   parse_svelte,
+  compile,
   compile_client,
   compile_server,
   version,
@@ -71,6 +72,28 @@ const server = compile_server(source, 'App');
 const ast = JSON.parse(parse_svelte(source).ast);
 
 console.log(version()); // the rsvelte compiler version
+```
+
+### Full compile options
+
+`compile(source, options)` accepts the full compile-options object, including the
+function forms Svelte's own `compile` supports. It returns the result as a JSON
+string (`{ js, css, warnings, metadata }`); the callbacks are input-only.
+
+```js
+const result = JSON.parse(
+  compile(source, {
+    filename: 'App.svelte',
+    generate: 'client',
+    // `customElement` / `css` / `runes` also accept `({ filename }) => value`.
+    css: 'injected',
+    // Filter compiler warnings (applied by the compiler).
+    warningFilter: (w) => !w.code.startsWith('a11y'),
+    // A constant scope hash, or a dynamic `cssHash({ hash, css, name, filename })`.
+    cssHash: ({ hash, css }) => `x-${hash(css)}`,
+  }),
+);
+console.log(result.js.code, result.warnings);
 ```
 
 ## Why it is fast

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -31,7 +31,7 @@ pprof = ["dep:pprof"]
 # `wasm` exports this crate's own `#[wasm_bindgen]` surface (the `wasm`
 # module — `parse_svelte`, `compile_client`, `svelte2tsx`, …) and is what
 # `pkg/` is built with.
-wasm = ["wasm-deps"]
+wasm = ["wasm-deps", "dep:js-sys"]
 # `wasm-deps` pulls only the wasm-bindgen toolchain + the wasm `getrandom`
 # backend, *without* enabling the `wasm` bindings module. Downstream wasm
 # crates (e.g. `rsvelte_fmt_wasm`) depend on `rsvelte_core` with this
@@ -118,6 +118,9 @@ chrono = "0.4"
 
 # WASM support (optional)
 wasm-bindgen = { version = "0.2", optional = true }
+# wasm-only: reading JS option objects and bridging JS callbacks (`cssHash`,
+# `warningFilter`) for the compiler's function-form compile options.
+js-sys = { version = "0.3", optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
 getrandom = { version = "0.4", optional = true }
 lazy_static = "1.5.0"

--- a/crates/rsvelte_core/src/wasm.rs
+++ b/crates/rsvelte_core/src/wasm.rs
@@ -317,15 +317,33 @@ fn default_css_hash(input: &CssHashInput, root_dir: Option<&str>) -> String {
     generate_css_hash(&fname)
 }
 
-fn build_warning_filter(func: js_sys::Function) -> WarningFilterFn {
+fn build_warning_filter(func: js_sys::Function, slot: ErrorSlot) -> WarningFilterFn {
     Arc::new(move |warning: &Warning| -> bool {
         let obj = warning_to_js(warning);
-        // A throwing filter keeps the warning rather than dropping it silently.
         match func.call1(&JsValue::NULL, &obj) {
             Ok(v) => v.as_bool().unwrap_or(true),
-            Err(_) => true,
+            // A throwing filter aborts compilation (matching upstream Svelte and
+            // the NAPI shim), surfaced via the shared error slot; the retained
+            // warning here is discarded once the caller sees the failure.
+            Err(e) => {
+                slot.lock()
+                    .unwrap()
+                    .get_or_insert_with(|| js_error_message(&e));
+                true
+            }
         }
     })
+}
+
+/// Extract a JS error's `.message`, falling back to its string form.
+fn js_error_message(e: &JsValue) -> String {
+    e.as_string()
+        .or_else(|| {
+            js_sys::Reflect::get(e, &JsValue::from_str("message"))
+                .ok()
+                .and_then(|m| m.as_string())
+        })
+        .unwrap_or_else(|| "callback threw".to_string())
 }
 
 /// Bridge a user `cssHash({ hash, css, name, filename }) => string` into a
@@ -362,15 +380,9 @@ fn build_css_hash(func: js_sys::Function, root_dir: Option<String>, slot: ErrorS
                 .as_string()
                 .unwrap_or_else(|| default_css_hash(input, root_dir.as_deref())),
             Err(e) => {
-                let msg = e
-                    .as_string()
-                    .or_else(|| {
-                        js_sys::Reflect::get(&e, &JsValue::from_str("message"))
-                            .ok()
-                            .and_then(|m| m.as_string())
-                    })
-                    .unwrap_or_else(|| "cssHash callback threw".to_string());
-                slot.lock().unwrap().get_or_insert(msg);
+                slot.lock()
+                    .unwrap()
+                    .get_or_insert_with(|| js_error_message(&e));
                 default_css_hash(input, root_dir.as_deref())
             }
         }
@@ -461,7 +473,7 @@ fn build_compile_options(
     }
 
     if let Some(func) = get_prop(options, "warningFilter").dyn_ref::<js_sys::Function>() {
-        opts.warning_filter = Some(build_warning_filter(func.clone()));
+        opts.warning_filter = Some(build_warning_filter(func.clone(), Arc::clone(error_slot)));
     }
 
     // A constant `cssHashOverride` wins; otherwise bridge a dynamic `cssHash`.

--- a/crates/rsvelte_core/src/wasm.rs
+++ b/crates/rsvelte_core/src/wasm.rs
@@ -3,10 +3,16 @@
 //! This module provides JavaScript-accessible functions for compiling
 //! Svelte components in the browser.
 
+use std::sync::{Arc, Mutex};
+
 use wasm_bindgen::prelude::*;
 
 use crate::compiler::phases::phase1_parse::{ParseOptions, parse};
-use crate::compiler::{CompileOptions, CssMode, GenerateMode, compile};
+use crate::compiler::phases::phase3_transform::css::{generate_css_hash, generate_raw_hash};
+use crate::compiler::{
+    CompileOptions, CompileResult, CssHashFn, CssHashInput, CssMode, GenerateMode, Namespace,
+    Warning, WarningFilterFn, compile,
+};
 use crate::svelte2tsx::{
     Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion,
     svelte2tsx as rust_svelte2tsx,
@@ -254,4 +260,303 @@ fn parse_svelte2tsx_options(options_json: &str) -> Svelte2TsxOptions {
         };
     }
     opts
+}
+
+// === Function-form compile options (issue #1680) ===
+//
+// `compile(source, options)` accepts the full compile-options object and
+// resolves the pieces the primitive `compile_client`/`compile_server` entries
+// can't: the function forms of `customElement`/`css`/`runes` (Svelte's
+// `parametric()`, evaluated once with `{ filename }`), a `warningFilter`
+// callback, a constant `cssHashOverride`, and a dynamic `cssHash` callback.
+// wasm compile is single-threaded, so the JS callbacks are invoked inline —
+// no threadsafe-function marshalling (unlike the NAPI backend).
+
+// On wasm32 (single-threaded) wasm-bindgen already makes `JsValue`/`Function`
+// Send + Sync, so the JS callbacks satisfy the shared `CssHashFn`/
+// `WarningFilterFn` bounds directly — the throwing-`cssHash` slot just needs a
+// thread-safe container (`Arc<Mutex<…>>`, uncontended here).
+type ErrorSlot = Arc<Mutex<Option<String>>>;
+
+fn get_prop(obj: &JsValue, key: &str) -> JsValue {
+    js_sys::Reflect::get(obj, &JsValue::from_str(key)).unwrap_or(JsValue::UNDEFINED)
+}
+
+/// Read `options[key]`, evaluating it once with `{ filename }` if it is a
+/// function (Svelte's `parametric()` normalization); otherwise return the raw
+/// value.
+fn resolve_maybe_fn(options: &JsValue, key: &str, filename: &str) -> JsValue {
+    let val = get_prop(options, key);
+    let Some(func) = val.dyn_ref::<js_sys::Function>() else {
+        return val;
+    };
+    let meta = js_sys::Object::new();
+    let _ = js_sys::Reflect::set(
+        &meta,
+        &JsValue::from_str("filename"),
+        &JsValue::from_str(filename),
+    );
+    func.call1(&JsValue::NULL, &meta)
+        .unwrap_or(JsValue::UNDEFINED)
+}
+
+/// Reproduce the compiler's default (no-`cssHash`) scope hash so a `cssHash`
+/// callback that returns a non-string can fall back to it: the rootDir-relative
+/// filename when known, else the CSS content.
+fn default_css_hash(input: &CssHashInput, root_dir: Option<&str>) -> String {
+    if input.filename == "(unknown)" {
+        return generate_css_hash(&input.css);
+    }
+    let mut fname = input.filename.replace('\\', "/");
+    if let Some(rd) = root_dir {
+        let rd = rd.replace('\\', "/");
+        if let Some(rest) = fname.strip_prefix(&rd) {
+            fname = rest.trim_start_matches('/').to_string();
+        }
+    }
+    generate_css_hash(&fname)
+}
+
+fn build_warning_filter(func: js_sys::Function) -> WarningFilterFn {
+    Arc::new(move |warning: &Warning| -> bool {
+        let obj = warning_to_js(warning);
+        // A throwing filter keeps the warning rather than dropping it silently.
+        match func.call1(&JsValue::NULL, &obj) {
+            Ok(v) => v.as_bool().unwrap_or(true),
+            Err(_) => true,
+        }
+    })
+}
+
+/// Bridge a user `cssHash({ hash, css, name, filename }) => string` into a
+/// `CssHashFn`. A callback that throws is recorded in `error_slot` (surfaced as
+/// a compile failure, matching upstream) and falls back to the default hash; a
+/// non-string return also falls back — the bridge never panics.
+fn build_css_hash(func: js_sys::Function, root_dir: Option<String>, slot: ErrorSlot) -> CssHashFn {
+    Arc::new(move |input: &CssHashInput| -> String {
+        let arg = js_sys::Object::new();
+        // The callback's `hash` arg is Svelte's raw digest (no `svelte-` prefix,
+        // unlike `CssHashInput::hash`) so a custom scope class matches upstream.
+        // The closure is dropped at the end of this synchronous call — no leak,
+        // no `.forget()`.
+        let closure = Closure::wrap(Box::new(|s: String| -> String { generate_raw_hash(&s) })
+            as Box<dyn Fn(String) -> String>);
+        let _ = js_sys::Reflect::set(&arg, &JsValue::from_str("hash"), closure.as_ref());
+        let _ = js_sys::Reflect::set(
+            &arg,
+            &JsValue::from_str("css"),
+            &JsValue::from_str(&input.css),
+        );
+        let _ = js_sys::Reflect::set(
+            &arg,
+            &JsValue::from_str("name"),
+            &JsValue::from_str(&input.name),
+        );
+        let _ = js_sys::Reflect::set(
+            &arg,
+            &JsValue::from_str("filename"),
+            &JsValue::from_str(&input.filename),
+        );
+        match func.call1(&JsValue::NULL, &arg) {
+            Ok(v) => v
+                .as_string()
+                .unwrap_or_else(|| default_css_hash(input, root_dir.as_deref())),
+            Err(e) => {
+                let msg = e
+                    .as_string()
+                    .or_else(|| {
+                        js_sys::Reflect::get(&e, &JsValue::from_str("message"))
+                            .ok()
+                            .and_then(|m| m.as_string())
+                    })
+                    .unwrap_or_else(|| "cssHash callback threw".to_string());
+                slot.lock().unwrap().get_or_insert(msg);
+                default_css_hash(input, root_dir.as_deref())
+            }
+        }
+    })
+}
+
+/// Build `CompileOptions` from a JS options object. `error_slot` collects a
+/// throwing `cssHash` so the caller can surface it as a compile failure.
+fn build_compile_options(
+    options: &JsValue,
+    error_slot: &ErrorSlot,
+) -> Result<CompileOptions, String> {
+    let mut opts = CompileOptions::default();
+    if options.is_undefined() || options.is_null() {
+        return Ok(opts);
+    }
+
+    let filename = get_prop(options, "filename").as_string();
+    // Svelte defaults `filename` to '(unknown)' before invoking parametric fns.
+    let meta_filename = filename.clone().unwrap_or_else(|| "(unknown)".to_string());
+    opts.filename = filename;
+    opts.root_dir = get_prop(options, "rootDir").as_string();
+    if let Some(n) = get_prop(options, "name").as_string() {
+        opts.name = Some(n);
+    }
+
+    let generate = resolve_maybe_fn(options, "generate", &meta_filename);
+    if let Some(s) = generate.as_string() {
+        opts.generate = match s.as_str() {
+            "client" | "dom" => GenerateMode::Client,
+            "server" | "ssr" => GenerateMode::Server,
+            "false" => GenerateMode::None,
+            _ => return Err("generate must be \"client\", \"server\" or false".to_string()),
+        };
+    } else if generate.as_bool() == Some(false) {
+        opts.generate = GenerateMode::None;
+    }
+
+    let css = resolve_maybe_fn(options, "css", &meta_filename);
+    if let Some(s) = css.as_string() {
+        opts.css = match s.as_str() {
+            "external" => CssMode::External,
+            "injected" => CssMode::Injected,
+            _ => {
+                return Err(
+                    "css should be either \"external\" (default, recommended) or \"injected\""
+                        .to_string(),
+                );
+            }
+        };
+    }
+
+    if let Some(b) = resolve_maybe_fn(options, "customElement", &meta_filename).as_bool() {
+        opts.custom_element = b;
+    }
+    // `runes` is tri-state: a boolean forces the mode, anything else auto-detects.
+    if let Some(b) = resolve_maybe_fn(options, "runes", &meta_filename).as_bool() {
+        opts.runes = Some(b);
+    }
+
+    if let Some(b) = get_prop(options, "dev").as_bool() {
+        opts.dev = b;
+    }
+    if let Some(b) = get_prop(options, "accessors").as_bool() {
+        opts.accessors = b;
+    }
+    if let Some(b) = get_prop(options, "immutable").as_bool() {
+        opts.immutable = b;
+    }
+    if let Some(b) = get_prop(options, "preserveComments").as_bool() {
+        opts.preserve_comments = b;
+    }
+    if let Some(b) = get_prop(options, "preserveWhitespace").as_bool() {
+        opts.preserve_whitespace = b;
+    }
+    if let Some(b) = get_prop(options, "discloseVersion").as_bool() {
+        opts.disclose_version = b;
+    }
+    if let Some(b) = get_prop(options, "hmr").as_bool() {
+        opts.hmr = b;
+    }
+    if let Some(s) = get_prop(options, "namespace").as_string() {
+        opts.namespace = match s.as_str() {
+            "svg" => Namespace::Svg,
+            "mathml" => Namespace::Mathml,
+            _ => Namespace::Html,
+        };
+    }
+
+    if let Some(func) = get_prop(options, "warningFilter").dyn_ref::<js_sys::Function>() {
+        opts.warning_filter = Some(build_warning_filter(func.clone()));
+    }
+
+    // A constant `cssHashOverride` wins; otherwise bridge a dynamic `cssHash`.
+    if let Some(hash) = get_prop(options, "cssHashOverride").as_string() {
+        opts.css_hash = Some(Arc::new(move |_: &CssHashInput| hash.clone()));
+    } else if let Some(func) = get_prop(options, "cssHash").dyn_ref::<js_sys::Function>() {
+        opts.css_hash = Some(build_css_hash(
+            func.clone(),
+            opts.root_dir.clone(),
+            Arc::clone(error_slot),
+        ));
+    }
+
+    Ok(opts)
+}
+
+fn warning_to_js(warning: &Warning) -> JsValue {
+    js_sys::JSON::parse(&warning_to_value(warning).to_string()).unwrap_or(JsValue::UNDEFINED)
+}
+
+fn warning_to_value(w: &Warning) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "code".to_string(),
+        serde_json::Value::String(w.code.clone()),
+    );
+    map.insert(
+        "message".to_string(),
+        serde_json::Value::String(w.message.clone()),
+    );
+    if let Some(ref filename) = w.filename {
+        map.insert(
+            "filename".to_string(),
+            serde_json::Value::String(filename.clone()),
+        );
+    }
+    let pos = |p: &crate::compiler::Position| serde_json::json!({ "line": p.line, "column": p.column, "character": p.character });
+    if let Some(ref start) = w.start {
+        map.insert("start".to_string(), pos(start));
+    }
+    if let Some(ref end) = w.end {
+        map.insert("end".to_string(), pos(end));
+    }
+    if let (Some(start), Some(end)) = (&w.start, &w.end) {
+        map.insert(
+            "position".to_string(),
+            serde_json::json!([start.character, end.character]),
+        );
+    }
+    serde_json::Value::Object(map)
+}
+
+fn compile_result_to_json(result: CompileResult) -> String {
+    let parse_map = |m: Option<&str>| {
+        m.and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+            .unwrap_or(serde_json::Value::Null)
+    };
+    let css = result
+        .css
+        .map(|c| {
+            serde_json::json!({
+                "code": c.code,
+                "map": parse_map(c.map.as_deref()),
+                "hasGlobal": c.has_global,
+            })
+        })
+        .unwrap_or(serde_json::Value::Null);
+    let warnings: Vec<serde_json::Value> = result.warnings.iter().map(warning_to_value).collect();
+    serde_json::json!({
+        "js": { "code": result.js.code, "map": parse_map(result.js.map.as_deref()) },
+        "css": css,
+        "warnings": warnings,
+        "metadata": { "runes": result.metadata.runes },
+    })
+    .to_string()
+}
+
+/// Compile a Svelte component with the full compile-options object.
+///
+/// Supports the function-form compile options (issue #1680): the `parametric`
+/// function forms of `customElement`/`css`/`runes`, a `warningFilter` callback,
+/// a constant `cssHashOverride`, and a dynamic `cssHash` callback. Returns the
+/// compile result as a JSON string (`{ js, css, warnings, metadata }`);
+/// callbacks are input-only. Throws on a parse failure, an invalid option, or a
+/// `cssHash` callback that throws.
+#[wasm_bindgen(js_name = compile)]
+pub fn compile_svelte(source: &str, options: JsValue) -> Result<String, JsValue> {
+    let error_slot: ErrorSlot = Arc::new(Mutex::new(None));
+    let opts = build_compile_options(&options, &error_slot).map_err(|e| JsValue::from_str(&e))?;
+    let result = compile(source, opts);
+    if let Some(msg) = error_slot.lock().unwrap().take() {
+        return Err(JsValue::from_str(&msg));
+    }
+    match result {
+        Ok(r) => Ok(compile_result_to_json(r)),
+        Err(e) => Err(JsValue::from_str(&format!("{e:?}"))),
+    }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"test:vps-shim": "node scripts/dev/test-vps-shim.mjs",
 		"test:vps-fixture": "node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:vps": "node scripts/dev/test-vps-shim.mjs && node scripts/dev/test-vps-vite-fixture.mjs",
+		"test:wasm-compile": "node scripts/dev/test-wasm-compile-options.mjs",
 		"build:oxlint-plugin": "pnpm --filter @rsvelte/oxlint-plugin run build",
 		"build:lint-native": "node scripts/dev/build-lint-native-local.mjs",
 		"test:oxlint-plugin": "node scripts/dev/test-oxlint-plugin.mjs",

--- a/scripts/dev/test-wasm-compile-options.mjs
+++ b/scripts/dev/test-wasm-compile-options.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+// E2E test for the @rsvelte/compiler wasm `compile(source, options)` entry and
+// its function-form compile options (issue #1680): the `parametric` function
+// forms of customElement/css/runes, a warningFilter callback, a constant
+// cssHashOverride, and a dynamic cssHash callback.
+//
+// The bundle is wasm-pack `--target web`, whose default `init` is async
+// (`fetch`); it also exposes a synchronous `initSync`, driven here with the
+// `.wasm` bytes read from disk (mirrors apps/npm/oxlint-plugin/src/wasm.js).
+//
+// Prereq: `pnpm run build:wasm:core`.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const jsUrl = new URL('../../pkg/rsvelte_lint.js', import.meta.url).href;
+const wasmPath = fileURLToPath(new URL('../../pkg/rsvelte_lint_bg.wasm', import.meta.url));
+
+const compiler = await import(jsUrl);
+compiler.initSync({ module: readFileSync(wasmPath) });
+
+let pass = 0;
+let fail = 0;
+function assert(name, cond, detail) {
+	if (cond) {
+		pass += 1;
+		console.log(`  ok   ${name}`);
+	} else {
+		fail += 1;
+		console.error(`  FAIL ${name}${detail ? ` — ${detail}` : ''}`);
+	}
+}
+
+const compile = (source, options) => JSON.parse(compiler.compile(source, options));
+
+// 1. Function-form customElement resolves to the same output as the boolean.
+const ceBool = compile('<svelte:options customElement="my-el" /><h1>hi</h1>', {
+	filename: 'El.svelte',
+	generate: 'client',
+	customElement: true,
+});
+const ceFn = compile('<svelte:options customElement="my-el" /><h1>hi</h1>', {
+	filename: 'El.svelte',
+	generate: 'client',
+	customElement: () => true,
+});
+assert(
+	'customElement function form resolves to boolean value',
+	ceFn.js.code === ceBool.js.code && ceBool.js.code.length > 0,
+);
+
+// 2. Function-form css resolves; `injected` folds CSS into the JS (css == null).
+const cssExternal = compile('<h1>hi</h1><style>h1{color:red}</style>', {
+	filename: 'C.svelte',
+	generate: 'client',
+	css: 'external',
+});
+const cssFn = compile('<h1>hi</h1><style>h1{color:red}</style>', {
+	filename: 'C.svelte',
+	generate: 'client',
+	css: () => 'injected',
+});
+assert(
+	'css function form resolves and injects styles',
+	cssFn.css == null && cssFn.js.code !== cssExternal.js.code,
+	JSON.stringify({ hasCss: cssFn.css != null }),
+);
+
+// 3. Function-form runes compiles.
+const runesFn = compile('<script>let count = $state(0);</script><h1>{count}</h1>', {
+	filename: 'R.svelte',
+	generate: 'client',
+	runes: () => true,
+});
+assert('runes function form compiles', typeof runesFn?.js?.code === 'string');
+
+// 4. cssHashOverride — a constant scope hash appears verbatim in the output.
+const hashed = compile('<h1>hi</h1><style>h1{color:red}</style>', {
+	filename: 'H.svelte',
+	generate: 'client',
+	css: 'injected',
+	cssHashOverride: 's-DEADBEEF',
+});
+assert(
+	'cssHashOverride sets the scope class',
+	hashed.js.code.includes('s-DEADBEEF'),
+	hashed.js.code.slice(0, 120),
+);
+
+// 5. warningFilter — the compiler drops warnings the filter rejects.
+const warnSrc = '<img src="x.png">';
+const unfiltered = compile(warnSrc, { filename: 'W.svelte', generate: 'client' });
+assert(
+	'component emits at least one warning to filter',
+	Array.isArray(unfiltered.warnings) && unfiltered.warnings.length > 0,
+	JSON.stringify(unfiltered.warnings.map((w) => w.code)),
+);
+const filtered = compile(warnSrc, {
+	filename: 'W.svelte',
+	generate: 'client',
+	warningFilter: (w) => !w.code.startsWith('a11y'),
+});
+assert(
+	'warningFilter drops matching warnings',
+	filtered.warnings.every((w) => !w.code.startsWith('a11y')) &&
+		filtered.warnings.length < unfiltered.warnings.length,
+	JSON.stringify(filtered.warnings.map((w) => w.code)),
+);
+
+// 6. Dynamic cssHash — a css-dependent scope hash bridged through js_sys.
+{
+	const src = '<h1>hi</h1><style>h1{color:red}</style>';
+	const seen = {};
+	const dyn = compile(src, {
+		filename: 'Dyn.svelte',
+		generate: 'client',
+		css: 'injected',
+		cssHash: ({ hash, css, name, filename }) => {
+			seen.name = name;
+			seen.filename = filename;
+			seen.hasHashFn = typeof hash === 'function';
+			return `x-${hash(css)}`;
+		},
+	});
+	assert(
+		'dynamic cssHash receives name/filename/hash',
+		seen.hasHashFn === true && seen.name === 'Dyn' && seen.filename === 'Dyn.svelte',
+		JSON.stringify(seen),
+	);
+	assert(
+		'dynamic cssHash class appears in output',
+		/x-[0-9a-z]+/.test(dyn.js.code),
+		dyn.js.code.slice(0, 160),
+	);
+
+	// Svelte defaults filename to '(unknown)' — the callback must see that.
+	let seenFilename;
+	compile('<h1>hi</h1><style>h1{color:red}</style>', {
+		generate: 'client',
+		css: 'injected',
+		cssHash: ({ hash, css, filename }) => {
+			seenFilename = filename;
+			return `x-${hash(css)}`;
+		},
+	});
+	assert('cssHash filename defaults to (unknown)', seenFilename === '(unknown)', String(seenFilename));
+
+	// Different CSS must yield a different hash (proves it is content-driven).
+	const a = compile('<h1>a</h1><style>h1{color:red}</style>', {
+		filename: 'A.svelte',
+		generate: 'client',
+		css: 'injected',
+		cssHash: ({ hash, css }) => `x-${hash(css)}`,
+	});
+	const b = compile('<h1>b</h1><style>h1{color:blue}</style>', {
+		filename: 'B.svelte',
+		generate: 'client',
+		css: 'injected',
+		cssHash: ({ hash, css }) => `x-${hash(css)}`,
+	});
+	const clsOf = (code) => (code.match(/x-[0-9a-z]+/) || [])[0];
+	assert(
+		'dynamic cssHash varies with CSS content',
+		clsOf(a.js.code) && clsOf(b.js.code) && clsOf(a.js.code) !== clsOf(b.js.code),
+		`${clsOf(a.js.code)} vs ${clsOf(b.js.code)}`,
+	);
+
+	// A throwing cssHash surfaces as a compile error (matches upstream).
+	let cssHashThrew = false;
+	try {
+		compiler.compile(src, {
+			filename: 'F.svelte',
+			generate: 'client',
+			css: 'injected',
+			cssHash: () => {
+				throw new Error('boom');
+			},
+		});
+	} catch (e) {
+		cssHashThrew = /boom/.test(String((e && e.message) || e));
+	}
+	assert('throwing cssHash surfaces as a compile error', cssHashThrew);
+
+	// A non-string return falls back to the compiler's default hash.
+	const fell = compile(src, {
+		filename: 'F.svelte',
+		generate: 'client',
+		css: 'injected',
+		cssHash: () => 42,
+	});
+	assert(
+		'non-string cssHash return falls back to default hash',
+		fell.js.code.includes('svelte-'),
+		fell.js.code.slice(0, 160),
+	);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/dev/test-wasm-compile-options.mjs
+++ b/scripts/dev/test-wasm-compile-options.mjs
@@ -106,6 +106,20 @@ assert(
 		filtered.warnings.length < unfiltered.warnings.length,
 	JSON.stringify(filtered.warnings.map((w) => w.code)),
 );
+// A throwing warningFilter aborts compilation (matches upstream Svelte / NAPI).
+let warnFilterThrew = false;
+try {
+	compiler.compile(warnSrc, {
+		filename: 'W.svelte',
+		generate: 'client',
+		warningFilter: () => {
+			throw new Error('warn-boom');
+		},
+	});
+} catch (e) {
+	warnFilterThrew = /warn-boom/.test(String((e && e.message) || e));
+}
+assert('throwing warningFilter surfaces as a compile error', warnFilterThrew);
 
 // 6. Dynamic cssHash — a css-dependent scope hash bridged through js_sys.
 {


### PR DESCRIPTION
## What

Extends the function-form compile options — implemented for the NAPI bindings in #1666/#1667 — to the **wasm `@rsvelte/compiler`** bindings.

The wasm compiler previously exposed only `compile_client(source, name)` / `compile_server(source, name)`, which accept no options object, so none of the five function options were reachable. This PR adds a new `compile(source, options)` wasm entry that accepts the full compile-options object and resolves the pieces the primitive entries can't:

- **parametric function forms** of `customElement` / `css` / `runes` (`({ filename }) => value`), evaluated once at the boundary (Svelte's `parametric()` normalization);
- **`warningFilter`** callback — applied natively by the compiler (`opts.warning_filter`), so it also covers module-compile warnings;
- **constant `cssHashOverride`** string; and
- **dynamic `cssHash`** callback, bridged through `js_sys::Function`. wasm compile is single-threaded, so the callback runs inline — no threadsafe-function / thread-marshalling needed (unlike the NAPI backend's TSFN path). The callback's `hash` argument is Svelte's raw digest (no `svelte-` prefix). A callback that throws surfaces as a compile error (matching upstream); a non-string return falls back to the compiler's default hash. The bridge never panics.

The result is returned as a JSON string (`{ js, css, warnings, metadata }`), consistent with the existing `svelte2tsx` wasm entry; callbacks are input-only. `compile_client` / `compile_server` are unchanged.

Implementation note: on the wasm target `js_sys` values are `Send + Sync`, so the JS callbacks satisfy the shared `CssHashFn` / `WarningFilterFn` bounds directly — **no `unsafe` `Send`/`Sync` wrapper**; the only thread-safe container needed is an `Arc<Mutex<Option<String>>>` slot for a throwing `cssHash`.

## Scope

- **wasm: fully implemented** ✅
- **C-API: out of scope** for this PR. `rsvelte_capi` takes options as a JSON blob and has no callback-pointer infrastructure. The parametric `customElement`/`css`/`runes` forms are meaningless across a C ABI (a C caller passes the resolved value), leaving only `warningFilter` + dynamic `cssHash`, which would require a new `#[repr(C)]` callback-pointer + userdata ABI and cbindgen header work with no current consumer. Deferred until needed — hence `Refs`, not `Fixes`.

## Tests

New node e2e (`pnpm run test:wasm-compile`, `scripts/dev/test-wasm-compile-options.mjs`) drives the real wasm build via `initSync` and covers all five options — 12/12 passing:

```
12 passed, 0 failed
```

Also verified: `cargo check`/`clippy` clean on both the wasm32 target and the native host with `--features wasm`; no changes to the NAPI or native paths (the wasm module is `#[cfg(feature = "wasm")]`).

Refs #1680

🤖 Generated with [Claude Code](https://claude.com/claude-code)