### PR TITLE
feat(vscode): ship our own Svelte grammar and language definition

### DIFF
--- a/apps/npm/vscode/README.md
+++ b/apps/npm/vscode/README.md
@@ -8,6 +8,11 @@ and launches it over stdio.
 
 ## Features
 
+- **Syntax highlighting** for `.svelte` files (including `<script lang="ts">`,
+  `<style lang="scss|less|postcss|sass|stylus">`, `<template lang="pug">`, and
+  ` ```svelte ` code blocks in Markdown), plus Svelte-aware bracket matching,
+  auto-closing, folding, and snippets. The official Svelte extension is **not**
+  required.
 - **Format on demand / on save** via the native `rsvelte-fmt` CLI. Works for
   `.svelte` plus the JS/TS/CSS/JSON families (everything is dispatched to oxfmt
   internally for a complete format).
@@ -35,6 +40,14 @@ The extension resolves `node_modules/.bin/rsvelte-fmt` from the workspace. If
 it isn't found, formatting is disabled (linting still works). You can point at a
 specific binary with `rsvelte.rsvelteFmtPath`.
 
+## Using it alongside the official Svelte extension
+
+This extension ships its own Svelte grammar and language definition, so it is a
+standalone replacement for `svelte.svelte-vscode`. Running both at once
+duplicates diagnostics and makes it non-deterministic which copy of the
+`source.svelte` grammar VS Code loads, so the extension warns once if it detects
+the official extension. Disable one of the two.
+
 ## Setup as the default formatter
 
 To format Svelte files with rsvelte, set it as the default formatter (so it
@@ -59,4 +72,6 @@ doesn't conflict with the official Svelte extension):
 
 ## License
 
-MIT
+MIT. The bundled grammars, snippets and language configurations are copied from
+[`sveltejs/language-tools`](https://github.com/sveltejs/language-tools) (MIT) —
+see [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md).

--- a/apps/npm/vscode/README.md
+++ b/apps/npm/vscode/README.md
@@ -44,9 +44,10 @@ specific binary with `rsvelte.rsvelteFmtPath`.
 
 This extension ships its own Svelte grammar and language definition, so it is a
 standalone replacement for `svelte.svelte-vscode`. Running both at once
-duplicates diagnostics and makes it non-deterministic which copy of the
-`source.svelte` grammar VS Code loads, so the extension warns once if it detects
-the official extension. Disable one of the two.
+duplicates diagnostics, completions and hovers, makes VS Code prompt for which
+formatter to use, and leaves it up to activation order which copy of the
+`source.svelte` grammar ends up registered. The extension warns once if it
+detects the official extension — disable one of the two.
 
 ## Setup as the default formatter
 

--- a/apps/npm/vscode/THIRD_PARTY_NOTICES.md
+++ b/apps/npm/vscode/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,63 @@
+# Third-party notices
+
+This extension bundles assets copied from third-party projects. Their original
+licenses are reproduced below and apply to the corresponding files.
+
+## sveltejs/language-tools
+
+Upstream: <https://github.com/sveltejs/language-tools> (`packages/svelte-vscode`)
+License: MIT
+
+The following files are copied from that package, either verbatim or compiled
+from its YAML sources with the same `js-yaml` step upstream uses
+(`npx js-yaml <file>.src.yaml`):
+
+| File in this extension | Upstream source |
+| --- | --- |
+| `syntaxes/svelte.tmLanguage.json` | `syntaxes/svelte.tmLanguage.src.yaml` (compiled) |
+| `syntaxes/postcss.json` | `syntaxes/postcss.src.yaml` (compiled) |
+| `syntaxes/pug-svelte.json` | `syntaxes/pug-svelte.json` |
+| `syntaxes/pug-svelte-tags.json` | `syntaxes/pug-svelte-tags.json` |
+| `syntaxes/pug-svelte-dotblock.json` | `syntaxes/pug-svelte-dotblock.json` |
+| `syntaxes/markdown-svelte.json` | `syntaxes/markdown-svelte.json` |
+| `syntaxes/markdown-svelte-js.json` | `syntaxes/markdown-svelte-js.json` |
+| `syntaxes/markdown-svelte-css.json` | `syntaxes/markdown-svelte-css.json` |
+| `snippets/svelte.json` | `snippets/svelte.json` |
+| `snippets/javascript.json` | `snippets/javascript.json` |
+| `snippets/typescript.json` | `snippets/typescript.json` |
+| `language-configuration.json` | `language-configuration.json` |
+| `language-configuration-start-tag.json` | `language-configuration-start-tag.json` |
+
+The Svelte language configuration applied at activation time in
+`src/extension.ts` (indentation rules, word pattern, on-enter rules, and the
+list of void HTML elements they reference) is also derived from that package's
+`src/extension.ts` and `src/html/htmlEmptyTagsShared.ts`.
+
+### License
+
+Copyright (c) 2020-Present [these people](https://github.com/sveltejs/language-tools/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## microsoft/vscode
+
+Upstream: <https://github.com/microsoft/vscode>
+(`extensions/html-language-features/client/src/htmlEmptyTagsShared.ts`)
+License: MIT
+
+The list of void HTML elements used by the on-enter rules in
+`src/extension.ts` originates here, by way of `sveltejs/language-tools`.
+
+### License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/apps/npm/vscode/language-configuration-start-tag.json
+++ b/apps/npm/vscode/language-configuration-start-tag.json
@@ -1,0 +1,32 @@
+{
+    "comments": {
+        "lineComment": "//",
+        "blockComment": ["/*", "*/"]
+    },
+    "brackets": [
+        ["<!--", "-->"],
+        ["{", "}"],
+        ["(", ")"],
+        ["[", "]"]
+    ],
+    "autoClosingPairs": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "'", "close": "'" },
+        { "open": "\"", "close": "\"" },
+        { "open": "`", "close": "`", "notIn": ["comment", "string"] },
+        { "open": "<!--", "close": "-->", "notIn": ["comment", "string"] },
+        { "open": "/**", "close": "*/", "notIn": ["string"] }
+    ],
+    "autoCloseBefore": ";:.,=}])><`/ \n\t",
+    "surroundingPairs": [
+        { "open": "'", "close": "'" },
+        { "open": "\"", "close": "\"" },
+        { "open": "`", "close": "`" },
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "<", "close": ">" }
+    ]
+}

--- a/apps/npm/vscode/language-configuration.json
+++ b/apps/npm/vscode/language-configuration.json
@@ -1,0 +1,38 @@
+{
+    "comments": {
+        "blockComment": ["<!--", "-->"]
+    },
+    "brackets": [
+        ["<!--", "-->"],
+        ["<", ">"],
+        ["{", "}"],
+        ["(", ")"],
+        ["[", "]"]
+    ],
+    "autoClosingPairs": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "'", "close": "'" },
+        { "open": "\"", "close": "\"" },
+        { "open": "`", "close": "`", "notIn": ["comment", "string"] },
+        { "open": "<!--", "close": "-->", "notIn": ["comment", "string"] },
+        { "open": "/**", "close": "*/", "notIn": ["string"] }
+    ],
+    "autoCloseBefore": ";:.,=}])><`/ \n\t",
+    "surroundingPairs": [
+        { "open": "'", "close": "'" },
+        { "open": "\"", "close": "\"" },
+        { "open": "`", "close": "`" },
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "<", "close": ">" }
+    ],
+    "folding": {
+        "markers": {
+            "start": "^\\s*(//|/\\*\\*?)\\s*#?region\\b|^<(template|style|script)[^>]*>|^\\s*<!--\\s*#region\\b",
+            "end": "^\\s*(//|/\\*\\*?)\\s*#?endregion\\b|^</(template|style|script)>|^\\s*<!--\\s*#endregion\\b"
+        }
+    }
+}

