### PR TITLE
feat(svelte-check): honor function warningFilter via Node sidecar

### DIFF
--- a/.changeset/feat-svelte-check-warning-filter.md
+++ b/.changeset/feat-svelte-check-warning-filter.md
@@ -1,0 +1,22 @@
+---
+"@rsvelte/svelte-check": minor
+---
+
+feat(svelte-check): honor function `compilerOptions.warningFilter` via a Node sidecar
+
+`rsvelte-check` reads diagnostic-relevant `compilerOptions` from `svelte.config.*`
+statically, but `warningFilter` is a JS predicate the native compiler can't
+evaluate, so it was silently ignored — a warnings-only divergence from the
+official `svelte-check` for projects that use it.
+
+When `svelte.config.js` declares a function `compilerOptions.warningFilter`,
+`rsvelte-check` now spawns the consumer's Node **once per run** against a small
+bundled sidecar (`lib/warning-filter.mjs`) that imports the config and applies
+the function to the run's collected compiler warnings in a single batch. Because
+`warningFilter` is a pure per-warning predicate, this post-pass is exactly
+equivalent to Svelte's emit-time filter (the same argument the NAPI shim uses).
+
+The sidecar never rejects: a missing Node, an unimportable config, a timeout, or
+a malformed response all degrade to "keep every warning" plus a one-time stderr
+note — the filter never silently drops a warning, and the exit code is unaffected.
+A project with no function `warningFilter` never spawns Node (zero overhead).

--- a/apps/npm/svelte-check/README.md
+++ b/apps/npm/svelte-check/README.md
@@ -104,6 +104,7 @@ Run `rsvelte-check --help` for the authoritative list.
 Highlights:
 
 - **SvelteKit-aware.** Honours `svelte.config.js`'s `kit.files` overrides; injects SvelteKit-generated kit-file augmentations for both `.ts` (real TS annotations) and `.js` (JSDoc) files.
+- **`warningFilter` support.** A function `compilerOptions.warningFilter` in `svelte.config.js` is honoured. The native compiler can't run the JS predicate itself, so the run's compiler warnings are collected and passed once to a small Node sidecar (bundled with this package) that imports your config and applies the function — equivalent to Svelte's emit-time filter since it's a pure per-warning predicate. If Node is unavailable or the config can't be imported, every warning is shown and a one-time note is printed (the filter never silently drops a warning). Projects without a function `warningFilter` pay nothing — the sidecar is never spawned.
 - **Incremental.** A per-file overlay manifest and a per-file warning cache (`<cacheDir>/warnings.json`) make warm runs near-instant.
 - **Parallel compile.** Files are compiled across rayon workers; the TS pass is the long pole.
 - **Watch mode.** Composes with `--incremental` for an editor-like inner loop.

--- a/apps/npm/svelte-check/bin/svelte-check.cjs
+++ b/apps/npm/svelte-check/bin/svelte-check.cjs
@@ -73,9 +73,22 @@ if (process.platform !== 'win32') {
 	}
 }
 
