### PR TITLE
test(svelte2tsx): fixtures ランナーを shrink-only ratchet 化

### DIFF
--- a/compatibility/svelte2tsx-fixtures-known-failures.json
+++ b/compatibility/svelte2tsx-fixtures-known-failures.json
@@ -1,0 +1,10 @@
+[
+	"attributes-foreign-ns",
+	"module-snippet-component-instance-reference.v5",
+	"props-variable-and-$props.id-destructured.v5",
+	"props-variable-and-$props.id-spread.v5",
+	"props-variable-and-$props.id.v5",
+	"ts-await-generics.v5",
+	"ts-runes-hoistable-props-false-6.v5",
+	"ts-type-assertion"
+]

--- a/compatibility/svelte2tsx-fixtures-known-failures.md
+++ b/compatibility/svelte2tsx-fixtures-known-failures.md
@@ -1,0 +1,93 @@
+# svelte2tsx-fixtures-known-failures.json — why entries are accepted
+
+The svelte2tsx **fixture** gate (`crates/rsvelte_core/tests/svelte2tsx_fixtures.rs`,
+logic in `crates/rsvelte_core/tests/common/svelte2tsx.rs`) runs every sample under
+`submodules/language-tools/packages/svelte2tsx/test/svelte2tsx/samples` and compares
+rsvelte's TSX against the checked-in `expectedv2.ts`. The ratchet may only shrink.
+
+This is a different gate from `svelte2tsx-known-failures.json`, which compares
+rsvelte against **official `svelte2tsx` run live** over the real-world corpus
+(`scripts/compat-corpus/svelte2tsx-verify.mjs`). This one is the upstream
+exact-fixture suite; that one is the real-world volume check.
+
+Until this ratchet existed the runner only *printed* its pass rate and always
+reported `ok`, so none of the entries below were gating anything. Recording them
+is what makes the suite a gate; every entry is a **pre-existing** divergence, not
+a newly accepted one.
+
+Adding an entry requires a written justification here. Removing one requires
+nothing but a green run:
+
+```bash
+UPDATE_S2TSX_FIXTURES_BASELINE=1 cargo test --test svelte2tsx_fixtures
+```
+
+`STRICT_S2TSX_FIXTURES=1` ignores the baseline entirely (every failure fails),
+which is how you check whether an entry is still needed.
+
+## Current baseline: 8 of 254 (pass rate 96.9%)
+
+### Harness gap — 1
+
+- **`attributes-foreign-ns`.** Upstream derives `namespace: 'foreign'` from the
+  sample-name suffix (`test/helpers.ts`: ``sampleName.endsWith('-foreign-ns') ?
+  'foreign' : null``); our `build_options` hardcodes `Svelte2TsxNamespace::Html`.
+  Under the HTML namespace rsvelte lowercases attribute names, so it emits
+  `svelteHTML.createElement("element", { "someattr": …, "someotherattribute": … })`
+  where the fixture expects `"someAttr"` / `"someOtherAttribute"` preserved.
+  Component props (`<Component someAttr="5" />`) already keep their case in both.
+  This is the cheapest entry to remove — it needs a runner change, not a compiler
+  change — but it is out of scope for the PR that introduced this ratchet.
+
+### `$props.id()` mis-resolved as a store — 3
+
+- **`props-variable-and-$props.id.v5`**
+- **`props-variable-and-$props.id-destructured.v5`**
+- **`props-variable-and-$props.id-spread.v5`**
+
+  All three declare a binding literally named `props` and then call `$props.id()`
+  (the Svelte 5 component-id rune). rsvelte's text-level `$name` scan
+  (`collect_store_references` / `collect_loose_dollar_names_from_script` in
+  `crates/rsvelte_core/src/svelte2tsx/script/mod.rs`) sees the `$props`
+  token, finds a declared binding `props`, and injects a store subscription:
+
+  ```
+  let props = $props()/*Ωignore_startΩ*/;let $props = __sveltets_2_store_get(props);/*Ωignore_endΩ*/;
+  ```
+
+  Upstream emits no subscription. `$props.id` is a rune namespace, never a store
+  auto-subscription, so the member-access form must be excluded from the scan even
+  when a same-named binding exists. Fixing this is a single rule in the loose-dollar
+  scanner; the three fixtures are the same bug at three destructuring shapes.
+
+### Statement ordering around `function $$render()` — 2
+
+- **`module-snippet-component-instance-reference.v5`.** A snippet declared in
+  `<script module>` that references a component instance. rsvelte emits the
+  `const iconSnippet = …` declaration **before** `function $$render() {`; upstream
+  emits it inside, as the first statement of the render body.
+
+- **`ts-runes-hoistable-props-false-6.v5`.** `type $$ComponentProps = { someProp:
+  typeof $store }` is hoisted above `function $$render()` by rsvelte even though
+  `$store` is a store subscription that only exists **inside** the render body
+  (`let $store = __sveltets_2_store_get(store)`). Upstream keeps the type inside.
+  A `typeof $<name>` reference to a store subscription must block hoisting —
+  `collect_type_body_deps` (same file) records `typeof IDENT` as a value
+  dependency, but the injected `$store` binding is not in `instance_value_names`,
+  so nothing blocks the hoist.
+
+### Type assertion rewritten in the instance script — 1
+
+- **`ts-type-assertion`.** For `<script context="module">` both sides rewrite
+  `<string>''` to `'' as string`. For the instance script the fixture keeps the
+  angle-bracket form (`let a = <HTMLInputElement>document.querySelector('#id');`)
+  while rsvelte rewrites it to `as`. rsvelte's output is the form that actually
+  parses as TSX, so matching the fixture means *not* rewriting where the rewrite is
+  needed; this one should be confirmed against current upstream behaviour before
+  being "fixed" in rsvelte's favour.
+
+### Whitespace — 1
+
+- **`ts-await-generics.v5`.** One space after `type $$ComponentProps = { prop?: T };`
+  — the fixture has two, rsvelte emits one. Cosmetic in effect, but the gate is
+  byte-exact so it is tracked like any other divergence.

