### PR TITLE
test(parse): cover `a?.b!.c` non-null mid optional-chain preservation

### DIFF
--- a/crates/rsvelte_core/tests/ts_assertion_expressions_extra.rs
+++ b/crates/rsvelte_core/tests/ts_assertion_expressions_extra.rs
@@ -116,6 +116,38 @@ fn non_null_as_member_object_preserves_wrapper() {
     );
 }
 
+#[test]
+fn non_null_mid_optional_chain_preserves_wrapper() {
+    // `a?.b!.c` — the `!` applies to the *middle* of the chain (`a?.b`), so the
+    // non-null wrapper is the object of the outer `.c` member, and its inner
+    // expression is the optional `a?.b` member. svelte/compiler keeps the whole
+    // `TSNonNullExpression` inside the `ChainExpression`; rsvelte's chain-element
+    // path must not unwrap it.
+    let source = "<script lang=\"ts\">let a: any = {};\nlet x = a?.b!.c;</script>";
+    let ast = parse_to_value(source);
+    let chain = find_node(&ast, "ChainExpression").expect("ChainExpression");
+    // Outer member is `.c` (non-optional); its object is the non-null wrapper.
+    assert_eq!(
+        chain
+            .pointer("/expression/object/type")
+            .and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+    // The wrapper's inner expression is the optional `a?.b` member.
+    assert_eq!(
+        chain
+            .pointer("/expression/object/expression/type")
+            .and_then(Value::as_str),
+        Some("MemberExpression")
+    );
+    assert_eq!(
+        chain
+            .pointer("/expression/object/expression/optional")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+}
+
 // ── parse-shape: template expression tag ───────────────────────────────────
 
 #[test]
@@ -177,6 +209,18 @@ fn type_assertion_and_instantiation_erased_from_codegen() {
 #[test]
 fn non_null_in_chain_erased_from_codegen() {
     let source = "<script lang=\"ts\">let a = { b: 1 };</script>{a!?.b}";
+    for code in [client_code(source), server_code(source)] {
+        assert!(
+            !code.contains("Unknown:"),
+            "TS wrapper leaked into codegen:\n{code}"
+        );
+    }
+}
+
+#[test]
+fn non_null_mid_chain_erased_from_codegen() {
+    // `a?.b!.c` (non-null in the middle of an optional chain) must strip cleanly.
+    let source = "<script lang=\"ts\">let a: any = { b: { c: 1 } };</script>{a?.b!.c}";
     for code in [client_code(source), server_code(source)] {
         assert!(
             !code.contains("Unknown:"),


### PR DESCRIPTION
## Summary

Follow-up verification for #1661, which tracked three TS expression forms still unwrapped at parse time after #1648:

- `TSTypeAssertion` (`<T>x`)
- `TSInstantiationExpression` (`f<T>`)
- `TSNonNullExpression` inside optional chains (`a?.b!.c`)

**The code fix for all three already landed in #1655** (merged 2026-07-21, ~4 hours before #1661 was filed). The parse-time unwraps are gone, there are no scope-out comments left in `read/expression.rs`, and `remove_typescript_nodes` erases the wrappers before analyze/transform so codegen is unchanged.

I verified every form against installed svelte 5.56.7 with a structural diff of `parse()` output. All are byte-identical, including 12 chain/assertion variants:

```
OK  a?.b!.c        OK  a?.b!.c.d      OK  a.b!.c
OK  a?.b!.c!.d      OK  a?.b.c!.d      OK  foo?.bar!()
OK  obj?.method()!.prop               OK  <number>y
OK  <Foo>y.bar      OK  f<number>      OK  g<A, B>
OK  (<number>y) + 1
```

The one genuine gap: the **mid-chain** form the issue explicitly names — `a?.b!.c`, where `!` applies to the middle `a?.b` (its object is the non-null wrapper, whose inner expression is the *optional* `a?.b` member) — had no explicit regression test. The existing suite only covered `a!?.b` (non-null as leftmost chain object) and `a!.b` (plain, non-optional member). This PR adds:

- `non_null_mid_optional_chain_preserves_wrapper` — asserts the `ChainExpression` keeps `TSNonNullExpression` as the outer member's object, with the optional `a?.b` member inside.
- `non_null_mid_chain_erased_from_codegen` — asserts the wrapper strips cleanly from client + server output (no `Unknown:` placeholder).

No production code changes — the fix already shipped in #1655, so no changeset is required.

## Verification

- `cargo test -p rsvelte_core --test ts_assertion_expressions_extra` — 9/9 pass (2 new)
- `cargo fmt` clean; `cargo clippy --test ts_assertion_expressions_extra -- -D warnings` clean

Fixes #1661

🤖 Generated with [Claude Code](https://claude.com/claude-code)