### PR TITLE
fix(fmt): break whitespace body of a wrapping inline element (#1707)

### DIFF
--- a/.changeset/fix-fmt-wrapping-whitespace-inline.md
+++ b/.changeset/fix-fmt-wrapping-whitespace-inline.md
@@ -24,3 +24,9 @@ and the default `false` glues the close tag and drops the whitespace body
 block-display elements are left to their existing layout. Also aligns
 `can_omit_softline_before_closing_tag` with prettier's `blockElements` (excluding
 `script`/`style`) via `is_html_block_display_element`.
+
+Also fixes a crash this uncovered: when the new whitespace-body edit overlapped
+the indent pass's edit on the same text node, the top-level section-span remap
+double-counted the dropped edit and shifted a later `<style>`/`<script>` boundary
+past the output end, panicking during section reorder. The remap is now computed
+from the overlap-resolved edit set, so it always agrees with the applied output.

--- a/.changeset/fix-fmt-wrapping-whitespace-inline.md
+++ b/.changeset/fix-fmt-wrapping-whitespace-inline.md
@@ -1,0 +1,26 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): break the whitespace body of a wrapping inline element (#1707)
+
+An inline element with a whitespace-only body whose open tag wraps
+(`<span class="…long…"> </span>`) was formatted by the non-port markup path with
+the raw whitespace glued after the wrapped `>` (`…"`\n`> </span>`). That both
+diverged from the prettier-plugin-svelte oracle and was non-idempotent — a
+multi-space body collapsed to a single space on a re-format.
+
+prettier prints such an element as `group([...openingTag, '>', line, '</tag>'])`,
+so the whitespace body is a `line` that breaks once the wrapped open tag forces
+the group open: the `>` glues to the last attribute line under `bracketSameLine`
+(else dedents) and the close tag drops to its own line, absorbing the whitespace.
+Output is now byte-identical to the oracle and idempotent for both
+`bracketSameLine` values.
+
+`<textarea>` is handled as the raw-text exception the oracle applies: `>` stays
+glued (never dedented for this shape), `bracketSameLine: true` breaks the body,
+and the default `false` glues the close tag and drops the whitespace body
+(`…"></textarea>`). Source-empty inline elements (`<span></span>`, hug) and
+block-display elements are left to their existing layout. Also aligns
+`can_omit_softline_before_closing_tag` with prettier's `blockElements` (excluding
+`script`/`style`) via `is_html_block_display_element`.

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -181,10 +181,50 @@ pub fn format(source: &str, options: &FormatOptions) -> Result<String, FormatErr
     let has_markup = root.fragment.nodes.iter().any(|n| {
         !matches!(n, rsvelte_core::ast::template::TemplateNode::Text(t) if crate::is_blank_text(t.data.as_str()))
     });
