### PR TITLE
refactor(a11y): compress constants.rs from 5,594 to 821 lines

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/1_parse/utils/fuzzymatch.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/utils/fuzzymatch.rs
@@ -254,9 +254,15 @@ impl FuzzySet {
 
         let vector_normal = (sum_of_squares as f64).sqrt();
 
-        // Build results list
+        // Build results list. Upstream keys `matches` by integer index and walks it with
+        // `for...in`, which visits integer-like keys in ascending order; both sorts below are
+        // stable, so this order is what breaks score ties.
+        let mut matched_indices: Vec<usize> = matches.keys().copied().collect();
+        matched_indices.sort_unstable();
+
         let mut results: Vec<(f64, String)> = Vec::new();
-        for (&index, &match_score) in &matches {
+        for index in matched_indices {
+            let match_score = matches[&index];
             if let Some((item_normal, item_value)) = items.get(index)
                 && *item_normal > 0.0
                 && vector_normal > 0.0

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/constants.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/constants.rs
@@ -4,11 +4,17 @@
 //!
 //! Corresponds to Svelte's `2-analyze/visitors/shared/a11y/constants.js`.
 //!
-//! This file is auto-generated from the official Svelte compiler.
-//! Do not edit manually.
+//! The upstream file is 300-odd lines because it imports its tables from the
+//! `aria-query` / `axobject-query` npm packages; rsvelte inlines those tables here.
+//! The data is therefore verbatim upstream data — only its *encoding* is condensed
+//! (shared prop-sets factored out, one row per entry).
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::LazyLock;
+
+#[cfg(test)]
+#[path = "constants_test.rs"]
+mod tests;
 
 /// Type for semantic role element entries: (element_name, optional_attributes, roles).
 type SemanticRoleElement = (
@@ -18,75 +24,31 @@ type SemanticRoleElement = (
 );
 
 /// ARIA attributes list.
+#[rustfmt::skip]
 pub const ARIA_ATTRIBUTES: &[&str] = &[
-    "activedescendant",
-    "atomic",
-    "autocomplete",
-    "braillelabel",
-    "brailleroledescription",
-    "busy",
-    "checked",
-    "colcount",
-    "colindex",
-    "colspan",
-    "controls",
-    "current",
-    "describedby",
-    "description",
-    "details",
-    "disabled",
-    "dropeffect",
-    "errormessage",
-    "expanded",
-    "flowto",
-    "grabbed",
-    "haspopup",
-    "hidden",
-    "invalid",
-    "keyshortcuts",
-    "label",
-    "labelledby",
-    "level",
-    "live",
-    "modal",
-    "multiline",
-    "multiselectable",
-    "orientation",
-    "owns",
-    "placeholder",
-    "posinset",
-    "pressed",
-    "readonly",
-    "relevant",
-    "required",
-    "roledescription",
-    "rowcount",
-    "rowindex",
-    "rowspan",
-    "selected",
-    "setsize",
-    "sort",
-    "valuemax",
-    "valuemin",
-    "valuenow",
+    "activedescendant", "atomic", "autocomplete", "braillelabel", "brailleroledescription", "busy",
+    "checked", "colcount", "colindex", "colspan", "controls", "current", "describedby",
+    "description", "details", "disabled", "dropeffect", "errormessage", "expanded", "flowto",
+    "grabbed", "haspopup", "hidden", "invalid", "keyshortcuts", "label", "labelledby", "level",
+    "live", "modal", "multiline", "multiselectable", "orientation", "owns", "placeholder",
+    "posinset", "pressed", "readonly", "relevant", "required", "roledescription", "rowcount",
+    "rowindex", "rowspan", "selected", "setsize", "sort", "valuemax", "valuemin", "valuenow",
     "valuetext",
 ];
 
 /// Required attributes for specific elements.
+#[rustfmt::skip]
+const A11Y_REQUIRED_ATTRIBUTES_TABLE: &[(&str, &[&str])] = &[
+    ("a", &["href"]),
+    ("area", &["alt", "aria-label", "aria-labelledby"]),
+    ("html", &["lang"]),
+    ("iframe", &["title"]),
+    ("img", &["alt"]),
+    ("object", &["title", "aria-label", "aria-labelledby"]),
+];
+
 pub static A11Y_REQUIRED_ATTRIBUTES: LazyLock<FxHashMap<&'static str, &'static [&'static str]>> =
-    LazyLock::new(|| {
-        let mut m = FxHashMap::default();
-        m.insert("a", &["href"] as &[&str]);
-        m.insert("area", &["alt", "aria-label", "aria-labelledby"] as &[&str]);
-        m.insert("html", &["lang"] as &[&str]);
-        m.insert("iframe", &["title"] as &[&str]);
-        m.insert("img", &["alt"] as &[&str]);
-        m.insert(
-            "object",
-            &["title", "aria-label", "aria-labelledby"] as &[&str],
-        );
-        m
-    });
+    LazyLock::new(|| A11Y_REQUIRED_ATTRIBUTES_TABLE.iter().copied().collect());
 
 /// Distracting elements.
 pub const A11Y_DISTRACTING_ELEMENTS: &[&str] = &["blink", "marquee"];
@@ -95,199 +57,117 @@ pub const A11Y_DISTRACTING_ELEMENTS: &[&str] = &["blink", "marquee"];
 pub const A11Y_REQUIRED_CONTENT: &[&str] = &["h1", "h2", "h3", "h4", "h5", "h6"];
 
 /// Labelable elements.
+#[rustfmt::skip]
 pub const A11Y_LABELABLE: &[&str] = &[
     "button", "input", "keygen", "meter", "output", "progress", "select", "textarea",
 ];
 
 /// Interactive event handlers.
+#[rustfmt::skip]
 pub const A11Y_INTERACTIVE_HANDLERS: &[&str] = &[
     // Keyboard events
-    "keypress",
-    "keydown",
-    "keyup",
+    "keypress", "keydown", "keyup",
     // Click events
-    "click",
-    "contextmenu",
-    "dblclick",
-    "drag",
-    "dragend",
-    "dragenter",
-    "dragexit",
-    "dragleave",
-    "dragover",
-    "dragstart",
-    "drop",
-    "mousedown",
-    "mouseenter",
-    "mouseleave",
-    "mousemove",
-    "mouseout",
-    "mouseover",
-    "mouseup",
+    "click", "contextmenu", "dblclick", "drag", "dragend", "dragenter", "dragexit", "dragleave",
+    "dragover", "dragstart", "drop", "mousedown", "mouseenter", "mouseleave", "mousemove",
+    "mouseout", "mouseover", "mouseup",
     // Pointer events
-    "pointerdown",
-    "pointerup",
-    "pointermove",
-    "pointerenter",
-    "pointerleave",
-    "pointerover",
-    "pointerout",
-    "pointercancel",
+    "pointerdown", "pointerup", "pointermove", "pointerenter", "pointerleave", "pointerover",
+    "pointerout", "pointercancel",
     // Touch events
-    "touchstart",
-    "touchend",
-    "touchmove",
-    "touchcancel",
+    "touchstart", "touchend", "touchmove", "touchcancel",
 ];
 
 /// Recommended interactive event handlers.
+#[rustfmt::skip]
 pub const A11Y_RECOMMENDED_INTERACTIVE_HANDLERS: &[&str] = &[
-    "click",
-    "mousedown",
-    "mouseup",
-    "keypress",
-    "keydown",
-    "keyup",
+    "click", "mousedown", "mouseup", "keypress", "keydown", "keyup",
 ];
 
 /// Nested implicit semantics map.
+#[rustfmt::skip]
+const A11Y_NESTED_IMPLICIT_SEMANTICS_TABLE: &[(&str, &str)] = &[
+    ("footer", "contentinfo"), ("header", "banner"),
+];
+
 pub static A11Y_NESTED_IMPLICIT_SEMANTICS: LazyLock<FxHashMap<&'static str, &'static str>> =
     LazyLock::new(|| {
-        let mut m = FxHashMap::default();
-        m.insert("header", "banner");
-        m.insert("footer", "contentinfo");
-        m
+        A11Y_NESTED_IMPLICIT_SEMANTICS_TABLE
+            .iter()
+            .copied()
+            .collect()
     });
 
 /// Implicit semantics map.
+#[rustfmt::skip]
+const A11Y_IMPLICIT_SEMANTICS_TABLE: &[(&str, &str)] = &[
+    ("a", "link"), ("area", "link"), ("article", "article"), ("aside", "complementary"),
+    ("body", "document"), ("button", "button"), ("datalist", "listbox"), ("dd", "definition"),
+    ("details", "group"), ("dfn", "term"), ("dialog", "dialog"), ("dt", "term"),
+    ("fieldset", "group"), ("figure", "figure"), ("form", "form"), ("h1", "heading"),
+    ("h2", "heading"), ("h3", "heading"), ("h4", "heading"), ("h5", "heading"), ("h6", "heading"),
+    ("hr", "separator"), ("img", "img"), ("li", "listitem"), ("link", "link"), ("main", "main"),
+    ("menu", "list"), ("meter", "progressbar"), ("nav", "navigation"), ("ol", "list"),
+    ("optgroup", "group"), ("option", "option"), ("output", "status"), ("progress", "progressbar"),
+    ("section", "region"), ("summary", "button"), ("table", "table"), ("tbody", "rowgroup"),
+    ("textarea", "textbox"), ("tfoot", "rowgroup"), ("thead", "rowgroup"), ("tr", "row"),
+    ("ul", "list"),
+];
+
 pub static A11Y_IMPLICIT_SEMANTICS: LazyLock<FxHashMap<&'static str, &'static str>> =
-    LazyLock::new(|| {
-        let mut m = FxHashMap::default();
-        m.insert("a", "link");
-        m.insert("area", "link");
-        m.insert("article", "article");
-        m.insert("aside", "complementary");
-        m.insert("body", "document");
-        m.insert("button", "button");
-        m.insert("datalist", "listbox");
-        m.insert("dd", "definition");
-        m.insert("dfn", "term");
-        m.insert("dialog", "dialog");
-        m.insert("details", "group");
-        m.insert("dt", "term");
-        m.insert("fieldset", "group");
-        m.insert("figure", "figure");
-        m.insert("form", "form");
-        m.insert("h1", "heading");
-        m.insert("h2", "heading");
-        m.insert("h3", "heading");
-        m.insert("h4", "heading");
-        m.insert("h5", "heading");
-        m.insert("h6", "heading");
-        m.insert("hr", "separator");
-        m.insert("img", "img");
-        m.insert("li", "listitem");
-        m.insert("link", "link");
-        m.insert("main", "main");
-        m.insert("menu", "list");
-        m.insert("meter", "progressbar");
-        m.insert("nav", "navigation");
-        m.insert("ol", "list");
-        m.insert("option", "option");
-        m.insert("optgroup", "group");
-        m.insert("output", "status");
-        m.insert("progress", "progressbar");
-        m.insert("section", "region");
-        m.insert("summary", "button");
-        m.insert("table", "table");
-        m.insert("tbody", "rowgroup");
-        m.insert("textarea", "textbox");
-        m.insert("tfoot", "rowgroup");
-        m.insert("thead", "rowgroup");
-        m.insert("tr", "row");
-        m.insert("ul", "list");
-        m
-    });
+    LazyLock::new(|| A11Y_IMPLICIT_SEMANTICS_TABLE.iter().copied().collect());
 
 /// Menuitem type to implicit role map.
+#[rustfmt::skip]
+const MENUITEM_TYPE_TO_IMPLICIT_ROLE_TABLE: &[(&str, &str)] = &[
+    ("checkbox", "menuitemcheckbox"), ("command", "menuitem"), ("radio", "menuitemradio"),
+];
+
 pub static MENUITEM_TYPE_TO_IMPLICIT_ROLE: LazyLock<FxHashMap<&'static str, &'static str>> =
     LazyLock::new(|| {
-        let mut m = FxHashMap::default();
-        m.insert("command", "menuitem");
-        m.insert("checkbox", "menuitemcheckbox");
-        m.insert("radio", "menuitemradio");
-        m
+        MENUITEM_TYPE_TO_IMPLICIT_ROLE_TABLE
+            .iter()
+            .copied()
+            .collect()
     });
 
 /// Input type to implicit role map.
+#[rustfmt::skip]
+const INPUT_TYPE_TO_IMPLICIT_ROLE_TABLE: &[(&str, &str)] = &[
+    ("button", "button"), ("checkbox", "checkbox"), ("email", "textbox"), ("image", "button"),
+    ("number", "spinbutton"), ("radio", "radio"), ("range", "slider"), ("reset", "button"),
+    ("search", "searchbox"), ("submit", "button"), ("tel", "textbox"), ("text", "textbox"),
+    ("url", "textbox"),
+];
+
 pub static INPUT_TYPE_TO_IMPLICIT_ROLE: LazyLock<FxHashMap<&'static str, &'static str>> =
-    LazyLock::new(|| {
-        let mut m = FxHashMap::default();
-        m.insert("button", "button");
-        m.insert("image", "button");
-        m.insert("reset", "button");
-        m.insert("submit", "button");
-        m.insert("checkbox", "checkbox");
-        m.insert("radio", "radio");
-        m.insert("range", "slider");
-        m.insert("number", "spinbutton");
-        m.insert("email", "textbox");
-        m.insert("search", "searchbox");
-        m.insert("tel", "textbox");
-        m.insert("text", "textbox");
-        m.insert("url", "textbox");
-        m
-    });
+    LazyLock::new(|| INPUT_TYPE_TO_IMPLICIT_ROLE_TABLE.iter().copied().collect());
+
+/// Interactive roles allowed on `ul` / `ol` / `menu`.
+#[rustfmt::skip]
+const LIST_CONTAINER_ROLES: &[&str] = &[
+    "listbox", "menu", "menubar", "radiogroup", "tablist", "tree", "treegrid",
+];
 
 /// Non-interactive element to interactive role exceptions.
+#[rustfmt::skip]
+const A11Y_NON_INTERACTIVE_ELEMENT_TO_INTERACTIVE_ROLE_EXCEPTIONS_TABLE: &[(&str, &[&str])] = &[
+    ("fieldset", &["radiogroup", "presentation"]),
+    ("li", &["menuitem", "option", "row", "tab", "treeitem"]),
+    ("menu", LIST_CONTAINER_ROLES),
+    ("ol", LIST_CONTAINER_ROLES),
+    ("table", &["grid"]),
+    ("td", &["gridcell"]),
+    ("ul", LIST_CONTAINER_ROLES),
+];
+
 pub static A11Y_NON_INTERACTIVE_ELEMENT_TO_INTERACTIVE_ROLE_EXCEPTIONS: LazyLock<
     FxHashMap<&'static str, &'static [&'static str]>,
 > = LazyLock::new(|| {
-    let mut m = FxHashMap::default();
-    m.insert(
-        "ul",
-        &[
-            "listbox",
-            "menu",
-            "menubar",
-            "radiogroup",
-            "tablist",
-            "tree",
-            "treegrid",
-        ] as &[&str],
-    );
-    m.insert(
-        "ol",
-        &[
-            "listbox",
-            "menu",
-            "menubar",
-            "radiogroup",
-            "tablist",
-            "tree",
-            "treegrid",
-        ] as &[&str],
-    );
-    m.insert(
-        "menu",
-        &[
-            "listbox",
-            "menu",
-            "menubar",
-            "radiogroup",
-            "tablist",
-            "tree",
-            "treegrid",
-        ] as &[&str],
-    );
-    m.insert(
-        "li",
-        &["menuitem", "option", "row", "tab", "treeitem"] as &[&str],
-    );
-    m.insert("table", &["grid"] as &[&str]);
-    m.insert("td", &["gridcell"] as &[&str]);
-    m.insert("fieldset", &["radiogroup", "presentation"] as &[&str]);
-    m
+    A11Y_NON_INTERACTIVE_ELEMENT_TO_INTERACTIVE_ROLE_EXCEPTIONS_TABLE
+        .iter()
+        .copied()
+        .collect()
 });
 
 /// Combobox if list.
@@ -297,71 +177,26 @@ pub const COMBOBOX_IF_LIST: &[&str] = &["email", "search", "tel", "text", "url"]
 pub const ADDRESS_TYPE_TOKENS: &[&str] = &["shipping", "billing"];
 
 /// Autofill field name tokens.
+#[rustfmt::skip]
 pub const AUTOFILL_FIELD_NAME_TOKENS: &[&str] = &[
-    "",
-    "on",
-    "off",
-    "name",
-    "honorific-prefix",
-    "given-name",
-    "additional-name",
-    "family-name",
-    "honorific-suffix",
-    "nickname",
-    "username",
-    "new-password",
-    "current-password",
-    "one-time-code",
-    "organization-title",
-    "organization",
-    "street-address",
-    "address-line1",
-    "address-line2",
-    "address-line3",
-    "address-level4",
-    "address-level3",
-    "address-level2",
-    "address-level1",
-    "country",
-    "country-name",
-    "postal-code",
-    "cc-name",
-    "cc-given-name",
-    "cc-additional-name",
-    "cc-family-name",
-    "cc-number",
-    "cc-exp",
-    "cc-exp-month",
-    "cc-exp-year",
-    "cc-csc",
-    "cc-type",
-    "transaction-currency",
-    "transaction-amount",
-    "language",
-    "bday",
-    "bday-day",
-    "bday-month",
-    "bday-year",
-    "sex",
-    "url",
-    "photo",
+    "", "on", "off", "name", "honorific-prefix", "given-name", "additional-name", "family-name",
+    "honorific-suffix", "nickname", "username", "new-password", "current-password", "one-time-code",
+    "organization-title", "organization", "street-address", "address-line1", "address-line2",
+    "address-line3", "address-level4", "address-level3", "address-level2", "address-level1",
+    "country", "country-name", "postal-code", "cc-name", "cc-given-name", "cc-additional-name",
+    "cc-family-name", "cc-number", "cc-exp", "cc-exp-month", "cc-exp-year", "cc-csc", "cc-type",
+    "transaction-currency", "transaction-amount", "language", "bday", "bday-day", "bday-month",
+    "bday-year", "sex", "url", "photo",
 ];
 
 /// Contact type tokens.
 pub const CONTACT_TYPE_TOKENS: &[&str] = &["home", "work", "mobile", "fax", "pager"];
 
 /// Autofill contact field name tokens.
+#[rustfmt::skip]
 pub const AUTOFILL_CONTACT_FIELD_NAME_TOKENS: &[&str] = &[
-    "tel",
-    "tel-country-code",
-    "tel-national",
-    "tel-area-code",
-    "tel-local",
-    "tel-local-prefix",
-    "tel-local-suffix",
-    "tel-extension",
-    "email",
-    "impp",
+    "tel", "tel-country-code", "tel-national", "tel-area-code", "tel-local", "tel-local-prefix",
+    "tel-local-suffix", "tel-extension", "email", "impp",
 ];
 
 /// Element interactivity enum values.
@@ -374,301 +209,75 @@ pub mod element_interactivity {
 /// Invisible elements.
 pub const INVISIBLE_ELEMENTS: &[&str] = &["meta", "html", "script", "style"];
 
+/// Abstract ARIA roles. Also part of `ARIA_ROLES`.
+#[rustfmt::skip]
+const ABSTRACT_ROLE_NAMES: &[&str] = &[
+    "command", "composite", "input", "landmark", "range", "roletype", "section", "sectionhead",
+    "select", "structure", "widget", "window",
+];
+
+/// Every ARIA role that is not abstract.
+#[rustfmt::skip]
+const CONCRETE_ROLE_NAMES: &[&str] = &[
+    "alert", "alertdialog", "application", "article", "banner", "blockquote", "button", "caption",
+    "cell", "checkbox", "code", "columnheader", "combobox", "complementary", "contentinfo",
+    "definition", "deletion", "dialog", "directory", "doc-abstract", "doc-acknowledgments",
+    "doc-afterword", "doc-appendix", "doc-backlink", "doc-biblioentry", "doc-bibliography",
+    "doc-biblioref", "doc-chapter", "doc-colophon", "doc-conclusion", "doc-cover", "doc-credit",
+    "doc-credits", "doc-dedication", "doc-endnote", "doc-endnotes", "doc-epigraph", "doc-epilogue",
+    "doc-errata", "doc-example", "doc-footnote", "doc-foreword", "doc-glossary", "doc-glossref",
+    "doc-index", "doc-introduction", "doc-noteref", "doc-notice", "doc-pagebreak", "doc-pagefooter",
+    "doc-pageheader", "doc-pagelist", "doc-part", "doc-preface", "doc-prologue", "doc-pullquote",
+    "doc-qna", "doc-subtitle", "doc-tip", "doc-toc", "document", "emphasis", "feed", "figure",
+    "form", "generic", "graphics-document", "graphics-object", "graphics-symbol", "grid",
+    "gridcell", "group", "heading", "img", "insertion", "link", "list", "listbox", "listitem",
+    "log", "main", "mark", "marquee", "math", "menu", "menubar", "menuitem", "menuitemcheckbox",
+    "menuitemradio", "meter", "navigation", "none", "note", "option", "paragraph", "presentation",
+    "progressbar", "radio", "radiogroup", "region", "row", "rowgroup", "rowheader", "scrollbar",
+    "search", "searchbox", "separator", "slider", "spinbutton", "status", "strong", "subscript",
+    "superscript", "switch", "tab", "table", "tablist", "tabpanel", "term", "textbox", "time",
+    "timer", "toolbar", "tooltip", "tree", "treegrid", "treeitem",
+];
+
 /// All ARIA roles.
 pub static ARIA_ROLES: LazyLock<FxHashSet<&'static str>> = LazyLock::new(|| {
-    let mut s = FxHashSet::default();
-    s.insert("command");
-    s.insert("composite");
-    s.insert("input");
-    s.insert("landmark");
-    s.insert("range");
-    s.insert("roletype");
-    s.insert("section");
-    s.insert("sectionhead");
-    s.insert("select");
-    s.insert("structure");
-    s.insert("widget");
-    s.insert("window");
-    s.insert("alert");
-    s.insert("alertdialog");
-    s.insert("application");
-    s.insert("article");
-    s.insert("banner");
-    s.insert("blockquote");
-    s.insert("button");
-    s.insert("caption");
-    s.insert("cell");
-    s.insert("checkbox");
-    s.insert("code");
-    s.insert("columnheader");
-    s.insert("combobox");
-    s.insert("complementary");
-    s.insert("contentinfo");
-    s.insert("definition");
-    s.insert("deletion");
-    s.insert("dialog");
-    s.insert("directory");
-    s.insert("document");
-    s.insert("emphasis");
-    s.insert("feed");
-    s.insert("figure");
-    s.insert("form");
-    s.insert("generic");
-    s.insert("grid");
-    s.insert("gridcell");
-    s.insert("group");
-    s.insert("heading");
-    s.insert("img");
-    s.insert("insertion");
-    s.insert("link");
-    s.insert("list");
-    s.insert("listbox");
-    s.insert("listitem");
-    s.insert("log");
-    s.insert("main");
-    s.insert("mark");
-    s.insert("marquee");
-    s.insert("math");
-    s.insert("menu");
-    s.insert("menubar");
-    s.insert("menuitem");
-    s.insert("menuitemcheckbox");
-    s.insert("menuitemradio");
-    s.insert("meter");
-    s.insert("navigation");
-    s.insert("none");
-    s.insert("note");
-    s.insert("option");
-    s.insert("paragraph");
-    s.insert("presentation");
-    s.insert("progressbar");
-    s.insert("radio");
-    s.insert("radiogroup");
-    s.insert("region");
-    s.insert("row");
-    s.insert("rowgroup");
-    s.insert("rowheader");
-    s.insert("scrollbar");
-    s.insert("search");
-    s.insert("searchbox");
-    s.insert("separator");
-    s.insert("slider");
-    s.insert("spinbutton");
-    s.insert("status");
-    s.insert("strong");
-    s.insert("subscript");
-    s.insert("superscript");
-    s.insert("switch");
-    s.insert("tab");
-    s.insert("table");
-    s.insert("tablist");
-    s.insert("tabpanel");
-    s.insert("term");
-    s.insert("textbox");
-    s.insert("time");
-    s.insert("timer");
-    s.insert("toolbar");
-    s.insert("tooltip");
-    s.insert("tree");
-    s.insert("treegrid");
-    s.insert("treeitem");
-    s.insert("doc-abstract");
-    s.insert("doc-acknowledgments");
-    s.insert("doc-afterword");
-    s.insert("doc-appendix");
-    s.insert("doc-backlink");
-    s.insert("doc-biblioentry");
-    s.insert("doc-bibliography");
-    s.insert("doc-biblioref");
-    s.insert("doc-chapter");
-    s.insert("doc-colophon");
-    s.insert("doc-conclusion");
-    s.insert("doc-cover");
-    s.insert("doc-credit");
-    s.insert("doc-credits");
-    s.insert("doc-dedication");
-    s.insert("doc-endnote");
-    s.insert("doc-endnotes");
-    s.insert("doc-epigraph");
-    s.insert("doc-epilogue");
-    s.insert("doc-errata");
-    s.insert("doc-example");
-    s.insert("doc-footnote");
-    s.insert("doc-foreword");
-    s.insert("doc-glossary");
-    s.insert("doc-glossref");
-    s.insert("doc-index");
-    s.insert("doc-introduction");
-    s.insert("doc-noteref");
-    s.insert("doc-notice");
-    s.insert("doc-pagebreak");
-    s.insert("doc-pagefooter");
-    s.insert("doc-pageheader");
-    s.insert("doc-pagelist");
-    s.insert("doc-part");
-    s.insert("doc-preface");
-    s.insert("doc-prologue");
-    s.insert("doc-pullquote");
-    s.insert("doc-qna");
-    s.insert("doc-subtitle");
-    s.insert("doc-tip");
-    s.insert("doc-toc");
-    s.insert("graphics-document");
-    s.insert("graphics-object");
-    s.insert("graphics-symbol");
-    s
+    ABSTRACT_ROLE_NAMES
+        .iter()
+        .chain(CONCRETE_ROLE_NAMES)
+        .copied()
+        .collect()
 });
 
 /// Abstract ARIA roles.
-pub static ABSTRACT_ROLES: LazyLock<FxHashSet<&'static str>> = LazyLock::new(|| {
-    let mut s = FxHashSet::default();
-    s.insert("command");
-    s.insert("composite");
-    s.insert("input");
-    s.insert("landmark");
-    s.insert("range");
-    s.insert("roletype");
-    s.insert("section");
-    s.insert("sectionhead");
-    s.insert("select");
-    s.insert("structure");
-    s.insert("widget");
-    s.insert("window");
-    s
-});
+pub static ABSTRACT_ROLES: LazyLock<FxHashSet<&'static str>> =
+    LazyLock::new(|| ABSTRACT_ROLE_NAMES.iter().copied().collect());
 
 /// Non-interactive roles.
+#[rustfmt::skip]
 pub const NON_INTERACTIVE_ROLES: &[&str] = &[
-    "alert",
-    "application",
-    "article",
-    "banner",
-    "blockquote",
-    "caption",
-    "code",
-    "complementary",
-    "contentinfo",
-    "definition",
-    "deletion",
-    "directory",
-    "document",
-    "emphasis",
-    "feed",
-    "figure",
-    "form",
-    "group",
-    "heading",
-    "img",
-    "insertion",
-    "list",
-    "listitem",
-    "log",
-    "main",
-    "mark",
-    "marquee",
-    "math",
-    "meter",
-    "navigation",
-    "none",
-    "note",
-    "paragraph",
-    "presentation",
-    "region",
-    "rowgroup",
-    "search",
-    "separator",
-    "status",
-    "strong",
-    "subscript",
-    "superscript",
-    "table",
-    "term",
-    "time",
-    "timer",
-    "tooltip",
-    "doc-abstract",
-    "doc-acknowledgments",
-    "doc-afterword",
-    "doc-appendix",
-    "doc-biblioentry",
-    "doc-bibliography",
-    "doc-chapter",
-    "doc-colophon",
-    "doc-conclusion",
-    "doc-cover",
-    "doc-credit",
-    "doc-credits",
-    "doc-dedication",
-    "doc-endnote",
-    "doc-endnotes",
-    "doc-epigraph",
-    "doc-epilogue",
-    "doc-errata",
-    "doc-example",
-    "doc-footnote",
-    "doc-foreword",
-    "doc-glossary",
-    "doc-index",
-    "doc-introduction",
-    "doc-notice",
-    "doc-pagebreak",
-    "doc-pagefooter",
-    "doc-pageheader",
-    "doc-pagelist",
-    "doc-part",
-    "doc-preface",
-    "doc-prologue",
-    "doc-pullquote",
-    "doc-qna",
-    "doc-subtitle",
-    "doc-tip",
-    "doc-toc",
-    "graphics-document",
-    "graphics-object",
-    "graphics-symbol",
-    "progressbar",
+    "alert", "application", "article", "banner", "blockquote", "caption", "code", "complementary",
+    "contentinfo", "definition", "deletion", "directory", "document", "emphasis", "feed", "figure",
+    "form", "group", "heading", "img", "insertion", "list", "listitem", "log", "main", "mark",
+    "marquee", "math", "meter", "navigation", "none", "note", "paragraph", "presentation", "region",
+    "rowgroup", "search", "separator", "status", "strong", "subscript", "superscript", "table",
+    "term", "time", "timer", "tooltip", "doc-abstract", "doc-acknowledgments", "doc-afterword",
+    "doc-appendix", "doc-biblioentry", "doc-bibliography", "doc-chapter", "doc-colophon",
+    "doc-conclusion", "doc-cover", "doc-credit", "doc-credits", "doc-dedication", "doc-endnote",
+    "doc-endnotes", "doc-epigraph", "doc-epilogue", "doc-errata", "doc-example", "doc-footnote",
+    "doc-foreword", "doc-glossary", "doc-index", "doc-introduction", "doc-notice", "doc-pagebreak",
+    "doc-pagefooter", "doc-pageheader", "doc-pagelist", "doc-part", "doc-preface", "doc-prologue",
+    "doc-pullquote", "doc-qna", "doc-subtitle", "doc-tip", "doc-toc", "graphics-document",
+    "graphics-object", "graphics-symbol", "progressbar",
 ];
 
 /// Interactive roles.
+#[rustfmt::skip]
 pub const INTERACTIVE_ROLES: &[&str] = &[
-    "alertdialog",
-    "button",
-    "cell",
-    "checkbox",
-    "columnheader",
-    "combobox",
-    "dialog",
-    "grid",
-    "gridcell",
-    "link",
-    "listbox",
-    "menu",
-    "menubar",
-    "menuitem",
-    "menuitemcheckbox",
-    "menuitemradio",
-    "option",
-    "radio",
-    "radiogroup",
-    "row",
-    "rowheader",
-    "scrollbar",
-    "searchbox",
-    "slider",
-    "spinbutton",
-    "switch",
-    "tab",
-    "tablist",
-    "tabpanel",
-    "textbox",
-    "toolbar",
-    "tree",
-    "treegrid",
-    "treeitem",
-    "doc-backlink",
-    "doc-biblioref",
-    "doc-glossref",
-    "doc-noteref",
+    "alertdialog", "button", "cell", "checkbox", "columnheader", "combobox", "dialog", "grid",
+    "gridcell", "link", "listbox", "menu", "menubar", "menuitem", "menuitemcheckbox",
+    "menuitemradio", "option", "radio", "radiogroup", "row", "rowheader", "scrollbar", "searchbox",
+    "slider", "spinbutton", "switch", "tab", "tablist", "tabpanel", "textbox", "toolbar", "tree",
+    "treegrid", "treeitem", "doc-backlink", "doc-biblioref", "doc-glossref", "doc-noteref",
 ];
 
 /// Presentation roles.
@@ -677,277 +286,138 @@ pub const PRESENTATION_ROLES: &[&str] = &["presentation", "none"];
 /// Schema for role relation concept.
 #[derive(Debug, Clone)]
 pub struct RoleRelationConcept {
-    pub name: String,
-    pub attributes: Option<Vec<RoleRelationConceptAttribute>>,
+    pub name: &'static str,
+    pub attributes: Option<&'static [RoleRelationConceptAttribute]>,
 }
 
 /// Schema attribute for role relation concept.
 #[derive(Debug, Clone)]
 pub struct RoleRelationConceptAttribute {
-    pub name: String,
-    pub value: Option<String>,
+    pub name: &'static str,
+    pub value: Option<&'static str>,
+}
+
+/// A schema matching `<name>` with no attribute constraints.
+const fn tag(name: &'static str) -> RoleRelationConcept {
+    RoleRelationConcept {
+        name,
+        attributes: None,
+    }
+}
+
+/// A schema matching `<name>` only when every listed attribute constraint holds.
+const fn tag_with(
+    name: &'static str,
+    attributes: &'static [RoleRelationConceptAttribute],
+) -> RoleRelationConcept {
+    RoleRelationConcept {
+        name,
+        attributes: Some(attributes),
+    }
+}
+
+/// An attribute constraint satisfied by the attribute's mere presence.
+const fn has(name: &'static str) -> RoleRelationConceptAttribute {
+    RoleRelationConceptAttribute { name, value: None }
+}
+
+/// An attribute constraint satisfied only by an exact static value.
+const fn eq(name: &'static str, value: &'static str) -> RoleRelationConceptAttribute {
+    RoleRelationConceptAttribute {
+        name,
+        value: Some(value),
+    }
 }
 
 /// Non-interactive element role schemas.
-pub static NON_INTERACTIVE_ELEMENT_ROLE_SCHEMAS: LazyLock<Vec<RoleRelationConcept>> =
-    LazyLock::new(|| {
-        vec![
-            RoleRelationConcept {
-                name: "article".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "header".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "blockquote".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "caption".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "code".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "aside".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "aside".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "aria-label".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "aside".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "aria-labelledby".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "footer".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "dd".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "del".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "html".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "em".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "figure".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "form".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "aria-label".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "form".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "aria-labelledby".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "form".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "name".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "details".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "fieldset".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "optgroup".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "address".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h1".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h2".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h3".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h4".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h5".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h6".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "img".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "alt".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "img".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "alt".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "ins".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "menu".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "ol".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "ul".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "li".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "main".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "mark".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "math".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "meter".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "nav".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "p".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "img".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "alt".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "progress".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "section".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "aria-label".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "section".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "aria-labelledby".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "tbody".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "tfoot".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "thead".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "hr".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "output".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "strong".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "sub".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "sup".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "table".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "dfn".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "dt".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "time".to_string(),
-                attributes: None,
-            },
-        ]
-    });
+#[rustfmt::skip]
+pub static NON_INTERACTIVE_ELEMENT_ROLE_SCHEMAS: &[RoleRelationConcept] = &[
+    tag("article"), tag("header"), tag("blockquote"), tag("caption"), tag("code"), tag("aside"),
+    tag_with("aside", &[has("aria-label")]), tag_with("aside", &[has("aria-labelledby")]),
+    tag("footer"), tag("dd"), tag("del"), tag("html"), tag("em"), tag("figure"),
+    tag_with("form", &[has("aria-label")]), tag_with("form", &[has("aria-labelledby")]),
+    tag_with("form", &[has("name")]), tag("details"), tag("fieldset"), tag("optgroup"),
+    tag("address"), tag("h1"), tag("h2"), tag("h3"), tag("h4"), tag("h5"), tag("h6"),
+    tag_with("img", &[has("alt")]), tag_with("img", &[has("alt")]), tag("ins"), tag("menu"),
+    tag("ol"), tag("ul"), tag("li"), tag("main"), tag("mark"), tag("math"), tag("meter"),
+    tag("nav"), tag("p"), tag_with("img", &[has("alt")]), tag("progress"),
+    tag_with("section", &[has("aria-label")]), tag_with("section", &[has("aria-labelledby")]),
+    tag("tbody"), tag("tfoot"), tag("thead"), tag("hr"), tag("output"), tag("strong"), tag("sub"),
+    tag("sup"), tag("table"), tag("dfn"), tag("dt"), tag("time"),
+];
+
+/// Interactive element role schemas.
+#[rustfmt::skip]
+pub static INTERACTIVE_ELEMENT_ROLE_SCHEMAS: &[RoleRelationConcept] = &[
+    tag_with("input", &[eq("type", "button")]), tag_with("input", &[eq("type", "image")]),
+    tag_with("input", &[eq("type", "reset")]), tag_with("input", &[eq("type", "submit")]),
+    tag("button"), tag("td"), tag_with("input", &[eq("type", "checkbox")]), tag("th"),
+    tag_with("th", &[eq("scope", "col")]), tag_with("th", &[eq("scope", "colgroup")]),
+    tag_with("input", &[has("list"), eq("type", "email")]),
+    tag_with("input", &[has("list"), eq("type", "search")]),
+    tag_with("input", &[has("list"), eq("type", "tel")]),
+    tag_with("input", &[has("list"), eq("type", "text")]),
+    tag_with("input", &[has("list"), eq("type", "url")]),
+    tag_with("select", &[has("multiple"), has("size")]), tag("dialog"), tag("td"),
+    tag_with("a", &[has("href")]), tag_with("area", &[has("href")]),
+    tag_with("select", &[has("size")]), tag_with("select", &[has("multiple")]), tag("datalist"),
+    tag("option"), tag_with("input", &[eq("type", "radio")]), tag("tr"),
+    tag_with("th", &[eq("scope", "row")]), tag_with("th", &[eq("scope", "rowgroup")]),
+    tag_with("input", &[has("list"), eq("type", "search")]),
+    tag_with("input", &[eq("type", "range")]), tag_with("input", &[eq("type", "number")]),
+    tag_with("input", &[has("type"), has("list")]),
+    tag_with("input", &[has("list"), eq("type", "email")]),
+    tag_with("input", &[has("list"), eq("type", "tel")]),
+    tag_with("input", &[has("list"), eq("type", "text")]),
+    tag_with("input", &[has("list"), eq("type", "url")]), tag("textarea"),
+];
+
+/// Interactive element AX object schemas.
+#[rustfmt::skip]
+pub static INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS: &[RoleRelationConcept] = &[
+    tag("audio"), tag("button"), tag("canvas"), tag("td"),
+    tag_with("input", &[eq("type", "checkbox")]), tag_with("input", &[eq("type", "color")]),
+    tag("th"), tag("select"), tag_with("input", &[eq("type", "date")]),
+    tag_with("input", &[eq("type", "datetime")]), tag("summary"), tag("embed"), tag("input"),
+    tag_with("input", &[eq("type", "time")]), tag_with("a", &[has("href")]), tag("option"),
+    tag("datalist"), tag("menuitem"), tag_with("input", &[eq("type", "radio")]),
+    tag_with("th", &[eq("scope", "row")]), tag_with("input", &[eq("type", "search")]),
+    tag_with("input", &[eq("type", "range")]), tag_with("input", &[eq("type", "number")]),
+    tag("textarea"), tag_with("input", &[eq("type", "text")]), tag("video"),
+];
+
+/// Non-interactive element AX object schemas.
+#[rustfmt::skip]
+pub static NON_INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS: &[RoleRelationConcept] = &[
+    tag("abbr"), tag("article"), tag("blockquote"), tag("caption"), tag("dfn"), tag("dd"),
+    tag("dl"), tag("dt"), tag("details"), tag("dir"), tag("figcaption"), tag("figure"),
+    tag("footer"), tag("form"), tag("h1"), tag("h2"), tag("h3"), tag("h4"), tag("h5"), tag("h6"),
+    tag_with("img", &[has("usemap")]), tag("img"), tag("label"), tag("legend"), tag("br"),
+    tag("li"), tag("ul"), tag("ol"), tag("main"), tag("mark"), tag("marquee"), tag("menu"),
+    tag("meter"), tag("nav"), tag("p"), tag("pre"), tag("progress"), tag("tr"), tag("ruby"),
+    tag("table"), tag("time"),
+];
+
+/// Index of schemas grouped by tag name for O(1) lookup.
+fn build_schema_index(schemas: &[RoleRelationConcept]) -> FxHashMap<&'static str, Vec<usize>> {
+    let mut index: FxHashMap<&'static str, Vec<usize>> = FxHashMap::default();
+    for (i, schema) in schemas.iter().enumerate() {
+        index.entry(schema.name).or_default().push(i);
+    }
+    index
+}
+
+pub static NON_INTERACTIVE_ELEMENT_ROLE_INDEX: LazyLock<FxHashMap<&'static str, Vec<usize>>> =
+    LazyLock::new(|| build_schema_index(NON_INTERACTIVE_ELEMENT_ROLE_SCHEMAS));
+
+pub static INTERACTIVE_ELEMENT_ROLE_INDEX: LazyLock<FxHashMap<&'static str, Vec<usize>>> =
+    LazyLock::new(|| build_schema_index(INTERACTIVE_ELEMENT_ROLE_SCHEMAS));
+
+pub static INTERACTIVE_ELEMENT_AX_OBJECT_INDEX: LazyLock<FxHashMap<&'static str, Vec<usize>>> =
+    LazyLock::new(|| build_schema_index(INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS));
+
+pub static NON_INTERACTIVE_ELEMENT_AX_OBJECT_INDEX: LazyLock<FxHashMap<&'static str, Vec<usize>>> =
+    LazyLock::new(|| build_schema_index(NON_INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS));
 
 /// ARIA property type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -973,1049 +443,107 @@ pub enum AriaPropertyType {
 }
 
 /// ARIA property definition.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct AriaPropertyDefinition {
     pub property_type: AriaPropertyType,
     pub values: Option<&'static [&'static str]>,
 }
 
