### PR TITLE
feat(capi): support cssHash / warningFilter compile callbacks (#1680)

### DIFF
--- a/.changeset/capi-fn-compile-callbacks.md
+++ b/.changeset/capi-fn-compile-callbacks.md
@@ -1,0 +1,28 @@
+---
+"@rsvelte/compiler": minor
+---
+
+feat(capi): support `cssHash` / `warningFilter` compile callbacks in the C ABI (`crates/rsvelte_capi`)
+
+The C shared library gains two callback-aware entry points,
+`rsvelte_compile_with_callbacks` and `rsvelte_compile_module_with_callbacks`,
+which resolve the two function-form compile options that can't be expressed as
+JSON — completing the C-API half of the function-compile-options work (the wasm
+side shipped separately, NAPI in earlier releases):
+
+- **`css_hash`** — a `(userdata, RsvelteCssHashInput) -> RsvelteStr` function
+  pointer. The input's `hash` field is the raw digest the compiler's default
+  `cssHash` produces (the filename when known, else the CSS; no `svelte-`
+  prefix), so `svelte-${hash}` reproduces the default class exactly. Returns a
+  borrowed string the library copies immediately; a constant `cssHashOverride`
+  in the options JSON still wins.
+- **`warning_filter`** — a `(userdata, warning_json, len) -> bool` function
+  pointer, applied natively by the compiler for both components and modules.
+
+Callbacks are opt-in via a new `RsvelteCallbacks` struct (any field may be
+NULL); the existing `rsvelte_compile` / `rsvelte_compile_module` entry points
+are unchanged. `include/rsvelte.h` regenerates via cbindgen.
+
+This does not change the published `@rsvelte/compiler` npm package's runtime
+behaviour — it is a parallel C distribution channel. The npm version is bumped
+so the new C ABI surface appears in the next release notes.

--- a/crates/rsvelte_capi/README.md
+++ b/crates/rsvelte_capi/README.md
@@ -136,11 +136,11 @@ whole struct to behave like `rsvelte_compile`):
   Return the CSS scope class name as a **borrowed** `RsvelteStr`
   (`{data, len}`; the library copies it immediately and never frees it),
   or `{NULL, 0}` to fall back to the default hash. `RsvelteCssHashInput.hash`
-  is the **raw digest** of the CSS with **no `svelte-` prefix** — prepend
-  `svelte-` yourself for the default class name (prepending it to an
-  already-prefixed digest would double the prefix; that's why the shared
-  digest is unprefixed). A constant `cssHashOverride` in `opts_json` wins
-  over this callback.
+  is the **raw digest** the compiler's default `cssHash` produces — upstream
+  digests the rootDir-relative `filename` when known, else `css` — with **no
+  `svelte-` prefix**, so prepending `svelte-` reproduces the default class
+  name exactly (the unprefixed digest is what avoids a doubled prefix). A
+  constant `cssHashOverride` in `opts_json` wins over this callback.
 - **`warning_filter`** — `bool (*)(void *userdata, const uint8_t *warning_json, uintptr_t len)`.
   Receives one warning as a `(pointer, length)` UTF-8 JSON object; return
   `true` to keep it, `false` to drop it. Honoured by both the component

