### PR TITLE
feat(bench): add a linter benchmark (rsvelte-lint vs eslint-plugin-svelte)

### DIFF
--- a/.github/workflows/site-benchmark.yml
+++ b/.github/workflows/site-benchmark.yml
@@ -3,8 +3,9 @@ name: Site Benchmark
 # Produces the JS-vs-Rust benchmark JSON that the /benchmark page on the docs
 # site renders (`apps/playground/static/benchmark-results.json`). This is
 # deliberately a manual, on-demand job — the numbers do not move per-push, and
-# running the full five-task comparison (compile-client / parse / svelte2tsx /
-# fmt / svelte-check) takes long enough that gating CI on it would be wasteful.
+# running the full comparison (compile-client / compile-server / parse /
+# svelte2tsx / fmt / lint / svelte-check) takes long enough that gating CI on it
+# would be wasteful.
 #
 # Flow: dispatch this workflow from a local checkout
 #   gh workflow run site-benchmark.yml
@@ -72,8 +73,9 @@ jobs:
 
       # The JS baselines (svelte/compiler, svelte2tsx, language-server,
       # svelte-check) are rollup/tsc build outputs that run-benchmark.mjs
-      # bootstraps on demand. Cache them keyed by submodule SHA so warm runs
-      # skip the ~several-minute build chain.
+      # bootstraps on demand; the `lint` baseline is the parity corpus' isolated
+      # eslint-plugin-svelte install, which it bootstraps the same way. Cache
+      # them keyed by submodule SHA so warm runs skip the build/install chain.
       - name: Cache JS baseline builds
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -89,7 +91,8 @@ jobs:
             submodules/language-tools/packages/svelte2tsx/index.mjs
             submodules/language-tools/packages/language-server/dist
             submodules/language-tools/packages/svelte-check/dist
-          key: js-baselines-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
+            scripts/compat-corpus/lint-oracle/node_modules
+          key: js-baselines-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules', 'scripts/compat-corpus/lint-oracle/package.json') }}
 
       # prettier + prettier-plugin-svelte (the JS `fmt` baseline) resolve from
       # the repo-root node_modules.
@@ -109,7 +112,7 @@ jobs:
       - name: Build Rust benchmark harnesses
         run: |
           cargo build --release --bin benchmark_runner --bin svelte_check
-          cargo build --profile=bench --bin fmt_benchmark_runner
+          cargo build --profile=bench --bin fmt_benchmark_runner --bin lint_benchmark_runner
         timeout-minutes: 45
 
       - name: Run benchmark
@@ -124,7 +127,7 @@ jobs:
         run: |
           echo '### Benchmark results' >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
-          node -e "const r=require('./benchmark-results.json');console.log(JSON.stringify({generatedAt:r.generatedAt,commitSha:r.commitSha,runner:r.runner,testFilesCount:r.testFilesCount,compileClient:r.speedup,parse:r.parse.speedup,svelte2tsx:r.svelte2tsx?.speedup,fmt:r.fmt?.speedup,svelteCheck:r.svelteCheck?.speedup},null,2))" >> "$GITHUB_STEP_SUMMARY"
+          node -e "const r=require('./benchmark-results.json');console.log(JSON.stringify({generatedAt:r.generatedAt,commitSha:r.commitSha,runner:r.runner,testFilesCount:r.testFilesCount,compileClient:r.speedup,parse:r.parse.speedup,svelte2tsx:r.svelte2tsx?.speedup,fmt:r.fmt?.speedup,lint:r.lint?.speedup,svelteCheck:r.svelteCheck?.speedup},null,2))" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload benchmark JSON

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,8 @@ compatibility/verify-svelte-compat/
 # they're outputs of local tooling (benchmarks, profilers, code-review
 # skills) that get regenerated on demand and should not pollute git.
 .benchmark-files.txt
+.benchmark-lint-rules.json
+.benchmark-lint-config.json
 benchmark-results.json
 .perf-log.md
 .perf/

--- a/README.md
+++ b/README.md
@@ -174,17 +174,23 @@ Multi-threaded rsvelte vs. the official JavaScript tool, same machine, same corp
 
 | Task | JS baseline | Rust (1 thread) | Rust (multi) | Multi vs JS |
 |---|---:|---:|---:|---:|
-| Compile — client (full pipeline) | 750.8 ms | 245.2 ms | 34.9 ms | **21.5×** |
-| Compile — server (SSR) | 600.1 ms | 138.7 ms | 20.6 ms | **29.2×** |
-| Parse only | 173.9 ms | 9.3 ms | 2.9 ms | **60.5×** |
-| `svelte2tsx` | 288.5 ms | 95.1 ms | 13.3 ms | **21.7×** |
-| Format (vs prettier-plugin-svelte) | 3,060.0 ms | 79.1 ms | 15.1 ms | **202.2×** |
-| `svelte-check` (500-file workspace) | 1,105.7 ms | 39.3 ms | 13.3 ms | **82.9×** |
+| Compile — client (full pipeline) | 746.8 ms | 248.3 ms | 34.1 ms | **21.9×** |
+| Compile — server (SSR) | 603.5 ms | 140.3 ms | 21.6 ms | **27.9×** |
+| Parse only | 175.2 ms | 9.3 ms | 2.9 ms | **61.3×** |
+| `svelte2tsx` | 288.8 ms | 95.5 ms | 15.5 ms | **18.7×** |
+| Format (vs prettier-plugin-svelte) | 3,102.6 ms | 82.6 ms | 15.4 ms | **201.5×** |
+| Lint (vs eslint + eslint-plugin-svelte) | 6,305.0 ms | 1,625.7 ms | 253.3 ms | **24.9×** |
+| `svelte-check` (500-file workspace) | 1,121.0 ms | 41.3 ms | 13.3 ms | **84.5×** |
 
 The corpus is Svelte's own test suite, restricted to the 3,412 of 3,869 files the official compiler
 accepts under the benchmark's options — otherwise the numbers would partly measure how fast each
 compiler throws. Of the 457 excluded, 290 are valid sources that merely need `experimental.async`
 (which the benchmark does not enable) and 167 are deliberately invalid error-case fixtures.