--- a/apps/npm/vscode/package.json
+++ b/apps/npm/vscode/package.json
@@ -43,6 +43,145 @@
     "onLanguage:less"
   ],
   "contributes": {
+    "languages": [
+      {
+        "id": "svelte",
+        "aliases": [
+          "Svelte",
+          "svelte"
+        ],
+        "extensions": [
+          ".svelte"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "svelte-start-tag",
+        "configuration": "./language-configuration-start-tag.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "svelte",
+        "scopeName": "source.svelte",
+        "path": "./syntaxes/svelte.tmLanguage.json",
+        "embeddedLanguages": {
+          "text.html.basic": "html",
+          "text.html.markdown": "markdown",
+          "text.pug": "jade",
+          "meta.tag.start.svelte": "svelte-start-tag",
+          "punctuation.definition.tag.begin.svelte": "svelte",
+          "source.css": "css",
+          "source.css.less": "less",
+          "source.css.scss": "scss",
+          "source.css.postcss": "postcss",
+          "source.sass": "sass",
+          "source.stylus": "stylus",
+          "source.js": "javascript",
+          "source.ts": "typescript",
+          "source.coffee": "coffeescript"
+        },
+        "unbalancedBracketScopes": [
+          "keyword.operator.relational",
+          "storage.type.function.arrow",
+          "keyword.operator.bitwise.shift",
+          "meta.brace.angle",
+          "punctuation.definition.tag"
+        ],
+        "tokenTypes": {
+          "punctuation.definition.template-expression": "other",
+          "entity.name.type.instance.jsdoc": "other",
+          "entity.name.function.tagged-template": "other",
+          "meta.import string.quoted": "other",
+          "variable.other.jsdoc": "other"
+        }
+      },
+      {
+        "scopeName": "svelte.pug",
+        "path": "./syntaxes/pug-svelte.json",
+        "injectTo": [
+          "source.svelte"
+        ],
+        "embeddedLanguages": {
+          "source.ts": "typescript",
+          "text.pug": "jade"
+        }
+      },
+      {
+        "scopeName": "svelte.pug.tags",
+        "path": "./syntaxes/pug-svelte-tags.json",
+        "injectTo": [
+          "source.svelte"
+        ],
+        "embeddedLanguages": {
+          "source.ts": "typescript",
+          "text.pug": "jade"
+        }
+      },
+      {
+        "scopeName": "svelte.pug.dotblock",
+        "path": "./syntaxes/pug-svelte-dotblock.json",
+        "injectTo": [
+          "source.svelte"
+        ],
+        "embeddedLanguages": {
+          "source.ts": "typescript"
+        }
+      },
+      {
+        "scopeName": "markdown.svelte.codeblock",
+        "path": "./syntaxes/markdown-svelte.json",
+        "injectTo": [
+          "text.html.markdown",
+          "source.mdx"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.svelte": "svelte"
+        }
+      },
+      {
+        "scopeName": "markdown.svelte.codeblock.script",
+        "path": "./syntaxes/markdown-svelte-js.json",
+        "injectTo": [
+          "text.html.markdown",
+          "source.mdx"
+        ]
+      },
+      {
+        "scopeName": "markdown.svelte.codeblock.style",
+        "path": "./syntaxes/markdown-svelte-css.json",
+        "injectTo": [
+          "text.html.markdown",
+          "source.mdx"
+        ]
+      },
+      {
+        "scopeName": "source.css.postcss",
+        "path": "./syntaxes/postcss.json",
+        "injectTo": [
+          "source.svelte"
+        ]
+      }
+    ],
+    "snippets": [
+      {
+        "language": "svelte",
+        "path": "./snippets/svelte.json"
+      },
+      {
+        "language": "javascript",
+        "path": "./snippets/javascript.json"
+      },
+      {
+        "language": "typescript",
+        "path": "./snippets/typescript.json"
+      }
+    ],
+    "breakpoints": [
+      {
+        "language": "svelte"
+      }
+    ],
     "configuration": {
       "title": "rsvelte",
       "properties": {

--- a/apps/npm/vscode/snippets/javascript.json
+++ b/apps/npm/vscode/snippets/javascript.json
@@ -1,0 +1,43 @@
+{
+    "SvelteKit Endpoint": {
+        "prefix": "kitEndpoint",
+        "description": "SvelteKit Endpoint",
+        "body": [
+            "/** @type {import('./\\$types').RequestHandler} */",
+            "export async function ${1|GET,POST,PUT,PATCH,DELETE|}($2) {",
+            "\t$3",
+            "\treturn new Response();",
+            "}"
+        ]
+    },
+    "SvelteKit Actions": {
+        "prefix": "kitActions",
+        "description": "SvelteKit Actions",
+        "body": [
+            "/** @type {import('./\\$types').Actions} */",
+            "export const actions = {",
+            "\t$1",
+            "};"
+        ]
+    },
+    "SvelteKit Load": {
+        "prefix": "kitLoad",
+        "description": "SvelteKit Load",
+        "body": [
+            "/** @type {import('./\\$types').${1|PageLoad,PageServerLoad,LayoutLoad,LayoutServerLoad|}} */",
+            "export async function load($2) {",
+            "\t$3",
+            "}"
+        ]
+    },
+    "SvelteKit Param Matcher": {
+        "prefix": "kitParamMatcher",
+        "description": "SvelteKit Param Matcher",
+        "body": [
+            "/** @type {import('./\\$types').ParamMatcher */",
+            "export function match(param) {",
+            "\treturn $1;",
+            "}"
+        ]
+    }
+}

--- a/apps/npm/vscode/snippets/svelte.json
+++ b/apps/npm/vscode/snippets/svelte.json
@@ -1,0 +1,26 @@
+{
+    "if": {
+        "body": ["{#if ${1:condition}}", "\t$TM_SELECTED_TEXT$0", "{/if}"],
+        "description": "if block"
+    },
+    "await": {
+        "body": ["{#await ${1:promise}}", "\t$TM_SELECTED_TEXT$0", "{/await}"],
+        "description": "await block"
+    },
+    "await then shorthand": {
+        "body": ["{#await ${1:promise} then $2}", "\t$TM_SELECTED_TEXT$0", "{/await}"],
+        "description": "await block without pending state"
+    },
+    "each": {
+        "body": ["{#each ${1:array} as ${2:item}}", "\t$TM_SELECTED_TEXT$0", "{/each}"],
+        "description": "each block"
+    },
+    "key": {
+        "body": ["{#key ${1:key}}", "\t$TM_SELECTED_TEXT$0", "{/key}"],
+        "description": "key block"
+    },
+    "snippet": {
+        "body": ["{#snippet ${1:snippet}(${2:parameter})}", "\t$TM_SELECTED_TEXT$0", "{/snippet}"],
+        "description": "snippet block"
+    }
+}

--- a/apps/npm/vscode/snippets/typescript.json
+++ b/apps/npm/vscode/snippets/typescript.json
@@ -1,0 +1,37 @@
+{
+    "SvelteKit Endpoint": {
+        "prefix": "kitEndpoint",
+        "description": "SvelteKit Endpoint",
+        "body": [
+            "export const ${1|GET,POST,PUT,PATCH,DELETE|}: RequestHandler = async ($2) => {",
+            "\t$3",
+            "\treturn new Response();",
+            "};"
+        ]
+    },
+    "SvelteKit Actions": {
+        "prefix": "kitActions",
+        "description": "SvelteKit Actions",
+        "body": ["export const actions: Actions = {", "\t$1", "};"]
+    },
+    "SvelteKit Load": {
+        "prefix": "kitLoad",
+        "description": "SvelteKit Load",
+        "body": [
+            "export const load: ${1|PageLoad,PageServerLoad,LayoutLoad,LayoutServerLoad|} = async ($2) => {",
+            "\t$3",
+            "};"
+        ]
+    },
+    "SvelteKit Param Matcher": {
+        "prefix": "kitParamMatcher",
+        "description": "SvelteKit Param Matcher",
+        "body": [
+            "import type { ParamMatcher } from '@sveltejs/kit';",
+            "",
+            "export const match: ParamMatcher = (param) => {",
+            "\treturn $1;",
+            "};"
+        ]
+    }
+}

--- a/apps/npm/vscode/src/extension.ts
+++ b/apps/npm/vscode/src/extension.ts
@@ -96,9 +96,9 @@ function registerSvelteLanguageConfiguration(context: ExtensionContext): void {
 }
 
 /**
- * Both extensions contribute the `source.svelte` grammar and Svelte
- * diagnostics, so running them together duplicates problems and makes which
- * grammar wins non-deterministic.
+ * Both extensions contribute the `source.svelte` grammar and register
+ * providers for the `svelte` language, so running them together duplicates
+ * every feature and makes which grammar wins depend on activation order.
  */
 async function warnAboutOfficialExtension(
   context: ExtensionContext,
@@ -109,7 +109,9 @@ async function warnAboutOfficialExtension(
   const dismiss = "Don't show again";
   const choice = await window.showWarningMessage(
     "rsvelte and the official Svelte extension (svelte.svelte-vscode) are both enabled. " +
-      "They contribute the same Svelte grammar and overlapping diagnostics — disable one of them.",
+      "They contribute the same Svelte grammar and overlapping diagnostics, and both register " +
+      "providers for Svelte files — expect duplicate problems, duplicate completions and hovers, " +
+      "and a formatter-picker prompt on every format. Disable one of them.",
     dismiss,
   );
   if (choice === dismiss) {

--- a/apps/npm/vscode/src/extension.ts
+++ b/apps/npm/vscode/src/extension.ts
@@ -5,7 +5,13 @@
  */
 
 import * as path from "node:path";
-import type { ExtensionContext } from "vscode";
+import {
+  IndentAction,
+  extensions,
+  languages,
+  window,
+  type ExtensionContext,
+} from "vscode";
 import {
   LanguageClient,
   TransportKind,
@@ -29,7 +35,92 @@ const DOCUMENT_SELECTOR = [
   { scheme: "file", language: "less" },
 ];
 
+/** HTML elements that never get a closing tag, so they must not trigger indent. */
+const VOID_ELEMENTS = [
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "keygen",
+  "link",
+  "menuitem",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+];
+
+const OFFICIAL_EXTENSION_ID = "svelte.svelte-vscode";
+const CONFLICT_DISMISSED_KEY = "rsvelte.officialExtensionConflictDismissed";
+
+function registerSvelteLanguageConfiguration(context: ExtensionContext): void {
+  const voidElements = VOID_ELEMENTS.join("|");
+  context.subscriptions.push(
+    languages.setLanguageConfiguration("svelte", {
+      indentationRules: {
+        // An opening tag that is not a doctype, void element, closing tag, or
+        // self-closed, and is not closed again on the same line — or `<!--`, or `{`.
+        increaseIndentPattern:
+          /<(?!\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*\/>)([-_.A-Za-z0-9]+)(?=\s|>)\b[^>]*>(?!.*<\/\1>)|<!--(?!.*-->)|\{[^}"']*$/,
+        // A leading closing tag other than `</html>`, or `-->`, or `}`.
+        decreaseIndentPattern: /^\s*(<\/(?!html)[-_.A-Za-z0-9]+\b[^>]*>|-->|\})/,
+      },
+      // A number with an optional sign/fraction, or a run of characters
+      // excluding whitespace and punctuation that cannot appear in an identifier.
+      wordPattern:
+        /(-?\d*\.\d\w*)|([^\`\~\!\@\#\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g,
+      onEnterRules: [
+        {
+          beforeText: new RegExp(
+            `<(?!(?:${voidElements}))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!/)>)[^<]*$`,
+            "i",
+          ),
+          afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>/i,
+          action: { indentAction: IndentAction.IndentOutdent },
+        },
+        {
+          beforeText: new RegExp(
+            `<(?!(?:${voidElements}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
+            "i",
+          ),
+          action: { indentAction: IndentAction.Indent },
+        },
+      ],
+    }),
+  );
+}
+
+/**
+ * Both extensions contribute the `source.svelte` grammar and Svelte
+ * diagnostics, so running them together duplicates problems and makes which
+ * grammar wins non-deterministic.
+ */
+async function warnAboutOfficialExtension(
+  context: ExtensionContext,
+): Promise<void> {
+  if (context.globalState.get<boolean>(CONFLICT_DISMISSED_KEY)) return;
+  if (!extensions.getExtension(OFFICIAL_EXTENSION_ID)) return;
+
+  const dismiss = "Don't show again";
+  const choice = await window.showWarningMessage(
+    "rsvelte and the official Svelte extension (svelte.svelte-vscode) are both enabled. " +
+      "They contribute the same Svelte grammar and overlapping diagnostics — disable one of them.",
+    dismiss,
+  );
+  if (choice === dismiss) {
+    await context.globalState.update(CONFLICT_DISMISSED_KEY, true);
+  }
+}
+
 export function activate(context: ExtensionContext): void {
+  registerSvelteLanguageConfiguration(context);
+  void warnAboutOfficialExtension(context);
+
   // The bundled server lives at dist/server.mjs, copied next to the extension
   // bundle by the build (see build.mjs).
   const serverModule = context.asAbsolutePath(

--- a/apps/npm/vscode/syntaxes/markdown-svelte-css.json
+++ b/apps/npm/vscode/syntaxes/markdown-svelte-css.json
@@ -1,0 +1,23 @@
+{
+    "scopeName": "markdown.svelte.codeblock.style",
+    "fileTypes": [],
+    "injectionSelector": "L:meta.style.svelte",
+    "patterns": [
+        {
+            "include": "#svelte-script-css"
+        }
+    ],
+    "repository": {
+        "svelte-script-css": {
+            "begin": "(?<=style.*>)(?!</)",
+            "end": "(?=</)",
+            "name": "meta.embedded.block.svelte.style",
+            "contentName": "source.css",
+            "patterns": [
+                {
+                    "include": "source.css"
+                }
+            ]
+        }
+    }
+}

--- a/apps/npm/vscode/syntaxes/markdown-svelte-js.json
+++ b/apps/npm/vscode/syntaxes/markdown-svelte-js.json
@@ -1,0 +1,23 @@
+{
+    "scopeName": "markdown.svelte.codeblock.script",
+    "fileTypes": [],
+    "injectionSelector": "L:meta.script.svelte",
+    "patterns": [
+        {
+            "include": "#svelte-script-js"
+        }
+    ],
+    "repository": {
+        "svelte-script-js": {
+            "begin": "(?<=script.*>)(?!</)",
+            "end": "(?=</)",
+            "name": "meta.embedded.block.svelte.script",
+            "contentName": "source.ts",
+            "patterns": [
+                {
+                    "include": "source.ts"
+                }
+            ]
+        }
+    }
+}

--- a/apps/npm/vscode/syntaxes/markdown-svelte.json
+++ b/apps/npm/vscode/syntaxes/markdown-svelte.json
@@ -1,0 +1,45 @@
+{
+    "scopeName": "markdown.svelte.codeblock",
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown, L:source.mdx",
+    "patterns": [
+        {
+            "include": "#svelte-code-block"
+        }
+    ],
+    "repository": {
+        "svelte-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(svelte|sv)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language"
+                },
+                "6": {
+                    "name": "fenced_code.block.language.attributes"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.svelte",
+                    "patterns": [
+                        {
+                            "include": "source.svelte"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/apps/npm/vscode/syntaxes/postcss.json
+++ b/apps/npm/vscode/syntaxes/postcss.json
@@ -1,0 +1,377 @@
+{
+  "name": "Svelte PostCSS",
+  "scopeName": "source.css.postcss",
+  "uuid": "90DAEA60-88AA-11E2-9E96-0800200C9A66",
+  "fileTypes": [
+    "pcss",
+    "postcss"
+  ],
+  "foldingStartMarker": "/\\*|^#|^\\*|^\\b|^\\.",
+  "foldingStopMarker": "\\*/|^\\s*$",
+  "patterns": [
+    {
+      "begin": "/\\*",
+      "end": "\\*/",
+      "name": "comment.block.postcss",
+      "patterns": [
+        {
+          "include": "#comment-tag"
+        }
+      ]
+    },
+    {
+      "include": "#double-slash"
+    },
+    {
+      "include": "#double-quoted"
+    },
+    {
+      "include": "#single-quoted"
+    },
+    {
+      "include": "#interpolation"
+    },
+    {
+      "include": "#placeholder-selector"
+    },
+    {
+      "include": "#variable"
+    },
+    {
+      "include": "#variable-root-css"
+    },
+    {
+      "include": "#numeric"
+    },
+    {
+      "include": "#unit"
+    },
+    {
+      "include": "#flag"
+    },
+    {
+      "include": "#dotdotdot"
+    },
+    {
+      "begin": "@include",
+      "end": "(?=\\n|\\(|{|;)",
+      "name": "support.function.name.postcss.library",
+      "captures": {
+        "0": {
+          "name": "keyword.control.at-rule.css.postcss"
+        }
+      }
+    },
+    {
+      "begin": "@mixin|@function",
+      "end": "$\\n?|(?=\\(|{)",
+      "name": "support.function.name.postcss.no-completions",
+      "captures": {
+        "0": {
+          "name": "keyword.control.at-rule.css.postcss"
+        }
+      },
+      "patterns": [
+        {
+          "match": "[\\w-]+",
+          "name": "entity.name.function"
+        }
+      ]
+    },
+    {
+      "match": "(?<=@import)\\s[\\w/.*-]+",
+      "name": "string.quoted.double.css.postcss"
+    },
+    {
+      "begin": "@",
+      "end": "$\\n?|\\s(?!(all|braille|embossed|handheld|print|projection|screen|speech|tty|tv|if|only|not)(\\s|,))|(?=;)",
+      "name": "keyword.control.at-rule.css.postcss"
+    },
+    {
+      "begin": "#",
+      "end": "$\\n?|(?=\\s|,|;|\\(|\\)|\\.|\\[|{|>)",
+      "name": "entity.other.attribute-name.id.css.postcss",
+      "patterns": [
+        {
+          "include": "#interpolation"
+        },
+        {
+          "include": "#pseudo-class"
+        }
+      ]
+    },
+    {
+      "begin": "\\.|(?<=&)(-|_)",
+      "end": "$\\n?|(?=\\s|,|;|\\(|\\)|\\[|{|>)",
+      "name": "entity.other.attribute-name.class.css.postcss",
+      "patterns": [
+        {
+          "include": "#interpolation"
+        },
+        {
+          "include": "#pseudo-class"
+        }
+      ]
+    },
+    {
+      "begin": "\\[",
+      "end": "\\]",
+      "name": "entity.other.attribute-selector.postcss",
+      "patterns": [
+        {
+          "include": "#double-quoted"
+        },
+        {
+          "include": "#single-quoted"
+        },
+        {
+          "match": "\\^|\\$|\\*|~",
+          "name": "keyword.other.regex.postcss"
+        }
+      ]
+    },
+    {
+      "match": "(?<=\\]|\\)|not\\(|\\*|>|>\\s):[a-z:-]+|(::|:-)[a-z:-]+",
+      "name": "entity.other.attribute-name.pseudo-class.css.postcss"
+    },
+    {
+      "begin": ":",
+      "end": "$\\n?|(?=;|\\s\\(|and\\(|{|}|\\),)",
+      "name": "meta.property-list.css.postcss",
+      "patterns": [
+        {
+          "include": "#double-slash"
+        },
+        {
+          "include": "#double-quoted"
+        },
+        {
+          "include": "#single-quoted"
+        },
+        {
+          "include": "#interpolation"
+        },
+        {
+          "include": "#variable"
+        },
+        {
+          "include": "#rgb-value"
+        },
+        {
+          "include": "#numeric"
+        },
+        {
+          "include": "#unit"
+        },
+        {
+          "include": "#flag"
+        },
+        {
+          "include": "#function"
+        },
+        {
+          "include": "#function-content"
+        },
+        {
+          "include": "#function-content-var"
+        },
+        {
+          "include": "#operator"
+        },
+        {
+          "include": "#parent-selector"
+        },
+        {
+          "include": "#property-value"
+        }
+      ]
+    },
+    {
+      "include": "#rgb-value"
+    },
+    {
+      "include": "#function"
+    },
+    {
+      "include": "#function-content"
+    },
+    {
+      "begin": "(?<!\\-|\\()\\b(a|abbr|acronym|address|applet|area|article|aside|audio|b|base|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|map|mark|menu|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|table|tbody|td|textarea|tfoot|th|thead|time|title|tr|tt|ul|var|video|main|svg|rect|ruby|center|circle|ellipse|line|polyline|polygon|path|text|u|x)\\b(?!-|\\)|:\\s)|&",
+      "end": "(?=\\s|,|;|\\(|\\)|\\.|\\[|{|>|-|_)",
+      "name": "entity.name.tag.css.postcss.symbol",
+      "patterns": [
+        {
+          "include": "#interpolation"
+        },
+        {
+          "include": "#pseudo-class"
+        }
+      ]
+    },
+    {
+      "include": "#operator"
+    },
+    {
+      "match": "[a-z-]+((?=:|#{))",
+      "name": "support.type.property-name.css.postcss"
+    },
+    {
+      "include": "#reserved-words"
+    },
+    {
+      "include": "#property-value"
+    }
+  ],
+  "repository": {
+    "comment-tag": {
+      "begin": "{{",
+      "end": "}}",
+      "name": "comment.tags.postcss",
+      "patterns": [
+        {
+          "match": "[\\w-]+",
+          "name": "comment.tag.postcss"
+        }
+      ]
+    },
+    "dotdotdot": {
+      "match": "\\.{3}",
+      "name": "variable.other"
+    },
+    "double-slash": {
+      "begin": "//",
+      "end": "$",
+      "name": "comment.line.postcss",
+      "patterns": [
+        {
+          "include": "#comment-tag"
+        }
+      ]
+    },
+    "double-quoted": {
+      "begin": "\"",
+      "end": "\"",
+      "name": "string.quoted.double.css.postcss",
+      "patterns": [
+        {
+          "include": "#quoted-interpolation"
+        }
+      ]
+    },
+    "flag": {
+      "match": "!(important|default|optional|global)",
+      "name": "keyword.other.important.css.postcss"
+    },
+    "function": {
+      "match": "(?<=[\\s|\\(|,|:])(?!url|format|attr)[\\w-][\\w-]*(?=\\()",
+      "name": "support.function.name.postcss"
+    },
+    "function-content": {
+      "match": "(?<=url\\(|format\\(|attr\\().+?(?=\\))",
+      "name": "string.quoted.double.css.postcss"
+    },
+    "function-content-var": {
+      "match": "(?<=var\\()[\\w-]+(?=\\))",
+      "name": "variable.parameter.postcss"
+    },
+    "interpolation": {
+      "begin": "#{",
+      "end": "}",
+      "name": "support.function.interpolation.postcss",
+      "patterns": [
+        {
+          "include": "#variable"
+        },
+        {
+          "include": "#numeric"
+        },
+        {
+          "include": "#operator"
+        },
+        {
+          "include": "#unit"
+        },
+        {
+          "include": "#double-quoted"
+        },
+        {
+          "include": "#single-quoted"
+        }
+      ]
+    },
+    "numeric": {
+      "match": "(-|\\.)?[0-9]+(\\.[0-9]+)?",
+      "name": "constant.numeric.css.postcss"
+    },
+    "operator": {
+      "match": "\\+|\\s-\\s|\\s-(?=\\$)|(?<=\\()-(?=\\$)|\\s-(?=\\()|\\*|/|%|=|!|<|>|~",
+      "name": "keyword.operator.postcss"
+    },
+    "parent-selector": {
+      "match": "&",
+      "name": "entity.name.tag.css.postcss"
+    },
+    "placeholder-selector": {
+      "begin": "(?<!\\d)%(?!\\d)",
+      "end": "$\\n?|\\s|(?=;|{)",
+      "name": "entity.other.attribute-name.placeholder-selector.postcss"
+    },
+    "property-value": {
+      "match": "[\\w-]+",
+      "name": "meta.property-value.css.postcss, support.constant.property-value.css.postcss"
+    },
+    "pseudo-class": {
+      "match": ":[a-z:-]+",
+      "name": "entity.other.attribute-name.pseudo-class.css.postcss"
+    },
+    "quoted-interpolation": {
+      "begin": "#{",
+      "end": "}",
+      "name": "support.function.interpolation.postcss",
+      "patterns": [
+        {
+          "include": "#variable"
+        },
+        {
+          "include": "#numeric"
+        },
+        {
+          "include": "#operator"
+        },
+        {
+          "include": "#unit"
+        }
+      ]
+    },
+    "reserved-words": {
+      "match": "\\b(false|from|in|not|null|through|to|true)\\b",
+      "name": "support.type.property-name.css.postcss"
+    },
+    "rgb-value": {
+      "match": "(#)([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\\b",
+      "name": "constant.other.color.rgb-value.css.postcss"
+    },
+    "single-quoted": {
+      "begin": "'",
+      "end": "'",
+      "name": "string.quoted.single.css.postcss",
+      "patterns": [
+        {
+          "include": "#quoted-interpolation"
+        }
+      ]
+    },
+    "unit": {
+      "match": "(?<=[\\d]|})(ch|cm|deg|dpcm|dpi|dppx|em|ex|grad|Hz|in|kHz|mm|ms|pc|pt|px|rad|rem|s|turn|vh|vmax|vmin|vw|%)",
+      "name": "keyword.other.unit.css.postcss"
+    },
+    "variable": {
+      "match": "\\$[\\w-]+",
+      "name": "variable.parameter.postcss"
+    },
+    "variable-root-css": {
+      "match": "(?<!&)--[\\w-]+",
+      "name": "variable.parameter.postcss"
+    }
+  }
+}

--- a/apps/npm/vscode/syntaxes/pug-svelte-dotblock.json
+++ b/apps/npm/vscode/syntaxes/pug-svelte-dotblock.json
@@ -1,0 +1,55 @@
+{
+    "scopeName": "svelte.pug.dotblock",
+    "fileTypes": [],
+    "injectionSelector": "L:text.block.pug -meta.embedded.ts",
+    "patterns": [
+        {
+            "include": "#interp-object-literal"
+        },
+        {
+            "include": "#interp"
+        }
+    ],
+    "repository": {
+        "interp-object-literal": {
+            "contentName": "meta.interpolation meta.embedded.ts",
+            "begin": "(?![!$#]){\\s*?(?={)",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.begin"
+                }
+            },
+            "end": "(?<=})\\s*?}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.end"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "source.ts#object-literal"
+                }
+            ]
+        },
+        "interp": {
+            "contentName": "meta.interpolation meta.embedded.ts",
+            "begin": "(?![!$#]){",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.begin"
+                }
+            },
+            "end": "}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.end"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "source.ts"
+                }
+            ]
+        }
+    }
+}

--- a/apps/npm/vscode/syntaxes/pug-svelte-tags.json
+++ b/apps/npm/vscode/syntaxes/pug-svelte-tags.json
@@ -1,0 +1,201 @@
+{
+    "scopeName": "svelte.pug.tags",
+    "fileTypes": [],
+    "injectionSelector": "L:text.pug meta.tag.other -meta.embedded.ts",
+    "patterns": [
+        {
+            "include": "#interp-object-literal"
+        },
+        {
+            "include": "#interp"
+        },
+        {
+            "include": "#attr-function"
+        },
+        {
+            "include": "#attr-interp"
+        },
+        {
+            "include": "#attr-interp-invalid-quotes"
+        },
+        {
+            "include": "#attr-interp-invalid-noquotes"
+        },
+        {
+            "include": "#attr-event"
+        },
+        {
+            "include": "#attr-variable"
+        }
+    ],
+    "repository": {
+        "interp-object-literal": {
+            "contentName": "meta.interpolation meta.embedded.ts",
+            "begin": "(?![!$#]){\\s*?(?={)",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.begin"
+                }
+            },
+            "end": "(?<=})\\s*?}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.end"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "source.ts#object-literal"
+                }
+            ]
+        },
+        "interp": {
+            "contentName": "meta.interpolation meta.embedded.ts",
+            "begin": "(?![!$#]){",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.begin"
+                }
+            },
+            "end": "}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.end"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "source.ts"
+                }
+            ]
+        },
+        "attr-interp": {
+            "match": "\\b(?<=[\\w$\\-_]*)\\s*?(!=|=)\\s*?([`'\"])((?![$!#]){.*})(\\k<2>)",
+            "captures": {
+                "1": {
+                    "patterns": [
+                        {
+                            "match": "=",
+                            "name": "invalid.illegal"
+                        },
+                        {
+                            "match": "!=",
+                            "name": "keyword.operator.assignment"
+                        }
+                    ]
+                },
+                "2": {
+                    "name": "punctuation.section.interpolation.begin"
+                },
+                "3": {
+                    "patterns": [
+                        {
+                            "include": "#interp"
+                        }
+                    ]
+                },
+                "4": {
+                    "name": "punctuation.section.interpolation.begin"
+                }
+            }
+        },
+        "attr-interp-invalid-quotes": {
+            "match": "\\b(?<=[\\w$\\-_]*)\\s*?(!=|=)\\s*?([`'\"])((?![$!#]){.*})(?!\\k<2>)",
+            "captures": {
+                "1": {
+                    "patterns": [
+                        {
+                            "match": "=",
+                            "name": "invalid.illegal"
+                        },
+                        {
+                            "match": "!=",
+                            "name": "keyword.operator.assignment"
+                        }
+                    ]
+                },
+                "2": {
+                    "name": "punctuation.section.interpolation.begin"
+                },
+                "3": {
+                    "name": "invalid.illegal"
+                },
+                "4": {
+                    "name": "invalid.illegal"
+                }
+            }
+        },
+        "attr-interp-invalid-noquotes": {
+            "match": "\\b(?<=[\\w$\\-_]*)\\s*?(!=|=)\\s*?(?![`'\"])((?![$!#]){.*})(?![`'\"])",
+            "captures": {
+                "1": {
+                    "patterns": [
+                        {
+                            "match": "=",
+                            "name": "invalid.illegal"
+                        },
+                        {
+                            "match": "!=",
+                            "name": "keyword.operator.assignment"
+                        }
+                    ]
+                },
+                "2": {
+                    "name": "invalid.illegal"
+                },
+                "3": {
+                    "patterns": [
+                        {
+                            "include": "#interp"
+                        }
+                    ]
+                },
+                "4": {
+                    "name": "invalid.illegal"
+                }
+            }
+        },
+        "attr-function": {
+            "match": "\\b(use|transition|in|out|animate)(:)(\\w+)",
+            "captures": {
+                "1": {
+                    "name": "entity.other.attribute-name"
+                },
+                "2": {
+                    "name": "keyword.operator.assignment"
+                },
+                "3": {
+                    "name": "variable.function"
+                }
+            }
+        },
+        "attr-event": {
+            "match": "\\b(on)(:)(\\w+)",
+            "captures": {
+                "1": {
+                    "name": "entity.other.attribute-name"
+                },
+                "2": {
+                    "name": "keyword.operator.assignment"
+                },
+                "3": {
+                    "name": "entity.name.type"
+                }
+            }
+        },
+        "attr-variable": {
+            "match": "\\b(bind|class|let)(:)(\\w+)",
+            "captures": {
+                "1": {
+                    "name": "entity.other.attribute-name"
+                },
+                "2": {
+                    "name": "keyword.operator.assignment"
+                },
+                "3": {
+                    "name": "variable.parameter"
+                }
+            }
+        }
+    }
+}

