### PR TITLE
fix(css): resolve multi-relative chains in :global()/nested-& sibling prune

### DIFF
--- a/.changeset/fix-css-prune-multi-relative-sibling.md
+++ b/.changeset/fix-css-prune-multi-relative-sibling.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(css): resolve multi-relative chains in `:global()`/nested-`&` sibling prune
+
+The `+`/`~` unused-CSS prune check resolved only single-relative selectors when
+expanding a leading `:global(X)` inner selector or a nested rule's `&` against
+its ancestor rules, so a descendant/child chain inside the compound was left
+unresolved and the rule was pruned even when the ancestor constraint was
+actually satisfied — e.g. `:global(.a .z) + .b` (`.z` really under `.a`) became
+`/* (unused) */` and `.grand { .foo > .a { & + & } }` became `/* (empty) */`.
+The `&`/`:global(...)` inner is now resolved through the full ancestor chain
+with the same structural matcher used for `>` child checks, matching
+`svelte/compiler` for both the kept and pruned cases (#1719).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -2367,7 +2367,11 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
                 return false;
             }
 
-            let inner_info = global_inner_selector_info(&rel_selectors[0]);
+            // Resolve the inner `:global(X)` compound. A multi-relative chain
+            // like `:global(.a .z)` becomes a `Chain` so the `.a` ancestor of a
+            // candidate `.z` sibling is verified (rather than left unresolved,
+            // which over-prunes even when the ancestor really exists).
+            let inner_matcher = resolve_global_inner_matcher(&rel_selectors[0]);
 
             // `:global(X) + Y` is used when some Y is preceded by a node X could
             // be: a real previous sibling matching X, an opaque boundary, or a
@@ -2391,12 +2395,9 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
                 } else {
                     &el.possible_prev_general
                 };
-                prevs.iter().any(|(idx, _)| {
-                    ctx.dom_structure
-                        .elements
-                        .get(*idx)
-                        .is_some_and(|sib| selector_matches_element(&inner_info, sib))
-                })
+                prevs
+                    .iter()
+                    .any(|(idx, _)| matcher_matches_at(&inner_matcher, *idx, ctx))
             });
 
             return !matches;
@@ -2481,11 +2482,17 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
         // The official compiler's prune() checks each element with direction=BACKWARD,
         // so we check: does any element matching 'after' have 'before' as a prev sibling?
 
+        // Resolve `&` operands to ancestor-aware matchers so a multi-relative
+        // parent (`.foo > .a { & + & }`) verifies the `.foo` ancestor instead of
+        // matching nothing; single-relative parents keep the `Info` path.
+        let before_m = resolve_sibling_matcher(before, ctx);
+        let after_m = resolve_sibling_matcher(after, ctx);
+
         // Find all elements that match 'after' selector
         let mut found_after_element = false;
         let mut any_after_has_incomplete_siblings = false;
