### PR TITLE
fix(fmt): match prettier for bracketSameLine empty/whitespace elements

### DIFF
--- a/.changeset/fix-fmt-bracket-same-line-empty-elements.md
+++ b/.changeset/fix-fmt-bracket-same-line-empty-elements.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): match prettier for two `bracketSameLine` empty/whitespace element cases
+
+Under `bracketSameLine: true` two residual divergences from prettier-plugin-svelte
+are fixed (both pre-existing, no effect on the default `false`):
+
+- a deliberate whitespace-only inline element in prose (`<p>text <span>   </span>
+  text</p>`) now keeps prettier's non-hug body (`<span> </span>`) instead of
+  collapsing to the source-empty hug form — the source whitespace is told apart
+  from the wrap artifact an earlier pass inserts into source-empty wrapped
+  elements;
+- a standalone source-empty element with a long wrapping open tag (a block
+  element's lone `<span class="…long…"></span>`) now dedents its `>` onto its own
+  line and glues `></span>` (applying `canOmitSoftlineBeforeClosingTag`) instead
+  of gluing the `>` to the last attribute and dangling `</span>`.

--- a/crates/rsvelte_formatter/src/children.rs
+++ b/crates/rsvelte_formatter/src/children.rs
@@ -422,7 +422,7 @@ pub(crate) fn enter_bracket_same_line(value: bool) -> BracketSameLineGuard {
     BracketSameLineGuard(BRACKET_SAME_LINE.replace(value))
 }
 
-fn bracket_same_line() -> bool {
+pub(crate) fn bracket_same_line() -> bool {
     BRACKET_SAME_LINE.with(std::cell::Cell::get)
 }
 
@@ -450,16 +450,11 @@ pub(crate) fn build_element_doc(el: ElementLayout) -> Doc {
     let is_empty = children
         .iter()
         .all(|c| matches!(c.text(), Some(t) if is_only_ws(t)));
-    // Under `bracketSameLine`, a source-empty element must take the hug layout, so
-    // drop any whitespace-only child an earlier pass left inside it (so
-    // `should_hug_*` and the empty `body` see no content, matching prettier, whose
-    // empty source element has no children at all). Gated to `bracketSameLine` so
-    // the default path keeps upstream's non-clearing behaviour untouched.
-    let children = if is_empty && bracket_same_line {
-        Vec::new()
-    } else {
-        children
-    };
+    // A source-empty element whose open tag wrapped may arrive with a
+    // whitespace-only artifact child an earlier pass inserted; the caller
+    // (`collapse.rs`) already drops those under `bracketSameLine`, so the
+    // `children` here mirror prettier's original AST children — empty ⇔
+    // source-empty, whitespace ⇔ source-whitespace — and no clearing is needed.
     // canOmitSoftlineBeforeClosingTag(node, path, options) — false unless
     // `bracketSameLine` is on; then it drops the softline before a hugged
     // element's closing `>` when the element doesn't hug the next node (or is the

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -5186,6 +5186,7 @@ fn build_inline_element_doc(
     for n in &e.fragment.nodes {
         children.push(node_to_child(out, n, line_width)?);
     }
+    let children = layout_children(out, &e.fragment.nodes, e.start, children);
     Some(build_element_doc(ElementLayout {
         name: e.name.to_string(),
         attrs,
@@ -5210,6 +5211,7 @@ fn build_component_doc(
     for n in &c.fragment.nodes {
         children.push(node_to_child(out, n, line_width)?);
     }
+    let children = layout_children(out, &c.fragment.nodes, c.start, children);
     Some(build_element_doc(ElementLayout {
         name: c.name.to_string(),
         attrs,
@@ -6770,6 +6772,53 @@ pub(crate) fn template_node_span(node: &TemplateNode) -> (u32, u32) {
 /// `<div />` stays self-closed instead of becoming `<div></div>`.
 fn did_self_close(out: &str, end: u32) -> bool {
     end >= 2 && out.as_bytes().get(end as usize - 2) == Some(&b'/')
+}
+
+/// Whether the element `<name …>…</name>` (spanning `el_start..` with children
+/// `nodes`) should be treated as having no body when hugging under
+/// `bracketSameLine` — i.e. its only children are whitespace-only wrap artifacts,
+/// not deliberate source whitespace like `<span> </span>`.
+///
+/// prettier keys the empty-element `body` on the ORIGINAL AST child count, but an
+/// earlier collapse pass inserts a whitespace-only artifact child when the open
+/// tag wraps across lines. The two are told apart by the open tag: a single-line
+/// open tag never receives a wrap artifact, so any whitespace child there is
+/// genuine source content and the element keeps its non-hug body; only a wrapped
+/// (multi-line) open tag can carry the artifact that must be dropped so the
+/// element hugs (matching prettier's source-empty `<span class="long"></span>`).
+fn element_source_empty(out: &str, nodes: &[TemplateNode], el_start: u32) -> bool {
+    let all_ws = nodes.iter().all(|n| {
+        matches!(n, TemplateNode::Text(t)
+            if out.get(t.start as usize..t.end as usize)
+                .is_some_and(|s| s.split_whitespace().next().is_none()))
+    });
+    if !all_ws {
+        return false;
+    }
+    let Some(first) = nodes.first() else {
+        return true; // no children at all — genuinely source-empty
+    };
+    // A single-line open tag never receives a wrap artifact, so a whitespace child
+    // there is deliberate source content (`<span> </span>`) and must be kept.
+    out.get(el_start as usize..node_start(first) as usize)
+        .is_some_and(|open| open.contains('\n'))
+}
+
+/// The `children` for an element's [`ElementLayout`], with whitespace-only wrap
+/// artifacts dropped under `bracketSameLine` so a source-empty element takes the
+/// hug layout (prettier's empty source element has no children). Genuine
+/// source-whitespace elements keep their child, so `<span> </span>` stays non-hug.
+fn layout_children(
+    out: &str,
+    nodes: &[TemplateNode],
+    el_start: u32,
+    children: Vec<crate::children::Child>,
+) -> Vec<crate::children::Child> {
+    if crate::children::bracket_same_line() && element_source_empty(out, nodes, el_start) {
+        Vec::new()
+    } else {
+        children
+    }
 }
 
 /// The structural half of prettier-plugin-svelte's

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -461,15 +461,46 @@ fn push_close_tag(
         let indent = indent_str(depth, &options.js);
         edits.push((start, end, format!("</{tag_name}\n{indent}>")));
     } else if open_wrapped && is_empty && options.bracket_same_line {
-        // `bracketSameLine` glues the wrapped open tag's `>` to the last
-        // attribute (`…role="c">`), so an empty element's close tag drops to its
-        // own line at the element indent (`…role="c">\n</div>`). Emit the
-        // newline as part of the close-tag replacement so it never conflicts
-        // with the open-tag edit that ends at this same position.
-        let indent = indent_str(depth, &options.js);
-        edits.push((start, end, format!("\n{indent}</{tag_name}>")));
+        // An empty element's wrapped open `>` dedents onto its own line (see the
+        // `!empty_element` guard in `push_open_tag`), so `>` and `</tag` glue as
+        // `…"`\n`></tag` — matching prettier's empty `shouldHugStart && hugEnd`
+        // branch. `canOmitSoftlineBeforeClosingTag` then decides the final `>`:
+        // when the element is followed by collapse-whitespace / the doc end / a
+        // block parent's close tag it is glued (`></tag>`), otherwise a softline
+        // dedents it onto its own line (`></tag`\n`>`), mirroring #1687's port.
+        if can_omit_softline_before_closing_tag(source, element_end) {
+            edits.push((start, end, format!("</{tag_name}>")));
+        } else {
+            let indent = indent_str(depth, &options.js);
+            edits.push((start, end, format!("</{tag_name}\n{indent}>")));
+        }
     } else {
         edits.push((start, end, format!("</{tag_name}>")));
+    }
+}
+
+/// prettier-plugin-svelte's `canOmitSoftlineBeforeClosingTag`, evaluated
+/// structurally from the text after the element's close tag (its caller already
+/// gates on `bracketSameLine`): `!hugsStartOfNextNode(node) ||
+/// isLastChildWithinParentBlockElement(path)`.
+///
+/// - `hugsStartOfNextNode` is false at the doc end or when HTML-collapse
+///   whitespace follows — the softline before the closing `>` may be omitted;
+/// - otherwise a node abuts the close tag, and the softline may still be omitted
+///   only when that node is a block parent's own close tag (`</block…`), i.e.
+///   this element is that block's last child.
+fn can_omit_softline_before_closing_tag(source: &str, element_end: u32) -> bool {
+    let rest = &source[element_end as usize..];
+    match rest.chars().next() {
+        None => true,
+        Some(' ' | '\t' | '\n' | '\u{0C}' | '\r') => true,
+        Some(_) => rest.strip_prefix("</").is_some_and(|after| {
+            let name: String = after
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == ':')
+                .collect();
+            is_block_element(&name)
+        }),
     }
 }
 
@@ -903,7 +934,13 @@ fn push_open_tag(
             depth,
             &options.js,
             hug_open,
-            options.bracket_same_line,
+            // An empty NON-self-closing element never glues its wrapped open `>`
+            // to the last attribute under `bracketSameLine`: prettier's empty
+            // `shouldHugStart && shouldHugEnd` branch keeps the `>` inside a
+            // hugged group that breaks onto its own line (`…"`\n`></span>`) when
+            // the attrs wrapped, so it dedents exactly like the default path. A
+            // self-closing element (`<input … />`) still glues its ` />`.
+            options.bracket_same_line && (self_closing || !empty_element),
         )
     } else {
         one_liner

--- a/crates/rsvelte_formatter/tests/options.rs
+++ b/crates/rsvelte_formatter/tests/options.rs
@@ -291,6 +291,60 @@ fn bracket_same_line_default_dangles_closer_before_if_block() {
     );
 }
 
+// A deliberate whitespace-only inline element in prose (`<span>   </span>`, open
+// tag NOT wrapped) keeps prettier's non-hug body — a single collapsed space —
+// under `bracketSameLine`, rather than collapsing to the source-empty hug form.
+// The source whitespace must be told apart from the wrap artifact an earlier pass
+// inserts into source-EMPTY wrapped elements. See issue #1699.
+#[test]
+fn bracket_same_line_keeps_whitespace_content_inline_element() {
+    let src = "<p>Some prose text <span>   </span> more prose after</p>";
+    let out = fmt(src, &width_80(true));
+    assert_eq!(
+        out,
+        "<p>Some prose text <span> </span> more prose after</p>\n"
+    );
+}
+
+// The source-EMPTY sibling of the case above (`<span></span>`) still prints the
+// hug/empty form — no space body — proving the whitespace vs empty distinction is
+// preserved, not lost to a blanket clear.
+#[test]
+fn bracket_same_line_source_empty_inline_stays_empty() {
+    let src = "<p>Some prose text <span></span> more prose after</p>";
+    let out = fmt(src, &width_80(true));
+    assert_eq!(
+        out,
+        "<p>Some prose text <span></span> more prose after</p>\n"
+    );
+}
+
+// A standalone source-empty element (sole child of a block `<div>`, outside the
+// children port) whose long open tag wraps must dedent its `>` onto its own line
+// and glue `></span>` — matching prettier — instead of gluing the `>` to the last
+// attribute and dangling `</span>`. Whitespace follows, so
+// `canOmitSoftlineBeforeClosingTag` is true. See issue #1699.
+#[test]
+fn bracket_same_line_standalone_empty_element_dedents_closer() {
+    let src = "<div>\n  <span class=\"a-really-long-class-name-that-forces-the-open-tag-to-wrap-well-past-eighty-columns\"></span>\n</div>";
+    let out = fmt(src, &width_80(true));
+    assert_eq!(
+        out,
+        "<div>\n  <span\n    class=\"a-really-long-class-name-that-forces-the-open-tag-to-wrap-well-past-eighty-columns\"\n  ></span>\n</div>\n"
+    );
+}
+
+// The same standalone shape is identical under the default (`bracketSameLine =
+// false`) — the fix must not diverge the two, since prettier's output does not
+// depend on the flag here.
+#[test]
+fn bracket_same_line_standalone_empty_element_matches_default() {
+    let src = "<div>\n  <span class=\"a-really-long-class-name-that-forces-the-open-tag-to-wrap-well-past-eighty-columns\"></span>\n</div>";
+    let expected = "<div>\n  <span\n    class=\"a-really-long-class-name-that-forces-the-open-tag-to-wrap-well-past-eighty-columns\"\n  ></span>\n</div>\n";
+    assert_eq!(fmt(src, &width_80(true)), expected);
+    assert_eq!(fmt(src, &width_80(false)), expected);
+}
+
 #[test]
 fn sort_order_parse_rejects_invalid() {
     assert!(SortOrderSpec::parse("scripts-markup").is_none());


### PR DESCRIPTION
Follow-up to #1654 / #1687. Fixes the two remaining `bracketSameLine: true` divergences from the prettier-plugin-svelte oracle described in #1699 — both pre-existing (reproduce on `main` before this change) and both only observable under `bracketSameLine: true`, so there is **zero svelte.dev-corpus impact** (the corpus formats with the default `false`).

## 1. Deliberate whitespace-content inline element in prose

`<p>text <span>   </span> text</p>` — after the main pass rsvelte could not tell a source-whitespace-only element from a source-empty one, because the children port cleared **every** whitespace-only child under `bracketSameLine` (an earlier pass inserts a whitespace child artifact into source-empty *wrapped* elements).

The clear now lives in `collapse::layout_children` and drops **only genuine wrap artifacts**: a whitespace child is an artifact only when the open tag wrapped across lines (a single-line open tag never receives one), so deliberate source whitespace is kept.

- `<span>   </span>` → `<span> </span>` (prettier's non-hug body) ✅
- `<span></span>` → `<span></span>` (still hugs) ✅

## 2. Standalone empty element with a long wrapping attribute (non-port path)

A block element's lone empty `<span class="…long…"></span>` is not claimed by the children port; the non-port markup path glued the wrapped `>` to the last attribute and dangled `</span>`:

```
<span
  class="…">
</span>
```

`push_open_tag` now dedents the `>` of an empty **non-self-closing** element (self-closing ` />` still glues, per #1654), and `push_close_tag` applies `canOmitSoftlineBeforeClosingTag` — matching the port logic #1687 added — so the close tag is `></span>` when whitespace / the doc end / a block-parent close follows, or `></span`⏎`>` otherwise:

```
<span
  class="…"
></span>
```

Verified byte-for-byte against `prettier` + `prettier-plugin-svelte@4.1.1` for `bracketSameLine` true **and** false, across the whitespace/empty and following-context (whitespace / adjacent text / block-parent close) permutations.

## Verification

- `cargo test -p rsvelte_formatter` and `-p rsvelte_fmt` — all green, including 4 new `options.rs` cases and the previously-failing `bracket_same_line_glues_self_closing_closer` guard (which caught, and drove, the self-closing carve-out).
- Both fixes are gated inside `bracketSameLine` (case 1 on the port's `bracket_same_line()`, case 2 inside the `options.bracket_same_line` branches), so the default `false` path is byte-identical to `main` — the corpus parity gate is unaffected.

Closes #1699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BM6fsLqScsDaXVxKtJ4Cev