--- a/apps/npm/vscode/syntaxes/pug-svelte.json
+++ b/apps/npm/vscode/syntaxes/pug-svelte.json
@@ -1,0 +1,293 @@
+{
+    "scopeName": "svelte.pug",
+    "fileTypes": [],
+    "injectionSelector": "L:text.pug -meta.embedded.ts -meta.tag.other -text.block.pug, L:inline.pug -meta.embedded.ts -meta.tag.other",
+    "patterns": [
+        {
+            "include": "#interp-object-literal"
+        },
+        {
+            "include": "#interp"
+        },
+        {
+            "include": "#tag-component"
+        },
+        {
+            "include": "#tag-component-no-params"
+        },
+        {
+            "include": "#mixin-svelte"
+        },
+        {
+            "include": "#mixin-else"
+        }
+    ],
+    "repository": {
+        "interp-object-literal": {
+            "contentName": "meta.interpolation meta.embedded.ts",
+            "begin": "(?![!$#]){\\s*?(?={)",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.begin"
+                }
+            },
+            "end": "(?<=})\\s*?}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.end"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "source.ts#object-literal"
+                }
+            ]
+        },
+        "interp": {
+            "contentName": "meta.interpolation meta.embedded.ts",
+            "begin": "(?![!$#]){",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.begin"
+                }
+            },
+            "end": "}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.interpolation.end"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "source.ts"
+                }
+            ]
+        },
+        "tag-component": {
+            "name": "meta.tag.svelte",
+            "begin": "(?<=^\\s*?|#\\[\\s*?|:\\s+?)([A-Z][a-zA-Z0-9_]*)\\s*?(?=\\()",
+            "beginCaptures": {
+                "0": {
+                    "name": "support.class.component.svelte"
+                }
+            },
+            "end": "(?<=\\))",
+            "endCaptures": {
+                "0": {
+                    "name": "constant.name.attribute.tag"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.pug#tag_attributes"
+                }
+            ]
+        },
+        "tag-component-no-params": {
+            "name": "meta.tag.svelte",
+            "match": "(?<=^\\s*?|#\\[\\s*?|:\\s+?)([A-Z][a-zA-Z0-9_]*)",
+            "captures": {
+                "0": {
+                    "name": "support.class.component.svelte"
+                }
+            }
+        },
+        "mixin-svelte": {
+            "match": "(?<=^\\s*?|#\\[\\s*?|:\\s+?)(\\+)(debug|if|elseif|then|catch|each|await|html|key)\\s*?(\\()\\s*?([`'\"])(.*?)(\\k<4>)\\s*?(\\))",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.keyword"
+                },
+                "2": {
+                    "patterns": [
+                        {
+                            "match": "debug",
+                            "name": "keyword.other.debugger"
+                        },
+                        {
+                            "match": "if|elseif",
+                            "name": "keyword.control.conditional"
+                        },
+                        {
+                            "match": "then|catch|await",
+                            "name": "keyword.control.flow"
+                        },
+                        {
+                            "match": "each",
+                            "name": "keyword.control"
+                        },
+                        {
+                            "match": "html|key",
+                            "name": "support.function"
+                        }
+                    ]
+                },
+                "3": {
+                    "name": "meta.brace.round"
+                },
+                "4": {
+                    "name": "punctuation.definition.generic.begin"
+                },
+                "5": {
+                    "patterns": [
+                        {
+                            "match": "(?<=each\\s*?\\(\\s*?')(.*)\\s+?(as\\s+?(.*?)(\\s*?,\\s*?)(.*?|)(\\s+?\\(.*\\)|)$)",
+                            "captures": {
+                                "1": {
+                                    "name": "meta.embedded.ts",
+                                    "patterns": [
+                                        {
+                                            "include": "source.ts"
+                                        }
+                                    ]
+                                },
+                                "2": {
+                                    "name": "keyword.control.as"
+                                },
+                                "3": {
+                                    "name": "meta.embedded.t",
+                                    "patterns": [
+                                        {
+                                            "include": "source.ts"
+                                        }
+                                    ]
+                                },
+                                "4": {
+                                    "name": "punctuation.separator"
+                                },
+                                "5": {
+                                    "name": "meta.embedded.t",
+                                    "patterns": [
+                                        {
+                                            "include": "source.ts"
+                                        }
+                                    ]
+                                },
+                                "6": {
+                                    "patterns": [
+                                        {
+                                            "match": "(\\()(.*)(\\))",
+                                            "captures": {
+                                                "1": {
+                                                    "name": "meta.brace.round"
+                                                },
+                                                "2": {
+                                                    "name": "variable"
+                                                },
+                                                "3": {
+                                                    "name": "meta.brace.round"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "match": "(?<=each\\s*?\\(\\s*?')(.*)\\s+?(as\\s+?(.*?)(\\s+?\\(.*\\)|)$)",
+                            "captures": {
+                                "1": {
+                                    "name": "meta.embedded.ts",
+                                    "patterns": [
+                                        {
+                                            "include": "source.ts"
+                                        }
+                                    ]
+                                },
+                                "2": {
+                                    "name": "keyword.control.as"
+                                },
+                                "3": {
+                                    "name": "meta.embedded.t",
+                                    "patterns": [
+                                        {
+                                            "include": "source.ts"
+                                        }
+                                    ]
+                                },
+                                "4": {
+                                    "patterns": [
+                                        {
+                                            "match": "(\\()(.*)(\\))",
+                                            "captures": {
+                                                "1": {
+                                                    "name": "meta.brace.round"
+                                                },
+                                                "2": {
+                                                    "name": "variable"
+                                                },
+                                                "3": {
+                                                    "name": "meta.brace.round"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "match": "(?<=await\\s*?\\(\\s*?')(.*)\\s+?(then(.*)$)",
+                            "captures": {
+                                "1": {
+                                    "name": "meta.embedded.ts",
+                                    "patterns": [
+                                        {
+                                            "include": "source.ts"
+                                        }
+                                    ]
+                                },
+                                "2": {
+                                    "name": "keyword.control.flow"
+                                },
+                                "3": {
+                                    "name": "variable"
+                                }
+                            }
+                        },
+                        {
+                            "match": "(?<=debug\\s*?\\(\\s*?')(\\w+?)(,|$)",
+                            "captures": {
+                                "1": {
+                                    "name": "variable"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator"
+                                }
+                            }
+                        },
+                        {
+                            "match": "(.*)$",
+                            "captures": {
+                                "0": {
+                                    "name": "meta.embedded.ts",
+                                    "patterns": [
+                                        {
+                                            "include": "source.ts"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "6": {
+                    "name": "punctuation.definition.generic.end"
+                },
+                "7": {
+                    "name": "meta.brace.round"
+                }
+            }
+        },
+        "mixin-else": {
+            "match": "(?<=^\\s*?|#\\[\\s*?|:\\s+?)(\\+)(else)",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.keyword"
+                },
+                "2": {
+                    "name": "keyword.control.conditional"
+                }
+            }
+        }
+    }
+}

--- a/apps/npm/vscode/syntaxes/svelte.tmLanguage.json
+++ b/apps/npm/vscode/syntaxes/svelte.tmLanguage.json
@@ -1,0 +1,1287 @@
+{
+  "name": "Svelte Component",
+  "scopeName": "source.svelte",
+  "fileTypes": [
+    "svelte"
+  ],
+  "uuid": "7582b62f-51d9-4a84-8c8d-fc189530faf6",
+  "injections": {
+    "L:(meta.script.svelte | meta.style.svelte) (meta.lang.js | meta.lang.javascript) - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.js",
+          "patterns": [
+            {
+              "include": "source.js"
+            }
+          ]
+        }
+      ]
+    },
+    "L:(meta.script.svelte | meta.style.svelte) (meta.lang.ts | meta.lang.typescript) - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?=[^\\n]+</(script|style)[\\s>])",
+          "end": "(?=</(script|style)[\\s>])",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.ts",
+          "patterns": [
+            {
+              "include": "source.ts"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=>)(?!</)",
+          "while": "^(?!\\s*</(script|style)[\\s>])",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.ts",
+          "patterns": [
+            {
+              "include": "source.ts"
+            }
+          ]
+        }
+      ]
+    },
+    "L:(meta.script.svelte | meta.style.svelte) meta.lang.coffee - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.coffee",
+          "patterns": [
+            {
+              "include": "source.coffee"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.script.svelte - meta.lang - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.js",
+          "patterns": [
+            {
+              "include": "source.js"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.svelte meta.lang.stylus - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.stylus",
+          "patterns": [
+            {
+              "include": "source.stylus"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.svelte meta.lang.sass - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.sass",
+          "patterns": [
+            {
+              "include": "source.sass"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.svelte meta.lang.css - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.css",
+          "patterns": [
+            {
+              "include": "source.css"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.svelte meta.lang.scss - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.css.scss",
+          "patterns": [
+            {
+              "include": "source.css.scss"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.svelte meta.lang.less - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.css.less",
+          "patterns": [
+            {
+              "include": "source.css.less"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.svelte meta.lang.postcss - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.css.postcss",
+          "patterns": [
+            {
+              "include": "source.css.postcss"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.style.svelte - meta.lang - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "source.css",
+          "patterns": [
+            {
+              "include": "source.css"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.template.svelte meta.lang.pug - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "name": "meta.embedded.block.svelte",
+          "contentName": "text.pug",
+          "patterns": [
+            {
+              "include": "text.pug"
+            }
+          ]
+        }
+      ]
+    },
+    "L:meta.template.svelte - meta.lang - (meta source)": {
+      "patterns": [
+        {
+          "begin": "(?<=>)\\s",
+          "end": "(?=</template)",
+          "patterns": [
+            {
+              "include": "#scope"
+            }
+          ]
+        }
+      ]
+    },
+    "L:(source.ts, source.js, source.coffee)": {
+      "patterns": [
+        {
+          "match": "(?<![_$./'\"[:alnum:]])\\$(?=[_[:alpha:]][_$[:alnum:]]*)",
+          "name": "punctuation.definition.variable.svelte"
+        },
+        {
+          "match": "(?<![_$./'\"[:alnum:]])(\\$\\$)(?=props|restProps|slots)",
+          "name": "punctuation.definition.variable.svelte"
+        }
+      ]
+    }
+  },
+  "patterns": [
+    {
+      "include": "#scope"
+    }
+  ],
+  "repository": {
+    "scope": {
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#special-tags"
+        },
+        {
+          "include": "#tags"
+        },
+        {
+          "include": "#interpolation"
+        },
+        {
+          "begin": "(?<=>|})",
+          "end": "(?=<|{)",
+          "name": "text.svelte"
+        }
+      ]
+    },
+    "comments": {
+      "begin": "<!--",
+      "end": "-->",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.svelte"
+        }
+      },
+      "name": "comment.block.svelte",
+      "patterns": [
+        {
+          "begin": "(@)(component)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.keyword.svelte"
+            },
+            "2": {
+              "name": "storage.type.class.component.svelte keyword.declaration.class.component.svelte"
+            }
+          },
+          "end": "(?=-->)",
+          "contentName": "comment.block.documentation.svelte",
+          "patterns": [
+            {
+              "match": ".*?(?=-->)",
+              "captures": {
+                "0": {
+                  "patterns": [
+                    {
+                      "include": "text.html.markdown"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "include": "text.html.markdown"
+            }
+          ]
+        },
+        {
+          "match": "\\G-?>|<!--(?!>)|<!-(?=-->)|--!>",
+          "name": "invalid.illegal.characters-not-allowed-here.svelte"
+        }
+      ]
+    },
+    "destructuring": {
+      "patterns": [
+        {
+          "begin": "(?={)",
+          "end": "(?<=})",
+          "name": "meta.embedded.expression.svelte source.ts",
+          "patterns": [
+            {
+              "include": "source.ts#object-binding-pattern"
+            }
+          ]
+        },
+        {
+          "begin": "(?=\\[)",
+          "end": "(?<=\\])",
+          "name": "meta.embedded.expression.svelte source.ts",
+          "patterns": [
+            {
+              "include": "source.ts#array-binding-pattern"
+            }
+          ]
+        }
+      ]
+    },
+    "destructuring-const": {
+      "patterns": [
+        {
+          "begin": "(?={)",
+          "end": "(?<=})",
+          "name": "meta.embedded.expression.svelte source.ts",
+          "patterns": [
+            {
+              "include": "source.ts#object-binding-pattern-const"
+            }
+          ]
+        },
+        {
+          "begin": "(?=\\[)",
+          "end": "(?<=\\])",
+          "name": "meta.embedded.expression.svelte source.ts",
+          "patterns": [
+            {
+              "include": "source.ts#array-binding-pattern-const"
+            }
+          ]
+        }
+      ]
+    },
+    "interpolation": {
+      "patterns": [
+        {
+          "begin": "\\{",
+          "end": "\\}",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.begin.svelte"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.svelte"
+            }
+          },
+          "contentName": "meta.embedded.expression.svelte source.ts",
+          "patterns": [
+            {
+              "begin": "\\G\\s*(?={)",
+              "end": "(?<=})",
+              "patterns": [
+                {
+                  "include": "source.ts#object-literal"
+                }
+              ]
+            },
+            {
+              "include": "source.ts"
+            }
+          ]
+        }
+      ]
+    },
+    "special-tags": {
+      "patterns": [
+        {
+          "include": "#special-tags-void"
+        },
+        {
+          "include": "#special-tags-block-begin"
+        },
+        {
+          "include": "#special-tags-block-end"
+        }
+      ]
+    },
+    "special-tags-keywords": {
+      "match": "([#@/:])(else\\s+if|[a-z]*)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.keyword.svelte"
+        },
+        "2": {
+          "patterns": [
+            {
+              "match": "if|else\\s+if|else",
+              "name": "keyword.control.conditional.svelte"
+            },
+            {
+              "match": "each|key",
+              "name": "keyword.control.svelte"
+            },
+            {
+              "match": "await|then|catch",
+              "name": "keyword.control.flow.svelte"
+            },
+            {
+              "match": "snippet",
+              "name": "keyword.control.svelte"
+            },
+            {
+              "match": "html",
+              "name": "keyword.other.svelte"
+            },
+            {
+              "match": "render",
+              "name": "keyword.other.svelte"
+            },
+            {
+              "match": "debug",
+              "name": "keyword.other.debugger.svelte"
+            },
+            {
+              "match": "const",
+              "name": "storage.type.svelte"
+            }
+          ]
+        }
+      }
+    },
+    "special-tags-modes": {
+      "patterns": [
+        {
+          "begin": "(?<=(if|key|then|catch|html|render).*?)\\G",
+          "end": "(?=})",
+          "name": "meta.embedded.expression.svelte source.ts",
+          "patterns": [
+            {
+              "include": "source.ts"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=snippet.*?)\\G",
+          "end": "(?=})",
+          "name": "meta.embedded.expression.svelte source.ts",
+          "patterns": [
+            {
+              "match": "\\G\\s*([_$[:alpha:]][_$[:alnum:]]*)\\s*(?=<)",
+              "captures": {
+                "1": {
+                  "name": "entity.name.function.ts"
+                }
+              }
+            },
+            {
+              "begin": "(?<=<)",
+              "end": "(?=>)",
+              "contentName": "meta.type.parameters.ts",
+              "patterns": [
+                {
+                  "include": "source.ts"
+                }
+              ]
+            },
+            {
+              "begin": "(?<=>\\s*\\()",
+              "end": "(?=})",
+              "name": "meta.embedded.expression.svelte source.ts",
+              "patterns": [
+                {
+                  "include": "source.ts"
+                }
+              ]
+            },
+            {
+              "begin": "\\G",
+              "end": "(?=})",
+              "name": "meta.embedded.expression.svelte source.ts",
+              "patterns": [
+                {
+                  "include": "source.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=const.*?)\\G",
+          "end": "(?=})",
+          "patterns": [
+            {
+              "include": "#destructuring-const"
+            },
+            {
+              "begin": "\\G\\s*([_$[:alpha:]][_$[:alnum:]]+)\\s*",
+              "end": "(?=[:=])",
+              "beginCaptures": {
+                "1": {
+                  "name": "variable.other.constant.svelte"
+                }
+              }
+            },
+            {
+              "begin": "(?=:)",
+              "end": "(?=\\=)",
+              "name": "meta.type.annotation.svelte",
+              "patterns": [
+                {
+                  "include": "source.ts"
+                }
+              ]
+            },
+            {
+              "begin": "(?=\\=)",
+              "name": "meta.embedded.expression.svelte source.ts",
+              "end": "(?=})",
+              "patterns": [
+                {
+                  "include": "source.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=each.*?)\\G",
+          "end": "(?=})",
+          "patterns": [
+            {
+              "begin": "\\G\\s*?(?=\\S)",
+              "end": "(?=(?:(?:^\\s*|\\s+)(as))|\\s*(}|,))",
+              "contentName": "meta.embedded.expression.svelte source.ts",
+              "patterns": [
+                {
+                  "include": "source.ts"
+                }
+              ]
+            },
+            {
+              "begin": "(as)|(?=}|,)",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.control.as.svelte"
+                }
+              },
+              "end": "(?=})",
+              "patterns": [
+                {
+                  "include": "#destructuring"
+                },
+                {
+                  "begin": "\\(",
+                  "end": "\\)|(?=})",
+                  "captures": {
+                    "0": {
+                      "name": "meta.brace.round.svelte"
+                    }
+                  },
+                  "contentName": "meta.embedded.expression.svelte source.ts",
+                  "patterns": [
+                    {
+                      "include": "source.ts"
+                    }
+                  ]
+                },
+                {
+                  "match": "(\\s*([_$[:alpha:]][_$[:alnum:]]*)\\s*)",
+                  "captures": {
+                    "1": {
+                      "name": "meta.embedded.expression.svelte source.ts",
+                      "patterns": [
+                        {
+                          "include": "source.ts"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "match": ",",
+                  "name": "punctuation.separator.svelte"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=await.*?)\\G",
+          "end": "(?=})",
+          "patterns": [
+            {
+              "begin": "\\G\\s*?(?=\\S)",
+              "end": "\\s+(then)|(?=})",
+              "endCaptures": {
+                "1": {
+                  "name": "keyword.control.flow.svelte"
+                }
+              },
+              "contentName": "meta.embedded.expression.svelte source.ts",
+              "patterns": [
+                {
+                  "include": "source.ts"
+                }
+              ]
+            },
+            {
+              "begin": "(?<=then\\b)",
+              "end": "(?=})",
+              "contentName": "meta.embedded.expression.svelte source.ts",
+              "patterns": [
+                {
+                  "include": "source.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?<=debug.*?)\\G",
+          "end": "(?=})",
+          "patterns": [
+            {
+              "match": "[_$[:alpha:]][_$[:alnum:]]*",
+              "captures": {
+                "0": {
+                  "name": "meta.embedded.expression.svelte source.ts",
+                  "patterns": [
+                    {
+                      "include": "source.ts"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.svelte"
+            }
+          ]
+        }
+      ]
+    },
+    "special-tags-void": {
+      "begin": "({)\\s*((?:[@:])(else\\s+if|[a-z]*))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.block.begin.svelte"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#special-tags-keywords"
+            }
+          ]
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.block.end.svelte"
+        }
+      },
+      "name": "meta.special.$3.svelte",
+      "patterns": [
+        {
+          "include": "#special-tags-modes"
+        }
+      ]
+    },
+    "special-tags-block-begin": {
+      "begin": "({)\\s*(#([a-z]*))",
+      "end": "(})",
+      "name": "meta.special.$3.svelte meta.special.start.svelte",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.block.begin.svelte"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#special-tags-keywords"
+            }
+          ]
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.block.end.svelte"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#special-tags-modes"
+        }
+      ]
+    },
+    "special-tags-block-end": {
+      "begin": "({)\\s*(/([a-z]*))",
+      "end": "(})",
+      "name": "meta.special.$3.svelte meta.special.end.svelte",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.block.begin.svelte"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#special-tags-keywords"
+            }
+          ]
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.block.end.svelte"
+        }
+      }
+    },
+    "attributes": {
+      "patterns": [
+        {
+          "include": "#attributes-comments"
+        },
+        {
+          "include": "#attributes-directives"
+        },
+        {
+          "include": "#attributes-keyvalue"
+        },
+        {
+          "include": "#attributes-attach"
+        },
+        {
+          "include": "#attributes-interpolated"
+        }
+      ]
+    },
+    "attributes-comments": {
+      "patterns": [
+        {
+          "match": "//.*$",
+          "name": "comment.line.double-slash.svelte"
+        },
+        {
+          "begin": "/\\*",
+          "end": "\\*/",
+          "name": "comment.block.svelte"
+        }
+      ]
+    },
+    "attributes-attach": {
+      "begin": "(?<!:|=)\\s*({@attach\\s)",
+      "end": "(\\})",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name.svelte"
+        }
+      },
+      "contentName": "meta.embedded.expression.svelte source.ts",
+      "patterns": [
+        {
+          "include": "source.ts"
+        }
+      ]
+    },
+    "attributes-interpolated": {
+      "begin": "(?<!:|=)\\s*({)",
+      "end": "(\\})",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name.svelte"
+        }
+      },
+      "contentName": "meta.embedded.expression.svelte source.ts",
+      "patterns": [
+        {
+          "include": "source.ts"
+        }
+      ]
+    },
+    "attributes-keyvalue": {
+      "begin": "((?:--)?[_$[:alpha:]][_\\-$[:alnum:]]*)",
+      "beginCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "match": "--.*",
+              "name": "support.type.property-name.svelte"
+            },
+            {
+              "match": ".*",
+              "name": "entity.other.attribute-name.svelte"
+            }
+          ]
+        }
+      },
+      "end": "(?=\\s*+[^=\\s])",
+      "name": "meta.attribute.$1.svelte",
+      "patterns": [
+        {
+          "begin": "=",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.key-value.svelte"
+            }
+          },
+          "end": "(?<=[^\\s=])(?!\\s*=)|(?=/?>)",
+          "patterns": [
+            {
+              "include": "#attributes-value"
+            }
+          ]
+        }
+      ]
+    },
+    "attributes-value": {
+      "patterns": [
+        {
+          "include": "#interpolation"
+        },
+        {
+          "match": "(?:(['\"])([0-9._]+[\\w%]{,4})(\\1))|(?:([0-9._]+[\\w%]{,4})(?=\\s|/?>))",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.svelte"
+            },
+            "2": {
+              "name": "constant.numeric.decimal.svelte"
+            },
+            "3": {
+              "name": "punctuation.definition.string.end.svelte"
+            },
+            "4": {
+              "name": "constant.numeric.decimal.svelte"
+            }
+          }
+        },
+        {
+          "match": "([^\\s\"'=<>`/]|/(?!>))+",
+          "name": "string.unquoted.svelte",
+          "patterns": [
+            {
+              "include": "#interpolation"
+            }
+          ]
+        },
+        {
+          "begin": "(['\"])",
+          "end": "\\1",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.svelte"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.svelte"
+            }
+          },
+          "name": "string.quoted.svelte",
+          "patterns": [
+            {
+              "include": "#interpolation"
+            }
+          ]
+        }
+      ]
+    },
+    "attributes-directives-keywords": {
+      "patterns": [
+        {
+          "match": "on|use|bind",
+          "name": "keyword.control.svelte"
+        },
+        {
+          "match": "transition|in|out|animate",
+          "name": "keyword.other.animation.svelte"
+        },
+        {
+          "match": "let",
+          "name": "storage.type.svelte"
+        },
+        {
+          "match": "class|style",
+          "name": "entity.other.attribute-name.svelte"
+        }
+      ]
+    },
+    "attributes-directives-types": {
+      "patterns": [
+        {
+          "match": "(?<=(on):).*$",
+          "name": "entity.name.type.svelte"
+        },
+        {
+          "match": "(?<=(bind):).*$",
+          "name": "variable.parameter.svelte"
+        },
+        {
+          "match": "(?<=(use|transition|in|out|animate):).*$",
+          "name": "variable.function.svelte"
+        },
+        {
+          "match": "(?<=(let|class|style):).*$",
+          "name": "variable.parameter.svelte"
+        }
+      ]
+    },
+    "attributes-directives-types-assigned": {
+      "patterns": [
+        {
+          "match": "(?<=(bind):)this$",
+          "name": "variable.language.svelte"
+        },
+        {
+          "match": "(?<=(bind):).*$",
+          "name": "entity.name.type.svelte"
+        },
+        {
+          "match": "(?<=(class):).*$",
+          "name": "entity.other.attribute-name.class.svelte"
+        },
+        {
+          "match": "(?<=(style):).*$",
+          "name": "support.type.property-name.svelte"
+        },
+        {
+          "include": "#attributes-directives-types"
+        }
+      ]
+    },
+    "attributes-directives": {
+      "begin": "(?<!<)(on|use|bind|transition|in|out|animate|let|class|style)(:)(?:((?:--)?[_$[:alpha:]][_\\-$[:alnum:]]*(?=\\s*=))|((?:--)?[_$[:alpha:]][_\\-$[:alnum:]]*))((\\|\\w+)*)",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#attributes-directives-keywords"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.definition.keyword.svelte"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#attributes-directives-types-assigned"
+            }
+          ]
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#attributes-directives-types"
+            }
+          ]
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\w+",
+              "name": "support.function.svelte"
+            },
+            {
+              "match": "\\|",
+              "name": "punctuation.separator.svelte"
+            }
+          ]
+        }
+      },
+      "end": "(?=\\s*+[^=\\s])",
+      "name": "meta.directive.$1.svelte",
+      "patterns": [
+        {
+          "begin": "=",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.key-value.svelte"
+            }
+          },
+          "end": "(?<=[^\\s=])(?!\\s*=)|(?=/?>)",
+          "patterns": [
+            {
+              "include": "#attributes-value"
+            }
+          ]
+        }
+      ]
+    },
+    "attributes-generics": {
+      "begin": "(generics)(=)([\"'])",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.other.attribute-name.svelte"
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.svelte"
+        },
+        "3": {
+          "name": "punctuation.definition.string.begin.svelte"
+        }
+      },
+      "end": "(\\3)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end.svelte"
+        }
+      },
+      "contentName": "meta.embedded.expression.svelte source.ts",
+      "patterns": [
+        {
+          "include": "#type-parameters"
+        }
+      ]
+    },
+    "type-parameters": {
+      "name": "meta.type.parameters.ts",
+      "patterns": [
+        {
+          "include": "source.ts#comment"
+        },
+        {
+          "name": "storage.modifier.ts",
+          "match": "(?<![_$[:alnum:]])(?:(?<=\\.\\.\\.)|(?<!\\.))(extends|in|out|const)(?![_$[:alnum:]])(?:(?=\\.\\.\\.)|(?!\\.))"
+        },
+        {
+          "include": "source.ts#type"
+        },
+        {
+          "include": "source.ts#punctuation-comma"
+        },
+        {
+          "name": "keyword.operator.assignment.ts",
+          "match": "(=)(?!>)"
+        }
+      ]
+    },
+    "tags": {
+      "patterns": [
+        {
+          "include": "#tags-lang"
+        },
+        {
+          "include": "#tags-void"
+        },
+        {
+          "include": "#tags-general-end"
+        },
+        {
+          "include": "#tags-general-start"
+        }
+      ]
+    },
+    "tags-name": {
+      "patterns": [
+        {
+          "match": "(svelte)(:)([a-z][\\w:-]*)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.svelte"
+            },
+            "2": {
+              "name": "punctuation.definition.keyword.svelte"
+            },
+            "3": {
+              "name": "entity.name.tag.svelte"
+            }
+          }
+        },
+        {
+          "match": "slot",
+          "name": "keyword.control.svelte"
+        },
+        {
+          "match": "([\\w]+(?:\\.[\\w]+)+)|([A-Z][\\w]*)",
+          "captures": {
+            "1": {
+              "patterns": [
+                {
+                  "match": "\\w+",
+                  "name": "support.class.component.svelte"
+                },
+                {
+                  "match": "\\.",
+                  "name": "punctuation.definition.keyword.svelte"
+                }
+              ]
+            },
+            "2": {
+              "name": "support.class.component.svelte"
+            }
+          }
+        },
+        {
+          "match": "[a-z][\\w0-9:]*-[\\w0-9:-]*",
+          "name": "meta.tag.custom.svelte entity.name.tag.svelte"
+        },
+        {
+          "match": "[a-z][\\w0-9:-]*",
+          "name": "entity.name.tag.svelte"
+        }
+      ]
+    },
+    "tags-start-attributes": {
+      "begin": "\\G",
+      "end": "(?=/?>)",
+      "name": "meta.tag.start.svelte",
+      "patterns": [
+        {
+          "include": "#attributes"
+        }
+      ]
+    },
+    "tags-lang-start-attributes": {
+      "begin": "\\G",
+      "end": "(?=/>)|>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.svelte"
+        }
+      },
+      "name": "meta.tag.start.svelte",
+      "patterns": [
+        {
+          "include": "#attributes-generics"
+        },
+        {
+          "include": "#attributes"
+        }
+      ]
+    },
+    "tags-start-node": {
+      "match": "(<)([^/\\s>/]*)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.svelte"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#tags-name"
+            }
+          ]
+        }
+      },
+      "name": "meta.tag.start.svelte"
+    },
+    "tags-end-node": {
+      "match": "(</)(.*?)\\s*(>)|(/>)",
+      "captures": {
+        "1": {
+          "name": "meta.tag.end.svelte punctuation.definition.tag.begin.svelte"
+        },
+        "2": {
+          "name": "meta.tag.end.svelte",
+          "patterns": [
+            {
+              "include": "#tags-name"
+            }
+          ]
+        },
+        "3": {
+          "name": "meta.tag.end.svelte punctuation.definition.tag.end.svelte"
+        },
+        "4": {
+          "name": "meta.tag.start.svelte punctuation.definition.tag.end.svelte"
+        }
+      }
+    },
+    "tags-lang": {
+      "begin": "<(script|style|template)",
+      "end": "</\\1\\s*>|/>",
+      "beginCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#tags-start-node"
+            }
+          ]
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#tags-end-node"
+            }
+          ]
+        }
+      },
+      "name": "meta.$1.svelte",
+      "patterns": [
+        {
+          "begin": "\\G(?=\\s*[^>]*?(type|lang)\\s*=\\s*(['\"]|)(?:text/)?(\\w+)\\2)",
+          "end": "(?=</|/>)",
+          "name": "meta.lang.$3.svelte",
+          "patterns": [
+            {
+              "include": "#tags-lang-start-attributes"
+            }
+          ]
+        },
+        {
+          "include": "#tags-lang-start-attributes"
+        }
+      ]
+    },
+    "tags-void": {
+      "begin": "(<)(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)(?=\\s|/?>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.svelte"
+        },
+        "2": {
+          "name": "entity.name.tag.svelte"
+        }
+      },
+      "end": "/?>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.begin.svelte"
+        }
+      },
+      "name": "meta.tag.void.svelte",
+      "patterns": [
+        {
+          "include": "#attributes"
+        }
+      ]
+    },
+    "tags-general-start": {
+      "begin": "(<)([^/\\s>/]*)",
+      "end": "(/?>)",
+      "beginCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#tags-start-node"
+            }
+          ]
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "meta.tag.start.svelte punctuation.definition.tag.end.svelte"
+        }
+      },
+      "name": "meta.scope.tag.$2.svelte",
+      "patterns": [
+        {
+          "include": "#tags-start-attributes"
+        }
+      ]
+    },
+    "tags-general-end": {
+      "begin": "(</)([^/\\s>]*)",
+      "end": "(>)",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.tag.end.svelte punctuation.definition.tag.begin.svelte"
+        },
+        "2": {
+          "name": "meta.tag.end.svelte",
+          "patterns": [
+            {
+              "include": "#tags-name"
+            }
+          ]
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "meta.tag.end.svelte punctuation.definition.tag.end.svelte"
+        }
+      },
+      "name": "meta.scope.tag.$2.svelte"
+    }
+  }
+}


