### PR TITLE
feat(fmt): honor sortTailwindcss.functions in the native Svelte path

### DIFF
--- a/.changeset/feat-fmt-tailwind-functions.md
+++ b/.changeset/feat-fmt-tailwind-functions.md
@@ -1,0 +1,29 @@
+---
+"@rsvelte/fmt": minor
+---
+
+feat(fmt): honor sortTailwindcss.functions in the native Svelte path
+
+`sortTailwindcss` previously sorted only fully static `class` attribute values.
+The oxfmt option `sortTailwindcss.functions` — sorting the class strings passed
+to wrapper calls like `cn(...)` / `cva(...)` / `clsx(...)` — was ignored inside
+`.svelte` files.
+
+rsvelte-fmt now mirrors oxfmt's `.svelte` pipeline (verified byte-for-byte
+against `oxfmt` + `prettier-plugin-tailwindcss`):
+
+- **`<script>` bodies**: string and substitution-free template-literal arguments
+  of a call whose callee is a bare identifier listed in `functions` are sorted.
+  The descent stops at a nested call, so `cn(a, notcn("…"))` sorts only `a`; a
+  nested call is sorted only when its own callee matches. Object keys, arrays,
+  and nested plain containers inside a matched call are sorted.
+- **`class={…}` mustaches** (and any configured `attributes`): every class
+  literal in the expression is sorted, regardless of an enclosing call — matching
+  the plugin's `transformSvelte`, which is not function-gated. `class:` directives
+  and standalone `{expr}` mustaches are left untouched.
+
+Sorting routes through the same class sorter as static attributes, so the native
+(zero-config) and Node-sidecar (custom-config) paths both apply. The default path
+stays untouched when `functions` is unset, and the fmt-parity corpus gate (sort
+off) is unaffected. Substitution-bearing template literals and mixed
+static-plus-`{expr}` class values remain out of scope.

--- a/.changeset/feat-fmt-tailwind-functions.md
+++ b/.changeset/feat-fmt-tailwind-functions.md
@@ -22,8 +22,12 @@ against `oxfmt` + `prettier-plugin-tailwindcss`):
   the plugin's `transformSvelte`, which is not function-gated. `class:` directives
   and standalone `{expr}` mustaches are left untouched.
 
+Template literals with `${…}` interpolations are sorted per static quasi; the
+token abutting an interpolation is pinned (`cn(\`flex m-2 ${x}\`)` keeps its
+structure), matching `prettier-plugin-tailwindcss`.
+
 Sorting routes through the same class sorter as static attributes, so the native
 (zero-config) and Node-sidecar (custom-config) paths both apply. The default path
 stays untouched when `functions` is unset, and the fmt-parity corpus gate (sort
-off) is unaffected. Substitution-bearing template literals and mixed
-static-plus-`{expr}` class values remain out of scope.
+off) is unaffected. Mixed static-plus-`{expr}` class attribute values remain out
+of scope.

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -627,6 +627,14 @@ fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> (FormatOptions, Option<
         tailwind::Decision::Off => (None, Vec::new(), None),
     };
 
+    // `functions` (script `cn(...)` / `cva(...)` sorting) applies only when a sort
+    // is actually active — native (`class_sorter`) or the JS sidecar (`pending_js`).
+    let tailwind_functions = if class_sorter.is_some() || pending_js.is_some() {
+        tailwind::function_names(cfg.sort_tailwindcss.as_ref())
+    } else {
+        Vec::new()
+    };
+
     // Embedded `<style>` blocks are formatted in-process via `oxc_formatter_css`
     // by default (same engine as `oxfmt`, no subprocess). `--no-native-css`
     // reverts to spawning `oxfmt`, which the batched Svelte pipeline drives.
@@ -648,6 +656,7 @@ fn build_format_options(cli: &Cli, cfg: &OxfmtConfig) -> (FormatOptions, Option<
         bracket_same_line: cfg.bracket_same_line.unwrap_or(false),
         class_sorter,
         class_attributes,
+        tailwind_functions,
     };
     (options, pending_js)
 }

--- a/crates/rsvelte_fmt/src/tailwind.rs
+++ b/crates/rsvelte_fmt/src/tailwind.rs
@@ -280,6 +280,20 @@ fn attribute_names(value: &serde_json::Value) -> Vec<String> {
     names
 }
 
