### PR TITLE
fix(parse): emit object-method typeParameters after body (#1711)

### DIFF
--- a/.changeset/fix-function-node-ast-fidelity.md
+++ b/.changeset/fix-function-node-ast-fidelity.md
@@ -5,7 +5,7 @@
 
 fix(parse): improve function-node AST fidelity to match acorn / acorn-typescript
 
-Three parse-AST fixes so the public `parse()` output matches svelte/compiler:
+Four parse-AST fixes so the public `parse()` output matches svelte/compiler:
 
 - `FunctionExpression` fields are ordered `id, expression, generator, async` to
   match acorn's uniform `initFunction` key order (#1689).

--- a/.changeset/fix-function-node-ast-fidelity.md
+++ b/.changeset/fix-function-node-ast-fidelity.md
@@ -18,8 +18,11 @@ Three parse-AST fixes so the public `parse()` output matches svelte/compiler:
   declarations (#1692). As a side effect, this also fixes a pure-JS bug where a
   default-valued arrow parameter (`(a = 1) => a`) lost its `AssignmentPattern`
   (default value) in the `parse()` output — `compile()` output was unaffected.
+- Object-method values (`{ m<T>(x: T) {} }`) keep their generics on the inner
+  `FunctionExpression` but emit `typeParameters` *after* `body` (like arrows),
+  not in the declaration/expression slot before `params` (#1711).
 
 The binary NAPI raw-parse envelope (consumed by
 `@rsvelte/vite-plugin-svelte-native`'s `parse-envelope.js` decoder) carries the
 same fields, so both packages need this release. The envelope `VERSION` is
-bumped to 3 alongside the wire-format change.
+bumped to 4 alongside the wire-format changes.

--- a/apps/npm/vite-plugin-svelte-native/parse-envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/parse-envelope.js
@@ -17,8 +17,9 @@ const { isWindowOutOfBounds, windowOutOfBoundsMessage } = require('./lib/bounds-
 const MAGIC = 0x3156_5052; // "RPV1" little-endian
 // Bumped for the function-node AST-fidelity changes (FunctionExpression field
 // reorder, `typeParameters` on function-like nodes, Identifier `optional`);
-// keep in lockstep with `napi_raw_parse.rs`'s `VERSION`.
-const VERSION = 3;
+// v4 adds the object-method `typeParameters`-after-`body` flag byte.
+// Keep in lockstep with `napi_raw_parse.rs`'s `VERSION`.
+const VERSION = 4;
 const HEADER_LEN = 24;
 
 // Tags — must mirror napi_raw_parse.rs.
@@ -820,15 +821,18 @@ function readJsFunctionExpression(ctx, start, end) {
 	const typeParameters = readOptTypeAnnotation(ctx);
 	const params = readChildArray(ctx);
 	const body = readOptNode(ctx);
+	// Object-method inner functions carry `typeParameters` after `body` (acorn).
+	const typeParametersAfterBody = readBool(ctx);
 	const node = { type: 'FunctionExpression', start, end };
 	if (loc !== null) node.loc = loc;
 	node.id = id;
 	node.expression = expression;
 	node.generator = generator;
 	node.async = asyncFlag;
-	if (typeParameters !== null) node.typeParameters = typeParameters;
+	if (typeParameters !== null && !typeParametersAfterBody) node.typeParameters = typeParameters;
 	node.params = params;
 	node.body = body;
+	if (typeParameters !== null && typeParametersAfterBody) node.typeParameters = typeParameters;
 	return node;
 }
 

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -187,6 +187,10 @@ pub enum JsNode {
         /// verbatim (acorn-typescript emits it between `async` and `params`).
         /// `None` for the overwhelming majority (non-generic) functions.
         type_parameters: Option<Box<serde_json::Value>>,
+        /// Object-method values carry generics on the inner function, but
+        /// acorn-typescript appends `typeParameters` *after* `body` there (like
+        /// arrows) rather than in the declaration/expression slot before `params`.
+        type_parameters_after_body: bool,
     },
     ClassExpression {
         start: u32,
@@ -1008,6 +1012,7 @@ impl Serialize for JsNode {
                 r#async,
                 expression,
                 type_parameters,
+                type_parameters_after_body,
             } => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "FunctionExpression")?;
@@ -1018,11 +1023,18 @@ impl Serialize for JsNode {
                 map.serialize_entry("expression", expression)?;
                 map.serialize_entry("generator", generator)?;
                 map.serialize_entry("async", r#async)?;
-                if let Some(tp) = type_parameters {
+                if let Some(tp) = type_parameters
+                    && !type_parameters_after_body
+                {
                     map.serialize_entry("typeParameters", tp.as_ref())?;
                 }
                 ser_children!(map, "params", params);
                 ser_opt_node!(map, "body", body);
+                if let Some(tp) = type_parameters
+                    && *type_parameters_after_body
+                {
+                    map.serialize_entry("typeParameters", tp.as_ref())?;
+                }
                 ser_comments!(map, *start, *end);
                 map.end()
             }
@@ -2479,6 +2491,7 @@ impl JsNode {
                         r#async: get_bool(obj, "async"),
                         expression: get_bool(obj, "expression"),
                         type_parameters: obj.get("typeParameters").cloned().map(Box::new),
+                        type_parameters_after_body: false,
                     },
                     "ClassExpression" => JsNode::ClassExpression {
                         start,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -4130,6 +4130,7 @@ fn convert_expression(
                 offset,
                 line_offsets,
                 type_parameters,
+                false,
             )
         }
         OxcExpression::ClassExpression(class_expr) => {
@@ -4780,6 +4781,9 @@ fn create_function_expression(
     // Method values carry their generics on the wrapping MethodDefinition, not
     // the inner function (acorn-typescript), so callers pass `None` there.
     type_parameters: Option<Box<serde_json::Value>>,
+    // Object-method values keep their generics on the inner function but emit
+    // them after `body` (acorn-typescript), unlike declarations/expressions.
+    type_parameters_after_body: bool,
 ) -> Expression {
     // id
     let id = func.id.as_ref().map(|id| {
@@ -4841,6 +4845,7 @@ fn create_function_expression(
         r#async: func.r#async,
         expression: false,
         type_parameters,
+        type_parameters_after_body,
     })
 }
 
@@ -5040,6 +5045,7 @@ fn convert_class_element_for_expr(
                 offset,
                 line_offsets,
                 None,
+                false,
             );
             obj.insert("value".to_string(), value.as_json().clone());
 
@@ -5144,6 +5150,20 @@ fn create_array_expression(
     })
 }
 
+/// Object-method values keep their generics on the inner `FunctionExpression`,
+/// but acorn-typescript serializes them *after* `body` (like arrows), not in the
+/// declaration/expression slot before `params`.
+fn mark_object_method_generics(node: &mut JsNode, is_method: bool) {
+    if is_method
+        && let JsNode::FunctionExpression {
+            type_parameters_after_body,
+            ..
+        } = node
+    {
+        *type_parameters_after_body = true;
+    }
+}
+
 fn create_object_expression(
     arena: &ParseArena,
     obj_expr: &oxc_ast::ast::ObjectExpression,
@@ -5162,6 +5182,8 @@ fn create_object_expression(
 
                 let key = convert_property_key_for_expr(arena, &p.key, offset, line_offsets);
                 let value = convert_expression(arena, &p.value, offset, line_offsets);
+                let mut value_node = expr_to_node(value);
+                mark_object_method_generics(&mut value_node, p.method);
 
                 let kind = match p.kind {
                     oxc_ast::ast::PropertyKind::Init => "init",
@@ -5174,7 +5196,7 @@ fn create_object_expression(
                     end: prop_end as u32,
                     loc: create_typed_loc(prop_start, prop_end, line_offsets),
                     key: arena.alloc_js_node(key),
-                    value: arena.alloc_js_node(expr_to_node(value)),
+                    value: arena.alloc_js_node(value_node),
                     kind: CompactString::from(kind),
                     method: p.method,
                     shorthand: p.shorthand,
@@ -8821,6 +8843,8 @@ fn convert_expression_for_program(
                         let key = convert_property_key(arena, &p.key, offset, line_offsets);
                         let value =
                             convert_expression_for_program(arena, &p.value, offset, line_offsets);
+                        let mut value_node = expr_to_node(value);
+                        mark_object_method_generics(&mut value_node, p.method);
                         let kind = match p.kind {
                             oxc_ast::ast::PropertyKind::Init => "init",
                             oxc_ast::ast::PropertyKind::Get => "get",
@@ -8834,7 +8858,7 @@ fn convert_expression_for_program(
                             shorthand: p.shorthand,
                             computed: p.computed,
                             key: arena.alloc_js_node(key),
-                            value: arena.alloc_js_node(expr_to_node(value)),
+                            value: arena.alloc_js_node(value_node),
                             kind: CompactString::from(kind),
                         }
                     }
@@ -8936,6 +8960,7 @@ fn convert_expression_for_program(
                 offset,
                 line_offsets,
                 type_parameters,
+                false,
             ))
         }
         OxcExpression::StaticMemberExpression(member) => {
@@ -9803,6 +9828,7 @@ fn convert_class_element_for_program_as_node(
                 offset,
                 line_offsets,
                 None,
+                false,
             );
             TypedClassElem::Node(JsNode::MethodDefinition {
                 start: start as u32,
@@ -10067,6 +10093,9 @@ fn convert_function_expression_for_program_as_node(
     line_offsets: &[usize],
     // `None` for method values (their generics live on the wrapper node).
     type_parameters: Option<Box<serde_json::Value>>,
+    // Object-method values keep their generics on the inner function but emit
+    // them after `body` (acorn-typescript), unlike declarations/expressions.
+    type_parameters_after_body: bool,
 ) -> JsNode {
     let start = offset + func.span.start as usize;
     let end = offset + func.span.end as usize;
@@ -10116,6 +10145,7 @@ fn convert_function_expression_for_program_as_node(
         r#async: func.r#async,
         expression: false,
         type_parameters,
+        type_parameters_after_body,
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4893,6 +4893,7 @@ fn collect_identifier_names_in_node(
             r#async: _,
             expression: _,
             type_parameters: _,
+            type_parameters_after_body: _,
         } => {
             walk_range(*params, out);
             walk_opt(body, out);

--- a/crates/rsvelte_core/src/napi_raw_parse.rs
+++ b/crates/rsvelte_core/src/napi_raw_parse.rs
@@ -59,8 +59,9 @@ use crate::ast::typed_expr::{JsNode, LiteralValue, Loc, RegexValue, TemplateElem
 pub const MAGIC: u32 = 0x3156_5052; // "RPV1" little-endian
 // Bumped for the function-node AST-fidelity changes (FunctionExpression field
 // reorder, `typeParameters` on function-like nodes, Identifier `optional`);
-// keep in lockstep with `parse-envelope.js`'s `VERSION`.
-pub const VERSION: u32 = 3;
+// v4 adds the object-method `typeParameters`-after-`body` flag byte.
+// Keep in lockstep with `parse-envelope.js`'s `VERSION`.
+pub const VERSION: u32 = 4;
 pub const HEADER_LEN: usize = 24;
 
 // Header `flags` word (offset 20):
@@ -1338,6 +1339,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             r#async,
             expression,
             type_parameters,
+            type_parameters_after_body,
         } => {
             write_preamble(w, JS_FUNCTION_EXPRESSION, *start, *end);
             write_typed_loc(w, loc.as_deref());
@@ -1348,6 +1350,8 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             write_opt_type_annotation(w, type_parameters.as_deref())?;
             write_id_range(w, *params, arena)?;
             write_opt_node_id(w, *body, arena)?;
+            // Object-method inner functions serialize `typeParameters` after `body`.
+            write_bool(w, *type_parameters_after_body);
         }
         JsNode::ClassExpression {
             start,

--- a/crates/rsvelte_core/tests/parse_ts_types.rs
+++ b/crates/rsvelte_core/tests/parse_ts_types.rs
@@ -463,6 +463,26 @@ fn object_method_generics_emit_type_parameters_after_body() {
     assert_key_order(&s[fn_at..], "\"params\"", "\"body\"", "\"typeParameters\"");
 }
 
+#[test]
+fn async_generator_object_method_generics_emit_type_parameters_after_body() {
+    // The after-`body` position applies to every object method, including
+    // async/generator ones.
+    let src = "<script lang=\"ts\">const o = { async *m<T>(x: T){ yield x } }</script>";
+    let s = parse_to_string(src);
+    let fn_at = s.find("\"FunctionExpression\"").unwrap();
+    assert_key_order(&s[fn_at..], "\"params\"", "\"body\"", "\"typeParameters\"");
+}
+
+#[test]
+fn object_function_value_keeps_type_parameters_before_params() {
+    // A function *value* (`m: function<T>(){}`) is not a method, so its generics
+    // stay in the declaration/expression slot before `params`, not after `body`.
+    let src = "<script lang=\"ts\">const o = { m: function<T>(x: T){ return x } }</script>";
+    let s = parse_to_string(src);
+    let fn_at = s.find("\"FunctionExpression\"").unwrap();
+    assert_key_order(&s[fn_at..], "\"async\"", "\"typeParameters\"", "\"params\"");
+}
+
 // #1692: the TS optional-parameter marker (`b?`) must round-trip as
 // `optional: true` (after `name`, before `typeAnnotation`, omitted when false).
 

--- a/crates/rsvelte_core/tests/parse_ts_types.rs
+++ b/crates/rsvelte_core/tests/parse_ts_types.rs
@@ -445,6 +445,24 @@ fn class_method_generics_stay_off_the_inner_function() {
     assert!(f.get("typeParameters").is_none());
 }
 
+#[test]
+fn object_method_generics_emit_type_parameters_after_body() {
+    // Object-method inner functions keep their generics, but acorn-typescript
+    // appends `typeParameters` after `body` (like arrows), not in the
+    // declaration/expression slot before `params`.
+    let src = "<script lang=\"ts\">const o = { m<T>(x: T){ return x } }</script>";
+    let ast = parse_to_json(src);
+    let f = find_node(&ast, "FunctionExpression").expect("FunctionExpression");
+    assert_eq!(
+        f.pointer("/typeParameters/params/0/name")
+            .and_then(|v| v.as_str()),
+        Some("T")
+    );
+    let s = parse_to_string(src);
+    let fn_at = s.find("\"FunctionExpression\"").unwrap();
+    assert_key_order(&s[fn_at..], "\"params\"", "\"body\"", "\"typeParameters\"");
+}
+
 // #1692: the TS optional-parameter marker (`b?`) must round-trip as
 // `optional: true` (after `name`, before `typeAnnotation`, omitted when false).
 

--- a/scripts/dev/test-parse-envelope-validation.mjs
+++ b/scripts/dev/test-parse-envelope-validation.mjs
@@ -17,7 +17,7 @@ const { decodeParseEnvelope } = await import(
 ).then((m) => m.default ?? m);
 
 const MAGIC = 0x3156_5052; // "RPV1"
-const VERSION = 3;
+const VERSION = 4;
 const HEADER_LEN = 24;
 const TAG_JSON = 0x00;
 const JS_IDENTIFIER = 0x80;


### PR DESCRIPTION
Closes #1711

## Problem
For object-method generics, e.g.

```ts
const o = { m<T>(x: T) { return x } }
```

acorn-typescript (svelte/compiler `parse()`) emits `typeParameters` on the inner `FunctionExpression` **after `body`**, while rsvelte serialized it in the fixed declaration/expression slot **between `async` and `params`**. Pre-existing non-match found in #1709's review (same AST-fidelity class as #1689/#1692/#1694/#1709), not a regression.

Object methods route through the same generic `convert_expression` path as standalone function expressions, so the inner function can't be distinguished at the converter — and unlike class methods, acorn *does* keep the key on the inner function; only the serialized position differs.

## Fix
- `JsNode::FunctionExpression` gains a `type_parameters_after_body` flag.
- The ObjectExpression property conversion sites (both the expression- and program-context paths) set it via a small `mark_object_method_generics` helper when `p.method` is true. All other construction sites pass `false`, so declarations, standalone expressions, and class methods (which already omit the key, #1709) are unchanged.
- Both serializers honor the flag: the serde `Serialize` impl and the NAPI raw-parse wire writer + `parse-envelope.js` reader. The binary envelope `VERSION` is bumped `3 → 4` (writer, JS reader, validation script) for the added flag byte.

## Verification
- Confirmed acorn's real output via `submodules/svelte` `parse()`: object-method inner `FunctionExpression` keys end `…async,params,body,typeParameters`; standalone keeps `…async,typeParameters,params,body`.
- New regression test `object_method_generics_emit_type_parameters_after_body` (asserts the `typeParameters` subtree is present and ordered after `body`), mirroring #1709's `class_method_generics_stay_off_the_inner_function`.
- `cargo test -p rsvelte_core`: parse_ts_types 22/22, parser suites, `--lib` 1545/1545; `parse-envelope` validation script green; `cargo clippy --all-targets --all-features -D warnings` and `cargo fmt` clean; `rsvelte_napi` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)