### PR TITLE
fix(client): keep <script> comments on the direct-AST codegen path

### DIFF
--- a/.changeset/fix-client-to-oxc-comments.md
+++ b/.changeset/fix-client-to-oxc-comments.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(client): keep `<script>` comments on the direct-AST codegen path
+
+Client codegen bailed to the legacy string codegen for any generated chunk
+carrying a comment, because esrap places comments positionally and a program
+reassembled from independently-parsed chunks had no shared coordinate space to
+place them in. Each comment-bearing chunk is now re-parsed at its own region of
+one unified buffer, with generated nodes reading as "no location" the way
+`svelte/compiler` distinguishes user-derived nodes from synthesized ones. The
+fallback rate over the Svelte test corpus drops from 122/3834 (3.18%) to 1/3834,
+and 62 components whose output the string codegen got wrong now match
+`svelte/compiler` byte-for-byte. Source-map positions inside a rewritten chunk
+now resolve to the chunk's start rather than per-statement.

--- a/crates/rsvelte_core/src/bin/roundtrip_probe.rs
+++ b/crates/rsvelte_core/src/bin/roundtrip_probe.rs
@@ -1,0 +1,299 @@
+//! Spike probe: measure how often esrap re-printing a `<script>` body reproduces
+//! the source text verbatim (the formatting the current text pipeline preserves).
+//!
+//! Not production code — measurement only. Run:
+//!   cargo run --release --bin roundtrip_probe -- [out.jsonl]
+
+use std::fs;
+use std::path::PathBuf;
+
+use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse};
+
+#[derive(Default)]
+struct Counts {
+    files: usize,
+    scripts: usize,
+    ts_skipped: usize,
+    empty_skipped: usize,
+    parse_fail: usize,
+    exact: usize,
+    // mismatch categories
+    ws_indent_blank: usize,
+    ws_linebreak: usize,
+    content_comment: usize,
+    content_other: usize,
+}
+
+fn main() {
+    let out_path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/tmp/roundtrip.jsonl".to_string());
+    let files = collect_files();
+    let mut c = Counts::default();
+    let mut records: Vec<String> = Vec::new();
+
+    let parse_opts = ParseOptions {
+        modern: true,
+        skip_expression_loc: true,
+        defer_script_parse: true,
+        ..Default::default()
+    };
+
+    for (path, content) in &files {
+        let alloc = oxc_allocator::Allocator::default();
+        let Ok(ast) = parse(content, &alloc, parse_opts) else {
+            continue;
+        };
+        c.files += 1;
+        let mut scripts: Vec<(&str, &rsvelte_core::ast::template::Script)> = Vec::new();
+        if let Some(s) = ast.instance.as_ref() {
+            scripts.push(("instance", s));
+        }
+        if let Some(s) = ast.module.as_ref() {
+            scripts.push(("module", s));
+        }
+        for (kind, script) in scripts {
+            c.scripts += 1;
+            if script.is_typescript {
+                c.ts_skipped += 1;
+                continue;
+            }
+            let raw: String = if script.raw_content.is_empty() {
+                String::new()
+            } else {
+                script.raw_content.clone()
+            };
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                c.empty_skipped += 1;
+                continue;
+            }
+            let verbatim = dedent(trimmed);
+
+            let a = oxc_allocator::Allocator::default();
+            let ret = oxc_parser::Parser::new(&a, &verbatim, oxc_span::SourceType::mjs()).parse();
+            if !ret.diagnostics.is_empty() {
+                c.parse_fail += 1;
+                continue;
+            }
+            let printed = rsvelte_esrap::print(&ret.program, &verbatim);
+            let printed = printed.trim_end().to_string();
+            let verbatim_cmp = verbatim.trim_end().to_string();
+
+            if printed == verbatim_cmp {
+                c.exact += 1;
+                continue;
+            }
+            let cat = classify(&verbatim_cmp, &printed, !ret.program.comments.is_empty());
+            match cat {
+                Cat::WsIndentBlank => c.ws_indent_blank += 1,
+                Cat::WsLineBreak => c.ws_linebreak += 1,
+                Cat::ContentComment => c.content_comment += 1,
+                Cat::ContentOther => c.content_other += 1,
+            }
+            let (ctx_a, ctx_b) = first_diff_context(&verbatim_cmp, &printed);
+            records.push(format!(
+                "{{\"file\":{},\"kind\":\"{}\",\"cat\":\"{}\",\"before\":{},\"after\":{}}}",
+                json_str(path),
+                kind,
+                cat.name(),
+                json_str(&ctx_a),
+                json_str(&ctx_b)
+            ));
+        }
+    }
+
+    let _ = fs::write(out_path.clone(), records.join("\n"));
+
+    let compared =
+        c.exact + c.ws_indent_blank + c.ws_linebreak + c.content_comment + c.content_other;
+    println!("files parsed:        {}", c.files);
+    println!("scripts total:       {}", c.scripts);
+    println!("  typescript skipped:{}", c.ts_skipped);
+    println!("  empty skipped:     {}", c.empty_skipped);
+    println!("  oxc parse fail:    {}", c.parse_fail);
+    println!("scripts compared:    {}", compared);
+    println!(
+        "EXACT:               {} ({:.2}%)",
+        c.exact,
+        c.exact as f64 / compared as f64 * 100.0
+    );
+    println!(
+        "  ws indent/blank:   {} ({:.2}%)",
+        c.ws_indent_blank,
+        c.ws_indent_blank as f64 / compared as f64 * 100.0
+    );
+    println!(
+        "  ws line-breaking:  {} ({:.2}%)",
+        c.ws_linebreak,
+        c.ws_linebreak as f64 / compared as f64 * 100.0
+    );
+    println!(
+        "  content (comment): {} ({:.2}%)",
+        c.content_comment,
+        c.content_comment as f64 / compared as f64 * 100.0
+    );
+    println!(
+        "  content (other):   {} ({:.2}%)",
+        c.content_other,
+        c.content_other as f64 / compared as f64 * 100.0
+    );
+    println!("jsonl: {}", out_path);
+
+    // === Pass 2: what does the CURRENT client pipeline actually emit? ===
+    // The default client codegen converts the whole IR (including the instance
+    // script `Raw` blob) to an oxc AST and prints it with esrap. Run with
+    // RSVELTE_CLIENT_TO_OXC_DEBUG=1 and count the fallbacks on stderr.
+    let mut ok = 0usize;
+    let mut err = 0usize;
+    for (path, content) in &files {
+        let r = rsvelte_core::compile(
+            content,
+            rsvelte_core::CompileOptions {
+                generate: rsvelte_core::GenerateMode::Client,
+                filename: Some(path.clone()),
+                ..Default::default()
+            },
+        );
+        match r {
+            Ok(_) => ok += 1,
+            Err(_) => err += 1,
+        }
+    }
+    println!("\n=== client compile ===");
+    println!("compiled ok: {ok}, compile error: {err}");
+}
+
+enum Cat {
+    WsIndentBlank,
+    WsLineBreak,
+    ContentComment,
+    ContentOther,
+}
+
+impl Cat {
+    fn name(&self) -> &'static str {
+        match self {
+            Cat::WsIndentBlank => "ws_indent_blank",
+            Cat::WsLineBreak => "ws_linebreak",
+            Cat::ContentComment => "content_comment",
+            Cat::ContentOther => "content_other",
+        }
+    }
+}
+
+fn classify(a: &str, b: &str, has_comments: bool) -> Cat {
+    let strip_ws = |s: &str| -> String { s.chars().filter(|ch| !ch.is_whitespace()).collect() };
+    if strip_ws(a) == strip_ws(b) {
+        // Whitespace-only. Distinguish "same line structure, different indent /
+        // blank lines" from "different line breaking".
+        let lines = |s: &str| -> Vec<String> {
+            s.lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .collect()
+        };
+        if lines(a) == lines(b) {
+            Cat::WsIndentBlank
+        } else {
+            Cat::WsLineBreak
+        }
+    } else if has_comments {
+        Cat::ContentComment
+    } else {
+        Cat::ContentOther
+    }
+}
+
+fn first_diff_context(a: &str, b: &str) -> (String, String) {
+    let ab = a.as_bytes();
+    let bb = b.as_bytes();
+    let mut i = 0;
+    while i < ab.len() && i < bb.len() && ab[i] == bb[i] {
+        i += 1;
+    }
+    let start = a[..i].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    let clip = |s: &str, from: usize| -> String {
+        let from = from.min(s.len());
+        let s = &s[from..];
+        let end = s.char_indices().nth(160).map(|(p, _)| p).unwrap_or(s.len());
+        s[..end].to_string()
+    };
+    let start_b = if start <= b.len() { start } else { 0 };
+    (clip(a, start), clip(b, start_b))
+}
+
+/// Replicate `formatting::detect_base_indent` + `strip_indent` (indent_level 1
+/// minus the added tab), i.e. what the current fast path preserves.
+fn dedent(code: &str) -> String {
+    let mut min_indent: Option<usize> = None;
+    for (i, line) in code.lines().enumerate() {
+        if i == 0 || line.trim().is_empty() {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        min_indent = Some(min_indent.map_or(indent, |m: usize| m.min(indent)));
+    }
+    let base = min_indent.unwrap_or(0);
+    let mut out = String::with_capacity(code.len());
+    for (i, line) in code.lines().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        if base == 0 || line.len() <= base {
+            out.push_str(line);
+            continue;
+        }
+        let leading = line.len() - line.trim_start().len();
+        if leading >= base {
+            out.push_str(&line[base..]);
+        } else {
+            out.push_str(line.trim_start());
+        }
+    }
+    out
+}
+
+fn json_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                use std::fmt::Write as _;
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn collect_files() -> Vec<(String, String)> {
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let dir = base.join("submodules/svelte/packages/svelte/tests");
+    let mut files = Vec::new();
+    collect_svelte_files(&dir, &mut files);
+    files
+}
+
+fn collect_svelte_files(dir: &std::path::Path, files: &mut Vec<(String, String)>) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_svelte_files(&path, files);
+            } else if path.extension().is_some_and(|e| e == "svelte")
+                && let Ok(content) = fs::read_to_string(&path)
+            {
+                files.push((path.display().to_string(), content));
+            }
+        }
+    }
+}