+/// `sortTailwindcss.functions` — wrapper call names (`cn`, `cva`, …) whose class
+/// arguments are sorted in `<script>` bodies. Empty when unset (oxfmt's default).
+pub fn function_names(sort_tailwindcss: Option<&serde_json::Value>) -> Vec<String> {
+    sort_tailwindcss
+        .and_then(|v| v.get("functions"))
+        .and_then(serde_json::Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn find_v3_config(dir: &Path) -> Option<String> {
     for name in [
         "tailwind.config.js",

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -2488,7 +2488,7 @@ fn sort_tailwindcss_functions_native_matches_oxfmt() {
         eprintln!("[tw-js] no Tailwind env / oxfmt; skipping.");
         return;
     };
-    let svelte_src = "<script>\n  const a = cn(\"text-lg p-8 m-4\");\n</script>\n\n<div class={cn(\"text-lg p-8 m-4\")}></div>\n<p>{cn(\"text-lg p-8 m-4\")}</p>\n";
+    let svelte_src = "<script>\n  const a = cn(\"text-lg p-8 m-4\");\n  const b = cn(`text-lg p-8 m-4 ${x}`);\n  const c = cn(`text-lg p-8 m-4${x}flex m-2 p-4`);\n</script>\n\n<div class={cn(\"text-lg p-8 m-4\")}></div>\n<div class={`text-lg p-8 m-4 ${x} flex m-2 p-4`}></div>\n<p>{cn(\"text-lg p-8 m-4\")}</p>\n";
     let sort_cfg = r#"{ "stylesheet": "./src/app.css", "functions": ["cn"] }"#;
     let oracle = oxfmt_oracle_cfg(&dir, &oxfmt, svelte_src, sort_cfg);
 
@@ -2521,7 +2521,7 @@ fn sort_tailwindcss_functions_js_matches_oxfmt() {
         eprintln!("[tw-js] no Tailwind env / oxfmt; skipping.");
         return;
     };
-    let svelte_src = "<script>\n  const a = cn(\"text-brand p-4 tab-4 flex m-2\");\n</script>\n\n<div class={cn(\"text-brand p-4 tab-4 flex m-2\")}></div>\n";
+    let svelte_src = "<script>\n  const a = cn(\"text-brand p-4 tab-4 flex m-2\");\n  const b = cn(`text-brand p-4 tab-4 ${x} flex m-2`);\n</script>\n\n<div class={cn(\"text-brand p-4 tab-4 flex m-2\")}></div>\n<div class={`text-brand p-4 tab-4 ${x} flex m-2`}></div>\n";
     let sort_cfg = r#"{ "stylesheet": "./src/app.css", "functions": ["cn"] }"#;
     let oracle = oxfmt_oracle_cfg(&dir, &oxfmt, svelte_src, sort_cfg);
 

--- a/crates/rsvelte_fmt/tests/cli.rs
+++ b/crates/rsvelte_fmt/tests/cli.rs
@@ -2369,3 +2369,177 @@ fn sort_tailwindcss_js_plugin_unresolvable_falls_back() {
         "expected a fallback warning:\n{stderr}"
     );
 }
+
+// ─── sortTailwindcss functions (cn()/cva() call arguments) ─────────────────
+
+/// `functions` sorts Tailwind classes inside a configured wrapper call in a
+/// `<script>` body and in a `class={…}` mustache, on the native default-config
+/// path (no Node needed). An unmatched function, a `class:` directive, and a
+/// standalone `{expr}` are left untouched.
+#[test]
+fn sort_tailwindcss_functions_native() {
+    let dir = tempdir();
+    std::fs::write(dir.join("app.css"), "@import \"tailwindcss\";\n").unwrap();
+    let cfg = dir.join(".oxfmtrc.json");
+    std::fs::write(
+        &cfg,
+        r#"{ "sortTailwindcss": { "stylesheet": "./app.css", "functions": ["cn"] } }"#,
+    )
+    .unwrap();
+
+    let src = "<script>\n  const a = cn(\"p-4 m-2 flex\");\n  const b = notcn(\"p-4 m-2 flex\");\n</script>\n\n<div class={cn(\"p-4 m-2 flex\")}></div>\n<div class:foo={cn(\"p-4 m-2 flex\")}></div>\n<p>{cn(\"p-4 m-2 flex\")}</p>\n";
+    let (stdout, stderr, code) = run_stdin(
+        src,
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            dir.join("x.svelte").to_str().unwrap(),
+            "--config",
+            cfg.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(!stderr.contains("warning"), "unexpected warning:\n{stderr}");
+    // Matched call in the script and in the class mustache are sorted.
+    assert!(
+        stdout.contains("const a = cn(\"m-2 flex p-4\");"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("class={cn(\"m-2 flex p-4\")}"), "{stdout}");
+    // Unmatched call, `class:` directive, and standalone `{expr}` are untouched.
+    assert!(
+        stdout.contains("const b = notcn(\"p-4 m-2 flex\");"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("class:foo={cn(\"p-4 m-2 flex\")}"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("<p>{cn(\"p-4 m-2 flex\")}</p>"), "{stdout}");
+}
+
+/// Without `functions`, a `<script>` `cn(...)` call is left alone, but a
+/// `class={…}` mustache is still sorted (the mustache sort is not
+/// function-gated — it mirrors oxfmt's `transformSvelte`).
+#[test]
+fn sort_tailwindcss_no_functions_leaves_script_calls() {
+    let dir = tempdir();
+    std::fs::write(dir.join("app.css"), "@import \"tailwindcss\";\n").unwrap();
+    let cfg = dir.join(".oxfmtrc.json");
+    std::fs::write(
+        &cfg,
+        r#"{ "sortTailwindcss": { "stylesheet": "./app.css" } }"#,
+    )
+    .unwrap();
+
+    let src = "<script>\n  const a = cn(\"p-4 m-2 flex\");\n</script>\n\n<div class={cn(\"p-4 m-2 flex\")}></div>\n";
+    let (stdout, stderr, code) = run_stdin(
+        src,
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            dir.join("x.svelte").to_str().unwrap(),
+            "--config",
+            cfg.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(
+        stdout.contains("const a = cn(\"p-4 m-2 flex\");"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("class={cn(\"m-2 flex p-4\")}"), "{stdout}");
+}
+
+/// A parity oracle that lets the caller supply the full `sortTailwindcss` config
+/// (so `functions` can be injected), unlike `oxfmt_oracle`.
+#[cfg(unix)]
+fn oxfmt_oracle_cfg(dir: &Path, oxfmt: &Path, svelte_src: &str, sort_cfg: &str) -> String {
+    let file = dir.join("src/Oracle.svelte");
+    std::fs::write(&file, svelte_src).unwrap();
+    let cfg = dir.join("oxfmt.oracle.json");
+    std::fs::write(
+        &cfg,
+        format!(r#"{{ "svelte": true, "sortTailwindcss": {sort_cfg} }}"#),
+    )
+    .unwrap();
+    let status = Command::new(oxfmt)
+        .current_dir(dir)
+        .args([
+            "--write",
+            "--config",
+            cfg.to_str().unwrap(),
+            file.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "oxfmt oracle failed");
+    std::fs::read_to_string(&file).unwrap()
+}
+
+/// `functions` on the native default-config path is byte-identical to the oxfmt
+/// oracle, for both a `<script>` call and a `class={…}` mustache.
+#[cfg(unix)]
+#[test]
+fn sort_tailwindcss_functions_native_matches_oxfmt() {
+    let Some((dir, _sidecar, oxfmt)) = tw_fixture("@import \"tailwindcss\";\n") else {
+        eprintln!("[tw-js] no Tailwind env / oxfmt; skipping.");
+        return;
+    };
+    let svelte_src = "<script>\n  const a = cn(\"text-lg p-8 m-4\");\n</script>\n\n<div class={cn(\"text-lg p-8 m-4\")}></div>\n<p>{cn(\"text-lg p-8 m-4\")}</p>\n";
+    let sort_cfg = r#"{ "stylesheet": "./src/app.css", "functions": ["cn"] }"#;
+    let oracle = oxfmt_oracle_cfg(&dir, &oxfmt, svelte_src, sort_cfg);
+
+    let cfg = dir.join("rsvelte.oxfmtrc.json");
+    std::fs::write(&cfg, format!(r#"{{ "sortTailwindcss": {sort_cfg} }}"#)).unwrap();
+    let (stdout, stderr, code) = run_stdin_in(
+        svelte_src,
+        &dir,
+        &[],
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            dir.join("src/Foo.svelte").to_str().unwrap(),
+            "--config",
+            cfg.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(!stderr.contains("warning"), "unexpected warning:\n{stderr}");
+    assert_eq!(stdout, oracle, "must match the oxfmt oracle byte-for-byte");
+}
+
+/// `functions` through the JS sidecar (a custom `@theme`/`@utility` config) is
+/// byte-identical to the oxfmt oracle in a `<script>` call and a mustache.
+#[cfg(unix)]
+#[test]
+fn sort_tailwindcss_functions_js_matches_oxfmt() {
+    let css = "@import \"tailwindcss\";\n@theme {\n  --color-brand: #1a2b3c;\n}\n@utility tab-4 {\n  tab-size: 4;\n}\n";
+    let Some((dir, sidecar, oxfmt)) = tw_fixture(css) else {
+        eprintln!("[tw-js] no Tailwind env / oxfmt; skipping.");
+        return;
+    };
+    let svelte_src = "<script>\n  const a = cn(\"text-brand p-4 tab-4 flex m-2\");\n</script>\n\n<div class={cn(\"text-brand p-4 tab-4 flex m-2\")}></div>\n";
+    let sort_cfg = r#"{ "stylesheet": "./src/app.css", "functions": ["cn"] }"#;
+    let oracle = oxfmt_oracle_cfg(&dir, &oxfmt, svelte_src, sort_cfg);
+
+    let cfg = dir.join("rsvelte.oxfmtrc.json");
+    std::fs::write(&cfg, format!(r#"{{ "sortTailwindcss": {sort_cfg} }}"#)).unwrap();
+    let (stdout, stderr, code) = run_stdin_in(
+        svelte_src,
+        &dir,
+        &[("RSVELTE_FMT_TAILWIND_SIDECAR", sidecar.as_path())],
+        &[
+            "--stdin",
+            "--stdin-filepath",
+            dir.join("src/Foo.svelte").to_str().unwrap(),
+            "--config",
+            cfg.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(!stderr.contains("warning"), "unexpected warning:\n{stderr}");
+    assert_eq!(stdout, oracle, "must match the oxfmt oracle byte-for-byte");
+}

--- a/crates/rsvelte_fmt_wasm/src/lib.rs
+++ b/crates/rsvelte_fmt_wasm/src/lib.rs
@@ -107,5 +107,6 @@ fn parse_options(options_json: &str) -> FormatOptions {
         sort_order,
         class_sorter: None,
         class_attributes: Vec::new(),
+        tailwind_functions: Vec::new(),
     }
 }

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -25,6 +25,7 @@ mod script;
 mod sort_order;
 mod style;
 mod style_css;
+mod tailwind_sort;
 
 pub use error::FormatError;
 pub use json::{JsonVariant, format_json_source};

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -1636,6 +1636,20 @@ fn render_single_expression_value(
     if inner_src.is_empty() {
         return Ok(format!("{}={{}}", node.name));
     }
+    // Tailwind class sort for a `class={expr}` (or configured attribute) mustache:
+    // reorder every class literal in the expression before formatting. Unlike the
+    // static path, this is not function-gated — mirrors oxfmt's `transformSvelte`.
+    let sorted_expr = if options.class_sorter.is_some()
+        && options
+            .class_attributes
+            .iter()
+            .any(|a| a == node.name.as_str())
+    {
+        crate::tailwind_sort::sort_class_expression(inner_src, options)
+    } else {
+        None
+    };
+    let inner_src = sorted_expr.as_deref().unwrap_or(inner_src);
     // When the open tag wraps, attribute values are narrowed so OXC breaks them
     // at the right column.  Two cases:
     //

--- a/crates/rsvelte_formatter/src/options.rs
+++ b/crates/rsvelte_formatter/src/options.rs
@@ -75,6 +75,12 @@ pub struct FormatOptions {
     /// default; the CLI sets it from `sortTailwindcss.attributes` (default
     /// `["class"]`).
     pub class_attributes: Vec<String>,
+
+    /// Wrapper function names (`sortTailwindcss.functions`, e.g. `["cn", "cva"]`)
+    /// whose string / template-literal class arguments [`Self::class_sorter`]
+    /// sorts inside `<script>` bodies. Empty by default. Independent of the
+    /// `class`-mustache sort, which is always on when `class_sorter` is set.
+    pub tailwind_functions: Vec<String>,
 }
 
 /// Callback that sorts a space-separated class attribute value. See
@@ -102,6 +108,7 @@ impl FormatOptions {
             bracket_same_line: false,
             class_sorter: None,
             class_attributes: Vec::new(),
+            tailwind_functions: Vec::new(),
         }
     }
 
@@ -137,6 +144,7 @@ impl std::fmt::Debug for FormatOptions {
                 &self.class_sorter.as_ref().map(|_| "<callback>"),
             )
             .field("class_attributes", &self.class_attributes)
+            .field("tailwind_functions", &self.tailwind_functions)
             .finish()
     }
 }

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -67,6 +67,11 @@ pub(crate) fn format_script(
     let (body_start, body_end) = body_span(source, script)?;
     let body = &source[body_start..body_end];
 
+    // Sort Tailwind class strings in configured `functions` calls (`cn(...)` /
+    // `cva(...)`) before formatting, so oxc re-prints from the sorted source.
+    let sorted_body = crate::tailwind_sort::sort_script_functions(body, options);
+    let body = sorted_body.as_deref().unwrap_or(body);
+
     if body.trim().is_empty() {
         // A whitespace-only body (e.g. `<script>\n\t\n</script>`) collapses to a
         // single newline so the close tag sits on its own line, matching oxfmt /

--- a/crates/rsvelte_formatter/src/tailwind_sort.rs
+++ b/crates/rsvelte_formatter/src/tailwind_sort.rs
@@ -4,18 +4,20 @@
 //! Two positions mirror what oxfmt's `.svelte` pipeline sorts (verified against
 //! the real `oxfmt` + `prettier-plugin-tailwindcss` oracle):
 //!
-//!   1. `<script>` bodies — string / no-substitution template literals inside a
+//!   1. `<script>` bodies — string and template literals inside a
 //!      `CallExpression` whose callee is a bare identifier in `functions`. The
 //!      descent stops at a nested `CallExpression`, so `cn(a, notcn("…"))` sorts
 //!      only `a`; a nested call is sorted only if its own callee matches.
-//!   2. `class` (and configured `attributes`) mustache values — *every* string /
-//!      no-substitution template literal in the expression, regardless of any
-//!      enclosing call. This mirrors the plugin's `transformSvelte`, which is not
-//!      function-gated.
+//!   2. `class` (and configured `attributes`) mustache values — *every* string
+//!      and template literal in the expression, regardless of any enclosing call.
+//!      This mirrors the plugin's `transformSvelte`, which is not function-gated.
 //!
-//! Only the literal's inner tokens are reordered (via the shared class sorter, so
-//! the native and JS-sidecar paths both apply). The surrounding source is
-//! re-parsed and re-printed unchanged, keeping quote/format decisions with oxc.
+//! Template literals with `${…}` are sorted per static quasi; the token abutting
+//! an interpolation is pinned so `cn(\`flex m-2 ${x}\`)` keeps its structure.
+//!
+//! Only class tokens are reordered (via the shared class sorter, so the native
+//! and JS-sidecar paths both apply). The surrounding source is re-parsed and
+//! re-printed unchanged, keeping quote/format decisions with oxc.
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{CallExpression, Expression, StringLiteral, TemplateLiteral};
@@ -23,7 +25,7 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_span::{GetSpan, SourceType};
 
-use crate::options::FormatOptions;
+use crate::options::{ClassSorter, FormatOptions};
 
 /// Rewrite Tailwind class literals inside `functions` calls in a `<script>` body.
 /// Returns the rewritten body when anything changed, else `None`.
@@ -69,28 +71,37 @@ fn rewrite(src: &str, wrap: bool, sort_all: bool, options: &FormatOptions) -> Op
         functions: &options.tailwind_functions,
         sort_all,
         call_matched: Vec::new(),
-        spans: Vec::new(),
+        edits: Vec::new(),
     };
     collector.visit_program(&parsed.program);
-    if collector.spans.is_empty() {
+    if collector.edits.is_empty() {
         return None;
     }
 
     // Apply right-to-left so earlier byte offsets stay valid.
-    let mut spans = collector.spans;
-    spans.sort_unstable_by_key(|s| std::cmp::Reverse(s.0));
+    let mut edits = collector.edits;
+    edits.sort_unstable_by_key(|e| std::cmp::Reverse(e.start()));
     let mut out = buf.clone();
     let mut changed = false;
-    for (start, end) in spans {
-        let (start, end) = (start as usize, end as usize);
-        // The literal span includes its delimiters (`"`, `'`, or `` ` ``).
-        let quote = &out[start..start + 1];
-        let inner = &out[start + 1..end - 1];
-        let sorted = sorter(inner);
-        if sorted == inner {
+    for edit in edits {
+        let (start, end) = (edit.start() as usize, edit.end() as usize);
+        let replacement = match edit {
+            Edit::StringLit { .. } => {
+                // The span includes its delimiters (`"` or `'`); sort the inner.
+                let quote = &out[start..start + 1];
+                let inner = &out[start + 1..end - 1];
+                format!("{quote}{}{quote}", sorter(inner))
+            }
+            // A template quasi span is the raw text between delimiters.
+            Edit::Quasi {
+                ignore_first,
+                ignore_last,
+                ..
+            } => sort_quasi(&out[start..end], ignore_first, ignore_last, sorter),
+        };
+        if replacement == out[start..end] {
             continue;
         }
-        let replacement = format!("{quote}{sorted}{quote}");
         out.replace_range(start..end, &replacement);
         changed = true;
     }
@@ -106,6 +117,62 @@ fn rewrite(src: &str, wrap: bool, sort_all: bool, options: &FormatOptions) -> Op
     }
 }
 
+/// One literal to rewrite in the source buffer.
+enum Edit {
+    /// A string literal; `start..end` spans the quotes.
+    StringLit { start: u32, end: u32 },
+    /// A template quasi; `start..end` spans the raw text (no delimiters).
+    /// `ignore_first` / `ignore_last` pin the boundary token that abuts a `${…}`,
+    /// mirroring `prettier-plugin-tailwindcss`'s `sortClasses`.
+    Quasi {
+        start: u32,
+        end: u32,
+        ignore_first: bool,
+        ignore_last: bool,
+    },
+}
+
+impl Edit {
+    fn start(&self) -> u32 {
+        match self {
+            Edit::StringLit { start, .. } | Edit::Quasi { start, .. } => *start,
+        }
+    }
+    fn end(&self) -> u32 {
+        match self {
+            Edit::StringLit { end, .. } | Edit::Quasi { end, .. } => *end,
+        }
+    }
+}
+
+/// Sort one template quasi's class tokens, pinning the boundary token adjacent to
+/// a `${…}` (`ignore_first` / `ignore_last`) and preserving the quasi's leading /
+/// trailing whitespace — the separators between a class and the interpolation.
+fn sort_quasi(raw: &str, ignore_first: bool, ignore_last: bool, sorter: &ClassSorter) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return raw.to_string();
+    }
+    let lead = &raw[..raw.len() - raw.trim_start().len()];
+    let trail = &raw[raw.trim_end().len()..];
+
+    let mut tokens: Vec<&str> = trimmed.split_whitespace().collect();
+    let pinned_first = (ignore_first && !tokens.is_empty()).then(|| tokens.remove(0));
+    let pinned_last = (ignore_last && !tokens.is_empty()).then(|| tokens.pop().unwrap());
+
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(f) = pinned_first {
+        parts.push(f.to_string());
+    }
+    if !tokens.is_empty() {
+        parts.push(sorter(&tokens.join(" ")));
+    }
+    if let Some(l) = pinned_last {
+        parts.push(l.to_string());
+    }
+    format!("{lead}{}{trail}", parts.join(" "))
+}
+
 struct Collector<'f> {
     functions: &'f [String],
     /// `true` = sort every literal (class-attribute mode); `false` = only inside a
@@ -113,7 +180,7 @@ struct Collector<'f> {
     sort_all: bool,
     /// Match state of each enclosing `CallExpression`; the innermost decides.
     call_matched: Vec<bool>,
-    spans: Vec<(u32, u32)>,
+    edits: Vec<Edit>,
 }
 
 impl Collector<'_> {
@@ -136,17 +203,37 @@ impl<'a> Visit<'a> for Collector<'_> {
     fn visit_string_literal(&mut self, lit: &StringLiteral<'a>) {
         if self.should_sort() {
             let span = lit.span();
-            self.spans.push((span.start, span.end));
+            self.edits.push(Edit::StringLit {
+                start: span.start,
+                end: span.end,
+            });
         }
     }
 
     fn visit_template_literal(&mut self, tpl: &TemplateLiteral<'a>) {
-        // Only a substitution-free `` `…` `` is a plain class list. Templates with
-        // `${…}` are left to their `${}` expressions, which are still walked.
-        if self.should_sort() && tpl.expressions.is_empty() && tpl.quasis.len() == 1 {
-            let span = tpl.span();
-            self.spans.push((span.start, span.end));
+        if self.should_sort() {
+            // Sort each quasi's static text; the token abutting a `${…}` is pinned
+            // so it stays contiguous with the interpolation (`cn(\`a ${x}b c\`)`).
+            let exprs = tpl.expressions.len();
+            for (i, quasi) in tpl.quasis.iter().enumerate() {
+                let raw = quasi.value.raw.as_str();
+                self.edits.push(Edit::Quasi {
+                    start: quasi.span.start,
+                    end: quasi.span.end,
+                    ignore_first: i > 0 && !starts_with_ws(raw),
+                    ignore_last: i < exprs && !ends_with_ws(raw),
+                });
+            }
         }
+        // Still walk the `${…}` expressions to reach nested calls.
         walk::walk_template_literal(self, tpl);
     }
+}
+
+fn starts_with_ws(s: &str) -> bool {
+    s.chars().next().is_some_and(char::is_whitespace)
+}
+
+fn ends_with_ws(s: &str) -> bool {
+    s.chars().next_back().is_some_and(char::is_whitespace)
 }

--- a/crates/rsvelte_formatter/src/tailwind_sort.rs
+++ b/crates/rsvelte_formatter/src/tailwind_sort.rs
@@ -1,0 +1,152 @@
+//! `sortTailwindcss.functions` support for the native `.svelte` path: sort the
+//! Tailwind class strings passed to wrapper calls like `cn(...)` / `cva(...)`.
+//!
+//! Two positions mirror what oxfmt's `.svelte` pipeline sorts (verified against
+//! the real `oxfmt` + `prettier-plugin-tailwindcss` oracle):
+//!
+//!   1. `<script>` bodies — string / no-substitution template literals inside a
+//!      `CallExpression` whose callee is a bare identifier in `functions`. The
+//!      descent stops at a nested `CallExpression`, so `cn(a, notcn("…"))` sorts
+//!      only `a`; a nested call is sorted only if its own callee matches.
+//!   2. `class` (and configured `attributes`) mustache values — *every* string /
+//!      no-substitution template literal in the expression, regardless of any
+//!      enclosing call. This mirrors the plugin's `transformSvelte`, which is not
+//!      function-gated.
+//!
+//! Only the literal's inner tokens are reordered (via the shared class sorter, so
+//! the native and JS-sidecar paths both apply). The surrounding source is
+//! re-parsed and re-printed unchanged, keeping quote/format decisions with oxc.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{CallExpression, Expression, StringLiteral, TemplateLiteral};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::{ParseOptions, Parser};
+use oxc_span::{GetSpan, SourceType};
+
+use crate::options::FormatOptions;
+
+/// Rewrite Tailwind class literals inside `functions` calls in a `<script>` body.
+/// Returns the rewritten body when anything changed, else `None`.
+pub(crate) fn sort_script_functions(body: &str, options: &FormatOptions) -> Option<String> {
+    if options.class_sorter.is_none() || options.tailwind_functions.is_empty() {
+        return None;
+    }
+    rewrite(body, false, false, options)
+}
+
+/// Rewrite every Tailwind class literal in a `class`-attribute mustache
+/// expression. Returns the rewritten expression source when anything changed.
+pub(crate) fn sort_class_expression(expr_src: &str, options: &FormatOptions) -> Option<String> {
+    // `rewrite` returns `None` when no class sorter is configured.
+    rewrite(expr_src, true, true, options)
+}
+
+/// Parse `src` (optionally wrapped in `(...)` so a bare object/expression parses),
+/// collect the class-literal spans to sort, and splice the sorted values back in.
+fn rewrite(src: &str, wrap: bool, sort_all: bool, options: &FormatOptions) -> Option<String> {
+    let sorter = options.class_sorter.as_ref()?;
+    let buf = if wrap {
+        format!("({src})")
+    } else {
+        src.to_string()
+    };
+
+    let allocator = Allocator::default();
+    // `.ts` is a superset of JS and matches the `<script>` parse dialect; only
+    // string/template spans are read, so the dialect never affects the result.
+    let source_type = SourceType::from_extension("ts").unwrap_or_else(|_| SourceType::ts());
+    let parsed = Parser::new(&allocator, &buf, source_type)
+        .with_options(ParseOptions {
+            preserve_parens: false,
+            ..ParseOptions::default()
+        })
+        .parse();
+    if !parsed.diagnostics.is_empty() {
+        return None;
+    }
+
+    let mut collector = Collector {
+        functions: &options.tailwind_functions,
+        sort_all,
+        call_matched: Vec::new(),
+        spans: Vec::new(),
+    };
+    collector.visit_program(&parsed.program);
+    if collector.spans.is_empty() {
+        return None;
+    }
+
+    // Apply right-to-left so earlier byte offsets stay valid.
+    let mut spans = collector.spans;
+    spans.sort_unstable_by_key(|s| std::cmp::Reverse(s.0));
+    let mut out = buf.clone();
+    let mut changed = false;
+    for (start, end) in spans {
+        let (start, end) = (start as usize, end as usize);
+        // The literal span includes its delimiters (`"`, `'`, or `` ` ``).
+        let quote = &out[start..start + 1];
+        let inner = &out[start + 1..end - 1];
+        let sorted = sorter(inner);
+        if sorted == inner {
+            continue;
+        }
+        let replacement = format!("{quote}{sorted}{quote}");
+        out.replace_range(start..end, &replacement);
+        changed = true;
+    }
+    if !changed {
+        return None;
+    }
+    if wrap {
+        // Strip the `(` / `)` added above; only inner literals were edited, so the
+        // wrapper delimiters are still the first and last bytes.
+        Some(out[1..out.len() - 1].to_string())
+    } else {
+        Some(out)
+    }
+}
+
+struct Collector<'f> {
+    functions: &'f [String],
+    /// `true` = sort every literal (class-attribute mode); `false` = only inside a
+    /// matched call (script `functions` mode).
+    sort_all: bool,
+    /// Match state of each enclosing `CallExpression`; the innermost decides.
+    call_matched: Vec<bool>,
+    spans: Vec<(u32, u32)>,
+}
+
+impl Collector<'_> {
+    fn should_sort(&self) -> bool {
+        self.sort_all || self.call_matched.last() == Some(&true)
+    }
+}
+
+impl<'a> Visit<'a> for Collector<'_> {
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        let matched = match &call.callee {
+            Expression::Identifier(id) => self.functions.iter().any(|f| f == id.name.as_str()),
+            _ => false,
+        };
+        self.call_matched.push(matched);
+        walk::walk_call_expression(self, call);
+        self.call_matched.pop();
+    }
+
+    fn visit_string_literal(&mut self, lit: &StringLiteral<'a>) {
+        if self.should_sort() {
+            let span = lit.span();
+            self.spans.push((span.start, span.end));
+        }
+    }
+
+    fn visit_template_literal(&mut self, tpl: &TemplateLiteral<'a>) {
+        // Only a substitution-free `` `…` `` is a plain class list. Templates with
+        // `${…}` are left to their `${}` expressions, which are still walked.
+        if self.should_sort() && tpl.expressions.is_empty() && tpl.quasis.len() == 1 {
+            let span = tpl.span();
+            self.spans.push((span.start, span.end));
+        }
+        walk::walk_template_literal(self, tpl);
+    }
+}

--- a/crates/rsvelte_formatter/tests/tailwind_functions.rs
+++ b/crates/rsvelte_formatter/tests/tailwind_functions.rs
@@ -85,12 +85,57 @@ fn script_sorts_plain_template_literal() {
 }
 
 #[test]
-fn script_leaves_substitution_template_untouched() {
+fn script_sorts_substitution_template_quasi() {
     let out = fmt(
         "<script>\n  const a = cn(`b a ${x}`);\n</script>\n",
         &["cn"],
     );
-    assert!(out.contains("cn(`b a ${x}`)"), "{out}");
+    assert!(out.contains("cn(`a b ${x}`)"), "{out}");
+}
+
+#[test]
+fn script_pins_token_abutting_interpolation() {
+    // No whitespace at the `${…}` boundary pins the abutting token: `b` stays
+    // last in quasi 0 (`c a b` → `a c b`) and `f` stays first in quasi 1
+    // (`f e d` → `f d e`).
+    let out = fmt(
+        "<script>\n  const a = cn(`c a b${x}f e d`);\n</script>\n",
+        &["cn"],
+    );
+    assert!(out.contains("cn(`a c b${x}f d e`)"), "{out}");
+}
+
+#[test]
+fn script_sorts_each_quasi_with_boundary_whitespace() {
+    let out = fmt(
+        "<script>\n  const a = cn(`c a b ${x} f e d`);\n</script>\n",
+        &["cn"],
+    );
+    assert!(out.contains("cn(`a b c ${x} d e f`)"), "{out}");
+}
+
+#[test]
+fn script_sorts_multi_substitution_template() {
+    let out = fmt(
+        "<script>\n  const a = cn(`c a ${x} f e ${y} i g`);\n</script>\n",
+        &["cn"],
+    );
+    assert!(out.contains("cn(`a c ${x} e f ${y} g i`)"), "{out}");
+}
+
+#[test]
+fn script_unmatched_substitution_template_is_untouched() {
+    let out = fmt(
+        "<script>\n  const a = notcn(`b a ${x}`);\n</script>\n",
+        &["cn"],
+    );
+    assert!(out.contains("notcn(`b a ${x}`)"), "{out}");
+}
+
+#[test]
+fn class_mustache_sorts_substitution_template() {
+    let out = fmt("<div class={`c a b ${x}`}></div>\n", &[]);
+    assert!(out.contains("class={`a b c ${x}`}"), "{out}");
 }
 
 #[test]

--- a/crates/rsvelte_formatter/tests/tailwind_functions.rs
+++ b/crates/rsvelte_formatter/tests/tailwind_functions.rs
@@ -1,0 +1,169 @@
+//! `sortTailwindcss.functions` traversal scope in the native `.svelte` path.
+//!
+//! These use a deterministic *fake* class sorter (lexicographic) so they assert
+//! exactly **which** literals are routed to the sorter — independent of the real
+//! Tailwind order. The byte-for-byte match against the oxfmt +
+//! prettier-plugin-tailwindcss oracle lives in `rsvelte_fmt`'s CLI tests.
+
+use std::sync::Arc;
+
+use rsvelte_formatter::{ClassSorter, FormatOptions, format};
+
+/// Sort whitespace-separated tokens lexicographically — a stand-in for the
+/// Tailwind sorter, so `"b a"` → `"a b"` deterministically.
+fn fake_sorter() -> ClassSorter {
+    Arc::new(|s: &str| {
+        let mut tokens: Vec<&str> = s.split_whitespace().collect();
+        tokens.sort_unstable();
+        tokens.join(" ")
+    })
+}
+
+fn opts(functions: &[&str]) -> FormatOptions {
+    FormatOptions {
+        class_sorter: Some(fake_sorter()),
+        class_attributes: vec!["class".to_string()],
+        tailwind_functions: functions.iter().map(|s| s.to_string()).collect(),
+        ..FormatOptions::default()
+    }
+}
+
+fn fmt(src: &str, functions: &[&str]) -> String {
+    format(src, &opts(functions)).expect("format ok")
+}
+
+// ─── Script `functions` calls ────────────────────────────────────────────
+
+#[test]
+fn script_matched_call_sorts_string_arg() {
+    let out = fmt("<script>\n  const a = cn(\"b a\");\n</script>\n", &["cn"]);
+    assert!(out.contains("cn(\"a b\")"), "{out}");
+}
+
+#[test]
+fn script_unmatched_call_is_untouched() {
+    let out = fmt(
+        "<script>\n  const a = notcn(\"b a\");\n</script>\n",
+        &["cn"],
+    );
+    assert!(out.contains("notcn(\"b a\")"), "{out}");
+}
+
+#[test]
+fn script_nested_unmatched_call_is_not_sorted() {
+    // The outer `cn` matches, but the descent stops at the nested `notcn`.
+    let out = fmt(
+        "<script>\n  const a = cn(\"b a\", notcn(\"d c\"));\n</script>\n",
+        &["cn"],
+    );
+    assert!(out.contains("cn(\"a b\", notcn(\"d c\"))"), "{out}");
+}
+
+#[test]
+fn script_nested_matched_call_is_sorted() {
+    let out = fmt(
+        "<script>\n  const a = cn(\"b a\", clsx(\"d c\"));\n</script>\n",
+        &["cn", "clsx"],
+    );
+    assert!(out.contains("cn(\"a b\", clsx(\"c d\"))"), "{out}");
+}
+
+#[test]
+fn script_sorts_object_keys_and_nested_containers() {
+    let out = fmt(
+        "<script>\n  const a = cn({ \"b a\": x }, [\"d c\"]);\n</script>\n",
+        &["cn"],
+    );
+    assert!(out.contains("\"a b\": x"), "key not sorted:\n{out}");
+    assert!(out.contains("[\"c d\"]"), "array elem not sorted:\n{out}");
+}
+
+#[test]
+fn script_sorts_plain_template_literal() {
+    let out = fmt("<script>\n  const a = cn(`b a`);\n</script>\n", &["cn"]);
+    assert!(out.contains("cn(`a b`)"), "{out}");
+}
+
+#[test]
+fn script_leaves_substitution_template_untouched() {
+    let out = fmt(
+        "<script>\n  const a = cn(`b a ${x}`);\n</script>\n",
+        &["cn"],
+    );
+    assert!(out.contains("cn(`b a ${x}`)"), "{out}");
+}
+
+#[test]
+fn script_member_callee_is_not_matched() {
+    // oxfmt matches only a bare identifier callee, not `tw.foo(...)`.
+    let out = fmt(
+        "<script>\n  const a = tw.foo(\"b a\");\n</script>\n",
+        &["tw"],
+    );
+    assert!(out.contains("tw.foo(\"b a\")"), "{out}");
+}
+
+#[test]
+fn script_without_functions_config_is_untouched() {
+    let out = fmt("<script>\n  const a = cn(\"b a\");\n</script>\n", &[]);
+    assert!(out.contains("cn(\"b a\")"), "{out}");
+}
+
+// ─── `class` mustache values (not function-gated) ─────────────────────────
+
+#[test]
+fn class_mustache_sorts_call_arg() {
+    let out = fmt("<div class={cn(\"b a\")}></div>\n", &["cn"]);
+    assert!(out.contains("class={cn(\"a b\")}"), "{out}");
+}
+
+#[test]
+fn class_mustache_sorts_regardless_of_function_name() {
+    // The class mustache sorts every literal, matched function or not.
+    let out = fmt("<div class={notcn(\"b a\")}></div>\n", &[]);
+    assert!(out.contains("class={notcn(\"a b\")}"), "{out}");
+}
+
+#[test]
+fn class_mustache_sorts_deeply_nested_calls() {
+    let out = fmt("<div class={foo(bar(\"b a\"))}></div>\n", &[]);
+    assert!(out.contains("class={foo(bar(\"a b\"))}"), "{out}");
+}
+
+#[test]
+fn class_mustache_sorts_ternary_branches() {
+    let out = fmt("<div class={cond ? \"b a\" : x}></div>\n", &[]);
+    assert!(out.contains("class={cond ? \"a b\" : x}"), "{out}");
+}
+
+#[test]
+fn class_directive_is_not_a_class_attribute() {
+    // `class:foo={...}` is a directive, not the `class` attribute — untouched.
+    let out = fmt("<div class:foo={cn(\"b a\")}></div>\n", &["cn"]);
+    assert!(out.contains("class:foo={cn(\"b a\")}"), "{out}");
+}
+
+#[test]
+fn standalone_mustache_is_untouched() {
+    let out = fmt("<p>{cn(\"b a\")}</p>\n", &["cn"]);
+    assert!(out.contains("{cn(\"b a\")}"), "{out}");
+}
+
+#[test]
+fn non_class_attribute_expression_is_untouched() {
+    let out = fmt("<div data-x={cn(\"b a\")}></div>\n", &["cn"]);
+    assert!(out.contains("data-x={cn(\"b a\")}"), "{out}");
+}
+
+#[test]
+fn sorting_off_without_class_sorter() {
+    let out = format(
+        "<script>\n  const a = cn(\"b a\");\n</script>\n<div class={cn(\"b a\")}></div>\n",
+        &FormatOptions::default(),
+    )
+    .expect("format ok");
+    assert!(
+        out.contains("cn(\"b a\")"),
+        "no sorting without a sorter:\n{out}"
+    );
+}


### PR DESCRIPTION
## What

Closes the `sortTailwindcss.functions` gap in rsvelte-fmt's native `.svelte`
path. Previously only fully static `class` attribute values were sorted; the
class strings passed to wrapper calls (`cn(...)`, `cva(...)`, `clsx(...)`) inside
`.svelte` files were ignored (PR #1605 / #1668 both left `functions` out of
scope). Bare `.js`/`.ts` files are unaffected — they delegate to the `oxfmt`
subprocess.

## Scope (mirrors oxfmt exactly)

Derived empirically from the real `oxfmt` + `prettier-plugin-tailwindcss` (oxfmt
runs its own AST traversal and only delegates the sort), then reproduced:

- **`<script>` bodies** — string and template-literal arguments of a
  `CallExpression` whose callee is a **bare identifier** in `functions`. The
  descent stops at a nested `CallExpression`, so `cn(a, notcn("…"))` sorts only
  `a`; a nested call is sorted only when its own callee matches
  (`cn(a, clsx("…"))` sorts both). Object **keys**, arrays, and nested plain
  containers inside a matched call are sorted. `tw.foo(...)` (member callee) is
  not matched.
- **`class={…}` mustaches** (plus any configured `attributes`) — **every** class
  literal in the expression, regardless of an enclosing call, matching the
  plugin's `transformSvelte` (not function-gated). `class:` directives and
  standalone `{expr}` mustaches are left untouched.
- **Template literals with `${…}`** — sorted **per static quasi**, pinning the
  token that abuts an interpolation (no boundary whitespace) via the plugin's
  `ignoreFirst`/`ignoreLast` rule and preserving the quasi's leading/trailing
  separator whitespace. `cn(`flex m-2 p-4 ${x}`)` → `cn(`m-2 flex p-4 ${x}`)`.

Both paths route through the same class sorter used for static attributes, so the
**native** (zero-config, pure-Rust) and **Node-sidecar** (custom-config) paths
apply transparently via the existing collect → sort → apply passes. The default
path is unchanged when `functions` is unset, and the fmt-parity corpus gate (sort
off) is unaffected.

Out of scope (documented): mixed static-plus-`{expr}` class attribute values.

## Implementation

- New `crates/rsvelte_formatter/src/tailwind_sort.rs`: parses the JS (wrapping a
  bare expression in `(...)`), collects string-literal and template-quasi edits
  via an `oxc_ast_visit::Visit` that tracks the innermost enclosing call's match
  state, and splices the sorted values back into the source (oxc re-prints
  unchanged). Template quasis carry per-quasi `ignore_first`/`ignore_last` flags.
- `FormatOptions.tailwind_functions`; hooked into `script.rs` (`<script>`) and
  `markup.rs` (`class={…}`); CLI reads `sortTailwindcss.functions`.

## Verification

- `cargo test -p rsvelte_formatter -p rsvelte_fmt -p rsvelte_fmt_wasm` — 462
  passed, 0 failed.
- Tests: 22 deterministic formatter-level cases (fake sorter, assert exactly
  which literals/quasis route to the sorter, incl. pinning & multi-interpolation)
  + CLI cases: native sort, functions-unset no-op, and two byte-for-byte
  oxfmt-oracle comparisons (native + JS-sidecar, each incl. template cases with a
  custom `@utility`), gated on a Tailwind env + `oxfmt`.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Changeset: `@rsvelte/fmt` minor.

Fixes #1678

🤖 Generated with [Claude Code](https://claude.com/claude-code)