### PR TITLE
fix(parse): function-node AST fidelity (field order, typeParameters, optional params)

### DIFF
--- a/.changeset/fix-function-node-ast-fidelity.md
+++ b/.changeset/fix-function-node-ast-fidelity.md
@@ -15,7 +15,9 @@ Three parse-AST fixes so the public `parse()` output matches svelte/compiler:
 - TS optional parameters (`b?: T`) round-trip their `optional: true` marker;
   program-context arrow params now route through the TS-aware parameter
   converter so they carry the same `typeAnnotation`/`optional` fidelity as
-  declarations (#1692).
+  declarations (#1692). As a side effect, this also fixes a pure-JS bug where a
+  default-valued arrow parameter (`(a = 1) => a`) lost its `AssignmentPattern`
+  (default value) in the `parse()` output — `compile()` output was unaffected.
 
 The binary NAPI raw-parse envelope (consumed by
 `@rsvelte/vite-plugin-svelte-native`'s `parse-envelope.js` decoder) carries the

--- a/.changeset/fix-function-node-ast-fidelity.md
+++ b/.changeset/fix-function-node-ast-fidelity.md
@@ -1,0 +1,23 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+fix(parse): improve function-node AST fidelity to match acorn / acorn-typescript
+
+Three parse-AST fixes so the public `parse()` output matches svelte/compiler:
+
+- `FunctionExpression` fields are ordered `id, expression, generator, async` to
+  match acorn's uniform `initFunction` key order (#1689).
+- Generic function-like nodes emit `typeParameters`
+  (`FunctionDeclaration`/`FunctionExpression` between `async` and `params`,
+  `ArrowFunctionExpression` after `body`) (#1694).
+- TS optional parameters (`b?: T`) round-trip their `optional: true` marker;
+  program-context arrow params now route through the TS-aware parameter
+  converter so they carry the same `typeAnnotation`/`optional` fidelity as
+  declarations (#1692).
+
+The binary NAPI raw-parse envelope (consumed by
+`@rsvelte/vite-plugin-svelte-native`'s `parse-envelope.js` decoder) carries the
+same fields, so both packages need this release. The envelope `VERSION` is
+bumped to 3 alongside the wire-format change.

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -15,9 +15,10 @@
 const { isWindowOutOfBounds, windowOutOfBoundsMessage } = require('./lib/bounds-check.js');
 
 const MAGIC = 0x3156_5052; // "RPV1" little-endian
-// Bumped for the `FunctionDeclaration.expression` bool byte added to the wire
-// format; keep in lockstep with `napi_raw_parse.rs`'s `VERSION`.
-const VERSION = 2;
+// Bumped for the function-node AST-fidelity changes (FunctionExpression field
+// reorder, `typeParameters` on function-like nodes, Identifier `optional`);
+// keep in lockstep with `napi_raw_parse.rs`'s `VERSION`.
+const VERSION = 3;
 const HEADER_LEN = 24;
 
 // Tags — must mirror napi_raw_parse.rs.
@@ -811,17 +812,17 @@ function readJsNewExpression(ctx, start, end) {
 function readJsFunctionExpression(ctx, start, end) {
 	const loc = readTypedLoc(ctx);
 	const id = readOptNode(ctx);
+	const expression = readBool(ctx);
 	const generator = readBool(ctx);
 	const asyncFlag = readBool(ctx);
-	const expression = readBool(ctx);
 	const params = readChildArray(ctx);
 	const body = readOptNode(ctx);
 	const node = { type: 'FunctionExpression', start, end };
 	if (loc !== null) node.loc = loc;
 	node.id = id;
+	node.expression = expression;
 	node.generator = generator;
 	node.async = asyncFlag;
-	node.expression = expression;
 	node.params = params;
 	node.body = body;
 	return node;

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -701,9 +701,11 @@ function readOptNode(ctx) {
 function readJsIdentifier(ctx, start, end) {
 	const loc = readTypedLoc(ctx);
 	const name = readStr(ctx);
+	const optional = readBool(ctx);
 	const node = { type: 'Identifier', start, end };
 	if (loc !== null) node.loc = loc;
 	node.name = name;
+	if (optional) node.optional = true;
 	const typeAnnotation = readOptTypeAnnotation(ctx);
 	if (typeAnnotation !== null) node.typeAnnotation = typeAnnotation;
 	return node;

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -815,6 +815,7 @@ function readJsFunctionExpression(ctx, start, end) {
 	const expression = readBool(ctx);
 	const generator = readBool(ctx);
 	const asyncFlag = readBool(ctx);
+	const typeParameters = readOptTypeAnnotation(ctx);
 	const params = readChildArray(ctx);
 	const body = readOptNode(ctx);
 	const node = { type: 'FunctionExpression', start, end };
@@ -823,6 +824,7 @@ function readJsFunctionExpression(ctx, start, end) {
 	node.expression = expression;
 	node.generator = generator;
 	node.async = asyncFlag;
+	if (typeParameters !== null) node.typeParameters = typeParameters;
 	node.params = params;
 	node.body = body;
 	return node;
@@ -849,6 +851,7 @@ function readJsArrowFunctionExpression(ctx, start, end) {
 	const asyncFlag = readBool(ctx);
 	const params = readChildArray(ctx);
 	const body = readNode(ctx);
+	const typeParameters = readOptTypeAnnotation(ctx);
 	const node = { type: 'ArrowFunctionExpression', start, end };
 	if (loc !== null) node.loc = loc;
 	node.id = id;
@@ -857,6 +860,7 @@ function readJsArrowFunctionExpression(ctx, start, end) {
 	node.async = asyncFlag;
 	node.params = params;
 	node.body = body;
+	if (typeParameters !== null) node.typeParameters = typeParameters;
 	return node;
 }
 
@@ -1176,6 +1180,7 @@ function readJsFunctionDeclaration(ctx, start, end) {
 	const expression = readBool(ctx);
 	const generator = readBool(ctx);
 	const asyncFlag = readBool(ctx);
+	const typeParameters = readOptTypeAnnotation(ctx);
 	const params = readChildArray(ctx);
 	const body = readOptNode(ctx);
 	const node = { type: 'FunctionDeclaration', start, end };
@@ -1184,6 +1189,7 @@ function readJsFunctionDeclaration(ctx, start, end) {
 	node.expression = expression;
 	node.generator = generator;
 	node.async = asyncFlag;
+	if (typeParameters !== null) node.typeParameters = typeParameters;
 	node.params = params;
 	node.body = body;
 	return node;

--- a/crates/rsvelte_core/src/ast/arena.rs
+++ b/crates/rsvelte_core/src/ast/arena.rs
@@ -375,6 +375,7 @@ mod tests {
             end: 0,
             loc: None,
             name: CompactString::new(name),
+            optional: false,
             type_annotation: None,
         }
     }

--- a/crates/rsvelte_core/src/ast/js.rs
+++ b/crates/rsvelte_core/src/ast/js.rs
@@ -111,6 +111,7 @@ impl Expression {
             end,
             loc: typed_loc,
             name: name.into(),
+            optional: false,
             type_annotation: None,
         }))
     }

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -90,6 +90,11 @@ pub enum JsNode {
         end: u32,
         loc: Option<Box<Loc>>,
         name: CompactString,
+        /// TS optional-parameter marker (`b?: T`). acorn-typescript emits
+        /// `optional: true` after `name` (before `typeAnnotation`) and omits it
+        /// when false, so this serializes only when `true`. `false` for the
+        /// overwhelming majority of identifiers.
+        optional: bool,
         /// Opaque, output-only TS `typeAnnotation` boundary blob (ESTree
         /// `TSTypeAnnotation`). Analyze never walks into it; it exists solely so
         /// a TS-annotated binding/declarator identifier can route through the
@@ -799,6 +804,7 @@ impl Serialize for JsNode {
                 end,
                 loc,
                 name,
+                optional,
                 type_annotation,
             } => {
                 let mut map = serializer.serialize_map(None)?;
@@ -807,6 +813,9 @@ impl Serialize for JsNode {
                 map.serialize_entry("end", end)?;
                 ser_loc!(map, loc);
                 map.serialize_entry("name", name.as_str())?;
+                if *optional {
+                    map.serialize_entry("optional", &true)?;
+                }
                 if let Some(ta) = type_annotation {
                     map.serialize_entry("typeAnnotation", ta.as_ref())?;
                 }
@@ -2364,6 +2373,7 @@ impl JsNode {
                         end,
                         loc,
                         name: get_str(obj, "name"),
+                        optional: get_bool(obj, "optional"),
                         type_annotation: obj.get("typeAnnotation").cloned().map(Box::new),
                     },
                     "PrivateIdentifier" => JsNode::PrivateIdentifier {

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -993,9 +993,9 @@ impl Serialize for JsNode {
                 map.serialize_entry("end", end)?;
                 ser_loc!(map, loc);
                 ser_opt_node!(map, "id", id);
+                map.serialize_entry("expression", expression)?;
                 map.serialize_entry("generator", generator)?;
                 map.serialize_entry("async", r#async)?;
-                map.serialize_entry("expression", expression)?;
                 ser_children!(map, "params", params);
                 ser_opt_node!(map, "body", body);
                 ser_comments!(map, *start, *end);

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -178,6 +178,10 @@ pub enum JsNode {
         generator: bool,
         r#async: bool,
         expression: bool,
+        /// Opaque, output-only TS `typeParameters` blob (`<T, U>`), serialized
+        /// verbatim (acorn-typescript emits it between `async` and `params`).
+        /// `None` for the overwhelming majority (non-generic) functions.
+        type_parameters: Option<Box<serde_json::Value>>,
     },
     ClassExpression {
         start: u32,
@@ -197,6 +201,10 @@ pub enum JsNode {
         expression: bool,
         generator: bool,
         r#async: bool,
+        /// Opaque, output-only TS `typeParameters` blob (`<T,>`). Unlike
+        /// declarations/expressions, acorn-typescript appends it *after* `body`
+        /// for arrows. `None` for the overwhelming majority (non-generic) arrows.
+        type_parameters: Option<Box<serde_json::Value>>,
     },
     AssignmentExpression {
         start: u32,
@@ -406,6 +414,10 @@ pub enum JsNode {
         // Always `false`: acorn only ever sets `expression: true` on arrow function
         // bodies without a block; declarations always have a block body.
         expression: bool,
+        /// Opaque, output-only TS `typeParameters` blob (`<T, U>`), serialized
+        /// verbatim (acorn-typescript emits it between `async` and `params`).
+        /// `None` for the overwhelming majority (non-generic) functions.
+        type_parameters: Option<Box<serde_json::Value>>,
     },
     ClassDeclaration {
         start: u32,
@@ -986,6 +998,7 @@ impl Serialize for JsNode {
                 generator,
                 r#async,
                 expression,
+                type_parameters,
             } => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "FunctionExpression")?;
@@ -996,6 +1009,9 @@ impl Serialize for JsNode {
                 map.serialize_entry("expression", expression)?;
                 map.serialize_entry("generator", generator)?;
                 map.serialize_entry("async", r#async)?;
+                if let Some(tp) = type_parameters {
+                    map.serialize_entry("typeParameters", tp.as_ref())?;
+                }
                 ser_children!(map, "params", params);
                 ser_opt_node!(map, "body", body);
                 ser_comments!(map, *start, *end);
@@ -1030,6 +1046,7 @@ impl Serialize for JsNode {
                 expression,
                 generator,
                 r#async,
+                type_parameters,
             } => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "ArrowFunctionExpression")?;
@@ -1042,6 +1059,10 @@ impl Serialize for JsNode {
                 map.serialize_entry("async", r#async)?;
                 ser_children!(map, "params", params);
                 ser_node!(map, "body", body);
+                // acorn-typescript appends `typeParameters` after `body` for arrows.
+                if let Some(tp) = type_parameters {
+                    map.serialize_entry("typeParameters", tp.as_ref())?;
+                }
                 ser_comments!(map, *start, *end);
                 map.end()
             }
@@ -1501,6 +1522,7 @@ impl Serialize for JsNode {
                 generator,
                 r#async,
                 expression,
+                type_parameters,
             } => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "FunctionDeclaration")?;
@@ -1511,6 +1533,9 @@ impl Serialize for JsNode {
                 map.serialize_entry("expression", expression)?;
                 map.serialize_entry("generator", generator)?;
                 map.serialize_entry("async", r#async)?;
+                if let Some(tp) = type_parameters {
+                    map.serialize_entry("typeParameters", tp.as_ref())?;
+                }
                 ser_children!(map, "params", params);
                 ser_opt_node!(map, "body", body);
                 ser_comments!(map, *start, *end);
@@ -2443,6 +2468,7 @@ impl JsNode {
                         generator: get_bool(obj, "generator"),
                         r#async: get_bool(obj, "async"),
                         expression: get_bool(obj, "expression"),
+                        type_parameters: obj.get("typeParameters").cloned().map(Box::new),
                     },
                     "ClassExpression" => JsNode::ClassExpression {
                         start,
@@ -2462,6 +2488,7 @@ impl JsNode {
                         expression: get_bool(obj, "expression"),
                         generator: get_bool(obj, "generator"),
                         r#async: get_bool(obj, "async"),
+                        type_parameters: obj.get("typeParameters").cloned().map(Box::new),
                     },
                     "AssignmentExpression" => JsNode::AssignmentExpression {
                         start,
@@ -2659,6 +2686,7 @@ impl JsNode {
                         generator: get_bool(obj, "generator"),
                         r#async: get_bool(obj, "async"),
                         expression: get_bool(obj, "expression"),
+                        type_parameters: obj.get("typeParameters").cloned().map(Box::new),
                     },
                     "ClassDeclaration" => JsNode::ClassDeclaration {
                         start,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -4120,7 +4120,17 @@ fn convert_expression(
         OxcExpression::FunctionExpression(func) => {
             let start = offset + func.span.start as usize - 1;
             let end = offset + func.span.end as usize - 1;
-            create_function_expression(arena, func, start, end, offset, line_offsets)
+            let type_parameters =
+                function_expression_type_parameters(arena, func, offset, line_offsets);
+            create_function_expression(
+                arena,
+                func,
+                start,
+                end,
+                offset,
+                line_offsets,
+                type_parameters,
+            )
         }
         OxcExpression::ClassExpression(class_expr) => {
             let start = offset + class_expr.span.start as usize - 1;
@@ -4767,6 +4777,9 @@ fn create_function_expression(
     end: usize,
     offset: usize,
     line_offsets: &[usize],
+    // Method values carry their generics on the wrapping MethodDefinition, not
+    // the inner function (acorn-typescript), so callers pass `None` there.
+    type_parameters: Option<Box<serde_json::Value>>,
 ) -> Expression {
     // id
     let id = func.id.as_ref().map(|id| {
@@ -4827,14 +4840,26 @@ fn create_function_expression(
         generator: func.generator,
         r#async: func.r#async,
         expression: false,
-        type_parameters: func.type_parameters.as_ref().map(|tp| {
-            Box::new(convert_ts_type_parameter_declaration(
-                arena,
-                tp,
-                offset - 1,
-                line_offsets,
-            ))
-        }),
+        type_parameters,
+    })
+}
+
+/// Convert an oxc `Function`'s generic type parameters into the opaque
+/// `TSTypeParameterDeclaration` blob, using the expression-context (`offset - 1`)
+/// span base. `None` when the function is non-generic.
+fn function_expression_type_parameters(
+    arena: &ParseArena,
+    func: &oxc_ast::ast::Function,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Option<Box<serde_json::Value>> {
+    func.type_parameters.as_ref().map(|tp| {
+        Box::new(convert_ts_type_parameter_declaration(
+            arena,
+            tp,
+            offset - 1,
+            line_offsets,
+        ))
     })
 }
 
@@ -5003,7 +5028,8 @@ fn convert_class_element_for_expr(
             let key = convert_property_key_for_expr(arena, &method.key, offset, line_offsets);
             obj.insert("key".to_string(), key.to_value());
 
-            // value (function expression)
+            // value (function expression). A method's generics live on the
+            // MethodDefinition (acorn-typescript), not the inner function.
             let value_start = offset + method.value.span.start as usize - 1;
             let value_end = offset + method.value.span.end as usize - 1;
             let value = create_function_expression(
@@ -5013,6 +5039,7 @@ fn convert_class_element_for_expr(
                 value_end,
                 offset,
                 line_offsets,
+                None,
             );
             obj.insert("value".to_string(), value.as_json().clone());
 
@@ -8900,9 +8927,17 @@ fn convert_expression_for_program(
                 }),
             })
         }
-        OxcExpression::FunctionExpression(func) => Expression::from_node(
-            convert_function_expression_for_program_as_node(arena, func, offset, line_offsets),
-        ),
+        OxcExpression::FunctionExpression(func) => {
+            let type_parameters =
+                program_function_expression_type_parameters(arena, func, offset, line_offsets);
+            Expression::from_node(convert_function_expression_for_program_as_node(
+                arena,
+                func,
+                offset,
+                line_offsets,
+                type_parameters,
+            ))
+        }
         OxcExpression::StaticMemberExpression(member) => {
             let start = offset + member.span.start as usize;
             let end = offset + member.span.end as usize;
@@ -9760,11 +9795,14 @@ fn convert_class_element_for_program_as_node(
                 oxc_ast::ast::MethodDefinitionKind::Set => "set",
             };
             let key = convert_property_key(arena, &method.key, offset, line_offsets);
+            // A method's generics live on the MethodDefinition, not the inner
+            // function (acorn-typescript), so the inner function gets `None`.
             let value = convert_function_expression_for_program_as_node(
                 arena,
                 &method.value,
                 offset,
                 line_offsets,
+                None,
             );
             TypedClassElem::Node(JsNode::MethodDefinition {
                 start: start as u32,
@@ -10027,6 +10065,8 @@ fn convert_function_expression_for_program_as_node(
     func: &oxc_ast::ast::Function,
     offset: usize,
     line_offsets: &[usize],
+    // `None` for method values (their generics live on the wrapper node).
+    type_parameters: Option<Box<serde_json::Value>>,
 ) -> JsNode {
     let start = offset + func.span.start as usize;
     let end = offset + func.span.end as usize;
@@ -10075,15 +10115,27 @@ fn convert_function_expression_for_program_as_node(
         generator: func.generator,
         r#async: func.r#async,
         expression: false,
-        type_parameters: func.type_parameters.as_ref().map(|tp| {
-            Box::new(convert_ts_type_parameter_declaration(
-                arena,
-                tp,
-                offset,
-                line_offsets,
-            ))
-        }),
+        type_parameters,
     }
+}
+
+/// Convert an oxc `Function`'s generic type parameters into the opaque
+/// `TSTypeParameterDeclaration` blob, using the program-context (`offset`) span
+/// base. `None` when the function is non-generic.
+fn program_function_expression_type_parameters(
+    arena: &ParseArena,
+    func: &oxc_ast::ast::Function,
+    offset: usize,
+    line_offsets: &[usize],
+) -> Option<Box<serde_json::Value>> {
+    func.type_parameters.as_ref().map(|tp| {
+        Box::new(convert_ts_type_parameter_declaration(
+            arena,
+            tp,
+            offset,
+            line_offsets,
+        ))
+    })
 }
 
 /// Convert a function body (statement or expression) to JSON value.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -867,6 +867,8 @@ fn try_parse_arrow_function(
         expression: true,
         generator: false,
         r#async: false,
+        // This fast path bails out on any TS syntax, so never generic.
+        type_parameters: None,
     }))
 }
 
@@ -4798,6 +4800,14 @@ fn create_function_expression(
         generator: func.generator,
         r#async: func.r#async,
         expression: false,
+        type_parameters: func.type_parameters.as_ref().map(|tp| {
+            Box::new(convert_ts_type_parameter_declaration(
+                arena,
+                tp,
+                offset - 1,
+                line_offsets,
+            ))
+        }),
     })
 }
 
@@ -5714,6 +5724,14 @@ fn create_arrow_function(
         expression: arrow.expression,
         generator: false,
         r#async: arrow.r#async,
+        type_parameters: arrow.type_parameters.as_ref().map(|tp| {
+            Box::new(convert_ts_type_parameter_declaration(
+                arena,
+                tp,
+                offset - 1,
+                line_offsets,
+            ))
+        }),
     })
 }
 
@@ -6043,6 +6061,14 @@ fn convert_statement(
                 generator: func_decl.generator,
                 r#async: func_decl.r#async,
                 expression: false,
+                type_parameters: func_decl.type_parameters.as_ref().map(|tp| {
+                    Box::new(convert_ts_type_parameter_declaration(
+                        arena,
+                        tp,
+                        offset - 1,
+                        line_offsets,
+                    ))
+                }),
             })
         }
         // Fallback to the program-context converter for other statement types
@@ -7184,6 +7210,14 @@ fn convert_statement_for_program(
                         generator: func_decl.generator,
                         r#async: func_decl.r#async,
                         expression: false,
+                        type_parameters: func_decl.type_parameters.as_ref().map(|tp| {
+                            Box::new(convert_ts_type_parameter_declaration(
+                                arena,
+                                tp,
+                                offset,
+                                line_offsets,
+                            ))
+                        }),
                     }
                 }
                 oxc_ast::ast::ExportDefaultDeclarationKind::ClassDeclaration(class_decl)
@@ -7949,6 +7983,14 @@ fn convert_function_declaration_as_node(
         generator: func_decl.generator,
         r#async: func_decl.r#async,
         expression: false,
+        type_parameters: func_decl.type_parameters.as_ref().map(|tp| {
+            Box::new(convert_ts_type_parameter_declaration(
+                arena,
+                tp,
+                offset,
+                line_offsets,
+            ))
+        }),
     })
 }
 
@@ -8817,6 +8859,14 @@ fn convert_expression_for_program(
                 r#async: arrow.r#async,
                 params: arena.alloc_js_children(params),
                 body: arena.alloc_js_node(body_node),
+                type_parameters: arrow.type_parameters.as_ref().map(|tp| {
+                    Box::new(convert_ts_type_parameter_declaration(
+                        arena,
+                        tp,
+                        offset,
+                        line_offsets,
+                    ))
+                }),
             })
         }
         OxcExpression::FunctionExpression(func) => Expression::from_node(
@@ -9994,6 +10044,14 @@ fn convert_function_expression_for_program_as_node(
         generator: func.generator,
         r#async: func.r#async,
         expression: false,
+        type_parameters: func.type_parameters.as_ref().map(|tp| {
+            Box::new(convert_ts_type_parameter_declaration(
+                arena,
+                tp,
+                offset,
+                line_offsets,
+            ))
+        }),
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -259,6 +259,7 @@ fn get_loose_identifier(
             end: end as u32,
             loc: None,
             name: CompactString::from(""),
+            optional: false,
             type_annotation: None,
         }));
     }
@@ -849,6 +850,7 @@ fn try_parse_arrow_function(
                 end: p_end as u32,
                 loc: create_typed_loc(p_start, p_end, line_offsets),
                 name: CompactString::from(p),
+                optional: false,
                 type_annotation: None,
             });
             cursor += chunk.len() + 1; // +1 for the consumed comma
@@ -1318,6 +1320,7 @@ fn try_parse_ident_or_member(
             end: (offset + seg_end) as u32,
             loc: create_typed_loc(offset + seg_start, offset + seg_end, line_offsets),
             name: CompactString::from(prop_name),
+            optional: false,
             type_annotation: None,
         };
 
@@ -1759,6 +1762,7 @@ fn create_invalid_identifier(start: usize, end: usize, _line_offsets: &[usize]) 
         end: end as u32,
         loc: None,
         name: CompactString::from(""),
+        optional: false,
         type_annotation: None,
     })
 }
@@ -2580,6 +2584,11 @@ fn convert_formal_parameter_inner(
                 }
                 obj.insert("name".to_string(), Value::String(name.to_string()));
 
+                // TS optional marker (`b?: T`); acorn emits it after `name`.
+                if param.optional {
+                    obj.insert("optional".to_string(), Value::Bool(true));
+                }
+
                 // Convert type annotation
                 let type_ann_obj = convert_type_annotation_adjusted(
                     arena,
@@ -2590,6 +2599,18 @@ fn convert_formal_parameter_inner(
                 obj.insert("typeAnnotation".to_string(), type_ann_obj);
 
                 Expression::from_json(Value::Object(obj))
+            } else if param.optional {
+                // Optional parameter without a type annotation (`b?`). acorn
+                // extends the identifier span to include the `?`.
+                let end = adjusted_offset + id.span.end as usize + 1;
+                Expression::from_node(JsNode::Identifier {
+                    start: start as u32,
+                    end: end as u32,
+                    loc: create_typed_loc(start, end, line_offsets),
+                    name: CompactString::from(name),
+                    optional: true,
+                    type_annotation: None,
+                })
             } else {
                 let end = adjusted_offset + id.span.end as usize;
                 create_identifier(name, start, end, line_offsets)
@@ -4282,6 +4303,7 @@ fn create_identifier(name: &str, start: usize, end: usize, line_offsets: &[usize
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
         name: CompactString::from(name),
+        optional: false,
         type_annotation: None,
     })
 }
@@ -4313,6 +4335,7 @@ fn create_identifier_for_binding(
         end: end as u32,
         loc: create_typed_loc_for_binding(start, end, line_offsets),
         name: CompactString::from(name),
+        optional: false,
         type_annotation: None,
     }
 }
@@ -4345,6 +4368,7 @@ fn create_identifier_for_binding_toplevel(
         end: end as u32,
         loc: create_typed_loc_for_binding_identifier(start, end, line_offsets),
         name: CompactString::from(name),
+        optional: false,
         type_annotation: None,
     }
 }
@@ -4416,6 +4440,7 @@ pub fn create_identifier_with_character(
         end: end as u32,
         loc: create_typed_loc_with_character(start, end, line_offsets),
         name: CompactString::from(name),
+        optional: false,
         type_annotation: None,
     })
 }
@@ -4428,6 +4453,7 @@ pub fn create_empty_identifier(name: &str, start: usize, end: usize) -> Expressi
         end: end as u32,
         loc: None,
         name: CompactString::from(name),
+        optional: false,
         type_annotation: None,
     })
 }
@@ -4634,6 +4660,7 @@ fn create_static_member_expression(
             end: prop_end as u32,
             loc: create_typed_loc(prop_start, prop_end, line_offsets),
             name: CompactString::from(member.property.name.as_str()),
+            optional: false,
             type_annotation: None,
         }),
         computed: false,
@@ -6184,6 +6211,7 @@ fn convert_binding_pattern_for_decl_as_node(
                     end: end as u32,
                     loc: create_typed_loc(start, end, line_offsets),
                     name: CompactString::from(id.name.as_str()),
+                    optional: false,
                     type_annotation: Some(Box::new(ta_value)),
                 }
             } else {
@@ -8551,6 +8579,7 @@ fn convert_variable_declarator_for_program(
                 end: ts_end as u32,
                 loc: create_typed_loc(id_start as usize, ts_end, line_offsets),
                 name,
+                optional: false,
                 type_annotation: Some(Box::new(ts_value)),
             }),
             // Annotated destructuring declarator id (`let { a }: T` / `let [ a ]: T`):
@@ -8817,7 +8846,9 @@ fn convert_expression_for_program(
                 .params
                 .items
                 .iter()
-                .map(|param| convert_binding_pattern(arena, &param.pattern, offset, line_offsets))
+                .map(|param| {
+                    expr_to_node(convert_formal_parameter(arena, param, offset, line_offsets))
+                })
                 .collect();
             if let Some(rest) = &arrow.params.rest {
                 let rest_start = offset + rest.span.start as usize;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4891,6 +4891,7 @@ fn collect_identifier_names_in_node(
             generator: _,
             r#async: _,
             expression: _,
+            type_parameters: _,
         } => {
             walk_range(*params, out);
             walk_opt(body, out);
@@ -4906,6 +4907,7 @@ fn collect_identifier_names_in_node(
             generator: _,
             r#async: _,
             expression: _,
+            type_parameters: _,
         } => {
             walk_range(*params, out);
             walk_opt(body, out);
@@ -4921,6 +4923,7 @@ fn collect_identifier_names_in_node(
             expression: _,
             generator: _,
             r#async: _,
+            type_parameters: _,
         } => {
             walk_range(*params, out);
             walk(*body, out);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4749,6 +4749,7 @@ fn collect_identifier_names_in_node(
             end: _,
             loc: _,
             name,
+            optional: _,
             type_annotation: _,
         } => {
             if !out.contains(name.as_str()) {

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -1196,11 +1196,13 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             end,
             loc,
             name,
+            optional,
             type_annotation,
         } => {
             write_preamble(w, JS_IDENTIFIER, *start, *end);
             write_typed_loc(w, loc.as_deref());
             write_str(w, name.as_str());
+            write_bool(w, *optional);
             write_opt_type_annotation(w, type_annotation.as_deref())?;
         }
         JsNode::PrivateIdentifier {

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -57,9 +57,10 @@ use crate::ast::template::*;
 use crate::ast::typed_expr::{JsNode, LiteralValue, Loc, RegexValue, TemplateElementValue};
 
 pub const MAGIC: u32 = 0x3156_5052; // "RPV1" little-endian
-// Bumped for the `FunctionDeclaration.expression` bool byte added to the wire
-// format; keep in lockstep with `parse-envelope.js`'s `VERSION`.
-pub const VERSION: u32 = 2;
+// Bumped for the function-node AST-fidelity changes (FunctionExpression field
+// reorder, `typeParameters` on function-like nodes, Identifier `optional`);
+// keep in lockstep with `parse-envelope.js`'s `VERSION`.
+pub const VERSION: u32 = 3;
 pub const HEADER_LEN: usize = 24;
 
 // Header `flags` word (offset 20):
@@ -1338,9 +1339,9 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             write_preamble(w, JS_FUNCTION_EXPRESSION, *start, *end);
             write_typed_loc(w, loc.as_deref());
             write_opt_node_id(w, *id, arena)?;
+            write_bool(w, *expression);
             write_bool(w, *generator);
             write_bool(w, *r#async);
-            write_bool(w, *expression);
             write_id_range(w, *params, arena)?;
             write_opt_node_id(w, *body, arena)?;
         }

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -1335,6 +1335,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             generator,
             r#async,
             expression,
+            type_parameters,
         } => {
             write_preamble(w, JS_FUNCTION_EXPRESSION, *start, *end);
             write_typed_loc(w, loc.as_deref());
@@ -1342,6 +1343,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             write_bool(w, *expression);
             write_bool(w, *generator);
             write_bool(w, *r#async);
+            write_opt_type_annotation(w, type_parameters.as_deref())?;
             write_id_range(w, *params, arena)?;
             write_opt_node_id(w, *body, arena)?;
         }
@@ -1369,6 +1371,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             expression,
             generator,
             r#async,
+            type_parameters,
         } => {
             write_preamble(w, JS_ARROW_FUNCTION_EXPRESSION, *start, *end);
             write_typed_loc(w, loc.as_deref());
@@ -1378,6 +1381,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             write_bool(w, *r#async);
             write_id_range(w, *params, arena)?;
             write_node_id(w, *body, arena)?;
+            write_opt_type_annotation(w, type_parameters.as_deref())?;
         }
         JsNode::AssignmentExpression {
             start,
@@ -1685,6 +1689,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             generator,
             r#async,
             expression,
+            type_parameters,
         } => {
             write_preamble(w, JS_FUNCTION_DECLARATION, *start, *end);
             write_typed_loc(w, loc.as_deref());
@@ -1692,6 +1697,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             write_bool(w, *expression);
             write_bool(w, *generator);
             write_bool(w, *r#async);
+            write_opt_type_annotation(w, type_parameters.as_deref())?;
             write_id_range(w, *params, arena)?;
             write_opt_node_id(w, *body, arena)?;
         }

--- a/crates/rsvelte_core/tests/parse_ts_types.rs
+++ b/crates/rsvelte_core/tests/parse_ts_types.rs
@@ -11,6 +11,12 @@ use serde_json::Value;
 
 /// Parse a Svelte source in modern mode and return the serialized AST as JSON.
 fn parse_to_json(source: &str) -> Value {
+    serde_json::from_str(&parse_to_string(source)).unwrap()
+}
+
+/// Parse a Svelte source in modern mode and return the raw serialized AST string
+/// (preserving `serialize_entry` key order, which the `Value` round-trip drops).
+fn parse_to_string(source: &str) -> String {
     let ast = parse(
         source,
         ParseOptions {
@@ -19,8 +25,21 @@ fn parse_to_json(source: &str) -> Value {
         },
     )
     .expect("parse should succeed");
-    let json = with_serialize_arena(&ast.arena, || serde_json::to_string(&ast).unwrap());
-    serde_json::from_str(&json).unwrap()
+    with_serialize_arena(&ast.arena, || serde_json::to_string(&ast).unwrap())
+}
+
+/// Assert that `a`, then `b`, then `c` appear in this order in `s`.
+fn assert_key_order(s: &str, a: &str, b: &str, c: &str) {
+    let ia = s.find(a).unwrap_or_else(|| panic!("missing {a}"));
+    let ib = s[ia..]
+        .find(b)
+        .map(|x| x + ia)
+        .unwrap_or_else(|| panic!("missing {b} after {a}"));
+    let ic = s[ib..]
+        .find(c)
+        .map(|x| x + ib)
+        .unwrap_or_else(|| panic!("missing {c} after {b}"));
+    assert!(ia < ib && ib < ic, "expected order {a} < {b} < {c} in: {s}");
 }
 
 /// Depth-first search for the first node of the given `type`.
@@ -344,4 +363,78 @@ fn constructor_type_is_preserved() {
             .and_then(|v| v.as_str()),
         Some("Foo")
     );
+}
+
+// #1694: generic function-like nodes must emit `typeParameters`, matching
+// acorn-typescript's shape and key position.
+
+#[test]
+fn generic_function_declaration_emits_type_parameters() {
+    let src = "<script lang=\"ts\">function f<T>(x: T){}</script>";
+    let ast = parse_to_json(src);
+    let f = find_node(&ast, "FunctionDeclaration").expect("FunctionDeclaration");
+    // `<T>` sits at bytes 28..31; the single param is `T`.
+    assert_eq!(
+        f.pointer("/typeParameters/type").and_then(|v| v.as_str()),
+        Some("TSTypeParameterDeclaration")
+    );
+    assert_eq!(
+        f.pointer("/typeParameters/start").and_then(|v| v.as_u64()),
+        Some(28)
+    );
+    assert_eq!(
+        f.pointer("/typeParameters/end").and_then(|v| v.as_u64()),
+        Some(31)
+    );
+    assert_eq!(
+        f.pointer("/typeParameters/params/0/name")
+            .and_then(|v| v.as_str()),
+        Some("T")
+    );
+    // acorn emits `typeParameters` between `async` and `params`.
+    let s = parse_to_string(src);
+    assert_key_order(&s, "\"async\"", "\"typeParameters\"", "\"params\"");
+}
+
+#[test]
+fn generic_function_expression_emits_type_parameters() {
+    let src = "<script lang=\"ts\">const f = function<T>(x: T){}</script>";
+    let ast = parse_to_json(src);
+    let f = find_node(&ast, "FunctionExpression").expect("FunctionExpression");
+    assert_eq!(
+        f.pointer("/typeParameters/params/0/name")
+            .and_then(|v| v.as_str()),
+        Some("T")
+    );
+    let s = parse_to_string(src);
+    assert_key_order(&s, "\"async\"", "\"typeParameters\"", "\"params\"");
+}
+
+#[test]
+fn generic_arrow_emits_type_parameters_after_body() {
+    let src = "<script lang=\"ts\">const g = <T>(x: T)=>{}</script>";
+    let ast = parse_to_json(src);
+    let a = find_node(&ast, "ArrowFunctionExpression").expect("ArrowFunctionExpression");
+    assert_eq!(
+        a.pointer("/typeParameters/params/0/name")
+            .and_then(|v| v.as_str()),
+        Some("T")
+    );
+    // Unlike declarations/expressions, acorn appends `typeParameters` after `body`.
+    let s = parse_to_string(src);
+    // Restrict to the arrow subtree to avoid matching an outer `params`/`body`.
+    let arrow_at = s.find("\"ArrowFunctionExpression\"").unwrap();
+    assert_key_order(
+        &s[arrow_at..],
+        "\"params\"",
+        "\"body\"",
+        "\"typeParameters\"",
+    );
+}
+
+#[test]
+fn non_generic_function_omits_type_parameters() {
+    let ast = parse_to_json("<script>function f(x){}</script>");
+    let f = find_node(&ast, "FunctionDeclaration").expect("FunctionDeclaration");
+    assert!(f.get("typeParameters").is_none());
 }

--- a/crates/rsvelte_core/tests/parse_ts_types.rs
+++ b/crates/rsvelte_core/tests/parse_ts_types.rs
@@ -436,6 +436,15 @@ fn non_generic_function_omits_type_parameters() {
     assert!(f.get("typeParameters").is_none());
 }
 
+#[test]
+fn class_method_generics_stay_off_the_inner_function() {
+    // acorn-typescript attaches a method's generics to the MethodDefinition, not
+    // the inner FunctionExpression, so the inner function must omit them.
+    let ast = parse_to_json("<script lang=\"ts\">class C { m<T>(x: T){} }</script>");
+    let f = find_node(&ast, "FunctionExpression").expect("FunctionExpression");
+    assert!(f.get("typeParameters").is_none());
+}
+
 // #1692: the TS optional-parameter marker (`b?`) must round-trip as
 // `optional: true` (after `name`, before `typeAnnotation`, omitted when false).
 

--- a/crates/rsvelte_core/tests/parse_ts_types.rs
+++ b/crates/rsvelte_core/tests/parse_ts_types.rs
@@ -266,12 +266,9 @@ fn function_type_parameters_and_return_type() {
 
     let b = &params[1];
     assert_eq!(b.pointer("/name").and_then(|v| v.as_str()), Some("b"));
-    // NOTE: svelte/compiler emits `optional: true` here (the `?` marker), but
-    // rsvelte currently drops it for *every* function/arrow parameter — not
-    // specific to TSFunctionType — because `JsNode::Identifier` has no
-    // `optional` field to round-trip it through the typed AST. Out of scope
-    // for #1660; tracked separately.
-    assert!(b.get("optional").is_none());
+    // #1692: the `?` optional marker now round-trips (JsNode::Identifier carries
+    // an `optional` field, emitted after `name` and only when true).
+    assert_eq!(b.get("optional"), Some(&Value::Bool(true)));
     assert_eq!(
         b.pointer("/typeAnnotation/typeAnnotation/type")
             .and_then(|v| v.as_str()),
@@ -437,4 +434,63 @@ fn non_generic_function_omits_type_parameters() {
     let ast = parse_to_json("<script>function f(x){}</script>");
     let f = find_node(&ast, "FunctionDeclaration").expect("FunctionDeclaration");
     assert!(f.get("typeParameters").is_none());
+}
+
+// #1692: the TS optional-parameter marker (`b?`) must round-trip as
+// `optional: true` (after `name`, before `typeAnnotation`, omitted when false).
+
+fn first_param<'a>(ast: &'a Value, ty: &str) -> &'a Value {
+    let node = find_node(ast, ty).unwrap_or_else(|| panic!("{ty} must be present"));
+    &node
+        .get("params")
+        .and_then(|p| p.as_array())
+        .expect("params")[0]
+}
+
+#[test]
+fn optional_parameter_marker_on_function_declaration() {
+    let ast = parse_to_json("<script lang=\"ts\">function f(b?: number){}</script>");
+    let p = first_param(&ast, "FunctionDeclaration");
+    assert_eq!(p.pointer("/name").and_then(|v| v.as_str()), Some("b"));
+    assert_eq!(p.get("optional"), Some(&Value::Bool(true)));
+    // The identifier span extends over the annotation (matching acorn).
+    assert_eq!(p.get("end").and_then(|v| v.as_u64()), Some(39));
+    assert_eq!(
+        p.pointer("/typeAnnotation/typeAnnotation/type")
+            .and_then(|v| v.as_str()),
+        Some("TSNumberKeyword")
+    );
+}
+
+#[test]
+fn optional_parameter_marker_on_arrow() {
+    let ast = parse_to_json("<script lang=\"ts\">const g = (b?: number) => {};</script>");
+    let p = first_param(&ast, "ArrowFunctionExpression");
+    assert_eq!(p.get("optional"), Some(&Value::Bool(true)));
+    assert_eq!(
+        p.pointer("/typeAnnotation/typeAnnotation/type")
+            .and_then(|v| v.as_str()),
+        Some("TSNumberKeyword")
+    );
+}
+
+#[test]
+fn optional_parameter_without_annotation_extends_span_over_question_mark() {
+    let ast = parse_to_json("<script lang=\"ts\">function f(b?){}</script>");
+    let p = first_param(&ast, "FunctionDeclaration");
+    assert_eq!(p.get("optional"), Some(&Value::Bool(true)));
+    // `b?` spans bytes 29..31 (the `?` is included), with no typeAnnotation.
+    assert_eq!(p.get("start").and_then(|v| v.as_u64()), Some(29));
+    assert_eq!(p.get("end").and_then(|v| v.as_u64()), Some(31));
+    assert!(p.get("typeAnnotation").is_none());
+}
+
+#[test]
+fn required_parameter_omits_optional() {
+    let ast = parse_to_json("<script lang=\"ts\">function f(b: number){}</script>");
+    let p = first_param(&ast, "FunctionDeclaration");
+    assert!(p.get("optional").is_none());
+    // `optional` must sit before `typeAnnotation` when present.
+    let s = parse_to_string("<script lang=\"ts\">function f(b?: number){}</script>");
+    assert_key_order(&s, "\"name\"", "\"optional\"", "\"typeAnnotation\"");
 }

--- a/scripts/dev/test-parse-envelope-validation.mjs
+++ b/scripts/dev/test-parse-envelope-validation.mjs
@@ -17,7 +17,7 @@ const { decodeParseEnvelope } = await import(
 ).then((m) => m.default ?? m);
 
 const MAGIC = 0x3156_5052; // "RPV1"
-const VERSION = 2;
+const VERSION = 3;
 const HEADER_LEN = 24;
 const TAG_JSON = 0x00;
 const JS_IDENTIFIER = 0x80;

--- a/scripts/dev/test-parse-envelope-validation.mjs
+++ b/scripts/dev/test-parse-envelope-validation.mjs
@@ -100,8 +100,8 @@ function buildParseEnvelope(json, over = {}) {
 function buildIdentifierEnvelope(name, over = {}) {
 	const nameBytes = Buffer.from(name, 'utf8');
 	const rootOffset = HEADER_LEN;
-	// node: tag(1) + start(4) + end(4) + nameLen(4) + nameBytes + typeAnnotationFlag(1)
-	const nodeLen = 1 + 4 + 4 + 4 + nameBytes.length + 1;
+	// node: tag(1) + start(4) + end(4) + nameLen(4) + nameBytes + optionalFlag(1) + typeAnnotationFlag(1)
+	const nodeLen = 1 + 4 + 4 + 4 + nameBytes.length + 1 + 1;
 	const total = HEADER_LEN + nodeLen;
 
 	const buf = Buffer.alloc(total);
@@ -123,6 +123,8 @@ function buildIdentifierEnvelope(name, over = {}) {
 	p += 4;
 	nameBytes.copy(buf, p);
 	p += nameBytes.length;
+	buf.writeUInt8(0, p); // optional = false
+	p += 1;
 	buf.writeUInt8(0, p); // no typeAnnotation
 
 	for (const [offset, value] of Object.entries(over)) {


### PR DESCRIPTION
## Summary

Three AST-fidelity fixes so rsvelte's public `parse()` output matches
svelte/compiler (acorn / acorn-typescript). Each is its own commit, plus a
follow-up commit addressing review.

- **#1689 — FunctionExpression field order.** acorn's `initFunction` emits
  `id, expression, generator, async` uniformly; `FunctionExpression` still
  serialized `generator, async, expression`. Reordered the JSON serializer and
  the NAPI raw-parse envelope so `expression` sits right after `id`.
  `ArrowFunctionExpression` already matched.

- **#1694 — `typeParameters` on generic function-like nodes.** Carried as an
  opaque output-only blob (like the existing `typeAnnotation` boundary) on
  `FunctionDeclaration`/`FunctionExpression`/`ArrowFunctionExpression`, built
  from oxc's `Function::type_parameters` via the existing
  `convert_ts_type_parameter_declaration`. Position matches acorn: between
  `async` and `params` for declarations/expressions, appended after `body` for
  arrows.

- **#1692 — TS optional-parameter marker (`b?`).** Added an `optional` field to
  `JsNode::Identifier` (serialized after `name`, before `typeAnnotation`, only
  when true) set from oxc's `FormalParameter::optional`. Program-context arrow
  params were converted via `convert_binding_pattern` (which sees only the
  pattern, so it dropped *every* FormalParameter-level marker); they now route
  through `convert_formal_parameter` like every other function form. **Side
  effect:** this also fixes a pure-JS bug where a default-valued arrow parameter
  (`(a = 1) => a`) lost its `AssignmentPattern` (default value) in the `parse()`
  output — `compile()` output was unaffected.

The binary NAPI raw-parse envelope (consumed by
`@rsvelte/vite-plugin-svelte-native`'s `parse-envelope.js` decoder) carries all
three fields; its `VERSION` is bumped to 3 in lockstep across the Rust writer,
the JS decoder, and the validation script. A changeset patches both packages.

`typeParameters`/`optional` are stripped during transform, so CSR/SSR compiled
output is unaffected — only the `parse()` AST (and svelte2tsx) change.

## Review fixes (follow-up commit)

- **Envelope validation script.** `scripts/dev/test-parse-envelope-validation.mjs`'s
  hand-built `JS_IDENTIFIER` envelope was missing the new `optional` bool byte,
  making `minimal identifier-root envelope decodes` throw. Added the byte (+
  `nodeLen`); `node scripts/dev/test-parse-envelope-validation.mjs` is now fully
  green.
- **Class-method generics.** acorn attaches a method's `typeParameters` to the
  MethodDefinition, not the inner function, so emitting them on the inner
  `FunctionExpression` was a small regression. The two shared converters now take
  the type-param blob as a parameter and the class-method sites pass `None`.

## Verification

- New/updated regression tests in `crates/rsvelte_core/tests/parse_ts_types.rs`
  (field order, typeParameters presence/position/values, class-method inner
  omits them, optional marker on declarations + arrows + un-annotated `b?`, and
  the `name < optional < typeAnnotation` key order). Byte positions checked
  against svelte 5.56.x.
- `node scripts/dev/test-parse-envelope-validation.mjs`: all assertions pass.
- Green locally: `compatibility_report`, `runtime` (legacy/runes/browser/
  hydration — legacy needs `RUST_MIN_STACK`/`--release` for its debug-mode
  recursion depth), `ssr`, `validator`, `parser_fixtures`, `svelte2tsx_fixtures`,
  `compiler_fixtures`, `parse_ts_types`. `cargo fmt` + full-workspace
  `cargo clippy --all-targets --all-features` clean.

## Known limitations (documented, not regressions)

- A trailing comma in a type-param list (`<T,>`) makes acorn add
  `extra.trailingComma`, which `convert_ts_type_parameter_declaration` does not
  model (pre-existing, shared with the #1660 TSFunctionType path).
- Object-method inner functions carry `typeParameters` between `async` and
  `params`; acorn appends them after `body`. This position depends on context
  that the shared standalone/object-method converter can't see, so it's a
  pre-existing non-match (acorn does emit the key, so it is not a spurious-key
  regression like the class-method case was).

Closes #1689
Closes #1694
Closes #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)