### PR DESCRIPTION
Wave 4 / M5, first slice. Until now `apps/npm/vscode` contributed three settings and nothing else — no `svelte` language definition, no TextMate grammar — so it only worked if the official Svelte extension was also installed. This makes it stand on its own.

## What was vendored, and from where

All from `submodules/language-tools/packages/svelte-vscode` (`sveltejs/language-tools`, MIT). Grammars whose upstream source of truth is YAML were compiled with the same `js-yaml` step upstream uses (`JSON.stringify(yaml.safeLoad(...), null, '  ')`, i.e. `npx js-yaml <file>`); the rest are verbatim copies.

| This extension | Upstream |
| --- | --- |
| `syntaxes/svelte.tmLanguage.json` | `syntaxes/svelte.tmLanguage.src.yaml` (compiled) |
| `syntaxes/postcss.json` | `syntaxes/postcss.src.yaml` (compiled) |
| `syntaxes/pug-svelte{,-tags,-dotblock}.json` | same names (verbatim) |
| `syntaxes/markdown-svelte{,-js,-css}.json` | same names (verbatim) |
| `snippets/{svelte,javascript,typescript}.json` | same names (verbatim) |
| `language-configuration.json` | same name (verbatim) |
| `language-configuration-start-tag.json` | same name (verbatim) |
| `setLanguageConfiguration` block in `src/extension.ts` | `src/extension.ts` + `src/html/htmlEmptyTagsShared.ts` |