-        for el in ctx.dom_structure.elements.iter() {
-            if selector_matches_element(&after_info, el) {
+        for (el_idx, el) in ctx.dom_structure.elements.iter().enumerate() {
+            if matcher_matches_at(&after_m, el_idx, ctx) {
                 found_after_element = true;
                 // Check possible previous siblings based on combinator type
                 let possible_siblings = if combinator == "+" {
@@ -2497,9 +2504,7 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
 
                 // Check if any possible previous sibling matches 'before' selector
                 for (sibling_idx, _certainty) in possible_siblings {
-                    if let Some(sibling) = ctx.dom_structure.elements.get(*sibling_idx)
-                        && selector_matches_element(&before_info, sibling)
-                    {
+                    if matcher_matches_at(&before_m, *sibling_idx, ctx) {
                         return false; // Found a match, not unused
                     }
                 }
@@ -2522,8 +2527,8 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
         if !found_after_element {
             // Also check forward: do any 'before' elements have 'after' as next sibling?
             let mut found_before_element = false;
-            for el in ctx.dom_structure.elements.iter() {
-                if selector_matches_element(&before_info, el) {
+            for (el_idx, el) in ctx.dom_structure.elements.iter().enumerate() {
+                if matcher_matches_at(&before_m, el_idx, ctx) {
                     found_before_element = true;
                     let possible_siblings = if combinator == "+" {
                         &el.possible_next_adjacent
@@ -2531,9 +2536,7 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
                         &el.possible_next_general
                     };
                     for (sibling_idx, _certainty) in possible_siblings {
-                        if let Some(sibling) = ctx.dom_structure.elements.get(*sibling_idx)
-                            && selector_matches_element(&after_info, sibling)
-                        {
+                        if matcher_matches_at(&after_m, *sibling_idx, ctx) {
                             return false; // Found a match
                         }
                     }
@@ -2712,6 +2715,124 @@ fn global_inner_selector_info(rel: &Value) -> SelectorInfo {
         return extract_selector_info_from_selectors(sels);
     }
     empty()
+}
+
+/// A resolved sibling operand for the `+` / `~` prune check: either a compound
+/// matched directly against an element, or a descendant/child ancestor-chain
+/// (subject last) verified structurally against an element's ancestors. The
+/// `Chain` variant lets `:global(.a .z) + .b` and `.foo > .a { & + & }` honour
+/// the ancestor constraint (`.a` above `.z`, `.foo` above `.a`) instead of
+/// bailing to unresolved on the multi-relative chain.
+enum SiblingMatcher {
+    Info(SelectorInfo),
+    Chain(Vec<Value>),
+}
+
+fn matcher_matches_at(matcher: &SiblingMatcher, idx: usize, ctx: &CssContext) -> bool {
+    let Some(el) = ctx.dom_structure.elements.get(idx) else {
+        return false;
+    };
+    match matcher {
+        SiblingMatcher::Info(info) => selector_matches_element(info, el),
+        SiblingMatcher::Chain(rels) => {
+            structural_element_matches_compound(el, &rels[rels.len() - 1])
+                && structural_ancestors_satisfy_links(rels, rels.len() - 1, idx, ctx)
+        }
+    }
+}
+
+/// The inner complex selector's relative-selector list for a single-argument
+/// `:global(X)` relative selector, or `None`.
+fn global_inner_complex_rels(rel: &Value) -> Option<&Vec<Value>> {
+    let first = rel
+        .get("selectors")
+        .and_then(|s| s.as_array())
+        .and_then(|a| a.first())?;
+    if first.get("type").and_then(|t| t.as_str()) != Some("PseudoClassSelector")
+        || first.get("name").and_then(|n| n.as_str()) != Some("global")
+    {
+        return None;
+    }
+    let complex = first
+        .get("args")
+        .and_then(|a| a.get("children"))
+        .and_then(|c| c.as_array())
+        .and_then(|c| c.first())?;
+    complex.get("children").and_then(|c| c.as_array())
+}
+
+/// True when a descendant/child chain (subject last) can be evaluated by the
+/// structural ancestor matcher: at least two links, only ` `/`>` combinators and
+/// only evaluable simple selectors (no `:global`/`&`/functional pseudo).
+fn chain_is_structurally_evaluable(rels: &[Value]) -> bool {
+    if rels.len() < 2 {
+        return false;
+    }
+    for rel in rels.iter().skip(1) {
+        let comb = rel
+            .get("combinator")
+            .and_then(|c| c.get("name"))
+            .and_then(|n| n.as_str())
+            .unwrap_or(" ");
+        if comb != " " && comb != ">" {
+            return false;
+        }
+    }
+    rels.iter().all(|rel| {
+        rel.get("selectors")
+            .and_then(|s| s.as_array())
+            .is_some_and(|sels| {
+                !sels.is_empty() && sels.iter().all(structural_simple_selector_is_evaluable)
+            })
+    })
+}
+
+/// Resolve a leading `:global(X)` relative selector into a [`SiblingMatcher`]:
+/// a `Chain` when `X` is a structurally-evaluable descendant/child chain (so the
+/// `.a` ancestor of `:global(.a .z)` is verified), otherwise the single-compound
+/// `Info` (unchanged behaviour).
+fn resolve_global_inner_matcher(rel: &Value) -> SiblingMatcher {
+    if let Some(rels) = global_inner_complex_rels(rel)
+        && chain_is_structurally_evaluable(rels)
+    {
+        return SiblingMatcher::Chain(rels.clone());
+    }
+    SiblingMatcher::Info(global_inner_selector_info(rel))
+}
+
+/// If `rel` is a bare `&` (a single NestingSelector) whose immediate parent rule
+/// prelude is a single structurally-evaluable descendant/child chain, return
+/// that chain (subject last) so `.foo > .a { & + & }` resolves `&` to the full
+/// `.foo > .a` with its ancestor constraint. Returns `None` for the
+/// single-relative parent (handled by [`extract_selector_info_resolving_nesting`])
+/// and for shapes the structural matcher cannot evaluate.
+fn resolve_bare_nesting_chain(rel: &Value, ctx: &CssContext) -> Option<Vec<Value>> {
+    let sels = rel.get("selectors").and_then(|s| s.as_array())?;
+    if sels.len() != 1 || sels[0].get("type").and_then(|t| t.as_str()) != Some("NestingSelector") {
+        return None;
+    }
+    let parent_preludes = ctx.parent_preludes.borrow();
+    let parent = parent_preludes.last()?;
+    let children = parent.get("children").and_then(|c| c.as_array())?;
+    if children.len() != 1 {
+        return None;
+    }
+    let rels = children[0].get("children").and_then(|c| c.as_array())?;
+    if chain_is_structurally_evaluable(rels) {
+        Some(rels.clone())
+    } else {
+        None
+    }
+}
+
+/// Resolve a sibling operand relative selector into a [`SiblingMatcher`],
+/// preferring an ancestor-aware `Chain` for a bare `&` with a multi-relative
+/// parent, else the existing compound `Info`.
+fn resolve_sibling_matcher(rel: &Value, ctx: &CssContext) -> SiblingMatcher {
+    if let Some(chain) = resolve_bare_nesting_chain(rel, ctx) {
+        return SiblingMatcher::Chain(chain);
+    }
+    SiblingMatcher::Info(extract_selector_info_resolving_nesting(rel, ctx))
 }
 
 fn extract_selector_info(rel_selector: &Value) -> SelectorInfo {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -2800,29 +2800,102 @@ fn resolve_global_inner_matcher(rel: &Value) -> SiblingMatcher {
     SiblingMatcher::Info(global_inner_selector_info(rel))
 }
 
-/// If `rel` is a bare `&` (a single NestingSelector) whose immediate parent rule
-/// prelude is a single structurally-evaluable descendant/child chain, return
-/// that chain (subject last) so `.foo > .a { & + & }` resolves `&` to the full
-/// `.foo > .a` with its ancestor constraint. Returns `None` for the
-/// single-relative parent (handled by [`extract_selector_info_resolving_nesting`])
-/// and for shapes the structural matcher cannot evaluate.
+/// True when a single nesting level's compounds can be evaluated by the
+/// structural ancestor matcher: only ` `/`>` combinators (the head compound may
+/// carry a null combinator) and only evaluable simple selectors (no
+/// `:global`/`&`/functional pseudo). Unlike [`chain_is_structurally_evaluable`]
+/// this accepts a single-compound level (a bare `.grand`).
+fn level_is_structurally_evaluable(rels: &[Value]) -> bool {
+    if rels.is_empty() {
+        return false;
+    }
+    for rel in rels.iter().skip(1) {
+        let comb = rel
+            .get("combinator")
+            .and_then(|c| c.get("name"))
+            .and_then(|n| n.as_str())
+            .unwrap_or(" ");
+        if comb != " " && comb != ">" {
+            return false;
+        }
+    }
+    rels.iter().all(|rel| {
+        rel.get("selectors")
+            .and_then(|s| s.as_array())
+            .is_some_and(|sels| {
+                !sels.is_empty() && sels.iter().all(structural_simple_selector_is_evaluable)
+            })
+    })
+}
+
+/// Clone a relative selector, forcing a null/absent combinator on its head to a
+/// descendant combinator. Mirrors upstream `get_relative_selectors`, which links
+/// a nested rule's prelude to its parent by prepending an implicit `&` +
+/// descendant combinator before recursing up.
+fn with_descendant_head(rel: &Value) -> Value {
+    let mut cloned = rel.clone();
+    let is_null = cloned
+        .get("combinator")
+        .map(|c| c.is_null())
+        .unwrap_or(true);
+    if is_null && let Value::Object(map) = &mut cloned {
+        map.insert(
+            "combinator".to_string(),
+            serde_json::json!({ "type": "Combinator", "name": " " }),
+        );
+    }
+    cloned
+}
+
+/// Build the full ancestor chain (subject last) for nesting levels
+/// `preludes[..level]`, mirroring upstream `get_relative_selectors` +
+/// `NestingSelector` resolution: each enclosing rule contributes its prelude,
+/// linked to the level below by an implicit descendant combinator, so
+/// `.grand { .foo > .a { … } }` resolves `&` to `.grand .foo > .a`. Returns
+/// `None` if any level is not a single structurally-evaluable descendant/child
+/// complex selector (multiple complex selectors, sibling combinators, nested
+/// `&`, `:global`, or functional pseudo) — the caller then falls back to the
+/// compound `Info` path.
+fn build_parent_chain(preludes: &[&Value], level: usize) -> Option<Vec<Value>> {
+    if level == 0 {
+        return None;
+    }
+    let prelude = preludes[level - 1];
+    let children = prelude.get("children").and_then(|c| c.as_array())?;
+    if children.len() != 1 {
+        return None;
+    }
+    let rels = children[0].get("children").and_then(|c| c.as_array())?;
+    if !level_is_structurally_evaluable(rels) {
+        return None;
+    }
+    if level == 1 {
+        return Some(rels.clone());
+    }
+    let mut chain = build_parent_chain(preludes, level - 1)?;
+    chain.push(with_descendant_head(&rels[0]));
+    chain.extend(rels[1..].iter().cloned());
+    Some(chain)
+}
+
+/// If `rel` is a bare `&` (a single NestingSelector), resolve it against the
+/// full stack of enclosing rule preludes into a descendant/child chain (subject
+/// last) so `.foo > .a { & + & }` and `.grand { .foo > .a { & + & } }` verify
+/// every ancestor level, not just the immediate parent. Returns `None` when the
+/// resolved chain is a single compound (no ancestor constraint — handled by
+/// [`extract_selector_info_resolving_nesting`]) or when any level is a shape the
+/// structural matcher cannot evaluate.
 fn resolve_bare_nesting_chain(rel: &Value, ctx: &CssContext) -> Option<Vec<Value>> {
     let sels = rel.get("selectors").and_then(|s| s.as_array())?;
     if sels.len() != 1 || sels[0].get("type").and_then(|t| t.as_str()) != Some("NestingSelector") {
         return None;
     }
     let parent_preludes = ctx.parent_preludes.borrow();
-    let parent = parent_preludes.last()?;
-    let children = parent.get("children").and_then(|c| c.as_array())?;
-    if children.len() != 1 {
+    let chain = build_parent_chain(&parent_preludes, parent_preludes.len())?;
+    if chain.len() < 2 {
         return None;
     }
-    let rels = children[0].get("children").and_then(|c| c.as_array())?;
-    if chain_is_structurally_evaluable(rels) {
-        Some(rels.clone())
-    } else {
-        None
-    }
+    Some(chain)
 }
 
 /// Resolve a sibling operand relative selector into a [`SiblingMatcher`],

--- a/crates/rsvelte_core/tests/css_global_sibling_1702.rs
+++ b/crates/rsvelte_core/tests/css_global_sibling_1702.rs
@@ -113,6 +113,30 @@ fn global_plus_no_sibling_in_snippet_nested_pruned() {
 }
 
 #[test]
+fn global_descendant_inner_with_ancestor_kept() {
+    // Issue #1719: `:global(.a .z) + .b` where the `.z` sibling of `.b` really
+    // has an `.a` ancestor. The inner descendant chain's ancestor constraint is
+    // satisfied, so the official compiler keeps the rule and scopes `.b`
+    // (`.a .z + .b.svelte-xxx`). Previously rsvelte only resolved single-relative
+    // `:global(...)` inners and over-pruned this as `(unused)`.
+    let out = css(
+        "<div class=\"a\"><span class=\"z\"></span><div class=\"b\"></div></div>\n\
+         <style>:global(.a .z) + .b { color: red; }</style>",
+    );
+    assert_kept(&out);
+}
+
+#[test]
+fn global_child_inner_with_ancestor_kept() {
+    // Same fix for a `>` child chain inside `:global(...)`.
+    let out = css(
+        "<div class=\"a\"><span class=\"z\"></span><div class=\"b\"></div></div>\n\
+         <style>:global(.a > .z) + .b { color: red; }</style>",
+    );
+    assert_kept(&out);
+}
+
+#[test]
 fn global_descendant_inner_without_ancestor_pruned() {
     // `:global(.a .z) + .b`: the `.z` sibling of `.b` has no `.a` ancestor. The
     // inner `.a .z` carries an ancestor constraint the compound matcher can't

--- a/crates/rsvelte_core/tests/css_nested_sibling_1703.rs
+++ b/crates/rsvelte_core/tests/css_nested_sibling_1703.rs
@@ -78,6 +78,38 @@ fn nested_amp_plus_amp_no_pair_pruned() {
 }
 
 #[test]
+fn nested_amp_plus_amp_multi_relative_parent_child_kept() {
+    // Issue #1719: `.foo > .a { & + & }` where `.a` really is a child of `.foo`
+    // and an adjacent pair exists. `&` resolves to the full `.foo > .a`; the
+    // ancestor constraint is satisfied, so the official compiler keeps the outer
+    // rule (`.foo.svelte-xxx > .a:where(.svelte-xxx) { & + & { … } }`). Previously
+    // rsvelte only resolved single-relative parents and dropped this as `(empty)`.
+    let out = css(
+        "<div class=\"foo\"><div class=\"a\"></div><div class=\"a\"></div></div>\n\
+         <style>.foo > .a { & + & { color: red; } }</style>",
+    );
+    assert!(!out.contains("(empty)"), "rule must be kept, got:\n{out}");
+    assert!(!out.contains("(unused)"), "rule must be kept, got:\n{out}");
+    assert!(out.contains("& + &"), "expected `& + &` kept in:\n{out}");
+    assert!(
+        out.contains(".foo.svelte-"),
+        "expected scoped `.foo` in:\n{out}"
+    );
+}
+
+#[test]
+fn nested_amp_tilde_amp_multi_relative_parent_child_kept() {
+    // Same fix for the general-sibling combinator inside a `>` parent chain.
+    let out = css(
+        "<div class=\"foo\"><div class=\"a\"></div><span></span><div class=\"a\"></div></div>\n\
+         <style>.foo > .a { & ~ & { color: red; } }</style>",
+    );
+    assert!(!out.contains("(empty)"), "rule must be kept, got:\n{out}");
+    assert!(!out.contains("(unused)"), "rule must be kept, got:\n{out}");
+    assert!(out.contains("& ~ &"), "expected `& ~ &` kept in:\n{out}");
+}
+
+#[test]
 fn nested_amp_plus_amp_multi_relative_parent_no_match_pruned() {
     // `.foo > .a { & + & }` where `.a` is not a child of `.foo`. `&` resolves to
     // the full `.foo > .a`, which this compound matcher can't verify, so it must

--- a/crates/rsvelte_core/tests/css_nested_sibling_1703.rs
+++ b/crates/rsvelte_core/tests/css_nested_sibling_1703.rs
@@ -110,6 +110,90 @@ fn nested_amp_tilde_amp_multi_relative_parent_child_kept() {
 }
 
 #[test]
+fn nested_three_level_plus_ancestor_satisfied_kept() {
+    // Issue #1719 review: three-level nesting must resolve *every* ancestor
+    // level, not just the immediate parent. `.grand { .foo > .a { & + & } }`
+    // with `.foo` actually a descendant of `.grand` and an adjacent `.a` pair →
+    // official keeps the rule.
+    let out = css(
+        "<div class=\"grand\"><div class=\"foo\"><div class=\"a\"></div><div class=\"a\"></div></div></div>\n\
+         <style>.grand { .foo > .a { & + & { color: red; } } }</style>",
+    );
+    assert!(!out.contains("(empty)"), "rule must be kept, got:\n{out}");
+    assert!(!out.contains("(unused)"), "rule must be kept, got:\n{out}");
+    assert!(out.contains("& + &"), "expected `& + &` kept in:\n{out}");
+    assert!(
+        out.contains(".grand.svelte-"),
+        "expected scoped `.grand` in:\n{out}"
+    );
+}
+
+#[test]
+fn nested_three_level_plus_ancestor_missing_pruned() {
+    // `.foo` is NOT a descendant of `.grand` (they are siblings), so the outer
+    // ancestor constraint is unsatisfied and the official compiler prunes the
+    // rule as `(empty)`. This is the regression the review caught: resolving
+    // only the immediate `.foo > .a` parent wrongly kept it.
+    let out = css(
+        "<div class=\"grand\"></div><div class=\"foo\"><div class=\"a\"></div><div class=\"a\"></div></div>\n\
+         <style>.grand { .foo > .a { & + & { color: red; } } }</style>",
+    );
+    assert!(
+        out.contains("(empty)"),
+        "`.grand` ancestor unsatisfied must prune `& + &` as empty, got:\n{out}"
+    );
+}
+
+#[test]
+fn nested_three_level_tilde_ancestor_satisfied_kept() {
+    let out = css(
+        "<div class=\"grand\"><div class=\"foo\"><div class=\"a\"></div><span></span><div class=\"a\"></div></div></div>\n\
+         <style>.grand { .foo > .a { & ~ & { color: red; } } }</style>",
+    );
+    assert!(!out.contains("(empty)"), "rule must be kept, got:\n{out}");
+    assert!(!out.contains("(unused)"), "rule must be kept, got:\n{out}");
+    assert!(out.contains("& ~ &"), "expected `& ~ &` kept in:\n{out}");
+}
+
+#[test]
+fn nested_three_level_tilde_ancestor_missing_pruned() {
+    let out = css(
+        "<div class=\"grand\"></div><div class=\"foo\"><div class=\"a\"></div><span></span><div class=\"a\"></div></div>\n\
+         <style>.grand { .foo > .a { & ~ & { color: red; } } }</style>",
+    );
+    assert!(
+        out.contains("(empty)"),
+        "`.grand` ancestor unsatisfied must prune `& ~ &` as empty, got:\n{out}"
+    );
+}
+
+#[test]
+fn nested_two_level_single_compound_ancestor_satisfied_kept() {
+    // `.grand { .a { & + & } }`: `&` resolves to `.grand .a`; the `.a` pair is
+    // under `.grand`, so official keeps.
+    let out = css(
+        "<div class=\"grand\"><div class=\"a\"></div><div class=\"a\"></div></div>\n\
+         <style>.grand { .a { & + & { color: red; } } }</style>",
+    );
+    assert!(!out.contains("(empty)"), "rule must be kept, got:\n{out}");
+    assert!(!out.contains("(unused)"), "rule must be kept, got:\n{out}");
+    assert!(out.contains("& + &"), "expected `& + &` kept in:\n{out}");
+}
+
+#[test]
+fn nested_two_level_single_compound_ancestor_missing_pruned() {
+    // The `.a` pair is at the root, not under `.grand`, so official prunes.
+    let out = css(
+        "<div class=\"grand\"></div><div class=\"a\"></div><div class=\"a\"></div>\n\
+         <style>.grand { .a { & + & { color: red; } } }</style>",
+    );
+    assert!(
+        out.contains("(empty)"),
+        "`.grand` ancestor unsatisfied must prune `& + &` as empty, got:\n{out}"
+    );
+}
+
+#[test]
 fn nested_amp_plus_amp_multi_relative_parent_no_match_pruned() {
     // `.foo > .a { & + & }` where `.a` is not a child of `.foo`. `&` resolves to
     // the full `.foo > .a`, which this compound matcher can't verify, so it must

--- a/scripts/compat-corpus/css-prune-sweep.mjs
+++ b/scripts/compat-corpus/css-prune-sweep.mjs
@@ -135,6 +135,37 @@ const ARRANGE_C = {
 	wrong: (_sel, inner) => `<section>${inner}</section>`,
 };
 
+// Family C3 — three-level nesting whose innermost `& +/~ &` must resolve every
+// ancestor level (`.grand` AND `.foo`), not just the immediate parent (issue
+// #1719 review regression). `sep` separates the two `.a` for `~`.
+const SELECTORS_C3 = [
+	{
+		id: '.grand{.foo>.a{&+&}}',
+		css: '.grand {\n\t\t.foo > .a { & + & { color: red; } }\n\t}',
+		rawCss: true,
+		sibs: ['a', 'a'],
+	},
+	{
+		id: '.grand{.foo>.a{&~&}}',
+		css: '.grand {\n\t\t.foo > .a { & ~ & { color: red; } }\n\t}',
+		rawCss: true,
+		sibs: ['a', 'a'],
+		sep: '<span></span>',
+	},
+];
+
+// Family C3 arrangements: `full` satisfies both ancestors; `no_grand` breaks the
+// outer link (`.foo` not under `.grand`); `no_foo` breaks the inner link (`.a`
+// directly under `.grand`); `flat` puts the pair at the root. Only `full` is a
+// keep — the rest prune — and official and rsvelte must agree in each.
+const ARRANGE_C3 = {
+	full: (inner) => `<div class="grand"><div class="foo">${inner}</div></div>`,
+	full_each: (inner) => `<div class="grand"><div class="foo">{#each list as _}${inner}{/each}</div></div>`,
+	no_grand: (inner) => `<div class="grand"></div><div class="foo">${inner}</div>`,
+	no_foo: (inner) => `<div class="grand">${inner}</div>`,
+	flat: (inner) => inner,
+};
+
 const wrapNest = (roles) => {
 	// build <outer>…<inner></inner>…</outer>, keeping the class on the div.
 	let inner = '';
@@ -252,6 +283,20 @@ function* generate() {
 			for (const [corrName, corr] of Object.entries(CORRUPTORS_STRUCTURAL)) {
 				yield {
 					id: `C/${sel.id}/${arrName}/${corrName}`,
+					source: assemble({ prefix: corr, markup, sel }),
+				};
+			}
+		}
+	}
+	// Family C3: three-level nested sibling selector × ancestor arrangement ×
+	// structural corruptor.
+	for (const sel of SELECTORS_C3) {
+		const inner = sel.sibs.map((r) => ROLE[r]).join(sel.sep ?? '');
+		for (const [arrName, arrFn] of Object.entries(ARRANGE_C3)) {
+			const markup = arrFn(inner);
+			for (const [corrName, corr] of Object.entries(CORRUPTORS_STRUCTURAL)) {
+				yield {
+					id: `C3/${sel.id}/${arrName}/${corrName}`,
 					source: assemble({ prefix: corr, markup, sel }),
 				};
 			}

--- a/scripts/compat-corpus/css-prune-sweep.mjs
+++ b/scripts/compat-corpus/css-prune-sweep.mjs
@@ -69,6 +69,7 @@ const ROLE = {
 	p: '<p></p>',
 	span: '<span class="x"></span>', // stands in for `*`
 	section: '<section></section>',
+	z: '<div class="z"></div>',
 };
 
 // Family A — flat sibling lists. `sibs` is the ordered list of adjacent
@@ -96,6 +97,43 @@ const SELECTORS_B = [
 	{ id: '.a>.b', css: '.a > .b', nest: ['a', 'b'] },
 	{ id: 'section>.a', css: 'section > .a', nest: ['section', 'a'] },
 ];
+
+// Family C — multi-relative sibling selectors whose match hinges on an ancestor
+// constraint (issue #1719): a sibling combinator sits after a descendant/child
+// chain, reached either through `:global(...)`'s inner selector or through a
+// nested rule's `&` resolving to a multi-relative parent prelude. `ancestor` is
+// the class wrapping the `sibs`; `sep` (optional) separates the two siblings for
+// a `~` combinator.
+const SELECTORS_C = [
+	{ id: 'global(.a_.z)+.b', css: ':global(.a .z) + .b', ancestor: 'a', sibs: ['z', 'b'] },
+	{ id: 'global(.a>.z)+.b', css: ':global(.a > .z) + .b', ancestor: 'a', sibs: ['z', 'b'] },
+	{
+		id: '.foo>.a{&+&}',
+		css: '.foo > .a {\n\t\t& + & { color: red; }\n\t}',
+		rawCss: true,
+		ancestor: 'foo',
+		sibs: ['a', 'a'],
+	},
+	{
+		id: '.foo>.a{&~&}',
+		css: '.foo > .a {\n\t\t& ~ & { color: red; }\n\t}',
+		rawCss: true,
+		ancestor: 'foo',
+		sibs: ['a', 'a'],
+		sep: '<span></span>',
+	},
+];
+
+// Family C arrangements: whether the ancestor constraint is satisfiable.
+// `ancestor` wraps the sibling pair in the required ancestor (positive);
+// `root` puts them at the top level and `wrong` under a mismatching ancestor
+// (both negatives). Official and rsvelte must agree in every arrangement.
+const ARRANGE_C = {
+	ancestor: (sel, inner) => `<div class="${sel.ancestor}">${inner}</div>`,
+	ancestor_each: (sel, inner) => `<div class="${sel.ancestor}">{#each list as _}${inner}{/each}</div>`,
+	root: (_sel, inner) => inner,
+	wrong: (_sel, inner) => `<section>${inner}</section>`,
+};
 
 const wrapNest = (roles) => {
 	// build <outer>…<inner></inner>…</outer>, keeping the class on the div.
@@ -202,6 +240,20 @@ function* generate() {
 						source: assemble({ prefix: '', markup, sel }),
 					};
 				}
+			}
+		}
+	}
+	// Family C: multi-relative sibling selector × ancestor arrangement ×
+	// structural corruptor.
+	for (const sel of SELECTORS_C) {
+		const inner = sel.sibs.map((r) => ROLE[r]).join(sel.sep ?? '');
+		for (const [arrName, arrFn] of Object.entries(ARRANGE_C)) {
+			const markup = arrFn(sel, inner);
+			for (const [corrName, corr] of Object.entries(CORRUPTORS_STRUCTURAL)) {
+				yield {
+					id: `C/${sel.id}/${arrName}/${corrName}`,
+					source: assemble({ prefix: corr, markup, sel }),
+				};
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #1719

## Problem

The `+` / `~` sibling-combinator prune check resolved only **single-relative** selectors when expanding a leading `:global(X)`'s inner selector or a nested rule's `&` against its parent prelude. A descendant/child chain inside the compound was left unresolved, so the rule was pruned even when the ancestor constraint was actually satisfied:

- `:global(.a .z) + .b` where the `.z` sibling of `.b` really has an `.a` ancestor → official keeps `.a .z + .b.svelte-xxx`, rsvelte emitted `/* (unused) */`.
- `.foo > .a { & + & }` where `.a` really is a child of `.foo` with an adjacent pair → official keeps the scoped rule, rsvelte emitted `/* (empty) */`.

The negative counterparts (ancestor **not** satisfied) already byte-matched and stay pruned.

## Fix

Introduce a `SiblingMatcher` that carries either a compound (`Info`, the unchanged path) or a descendant/child ancestor-chain (`Chain`). The `Chain` variant is verified with the **same recursive ancestor matcher already used for `>` child checks** — `structural_element_matches_compound` + `structural_ancestors_satisfy_links` — mirroring upstream `css-prune.js` where `:global(X)` runs `apply_selector(X.children, …, BACKWARD)` and `&` runs `apply_selector(get_relative_selectors(parent), …)`.

A `Chain` is produced **only** for:
- a `:global(...)` inner that is a structurally-evaluable multi-relative descendant/child chain, or
- a bare `&` whose immediate parent prelude is a single structurally-evaluable multi-relative descendant/child chain.

Every other shape (single-relative, sibling combinators inside, functional pseudo, dynamic-unevaluable) falls back to the existing `Info` behaviour, so single-relative and all negative cases remain byte-identical.

## Verification

Output compared against `svelte/compiler` (5.56.4) — kept and pruned cases both match byte-for-byte:

| case | official | rsvelte (after) |
|---|---|---|
| `:global(.a .z) + .b` with `.a` ancestor | `.a .z + .b.svelte-x` | kept ✅ |
| `:global(.a .z) + .b` no `.a` ancestor | `/* (unused) */` | pruned ✅ |
| `.foo > .a { & + & }` `.a` child of `.foo` | scoped, kept | kept ✅ |
| `.foo > .a { & + & }` `.a` not child | `/* (empty) */` | pruned ✅ |

Tests (positive + negative, mirroring the existing #1702/#1703 pins):
- `css_global_sibling_1702.rs` — 9 passed (adds `global_descendant_inner_with_ancestor_kept`, `global_child_inner_with_ancestor_kept`)
- `css_nested_sibling_1703.rs` — 7 passed (adds `nested_amp_plus_amp_multi_relative_parent_child_kept`, `nested_amp_tilde_amp_multi_relative_parent_child_kept`)

Regression suites (all green): CSS scoping suite + all `css_*` pins, compiler snapshot (17), validator (16), SSR (16), runtime browser/hydration/runes/legacy.

## css-prune differential sweep

Added a multi-relative ancestor axis (Family C) plus a three-level nesting axis (Family C3, from the review follow-up) to `scripts/compat-corpus/css-prune-sweep.mjs`: the `:global(...)`-inner and nested-`&` shapes crossed with ancestor-present / root / wrong-ancestor / each-wrapped arrangements, and the 3-level `.grand { .foo > .a { & +/~ & } }` shapes crossed with full / full_each / no_grand / no_foo / flat arrangements, times the structural corruptors. Full sweep: **1430 components, 0 diverged** (`--check` passes; the shrink-only ratchet stays empty).

## Follow-up: review fix (multi-level ancestor resolution)

The review caught a regression at three-level nesting: the first pass resolved only the immediate parent prelude, so `.grand { .foo > .a { & + & } }` kept the rule even when `.foo` was not a descendant of `.grand`. Fixed by walking the full `parent_preludes` stack (`build_parent_chain`), linking each level with an implicit descendant combinator like upstream `get_relative_selectors` + `NestingSelector`. Verified against `svelte/compiler` for 2/3/4-level × ancestor present/absent × `+`/`~`; new pins added in `css_nested_sibling_1703.rs` (13 passed) and a 3-level sweep axis (Family C3).

## Known limitation (tracked in #1731)

The nested-`&` fix flattens the nesting stack into one descendant/child chain and bails all-or-nothing when an **intermediate** level is not a single evaluable compound. Three shapes therefore remain over-pruned — the official compiler keeps the inner rule, rsvelte drops the whole rule as `(empty)`:

- comma-separated intermediate level: `.grand, .other { .foo > .a { & + & {} } }`
- functional-pseudo intermediate level: `:is(.grand) { .foo > .a { & + & {} } }`
- sibling-combinator intermediate level: `.x + .grand { .foo > .a { & + & {} } }`

This is the **safe side** (over-prune, same direction as the pre-existing design — never over-keep) and matches main for these shapes; a proper per-branch resolution is a larger refactor deferred to #1731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