--- a/crates/rsvelte_capi/README.md
+++ b/crates/rsvelte_capi/README.md
@@ -117,7 +117,38 @@ RsvelteBuf  rsvelte_compile_module(const uint8_t *src, uintptr_t src_len,
 // out-parameter variants — write result through `out`
 void        rsvelte_compile_into       (..., RsvelteBuf *out);
 void        rsvelte_compile_module_into(..., RsvelteBuf *out);
+
+// callback variants — resolve the `cssHash` / `warningFilter` compile
+// options that can't cross the JSON boundary (issue #1680)
+RsvelteBuf  rsvelte_compile_with_callbacks       (const uint8_t *src, uintptr_t src_len,
+                                                  const uint8_t *opts_json, uintptr_t opts_len,
+                                                  const RsvelteCallbacks *callbacks);
+RsvelteBuf  rsvelte_compile_module_with_callbacks(..., const RsvelteCallbacks *callbacks);
 ```
+
+### Callbacks (`cssHash` / `warningFilter`)
+
+The function-form compile options are supplied through a
+`RsvelteCallbacks` struct (any field may be `NULL`; pass `NULL` for the
+whole struct to behave like `rsvelte_compile`):
+
+- **`css_hash`** — `RsvelteStr (*)(void *userdata, const RsvelteCssHashInput *)`.
+  Return the CSS scope class name as a **borrowed** `RsvelteStr`
+  (`{data, len}`; the library copies it immediately and never frees it),
+  or `{NULL, 0}` to fall back to the default hash. `RsvelteCssHashInput.hash`
+  is the **raw digest** of the CSS with **no `svelte-` prefix** — prepend
+  `svelte-` yourself for the default class name (prepending it to an
+  already-prefixed digest would double the prefix; that's why the shared
+  digest is unprefixed). A constant `cssHashOverride` in `opts_json` wins
+  over this callback.
+- **`warning_filter`** — `bool (*)(void *userdata, const uint8_t *warning_json, uintptr_t len)`.
+  Receives one warning as a `(pointer, length)` UTF-8 JSON object; return
+  `true` to keep it, `false` to drop it. Honoured by both the component
+  and module callback entry points (modules ignore `css_hash`).
+
+Each `*_userdata` pointer is passed back verbatim and is opaque to the
+library — the caller owns whatever it points at and is responsible for
+its thread-safety.
 
 ### JSON envelope
 
@@ -156,11 +187,12 @@ defaults.
 
 Each example exercises: default options, runes+dev, SSR generation,
 `compile_module` with a `$state` rune, and the malformed-options error
-path.
+path. The C example additionally drives `rsvelte_compile_with_callbacks`
+with a `cssHash` + `warningFilter` pair.
 
 ## Test infrastructure (breaking-change guard)
 
-`crates/rsvelte_capi/tests/` contains five Rust integration test files
+`crates/rsvelte_capi/tests/` contains six Rust integration test files
 designed to make any breaking change to the FFI surface fail loudly in
 CI:
 
@@ -169,6 +201,7 @@ CI:
 | `envelope.rs`          | The exact JSON envelope shape (`ok`, `result.js.code`, `warnings[].code`, etc.)           |
 | `options_coverage.rs`  | Every documented `CompileOption` is accepted, and most have observable codegen effect     |
 | `module.rs`            | `rsvelte_compile_module` envelope shape + runes / SSR variants                            |
+| `callbacks.rs`         | `cssHash` / `warningFilter` callback path incl. the raw-digest (no double-prefix) guard   |
 | `header_invariants.rs` | Required exports are present in `include/rsvelte.h` AND it byte-matches fresh cbindgen    |
 | `memory.rs`            | Free is no-op on empty buffer; 1000-iteration compile loop checks for double-free / leaks |
 

--- a/crates/rsvelte_capi/examples/c/smoke.c
+++ b/crates/rsvelte_capi/examples/c/smoke.c
@@ -56,6 +56,105 @@ static int run_case_with(const char *label, const char *source,
 #define run_case(label, src, opts)        run_case_with(label, src, opts, rsvelte_compile)
 #define run_module_case(label, src, opts) run_case_with(label, src, opts, rsvelte_compile_module)
 
+/* --- callback demo (issue #1680) --- */
+
+/* Portable substring search over a non-NUL-terminated buffer. */
+static int buf_contains(const uint8_t *hay, size_t hay_len, const char *needle) {
+  size_t n = strlen(needle);
+  if (n == 0 || n > hay_len) return 0;
+  for (size_t i = 0; i + n <= hay_len; i++) {
+    if (memcmp(hay + i, needle, n) == 0) return 1;
+  }
+  return 0;
+}
+
+/* State the cssHash callback records + a scratch buffer for its return. */
+struct css_hash_state {
+  int invoked;
+  int saw_svelte_prefix; /* whether the raw digest was already prefixed */
+  char scratch[64];
+};
+
+/* cssHash: build `svelte-${hash}` from the raw digest. Since the shared
+ * digest is unprefixed, this yields a single `svelte-` prefix. */
+static RsvelteStr css_hash_cb(void *userdata, const RsvelteCssHashInput *input) {
+  struct css_hash_state *st = (struct css_hash_state *)userdata;
+  st->invoked = 1;
+  /* Guard: the digest must NOT already start with "svelte-". */
+  if (input->hash_len >= 7 && memcmp(input->hash, "svelte-", 7) == 0) {
+    st->saw_svelte_prefix = 1;
+  }
+  int n = snprintf(st->scratch, sizeof(st->scratch), "svelte-%.*s",
+                   (int)input->hash_len, (const char *)input->hash);
+  RsvelteStr out;
+  out.data = (const uint8_t *)st->scratch;
+  out.len = (n > 0 && (size_t)n < sizeof(st->scratch)) ? (size_t)n : 0;
+  return out;
+}
+
+/* warningFilter: drop every warning (return false). */
+static bool warning_filter_cb(void *userdata, const uint8_t *warning_json,
+                              uintptr_t warning_json_len) {
+  int *count = (int *)userdata;
+  (void)warning_json;
+  (void)warning_json_len;
+  (*count)++;
+  return false;
+}
+
+static int run_callbacks_case(void) {
+  printf("\n=== callbacks: cssHash + warningFilter ===\n");
+  struct css_hash_state st = {0, 0, {0}};
+  int filtered = 0;
+  RsvelteCallbacks cb = {0};
+  cb.css_hash = css_hash_cb;
+  cb.css_hash_userdata = &st;
+  cb.warning_filter = warning_filter_cb;
+  cb.warning_filter_userdata = &filtered;
+
+  const char *src =
+      "<h1>x</h1>\n<style>h1{color:red}.unused{color:blue}</style>";
+  const char *opts = "{\"filename\":\"App.svelte\",\"css\":\"external\"}";
+  RsvelteBuf out = rsvelte_compile_with_callbacks(
+      (const uint8_t *)src, strlen(src),
+      (const uint8_t *)opts, strlen(opts), &cb);
+
+  int failures = 0;
+  if (out.data == NULL || out.len == 0) {
+    fprintf(stderr, "FAIL: callbacks produced empty buffer\n");
+    rsvelte_free(out);
+    return 1;
+  }
+  fwrite(out.data, 1, out.len < 400 ? out.len : 400, stdout);
+  printf("\n");
+
+  if (!st.invoked) {
+    fprintf(stderr, "FAIL: cssHash callback was not invoked\n");
+    failures++;
+  }
+  if (st.saw_svelte_prefix) {
+    fprintf(stderr, "FAIL: raw digest was already `svelte-` prefixed (double-prefix bug)\n");
+    failures++;
+  }
+  /* The single-prefixed class must appear; the doubled form must not. */
+  if (buf_contains(out.data, out.len, "svelte-svelte-")) {
+    fprintf(stderr, "FAIL: doubled `svelte-svelte-` prefix in output\n");
+    failures++;
+  }
+  if (filtered == 0) {
+    fprintf(stderr, "FAIL: warningFilter never saw the unused-selector warning\n");
+    failures++;
+  }
+  /* warnings were dropped -> the envelope's warnings array is empty. */
+  if (buf_contains(out.data, out.len, "css_unused_selector")) {
+    fprintf(stderr, "FAIL: warningFilter=false should have dropped the warning\n");
+    failures++;
+  }
+  rsvelte_free(out);
+  printf("cssHash invoked=%d, warnings filtered=%d\n", st.invoked, filtered);
+  return failures;
+}
+
 int main(void) {
   printf("rsvelte version: %s\n", rsvelte_version());
 
@@ -80,6 +179,8 @@ int main(void) {
       "module: $state rune",
       "export const counter = $state(0);",
       "{\"filename\":\"counter.svelte.js\"}");
+
+  failures += run_callbacks_case();
 
   /* Error path: malformed JSON options. */
   {

--- a/crates/rsvelte_capi/include/rsvelte.h
+++ b/crates/rsvelte_capi/include/rsvelte.h
@@ -33,6 +33,103 @@ typedef struct RsvelteBuf {
   uintptr_t cap;
 } RsvelteBuf;
 
+/**
+ * Borrowed UTF-8 string view returned by a callback into this library.
+ *
+ * Unlike [`RsvelteBuf`], the library does NOT take ownership of these
+ * bytes and never frees them. The pointer must stay valid only for the
+ * duration of the callback invocation that returned it (this library
+ * copies the bytes synchronously before the callback returns control
+ * upstream). A `{ data: NULL, len: 0 }` value means "no value — fall
+ * back to the compiler default".
+ */
+typedef struct RsvelteStr {
+  /**
+   * Pointer to borrowed UTF-8 bytes. NULL means "no value".
+   */
+  const uint8_t *data;
+  /**
+   * Length in bytes (does NOT include any trailing NUL).
+   */
+  uintptr_t len;
+} RsvelteStr;
+
+/**
+ * Input handed to a [`RsvelteCssHashFn`] callback.
+ *
+ * Every field is a borrowed `(pointer, length)` UTF-8 slice, valid only
+ * for the duration of the callback. `hash` is the raw digest of `css`
+ * (the compiler's default scope digest, WITHOUT the `svelte-` prefix) —
+ * prepend `svelte-` yourself to reproduce the default class name. It is
+ * exactly the value the compiler's own default `cssHash` receives.
+ */
+typedef struct RsvelteCssHashInput {
+  /**
+   * The component's CSS source.
+   */
+  const uint8_t *css;
+  /**
+   * Length of `css` in bytes.
+   */
+  uintptr_t css_len;
+  /**
+   * The rootDir-relative (or absolute) filename, or `(unknown)`.
+   */
+  const uint8_t *filename;
+  /**
+   * Length of `filename` in bytes.
+   */
+  uintptr_t filename_len;
+  /**
+   * The derived component name.
+   */
+  const uint8_t *name;
+  /**
+   * Length of `name` in bytes.
+   */
+  uintptr_t name_len;
+  /**
+   * The raw digest of `css` (no `svelte-` prefix).
+   */
+  const uint8_t *hash;
+  /**
+   * Length of `hash` in bytes.
+   */
+  uintptr_t hash_len;
+} RsvelteCssHashInput;
+
+/**
+ * Optional compile callbacks (issue #1680).
+ *
+ * Passed by pointer to the `*_with_callbacks` entry points. A NULL
+ * function-pointer field disables that callback. Each `*_userdata`
+ * pointer is passed back verbatim to its callback and is otherwise
+ * opaque to this library — use it to carry closure state. When a
+ * constant `cssHashOverride` is also set in the options JSON, that
+ * constant wins and `css_hash` is not invoked (mirrors the wasm/NAPI
+ * precedence).
+ */
+typedef struct RsvelteCallbacks {
+  /**
+   * CSS hash callback (a [`RsvelteCssHashFn`]), or NULL. Inlined rather
+   * than referenced via the alias so cbindgen emits a nullable function
+   * pointer instead of an opaque `Option_*` struct.
+   */
+  struct RsvelteStr (*css_hash)(void *userdata, const struct RsvelteCssHashInput *input);
+  /**
+   * Opaque state pointer passed to `css_hash`.
+   */
+  void *css_hash_userdata;
+  /**
+   * Warning filter callback (a [`RsvelteWarningFilterFn`]), or NULL.
+   */
+  bool (*warning_filter)(void *userdata, const uint8_t *warning_json, uintptr_t warning_json_len);
+  /**
+   * Opaque state pointer passed to `warning_filter`.
+   */
+  void *warning_filter_userdata;
+} RsvelteCallbacks;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -98,6 +195,42 @@ struct RsvelteBuf rsvelte_compile_module(const uint8_t *source,
                                          uintptr_t source_len,
                                          const uint8_t *options_json,
                                          uintptr_t options_len);
+
+/**
+ * Compile a Svelte component with optional `cssHash` / `warningFilter`
+ * callbacks (issue #1680).
+ *
+ * Identical to [`rsvelte_compile`] but also resolves the two callback
+ * compile options that can't cross the JSON boundary. `callbacks` may
+ * be NULL (equivalent to [`rsvelte_compile`]); individual callback
+ * fields may be NULL too. The callbacks are input-only and are never
+ * retained past this call.
+ *
+ * # Safety
+ * - Source/options pointers follow [`rsvelte_compile`]'s rules.
+ * - `callbacks` must be NULL or point to a valid [`RsvelteCallbacks`];
+ *   each non-NULL function pointer must be callable with the documented
+ *   signature and its paired `*_userdata` value.
+ */
+struct RsvelteBuf rsvelte_compile_with_callbacks(const uint8_t *source,
+                                                 uintptr_t source_len,
+                                                 const uint8_t *options_json,
+                                                 uintptr_t options_len,
+                                                 const struct RsvelteCallbacks *callbacks);
+
+/**
+ * Compile a Svelte `.svelte.js` / `.svelte.ts` module with an optional
+ * `warningFilter` callback (issue #1680). Modules have no CSS, so the
+ * `css_hash` field of `callbacks` is ignored.
+ *
+ * # Safety
+ * See [`rsvelte_compile_with_callbacks`].
+ */
+struct RsvelteBuf rsvelte_compile_module_with_callbacks(const uint8_t *source,
+                                                        uintptr_t source_len,
+                                                        const uint8_t *options_json,
+                                                        uintptr_t options_len,
+                                                        const struct RsvelteCallbacks *callbacks);
 
 /**
  * Out-parameter variant of [`rsvelte_compile`] for hosts whose FFI

--- a/crates/rsvelte_capi/include/rsvelte.h
+++ b/crates/rsvelte_capi/include/rsvelte.h
@@ -58,10 +58,10 @@ typedef struct RsvelteStr {
  * Input handed to a [`RsvelteCssHashFn`] callback.
  *
  * Every field is a borrowed `(pointer, length)` UTF-8 slice, valid only
- * for the duration of the callback. `hash` is the raw digest of `css`
- * (the compiler's default scope digest, WITHOUT the `svelte-` prefix) —
- * prepend `svelte-` yourself to reproduce the default class name. It is
- * exactly the value the compiler's own default `cssHash` receives.
+ * for the duration of the callback. `hash` is the raw digest (WITHOUT the
+ * `svelte-` prefix) that the compiler's *default* `cssHash` produces —
+ * upstream digests the rootDir-relative `filename` when known, else `css`
+ * — so prepending `svelte-` reproduces the default class name exactly.
  */
 typedef struct RsvelteCssHashInput {
   /**
@@ -89,7 +89,8 @@ typedef struct RsvelteCssHashInput {
    */
   uintptr_t name_len;
   /**
-   * The raw digest of `css` (no `svelte-` prefix).
+   * The raw digest the default `cssHash` produces — the filename when
+   * known, else the css (no `svelte-` prefix).
    */
   const uint8_t *hash;
   /**

--- a/crates/rsvelte_capi/src/lib.rs
+++ b/crates/rsvelte_capi/src/lib.rs
@@ -26,11 +26,11 @@
 //! { "ok": false, "error":  { "message": "..." } }
 //! ```
 
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 
 use rsvelte_core::compiler::{
-    CompileOptions, CssMode, ExperimentalOptions, GenerateMode, ModuleCompileOptions, Namespace,
-    compile as rust_compile, compile_module as rust_compile_module,
+    CompileOptions, CssHashInput, CssMode, ExperimentalOptions, GenerateMode, ModuleCompileOptions,
+    Namespace, Warning, compile as rust_compile, compile_module as rust_compile_module,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -66,6 +66,121 @@ impl RsvelteBuf {
         Self { data, len, cap }
     }
 }
+
+/// Borrowed UTF-8 string view returned by a callback into this library.
+///
+/// Unlike [`RsvelteBuf`], the library does NOT take ownership of these
+/// bytes and never frees them. The pointer must stay valid only for the
+/// duration of the callback invocation that returned it (this library
+/// copies the bytes synchronously before the callback returns control
+/// upstream). A `{ data: NULL, len: 0 }` value means "no value — fall
+/// back to the compiler default".
+#[repr(C)]
+pub struct RsvelteStr {
+    /// Pointer to borrowed UTF-8 bytes. NULL means "no value".
+    pub data: *const u8,
+    /// Length in bytes (does NOT include any trailing NUL).
+    pub len: usize,
+}
+
+/// Input handed to a [`RsvelteCssHashFn`] callback.
+///
+/// Every field is a borrowed `(pointer, length)` UTF-8 slice, valid only
+/// for the duration of the callback. `hash` is the raw digest of `css`
+/// (the compiler's default scope digest, WITHOUT the `svelte-` prefix) —
+/// prepend `svelte-` yourself to reproduce the default class name. It is
+/// exactly the value the compiler's own default `cssHash` receives.
+#[repr(C)]
+pub struct RsvelteCssHashInput {
+    /// The component's CSS source.
+    pub css: *const u8,
+    /// Length of `css` in bytes.
+    pub css_len: usize,
+    /// The rootDir-relative (or absolute) filename, or `(unknown)`.
+    pub filename: *const u8,
+    /// Length of `filename` in bytes.
+    pub filename_len: usize,
+    /// The derived component name.
+    pub name: *const u8,
+    /// Length of `name` in bytes.
+    pub name_len: usize,
+    /// The raw digest of `css` (no `svelte-` prefix).
+    pub hash: *const u8,
+    /// Length of `hash` in bytes.
+    pub hash_len: usize,
+}
+
+/// A `cssHash` callback: `(userdata, input) -> class name`.
+///
+/// Returns the CSS scope class name as a borrowed [`RsvelteStr`]. Return
+/// `{ NULL, 0 }` to fall back to the compiler's default hash. The
+/// returned bytes must stay valid until the callback returns; this
+/// library copies them immediately.
+pub type RsvelteCssHashFn =
+    extern "C" fn(userdata: *mut c_void, input: *const RsvelteCssHashInput) -> RsvelteStr;
+
+/// A `warningFilter` callback: `(userdata, warning_json) -> keep`.
+///
+/// `warning_json` is a borrowed `(pointer, length)` UTF-8 JSON object
+/// (`{ code, message, filename?, start?, end?, position?, frame? }`),
+/// matching the warnings in the compile envelope. Return `true` to keep
+/// the warning, `false` to drop it.
+pub type RsvelteWarningFilterFn =
+    extern "C" fn(userdata: *mut c_void, warning_json: *const u8, warning_json_len: usize) -> bool;
+
+/// Optional compile callbacks (issue #1680).
+///
+/// Passed by pointer to the `*_with_callbacks` entry points. A NULL
+/// function-pointer field disables that callback. Each `*_userdata`
+/// pointer is passed back verbatim to its callback and is otherwise
+/// opaque to this library — use it to carry closure state. When a
+/// constant `cssHashOverride` is also set in the options JSON, that
+/// constant wins and `css_hash` is not invoked (mirrors the wasm/NAPI
+/// precedence).
+#[repr(C)]
+pub struct RsvelteCallbacks {
+    /// CSS hash callback (a [`RsvelteCssHashFn`]), or NULL. Inlined rather
+    /// than referenced via the alias so cbindgen emits a nullable function
+    /// pointer instead of an opaque `Option_*` struct.
+    pub css_hash: Option<
+        extern "C" fn(userdata: *mut c_void, input: *const RsvelteCssHashInput) -> RsvelteStr,
+    >,
+    /// Opaque state pointer passed to `css_hash`.
+    pub css_hash_userdata: *mut c_void,
+    /// Warning filter callback (a [`RsvelteWarningFilterFn`]), or NULL.
+    pub warning_filter: Option<
+        extern "C" fn(
+            userdata: *mut c_void,
+            warning_json: *const u8,
+            warning_json_len: usize,
+        ) -> bool,
+    >,
+    /// Opaque state pointer passed to `warning_filter`.
+    pub warning_filter_userdata: *mut c_void,
+}
+
+/// Opaque userdata pointer made `Send + Sync` so the callback closures
+/// satisfy the compiler's `CssHashFn` / `WarningFilterFn` bounds. The
+/// pointer is only ever dereferenced inside the caller's own callback,
+/// which the caller is responsible for making thread-safe.
+#[derive(Clone, Copy)]
+struct Userdata(*mut c_void);
+
+impl Userdata {
+    // A method (rather than a bare `.0` field access) so closures capture the
+    // whole `Userdata` (which is `Send + Sync`) instead of the raw pointer field
+    // under Rust 2021 disjoint closure captures.
+    fn get(&self) -> *mut c_void {
+        self.0
+    }
+}
+
+// SAFETY: the pointer is opaque to this library; thread-safety of any
+// data it references is the caller's responsibility, exactly as for the
+// callback function itself.
+unsafe impl Send for Userdata {}
+// SAFETY: see the `Send` impl above — same rationale.
+unsafe impl Sync for Userdata {}
 
 /// Library version (matches the `rsvelte_core` crate version).
 ///
@@ -172,6 +287,78 @@ pub unsafe extern "C" fn rsvelte_compile_module(
         Ok(o) => o,
         Err(msg) => return error_envelope(&msg),
     };
+
+    match rust_compile_module(source_str, opts) {
+        Ok(result) => success_envelope(compile_result_to_json(&result)),
+        Err(e) => error_envelope(&format!("{e}")),
+    }
+}
+
+/// Compile a Svelte component with optional `cssHash` / `warningFilter`
+/// callbacks (issue #1680).
+///
+/// Identical to [`rsvelte_compile`] but also resolves the two callback
+/// compile options that can't cross the JSON boundary. `callbacks` may
+/// be NULL (equivalent to [`rsvelte_compile`]); individual callback
+/// fields may be NULL too. The callbacks are input-only and are never
+/// retained past this call.
+///
+/// # Safety
+/// - Source/options pointers follow [`rsvelte_compile`]'s rules.
+/// - `callbacks` must be NULL or point to a valid [`RsvelteCallbacks`];
+///   each non-NULL function pointer must be callable with the documented
+///   signature and its paired `*_userdata` value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsvelte_compile_with_callbacks(
+    source: *const u8,
+    source_len: usize,
+    options_json: *const u8,
+    options_len: usize,
+    callbacks: *const RsvelteCallbacks,
+) -> RsvelteBuf {
+    // SAFETY: upheld by this function's documented `# Safety` contract.
+    let Some(source_str) = (unsafe { borrow_utf8(source, source_len) }) else {
+        return error_envelope("source is not valid UTF-8 or pointer is null");
+    };
+    // SAFETY: upheld by this function's documented `# Safety` contract.
+    let mut opts = match unsafe { parse_compile_options(options_json, options_len) } {
+        Ok(o) => o,
+        Err(msg) => return error_envelope(&msg),
+    };
+    // SAFETY: `callbacks` is NULL or a valid `RsvelteCallbacks` per the contract.
+    unsafe { apply_component_callbacks(&mut opts, callbacks) };
+
+    match rust_compile(source_str, opts) {
+        Ok(result) => success_envelope(compile_result_to_json(&result)),
+        Err(e) => error_envelope(&format!("{e}")),
+    }
+}
+
+/// Compile a Svelte `.svelte.js` / `.svelte.ts` module with an optional
+/// `warningFilter` callback (issue #1680). Modules have no CSS, so the
+/// `css_hash` field of `callbacks` is ignored.
+///
+/// # Safety
+/// See [`rsvelte_compile_with_callbacks`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsvelte_compile_module_with_callbacks(
+    source: *const u8,
+    source_len: usize,
+    options_json: *const u8,
+    options_len: usize,
+    callbacks: *const RsvelteCallbacks,
+) -> RsvelteBuf {
+    // SAFETY: upheld by this function's documented `# Safety` contract.
+    let Some(source_str) = (unsafe { borrow_utf8(source, source_len) }) else {
+        return error_envelope("source is not valid UTF-8 or pointer is null");
+    };
+    // SAFETY: upheld by this function's documented `# Safety` contract.
+    let mut opts = match unsafe { parse_module_options(options_json, options_len) } {
+        Ok(o) => o,
+        Err(msg) => return error_envelope(&msg),
+    };
+    // SAFETY: `callbacks` is NULL or a valid `RsvelteCallbacks` per the contract.
+    unsafe { apply_module_callbacks(&mut opts, callbacks) };
 
     match rust_compile_module(source_str, opts) {
         Ok(result) => success_envelope(compile_result_to_json(&result)),
@@ -473,7 +660,153 @@ unsafe fn parse_module_options(ptr: *const u8, len: usize) -> Result<ModuleCompi
     Ok(opts)
 }
 
+// --- callback bridging ----------------------------------------------------
+
+/// Reproduce the compiler's default (no-`cssHash`) scope hash, used when a
+/// `css_hash` callback declines (returns `{ NULL, 0 }` or non-UTF-8): the
+/// rootDir-relative filename when known, else the CSS content. Mirrors the
+/// wasm bridge's `default_css_hash`.
+fn default_css_hash(input: &CssHashInput, root_dir: Option<&str>) -> String {
+    use rsvelte_core::compiler::phases::phase3_transform::css::generate_css_hash;
+    if input.filename == "(unknown)" {
+        return generate_css_hash(&input.css);
+    }
+    let mut fname = input.filename.replace('\\', "/");
+    if let Some(rd) = root_dir {
+        let rd = rd.replace('\\', "/");
+        if let Some(rest) = fname.strip_prefix(&rd) {
+            fname = rest.trim_start_matches('/').to_string();
+        }
+    }
+    generate_css_hash(&fname)
+}
+
+/// Wrap a `warningFilter` C callback into a core `WarningFilterFn`.
+fn build_warning_filter(
+    func: RsvelteWarningFilterFn,
+    userdata: *mut c_void,
+) -> impl Fn(&Warning) -> bool {
+    let ud = Userdata(userdata);
+    move |warning: &Warning| -> bool {
+        let json = warning_to_value(warning).to_string();
+        let bytes = json.as_bytes();
+        // SAFETY: `func` is a valid extern fn per the caller's `RsvelteCallbacks`
+        // contract; the JSON slice is valid for this synchronous call.
+        func(ud.get(), bytes.as_ptr(), bytes.len())
+    }
+}
+
+/// # Safety
+/// `callbacks` must be NULL or point to a valid [`RsvelteCallbacks`].
+unsafe fn apply_component_callbacks(opts: &mut CompileOptions, callbacks: *const RsvelteCallbacks) {
+    if callbacks.is_null() {
+        return;
+    }
+    // SAFETY: non-null and valid per the caller's contract.
+    let cb = unsafe { &*callbacks };
+
+    if let Some(func) = cb.warning_filter {
+        let filter = build_warning_filter(func, cb.warning_filter_userdata);
+        opts.warning_filter = Some(std::sync::Arc::new(filter));
+    }
+
+    // A constant `cssHashOverride` (already set by `parse_compile_options`)
+    // wins; only bridge the dynamic callback when no override was supplied.
+    if opts.css_hash.is_none()
+        && let Some(func) = cb.css_hash
+    {
+        let ud = Userdata(cb.css_hash_userdata);
+        let root_dir = opts.root_dir.clone();
+        opts.css_hash = Some(std::sync::Arc::new(move |input: &CssHashInput| -> String {
+            // Trust the shared raw digest (`CssHashInput::hash`, PR #1705): it is
+            // already unprefixed, so the callback receives a raw hash and the
+            // `svelte-` prefix is never doubled.
+            let raw = (input.hash)(&input.css);
+            let c_input = RsvelteCssHashInput {
+                css: input.css.as_ptr(),
+                css_len: input.css.len(),
+                filename: input.filename.as_ptr(),
+                filename_len: input.filename.len(),
+                name: input.name.as_ptr(),
+                name_len: input.name.len(),
+                hash: raw.as_ptr(),
+                hash_len: raw.len(),
+            };
+            // SAFETY: `func` is a valid extern fn per the caller's contract; the
+            // borrowed slices in `c_input` outlive this synchronous call.
+            let ret = func(ud.get(), &c_input);
+            if ret.data.is_null() || ret.len == 0 {
+                return default_css_hash(input, root_dir.as_deref());
+            }
+            // SAFETY: callback contract — `ret` borrows valid UTF-8 for this call.
+            let bytes = unsafe { std::slice::from_raw_parts(ret.data, ret.len) };
+            match std::str::from_utf8(bytes) {
+                Ok(s) => s.to_string(),
+                Err(_) => default_css_hash(input, root_dir.as_deref()),
+            }
+        }));
+    }
+}
+
+/// # Safety
+/// `callbacks` must be NULL or point to a valid [`RsvelteCallbacks`].
+unsafe fn apply_module_callbacks(
+    opts: &mut ModuleCompileOptions,
+    callbacks: *const RsvelteCallbacks,
+) {
+    if callbacks.is_null() {
+        return;
+    }
+    // SAFETY: non-null and valid per the caller's contract.
+    let cb = unsafe { &*callbacks };
+    if let Some(func) = cb.warning_filter {
+        let filter = build_warning_filter(func, cb.warning_filter_userdata);
+        opts.warning_filter = Some(std::sync::Arc::new(filter));
+    }
+}
+
 // --- result encoding ------------------------------------------------------
+
+/// Encode a single warning as the JSON object shared by the compile
+/// envelope and the `warningFilter` callback.
+fn warning_to_value(w: &Warning) -> Value {
+    let mut map = serde_json::Map::new();
+    map.insert("code".to_string(), Value::String(w.code.clone()));
+    map.insert("message".to_string(), Value::String(w.message.clone()));
+    if let Some(ref filename) = w.filename {
+        map.insert("filename".to_string(), Value::String(filename.clone()));
+    }
+    if let Some(ref start) = w.start {
+        map.insert(
+            "start".to_string(),
+            serde_json::json!({
+                "line": start.line,
+                "column": start.column,
+                "character": start.character,
+            }),
+        );
+    }
+    if let Some(ref end) = w.end {
+        map.insert(
+            "end".to_string(),
+            serde_json::json!({
+                "line": end.line,
+                "column": end.column,
+                "character": end.character,
+            }),
+        );
+    }
+    if let (Some(start), Some(end)) = (&w.start, &w.end) {
+        map.insert(
+            "position".to_string(),
+            serde_json::json!([start.character, end.character]),
+        );
+    }
+    if let Some(ref frame) = w.frame {
+        map.insert("frame".to_string(), Value::String(frame.clone()));
+    }
+    Value::Object(map)
+}
 
 fn compile_result_to_json(result: &rsvelte_core::compiler::CompileResult) -> Value {
     let js_obj = serde_json::json!({
@@ -498,48 +831,7 @@ fn compile_result_to_json(result: &rsvelte_core::compiler::CompileResult) -> Val
         })
     });
 