--- a/crates/rsvelte_core/tests/svelte2tsx_fixtures.rs
+++ b/crates/rsvelte_core/tests/svelte2tsx_fixtures.rs
@@ -6,11 +6,62 @@
 //!   cargo test --test svelte2tsx_fixtures -- --nocapture
 //!
 //! Prints per-sample status and a final pass-rate summary.
+//!
+//! Ratchet baseline: `compatibility/svelte2tsx-fixtures-known-failures.json`
+//! (checked in, may only shrink). The test fails when a sample NOT in the
+//! baseline fails (a regression). When previously-known failures now pass, a
+//! reminder to shrink the baseline is printed:
+//!   UPDATE_S2TSX_FIXTURES_BASELINE=1 cargo test --test svelte2tsx_fixtures
+//! `STRICT_S2TSX_FIXTURES=1` ignores the baseline: any failure fails.
 
 mod common;
 
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
 use common::TestStatus;
 use common::svelte2tsx::iter_svelte2tsx_outcomes;
+
+fn baseline_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("compatibility/svelte2tsx-fixtures-known-failures.json")
+}
+
+fn read_baseline() -> BTreeSet<String> {
+    if std::env::var("STRICT_S2TSX_FIXTURES").is_ok() {
+        return BTreeSet::new();
+    }
+    let path = baseline_path();
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return BTreeSet::new();
+    };
+    serde_json::from_str::<Vec<String>>(&text)
+        .unwrap_or_else(|e| panic!("{} is not a JSON string array: {e}", path.display()))
+        .into_iter()
+        .collect()
+}
+
+/// Mirrors the `.mjs` gates' `JSON.stringify(list, null, '\t')` layout so all
+/// ratchet files in `compatibility/` stay diff-comparable.
+fn write_baseline(names: &BTreeSet<String>) {
+    let path = baseline_path();
+    let body = if names.is_empty() {
+        "[]".to_string()
+    } else {
+        let rows: Vec<String> = names
+            .iter()
+            .map(|n| format!("\t{}", serde_json::to_string(n).expect("name serializes")))
+            .collect();
+        format!("[\n{}\n]", rows.join(",\n"))
+    };
+    std::fs::write(&path, body + "\n").expect("baseline is writable");
+    println!(
+        "\n[s2tsx-fixtures] baseline updated: {} known failures -> {}",
+        names.len(),
+        path.display()
+    );
+}
 
 #[test]
 fn test_svelte2tsx_fixtures() {
@@ -28,6 +79,7 @@ fn test_svelte2tsx_fixtures() {
     let mut error_count = 0u32;
     let mut panic_count = 0u32;
     let mut failures: Vec<String> = Vec::new();
+    let mut failing: BTreeSet<String> = BTreeSet::new();
 
     for outcome in &outcomes {
         match outcome.status {
@@ -37,6 +89,7 @@ fn test_svelte2tsx_fixtures() {
             }
             TestStatus::Failed => {
                 failed += 1;
+                failing.insert(outcome.name.clone());
                 let msg = outcome.message.clone().unwrap_or_default();
                 failures.push(format!("FAIL: {}\n{}", outcome.name, msg));
             }
@@ -45,6 +98,7 @@ fn test_svelte2tsx_fixtures() {
             }
             TestStatus::Error => {
                 failed += 1;
+                failing.insert(outcome.name.clone());
                 let msg = outcome.message.clone().unwrap_or_default();
                 if msg.starts_with("PANIC:") {
                     panic_count += 1;
@@ -89,6 +143,51 @@ fn test_svelte2tsx_fixtures() {
             (passed as f64 / total_tested as f64) * 100.0,
             passed,
             total_tested
+        );
+    }
+
+    if std::env::var("UPDATE_S2TSX_FIXTURES_BASELINE").is_ok() {
+        write_baseline(&failing);
+        return;
+    }
+
+    let baseline = read_baseline();
+    let regressions: Vec<&String> = failing.difference(&baseline).collect();
+    let fixed_known: Vec<&String> = baseline.difference(&failing).collect();
+
+    if !fixed_known.is_empty() {
+        println!(
+            "\n[s2tsx-fixtures] 🎉 {} known failures now PASS — shrink the baseline:",
+            fixed_known.len()
+        );
+        for name in &fixed_known {
+            println!("  - {name}");
+        }
+        println!("  UPDATE_S2TSX_FIXTURES_BASELINE=1 cargo test --test svelte2tsx_fixtures");
+    }
+
+    assert!(
+        regressions.is_empty(),
+        "\n[s2tsx-fixtures] ❌ {} NEW failures (not in \
+         compatibility/svelte2tsx-fixtures-known-failures.json):\n{}\n\
+         Fix them, or — only with a written justification in \
+         compatibility/svelte2tsx-fixtures-known-failures.md — record them with\n  \
+         UPDATE_S2TSX_FIXTURES_BASELINE=1 cargo test --test svelte2tsx_fixtures\n\
+         Re-run with `-- --nocapture` to see the diffs.",
+        regressions.len(),
+        regressions
+            .iter()
+            .map(|n| format!("  - {n}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+
+    if failing.is_empty() {
+        println!("\n[s2tsx-fixtures] ✅ all fixtures pass");
+    } else {
+        println!(
+            "\n[s2tsx-fixtures] ✅ no regressions ({} known failures remain)",
+            failing.len()
         );
     }
 }


### PR DESCRIPTION
Closes #1752.

## 問題

`crates/rsvelte_core/tests/svelte2tsx_fixtures.rs` は pass 数を**一切アサートせず**、結果を print するだけでした（`assert!` / `panic!` / `process::exit` がゼロ）。そのため何件失敗しても `test result: ok` を返し、**CI ゲートとして機能していませんでした**。

その結果、実際には 254 件中 8 件が失敗している（246/254 = 96.9%）にもかかわらず、README は「100% パス」、CLAUDE.md は「253/253」と表示したままになっていました。

## 変更

他のゲート（`known-failures.{client,server}.json` / `fmt-known-failures.json` / `svelte2tsx-known-failures.json` / `lint-known-failures.json`）と同じ **shrink-only ratchet** をランナーに導入します。

- `compatibility/svelte2tsx-fixtures-known-failures.json` — 既知失敗 8 件
- `compatibility/svelte2tsx-fixtures-known-failures.md` — **8 件すべてに根本原因レベルの justification**（該当ファイル・関数まで特定）
- baseline 外が 1 件でも失敗したら `panic!`
- baseline 内が pass したら「baseline を縮められる」と表示
- `UPDATE_S2TSX_FIXTURES_BASELINE=1` で baseline 更新、`STRICT_S2TSX_FIXTURES=1` で baseline 無視

## 既知失敗 8 件の内訳

| 分類 | 件数 | 概要 |
|---|---|---|
| ハーネスのギャップ | 1 | `attributes-foreign-ns` — 上流はサンプル名の `-foreign-ns` 接尾辞から `namespace: 'foreign'` を導出するが、こちらは `Html` 固定。**ランナー修正だけで解消可能な最も安価な項目** |
| `$props.id()` をストアと誤認 | 3 | `props` という名前の束縛がある状態で `$props.id()` を呼ぶと、loose-dollar スキャンがストア購読を注入してしまう。ルーン名前空間はストア自動購読ではない |
| `function $$render()` 周りの文の順序 | 2 | snippet 宣言 / `$$ComponentProps` 型が `$$render()` の外に出る。特に後者は `typeof $store` がレンダー本体内にしか存在しない束縛を参照しているためホイスト不可のはず |
| 型アサーションの書き換え | 1 | `ts-type-assertion` — instance script で `<T>expr` → `expr as T` に書き換えている。rsvelte の出力の方が TSX として正しく parse される形なので、**上流の現在の挙動を確認してから**修正方針を決めるべき |
| 空白 | 1 | `ts-await-generics.v5` — スペース 1 個の差 |

**この PR では 8 件の修正は行いません**（ratchet 導入がスコープ）。`README.md` / `CLAUDE.md` の数値も、compatibility-report 側の総数との整合が必要なため別途対応します。

## 検証

- 通常実行: `ok`（8 件は既知として許容）
- `STRICT_S2TSX_FIXTURES=1`: **FAILED**（8 件が正しく検出される）
- baseline から 1 件（`ts-await-generics.v5`）を外して実行: **exit 101 で FAILED**、当該サンプル名を明示して baseline 更新コマンドを案内 — ゲートが実際に機能することを確認済み
- `cargo clippy --all-targets --all-features -- -D warnings`: クリーン