### PR TITLE
fix(fmt): oracle-match a wrapping empty/whitespace block-display element (#1721)

### DIFF
--- a/.changeset/fix-fmt-block-display-whitespace-wrap.md
+++ b/.changeset/fix-fmt-block-display-whitespace-wrap.md
@@ -19,3 +19,9 @@ collapse pass keeps the resulting break instead of re-gluing it. Folding this in
 body's inserted newline, making the `true` case non-idempotent; `try_collapse` now
 preserves the break whenever the wrapped open tag glued its `>`, so output is
 byte-identical to the oracle and idempotent for both `bracketSameLine` values.
+
+The `try_collapse` change is not limited to block-display elements — it applies to
+every non-whitespace-sensitive empty body (Components, `<slot>`, `svelte:*`), so
+the same-shape divergence for a top-level Component or `<slot>` with a whitespace-
+only body and a wrapping open tag (where `main` failed to break the close tag onto
+its own line) is fixed too. This moves those cases toward the oracle, not away.

--- a/.changeset/fix-fmt-block-display-whitespace-wrap.md
+++ b/.changeset/fix-fmt-block-display-whitespace-wrap.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): oracle-match a wrapping empty/whitespace block-display element (#1721)
+
+A block-display element with a whitespace-only (or truly empty) body whose open
+tag wraps (`<div class="…long…"> </div>`) diverged from the
+prettier-plugin-svelte oracle under `bracketSameLine: true`: rsvelte dedented the
+`>` onto its own line and glued the close tag (`…"`\n`></div>`), whereas the
+oracle glues the `>` to the last attribute line and drops `</div>` to its own
+line (`…">`\n`</div>`). The default (`bracketSameLine: false`) already matched
+(`…"`\n`></div>`).
+
+Under `bracketSameLine`, a block-display element's wrapped open `>` now glues to
+the last attribute (like the inline whitespace-body case fixed in #1707), and the
+collapse pass keeps the resulting break instead of re-gluing it. Folding this into
+#1707 was previously deferred because the collapse pass stripped an empty block
+body's inserted newline, making the `true` case non-idempotent; `try_collapse` now
+preserves the break whenever the wrapped open tag glued its `>`, so output is
+byte-identical to the oracle and idempotent for both `bracketSameLine` values.

--- a/crates/rsvelte_formatter/src/collapse.rs
+++ b/crates/rsvelte_formatter/src/collapse.rs
@@ -2851,7 +2851,29 @@ fn try_collapse(
             let result = format!("{open} {close}");
             return (result != whole).then_some((start, end, result));
         }
-        // Case 1: block/component — collapse completely.
+        // Case 1: block/component/slot. When a wrapped open tag glued its `>` to
+        // the last attribute line (`bracketSameLine` on a block-display element,
+        // #1721), the close tag drops to its own line at the element indent
+        // (`<div`\n`  …">`\n`</div>`) — so the inserted break must be preserved,
+        // not collapsed away. The `>` is glued exactly when the open tag's last
+        // line is not the dedented lone `>` (`…"`\n`></div>`, the default
+        // `bracketSameLine: false` form) — in every other case (inline open tag,
+        // or a wrapped open tag whose `>` dedented) the body whitespace is
+        // dropped entirely.
+        let bracket_glued = open.contains('\n')
+            && open
+                .rsplit('\n')
+                .next()
+                .is_some_and(|last| last.trim() != ">");
+        if bracket_glued {
+            let line_start = out[..s].rfind('\n').map_or(0, |i| i + 1);
+            let indent: String = out[line_start..s]
+                .chars()
+                .take_while(|c| *c == ' ' || *c == '\t')
+                .collect();
+            let result = format!("{open}\n{indent}{close}");
+            return (result != whole).then_some((start, end, result));
+        }
         let result = format!("{open}{close}");
         return (result != whole).then_some((start, end, result));
     }

--- a/crates/rsvelte_formatter/src/markup.rs
+++ b/crates/rsvelte_formatter/src/markup.rs
@@ -536,6 +536,27 @@ fn push_close_tag(
     } else if hug_close {
         let indent = indent_str(depth, &options.js);
         edits.push((start, end, format!("</{tag_name}\n{indent}>")));
+    } else if open_wrapped
+        && is_empty
+        && options.bracket_same_line
+        && is_html_block_display_element(tag_name)
+    {
+        // A block-display element with a wrapping open tag whose body is empty (or
+        // whitespace-only, which the oracle treats as empty): under
+        // `bracketSameLine` the open `>` glues to the last attribute (see
+        // `push_open_tag`), so the close tag drops to its own line and any
+        // whitespace body is absorbed into that break — matching the oracle
+        // `<div`\n`  …">`\n`</div>`. The default (`bracketSameLine: false`) keeps
+        // the dedented `></div>` form of the branch below. See #1721.
+        let bytes = source.as_bytes();
+        let mut content_end = start as usize;
+        while content_end > 0
+            && matches!(bytes[content_end - 1], b' ' | b'\t' | b'\n' | b'\r' | 0x0c)
+        {
+            content_end -= 1;
+        }
+        let indent = indent_str(depth, &options.js);
+        edits.push((content_end as u32, end, format!("\n{indent}</{tag_name}>")));
     } else if open_wrapped && is_empty && options.bracket_same_line {
         // An empty element's wrapped open `>` dedents onto its own line (see the
         // `!empty_element` guard in `push_open_tag`), so `>` and `</tag` glue as
@@ -1036,7 +1057,14 @@ fn push_open_tag(
             // (`<span> </span>`, not a hug) instead glues `>` to the last attribute
             // line (`…">`), matching prettier's `group([...openingTag, '>', line, …])`.
             // A self-closing element (`<input … />`) always glues its ` />`.
-            options.bracket_same_line && (self_closing || !empty_element || empty_nonhug),
+            // A block-display element never hugs, so its `>` glues to the last
+            // attribute under `bracketSameLine` even when empty (`<div …">`\n`</div>`,
+            // vs the inline empty hug `></span>`). See #1721.
+            options.bracket_same_line
+                && (self_closing
+                    || !empty_element
+                    || empty_nonhug
+                    || is_html_block_display_element(tag_name)),
         )
     } else {
         one_liner

--- a/crates/rsvelte_formatter/tests/options.rs
+++ b/crates/rsvelte_formatter/tests/options.rs
@@ -456,3 +456,80 @@ fn sort_order_parse_rejects_invalid() {
     assert!(SortOrderSpec::parse("options-scripts-markup-styles").is_some());
     assert!(SortOrderSpec::parse("none").is_some());
 }
+
+// issue #1721: a BLOCK-display element (`<div>`) with a whitespace-only body whose
+// open tag wraps. The oracle treats the whitespace body as empty. Under
+// `bracketSameLine: true` the `>` glues to the last attribute and `</div>` drops to
+// its own line (`…">`\n`</div>`); under the default `false` the `>` dedents onto its
+// own line and glues the close tag (`…"`\n`></div>`). rsvelte previously emitted the
+// dedented `></div>` form at BOTH values (correct only for `false`) — the `true`
+// case diverged. Folding this into #1707's inline fix was deferred because the
+// collapse pass stripped the inserted break (re-gluing the close tag); the fix
+// teaches `try_collapse` to keep the break when the wrapped open tag glued its `>`.
+#[test]
+fn block_display_wrapping_whitespace_body_matches_oracle() {
+    let src = "<div class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\"> </div>";
+    // bracketSameLine: true — `>` glued to the last attribute, `</div>` on its own line.
+    assert_eq!(
+        fmt(src, &width_80(true)),
+        "<div\n  class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\">\n</div>\n"
+    );
+    // Default (false) — `>` dedents onto its own line, close tag glued.
+    assert_eq!(
+        fmt(src, &width_80(false)),
+        "<div\n  class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\"\n></div>\n"
+    );
+}
+
+// A source-EMPTY block element (`<div></div>`) with a wrapping open tag is
+// byte-identical to the whitespace-body case — the oracle drops the whitespace, so
+// the two shapes converge.
+#[test]
+fn block_display_wrapping_empty_matches_oracle() {
+    let src = "<div class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\"></div>";
+    assert_eq!(
+        fmt(src, &width_80(true)),
+        "<div\n  class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\">\n</div>\n"
+    );
+    assert_eq!(
+        fmt(src, &width_80(false)),
+        "<div\n  class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\"\n></div>\n"
+    );
+}
+
+// The same shape nested inside a block element (indented one level) matches the
+// oracle under both option values.
+#[test]
+fn block_display_nested_wrapping_whitespace_body_matches_oracle() {
+    let src = "<section>\n  <div class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\"> </div>\n</section>";
+    assert_eq!(
+        fmt(src, &width_80(true)),
+        "<section>\n  <div\n    class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\">\n  </div>\n</section>\n"
+    );
+    assert_eq!(
+        fmt(src, &width_80(false)),
+        "<section>\n  <div\n    class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\"\n  ></div>\n</section>\n"
+    );
+}
+
+// Idempotency (format(format(x)) == format(x)) at BOTH option values, including a
+// multi-space body — the interaction with the collapse pass that made #1718 defer
+// this. Without the `try_collapse` fix the `bracketSameLine: true` output was
+// non-idempotent (the second pass re-glued `></div>`).
+#[test]
+fn block_display_wrapping_whitespace_body_is_idempotent() {
+    for src in [
+        "<div class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\"> </div>",
+        "<div class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\">   </div>",
+        "<div class=\"very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines\"></div>",
+    ] {
+        for bsl in [true, false] {
+            let once = fmt(src, &width_80(bsl));
+            let twice = fmt(&once, &width_80(bsl));
+            assert_eq!(
+                once, twice,
+                "formatting must be idempotent (bsl={bsl}, src={src:?})"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1721

## Problem

A block-display element with a whitespace-only (or truly empty) body whose open tag wraps —

```svelte
<div class="very-long-class-that-forces-the-open-tag-to-wrap-across-multiple-lines"> </div>
```

— diverged from the oxfmt(`svelte: true`) oracle under **`bracketSameLine: true`**. rsvelte dedented the `>` onto its own line and glued the close tag (`…"`⏎`></div>`), whereas the oracle glues the `>` to the last attribute line and drops `</div>` onto its own line:

```
<div
  class="…">
</div>
```

The default (`bracketSameLine: false`) already matched the oracle (`…"`⏎`></div>` — the oracle drops the whitespace body). Confirmed byte-for-byte against `oxfmt` **0.59.0** (the pinned version) and **0.56.0**, which agree.

> Note: the issue text described the oracle as breaking the body at *both* values; the actual oxfmt oracle only diverges at `bracketSameLine: true` (the default already matched). Per the issue's own instruction, expected values were generated directly from `oxfmt(svelte: true)` and the tests are pinned to those.

## Why this was deferred from #1707/#1718

Folding block-display into #1707's inline whitespace-body fix made the `bracketSameLine: true` case **non-idempotent**: the collapse pass stripped the empty block body's inserted newline, so a second format re-glued `></div>` and re-dedented the `>`. Resolving that interaction is this issue's actual work item.

## Fix

- **`push_open_tag`** — a block-display element's wrapped open `>` now glues to the last attribute line under `bracketSameLine` (matching the inline whitespace-body case), instead of dedenting like the inline *empty* hug (`></span>`, which stays correct). Inline empty elements and components are unchanged.
- **`push_close_tag`** — for a wrapping empty/whitespace block-display element under `bracketSameLine`, the close tag drops to its own line (`\n{indent}</div>`), absorbing any whitespace body.
- **`collapse::try_collapse`** — the empty-body collapse (Case 1) used to glue `>` and `</tag>` unconditionally (`format!("{open}{close}")`), which **stripped the break** that `push_close_tag` inserted. It now preserves the break whenever the wrapped open tag glued its `>` to the last attribute (detected by the open tag's last line not being a dedented lone `>`). This is what makes the `true` case idempotent — the exact interaction #1718 deferred.

All three changes are gated so the default `bracketSameLine: false` path is **byte-identical to before**: the open-tag glue is inside `options.bracket_same_line`, and the collapse break only fires when the `>` is glued (which never happens for an empty block at `false`).

### Scope of the collapse change

The `try_collapse` (Case 1) change is **not** gated on `is_html_block_display_element` — it applies to every non-whitespace-sensitive empty body it already handled (`trims_edge`: block-display **plus** Components, `<slot>`, `svelte:*`). So beyond the `<div>` case, the same-shape divergence for a **top-level Component or `<slot>`** with a whitespace-only body and a wrapping open tag — where `main` failed to break the close tag onto its own line — is fixed as a side effect. Independently verified to move those cases **toward** the oracle (an improvement, not a regression).

## Verification

- New `crates/rsvelte_formatter/tests/options.rs` cases: parity at both option values (whitespace body, source-empty, nested), plus idempotency across single-space / multi-space / empty bodies at both values.
- Full `rsvelte_formatter` and `rsvelte_fmt` suites, `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` — all clean.
- **svelte.dev formatter-parity corpus**: `1102/1103` — identical to `main`. The sole failure is the pre-existing `SearchBox.svelte` oxfmt-version skew (`| HTMLElement` TS union), unrelated to this change (the issue notes 0 corpus hits for this construct).
- `fmt-known-failures.json` unchanged (no entry for this construct; the ratchet is not touched).
- `@rsvelte/fmt` changeset added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)