+use AriaPropertyType as T;
+
+#[rustfmt::skip]
+const ARIA_PROPERTY_TABLE: &[(&str, AriaPropertyType, Option<&[&str]>)] = &[
+    ("aria-activedescendant", T::Id, None),
+    ("aria-atomic", T::Boolean, None),
+    ("aria-autocomplete", T::Token, Some(&["inline", "list", "both", "none"])),
+    ("aria-braillelabel", T::String, None),
+    ("aria-brailleroledescription", T::String, None),
+    ("aria-busy", T::Boolean, None),
+    ("aria-checked", T::Tristate, None),
+    ("aria-colcount", T::Integer, None),
+    ("aria-colindex", T::Integer, None),
+    ("aria-colspan", T::Integer, None),
+    ("aria-controls", T::IdList, None),
+    ("aria-current", T::Token, Some(&["page", "step", "location", "date", "time", "true", "false"])),
+    ("aria-describedby", T::IdList, None),
+    ("aria-description", T::String, None),
+    ("aria-details", T::Id, None),
+    ("aria-disabled", T::Boolean, None),
+    ("aria-dropeffect", T::TokenList, Some(&["copy", "execute", "link", "move", "none", "popup"])),
+    ("aria-errormessage", T::Id, None),
+    ("aria-expanded", T::Boolean, None),
+    ("aria-flowto", T::IdList, None),
+    ("aria-grabbed", T::Boolean, None),
+    ("aria-haspopup", T::Token, Some(&["false", "true", "menu", "listbox", "tree", "grid", "dialog"])),
+    ("aria-hidden", T::Boolean, None),
+    ("aria-invalid", T::Token, Some(&["grammar", "false", "spelling", "true"])),
+    ("aria-keyshortcuts", T::String, None),
+    ("aria-label", T::String, None),
+    ("aria-labelledby", T::IdList, None),
+    ("aria-level", T::Integer, None),
+    ("aria-live", T::Token, Some(&["assertive", "off", "polite"])),
+    ("aria-modal", T::Boolean, None),
+    ("aria-multiline", T::Boolean, None),
+    ("aria-multiselectable", T::Boolean, None),
+    ("aria-orientation", T::Token, Some(&["vertical", "undefined", "horizontal"])),
+    ("aria-owns", T::IdList, None),
+    ("aria-placeholder", T::String, None),
+    ("aria-posinset", T::Integer, None),
+    ("aria-pressed", T::Tristate, None),
+    ("aria-readonly", T::Boolean, None),
+    ("aria-relevant", T::TokenList, Some(&["additions", "all", "removals", "text"])),
+    ("aria-required", T::Boolean, None),
+    ("aria-roledescription", T::String, None),
+    ("aria-rowcount", T::Integer, None),
+    ("aria-rowindex", T::Integer, None),
+    ("aria-rowspan", T::Integer, None),
+    ("aria-selected", T::Boolean, None),
+    ("aria-setsize", T::Integer, None),
+    ("aria-sort", T::Token, Some(&["ascending", "descending", "none", "other"])),
+    ("aria-valuemax", T::Number, None),
+    ("aria-valuemin", T::Number, None),
+    ("aria-valuenow", T::Number, None),
+    ("aria-valuetext", T::String, None),
+];
+
 /// ARIA property definitions map.
 pub static ARIA_PROPERTY_DEFINITIONS: LazyLock<FxHashMap<&'static str, AriaPropertyDefinition>> =
     LazyLock::new(|| {
-        let mut m = FxHashMap::default();
-        m.insert(
-            "aria-activedescendant",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Id,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-atomic",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-autocomplete",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Token,
-                values: Some(&["inline", "list", "both", "none"]),
-            },
-        );
-        m.insert(
-            "aria-braillelabel",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::String,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-brailleroledescription",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::String,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-busy",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-checked",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Tristate,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-colcount",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Integer,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-colindex",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Integer,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-colspan",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Integer,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-controls",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::IdList,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-current",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Token,
-                values: Some(&["page", "step", "location", "date", "time", "true", "false"]),
-            },
-        );
-        m.insert(
-            "aria-describedby",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::IdList,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-description",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::String,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-details",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Id,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-disabled",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-dropeffect",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::TokenList,
-                values: Some(&["copy", "execute", "link", "move", "none", "popup"]),
-            },
-        );
-        m.insert(
-            "aria-errormessage",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Id,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-expanded",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-flowto",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::IdList,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-grabbed",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-haspopup",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Token,
-                values: Some(&["false", "true", "menu", "listbox", "tree", "grid", "dialog"]),
-            },
-        );
-        m.insert(
-            "aria-hidden",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-invalid",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Token,
-                values: Some(&["grammar", "false", "spelling", "true"]),
-            },
-        );
-        m.insert(
-            "aria-keyshortcuts",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::String,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-label",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::String,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-labelledby",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::IdList,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-level",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Integer,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-live",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Token,
-                values: Some(&["assertive", "off", "polite"]),
-            },
-        );
-        m.insert(
-            "aria-modal",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-multiline",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-multiselectable",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-orientation",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Token,
-                values: Some(&["vertical", "undefined", "horizontal"]),
-            },
-        );
-        m.insert(
-            "aria-owns",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::IdList,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-placeholder",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::String,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-posinset",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Integer,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-pressed",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Tristate,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-readonly",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-relevant",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::TokenList,
-                values: Some(&["additions", "all", "removals", "text"]),
-            },
-        );
-        m.insert(
-            "aria-required",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-roledescription",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::String,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-rowcount",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Integer,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-rowindex",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Integer,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-rowspan",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Integer,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-selected",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Boolean,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-setsize",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Integer,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-sort",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Token,
-                values: Some(&["ascending", "descending", "none", "other"]),
-            },
-        );
-        m.insert(
-            "aria-valuemax",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Number,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-valuemin",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Number,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-valuenow",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::Number,
-                values: None,
-            },
-        );
-        m.insert(
-            "aria-valuetext",
-            AriaPropertyDefinition {
-                property_type: AriaPropertyType::String,
-                values: None,
-            },
-        );
-        m
+        ARIA_PROPERTY_TABLE
+            .iter()
+            .map(|&(name, property_type, values)| {
+                (
+                    name,
+                    AriaPropertyDefinition {
+                        property_type,
+                        values,
+                    },
+                )
+            })
+            .collect()
     });
