### PR TITLE
fix(analyze): hand raw digest to cssHash callbacks via CssHashInput.hash

### DIFF
--- a/.changeset/fix-css-hash-input-raw-digest.md
+++ b/.changeset/fix-css-hash-input-raw-digest.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(analyze): hand the raw digest to `cssHash` callbacks via `CssHashInput.hash`
+
+`CssHashInput.hash` now carries the unprefixed raw digest, matching upstream's
+default `cssHash` (`svelte-${hash(...)}`) where the `hash` argument is the raw
+digest and the `svelte-` prefix is applied by the default implementation itself.
+The prefix is now materialized only where the default hash is produced. The wasm
+`cssHash` bridge no longer recomputes its own raw hash and instead trusts the
+shared field. No compiler output changes.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -171,7 +171,8 @@ pub struct CssHashInput {
     pub filename: String,
     /// CSS code.
     pub css: String,
-    /// Hash function.
+    /// Raw digest function (no `svelte-` prefix), matching the `hash` argument
+    /// upstream hands to a user `cssHash` callback.
     pub hash: Arc<dyn Fn(&str) -> String + Send + Sync>,
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -2146,8 +2146,10 @@ impl ComponentAnalysis {
                 name: component_name,
                 filename,
                 css: css.content.styles.clone(),
+                // Matches upstream's default `cssHash` (`svelte-${hash(...)}`):
+                // the `hash` handed to the callback is the raw digest, unprefixed.
                 hash: std::sync::Arc::new(|s: &str| {
-                    crate::compiler::phases::phase3_transform::css::generate_css_hash(s)
+                    crate::compiler::phases::phase3_transform::css::generate_raw_hash(s)
                 }),
             };
             css_hash_fn(&input)

--- a/crates/rsvelte_core/src/wasm.rs
+++ b/crates/rsvelte_core/src/wasm.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use wasm_bindgen::prelude::*;
 
 use crate::compiler::phases::phase1_parse::{ParseOptions, parse};
-use crate::compiler::phases::phase3_transform::css::{generate_css_hash, generate_raw_hash};
+use crate::compiler::phases::phase3_transform::css::generate_css_hash;
 use crate::compiler::{
     CompileOptions, CompileResult, CssHashFn, CssHashInput, CssMode, GenerateMode, Namespace,
     Warning, WarningFilterFn, compile,
@@ -353,12 +353,14 @@ fn js_error_message(e: &JsValue) -> String {
 fn build_css_hash(func: js_sys::Function, root_dir: Option<String>, slot: ErrorSlot) -> CssHashFn {
     Arc::new(move |input: &CssHashInput| -> String {
         let arg = js_sys::Object::new();
-        // The callback's `hash` arg is Svelte's raw digest (no `svelte-` prefix,
-        // unlike `CssHashInput::hash`) so a custom scope class matches upstream.
-        // The closure is dropped at the end of this synchronous call — no leak,
-        // no `.forget()`.
-        let closure = Closure::wrap(Box::new(|s: String| -> String { generate_raw_hash(&s) })
-            as Box<dyn Fn(String) -> String>);
+        // The callback's `hash` arg is the shared `CssHashInput::hash` — Svelte's
+        // raw digest (no `svelte-` prefix) — so a custom scope class matches
+        // upstream. The closure is dropped at the end of this synchronous call —
+        // no leak, no `.forget()`.
+        let hash_fn = input.hash.clone();
+        let closure =
+            Closure::wrap(Box::new(move |s: String| -> String { hash_fn(&s) })
+                as Box<dyn Fn(String) -> String>);
         let _ = js_sys::Reflect::set(&arg, &JsValue::from_str("hash"), closure.as_ref());
         let _ = js_sys::Reflect::set(
             &arg,

--- a/crates/rsvelte_core/tests/css_hash_callback_raw_digest.rs
+++ b/crates/rsvelte_core/tests/css_hash_callback_raw_digest.rs
@@ -1,0 +1,55 @@
+//! Regression test for issue #1697.
+//!
+//! The `hash` argument handed to a user `cssHash` callback (`CssHashInput.hash`)
+//! must be the raw digest, without the `svelte-` prefix — matching upstream's
+//! default `cssHash` (`svelte-${hash(...)}`), where the prefix is applied by the
+//! default implementation, not carried by `hash`. Before the fix this field
+//! reproduced the fully-prefixed scope class, so any consumer trusting it would
+//! double-prefix.
+
+use std::sync::{Arc, Mutex};
+
+use rsvelte_core::{
+    CompileOptions, GenerateMode, compile,
+    compiler::{CssHashInput, CssMode},
+};
+
+#[test]
+fn css_hash_callback_receives_unprefixed_raw_digest() {
+    let seen: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let seen_cb = Arc::clone(&seen);
+
+    let css_hash = Arc::new(move |input: &CssHashInput| -> String {
+        let raw = (input.hash)(&input.css);
+        *seen_cb.lock().unwrap() = Some(raw.clone());
+        format!("x-{raw}")
+    });
+
+    let result = compile(
+        "<h1>hi</h1><style>h1{color:red}</style>",
+        CompileOptions {
+            filename: Some("App.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::Injected,
+            runes: Some(true),
+            css_hash: Some(css_hash),
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+
+    let raw = seen.lock().unwrap().clone().expect("callback ran");
+    assert!(
+        !raw.starts_with("svelte-"),
+        "hash arg must be the raw digest, not the svelte- scope class; got {raw}"
+    );
+    assert!(!raw.is_empty(), "raw digest must be non-empty");
+
+    // The callback's returned scope class must reach the output verbatim.
+    let scope = format!("x-{raw}");
+    assert!(
+        result.js.code.contains(&scope),
+        "custom scope class {scope} must appear in output"
+    );
+}


### PR DESCRIPTION
Closes #1697

## Problem

`CssHashInput.hash` was populated with `generate_css_hash` — the `svelte-`-prefixed
scope class — but upstream's default `cssHash` implementation is
`svelte-${hash(filename ?? css)}`, which shows the `hash` argument handed to a
user `cssHash` callback must be the **raw digest**, without the prefix.

No observable bug today (the only in-tree consumer, the wasm bridge, distrusted
the field and recomputed the raw hash itself), but the shared type was wrong at
the contract level: any future consumer trusting it directly — e.g. a C-API
callback bridge (issue #1680's deferred half) — would hand callbacks a
double-prefixed value.

## Fix

- `CssHashInput.hash` now carries the unprefixed raw digest (`generate_raw_hash`).
  The `svelte-` prefix is applied only where the default hash is materialized.
- The wasm `cssHash` bridge no longer recomputes its own raw hash; it wraps the
  shared `CssHashInput::hash` instead, removing the duplicated reimplementation.

No compiler output changes: the default (no-callback) path still produces
`svelte-XXXX` scope classes, and callback behavior is byte-identical (the wasm
bridge's old inline `generate_raw_hash` and the new shared field return the same
value).

NAPI's callback bridge (PR #1667) lives on an unmerged feature branch and is not
present on `main`, so its duplicated raw-hash reimplementation is left for that
PR to drop when it rebases onto this contract.

## Verification

- New Rust regression test (`css_hash_callback_raw_digest.rs`) asserting the
  callback receives an unprefixed raw digest and that the returned custom scope
  class reaches the output.
- `cargo test --release` css + compiler snapshot suites.
- wasm `cssHash` callback E2E (`scripts/dev/test-wasm-compile-options.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
