### PR TITLE
refactor(analyze): compress error/warning constructors into a declarative table

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/diagnostic.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/diagnostic.rs
@@ -1,0 +1,46 @@
+//! Declarative form for the compiler's error and warning constructors.
+//!
+//! `errors.rs` and `warnings.rs` mirror Svelte's `errors.js` / `warnings.js`, which are
+//! themselves generated from `packages/svelte/messages/**/*.md`. Here the same tables are
+//! written as declarations so that the code, the message template and the argument types
+//! stay on one line each.
+
+/// Declare diagnostic constructors.
+///
+/// ```ignore
+/// diagnostics! {
+///     error => AnalysisError;
+///
+///     /// doc comment
+///     attribute_duplicate() => "Attributes need to be unique";
+///     props_duplicate(rune: &str) => "`{}` has already been declared", rune;
+///     // `as "..."` overrides the code when it differs from the function name
+///     foo_bar as "foo"() => "…";
+/// }
+/// ```
+macro_rules! diagnostics {
+    (@code $name:ident) => { stringify!($name) };
+    (@code $name:ident $code:literal) => { $code };
+    (@message $message:literal) => { $message };
+    (@message $message:literal, $($arg:expr),+) => { format!($message, $($arg),+) };
+    (
+        $constructor:path => $return_type:ty;
+        $(
+            $(#[$meta:meta])*
+            $name:ident $(as $code:literal)? ($($param:ident: $param_type:ty),* $(,)?)
+                => $message:literal $(, $arg:expr)* ;
+        )*
+    ) => {
+        $(
+            $(#[$meta])*
+            pub fn $name($($param: $param_type),*) -> $return_type {
+                $constructor(
+                    diagnostics!(@code $name $($code)?),
+                    diagnostics!(@message $message $(, $arg)*),
+                )
+            }
+        )*
+    };
+}
+
+pub(super) use diagnostics;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/errors.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/errors.rs
@@ -6,6 +6,7 @@
 //! Corresponds to Svelte's `errors.js`.
 
 use super::AnalysisError;
+use super::diagnostic::diagnostics;
 
 /// Create an error with a specific code and message.
 fn error(code: &str, message: impl Into<String>) -> AnalysisError {
@@ -17,130 +18,422 @@ fn error(code: &str, message: impl Into<String>) -> AnalysisError {
 
 // Rune-related errors
 
-/// `$bindable()` can only be used inside a `$props()` declaration
-pub fn bindable_invalid_location() -> AnalysisError {
-    error(
-        "bindable_invalid_location",
-        "`$bindable()` can only be used inside a `$props()` declaration",
-    )
+diagnostics! {
+    error => AnalysisError;
+
+    /// `$bindable()` can only be used inside a `$props()` declaration
+    bindable_invalid_location() => "`$bindable()` can only be used inside a `$props()` declaration";
+
+    /// `$host()` can only be used inside custom element component instances
+    host_invalid_placement() => "`$host()` can only be used inside custom element component instances";
+
+    /// `$props()` can only be used as a variable declaration initializer at the top level of the `<script>` tag
+    props_invalid_placement() => "`$props()` can only be used as a variable declaration initializer at the top level of the `<script>` tag";
+
+    /// `$props()` can only be used with an object destructuring pattern or an identifier
+    props_invalid_identifier() => "`$props()` can only be used with an object destructuring pattern or an identifier";
+
+    /// `%rune%` has already been declared
+    props_duplicate(rune: &str) => "`{}` has already been declared", rune;
+
+    /// Declaring or accessing a prop starting with `$$` is illegal (they are reserved for Svelte internals)
+    props_illegal_name() => "Declaring or accessing a prop starting with `$$` is illegal (they are reserved for Svelte internals)";
+
+    /// `$props.id()` can only be used as a variable declaration initializer at the top level of the `<script>` tag
+    props_id_invalid_placement() => "`$props.id()` can only be used as a variable declaration initializer at the top level of the `<script>` tag";
+
+    /// `%rune%` cannot be used with arguments
+    rune_invalid_arguments(rune: &str) => "`{}` cannot be used with arguments", rune;
+
+    /// `%rune%` cannot be used with spread arguments
+    rune_invalid_spread(rune: &str) => "`{}` cannot be used with spread arguments", rune;
+
+    /// `%rune%` requires %expected%
+    rune_invalid_arguments_length(rune: &str, expected: &str) => "`{}` requires {}", rune, expected;
+
+    /// `%rune%` can only be used as a variable declaration initializer, a class field declaration, or the first assignment to a class field at the top level of the constructor.
+    state_invalid_placement(rune: &str) => "`{}(...)` can only be used as a variable declaration initializer, a class field declaration, or the first assignment to a class field at the top level of the constructor.\nhttps://svelte.dev/e/state_invalid_placement", rune;
+
+    /// `$effect()` can only be used as an expression statement
+    effect_invalid_placement() => "`$effect()` can only be used as an expression statement";
+
+    /// `$inspect.trace()` can only be called as a statement within the body of a function
+    inspect_trace_invalid_placement() => "`$inspect.trace()` can only be called as a statement within the body of a function";
+
+    /// Generator functions cannot be used with $inspect.trace
+    inspect_trace_generator() => "Generator functions cannot be used with $inspect.trace";
+
+    // Binding-related errors
+
+    /// `%name%` can only be bound to %target%
+    bind_invalid_target(name: &str, target: &str) => "`{}` can only be bound to {}", name, target;
+
+    /// Cannot assign to %thing%
+    constant_assignment(thing: &str) => "Cannot assign to {}", thing;
+
+    /// Cannot bind to %thing%
+    constant_binding(thing: &str) => "Cannot bind to {}", thing;
+
+    // Attribute-related errors
+
+    /// Attributes need to be unique
+    attribute_duplicate() => "Attributes need to be unique";
+
+    /// '%name%' attribute cannot be dynamic
+    attribute_invalid_type(name: &str) => "'{}' attribute cannot be dynamic", name;
+
+    /// The 'multiple' attribute must be static if select uses two-way binding
+    attribute_invalid_multiple() => "'multiple' attribute must be static if select uses two-way binding\nhttps://svelte.dev/e/attribute_invalid_multiple";
+
+    // Declaration-related errors
+
+    /// `%name%` has already been declared
+    declaration_duplicate(name: &str) => "`{}` has already been declared", name;
+
+    // Class-related errors
+
+    /// `%name%` has already been declared
+    duplicate_class_field(name: &str) => "`{}` has already been declared", name;
+
+    /// `%name%` has already been declared on this class
+    state_field_duplicate(name: &str) => "`{}` has already been declared on this class", name;
+
+    /// Cannot declare a variable with the same name as an import inside `<script module>`
+    declaration_duplicate_module_import() => "Cannot declare a variable with the same name as an import inside `<script module>`";
+
+    // Export-related errors
+
+    /// Cannot export derived state from a module
+    derived_invalid_export() => "Cannot export derived state from a module. To expose the current derived value, export a function returning its value\nhttps://svelte.dev/e/derived_invalid_export";
+
+    /// A component cannot have a default export
+    module_illegal_default_export() => "A component cannot have a default export\nhttps://svelte.dev/e/module_illegal_default_export";
+
+    // Element-related errors
+
+    /// `<svelte:element>` must have a 'this' attribute with a value
+    svelte_element_missing_this() => "`<svelte:element>` must have a 'this' attribute with a value";
+
+    /// `<svelte:component>` must have a `this` attribute (issue #453, H-046)
+    svelte_component_missing_this() => "`<svelte:component>` must have a 'this' attribute";
+
+    /// A component can only have one `<%name%>` element
+    svelte_meta_duplicate(name: &str) => "A component can only have one `<{}>` element", name;
+
+    /// `<%name%>` tags cannot be inside elements or blocks
+    svelte_meta_invalid_placement(name: &str) => "`<{}>` tags cannot be inside elements or blocks", name;
+
+    // Render tag errors
+
+    /// `{@render ...}` tags can only contain call expressions
+    render_tag_invalid_expression() => "`{@render ...}` tags can only contain call expressions";
+
+    /// Cannot use spread arguments in `{@render ...}` tags
+    render_tag_invalid_spread_argument() => "cannot use spread arguments in `{@render ...}` tags";
+
+    /// Calling a snippet function using apply, bind or call is not allowed
+    render_tag_invalid_call_expression() => "Calling a snippet function using apply, bind or call is not allowed";
+
+    // Assignment-related errors
+
+    /// Cannot reassign or bind to each block item
+    each_item_invalid_assignment() => "Cannot reassign or bind to each block item";
+
+    /// Cannot reassign or bind to snippet parameter
+    snippet_parameter_assignment() => "Cannot reassign or bind to snippet parameter";
+
+    /// Cannot use `$` as a variable name
+    dollar_binding_invalid() => "Cannot use `$` as a variable name";
+
+    /// Variable name cannot start with `$`
+    dollar_prefix_invalid() => "Variable name cannot start with `$` except for special Svelte stores";
+
+    /// Cannot export state from a module if it is reassigned
+    state_invalid_export() => "Cannot export state from a module if it is reassigned. Either export a function returning the state value or only mutate the state value's properties\nhttps://svelte.dev/e/state_invalid_export";
+
+    // Block-related errors
+
+    /// {@const} tag can only be used in certain contexts
+    const_tag_invalid_placement() => "`{@const}` must be the immediate child of `{#snippet}`, `{#if}`, `{:else if}`, `{:else}`, `{#each}`, `{:then}`, `{:catch}`, `<svelte:fragment>`, `<svelte:boundary>` or `<Component>`\nhttps://svelte.dev/e/const_tag_invalid_placement";
+
+    /// Declaration tags (`{let …}` / `{const …}`) are not allowed in legacy mode.
+    /// Svelte 5.56.0 (#18282).
+    declaration_tag_no_legacy_mode() => "Declaration tags cannot be used in legacy mode\nhttps://svelte.dev/e/declaration_tag_no_legacy_mode";
+
+    /// A declaration tag must contain a plain `let` or `const` VariableDeclaration.
+    /// Svelte 5.56.0 (#18282).
+    declaration_tag_invalid_type() => "Declaration tags can only contain `let` or `const` variable declarations\nhttps://svelte.dev/e/declaration_tag_invalid_type";
+
+    /// Block must start with expected character
+    block_unexpected_character(expected: &str) => "Expected a `{}` character immediately following the opening bracket\nhttps://svelte.dev/e/block_unexpected_character", expected;
+
+    /// `{#each}` block with a key requires an `as` binding
+    each_key_without_as() => "An `{#each ...}` block without an `as` clause cannot have a key";
+
+    /// Cannot assign to %thing% before initialization
+    state_field_invalid_assignment() => "Cannot assign to state field before initialization in constructor";
+
+    /// %name% cannot have children
+    svelte_meta_invalid_content(name: &str) => "`<{}>` cannot have children", name;
+
+    /// `use:`, `transition:` and `animate:` directives, attachments and bindings do not support await expressions
+    illegal_await_expression() => "`use:`, `transition:` and `animate:` directives, attachments and bindings do not support await expressions";
+
+    /// `arguments` cannot be used outside of functions
+    invalid_arguments_usage() => "`arguments` cannot be used outside of functions";
+
+    /// Runes cannot use computed properties
+    rune_invalid_computed_property() => "Runes cannot use computed member expressions";
+
+    /// Rune %old_name% has been renamed to %new_name%
+    rune_renamed(old_name: &str, new_name: &str) => "`{}` has been renamed to `{}`", old_name, new_name;
+
+    /// Rune %name% has been removed
+    rune_removed(name: &str) => "`{}` has been removed", name;
+
+    /// Invalid rune name %name%
+    rune_invalid_name(name: &str) => "`{}` is not a valid rune", name;
+
+    /// Runes must be called
+    rune_missing_parentheses() => "Runes must be called as functions";
+
+    /// {@const} tag cannot reference %name% in this context
+    const_tag_invalid_reference(name: &str) => "{{@const}} tag cannot reference `{}` in this context - it can only be used with declarations from an implicit children snippet", name;
+
+    // Slot element errors
+
+    /// `<slot>` can only receive attributes and (optionally) let directives
+    slot_element_invalid_attribute() => "`<slot>` can only receive attributes and (optionally) let directives";
+
+    /// slot attribute must be a static value
+    slot_element_invalid_name() => "slot attribute must be a static value";
+
+    /// `default` is a reserved word — it cannot be used as a slot name
+    slot_element_invalid_name_default() => "`default` is a reserved word — it cannot be used as a slot name";
+
+    // Event handler errors
+
+    /// Event modifiers other than 'once' can only be used on DOM elements
+    event_handler_invalid_component_modifier() => "Event modifiers other than 'once' can only be used on DOM elements\nhttps://svelte.dev/e/event_handler_invalid_component_modifier";
+
+    // Transition/animation directive errors
+
+    /// An element can only have one '%name%' directive
+    transition_duplicate(directive_name: &str) => "An element can only have one '{}' directive", directive_name;
+
+    /// An element cannot have both '%a%' and '%b%' directives
+    transition_conflict(a: &str, b: &str) => "An element cannot have both '{}' and '{}' directives", a, b;
+
+    /// An element can only have one animate directive
+    animation_duplicate() => "An element can only have one 'animate' directive\nhttps://svelte.dev/e/animation_duplicate";
+
+    /// An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block
+    animation_invalid_placement() => "An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block\nhttps://svelte.dev/e/animation_invalid_placement";
+
+    /// An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block. Did you forget to add a key to your each block?
+    animation_missing_key() => "An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block. Did you forget to add a key to your each block?\nhttps://svelte.dev/e/animation_missing_key";
+
+    // CSS-related errors
+
+    /// `:global(...)` must contain exactly one selector
+    css_global_invalid_selector() => "`:global(...)` must contain exactly one selector";
+
+    /// `:global(...)` must not contain type or universal selectors when used in a compound selector
+    css_global_invalid_selector_list() => "`:global(...)` must not contain type or universal selectors when used in a compound selector";
+
+    /// `:global(...)` can be at the start or end of a selector sequence, but not in the middle
+    css_global_invalid_placement() => "`:global(...)` can be at the start or end of a selector sequence, but not in the middle";
+
+    /// Invalid selector
+    css_selector_invalid() => "Invalid selector";
+
+    /// A `:global` selector cannot be inside a pseudoclass
+    css_global_block_invalid_placement() => "A `:global` selector cannot be inside a pseudoclass";
+
+    /// A `:global` selector cannot follow a `%name%` combinator
+    css_global_block_invalid_combinator(combinator_name: &str) => "A `:global` selector cannot follow a `{}` combinator", combinator_name;
+
+    /// A top-level `:global {{...}}` block can only contain rules, not declarations
+    css_global_block_invalid_declaration() => "A top-level `:global {...}` block can only contain rules, not declarations";
+
+    /// A `:global` selector cannot be part of a selector list with entries that don't contain `:global`
+    css_global_block_invalid_list() => "A `:global` selector cannot be part of a selector list with entries that don't contain `:global`";
+
+    /// A `:global` selector cannot modify an existing selector
+    css_global_block_invalid_modifier() => "A `:global` selector cannot modify an existing selector";
+
+    /// A `:global` selector can only be modified if it is a descendant of other selectors
+    css_global_block_invalid_modifier_start() => "A `:global` selector can only be modified if it is a descendant of other selectors";
+
+    /// Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`
+    css_nesting_selector_invalid_placement() => "Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`";
+
+    /// Type selector cannot appear after `:global(...)`
+    css_type_selector_invalid_placement() => "Type selector cannot appear after `:global(...)`";
+
+    /// Declaration cannot be empty
+    css_empty_declaration() => "Declaration cannot be empty";
+
+    // Attribute-related errors
+
+    /// '%name%' is not a valid attribute name
+    attribute_invalid_name(name: &str) => "'{}' is not a valid attribute name", name;
+
+    /// 'contenteditable' attribute cannot be dynamic if element uses two-way binding
+    attribute_contenteditable_dynamic() => "'contenteditable' attribute cannot be dynamic if element uses two-way binding";
+
+    /// 'contenteditable' attribute is required for textContent, innerHTML and innerText two-way bindings
+    attribute_contenteditable_missing() => "'contenteditable' attribute is required for textContent, innerHTML and innerText two-way bindings";
+
+    /// Cannot use `%rune%` rune in non-runes mode
+    rune_invalid_usage(rune: &str) => "Cannot use `{}` rune in non-runes mode\nhttps://svelte.dev/e/rune_invalid_usage", rune;
+
+    /// Props destructuring pattern cannot use computed properties
+    props_invalid_pattern() => "Props destructuring pattern cannot use computed properties or non-identifier keys";
+
+    // Component-related errors
+
+    /// This type of directive is not valid on components
+    component_invalid_directive() => "This type of directive is not valid on components";
+
+    // Svelte element errors
+
+    /// `<svelte:head>` cannot have attributes nor directives
+    svelte_head_illegal_attribute() => "`<svelte:head>` cannot have attributes nor directives";
+
+    // Title element errors
+
+    /// `<title>` cannot have attributes nor directives
+    title_illegal_attribute() => "`<title>` cannot have attributes nor directives";
+
+    // Reactive declaration errors
+
+    /// Cyclical dependency detected: %cycle%
+    reactive_declaration_cycle(cycle: &str) => "Cyclical dependency detected: {}", cycle;
+
+    /// {@%name% ...} tag cannot be %location%
+    tag_invalid_placement(name: &str, location: &str) => "{{@{} ...}} tag cannot be {}\nhttps://svelte.dev/e/tag_invalid_placement", name, location;
+
+    /// %message%. The browser will 'repair' the HTML (by moving, removing, or inserting elements) which breaks Svelte's assumptions about the structure of your components.
+    node_invalid_placement(message: &str) => "{}. The browser will 'repair' the HTML (by moving, removing, or inserting elements) which breaks Svelte's assumptions about the structure of your components.\nhttps://svelte.dev/e/node_invalid_placement", message;
+
+    /// A `<textarea>` can have either a value attribute or (equivalently) child content, but not both
+    textarea_invalid_content() => "A `<textarea>` can have either a value attribute or (equivalently) child content, but not both\nhttps://svelte.dev/e/textarea_invalid_content";
+
+    /// Cannot reference store value outside a `.svelte` file
+    store_invalid_subscription_module() => "Cannot reference store value outside a `.svelte` file\nhttps://svelte.dev/e/store_invalid_subscription_module";
+
+    /// Mixing old (on:event) and new syntaxes for event handling is not allowed
+    mixed_event_handler_syntaxes(name: &str) => "Mixing old (on:{}) and new syntaxes for event handling is not allowed. Use only the on{} syntax\nhttps://svelte.dev/e/mixed_event_handler_syntaxes", name, name;
+
+    /// Imports of `svelte/internal/*` are forbidden
+    import_svelte_internal_forbidden() => "Imports of `svelte/internal/*` are forbidden. It contains private runtime code which is subject to change without notice.\nhttps://svelte.dev/e/import_svelte_internal_forbidden";
+
+    /// %name% cannot be used in runes mode
+    runes_mode_invalid_import(name: &str) => "{} cannot be used in runes mode\nhttps://svelte.dev/e/runes_mode_invalid_import", name;
+
+    /// Cannot use `export let` in runes mode — use `$props()` instead
+    legacy_export_invalid() => "Cannot use `export let` in runes mode — use `$props()` instead\nhttps://svelte.dev/e/legacy_export_invalid";
+
+    /// `$:` is not allowed in runes mode, use `$derived` or `$effect` instead
+    legacy_reactive_statement_invalid() => "`$:` is not allowed in runes mode, use `$derived` or `$effect` instead\nhttps://svelte.dev/e/legacy_reactive_statement_invalid";
+
+    /// Cannot subscribe to stores that are not declared at the top level of the component
+    store_invalid_scoped_subscription() => "Cannot subscribe to stores that are not declared at the top level of the component\nhttps://svelte.dev/e/store_invalid_scoped_subscription";
+
+    /// Cannot reference store value inside `<script module>`
+    store_invalid_subscription() => "Cannot reference store value inside `<script module>`\nhttps://svelte.dev/e/store_invalid_subscription";
+
+    /// `%name%` is not defined
+    export_undefined(name: &str) => "`{}` is not defined\nhttps://svelte.dev/e/export_undefined", name;
+
+    /// Duplicate slot name '%name%' in <%component%>
+    slot_attribute_duplicate(name: &str, component: &str) => "Duplicate slot name '{}' in <{}>\nhttps://svelte.dev/e/slot_attribute_duplicate", name, component;
+
+    /// Found default slot content alongside an explicit slot="default"
+    slot_default_duplicate() => "Found default slot content alongside an explicit slot=\"default\"\nhttps://svelte.dev/e/slot_default_duplicate";
+
+    /// This snippet is shadowing the prop `%prop%` with the same name
+    snippet_shadowing_prop(prop: &str) => "This snippet is shadowing the prop `{}` with the same name\nhttps://svelte.dev/e/snippet_shadowing_prop", prop;
+
+    /// Element with a slot='...' attribute must be a child of a component or a descendant of a custom element
+    slot_attribute_invalid_placement() => "Element with a slot='...' attribute must be a child of a component or a descendant of a custom element\nhttps://svelte.dev/e/slot_attribute_invalid_placement";
+
+    /// slot attribute must be a static value
+    slot_attribute_invalid() => "slot attribute must be a static value\nhttps://svelte.dev/e/slot_attribute_invalid";
+
+    /// `<svelte:fragment>` must be the direct child of a component
+    svelte_fragment_invalid_placement() => "`<svelte:fragment>` must be the direct child of a component\nhttps://svelte.dev/e/svelte_fragment_invalid_placement";
+
+    /// Cyclical dependency detected: %cycle%
+    const_tag_cycle(cycle: &str) => "Cyclical dependency detected: {}\nhttps://svelte.dev/e/const_tag_cycle", cycle;
+
+    /// Attribute shorthand cannot be empty
+    attribute_empty_shorthand() => "Attribute shorthand cannot be empty\nhttps://svelte.dev/e/attribute_empty_shorthand";
+
+    /// `%type%` name cannot be empty
+    directive_missing_name(directive_type: &str) => "`{}` name cannot be empty\nhttps://svelte.dev/e/directive_missing_name", directive_type;
+
+    /// Sequence expressions are not allowed as attribute/directive values in runes mode, unless wrapped in parentheses
+    attribute_invalid_sequence_expression() => "Sequence expressions are not allowed as attribute/directive values in runes mode, unless wrapped in parentheses\nhttps://svelte.dev/e/attribute_invalid_sequence_expression";
+
+    /// `%name%` is an illegal variable name. To reference a global variable called `%name%`, use `globalThis.%name%`
+    global_reference_invalid(name: &str) => "`{}` is an illegal variable name. To reference a global variable called `{}`, use `globalThis.{}`\nhttps://svelte.dev/e/global_reference_invalid", name, name, name;
+
+    /// Valid `<svelte:...>` tag names are %list%
+    svelte_meta_invalid_tag(list: &str) => "Valid `<svelte:...>` tag names are {}\nhttps://svelte.dev/e/svelte_meta_invalid_tag", list;
+
+    /// Expected a valid element or component name. Components must have a valid variable name or dot notation expression
+    tag_invalid_name() => "Expected a valid element or component name. Components must have a valid variable name or dot notation expression\nhttps://svelte.dev/e/tag_invalid_name";
+
+    /// Cannot use `<slot>` syntax and `{@render ...}` tags in the same component. Migrate towards `{@render ...}` tags completely
+    slot_snippet_conflict() => "Cannot use `<slot>` syntax and `{@render ...}` tags in the same component. Migrate towards `{@render ...}` tags completely\nhttps://svelte.dev/e/slot_snippet_conflict";
+
+    /// Cannot use explicit children snippet at the same time as implicit children content. Remove either the non-whitespace content or the children snippet block
+    snippet_conflict() => "Cannot use explicit children snippet at the same time as implicit children content. Remove either the non-whitespace content or the children snippet block\nhttps://svelte.dev/e/snippet_conflict";
+
+    /// An exported snippet can only reference things declared in a `<script module>`, or other exportable snippets
+    snippet_invalid_export() => "An exported snippet can only reference things declared in a `<script module>`, or other exportable snippets\nhttps://svelte.dev/e/snippet_invalid_export";
+
+    /// Attribute values containing `{...}` must be enclosed in quote marks, unless the value only contains the expression
+    attribute_unquoted_sequence() => "Attribute values containing `{...}` must be enclosed in quote marks, unless the value only contains the expression\nhttps://svelte.dev/e/attribute_unquoted_sequence";
+
+    /// Event attribute must be a JavaScript expression, not a string
+    attribute_invalid_event_handler() => "Event attribute must be a JavaScript expression, not a string\nhttps://svelte.dev/e/attribute_invalid_event_handler";
+
+    /// A component can only have one instance-level `<script>` element
+    script_duplicate() => "A component can only have one instance-level `<script>` element\nhttps://svelte.dev/e/script_duplicate";
+
+    /// `let:` directive at invalid position
+    let_directive_invalid_placement() => "`let:` directive at invalid position\nhttps://svelte.dev/e/let_directive_invalid_placement";
+
+    /// `<svelte:element>` or `<svelte:window>` cannot have spread attributes
+    illegal_element_attribute(element: &str) => "`<{}>` cannot have spread attributes\nhttps://svelte.dev/e/illegal_element_attribute", element;
+
+    /// `{@debug ...}` arguments must be identifiers
+    debug_tag_invalid_arguments() => "{@debug ...} arguments must be identifiers, not arbitrary expressions\nhttps://svelte.dev/e/debug_tag_invalid_arguments";
+
+    /// Title element can only contain text and `{expression}`
+    title_invalid_content() => "`<title>` can only contain text and {tags}\nhttps://svelte.dev/e/title_invalid_content";
+
+    /// Logic block or expression inside textarea
+    block_invalid_placement(thing: &str) => "{} block cannot be inside <textarea>\nhttps://svelte.dev/e/block_invalid_placement", thing;
+
+    /// Style directive modifier invalid
+    style_directive_invalid_modifier() => "`style:` directive can only use the `important` modifier\nhttps://svelte.dev/e/style_directive_invalid_modifier";
+
+    /// Directive value must be an expression
+    directive_invalid_value() => "Directive value must be a JavaScript expression enclosed in curly braces\nhttps://svelte.dev/e/directive_invalid_value";
+
+    /// `bind:value` on wrong element
+    bind_invalid_value(element: &str) => "`bind:value` can only be used on `<input>`, `<textarea>` or `<select>`, not `<{}>`\nhttps://svelte.dev/e/bind_invalid_value", element;
+
+    /// TypeScript feature invalid
+    typescript_invalid_feature(feature: &str) => "TypeScript {} are not supported in Svelte components\nhttps://svelte.dev/e/typescript_invalid_feature", feature;
 }
 
-/// `$host()` can only be used inside custom element component instances
-pub fn host_invalid_placement() -> AnalysisError {
-    error(
-        "host_invalid_placement",
-        "`$host()` can only be used inside custom element component instances",
-    )
-}
-
-/// `$props()` can only be used as a variable declaration initializer at the top level of the `<script>` tag
-pub fn props_invalid_placement() -> AnalysisError {
-    error(
-        "props_invalid_placement",
-        "`$props()` can only be used as a variable declaration initializer at the top level of the `<script>` tag",
-    )
-}
-
-/// `$props()` can only be used with an object destructuring pattern or an identifier
-pub fn props_invalid_identifier() -> AnalysisError {
-    error(
-        "props_invalid_identifier",
-        "`$props()` can only be used with an object destructuring pattern or an identifier",
-    )
-}
-
-/// `%rune%` has already been declared
-pub fn props_duplicate(rune: &str) -> AnalysisError {
-    error(
-        "props_duplicate",
-        format!("`{}` has already been declared", rune),
-    )
-}
-
-/// Declaring or accessing a prop starting with `$$` is illegal (they are reserved for Svelte internals)
-pub fn props_illegal_name() -> AnalysisError {
-    error(
-        "props_illegal_name",
-        "Declaring or accessing a prop starting with `$$` is illegal (they are reserved for Svelte internals)",
-    )
-}
-
-/// `$props.id()` can only be used as a variable declaration initializer at the top level of the `<script>` tag
-pub fn props_id_invalid_placement() -> AnalysisError {
-    error(
-        "props_id_invalid_placement",
-        "`$props.id()` can only be used as a variable declaration initializer at the top level of the `<script>` tag",
-    )
-}
-
-/// `%rune%` cannot be used with arguments
-pub fn rune_invalid_arguments(rune: &str) -> AnalysisError {
-    error(
-        "rune_invalid_arguments",
-        format!("`{}` cannot be used with arguments", rune),
-    )
-}
-
-/// `%rune%` cannot be used with spread arguments
-pub fn rune_invalid_spread(rune: &str) -> AnalysisError {
-    error(
-        "rune_invalid_spread",
-        format!("`{}` cannot be used with spread arguments", rune),
-    )
-}
-
-/// `%rune%` requires %expected%
-pub fn rune_invalid_arguments_length(rune: &str, expected: &str) -> AnalysisError {
-    error(
-        "rune_invalid_arguments_length",
-        format!("`{}` requires {}", rune, expected),
-    )
-}
-
-/// `%rune%` can only be used as a variable declaration initializer, a class field declaration, or the first assignment to a class field at the top level of the constructor.
-pub fn state_invalid_placement(rune: &str) -> AnalysisError {
-    error(
-        "state_invalid_placement",
-        format!(
-            "`{}(...)` can only be used as a variable declaration initializer, a class field declaration, or the first assignment to a class field at the top level of the constructor.\nhttps://svelte.dev/e/state_invalid_placement",
-            rune
-        ),
-    )
-}
-
-/// `$effect()` can only be used as an expression statement
-pub fn effect_invalid_placement() -> AnalysisError {
-    error(
-        "effect_invalid_placement",
-        "`$effect()` can only be used as an expression statement",
-    )
-}
-
-/// `$inspect.trace()` can only be called as a statement within the body of a function
-pub fn inspect_trace_invalid_placement() -> AnalysisError {
-    error(
-        "inspect_trace_invalid_placement",
-        "`$inspect.trace()` can only be called as a statement within the body of a function",
-    )
-}
-
-/// Generator functions cannot be used with $inspect.trace
-pub fn inspect_trace_generator() -> AnalysisError {
-    error(
-        "inspect_trace_generator",
-        "Generator functions cannot be used with $inspect.trace",
-    )
-}
-
-// Binding-related errors
-
-/// `%name%` can only be bound to %target%
-pub fn bind_invalid_target(name: &str, target: &str) -> AnalysisError {
-    error(
-        "bind_invalid_target",
-        format!("`{}` can only be bound to {}", name, target),
-    )
-}
+// Diagnostics whose message is assembled conditionally, or that carry a span,
+// do not fit the declarative form above.
 
 /// `bind:%name%` is not a valid binding. %explanation%
 pub fn bind_invalid_name(name: &str, explanation: Option<&str>) -> AnalysisError {
@@ -156,954 +449,4 @@ pub fn bind_invalid_name(name: &str, explanation: Option<&str>) -> AnalysisError
         )
     };
     error("bind_invalid_name", message)
-}
-
-/// Cannot assign to %thing%
-pub fn constant_assignment(thing: &str) -> AnalysisError {
-    error("constant_assignment", format!("Cannot assign to {}", thing))
-}
-
-/// Cannot bind to %thing%
-pub fn constant_binding(thing: &str) -> AnalysisError {
-    error("constant_binding", format!("Cannot bind to {}", thing))
-}
-
-// Attribute-related errors
-
-/// Attributes need to be unique
-pub fn attribute_duplicate() -> AnalysisError {
-    error("attribute_duplicate", "Attributes need to be unique")
-}
-
-/// '%name%' attribute cannot be dynamic
-pub fn attribute_invalid_type(name: &str) -> AnalysisError {
-    error(
-        "attribute_invalid_type",
-        format!("'{}' attribute cannot be dynamic", name),
-    )
-}
-
-/// The 'multiple' attribute must be static if select uses two-way binding
-pub fn attribute_invalid_multiple() -> AnalysisError {
-    error(
-        "attribute_invalid_multiple",
-        "'multiple' attribute must be static if select uses two-way binding\nhttps://svelte.dev/e/attribute_invalid_multiple",
-    )
-}
-
-// Declaration-related errors
-
-/// `%name%` has already been declared
-pub fn declaration_duplicate(name: &str) -> AnalysisError {
-    error(
-        "declaration_duplicate",
-        format!("`{}` has already been declared", name),
-    )
-}
-
-// Class-related errors
-
-/// `%name%` has already been declared
-pub fn duplicate_class_field(name: &str) -> AnalysisError {
-    error(
-        "duplicate_class_field",
-        format!("`{}` has already been declared", name),
-    )
-}
-
-/// `%name%` has already been declared on this class
-pub fn state_field_duplicate(name: &str) -> AnalysisError {
-    error(
-        "state_field_duplicate",
-        format!("`{}` has already been declared on this class", name),
-    )
-}
-
-/// Cannot declare a variable with the same name as an import inside `<script module>`
-pub fn declaration_duplicate_module_import() -> AnalysisError {
-    error(
-        "declaration_duplicate_module_import",
-        "Cannot declare a variable with the same name as an import inside `<script module>`",
-    )
-}
-
-// Export-related errors
-
-/// Cannot export derived state from a module
-pub fn derived_invalid_export() -> AnalysisError {
-    error(
-        "derived_invalid_export",
-        "Cannot export derived state from a module. To expose the current derived value, export a function returning its value\nhttps://svelte.dev/e/derived_invalid_export",
-    )
-}
-
-/// A component cannot have a default export
-pub fn module_illegal_default_export() -> AnalysisError {
-    error(
-        "module_illegal_default_export",
-        "A component cannot have a default export\nhttps://svelte.dev/e/module_illegal_default_export",
-    )
-}
-
-// Element-related errors
-
-/// `<svelte:element>` must have a 'this' attribute with a value
-pub fn svelte_element_missing_this() -> AnalysisError {
-    error(
-        "svelte_element_missing_this",
-        "`<svelte:element>` must have a 'this' attribute with a value",
-    )
-}
-
-/// `<svelte:component>` must have a `this` attribute (issue #453, H-046)
-pub fn svelte_component_missing_this() -> AnalysisError {
-    error(
-        "svelte_component_missing_this",
-        "`<svelte:component>` must have a 'this' attribute",
-    )
-}
-
-/// A component can only have one `<%name%>` element
-pub fn svelte_meta_duplicate(name: &str) -> AnalysisError {
-    error(
-        "svelte_meta_duplicate",
-        format!("A component can only have one `<{}>` element", name),
-    )
-}
-
-/// `<%name%>` tags cannot be inside elements or blocks
-pub fn svelte_meta_invalid_placement(name: &str) -> AnalysisError {
-    error(
-        "svelte_meta_invalid_placement",
-        format!("`<{}>` tags cannot be inside elements or blocks", name),
-    )
-}
-
-// Render tag errors
-
-/// `{@render ...}` tags can only contain call expressions
-pub fn render_tag_invalid_expression() -> AnalysisError {
-    error(
-        "render_tag_invalid_expression",
-        "`{@render ...}` tags can only contain call expressions",
-    )
-}
-
-/// Cannot use spread arguments in `{@render ...}` tags
-pub fn render_tag_invalid_spread_argument() -> AnalysisError {
-    error(
-        "render_tag_invalid_spread_argument",
-        "cannot use spread arguments in `{@render ...}` tags",
-    )
-}
-
-/// Calling a snippet function using apply, bind or call is not allowed
-pub fn render_tag_invalid_call_expression() -> AnalysisError {
-    error(
-        "render_tag_invalid_call_expression",
-        "Calling a snippet function using apply, bind or call is not allowed",
-    )
-}
-
-// Assignment-related errors
-
-/// Cannot reassign or bind to each block item
-pub fn each_item_invalid_assignment() -> AnalysisError {
-    error(
-        "each_item_invalid_assignment",
-        "Cannot reassign or bind to each block item",
-    )
-}
-
-/// Cannot reassign or bind to snippet parameter
-pub fn snippet_parameter_assignment() -> AnalysisError {
-    error(
-        "snippet_parameter_assignment",
-        "Cannot reassign or bind to snippet parameter",
-    )
-}
-
-/// Cannot use `$` as a variable name
-pub fn dollar_binding_invalid() -> AnalysisError {
-    error(
-        "dollar_binding_invalid",
-        "Cannot use `$` as a variable name",
-    )
-}
-
-/// Variable name cannot start with `$`
-pub fn dollar_prefix_invalid() -> AnalysisError {
-    error(
-        "dollar_prefix_invalid",
-        "Variable name cannot start with `$` except for special Svelte stores",
-    )
-}
-
-/// Cannot export state from a module if it is reassigned
-pub fn state_invalid_export() -> AnalysisError {
-    error(
-        "state_invalid_export",
-        "Cannot export state from a module if it is reassigned. Either export a function returning the state value or only mutate the state value's properties\nhttps://svelte.dev/e/state_invalid_export",
-    )
-}
-
-// Block-related errors
-
-/// {@const} tag can only be used in certain contexts
-pub fn const_tag_invalid_placement() -> AnalysisError {
-    error(
-        "const_tag_invalid_placement",
-        "`{@const}` must be the immediate child of `{#snippet}`, `{#if}`, `{:else if}`, `{:else}`, `{#each}`, `{:then}`, `{:catch}`, `<svelte:fragment>`, `<svelte:boundary>` or `<Component>`\nhttps://svelte.dev/e/const_tag_invalid_placement",
-    )
-}
-
-/// Declaration tags (`{let …}` / `{const …}`) are not allowed in legacy mode.
-/// Svelte 5.56.0 (#18282).
-pub fn declaration_tag_no_legacy_mode() -> AnalysisError {
-    error(
-        "declaration_tag_no_legacy_mode",
-        "Declaration tags cannot be used in legacy mode\nhttps://svelte.dev/e/declaration_tag_no_legacy_mode",
-    )
-}
-
-/// A declaration tag must contain a plain `let` or `const` VariableDeclaration.
-/// Svelte 5.56.0 (#18282).
-pub fn declaration_tag_invalid_type() -> AnalysisError {
-    error(
-        "declaration_tag_invalid_type",
-        "Declaration tags can only contain `let` or `const` variable declarations\nhttps://svelte.dev/e/declaration_tag_invalid_type",
-    )
-}
-
-/// Block must start with expected character
-pub fn block_unexpected_character(expected: &str) -> AnalysisError {
-    error(
-        "block_unexpected_character",
-        format!(
-            "Expected a `{}` character immediately following the opening bracket\nhttps://svelte.dev/e/block_unexpected_character",
-            expected
-        ),
-    )
-}
-
-/// `{#each}` block with a key requires an `as` binding
-pub fn each_key_without_as() -> AnalysisError {
-    error(
-        "each_key_without_as",
-        "An `{#each ...}` block without an `as` clause cannot have a key",
-    )
-}
-
-/// Cannot assign to %thing% before initialization
-pub fn state_field_invalid_assignment() -> AnalysisError {
-    error(
-        "state_field_invalid_assignment",
-        "Cannot assign to state field before initialization in constructor",
-    )
-}
-
-/// %name% cannot have children
-pub fn svelte_meta_invalid_content(name: &str) -> AnalysisError {
-    error(
-        "svelte_meta_invalid_content",
-        format!("`<{}>` cannot have children", name),
-    )
-}
-
-/// `use:`, `transition:` and `animate:` directives, attachments and bindings do not support await expressions
-pub fn illegal_await_expression() -> AnalysisError {
-    error(
-        "illegal_await_expression",
-        "`use:`, `transition:` and `animate:` directives, attachments and bindings do not support await expressions",
-    )
-}
-
-/// `arguments` cannot be used outside of functions
-pub fn invalid_arguments_usage() -> AnalysisError {
-    error(
-        "invalid_arguments_usage",
-        "`arguments` cannot be used outside of functions",
-    )
-}
-
-/// Runes cannot use computed properties
-pub fn rune_invalid_computed_property() -> AnalysisError {
-    error(
-        "rune_invalid_computed_property",
-        "Runes cannot use computed member expressions",
-    )
-}
-
-/// Rune %old_name% has been renamed to %new_name%
-pub fn rune_renamed(old_name: &str, new_name: &str) -> AnalysisError {
-    error(
-        "rune_renamed",
-        format!("`{}` has been renamed to `{}`", old_name, new_name),
-    )
-}
-
-/// Rune %name% has been removed
-pub fn rune_removed(name: &str) -> AnalysisError {
-    error("rune_removed", format!("`{}` has been removed", name))
-}
-
-/// Invalid rune name %name%
-pub fn rune_invalid_name(name: &str) -> AnalysisError {
-    error(
-        "rune_invalid_name",
-        format!("`{}` is not a valid rune", name),
-    )
-}
-
-/// Runes must be called
-pub fn rune_missing_parentheses() -> AnalysisError {
-    error(
-        "rune_missing_parentheses",
-        "Runes must be called as functions",
-    )
-}
-
-/// {@const} tag cannot reference %name% in this context
-pub fn const_tag_invalid_reference(name: &str) -> AnalysisError {
-    error(
-        "const_tag_invalid_reference",
-        format!(
-            "{{@const}} tag cannot reference `{}` in this context - it can only be used with declarations from an implicit children snippet",
-            name
-        ),
-    )
-}
-
-// Slot element errors
-
-/// `<slot>` can only receive attributes and (optionally) let directives
-pub fn slot_element_invalid_attribute() -> AnalysisError {
-    error(
-        "slot_element_invalid_attribute",
-        "`<slot>` can only receive attributes and (optionally) let directives",
-    )
-}
-
-/// slot attribute must be a static value
-pub fn slot_element_invalid_name() -> AnalysisError {
-    error(
-        "slot_element_invalid_name",
-        "slot attribute must be a static value",
-    )
-}
-
-/// `default` is a reserved word — it cannot be used as a slot name
-pub fn slot_element_invalid_name_default() -> AnalysisError {
-    error(
-        "slot_element_invalid_name_default",
-        "`default` is a reserved word — it cannot be used as a slot name",
-    )
-}
-
-// Event handler errors
-
-/// Event modifiers other than 'once' can only be used on DOM elements
-pub fn event_handler_invalid_component_modifier() -> AnalysisError {
-    error(
-        "event_handler_invalid_component_modifier",
-        "Event modifiers other than 'once' can only be used on DOM elements\nhttps://svelte.dev/e/event_handler_invalid_component_modifier",
-    )
-}
-
-// Transition/animation directive errors
-
-/// An element can only have one '%name%' directive
-pub fn transition_duplicate(directive_name: &str) -> AnalysisError {
-    error(
-        "transition_duplicate",
-        format!(
-            "An element can only have one '{}' directive",
-            directive_name
-        ),
-    )
-}
-
-/// An element cannot have both '%a%' and '%b%' directives
-pub fn transition_conflict(a: &str, b: &str) -> AnalysisError {
-    error(
-        "transition_conflict",
-        format!("An element cannot have both '{}' and '{}' directives", a, b),
-    )
-}
-
-/// An element can only have one animate directive
-pub fn animation_duplicate() -> AnalysisError {
-    error(
-        "animation_duplicate",
-        "An element can only have one 'animate' directive\nhttps://svelte.dev/e/animation_duplicate",
-    )
-}
-
-/// An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block
-pub fn animation_invalid_placement() -> AnalysisError {
-    error(
-        "animation_invalid_placement",
-        "An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block\nhttps://svelte.dev/e/animation_invalid_placement",
-    )
-}
-
-/// An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block. Did you forget to add a key to your each block?
-pub fn animation_missing_key() -> AnalysisError {
-    error(
-        "animation_missing_key",
-        "An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block. Did you forget to add a key to your each block?\nhttps://svelte.dev/e/animation_missing_key",
-    )
-}
-
-// CSS-related errors
-
-/// `:global(...)` must contain exactly one selector
-pub fn css_global_invalid_selector() -> AnalysisError {
-    error(
-        "css_global_invalid_selector",
-        "`:global(...)` must contain exactly one selector",
-    )
-}
-
-/// `:global(...)` must not contain type or universal selectors when used in a compound selector
-pub fn css_global_invalid_selector_list() -> AnalysisError {
-    error(
-        "css_global_invalid_selector_list",
-        "`:global(...)` must not contain type or universal selectors when used in a compound selector",
-    )
-}
-
-/// `:global(...)` can be at the start or end of a selector sequence, but not in the middle
-pub fn css_global_invalid_placement() -> AnalysisError {
-    error(
-        "css_global_invalid_placement",
-        "`:global(...)` can be at the start or end of a selector sequence, but not in the middle",
-    )
-}
-
-/// Invalid selector
-pub fn css_selector_invalid() -> AnalysisError {
-    error("css_selector_invalid", "Invalid selector")
-}
-
-/// A `:global` selector cannot be inside a pseudoclass
-pub fn css_global_block_invalid_placement() -> AnalysisError {
-    error(
-        "css_global_block_invalid_placement",
-        "A `:global` selector cannot be inside a pseudoclass",
-    )
-}
-
-/// A `:global` selector cannot follow a `%name%` combinator
-pub fn css_global_block_invalid_combinator(combinator_name: &str) -> AnalysisError {
-    error(
-        "css_global_block_invalid_combinator",
-        format!(
-            "A `:global` selector cannot follow a `{}` combinator",
-            combinator_name
-        ),
-    )
-}
-
-/// A top-level `:global {{...}}` block can only contain rules, not declarations
-pub fn css_global_block_invalid_declaration() -> AnalysisError {
-    error(
-        "css_global_block_invalid_declaration",
-        "A top-level `:global {...}` block can only contain rules, not declarations",
-    )
-}
-
-/// A `:global` selector cannot be part of a selector list with entries that don't contain `:global`
-pub fn css_global_block_invalid_list() -> AnalysisError {
-    error(
-        "css_global_block_invalid_list",
-        "A `:global` selector cannot be part of a selector list with entries that don't contain `:global`",
-    )
-}
-
-/// A `:global` selector cannot modify an existing selector
-pub fn css_global_block_invalid_modifier() -> AnalysisError {
-    error(
-        "css_global_block_invalid_modifier",
-        "A `:global` selector cannot modify an existing selector",
-    )
-}
-
-/// A `:global` selector can only be modified if it is a descendant of other selectors
-pub fn css_global_block_invalid_modifier_start() -> AnalysisError {
-    error(
-        "css_global_block_invalid_modifier_start",
-        "A `:global` selector can only be modified if it is a descendant of other selectors",
-    )
-}
-
-/// Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`
-pub fn css_nesting_selector_invalid_placement() -> AnalysisError {
-    error(
-        "css_nesting_selector_invalid_placement",
-        "Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`",
-    )
-}
-
-/// Type selector cannot appear after `:global(...)`
-pub fn css_type_selector_invalid_placement() -> AnalysisError {
-    error(
-        "css_type_selector_invalid_placement",
-        "Type selector cannot appear after `:global(...)`",
-    )
-}
-
-/// Declaration cannot be empty
-pub fn css_empty_declaration() -> AnalysisError {
-    error("css_empty_declaration", "Declaration cannot be empty")
-}
-
-// Attribute-related errors
-
-/// '%name%' is not a valid attribute name
-pub fn attribute_invalid_name(name: &str) -> AnalysisError {
-    error(
-        "attribute_invalid_name",
-        format!("'{}' is not a valid attribute name", name),
-    )
-}
-
-/// 'contenteditable' attribute cannot be dynamic if element uses two-way binding
-pub fn attribute_contenteditable_dynamic() -> AnalysisError {
-    error(
-        "attribute_contenteditable_dynamic",
-        "'contenteditable' attribute cannot be dynamic if element uses two-way binding",
-    )
-}
-
-/// 'contenteditable' attribute is required for textContent, innerHTML and innerText two-way bindings
-pub fn attribute_contenteditable_missing() -> AnalysisError {
-    error(
-        "attribute_contenteditable_missing",
-        "'contenteditable' attribute is required for textContent, innerHTML and innerText two-way bindings",
-    )
-}
-
-/// Cannot use `%rune%` rune in non-runes mode
-pub fn rune_invalid_usage(rune: &str) -> AnalysisError {
-    error(
-        "rune_invalid_usage",
-        format!(
-            "Cannot use `{}` rune in non-runes mode\nhttps://svelte.dev/e/rune_invalid_usage",
-            rune
-        ),
-    )
-}
-
-/// Props destructuring pattern cannot use computed properties
-pub fn props_invalid_pattern() -> AnalysisError {
-    error(
-        "props_invalid_pattern",
-        "Props destructuring pattern cannot use computed properties or non-identifier keys",
-    )
-}
-
-// Component-related errors
-
-/// This type of directive is not valid on components
-pub fn component_invalid_directive() -> AnalysisError {
-    error(
-        "component_invalid_directive",
-        "This type of directive is not valid on components",
-    )
-}
-
-// Svelte element errors
-
-/// `<svelte:head>` cannot have attributes nor directives
-pub fn svelte_head_illegal_attribute() -> AnalysisError {
-    error(
-        "svelte_head_illegal_attribute",
-        "`<svelte:head>` cannot have attributes nor directives",
-    )
-}
-
-// Title element errors
-
-/// `<title>` cannot have attributes nor directives
-pub fn title_illegal_attribute() -> AnalysisError {
-    error(
-        "title_illegal_attribute",
-        "`<title>` cannot have attributes nor directives",
-    )
-}
-
-// Reactive declaration errors
-
-/// Cyclical dependency detected: %cycle%
-pub fn reactive_declaration_cycle(cycle: &str) -> AnalysisError {
-    error(
-        "reactive_declaration_cycle",
-        format!("Cyclical dependency detected: {}", cycle),
-    )
-}
-
-/// {@%name% ...} tag cannot be %location%
-pub fn tag_invalid_placement(name: &str, location: &str) -> AnalysisError {
-    error(
-        "tag_invalid_placement",
-        format!(
-            "{{@{} ...}} tag cannot be {}\nhttps://svelte.dev/e/tag_invalid_placement",
-            name, location
-        ),
-    )
-}
-
-/// %message%. The browser will 'repair' the HTML (by moving, removing, or inserting elements) which breaks Svelte's assumptions about the structure of your components.
-pub fn node_invalid_placement(message: &str) -> AnalysisError {
-    error(
-        "node_invalid_placement",
-        format!(
-            "{}. The browser will 'repair' the HTML (by moving, removing, or inserting elements) which breaks Svelte's assumptions about the structure of your components.\nhttps://svelte.dev/e/node_invalid_placement",
-            message
-        ),
-    )
-}
-
-/// A `<textarea>` can have either a value attribute or (equivalently) child content, but not both
-pub fn textarea_invalid_content() -> AnalysisError {
-    error(
-        "textarea_invalid_content",
-        "A `<textarea>` can have either a value attribute or (equivalently) child content, but not both\nhttps://svelte.dev/e/textarea_invalid_content",
-    )
-}
-
-/// Cannot reference store value outside a `.svelte` file
-pub fn store_invalid_subscription_module() -> AnalysisError {
-    error(
-        "store_invalid_subscription_module",
-        "Cannot reference store value outside a `.svelte` file\nhttps://svelte.dev/e/store_invalid_subscription_module",
-    )
-}
-
-/// Mixing old (on:event) and new syntaxes for event handling is not allowed
-pub fn mixed_event_handler_syntaxes(name: &str) -> AnalysisError {
-    error(
-        "mixed_event_handler_syntaxes",
-        format!(
-            "Mixing old (on:{}) and new syntaxes for event handling is not allowed. Use only the on{} syntax\nhttps://svelte.dev/e/mixed_event_handler_syntaxes",
-            name, name
-        ),
-    )
-}
-
-/// Imports of `svelte/internal/*` are forbidden
-pub fn import_svelte_internal_forbidden() -> AnalysisError {
-    error(
-        "import_svelte_internal_forbidden",
-        "Imports of `svelte/internal/*` are forbidden. It contains private runtime code which is subject to change without notice.\nhttps://svelte.dev/e/import_svelte_internal_forbidden",
-    )
-}
-
-/// %name% cannot be used in runes mode
-pub fn runes_mode_invalid_import(name: &str) -> AnalysisError {
-    error(
-        "runes_mode_invalid_import",
-        format!(
-            "{} cannot be used in runes mode\nhttps://svelte.dev/e/runes_mode_invalid_import",
-            name
-        ),
-    )
-}
-
-/// Cannot use `export let` in runes mode — use `$props()` instead
-pub fn legacy_export_invalid() -> AnalysisError {
-    error(
-        "legacy_export_invalid",
-        "Cannot use `export let` in runes mode — use `$props()` instead\nhttps://svelte.dev/e/legacy_export_invalid",
-    )
-}
-
-/// `$:` is not allowed in runes mode, use `$derived` or `$effect` instead
-pub fn legacy_reactive_statement_invalid() -> AnalysisError {
-    error(
-        "legacy_reactive_statement_invalid",
-        "`$:` is not allowed in runes mode, use `$derived` or `$effect` instead\nhttps://svelte.dev/e/legacy_reactive_statement_invalid",
-    )
-}
-
-/// Cannot subscribe to stores that are not declared at the top level of the component
-pub fn store_invalid_scoped_subscription() -> AnalysisError {
-    error(
-        "store_invalid_scoped_subscription",
-        "Cannot subscribe to stores that are not declared at the top level of the component\nhttps://svelte.dev/e/store_invalid_scoped_subscription",
-    )
-}
-
-/// Cannot reference store value inside `<script module>`
-pub fn store_invalid_subscription() -> AnalysisError {
-    error(
-        "store_invalid_subscription",
-        "Cannot reference store value inside `<script module>`\nhttps://svelte.dev/e/store_invalid_subscription",
-    )
-}
-
-/// `%name%` is not defined
-pub fn export_undefined(name: &str) -> AnalysisError {
-    error(
-        "export_undefined",
-        format!(
-            "`{}` is not defined\nhttps://svelte.dev/e/export_undefined",
-            name
-        ),
-    )
-}
-
-/// Duplicate slot name '%name%' in <%component%>
-pub fn slot_attribute_duplicate(name: &str, component: &str) -> AnalysisError {
-    error(
-        "slot_attribute_duplicate",
-        format!(
-            "Duplicate slot name '{}' in <{}>\nhttps://svelte.dev/e/slot_attribute_duplicate",
-            name, component
-        ),
-    )
-}
-
-/// Found default slot content alongside an explicit slot="default"
-pub fn slot_default_duplicate() -> AnalysisError {
-    error(
-        "slot_default_duplicate",
-        "Found default slot content alongside an explicit slot=\"default\"\nhttps://svelte.dev/e/slot_default_duplicate",
-    )
-}
-
-/// This snippet is shadowing the prop `%prop%` with the same name
-pub fn snippet_shadowing_prop(prop: &str) -> AnalysisError {
-    error(
-        "snippet_shadowing_prop",
-        format!(
-            "This snippet is shadowing the prop `{}` with the same name\nhttps://svelte.dev/e/snippet_shadowing_prop",
-            prop
-        ),
-    )
-}
-
-/// Element with a slot='...' attribute must be a child of a component or a descendant of a custom element
-pub fn slot_attribute_invalid_placement() -> AnalysisError {
-    error(
-        "slot_attribute_invalid_placement",
-        "Element with a slot='...' attribute must be a child of a component or a descendant of a custom element\nhttps://svelte.dev/e/slot_attribute_invalid_placement",
-    )
-}
-
-/// slot attribute must be a static value
-pub fn slot_attribute_invalid() -> AnalysisError {
-    error(
-        "slot_attribute_invalid",
-        "slot attribute must be a static value\nhttps://svelte.dev/e/slot_attribute_invalid",
-    )
-}
-
-/// `<svelte:fragment>` must be the direct child of a component
-pub fn svelte_fragment_invalid_placement() -> AnalysisError {
-    error(
-        "svelte_fragment_invalid_placement",
-        "`<svelte:fragment>` must be the direct child of a component\nhttps://svelte.dev/e/svelte_fragment_invalid_placement",
-    )
-}
-
-/// Cyclical dependency detected: %cycle%
-pub fn const_tag_cycle(cycle: &str) -> AnalysisError {
-    error(
-        "const_tag_cycle",
-        format!(
-            "Cyclical dependency detected: {}\nhttps://svelte.dev/e/const_tag_cycle",
-            cycle
-        ),
-    )
-}
-
-/// Attribute shorthand cannot be empty
-pub fn attribute_empty_shorthand() -> AnalysisError {
-    error(
-        "attribute_empty_shorthand",
-        "Attribute shorthand cannot be empty\nhttps://svelte.dev/e/attribute_empty_shorthand",
-    )
-}
-
-/// `%type%` name cannot be empty
-pub fn directive_missing_name(directive_type: &str) -> AnalysisError {
-    error(
-        "directive_missing_name",
-        format!(
-            "`{}` name cannot be empty\nhttps://svelte.dev/e/directive_missing_name",
-            directive_type
-        ),
-    )
-}
-
-/// Sequence expressions are not allowed as attribute/directive values in runes mode, unless wrapped in parentheses
-pub fn attribute_invalid_sequence_expression() -> AnalysisError {
-    error(
-        "attribute_invalid_sequence_expression",
-        "Sequence expressions are not allowed as attribute/directive values in runes mode, unless wrapped in parentheses\nhttps://svelte.dev/e/attribute_invalid_sequence_expression",
-    )
-}
-
-/// `%name%` is an illegal variable name. To reference a global variable called `%name%`, use `globalThis.%name%`
-pub fn global_reference_invalid(name: &str) -> AnalysisError {
-    error(
-        "global_reference_invalid",
-        format!(
-            "`{}` is an illegal variable name. To reference a global variable called `{}`, use `globalThis.{}`\nhttps://svelte.dev/e/global_reference_invalid",
-            name, name, name
-        ),
-    )
-}
-
-/// Valid `<svelte:...>` tag names are %list%
-pub fn svelte_meta_invalid_tag(list: &str) -> AnalysisError {
-    error(
-        "svelte_meta_invalid_tag",
-        format!(
-            "Valid `<svelte:...>` tag names are {}\nhttps://svelte.dev/e/svelte_meta_invalid_tag",
-            list
-        ),
-    )
-}
-
-/// Expected a valid element or component name. Components must have a valid variable name or dot notation expression
-pub fn tag_invalid_name() -> AnalysisError {
-    error(
-        "tag_invalid_name",
-        "Expected a valid element or component name. Components must have a valid variable name or dot notation expression\nhttps://svelte.dev/e/tag_invalid_name",
-    )
-}
-
-/// Cannot use `<slot>` syntax and `{@render ...}` tags in the same component. Migrate towards `{@render ...}` tags completely
-pub fn slot_snippet_conflict() -> AnalysisError {
-    error(
-        "slot_snippet_conflict",
-        "Cannot use `<slot>` syntax and `{@render ...}` tags in the same component. Migrate towards `{@render ...}` tags completely\nhttps://svelte.dev/e/slot_snippet_conflict",
-    )
-}
-
-/// Cannot use explicit children snippet at the same time as implicit children content. Remove either the non-whitespace content or the children snippet block
-pub fn snippet_conflict() -> AnalysisError {
-    error(
-        "snippet_conflict",
-        "Cannot use explicit children snippet at the same time as implicit children content. Remove either the non-whitespace content or the children snippet block\nhttps://svelte.dev/e/snippet_conflict",
-    )
-}
-
-/// An exported snippet can only reference things declared in a `<script module>`, or other exportable snippets
-pub fn snippet_invalid_export() -> AnalysisError {
-    error(
-        "snippet_invalid_export",
-        "An exported snippet can only reference things declared in a `<script module>`, or other exportable snippets\nhttps://svelte.dev/e/snippet_invalid_export",
-    )
-}
-
-/// Attribute values containing `{...}` must be enclosed in quote marks, unless the value only contains the expression
-pub fn attribute_unquoted_sequence() -> AnalysisError {
-    error(
-        "attribute_unquoted_sequence",
-        "Attribute values containing `{...}` must be enclosed in quote marks, unless the value only contains the expression\nhttps://svelte.dev/e/attribute_unquoted_sequence",
-    )
-}
-
-/// Event attribute must be a JavaScript expression, not a string
-pub fn attribute_invalid_event_handler() -> AnalysisError {
-    error(
-        "attribute_invalid_event_handler",
-        "Event attribute must be a JavaScript expression, not a string\nhttps://svelte.dev/e/attribute_invalid_event_handler",
-    )
-}
-
-/// A component can only have one instance-level `<script>` element
-pub fn script_duplicate() -> AnalysisError {
-    error(
-        "script_duplicate",
-        "A component can only have one instance-level `<script>` element\nhttps://svelte.dev/e/script_duplicate",
-    )
-}
-
-/// `let:` directive at invalid position
-pub fn let_directive_invalid_placement() -> AnalysisError {
-    error(
-        "let_directive_invalid_placement",
-        "`let:` directive at invalid position\nhttps://svelte.dev/e/let_directive_invalid_placement",
-    )
-}
-
-/// `<svelte:element>` or `<svelte:window>` cannot have spread attributes
-pub fn illegal_element_attribute(element: &str) -> AnalysisError {
-    error(
-        "illegal_element_attribute",
-        format!(
-            "`<{}>` cannot have spread attributes\nhttps://svelte.dev/e/illegal_element_attribute",
-            element
-        ),
-    )
-}
-
-/// `{@debug ...}` arguments must be identifiers
-pub fn debug_tag_invalid_arguments() -> AnalysisError {
-    error(
-        "debug_tag_invalid_arguments",
-        "{@debug ...} arguments must be identifiers, not arbitrary expressions\nhttps://svelte.dev/e/debug_tag_invalid_arguments",
-    )
-}
-
-/// Title element can only contain text and `{expression}`
-pub fn title_invalid_content() -> AnalysisError {
-    error(
-        "title_invalid_content",
-        "`<title>` can only contain text and {tags}\nhttps://svelte.dev/e/title_invalid_content",
-    )
-}
-
-/// Logic block or expression inside textarea
-pub fn block_invalid_placement(thing: &str) -> AnalysisError {
-    error(
-        "block_invalid_placement",
-        format!(
-            "{} block cannot be inside <textarea>\nhttps://svelte.dev/e/block_invalid_placement",
-            thing
-        ),
-    )
-}
-
-/// Style directive modifier invalid
-pub fn style_directive_invalid_modifier() -> AnalysisError {
-    error(
-        "style_directive_invalid_modifier",
-        "`style:` directive can only use the `important` modifier\nhttps://svelte.dev/e/style_directive_invalid_modifier",
-    )
-}
-
-/// Directive value must be an expression
-pub fn directive_invalid_value() -> AnalysisError {
-    error(
-        "directive_invalid_value",
-        "Directive value must be a JavaScript expression enclosed in curly braces\nhttps://svelte.dev/e/directive_invalid_value",
-    )
-}
-
-/// `bind:value` on wrong element
-pub fn bind_invalid_value(element: &str) -> AnalysisError {
-    error(
-        "bind_invalid_value",
-        format!(
-            "`bind:value` can only be used on `<input>`, `<textarea>` or `<select>`, not `<{}>`\nhttps://svelte.dev/e/bind_invalid_value",
-            element
-        ),
-    )
-}
-
-/// TypeScript feature invalid
-pub fn typescript_invalid_feature(feature: &str) -> AnalysisError {
-    error(
-        "typescript_invalid_feature",
-        format!(
-            "TypeScript {} are not supported in Svelte components\nhttps://svelte.dev/e/typescript_invalid_feature",
-            feature
-        ),
-    )
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -20,6 +20,7 @@ pub mod blockers;
 pub mod control_flow;
 pub mod css;
 mod css_scoping;
+mod diagnostic;
 pub mod errors;
 mod pattern_ids;
 pub mod scope;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/warnings.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/warnings.rs
@@ -5,6 +5,8 @@
 //!
 //! Corresponds to Svelte's `warnings.js`.
 
+use super::diagnostic::diagnostics;
+
 /// Warning type for analysis phase.
 #[derive(Debug, Clone)]
 pub struct AnalysisWarning {
@@ -37,14 +39,265 @@ fn warning(code: &str, message: impl Into<String>) -> AnalysisWarning {
 
 // Component creation warnings
 
-/// Creating a component with `new ComponentName({ target: ... })` is deprecated.
-/// Use `mount(ComponentName, { target: ... })` instead.
-pub fn legacy_component_creation() -> AnalysisWarning {
-    warning(
-        "legacy_component_creation",
-        "Svelte 5 components are no longer classes. Instantiate them using `mount` or `hydrate` (imported from 'svelte') instead.\nhttps://svelte.dev/e/legacy_component_creation",
-    )
+diagnostics! {
+    warning => AnalysisWarning;
+
+    /// Creating a component with `new ComponentName({ target: ... })` is deprecated.
+    /// Use `mount(ComponentName, { target: ... })` instead.
+    legacy_component_creation() => "Svelte 5 components are no longer classes. Instantiate them using `mount` or `hydrate` (imported from 'svelte') instead.\nhttps://svelte.dev/e/legacy_component_creation";
+
+    /// Reactive declaration references module script dependency
+    reactive_declaration_module_script_dependency() => "Reassignments of module-level declarations will not cause reactive statements to update\nhttps://svelte.dev/e/reactive_declaration_module_script_dependency";
+
+    /// Non-reactive update warning - variable is updated but not declared with $state
+    non_reactive_update(name: &str) => "`{}` is updated, but is not declared with `$state(...)`. Changing its value will not correctly trigger updates\nhttps://svelte.dev/e/non_reactive_update", name;
+
+    /// Store/rune naming conflict warning
+    store_rune_conflict(store_name: &str) => "It looks like you're using the `${}` rune, but there is a local binding called `{}`. Referencing a local variable with a `$` prefix will create a store subscription. Please rename `{}` to avoid the ambiguity\nhttps://svelte.dev/e/store_rune_conflict", store_name, store_name, store_name;
+
+    /// Global event reference warning
+    attribute_global_event_reference(name: &str) => "You are referencing `globalThis.{}`. Did you forget to declare a variable with that name?\nhttps://svelte.dev/e/attribute_global_event_reference", name;
+
+    /// Reactive declaration is invalid placement (not at the top level of an instance script)
+    reactive_declaration_invalid_placement() => "Reactive declarations are only valid at the top level of the instance script";
+
+    // Performance warnings
+
+    /// Avoid 'new class' — instead, declare the class at the top level scope
+    perf_avoid_inline_class() => "Avoid 'new class' — instead, declare the class at the top level scope\nhttps://svelte.dev/e/perf_avoid_inline_class";
+
+    /// Avoid declaring classes below the top level scope
+    perf_avoid_nested_class() => "Avoid declaring classes below the top level scope\nhttps://svelte.dev/e/perf_avoid_nested_class";
+
+    // Security warnings
+
+    /// Bidirectional control character detected in code.
+    ///
+    /// These Unicode characters can alter the visual direction of code
+    /// and could have unintended security consequences.
+    ///
+    /// Corresponds to Svelte's `bidirectional_control_characters` warning.
+    bidirectional_control_characters() => "A bidirectional control character was detected in your code. These characters can be used to alter the visual direction of your code and could have unintended consequences\nhttps://svelte.dev/e/bidirectional_control_characters";
+
+    // Slot element warnings
+
+    /// Using `<slot>` to render parent content is deprecated. Use `{@render ...}` tags instead
+    slot_element_deprecated() => "Using `<slot>` to render parent content is deprecated. Use `{@render ...}` tags instead\nhttps://svelte.dev/e/slot_element_deprecated";
+
+    /// `<svelte:self>` is deprecated — use self-imports (e.g. `import Component from './Component.svelte'`) instead
+    svelte_self_deprecated(name: &str, basename: &str) => "`<svelte:self>` is deprecated — use self-imports (e.g. `import {} from './{}'`) instead\nhttps://svelte.dev/e/svelte_self_deprecated", name, basename;
+
+    /// `<svelte:component>` is deprecated in runes mode — components are dynamic by default
+    svelte_component_deprecated() => "`<svelte:component>` is deprecated in runes mode — components are dynamic by default\nhttps://svelte.dev/e/svelte_component_deprecated";
+
+    // Attribute warnings
+
+    /// Attributes should not contain ':' characters to prevent ambiguity with Svelte directives
+    attribute_illegal_colon() => "Attributes should not contain ':' characters to prevent ambiguity with Svelte directives";
+
+    // A11y warnings
+
+    /// Avoid using accesskey
+    a11y_accesskey() => "Avoid using accesskey\nhttps://svelte.dev/e/a11y_accesskey";
+
+    /// An element with an aria-activedescendant attribute should have a tabindex value
+    a11y_aria_activedescendant_has_tabindex() => "An element with an aria-activedescendant attribute should have a tabindex value\nhttps://svelte.dev/e/a11y_aria_activedescendant_has_tabindex";
+
+    /// Element should not have aria-* attributes
+    a11y_aria_attributes(name: &str) => "`<{}>` should not have aria-* attributes\nhttps://svelte.dev/e/a11y_aria_attributes", name;
+
+    /// Invalid value for autocomplete on input element
+    a11y_autocomplete_valid(value: &str, input_type: &str) => "'{}' is an invalid value for 'autocomplete' on `<input type=\"{}\">`\nhttps://svelte.dev/e/a11y_autocomplete_valid", value, input_type;
+
+    /// Avoid using autofocus
+    a11y_autofocus() => "Avoid using autofocus\nhttps://svelte.dev/e/a11y_autofocus";
+
+    /// Visible, non-interactive element with a click event must be accompanied by a keyboard event handler.
+    /// The element tag name is interpolated into the message (Svelte 5.56.0 #18272).
+    a11y_click_events_have_key_events(tag_name: &str) => "Visible, non-interactive element `<{}>` with a click event must be accompanied by a keyboard event handler. Consider whether an interactive element such as `<button type=\"button\">` or `<a>` might be more appropriate\nhttps://svelte.dev/e/a11y_click_events_have_key_events", tag_name;
+
+    /// Buttons and links should either contain text or have an aria-label, aria-labelledby or title attribute
+    a11y_consider_explicit_label() => "Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute\nhttps://svelte.dev/e/a11y_consider_explicit_label";
+
+    /// Avoid distracting elements
+    a11y_distracting_elements(name: &str) => "Avoid `<{}>` elements\nhttps://svelte.dev/e/a11y_distracting_elements", name;
+
+    /// `<figcaption>` must be first or last child of `<figure>`
+    a11y_figcaption_index() => "`<figcaption>` must be first or last child of `<figure>`\nhttps://svelte.dev/e/a11y_figcaption_index";
+
+    /// `<figcaption>` must be an immediate child of `<figure>`
+    a11y_figcaption_parent() => "`<figcaption>` must be an immediate child of `<figure>`\nhttps://svelte.dev/e/a11y_figcaption_parent";
+
+    /// Element should not be hidden
+    a11y_hidden(name: &str) => "`<{}>` element should not be hidden\nhttps://svelte.dev/e/a11y_hidden", name;
+
+    /// Screenreaders already announce `<img>` elements as an image
+    a11y_img_redundant_alt() => "Screenreaders already announce `<img>` elements as an image\nhttps://svelte.dev/e/a11y_img_redundant_alt";
+
+    /// Elements with the interactive role must have a tabindex value
+    a11y_interactive_supports_focus(role: &str) => "Elements with the '{}' interactive role must have a tabindex value\nhttps://svelte.dev/e/a11y_interactive_supports_focus", role;
+
+    /// Invalid href attribute value
+    a11y_invalid_attribute(href_value: &str, href_attribute: &str) => "'{}' is not a valid {} attribute\nhttps://svelte.dev/e/a11y_invalid_attribute", href_value, href_attribute;
+
+    /// A form label must be associated with a control
+    a11y_label_has_associated_control() => "A form label must be associated with a control\nhttps://svelte.dev/e/a11y_label_has_associated_control";
+
+    /// `<video>` elements must have a `<track kind="captions">`
+    a11y_media_has_caption() => "`<video>` elements must have a `<track kind=\"captions\">`\nhttps://svelte.dev/e/a11y_media_has_caption";
+
+    /// Element should not have role attribute
+    a11y_misplaced_role(name: &str) => "`<{}>` should not have role attribute\nhttps://svelte.dev/e/a11y_misplaced_role", name;
+
+    /// The scope attribute should only be used with `<th>` elements
+    a11y_misplaced_scope() => "The scope attribute should only be used with `<th>` elements\nhttps://svelte.dev/e/a11y_misplaced_scope";
+
+    /// Element should have required attribute
+    a11y_missing_attribute(name: &str, article: &str, sequence: &str) => "`<{}>` element should have {} {} attribute\nhttps://svelte.dev/e/a11y_missing_attribute", name, article, sequence;
+
+    /// Element should contain text
+    a11y_missing_content(name: &str) => "`<{}>` element should contain text\nhttps://svelte.dev/e/a11y_missing_content", name;
+
+    /// Mouse event must be accompanied by keyboard event
+    a11y_mouse_events_have_key_events(event: &str, accompanied_by: &str) => "'{}' event must be accompanied by '{}' event\nhttps://svelte.dev/e/a11y_mouse_events_have_key_events", event, accompanied_by;
+
+    /// Abstract role is forbidden
+    a11y_no_abstract_role(role: &str) => "Abstract role '{}' is forbidden\nhttps://svelte.dev/e/a11y_no_abstract_role", role;
+
+    /// Interactive element cannot have non-interactive role
+    a11y_no_interactive_element_to_noninteractive_role(element: &str, role: &str) => "`<{}>` cannot have role '{}'\nhttps://svelte.dev/e/a11y_no_interactive_element_to_noninteractive_role", element, role;
+
+    /// Non-interactive element should not be assigned mouse or keyboard event listeners
+    a11y_no_noninteractive_element_interactions(element: &str) => "Non-interactive element `<{}>` should not be assigned mouse or keyboard event listeners\nhttps://svelte.dev/e/a11y_no_noninteractive_element_interactions", element;
+
+    /// Non-interactive element cannot have interactive role
+    a11y_no_noninteractive_element_to_interactive_role(element: &str, role: &str) => "Non-interactive element `<{}>` cannot have interactive role '{}'\nhttps://svelte.dev/e/a11y_no_noninteractive_element_to_interactive_role", element, role;
+
+    /// Noninteractive element cannot have nonnegative tabIndex value
+    a11y_no_noninteractive_tabindex() => "noninteractive element cannot have nonnegative tabIndex value\nhttps://svelte.dev/e/a11y_no_noninteractive_tabindex";
+
+    /// Redundant role
+    a11y_no_redundant_roles(role: &str) => "Redundant role '{}'\nhttps://svelte.dev/e/a11y_no_redundant_roles", role;
+
+    /// Elements with the ARIA role must have required attributes
+    a11y_role_has_required_aria_props(role: &str, props: &str) => "Elements with the ARIA role \"{}\" must have the following attributes defined: {}\nhttps://svelte.dev/e/a11y_role_has_required_aria_props", role, props;
+
+    /// The attribute is not supported by the role (explicit)
+    a11y_role_supports_aria_props(attribute: &str, role: &str) => "The attribute '{}' is not supported by the role '{}'\nhttps://svelte.dev/e/a11y_role_supports_aria_props", attribute, role;
+
+    /// The attribute is not supported by the role (implicit on the element)
+    a11y_role_supports_aria_props_implicit(attribute: &str, role: &str, name: &str) => "The attribute '{}' is not supported by the role '{}'. This role is implicit on the element `<{}>`\nhttps://svelte.dev/e/a11y_role_supports_aria_props_implicit", attribute, role, name;
+
+    /// Element with handler must have an ARIA role
+    a11y_no_static_element_interactions(element: &str, handler: &str) => "`<{}>` with a {} handler must have an ARIA role\nhttps://svelte.dev/e/a11y_no_static_element_interactions", element, handler;
+
+    /// Avoid tabindex values above zero
+    a11y_positive_tabindex() => "Avoid tabindex values above zero\nhttps://svelte.dev/e/a11y_positive_tabindex";
+
+    // ARIA proptypes warnings
+
+    /// The value of the attribute must be a specific type (generic)
+    a11y_incorrect_aria_attribute_type(attribute: &str, expected_type: &str) => "The value of '{}' must be a {}\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type", attribute, expected_type;
+
+    /// The value of the attribute must be 'true' or 'false' (boolean)
+    a11y_incorrect_aria_attribute_type_boolean(attribute: &str) => "The value of '{}' must be either 'true' or 'false'. It cannot be empty\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_boolean", attribute;
+
+    /// The value of the attribute must be a DOM element ID
+    a11y_incorrect_aria_attribute_type_id(attribute: &str) => "The value of '{}' must be a string that represents a DOM element ID\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_id", attribute;
+
+    /// The value of the attribute must be a space-separated list of DOM element IDs
+    a11y_incorrect_aria_attribute_type_idlist(attribute: &str) => "The value of '{}' must be a space-separated list of strings that represent DOM element IDs\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_idlist", attribute;
+
+    /// The value of the attribute must be an integer
+    a11y_incorrect_aria_attribute_type_integer(attribute: &str) => "The value of '{}' must be an integer\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_integer", attribute;
+
+    /// The value of the attribute must be one of the specified tokens
+    a11y_incorrect_aria_attribute_type_token(attribute: &str, values: &str) => "The value of '{}' must be exactly one of {}\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_token", attribute, values;
+
+    /// The value of the attribute must be a space-separated list of the specified tokens
+    a11y_incorrect_aria_attribute_type_tokenlist(attribute: &str, values: &str) => "The value of '{}' must be a space-separated list of one or more of {}\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_tokenlist", attribute, values;
+
+    /// The value of the attribute must be 'true', 'false', or 'mixed'
+    a11y_incorrect_aria_attribute_type_tristate(attribute: &str) => "The value of '{}' must be exactly one of true, false, or mixed\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_tristate", attribute;
+
+    // Custom element warnings
+
+    /// When creating a custom element, props should be defined using the `customElement.props` compiler option
+    custom_element_props_identifier() => "When creating a custom element, props should be defined using the `customElement.props` compiler option";
+
+    // Node placement warnings
+
+    /// Node placement SSR warning - when an element placement is invalid but can work on client
+    /// because it's inside a conditional block that creates separate template strings.
+    node_invalid_placement_ssr(message: &str) => "{}. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning\nhttps://svelte.dev/e/node_invalid_placement_ssr", message;
+
+    // Element warnings
+
+    /// Self-closing HTML tags for non-void elements are ambiguous
+    element_invalid_self_closing_tag(name: &str) => "Self-closing HTML tags for non-void elements are ambiguous — use `<{} ...></{}>` rather than `<{} ... />`\nhttps://svelte.dev/e/element_invalid_self_closing_tag", name, name, name;
+
+    // Script warnings
+
+    /// `context="module"` is deprecated, use the `module` attribute instead
+    script_context_deprecated() => "`context=\"module\"` is deprecated, use the `module` attribute instead\nhttps://svelte.dev/e/script_context_deprecated";
+
+    /// Unrecognised script attribute
+    script_unknown_attribute() => "Unrecognised attribute — should be one of `generics`, `lang` or `module`. If this exists for a preprocessor, ensure that the preprocessor removes it\nhttps://svelte.dev/e/script_unknown_attribute";
+
+    // Component warnings
+
+    /// Component name starts with a lowercase letter - will be treated as an HTML element
+    component_name_lowercase(name: &str) => "`<{}>` will be treated as an HTML element unless it begins with a capital letter\nhttps://svelte.dev/e/component_name_lowercase", name;
+
+    /// Empty block warning
+    block_empty() => "Empty block\nhttps://svelte.dev/e/block_empty";
+
+    // Additional warnings for validator tests
+
+    /// The `accessors` option has been deprecated. It will have no effect in runes mode
+    options_deprecated_accessors() => "The `accessors` option has been deprecated. It will have no effect in runes mode\nhttps://svelte.dev/e/options_deprecated_accessors";
+
+    /// The `immutable` option has been deprecated. It will have no effect in runes mode
+    options_deprecated_immutable() => "The `immutable` option has been deprecated. It will have no effect in runes mode\nhttps://svelte.dev/e/options_deprecated_immutable";
+
+    /// The customElement option is used when generating a custom element
+    options_missing_custom_element() => "The `customElement` option is used when generating a custom element. Did you forget the `customElement: true` compile option?\nhttps://svelte.dev/e/options_missing_custom_element";
+
+    /// Using a rest element or a non-destructured declaration with $props()
+    custom_element_props_identifier_rest as "custom_element_props_identifier"() => "Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.\nhttps://svelte.dev/e/custom_element_props_identifier";
+
+    /// Binding to a rest element in an each block
+    bind_invalid_each_rest(name: &str) => "The rest operator (...) will create a new object and binding '{}' with the original object will not work\nhttps://svelte.dev/e/bind_invalid_each_rest", name;
+
+    /// Quoted single-expression attribute warning
+    attribute_quoted() => "Quoted attribute values will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes\nhttps://svelte.dev/e/attribute_quoted";
+
+    // Event directive warnings
+
+    /// Attribute invalid property name - React style property used in Svelte
+    attribute_invalid_property_name(name: &str, correct_name: &str) => "'{}' is not a valid HTML attribute. Did you mean '{}'?\nhttps://svelte.dev/e/attribute_invalid_property_name", name, correct_name;
+
+    /// Element was implicitly closed by another element
+    element_implicitly_closed(tag: &str, closing: &str) => "This element is implicitly closed by the following `{}`, which can cause an unexpected DOM structure. Add an explicit `{}` to avoid surprises.\nhttps://svelte.dev/e/element_implicitly_closed", tag, closing;
+
+    /// Legacy code warning for svelte-ignore using old hyphenated codes in runes mode
+    legacy_code(old_code: &str, new_code: &str) => "`{}` is no longer valid — please use `{}` instead\nhttps://svelte.dev/e/legacy_code", old_code, new_code;
+
+    /// Exported `let` variable is not used in the template
+    export_let_unused(name: &str) => "Component has unused export property '{}'. If it is for external reference only, please consider using `export const {}`\nhttps://svelte.dev/e/export_let_unused", name, name;
+
+    /// Using `on:name` to listen to the event is deprecated. Use the event attribute `onname` instead.
+    event_directive_deprecated(name: &str) => "Using `on:{}` to listen to the {} event is deprecated. Use the event attribute `on{}` instead\nhttps://svelte.dev/e/event_directive_deprecated", name, name, name;
+
+    /// The `is` attribute is not supported on elements. Use `{...spread}` instead.
+    attribute_avoid_is() => "The \"is\" attribute is not supported cross-browser and should be avoided\nhttps://svelte.dev/e/attribute_avoid_is";
+
+    /// `this` should be an `{expression}`. Using a string attribute value will cause an error in future versions of Svelte
+    svelte_element_invalid_this() => "`this` should be an `{expression}`. Using a string attribute value will cause an error in future versions of Svelte\nhttps://svelte.dev/e/svelte_element_invalid_this";
 }
+
+// Diagnostics whose message is assembled conditionally, or that carry a span,
+// do not fit the declarative form above.
 
 /// State referenced locally - may not be reactive
 pub fn state_referenced_locally(
@@ -63,456 +316,6 @@ pub fn state_referenced_locally(
     w.start = node_start;
     w.end = node_end;
     w
-}
-
-/// Reactive declaration references module script dependency
-pub fn reactive_declaration_module_script_dependency() -> AnalysisWarning {
-    warning(
-        "reactive_declaration_module_script_dependency",
-        "Reassignments of module-level declarations will not cause reactive statements to update\nhttps://svelte.dev/e/reactive_declaration_module_script_dependency",
-    )
-}
-
-/// Non-reactive update warning - variable is updated but not declared with $state
-pub fn non_reactive_update(name: &str) -> AnalysisWarning {
-    warning(
-        "non_reactive_update",
-        format!(
-            "`{}` is updated, but is not declared with `$state(...)`. Changing its value will not correctly trigger updates\nhttps://svelte.dev/e/non_reactive_update",
-            name
-        ),
-    )
-}
-
-/// Store/rune naming conflict warning
-pub fn store_rune_conflict(store_name: &str) -> AnalysisWarning {
-    warning(
-        "store_rune_conflict",
-        format!(
-            "It looks like you're using the `${}` rune, but there is a local binding called `{}`. Referencing a local variable with a `$` prefix will create a store subscription. Please rename `{}` to avoid the ambiguity\nhttps://svelte.dev/e/store_rune_conflict",
-            store_name, store_name, store_name
-        ),
-    )
-}
-
-/// Global event reference warning
-pub fn attribute_global_event_reference(name: &str) -> AnalysisWarning {
-    warning(
-        "attribute_global_event_reference",
-        format!(
-            "You are referencing `globalThis.{}`. Did you forget to declare a variable with that name?\nhttps://svelte.dev/e/attribute_global_event_reference",
-            name
-        ),
-    )
-}
-
-/// Reactive declaration is invalid placement (not at the top level of an instance script)
-pub fn reactive_declaration_invalid_placement() -> AnalysisWarning {
-    warning(
-        "reactive_declaration_invalid_placement",
-        "Reactive declarations are only valid at the top level of the instance script",
-    )
-}
-
-// Performance warnings
-
-/// Avoid 'new class' — instead, declare the class at the top level scope
-pub fn perf_avoid_inline_class() -> AnalysisWarning {
-    warning(
-        "perf_avoid_inline_class",
-        "Avoid 'new class' — instead, declare the class at the top level scope\nhttps://svelte.dev/e/perf_avoid_inline_class",
-    )
-}
-
-/// Avoid declaring classes below the top level scope
-pub fn perf_avoid_nested_class() -> AnalysisWarning {
-    warning(
-        "perf_avoid_nested_class",
-        "Avoid declaring classes below the top level scope\nhttps://svelte.dev/e/perf_avoid_nested_class",
-    )
-}
-
-// Security warnings
-
-/// Bidirectional control character detected in code.
-///
-/// These Unicode characters can alter the visual direction of code
-/// and could have unintended security consequences.
-///
-/// Corresponds to Svelte's `bidirectional_control_characters` warning.
-pub fn bidirectional_control_characters() -> AnalysisWarning {
-    warning(
-        "bidirectional_control_characters",
-        "A bidirectional control character was detected in your code. These characters can be used to alter the visual direction of your code and could have unintended consequences\nhttps://svelte.dev/e/bidirectional_control_characters",
-    )
-}
-
-// Slot element warnings
-
-/// Using `<slot>` to render parent content is deprecated. Use `{@render ...}` tags instead
-pub fn slot_element_deprecated() -> AnalysisWarning {
-    warning(
-        "slot_element_deprecated",
-        "Using `<slot>` to render parent content is deprecated. Use `{@render ...}` tags instead\nhttps://svelte.dev/e/slot_element_deprecated",
-    )
-}
-
-/// `<svelte:self>` is deprecated — use self-imports (e.g. `import Component from './Component.svelte'`) instead
-pub fn svelte_self_deprecated(name: &str, basename: &str) -> AnalysisWarning {
-    warning(
-        "svelte_self_deprecated",
-        format!(
-            "`<svelte:self>` is deprecated — use self-imports (e.g. `import {} from './{}'`) instead\nhttps://svelte.dev/e/svelte_self_deprecated",
-            name, basename
-        ),
-    )
-}
-
-/// `<svelte:component>` is deprecated in runes mode — components are dynamic by default
-pub fn svelte_component_deprecated() -> AnalysisWarning {
-    warning(
-        "svelte_component_deprecated",
-        "`<svelte:component>` is deprecated in runes mode — components are dynamic by default\nhttps://svelte.dev/e/svelte_component_deprecated",
-    )
-}
-
-// Attribute warnings
-
-/// Attributes should not contain ':' characters to prevent ambiguity with Svelte directives
-pub fn attribute_illegal_colon() -> AnalysisWarning {
-    warning(
-        "attribute_illegal_colon",
-        "Attributes should not contain ':' characters to prevent ambiguity with Svelte directives",
-    )
-}
-
-// A11y warnings
-
-/// Avoid using accesskey
-pub fn a11y_accesskey() -> AnalysisWarning {
-    warning(
-        "a11y_accesskey",
-        "Avoid using accesskey\nhttps://svelte.dev/e/a11y_accesskey",
-    )
-}
-
-/// An element with an aria-activedescendant attribute should have a tabindex value
-pub fn a11y_aria_activedescendant_has_tabindex() -> AnalysisWarning {
-    warning(
-        "a11y_aria_activedescendant_has_tabindex",
-        "An element with an aria-activedescendant attribute should have a tabindex value\nhttps://svelte.dev/e/a11y_aria_activedescendant_has_tabindex",
-    )
-}
-
-/// Element should not have aria-* attributes
-pub fn a11y_aria_attributes(name: &str) -> AnalysisWarning {
-    warning(
-        "a11y_aria_attributes",
-        format!(
-            "`<{}>` should not have aria-* attributes\nhttps://svelte.dev/e/a11y_aria_attributes",
-            name
-        ),
-    )
-}
-
-/// Invalid value for autocomplete on input element
-pub fn a11y_autocomplete_valid(value: &str, input_type: &str) -> AnalysisWarning {
-    warning(
-        "a11y_autocomplete_valid",
-        format!(
-            "'{}' is an invalid value for 'autocomplete' on `<input type=\"{}\">`\nhttps://svelte.dev/e/a11y_autocomplete_valid",
-            value, input_type
-        ),
-    )
-}
-
-/// Avoid using autofocus
-pub fn a11y_autofocus() -> AnalysisWarning {
-    warning(
-        "a11y_autofocus",
-        "Avoid using autofocus\nhttps://svelte.dev/e/a11y_autofocus",
-    )
-}
-
-/// Visible, non-interactive element with a click event must be accompanied by a keyboard event handler.
-/// The element tag name is interpolated into the message (Svelte 5.56.0 #18272).
-pub fn a11y_click_events_have_key_events(tag_name: &str) -> AnalysisWarning {
-    warning(
-        "a11y_click_events_have_key_events",
-        format!(
-            "Visible, non-interactive element `<{}>` with a click event must be accompanied by a keyboard event handler. Consider whether an interactive element such as `<button type=\"button\">` or `<a>` might be more appropriate\nhttps://svelte.dev/e/a11y_click_events_have_key_events",
-            tag_name
-        ),
-    )
-}
-
-/// Buttons and links should either contain text or have an aria-label, aria-labelledby or title attribute
-pub fn a11y_consider_explicit_label() -> AnalysisWarning {
-    warning(
-        "a11y_consider_explicit_label",
-        "Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute\nhttps://svelte.dev/e/a11y_consider_explicit_label",
-    )
-}
-
-/// Avoid distracting elements
-pub fn a11y_distracting_elements(name: &str) -> AnalysisWarning {
-    warning(
-        "a11y_distracting_elements",
-        format!(
-            "Avoid `<{}>` elements\nhttps://svelte.dev/e/a11y_distracting_elements",
-            name
-        ),
-    )
-}
-
-/// `<figcaption>` must be first or last child of `<figure>`
-pub fn a11y_figcaption_index() -> AnalysisWarning {
-    warning(
-        "a11y_figcaption_index",
-        "`<figcaption>` must be first or last child of `<figure>`\nhttps://svelte.dev/e/a11y_figcaption_index",
-    )
-}
-
-/// `<figcaption>` must be an immediate child of `<figure>`
-pub fn a11y_figcaption_parent() -> AnalysisWarning {
-    warning(
-        "a11y_figcaption_parent",
-        "`<figcaption>` must be an immediate child of `<figure>`\nhttps://svelte.dev/e/a11y_figcaption_parent",
-    )
-}
-
-/// Element should not be hidden
-pub fn a11y_hidden(name: &str) -> AnalysisWarning {
-    warning(
-        "a11y_hidden",
-        format!(
-            "`<{}>` element should not be hidden\nhttps://svelte.dev/e/a11y_hidden",
-            name
-        ),
-    )
-}
-
-/// Screenreaders already announce `<img>` elements as an image
-pub fn a11y_img_redundant_alt() -> AnalysisWarning {
-    warning(
-        "a11y_img_redundant_alt",
-        "Screenreaders already announce `<img>` elements as an image\nhttps://svelte.dev/e/a11y_img_redundant_alt",
-    )
-}
-
-/// Elements with the interactive role must have a tabindex value
-pub fn a11y_interactive_supports_focus(role: &str) -> AnalysisWarning {
-    warning(
-        "a11y_interactive_supports_focus",
-        format!(
-            "Elements with the '{}' interactive role must have a tabindex value\nhttps://svelte.dev/e/a11y_interactive_supports_focus",
-            role
-        ),
-    )
-}
-
-/// Invalid href attribute value
-pub fn a11y_invalid_attribute(href_value: &str, href_attribute: &str) -> AnalysisWarning {
-    warning(
-        "a11y_invalid_attribute",
-        format!(
-            "'{}' is not a valid {} attribute\nhttps://svelte.dev/e/a11y_invalid_attribute",
-            href_value, href_attribute
-        ),
-    )
-}
-
-/// A form label must be associated with a control
-pub fn a11y_label_has_associated_control() -> AnalysisWarning {
-    warning(
-        "a11y_label_has_associated_control",
-        "A form label must be associated with a control\nhttps://svelte.dev/e/a11y_label_has_associated_control",
-    )
-}
-
-/// `<video>` elements must have a `<track kind="captions">`
-pub fn a11y_media_has_caption() -> AnalysisWarning {
-    warning(
-        "a11y_media_has_caption",
-        "`<video>` elements must have a `<track kind=\"captions\">`\nhttps://svelte.dev/e/a11y_media_has_caption",
-    )
-}
-
-/// Element should not have role attribute
-pub fn a11y_misplaced_role(name: &str) -> AnalysisWarning {
-    warning(
-        "a11y_misplaced_role",
-        format!(
-            "`<{}>` should not have role attribute\nhttps://svelte.dev/e/a11y_misplaced_role",
-            name
-        ),
-    )
-}
-
-/// The scope attribute should only be used with `<th>` elements
-pub fn a11y_misplaced_scope() -> AnalysisWarning {
-    warning(
-        "a11y_misplaced_scope",
-        "The scope attribute should only be used with `<th>` elements\nhttps://svelte.dev/e/a11y_misplaced_scope",
-    )
-}
-
-/// Element should have required attribute
-pub fn a11y_missing_attribute(name: &str, article: &str, sequence: &str) -> AnalysisWarning {
-    warning(
-        "a11y_missing_attribute",
-        format!(
-            "`<{}>` element should have {} {} attribute\nhttps://svelte.dev/e/a11y_missing_attribute",
-            name, article, sequence
-        ),
-    )
-}
-
-/// Element should contain text
-pub fn a11y_missing_content(name: &str) -> AnalysisWarning {
-    warning(
-        "a11y_missing_content",
-        format!(
-            "`<{}>` element should contain text\nhttps://svelte.dev/e/a11y_missing_content",
-            name
-        ),
-    )
-}
-
-/// Mouse event must be accompanied by keyboard event
-pub fn a11y_mouse_events_have_key_events(event: &str, accompanied_by: &str) -> AnalysisWarning {
-    warning(
-        "a11y_mouse_events_have_key_events",
-        format!(
-            "'{}' event must be accompanied by '{}' event\nhttps://svelte.dev/e/a11y_mouse_events_have_key_events",
-            event, accompanied_by
-        ),
-    )
-}
-
-/// Abstract role is forbidden
-pub fn a11y_no_abstract_role(role: &str) -> AnalysisWarning {
-    warning(
-        "a11y_no_abstract_role",
-        format!(
-            "Abstract role '{}' is forbidden\nhttps://svelte.dev/e/a11y_no_abstract_role",
-            role
-        ),
-    )
-}
-
-/// Interactive element cannot have non-interactive role
-pub fn a11y_no_interactive_element_to_noninteractive_role(
-    element: &str,
-    role: &str,
-) -> AnalysisWarning {
-    warning(
-        "a11y_no_interactive_element_to_noninteractive_role",
-        format!(
-            "`<{}>` cannot have role '{}'\nhttps://svelte.dev/e/a11y_no_interactive_element_to_noninteractive_role",
-            element, role
-        ),
-    )
-}
-
-/// Non-interactive element should not be assigned mouse or keyboard event listeners
-pub fn a11y_no_noninteractive_element_interactions(element: &str) -> AnalysisWarning {
-    warning(
-        "a11y_no_noninteractive_element_interactions",
-        format!(
-            "Non-interactive element `<{}>` should not be assigned mouse or keyboard event listeners\nhttps://svelte.dev/e/a11y_no_noninteractive_element_interactions",
-            element
-        ),
-    )
-}
-
-/// Non-interactive element cannot have interactive role
-pub fn a11y_no_noninteractive_element_to_interactive_role(
-    element: &str,
-    role: &str,
-) -> AnalysisWarning {
-    warning(
-        "a11y_no_noninteractive_element_to_interactive_role",
-        format!(
-            "Non-interactive element `<{}>` cannot have interactive role '{}'\nhttps://svelte.dev/e/a11y_no_noninteractive_element_to_interactive_role",
-            element, role
-        ),
-    )
-}
-
-/// Noninteractive element cannot have nonnegative tabIndex value
-pub fn a11y_no_noninteractive_tabindex() -> AnalysisWarning {
-    warning(
-        "a11y_no_noninteractive_tabindex",
-        "noninteractive element cannot have nonnegative tabIndex value\nhttps://svelte.dev/e/a11y_no_noninteractive_tabindex",
-    )
-}
-
-/// Redundant role
-pub fn a11y_no_redundant_roles(role: &str) -> AnalysisWarning {
-    warning(
-        "a11y_no_redundant_roles",
-        format!(
-            "Redundant role '{}'\nhttps://svelte.dev/e/a11y_no_redundant_roles",
-            role
-        ),
-    )
-}
-
-/// Elements with the ARIA role must have required attributes
-pub fn a11y_role_has_required_aria_props(role: &str, props: &str) -> AnalysisWarning {
-    warning(
-        "a11y_role_has_required_aria_props",
-        format!(
-            "Elements with the ARIA role \"{}\" must have the following attributes defined: {}\nhttps://svelte.dev/e/a11y_role_has_required_aria_props",
-            role, props
-        ),
-    )
-}
-
-/// The attribute is not supported by the role (explicit)
-pub fn a11y_role_supports_aria_props(attribute: &str, role: &str) -> AnalysisWarning {
-    warning(
-        "a11y_role_supports_aria_props",
-        format!(
-            "The attribute '{}' is not supported by the role '{}'\nhttps://svelte.dev/e/a11y_role_supports_aria_props",
-            attribute, role
-        ),
-    )
-}
-
-/// The attribute is not supported by the role (implicit on the element)
-pub fn a11y_role_supports_aria_props_implicit(
-    attribute: &str,
-    role: &str,
-    name: &str,
-) -> AnalysisWarning {
-    warning(
-        "a11y_role_supports_aria_props_implicit",
-        format!(
-            "The attribute '{}' is not supported by the role '{}'. This role is implicit on the element `<{}>`\nhttps://svelte.dev/e/a11y_role_supports_aria_props_implicit",
-            attribute, role, name
-        ),
-    )
-}
-
-/// Element with handler must have an ARIA role
-pub fn a11y_no_static_element_interactions(element: &str, handler: &str) -> AnalysisWarning {
-    warning(
-        "a11y_no_static_element_interactions",
-        format!(
-            "`<{}>` with a {} handler must have an ARIA role\nhttps://svelte.dev/e/a11y_no_static_element_interactions",
-            element, handler
-        ),
-    )
-}
-
-/// Avoid tabindex values above zero
-pub fn a11y_positive_tabindex() -> AnalysisWarning {
-    warning(
-        "a11y_positive_tabindex",
-        "Avoid tabindex values above zero\nhttps://svelte.dev/e/a11y_positive_tabindex",
-    )
 }
 
 /// Unknown ARIA attribute
@@ -547,263 +350,6 @@ pub fn a11y_unknown_role(role: &str, suggestion: Option<&str>) -> AnalysisWarnin
     warning("a11y_unknown_role", message)
 }
 
-// ARIA proptypes warnings
-
-/// The value of the attribute must be a specific type (generic)
-pub fn a11y_incorrect_aria_attribute_type(attribute: &str, expected_type: &str) -> AnalysisWarning {
-    warning(
-        "a11y_incorrect_aria_attribute_type",
-        format!(
-            "The value of '{}' must be a {}\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type",
-            attribute, expected_type
-        ),
-    )
-}
-
-/// The value of the attribute must be 'true' or 'false' (boolean)
-pub fn a11y_incorrect_aria_attribute_type_boolean(attribute: &str) -> AnalysisWarning {
-    warning(
-        "a11y_incorrect_aria_attribute_type_boolean",
-        format!(
-            "The value of '{}' must be either 'true' or 'false'. It cannot be empty\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_boolean",
-            attribute
-        ),
-    )
-}
-
-/// The value of the attribute must be a DOM element ID
-pub fn a11y_incorrect_aria_attribute_type_id(attribute: &str) -> AnalysisWarning {
-    warning(
-        "a11y_incorrect_aria_attribute_type_id",
-        format!(
-            "The value of '{}' must be a string that represents a DOM element ID\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_id",
-            attribute
-        ),
-    )
-}
-
-/// The value of the attribute must be a space-separated list of DOM element IDs
-pub fn a11y_incorrect_aria_attribute_type_idlist(attribute: &str) -> AnalysisWarning {
-    warning(
-        "a11y_incorrect_aria_attribute_type_idlist",
-        format!(
-            "The value of '{}' must be a space-separated list of strings that represent DOM element IDs\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_idlist",
-            attribute
-        ),
-    )
-}
-
-/// The value of the attribute must be an integer
-pub fn a11y_incorrect_aria_attribute_type_integer(attribute: &str) -> AnalysisWarning {
-    warning(
-        "a11y_incorrect_aria_attribute_type_integer",
-        format!(
-            "The value of '{}' must be an integer\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_integer",
-            attribute
-        ),
-    )
-}
-
-/// The value of the attribute must be one of the specified tokens
-pub fn a11y_incorrect_aria_attribute_type_token(attribute: &str, values: &str) -> AnalysisWarning {
-    warning(
-        "a11y_incorrect_aria_attribute_type_token",
-        format!(
-            "The value of '{}' must be exactly one of {}\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_token",
-            attribute, values
-        ),
-    )
-}
-
-/// The value of the attribute must be a space-separated list of the specified tokens
-pub fn a11y_incorrect_aria_attribute_type_tokenlist(
-    attribute: &str,
-    values: &str,
-) -> AnalysisWarning {
-    warning(
-        "a11y_incorrect_aria_attribute_type_tokenlist",
-        format!(
-            "The value of '{}' must be a space-separated list of one or more of {}\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_tokenlist",
-            attribute, values
-        ),
-    )
-}
-
-/// The value of the attribute must be 'true', 'false', or 'mixed'
-pub fn a11y_incorrect_aria_attribute_type_tristate(attribute: &str) -> AnalysisWarning {
-    warning(
-        "a11y_incorrect_aria_attribute_type_tristate",
-        format!(
-            "The value of '{}' must be exactly one of true, false, or mixed\nhttps://svelte.dev/e/a11y_incorrect_aria_attribute_type_tristate",
-            attribute
-        ),
-    )
-}
-
-// Custom element warnings
-
-/// When creating a custom element, props should be defined using the `customElement.props` compiler option
-pub fn custom_element_props_identifier() -> AnalysisWarning {
-    warning(
-        "custom_element_props_identifier",
-        "When creating a custom element, props should be defined using the `customElement.props` compiler option",
-    )
-}
-
-// Node placement warnings
-
-/// Node placement SSR warning - when an element placement is invalid but can work on client
-/// because it's inside a conditional block that creates separate template strings.
-pub fn node_invalid_placement_ssr(message: &str) -> AnalysisWarning {
-    warning(
-        "node_invalid_placement_ssr",
-        format!(
-            "{}. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning\nhttps://svelte.dev/e/node_invalid_placement_ssr",
-            message
-        ),
-    )
-}
-
-// Element warnings
-
-/// Self-closing HTML tags for non-void elements are ambiguous
-pub fn element_invalid_self_closing_tag(name: &str) -> AnalysisWarning {
-    warning(
-        "element_invalid_self_closing_tag",
-        format!(
-            "Self-closing HTML tags for non-void elements are ambiguous — use `<{} ...></{}>` rather than `<{} ... />`\nhttps://svelte.dev/e/element_invalid_self_closing_tag",
-            name, name, name
-        ),
-    )
-}
-
-// Script warnings
-
-/// `context="module"` is deprecated, use the `module` attribute instead
-pub fn script_context_deprecated() -> AnalysisWarning {
-    warning(
-        "script_context_deprecated",
-        "`context=\"module\"` is deprecated, use the `module` attribute instead\nhttps://svelte.dev/e/script_context_deprecated",
-    )
-}
-
-/// Unrecognised script attribute
-pub fn script_unknown_attribute() -> AnalysisWarning {
-    warning(
-        "script_unknown_attribute",
-        "Unrecognised attribute — should be one of `generics`, `lang` or `module`. If this exists for a preprocessor, ensure that the preprocessor removes it\nhttps://svelte.dev/e/script_unknown_attribute",
-    )
-}
-
-// Component warnings
-
-/// Component name starts with a lowercase letter - will be treated as an HTML element
-pub fn component_name_lowercase(name: &str) -> AnalysisWarning {
-    warning(
-        "component_name_lowercase",
-        format!(
-            "`<{}>` will be treated as an HTML element unless it begins with a capital letter\nhttps://svelte.dev/e/component_name_lowercase",
-            name
-        ),
-    )
-}
-
-/// Empty block warning
-pub fn block_empty() -> AnalysisWarning {
-    warning(
-        "block_empty",
-        "Empty block\nhttps://svelte.dev/e/block_empty",
-    )
-}
-
-// Additional warnings for validator tests
-
-/// The `accessors` option has been deprecated. It will have no effect in runes mode
-pub fn options_deprecated_accessors() -> AnalysisWarning {
-    warning(
-        "options_deprecated_accessors",
-        "The `accessors` option has been deprecated. It will have no effect in runes mode\nhttps://svelte.dev/e/options_deprecated_accessors",
-    )
-}
-
-/// The `immutable` option has been deprecated. It will have no effect in runes mode
-pub fn options_deprecated_immutable() -> AnalysisWarning {
-    warning(
-        "options_deprecated_immutable",
-        "The `immutable` option has been deprecated. It will have no effect in runes mode\nhttps://svelte.dev/e/options_deprecated_immutable",
-    )
-}
-
-/// The customElement option is used when generating a custom element
-pub fn options_missing_custom_element() -> AnalysisWarning {
-    warning(
-        "options_missing_custom_element",
-        "The `customElement` option is used when generating a custom element. Did you forget the `customElement: true` compile option?\nhttps://svelte.dev/e/options_missing_custom_element",
-    )
-}
-
-/// Using a rest element or a non-destructured declaration with $props()
-pub fn custom_element_props_identifier_rest() -> AnalysisWarning {
-    warning(
-        "custom_element_props_identifier",
-        "Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.\nhttps://svelte.dev/e/custom_element_props_identifier",
-    )
-}
-
-/// Binding to a rest element in an each block
-pub fn bind_invalid_each_rest(name: &str) -> AnalysisWarning {
-    warning(
-        "bind_invalid_each_rest",
-        format!(
-            "The rest operator (...) will create a new object and binding '{}' with the original object will not work\nhttps://svelte.dev/e/bind_invalid_each_rest",
-            name
-        ),
-    )
-}
-
-/// Quoted single-expression attribute warning
-pub fn attribute_quoted() -> AnalysisWarning {
-    warning(
-        "attribute_quoted",
-        "Quoted attribute values will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes\nhttps://svelte.dev/e/attribute_quoted",
-    )
-}
-
-// Event directive warnings
-
-/// Attribute invalid property name - React style property used in Svelte
-pub fn attribute_invalid_property_name(name: &str, correct_name: &str) -> AnalysisWarning {
-    warning(
-        "attribute_invalid_property_name",
-        format!(
-            "'{}' is not a valid HTML attribute. Did you mean '{}'?\nhttps://svelte.dev/e/attribute_invalid_property_name",
-            name, correct_name
-        ),
-    )
-}
-
-/// Element was implicitly closed by another element
-pub fn element_implicitly_closed(tag: &str, closing: &str) -> AnalysisWarning {
-    warning(
-        "element_implicitly_closed",
-        format!(
-            "This element is implicitly closed by the following `{}`, which can cause an unexpected DOM structure. Add an explicit `{}` to avoid surprises.\nhttps://svelte.dev/e/element_implicitly_closed",
-            tag, closing
-        ),
-    )
-}
-
-/// Legacy code warning for svelte-ignore using old hyphenated codes in runes mode
-pub fn legacy_code(old_code: &str, new_code: &str) -> AnalysisWarning {
-    warning(
-        "legacy_code",
-        format!(
-            "`{}` is no longer valid — please use `{}` instead\nhttps://svelte.dev/e/legacy_code",
-            old_code, new_code
-        ),
-    )
-}
-
 /// Unknown code in svelte-ignore comment
 pub fn unknown_code(code: &str, suggestion: Option<&str>) -> AnalysisWarning {
     let message = if let Some(suggestion) = suggestion {
@@ -818,42 +364,4 @@ pub fn unknown_code(code: &str, suggestion: Option<&str>) -> AnalysisWarning {
         )
     };
     warning("unknown_code", message)
-}
-
-/// Exported `let` variable is not used in the template
-pub fn export_let_unused(name: &str) -> AnalysisWarning {
-    warning(
-        "export_let_unused",
-        format!(
-            "Component has unused export property '{}'. If it is for external reference only, please consider using `export const {}`\nhttps://svelte.dev/e/export_let_unused",
-            name, name
-        ),
-    )
-}
-
-/// Using `on:name` to listen to the event is deprecated. Use the event attribute `onname` instead.
-pub fn event_directive_deprecated(name: &str) -> AnalysisWarning {
-    warning(
-        "event_directive_deprecated",
-        format!(
-            "Using `on:{}` to listen to the {} event is deprecated. Use the event attribute `on{}` instead\nhttps://svelte.dev/e/event_directive_deprecated",
-            name, name, name
-        ),
-    )
-}
-
-/// The `is` attribute is not supported on elements. Use `{...spread}` instead.
-pub fn attribute_avoid_is() -> AnalysisWarning {
-    warning(
-        "attribute_avoid_is",
-        "The \"is\" attribute is not supported cross-browser and should be avoided\nhttps://svelte.dev/e/attribute_avoid_is",
-    )
-}
-
-/// `this` should be an `{expression}`. Using a string attribute value will cause an error in future versions of Svelte
-pub fn svelte_element_invalid_this() -> AnalysisWarning {
-    warning(
-        "svelte_element_invalid_this",
-        "`this` should be an `{expression}`. Using a string attribute value will cause an error in future versions of Svelte\nhttps://svelte.dev/e/svelte_element_invalid_this",
-    )
 }


### PR DESCRIPTION
## What

`crates/rsvelte_core/src/compiler/phases/2_analyze/{errors,warnings}.rs` held **202 hand-written
constructors** that all expand to the same three things: a code, a message literal, and (optionally)
a `format!` argument list. This PR replaces that boilerplate with a `diagnostics!` macro so each
diagnostic is **one declaration line** plus its doc comment.

```rust
diagnostics! {
    error => AnalysisError;

    /// Attributes need to be unique
    attribute_duplicate() => "Attributes need to be unique";

    /// `%rune%` has already been declared
    props_duplicate(rune: &str) => "`{}` has already been declared", rune;
}
```

## Line counts (measured, rebased onto `920912be`)

| File | Before | After | Δ |
|---|---:|---:|---:|
| `2_analyze/errors.rs` | 1109 | 452 | −657 (−59.2%) |
| `2_analyze/warnings.rs` | 859 | 367 | −492 (−57.3%) |
| `2_analyze/diagnostic.rs` (new, the macro) | 0 | 46 | +46 |
| `2_analyze/mod.rs` | — | — | +1 (`mod diagnostic;`) |
| **Total** | **1968** | **865** | **−1103 (−56.0%)** |

`git diff --shortstat origin/main HEAD`: `556 insertions(+), 1658 deletions(-)`.

## Method chosen, and why not build.rs codegen

Two options were considered: (A) generating the tables from
`submodules/svelte/packages/svelte/messages/**/*.md` in `build.rs`, like the official compiler does
with `scripts/process-messages`, or (B) compressing them with a declarative macro. **B was chosen.**

1. **`build.rs` must keep working without the submodule.** The existing
   `crates/rsvelte_core/build.rs` explicitly tolerates a missing `submodules/svelte` (it only emits
   `SVELTE_VERSION` if the path exists, otherwise the code falls back to a default). Making 202
   constructors depend on the submodule would break that property; to preserve it we would have to
   commit a fallback generated table to the source tree — i.e. keep the full 2000 lines anyway, and
   the reduction evaporates.
2. **The messages are not 1:1 with the official `.md` files.** rsvelte has a diagnostic whose code
   differs from its function name (`custom_element_props_identifier_rest` →
   `custom_element_props_identifier`, because `custom_element_props_identifier()` already exists),
   four constructors that assemble the message conditionally from an `Option` argument, and one that
   carries a source span. None of that is expressible from the `.md` files.
3. **The `.md` files carry no Rust type information.** Call sites use typed functions
   (`&str`, `Option<&str>`, `Option<u32>`); generating them would require a hand-maintained type
   table next to the generator, which is the boilerplate we are trying to delete.
4. Macro output stays in the source tree, so `grep` for an error code still lands on the definition,
   and there is no `target/`-only generated file to chase while debugging.

## Structure

- New `2_analyze/diagnostic.rs` (46 lines) defines `diagnostics!`, parameterised by the constructor
  helper and return type, so `errors.rs` and `warnings.rs` share one definition.
- `as "code"` overrides the code when it differs from the function name (one occurrence).
- **5 constructors stay hand-written**, grouped at the end of their file: `bind_invalid_name`,
  `a11y_unknown_aria_attribute`, `a11y_unknown_role`, `unknown_code` (conditional message from an
  `Option` argument) and `state_referenced_locally` (sets `start`/`end`). Forcing these into the
  declarative form would have made them harder to read, not easier.
- Doc comments (the official `%placeholder%` message templates) are preserved verbatim on every
  entry, and the section comments (`// Rune-related errors`, …) and the original declaration order
  are preserved too.

## Output-equality verification (byte-identical)

A temporary integration test was generated that calls **every** constructor and dumps `Debug` of the
result (code + message + span), expanding each `Option` argument in **both** the `Some` and `None`
branch — **209 call sites** for the 202 constructors. String arguments were given distinctive
sentinel values (`"<name>"`, `"<rune>"`, …) so that argument order and repetition (e.g.
`export_let_unused` uses its argument twice) show up in the expanded message. Example line:

```
errors::props_duplicate(&str) args=["<rune>"] => ValidationWithCode { code: "props_duplicate", message: "`<rune>` has already been declared" }
```

The same harness was run on `origin/main` and on this branch:

```
030f9d467ce39c79b6a77a082351636a127ebd7e935be97d8ea45ec2b2be316a  before.txt   (origin/main)
030f9d467ce39c79b6a77a082351636a127ebd7e935be97d8ea45ec2b2be316a  after.txt    (this branch)
```

`diff before.txt after.txt` → empty. Every code, every message and every `Debug`-visible field is
byte-identical.

The branch was originally cut before #1742 landed. After rebasing, the same comparison was also run
against the **pre-#1742** dump to confirm the rebase dropped exactly the five dead constructors that
#1742 deleted (`attribute_ambiguous`, `svelte_element_duplicate_this`, `slot_duplicate`,
`not_implemented`, `script_module_duplicate`) and nothing else — the sorted diff is exactly those
five lines, all deletions, with no additions and no message changes.

The harness was removed before committing (it is a one-shot equivalence check, and the fixture
suites below are the standing regression guard).

## Tests

```
cargo fmt --all --check                                          clean
cargo clippy --all-targets --all-features -- -D warnings         clean
cargo build --workspace --all-targets                            ok
cargo test -p rsvelte_core --test compiler_errors                145/145 passed (0 skipped)
cargo test -p rsvelte_core --test validator                      332/332 passed (0 skipped)
cargo test -p rsvelte_core --test compiler_fixtures              30/30 passed (0 skipped)
cargo test -p rsvelte_core --lib                                 1536 passed; 0 failed; 1 ignored
```

(`RUST_MIN_STACK=33554432` for the integration suites.)

No changeset: internal refactor with no observable behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqdHfZSN3LFxPkyKFaCyoF