-
-/// Interactive element role schemas.
-pub static INTERACTIVE_ELEMENT_ROLE_SCHEMAS: LazyLock<Vec<RoleRelationConcept>> =
-    LazyLock::new(|| {
-        vec![
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("button".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("image".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("reset".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("submit".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "button".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "td".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("checkbox".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "th".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "th".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "scope".to_string(),
-                    value: Some("col".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "th".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "scope".to_string(),
-                    value: Some("colgroup".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("email".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("search".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("tel".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("text".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("url".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "select".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "multiple".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "size".to_string(),
-                        value: None,
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "dialog".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "td".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "a".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "href".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "area".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "href".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "select".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "size".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "select".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "multiple".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "datalist".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "option".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("radio".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "tr".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "th".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "scope".to_string(),
-                    value: Some("row".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "th".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "scope".to_string(),
-                    value: Some("rowgroup".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("search".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("range".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("number".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("email".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("tel".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("text".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![
-                    RoleRelationConceptAttribute {
-                        name: "list".to_string(),
-                        value: None,
-                    },
-                    RoleRelationConceptAttribute {
-                        name: "type".to_string(),
-                        value: Some("url".to_string()),
-                    },
-                ]),
-            },
-            RoleRelationConcept {
-                name: "textarea".to_string(),
-                attributes: None,
-            },
-        ]
-    });
-
-/// Interactive element AX object schemas.
-pub static INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS: LazyLock<Vec<RoleRelationConcept>> =
-    LazyLock::new(|| {
-        vec![
-            RoleRelationConcept {
-                name: "audio".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "button".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "canvas".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "td".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("checkbox".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("color".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "th".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "select".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("date".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("datetime".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "summary".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "embed".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("time".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "a".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "href".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "option".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "datalist".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "menuitem".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("radio".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "th".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "scope".to_string(),
-                    value: Some("row".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("search".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("range".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("number".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "textarea".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "input".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "type".to_string(),
-                    value: Some("text".to_string()),
-                }]),
-            },
-            RoleRelationConcept {
-                name: "video".to_string(),
-                attributes: None,
-            },
-        ]
-    });
-
-/// Non-interactive element AX object schemas.
-pub static NON_INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS: LazyLock<Vec<RoleRelationConcept>> =
-    LazyLock::new(|| {
-        vec![
-            RoleRelationConcept {
-                name: "abbr".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "article".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "blockquote".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "caption".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "dfn".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "dd".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "dl".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "dt".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "details".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "dir".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "figcaption".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "figure".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "footer".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "form".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h1".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h2".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h3".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h4".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h5".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "h6".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "img".to_string(),
-                attributes: Some(vec![RoleRelationConceptAttribute {
-                    name: "usemap".to_string(),
-                    value: None,
-                }]),
-            },
-            RoleRelationConcept {
-                name: "img".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "label".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "legend".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "br".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "li".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "ul".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "ol".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "main".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "mark".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "marquee".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "menu".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "meter".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "nav".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "p".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "pre".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "progress".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "tr".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "ruby".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "table".to_string(),
-                attributes: None,
-            },
-            RoleRelationConcept {
-                name: "time".to_string(),
-                attributes: None,
-            },
-        ]
-    });
-
-/// Index of schemas grouped by tag name for O(1) lookup.
-fn build_schema_index(schemas: &[RoleRelationConcept]) -> FxHashMap<String, Vec<usize>> {
-    let mut index: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-    for (i, schema) in schemas.iter().enumerate() {
-        index.entry(schema.name.clone()).or_default().push(i);
-    }
-    index
-}
-
-pub static NON_INTERACTIVE_ELEMENT_ROLE_INDEX: LazyLock<FxHashMap<String, Vec<usize>>> =
-    LazyLock::new(|| build_schema_index(&NON_INTERACTIVE_ELEMENT_ROLE_SCHEMAS));
-
-pub static INTERACTIVE_ELEMENT_ROLE_INDEX: LazyLock<FxHashMap<String, Vec<usize>>> =
-    LazyLock::new(|| build_schema_index(&INTERACTIVE_ELEMENT_ROLE_SCHEMAS));
-
-pub static INTERACTIVE_ELEMENT_AX_OBJECT_INDEX: LazyLock<FxHashMap<String, Vec<usize>>> =
-    LazyLock::new(|| build_schema_index(&INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS));
-
-pub static NON_INTERACTIVE_ELEMENT_AX_OBJECT_INDEX: LazyLock<FxHashMap<String, Vec<usize>>> =
-    LazyLock::new(|| build_schema_index(&NON_INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS));
 
 /// Map of ARIA roles to their required properties.
 /// Sourced from aria-query roles_map requiredProps.
 /// Only roles that have non-empty requiredProps are included.
+#[rustfmt::skip]
+const ROLE_REQUIRED_PROPS_TABLE: &[(&str, &[&str])] = &[
+    ("checkbox", &["aria-checked"]),
+    ("combobox", &["aria-controls", "aria-expanded"]),
+    ("heading", &["aria-level"]),
+    ("menuitemcheckbox", &["aria-checked"]),
+    ("menuitemradio", &["aria-checked"]),
+    ("meter", &["aria-valuenow"]),
+    ("option", &["aria-selected"]),
+    ("radio", &["aria-checked"]),
+    ("scrollbar", &["aria-controls", "aria-valuenow"]),
+    ("slider", &["aria-valuenow"]),
+    ("switch", &["aria-checked"]),
+    ("treeitem", &["aria-selected"]),
+];
+
 pub static ROLE_REQUIRED_PROPS: LazyLock<FxHashMap<&'static str, &'static [&'static str]>> =
-    LazyLock::new(|| {
-        let mut map = FxHashMap::default();
-        map.insert("checkbox", &["aria-checked"][..]);
-        map.insert("combobox", &["aria-controls", "aria-expanded"][..]);
-        map.insert("heading", &["aria-level"][..]);
-        map.insert("menuitemcheckbox", &["aria-checked"][..]);
-        map.insert("menuitemradio", &["aria-checked"][..]);
-        map.insert("meter", &["aria-valuenow"][..]);
-        map.insert("option", &["aria-selected"][..]);
-        map.insert("radio", &["aria-checked"][..]);
-        map.insert("scrollbar", &["aria-controls", "aria-valuenow"][..]);
-        map.insert("slider", &["aria-valuenow"][..]);
-        map.insert("switch", &["aria-checked"][..]);
-        map.insert("treeitem", &["aria-selected"][..]);
-        map
-    });
+    LazyLock::new(|| ROLE_REQUIRED_PROPS_TABLE.iter().copied().collect());
 
 /// Map of elements (with optional attributes) to the roles they semantically represent.
 /// Used by `is_semantic_role_element` to determine if an element naturally carries a role.
@@ -2023,3572 +551,258 @@ pub static ROLE_REQUIRED_PROPS: LazyLock<FxHashMap<&'static str, &'static [&'sta
 ///
 /// Format: (element_name, optional_attributes, roles)
 /// If an element matches (name + attributes), it semantically maps to those roles.
-pub static SEMANTIC_ROLE_ELEMENTS: LazyLock<Vec<SemanticRoleElement>> = LazyLock::new(|| {
-    vec![
-        // input[type=checkbox] -> checkbox, switch
-        (
-            "input",
-            Some(&[("type", "checkbox")][..]),
-            &["checkbox", "switch"][..],
-        ),
-        // input[type=radio] -> radio
-        ("input", Some(&[("type", "radio")][..]), &["radio"][..]),
-        // input[type=range] -> slider
-        ("input", Some(&[("type", "range")][..]), &["slider"][..]),
-        // select -> combobox, listbox
-        ("select", None, &["combobox", "listbox"][..]),
-        // option -> option
-        ("option", None, &["option"][..]),
-        // h1-h6 -> heading
-        ("h1", None, &["heading"][..]),
-        ("h2", None, &["heading"][..]),
-        ("h3", None, &["heading"][..]),
-        ("h4", None, &["heading"][..]),
-        ("h5", None, &["heading"][..]),
-        ("h6", None, &["heading"][..]),
-        // meter -> meter
-        ("meter", None, &["meter"][..]),
-        // menuitemcheckbox
-        (
-            "menuitem",
-            Some(&[("type", "checkbox")][..]),
-            &["menuitemcheckbox"][..],
-        ),
-        // menuitemradio
-        (
-            "menuitem",
-            Some(&[("type", "radio")][..]),
-            &["menuitemradio"][..],
-        ),
-        // treeitem -> treeitem
-        ("treeitem", None, &["treeitem"][..]),
-    ]
-});
+#[rustfmt::skip]
+pub static SEMANTIC_ROLE_ELEMENTS: &[SemanticRoleElement] = &[
+    ("input", Some(&[("type", "checkbox")]), &["checkbox", "switch"]),
+    ("input", Some(&[("type", "radio")]), &["radio"]),
+    ("input", Some(&[("type", "range")]), &["slider"]),
+    ("select", None, &["combobox", "listbox"]),
+    ("option", None, &["option"]),
+    ("h1", None, &["heading"]),
+    ("h2", None, &["heading"]),
+    ("h3", None, &["heading"]),
+    ("h4", None, &["heading"]),
+    ("h5", None, &["heading"]),
+    ("h6", None, &["heading"]),
+    ("meter", None, &["meter"]),
+    ("menuitem", Some(&[("type", "checkbox")]), &["menuitemcheckbox"]),
+    ("menuitem", Some(&[("type", "radio")]), &["menuitemradio"]),
+    ("treeitem", None, &["treeitem"]),
+];
+
+/// The ARIA props shared by every role except `doc-pullquote` / `none`
+/// (aria-query's `roletype` prop set). Spliced into every `aria_props!` set below.
+macro_rules! aria_props {
+    ($($extra:literal),* $(,)?) => {
+        &[
+            "aria-atomic", "aria-busy", "aria-controls", "aria-current", "aria-describedby",
+            "aria-details", "aria-dropeffect", "aria-flowto", "aria-grabbed", "aria-hidden",
+            "aria-keyshortcuts", "aria-label", "aria-labelledby", "aria-live", "aria-owns",
+            "aria-relevant", "aria-roledescription",
+            $($extra,)*
+        ]
+    };
+}
+
+const PROPS_ROLETYPE: &[&str] = aria_props![];
+const PROPS_ALERTDIALOG: &[&str] = aria_props!["aria-modal"];
+#[rustfmt::skip]
+const PROPS_APPLICATION: &[&str] = aria_props![
+    "aria-activedescendant", "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup",
+    "aria-invalid",
+];
+const PROPS_ARTICLE: &[&str] = aria_props!["aria-posinset", "aria-setsize"];
+#[rustfmt::skip]
+const PROPS_BUTTON: &[&str] = aria_props![
+    "aria-disabled", "aria-expanded", "aria-haspopup", "aria-pressed",
+];
+#[rustfmt::skip]
+const PROPS_CELL: &[&str] = aria_props![
+    "aria-colindex", "aria-colspan", "aria-rowindex", "aria-rowspan",
+];
+#[rustfmt::skip]
+const PROPS_CHECKBOX: &[&str] = aria_props![
+    "aria-checked", "aria-disabled", "aria-errormessage", "aria-expanded", "aria-invalid",
+    "aria-readonly", "aria-required",
+];
+#[rustfmt::skip]
+const PROPS_COLUMNHEADER: &[&str] = aria_props![
+    "aria-colindex", "aria-colspan", "aria-disabled", "aria-errormessage", "aria-expanded",
+    "aria-haspopup", "aria-invalid", "aria-readonly", "aria-required", "aria-rowindex",
+    "aria-rowspan", "aria-selected", "aria-sort",
+];
+#[rustfmt::skip]
+const PROPS_COMBOBOX: &[&str] = aria_props![
+    "aria-activedescendant", "aria-autocomplete", "aria-disabled", "aria-errormessage",
+    "aria-expanded", "aria-haspopup", "aria-invalid", "aria-readonly", "aria-required",
+];
+const PROPS_COMPOSITE: &[&str] = aria_props!["aria-activedescendant", "aria-disabled"];
+#[rustfmt::skip]
+const PROPS_DOC_ABSTRACT: &[&str] = aria_props![
+    "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup", "aria-invalid",
+];
+#[rustfmt::skip]
+const PROPS_DOC_BIBLIOENTRY: &[&str] = aria_props![
+    "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup", "aria-invalid",
+    "aria-level", "aria-posinset", "aria-setsize",
+];
+#[rustfmt::skip]
+const PROPS_DOC_PAGEBREAK: &[&str] = aria_props![
+    "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup", "aria-invalid",
+    "aria-orientation", "aria-valuemax", "aria-valuemin", "aria-valuenow", "aria-valuetext",
+];
+#[rustfmt::skip]
+const PROPS_DOC_PAGEFOOTER: &[&str] = aria_props![
+    "aria-braillelabel", "aria-brailleroledescription", "aria-description", "aria-disabled",
+    "aria-errormessage", "aria-haspopup", "aria-invalid",
+];
+#[rustfmt::skip]
+const PROPS_GRID: &[&str] = aria_props![
+    "aria-activedescendant", "aria-colcount", "aria-disabled", "aria-multiselectable",
+    "aria-readonly", "aria-rowcount",
+];
+#[rustfmt::skip]
+const PROPS_GRIDCELL: &[&str] = aria_props![
+    "aria-colindex", "aria-colspan", "aria-disabled", "aria-errormessage", "aria-expanded",
+    "aria-haspopup", "aria-invalid", "aria-readonly", "aria-required", "aria-rowindex",
+    "aria-rowspan", "aria-selected",
+];
+const PROPS_HEADING: &[&str] = aria_props!["aria-level"];
+const PROPS_INPUT: &[&str] = aria_props!["aria-disabled"];
+const PROPS_LINK: &[&str] = aria_props!["aria-disabled", "aria-expanded", "aria-haspopup"];
+#[rustfmt::skip]
+const PROPS_LISTBOX: &[&str] = aria_props![
+    "aria-activedescendant", "aria-disabled", "aria-errormessage", "aria-expanded", "aria-invalid",
+    "aria-multiselectable", "aria-orientation", "aria-readonly", "aria-required",
+];
+const PROPS_LISTITEM: &[&str] = aria_props!["aria-level", "aria-posinset", "aria-setsize"];
+#[rustfmt::skip]
+const PROPS_MARK: &[&str] = aria_props![
+    "aria-braillelabel", "aria-brailleroledescription", "aria-description",
+];
+#[rustfmt::skip]
+const PROPS_MENU: &[&str] = aria_props![
+    "aria-activedescendant", "aria-disabled", "aria-orientation",
+];
+#[rustfmt::skip]
+const PROPS_MENUITEM: &[&str] = aria_props![
+    "aria-disabled", "aria-expanded", "aria-haspopup", "aria-posinset", "aria-setsize",
+];
+#[rustfmt::skip]
+const PROPS_MENUITEMCHECKBOX: &[&str] = aria_props![
+    "aria-checked", "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup",
+    "aria-invalid", "aria-posinset", "aria-readonly", "aria-required", "aria-setsize",
+];
+#[rustfmt::skip]
+const PROPS_METER: &[&str] = aria_props![
+    "aria-valuemax", "aria-valuemin", "aria-valuenow", "aria-valuetext",
+];
+#[rustfmt::skip]
+const PROPS_OPTION: &[&str] = aria_props![
+    "aria-checked", "aria-disabled", "aria-posinset", "aria-selected", "aria-setsize",
+];
+#[rustfmt::skip]
+const PROPS_RADIO: &[&str] = aria_props![
+    "aria-checked", "aria-disabled", "aria-posinset", "aria-setsize",
+];
+#[rustfmt::skip]
+const PROPS_RADIOGROUP: &[&str] = aria_props![
+    "aria-activedescendant", "aria-disabled", "aria-errormessage", "aria-invalid",
+    "aria-orientation", "aria-readonly", "aria-required",
+];
+const PROPS_RANGE: &[&str] = aria_props!["aria-valuemax", "aria-valuemin", "aria-valuenow"];
+#[rustfmt::skip]
+const PROPS_ROW: &[&str] = aria_props![
+    "aria-activedescendant", "aria-colindex", "aria-disabled", "aria-expanded", "aria-level",
+    "aria-posinset", "aria-rowindex", "aria-selected", "aria-setsize",
+];
+#[rustfmt::skip]
+const PROPS_SCROLLBAR: &[&str] = aria_props![
+    "aria-disabled", "aria-orientation", "aria-valuemax", "aria-valuemin", "aria-valuenow",
+    "aria-valuetext",
+];
+#[rustfmt::skip]
+const PROPS_SEARCHBOX: &[&str] = aria_props![
+    "aria-activedescendant", "aria-autocomplete", "aria-disabled", "aria-errormessage",
+    "aria-haspopup", "aria-invalid", "aria-multiline", "aria-placeholder", "aria-readonly",
+    "aria-required",
+];
+#[rustfmt::skip]
+const PROPS_SLIDER: &[&str] = aria_props![
+    "aria-disabled", "aria-errormessage", "aria-haspopup", "aria-invalid", "aria-orientation",
+    "aria-readonly", "aria-valuemax", "aria-valuemin", "aria-valuenow", "aria-valuetext",
+];
+#[rustfmt::skip]
+const PROPS_SPINBUTTON: &[&str] = aria_props![
+    "aria-activedescendant", "aria-disabled", "aria-errormessage", "aria-invalid", "aria-readonly",
+    "aria-required", "aria-valuemax", "aria-valuemin", "aria-valuenow", "aria-valuetext",
+];
+#[rustfmt::skip]
+const PROPS_TAB: &[&str] = aria_props![
+    "aria-disabled", "aria-expanded", "aria-haspopup", "aria-posinset", "aria-selected",
+    "aria-setsize",
+];
+const PROPS_TABLE: &[&str] = aria_props!["aria-colcount", "aria-rowcount"];
+#[rustfmt::skip]
+const PROPS_TABLIST: &[&str] = aria_props![
+    "aria-activedescendant", "aria-disabled", "aria-level", "aria-multiselectable",
+    "aria-orientation",
+];
+#[rustfmt::skip]
+const PROPS_TREE: &[&str] = aria_props![
+    "aria-activedescendant", "aria-disabled", "aria-errormessage", "aria-invalid",
+    "aria-multiselectable", "aria-orientation", "aria-required",
+];
+#[rustfmt::skip]
+const PROPS_TREEGRID: &[&str] = aria_props![
+    "aria-activedescendant", "aria-colcount", "aria-disabled", "aria-errormessage", "aria-invalid",
+    "aria-multiselectable", "aria-orientation", "aria-readonly", "aria-required", "aria-rowcount",
+];
+#[rustfmt::skip]
+const PROPS_TREEITEM: &[&str] = aria_props![
+    "aria-checked", "aria-disabled", "aria-expanded", "aria-haspopup", "aria-level",
+    "aria-posinset", "aria-selected", "aria-setsize",
+];
 
 /// Map of WAI-ARIA roles to their allowed ARIA properties.
 /// Generated from aria-query@5.3.1 roles map.
+#[rustfmt::skip]
+const ROLE_ALLOWED_ARIA_PROPS_TABLE: &[(&str, &[&str])] = &[
+    ("alert", PROPS_ROLETYPE), ("alertdialog", PROPS_ALERTDIALOG),
+    ("application", PROPS_APPLICATION), ("article", PROPS_ARTICLE), ("banner", PROPS_ROLETYPE),
+    ("blockquote", PROPS_ROLETYPE), ("button", PROPS_BUTTON), ("caption", PROPS_ROLETYPE),
+    ("cell", PROPS_CELL), ("checkbox", PROPS_CHECKBOX), ("code", PROPS_ROLETYPE),
+    ("columnheader", PROPS_COLUMNHEADER), ("combobox", PROPS_COMBOBOX), ("command", PROPS_ROLETYPE),
+    ("complementary", PROPS_ROLETYPE), ("composite", PROPS_COMPOSITE),
+    ("contentinfo", PROPS_ROLETYPE), ("definition", PROPS_ROLETYPE), ("deletion", PROPS_ROLETYPE),
+    ("dialog", PROPS_ALERTDIALOG), ("directory", PROPS_ROLETYPE),
+    ("doc-abstract", PROPS_DOC_ABSTRACT), ("doc-acknowledgments", PROPS_DOC_ABSTRACT),
+    ("doc-afterword", PROPS_DOC_ABSTRACT), ("doc-appendix", PROPS_DOC_ABSTRACT),
+    ("doc-backlink", PROPS_DOC_ABSTRACT), ("doc-biblioentry", PROPS_DOC_BIBLIOENTRY),
+    ("doc-bibliography", PROPS_DOC_ABSTRACT), ("doc-biblioref", PROPS_DOC_ABSTRACT),
+    ("doc-chapter", PROPS_DOC_ABSTRACT), ("doc-colophon", PROPS_DOC_ABSTRACT),
+    ("doc-conclusion", PROPS_DOC_ABSTRACT), ("doc-cover", PROPS_DOC_ABSTRACT),
+    ("doc-credit", PROPS_DOC_ABSTRACT), ("doc-credits", PROPS_DOC_ABSTRACT),
+    ("doc-dedication", PROPS_DOC_ABSTRACT), ("doc-endnote", PROPS_DOC_BIBLIOENTRY),
+    ("doc-endnotes", PROPS_DOC_ABSTRACT), ("doc-epigraph", PROPS_DOC_ABSTRACT),
+    ("doc-epilogue", PROPS_DOC_ABSTRACT), ("doc-errata", PROPS_DOC_ABSTRACT),
+    ("doc-example", PROPS_DOC_ABSTRACT), ("doc-footnote", PROPS_DOC_ABSTRACT),
+    ("doc-foreword", PROPS_DOC_ABSTRACT), ("doc-glossary", PROPS_DOC_ABSTRACT),
+    ("doc-glossref", PROPS_DOC_ABSTRACT), ("doc-index", PROPS_DOC_ABSTRACT),
+    ("doc-introduction", PROPS_DOC_ABSTRACT), ("doc-noteref", PROPS_DOC_ABSTRACT),
+    ("doc-notice", PROPS_DOC_ABSTRACT), ("doc-pagebreak", PROPS_DOC_PAGEBREAK),
+    ("doc-pagefooter", PROPS_DOC_PAGEFOOTER), ("doc-pageheader", PROPS_DOC_PAGEFOOTER),
+    ("doc-pagelist", PROPS_DOC_ABSTRACT), ("doc-part", PROPS_DOC_ABSTRACT),
+    ("doc-preface", PROPS_DOC_ABSTRACT), ("doc-prologue", PROPS_DOC_ABSTRACT),
+    ("doc-pullquote", &[]), ("doc-qna", PROPS_DOC_ABSTRACT), ("doc-subtitle", PROPS_DOC_ABSTRACT),
+    ("doc-tip", PROPS_DOC_ABSTRACT), ("doc-toc", PROPS_DOC_ABSTRACT), ("document", PROPS_ROLETYPE),
+    ("emphasis", PROPS_ROLETYPE), ("feed", PROPS_ROLETYPE), ("figure", PROPS_ROLETYPE),
+    ("form", PROPS_ROLETYPE), ("generic", PROPS_ROLETYPE),
+    ("graphics-document", PROPS_DOC_ABSTRACT), ("graphics-object", PROPS_APPLICATION),
+    ("graphics-symbol", PROPS_DOC_ABSTRACT), ("grid", PROPS_GRID), ("gridcell", PROPS_GRIDCELL),
+    ("group", PROPS_COMPOSITE), ("heading", PROPS_HEADING), ("img", PROPS_ROLETYPE),
+    ("input", PROPS_INPUT), ("insertion", PROPS_ROLETYPE), ("landmark", PROPS_ROLETYPE),
+    ("link", PROPS_LINK), ("list", PROPS_ROLETYPE), ("listbox", PROPS_LISTBOX),
+    ("listitem", PROPS_LISTITEM), ("log", PROPS_ROLETYPE), ("main", PROPS_ROLETYPE),
+    ("mark", PROPS_MARK), ("marquee", PROPS_ROLETYPE), ("math", PROPS_ROLETYPE),
+    ("menu", PROPS_MENU), ("menubar", PROPS_MENU), ("menuitem", PROPS_MENUITEM),
+    ("menuitemcheckbox", PROPS_MENUITEMCHECKBOX), ("menuitemradio", PROPS_MENUITEMCHECKBOX),
+    ("meter", PROPS_METER), ("navigation", PROPS_ROLETYPE), ("none", &[]), ("note", PROPS_ROLETYPE),
+    ("option", PROPS_OPTION), ("paragraph", PROPS_ROLETYPE), ("presentation", PROPS_ROLETYPE),
+    ("progressbar", PROPS_METER), ("radio", PROPS_RADIO), ("radiogroup", PROPS_RADIOGROUP),
+    ("range", PROPS_RANGE), ("region", PROPS_ROLETYPE), ("roletype", PROPS_ROLETYPE),
+    ("row", PROPS_ROW), ("rowgroup", PROPS_ROLETYPE), ("rowheader", PROPS_COLUMNHEADER),
+    ("scrollbar", PROPS_SCROLLBAR), ("search", PROPS_ROLETYPE), ("searchbox", PROPS_SEARCHBOX),
+    ("section", PROPS_ROLETYPE), ("sectionhead", PROPS_ROLETYPE), ("select", PROPS_MENU),
+    ("separator", PROPS_SCROLLBAR), ("slider", PROPS_SLIDER), ("spinbutton", PROPS_SPINBUTTON),
+    ("status", PROPS_ROLETYPE), ("strong", PROPS_ROLETYPE), ("structure", PROPS_ROLETYPE),
+    ("subscript", PROPS_ROLETYPE), ("superscript", PROPS_ROLETYPE), ("switch", PROPS_CHECKBOX),
+    ("tab", PROPS_TAB), ("table", PROPS_TABLE), ("tablist", PROPS_TABLIST),
+    ("tabpanel", PROPS_ROLETYPE), ("term", PROPS_ROLETYPE), ("textbox", PROPS_SEARCHBOX),
+    ("time", PROPS_ROLETYPE), ("timer", PROPS_ROLETYPE), ("toolbar", PROPS_MENU),
+    ("tooltip", PROPS_ROLETYPE), ("tree", PROPS_TREE), ("treegrid", PROPS_TREEGRID),
+    ("treeitem", PROPS_TREEITEM), ("widget", PROPS_ROLETYPE), ("window", PROPS_ALERTDIALOG),
+];
+
 pub static ROLE_ALLOWED_ARIA_PROPS: LazyLock<FxHashMap<&'static str, &'static [&'static str]>> =
-    LazyLock::new(|| {
-        let mut m = FxHashMap::default();
-        m.insert(
-            "command",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "composite",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "input",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "landmark",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "range",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-valuemax",
-                "aria-valuemin",
-                "aria-valuenow",
-            ][..],
-        );
-        m.insert(
-            "roletype",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "section",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "sectionhead",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "select",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-orientation",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "structure",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "widget",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "window",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-modal",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "alert",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "alertdialog",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-modal",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "application",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "article",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "banner",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "blockquote",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "button",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-pressed",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "caption",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "cell",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-colindex",
-                "aria-colspan",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-rowindex",
-                "aria-rowspan",
-            ][..],
-        );
-        m.insert(
-            "checkbox",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-checked",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "code",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "columnheader",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-colindex",
-                "aria-colspan",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-                "aria-rowindex",
-                "aria-rowspan",
-                "aria-selected",
-                "aria-sort",
-            ][..],
-        );
-        m.insert(
-            "combobox",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-autocomplete",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "complementary",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "contentinfo",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "definition",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "deletion",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "dialog",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-modal",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "directory",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "document",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "emphasis",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "feed",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "figure",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "form",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "generic",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "grid",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-colcount",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-multiselectable",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-rowcount",
-            ][..],
-        );
-        m.insert(
-            "gridcell",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-colindex",
-                "aria-colspan",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-                "aria-rowindex",
-                "aria-rowspan",
-                "aria-selected",
-            ][..],
-        );
-        m.insert(
-            "group",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "heading",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-level",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "img",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "insertion",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "link",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "list",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "listbox",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-multiselectable",
-                "aria-orientation",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "listitem",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-level",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "log",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "main",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "mark",
-            &[
-                "aria-atomic",
-                "aria-braillelabel",
-                "aria-brailleroledescription",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-description",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "marquee",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "math",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "menu",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-orientation",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "menubar",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-orientation",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "menuitem",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "menuitemcheckbox",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-checked",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "menuitemradio",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-checked",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "meter",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-valuemax",
-                "aria-valuemin",
-                "aria-valuenow",
-                "aria-valuetext",
-            ][..],
-        );
-        m.insert(
-            "navigation",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert("none", &[][..]);
-        m.insert(
-            "note",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "option",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-checked",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-selected",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "paragraph",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "presentation",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "progressbar",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-valuemax",
-                "aria-valuemin",
-                "aria-valuenow",
-                "aria-valuetext",
-            ][..],
-        );
-        m.insert(
-            "radio",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-checked",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "radiogroup",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-orientation",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "region",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "row",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-colindex",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-level",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-rowindex",
-                "aria-selected",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "rowgroup",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "rowheader",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-colindex",
-                "aria-colspan",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-                "aria-rowindex",
-                "aria-rowspan",
-                "aria-selected",
-                "aria-sort",
-            ][..],
-        );
-        m.insert(
-            "scrollbar",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-orientation",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-valuemax",
-                "aria-valuemin",
-                "aria-valuenow",
-                "aria-valuetext",
-            ][..],
-        );
-        m.insert(
-            "search",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "searchbox",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-autocomplete",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-multiline",
-                "aria-owns",
-                "aria-placeholder",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "separator",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-orientation",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-valuemax",
-                "aria-valuemin",
-                "aria-valuenow",
-                "aria-valuetext",
-            ][..],
-        );
-        m.insert(
-            "slider",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-orientation",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-valuemax",
-                "aria-valuemin",
-                "aria-valuenow",
-                "aria-valuetext",
-            ][..],
-        );
-        m.insert(
-            "spinbutton",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-                "aria-valuemax",
-                "aria-valuemin",
-                "aria-valuenow",
-                "aria-valuetext",
-            ][..],
-        );
-        m.insert(
-            "status",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "strong",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "subscript",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "superscript",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "switch",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-checked",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "tab",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-selected",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "table",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-colcount",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-rowcount",
-            ][..],
-        );
-        m.insert(
-            "tablist",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-level",
-                "aria-live",
-                "aria-multiselectable",
-                "aria-orientation",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "tabpanel",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "term",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "textbox",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-autocomplete",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-multiline",
-                "aria-owns",
-                "aria-placeholder",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "time",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "timer",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "toolbar",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-orientation",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "tooltip",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-dropeffect",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "tree",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-multiselectable",
-                "aria-orientation",
-                "aria-owns",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "treegrid",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-colcount",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-multiselectable",
-                "aria-orientation",
-                "aria-owns",
-                "aria-readonly",
-                "aria-relevant",
-                "aria-required",
-                "aria-roledescription",
-                "aria-rowcount",
-            ][..],
-        );
-        m.insert(
-            "treeitem",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-checked",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-level",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-selected",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "doc-abstract",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-acknowledgments",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-afterword",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-appendix",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-backlink",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-biblioentry",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-level",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "doc-bibliography",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-biblioref",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-chapter",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-colophon",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-conclusion",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-cover",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-credit",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-credits",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-dedication",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-endnote",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-level",
-                "aria-live",
-                "aria-owns",
-                "aria-posinset",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-setsize",
-            ][..],
-        );
-        m.insert(
-            "doc-endnotes",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-epigraph",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-epilogue",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-errata",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-example",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-footnote",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-foreword",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-glossary",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-glossref",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-index",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-introduction",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-noteref",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-notice",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-pagebreak",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-orientation",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-                "aria-valuemax",
-                "aria-valuemin",
-                "aria-valuenow",
-                "aria-valuetext",
-            ][..],
-        );
-        m.insert(
-            "doc-pagefooter",
-            &[
-                "aria-atomic",
-                "aria-braillelabel",
-                "aria-brailleroledescription",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-description",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-pageheader",
-            &[
-                "aria-atomic",
-                "aria-braillelabel",
-                "aria-brailleroledescription",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-description",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-pagelist",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-part",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-preface",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-prologue",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert("doc-pullquote", &[][..]);
-        m.insert(
-            "doc-qna",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-subtitle",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-tip",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "doc-toc",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "graphics-document",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "graphics-object",
-            &[
-                "aria-activedescendant",
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m.insert(
-            "graphics-symbol",
-            &[
-                "aria-atomic",
-                "aria-busy",
-                "aria-controls",
-                "aria-current",
-                "aria-describedby",
-                "aria-details",
-                "aria-disabled",
-                "aria-dropeffect",
-                "aria-errormessage",
-                "aria-expanded",
-                "aria-flowto",
-                "aria-grabbed",
-                "aria-haspopup",
-                "aria-hidden",
-                "aria-invalid",
-                "aria-keyshortcuts",
-                "aria-label",
-                "aria-labelledby",
-                "aria-live",
-                "aria-owns",
-                "aria-relevant",
-                "aria-roledescription",
-            ][..],
-        );
-        m
-    });
+    LazyLock::new(|| ROLE_ALLOWED_ARIA_PROPS_TABLE.iter().copied().collect());

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/constants.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/constants.rs
@@ -209,44 +209,43 @@ pub mod element_interactivity {
 /// Invisible elements.
 pub const INVISIBLE_ELEMENTS: &[&str] = &["meta", "html", "script", "style"];
 
-/// Abstract ARIA roles. Also part of `ARIA_ROLES`.
+/// Abstract ARIA roles. Also the first 12 entries of `ARIA_ROLE_NAMES`.
 #[rustfmt::skip]
 const ABSTRACT_ROLE_NAMES: &[&str] = &[
     "command", "composite", "input", "landmark", "range", "roletype", "section", "sectionhead",
     "select", "structure", "widget", "window",
 ];
 
-/// Every ARIA role that is not abstract.
+/// All ARIA roles, in aria-query's `roles` map key order. The order is load-bearing:
+/// `fuzzymatch` breaks score ties by first occurrence, so `ARIA_ROLES` (a set) must never
+/// be the source for suggestion lists.
 #[rustfmt::skip]
-const CONCRETE_ROLE_NAMES: &[&str] = &[
-    "alert", "alertdialog", "application", "article", "banner", "blockquote", "button", "caption",
-    "cell", "checkbox", "code", "columnheader", "combobox", "complementary", "contentinfo",
-    "definition", "deletion", "dialog", "directory", "doc-abstract", "doc-acknowledgments",
-    "doc-afterword", "doc-appendix", "doc-backlink", "doc-biblioentry", "doc-bibliography",
-    "doc-biblioref", "doc-chapter", "doc-colophon", "doc-conclusion", "doc-cover", "doc-credit",
-    "doc-credits", "doc-dedication", "doc-endnote", "doc-endnotes", "doc-epigraph", "doc-epilogue",
-    "doc-errata", "doc-example", "doc-footnote", "doc-foreword", "doc-glossary", "doc-glossref",
-    "doc-index", "doc-introduction", "doc-noteref", "doc-notice", "doc-pagebreak", "doc-pagefooter",
+pub const ARIA_ROLE_NAMES: &[&str] = &[
+    "command", "composite", "input", "landmark", "range", "roletype", "section", "sectionhead",
+    "select", "structure", "widget", "window", "alert", "alertdialog", "application", "article",
+    "banner", "blockquote", "button", "caption", "cell", "checkbox", "code", "columnheader",
+    "combobox", "complementary", "contentinfo", "definition", "deletion", "dialog", "directory",
+    "document", "emphasis", "feed", "figure", "form", "generic", "grid", "gridcell", "group",
+    "heading", "img", "insertion", "link", "list", "listbox", "listitem", "log", "main", "mark",
+    "marquee", "math", "menu", "menubar", "menuitem", "menuitemcheckbox", "menuitemradio", "meter",
+    "navigation", "none", "note", "option", "paragraph", "presentation", "progressbar", "radio",
+    "radiogroup", "region", "row", "rowgroup", "rowheader", "scrollbar", "search", "searchbox",
+    "separator", "slider", "spinbutton", "status", "strong", "subscript", "superscript", "switch",
+    "tab", "table", "tablist", "tabpanel", "term", "textbox", "time", "timer", "toolbar", "tooltip",
+    "tree", "treegrid", "treeitem", "doc-abstract", "doc-acknowledgments", "doc-afterword",
+    "doc-appendix", "doc-backlink", "doc-biblioentry", "doc-bibliography", "doc-biblioref",
+    "doc-chapter", "doc-colophon", "doc-conclusion", "doc-cover", "doc-credit", "doc-credits",
+    "doc-dedication", "doc-endnote", "doc-endnotes", "doc-epigraph", "doc-epilogue", "doc-errata",
+    "doc-example", "doc-footnote", "doc-foreword", "doc-glossary", "doc-glossref", "doc-index",
+    "doc-introduction", "doc-noteref", "doc-notice", "doc-pagebreak", "doc-pagefooter",
     "doc-pageheader", "doc-pagelist", "doc-part", "doc-preface", "doc-prologue", "doc-pullquote",
-    "doc-qna", "doc-subtitle", "doc-tip", "doc-toc", "document", "emphasis", "feed", "figure",
-    "form", "generic", "graphics-document", "graphics-object", "graphics-symbol", "grid",
-    "gridcell", "group", "heading", "img", "insertion", "link", "list", "listbox", "listitem",
-    "log", "main", "mark", "marquee", "math", "menu", "menubar", "menuitem", "menuitemcheckbox",
-    "menuitemradio", "meter", "navigation", "none", "note", "option", "paragraph", "presentation",
-    "progressbar", "radio", "radiogroup", "region", "row", "rowgroup", "rowheader", "scrollbar",
-    "search", "searchbox", "separator", "slider", "spinbutton", "status", "strong", "subscript",
-    "superscript", "switch", "tab", "table", "tablist", "tabpanel", "term", "textbox", "time",
-    "timer", "toolbar", "tooltip", "tree", "treegrid", "treeitem",
+    "doc-qna", "doc-subtitle", "doc-tip", "doc-toc", "graphics-document", "graphics-object",
+    "graphics-symbol",
 ];
 
 /// All ARIA roles.
-pub static ARIA_ROLES: LazyLock<FxHashSet<&'static str>> = LazyLock::new(|| {
-    ABSTRACT_ROLE_NAMES
-        .iter()
-        .chain(CONCRETE_ROLE_NAMES)
-        .copied()
-        .collect()
-});
+pub static ARIA_ROLES: LazyLock<FxHashSet<&'static str>> =
+    LazyLock::new(|| ARIA_ROLE_NAMES.iter().copied().collect());
 
 /// Abstract ARIA roles.
 pub static ABSTRACT_ROLES: LazyLock<FxHashSet<&'static str>> =
@@ -584,8 +583,11 @@ macro_rules! aria_props {
     };
 }
 
+/// Shared by 46 roles.
 const PROPS_ROLETYPE: &[&str] = aria_props![];
+/// Shared by: alertdialog, dialog, window.
 const PROPS_ALERTDIALOG: &[&str] = aria_props!["aria-modal"];
+/// Shared by: application, graphics-object.
 #[rustfmt::skip]
 const PROPS_APPLICATION: &[&str] = aria_props![
     "aria-activedescendant", "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup",
@@ -600,11 +602,13 @@ const PROPS_BUTTON: &[&str] = aria_props![
 const PROPS_CELL: &[&str] = aria_props![
     "aria-colindex", "aria-colspan", "aria-rowindex", "aria-rowspan",
 ];
+/// Shared by: checkbox, switch.
 #[rustfmt::skip]
 const PROPS_CHECKBOX: &[&str] = aria_props![
     "aria-checked", "aria-disabled", "aria-errormessage", "aria-expanded", "aria-invalid",
     "aria-readonly", "aria-required",
 ];
+/// Shared by: columnheader, rowheader.
 #[rustfmt::skip]
 const PROPS_COLUMNHEADER: &[&str] = aria_props![
     "aria-colindex", "aria-colspan", "aria-disabled", "aria-errormessage", "aria-expanded",
@@ -616,11 +620,14 @@ const PROPS_COMBOBOX: &[&str] = aria_props![
     "aria-activedescendant", "aria-autocomplete", "aria-disabled", "aria-errormessage",
     "aria-expanded", "aria-haspopup", "aria-invalid", "aria-readonly", "aria-required",
 ];
+/// Shared by: composite, group.
 const PROPS_COMPOSITE: &[&str] = aria_props!["aria-activedescendant", "aria-disabled"];
+/// Shared by 37 roles.
 #[rustfmt::skip]
 const PROPS_DOC_ABSTRACT: &[&str] = aria_props![
     "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup", "aria-invalid",
 ];
+/// Shared by: doc-biblioentry, doc-endnote.
 #[rustfmt::skip]
 const PROPS_DOC_BIBLIOENTRY: &[&str] = aria_props![
     "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup", "aria-invalid",
@@ -631,6 +638,7 @@ const PROPS_DOC_PAGEBREAK: &[&str] = aria_props![
     "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup", "aria-invalid",
     "aria-orientation", "aria-valuemax", "aria-valuemin", "aria-valuenow", "aria-valuetext",
 ];
+/// Shared by: doc-pagefooter, doc-pageheader.
 #[rustfmt::skip]
 const PROPS_DOC_PAGEFOOTER: &[&str] = aria_props![
     "aria-braillelabel", "aria-brailleroledescription", "aria-description", "aria-disabled",
@@ -660,6 +668,7 @@ const PROPS_LISTITEM: &[&str] = aria_props!["aria-level", "aria-posinset", "aria
 const PROPS_MARK: &[&str] = aria_props![
     "aria-braillelabel", "aria-brailleroledescription", "aria-description",
 ];
+/// Shared by: menu, menubar, select, toolbar.
 #[rustfmt::skip]
 const PROPS_MENU: &[&str] = aria_props![
     "aria-activedescendant", "aria-disabled", "aria-orientation",
@@ -668,11 +677,13 @@ const PROPS_MENU: &[&str] = aria_props![
 const PROPS_MENUITEM: &[&str] = aria_props![
     "aria-disabled", "aria-expanded", "aria-haspopup", "aria-posinset", "aria-setsize",
 ];
+/// Shared by: menuitemcheckbox, menuitemradio.
 #[rustfmt::skip]
 const PROPS_MENUITEMCHECKBOX: &[&str] = aria_props![
     "aria-checked", "aria-disabled", "aria-errormessage", "aria-expanded", "aria-haspopup",
     "aria-invalid", "aria-posinset", "aria-readonly", "aria-required", "aria-setsize",
 ];
+/// Shared by: meter, progressbar.
 #[rustfmt::skip]
 const PROPS_METER: &[&str] = aria_props![
     "aria-valuemax", "aria-valuemin", "aria-valuenow", "aria-valuetext",
@@ -696,11 +707,13 @@ const PROPS_ROW: &[&str] = aria_props![
     "aria-activedescendant", "aria-colindex", "aria-disabled", "aria-expanded", "aria-level",
     "aria-posinset", "aria-rowindex", "aria-selected", "aria-setsize",
 ];
+/// Shared by: scrollbar, separator.
 #[rustfmt::skip]
 const PROPS_SCROLLBAR: &[&str] = aria_props![
     "aria-disabled", "aria-orientation", "aria-valuemax", "aria-valuemin", "aria-valuenow",
     "aria-valuetext",
 ];
+/// Shared by: searchbox, textbox.
 #[rustfmt::skip]
 const PROPS_SEARCHBOX: &[&str] = aria_props![
     "aria-activedescendant", "aria-autocomplete", "aria-disabled", "aria-errormessage",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/constants_test.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/constants_test.rs
@@ -1,0 +1,160 @@
+//! Guards for the inlined `aria-query` / `axobject-query` tables in `constants.rs`.
+//!
+//! The tables are stored in a condensed encoding (shared prop-sets factored behind
+//! `aria_props!`, one row per entry), so these tests pin down both the entry counts and
+//! the structural invariants that encoding relies on.
+
+use super::*;
+
+/// The 17 `roletype` props that `aria_props!` splices into every set.
+const ROLETYPE_GLOBALS: &[&str] = &[
+    "aria-atomic",
+    "aria-busy",
+    "aria-controls",
+    "aria-current",
+    "aria-describedby",
+    "aria-details",
+    "aria-dropeffect",
+    "aria-flowto",
+    "aria-grabbed",
+    "aria-hidden",
+    "aria-keyshortcuts",
+    "aria-label",
+    "aria-labelledby",
+    "aria-live",
+    "aria-owns",
+    "aria-relevant",
+    "aria-roledescription",
+];
+
+/// The only two roles whose allowed-prop set is empty.
+const ROLES_WITHOUT_ALLOWED_PROPS: &[&str] = &["doc-pullquote", "none"];
+
+#[test]
+fn table_sizes_are_intact() {
+    assert_eq!(ARIA_ATTRIBUTES.len(), 51);
+    assert_eq!(AUTOFILL_FIELD_NAME_TOKENS.len(), 47);
+    assert_eq!(ARIA_ROLES.len(), 139);
+    assert_eq!(ABSTRACT_ROLES.len(), 12);
+    assert_eq!(NON_INTERACTIVE_ROLES.len(), 88);
+    assert_eq!(INTERACTIVE_ROLES.len(), 38);
+    assert_eq!(ARIA_PROPERTY_DEFINITIONS.len(), 51);
+    assert_eq!(ROLE_REQUIRED_PROPS.len(), 12);
+    assert_eq!(ROLE_ALLOWED_ARIA_PROPS.len(), 139);
+    assert_eq!(SEMANTIC_ROLE_ELEMENTS.len(), 15);
+    assert_eq!(NON_INTERACTIVE_ELEMENT_ROLE_SCHEMAS.len(), 56);
+    assert_eq!(INTERACTIVE_ELEMENT_ROLE_SCHEMAS.len(), 37);
+    assert_eq!(INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS.len(), 26);
+    assert_eq!(NON_INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS.len(), 41);
+}
+
+#[test]
+fn abstract_roles_are_a_subset_of_aria_roles() {
+    for role in ABSTRACT_ROLES.iter() {
+        assert!(ARIA_ROLES.contains(role), "{role} missing from ARIA_ROLES");
+    }
+}
+
+#[test]
+fn every_aria_role_has_an_allowed_prop_set() {
+    for role in ARIA_ROLES.iter() {
+        assert!(
+            ROLE_ALLOWED_ARIA_PROPS.contains_key(role),
+            "{role} missing from ROLE_ALLOWED_ARIA_PROPS"
+        );
+    }
+}
+
+#[test]
+fn allowed_prop_sets_are_unique_and_valid() {
+    for (role, props) in ROLE_ALLOWED_ARIA_PROPS.iter() {
+        let mut deduped = props.to_vec();
+        deduped.sort_unstable();
+        deduped.dedup();
+        assert_eq!(
+            deduped.len(),
+            props.len(),
+            "{role}: an extra prop duplicates a roletype global"
+        );
+
+        for prop in *props {
+            let suffix = prop
+                .strip_prefix("aria-")
+                .unwrap_or_else(|| panic!("{role}: {prop} is not an aria-* attribute"));
+            assert!(
+                ARIA_ATTRIBUTES.contains(&suffix),
+                "{role}: {prop} is not in ARIA_ATTRIBUTES"
+            );
+        }
+    }
+}
+
+#[test]
+fn roletype_globals_are_allowed_on_every_role_but_two() {
+    for (role, props) in ROLE_ALLOWED_ARIA_PROPS.iter() {
+        if ROLES_WITHOUT_ALLOWED_PROPS.contains(role) {
+            assert!(props.is_empty(), "{role} should allow no props");
+            continue;
+        }
+        for global in ROLETYPE_GLOBALS {
+            assert!(props.contains(global), "{role} should allow {global}");
+        }
+    }
+}
+
+#[test]
+fn required_props_are_allowed_props() {
+    for (role, required) in ROLE_REQUIRED_PROPS.iter() {
+        let allowed = ROLE_ALLOWED_ARIA_PROPS[role];
+        for prop in *required {
+            assert!(
+                allowed.contains(prop),
+                "{role}: {prop} required but not allowed"
+            );
+        }
+    }
+}
+
+#[test]
+fn schema_indices_cover_every_schema() {
+    let cases: [(&[RoleRelationConcept], &FxHashMap<&'static str, Vec<usize>>); 4] = [
+        (
+            NON_INTERACTIVE_ELEMENT_ROLE_SCHEMAS,
+            &NON_INTERACTIVE_ELEMENT_ROLE_INDEX,
+        ),
+        (
+            INTERACTIVE_ELEMENT_ROLE_SCHEMAS,
+            &INTERACTIVE_ELEMENT_ROLE_INDEX,
+        ),
+        (
+            INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS,
+            &INTERACTIVE_ELEMENT_AX_OBJECT_INDEX,
+        ),
+        (
+            NON_INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS,
+            &NON_INTERACTIVE_ELEMENT_AX_OBJECT_INDEX,
+        ),
+    ];
+    for (schemas, index) in cases {
+        let indexed: usize = index.values().map(Vec::len).sum();
+        assert_eq!(indexed, schemas.len());
+        for (i, schema) in schemas.iter().enumerate() {
+            assert!(
+                index[schema.name].contains(&i),
+                "{} #{i} missing from its index bucket",
+                schema.name
+            );
+        }
+    }
+}
+
+#[test]
+fn aria_property_definitions_cover_every_aria_attribute() {
+    for attr in ARIA_ATTRIBUTES {
+        let name = format!("aria-{attr}");
+        assert!(
+            ARIA_PROPERTY_DEFINITIONS.contains_key(name.as_str()),
+            "{name} has no property definition"
+        );
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/constants_test.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/constants_test.rs
@@ -1,10 +1,11 @@
 //! Guards for the inlined `aria-query` / `axobject-query` tables in `constants.rs`.
 //!
 //! The tables are stored in a condensed encoding (shared prop-sets factored behind
-//! `aria_props!`, one row per entry), so these tests pin down both the entry counts and
-//! the structural invariants that encoding relies on.
+//! `aria_props!`, one row per entry), so these tests pin down the exact contents, the
+//! entry counts, and the structural invariants that encoding relies on.
 
 use super::*;
+use crate::compiler::phases::phase1_parse::utils::fuzzymatch::fuzzymatch;
 
 /// The 17 `roletype` props that `aria_props!` splices into every set.
 const ROLETYPE_GLOBALS: &[&str] = &[
@@ -30,6 +31,101 @@ const ROLETYPE_GLOBALS: &[&str] = &[
 /// The only two roles whose allowed-prop set is empty.
 const ROLES_WITHOUT_ALLOWED_PROPS: &[&str] = &["doc-pullquote", "none"];
 
+/// Number of allowed ARIA props per role, from aria-query@5.3.1.
+#[rustfmt::skip]
+const ROLE_ALLOWED_PROP_COUNTS: &[(&str, usize)] = &[
+    ("alert", 17), ("alertdialog", 18), ("application", 23), ("article", 19), ("banner", 17),
+    ("blockquote", 17), ("button", 21), ("caption", 17), ("cell", 21), ("checkbox", 24),
+    ("code", 17), ("columnheader", 30), ("combobox", 26), ("command", 17), ("complementary", 17),
+    ("composite", 19), ("contentinfo", 17), ("definition", 17), ("deletion", 17), ("dialog", 18),
+    ("directory", 17), ("doc-abstract", 22), ("doc-acknowledgments", 22), ("doc-afterword", 22),
+    ("doc-appendix", 22), ("doc-backlink", 22), ("doc-biblioentry", 25), ("doc-bibliography", 22),
+    ("doc-biblioref", 22), ("doc-chapter", 22), ("doc-colophon", 22), ("doc-conclusion", 22),
+    ("doc-cover", 22), ("doc-credit", 22), ("doc-credits", 22), ("doc-dedication", 22),
+    ("doc-endnote", 25), ("doc-endnotes", 22), ("doc-epigraph", 22), ("doc-epilogue", 22),
+    ("doc-errata", 22), ("doc-example", 22), ("doc-footnote", 22), ("doc-foreword", 22),
+    ("doc-glossary", 22), ("doc-glossref", 22), ("doc-index", 22), ("doc-introduction", 22),
+    ("doc-noteref", 22), ("doc-notice", 22), ("doc-pagebreak", 27), ("doc-pagefooter", 24),
+    ("doc-pageheader", 24), ("doc-pagelist", 22), ("doc-part", 22), ("doc-preface", 22),
+    ("doc-prologue", 22), ("doc-pullquote", 0), ("doc-qna", 22), ("doc-subtitle", 22),
+    ("doc-tip", 22), ("doc-toc", 22), ("document", 17), ("emphasis", 17), ("feed", 17),
+    ("figure", 17), ("form", 17), ("generic", 17), ("graphics-document", 22),
+    ("graphics-object", 23), ("graphics-symbol", 22), ("grid", 23), ("gridcell", 29), ("group", 19),
+    ("heading", 18), ("img", 17), ("input", 18), ("insertion", 17), ("landmark", 17), ("link", 20),
+    ("list", 17), ("listbox", 26), ("listitem", 20), ("log", 17), ("main", 17), ("mark", 20),
+    ("marquee", 17), ("math", 17), ("menu", 20), ("menubar", 20), ("menuitem", 22),
+    ("menuitemcheckbox", 27), ("menuitemradio", 27), ("meter", 21), ("navigation", 17), ("none", 0),
+    ("note", 17), ("option", 22), ("paragraph", 17), ("presentation", 17), ("progressbar", 21),
+    ("radio", 21), ("radiogroup", 24), ("range", 20), ("region", 17), ("roletype", 17), ("row", 26),
+    ("rowgroup", 17), ("rowheader", 30), ("scrollbar", 23), ("search", 17), ("searchbox", 27),
+    ("section", 17), ("sectionhead", 17), ("select", 20), ("separator", 23), ("slider", 27),
+    ("spinbutton", 27), ("status", 17), ("strong", 17), ("structure", 17), ("subscript", 17),
+    ("superscript", 17), ("switch", 24), ("tab", 23), ("table", 19), ("tablist", 22),
+    ("tabpanel", 17), ("term", 17), ("textbox", 27), ("time", 17), ("timer", 17), ("toolbar", 20),
+    ("tooltip", 17), ("tree", 24), ("treegrid", 27), ("treeitem", 25), ("widget", 17),
+    ("window", 18),
+];
+
+/// FNV-1a 64 of `"<role>=<comma-joined sorted props>\n"` for every role, roles sorted.
+/// Pinned from `main`'s table before the encoding change, so any substituted, dropped or
+/// added prop fails here even when the per-role counts still line up.
+const ROLE_ALLOWED_ARIA_PROPS_DIGEST: u64 = 0x3b86_c5a3_fcbb_a149;
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Canonical, order-independent rendering of `ROLE_ALLOWED_ARIA_PROPS`.
+fn role_allowed_aria_props_canonical() -> String {
+    let mut roles: Vec<&str> = ROLE_ALLOWED_ARIA_PROPS.keys().copied().collect();
+    roles.sort_unstable();
+    let mut out = String::new();
+    for role in roles {
+        let mut props = ROLE_ALLOWED_ARIA_PROPS[role].to_vec();
+        props.sort_unstable();
+        out.push_str(role);
+        out.push('=');
+        out.push_str(&props.join(","));
+        out.push('\n');
+    }
+    out
+}
+
+#[test]
+fn role_allowed_aria_props_content_is_pinned() {
+    assert_eq!(
+        fnv1a64(role_allowed_aria_props_canonical().as_bytes()),
+        ROLE_ALLOWED_ARIA_PROPS_DIGEST,
+        "ROLE_ALLOWED_ARIA_PROPS changed; see the per-role counts test for which role"
+    );
+}
+
+#[test]
+fn every_role_allows_exactly_the_expected_number_of_props() {
+    assert_eq!(
+        ROLE_ALLOWED_PROP_COUNTS.len(),
+        ROLE_ALLOWED_ARIA_PROPS.len()
+    );
+    let mut total = 0;
+    for (role, expected) in ROLE_ALLOWED_PROP_COUNTS {
+        let props = ROLE_ALLOWED_ARIA_PROPS
+            .get(role)
+            .unwrap_or_else(|| panic!("{role} missing from ROLE_ALLOWED_ARIA_PROPS"));
+        assert_eq!(
+            props.len(),
+            *expected,
+            "{role}: wrong number of allowed props"
+        );
+        total += props.len();
+    }
+    assert_eq!(total, 2833);
+}
+
 #[test]
 fn table_sizes_are_intact() {
     assert_eq!(ARIA_ATTRIBUTES.len(), 51);
@@ -46,6 +142,29 @@ fn table_sizes_are_intact() {
     assert_eq!(INTERACTIVE_ELEMENT_ROLE_SCHEMAS.len(), 37);
     assert_eq!(INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS.len(), 26);
     assert_eq!(NON_INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS.len(), 41);
+}
+
+#[test]
+fn aria_role_names_lead_with_the_abstract_roles_in_aria_query_order() {
+    assert_eq!(ARIA_ROLE_NAMES.len(), 139);
+    assert_eq!(
+        &ARIA_ROLE_NAMES[..ABSTRACT_ROLE_NAMES.len()],
+        ABSTRACT_ROLE_NAMES
+    );
+    assert_eq!(
+        ARIA_ROLE_NAMES.iter().collect::<FxHashSet<_>>().len(),
+        ARIA_ROLE_NAMES.len(),
+        "ARIA_ROLE_NAMES must not repeat a role"
+    );
+    // aria-query's key order, not alphabetical: `fuzzymatch` resolves ties by first
+    // occurrence, so `none` (idx 59) must still beat `note` (idx 60).
+    assert_eq!(ARIA_ROLE_NAMES.iter().position(|r| *r == "none"), Some(59));
+    assert_eq!(ARIA_ROLE_NAMES.iter().position(|r| *r == "note"), Some(60));
+}
+
+#[test]
+fn unknown_role_suggestions_follow_aria_query_order() {
+    assert_eq!(fuzzymatch("noe", ARIA_ROLE_NAMES).as_deref(), Some("none"));
 }
 
 #[test]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
@@ -154,8 +154,8 @@ pub fn check_element(node: &RegularElement, ancestor_names: &[String]) -> Vec<w:
                         if is_abstract_role(current_role) {
                             warnings.push(w::a11y_no_abstract_role(current_role));
                         } else if !ARIA_ROLES.contains(current_role) {
-                            let aria_roles_vec: Vec<&str> = ARIA_ROLES.iter().copied().collect();
-                            let suggestion = fuzzymatch(current_role, &aria_roles_vec);
+                            // Ordered list, not the set: fuzzymatch breaks ties by first occurrence.
+                            let suggestion = fuzzymatch(current_role, ARIA_ROLE_NAMES);
                             warnings
                                 .push(w::a11y_unknown_role(current_role, suggestion.as_deref()));
                         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
@@ -663,7 +663,7 @@ fn has_disabled_attribute(attribute_map: &FxHashMap<String, &AttributeNode>) -> 
 
 fn match_schemas_by_index(
     schemas: &[RoleRelationConcept],
-    index: &FxHashMap<String, Vec<usize>>,
+    index: &FxHashMap<&'static str, Vec<usize>>,
     tag_name: &str,
     attribute_map: &FxHashMap<String, &AttributeNode>,
 ) -> bool {
@@ -681,10 +681,10 @@ fn match_schema_attrs(
     schema: &RoleRelationConcept,
     attribute_map: &FxHashMap<String, &AttributeNode>,
 ) -> bool {
-    if let Some(schema_attrs) = &schema.attributes {
+    if let Some(schema_attrs) = schema.attributes {
         for schema_attr in schema_attrs {
-            if let Some(attribute) = attribute_map.get(&schema_attr.name) {
-                if let Some(expected_value) = &schema_attr.value {
+            if let Some(attribute) = attribute_map.get(schema_attr.name) {
+                if let Some(expected_value) = schema_attr.value {
                     if let Some(actual_value) = get_static_value(attribute) {
                         if actual_value != expected_value {
                             return false;
@@ -706,7 +706,7 @@ fn element_interactivity(
     attribute_map: &FxHashMap<String, &AttributeNode>,
 ) -> &'static str {
     if match_schemas_by_index(
-        &INTERACTIVE_ELEMENT_ROLE_SCHEMAS,
+        INTERACTIVE_ELEMENT_ROLE_SCHEMAS,
         &INTERACTIVE_ELEMENT_ROLE_INDEX,
         tag_name,
         attribute_map,
@@ -716,7 +716,7 @@ fn element_interactivity(
 
     if tag_name != "header"
         && match_schemas_by_index(
-            &NON_INTERACTIVE_ELEMENT_ROLE_SCHEMAS,
+            NON_INTERACTIVE_ELEMENT_ROLE_SCHEMAS,
             &NON_INTERACTIVE_ELEMENT_ROLE_INDEX,
             tag_name,
             attribute_map,
@@ -726,7 +726,7 @@ fn element_interactivity(
     }
 
     if match_schemas_by_index(
-        &INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS,
+        INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS,
         &INTERACTIVE_ELEMENT_AX_OBJECT_INDEX,
         tag_name,
         attribute_map,
@@ -735,7 +735,7 @@ fn element_interactivity(
     }
 
     if match_schemas_by_index(
-        &NON_INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS,
+        NON_INTERACTIVE_ELEMENT_AX_OBJECT_SCHEMAS,
         &NON_INTERACTIVE_ELEMENT_AX_OBJECT_INDEX,
         tag_name,
         attribute_map,


### PR DESCRIPTION
Fixes #1747

## What

Re-encodes `crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/constants.rs`.
**No data was added, removed, or changed** — only its representation.

Upstream Svelte's `constants.js` is ~334 lines because it imports its tables from the
`aria-query` / `axobject-query` npm packages. rsvelte inlines those tables, and they were
written one array element per line.

## Line count

| File | Before | After |
|---|---:|---:|
| `a11y/constants.rs` | **5,594** | **821** (−85.3%) |
| `a11y/constants_test.rs` (new) | — | 279 |
| `a11y/mod.rs` | 1,142 | 1,142 (4 lines touched) |
| `1_parse/utils/fuzzymatch.rs` | — | +6 (see "Ordering" below) |

`ROLE_ALLOWED_ARIA_PROPS` alone was 3,526 of those lines (139 roles × ~25 lines).

## How

- **`ROLE_ALLOWED_ARIA_PROPS`** — the 139 roles have only **41 distinct non-empty prop-sets**,
  and **17 props (aria-query's `roletype` globals) are shared by 137 of them** (`none` and
  `doc-pullquote` allow nothing). Those 17 now live in an `aria_props!` macro that splices them
  into each set, each of the 41 sets is a named `PROPS_*` const holding only its delta, and the
  role→set map is a one-row-per-role const table collected into the same
  `LazyLock<FxHashMap<&'static str, &'static [&'static str]>>` as before.
  ```rust
  /// Shared by: alertdialog, dialog, window.
  const PROPS_ALERTDIALOG: &[&str] = aria_props!["aria-modal"];
  ...
  ("button", PROPS_BUTTON), ("caption", PROPS_ROLETYPE), ("cell", PROPS_CELL),
  ```
  Every prop-set used by more than one role carries a `/// Shared by: …` doc comment, so a future
  aria-query bump that changes only one of them is visibly a "split this set" edit.
- **`RoleRelationConcept` / `RoleRelationConceptAttribute`** — `String` → `&'static str`, so the
  four schema tables (894 lines / 160 entries) become plain `&[RoleRelationConcept]` consts built
  with `tag` / `tag_with` / `has` / `eq` const fns, one entry per row instead of a runtime
  `vec![]` + `to_string()` per field. The schema index maps are now keyed by `&'static str`
  (no more `name.clone()` per entry at first use).
- **`ARIA_PROPERTY_DEFINITIONS`** (364 lines / 51 entries) and the other maps become const
  `&[(&str, ..)]` tables `.iter().copied().collect()`ed into their existing `LazyLock` maps.
- Long name lists are packed under `#[rustfmt::skip]`.
- No `build.rs` / codegen: everything stays plain Rust source.

## Ordering: `ARIA_ROLES` is a set, so it must not feed `fuzzymatch`

`a11y_unknown_role` suggestions came from `ARIA_ROLES.iter()` — a `FxHashSet`. `fuzzymatch`
resolves score ties by candidate order, so the suggestion text depended on hash iteration order.
An earlier revision of this PR listed the roles alphabetically and silently changed
`<div role="noe">` from `Did you mean 'none'?` to `'note'`. Fixed in three parts:

1. `ARIA_ROLE_NAMES` is a new ordered `&[&str]` in **aria-query's `roles` map key order**
   (abstract roles first, exactly reproducing `main`'s insert order), and `ARIA_ROLES` is derived
   from it. `none` is index 59, `note` is index 60.
2. `a11y/mod.rs` passes `ARIA_ROLE_NAMES` to `fuzzymatch` instead of collecting the set, so the
   suggestion no longer depends on hash order at all. The only other `fuzzymatch` call sites
   (`ARIA_ATTRIBUTES`, `VALID_WARNING_CODES`) were already ordered slices.
3. **`fuzzymatch.rs`**: `FuzzySet::get_with_gram_size` iterated its `FxHashMap<usize, usize>` of
   match scores in hash order before two *stable* sorts, so hash order — not candidate order —
   was the real tie-break. Upstream keys that map by integer index and walks it with `for…in`,
   which visits integer-like keys in **ascending numeric order** (`fuzzymatch.js:250`). Now
   sorted ascending to match.

Steps 1+2 alone were **not** sufficient — measured, `fuzzymatch("noe", ARIA_ROLE_NAMES)` still
returned `note` until step 3. End-to-end after all three:

```
$ compile(r#"<div role="noe">x</div>"#)
WARNING a11y_unknown_role :: Unknown role 'noe' (did you mean 'none'?)
```

which matches `main` and upstream (verified against upstream `fuzzymatch.js` + aria-query@5.3.1).

### Why a `fuzzymatch` fix ships in an a11y-constants PR

Step 3 is a pre-existing bug (#1747) and would normally be its own PR, but splitting it here would
leave a regression on `main`: steps 1+2 alone were measured to still return `note`, so merging only
the constants change would make `role="noe"` diverge from upstream the moment it lands. It is also
the change that makes the invariant this PR now *relies on and documents* — the comment at
`a11y/mod.rs:157` says ties break by first occurrence — actually true; leaving that 6-line fix in a
separate PR would separate the code from its stated premise. The three `fuzzymatch` call sites in
the tree are `ARIA_ATTRIBUTES`, `ARIA_ROLE_NAMES` and `VALID_WARNING_CODES`; the other two were
already ordered const slices, so the blast radius is exactly those three lists. It is isolated in
its own commit if it needs to be lifted out.

## Proof of data equality

A temporary `#[test]` was added that dumps **every** table in a deterministic order
(map keys sorted; slices in declaration order; `ROLE_ALLOWED_ARIA_PROPS` prop lists sorted,
since the consumer only does `contains` — verified separately that all 139 original lists were
already alphabetically sorted, so this normalization is a no-op on the "before" side).

The **identical** dump code was run on `main`'s `constants.rs` and on the final, `cargo fmt`-ed
version of this branch:

```
$ diff a11y_before.txt a11y_after.txt   # no output
$ shasum -a 256 a11y_before.txt a11y_after.txt
2b8e6430abc2eb4af4e1a2d74eaaf43928e2c77ce8c7ff738d52b42b26a7b226  a11y_before.txt
2b8e6430abc2eb4af4e1a2d74eaaf43928e2c77ce8c7ff738d52b42b26a7b226  a11y_after.txt
```

1,382 lines / 59,088 bytes covering all 24 public tables: `ARIA_ATTRIBUTES`,
`A11Y_REQUIRED_ATTRIBUTES`, `A11Y_DISTRACTING_ELEMENTS`, `A11Y_REQUIRED_CONTENT`,
`A11Y_LABELABLE`, `A11Y_INTERACTIVE_HANDLERS`, `A11Y_RECOMMENDED_INTERACTIVE_HANDLERS`,
`A11Y_NESTED_IMPLICIT_SEMANTICS`, `A11Y_IMPLICIT_SEMANTICS`, `MENUITEM_TYPE_TO_IMPLICIT_ROLE`,
`INPUT_TYPE_TO_IMPLICIT_ROLE`, `A11Y_NON_INTERACTIVE_ELEMENT_TO_INTERACTIVE_ROLE_EXCEPTIONS`,
`COMBOBOX_IF_LIST`, `ADDRESS_TYPE_TOKENS`, `AUTOFILL_FIELD_NAME_TOKENS`, `CONTACT_TYPE_TOKENS`,
`AUTOFILL_CONTACT_FIELD_NAME_TOKENS`, `INVISIBLE_ELEMENTS`, `ARIA_ROLES`, `ABSTRACT_ROLES`,
`NON_INTERACTIVE_ROLES`, `INTERACTIVE_ROLES`, `PRESENTATION_ROLES`, the 4 schema tables **and
their 4 derived indices** (bucket contents compared element-wise), `ARIA_PROPERTY_DEFINITIONS`,
`ROLE_REQUIRED_PROPS`, `SEMANTIC_ROLE_ELEMENTS` and `ROLE_ALLOWED_ARIA_PROPS`.

The first run of this comparison caught a real bug in my own conversion — a leading `""` entry in
`AUTOFILL_FIELD_NAME_TOKENS` had been dropped — which is exactly what the check is for. The dump
was re-run and re-compared after every subsequent edit, including the `ARIA_ROLE_NAMES` reorder
(same sha256).

## Permanent guards (`constants_test.rs`, 13 tests)

The temporary dump test is not part of the diff; its detection power is preserved by:

- **`ROLE_ALLOWED_ARIA_PROPS_DIGEST`** — FNV-1a 64 of the canonical `role=props\n` rendering,
  pinned at `0x3b86_c5a3_fcbb_a149` from `main`'s table. Any dropped, added or *substituted* prop
  fails here.
- **`ROLE_ALLOWED_PROP_COUNTS`** — per-role prop counts for all 139 roles plus a 2,833 total, so a
  failure names the role rather than just reporting a digest mismatch.
- `ARIA_ROLE_NAMES` is 139 unique entries, starts with `ABSTRACT_ROLE_NAMES`, and keeps
  `none`@59 / `note`@60.
- `fuzzymatch("noe", ARIA_ROLE_NAMES) == Some("none")`.
- Entry counts for 14 tables; `ABSTRACT_ROLES ⊆ ARIA_ROLES`; every ARIA role has a prop-set;
  every allowed prop is a real `ARIA_ATTRIBUTES` entry with no duplicates; the 17 globals hold on
  every role but the two known exceptions; `ROLE_REQUIRED_PROPS ⊆ ROLE_ALLOWED_ARIA_PROPS`; the
  schema indices cover every schema; every ARIA attribute has a property definition.

Sanity-checked against the mutation raised in review: deleting `aria-modal` from
`PROPS_ALERTDIALOG` now fails both the digest test and the count test (naming `alertdialog`,
`dialog`, `window`).

## Consumer impact

`a11y/mod.rs` is the only consumer of `constants` (`mod constants;` is private). All use sites
were audited; besides the `fuzzymatch` change above, the edits are type-mechanical and
order-independent:

- `match_schemas_by_index(index: &FxHashMap<String, …>)` → `&FxHashMap<&'static str, …>`
- `&SCHEMAS` → `SCHEMAS` (the statics are already slice refs)
- `&schema.attributes` / `&schema_attr.value` → by-value (`Option<&'static str>` is `Copy`)
- `attribute_map.get(&schema_attr.name)` → `.get(schema_attr.name)`

`ROLE_ALLOWED_ARIA_PROPS[rv]` still yields `&'static [&'static str]` and is still used via
`allowed_props.contains(&attr_name)`, so prop ordering inside a set is irrelevant (the new
encoding lists globals first, then the role's extras).

## Verification

```
cargo fmt --all                                              # clean
cargo clippy --all-targets --all-features -- -D warnings     # clean
cargo test -p rsvelte_core --release                         # all suites, 0 failed
cargo test -p rsvelte_core --lib                             # 1556 passed; 0 failed
cargo test -p rsvelte_core --test validator                  # Total: 332/332 passed (0 skipped)
```

Validator is the suite that exercises the a11y warnings (`a11y-role-supports-aria-props`,
`a11y-role-has-required-aria-props`, `a11y-aria-proptypes-*`, `a11y-no-noninteractive-*`, …):
**332/332, zero failures, zero skips**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqdHfZSN3LFxPkyKFaCyoF
