### PR TITLE
docs(svelte2tsx): 誤って連結された doc コメントを本来の項目へ戻す

### DIFF
--- a/crates/rsvelte_core/src/svelte2tsx/script/hoistable_types.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/script/hoistable_types.rs
@@ -6,13 +6,6 @@ use std::collections::HashSet;
 use super::super::magic_string::MagicString;
 use super::ExportedNames;
 
-/// Walk every `TSTypeAssertion` in a module script's AST and rewrite
-/// `<Type>expr` to `expr as Type` via `MagicString.overwrite`. Nested
-/// Rewrite a top-level `interface X { ... }` (with optional `extends Y, Z`)
-/// into `type X = Y & Z & { ... }` for dts-mode output. Indirectly using
-/// interfaces inside the return type of a function is forbidden by the
-/// declaration emitter, so the JS reference's
-/// `transformInterfacesToTypes(...)` performs this rewrite. Mirror that here.
 /// One top-level `type X = ...` or `interface X { ... }` from the instance
 /// script that may be hoistable above `function $$render()`.
 #[derive(Debug, Clone)]
@@ -712,6 +705,11 @@ fn has_whole_ident(text: &str, name: &str) -> bool {
     false
 }
 
+/// Rewrite a top-level `interface X { ... }` (with optional `extends Y, Z`)
+/// into `type X = Y & Z & { ... }` for dts-mode output. Indirectly using
+/// interfaces inside the return type of a function is forbidden by the
+/// declaration emitter, so the JS reference's
+/// `transformInterfacesToTypes(...)` performs this rewrite. Mirror that here.
 ///
 /// Concretely:
 /// - `interface X { … }`                  → `type X ={ … }`


### PR DESCRIPTION
## 問題

`script/hoistable_types.rs` の `HoistCandidate` に、**無関係な 3 つの doc ブロックが連結**されていました。

```rust
/// Walk every `TSTypeAssertion` in a module script's AST and rewrite
/// `<Type>expr` to `expr as Type` via `MagicString.overwrite`. Nested   ← ここで途切れている
/// Rewrite a top-level `interface X { ... }` (with optional `extends Y, Z`)
/// into `type X = Y & Z & { ... }` for dts-mode output. …
/// One top-level `type X = ...` or `interface X { ... }` from the instance
/// script that may be hoistable above `function $$render()`.
struct HoistCandidate { … }
```

対になる形で、`rewrite_interface_to_type_dts` は導入段落を失い、裸の `///` から始まっていました:

```rust
///
/// Concretely:
/// - `interface X { … }` → `type X ={ … }`
pub(super) fn rewrite_interface_to_type_dts(…)
```

`git log -S` で追ったところ、この連結は **svelte2tsx の分割リファクタリング (#1745〜#1769) より前から存在**していました（少なくとも #1480 の時点で確認）。分割 PR では純粋移動の原則に従いそのまま移動させています。

## 変更

- ブロック 2（`interface`→`type` 書き換えの説明）を `rewrite_interface_to_type_dts` の導入段落として復元
- ブロック 1（"Nested" で途切れた `TSTypeAssertion` の説明の断片）を削除。同じ処理は `type_assertion.rs` の `rewrite_type_assertions_with_program` が完全な説明を持っています
- ブロック 3（本来の `HoistCandidate` の説明）はそのまま

**コメントのみの変更で、コードには一切影響しません。**

## 同種の破損がないことの確認

`crates/rsvelte_core/src/svelte2tsx/` 配下の全 `.rs` を走査し、「文が途中で切れた `///` 行の直後に、典型的な doc 開始動詞で始まる `///` 行が続く」パターンを検出するスクリプトをかけました。**この 1 件を修正後、検出 0 件**です。

なお同系統の事故が template 側にも 1 件あり（`handle_expression_tag` の doc が `comments_in_opener_range` に連結）、そちらは #1760 で分割に伴い切り分け済みです。