### PR TITLE
refactor(svelte2tsx): instance script の imports あり/なし分岐の重複を解消

### DIFF
--- a/crates/rsvelte_core/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/process_instance_script_tag.rs
@@ -123,476 +123,275 @@ pub(crate) fn process_instance_script_tag(
     // Find import declarations in the instance script content
     let imports = find_instance_imports(instance, source);
 
-    if !imports.is_empty() {
-        // Lift imports above $$render(). Each import is collected
-        // individually (without leading whitespace), then inserted
-        // into the <script> tag replacement. The original import
-        // positions are blanked with whitespace-preserving content.
+    let has_imports = !imports.is_empty();
+    // Lift imports above $$render(): each import is collected individually
+    // (without leading whitespace) and inserted into the <script> tag
+    // replacement, with the original positions blanked out.
+    let import_text = if has_imports {
+        collect_lifted_imports(&imports, source, content_start, str)
+    } else {
+        String::new()
+    };
+    // With imports the `\n` separating the type alias from what precedes it
+    // already comes from `import_text`; without them the alias has to carry it.
+    let type_decl_prefix = if has_imports { "" } else { "\n" };
 
-        let import_text = collect_lifted_imports(&imports, source, content_start, str);
-
-        // Build $$ComponentProps type declaration for TS files
-        //
-        // Determine if the $$ComponentProps type must go INSIDE $$render
-        // rather than before it. This is needed when the type references:
-        // - `typeof x` (runtime value dependency on instance variables)
-        // - generic type parameters from the `generics` attribute on <script>
-        // - types that shadow module-level types
-        let force_inside_render = exported_names.has_component_props_typedef
-            && exported_names.props_type_text.is_some()
-            && !exported_names.type_already_inserted
-            && {
-                let type_text = exported_names.props_type_text.as_ref().unwrap();
-                // Check if type references an instance-local value via
-                // `typeof` (an imported `typeof` stays hoistable).
-                let has_typeof = type_text_typeof_references_local_value(
-                    type_text,
-                    &exported_names.instance_value_names,
-                    &exported_names.instance_import_names,
-                    &exported_names.module_import_names,
-                );
-                // Check if type references generics from $$render
-                let has_generic_dep = !render_generics.is_empty()
-                    && generics_param
-                        .as_ref()
-                        .map(|g| {
-                            // Extract generic param names and check if any appear in the type
-                            split_generic_param_names(g)
-                                .iter()
-                                .any(|name| type_text.contains(name.as_str()))
-                        })
-                        .unwrap_or(false);
-                // Check if type references a type/interface name that is
-                // declared at the top level of the instance script AND
-                // *isn't* also slated for hoisting. References to a
-                // hoisted type are fine — the hoisted declaration sits
-                // above `function $$render()`, so referring to it from
-                // a hoisted `$$ComponentProps` resolves correctly.
-                let non_hoistable_instance_types: std::collections::HashSet<String> =
-                    exported_names
-                        .instance_type_names
-                        .difference(&exported_names.hoistable_instance_type_names)
-                        .cloned()
-                        .collect();
-                let has_shadowed_type =
-                    type_text_references_any(type_text, &non_hoistable_instance_types);
-                has_typeof || has_generic_dep || has_shadowed_type
-            };
-
-        let ts_component_props_before_render = if exported_names.has_component_props_typedef
-            && !exported_names.type_already_inserted
-            && !force_inside_render
-            && let Some(type_text) = exported_names.props_type_text.as_ref()
-        {
-            format!(";type $$ComponentProps =  {};", type_text)
-        } else {
-            String::new()
+    // Build $$ComponentProps type declaration for TS files
+    //
+    // Determine if the $$ComponentProps type must go INSIDE $$render
+    // rather than before it. This is needed when the type references:
+    // - `typeof x` (runtime value dependency on instance variables)
+    // - generic type parameters from the `generics` attribute on <script>
+    // - types that shadow module-level types
+    let force_inside_render = exported_names.has_component_props_typedef
+        && exported_names.props_type_text.is_some()
+        && !exported_names.type_already_inserted
+        && {
+            let type_text = exported_names.props_type_text.as_ref().unwrap();
+            // Check if type references an instance-local value via
+            // `typeof` (an imported `typeof` stays hoistable).
+            let has_typeof = type_text_typeof_references_local_value(
+                type_text,
+                &exported_names.instance_value_names,
+                &exported_names.instance_import_names,
+                &exported_names.module_import_names,
+            );
+            // Check if type references generics from $$render
+            let has_generic_dep = !render_generics.is_empty()
+                && generics_param
+                    .as_ref()
+                    .map(|g| {
+                        // Extract generic param names and check if any appear in the type
+                        split_generic_param_names(g)
+                            .iter()
+                            .any(|name| type_text.contains(name.as_str()))
+                    })
+                    .unwrap_or(false);
+            // Check if type references a type/interface name that is
+            // declared at the top level of the instance script AND
+            // *isn't* also slated for hoisting. References to a
+            // hoisted type are fine — the hoisted declaration sits
+            // above `function $$render()`, so referring to it from
+            // a hoisted `$$ComponentProps` resolves correctly.
+            let non_hoistable_instance_types: std::collections::HashSet<String> = exported_names
+                .instance_type_names
+                .difference(&exported_names.hoistable_instance_type_names)
+                .cloned()
+                .collect();
+            let has_shadowed_type =
+                type_text_references_any(type_text, &non_hoistable_instance_types);
+            has_typeof || has_generic_dep || has_shadowed_type
         };
 
-        // For best-effort auto-generated types, insert INSIDE $$render.
-        //
-        // If we have an explicit `props_let_abs_pos`, defer the insertion to
-        // a `str.append_left` after the overwrite so the
-        // `;type $$ComponentProps = ...;` lands right before the
-        // `let { ... } = $props()` statement, matching the JS reference's
-        // `preprendStr(node.parent.pos + astOffset, ...)` /
-        // `move(generic_arg.pos, generic_arg.end, node.parent.pos)`.
-        let inline_type_at_let = (force_inside_render || exported_names.type_already_inserted)
-            && exported_names.props_let_abs_pos.is_some()
-            && exported_names.props_type_text.is_some();
-        let ts_component_props_inside_render = if (exported_names.type_already_inserted
-            || force_inside_render)
-            && !inline_type_at_let
-            && let Some(type_text) = exported_names.props_type_text.as_ref()
-        {
-            if force_inside_render {
-                format!("\n;type $$ComponentProps =  {};", type_text)
-            } else {
-                format!(
-                    "\n/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
-                    type_text
-                )
-            }
-        } else {
-            String::new()
-        };
+    let ts_component_props_before_render = if exported_names.has_component_props_typedef
+        && !exported_names.type_already_inserted
+        && !force_inside_render
+        && let Some(type_text) = exported_names.props_type_text.as_ref()
+    {
+        format!(
+            "{};type $$ComponentProps =  {};",
+            type_decl_prefix, type_text
+        )
+    } else {
+        String::new()
+    };
 
-        // Build the <script> replacement, split into two parts so that
-        // module-hoistable snippets and types can be moved into the gap:
-        //   Part A: `;\n[\n if module]<imports>`
-        //   Part B: `<before_render_type><async_prefix>function $$render(){...`
-        //
-        // The synthesised `;type $$ComponentProps = ...;` lives in part_b
-        // (not part_a) so it lands AFTER any hoisted type/interface
-        // declarations — `$$ComponentProps` may reference them, so it has
-        // to appear after them in the output.
-        // `import_text` provides its own leading `\n` (or absorbs it
-        // into a leading-line-comment) — see the new-line accounting
-        // above. `part_a` only carries the `;` (which replaces the `<`)
-        // plus an extra `\n` when there is also a module script (mirrors
-        // `'\n' + (hasModuleScript ? '\n' : '')` in
-        // `handleFirstInstanceImport`).
-        let mut part_a = String::from(";");
+    // For best-effort auto-generated types, insert INSIDE $$render.
+    //
+    // If we have an explicit `props_let_abs_pos`, defer the insertion to
+    // a `str.append_left` after the overwrite so the
+    // `;type $$ComponentProps = ...;` lands right before the
+    // `let { ... } = $props()` statement, matching the JS reference's
+    // `preprendStr(node.parent.pos + astOffset, ...)` /
+    // `move(generic_arg.pos, generic_arg.end, node.parent.pos)`.
+    let inline_type_at_let = (force_inside_render || exported_names.type_already_inserted)
+        && exported_names.props_let_abs_pos.is_some()
+        && exported_names.props_type_text.is_some();
+    let ts_component_props_inside_render = if (exported_names.type_already_inserted
+        || force_inside_render)
+        && !inline_type_at_let
+        && let Some(type_text) = exported_names.props_type_text.as_ref()
+    {
+        if force_inside_render {
+            format!("\n;type $$ComponentProps =  {};", type_text)
+        } else {
+            format!(
+                "\n/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
+                type_text
+            )
+        }
+    } else {
+        String::new()
+    };
+
+    // Build the <script> replacement, split into two parts so that
+    // module-hoistable snippets and types can be moved into the gap:
+    //   Part A: `;\n[\n if module]<imports>`
+    //   Part B: `<before_render_type><async_prefix>function $$render(){...`
+    //
+    // The synthesised `;type $$ComponentProps = ...;` lives in part_b
+    // (not part_a) so it lands AFTER any hoisted type/interface
+    // declarations — `$$ComponentProps` may reference them, so it has
+    // to appear after them in the output.
+    // `import_text` provides its own leading `\n` (or absorbs it
+    // into a leading-line-comment) — see the new-line accounting
+    // above. `part_a` only carries the `;` (which replaces the `<`)
+    // plus an extra `\n` when there is also a module script (mirrors
+    // `'\n' + (hasModuleScript ? '\n' : '')` in
+    // `handleFirstInstanceImport`).
+    let mut part_a = String::from(";");
+    if has_imports {
         if has_module_script {
             part_a.push('\n');
         }
         part_a.push_str(&import_text);
-        // When there are hoistable snippets and a $$ComponentProps typedef to
-        // emit before $$render, the typedef must appear BEFORE the snippets in
-        // the output. Because snippets are moved to `sp` (after `part_a`) and
-        // `part_b` is placed after them, we append the typedef to `part_a` so
-        // it lands between the imports and the snippets. A `\n` separator is
-        // also added to match the blank line the JS reference produces.
-        let ts_component_props_in_part_a =
-            !hoistable_snippet_ranges.is_empty() && !ts_component_props_before_render.is_empty();
-        if ts_component_props_in_part_a {
-            part_a.push('\n');
-            part_a.push_str(&ts_component_props_before_render);
-        }
-        let trailing_newline = if ts_component_props_inside_render.is_empty() {
-            "\n"
-        } else {
-            ""
-        };
-        // When there's a hoistable type/interface, JS reference puts a
-        // newline between the moved declaration and the synthesised
-        // `;type $$ComponentProps = ...;function $$render() {` (which
-        // sits in `ts_component_props_before_render`). Mirror that with
-        // a `\n` prefix on part_b in that case.
-        let part_b_prefix = if !exported_names.hoistable_type_ranges.is_empty()
-            && !ts_component_props_before_render.is_empty()
-            && !ts_component_props_in_part_a
-        {
-            "\n"
-        } else {
-            ""
-        };
-        let part_b_component_props = if ts_component_props_in_part_a {
-            ""
-        } else {
-            &ts_component_props_before_render
-        };
-        let part_b = format!(
-            "{}{}{}{}function $$render{}() {{{}{}{}",
-            part_b_prefix,
-            part_b_component_props,
-            template_comment,
-            async_prefix,
-            render_generics,
-            dollar_decls,
-            ts_component_props_inside_render,
-            trailing_newline
-        );
-
-        let has_hoistable_chunks = !hoistable_snippet_ranges.is_empty()
-            || !exported_names.hoistable_type_ranges.is_empty()
-            || !exported_names.dollar_generic_referenced_ranges.is_empty()
-            || exported_names.props_type_arg_hoist.is_some();
-        // Split position: right after the `<` of `<script>`. This matches
-        // the JS reference's `scriptTag.start + 1`, so moved chunks land
-        // between the `;` (from the `<` overwrite) and the function
-        // declaration that replaces the rest of the script tag.
-        let split_pos = if has_hoistable_chunks && content_start > script_start + 1 {
-            Some(script_start + 1)
-        } else {
-            None
-        };
-        if let Some(sp) = split_pos {
-            if script_start < sp {
-                str.overwrite(script_start, sp, &part_a);
-            }
-            // Move hoistable type/interface declarations first so they
-            // sit BEFORE the snippets in the chunk list, matching the JS
-            // reference's `scriptTag.start + 1` ordering.
-            //
-            // Each chunk already extends backward through the original
-            // leading whitespace (see `resolve_hoistable_type_decls`),
-            // so a single `;` prepend is enough — the chunk supplies
-            // its own newline + indent, and the trailing `;` mirrors
-            // `appendLeft(node.end, ';')` from the JS reference so the
-            // declaration is statement-terminated.
-            // Preserve the promotion (topological) order produced by
-            // `resolve_hoistable_type_decls`, which mirrors the JS
-            // reference's `Map` insertion order: a dependency is moved
-            // BEFORE the interface that depends on it, even when it appears
-            // later in source. Sorting by start position would wrongly
-            // restore source order.
-            let type_ranges = exported_names.hoistable_type_ranges.clone();
-            for (s, e) in type_ranges {
-                if s < e && (e as usize) <= source.len() {
-                    // `prepend_right` / `append_left` add to the moved
-                    // chunk itself (intro / outro of the [s..e] chunk),
-                    // so the `;` markers travel with the chunk to its
-                    // hoist target — `prepend_left` would leave the
-                    // semicolon stranded at the original location.
-                    str.prepend_right(s, ";");
-                    str.append_left(e, ";");
-                    str.move_range(s, e, sp);
-                }
-            }
-            // Move the inline type arg from `$props<{ ... }>()` to the hoist target.
-            // `\ntype $$ComponentProps = ` and `;` were already added via
-            // `prepend_right`/`append_left` in `apply_props_typedef`.
-            // Mirrors upstream's `moveHoistableInterfaces` for `$$ComponentProps`.
-            if let Some((s, e)) = exported_names.props_type_arg_hoist
-                && s < e
-                && (e as usize) <= source.len()
-            {
-                str.move_range(s, e, sp);
-            }
-            // Move `$$Generic<X>`-referenced types. Mirrors the JS
-            // reference's `nodesToMove` path (`moveNode`) — uses
-            // `node.getStart()` (no leading trivia) and ends the chunk
-            // with `\n` so the following text in `part_b` (`function
-            // $$render`) starts on its own line.
-            let mut nodes_to_move = exported_names.dollar_generic_referenced_ranges.clone();
-            nodes_to_move.sort_by_key(|(s, _)| *s);
-            for (s, e) in nodes_to_move {
-                if s < e && (e as usize) <= source.len() {
-                    str.prepend_right(s, "\n");
-                    str.append_left(e, "\n");
-                    str.move_range(s, e, sp);
-                }
-            }
-            for (s, e) in hoistable_snippet_ranges.iter() {
-                str.move_range(*s, *e, sp);
-            }
-            str.overwrite(sp, content_start, &part_b);
-        } else if script_start < content_start {
-            str.overwrite(
-                script_start,
-                content_start,
-                &format!("{}{}", part_a, part_b),
-            );
-        }
-
-        if inline_type_at_let
-            && let (Some(let_pos), Some(type_text)) = (
-                exported_names.props_let_abs_pos,
-                exported_names.props_type_text.as_ref(),
-            )
-        {
-            let snippet = if force_inside_render {
-                format!(";type $$ComponentProps =  {};", type_text)
-            } else {
-                // type_already_inserted (auto-generated SvelteKit / fallback type).
-                // JS reference wraps in surroundWithIgnoreComments.
-                format!(
-                    "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
-                    type_text
-                )
-            };
-            str.append_left(let_pos, &snippet);
-        }
+    }
+    // When there are hoistable snippets and a $$ComponentProps typedef to
+    // emit before $$render, the typedef must appear BEFORE the snippets in
+    // the output. Because snippets are moved to `sp` (after `part_a`) and
+    // `part_b` is placed after them, we append the typedef to `part_a` so
+    // it lands between the imports and the snippets. A `\n` separator is
+    // also added to match the blank line the JS reference produces.
+    let ts_component_props_in_part_a =
+        !hoistable_snippet_ranges.is_empty() && !ts_component_props_before_render.is_empty();
+    if ts_component_props_in_part_a {
+        part_a.push('\n');
+        part_a.push_str(&ts_component_props_before_render);
+    }
+    let trailing_newline = if ts_component_props_inside_render.is_empty() {
+        "\n"
     } else {
-        // No imports: overwrite the entire <script> tag at once
-        let force_inside_render_no_imports = exported_names.has_component_props_typedef
-            && exported_names.props_type_text.is_some()
-            && !exported_names.type_already_inserted
-            && {
-                let type_text = exported_names.props_type_text.as_ref().unwrap();
-                let has_typeof = type_text_typeof_references_local_value(
-                    type_text,
-                    &exported_names.instance_value_names,
-                    &exported_names.instance_import_names,
-                    &exported_names.module_import_names,
-                );
-                let has_generic_dep = !render_generics.is_empty()
-                    && generics_param
-                        .as_ref()
-                        .map(|g| {
-                            split_generic_param_names(g)
-                                .iter()
-                                .any(|name| type_text.contains(name.as_str()))
-                        })
-                        .unwrap_or(false);
-                // Match the imports branch: skip names that are
-                // themselves slated for hoisting — referencing them
-                // from `$$ComponentProps` is fine when the hoisted
-                // declaration sits above `$$render`.
-                let non_hoistable_instance_types: std::collections::HashSet<String> =
-                    exported_names
-                        .instance_type_names
-                        .difference(&exported_names.hoistable_instance_type_names)
-                        .cloned()
-                        .collect();
-                let has_shadowed_type =
-                    type_text_references_any(type_text, &non_hoistable_instance_types);
-                has_typeof || has_generic_dep || has_shadowed_type
-            };
+        ""
+    };
+    // When there's a hoistable type/interface, JS reference puts a
+    // newline between the moved declaration and the synthesised
+    // `;type $$ComponentProps = ...;function $$render() {` (which
+    // sits in `ts_component_props_before_render`). Mirror that with
+    // a `\n` prefix on part_b in that case.
+    let part_b_prefix = if !exported_names.hoistable_type_ranges.is_empty()
+        && !ts_component_props_before_render.is_empty()
+        && !ts_component_props_in_part_a
+    {
+        "\n"
+    } else {
+        ""
+    };
+    let part_b_component_props = if ts_component_props_in_part_a {
+        ""
+    } else {
+        &ts_component_props_before_render
+    };
+    let part_b = format!(
+        "{}{}{}{}function $$render{}() {{{}{}{}",
+        part_b_prefix,
+        part_b_component_props,
+        template_comment,
+        async_prefix,
+        render_generics,
+        dollar_decls,
+        ts_component_props_inside_render,
+        trailing_newline
+    );
 
-        let ts_component_props_before_render = if exported_names.has_component_props_typedef
-            && !exported_names.type_already_inserted
-            && !force_inside_render_no_imports
-            && let Some(type_text) = exported_names.props_type_text.as_ref()
-        {
-            format!("\n;type $$ComponentProps =  {};", type_text)
-        } else {
-            String::new()
-        };
-
-        // For best-effort auto-generated types, insert INSIDE $$render.
-        // See the imports branch above for the `inline_type_at_let` rationale.
-        let inline_type_at_let = (force_inside_render_no_imports
-            || exported_names.type_already_inserted)
-            && exported_names.props_let_abs_pos.is_some()
-            && exported_names.props_type_text.is_some();
-        let ts_component_props_inside_render = if (exported_names.type_already_inserted
-            || force_inside_render_no_imports)
-            && !inline_type_at_let
-            && let Some(type_text) = exported_names.props_type_text.as_ref()
-        {
-            if force_inside_render_no_imports {
-                format!("\n;type $$ComponentProps =  {};", type_text)
-            } else {
-                format!(
-                    "\n/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
-                    type_text
-                )
-            }
-        } else {
-            String::new()
-        };
-
-        let trailing_newline = if ts_component_props_inside_render.is_empty() {
-            "\n"
-        } else {
-            ""
-        };
-        // No-imports branch: same split rationale as the imports branch
-        // above — keep the synthesised `;type $$ComponentProps = ...;` in
-        // part_b so it follows any hoisted type/interface declarations.
-        // When there are hoistable snippets, move it to part_a so it
-        // appears before them (mirrors the imports-branch behaviour).
-        let ts_component_props_in_part_a =
-            !hoistable_snippet_ranges.is_empty() && !ts_component_props_before_render.is_empty();
-        let mut part_a = String::from(";");
-        if ts_component_props_in_part_a {
-            part_a.push('\n');
-            part_a.push_str(&ts_component_props_before_render);
+    let has_hoistable_chunks = !hoistable_snippet_ranges.is_empty()
+        || !exported_names.hoistable_type_ranges.is_empty()
+        || !exported_names.dollar_generic_referenced_ranges.is_empty()
+        || exported_names.props_type_arg_hoist.is_some();
+    // Split position: right after the `<` of `<script>`. This matches
+    // the JS reference's `scriptTag.start + 1`, so moved chunks land
+    // between the `;` (from the `<` overwrite) and the function
+    // declaration that replaces the rest of the script tag.
+    let split_pos = if has_hoistable_chunks && content_start > script_start + 1 {
+        Some(script_start + 1)
+    } else {
+        None
+    };
+    if let Some(sp) = split_pos {
+        if script_start < sp {
+            str.overwrite(script_start, sp, &part_a);
         }
-        let part_b_prefix = if !exported_names.hoistable_type_ranges.is_empty()
-            && !ts_component_props_before_render.is_empty()
-            && !ts_component_props_in_part_a
-        {
-            "\n"
-        } else {
-            ""
-        };
-        let part_b_component_props = if ts_component_props_in_part_a {
-            ""
-        } else {
-            &ts_component_props_before_render
-        };
-        let part_b = format!(
-            "{}{}{}{}function $$render{}() {{{}{}{}",
-            part_b_prefix,
-            part_b_component_props,
-            template_comment,
-            async_prefix,
-            render_generics,
-            dollar_decls,
-            ts_component_props_inside_render,
-            trailing_newline
-        );
-        let has_hoistable_chunks = !hoistable_snippet_ranges.is_empty()
-            || !exported_names.hoistable_type_ranges.is_empty()
-            || !exported_names.dollar_generic_referenced_ranges.is_empty()
-            || exported_names.props_type_arg_hoist.is_some();
-        // Split position: right after the `<` of `<script>`. This matches
-        // the JS reference's `scriptTag.start + 1`, so moved chunks land
-        // between the `;` (from the `<` overwrite) and the function
-        // declaration that replaces the rest of the script tag.
-        let split_pos = if has_hoistable_chunks && content_start > script_start + 1 {
-            Some(script_start + 1)
-        } else {
-            None
-        };
-        if let Some(sp) = split_pos {
-            if script_start < sp {
-                str.overwrite(script_start, sp, &part_a);
-            }
-            // Move hoistable type/interface declarations first so they
-            // sit BEFORE the snippets in the chunk list, matching the JS
-            // reference's `scriptTag.start + 1` ordering.
-            //
-            // Each chunk already extends backward through the original
-            // leading whitespace (see `resolve_hoistable_type_decls`),
-            // so a single `;` prepend is enough — the chunk supplies
-            // its own newline + indent, and the trailing `;` mirrors
-            // `appendLeft(node.end, ';')` from the JS reference so the
-            // declaration is statement-terminated.
-            // Preserve the promotion (topological) order produced by
-            // `resolve_hoistable_type_decls`, which mirrors the JS
-            // reference's `Map` insertion order: a dependency is moved
-            // BEFORE the interface that depends on it, even when it appears
-            // later in source. Sorting by start position would wrongly
-            // restore source order.
-            let type_ranges = exported_names.hoistable_type_ranges.clone();
-            for (s, e) in type_ranges {
-                if s < e && (e as usize) <= source.len() {
-                    // `prepend_right` / `append_left` add to the moved
-                    // chunk itself (intro / outro of the [s..e] chunk),
-                    // so the `;` markers travel with the chunk to its
-                    // hoist target — `prepend_left` would leave the
-                    // semicolon stranded at the original location.
-                    str.prepend_right(s, ";");
-                    str.append_left(e, ";");
-                    str.move_range(s, e, sp);
-                }
-            }
-            // Move the inline type arg from `$props<{ ... }>()` to the hoist target.
-            // `\ntype $$ComponentProps = ` and `;` were already added via
-            // `prepend_right`/`append_left` in `apply_props_typedef`.
-            // Mirrors upstream's `moveHoistableInterfaces` for `$$ComponentProps`.
-            if let Some((s, e)) = exported_names.props_type_arg_hoist
-                && s < e
-                && (e as usize) <= source.len()
-            {
+        // Move hoistable type/interface declarations first so they
+        // sit BEFORE the snippets in the chunk list, matching the JS
+        // reference's `scriptTag.start + 1` ordering.
+        //
+        // Each chunk already extends backward through the original
+        // leading whitespace (see `resolve_hoistable_type_decls`),
+        // so a single `;` prepend is enough — the chunk supplies
+        // its own newline + indent, and the trailing `;` mirrors
+        // `appendLeft(node.end, ';')` from the JS reference so the
+        // declaration is statement-terminated.
+        // Preserve the promotion (topological) order produced by
+        // `resolve_hoistable_type_decls`, which mirrors the JS
+        // reference's `Map` insertion order: a dependency is moved
+        // BEFORE the interface that depends on it, even when it appears
+        // later in source. Sorting by start position would wrongly
+        // restore source order.
+        let type_ranges = exported_names.hoistable_type_ranges.clone();
+        for (s, e) in type_ranges {
+            if s < e && (e as usize) <= source.len() {
+                // `prepend_right` / `append_left` add to the moved
+                // chunk itself (intro / outro of the [s..e] chunk),
+                // so the `;` markers travel with the chunk to its
+                // hoist target — `prepend_left` would leave the
+                // semicolon stranded at the original location.
+                str.prepend_right(s, ";");
+                str.append_left(e, ";");
                 str.move_range(s, e, sp);
             }
-            // Move `$$Generic<X>`-referenced types. Mirrors the JS
-            // reference's `nodesToMove` path (`moveNode`) — uses
-            // `node.getStart()` (no leading trivia) and ends the chunk
-            // with `\n` so the following text in `part_b` (`function
-            // $$render`) starts on its own line.
-            let mut nodes_to_move = exported_names.dollar_generic_referenced_ranges.clone();
-            nodes_to_move.sort_by_key(|(s, _)| *s);
-            for (s, e) in nodes_to_move {
-                if s < e && (e as usize) <= source.len() {
-                    str.prepend_right(s, "\n");
-                    str.append_left(e, "\n");
-                    str.move_range(s, e, sp);
-                }
-            }
-            for (s, e) in hoistable_snippet_ranges.iter() {
-                str.move_range(*s, *e, sp);
-            }
-            str.overwrite(sp, content_start, &part_b);
-        } else if script_start < content_start {
-            str.overwrite(
-                script_start,
-                content_start,
-                &format!("{}{}", part_a, part_b),
-            );
         }
-
-        if inline_type_at_let
-            && let (Some(let_pos), Some(type_text)) = (
-                exported_names.props_let_abs_pos,
-                exported_names.props_type_text.as_ref(),
-            )
+        // Move the inline type arg from `$props<{ ... }>()` to the hoist target.
+        // `\ntype $$ComponentProps = ` and `;` were already added via
+        // `prepend_right`/`append_left` in `apply_props_typedef`.
+        // Mirrors upstream's `moveHoistableInterfaces` for `$$ComponentProps`.
+        if let Some((s, e)) = exported_names.props_type_arg_hoist
+            && s < e
+            && (e as usize) <= source.len()
         {
-            let snippet = if force_inside_render_no_imports {
-                format!(";type $$ComponentProps =  {};", type_text)
-            } else {
-                format!(
-                    "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
-                    type_text
-                )
-            };
-            str.append_left(let_pos, &snippet);
+            str.move_range(s, e, sp);
         }
+        // Move `$$Generic<X>`-referenced types. Mirrors the JS
+        // reference's `nodesToMove` path (`moveNode`) — uses
+        // `node.getStart()` (no leading trivia) and ends the chunk
+        // with `\n` so the following text in `part_b` (`function
+        // $$render`) starts on its own line.
+        let mut nodes_to_move = exported_names.dollar_generic_referenced_ranges.clone();
+        nodes_to_move.sort_by_key(|(s, _)| *s);
+        for (s, e) in nodes_to_move {
+            if s < e && (e as usize) <= source.len() {
+                str.prepend_right(s, "\n");
+                str.append_left(e, "\n");
+                str.move_range(s, e, sp);
+            }
+        }
+        for (s, e) in hoistable_snippet_ranges.iter() {
+            str.move_range(*s, *e, sp);
+        }
+        str.overwrite(sp, content_start, &part_b);
+    } else if script_start < content_start {
+        str.overwrite(
+            script_start,
+            content_start,
+            &format!("{}{}", part_a, part_b),
+        );
+    }
+
+    if inline_type_at_let
+        && let (Some(let_pos), Some(type_text)) = (
+            exported_names.props_let_abs_pos,
+            exported_names.props_type_text.as_ref(),
+        )
+    {
+        let snippet = if force_inside_render {
+            format!(";type $$ComponentProps =  {};", type_text)
+        } else {
+            // type_already_inserted (auto-generated SvelteKit / fallback type).
+            // JS reference wraps in surroundWithIgnoreComments.
+            format!(
+                "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
+                type_text
+            )
+        };
+        str.append_left(let_pos, &snippet);
     }
 
     // Overwrite `</script>` with slot declaration + `async () => {`.

--- a/crates/rsvelte_core/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/process_instance_script_tag.rs
@@ -129,134 +129,7 @@ pub(crate) fn process_instance_script_tag(
         // into the <script> tag replacement. The original import
         // positions are blanked with whitespace-preserving content.
 
-        let mut import_text = String::new();
-        for (i, &(comments_start, import_start_rel, import_end)) in imports.iter().enumerate() {
-            let abs_comments_start = comments_start + content_start;
-            let abs_import_start = import_start_rel + content_start;
-            let abs_end = import_end + content_start;
-
-            // Split into the leading comment region and the import
-            // statement itself so they can be processed independently.
-            // The JS reference (`utils/tsAst.ts::moveNode`) moves each
-            // leading comment as its own chunk and drops the trivia
-            // between them; for the first import,
-            // `handleFirstInstanceImport` inserts an extra `\n` either
-            // before a leading multiline comment or before the `import`
-            // keyword.
-            let comments_raw = slice_src(
-                source,
-                abs_comments_start as usize,
-                abs_import_start as usize,
-            );
-            let import_raw = slice_src(source, abs_import_start as usize, abs_end as usize);
-
-            // Collect leading comment lines while preserving block-comment
-            // interior indentation verbatim.  The JS reference (`moveNode`)
-            // uses `str.move()` which copies source text byte-for-byte, so
-            // `/* … */` inner lines must retain their original leading spaces.
-            // Only the opener line (`/*...`) is fully trimmed (leading indent
-            // is dropped; trailing spaces after `/*` are stripped); all other
-            // block-comment lines are preserved as-is.  Lines that are purely
-            // whitespace outside a block comment are filtered out.
-            let comment_lines: Vec<String> = {
-                let mut lines: Vec<String> = Vec::new();
-                let mut in_block = false;
-                for line in comments_raw.lines() {
-                    if in_block {
-                        // Preserve interior indentation verbatim.
-                        if line.contains("*/") {
-                            in_block = false;
-                        }
-                        lines.push(line.to_string());
-                    } else {
-                        let trimmed = line.trim();
-                        if trimmed.is_empty() {
-                            continue; // skip whitespace-only lines
-                        }
-                        if trimmed.starts_with("/*") {
-                            // Block-comment opener: trim fully so the
-                            // leading indent and any trailing spaces after
-                            // `/*` are dropped (e.g. `  /*  ` → `/*`).
-                            in_block = !trimmed.contains("*/");
-                            lines.push(trimmed.to_string());
-                        } else {
-                            // Line comment (`//`) or other: fully trim.
-                            lines.push(trimmed.to_string());
-                        }
-                    }
-                }
-                lines
-            };
-
-            // Was the last comment on the same line as the `import`
-            // keyword? True when `comments_raw`'s final line is not
-            // whitespace-only — e.g. `/*hi*/import X` keeps the comment
-            // and the import on a single line.
-            let last_comment_inline = !comments_raw.is_empty()
-                && comments_raw
-                    .lines()
-                    .last()
-                    .is_some_and(|l| !l.trim().is_empty());
-
-            let import_text_clean: String = import_raw
-                .lines()
-                .map(|line| line.trim_start())
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            // Preserve gap when this import is part of a separate group
-            // (a blank line in the source between this import and the
-            // previous one).
-            if i > 0 {
-                let prev_end = imports[i - 1].2 + content_start;
-                let between = slice_src(source, prev_end as usize, abs_comments_start as usize);
-                let newline_count = between.chars().filter(|&c| c == '\n').count();
-                if newline_count >= 2 {
-                    import_text.push('\n');
-                }
-            }
-
-            let first_comment_is_block = comment_lines.first().is_some_and(|c| c.starts_with("/*"));
-            let needs_leading_newline =
-                i == 0 && (comment_lines.is_empty() || first_comment_is_block);
-
-            if needs_leading_newline {
-                import_text.push('\n');
-            }
-            for (idx, line) in comment_lines.iter().enumerate() {
-                import_text.push_str(line);
-                let is_last = idx + 1 == comment_lines.len();
-                if !(is_last && last_comment_inline) {
-                    import_text.push('\n');
-                }
-            }
-            if i == 0 && !first_comment_is_block && !comment_lines.is_empty() {
-                // `appendRight(firstImport.getStart(), '\n')` —
-                // separating the trailing leading-line-comment from the
-                // import keyword with an explicit blank line.
-                import_text.push('\n');
-            }
-
-            import_text.push_str(&import_text_clean);
-
-            // Add semicolon to the last import if it doesn't have one
-            if i == imports.len() - 1 {
-                // `.last()` avoids a `len() - 1` underflow when the cleaned
-                // import text is empty (zero-length span edge case).
-                if import_text_clean.as_bytes().last() != Some(&b';') {
-                    import_text.push_str(";\n");
-                } else {
-                    import_text.push('\n');
-                }
-            } else {
-                import_text.push('\n');
-            }
-
-            // Blank out the original [leading comments .. import] span.
-            // The indentation before the comments stays because it's
-            // outside the captured span.
-            str.overwrite(abs_comments_start, abs_end, "");
-        }
+        let import_text = collect_lifted_imports(&imports, source, content_start, str);
 
         // Build $$ComponentProps type declaration for TS files
         //
@@ -760,4 +633,144 @@ pub(crate) fn process_instance_script_tag(
     // output oxfmt cannot reformat (so only blank-line stripping applies).
 
     has_top_level_await
+}
+
+/// Collect the instance script's top-level imports into the text that will be
+/// spliced above `$$render()`, blanking each original `[leading comments .. import]`
+/// span in `str`.
+fn collect_lifted_imports(
+    imports: &[(u32, u32, u32)],
+    source: &str,
+    content_start: u32,
+    str: &mut MagicString,
+) -> String {
+    let mut import_text = String::new();
+    for (i, &(comments_start, import_start_rel, import_end)) in imports.iter().enumerate() {
+        let abs_comments_start = comments_start + content_start;
+        let abs_import_start = import_start_rel + content_start;
+        let abs_end = import_end + content_start;
+
+        // Split into the leading comment region and the import
+        // statement itself so they can be processed independently.
+        // The JS reference (`utils/tsAst.ts::moveNode`) moves each
+        // leading comment as its own chunk and drops the trivia
+        // between them; for the first import,
+        // `handleFirstInstanceImport` inserts an extra `\n` either
+        // before a leading multiline comment or before the `import`
+        // keyword.
+        let comments_raw = slice_src(
+            source,
+            abs_comments_start as usize,
+            abs_import_start as usize,
+        );
+        let import_raw = slice_src(source, abs_import_start as usize, abs_end as usize);
+
+        // Collect leading comment lines while preserving block-comment
+        // interior indentation verbatim.  The JS reference (`moveNode`)
+        // uses `str.move()` which copies source text byte-for-byte, so
+        // `/* … */` inner lines must retain their original leading spaces.
+        // Only the opener line (`/*...`) is fully trimmed (leading indent
+        // is dropped; trailing spaces after `/*` are stripped); all other
+        // block-comment lines are preserved as-is.  Lines that are purely
+        // whitespace outside a block comment are filtered out.
+        let comment_lines: Vec<String> = {
+            let mut lines: Vec<String> = Vec::new();
+            let mut in_block = false;
+            for line in comments_raw.lines() {
+                if in_block {
+                    // Preserve interior indentation verbatim.
+                    if line.contains("*/") {
+                        in_block = false;
+                    }
+                    lines.push(line.to_string());
+                } else {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue; // skip whitespace-only lines
+                    }
+                    if trimmed.starts_with("/*") {
+                        // Block-comment opener: trim fully so the
+                        // leading indent and any trailing spaces after
+                        // `/*` are dropped (e.g. `  /*  ` → `/*`).
+                        in_block = !trimmed.contains("*/");
+                        lines.push(trimmed.to_string());
+                    } else {
+                        // Line comment (`//`) or other: fully trim.
+                        lines.push(trimmed.to_string());
+                    }
+                }
+            }
+            lines
+        };
+
+        // Was the last comment on the same line as the `import`
+        // keyword? True when `comments_raw`'s final line is not
+        // whitespace-only — e.g. `/*hi*/import X` keeps the comment
+        // and the import on a single line.
+        let last_comment_inline = !comments_raw.is_empty()
+            && comments_raw
+                .lines()
+                .last()
+                .is_some_and(|l| !l.trim().is_empty());
+
+        let import_text_clean: String = import_raw
+            .lines()
+            .map(|line| line.trim_start())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Preserve gap when this import is part of a separate group
+        // (a blank line in the source between this import and the
+        // previous one).
+        if i > 0 {
+            let prev_end = imports[i - 1].2 + content_start;
+            let between = slice_src(source, prev_end as usize, abs_comments_start as usize);
+            let newline_count = between.chars().filter(|&c| c == '\n').count();
+            if newline_count >= 2 {
+                import_text.push('\n');
+            }
+        }
+
+        let first_comment_is_block = comment_lines.first().is_some_and(|c| c.starts_with("/*"));
+        let needs_leading_newline = i == 0 && (comment_lines.is_empty() || first_comment_is_block);
+
+        if needs_leading_newline {
+            import_text.push('\n');
+        }
+        for (idx, line) in comment_lines.iter().enumerate() {
+            import_text.push_str(line);
+            let is_last = idx + 1 == comment_lines.len();
+            if !(is_last && last_comment_inline) {
+                import_text.push('\n');
+            }
+        }
+        if i == 0 && !first_comment_is_block && !comment_lines.is_empty() {
+            // `appendRight(firstImport.getStart(), '\n')` —
+            // separating the trailing leading-line-comment from the
+            // import keyword with an explicit blank line.
+            import_text.push('\n');
+        }
+
+        import_text.push_str(&import_text_clean);
+
+        // Add semicolon to the last import if it doesn't have one
+        if i == imports.len() - 1 {
+            // `.last()` avoids a `len() - 1` underflow when the cleaned
+            // import text is empty (zero-length span edge case).
+            if import_text_clean.as_bytes().last() != Some(&b';') {
+                import_text.push_str(";\n");
+            } else {
+                import_text.push('\n');
+            }
+        } else {
+            import_text.push('\n');
+        }
+
+        // Blank out the original [leading comments .. import] span.
+        // The indentation before the comments stays because it's
+        // outside the captured span.
+        str.overwrite(abs_comments_start, abs_end, "");
+    }
+
+    import_text
 }


### PR DESCRIPTION
> base は #1759（`refactor/s2t-entry-fn`）。#1749 → #1759 → 本 PR の順にマージしてください。

## なぜ

`process_instance_script_tag` の `if !imports.is_empty() { … } else { … }` は、
**imports 収集ループを除くと約 160 行がほぼ丸ごと重複**していた。
この一連のリファクタで唯一の**ロジック変更 PR** がこれ。

## 分岐の機械 diff

統合の前に 2 分岐をコメント・空行を除いて機械 diff した結果:

| | 生の行数 | コード行数 |
|---|---|---|
| imports あり | 387 | 242 |
| imports なし | 208 | 158 |

imports あり分岐の**先頭 81 行は import 収集ループ**（imports なし側に対応物なし＝固有ロジック）。
**その後ろの 162 行 vs 159 行は、変数名の rename を正規化すると差分が 3 点しかなかった。**

1. `force_inside_render` vs `force_inside_render_no_imports` — 純粋な名前違い。式は 1 文字も違わない
2. `ts_component_props_before_render` の先頭 `\n` の有無
   ```rust
   format!(";type $$ComponentProps =  {};", type_text)    // imports あり
   format!("\n;type $$ComponentProps =  {};", type_text)  // imports なし
   ```
3. `part_a` の組み立て
   ```rust
   let mut part_a = String::from(";");
   if has_module_script { part_a.push('\n'); }   // imports あり側にのみ存在
   part_a.push_str(&import_text);                // 〃
   ```

これ以外は完全に同一。`part_b` / `part_b_prefix` / `split_pos` / `str.overwrite` /
`append_left` / `move_range` の呼び出しから末尾処理まで 1 バイトも違わない。
（`trailing_newline` と `ts_component_props_in_part_a` の宣言順が入れ替わっていたが、
いずれも副作用のない `let` なので意味は同じ）

## 何をしたか

差分 2 と 3 は**どちらも `has_imports: bool` 1 個で駆動できる**ので、分岐を 1 本化した。
フラグが増殖して読みにくくなるようなら統合を見送る方針だったが、増えたのは bool 1 個だけ。

```rust
let has_imports = !imports.is_empty();
let import_text = if has_imports {
    collect_lifted_imports(&imports, source, content_start, str)
} else {
    String::new()
};
// With imports the `\n` separating the type alias from what precedes it
// already comes from `import_text`; without them the alias has to carry it.
let type_decl_prefix = if has_imports { "" } else { "\n" };
...
let mut part_a = String::from(";");
if has_imports {
    if has_module_script { part_a.push('\n'); }
    part_a.push_str(&import_text);
}
```

81 行の import 収集ループは `collect_lifted_imports` として名前を付けて切り出した
（原文の `str.overwrite` によるブランキングもこの中。呼び出し順は元と同じく先頭）。

`process_instance_script_tag.rs` **763 → 576 行**。

## 検証

### 出力バイト一致（最重要）

これはロジック変更 PR なので、バイト一致が唯一の安全網になる。
`submodules/svelte/packages/svelte/tests/**/*.svelte` と
`submodules/language-tools/packages/svelte2tsx/test/**/*.svelte` の **4894 ファイル** ×
10 オプション組み合わせ = **48,940 変換**について、`code` + `map` + `forward_map` +
エラーメッセージのダイジェストがリファクタ前と**完全一致**:

```
code / map / forward_map / エラーメッセージ   md5 7f72fb153132808766be29e60ef6b604   一致
全出力（トークン順正規化後）                  md5 349bf2c1be5317bd8e50b75c59fbd604   一致
```

この md5 は #1749 / #1759 と同一、すなわち**分割前の main と同じ**。

### テスト・ビルド

| コマンド | 結果 |
|---|---|
| `cargo fmt --check` | OK |
| `cargo clippy --all-targets --all-features -- -D warnings` | 警告ゼロ |
| `cargo test --test svelte2tsx_fixtures` | ok (15 passed, 0 failed) / 246/254（#1752 のベースラインどおり）|
| `crates/rsvelte_core/tests/svelte2tsx_*.rs` 24 本 | 全 pass（0 failed）|
| `cargo test --test svelte_check_golden --test svelte_check_pin` | ok (3 + 1 passed, 0 failed) |
| `cargo build -p rsvelte_napi` | 成功 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017T7cNGue7nhLbVxayXtJic