+// Hand the native binary the Node interpreter + `warningFilter` sidecar script
+// it needs to evaluate `compilerOptions.warningFilter` (a JS predicate the Rust
+// compiler can't run). The script lives in this launcher's own package; the
+// binary re-spawns this same Node against it. Absent env vars simply disable the
+// feature (warnings are then all shown), so this is best-effort.
+const sidecar = path.join(__dirname, '..', 'lib', 'warning-filter.mjs');
+const childEnv = {
+	...process.env,
+	RSVELTE_CHECK_NODE: process.execPath,
+	RSVELTE_CHECK_WARNING_FILTER_SIDECAR: sidecar,
+};
+
 const result = spawnSync(binPath, process.argv.slice(2), {
 	stdio: 'inherit',
 	windowsHide: true,
+	env: childEnv,
 });
 
 if (result.error) {

--- a/apps/npm/svelte-check/lib/warning-filter.mjs
+++ b/apps/npm/svelte-check/lib/warning-filter.mjs
@@ -1,0 +1,86 @@
+// One-shot warning-filter sidecar for @rsvelte/svelte-check.
+//
+// `compilerOptions.warningFilter` is a JS predicate the native Rust compiler
+// can't evaluate. This script imports the project's Svelte config, pulls out the
+// function, and applies it to the batch of warnings collected across the whole
+// run — a single post-pass that is exactly equivalent to Svelte's emit-time
+// filter (it's a pure per-warning predicate).
+//
+// Protocol: one JSON request on stdin, one framed JSON response on stdout.
+//   request : { configPath, warnings: Warning[] }
+//   response: { ok: true, keep: boolean[] } | { ok: false, error: string }
+//
+// Never rejects or exits non-zero: the Rust side treats a non-`ok` (or absent)
+// response as "keep every warning", so a missing config or a throwing filter
+// fails open — a warningFilter that can't run must never silently drop warnings.
+
+import { pathToFileURL } from 'node:url';
+
+// Guard the JSON channel: importing the config may print to stdout (a banner, a
+// debug line). Route all stray stdout to stderr and emit only the framed JSON on
+// the real stdout.
+const realStdoutWrite = process.stdout.write.bind(process.stdout);
+process.stdout.write = process.stderr.write.bind(process.stderr);
+
+// A native addon can write straight to fd 1, bypassing the patch above. Framing
+// the response between markers lets the Rust side extract only the payload. Kept
+// byte-identical to `RESP_MARKER` in `warning_filter.rs`.
+const RESP_MARKER = '\x00<<rsvelte-warning-filter>>\x00';
+
+function readStdin() {
+	return new Promise((resolve) => {
+		let data = '';
+		process.stdin.setEncoding('utf8');
+		process.stdin.on('data', (chunk) => {
+			data += chunk;
+		});
+		process.stdin.on('end', () => resolve(data));
+		process.stdin.on('error', () => resolve(data));
+	});
+}
+
+async function main() {
+	let req;
+	try {
+		req = JSON.parse(await readStdin());
+	} catch (err) {
+		return { ok: false, error: `invalid request: ${err && err.message}` };
+	}
+
+	const warnings = Array.isArray(req.warnings) ? req.warnings : [];
+	if (warnings.length === 0) {
+		return { ok: true, keep: [] };
+	}
+
+	let mod;
+	try {
+		mod = await import(pathToFileURL(req.configPath).href);
+	} catch (err) {
+		return { ok: false, error: `config not importable: ${err && err.message}` };
+	}
+
+	const config = mod && mod.default != null ? mod.default : mod;
+	const filter = config && config.compilerOptions && config.compilerOptions.warningFilter;
+	if (typeof filter !== 'function') {
+		// No usable filter after loading: keep everything (fail open).
+		return { ok: true, keep: warnings.map(() => true) };
+	}
+
+	const keep = warnings.map((warning) => {
+		try {
+			return filter(warning) !== false;
+		} catch {
+			// A throwing predicate keeps the warning rather than dropping it.
+			return true;
+		}
+	});
+	return { ok: true, keep };
+}
+
+function emit(result) {
+	realStdoutWrite(RESP_MARKER + JSON.stringify(result) + RESP_MARKER);
+}
+
+main()
+	.then(emit)
+	.catch((err) => emit({ ok: false, error: String(err && err.message) }));

--- a/apps/npm/svelte-check/lib/warning-filter.mjs
+++ b/apps/npm/svelte-check/lib/warning-filter.mjs
@@ -68,7 +68,10 @@ async function main() {
 
 	const keep = warnings.map((warning) => {
 		try {
-			return filter(warning) !== false;
+			// Match Svelte's `if (!warning_filter(warning)) return;` — a *truthiness*
+			// test, so any falsy return (`undefined`/`0`/`''`/`null`/`NaN`) drops the
+			// warning, not only a strict `false`.
+			return Boolean(filter(warning));
 		} catch {
 			// A throwing predicate keeps the warning rather than dropping it.
 			return true;

--- a/apps/npm/svelte-check/package.json
+++ b/apps/npm/svelte-check/package.json
@@ -23,7 +23,8 @@
     "rsvelte-check": "bin/svelte-check.cjs"
   },
   "files": [
-    "bin/svelte-check.cjs"
+    "bin/svelte-check.cjs",
+    "lib/warning-filter.mjs"
   ],
   "optionalDependencies": {
     "@rsvelte/svelte-check-darwin-arm64": "workspace:^",

--- a/crates/rsvelte_core/src/svelte_check/config.rs
+++ b/crates/rsvelte_core/src/svelte_check/config.rs
@@ -376,9 +376,11 @@ fn extract_compiler_options(obj: &oxc::ObjectExpression, settings: &mut Compiler
 /// after actually loading the config.
 ///
 /// Only `svelte.config.*` is considered (matching where the official
-/// svelte-check reads `compilerOptions.warningFilter`); a `vite.config.*`
-/// carrying the filter inside a plugin call is not loaded standalone.
-/// Returns `None` when no such file/property is found.
+/// svelte-check reads `compilerOptions.warningFilter`). A `warningFilter` passed
+/// inline to the `svelte()` / `sveltekit()` plugin in `vite.config.*` is
+/// intentionally NOT supported: unlike the scalar options, importing a
+/// `vite.config.*` standalone in the sidecar would drag in the whole Vite plugin
+/// graph. Returns `None` when no such file/property is found.
 pub fn warning_filter_config_path(workspace: &Path, config: Option<&Path>) -> Option<PathBuf> {
     // `--config` wins when it names a Svelte config; a vite.config is not a
     // standalone-importable source of `warningFilter`.

--- a/crates/rsvelte_core/src/svelte_check/config.rs
+++ b/crates/rsvelte_core/src/svelte_check/config.rs
@@ -27,7 +27,7 @@
 //! to defaults. This matches the existing `load_kit_files_settings`
 //! contract in `kit_file.rs`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast as oxc;
@@ -364,6 +364,92 @@ fn extract_compiler_options(obj: &oxc::ObjectExpression, settings: &mut Compiler
     }
 }
 
+/// Locate the Svelte config file (`svelte.config.*`, or the `--config`
+/// path when it names a Svelte config) whose `compilerOptions` statically
+/// declares a **function** `warningFilter`.
+///
+/// `warningFilter` is a JS predicate the native compiler can't evaluate, so
+/// the CLI hands this file to a Node sidecar that imports it and applies the
+/// real function to the collected warnings. This is a cheap static probe —
+/// it only confirms a function-shaped `warningFilter` is present so a project
+/// without one never spawns Node; the sidecar re-checks `typeof === 'function'`
+/// after actually loading the config.
+///
+/// Only `svelte.config.*` is considered (matching where the official
+/// svelte-check reads `compilerOptions.warningFilter`); a `vite.config.*`
+/// carrying the filter inside a plugin call is not loaded standalone.
+/// Returns `None` when no such file/property is found.
+pub fn warning_filter_config_path(workspace: &Path, config: Option<&Path>) -> Option<PathBuf> {
+    // `--config` wins when it names a Svelte config; a vite.config is not a
+    // standalone-importable source of `warningFilter`.
+    if let Some(path) = config {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if name.starts_with("vite.config") {
+            return None;
+        }
+        return declares_function_warning_filter(path).then(|| path.to_path_buf());
+    }
+    for name in SVELTE_CONFIG_CANDIDATES {
+        let candidate = workspace.join(name);
+        if candidate.is_file() && declares_function_warning_filter(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Whether `path`'s exported config object has a `compilerOptions.warningFilter`
+/// whose value is statically function-shaped (an arrow/function expression, or
+/// a reference like an identifier / call / member that could resolve to one).
+fn declares_function_warning_filter(path: &Path) -> bool {
+    let Ok(source) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
+    let is_ts = name.ends_with(".ts") || name.ends_with(".mts") || name.ends_with(".cts");
+    let source_type = if is_ts {
+        SourceType::ts()
+    } else {
+        SourceType::default()
+    };
+    let allocator = Allocator::default();
+    let parser = OxcParser::new(&allocator, &source, source_type);
+    let result = parser.parse();
+    result.program.body.iter().any(|stmt| {
+        config_object_from_stmt(stmt)
+            .and_then(|obj| lookup_property(obj, "compilerOptions"))
+            .and_then(|co| match co {
+                oxc::Expression::ObjectExpression(co) => lookup_property(co, "warningFilter"),
+                _ => None,
+            })
+            .is_some_and(is_function_shaped)
+    })
+}
+
+/// Conservatively classify an expression as "could be a function". Literal
+/// non-functions (a boolean, a plain object, …) are excluded so they never
+/// trigger a needless Node spawn; anything referential is accepted and the
+/// sidecar makes the final `typeof` call.
+fn is_function_shaped(expr: &oxc::Expression) -> bool {
+    matches!(
+        expr,
+        oxc::Expression::ArrowFunctionExpression(_)
+            | oxc::Expression::FunctionExpression(_)
+            | oxc::Expression::Identifier(_)
+            | oxc::Expression::CallExpression(_)
+            | oxc::Expression::StaticMemberExpression(_)
+            | oxc::Expression::ComputedMemberExpression(_)
+            | oxc::Expression::ParenthesizedExpression(_)
+            | oxc::Expression::ConditionalExpression(_)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -637,6 +723,72 @@ mod tests {
         );
         let s = load_compiler_options(&dir);
         assert!(s.experimental_async);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn detects_function_warning_filter_in_svelte_config() {
+        let dir = workspace("wf_present");
+        write(
+            &dir,
+            "svelte.config.js",
+            "export default { compilerOptions: { warningFilter: (w) => w.code !== 'a11y_x' } };",
+        );
+        assert_eq!(
+            warning_filter_config_path(&dir, None),
+            Some(dir.join("svelte.config.js"))
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn detects_identifier_warning_filter() {
+        let dir = workspace("wf_ident");
+        write(
+            &dir,
+            "svelte.config.js",
+            "import { filter } from './f.js';\nexport default { compilerOptions: { warningFilter: filter } };",
+        );
+        assert_eq!(
+            warning_filter_config_path(&dir, None),
+            Some(dir.join("svelte.config.js"))
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn no_warning_filter_returns_none() {
+        let dir = workspace("wf_absent");
+        write(
+            &dir,
+            "svelte.config.js",
+            "export default { compilerOptions: { runes: true } };",
+        );
+        assert_eq!(warning_filter_config_path(&dir, None), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn non_function_warning_filter_ignored() {
+        // A misconfigured non-function value must not trigger a Node spawn.
+        let dir = workspace("wf_nonfn");
+        write(
+            &dir,
+            "svelte.config.js",
+            "export default { compilerOptions: { warningFilter: true } };",
+        );
+        assert_eq!(warning_filter_config_path(&dir, None), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn vite_config_is_not_a_warning_filter_source() {
+        let dir = workspace("wf_vite");
+        write(&dir, "vite.config.ts", "export default { plugins: [] };");
+        assert_eq!(
+            warning_filter_config_path(&dir, Some(&dir.join("vite.config.ts"))),
+            None
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/rsvelte_core/src/svelte_check/mod.rs
+++ b/crates/rsvelte_core/src/svelte_check/mod.rs
@@ -17,6 +17,7 @@ pub mod overlay;
 pub mod runner;
 pub mod tsgo;
 pub mod walker;
+pub mod warning_filter;
 pub mod watch;
 pub mod writers;
 

--- a/crates/rsvelte_core/src/svelte_check/runner.rs
+++ b/crates/rsvelte_core/src/svelte_check/runner.rs
@@ -11,7 +11,9 @@ use std::path::{Path, PathBuf};
 
 use crate::compiler::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
 
-use super::config::{CompilerOptionsSettings, load_compiler_options_with_config};
+use super::config::{
+    CompilerOptionsSettings, load_compiler_options_with_config, warning_filter_config_path,
+};
 use super::diagnostic::{Diagnostic, DiagnosticSeverity, Position, Range};
 use super::kit_file::load_kit_files_settings_with_config;
 use super::manifest::{
@@ -236,7 +238,33 @@ pub fn run(options: &RunOptions) -> RunResult {
 
     apply_filters(&mut result.diagnostics, options);
 
+    // Honor `compilerOptions.warningFilter` — a JS predicate the native compiler
+    // can't run — via a one-shot Node sidecar. Applied last, over the fully
+    // resolved warning set, which is equivalent to Svelte's emit-time filter
+    // because it's a pure per-warning predicate (#1666). Zero cost when the
+    // config declares no function `warningFilter`.
+    apply_warning_filter(&mut result.diagnostics, options);
+
     result
+}
+
+/// Run the project's function `warningFilter` over the collected Svelte warnings
+/// through the Node sidecar, when both a filter is declared and the sidecar is
+/// available. A no-op otherwise (and a fail-open on any sidecar error).
+fn apply_warning_filter(diagnostics: &mut Vec<Diagnostic>, options: &RunOptions) {
+    let Some(config_path) =
+        warning_filter_config_path(&options.workspace, options.config.as_deref())
+    else {
+        return;
+    };
+    let Some(env) = super::warning_filter::SidecarEnv::from_env() else {
+        eprintln!(
+            "rsvelte-check: warning: `compilerOptions.warningFilter` is set but could not be \
+             evaluated (no Node sidecar available). All warnings are shown."
+        );
+        return;
+    };
+    super::warning_filter::apply(&env, &config_path, diagnostics);
 }
 
 /// Drop diagnostics whose file lives outside the checked workspace root.

--- a/crates/rsvelte_core/src/svelte_check/runner.rs
+++ b/crates/rsvelte_core/src/svelte_check/runner.rs
@@ -236,14 +236,17 @@ pub fn run(options: &RunOptions) -> RunResult {
     // the workspace root are dropped.
     drop_out_of_workspace_diagnostics(&mut result.diagnostics, &options.workspace);
 
-    apply_filters(&mut result.diagnostics, options);
-
     // Honor `compilerOptions.warningFilter` — a JS predicate the native compiler
-    // can't run — via a one-shot Node sidecar. Applied last, over the fully
-    // resolved warning set, which is equivalent to Svelte's emit-time filter
-    // because it's a pure per-warning predicate (#1666). Zero cost when the
-    // config declares no function `warningFilter`.
+    // can't run — via a one-shot Node sidecar. This is equivalent to Svelte's
+    // emit-time filter because it's a pure per-warning predicate (#1666). It must
+    // run BEFORE `apply_filters`: the official order is filter-then-promote (the
+    // compiler applies `warningFilter` during `compile()`, and svelte-check's
+    // `--compiler-warnings` `ignore`/`error` handling happens afterwards), so a
+    // warning the filter rejects must be gone before a `code:error` override
+    // could promote it. Zero cost when no function `warningFilter` is declared.
     apply_warning_filter(&mut result.diagnostics, options);
+
+    apply_filters(&mut result.diagnostics, options);
 
     result
 }
@@ -258,10 +261,14 @@ fn apply_warning_filter(diagnostics: &mut Vec<Diagnostic>, options: &RunOptions)
         return;
     };
     let Some(env) = super::warning_filter::SidecarEnv::from_env() else {
-        eprintln!(
-            "rsvelte-check: warning: `compilerOptions.warningFilter` is set but could not be \
-             evaluated (no Node sidecar available). All warnings are shown."
-        );
+        // Once per process, so `--watch` doesn't re-print it on every rebuild.
+        static NO_NODE_NOTE: std::sync::Once = std::sync::Once::new();
+        NO_NODE_NOTE.call_once(|| {
+            eprintln!(
+                "rsvelte-check: warning: `compilerOptions.warningFilter` is set but could not be \
+                 evaluated (no Node sidecar available). All warnings are shown."
+            );
+        });
         return;
     };
     super::warning_filter::apply(&env, &config_path, diagnostics);

--- a/crates/rsvelte_core/src/svelte_check/warning_filter.rs
+++ b/crates/rsvelte_core/src/svelte_check/warning_filter.rs
@@ -1,0 +1,374 @@
+//! One-shot Node sidecar that applies a project's `compilerOptions.warningFilter`
+//! — a JS predicate the native compiler can't evaluate — to the compiler warnings
+//! a `rsvelte-check` run produced.
+//!
+//! `warningFilter` is a pure per-warning predicate applied by the official Svelte
+//! compiler at emit time; because a dropped warning never affects anything else,
+//! filtering the full collected batch in one post-pass is exactly equivalent to
+//! filtering at emit time (the same argument the NAPI shim uses, #1666). So the
+//! whole run's warnings are gathered and sent to Node **once**, the sidecar loads
+//! the config, calls the function on each warning, and returns a keep/drop mask.
+//!
+//! The sidecar never rejects: a missing Node, an unimportable config, a timeout,
+//! or a malformed response all degrade to "keep every warning" (plus a single
+//! stderr note) — a warningFilter that can't run must never silently *drop* a
+//! warning, only fail open. The exit code is unaffected: it's recomputed from the
+//! surviving diagnostics like any other filter.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use super::diagnostic::{Diagnostic, DiagnosticSeverity};
+
+/// Upper bound before a hung sidecar is killed and the run falls back to
+/// keeping every warning — a stuck Node / config must never block the CLI.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const POLL: Duration = Duration::from_millis(10);
+
+/// The sidecar frames its JSON response between these markers so a config that
+/// prints to stdout on import (a banner, a debug line, a native addon writing
+/// straight to fd 1) can't corrupt the channel: the Rust side extracts only the
+/// framed payload. Kept byte-identical to `RESP_MARKER` in `warning-filter.mjs`.
+const RESP_MARKER: &[u8] = b"\x00<<rsvelte-warning-filter>>\x00";
+
+/// Env var naming the Node interpreter the CLI launcher recorded (its own
+/// `process.execPath`). Falls back to `node` on `PATH`.
+const NODE_ENV: &str = "RSVELTE_CHECK_NODE";
+/// Env var naming the `warning-filter.mjs` sidecar script the CLI launcher
+/// ships alongside itself. Absent → the filter path is disabled.
+const SIDECAR_ENV: &str = "RSVELTE_CHECK_WARNING_FILTER_SIDECAR";
+
+/// Node interpreter + `warning-filter.mjs` script + timeout.
+pub struct SidecarEnv {
+    pub node: PathBuf,
+    pub script: PathBuf,
+    /// Overridable so tests can exercise the timeout path without a 30s wait.
+    pub timeout: Duration,
+}
+
+impl SidecarEnv {
+    /// Resolve the sidecar from the environment the launcher set. `None`
+    /// disables the JS filter (the run keeps every warning). A runnable Node is
+    /// required, so a misconfigured `RSVELTE_CHECK_NODE` degrades gracefully.
+    pub fn from_env() -> Option<Self> {
+        let script = PathBuf::from(std::env::var_os(SIDECAR_ENV)?);
+        if !script.is_file() {
+            return None;
+        }
+        let node = std::env::var_os(NODE_ENV)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("node"));
+        node_runnable(&node).then_some(SidecarEnv {
+            node,
+            script,
+            timeout: DEFAULT_TIMEOUT,
+        })
+    }
+}
+
+/// Apply the config's `warningFilter` to `diagnostics` in place, dropping every
+/// Svelte compiler **warning** the predicate rejects. Errors and non-Svelte
+/// (e.g. TypeScript) diagnostics are never touched — `warningFilter` only ever
+/// sees compiler warnings. On any sidecar failure the diagnostics are left
+/// untouched and a single note is printed to stderr.
+pub fn apply(env: &SidecarEnv, config_path: &Path, diagnostics: &mut Vec<Diagnostic>) {
+    // Indices of the Svelte warnings the filter is allowed to judge, in order.
+    let indices: Vec<usize> = diagnostics
+        .iter()
+        .enumerate()
+        .filter(|(_, d)| d.severity == DiagnosticSeverity::Warning && d.source == "svelte")
+        .map(|(i, _)| i)
+        .collect();
+    if indices.is_empty() {
+        return;
+    }
+
+    let warnings: Vec<_> = indices
+        .iter()
+        .map(|&i| warning_json(&diagnostics[i]))
+        .collect();
+    let Some(keep) = run_sidecar(env, config_path, &warnings) else {
+        eprintln!(
+            "rsvelte-check: warning: `compilerOptions.warningFilter` left unapplied — the Node \
+             sidecar could not evaluate it (is Node available and the config importable?). All \
+             warnings are shown."
+        );
+        return;
+    };
+
+    // `keep[k]` corresponds to `indices[k]`; drop the rejected originals.
+    let drop: std::collections::HashSet<usize> = indices
+        .iter()
+        .zip(keep)
+        .filter_map(|(&i, k)| (!k).then_some(i))
+        .collect();
+    if drop.is_empty() {
+        return;
+    }
+    let mut i = 0;
+    diagnostics.retain(|_| {
+        let keep = !drop.contains(&i);
+        i += 1;
+        keep
+    });
+}
+
+/// The warning object shape the official svelte-check passes to `warningFilter`
+/// (Svelte's `Warning`): `code`, `message`, `filename`, and 1-indexed
+/// `start`/`end` `{ line, column }`. Reconstructed from the diagnostic.
+fn warning_json(d: &Diagnostic) -> serde_json::Value {
+    let loc =
+        |p: &super::diagnostic::Position| serde_json::json!({ "line": p.line, "column": p.column });
+    serde_json::json!({
+        "code": d.code,
+        "message": d.message,
+        "filename": d.file.to_string_lossy(),
+        "start": d.range.map(|r| loc(&r.start)),
+        "end": d.range.map(|r| loc(&r.end)),
+    })
+}
+
+/// Spawn the sidecar once and return the keep/drop mask (one bool per warning,
+/// in order). `None` on any failure so the caller fails open.
+fn run_sidecar(
+    env: &SidecarEnv,
+    config_path: &Path,
+    warnings: &[serde_json::Value],
+) -> Option<Vec<bool>> {
+    let payload = serde_json::json!({
+        "configPath": config_path.to_string_lossy(),
+        "warnings": warnings,
+    });
+    let body = serde_json::to_vec(&payload).ok()?;
+
+    let mut child = Command::new(&env.node)
+        .arg(&env.script)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    // Any early exit past here must reap the child so a broken pipe never leaves
+    // a zombie behind.
+    let (Some(mut stdin), Some(mut stdout)) = (child.stdin.take(), child.stdout.take()) else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return None;
+    };
+
+    // Feed stdin and drain stdout on separate threads so a child that writes a
+    // large burst before reading all of stdin can't deadlock our write. Dropping
+    // the stdin handle closes the pipe, signalling EOF to the sidecar.
+    let writer = std::thread::spawn(move || {
+        let _ = stdin.write_all(&body);
+    });
+    let reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stdout.read_to_end(&mut buf);
+        buf
+    });
+
+    let deadline = Instant::now() + env.timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+            Ok(None) => std::thread::sleep(POLL),
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+        }
+    };
+    let _ = writer.join();
+    let stdout = reader.join().unwrap_or_default();
+    if !status?.success() {
+        return None;
+    }
+
+    let payload = extract_framed(&stdout)?;
+    let resp: serde_json::Value = serde_json::from_slice(payload).ok()?;
+    if resp.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
+        return None;
+    }
+    let keep: Vec<bool> = resp
+        .get("keep")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_bool().unwrap_or(true))
+        .collect();
+    (keep.len() == warnings.len()).then_some(keep)
+}
+
+/// Extract the JSON payload framed by [`RESP_MARKER`] from raw stdout, discarding
+/// any stray bytes around it. `None` when the frame is absent.
+fn extract_framed(buf: &[u8]) -> Option<&[u8]> {
+    let start = find_subslice(buf, RESP_MARKER)? + RESP_MARKER.len();
+    let rest = &buf[start..];
+    let end = find_subslice(rest, RESP_MARKER)?;
+    Some(&rest[..end])
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Whether `node --version` runs, so a missing Node disables the path cleanly.
+fn node_runnable(node: &Path) -> bool {
+    Command::new(node)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::svelte_check::diagnostic::{Position, Range};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn warn(code: &str) -> Diagnostic {
+        Diagnostic {
+            file: PathBuf::from("Foo.svelte"),
+            severity: DiagnosticSeverity::Warning,
+            code: Some(code.into()),
+            message: "msg".into(),
+            range: Some(Range {
+                start: Position { line: 1, column: 0 },
+                end: Position { line: 1, column: 4 },
+            }),
+            source: "svelte",
+        }
+    }
+
+    #[test]
+    fn extract_framed_picks_payload_out_of_noise() {
+        let mut buf = b"stray banner\n".to_vec();
+        buf.extend_from_slice(RESP_MARKER);
+        buf.extend_from_slice(br#"{"ok":true}"#);
+        buf.extend_from_slice(RESP_MARKER);
+        buf.extend_from_slice(b"trailing junk");
+        assert_eq!(extract_framed(&buf), Some(&br#"{"ok":true}"#[..]));
+    }
+
+    #[test]
+    fn extract_framed_absent_marker_is_none() {
+        assert_eq!(extract_framed(b"no markers here"), None);
+        assert_eq!(extract_framed(RESP_MARKER), None);
+    }
+
+    fn node() -> Option<PathBuf> {
+        let node = PathBuf::from("node");
+        node_runnable(&node).then_some(node)
+    }
+
+    /// Write `body` to a unique temp `.mjs` and build a `SidecarEnv`.
+    fn env_with_script(node: PathBuf, body: &str, timeout: Duration) -> (SidecarEnv, PathBuf) {
+        static N: AtomicU32 = AtomicU32::new(0);
+        let script = std::env::temp_dir().join(format!(
+            "rsvelte-wf-sidecar-test-{}-{}.mjs",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&script, body).unwrap();
+        (
+            SidecarEnv {
+                node,
+                script: script.clone(),
+                timeout,
+            },
+            script,
+        )
+    }
+
+    /// A fake sidecar that keeps warnings whose `code` isn't "drop_me",
+    /// exercising the real framed request/response protocol end-to-end.
+    const FAKE_SIDECAR: &str = r#"
+        const M = '\x00<<rsvelte-warning-filter>>\x00';
+        let data = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', (c) => (data += c));
+        process.stdin.on('end', () => {
+            const req = JSON.parse(data);
+            const keep = req.warnings.map((w) => w.code !== 'drop_me');
+            process.stdout.write(M + JSON.stringify({ ok: true, keep }) + M);
+        });
+    "#;
+
+    #[test]
+    fn drops_rejected_warning_keeps_others() {
+        let Some(node) = node() else { return };
+        let (env, script) = env_with_script(node, FAKE_SIDECAR, DEFAULT_TIMEOUT);
+        let mut diags = vec![warn("drop_me"), warn("keep_me")];
+        apply(&env, Path::new("svelte.config.js"), &mut diags);
+        let codes: Vec<_> = diags.iter().map(|d| d.code.clone().unwrap()).collect();
+        assert_eq!(codes, vec!["keep_me".to_string()]);
+        let _ = std::fs::remove_file(script);
+    }
+
+    #[test]
+    fn hung_sidecar_times_out_and_keeps_all() {
+        let Some(node) = node() else { return };
+        let (env, script) = env_with_script(
+            node,
+            "setInterval(() => {}, 1000);",
+            Duration::from_millis(200),
+        );
+        let mut diags = vec![warn("a"), warn("b")];
+        apply(&env, Path::new("svelte.config.js"), &mut diags);
+        assert_eq!(diags.len(), 2, "a timeout must keep every warning");
+        let _ = std::fs::remove_file(script);
+    }
+
+    #[test]
+    fn malformed_response_keeps_all() {
+        let Some(node) = node() else { return };
+        let (env, script) = env_with_script(
+            node,
+            "process.stdout.write('not framed json');",
+            DEFAULT_TIMEOUT,
+        );
+        let mut diags = vec![warn("a")];
+        apply(&env, Path::new("svelte.config.js"), &mut diags);
+        assert_eq!(diags.len(), 1);
+        let _ = std::fs::remove_file(script);
+    }
+
+    #[test]
+    fn non_svelte_and_error_diagnostics_are_untouched() {
+        let Some(node) = node() else { return };
+        // Even a filter that drops everything must not remove errors / ts diags.
+        let sidecar = r#"
+            const M = '\x00<<rsvelte-warning-filter>>\x00';
+            let data = '';
+            process.stdin.setEncoding('utf8');
+            process.stdin.on('data', (c) => (data += c));
+            process.stdin.on('end', () => {
+                const req = JSON.parse(data);
+                process.stdout.write(M + JSON.stringify({ ok: true, keep: req.warnings.map(() => false) }) + M);
+            });
+        "#;
+        let (env, script) = env_with_script(node, sidecar, DEFAULT_TIMEOUT);
+        let mut err = warn("x");
+        err.severity = DiagnosticSeverity::Error;
+        let mut ts = warn("y");
+        ts.source = "ts";
+        let mut diags = vec![warn("droppable"), err, ts];
+        apply(&env, Path::new("svelte.config.js"), &mut diags);
+        // Only the single svelte warning is removed.
+        assert_eq!(diags.len(), 2);
+        assert!(diags.iter().all(|d| d.code.as_deref() != Some("droppable")));
+        let _ = std::fs::remove_file(script);
+    }
+}

--- a/crates/rsvelte_core/src/svelte_check/warning_filter.rs
+++ b/crates/rsvelte_core/src/svelte_check/warning_filter.rs
@@ -90,11 +90,15 @@ pub fn apply(env: &SidecarEnv, config_path: &Path, diagnostics: &mut Vec<Diagnos
         .map(|&i| warning_json(&diagnostics[i]))
         .collect();
     let Some(keep) = run_sidecar(env, config_path, &warnings) else {
-        eprintln!(
-            "rsvelte-check: warning: `compilerOptions.warningFilter` left unapplied — the Node \
-             sidecar could not evaluate it (is Node available and the config importable?). All \
-             warnings are shown."
-        );
+        // Once per process, so `--watch` doesn't re-print it on every rebuild.
+        static FAILED_NOTE: std::sync::Once = std::sync::Once::new();
+        FAILED_NOTE.call_once(|| {
+            eprintln!(
+                "rsvelte-check: warning: `compilerOptions.warningFilter` left unapplied — the Node \
+                 sidecar could not evaluate it (is Node available and the config importable?). All \
+                 warnings are shown."
+            );
+        });
         return;
     };
 
@@ -232,25 +236,13 @@ fn node_runnable(node: &Path) -> bool {
         .unwrap_or(false)
 }
 
+// Only the pure, Node-free logic is unit-tested here so the `--lib` test-unit CI
+// job stays runnable without a Node interpreter. The Node-backed `apply()`
+// behaviour (sidecar spawn, timeout, protocol) is covered in the integration
+// suite `tests/svelte_check_warning_filter.rs`, whose CI job installs Node.
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::svelte_check::diagnostic::{Position, Range};
-    use std::sync::atomic::{AtomicU32, Ordering};
-
-    fn warn(code: &str) -> Diagnostic {
-        Diagnostic {
-            file: PathBuf::from("Foo.svelte"),
-            severity: DiagnosticSeverity::Warning,
-            code: Some(code.into()),
-            message: "msg".into(),
-            range: Some(Range {
-                start: Position { line: 1, column: 0 },
-                end: Position { line: 1, column: 4 },
-            }),
-            source: "svelte",
-        }
-    }
 
     #[test]
     fn extract_framed_picks_payload_out_of_noise() {
@@ -266,109 +258,5 @@ mod tests {
     fn extract_framed_absent_marker_is_none() {
         assert_eq!(extract_framed(b"no markers here"), None);
         assert_eq!(extract_framed(RESP_MARKER), None);
-    }
-
-    fn node() -> Option<PathBuf> {
-        let node = PathBuf::from("node");
-        node_runnable(&node).then_some(node)
-    }
-
-    /// Write `body` to a unique temp `.mjs` and build a `SidecarEnv`.
-    fn env_with_script(node: PathBuf, body: &str, timeout: Duration) -> (SidecarEnv, PathBuf) {
-        static N: AtomicU32 = AtomicU32::new(0);
-        let script = std::env::temp_dir().join(format!(
-            "rsvelte-wf-sidecar-test-{}-{}.mjs",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        std::fs::write(&script, body).unwrap();
-        (
-            SidecarEnv {
-                node,
-                script: script.clone(),
-                timeout,
-            },
-            script,
-        )
-    }
-
-    /// A fake sidecar that keeps warnings whose `code` isn't "drop_me",
-    /// exercising the real framed request/response protocol end-to-end.
-    const FAKE_SIDECAR: &str = r#"
-        const M = '\x00<<rsvelte-warning-filter>>\x00';
-        let data = '';
-        process.stdin.setEncoding('utf8');
-        process.stdin.on('data', (c) => (data += c));
-        process.stdin.on('end', () => {
-            const req = JSON.parse(data);
-            const keep = req.warnings.map((w) => w.code !== 'drop_me');
-            process.stdout.write(M + JSON.stringify({ ok: true, keep }) + M);
-        });
-    "#;
-
-    #[test]
-    fn drops_rejected_warning_keeps_others() {
-        let Some(node) = node() else { return };
-        let (env, script) = env_with_script(node, FAKE_SIDECAR, DEFAULT_TIMEOUT);
-        let mut diags = vec![warn("drop_me"), warn("keep_me")];
-        apply(&env, Path::new("svelte.config.js"), &mut diags);
-        let codes: Vec<_> = diags.iter().map(|d| d.code.clone().unwrap()).collect();
-        assert_eq!(codes, vec!["keep_me".to_string()]);
-        let _ = std::fs::remove_file(script);
-    }
-
-    #[test]
-    fn hung_sidecar_times_out_and_keeps_all() {
-        let Some(node) = node() else { return };
-        let (env, script) = env_with_script(
-            node,
-            "setInterval(() => {}, 1000);",
-            Duration::from_millis(200),
-        );
-        let mut diags = vec![warn("a"), warn("b")];
-        apply(&env, Path::new("svelte.config.js"), &mut diags);
-        assert_eq!(diags.len(), 2, "a timeout must keep every warning");
-        let _ = std::fs::remove_file(script);
-    }
-
-    #[test]
-    fn malformed_response_keeps_all() {
-        let Some(node) = node() else { return };
-        let (env, script) = env_with_script(
-            node,
-            "process.stdout.write('not framed json');",
-            DEFAULT_TIMEOUT,
-        );
-        let mut diags = vec![warn("a")];
-        apply(&env, Path::new("svelte.config.js"), &mut diags);
-        assert_eq!(diags.len(), 1);
-        let _ = std::fs::remove_file(script);
-    }
-
-    #[test]
-    fn non_svelte_and_error_diagnostics_are_untouched() {
-        let Some(node) = node() else { return };
-        // Even a filter that drops everything must not remove errors / ts diags.
-        let sidecar = r#"
-            const M = '\x00<<rsvelte-warning-filter>>\x00';
-            let data = '';
-            process.stdin.setEncoding('utf8');
-            process.stdin.on('data', (c) => (data += c));
-            process.stdin.on('end', () => {
-                const req = JSON.parse(data);
-                process.stdout.write(M + JSON.stringify({ ok: true, keep: req.warnings.map(() => false) }) + M);
-            });
-        "#;
-        let (env, script) = env_with_script(node, sidecar, DEFAULT_TIMEOUT);
-        let mut err = warn("x");
-        err.severity = DiagnosticSeverity::Error;
-        let mut ts = warn("y");
-        ts.source = "ts";
-        let mut diags = vec![warn("droppable"), err, ts];
-        apply(&env, Path::new("svelte.config.js"), &mut diags);
-        // Only the single svelte warning is removed.
-        assert_eq!(diags.len(), 2);
-        assert!(diags.iter().all(|d| d.code.as_deref() != Some("droppable")));
-        let _ = std::fs::remove_file(script);
     }
 }

--- a/crates/rsvelte_core/tests/svelte_check_warning_filter.rs
+++ b/crates/rsvelte_core/tests/svelte_check_warning_filter.rs
@@ -14,6 +14,10 @@
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::time::Duration;
+
+use rsvelte_core::svelte_check::diagnostic::{Diagnostic, DiagnosticSeverity, Position, Range};
+use rsvelte_core::svelte_check::warning_filter::{DEFAULT_TIMEOUT, SidecarEnv, apply};
 
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_svelte_check")
@@ -98,6 +102,35 @@ fn function_warning_filter_drops_matching_warning() {
     assert!(
         !stdout.contains("Unused CSS selector"),
         "warningFilter should drop the css_unused_selector warning; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("0 errors and 0 warnings"),
+        "the dropped warning must not be counted; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn falsy_non_false_return_drops_warning() {
+    if !node_available() {
+        return;
+    }
+    // Svelte uses a truthiness test (`if (!warning_filter(w)) return;`), so a
+    // predicate returning `undefined` (falsy, but not strictly `false`) must
+    // drop the warning — not keep it.
+    let dir = workspace("falsy");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+    write(
+        &dir,
+        "svelte.config.js",
+        "export default { compilerOptions: { warningFilter: (w) => (w.code === 'css_unused_selector' ? undefined : true) } };",
+    );
+
+    let out = run_with_sidecar(&dir, &["--no-type-check"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("Unused CSS selector"),
+        "a falsy (undefined) return must drop the warning; got:\n{stdout}"
     );
     assert!(
         stdout.contains("0 errors and 0 warnings"),
@@ -202,4 +235,169 @@ fn broken_config_fails_open() {
         "a config that fails to import must fail open; got:\n{stdout}"
     );
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn warning_filter_wins_over_compiler_warnings_error_promotion() {
+    if !node_available() {
+        return;
+    }
+    // A warning the filter rejects must be *gone* before `--compiler-warnings
+    // code:error` could promote it — matching the official filter-then-promote
+    // order. Without the fix the rejected warning would surface as an ERROR and
+    // flip the exit code.
+    let dir = workspace("filter_then_promote");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+    write(
+        &dir,
+        "svelte.config.js",
+        "export default { compilerOptions: { warningFilter: (w) => w.code !== 'css_unused_selector' } };",
+    );
+
+    let out = run_with_sidecar(
+        &dir,
+        &[
+            "--no-type-check",
+            "--compiler-warnings",
+            "css_unused_selector:error",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("Unused CSS selector"),
+        "a filtered warning must not be promoted to an error; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("0 errors and 0 warnings"),
+        "the filtered warning must not be counted as an error; got:\n{stdout}"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a filtered-away warning must not flip the exit code via error promotion"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ── `warning_filter::apply()` protocol coverage ─────────────────────────────
+// These drive the Rust sidecar runner directly against fake Node scripts, so
+// they need a Node interpreter — hence they live in this integration suite (its
+// CI job installs Node) rather than in the `--lib` unit tests.
+
+fn node_bin() -> Option<PathBuf> {
+    node_available().then(|| PathBuf::from("node"))
+}
+
+fn warn(code: &str) -> Diagnostic {
+    Diagnostic {
+        file: PathBuf::from("Foo.svelte"),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.into()),
+        message: "msg".into(),
+        range: Some(Range {
+            start: Position { line: 1, column: 0 },
+            end: Position { line: 1, column: 4 },
+        }),
+        source: "svelte",
+    }
+}
+
+/// Write `body` to a unique temp `.mjs` and build a `SidecarEnv` around it.
+fn env_with_script(node: PathBuf, body: &str, timeout: Duration) -> (SidecarEnv, PathBuf) {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static N: AtomicU32 = AtomicU32::new(0);
+    let script = std::env::temp_dir().join(format!(
+        "rsvelte-wf-sidecar-test-{}-{}.mjs",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::write(&script, body).unwrap();
+    (
+        SidecarEnv {
+            node,
+            script: script.clone(),
+            timeout,
+        },
+        script,
+    )
+}
+
+/// A fake sidecar that keeps warnings whose `code` isn't "drop_me",
+/// exercising the real framed request/response protocol end-to-end.
+const FAKE_SIDECAR: &str = r#"
+    const M = '\x00<<rsvelte-warning-filter>>\x00';
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => {
+        const req = JSON.parse(data);
+        const keep = req.warnings.map((w) => w.code !== 'drop_me');
+        process.stdout.write(M + JSON.stringify({ ok: true, keep }) + M);
+    });
+"#;
+
+#[test]
+fn apply_drops_rejected_warning_keeps_others() {
+    let Some(node) = node_bin() else { return };
+    let (env, script) = env_with_script(node, FAKE_SIDECAR, DEFAULT_TIMEOUT);
+    let mut diags = vec![warn("drop_me"), warn("keep_me")];
+    apply(&env, Path::new("svelte.config.js"), &mut diags);
+    let codes: Vec<_> = diags.iter().map(|d| d.code.clone().unwrap()).collect();
+    assert_eq!(codes, vec!["keep_me".to_string()]);
+    let _ = std::fs::remove_file(script);
+}
+
+#[test]
+fn apply_hung_sidecar_times_out_and_keeps_all() {
+    let Some(node) = node_bin() else { return };
+    let (env, script) = env_with_script(
+        node,
+        "setInterval(() => {}, 1000);",
+        Duration::from_millis(200),
+    );
+    let mut diags = vec![warn("a"), warn("b")];
+    apply(&env, Path::new("svelte.config.js"), &mut diags);
+    assert_eq!(diags.len(), 2, "a timeout must keep every warning");
+    let _ = std::fs::remove_file(script);
+}
+
+#[test]
+fn apply_malformed_response_keeps_all() {
+    let Some(node) = node_bin() else { return };
+    let (env, script) = env_with_script(
+        node,
+        "process.stdout.write('not framed json');",
+        DEFAULT_TIMEOUT,
+    );
+    let mut diags = vec![warn("a")];
+    apply(&env, Path::new("svelte.config.js"), &mut diags);
+    assert_eq!(diags.len(), 1);
+    let _ = std::fs::remove_file(script);
+}
+
+#[test]
+fn apply_leaves_non_svelte_and_error_diagnostics_untouched() {
+    let Some(node) = node_bin() else { return };
+    // Even a filter that drops everything must not remove errors / ts diags.
+    let sidecar = r#"
+        const M = '\x00<<rsvelte-warning-filter>>\x00';
+        let data = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', (c) => (data += c));
+        process.stdin.on('end', () => {
+            const req = JSON.parse(data);
+            process.stdout.write(M + JSON.stringify({ ok: true, keep: req.warnings.map(() => false) }) + M);
+        });
+    "#;
+    let (env, script) = env_with_script(node, sidecar, DEFAULT_TIMEOUT);
+    let mut err = warn("x");
+    err.severity = DiagnosticSeverity::Error;
+    let mut ts = warn("y");
+    ts.source = "ts";
+    let mut diags = vec![warn("droppable"), err, ts];
+    apply(&env, Path::new("svelte.config.js"), &mut diags);
+    // Only the single svelte warning is removed.
+    assert_eq!(diags.len(), 2);
+    assert!(diags.iter().all(|d| d.code.as_deref() != Some("droppable")));
+    let _ = std::fs::remove_file(script);
 }

--- a/crates/rsvelte_core/tests/svelte_check_warning_filter.rs
+++ b/crates/rsvelte_core/tests/svelte_check_warning_filter.rs
@@ -1,0 +1,205 @@
+//! End-to-end coverage for issue #1679 — `rsvelte-check` must honor a
+//! function `compilerOptions.warningFilter` declared in `svelte.config.js`.
+//!
+//! The native compiler can't evaluate the JS predicate, so the CLI hands the
+//! collected warnings to a one-shot Node sidecar (`warning-filter.mjs`) that
+//! imports the config and applies the real function. These tests spawn the
+//! compiled `svelte_check` binary with the sidecar env vars the npm launcher
+//! sets, and assert the observable warnings-only behaviour: warnings dropped
+//! when a filter rejects them, and a clean fail-open (all warnings shown) when
+//! Node is unavailable or the config is broken.
+//!
+//! Run with:
+//!     cargo test --test svelte_check_warning_filter
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_svelte_check")
+}
+
+/// The bundled sidecar script, resolved from the workspace `apps/npm` tree so
+/// the test exercises the real `warning-filter.mjs`, not a fake.
+fn sidecar_script() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../apps/npm/svelte-check/lib/warning-filter.mjs")
+}
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn workspace(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "rsvelte_wf_{tag}_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(dir: &Path, name: &str, body: &str) {
+    std::fs::write(dir.join(name), body).unwrap();
+}
+
+/// A `.svelte` file whose only diagnostic is a single css_unused_selector
+/// warning.
+const WARN_ONLY: &str = "<div>hello</div>\n<style>\n  .unused { color: red; }\n</style>\n";
+
+/// Run the CLI with the sidecar env vars the npm launcher provides.
+fn run_with_sidecar(dir: &Path, args: &[&str]) -> Output {
+    Command::new(bin())
+        .arg("--workspace")
+        .arg(dir)
+        .args(args)
+        .env("RSVELTE_CHECK_NODE", "node")
+        .env("RSVELTE_CHECK_WARNING_FILTER_SIDECAR", sidecar_script())
+        .output()
+        .expect("failed to spawn svelte_check binary")
+}
+
+/// Run the CLI WITHOUT the sidecar env vars (as if Node were unavailable).
+fn run_without_sidecar(dir: &Path, args: &[&str]) -> Output {
+    Command::new(bin())
+        .arg("--workspace")
+        .arg(dir)
+        .args(args)
+        .env_remove("RSVELTE_CHECK_NODE")
+        .env_remove("RSVELTE_CHECK_WARNING_FILTER_SIDECAR")
+        .output()
+        .expect("failed to spawn svelte_check binary")
+}
+
+#[test]
+fn function_warning_filter_drops_matching_warning() {
+    if !node_available() {
+        return;
+    }
+    let dir = workspace("drop");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+    write(
+        &dir,
+        "svelte.config.js",
+        "export default { compilerOptions: { warningFilter: (w) => w.code !== 'css_unused_selector' } };",
+    );
+
+    let out = run_with_sidecar(&dir, &["--no-type-check"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("Unused CSS selector"),
+        "warningFilter should drop the css_unused_selector warning; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("0 errors and 0 warnings"),
+        "the dropped warning must not be counted; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn function_warning_filter_keeps_non_matching_warning() {
+    if !node_available() {
+        return;
+    }
+    let dir = workspace("keep");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+    // Filter rejects a different code, so our warning survives.
+    write(
+        &dir,
+        "svelte.config.js",
+        "export default { compilerOptions: { warningFilter: (w) => w.code !== 'a11y_missing_attribute' } };",
+    );
+
+    let out = run_with_sidecar(&dir, &["--no-type-check"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Unused CSS selector"),
+        "a filter that doesn't match must keep the warning; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("0 errors and 1 warning"),
+        "the kept warning must be counted; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn no_warning_filter_configured_does_not_change_output() {
+    // With no warningFilter, the sidecar is never spawned and every warning
+    // is shown exactly as before (zero-overhead path).
+    let dir = workspace("none");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+    write(
+        &dir,
+        "svelte.config.js",
+        "export default { compilerOptions: { runes: true } };",
+    );
+
+    let out = run_with_sidecar(&dir, &["--no-type-check"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Unused CSS selector") && stdout.contains("0 errors and 1 warning"),
+        "no warningFilter must leave all warnings intact; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn missing_sidecar_fails_open_with_note() {
+    // A function warningFilter is declared but no Node sidecar is available:
+    // the run must keep every warning and print a one-time stderr note.
+    let dir = workspace("failopen");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+    write(
+        &dir,
+        "svelte.config.js",
+        "export default { compilerOptions: { warningFilter: (w) => false } };",
+    );
+
+    let out = run_without_sidecar(&dir, &["--no-type-check"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("Unused CSS selector"),
+        "with no sidecar the warning must still be shown (fail open); got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("warningFilter"),
+        "a fail-open must explain why the filter was skipped; got:\n{stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn broken_config_fails_open() {
+    if !node_available() {
+        return;
+    }
+    // The static probe sees a function-shaped warningFilter, but the config
+    // throws on import → the sidecar returns non-ok → keep every warning.
+    let dir = workspace("broken");
+    write(&dir, "Warn.svelte", WARN_ONLY);
+    write(
+        &dir,
+        "svelte.config.js",
+        "throw new Error('boom');\nexport default { compilerOptions: { warningFilter: (w) => false } };",
+    );
+
+    let out = run_with_sidecar(&dir, &["--no-type-check"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Unused CSS selector"),
+        "a config that fails to import must fail open; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## What

`rsvelte-check` reads diagnostic-relevant `compilerOptions` from `svelte.config.*` statically, but `compilerOptions.warningFilter` is a JS predicate the native compiler can't evaluate, so it was silently ignored. Projects that use `warningFilter` therefore saw a warnings-only diff versus the official `svelte-check` ([#1679](https://github.com/baseballyama/rsvelte/issues/1679)).

This wires up the Node-sidecar pattern (from #1668 / #1686) so the native CLI honors a function `warningFilter`.

## How

- **Static probe** (`config.rs`): `warning_filter_config_path()` parses `svelte.config.*` (or the `--config` path when it names a Svelte config) with oxc and returns the file only when `compilerOptions.warningFilter` is statically function-shaped. A project without one never spawns Node (zero overhead); the sidecar re-checks `typeof === 'function'` after actually importing.
- **Sidecar** (`apps/npm/svelte-check/lib/warning-filter.mjs`): one-shot, framed request/response over stdin/stdout. Imports the config (ESM/CJS via dynamic `import()`), pulls out `compilerOptions.warningFilter`, and returns a keep/drop mask for the batch. Stray stdout from importing the config is routed to stderr, and the JSON payload is framed between markers so a native addon writing straight to fd 1 can't corrupt the channel.
- **Runner** (`runner.rs`): after all other filters, `run()` collects the run's Svelte compiler warnings and applies the mask through the sidecar in a **single** call per run. Errors and non-Svelte (TypeScript) diagnostics are never touched — `warningFilter` only ever sees compiler warnings.
- **Launcher** (`bin/svelte-check.cjs`): passes `process.execPath` and the sidecar path to the native binary via env vars, and ships `lib/warning-filter.mjs` in the package `files`.
- Watch mode re-runs `run()` each cycle, so a `svelte.config.js` edit re-evaluates the filter automatically.

## Equivalence argument

`warningFilter` is a pure per-warning predicate that the official Svelte compiler applies at emit time; a dropped warning affects nothing else. So filtering the fully collected warning batch in one post-pass is exactly equivalent to filtering at emit time — the same reasoning the NAPI shim uses in #1666. The warning object handed to the predicate is reconstructed from the diagnostic and carries Svelte's `Warning` fields `code` / `message` / `filename` / `start` / `end` (1-indexed `{ line, column }`).

## Fallback behavior

The sidecar never rejects. A missing Node, an unimportable/throwing config, a timeout (injectable; 30s default), or a malformed response all degrade to **keep every warning** plus a one-time stderr note. A `warningFilter` that can't run must never silently drop a warning — it fails open. The exit code is recomputed from the surviving diagnostics like any other filter, so it's unaffected.

## Tests

- `warning_filter.rs` `--lib` unit tests: only the Node-free `extract_framed` marker logic (so the no-Node test-unit CI job stays runnable).
- `svelte_check_warning_filter.rs` integration `apply()` tests (Node-backed, its CI job installs Node; skipped when Node absent): drops rejected / keeps others via the real framed protocol, hung-sidecar timeout keeps all, malformed response keeps all, error/TS diagnostics untouched.
- `config.rs`: static detection of arrow / identifier `warningFilter`, non-function ignored, absent → none, vite.config is not a source.
- `svelte_check_warning_filter.rs` e2e (spawns the compiled binary + the real `warning-filter.mjs`): function filter drops the matching warning and clears the count; a **falsy (`undefined`) return also drops**; non-matching filter keeps it; no filter is unchanged; missing sidecar fails open with a note; a throwing config fails open; and a **filtered-away warning is not re-promoted by `--compiler-warnings code:error`** (order + exit-code check).
- `cargo fmt` + `cargo clippy -p rsvelte_core --all-targets --all-features -D warnings` clean; existing svelte-check suites green.

## Known limitations

- **`frame` / `position` are not reconstructed.** The predicate receives `code` / `message` / `filename` / `start` / `end`, but not the source `frame` string or the `position` char-offset tuple that the official emit-time `Warning` carries. A `warningFilter` that inspects `warning.frame` or `warning.position` will see `undefined` and can therefore misbehave silently. In practice filters key off `code` / `filename` / `message`; extending the shape would mean threading extra fields through the diagnostic + incremental cache.
- **Inline `vite.config.*` plugin `warningFilter`** is intentionally unsupported (only `svelte.config.*`), since importing a `vite.config.*` standalone would drag in the whole Vite plugin graph.

## Review follow-ups (addressed)

- Truthiness parity: the sidecar drops on any falsy return (`Boolean(filter(w))`), matching Svelte's `if (!warning_filter(w)) return;`.
- Ordering: `warningFilter` now runs **before** `--compiler-warnings` `code:error` promotion (official filter-then-promote order), so a filtered warning can't resurface as an error or flip the exit code.
- The one-time fail-open stderr notes are `Once`-guarded so `--watch` doesn't re-print them each rebuild.

Fixes #1679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