+
+    // Resolve overlapping edits ONCE, before both the section remap and the
+    // application, so the two never disagree. Two passes (markup.rs and indent.rs)
+    // can emit an edit for the same span — e.g. markup.rs replaces a whitespace
+    // body + close tag with `\n{indent}</tag>` at the same `[start, end)` that
+    // indent.rs would normalise to `\n{indent}`. Markup edits are pushed first
+    // (line 100 before line 105), so after the stable descending sort they appear
+    // before indent edits with the same start; the first one wins and the overlap
+    // is dropped here. Computing the remap from this resolved set (rather than the
+    // raw edits) is essential: a *skipped* edit must not contribute to the section
+    // offset delta, otherwise a length-changing markup edit that superseded an
+    // indent edit would shift the section boundary past the output end (#1707).
+    edits.sort_by_key(|(start, _, _)| std::cmp::Reverse(*start));
+    let mut applied: Vec<(u32, u32, String)> = Vec::with_capacity(edits.len());
+    let mut last_applied: (u32, u32) = (u32::MAX, u32::MAX);
+    for (start, end, new_text) in edits {
+        let (la_s, la_e) = last_applied;
+        let incoming_nonempty = end > start;
+        let applied_nonempty = la_e > la_s;
+        // Two non-zero-length edits overlap when their ranges intersect.
+        // Zero-length inserts (start == end) never conflict with a range edit
+        // because they don't consume any source bytes.
+        let overlaps = applied_nonempty && incoming_nonempty && start < la_e && end > la_s;
+        if overlaps {
+            continue;
+        }
+        // Only update the guard for non-zero-length edits (range replacements).
+        // Zero-length inserts don't "own" a range.
+        if end > start {
+            last_applied = (start, end);
+        }
+        applied.push((start, end, new_text));
+    }
+
+    // Snapshot + remap the top-level section spans through the RESOLVED edits, so
+    // the reorder post-pass can run on the formatted output WITHOUT re-parsing it.
+    // An edit never straddles a top-level element boundary, so a boundary's new
+    // offset is its original offset plus the net length change of every applied
+    // edit ending at or before it. Only remap when reordering could change
+    // something (more than one top-level unit); otherwise the pass is skipped.
     let reorder_spans: Vec<(u8, usize, usize)> =
         if sections.len() > 1 || (sections.len() == 1 && has_markup) {
             let remap = |pos: u32| -> usize {
-                let delta: isize = edits
+                let delta: isize = applied
                     .iter()
                     .filter(|(_, end, _)| *end <= pos)
                     .map(|(start, end, repl)| repl.len() as isize - (*end - *start) as isize)
@@ -199,36 +239,10 @@ pub fn format(source: &str, options: &FormatOptions) -> Result<String, FormatErr
             Vec::new()
         };
 
-    // Apply edits from the back so earlier offsets remain valid.
-    edits.sort_by_key(|(start, _, _)| std::cmp::Reverse(*start));
+    // Apply the resolved edits from the back so earlier offsets stay valid.
     let mut out = source.to_string();
-    // Track the range of the last applied non-zero-length edit so we can skip
-    // any subsequent edit whose range overlaps it.  Two passes (markup.rs and
-    // indent.rs) can both emit an edit for the same span — e.g. markup.rs
-    // replaces trailing whitespace with `</tag>` at the same `[start, end)`
-    // that indent.rs would normalise to `\n{indent}`.  Markup edits are pushed
-    // first (lib.rs line 100 before line 105), so after the stable descending
-    // sort they appear before indent edits with the same start.  The first one
-    // wins; the second is skipped here to avoid a double-replace that would
-    // clobber the first replacement.
-    let mut last_applied: (u32, u32) = (u32::MAX, u32::MAX);
-    for (start, end, new_text) in edits {
-        let (la_s, la_e) = last_applied;
-        let incoming_nonempty = end > start;
-        let applied_nonempty = la_e > la_s;
-        // Two non-zero-length edits overlap when their ranges intersect.
-        // Zero-length inserts (start == end) never conflict with a range edit
-        // because they don't consume any source bytes.
-        let overlaps = applied_nonempty && incoming_nonempty && start < la_e && end > la_s;
-        if overlaps {
-            continue;
-        }
-        out.replace_range(start as usize..end as usize, &new_text);
-        // Only update the guard for non-zero-length edits (range replacements).
-        // Zero-length inserts don't "own" a range.
-        if end > start {
-            last_applied = (start, end);
-        }
+    for (start, end, new_text) in &applied {
+        out.replace_range(*start as usize..*end as usize, new_text);
     }
 
     // Post-pass: reorder top-level sections into prettier's canonical order

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -514,6 +514,11 @@ fn push_close_tag(
         // tag drops to its own line at the element indent and the whitespace body
         // is absorbed into that break. The open `>` glued to the last attribute
         // line under `bracketSameLine` (see `push_open_tag`) or dedented otherwise.
+        //
+        // `<textarea>` is a raw-text exception: the oracle glues `>` and, under the
+        // default `bracketSameLine: false`, glues the close tag too (`…"></textarea>`,
+        // no break — the whitespace body is dropped). Only `bracketSameLine: true`
+        // breaks the body (`…">`\n`</textarea>`).
         let bytes = source.as_bytes();
         let mut content_end = start as usize;
         while content_end > 0
@@ -521,8 +526,13 @@ fn push_close_tag(
         {
             content_end -= 1;
         }
-        let indent = indent_str(depth, &options.js);
-        edits.push((content_end as u32, end, format!("\n{indent}</{tag_name}>")));
+        let raw_text_glues_close = tag_name == "textarea" && !options.bracket_same_line;
+        if raw_text_glues_close {
+            edits.push((content_end as u32, end, format!("</{tag_name}>")));
+        } else {
+            let indent = indent_str(depth, &options.js);
+            edits.push((content_end as u32, end, format!("\n{indent}</{tag_name}>")));
+        }
     } else if hug_close {
         let indent = indent_str(depth, &options.js);
         edits.push((start, end, format!("</{tag_name}\n{indent}>")));
@@ -972,15 +982,24 @@ fn push_open_tag(
         rendered_attrs
     };
 
-    // An empty `<textarea>` glues its `>` to the last attribute line by default
-    // (`hug_open`), but prettier's empty `shouldHugStart && shouldHugEnd` branch
-    // dangles the `>` onto its own line (`…"`\n`></textarea>`) when the glued
+    // A source-empty `<textarea>` glues its `>` to the last attribute line by
+    // default (`hug_open`), but prettier's empty `shouldHugStart && shouldHugEnd`
+    // branch dangles the `>` onto its own line (`…"`\n`></textarea>`) when the glued
     // last line — `{indent}{last attr}></textarea>` — would exceed the print
     // width. (`<pre>` is a block element and always glues, so it is untouched.)
     // Detect that by rendering the glued form and measuring its last line plus
     // the `</textarea>` close width. `shape_two` handles the single-attribute
     // on-tag-line shape separately, so this only applies on the wrapped path.
-    let hug_open = if empty_element && tag_name == "textarea" && wrapped && !shape_two && hug_open {
+    // A whitespace-*body* `<textarea>` (`empty_nonhug`) is exempt: the oracle keeps
+    // its `>` glued in that shape (the body break / drop is handled in
+    // `push_close_tag`), so the width-based dangle must not fire.
+    let hug_open = if empty_element
+        && !empty_nonhug
+        && tag_name == "textarea"
+        && wrapped
+        && !shape_two
+        && hug_open
+    {
         let glued = render_multi_line(
             tag_name,
             &rendered_attrs,

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -88,6 +88,7 @@ pub(crate) fn collect_options_open_tag_edit(
         None,
         0,
         false,
+        false,
         options,
         edits,
     )?;
@@ -100,6 +101,36 @@ fn is_empty_fragment(fragment: &Fragment) -> bool {
         .nodes
         .iter()
         .all(|n| matches!(n, TemplateNode::Text(t) if crate::is_blank_text(t.data.as_str())))
+}
+
+/// Whether an (empty) fragment carries a whitespace-only text body — the
+/// `<span> </span>` shape — as opposed to a truly source-empty `<span></span>`.
+/// prettier keys `shouldHugStart`/`shouldHugEnd` on this: an inline element with
+/// a whitespace body does NOT hug (its body prints as a `line`), whereas a
+/// source-empty inline element hugs (`></span>`).
+fn fragment_has_whitespace_body(fragment: &Fragment) -> bool {
+    fragment.nodes.iter().any(|n| {
+        matches!(n, TemplateNode::Text(t)
+            if t.data.chars().next().is_some_and(|c| c.is_ascii_whitespace()))
+    })
+}
+
+/// An inline element whose only body is whitespace (`<span> </span>`) — the shape
+/// this targets. It is NOT `shouldHugStart && shouldHugEnd` (the whitespace body
+/// blocks hugging), so prettier prints `group([...openingTag, '>', line, '</tag>'])`:
+/// under a wrapping open tag the `>` glues to the last attribute line (under
+/// `bracketSameLine`, else dedents), and the whitespace body prints as a `line`
+/// that breaks, dropping the close tag to its own line. Without this the non-port
+/// path keeps the raw whitespace glued (`> </span>`), which both diverges from the
+/// oracle and is non-idempotent (multi-space collapses on a re-format).
+///
+/// Restricted to inline elements. A source-empty inline element (`<span></span>`)
+/// hugs (`></span>`) and is already correct. Block-display elements (and
+/// `script` / `style`, which prettier's `blockElements` excludes) are left to their
+/// existing layout: their empty body is subject to the collapse pass's own
+/// restructuring, which this edit-based path must not fight.
+fn is_empty_nonhug_element(name: &str, fragment: &Fragment) -> bool {
+    !is_block_element(name) && is_empty_fragment(fragment) && fragment_has_whitespace_body(fragment)
 }
 
 /// Emit the open-tag + close-tag rewrite edits for one attribute-bearing
@@ -120,6 +151,7 @@ fn handle_element(
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<(), FormatError> {
     let is_empty = is_empty_fragment(fragment);
+    let empty_nonhug = is_empty_nonhug_element(name, fragment);
     let wrapped = push_open_tag(
         source,
         start,
@@ -128,10 +160,21 @@ fn handle_element(
         this_expression,
         depth,
         is_empty,
+        empty_nonhug,
         options,
         edits,
     )?;
-    push_close_tag(source, end, name, wrapped, depth, is_empty, options, edits);
+    push_close_tag(
+        source,
+        end,
+        name,
+        wrapped,
+        depth,
+        is_empty,
+        empty_nonhug,
+        options,
+        edits,
+    );
     collect_open_tag_edits(source, fragment, depth + 1, options, edits)?;
     Ok(())
 }
@@ -225,6 +268,9 @@ fn collect_node_open_tag_edits(
                     None,
                     depth,
                     empty,
+                    // `<svelte:window>` is always self-closing when empty, so the
+                    // non-hug empty layout never applies.
+                    false,
                     options,
                     edits,
                 )?;
@@ -339,6 +385,10 @@ fn push_close_tag(
     // non-whitespace content inside the element.  Empty elements (e.g.
     // `<duiv>\n`) have their whitespace preserved by the collapse pass.
     is_empty: bool,
+    // Inline element with a whitespace-only body (`<span> </span>`): when its open
+    // tag wraps, the close tag drops to its own line and the whitespace body is
+    // absorbed into that break. See [`is_empty_nonhug_element`].
+    empty_nonhug: bool,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) {
@@ -457,7 +507,23 @@ fn push_close_tag(
             .checked_sub(1)
             .and_then(|i| source.as_bytes().get(i))
             .is_some_and(|&b| !b.is_ascii_whitespace() && b != b'>');
-    if hug_close {
+    if empty_nonhug && open_wrapped {
+        // Inline element with a whitespace body and a wrapped open tag: prettier
+        // prints `group([...openingTag, '>', line, '</tag>'])`, and the `line`
+        // breaks because the wrapped open tag forces the group open — so the close
+        // tag drops to its own line at the element indent and the whitespace body
+        // is absorbed into that break. The open `>` glued to the last attribute
+        // line under `bracketSameLine` (see `push_open_tag`) or dedented otherwise.
+        let bytes = source.as_bytes();
+        let mut content_end = start as usize;
+        while content_end > 0
+            && matches!(bytes[content_end - 1], b' ' | b'\t' | b'\n' | b'\r' | 0x0c)
+        {
+            content_end -= 1;
+        }
+        let indent = indent_str(depth, &options.js);
+        edits.push((content_end as u32, end, format!("\n{indent}</{tag_name}>")));
+    } else if hug_close {
         let indent = indent_str(depth, &options.js);
         edits.push((start, end, format!("</{tag_name}\n{indent}>")));
     } else if open_wrapped && is_empty && options.bracket_same_line {
@@ -489,6 +555,11 @@ fn push_close_tag(
 /// - otherwise a node abuts the close tag, and the softline may still be omitted
 ///   only when that node is a block parent's own close tag (`</block…`), i.e.
 ///   this element is that block's last child.
+///
+/// The block test uses `is_html_block_display_element` — prettier's `blockElements`
+/// list, which excludes `script`/`style` — to match `isLastChildWithinParentBlockElement`
+/// exactly (and its collapse-pass mirror `omit_softline_allowed`, which uses the
+/// same `is_block_display`).
 fn can_omit_softline_before_closing_tag(source: &str, element_end: u32) -> bool {
     let rest = &source[element_end as usize..];
     match rest.chars().next() {
@@ -499,7 +570,7 @@ fn can_omit_softline_before_closing_tag(source: &str, element_end: u32) -> bool 
                 .chars()
                 .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == ':')
                 .collect();
-            is_block_element(&name)
+            is_html_block_display_element(&name)
         }),
     }
 }
@@ -648,6 +719,11 @@ fn push_open_tag(
     this_expression: Option<&Expression>,
     depth: usize,
     empty_element: bool,
+    // Inline element with a whitespace-only body (`<span> </span>`): its wrapped
+    // open `>` glues to the last attribute line under `bracketSameLine`, unlike the
+    // hug case (source-empty inline) whose `>` dedents onto its own line. See
+    // [`is_empty_nonhug_element`].
+    empty_nonhug: bool,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<bool, FormatError> {
@@ -934,13 +1010,14 @@ fn push_open_tag(
             depth,
             &options.js,
             hug_open,
-            // An empty NON-self-closing element never glues its wrapped open `>`
-            // to the last attribute under `bracketSameLine`: prettier's empty
-            // `shouldHugStart && shouldHugEnd` branch keeps the `>` inside a
-            // hugged group that breaks onto its own line (`…"`\n`></span>`) when
-            // the attrs wrapped, so it dedents exactly like the default path. A
-            // self-closing element (`<input … />`) still glues its ` />`.
-            options.bracket_same_line && (self_closing || !empty_element),
+            // A source-empty inline element (`shouldHugStart && shouldHugEnd`)
+            // keeps its wrapped open `>` inside a hugged group that breaks onto its
+            // own line (`…"`\n`></span>`), so it dedents even under
+            // `bracketSameLine`. An inline element with a whitespace body
+            // (`<span> </span>`, not a hug) instead glues `>` to the last attribute
+            // line (`…">`), matching prettier's `group([...openingTag, '>', line, …])`.
+            // A self-closing element (`<input … />`) always glues its ` />`.
+            options.bracket_same_line && (self_closing || !empty_element || empty_nonhug),
         )
     } else {
         one_liner

--- a/crates/rsvelte_formatter/tests/options.rs
+++ b/crates/rsvelte_formatter/tests/options.rs
@@ -345,6 +345,62 @@ fn bracket_same_line_standalone_empty_element_matches_default() {
     assert_eq!(fmt(src, &width_80(false)), expected);
 }
 
+// issue #1707: a source-whitespace inline element (`<span> </span>`) whose open
+// tag wraps must break its whitespace body onto its own line — prettier's `line`
+// body flexes to a newline once the wrapped open tag forces the group open — so
+// the `>` glues to the last attribute under `bracketSameLine` and `</span>` drops
+// below it. The non-port path previously kept the raw whitespace glued
+// (`…"\n> </span>`), which both diverged from the oracle and was non-idempotent
+// (a multi-space body collapsed to one space on a re-format).
+#[test]
+fn bracket_same_line_wrapping_whitespace_inline_breaks_body() {
+    let src = "<span class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-in-output\"> </span>";
+    let out = fmt(src, &width_80(true));
+    assert_eq!(
+        out,
+        "<span\n  class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-in-output\">\n</span>\n"
+    );
+}
+
+// Default (`bracketSameLine = false`): the `>` dedents onto its own line and the
+// whitespace body still breaks, dropping `</span>` below it.
+#[test]
+fn default_wrapping_whitespace_inline_breaks_body() {
+    let src = "<span class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-in-output\"> </span>";
+    let out = fmt(src, &width_80(false));
+    assert_eq!(
+        out,
+        "<span\n  class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-in-output\"\n>\n</span>\n"
+    );
+}
+
+// The same shape nested inside a block element (indented one level) matches the
+// oracle under both option values.
+#[test]
+fn bracket_same_line_nested_wrapping_whitespace_inline_breaks_body() {
+    let src = "<div>\n  <span class=\"a-really-long-class-name-that-forces-the-open-tag-to-wrap-well-past-eighty-columns\"> </span>\n</div>";
+    assert_eq!(
+        fmt(src, &width_80(true)),
+        "<div>\n  <span\n    class=\"a-really-long-class-name-that-forces-the-open-tag-to-wrap-well-past-eighty-columns\">\n  </span>\n</div>\n"
+    );
+    assert_eq!(
+        fmt(src, &width_80(false)),
+        "<div>\n  <span\n    class=\"a-really-long-class-name-that-forces-the-open-tag-to-wrap-well-past-eighty-columns\"\n  >\n  </span>\n</div>\n"
+    );
+}
+
+// The fix is idempotent, including for a multi-space body that previously
+// collapsed to a single space on a re-format (the non-idempotency of #1707).
+#[test]
+fn wrapping_whitespace_inline_is_idempotent() {
+    let multi = "<span class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-in-output\">   </span>";
+    for bsl in [true, false] {
+        let once = fmt(multi, &width_80(bsl));
+        let twice = fmt(&once, &width_80(bsl));
+        assert_eq!(once, twice, "formatting must be idempotent (bsl={bsl})");
+    }
+}
+
 #[test]
 fn sort_order_parse_rejects_invalid() {
     assert!(SortOrderSpec::parse("scripts-markup").is_none());

--- a/crates/rsvelte_formatter/tests/options.rs
+++ b/crates/rsvelte_formatter/tests/options.rs
@@ -432,6 +432,22 @@ fn textarea_source_empty_dangles_closer_unchanged() {
     assert_eq!(fmt(src, &width_80(false)), expected);
 }
 
+// Regression for the #1707 whitespace-body rewrite interacting with the
+// section-reorder remap: the markup edit that rewrites a whitespace body +
+// close tag overlaps the indent pass's edit on the same whitespace text node, so
+// one is dropped when the edits are applied. The section-span remap must be
+// computed from the SAME overlap-resolved edit set — counting the dropped edit's
+// length change shifted the `<style>` boundary past the output end and panicked
+// in `sort_order::reorder_sections` ("end byte index … out of bounds").
+#[test]
+fn whitespace_body_rewrite_does_not_panic_reorder_remap() {
+    let src = "<ul>\n\t<li>\n\t\t<a\n\t\t\tid=\"x\"\n\t\t\thref=\"https://example.com/some/really/long/url/that/forces/the/open/tag/to/wrap\"\n\t\t\taria-label=\"label\"\n\t\t>\n\t\t</a>\n\t</li>\n</ul>\n\n<style>\n\ta {\n\t\tcolor: red;\n\t}\n</style>";
+    // The `<style>` body keeps the source indentation here — `width_80` configures
+    // no CSS formatter — which is irrelevant to the reorder-remap regression.
+    let expected = "<ul>\n  <li>\n    <a\n      id=\"x\"\n      href=\"https://example.com/some/really/long/url/that/forces/the/open/tag/to/wrap\"\n      aria-label=\"label\"\n    >\n    </a>\n  </li>\n</ul>\n\n<style>\n\ta {\n\t\tcolor: red;\n\t}\n</style>\n";
+    assert_eq!(fmt(src, &width_80(false)), expected);
+}
+
 #[test]
 fn sort_order_parse_rejects_invalid() {
     assert!(SortOrderSpec::parse("scripts-markup").is_none());

--- a/crates/rsvelte_formatter/tests/options.rs
+++ b/crates/rsvelte_formatter/tests/options.rs
@@ -401,6 +401,37 @@ fn wrapping_whitespace_inline_is_idempotent() {
     }
 }
 
+// `<textarea>` is a raw-text exception to the inline whitespace-body rule: the
+// oracle keeps `>` glued (never dedented) and, under the default
+// `bracketSameLine: false`, glues the close tag too (dropping the whitespace
+// body), while `bracketSameLine: true` breaks the body onto its own line. This
+// exercises the `empty_nonhug` interaction with the empty-`<textarea>` width
+// check.
+#[test]
+fn textarea_whitespace_body_matches_oracle_raw_text_layout() {
+    let src = "<textarea class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-x\"> </textarea>";
+    // bracketSameLine: true — `>` glued to the last attribute, body broken.
+    assert_eq!(
+        fmt(src, &width_80(true)),
+        "<textarea\n  class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-x\">\n</textarea>\n"
+    );
+    // Default (false) — `>` glued, close glued, whitespace body dropped.
+    assert_eq!(
+        fmt(src, &width_80(false)),
+        "<textarea\n  class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-x\"></textarea>\n"
+    );
+}
+
+// A source-empty `<textarea>` still dangles its `>` onto its own line when the
+// glued last line would overflow — unchanged by the whitespace-body handling.
+#[test]
+fn textarea_source_empty_dangles_closer_unchanged() {
+    let src = "<textarea class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-x\"></textarea>";
+    let expected = "<textarea\n  class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines-x\"\n></textarea>\n";
+    assert_eq!(fmt(src, &width_80(true)), expected);
+    assert_eq!(fmt(src, &width_80(false)), expected);
+}
+
 #[test]
 fn sort_order_parse_rejects_invalid() {
     assert!(SortOrderSpec::parse("scripts-markup").is_none());


### PR DESCRIPTION
Closes #1707

## Problem

An inline element whose body is whitespace-only and whose open tag wraps because of a long attribute —

```svelte
<span class="very-long-class-that-forces-the-open-tag-to-wrap-…"> </span>
```

— was formatted by the non-port (edit-based) markup path with the raw whitespace glued after the wrapped `>`:

```
<span
  class="…"
> </span>
```

This both **diverged from the prettier-plugin-svelte oracle** and was **non-idempotent** — a multi-space body (`>   </span>`) collapsed to a single space (`> </span>`) on a re-format.

## Root cause

prettier prints such an element as `group([...openingTag, '>', line, '</tag>'])`. `shouldHugStart`/`shouldHugEnd` are both false (the whitespace body blocks hugging), so it is *not* the hugged empty branch. The `line` body flexes to a newline once the wrapped open tag forces the group open, so the oracle produces (for `bracketSameLine: true`):

```
<span
  class="…">
</span>
```

The edit-based path instead kept the raw source whitespace verbatim and left the close tag glued, so the body never broke.

## Fix

Port that shape into the edit-based path (`crates/rsvelte_formatter/src/markup.rs`):

- `is_empty_nonhug_element` detects an **inline** element with a whitespace-only body.
- Under a wrapping open tag, the open `>` now glues to the last attribute line under `bracketSameLine` (dedents to its own line otherwise), matching `push_open_tag`'s hug/non-hug distinction.
- `push_close_tag` rewrites the whitespace body + close tag as `\n{indent}</tag>`, so the body breaks and the close tag drops to its own line.

Output is now **byte-identical to the oracle and idempotent for both `bracketSameLine` values**.

### `<textarea>` (raw-text exception)

`<textarea>` is whitespace-sensitive raw text, so the oracle keeps its `>` **glued** (never dedented) for this shape. Under the default `bracketSameLine: false` it also glues the close tag and **drops** the whitespace body (`…"></textarea>`); `bracketSameLine: true` breaks the body (`…">` newline `</textarea>`). The whitespace-body `<textarea>` is exempted from the empty-`<textarea>` open-tag width dangle, and its close tag is glued under the default — so both option values are byte-identical to the oracle. A source-empty `<textarea>` still dangles its `>` on overflow (unchanged).

The default-`false` `<textarea>` re-format is non-idempotent, but this is **inherited from the oracle itself**: oxfmt drops the whitespace body, turning the node into a truly-empty `<textarea>` that it then formats differently (`\n></textarea>`). rsvelte matches the oracle at *every* pass (pass 2 == `oracle(pass-1 output)`), so parity is exact — idempotency and oracle-parity are mutually exclusive here because the oracle discards the whitespace content.

### Comment findings

- **Composite case (comment 1)** — the genuine-whitespace-content + attribute-caused-wrap case is exactly what this fixes for **inline** elements. Verified byte-identical to the oracle for `bracketSameLine` true *and* false, single- and multi-space bodies, top-level and nested-in-block, plus the `<textarea>` raw-text variant.
- **Maintainability (comment 2)** — `can_omit_softline_before_closing_tag` now tests `is_html_block_display_element` (prettier's `blockElements`, which excludes `script`/`style`) instead of the slightly wider `is_block_element`, matching `isLastChildWithinParentBlockElement` and its collapse-pass mirror `omit_softline_allowed`.

### Deliberately out of scope

- **Source-empty inline** (`<span></span>`): already hugs correctly (`></span>`) — untouched.
- **Block-display elements** with a wrapping open tag (whitespace body or truly empty): left to the collapse pass's own restructuring. These have a residual divergence from the oracle **at both `bracketSameLine` values** (not just `true`), but the behaviour is **unchanged from `main`** (not a regression), **hits nothing in the svelte.dev parity corpus** (1102/1103, see below), and folding it in would be net-negative — including block elements made the `bracketSameLine: true` case non-idempotent because the collapse pass strips an empty block body's inserted newline, so a second format re-dedents the `>`. The block-display divergence should be tracked in a separate issue.

## Verification

- **svelte.dev formatter-parity hard gate** (`svelte_dev_corpus`): `1102/1103` — identical to `main` (confirmed by stashing the change and re-running, before and after the `<textarea>` follow-up). The sole failure is a pre-existing local toolchain skew (oracle generated with `oxfmt` 0.56.0 vs the worktree's Rust `oxc_formatter` 0.59.0 differing on one TS union type in `SearchBox.svelte`), not related to this change.
- New regression tests in `crates/rsvelte_formatter/tests/options.rs` cover parity (both option values, top-level + nested), idempotency (multi-space body), and the `<textarea>` raw-text layout (whitespace-body + source-empty).
- Full `rsvelte_formatter` + `rsvelte_fmt` suites, `cargo fmt`, and `cargo clippy --all-targets --all-features -D warnings` all clean.
- `@rsvelte/fmt` changeset added (`.changeset/fix-fmt-wrapping-whitespace-inline.md`).
- `fmt-known-failures.json` left unchanged: this narrow construct fix does not verifiably flip any whole ecosystem-corpus file to passing, and CI runs `fmt-verify` non-strict (a newly-passing entry is a warning, not a failure), so no ratchet edit is warranted or safe without the ecosystem submodules (absent in this worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)