-    let warnings: Vec<Value> = result
-        .warnings
-        .iter()
-        .map(|w| {
-            let mut map = serde_json::Map::new();
-            map.insert("code".to_string(), Value::String(w.code.clone()));
-            map.insert("message".to_string(), Value::String(w.message.clone()));
-            if let Some(ref filename) = w.filename {
-                map.insert("filename".to_string(), Value::String(filename.clone()));
-            }
-            if let Some(ref start) = w.start {
-                map.insert(
-                    "start".to_string(),
-                    serde_json::json!({
-                        "line": start.line,
-                        "column": start.column,
-                        "character": start.character,
-                    }),
-                );
-            }
-            if let Some(ref end) = w.end {
-                map.insert(
-                    "end".to_string(),
-                    serde_json::json!({
-                        "line": end.line,
-                        "column": end.column,
-                        "character": end.character,
-                    }),
-                );
-            }
-            if let (Some(start), Some(end)) = (&w.start, &w.end) {
-                map.insert(
-                    "position".to_string(),
-                    serde_json::json!([start.character, end.character]),
-                );
-            }
-            if let Some(ref frame) = w.frame {
-                map.insert("frame".to_string(), Value::String(frame.clone()));
-            }
-            Value::Object(map)
-        })
-        .collect();
+    let warnings: Vec<Value> = result.warnings.iter().map(warning_to_value).collect();
 
     serde_json::json!({
         "js": js_obj,

--- a/crates/rsvelte_capi/src/lib.rs
+++ b/crates/rsvelte_capi/src/lib.rs
@@ -86,10 +86,10 @@ pub struct RsvelteStr {
 /// Input handed to a [`RsvelteCssHashFn`] callback.
 ///
 /// Every field is a borrowed `(pointer, length)` UTF-8 slice, valid only
-/// for the duration of the callback. `hash` is the raw digest of `css`
-/// (the compiler's default scope digest, WITHOUT the `svelte-` prefix) —
-/// prepend `svelte-` yourself to reproduce the default class name. It is
-/// exactly the value the compiler's own default `cssHash` receives.
+/// for the duration of the callback. `hash` is the raw digest (WITHOUT the
+/// `svelte-` prefix) that the compiler's *default* `cssHash` produces —
+/// upstream digests the rootDir-relative `filename` when known, else `css`
+/// — so prepending `svelte-` reproduces the default class name exactly.
 #[repr(C)]
 pub struct RsvelteCssHashInput {
     /// The component's CSS source.
@@ -104,7 +104,8 @@ pub struct RsvelteCssHashInput {
     pub name: *const u8,
     /// Length of `name` in bytes.
     pub name_len: usize,
-    /// The raw digest of `css` (no `svelte-` prefix).
+    /// The raw digest the default `cssHash` produces — the filename when
+    /// known, else the css (no `svelte-` prefix).
     pub hash: *const u8,
     /// Length of `hash` in bytes.
     pub hash_len: usize,
@@ -662,14 +663,13 @@ unsafe fn parse_module_options(ptr: *const u8, len: usize) -> Result<ModuleCompi
 
 // --- callback bridging ----------------------------------------------------
 
-/// Reproduce the compiler's default (no-`cssHash`) scope hash, used when a
-/// `css_hash` callback declines (returns `{ NULL, 0 }` or non-UTF-8): the
-/// rootDir-relative filename when known, else the CSS content. Mirrors the
-/// wasm bridge's `default_css_hash`.
-fn default_css_hash(input: &CssHashInput, root_dir: Option<&str>) -> String {
-    use rsvelte_core::compiler::phases::phase3_transform::css::generate_css_hash;
+/// The string the compiler's default `cssHash` digests — the rootDir-relative
+/// filename when known, else the CSS content. Mirrors upstream's
+/// `hash(filename === '(unknown)' ? css : filename ?? css)`
+/// (validate-options.js) with the same rootDir stripping as core's `analyze_css`.
+fn css_hash_source(input: &CssHashInput, root_dir: Option<&str>) -> String {
     if input.filename == "(unknown)" {
-        return generate_css_hash(&input.css);
+        return input.css.clone();
     }
     let mut fname = input.filename.replace('\\', "/");
     if let Some(rd) = root_dir {
@@ -678,7 +678,14 @@ fn default_css_hash(input: &CssHashInput, root_dir: Option<&str>) -> String {
             fname = rest.trim_start_matches('/').to_string();
         }
     }
-    generate_css_hash(&fname)
+    fname
+}
+
+/// Reproduce the compiler's default (no-`cssHash`) scope class, used when a
+/// `css_hash` callback declines (returns `{ NULL, 0 }` or non-UTF-8).
+fn default_css_hash(input: &CssHashInput, root_dir: Option<&str>) -> String {
+    use rsvelte_core::compiler::phases::phase3_transform::css::generate_css_hash;
+    generate_css_hash(&css_hash_source(input, root_dir))
 }
 
 /// Wrap a `warningFilter` C callback into a core `WarningFilterFn`.
@@ -718,10 +725,11 @@ unsafe fn apply_component_callbacks(opts: &mut CompileOptions, callbacks: *const
         let ud = Userdata(cb.css_hash_userdata);
         let root_dir = opts.root_dir.clone();
         opts.css_hash = Some(std::sync::Arc::new(move |input: &CssHashInput| -> String {
-            // Trust the shared raw digest (`CssHashInput::hash`, PR #1705): it is
-            // already unprefixed, so the callback receives a raw hash and the
-            // `svelte-` prefix is never doubled.
-            let raw = (input.hash)(&input.css);
+            // The `hash` handed to the callback is the raw (unprefixed, PR #1705)
+            // digest the compiler's *default* `cssHash` would produce — upstream
+            // digests the filename when known, else the CSS — so `svelte-${hash}`
+            // reproduces the default class exactly, with no doubled prefix.
+            let raw = (input.hash)(&css_hash_source(input, root_dir.as_deref()));
             let c_input = RsvelteCssHashInput {
                 css: input.css.as_ptr(),
                 css_len: input.css.len(),

--- a/crates/rsvelte_capi/tests/callbacks.rs
+++ b/crates/rsvelte_capi/tests/callbacks.rs
@@ -191,6 +191,78 @@ fn css_hash_input_is_raw_digest_no_double_prefix() {
     assert_eq!(probe.seen_filename, "App.svelte");
 }
 
+/// Extract the first `svelte-<base36>` scope class from a CSS string.
+fn first_svelte_class(css: &str) -> String {
+    let idx = css
+        .find("svelte-")
+        .expect("CSS should contain a svelte- class");
+    let rest = &css[idx + "svelte-".len()..];
+    let end = rest
+        .find(|c: char| !c.is_ascii_alphanumeric())
+        .unwrap_or(rest.len());
+    format!("svelte-{}", &rest[..end])
+}
+
+/// The raw digest handed to the callback must be the one the compiler's
+/// *default* `cssHash` digests — the filename when known (not always the
+/// CSS). Building `svelte-${hash}` from what the callback received must
+/// therefore equal the default (no-callback) scope class, for both a known
+/// filename and an unknown one. Guards the regression where the bridge
+/// always hashed the CSS regardless of filename.
+#[test]
+fn css_hash_input_matches_default_source_selection() {
+    let css = "<h1>x</h1>\n<style>h1{color:red}</style>";
+
+    // (a) filename known -> upstream digests the filename.
+    let default_named = drive(
+        css,
+        r#"{"filename":"App.svelte","css":"external"}"#,
+        &empty_callbacks(),
+    );
+    let default_named_class =
+        first_svelte_class(default_named["result"]["css"]["code"].as_str().unwrap());
+    let mut probe_named = CssHashProbe::default();
+    let cb_named = RsvelteCallbacks {
+        css_hash: Some(css_hash_cb),
+        css_hash_userdata: &mut probe_named as *mut _ as *mut c_void,
+        ..empty_callbacks()
+    };
+    let _ = drive(
+        css,
+        r#"{"filename":"App.svelte","css":"external"}"#,
+        &cb_named,
+    );
+    assert_eq!(
+        format!("svelte-{}", probe_named.seen_hash),
+        default_named_class,
+        "with a known filename, `svelte-${{hash}}` from the callback input must equal the default class"
+    );
+
+    // (b) no filename -> upstream digests the CSS.
+    let default_anon = drive(css, r#"{"css":"external"}"#, &empty_callbacks());
+    let default_anon_class =
+        first_svelte_class(default_anon["result"]["css"]["code"].as_str().unwrap());
+    let mut probe_anon = CssHashProbe::default();
+    let cb_anon = RsvelteCallbacks {
+        css_hash: Some(css_hash_cb),
+        css_hash_userdata: &mut probe_anon as *mut _ as *mut c_void,
+        ..empty_callbacks()
+    };
+    let _ = drive(css, r#"{"css":"external"}"#, &cb_anon);
+    assert_eq!(
+        format!("svelte-{}", probe_anon.seen_hash),
+        default_anon_class,
+        "with no filename, `svelte-${{hash}}` from the callback input must equal the default class"
+    );
+
+    // The two sources differ, so the digests must differ — proving the
+    // selection is filename-vs-css, not a constant.
+    assert_ne!(
+        probe_named.seen_hash, probe_anon.seen_hash,
+        "filename-based and css-based digests must differ"
+    );
+}
+
 extern "C" fn css_hash_null_cb(
     _userdata: *mut c_void,
     _input: *const RsvelteCssHashInput,

--- a/crates/rsvelte_capi/tests/callbacks.rs
+++ b/crates/rsvelte_capi/tests/callbacks.rs
@@ -1,0 +1,381 @@
+//! FFI coverage for the `cssHash` / `warningFilter` compile callbacks
+//! (issue #1680). Drives `rsvelte_compile_with_callbacks` with real
+//! `extern "C"` callbacks so the full function-pointer path is exercised
+//! exactly as a C host would.
+
+use std::os::raw::c_void;
+
+use rsvelte_capi::{
+    RsvelteBuf, RsvelteCallbacks, RsvelteCssHashInput, RsvelteStr,
+    rsvelte_compile_module_with_callbacks, rsvelte_compile_with_callbacks, rsvelte_free,
+};
+use serde_json::Value;
+
+fn drive(source: &str, options_json: &str, callbacks: &RsvelteCallbacks) -> Value {
+    drive_with(source, options_json, callbacks, false)
+}
+
+fn drive_module(source: &str, options_json: &str, callbacks: &RsvelteCallbacks) -> Value {
+    drive_with(source, options_json, callbacks, true)
+}
+
+fn drive_with(
+    source: &str,
+    options_json: &str,
+    callbacks: &RsvelteCallbacks,
+    module: bool,
+) -> Value {
+    let src = source.as_bytes();
+    let opts = options_json.as_bytes();
+    // SAFETY: `src`/`opts` are valid byte slices owned for this call; the
+    // callbacks struct is valid for the call's duration.
+    let buf: RsvelteBuf = unsafe {
+        let src_ptr = if src.is_empty() {
+            std::ptr::null()
+        } else {
+            src.as_ptr()
+        };
+        let opt_ptr = if opts.is_empty() {
+            std::ptr::null()
+        } else {
+            opts.as_ptr()
+        };
+        if module {
+            rsvelte_compile_module_with_callbacks(
+                src_ptr,
+                src.len(),
+                opt_ptr,
+                opts.len(),
+                callbacks,
+            )
+        } else {
+            rsvelte_compile_with_callbacks(src_ptr, src.len(), opt_ptr, opts.len(), callbacks)
+        }
+    };
+    assert!(
+        !buf.data.is_null() && buf.len > 0,
+        "FFI returned empty buffer"
+    );
+    // SAFETY: non-null buffer described by (data, len); copied before freeing.
+    let bytes = unsafe { std::slice::from_raw_parts(buf.data, buf.len) }.to_vec();
+    // SAFETY: `buf` came from the call above; freed exactly once.
+    unsafe { rsvelte_free(buf) };
+    serde_json::from_slice(&bytes).expect("valid JSON envelope")
+}
+
+fn empty_callbacks() -> RsvelteCallbacks {
+    RsvelteCallbacks {
+        css_hash: None,
+        css_hash_userdata: std::ptr::null_mut(),
+        warning_filter: None,
+        warning_filter_userdata: std::ptr::null_mut(),
+    }
+}
+
+fn ok(env: &Value) -> &Value {
+    assert_eq!(env["ok"], Value::Bool(true), "expected ok=true, got {env}");
+    &env["result"]
+}
+
+// ---------------------------------------------------------------------------
+// cssHash callback
+// ---------------------------------------------------------------------------
+
+/// State the `css_hash` callback records so the test can inspect what the
+/// compiler handed it. `returned` is kept alive for the borrowed
+/// `RsvelteStr` the callback returns.
+#[derive(Default)]
+struct CssHashProbe {
+    seen_hash: String,
+    seen_css: String,
+    seen_name: String,
+    seen_filename: String,
+    invocations: u32,
+    returned: String,
+}
+
+extern "C" fn css_hash_cb(userdata: *mut c_void, input: *const RsvelteCssHashInput) -> RsvelteStr {
+    // SAFETY: `userdata` is the `&mut CssHashProbe` we passed in; `input`
+    // is a valid `RsvelteCssHashInput` for this call.
+    let probe = unsafe { &mut *(userdata as *mut CssHashProbe) };
+    // SAFETY: `input` is a valid `RsvelteCssHashInput` for this call.
+    let inp = unsafe { &*input };
+    let slice = |ptr: *const u8, len: usize| -> String {
+        if ptr.is_null() || len == 0 {
+            String::new()
+        } else {
+            // SAFETY: `(ptr, len)` is a borrowed UTF-8 slice valid for this call.
+            let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+            String::from_utf8_lossy(bytes).into_owned()
+        }
+    };
+    probe.seen_hash = slice(inp.hash, inp.hash_len);
+    probe.seen_css = slice(inp.css, inp.css_len);
+    probe.seen_name = slice(inp.name, inp.name_len);
+    probe.seen_filename = slice(inp.filename, inp.filename_len);
+    probe.invocations += 1;
+    // Reproduce upstream's default scope class: `svelte-${hash}`. Because the
+    // shared digest is unprefixed (PR #1705), this yields a SINGLE prefix.
+    probe.returned = format!("svelte-{}", probe.seen_hash);
+    RsvelteStr {
+        data: probe.returned.as_ptr(),
+        len: probe.returned.len(),
+    }
+}
+
+#[test]
+fn css_hash_callback_class_appears_in_css() {
+    let mut probe = CssHashProbe::default();
+    let callbacks = RsvelteCallbacks {
+        css_hash: Some(css_hash_cb),
+        css_hash_userdata: &mut probe as *mut _ as *mut c_void,
+        ..empty_callbacks()
+    };
+    let env = drive(
+        "<h1>x</h1>\n<style>h1{color:red}</style>",
+        r#"{"filename":"App.svelte","css":"external"}"#,
+        &callbacks,
+    );
+    let css_code = ok(&env)["css"]["code"].as_str().unwrap_or("").to_string();
+    assert!(
+        probe.invocations >= 1,
+        "css_hash callback was never invoked"
+    );
+    assert!(
+        css_code.contains(&probe.returned),
+        "callback class `{}` must appear in CSS; got: {css_code}",
+        probe.returned
+    );
+}
+
+/// The #1697 double-prefix guard: the shared `hash` field is the RAW digest
+/// (no `svelte-` prefix, per PR #1705). A callback that prepends `svelte-`
+/// must produce a single-prefixed class — never `svelte-svelte-`.
+#[test]
+fn css_hash_input_is_raw_digest_no_double_prefix() {
+    let mut probe = CssHashProbe::default();
+    let callbacks = RsvelteCallbacks {
+        css_hash: Some(css_hash_cb),
+        css_hash_userdata: &mut probe as *mut _ as *mut c_void,
+        ..empty_callbacks()
+    };
+    let env = drive(
+        "<h1>x</h1>\n<style>h1{color:red}</style>",
+        r#"{"filename":"App.svelte","css":"external"}"#,
+        &callbacks,
+    );
+    let css_code = ok(&env)["css"]["code"].as_str().unwrap_or("").to_string();
+    assert!(
+        !probe.seen_hash.is_empty(),
+        "callback should receive a non-empty raw digest"
+    );
+    assert!(
+        !probe.seen_hash.starts_with("svelte-"),
+        "the `hash` field must be the raw digest without the `svelte-` prefix; got `{}`",
+        probe.seen_hash
+    );
+    assert!(
+        !css_code.contains("svelte-svelte-"),
+        "trusting the shared raw digest must not double the prefix; got: {css_code}"
+    );
+    assert!(
+        css_code.contains(&format!("svelte-{}", probe.seen_hash)),
+        "single-prefixed class must appear in CSS; got: {css_code}"
+    );
+    // The callback saw the real css/name/filename too.
+    assert!(probe.seen_css.contains("color"), "css was passed through");
+    assert_eq!(
+        probe.seen_name, "App",
+        "component name derived from filename"
+    );
+    assert_eq!(probe.seen_filename, "App.svelte");
+}
+
+extern "C" fn css_hash_null_cb(
+    _userdata: *mut c_void,
+    _input: *const RsvelteCssHashInput,
+) -> RsvelteStr {
+    // Decline — the library must fall back to the default hash.
+    RsvelteStr {
+        data: std::ptr::null(),
+        len: 0,
+    }
+}
+
+#[test]
+fn css_hash_callback_null_return_falls_back_to_default() {
+    let callbacks = RsvelteCallbacks {
+        css_hash: Some(css_hash_null_cb),
+        ..empty_callbacks()
+    };
+    let with_cb = drive(
+        "<h1>x</h1>\n<style>h1{color:red}</style>",
+        r#"{"filename":"App.svelte","css":"external"}"#,
+        &callbacks,
+    );
+    let plain = drive(
+        "<h1>x</h1>\n<style>h1{color:red}</style>",
+        r#"{"filename":"App.svelte","css":"external"}"#,
+        &empty_callbacks(),
+    );
+    assert_eq!(
+        with_cb["result"]["css"]["code"], plain["result"]["css"]["code"],
+        "a declining css_hash callback must match the default-hash output"
+    );
+}
+
+#[test]
+fn css_hash_override_wins_over_callback() {
+    let mut probe = CssHashProbe::default();
+    let callbacks = RsvelteCallbacks {
+        css_hash: Some(css_hash_cb),
+        css_hash_userdata: &mut probe as *mut _ as *mut c_void,
+        ..empty_callbacks()
+    };
+    let env = drive(
+        "<h1>x</h1>\n<style>h1{color:red}</style>",
+        r#"{"filename":"App.svelte","css":"external","cssHashOverride":"svelte-zzzzzz"}"#,
+        &callbacks,
+    );
+    let css_code = ok(&env)["css"]["code"].as_str().unwrap_or("").to_string();
+    assert!(
+        css_code.contains("svelte-zzzzzz"),
+        "constant cssHashOverride must win; got: {css_code}"
+    );
+    assert_eq!(
+        probe.invocations, 0,
+        "css_hash callback must not be invoked when cssHashOverride is set"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// warningFilter callback
+// ---------------------------------------------------------------------------
+
+struct FilterProbe {
+    keep: bool,
+    seen: Vec<String>,
+}
+
+extern "C" fn warning_filter_cb(
+    userdata: *mut c_void,
+    warning_json: *const u8,
+    warning_json_len: usize,
+) -> bool {
+    // SAFETY: `userdata` is the `&mut FilterProbe` passed in; the JSON slice
+    // is valid for this call.
+    let probe = unsafe { &mut *(userdata as *mut FilterProbe) };
+    // SAFETY: `(warning_json, warning_json_len)` is a borrowed UTF-8 slice valid for this call.
+    let bytes = unsafe { std::slice::from_raw_parts(warning_json, warning_json_len) };
+    let json: Value = serde_json::from_slice(bytes).expect("warning JSON is valid");
+    probe
+        .seen
+        .push(json["code"].as_str().unwrap_or("").to_string());
+    probe.keep
+}
+
+/// An unused CSS selector reliably produces a `css_unused_selector` warning.
+const WARN_SOURCE: &str = "<h1>x</h1>\n<style>.unused{color:red}</style>";
+
+fn warning_codes(env: &Value) -> Vec<String> {
+    ok(env)["warnings"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|w| w["code"].as_str().unwrap_or("").to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn warning_filter_drops_warnings_when_false() {
+    // Sanity: the baseline compile emits at least one warning.
+    let baseline = drive(
+        WARN_SOURCE,
+        r#"{"filename":"App.svelte"}"#,
+        &empty_callbacks(),
+    );
+    assert!(
+        !warning_codes(&baseline).is_empty(),
+        "baseline should emit a warning to filter"
+    );
+
+    let mut probe = FilterProbe {
+        keep: false,
+        seen: Vec::new(),
+    };
+    let callbacks = RsvelteCallbacks {
+        warning_filter: Some(warning_filter_cb),
+        warning_filter_userdata: &mut probe as *mut _ as *mut c_void,
+        ..empty_callbacks()
+    };
+    let env = drive(WARN_SOURCE, r#"{"filename":"App.svelte"}"#, &callbacks);
+    assert!(
+        warning_codes(&env).is_empty(),
+        "warning_filter returning false must drop every warning"
+    );
+    assert!(
+        !probe.seen.is_empty(),
+        "the filter callback must have seen the warning(s)"
+    );
+}
+
+#[test]
+fn warning_filter_keeps_warnings_when_true() {
+    let baseline = warning_codes(&drive(
+        WARN_SOURCE,
+        r#"{"filename":"App.svelte"}"#,
+        &empty_callbacks(),
+    ));
+    let mut probe = FilterProbe {
+        keep: true,
+        seen: Vec::new(),
+    };
+    let callbacks = RsvelteCallbacks {
+        warning_filter: Some(warning_filter_cb),
+        warning_filter_userdata: &mut probe as *mut _ as *mut c_void,
+        ..empty_callbacks()
+    };
+    let env = drive(WARN_SOURCE, r#"{"filename":"App.svelte"}"#, &callbacks);
+    assert_eq!(
+        warning_codes(&env),
+        baseline,
+        "warning_filter returning true must keep every warning"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// null / passthrough
+// ---------------------------------------------------------------------------
+
+#[test]
+fn null_callbacks_match_plain_compile() {
+    let env = drive(
+        "<h1>x</h1>",
+        r#"{"filename":"App.svelte"}"#,
+        &empty_callbacks(),
+    );
+    assert_eq!(env["ok"], Value::Bool(true));
+}
+
+#[test]
+fn module_warning_filter_is_applied() {
+    // Module compilation honours warningFilter too; css_hash is ignored.
+    let mut probe = FilterProbe {
+        keep: true,
+        seen: Vec::new(),
+    };
+    let callbacks = RsvelteCallbacks {
+        css_hash: Some(css_hash_cb), // ignored for modules
+        warning_filter: Some(warning_filter_cb),
+        warning_filter_userdata: &mut probe as *mut _ as *mut c_void,
+        ..empty_callbacks()
+    };
+    let env = drive_module(
+        "export const counter = $state(0);",
+        r#"{"filename":"counter.svelte.js"}"#,
+        &callbacks,
+    );
+    assert_eq!(env["ok"], Value::Bool(true));
+}

--- a/crates/rsvelte_capi/tests/header_invariants.rs
+++ b/crates/rsvelte_capi/tests/header_invariants.rs
@@ -27,8 +27,13 @@ fn required_exports_are_present() {
         "rsvelte_compile_module",
         "rsvelte_compile_into",
         "rsvelte_compile_module_into",
-        // Struct
+        "rsvelte_compile_with_callbacks",
+        "rsvelte_compile_module_with_callbacks",
+        // Structs
         "struct RsvelteBuf",
+        "struct RsvelteCallbacks",
+        "struct RsvelteCssHashInput",
+        "struct RsvelteStr",
         // Struct fields (renaming any breaks every wrapper)
         "*data",
         "len",


### PR DESCRIPTION
## What

Completes the **C-API** half of issue #1680 — the function-form compile options that can't be expressed as JSON. The wasm side landed in #1691 and NAPI in #1666/#1667; this brings `crates/rsvelte_capi` to parity.

Before this PR the C-API only exposed a constant `cssHashOverride` and had no `warningFilter` at all. Now C hosts can supply real callbacks via function pointers + opaque userdata.

## API

Two new entry points take an optional `RsvelteCallbacks` struct alongside the existing JSON options (both may be `NULL`, individual fields may be `NULL`):

```c
RsvelteBuf rsvelte_compile_with_callbacks(const uint8_t *src, uintptr_t src_len,
                                          const uint8_t *opts_json, uintptr_t opts_len,
                                          const RsvelteCallbacks *callbacks);
RsvelteBuf rsvelte_compile_module_with_callbacks(/* … */, const RsvelteCallbacks *callbacks);
```

- **`css_hash`** — `RsvelteStr (*)(void *userdata, const RsvelteCssHashInput *)`. Returns the scope class name as a **borrowed** `{data,len}` string (copied immediately, never freed by the library) or `{NULL,0}` to fall back to the default hash. `RsvelteCssHashInput.hash` is the **raw digest** (no `svelte-` prefix), trusting the shared `CssHashInput.hash` field fixed in #1705 — the callback prepends `svelte-` itself and the prefix is never doubled. A constant `cssHashOverride` in the JSON still wins (matches wasm/NAPI precedence).
- **`warning_filter`** — `bool (*)(void *userdata, const uint8_t *warning_json, uintptr_t len)`. Receives one warning as the same JSON object used in the compile envelope; return `true` to keep, `false` to drop. Honoured for both components and modules (modules ignore `css_hash`).

## Ownership / safety

Borrowed-return string convention avoids any cross-allocator free; each `*_userdata` is opaque and passed back verbatim. Userdata is wrapped in a `Send + Sync` newtype so the closures satisfy the core `CssHashFn` / `WarningFilterFn` bounds; thread-safety of what it points at is the caller's responsibility, exactly as for the callback itself.

## Header / tests

- `include/rsvelte.h` regenerates via cbindgen. Callback signatures are inlined inside the struct so cbindgen emits proper nullable function pointers rather than an opaque `Option_*` struct.
- New `tests/callbacks.rs` drives the full function-pointer path with real `extern "C"` callbacks — class-in-CSS, the **#1697 double-prefix guard** (asserts the received `hash` is unprefixed and the output never contains `svelte-svelte-`), `cssHashOverride` precedence, null-return fallback, warning keep/drop, and module warningFilter.
- The C smoke example (`examples/c/smoke.c`, run on every PR across ubuntu + macos) gains a matching `cssHash` + `warningFilter` case with the same double-prefix guard.
- `header_invariants.rs` updated with the new exports; the CI header-drift check (`RSVELTE_CAPI_CHECK_HEADER=1`) passes.

## Verification

`cargo test -p rsvelte_capi` (44 tests incl. 9 in `callbacks.rs`), `cargo clippy -p rsvelte_capi --all-targets --all-features -D warnings`, `cargo fmt`, and the real `cc`-linked C smoke all pass locally. A changeset (`@rsvelte/compiler`, minor) follows the #297 C-ABI precedent — the npm runtime behaviour is unchanged (parallel C distribution surface only).


## Review follow-ups

- **cssHash digest source (fixed)** — the raw digest handed to the callback now hashes the same source the compiler's default `cssHash` digests (`filename === '(unknown)' ? css : filename`, per `validate-options.js`), not always the CSS. A regression test asserts `svelte-${hash}` from the callback input equals the default scope class for both a known and an unknown filename.
- **changeset** — added per the #297 precedent (`@rsvelte/compiler` minor); the `skip-changeset` label was removed.
- **`frame` field (record only)** — the capi warning JSON includes a `frame` field the wasm `warning_to_value` omits. Pre-existing difference in the capi envelope, not introduced by this PR.
- **crate version (record only)** — `crates/rsvelte_capi/Cargo.toml` is intentionally not bumped here; the tag-driven capi release (`capi-v*`) is handled separately.

Closes #1680

🤖 Generated with [Claude Code](https://claude.com/claude-code)