The compiled JSON is committed rather than generated at build time: these are vendored assets we do not edit, and committing them keeps `build.mjs` free of a YAML toolchain and removes any build-order risk for the `.vsix`.

`contributes` now has `languages` (`svelte` + the `svelte-start-tag` helper language the grammar's `embeddedLanguages` maps `meta.tag.start.svelte` onto — the grammar misbehaves without it), `grammars`, `snippets` and `breakpoints`. Upstream's third language contribution (`json` for `.prettierrc`) was deliberately left out — it is prettier-specific, not Svelte support.

Attribution lives in a standalone `apps/npm/vscode/THIRD_PARTY_NOTICES.md` with the full MIT text of `sveltejs/language-tools` and of `microsoft/vscode` (the void-element list originates there, by way of language-tools). No provenance comments were added to code.

## scopeName: kept identical to upstream

`source.svelte`, plus `svelte.pug{,.tags,.dotblock}`, `markdown.svelte.codeblock{,.script,.style}` and `source.css.postcss` — all unchanged from upstream. Renaming them was considered and rejected:

- `source.svelte` is the ecosystem's public contract. `markdown-svelte.json` includes it by scope name to highlight ` ```svelte ` blocks, and third-party injection grammars (Tailwind CSS IntelliSense, comment taggers, …) target it via `injectTo: ["source.svelte"]`. A private scope name would silently lose all of that.
- For the co-installed case, identical scope names are the *safer* choice, not the riskier one. VS Code keys grammars by scope name: `TMScopeRegistry` does `this._scopeNameToLanguageRegistration[def.scopeName] = def`, so the second registration logs a warning and then **overwrites** the first — last one wins, and which extension that is depends on activation order, so it is not predictable. Since both copies derive from the same upstream source, either winner produces identical highlighting today. The implication to keep in mind: if upstream's grammar changes and our vendored copy lags behind, a co-installed user gets whichever version happened to register last. Renaming our injection grammars would be worse still — *both* copies would register and inject into `source.svelte` twice.

So co-installation degrades to "a duplicate-scope warning in the log plus duplicated features", never to broken highlighting.

## Conflict detection

On activate, if `extensions.getExtension('svelte.svelte-vscode')` resolves, a single warning notification explains the overlap — same grammar, and both extensions register providers for `svelte`, so problems, completions and hovers double up and VS Code prompts for which formatter to use — and asks the user to disable one. Its only action is **Don't show again**, which sets a flag in `context.globalState` so it never fires again. No polling, no command, no config surface.

## How `.vsix` inclusion was verified

`.vscodeignore` is a blocklist (`src/**`, `build.mjs`, `tsconfig.json`, `.gitignore`, `**/*.map`, `dist/lib/**`) and `package.json` has no `files` field, so the new assets are included by default — no ignore-rule change was needed. Rather than assert that, it was checked directly:

- `npx @vscode/vsce@^3 ls --no-dependencies` → lists all 8 grammars, 3 snippets, both `language-configuration*.json` and `THIRD_PARTY_NOTICES.md`.
- A real `vsce package` run (with a stub language-server bundle standing in for the wasm build, which needs `cargo`/`wasm-pack`) produced a `.vsix`; `unzip -l` confirms `extension/language-configuration.json`, `extension/language-configuration-start-tag.json`, `extension/THIRD_PARTY_NOTICES.md`, `extension/syntaxes/*` and `extension/snippets/*` are inside. The stub artifacts were removed afterwards (both paths are gitignored).

Other checks: every vendored `.json` / `.tmLanguage.json` plus `package.json` round-trips through `JSON.parse` (14/14 OK); `pnpm --filter rsvelte-vscode run typecheck` passes; `node build.mjs` bundles `dist/extension.js` successfully and then stops at the pre-existing "language-server bundle missing" guard, which is unrelated to this change and is satisfied in CI.

## Not in this PR

`svelte.*` setting compatibility, commands, SvelteKit file generation, language-server changes, Marketplace publishing.

Refs #1766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tsoBsfzrKu4kfbfrdFYJS