--- a/crates/rsvelte_core/src/bin/roundtrip_probe.rs
+++ b/crates/rsvelte_core/src/bin/roundtrip_probe.rs
@@ -25,6 +25,23 @@ struct Counts {
 }
 
 fn main() {
+    // `roundtrip_probe <file.svelte>`: print that file's client output.
+    if let Some(p) = std::env::args().nth(1)
+        && p.ends_with(".svelte")
+    {
+        let content = fs::read_to_string(&p).unwrap();
+        let out = rsvelte_core::compile(
+            &content,
+            rsvelte_core::CompileOptions {
+                generate: rsvelte_core::GenerateMode::Client,
+                filename: Some(p),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        print!("{}", out.js.code);
+        return;
+    }
     let out_path = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "/tmp/roundtrip.jsonl".to_string());
@@ -146,6 +163,8 @@ fn main() {
     // RSVELTE_CLIENT_TO_OXC_DEBUG=1 and count the fallbacks on stderr.
     let mut ok = 0usize;
     let mut err = 0usize;
+    // Output digest per file, so a before/after run can prove byte-equality.
+    let mut digests: Vec<String> = Vec::new();
     for (path, content) in &files {
         let r = rsvelte_core::compile(
             content,
@@ -156,12 +175,34 @@ fn main() {
             },
         );
         match r {
-            Ok(_) => ok += 1,
+            Ok(out) => {
+                ok += 1;
+                digests.push(format!("{}\t{:016x}", short(path), fnv1a(&out.js.code)));
+            }
             Err(_) => err += 1,
         }
     }
     println!("\n=== client compile ===");
     println!("compiled ok: {ok}, compile error: {err}");
+    if let Some(p) = std::env::args().nth(2) {
+        let _ = fs::write(p, digests.join("\n"));
+    }
+}
+
+fn short(path: &str) -> &str {
+    match path.find("packages/svelte/tests/") {
+        Some(i) => &path[i..],
+        None => path,
+    }
+}
+
+fn fnv1a(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x1000_0000_01b3);
+    }
+    h
 }
 
 enum Cat {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2212,31 +2212,48 @@ fn transform_client_with_visitors(
 
     // Direct-AST codegen via to_oxc + esrap — the DEFAULT client codegen path.
     // The string codegen (`generate` / `generate_with_sourcemap`) is the fallback
-    // for the ~6% of components where to_oxc bails (a comment-bearing chunk, which
-    // keeps the comments verbatim, or an unsupported node). `RSVELTE_CLIENT_NO_OXC`
-    // forces the legacy string path (escape hatch). Span-stamping (`Spanned` /
-    // `RawMapped` → original-source offsets) feeds esrap `print_with_map` for the
-    // sourcemap branch.
+    // for the ~0.03% of components carrying a node shape `to_oxc` does not model
+    // yet (`{@const}` computed destructuring is the only one left in the Svelte
+    // corpus). `RSVELTE_CLIENT_NO_OXC` forces the legacy string path (escape
+    // hatch). Span-stamping (`Spanned` / `RawMapped` → original-source offsets)
+    // feeds esrap `print_with_map` for the sourcemap branch.
     if std::env::var_os("RSVELTE_CLIENT_NO_OXC").is_none() {
         let converted = CLIENT_TO_OXC_ALLOCATOR.with(|cell| {
             let mut alloc = cell.borrow_mut();
             alloc.reset();
             super::js_ast::to_oxc::program_to_oxc(&program, &context.arena, &alloc).map(
-                |oxc_prog| {
+                |converted| {
                     // Keep `;` empty statements: the parsed-`Raw` `;;` are real
                     // EmptyStatement nodes the official compiler output preserves.
                     let print_opts = rsvelte_esrap::PrintOptions {
                         keep_empty_statements: true,
                         ..Default::default()
                     };
-                    if options.enable_sourcemap {
-                        let pm = rsvelte_esrap::print_with_map_opts(&oxc_prog, source, &print_opts);
-                        (pm.code, esrap_mappings_to_source_mappings(&pm.mappings))
-                    } else {
-                        (
-                            rsvelte_esrap::print_with(&oxc_prog, "", &print_opts),
+                    let oxc_prog = &converted.program;
+                    match &converted.comment_source {
+                        // The program carries comments, so it prints in the
+                        // unified comment coordinate space `to_oxc` built.
+                        Some(comment_source) => {
+                            let map_source = options.enable_sourcemap.then_some(source);
+                            let pm = rsvelte_esrap::print_split(
+                                oxc_prog,
+                                comment_source,
+                                converted.loc_base,
+                                map_source,
+                                &converted.loc_map,
+                                &print_opts,
+                            );
+                            (pm.code, esrap_mappings_to_source_mappings(&pm.mappings))
+                        }
+                        None if options.enable_sourcemap => {
+                            let pm =
+                                rsvelte_esrap::print_with_map_opts(oxc_prog, source, &print_opts);
+                            (pm.code, esrap_mappings_to_source_mappings(&pm.mappings))
+                        }
+                        None => (
+                            rsvelte_esrap::print_with(oxc_prog, "", &print_opts),
                             Vec::new(),
-                        )
+                        ),
                     }
                 },
             )

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -21,9 +21,21 @@
 //! and `JsStatement::RawMapped`, which carry opaque source text the structural
 //! esrap printer cannot reconstruct.
 //!
-//! All spans use the dummy [`oxc_span::SPAN`]: esrap formats structurally, so
-//! spans do not affect output for comment-free programs (and these IR nodes
-//! carry no comments).
+//! # Comments and the unified coordinate space
+//!
+//! Synthesized nodes use the dummy [`oxc_span::SPAN`]: esrap formats
+//! structurally, so their spans do not affect output. Comments are the one
+//! exception — esrap places them *positionally*, and a program reassembled from
+//! independently-parsed `Raw` chunks has no shared coordinate space to place
+//! them in.
+//!
+//! [`Synth`] builds one. Each comment-bearing chunk is re-parsed from a
+//! `pad + chunk` buffer so its spans (and its comments') land in a private,
+//! monotonically increasing region of a unified buffer above `loc_base`;
+//! container nodes get the span of the region their children consumed. Spans
+//! below `loc_base` — synthesized nodes, and the original-source spans stamped
+//! by `Spanned`/`RawMapped` — read as "no location" to the printer, mirroring
+//! esrap's `if (node.loc)` guards.
 
 use super::arena::{ExprId, JsArena};
 use super::nodes::*;
@@ -35,38 +47,141 @@ use oxc_syntax::number::{BigintBase, NumberBase};
 use oxc_syntax::operator::{
     AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
 };
+use std::cell::RefCell;
+
+/// A converted program plus the comment coordinate space it needs to be printed
+/// in (see the module docs). `comment_source` is `None` for the common
+/// comment-free program, which prints exactly as before.
+pub struct Converted<'a> {
+    pub program: oxc_ast::ast::Program<'a>,
+    pub comment_source: Option<String>,
+    pub loc_base: u32,
+    pub loc_map: Vec<(u32, u32, Option<u32>)>,
+}
 
 /// Convert a whole [`JsProgram`] into an oxc [`oxc_ast::ast::Program`].
 ///
 /// Returns `None` if any node in the program is not handled by this converter
 /// (see the module docs). The returned program borrows `allocator`, so the
 /// allocator must outlive the program (and any `rsvelte_esrap::print` of it).
+///
+/// Runs as a probe pass followed, only when a chunk turned out to carry
+/// comments, by a second pass that knows where to put the comment coordinate
+/// space — it has to sit above every span the first pass produced.
 pub fn program_to_oxc<'a>(
     program: &JsProgram,
     arena: &JsArena,
     allocator: &'a oxc_allocator::Allocator,
-) -> Option<oxc_ast::ast::Program<'a>> {
+) -> Option<Converted<'a>> {
+    let (probe, synth) = convert_once(program, arena, allocator, None)?;
+    if !synth.saw_comments {
+        return Some(probe);
+    }
+    let loc_base = synth.max_span.saturating_add(2);
+    let (converted, synth) = convert_once(program, arena, allocator, Some(loc_base))?;
+    // Every span the pass produced outside a chunk region must stay below
+    // `loc_base`, or the printer would mistake it for a real location.
+    if synth.max_span >= loc_base {
+        return None;
+    }
+    Some(converted)
+}
+
+fn convert_once<'a>(
+    program: &JsProgram,
+    arena: &JsArena,
+    allocator: &'a oxc_allocator::Allocator,
+    loc_base: Option<u32>,
+) -> Option<(Converted<'a>, Synth)> {
     let ab = AstBuilder::new(allocator);
-    let cx = Cx { ab, arena };
+    let cx = Cx {
+        ab,
+        arena,
+        synth: RefCell::new(Synth::new(loc_base)),
+    };
 
     // Collect, flattening multi-statement `Raw` blobs inline. A single None
     // (parse failure / unhandled node) bails the whole program.
-    let mut body: Vec<Statement<'a>> = Vec::with_capacity(program.body.len());
-    for s in &program.body {
-        body.extend(cx.expand_stmt(s)?);
-    }
+    let (body, span) = cx.consumed(|| {
+        let mut body: Vec<Statement<'a>> = Vec::with_capacity(program.body.len());
+        for s in &program.body {
+            body.extend(cx.expand_stmt(s)?);
+        }
+        Some(body)
+    })?;
 
+    let synth = cx.synth.into_inner();
     let body = ArenaVec::from_iter_in(body, &ab);
-    Some(Program::new(
-        SPAN,
+    let comments = ArenaVec::from_iter_in(synth.comments.iter().cloned(), &ab);
+    let program = Program::new(
+        span,
         oxc_span::SourceType::mjs(),
         "",
-        ArenaVec::new_in(&ab),
+        comments,
         None,
         ArenaVec::new_in(&ab),
         body,
         &ab,
-    ))
+    );
+    let converted = Converted {
+        program,
+        comment_source: synth.enabled.then(|| synth.source.clone()),
+        loc_base: synth.loc_base,
+        loc_map: synth.loc_map.clone(),
+    };
+    Some((converted, synth))
+}
+
+/// The unified comment coordinate space for a reassembled program.
+struct Synth {
+    /// Whether this pass places comments (`false` for the probe pass).
+    enabled: bool,
+    /// The buffer comment spans index into. Starts as a `loc_base`-long pad so
+    /// the first chunk's region begins at `loc_base`; each comment-bearing chunk
+    /// is appended verbatim, followed by a newline.
+    source: String,
+    loc_base: u32,
+    comments: Vec<Comment>,
+    /// Per-chunk `(start, end, original-source offset)`, for source maps.
+    loc_map: Vec<(u32, u32, Option<u32>)>,
+    /// Region the chunk just parsed occupies, consumed by the caller that knows
+    /// the chunk's original-source offset.
+    pending_region: Option<(u32, u32)>,
+    saw_comments: bool,
+    /// Upper bound on every span produced outside a chunk region.
+    max_span: u32,
+}
+
+impl Synth {
+    fn new(loc_base: Option<u32>) -> Self {
+        let loc_base = loc_base.unwrap_or(0);
+        let mut source = String::new();
+        if loc_base > 0 {
+            // Pad ends with a newline so a comment on the chunk's first line
+            // sees an empty indentation prefix, as it would unpadded.
+            source.push_str(&" ".repeat(loc_base as usize - 1));
+            source.push('\n');
+        }
+        Self {
+            enabled: loc_base > 0,
+            source,
+            loc_base,
+            comments: Vec::new(),
+            loc_map: Vec::new(),
+            pending_region: None,
+            saw_comments: false,
+            max_span: 0,
+        }
+    }
+
+    /// The offset the next chunk region would start at.
+    fn cursor(&self) -> u32 {
+        self.source.len() as u32
+    }
+
+    fn note_span(&mut self, end: u32) {
+        self.max_span = self.max_span.max(end);
+    }
 }
 
 /// Conversion context: holds the oxc [`AstBuilder`] and the IR arena used to
@@ -74,6 +189,7 @@ pub fn program_to_oxc<'a>(
 struct Cx<'a, 'arena> {
     ab: AstBuilder<'a>,
     arena: &'arena JsArena,
+    synth: RefCell<Synth>,
 }
 
 impl<'a, 'arena> Cx<'a, 'arena> {
@@ -89,6 +205,37 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     #[inline]
     fn expr_id(&self, id: ExprId) -> Option<Expression<'a>> {
         self.expr(self.arena.get_expr(id))
+    }
+
+    /// Run `f` and report the comment-buffer region it consumed, so a container
+    /// node can span the comments its children carry (esrap brackets a body's
+    /// leading/trailing comments by the body's own `loc`). [`SPAN`] when the
+    /// subtree consumed nothing, i.e. carries no comments.
+    fn consumed<T>(&self, f: impl FnOnce() -> Option<T>) -> Option<(T, Span)> {
+        let before = self.synth.borrow().cursor();
+        let value = f()?;
+        let after = self.synth.borrow().cursor();
+        let span = if after > before {
+            Span::new(before, after)
+        } else {
+            SPAN
+        };
+        Some((value, span))
+    }
+
+    /// Record a span the printer must NOT read as a chunk location.
+    #[inline]
+    fn note_span(&self, end: u32) {
+        self.synth.borrow_mut().note_span(end);
+    }
+
+    /// Attach the region the chunk just parsed occupies to its original-source
+    /// offset (for source maps). Returns the region, if any.
+    fn take_chunk_region(&self, source_offset: Option<u32>) -> Option<(u32, u32)> {
+        let mut synth = self.synth.borrow_mut();
+        let region = synth.pending_region.take()?;
+        synth.loc_map.push((region.0, region.1, source_offset));
+        Some(region)
     }
 
     // -- statements ---------------------------------------------------------
@@ -112,9 +259,9 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             }
             JsStatement::VariableDeclaration(decl) => self.variable_declaration(decl),
             JsStatement::Block(b) => {
-                let stmts = self.statements(&b.body)?;
+                let (stmts, span) = self.statements(&b.body)?;
                 Some(Statement::BlockStatement(BlockStatement::boxed(
-                    SPAN, stmts, &self.ab,
+                    span, stmts, &self.ab,
                 )))
             }
             JsStatement::Empty => Some(Statement::EmptyStatement(EmptyStatement::boxed(
@@ -189,20 +336,29 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             // body): parse the text; a lone statement is returned directly, a
             // multi-statement blob is wrapped in a block. (Statement-LIST sites
             // use `expand_stmt` instead, which flattens inline.)
-            JsStatement::Raw(code) => self.raw_single_statement(code),
-            JsStatement::RawMapped { code, .. } => self.raw_single_statement(code),
+            JsStatement::Raw(code) => self.raw_single_statement(code, None),
+            JsStatement::RawMapped {
+                code,
+                source_offset,
+            } => self.raw_single_statement(code, Some(*source_offset)),
         }
     }
 
     /// Convert a `Raw` statement at a single-statement position: one parsed
     /// statement is returned as-is; several are wrapped in a `{ … }` block.
-    fn raw_single_statement(&self, code: &str) -> Option<Statement<'a>> {
+    fn raw_single_statement(
+        &self,
+        code: &str,
+        source_offset: Option<u32>,
+    ) -> Option<Statement<'a>> {
         let stmts = self.parse_raw_statements(code)?;
+        let region = self.take_chunk_region(source_offset);
         if stmts.len() == 1 {
             stmts.into_iter().next()
         } else {
+            let span = region.map_or(SPAN, |(a, b)| Span::new(a, b));
             Some(Statement::BlockStatement(BlockStatement::boxed(
-                SPAN,
+                span,
                 ArenaVec::from_iter_in(stmts, &self.ab),
                 &self.ab,
             )))
@@ -302,8 +458,8 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 Some(id) => Some(self.expr_id(id)?),
                 None => None,
             };
-            let consequent = self.statements(&case.consequent)?;
-            cases.push(SwitchCase::new(SPAN, test, consequent, &self.ab));
+            let (consequent, span) = self.statements(&case.consequent)?;
+            cases.push(SwitchCase::new(span, test, consequent, &self.ab));
         }
         Some(Statement::SwitchStatement(SwitchStatement::boxed(
             SPAN,
@@ -316,8 +472,8 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// Build a `try { } catch (e) { } finally { }` statement. Bails on a
     /// destructuring catch parameter.
     fn try_statement(&self, t: &JsTryStatement) -> Option<Statement<'a>> {
-        let block_stmts = self.statements(&t.block.body)?;
-        let block = BlockStatement::boxed(SPAN, block_stmts, &self.ab);
+        let (block_stmts, block_span) = self.statements(&t.block.body)?;
+        let block = BlockStatement::boxed(block_span, block_stmts, &self.ab);
 
         let handler = match &t.handler {
             None => None,
@@ -329,17 +485,17 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                         Some(CatchParameter::new(SPAN, pattern, oxc_ast::NONE, &self.ab))
                     }
                 };
-                let body_stmts = self.statements(&catch.body.body)?;
-                let body = BlockStatement::boxed(SPAN, body_stmts, &self.ab);
-                Some(CatchClause::new(SPAN, param, body, &self.ab))
+                let (body_stmts, body_span) = self.statements(&catch.body.body)?;
+                let body = BlockStatement::boxed(body_span, body_stmts, &self.ab);
+                Some(CatchClause::new(body_span, param, body, &self.ab))
             }
         };
 
         let finalizer = match &t.finalizer {
             None => None,
             Some(block) => {
-                let stmts = self.statements(&block.body)?;
-                Some(BlockStatement::boxed(SPAN, stmts, &self.ab))
+                let (stmts, span) = self.statements(&block.body)?;
+                Some(BlockStatement::boxed(span, stmts, &self.ab))
             }
         };
 
@@ -486,8 +642,8 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             .as_ref()
             .map(|name| BindingIdentifier::new(SPAN, self.str(name), &self.ab));
         let params = self.formal_params(&func.params)?;
-        let stmts = self.statements(&func.body.body)?;
-        let body = FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab);
+        let (stmts, span) = self.statements(&func.body.body)?;
+        let body = FunctionBody::new(span, ArenaVec::new_in(&self.ab), stmts, &self.ab);
         Some(Function::boxed(
             SPAN,
             func_type,
@@ -505,13 +661,16 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     }
 
     /// Convert a slice of IR statements into an arena `Vec`, bailing on any
-    /// unhandled statement.
-    fn statements(&self, body: &[JsStatement]) -> Option<ArenaVec<'a, Statement<'a>>> {
-        let mut v: Vec<Statement<'a>> = Vec::with_capacity(body.len());
-        for s in body {
-            v.extend(self.expand_stmt(s)?);
-        }
-        Some(ArenaVec::from_iter_in(v, &self.ab))
+    /// unhandled statement. The span is the comment-buffer region the statements
+    /// consumed, which their container must carry (see [`Cx::consumed`]).
+    fn statements(&self, body: &[JsStatement]) -> Option<(ArenaVec<'a, Statement<'a>>, Span)> {
+        self.consumed(|| {
+            let mut v: Vec<Statement<'a>> = Vec::with_capacity(body.len());
+            for s in body {
+                v.extend(self.expand_stmt(s)?);
+            }
+            Some(ArenaVec::from_iter_in(v, &self.ab))
+        })
     }
 
     /// Build an optional `LabelIdentifier` for `break`/`continue` labels.
@@ -869,6 +1028,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             JsExpr::Spanned(inner, start, end) => {
                 let mut e = self.expr_id(*inner)?;
                 *e.span_mut() = Span::new(*start, *end);
+                self.note_span(*end);
                 Some(e)
             }
             // `Raw` carries opaque JS expression text. Parse it into a real oxc
@@ -884,18 +1044,11 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// strips the synthetic parens. Returns `None` on a parse error.
     fn parse_raw_expression(&self, code: &str) -> Option<Expression<'a>> {
         let wrapped = format!("({})", code.trim());
-        let owned = self.ab.allocator.alloc_str(&wrapped);
-        let ret =
-            oxc_parser::Parser::new(self.ab.allocator, owned, oxc_span::SourceType::mjs()).parse();
-        // Bail on any comment-bearing chunk: re-printing a parsed AST drops the
-        // comments (esrap places them by source line, which a reassembled program
-        // has no unified coordinate for). Falling back to the verbatim string
-        // codegen for these preserves the comments exactly. (KNOWN GAP: AST-side
-        // comment preservation.)
-        if !ret.diagnostics.is_empty() || !ret.program.comments.is_empty() {
-            return None;
-        }
-        for stmt in ret.program.body {
+        let stmts = self.parse_chunk(&wrapped)?;
+        // The synthetic parens are part of the chunk text, so the region already
+        // covers them; no caller needs it for an expression.
+        self.take_chunk_region(None);
+        for stmt in stmts {
             if let Statement::ExpressionStatement(es) = stmt {
                 let mut e = es.unbox().expression;
                 while let Expression::ParenthesizedExpression(p) = e {
@@ -910,14 +1063,51 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// Parse a raw JS statement source string into a vec of oxc [`Statement`]s
     /// (`Raw` may hold several statements). Returns `None` on a parse error.
     fn parse_raw_statements(&self, code: &str) -> Option<Vec<Statement<'a>>> {
-        let owned = self.ab.allocator.alloc_str(code.trim());
+        self.parse_chunk(code.trim())
+    }
+
+    /// Parse one opaque chunk of generated JS. A comment-free chunk parses in
+    /// place, exactly as before. A comment-bearing chunk is re-parsed from a
+    /// `pad + text` buffer so its spans land at the chunk's own region of the
+    /// unified comment buffer, and its comments are collected there.
+    fn parse_chunk(&self, text: &str) -> Option<Vec<Statement<'a>>> {
+        let owned = self.ab.allocator.alloc_str(text);
         let ret =
             oxc_parser::Parser::new(self.ab.allocator, owned, oxc_span::SourceType::mjs()).parse();
-        // Bail on comments so the verbatim string codegen preserves them (see
-        // `parse_raw_expression`).
-        if !ret.diagnostics.is_empty() || !ret.program.comments.is_empty() {
+        if !ret.diagnostics.is_empty() {
             return None;
         }
+        if ret.program.comments.is_empty() {
+            // Chunk-local spans stay below `loc_base`, so they read as "no
+            // location"; record the bound the second pass has to clear.
+            self.note_span(text.len() as u32);
+            return Some(ret.program.body.into_iter().collect());
+        }
+        self.synth.borrow_mut().saw_comments = true;
+        if !self.synth.borrow().enabled {
+            // Probe pass: the comments are dropped here, but the result is
+            // discarded — it only tells the driver a second pass is needed.
+            self.note_span(text.len() as u32);
+            return Some(ret.program.body.into_iter().collect());
+        }
+
+        let base = self.synth.borrow().cursor();
+        let mut padded = String::with_capacity(base as usize + text.len());
+        padded.extend(std::iter::repeat_n(' ', base as usize - 1));
+        padded.push('\n');
+        padded.push_str(text);
+        let owned = self.ab.allocator.alloc_str(&padded);
+        let ret =
+            oxc_parser::Parser::new(self.ab.allocator, owned, oxc_span::SourceType::mjs()).parse();
+        if !ret.diagnostics.is_empty() {
+            return None;
+        }
+        let mut synth = self.synth.borrow_mut();
+        synth.source.push_str(text);
+        synth.source.push('\n');
+        synth.comments.extend(ret.program.comments.iter().cloned());
+        synth.pending_region = Some((base, base + text.len() as u32));
+        drop(synth);
         Some(ret.program.body.into_iter().collect())
     }
 
@@ -927,12 +1117,21 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// block bodies) so a multi-statement `Raw` flattens inline.
     fn expand_stmt(&self, stmt: &JsStatement) -> Option<Vec<Statement<'a>>> {
         match stmt {
-            JsStatement::Raw(code) => self.parse_raw_statements(code),
+            JsStatement::Raw(code) => {
+                let stmts = self.parse_raw_statements(code)?;
+                self.take_chunk_region(None);
+                Some(stmts)
+            }
             JsStatement::RawMapped {
                 code,
                 source_offset,
             } => {
                 let mut stmts = self.parse_raw_statements(code)?;
+                if self.take_chunk_region(Some(*source_offset)).is_some() {
+                    // The chunk's own spans are its comment anchors; the source
+                    // offset is carried by the region's `loc_map` entry instead.
+                    return Some(stmts);
+                }
                 // Stamp each statement with the original-source offset so esrap's
                 // `print_with_map` maps the (transformed) instance-script lines
                 // back to the user source — mirroring the text codegen's
@@ -941,6 +1140,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 for s in &mut stmts {
                     *s.span_mut() = sp;
                 }
+                self.note_span(*source_offset);
                 Some(stmts)
             }
             other => Some(vec![self.stmt(other)?]),
@@ -1080,8 +1280,8 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             .as_ref()
             .map(|name| BindingIdentifier::new(SPAN, self.str(name), &self.ab));
         let params = self.formal_params(&func.params)?;
-        let stmts = self.statements(&func.body.body)?;
-        let body = FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab);
+        let (stmts, span) = self.statements(&func.body.body)?;
+        let body = FunctionBody::new(span, ArenaVec::new_in(&self.ab), stmts, &self.ab);
         Some(Function::boxed(
             SPAN,
             FunctionType::FunctionExpression,
@@ -1520,10 +1720,10 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 )
             }
             JsArrowBody::Block(block) => {
-                let stmts = self.statements(&block.body)?;
+                let (stmts, span) = self.statements(&block.body)?;
                 (
                     false,
-                    FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab),
+                    FunctionBody::new(span, ArenaVec::new_in(&self.ab), stmts, &self.ab),
                 )
             }
         };
@@ -1574,8 +1774,8 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             .as_ref()
             .map(|name| BindingIdentifier::new(SPAN, self.str(name), &self.ab));
         let params = self.formal_params(&func.params)?;
-        let stmts = self.statements(&func.body.body)?;
-        let body = FunctionBody::new(SPAN, ArenaVec::new_in(&self.ab), stmts, &self.ab);
+        let (stmts, span) = self.statements(&func.body.body)?;
+        let body = FunctionBody::new(span, ArenaVec::new_in(&self.ab), stmts, &self.ab);
         Some(Expression::FunctionExpression(Function::boxed(
             SPAN,
             FunctionType::FunctionExpression,

--- a/crates/rsvelte_core/tests/client_script_comments_pin.rs
+++ b/crates/rsvelte_core/tests/client_script_comments_pin.rs
@@ -1,0 +1,61 @@
+//! Client codegen keeps `<script>` comments, byte-for-byte with the official
+//! compiler.
+//!
+//! These go through `to_oxc`'s comment coordinate space (`Synth`): the script
+//! chunk is re-parsed at its own region of a unified buffer so esrap can place
+//! its comments positionally, while the surrounding synthesized nodes carry no
+//! location. Before that existed, a comment-bearing chunk bailed to the string
+//! codegen — which produced *different* output for every one of these.
+//!
+//! Expected outputs are the official Svelte compiler's, verbatim.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(name: &str, source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            filename: Some(format!("{name}/index.svelte")),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn leading_script_comment_matches_upstream() {
+    let source = "<script>\n\t// leading note\n\tlet x = 1;\n</script>\n\n<p>{x}</p>\n";
+    let expected = "import 'svelte/internal/disclose-version';\nimport 'svelte/internal/flags/legacy';\nimport * as $ from 'svelte/internal/client';\n\nvar root = $.from_html(`<p></p>`);\n\nexport default function Leading($$anchor) {\n\t// leading note\n\tlet x = 1;\n\n\tvar p = root();\n\n\tp.textContent = '1';\n\t$.append($$anchor, p);\n}";
+    assert_eq!(client("leading", source), expected);
+}
+
+/// KNOWN DIVERGENCE (#1784): a comment after the script's last statement
+/// migrates to the end of the enclosing function body, because the only span
+/// bracketing it is the function body's. Upstream flushes it at the next
+/// generated node instead (`var // trailing note\n\tp = root();`). The comment is
+/// never lost — only repositioned. Pinned so the position cannot drift further
+/// unnoticed.
+#[test]
+fn trailing_script_comment_moves_to_the_body_tail() {
+    let source =
+        "<script>\n\t// leading note\n\tlet x = 1;\n\t// trailing note\n</script>\n\n<p>{x}</p>\n";
+    let actual = client("leading_and_trailing", source);
+    assert!(
+        actual.contains("\t// leading note\n\tlet x = 1;"),
+        "{actual}"
+    );
+    assert!(
+        actual.contains("\t$.append($$anchor, p);\n\t// trailing note\n}"),
+        "{actual}"
+    );
+}
+
+#[test]
+fn module_and_instance_script_comments() {
+    let source = "<script module>\n\t// module note\n\texport const version = 1;\n</script>\n\n<script>\n\t/* instance note */\n\tlet n = 0;\n</script>\n\n<button onclick={() => n++}>{n}</button>\n";
+    let expected = "import 'svelte/internal/disclose-version';\nimport 'svelte/internal/flags/legacy';\nimport * as $ from 'svelte/internal/client';\n\nexport const version = 1;\n\nvar root = $.from_html(`<button> </button>`);\n\nexport default function Module_and_instance($$anchor) {\n\t/* instance note */\n\tlet n = $.mutable_source(0);\n\n\tvar button = root();\n\tvar text = $.child(button, true);\n\n\t$.reset(button);\n\t$.template_effect(() => $.set_text(text, $.get(n)));\n\t$.delegated('click', button, () => $.update(n));\n\t$.append($$anchor, button);\n}\n\n$.delegate(['click']);";
+    assert_eq!(client("module_and_instance", source), expected);
+}

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -87,6 +87,51 @@ pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -
     command::print(&ctx.into_commands(), &options.indent)
 }
 
+/// Print a program whose comment coordinates and source-map coordinates live in
+/// two different buffers — the shape a *reassembled* program has, where the
+/// nodes carrying comments were parsed from generated chunks rather than from
+/// the original file.
+///
+/// * `comment_source` is the buffer the program's comment spans (and the spans
+///   of the nodes those comments attach to) index into.
+/// * `loc_base` splits the two: spans below it are synthesized nodes that carry
+///   no location, exactly like a missing `node.loc` in esrap, and take part in
+///   no comment placement.
+/// * `map_source` (when `Some`) is the buffer source-map line/columns resolve
+///   against, with `loc_map` translating comment-space offsets back into it —
+///   sorted and disjoint, one entry per chunk, a `None` third field meaning the
+///   chunk has no original-source anchor. `map_source: None` prints without
+///   source-map anchors.
+///
+/// A chunk maps to a single point, so source-map *resolution* inside a chunk is
+/// chunk-granular, not statement-granular.
+pub fn print_split(
+    program: &Program<'_>,
+    comment_source: &str,
+    loc_base: u32,
+    map_source: Option<&str>,
+    loc_map: &[(u32, u32, Option<u32>)],
+    options: &PrintOptions,
+) -> PrintWithMap {
+    let comments = printer::build_comments(program, comment_source);
+    let map_line_starts = map_source.map(printer::line_starts).unwrap_or_default();
+    let mut printer =
+        printer::Printer::with_comments(options, comments, printer::line_starts(comment_source))
+            .with_split_coordinates(map_line_starts, loc_base, loc_map);
+    let mut ctx = context::Context::new();
+    printer.print_program(program, &mut ctx);
+    let commands = ctx.into_commands();
+    if map_source.is_some() {
+        let (code, mappings) = command::flatten_with_map(&commands, &options.indent);
+        PrintWithMap { code, mappings }
+    } else {
+        PrintWithMap {
+            code: command::print(&commands, &options.indent),
+            mappings: Vec::new(),
+        }
+    }
+}
+
 /// A synthetic comment injected by a [`CommentHooks`] callback (esrap's
 /// `BaseComment`). `block` chooses `/* … */` vs `// …`; `value` is the interior
 /// text (without delimiters).

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -55,9 +55,21 @@ pub struct Printer<'opt> {
     /// node's last line) rather than attaching them to AST nodes.
     comments: Vec<Cmt>,
     comment_index: usize,
-    /// Byte offsets of each line start, for offset→line lookups when placing
-    /// comments. Empty when printing without comments.
+    /// Byte offsets of each line start in the buffer the comment spans index
+    /// into, for offset→line lookups when placing comments. Empty when printing
+    /// without comments.
     line_starts: Vec<u32>,
+    /// Byte offsets of each line start in the buffer source-map positions are
+    /// resolved against. Same as `line_starts` unless the caller split the two
+    /// coordinate spaces (see [`crate::print_split`]).
+    map_line_starts: Vec<u32>,
+    /// Spans below this offset are synthesized and carry no source location, so
+    /// they take no part in comment placement — the Rust equivalent of esrap's
+    /// `if (node.loc)` guards. `None` = every span is a real location.
+    loc_base: Option<u32>,
+    /// Sorted, disjoint `(start, end, mapped)` ranges translating a comment-space
+    /// offset back to a source-map-space offset. `None` mapped = unmapped.
+    loc_map: Vec<(u32, u32, Option<u32>)>,
     /// Optional caller hooks that inject synthetic leading/trailing comments per
     /// statement (esrap's `getLeadingComments` / `getTrailingComments`).
     hooks: Option<&'opt crate::CommentHooks<'opt>>,
@@ -391,6 +403,9 @@ impl<'opt> Printer<'opt> {
             comments: Vec::new(),
             comment_index: 0,
             line_starts: Vec::new(),
+            map_line_starts: Vec::new(),
+            loc_base: None,
+            loc_map: Vec::new(),
             hooks: None,
         }
     }
@@ -407,9 +422,28 @@ impl<'opt> Printer<'opt> {
             missing: None,
             comments,
             comment_index: 0,
+            map_line_starts: line_starts.clone(),
             line_starts,
+            loc_base: None,
+            loc_map: Vec::new(),
             hooks: None,
         }
+    }
+
+    /// Resolve source-map positions against a different buffer than the one the
+    /// comment spans index into, and treat spans below `loc_base` as
+    /// synthesized (no location). `loc_map` translates comment-space offsets
+    /// back into map-space offsets.
+    pub fn with_split_coordinates(
+        mut self,
+        map_line_starts: Vec<u32>,
+        loc_base: u32,
+        loc_map: &[(u32, u32, Option<u32>)],
+    ) -> Self {
+        self.map_line_starts = map_line_starts;
+        self.loc_base = Some(loc_base);
+        self.loc_map = loc_map.to_vec();
+        self
     }
 
     /// Attach caller comment hooks (builder-style).
@@ -423,18 +457,46 @@ impl<'opt> Printer<'opt> {
         self.line_starts.partition_point(|&s| s <= offset) as u32
     }
 
+    /// esrap's `if (node.loc)`: whether a span offset is a real source position
+    /// (and so may carry comments) rather than a synthesized node's placeholder.
+    fn has_loc(&self, offset: u32) -> bool {
+        self.loc_base.is_none_or(|base| offset >= base)
+    }
+
     /// Convert a byte offset to `(line_1based, column_0based)` using
     /// `line_starts`, mirroring ESTree `loc` (1-based line, 0-based column). The
     /// column is the offset relative to the start of its line; for ASCII / BMP
     /// source this equals the UTF-16 column esrap uses. Returns `None` when
     /// there are no line starts (printing without source context).
     fn offset_to_line_col(&self, offset: u32) -> Option<(u32, u32)> {
-        if self.line_starts.is_empty() {
+        if self.map_line_starts.is_empty() {
             return None;
         }
-        let line = self.line_of(offset);
+        let offset = if self.loc_map.is_empty() {
+            offset
+        } else {
+            match self
+                .loc_map
+                .binary_search_by(|(start, end, _)| {
+                    if offset < *start {
+                        std::cmp::Ordering::Greater
+                    } else if offset >= *end {
+                        std::cmp::Ordering::Less
+                    } else {
+                        std::cmp::Ordering::Equal
+                    }
+                })
+                .ok()
+                .map(|i| self.loc_map[i].2)
+            {
+                Some(Some(mapped)) => mapped,
+                Some(None) => return None,
+                None => offset,
+            }
+        };
+        let line = self.map_line_starts.partition_point(|&s| s <= offset) as u32;
         // `line` is 1-based; its start offset lives at index `line - 1`.
-        let line_start = self.line_starts[(line - 1) as usize];
+        let line_start = self.map_line_starts[(line - 1) as usize];
         Some((line, offset.saturating_sub(line_start)))
     }
 
@@ -560,6 +622,9 @@ impl<'opt> Printer<'opt> {
         from_line: Option<u32>,
         pad: bool,
     ) {
+        if !self.has_loc(to) {
+            return;
+        }
         let mut first = true;
         while self.comment_index < self.comments.len() {
             let cmt = &self.comments[self.comment_index];
@@ -593,9 +658,16 @@ impl<'opt> Printer<'opt> {
     fn flush_trailing_comments(
         &mut self,
         ctx: &mut Context,
-        prev_end_line: u32,
+        prev_end: u32,
         next: Option<u32>,
     ) -> bool {
+        if !self.has_loc(prev_end) {
+            return false;
+        }
+        // A `next` boundary that is itself synthesized bounds nothing (esrap's
+        // `next` is `null` when the following node has no `loc`).
+        let next = next.filter(|n| self.has_loc(*n));
+        let prev_end_line = self.line_of(prev_end);
         let mut emitted_line_newline = false;
         while self.comment_index < self.comments.len() {
             let cmt = &self.comments[self.comment_index];
@@ -620,6 +692,9 @@ impl<'opt> Printer<'opt> {
     /// esrap's `reset_comment_index`: re-sync the cursor to the first comment
     /// at/after `node_start` (so a nested body doesn't replay earlier comments).
     fn reset_comment_index(&mut self, node_start: u32) {
+        if !self.has_loc(node_start) {
+            return;
+        }
         let cur = self.comments.get(self.comment_index);
         let prev = self
             .comment_index
@@ -693,7 +768,7 @@ impl<'opt> Printer<'opt> {
             // start, or `until` for the final node.
             let next = if i == n - 1 { until } else { starts[i + 1] };
             if let Some(end) = node.end {
-                self.flush_trailing_comments(&mut child, self.line_of(end), next);
+                self.flush_trailing_comments(&mut child, end, next);
             }
 
             length += child.measure() as i64 + 1;
@@ -739,6 +814,7 @@ impl<'opt> Printer<'opt> {
             let from_line = nodes
                 .last()
                 .and_then(|node| node.end)
+                .filter(|&e| self.has_loc(e))
                 .map(|e| self.line_of(e));
             self.flush_comments_until(parent, until, self.line_of(until), from_line, false);
         }
@@ -827,9 +903,8 @@ impl<'opt> Printer<'opt> {
             let multiline = child.multiline;
             ctx.append(child);
 
-            let end_line = self.line_of(elem.span_end());
             let next = non_empty.get(i + 1).map(|e| e.span_start());
-            self.flush_trailing_comments(ctx, end_line, next);
+            self.flush_trailing_comments(ctx, elem.span_end(), next);
 
             prev = Some((elem, multiline));
         }
@@ -842,7 +917,11 @@ impl<'opt> Printer<'opt> {
         // `empty()`, so a comment-free `{}` is unaffected.
         ctx.newline();
         if !self.comments.is_empty() {
-            let from_line = non_empty.last().map(|e| self.line_of(e.span_end()));
+            let from_line = non_empty
+                .last()
+                .map(|e| e.span_end())
+                .filter(|&end| self.has_loc(end))
+                .map(|end| self.line_of(end));
             self.flush_comments_until(ctx, body_end, self.line_of(body_end), from_line, false);
         }
     }
@@ -2109,6 +2188,8 @@ impl<'opt> Printer<'opt> {
                 //    sequence visitor.)
                 if matches!(p.expression, Expression::SequenceExpression(_)) {
                     self.print_expression(&p.expression, ctx);
+                // No `has_loc` guard needed: every comment offset is >= `loc_base`
+                // by construction, so a synthesized span never contains one.
                 } else if self.comment_in_span(p.span.start, p.span.end) {
                     ctx.write("(");
                     self.print_expression(&p.expression, ctx);
@@ -2900,6 +2981,9 @@ impl<'opt> Printer<'opt> {
             let is_last = i == n - 1;
             let arg_start = arg.span().start;
 
+            // No `has_loc` guard needed: every comment offset is >= `loc_base` by
+            // construction, so `c.start < arg_start` is already false for a
+            // synthesized argument span.
             if is_last
                 && let Some(c) = self.comments.get(self.comment_index)
                 && c.start < arg_start
@@ -2928,8 +3012,7 @@ impl<'opt> Printer<'opt> {
             } else {
                 Some(args[i + 1].span().start)
             };
-            let emitted_line =
-                self.flush_trailing_comments(&mut child, self.line_of(arg.span().end), next);
+            let emitted_line = self.flush_trailing_comments(&mut child, arg.span().end, next);
             // esrap accumulates all non-final args in one `child_context` and
             // `append`s a `join` context after each, which propagates the
             // trailing line comment's pending newline into `child_context.multiline`

--- a/crates/rsvelte_esrap/tests/split_coordinates.rs
+++ b/crates/rsvelte_esrap/tests/split_coordinates.rs
@@ -1,0 +1,277 @@
+//! [`rsvelte_esrap::print_split`] — printing a *reassembled* program, whose
+//! comment coordinates and source-map coordinates live in two different buffers.
+//!
+//! This is the contract rsvelte's client codegen relies on: a program built from
+//! independently-parsed generated chunks has no shared coordinate space, so each
+//! comment-bearing chunk is re-parsed at its own region of one unified buffer
+//! above `loc_base`, and every span below `loc_base` is a synthesized node that
+//! must take no part in comment placement (esrap's `if (node.loc)`).
+//!
+//! The assembly below deliberately mirrors the converter's `Synth`: a
+//! comment-free chunk parses at offset 0 (its spans land below `loc_base`, which
+//! is exactly what makes it "synthesized" to the printer), and a comment-bearing
+//! chunk parses from `pad + text` so its spans land at its region.
+
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_ast::AstBuilder;
+use oxc_ast::ast::{Program, Statement};
+use oxc_parser::Parser;
+use oxc_span::{SourceType, Span};
+
+use rsvelte_esrap::{PrintOptions, print_split};
+
+/// Region of one chunk in the unified buffer, plus the map-space offset it
+/// resolves to (`None` = unmapped).
+type LocMapEntry = (u32, u32, Option<u32>);
+
+/// Builds a reassembled program the way the client converter does.
+struct Assembler<'a> {
+    ab: AstBuilder<'a>,
+    /// The unified buffer comment spans index into; starts as a `loc_base`-long
+    /// pad so the first chunk's region begins exactly at `loc_base`.
+    source: String,
+    loc_base: u32,
+    body: Vec<Statement<'a>>,
+    comments: Vec<oxc_ast::ast::Comment>,
+    loc_map: Vec<LocMapEntry>,
+}
+
+impl<'a> Assembler<'a> {
+    fn new(allocator: &'a Allocator, loc_base: u32) -> Self {
+        let mut source = " ".repeat(loc_base as usize - 1);
+        source.push('\n');
+        Self {
+            ab: AstBuilder::new(allocator),
+            source,
+            loc_base,
+            body: Vec::new(),
+            comments: Vec::new(),
+            loc_map: Vec::new(),
+        }
+    }
+
+    fn parse(&self, text: &'a str) -> Program<'a> {
+        let ret = Parser::new(self.ab.allocator, text, SourceType::mjs()).parse();
+        assert!(ret.diagnostics.is_empty(), "parse error in {text:?}");
+        ret.program
+    }
+
+    /// A generated chunk with no comments: parsed in place, so all its spans sit
+    /// below `loc_base` and read as synthesized.
+    fn push_synthesized(&mut self, text: &str) {
+        let owned = self.ab.allocator.alloc_str(text);
+        assert!(
+            (owned.len() as u32) < self.loc_base,
+            "test chunk must stay below loc_base"
+        );
+        let program = self.parse(owned);
+        assert!(
+            program.comments.is_empty(),
+            "push_synthesized is for comment-free chunks"
+        );
+        self.body.extend(program.body);
+    }
+
+    /// A comment-bearing chunk: re-parsed from `pad + text` so its spans, and
+    /// its comments', land at the chunk's own region of the unified buffer.
+    fn push_chunk(&mut self, text: &str, maps_to: Option<u32>) {
+        let base = self.source.len() as u32;
+        let mut padded = " ".repeat(base as usize - 1);
+        padded.push('\n');
+        padded.push_str(text);
+        let owned = self.ab.allocator.alloc_str(&padded);
+        let program = self.parse(owned);
+        assert!(
+            !program.comments.is_empty(),
+            "push_chunk is for comment-bearing chunks"
+        );
+        self.source.push_str(text);
+        self.source.push('\n');
+        self.comments.extend(program.comments.iter().cloned());
+        self.loc_map.push((base, base + text.len() as u32, maps_to));
+        self.body.extend(program.body);
+    }
+
+    fn finish(self) -> Assembled<'a> {
+        // The program spans the whole consumed region, so it brackets the
+        // leading and trailing comments of the chunks it holds.
+        let span = Span::new(self.loc_base, self.source.len() as u32);
+        let comments = ArenaVec::from_iter_in(self.comments, &self.ab);
+        let body = ArenaVec::from_iter_in(self.body, &self.ab);
+        let program = Program::new(
+            span,
+            SourceType::mjs(),
+            "",
+            comments,
+            None,
+            ArenaVec::new_in(&self.ab),
+            body,
+            &self.ab,
+        );
+        Assembled {
+            program,
+            source: self.source,
+            loc_base: self.loc_base,
+            loc_map: self.loc_map,
+        }
+    }
+}
+
+struct Assembled<'a> {
+    program: Program<'a>,
+    source: String,
+    loc_base: u32,
+    loc_map: Vec<LocMapEntry>,
+}
+
+impl Assembled<'_> {
+    fn print(&self) -> String {
+        print_split(
+            &self.program,
+            &self.source,
+            self.loc_base,
+            None,
+            &self.loc_map,
+            &PrintOptions::default(),
+        )
+        .code
+    }
+
+    fn print_mapped(&self, map_source: &str) -> rsvelte_esrap::PrintWithMap {
+        print_split(
+            &self.program,
+            &self.source,
+            self.loc_base,
+            Some(map_source),
+            &self.loc_map,
+            &PrintOptions::default(),
+        )
+    }
+}
+
+/// Byte index of `needle` in `haystack`, asserting it appears exactly once.
+fn index_of_unique(haystack: &str, needle: &str) -> usize {
+    assert_eq!(
+        haystack.matches(needle).count(),
+        1,
+        "{needle:?} should appear exactly once in:\n{haystack}"
+    );
+    haystack.find(needle).unwrap()
+}
+
+#[test]
+fn synthesized_statements_do_not_absorb_chunk_comments() {
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    a.push_synthesized("foo();");
+    a.push_chunk("// lead\nconst x = 1;", None);
+    a.push_synthesized("bar();");
+    let out = a.finish().print();
+
+    let foo = index_of_unique(&out, "foo();");
+    let lead = index_of_unique(&out, "// lead");
+    let decl = index_of_unique(&out, "const x = 1;");
+    let bar = index_of_unique(&out, "bar();");
+
+    // The comment stays attached to the statement it leads, between the two
+    // synthesized statements that carry no location.
+    assert!(foo < lead, "comment must not precede `foo()`:\n{out}");
+    assert!(lead < decl, "comment must lead its statement:\n{out}");
+    assert!(decl < bar, "chunk must stay before `bar()`:\n{out}");
+    // The comment sits on its own line directly above the declaration.
+    assert!(out.contains("// lead\nconst x = 1;"), "{out}");
+}
+
+#[test]
+fn trailing_chunk_comment_is_not_dropped() {
+    // The comment after the chunk's last statement is only reachable because the
+    // program's span brackets the chunk's whole region.
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    a.push_chunk("const x = 1;\n// tail note", None);
+    let out = a.finish().print();
+
+    assert!(out.contains("const x = 1;"), "{out}");
+    index_of_unique(&out, "// tail note");
+}
+
+#[test]
+fn two_chunks_keep_their_comments_in_order() {
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    a.push_chunk("// first\nconst a = 1;", None);
+    a.push_synthesized("between();");
+    a.push_chunk("// second\nconst b = 2;", None);
+    let out = a.finish().print();
+
+    let first = index_of_unique(&out, "// first");
+    let decl_a = index_of_unique(&out, "const a = 1;");
+    let between = index_of_unique(&out, "between();");
+    let second = index_of_unique(&out, "// second");
+    let decl_b = index_of_unique(&out, "const b = 2;");
+
+    assert!(
+        first < decl_a && decl_a < between && between < second && second < decl_b,
+        "chunk comments must stay with their own chunk:\n{out}"
+    );
+}
+
+#[test]
+fn comment_free_program_prints_without_a_comment_buffer() {
+    // Nothing consumed the unified buffer, so no comment machinery runs at all.
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    a.push_synthesized("foo();\nbar();");
+    let out = a.finish().print();
+    assert_eq!(out, "foo();\nbar();");
+}
+
+#[test]
+fn loc_map_resolves_chunk_positions_back_into_the_source() {
+    // Map the chunk's whole region onto the `const count` line of a stand-in
+    // original source; every keyword anchor inside the chunk must resolve there.
+    let map_source = "<script>\n\tlet count = 0;\n</script>\n";
+    let anchor = map_source.find("let count").unwrap() as u32;
+
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    a.push_chunk("// c\nconst x = 1;", Some(anchor));
+    let assembled = a.finish();
+    let mapped = assembled.print_mapped(map_source);
+
+    let segs: Vec<_> = mapped.mappings.iter().flatten().collect();
+    assert!(
+        !segs.is_empty(),
+        "no mapped segment:\n{:?}",
+        mapped.mappings
+    );
+    // `anchor` is on 0-based line 1, column 1 (the tab). Every segment must land
+    // there rather than at a position in the unified comment buffer, which has
+    // no line 1 at all.
+    // `anchor` is on 0-based line 1, column 1 (the tab). Without `loc_map` the
+    // chunk's offsets (past `loc_base`) would resolve off the end of
+    // `map_source` instead.
+    assert_eq!((segs[0][2], segs[0][3]), (1, 1), "{segs:?}");
+    for seg in &segs {
+        assert_eq!(
+            seg[2], 1,
+            "every chunk offset maps to the anchor line: {seg:?}"
+        );
+    }
+}
+
+#[test]
+fn unmapped_chunks_emit_no_source_positions() {
+    let map_source = "<script>\n\tlet count = 0;\n</script>\n";
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    a.push_chunk("// c\nconst x = 1;", None);
+    let assembled = a.finish();
+    let mapped = assembled.print_mapped(map_source);
+
+    assert!(
+        mapped.mappings.iter().flatten().count() == 0,
+        "a chunk with no source anchor must not emit segments: {:?}",
+        mapped.mappings
+    );
+}


### PR DESCRIPTION
## Why

The direct-AST client codegen (`js_ast/to_oxc.rs` → `rsvelte_esrap`) bailed to
the legacy string codegen for **any** chunk carrying a comment:

```rust
if !ret.diagnostics.is_empty() || !ret.program.comments.is_empty() {
    return None;
}
```

The reason was real, not laziness: esrap places comments *positionally*, and a
program reassembled from independently-parsed `Raw` / `RawMapped` chunks has no
shared coordinate space to place them in.

This was the blocker for the planned removal of the ~54k-line text-transform
path — you cannot delete the fallback while 3% of components still need it.

## How

The official compiler solves this by passing `analysis.comments` (original-source
coordinates) to esrap while **synthesized nodes carry no `loc` at all**, so
esrap's `if (node.loc)` guards skip them. This PR reproduces that model for a
reassembled program:

- Each **comment-bearing chunk** is re-parsed from a `pad + chunk` buffer, so
  its spans — and its comments' — land in a private, monotonically increasing
  region of one unified buffer above `loc_base`. That buffer is what
  `build_comments` slices comment bodies and line numbers from.
- **Container nodes** (`Program`, `BlockStatement`, `FunctionBody`,
  `SwitchCase`, `CatchClause`) take the span of the region their children
  consumed, so a body brackets its own leading/trailing comments.
- Everything below `loc_base` — synthesized nodes, and the original-source spans
  stamped by `Spanned` / `RawMapped` — reads as **"no location"** to the printer
  (`Printer::has_loc`), the Rust equivalent of esrap's `if (node.loc)`. All four
  comment primitives (`flush_comments_until`, `flush_trailing_comments`,
  `reset_comment_index`, `flush_leading`) guard on it centrally.
- `loc_base` has to sit above every other span the conversion produces, and that
  is only known after the fact, so conversion runs as a **probe pass** followed —
  *only when a chunk turned out to carry comments* — by a second pass that knows
  where to put the coordinate space. Comment-free programs (the 96.8% majority)
  convert exactly once, as before. The second pass re-checks
  `max_span < loc_base` and bails to the string codegen if the invariant does not
  hold.

## Measured

Corpus: every `.svelte` under `submodules/svelte/packages/svelte/tests`
(4454 files, 3834 compiling), via `crates/rsvelte_core/src/bin/roundtrip_probe.rs`
with `RSVELTE_CLIENT_TO_OXC_DEBUG=1`.

| | fallbacks | rate |
|---|---|---|
| before | 122 / 3834 | **3.18%** |
| after | 1 / 3834 | **0.026%** |

The single remaining bail is *not* a comment:
`runtime-legacy/samples/const-tag-await-then-destructuring-computed-in-computed`
— computed destructuring patterns in `{@const}` that the converter does not
model yet.

### Byte-exactness

Client output digests for all 3834 compiling files, before vs after: **96 files
changed, 3738 byte-identical**. Every one of the 96 was previously on the
fallback path.

Those 96 compiled with the official compiler (same SHA, `generate: 'client'`)
and compared byte-for-byte:

| | byte-exact vs official |
|---|---|
| before (string codegen) | 0 / 96 |
| after (direct AST) | **62 / 96** |
| regressed | **0** |

Independent review additionally confirmed 0 regressions under `dev` and
`devhmr` (where 8 more files change, 43 and 40 of them newly matching upstream),
all generated code syntactically valid, no comment ever dropped, and the
real-world corpus at 12,268 match / 0 mismatch.

### The 34 that stay divergent

All 34 were **already** divergent before this PR — none is a pass→fail
regression — but two of the causes are made visible by this change and are now
tracked:

- **#1783 — paren stripping.** `parse_raw_expression` unwraps every
  `ParenthesizedExpression` after removing its synthetic `( … )` wrapper, so
  parens the chunk text already had are dropped:
  `() => ($.get(y))` → `() => $.get(y)`. 2 files.
- **#1784 — trailing comment placement.** A comment after the script's last
  statement migrates to the end of the generated function body, because the only
  span bracketing it is the function body's; upstream flushes it at the next
  generated node. The comment is never lost, only repositioned — but for this
  shape the direct-AST path lands *further* from upstream than the string
  codegen did. 11 of the 34 differ from upstream in comment placement only.

The rest are pre-existing and unrelated (a `// svelte-ignore` comment rsvelte
carries into the script that upstream drops; comments attached to template
expressions, which upstream emits *inside* the interpolation).

### Source maps: resolution degrades to chunk granularity

The coordinate *space* is preserved — chunk offsets resolve back into the
original source through a per-chunk `(start, end, source offset)` table — but the
*resolution* is not. A `RawMapped` chunk maps to a **single point**
(`source_offset`), with esrap's column arithmetic layered on top, so positions
inside a rewritten chunk no longer track individual statements. Measured over the
121 affected files:

| | base | this PR |
|---|---|---|
| mapping segments | 3,070 | 2,951 |
| **segments pointing outside the original source** | **0** | **482 (16.3%)** |
| files affected | 0 | 116 / 121 |
| distinct source positions referenced (resolution) | 2,813 | **820 (−71%)** |

Concretely, `tests/sourcemaps/samples/typescript` (whose `_config.js` asserts
`client: ['count', 'setInterval']`) passes on base and fails here: `count` maps
to `1:22`, past the end of line 1 (`<script lang="ts">`, 18 chars), instead of
`4:5`.

**This is not a new class of bug.** On the pre-existing direct-AST path — the
3,713 files this PR does not touch — 9,164 / 70,787 segments (12.9%) already
point outside the source, at 36% resolution. What this PR does is remove the last
island of accurate maps, the 121 files that were still taking the string codegen.
Tracked separately by the reviewer.

## Tests

New:

- `crates/rsvelte_esrap/tests/split_coordinates.rs` — 6 tests over `print_split`
  / `has_loc` / `loc_map`, assembling a reassembled program the way the converter
  does: synthesized nodes take no comments, a trailing chunk comment survives,
  two chunks keep their comments in order, and chunk offsets resolve through
  `loc_map` (or produce no segment when unmapped).
- `crates/rsvelte_core/tests/client_script_comments_pin.rs` — end-to-end client
  output pinned to the official compiler's, plus the #1784 divergence pinned
  explicitly so it cannot drift further unnoticed.

Existing:

```
cargo fmt --all
cargo clippy --all-targets --all-features -- -D warnings   # clean
cargo test -p rsvelte_core --test compiler_fixtures --test runtime \
    --test ssr --test validator --test compiler_errors --test sourcemaps
cargo test -p rsvelte_core --lib                            # 1536 pass
cargo test -p rsvelte_esrap                                 # all pass (golden ratchet held)
```

Re-run after rebasing onto current `main`; output digests for all 3834 files are
byte-identical to the validated run above.

## Notes

`crates/rsvelte_core/src/bin/roundtrip_probe.rs` is the measurement harness every
number here comes from (fallback counting, output digests, single-file emit). It
sits alongside the ten existing ungated measurement bins in `src/bin/`
(`fastpath_coverage`, `oxc_call_counter`, …) and follows the same convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqdHfZSN3LFxPkyKFaCyoF
