### PR TITLE
test(svelte2tsx): move 後の overwrite/remove が無関係チャンクを消さないことを固定

### DIFF
--- a/crates/rsvelte_core/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_core/src/svelte2tsx/magic_string.rs
@@ -1330,4 +1330,26 @@ mod tests {
         let t = sm.lookup_token(0, 4).expect("token at generated col 4");
         assert_eq!(t.get_src_col(), 4);
     }
+
+    /// `overwrite` and `remove` walk by ORIGINAL position, not by the chunk
+    /// linked list, so a `move_range` that interleaves a foreign chunk into the
+    /// target range cannot blank it. Locking this in: the property is what
+    /// makes svelte2tsx's phase ordering forgiving, and only a comment guarded
+    /// it before.
+    #[test]
+    fn overwrite_and_remove_ignore_chunks_relocated_into_the_range() {
+        // A=[0,3) B=[3,6) C=[6,9); move C between A and B.
+        let mut s = MagicString::new("AAABBBCCC");
+        s.move_range(6, 9, 3);
+        assert_eq!(s.to_string(), "AAACCCBBB");
+        // [0,6) is A+B in original coordinates; a next-pointer walk would also
+        // reach the relocated C.
+        s.overwrite(0, 6, "X");
+        assert_eq!(s.to_string(), "XCCC");
+
+        let mut s = MagicString::new("AAABBBCCC");
+        s.move_range(6, 9, 3);
+        s.remove(0, 6);
+        assert_eq!(s.to_string(), "CCC");
+    }
 }


### PR DESCRIPTION
## 背景

svelte2tsx の分割リファクタリング (#1749 / #1759) のレビューで、次の設計リスクが指摘されました。

> `svelte2tsx.rs:316` の「全 `overwrite` は全 `move_range` より前」という制約は、以前は 1 つの巨大関数の中に上から下まで書かれていて目視で追えたが、分割後は関数境界を跨いだ**暗黙の呼び出し順序依存**に格下げされた。コンパイラは強制しない。

当初はこの順序を `debug_assert` で機械強制するつもりでしたが、**実装を読んだところ前提が違っていました。**

## 分かったこと

`MagicString::overwrite` と `remove` は、チャンクの連結リスト（`next` ポインタ）ではなく**元ソース位置**（`by_start`）で走査します。そのため `move_range` が対象範囲の途中に別位置のチャンクを差し込んでも、そのチャンクは走査対象に入りません。

つまり `svelte2tsx.rs:316` のコメントが警告している故障モード

> after a move, chunks from other parts of the source can appear between the start and end positions, causing them to be blanked out

は、**`MagicString` の層で既に解消済み**です。実験で確認しました:

```rust
let mut s = MagicString::new("AAABBBCCC");
s.move_range(6, 9, 3);          // 連結リスト順: A, C, B
s.overwrite(0, 6, "X");         // 元座標では A+B のみ
assert_eq!(s.to_string(), "XCCC");  // C は無傷 → pass
```

したがって順序制約に対する `debug_assert` は、存在しない危険に対するアサートになるため**追加しません**。

## 変更

代わりに、この性質を**回帰テストで固定**します。現状これを守っているのは実装内のコメントだけで、走査を `next` ポインタ方式に戻す変更を入れても既存テストでは検出できません（`overwrite` / `remove` の両方を確認）。

`svelte2tsx.rs:316` の順序コメントはそのまま残します。この性質があるため制約は防御的なものに留まりますが、`append_left` / `prepend_right` の位置指定など他の順序依存まで検証したわけではないので、コメントを消す判断はしていません。