+
+The lint row runs **the same 72 rules on both sides** — the rule universe the
+[lint output-parity gate](#verified-against-real-world-code-not-just-fixtures) diffs, so speed and
+parity are measured over identical work. It is a conservative figure: `rsvelte-lint` additionally
+runs its compiler validator pass on every file, which the ESLint side does not.
 
 Because the corpus is Svelte's test suite, files are small (~236 bytes on average) and the numbers
 are dominated by per-file fixed costs rather than throughput on realistic components.

--- a/apps/playground/src/lib/types/benchmark.ts
+++ b/apps/playground/src/lib/types/benchmark.ts
@@ -20,6 +20,13 @@ export interface SvelteCheckBenchmarkTaskResults extends BenchmarkTaskResults {
 	filesCount: number;
 }
 
+export interface LintBenchmarkTaskResults extends BenchmarkTaskResults {
+	// Rules enabled on BOTH sides of the lint comparison (the parity corpus'
+	// rule universe) — a lint benchmark only means something alongside the
+	// rule count it measured.
+	rulesCount: number;
+}
+
 export interface RunnerInfo {
 	// Free-form label that names the host. In CI this is the GitHub-hosted
 	// runner label (e.g. "ubuntu-22.04-arm-16-cores"); locally it's "local".
@@ -49,5 +56,8 @@ export interface BenchmarkResults extends BenchmarkTaskResults {
 	// rsvelte_formatter vs prettier-plugin-svelte. Optional — older JSON
 	// snapshots predate the fmt task.
 	fmt?: BenchmarkTaskResults;
+	// rsvelte_lint vs eslint + eslint-plugin-svelte. Optional — older JSON
+	// snapshots predate the lint task.
+	lint?: LintBenchmarkTaskResults;
 	svelteCheck?: SvelteCheckBenchmarkTaskResults;
 }

--- a/apps/playground/src/routes/benchmark/+page.svelte
+++ b/apps/playground/src/routes/benchmark/+page.svelte
@@ -10,7 +10,7 @@
 
 	let { data }: { data: PageData } = $props();
 
-	type TaskId = 'full' | 'full-ssr' | 'parse' | 'svelte2tsx' | 'fmt' | 'svelte-check';
+	type TaskId = 'full' | 'full-ssr' | 'parse' | 'svelte2tsx' | 'fmt' | 'lint' | 'svelte-check';
 
 	// `animationTime` is the elapsed wall-clock ms since the run started.
 	// Each bar across every task shows `min(animationTime, this.durationMs)`,
@@ -94,6 +94,16 @@
 				group: 'ecosystem',
 				baseline: 'prettier-plugin-svelte',
 				data: r.fmt
+			});
+		}
+		if (r.lint) {
+			list.push({
+				id: 'lint',
+				label: 'Lint',
+				sub: `linter · ${r.lint.rulesCount} shared rules`,
+				group: 'ecosystem',
+				baseline: 'eslint + eslint-plugin-svelte',
+				data: r.lint
 			});
 		}
 		if (r.svelteCheck) {
@@ -333,7 +343,7 @@
 				<pre><code><span class="c-cmt"># 1. Build the Rust compiler in release mode</span>
 <span class="c-prompt">$</span> cargo build <span class="c-flag">--release</span>
 
-<span class="c-cmt"># 2. Run the corpus benchmark (compile / parse / svelte2tsx / fmt / svelte-check)</span>
+<span class="c-cmt"># 2. Run the corpus benchmark (compile / parse / svelte2tsx / fmt / lint / svelte-check)</span>
 <span class="c-prompt">$</span> pnpm run generate-benchmark
 
 <span class="c-cmt"># 3. View the report locally</span>

--- a/apps/playground/static/benchmark-results.json
+++ b/apps/playground/static/benchmark-results.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-25T03:36:37.470Z",
-  "commitSha": "8e3f438a",
+  "generatedAt": "2026-07-25T06:21:31.618Z",
+  "commitSha": "801b0381",
   "runner": {
     "label": "local",
     "os": "darwin",
@@ -9,206 +9,240 @@
     "cpuModel": "Apple M1 Pro",
     "nodeVersion": "24.13.0",
     "v8Version": "13.6.233.17-node.37",
-    "loadAvg1min": 2.71337890625,
+    "loadAvg1min": 2.09619140625,
     "warmupIterations": 3,
     "benchmarkIterations": 10
   },
   "testFilesCount": 3412,
   "excludedFilesCount": 457,
   "javascript": {
-    "durationMs": 750.8057289999992,
-    "throughputFilesPerSec": 4544.451205166554,
-    "minMs": 720.8946250000008,
-    "maxMs": 782.2104580000005,
-    "meanMs": 748.5770334,
-    "stdDevMs": 18.89448629347508,
+    "durationMs": 746.8195830000004,
+    "throughputFilesPerSec": 4568.707192028732,
+    "minMs": 729.1722919999993,
+    "maxMs": 771.6621669999995,
+    "meanMs": 746.8453875999998,
+    "stdDevMs": 11.515704988597477,
     "samples": 10
   },
   "rustSingleThread": {
-    "durationMs": 245.20510000000002,
-    "throughputFilesPerSec": 13914.88186828088,
-    "minMs": 244.5518,
-    "maxMs": 246.0884,
-    "meanMs": 245.26798000000002,
-    "stdDevMs": 0.405433197456751,
+    "durationMs": 248.34235,
+    "throughputFilesPerSec": 13739.098466290585,
+    "minMs": 245.9711,
+    "maxMs": 253.8783,
+    "meanMs": 248.76124,
+    "stdDevMs": 2.382089395131927,
     "samples": 10
   },
   "rustMultiThread": {
-    "durationMs": 34.87215,
-    "throughputFilesPerSec": 97843.12122997866,
-    "minMs": 32.777,
-    "maxMs": 37.7151,
-    "meanMs": 34.88951,
-    "stdDevMs": 1.8544247557935591,
+    "durationMs": 34.082750000000004,
+    "throughputFilesPerSec": 100109.29282408254,
+    "minMs": 32.0675,
+    "maxMs": 38.2017,
+    "meanMs": 34.14474,
+    "stdDevMs": 1.6394730923074035,
     "samples": 10
   },
   "speedup": {
-    "singleThreadVsJs": 3.0619498901123965,
-    "multiThreadVsJs": 21.53023914499104
+    "singleThreadVsJs": 3.0072179916152053,
+    "multiThreadVsJs": 21.911952028518836
   },
   "compileServer": {
     "javascript": {
-      "durationMs": 600.0790204999994,
-      "throughputFilesPerSec": 5685.917826550651,
-      "minMs": 587.8928750000014,
-      "maxMs": 617.1245420000014,
-      "meanMs": 602.2624875000001,
-      "stdDevMs": 8.767506170893114,
+      "durationMs": 603.4865415000004,
+      "throughputFilesPerSec": 5653.812911087095,
+      "minMs": 591.1476659999971,
+      "maxMs": 616.7404590000006,
+      "meanMs": 603.1380833999999,
+      "stdDevMs": 8.019756161314818,
       "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 138.6997,
-      "throughputFilesPerSec": 24599.909012059863,
-      "minMs": 138.3315,
-      "maxMs": 139.4955,
-      "meanMs": 138.71674000000002,
-      "stdDevMs": 0.34223539326025054,
+      "durationMs": 140.27465,
+      "throughputFilesPerSec": 24323.71066333083,
+      "minMs": 139.243,
+      "maxMs": 142.3689,
+      "meanMs": 140.3127,
+      "stdDevMs": 0.8509017839915467,
       "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 20.56185,
-      "throughputFilesPerSec": 165938.37616751413,
-      "minMs": 18.5512,
-      "maxMs": 22.8272,
-      "meanMs": 20.65922,
-      "stdDevMs": 1.7073601516961792,
+      "durationMs": 21.59435,
+      "throughputFilesPerSec": 158004.29278954913,
+      "minMs": 18.3577,
+      "maxMs": 23.7556,
+      "meanMs": 21.44681,
+      "stdDevMs": 1.7855792211212584,
       "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 4.3264622814613105,
-      "multiThreadVsJs": 29.184096786038193
+      "singleThreadVsJs": 4.30217820183476,
+      "multiThreadVsJs": 27.946501816447377
     }
   },
   "parse": {
     "javascript": {
-      "durationMs": 173.8689164999978,
-      "throughputFilesPerSec": 19623.979194694315,
-      "minMs": 170.34825000000274,
-      "maxMs": 181.18483399999968,
-      "meanMs": 174.0598958999999,
-      "stdDevMs": 3.0511911697688396,
+      "durationMs": 175.23118749999958,
+      "throughputFilesPerSec": 19471.419720875932,
+      "minMs": 171.62637499999983,
+      "maxMs": 182.48558400000184,
+      "meanMs": 175.68847090000017,
+      "stdDevMs": 3.096398971501207,
       "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 9.29925,
-      "throughputFilesPerSec": 366911.3100518859,
-      "minMs": 9.2949,
-      "maxMs": 9.3414,
-      "meanMs": 9.30432,
-      "stdDevMs": 0.01347885751835058,
+      "durationMs": 9.33065,
+      "throughputFilesPerSec": 365676.56058259605,
+      "minMs": 9.2879,
+      "maxMs": 9.546,
+      "meanMs": 9.35202,
+      "stdDevMs": 0.07813850267313788,
       "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 2.8735999999999997,
-      "throughputFilesPerSec": 1187360.8017817372,
-      "minMs": 1.5892,
-      "maxMs": 2.9256,
-      "meanMs": 2.6095499999999996,
-      "stdDevMs": 0.5046528316575664,
+      "durationMs": 2.85905,
+      "throughputFilesPerSec": 1193403.403228345,
+      "minMs": 1.6416,
+      "maxMs": 2.9173,
+      "meanMs": 2.7470499999999998,
+      "stdDevMs": 0.369738137740753,
       "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 18.697090249213407,
-      "multiThreadVsJs": 60.50560847021082
+      "singleThreadVsJs": 18.780169387984714,
+      "multiThreadVsJs": 61.29000454696476
     }
   },
   "svelte2tsx": {
     "javascript": {
-      "durationMs": 288.5428129999964,
-      "throughputFilesPerSec": 11824.934970742253,
-      "minMs": 283.3640419999938,
-      "maxMs": 316.51837499999965,
-      "meanMs": 292.7743958999963,
-      "stdDevMs": 10.476209245996479,
+      "durationMs": 288.7904374999998,
+      "throughputFilesPerSec": 11814.795633598505,
+      "minMs": 285.03224999999657,
+      "maxMs": 316.594290999994,
+      "meanMs": 293.52182909999755,
+      "stdDevMs": 9.965896026808151,
       "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 95.09455,
-      "throughputFilesPerSec": 35880.079352602224,
-      "minMs": 94.742,
-      "maxMs": 96.3838,
-      "meanMs": 95.31469999999999,
-      "stdDevMs": 0.5450571236118275,
+      "durationMs": 95.5216,
+      "throughputFilesPerSec": 35719.669687274916,
+      "minMs": 94.9249,
+      "maxMs": 96.1997,
+      "meanMs": 95.5329,
+      "stdDevMs": 0.3560883766707393,
       "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 13.2966,
-      "throughputFilesPerSec": 256606.95215318204,
-      "minMs": 13.0071,
-      "maxMs": 16.0016,
-      "meanMs": 14.103110000000001,
-      "stdDevMs": 1.1430574696400877,
+      "durationMs": 15.45205,
+      "throughputFilesPerSec": 220812.12525198923,
+      "minMs": 13.4067,
+      "maxMs": 18.1381,
+      "meanMs": 15.139890000000003,
+      "stdDevMs": 1.3476276922429282,
       "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 3.0342728684240727,
-      "multiThreadVsJs": 21.7004958410418
+      "singleThreadVsJs": 3.02329983480176,
+      "multiThreadVsJs": 18.689457871285676
     }
   },
   "fmt": {
     "javascript": {
-      "durationMs": 3059.9839379999976,
-      "throughputFilesPerSec": 1115.0385325976843,
-      "minMs": 3041.1240830000024,
-      "maxMs": 3091.2462499999965,
-      "meanMs": 3062.216425000001,
-      "stdDevMs": 17.536413053829094,
+      "durationMs": 3102.6074584999988,
+      "throughputFilesPerSec": 1099.7201694504988,
+      "minMs": 3055.197,
+      "maxMs": 3315.8620420000007,
+      "meanMs": 3128.7384001,
+      "stdDevMs": 75.52570085797592,
       "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 79.1396,
-      "throughputFilesPerSec": 43113.687711335406,
-      "minMs": 78.8125,
-      "maxMs": 80.2001,
-      "meanMs": 79.24367,
-      "stdDevMs": 0.4507445086742628,
+      "durationMs": 82.59175,
+      "throughputFilesPerSec": 41311.63221508201,
+      "minMs": 82.233,
+      "maxMs": 84.6404,
+      "meanMs": 82.87982,
+      "stdDevMs": 0.6958476468308269,
       "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 15.1327,
-      "throughputFilesPerSec": 225471.99111857105,
-      "minMs": 12.5385,
-      "maxMs": 18.4256,
-      "meanMs": 15.14468,
-      "stdDevMs": 1.4827021317850728,
+      "durationMs": 15.39625,
+      "throughputFilesPerSec": 221612.40561825118,
+      "minMs": 14.7587,
+      "maxMs": 17.5692,
+      "meanMs": 15.69408,
+      "stdDevMs": 0.7721001240771818,
       "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 38.665648272167125,
-      "multiThreadVsJs": 202.21004434106257
+      "singleThreadVsJs": 37.56558564868765,
+      "multiThreadVsJs": 201.51708750507422
     }
+  },
+  "lint": {
+    "javascript": {
+      "durationMs": 6305.038645500001,
+      "throughputFilesPerSec": 541.1544943400459,
+      "minMs": 6108.343333999997,
+      "maxMs": 6651.758291999999,
+      "meanMs": 6326.6641417,
+      "stdDevMs": 148.3145141106088,
+      "samples": 10
+    },
+    "rustSingleThread": {
+      "durationMs": 1625.7017500000002,
+      "throughputFilesPerSec": 2098.785955049873,
+      "minMs": 1623.4143,
+      "maxMs": 1631.7027,
+      "meanMs": 1626.26026,
+      "stdDevMs": 2.2354252594081725,
+      "samples": 10
+    },
+    "rustMultiThread": {
+      "durationMs": 253.3426,
+      "throughputFilesPerSec": 13467.928409987107,
+      "minMs": 240.2381,
+      "maxMs": 296.7761,
+      "meanMs": 258.50486,
+      "stdDevMs": 17.10939334676715,
+      "samples": 10
+    },
+    "speedup": {
+      "singleThreadVsJs": 3.8783489317766926,
+      "multiThreadVsJs": 24.88740008786521
+    },
+    "rulesCount": 72
   },
   "svelteCheck": {
     "javascript": {
-      "durationMs": 1105.6864580000001,
-      "throughputFilesPerSec": 452.2077632246808,
-      "minMs": 1097.2755,
-      "maxMs": 1114.860417,
-      "meanMs": 1105.8646376,
-      "stdDevMs": 5.233028109151084,
+      "durationMs": 1121.0481249999998,
+      "throughputFilesPerSec": 446.0111826153762,
+      "minMs": 1113.938375,
+      "maxMs": 1126.564416,
+      "meanMs": 1121.0591583,
+      "stdDevMs": 4.126489160224442,
       "samples": 10
     },
     "rustSingleThread": {
-      "durationMs": 39.321124999999995,
-      "throughputFilesPerSec": 12715.8111574885,
-      "minMs": 39.135542,
-      "maxMs": 40.185666,
-      "meanMs": 39.521887400000004,
-      "stdDevMs": 0.39634703987091907,
+      "durationMs": 41.330542,
+      "throughputFilesPerSec": 12097.591171197319,
+      "minMs": 39.625583,
+      "maxMs": 43.387417,
+      "meanMs": 41.4403751,
+      "stdDevMs": 1.042998372122455,
       "samples": 10
     },
     "rustMultiThread": {
-      "durationMs": 13.343125,
-      "throughputFilesPerSec": 37472.48114665792,
-      "minMs": 13.103625,
-      "maxMs": 13.587541,
-      "meanMs": 13.372508100000001,
-      "stdDevMs": 0.1538679006254718,
+      "durationMs": 13.259854,
+      "throughputFilesPerSec": 37707.805832552905,
+      "minMs": 12.931125,
+      "maxMs": 13.717166,
+      "meanMs": 13.301899800000001,
+      "stdDevMs": 0.2462847565582575,
       "samples": 10
     },
     "speedup": {
-      "singleThreadVsJs": 28.119400398640686,
-      "multiThreadVsJs": 82.86562990303996
+      "singleThreadVsJs": 27.12396379897461,
+      "multiThreadVsJs": 84.54453005289498
     },
     "filesCount": 500
   }

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -20,6 +20,13 @@ name = "rsvelte-lint"
 path = "src/main.rs"
 required-features = ["cli"]
 
+# Benchmark driver invoked by `scripts/bench/run-benchmark.mjs` for the `lint`
+# task (the ESLint + eslint-plugin-svelte comparison).
+[[bin]]
+name = "lint_benchmark_runner"
+path = "src/bin/lint_benchmark_runner.rs"
+required-features = ["cli"]
+
 [features]
 default = ["cli"]
 # The CLI: native compiler backend + ESLint-config import + the bin's runtime

--- a/crates/rsvelte_lint/src/bin/lint_benchmark_runner.rs
+++ b/crates/rsvelte_lint/src/bin/lint_benchmark_runner.rs
@@ -1,0 +1,256 @@
+//! Benchmark runner for the `lint` task.
+//!
+//! Mirrors `rsvelte_fmt`'s `fmt_benchmark_runner` (same CLI surface and JSON
+//! output) but lints `.svelte` sources with [`rsvelte_lint::lint_source`].
+//!
+//! `--config` takes the same JSON config the `rsvelte-lint` CLI accepts, so
+//! `scripts/bench/run-benchmark.mjs` can enable exactly the rule universe the
+//! ESLint baseline runs — a lint benchmark is only meaningful when both sides
+//! evaluate the same rules.
+//!
+//! Invoked under the `bench` profile (`panic = "unwind"`) so the per-file
+//! `catch_unwind` below actually isolates a panic instead of aborting the run:
+//!
+//! ```text
+//! cargo run --profile=bench --bin lint_benchmark_runner -- \
+//!     --mode single|multi --files <list> --config <json> --iterations N --warmup N
+//! ```
+//!
+//! Output (stdout): `{"times": [<ms>, ...]}`.
+
+use std::env;
+use std::fs;
+use std::io::{self, BufRead};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use rayon::prelude::*;
+use rsvelte_core::CompileOptions;
+use rsvelte_lint::{LintConfig, lint_source};
+
+/// Files the linter panicked on across the whole run, reported once at the end
+/// rather than aborting a multi-thousand-file benchmark.
+static PANIC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct Config {
+    mode: String,
+    files_path: String,
+    config_path: String,
+    iterations: usize,
+    warmup: usize,
+    list_rules: bool,
+}
+
+fn parse_args() -> Result<Config, String> {
+    let args: Vec<String> = env::args().collect();
+    let mut mode = String::from("single");
+    let mut files_path = String::new();
+    let mut config_path = String::new();
+    let mut iterations = 5;
+    let mut warmup = 2;
+    let mut list_rules = false;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            // Same output as `rsvelte-lint --list-rules`, so the benchmark can
+            // derive the shared rule universe without also building the CLI.
+            "--list-rules" => {
+                list_rules = true;
+            }
+            "--mode" => {
+                i += 1;
+                if i < args.len() {
+                    mode = args[i].clone();
+                }
+            }
+            // Accepted and ignored: this runner only has one task, but keeping
+            // the flag lets `run-benchmark.mjs` pass `--task lint` uniformly.
+            "--task" => {
+                i += 1;
+            }
+            "--files" => {
+                i += 1;
+                if i < args.len() {
+                    files_path = args[i].clone();
+                }
+            }
+            "--config" => {
+                i += 1;
+                if i < args.len() {
+                    config_path = args[i].clone();
+                }
+            }
+            "--iterations" => {
+                i += 1;
+                if i < args.len() {
+                    match args[i].parse() {
+                        Ok(n) => iterations = n,
+                        Err(_) => eprintln!(
+                            "warning: invalid --iterations value '{}', using default {}",
+                            args[i], iterations
+                        ),
+                    }
+                }
+            }
+            "--warmup" => {
+                i += 1;
+                if i < args.len() {
+                    match args[i].parse() {
+                        Ok(n) => warmup = n,
+                        Err(_) => eprintln!(
+                            "warning: invalid --warmup value '{}', using default {}",
+                            args[i], warmup
+                        ),
+                    }
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    if files_path.is_empty() && !list_rules {
+        return Err("--files argument is required".to_string());
+    }
+
+    Ok(Config {
+        mode,
+        files_path,
+        config_path,
+        iterations,
+        warmup,
+        list_rules,
+    })
+}
+
+fn load_files(files_path: &str) -> io::Result<Vec<(String, String)>> {
+    let file = fs::File::open(files_path)?;
+    let reader = io::BufReader::new(file);
+    let mut files = Vec::new();
+
+    for line in reader.lines() {
+        let path = line?;
+        if path.is_empty() {
+            continue;
+        }
+        if let Ok(content) = fs::read_to_string(&path) {
+            files.push((path, content));
+        }
+    }
+
+    Ok(files)
+}
+
+fn load_config(config_path: &str) -> Result<LintConfig, String> {
+    if config_path.is_empty() {
+        return Ok(LintConfig::recommended());
+    }
+    let raw = fs::read_to_string(config_path).map_err(|e| format!("{config_path}: {e}"))?;
+    LintConfig::from_json_str(&raw).map_err(|e| format!("{config_path}: {e}"))
+}
+
+fn lint_one(path: &str, source: &str, config: &LintConfig) {
+    let file = Path::new(path);
+    let options = CompileOptions {
+        filename: Some(path.to_string()),
+        ..Default::default()
+    };
+    // Diagnostics are dropped: the benchmark times work, not correctness (the
+    // lint-parity corpus covers correctness).
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        lint_source(source, file, &options, config)
+    }));
+    if result.is_err() {
+        PANIC_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn run_single_threaded(files: &[(String, String)], config: &LintConfig) {
+    for (path, content) in files {
+        lint_one(path, content, config);
+    }
+}
+
+fn run_multi_threaded(files: &[(String, String)], config: &LintConfig) {
+    files
+        .par_iter()
+        .for_each(|(path, content)| lint_one(path, content, config));
+}
+
+fn main() {
+    let config = match parse_args() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if config.list_rules {
+        print!("{}", rsvelte_lint::presets::list_rules());
+        return;
+    }
+
+    let files = match load_files(&config.files_path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error loading files: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let lint_config = match load_config(&config.config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error loading lint config: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    eprintln!(
+        "Loaded {} files, mode: {}, task: lint, iterations: {}, warmup: {}",
+        files.len(),
+        config.mode,
+        config.iterations,
+        config.warmup
+    );
+
+    // Swallow per-panic backtrace spam; one aggregate count is reported below.
+    std::panic::set_hook(Box::new(|_| {}));
+
+    let is_multi = config.mode == "multi";
+
+    for _ in 0..config.warmup {
+        if is_multi {
+            run_multi_threaded(&files, &lint_config);
+        } else {
+            run_single_threaded(&files, &lint_config);
+        }
+    }
+
+    let mut times = Vec::with_capacity(config.iterations);
+    for _ in 0..config.iterations {
+        let start = Instant::now();
+        if is_multi {
+            run_multi_threaded(&files, &lint_config);
+        } else {
+            run_single_threaded(&files, &lint_config);
+        }
+        times.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    let panics = PANIC_COUNT.load(Ordering::Relaxed);
+    if panics > 0 {
+        let passes = config.warmup + config.iterations;
+        eprintln!(
+            "note: linter panicked on ~{} file(s) (skipped, not counted as work)",
+            panics / passes.max(1)
+        );
+    }
+
+    let times_json: Vec<String> = times.iter().map(|t| format!("{t:.4}")).collect();
+    println!("{{\"times\": [{}]}}", times_json.join(", "));
+}

--- a/scripts/bench/run-benchmark.mjs
+++ b/scripts/bench/run-benchmark.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Benchmark script that measures JS vs Rust compiler performance across
- * five tasks: compile-client, compile-server, parse, svelte2tsx, svelte-check.
+ * Benchmark script that measures JS vs Rust performance across seven tasks:
+ * compile-client, compile-server, parse, svelte2tsx, fmt, lint, svelte-check.
  *
  * The JS baselines (`svelte/compiler`, `svelte2tsx`, `svelte-check`) live in
  * submodules and publish their consumable entrypoints as rollup build
@@ -84,6 +84,14 @@ function ensureBenchDeps() {
 			console.error(`[run-benchmark] building language-tools/${pkg.name} (one-time)…`);
 			run(pkg.cmd, pkg.cwd);
 		}
+	}
+
+	// 3. The lint baseline is the real eslint-plugin-svelte, installed in the
+	// parity corpus' isolated oracle package (same pin the lint gate compares
+	// against) rather than as a root devDependency.
+	if (!built('scripts/compat-corpus/lint-oracle/node_modules/eslint-plugin-svelte')) {
+		console.error('[run-benchmark] installing lint oracle (one-time)…');
+		run('npm install --no-package-lock', 'scripts/compat-corpus/lint-oracle');
 	}
 }
 
@@ -262,21 +270,21 @@ function benchmarkJavaScript(files, iterations, task) {
  * `rsvelte_fmt` (the formatter can't live in the compiler crate without a
  * dependency cycle). Both share the same CLI + JSON-output contract.
  */
-async function benchmarkRust(files, singleThread, task, binName = 'benchmark_runner') {
+async function benchmarkRust(files, singleThread, task, binName = 'benchmark_runner', extraArgs = []) {
 	const mode = singleThread ? 'single' : 'multi';
 
 	const fileList = files.map((f) => f.path).join('\n');
 	const tempFile = join(__dirname, '../../.benchmark-files.txt');
 	writeFileSync(tempFile, fileList);
 
-	// `profile.release` sets `panic = "abort"`, so a formatter panic on a
-	// malformed corpus file would kill the whole run. The fmt runner relies
-	// on `catch_unwind` to skip such files, which only works under a profile
-	// with `panic = "unwind"` — that's exactly what `profile.bench` is for
-	// (it inherits release's optimisation flags, so the timings stay
+	// `profile.release` sets `panic = "abort"`, so a formatter/linter panic on
+	// a malformed corpus file would kill the whole run. Both runners rely on
+	// `catch_unwind` to skip such files, which only works under a profile with
+	// `panic = "unwind"` — that's exactly what `profile.bench` is for (it
+	// inherits release's optimisation flags, so the timings stay
 	// representative). Compiler tasks don't panic on this corpus, so they
 	// keep the faster-to-link release profile.
-	const profileFlag = binName === 'fmt_benchmark_runner' ? '--profile=bench' : '--release';
+	const profileFlag = binName === 'benchmark_runner' ? '--release' : '--profile=bench';
 
 	return new Promise((resolve, reject) => {
 		const args = [
@@ -295,6 +303,7 @@ async function benchmarkRust(files, singleThread, task, binName = 'benchmark_run
 			String(BENCHMARK_ITERATIONS),
 			'--warmup',
 			String(WARMUP_ITERATIONS),
+			...extraArgs,
 		];
 
 		const proc = spawn('cargo', args, {
@@ -544,6 +553,133 @@ async function runFmtTask(files) {
 	};
 }
 
+// The `lint` task pits ESLint + eslint-plugin-svelte against `rsvelte_lint`
+// over the shared per-file corpus.
+//
+// Fairness rests on one thing: **both sides must evaluate the same rules.** A
+// linter's cost is the sum of its enabled rules, so comparing rsvelte's rule
+// set against the plugin's `recommended` preset would measure preset
+// composition, not implementation speed. Both sides therefore run the parity
+// corpus' rule universe (`scripts/compat-corpus/lint-universe.mjs`) — the
+// intersection of "rules rsvelte implements" and "rules the pinned plugin
+// exposes", minus the handful that are structurally incomparable (type-aware
+// rules the oracle can't evaluate without a checker, and the compiler
+// meta-rules whose cost is the compiler's, not the linter's). That is the same
+// universe the lint output-parity gate diffs, so speed and parity are measured
+// over identical work.
+//
+// The JS side is timed in-process by the oracle's own `run.mjs --bench`, so
+// neither side pays node startup or ESLint config resolution inside the
+// measured loop, and both pre-read every source before timing starts.
+//
+// One asymmetry is left in deliberately, and it counts AGAINST rsvelte:
+// `rsvelte-lint` always runs its compiler validator pass (the analyzer's own
+// warnings are part of what the tool reports), while the ESLint side's
+// equivalent — `svelte/valid-compile` — sits outside the shared universe. The
+// reported ratio therefore understates a rule-engine-only comparison.
+
+const LINT_BENCH_BIN = join(REPO_ROOT, 'target/release/lint_benchmark_runner');
+const LINT_ORACLE_DIR = join(REPO_ROOT, 'scripts/compat-corpus/lint-oracle');
+
+function ensureLintBenchRunnerBuilt() {
+	if (existsSync(LINT_BENCH_BIN)) return;
+	console.error('  Building lint_benchmark_runner (one-time)...');
+	// `--profile=bench` for the same reason the fmt runner uses it: the runner
+	// isolates a per-file panic with `catch_unwind`, which needs unwinding.
+	const r = spawnSync(
+		'cargo',
+		['build', '--profile=bench', '--bin', 'lint_benchmark_runner'],
+		{ cwd: REPO_ROOT, stdio: ['ignore', 2, 'inherit'] },
+	);
+	if (r.status !== 0) throw new Error('cargo build --bin lint_benchmark_runner failed');
+}
+
+async function runLintTask(files) {
+	console.error('\n=== lint ===');
+
+	ensureLintBenchRunnerBuilt();
+	const { ruleUniverse } = await import('../compat-corpus/lint-universe.mjs');
+	const universe = ruleUniverse(LINT_BENCH_BIN);
+	console.error(`  Rule universe: ${universe.length} rules enabled on both sides`);
+
+	const rulesFile = join(REPO_ROOT, '.benchmark-lint-rules.json');
+	const configFile = join(REPO_ROOT, '.benchmark-lint-config.json');
+	writeFileSync(rulesFile, JSON.stringify(universe));
+	writeFileSync(
+		configFile,
+		JSON.stringify({
+			extends: ['none'],
+			rules: Object.fromEntries(universe.map((id) => [id, 'warn'])),
+		}),
+	);
+
+	console.error('  Benchmarking JavaScript (eslint + eslint-plugin-svelte)...');
+	const jsProc = spawnSync(
+		'node',
+		[
+			'run.mjs',
+			'--rules',
+			rulesFile,
+			'--stdin',
+			'--bench',
+			'--iterations',
+			String(BENCHMARK_ITERATIONS),
+			'--warmup',
+			String(WARMUP_ITERATIONS),
+		],
+		{
+			cwd: LINT_ORACLE_DIR,
+			input: files.map((f) => f.path).join('\0'),
+			encoding: 'utf8',
+			maxBuffer: 1 << 28,
+			stdio: ['pipe', 'pipe', 'inherit'],
+		},
+	);
+	if (jsProc.status !== 0) throw new Error('lint oracle benchmark failed');
+	const jsTimes = JSON.parse(jsProc.stdout).times;
+	const jsStats = calculateStats(jsTimes, files.length);
+	console.error(
+		`    ${jsStats.durationMs.toFixed(2)}ms (${jsStats.throughputFilesPerSec.toFixed(0)} files/sec)`,
+	);
+
+	console.error('  Benchmarking Rust (single-threaded)...');
+	const rustSingleTimes = await benchmarkRust(files, true, 'lint', 'lint_benchmark_runner', [
+		'--config',
+		configFile,
+	]);
+	const rustSingleStats = calculateStats(rustSingleTimes, files.length);
+	console.error(
+		`    ${rustSingleStats.durationMs.toFixed(2)}ms (${rustSingleStats.throughputFilesPerSec.toFixed(0)} files/sec)`,
+	);
+
+	console.error('  Benchmarking Rust (multi-threaded)...');
+	const rustMultiTimes = await benchmarkRust(files, false, 'lint', 'lint_benchmark_runner', [
+		'--config',
+		configFile,
+	]);
+	const rustMultiStats = calculateStats(rustMultiTimes, files.length);
+	console.error(
+		`    ${rustMultiStats.durationMs.toFixed(2)}ms (${rustMultiStats.throughputFilesPerSec.toFixed(0)} files/sec)`,
+	);
+
+	const speedupSingle = jsStats.durationMs / rustSingleStats.durationMs;
+	const speedupMulti = jsStats.durationMs / rustMultiStats.durationMs;
+	console.error(`  Speedup: single=${speedupSingle.toFixed(1)}x, multi=${speedupMulti.toFixed(1)}x`);
+
+	return {
+		task: 'lint',
+		taskLabel: 'lint',
+		rulesCount: universe.length,
+		javascript: { ...jsStats },
+		rustSingleThread: { ...rustSingleStats },
+		rustMultiThread: { ...rustMultiStats },
+		speedup: {
+			singleThreadVsJs: speedupSingle,
+			multiThreadVsJs: speedupMulti,
+		},
+	};
+}
+
 // Unlike the other tasks, svelte-check is a project-wise CLI, not a per-file
 // API. We materialise a synthetic workspace of N `.svelte` files and time each
 // CLI's wall-clock cost end-to-end.
@@ -708,12 +844,13 @@ async function main() {
 	const parse = await runBenchmarkTask(files, 'parse');
 	const svelte2tsx = await runBenchmarkTask(files, 'svelte2tsx');
 	const fmt = await runFmtTask(files);
+	const lint = await runLintTask(files);
 	const svelteCheck = await runSvelteCheckTask();
 
 	// Output combined JSON. Compile-client (CSR) lives at the top level for
 	// backward compatibility with the existing benchmark page; compile-server
-	// (SSR), parse, svelte2tsx, fmt and svelte-check are nested siblings so the
-	// page can render each as its own section.
+	// (SSR), parse, svelte2tsx, fmt, lint and svelte-check are nested siblings
+	// so the page can render each as its own section.
 	const output = {
 		generatedAt: new Date().toISOString(),
 		commitSha: getCommitSha(),
@@ -725,6 +862,7 @@ async function main() {
 		parse: asTaskResults(parse),
 		svelte2tsx: asTaskResults(svelte2tsx),
 		fmt: asTaskResults(fmt),
+		lint: { ...asTaskResults(lint), rulesCount: lint.rulesCount },
 		svelteCheck: { ...svelteCheck, filesCount: SVELTE_CHECK_FILES },
 	};
 

--- a/scripts/compat-corpus/lint-oracle/run.mjs
+++ b/scripts/compat-corpus/lint-oracle/run.mjs
@@ -49,10 +49,16 @@ const browserGlobals = {
 const args = process.argv.slice(2);
 let rulesPath = null;
 let useStdin = false;
+let bench = false;
+let iterations = 3;
+let warmup = 1;
 const files = [];
 for (let i = 0; i < args.length; i++) {
 	if (args[i] === '--rules') rulesPath = args[++i];
 	else if (args[i] === '--stdin') useStdin = true;
+	else if (args[i] === '--bench') bench = true;
+	else if (args[i] === '--iterations') iterations = Number(args[++i]);
+	else if (args[i] === '--warmup') warmup = Number(args[++i]);
 	else files.push(args[i]);
 }
 
@@ -135,6 +141,38 @@ const eslint = new ESLint({
 		}
 	]
 });
+
+if (bench) {
+	const sources = [];
+	for (const f of targets) {
+		try {
+			sources.push([f, readFileSync(f, 'utf8')]);
+		} catch {
+			// Unreadable file: skipped on this side exactly as the Rust runner
+			// skips it, so both time the same set.
+		}
+	}
+	const pass = async () => {
+		for (const [f, source] of sources) {
+			try {
+				await eslint.lintText(source, { filePath: f, warnIgnored: false });
+			} catch {
+				// A file the parser rejects still costs work on both sides; the
+				// benchmark times work, not correctness.
+			}
+		}
+	};
+	for (let i = 0; i < warmup; i++) await pass();
+	const times = [];
+	for (let i = 0; i < iterations; i++) {
+		const start = performance.now();
+		await pass();
+		times.push(performance.now() - start);
+	}
+	process.stderr.write(`[lint-oracle] benched ${sources.length} files\n`);
+	process.stdout.write(JSON.stringify({ times }));
+	process.exit(0);
+}
 
 // Lint each file via `lintText` with its real path, so the config's
 // extension-based processor/parser selection applies regardless of where the

--- a/scripts/compat-corpus/lint-universe.mjs
+++ b/scripts/compat-corpus/lint-universe.mjs
@@ -1,0 +1,90 @@
+/**
+ * The rule universe shared by the two places that compare rsvelte-lint against
+ * the real eslint-plugin-svelte: the parity corpus (`lint-verify.mjs`) and the
+ * `lint` benchmark task (`scripts/bench/run-benchmark.mjs`).
+ *
+ * Both need the *same* answer to "which rules do both linters run?" — a
+ * benchmark that timed a different rule set than the parity gate compares would
+ * be measuring two different workloads.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const ORACLE_DIR = path.join(__dirname, 'lint-oracle');
+
+// Rules excluded from the parity universe, each for a structural reason that
+// makes a finding-level comparison meaningless on this corpus (NOT a place to
+// hide real divergences — those go in known-failures.json and must shrink).
+export const EXCLUDE = new Set([
+	// ── Type-aware: need the TypeScript checker (tsgo) to match upstream. The
+	//    type-aware path is covered separately by `rsvelte_lint_types`.
+	'svelte/no-unused-props',
+	'svelte/no-navigation-without-resolve',
+	// `require-event-prefix` resolves component event names from TS types; the
+	//    corpus oracle has only the TS *parser* (no type checker), so it returns
+	//    `{}` and stays silent even on its own invalid fixtures. rsvelte's
+	//    syntactic port recovers them, so a finding-level comparison here is
+	//    meaningless (the rule IS exercised by the exact-fixture oracle test).
+	'svelte/require-event-prefix',
+	// ── Option-required: schema rejects an empty option list, so the rule is a
+	//    no-op without a per-project allowlist. rsvelte defaults it off too.
+	'svelte/no-restricted-html-elements',
+	// ── Svelte 3/4-only (`meta.conditions: svelteVersions: ['3/4']`). The corpus
+	//    declares Svelte 5 (see lint-collect's synthetic package.json), so the
+	//    oracle skips these; rsvelte doesn't version-gate, so it would over-report.
+	'svelte/experimental-require-strict-events',
+	'svelte/require-event-dispatcher-types',
+	// ── `indent`: a stylistic whitespace rule only partially ported (template
+	//    level; the JS/TS-AST script indentation the fixture oracle skips). Full
+	//    real-world parity is a tracked follow-up — see lint-corpus README. It
+	//    dominates (~84%) the raw divergence count and would drown the gate.
+	'svelte/indent',
+	// ── Compiler/CSS-parser meta-rules: these run the Svelte compiler / CSS
+	//    parser and surface its warnings (a11y, unused-selector, CSS parse
+	//    errors). Their parity is governed by the compiler's own extensive test
+	//    suites (validator/snapshot/CSS fixtures — all at 100%) and the fixture
+	//    oracle, not the lint port. Comparing them here just re-surfaces
+	//    compiler-level differences already tracked elsewhere.
+	'svelte/valid-compile',
+	'svelte/valid-style-parse'
+]);
+
+/**
+ * Intersect the rules rsvelte implements with the rules the pinned
+ * eslint-plugin-svelte exposes, minus `EXCLUDE`.
+ *
+ * `bin` is any binary that answers `--list-rules` (the `rsvelte-lint` CLI, or
+ * the benchmark runner, which mirrors the flag for exactly this reason).
+ */
+export function ruleUniverse(bin) {
+	const listed = execFileSync(bin, ['--list-rules'], { encoding: 'utf8', maxBuffer: 1 << 24 });
+	const rsvelte = new Set(
+		listed
+			.split('\n')
+			.map((l) => l.match(/^(svelte\/[a-z0-9-]+)/))
+			.filter(Boolean)
+			.map((m) => m[1])
+	);
+	const pluginList = JSON.parse(
+		execFileSync(
+			'node',
+			[
+				'-e',
+				'import("eslint-plugin-svelte").then(m=>process.stdout.write(JSON.stringify(Object.keys(m.default.rules).map(n=>"svelte/"+n))))'
+			],
+			{ cwd: ORACLE_DIR, encoding: 'utf8' }
+		)
+	);
+	const plugin = new Set(pluginList);
+	return [...rsvelte].filter((id) => plugin.has(id) && !EXCLUDE.has(id)).sort();
+}
+
+/** True when the oracle package's dependencies are installed. */
+export function oracleInstalled() {
+	return fs.existsSync(path.join(ORACLE_DIR, 'node_modules', 'eslint-plugin-svelte'));
+}

--- a/scripts/compat-corpus/lint-verify.mjs
+++ b/scripts/compat-corpus/lint-verify.mjs
@@ -24,59 +24,22 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { ORACLE_DIR, ruleUniverse } from './lint-universe.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
 const CORPUS = path.join(ROOT, 'compatibility');
 const SOURCES = path.join(CORPUS, 'lint-sources');
-const ORACLE_DIR = path.join(__dirname, 'lint-oracle');
 const KNOWN = path.join(CORPUS, 'lint-known-failures.json');
 
 const args = process.argv.slice(2);
 const UPDATE = args.includes('--update');
 const SHOW = args.includes('--show') ? Number(args[args.indexOf('--show') + 1] || 50) : 50;
 
-// Rules excluded from the parity universe, each for a structural reason that
-// makes a finding-level comparison meaningless on this corpus (NOT a place to
-// hide real divergences — those go in known-failures.json and must shrink).
-const EXCLUDE = new Set([
-	// ── Type-aware: need the TypeScript checker (tsgo) to match upstream. The
-	//    type-aware path is covered separately by `rsvelte_lint_types`.
-	'svelte/no-unused-props',
-	'svelte/no-navigation-without-resolve',
-	// `require-event-prefix` resolves component event names from TS types; the
-	//    corpus oracle has only the TS *parser* (no type checker), so it returns
-	//    `{}` and stays silent even on its own invalid fixtures. rsvelte's
-	//    syntactic port recovers them, so a finding-level comparison here is
-	//    meaningless (the rule IS exercised by the exact-fixture oracle test).
-	'svelte/require-event-prefix',
-	// ── Option-required: schema rejects an empty option list, so the rule is a
-	//    no-op without a per-project allowlist. rsvelte defaults it off too.
-	'svelte/no-restricted-html-elements',
-	// ── Svelte 3/4-only (`meta.conditions: svelteVersions: ['3/4']`). The corpus
-	//    declares Svelte 5 (see lint-collect's synthetic package.json), so the
-	//    oracle skips these; rsvelte doesn't version-gate, so it would over-report.
-	'svelte/experimental-require-strict-events',
-	'svelte/require-event-dispatcher-types',
-	// ── `indent`: a stylistic whitespace rule only partially ported (template
-	//    level; the JS/TS-AST script indentation the fixture oracle skips). Full
-	//    real-world parity is a tracked follow-up — see lint-corpus README. It
-	//    dominates (~84%) the raw divergence count and would drown the gate.
-	'svelte/indent',
-	// ── Compiler/CSS-parser meta-rules: these run the Svelte compiler / CSS
-	//    parser and surface its warnings (a11y, unused-selector, CSS parse
-	//    errors). Their parity is governed by the compiler's own extensive test
-	//    suites (validator/snapshot/CSS fixtures — all at 100%) and the fixture
-	//    oracle, not the lint port. Comparing them here just re-surfaces
-	//    compiler-level differences already tracked elsewhere.
-	'svelte/valid-compile',
-	'svelte/valid-style-parse'
-]);
-
 // Individual findings excluded for a structural reason OUTSIDE rsvelte's
 // control (a version skew in the oracle's tooling, or a capability rsvelte does
-// not implement) — the finding-scoped analogue of the per-rule `EXCLUDE` above,
-// NOT a place to hide real divergences. Each entry is a full
+// not implement) — the finding-scoped analogue of the per-rule `EXCLUDE` in
+// lint-universe.mjs, NOT a place to hide real divergences. Each entry is a full
 // `<corpus-id>|<+|-><rule>\t<line>:<col>\t<message>` string and MUST carry a
 // documented justification (see compatibility/lint-known-failures.md).
 const MANUAL_EXCLUSIONS = new Set([
@@ -113,32 +76,6 @@ function findBinary() {
 	}
 	console.error('[lint-verify] rsvelte-lint binary not found; run `cargo build --bin rsvelte-lint`');
 	process.exit(2);
-}
-
-function ruleUniverse(bin) {
-	// rsvelte rule ids (the implemented set)…
-	const listed = execFileSync(bin, ['--list-rules'], { encoding: 'utf8', maxBuffer: 1 << 24 });
-	const rsvelte = new Set(
-		listed
-			.split('\n')
-			.map((l) => l.match(/^(svelte\/[a-z0-9-]+)/))
-			.filter(Boolean)
-			.map((m) => m[1])
-	);
-	// …intersected with the plugin's rule ids (read from the oracle env).
-	const pluginList = JSON.parse(
-		execFileSync(
-			'node',
-			[
-				'-e',
-				'import("eslint-plugin-svelte").then(m=>process.stdout.write(JSON.stringify(Object.keys(m.default.rules).map(n=>"svelte/"+n))))'
-			],
-			{ cwd: ORACLE_DIR, encoding: 'utf8' }
-		)
-	);
-	const plugin = new Set(pluginList);
-	const universe = [...rsvelte].filter((id) => plugin.has(id) && !EXCLUDE.has(id)).sort();
-	return universe;
 }
 
 function corpusFiles() {


### PR DESCRIPTION
## Why

The `/benchmark` page and the README table covered compile / parse / svelte2tsx / fmt / svelte-check — every shipped tool except the linter. This adds the missing `lint` task.

## Result

| Task | JS baseline | Rust (1 thread) | Rust (multi) | Multi vs JS |
|---|---:|---:|---:|---:|
| Lint (vs eslint + eslint-plugin-svelte) | 6,305.0 ms | 1,625.7 ms | 253.3 ms | **24.9×** |

M1 Pro 10-core, 3,412-file corpus, 10 iterations after 3 warmup. Three independent runs gave 25.3× / 22.4× / 24.9× — the published run is the median ratio.

## How it is measured

Same shape as the `fmt` task:

- **Rust side** — a new `lint_benchmark_runner` bin (`crates/rsvelte_lint/src/bin/`) drives `lint_source` over the shared file list in single/multi mode and prints `{"times": […]}`, the same CLI contract the other runners use. Built under `--profile=bench` so its per-file `catch_unwind` isolation actually holds (the shared `release` profile is `panic = "abort"`).
- **JS side** — timed in-process by the parity oracle's own `run.mjs --bench`, so ESLint and the plugin resolve from the pinned isolated install and neither side pays node startup or config resolution inside the measured loop. Both sides pre-read every source, so file I/O is out of the loop too.

### Fairness

A linter's cost is the sum of its enabled rules, so comparing rsvelte's rule set against the plugin's `recommended` preset would measure preset composition rather than implementation speed. Both sides therefore run **the same 72 rules** — the rule universe the lint output-parity gate diffs (rules rsvelte implements ∩ rules the pinned plugin exposes, minus the structurally incomparable ones). That universe is now extracted into `scripts/compat-corpus/lint-universe.mjs` and imported by both `lint-verify.mjs` and the benchmark, so speed and parity cannot drift onto different rule sets.

One asymmetry is left in deliberately, and it counts **against** rsvelte: `rsvelte-lint` always runs its compiler validator pass (those diagnostics are part of what the tool reports), while the ESLint side's equivalent (`svelte/valid-compile`) sits outside the shared universe. The 24.9× is therefore conservative for a rule-engine-only comparison. This is noted in the README and in the script.

## Also in this PR

- `/benchmark` page + landing page pick the task up from the JSON automatically; added the `lint` panel wiring and a `LintBenchmarkTaskResults` type carrying `rulesCount` (the page shows "72 shared rules" so the number is never read without its rule count).
- `site-benchmark.yml` pre-builds the new runner and caches the oracle install; `run-benchmark.mjs` bootstraps that install on demand like the other baselines.
- The published JSON is a fresh full run, so the other rows shift slightly within their run-to-run band. `svelte2tsx` multi is the visible one: the previous publication caught a fast 13.3 ms sample, three fresh runs land 15.3–17.4 ms. No code changed on those paths in this PR.

## Test plan

- `node scripts/compat-corpus/lint-verify.mjs` after the shared-module refactor → `80 current, 80 known, 0 new, 0 fixed` (unchanged).
- Three full benchmark runs on an idle machine; ratios above.
- `cargo clippy --profile=bench --bin lint_benchmark_runner` + `cargo fmt --check -p rsvelte_lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp