### PR TITLE
refactor: compress hand-built ESTree JSON in legacy.rs and expression.rs (−656 lines)

### DIFF
--- a/crates/rsvelte_core/src/compiler/legacy.rs
+++ b/crates/rsvelte_core/src/compiler/legacy.rs
@@ -21,6 +21,8 @@ use regex::Regex;
 use serde_json::{Map, Value, json};
 use std::sync::LazyLock;
 
+use crate::ast::js::Expression;
+use crate::ast::span::SourceLocation;
 use crate::ast::{
     AnimateDirective, AttachTag, Attribute, AttributeNode, AttributeValue, AttributeValuePart,
     AwaitBlock, BindDirective, ClassDirective, Comment, Component, ConstTag, DebugTag, EachBlock,
@@ -29,6 +31,34 @@ use crate::ast::{
     SvelteComponentElement, SvelteDynamicElement, SvelteElement, TemplateNode, Text, TitleElement,
     TransitionDirective, UseDirective,
 };
+
+/// Insert ESTree fields into an existing `Map`, in written order.
+///
+/// `serde_json` is built with `preserve_order`, so insertion order *is* the JSON
+/// key order and therefore part of the legacy AST's compatibility contract. The
+/// macro expands to plain sequential `insert` calls, keeping source order and
+/// wire order identical. `"key": value` wraps `value` in `json!`; `"key" =>
+/// value` inserts an existing `Value` verbatim.
+macro_rules! estree_fields {
+    ($obj:ident, $key:literal : $value:expr $(, $($rest:tt)*)?) => {
+        $obj.insert($key.to_string(), json!($value));
+        $( estree_fields!($obj, $($rest)*); )?
+    };
+    ($obj:ident, $key:literal => $value:expr $(, $($rest:tt)*)?) => {
+        $obj.insert($key.to_string(), $value);
+        $( estree_fields!($obj, $($rest)*); )?
+    };
+    ($obj:ident $(,)?) => {};
+}
+
+/// `estree_fields!` for a fresh object; evaluates to the built `Value::Object`.
+macro_rules! estree_obj {
+    ($($fields:tt)*) => {{
+        let mut obj = Map::new();
+        estree_fields!(obj, $($fields)*);
+        Value::Object(obj)
+    }};
+}
 
 // Regex patterns for whitespace handling
 static REGEX_STARTS_WITH_WHITESPACE: LazyLock<Regex> =
@@ -245,20 +275,13 @@ fn convert_to_legacy_inner(source: &str, ast: Root) -> Value {
     }
 
     // Build html fragment
-    let mut html = Map::new();
-    html.insert("type".to_string(), json!("Fragment"));
-    html.insert("start".to_string(), json!(start));
-    html.insert("end".to_string(), json!(end));
-    html.insert(
-        "children".to_string(),
-        json!(
-            fragment_nodes
-                .iter()
-                .map(|node| convert_node(source, node, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert("html".to_string(), Value::Object(html));
+    let html = estree_obj! {
+        "type": "Fragment",
+        "start": start,
+        "end": end,
+        "children" => children_json(source, &fragment_nodes, &[]),
+    };
+    estree_fields!(result, "html" => html);
 
     // Convert instance script
     if let Some(instance) = ast.instance {
@@ -309,11 +332,14 @@ fn convert_to_legacy_inner(source: &str, ast: Root) -> Value {
 /// scripts — without round-tripping through `as_object_mut().unwrap()`.
 fn convert_script(script: &Script) -> Map<String, Value> {
     let mut result = Map::new();
-    result.insert("type".to_string(), json!("Script"));
-    result.insert("start".to_string(), json!(script.start));
-    result.insert("end".to_string(), json!(script.end));
-    result.insert("context".to_string(), json!(script.context));
-    result.insert("content".to_string(), script.content.as_json().clone());
+    estree_fields!(
+        result,
+        "type": "Script",
+        "start": script.start,
+        "end": script.end,
+        "context": script.context,
+        "content" => script.content.as_json().clone(),
+    );
     result
 }
 
@@ -420,13 +446,11 @@ fn convert_text(text: &Text, path: &[&str]) -> Value {
     let in_style = path.last() == Some(&"style");
 
     let mut result = Map::new();
-    result.insert("type".to_string(), json!("Text"));
-    result.insert("start".to_string(), json!(text.start));
-    result.insert("end".to_string(), json!(text.end));
+    estree_fields!(result, "type": "Text", "start": text.start, "end": text.end);
     if !in_style {
-        result.insert("raw".to_string(), json!(text.raw.as_ref()));
+        estree_fields!(result, "raw": text.raw.as_ref());
     }
-    result.insert("data".to_string(), json!(text.data.as_ref()));
+    estree_fields!(result, "data": text.data.as_ref());
     Value::Object(result)
 }
 
@@ -434,13 +458,13 @@ fn convert_comment(comment: &Comment) -> Value {
     // Extract svelte-ignore directives
     let ignores = extract_svelte_ignore(&comment.data);
 
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Comment"));
-    result.insert("start".to_string(), json!(comment.start));
-    result.insert("end".to_string(), json!(comment.end));
-    result.insert("data".to_string(), json!(comment.data.as_str()));
-    result.insert("ignores".to_string(), json!(ignores));
-    Value::Object(result)
+    estree_obj! {
+        "type": "Comment",
+        "start": comment.start,
+        "end": comment.end,
+        "data": comment.data.as_str(),
+        "ignores": ignores,
+    }
 }
 
 fn extract_svelte_ignore(data: &str) -> Vec<String> {
@@ -462,35 +486,28 @@ fn extract_svelte_ignore(data: &str) -> Vec<String> {
 }
 
 fn convert_expression_tag(expr_tag: &ExpressionTag, path: &[&str]) -> Value {
-    // Check if parent is an Attribute and starts with {
-    let in_attribute = path.last() == Some(&"Attribute");
-
-    let mut result = Map::new();
-    if in_attribute {
-        // This is an AttributeShorthand
-        result.insert("type".to_string(), json!("AttributeShorthand"));
+    // An expression tag whose parent is an Attribute is the `{id}` shorthand.
+    let ty = if path.last() == Some(&"Attribute") {
+        "AttributeShorthand"
     } else {
-        result.insert("type".to_string(), json!("MustacheTag"));
+        "MustacheTag"
+    };
+
+    estree_obj! {
+        "type": ty,
+        "start": expr_tag.start,
+        "end": expr_tag.end,
+        "expression" => expr_tag.expression.as_json().clone(),
     }
-    result.insert("start".to_string(), json!(expr_tag.start));
-    result.insert("end".to_string(), json!(expr_tag.end));
-    result.insert(
-        "expression".to_string(),
-        expr_tag.expression.as_json().clone(),
-    );
-    Value::Object(result)
 }
 
 fn convert_html_tag(html_tag: &HtmlTag) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("RawMustacheTag"));
-    result.insert("start".to_string(), json!(html_tag.start));
-    result.insert("end".to_string(), json!(html_tag.end));
-    result.insert(
-        "expression".to_string(),
-        html_tag.expression.as_json().clone(),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "RawMustacheTag",
+        "start": html_tag.start,
+        "end": html_tag.end,
+        "expression" => html_tag.expression.as_json().clone(),
+    }
 }
 
 fn convert_const_tag(const_tag: &ConstTag) -> Value {
@@ -517,13 +534,11 @@ fn convert_const_tag(const_tag: &ConstTag) -> Value {
             .unwrap_or(0);
         let decl_end = declaration.get("end").and_then(|s| s.as_u64()).unwrap_or(0);
 
-        let mut result = Map::new();
-        result.insert("type".to_string(), json!("ConstTag"));
-        result.insert("start".to_string(), json!(const_tag.start));
-        result.insert("end".to_string(), json!(const_tag.end));
-        result.insert(
-            "expression".to_string(),
-            json!({
+        return estree_obj! {
+            "type": "ConstTag",
+            "start": const_tag.start,
+            "end": const_tag.end,
+            "expression": json!({
                 "type": "AssignmentExpression",
                 "start": decl_start + 6, // Skip 'const '
                 "end": decl_end,
@@ -531,8 +546,7 @@ fn convert_const_tag(const_tag: &ConstTag) -> Value {
                 "left": id,
                 "right": init
             }),
-        );
-        return Value::Object(result);
+        };
     }
 
     // Fallback
@@ -552,57 +566,43 @@ fn convert_const_tag(const_tag: &ConstTag) -> Value {
 /// consumers (svelte2tsx, etc.) expect the declaration kind (`let` / `const`)
 /// and may have multiple declarators.
 fn convert_declaration_tag(decl_tag: &crate::ast::template::DeclarationTag) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("DeclarationTag"));
-    result.insert("start".to_string(), json!(decl_tag.start));
-    result.insert("end".to_string(), json!(decl_tag.end));
-    result.insert(
-        "declaration".to_string(),
-        decl_tag.declaration.as_json().clone(),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "DeclarationTag",
+        "start": decl_tag.start,
+        "end": decl_tag.end,
+        "declaration" => decl_tag.declaration.as_json().clone(),
+    }
 }
 
 fn convert_debug_tag(debug_tag: &DebugTag) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("DebugTag"));
-    result.insert("start".to_string(), json!(debug_tag.start));
-    result.insert("end".to_string(), json!(debug_tag.end));
-    result.insert(
-        "identifiers".to_string(),
-        json!(
-            debug_tag
-                .identifiers
-                .iter()
-                .map(|e| e.as_json().clone())
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "DebugTag",
+        "start": debug_tag.start,
+        "end": debug_tag.end,
+        "identifiers": debug_tag
+            .identifiers
+            .iter()
+            .map(|e| e.as_json().clone())
+            .collect::<Vec<_>>(),
+    }
 }
 
 fn convert_render_tag(render_tag: &RenderTag) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("RenderTag"));
-    result.insert("start".to_string(), json!(render_tag.start));
-    result.insert("end".to_string(), json!(render_tag.end));
-    result.insert(
-        "expression".to_string(),
-        render_tag.expression.as_json().clone(),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "RenderTag",
+        "start": render_tag.start,
+        "end": render_tag.end,
+        "expression" => render_tag.expression.as_json().clone(),
+    }
 }
 
 fn convert_attach_tag(attach_tag: &AttachTag) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("AttachTag"));
-    result.insert("start".to_string(), json!(attach_tag.start));
-    result.insert("end".to_string(), json!(attach_tag.end));
-    result.insert(
-        "expression".to_string(),
-        attach_tag.expression.as_json().clone(),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "AttachTag",
+        "start": attach_tag.start,
+        "end": attach_tag.end,
+        "expression" => attach_tag.expression.as_json().clone(),
+    }
 }
 
 fn convert_if_block(source: &str, if_block: &IfBlock) -> Value {
@@ -628,20 +628,15 @@ fn convert_if_block(source: &str, if_block: &IfBlock) -> Value {
             .unwrap_or(end);
 
         // Remove surrounding whitespace from nodes
-        let mut legacy_nodes: Vec<Value> = Vec::new();
         let mut alt_nodes = alternate.nodes.clone();
         remove_surrounding_whitespace_nodes(&mut alt_nodes);
 
-        for node in &alt_nodes {
-            legacy_nodes.push(convert_node(source, node, &[]));
-        }
-
-        else_block = Some(json!({
+        else_block = Some(estree_obj! {
             "type": "ElseBlock",
             "start": start,
             "end": end,
-            "children": legacy_nodes
-        }));
+            "children" => children_json(source, &alt_nodes, &[]),
+        });
     }
 
     // Calculate start position for elseif blocks
@@ -661,24 +656,19 @@ fn convert_if_block(source: &str, if_block: &IfBlock) -> Value {
     remove_surrounding_whitespace_nodes(&mut consequent_nodes);
 
     let mut result = Map::new();
-    result.insert("type".to_string(), json!("IfBlock"));
-    result.insert("start".to_string(), json!(start));
-    result.insert("end".to_string(), json!(if_block.end));
-    result.insert("expression".to_string(), if_block.test.as_json().clone());
-    result.insert(
-        "children".to_string(),
-        json!(
-            consequent_nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
+    estree_fields!(
+        result,
+        "type": "IfBlock",
+        "start": start,
+        "end": if_block.end,
+        "expression" => if_block.test.as_json().clone(),
+        "children" => children_json(source, &consequent_nodes, &[]),
     );
     if let Some(else_block) = else_block {
-        result.insert("else".to_string(), else_block);
+        estree_fields!(result, "else" => else_block);
     }
     if if_block.elseif {
-        result.insert("elseif".to_string(), json!(true));
+        estree_fields!(result, "elseif": true);
     }
     Value::Object(result)
 }
@@ -697,50 +687,39 @@ fn convert_each_block(source: &str, each_block: &EachBlock) -> Value {
         let mut fallback_nodes = fallback.nodes.clone();
         remove_surrounding_whitespace_nodes(&mut fallback_nodes);
 
-        else_block = Some(json!({
+        else_block = Some(estree_obj! {
             "type": "ElseBlock",
             "start": start,
             "end": end,
-            "children": fallback_nodes.iter().map(|n| convert_node(source, n, &[])).collect::<Vec<_>>()
-        }));
+            "children" => children_json(source, &fallback_nodes, &[]),
+        });
     }
 
     let mut body_nodes = each_block.body.nodes.clone();
     remove_surrounding_whitespace_nodes(&mut body_nodes);
 
     let mut result = Map::new();
-    result.insert("type".to_string(), json!("EachBlock"));
-    result.insert("start".to_string(), json!(each_block.start));
-    result.insert("end".to_string(), json!(each_block.end));
-    result.insert(
-        "children".to_string(),
-        json!(
-            body_nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "context".to_string(),
-        each_block
+    estree_fields!(
+        result,
+        "type": "EachBlock",
+        "start": each_block.start,
+        "end": each_block.end,
+        "children" => children_json(source, &body_nodes, &[]),
+        "context" => each_block
             .context
             .as_ref()
             .map(|c| c.as_json().clone())
             .unwrap_or(json!(null)),
-    );
-    result.insert(
-        "expression".to_string(),
-        each_block.expression.as_json().clone(),
+        "expression" => each_block.expression.as_json().clone(),
     );
     if let Some(ref index) = each_block.index {
-        result.insert("index".to_string(), json!(index.as_str()));
+        estree_fields!(result, "index": index.as_str());
     }
     if let Some(ref key) = each_block.key {
-        result.insert("key".to_string(), key.as_json().clone());
+        estree_fields!(result, "key" => key.as_json().clone());
     }
     if let Some(else_block) = else_block {
-        result.insert("else".to_string(), else_block);
+        estree_fields!(result, "else" => else_block);
     }
     Value::Object(result)
 }
@@ -754,29 +733,20 @@ fn convert_await_block(source: &str, await_block: &AwaitBlock) -> Value {
         .and_then(|e| e.as_u64())
         .unwrap_or(await_block.start as u64) as usize;
 
-    let mut pending_block = json!({
-        "type": "PendingBlock",
-        "start": null,
-        "end": null,
-        "children": [],
-        "skip": true
-    });
+    // A branch that is absent in the source is emitted as a skipped placeholder.
+    let skipped = |ty: &str| {
+        estree_obj! {
+            "type": ty,
+            "start": json!(null),
+            "end": json!(null),
+            "children": [] as [Value; 0],
+            "skip": true,
+        }
+    };
 
-    let mut then_block = json!({
-        "type": "ThenBlock",
-        "start": null,
-        "end": null,
-        "children": [],
-        "skip": true
-    });
-
-    let mut catch_block = json!({
-        "type": "CatchBlock",
-        "start": null,
-        "end": null,
-        "children": [],
-        "skip": true
-    });
+    let mut pending_block = skipped("PendingBlock");
+    let mut then_block = skipped("ThenBlock");
+    let mut catch_block = skipped("CatchBlock");
 
     if let Some(ref pending) = await_block.pending {
         let first_start = pending.nodes.first().map(|n| get_node_start(n) as usize);
@@ -785,13 +755,13 @@ fn convert_await_block(source: &str, await_block: &AwaitBlock) -> Value {
         let start = first_start.unwrap_or_else(|| find_closing_brace_after(source, expr_end));
         let end = last_end.unwrap_or(start);
 
-        pending_block = json!({
+        pending_block = estree_obj! {
             "type": "PendingBlock",
             "start": start,
             "end": end,
-            "children": pending.nodes.iter().map(|n| convert_node(source, n, &[])).collect::<Vec<_>>(),
-            "skip": false
-        });
+            "children" => children_json(source, &pending.nodes, &[]),
+            "skip": false,
+        };
     }
 
     let pending_end = pending_block
@@ -817,13 +787,13 @@ fn convert_await_block(source: &str, await_block: &AwaitBlock) -> Value {
             }
         });
 
-        then_block = json!({
+        then_block = estree_obj! {
             "type": "ThenBlock",
             "start": start,
             "end": end,
-            "children": then.nodes.iter().map(|n| convert_node(source, n, &[])).collect::<Vec<_>>(),
-            "skip": false
-        });
+            "children" => children_json(source, &then.nodes, &[]),
+            "skip": false,
+        };
     }
 
     let then_end = then_block
@@ -850,67 +820,47 @@ fn convert_await_block(source: &str, await_block: &AwaitBlock) -> Value {
             }
         });
 
-        catch_block = json!({
+        catch_block = estree_obj! {
             "type": "CatchBlock",
             "start": start,
             "end": end,
-            "children": catch.nodes.iter().map(|n| convert_node(source, n, &[])).collect::<Vec<_>>(),
-            "skip": false
-        });
+            "children" => children_json(source, &catch.nodes, &[]),
+            "skip": false,
+        };
     }
 
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("AwaitBlock"));
-    result.insert("start".to_string(), json!(await_block.start));
-    result.insert("end".to_string(), json!(await_block.end));
-    result.insert(
-        "expression".to_string(),
-        await_block.expression.as_json().clone(),
-    );
-    result.insert(
-        "value".to_string(),
-        await_block
+    estree_obj! {
+        "type": "AwaitBlock",
+        "start": await_block.start,
+        "end": await_block.end,
+        "expression" => await_block.expression.as_json().clone(),
+        "value" => await_block
             .value
             .as_ref()
             .map(|v| v.as_json().clone())
             .unwrap_or(json!(null)),
-    );
-    result.insert(
-        "error".to_string(),
-        await_block
+        "error" => await_block
             .error
             .as_ref()
             .map(|e| e.as_json().clone())
             .unwrap_or(json!(null)),
-    );
-    result.insert("pending".to_string(), pending_block);
-    result.insert("then".to_string(), then_block);
-    result.insert("catch".to_string(), catch_block);
-    Value::Object(result)
+        "pending" => pending_block,
+        "then" => then_block,
+        "catch" => catch_block,
+    }
 }
 
 fn convert_key_block(source: &str, key_block: &KeyBlock) -> Value {
     let mut fragment_nodes = key_block.fragment.nodes.clone();
     remove_surrounding_whitespace_nodes(&mut fragment_nodes);
 
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("KeyBlock"));
-    result.insert("start".to_string(), json!(key_block.start));
-    result.insert("end".to_string(), json!(key_block.end));
-    result.insert(
-        "expression".to_string(),
-        key_block.expression.as_json().clone(),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            fragment_nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "KeyBlock",
+        "start": key_block.start,
+        "end": key_block.end,
+        "expression" => key_block.expression.as_json().clone(),
+        "children" => children_json(source, &fragment_nodes, &[]),
+    }
 }
 
 fn convert_snippet_block(source: &str, snippet_block: &SnippetBlock) -> Value {
@@ -918,34 +868,21 @@ fn convert_snippet_block(source: &str, snippet_block: &SnippetBlock) -> Value {
     remove_surrounding_whitespace_nodes(&mut body_nodes);
 
     let mut result = Map::new();
-    result.insert("type".to_string(), json!("SnippetBlock"));
-    result.insert("start".to_string(), json!(snippet_block.start));
-    result.insert("end".to_string(), json!(snippet_block.end));
-    result.insert(
-        "expression".to_string(),
-        snippet_block.expression.as_json().clone(),
-    );
-    result.insert(
-        "parameters".to_string(),
-        json!(
-            snippet_block
-                .parameters
-                .iter()
-                .map(|p| p.as_json().clone())
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            body_nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
+    estree_fields!(
+        result,
+        "type": "SnippetBlock",
+        "start": snippet_block.start,
+        "end": snippet_block.end,
+        "expression" => snippet_block.expression.as_json().clone(),
+        "parameters": snippet_block
+            .parameters
+            .iter()
+            .map(|p| p.as_json().clone())
+            .collect::<Vec<_>>(),
+        "children" => children_json(source, &body_nodes, &[]),
     );
     if let Some(ref type_params) = snippet_block.type_params {
-        result.insert("typeParams".to_string(), json!(type_params.as_str()));
+        estree_fields!(result, "typeParams": type_params.as_str());
     }
     Value::Object(result)
 }
@@ -953,222 +890,133 @@ fn convert_snippet_block(source: &str, snippet_block: &SnippetBlock) -> Value {
 // Element / InlineComponent / Slot (below) don't carry a `name_loc` in the
 // legacy format, unlike their modern-AST counterparts.
 
+/// `type`, `start`, `end`, `name`, `attributes`, `children` — the key order the
+/// legacy AST uses for elements whose tag name comes from the source.
+fn convert_element_like(
+    source: &str,
+    ty: &str,
+    name: &str,
+    start: u32,
+    end: u32,
+    attributes: &[Attribute],
+    nodes: &[TemplateNode],
+    path: &[&str],
+) -> Value {
+    estree_obj! {
+        "type": ty,
+        "start": start,
+        "end": end,
+        "name": name,
+        "attributes" => attrs_json(source, attributes),
+        "children" => children_json(source, nodes, path),
+    }
+}
+
+/// `type`, `name`, `start`, `end`, `attributes`, `children` — the key order the
+/// legacy AST uses for `<svelte:*>` elements, whose name is a fixed literal.
+fn convert_svelte_element_like(
+    source: &str,
+    ty: &str,
+    name: &str,
+    element: &SvelteElement,
+    nodes: &[TemplateNode],
+) -> Value {
+    estree_obj! {
+        "type": ty,
+        "name": name,
+        "start": element.start,
+        "end": element.end,
+        "attributes" => attrs_json(source, &element.attributes),
+        "children" => children_json(source, nodes, &[]),
+    }
+}
+
 fn convert_regular_element(source: &str, element: &RegularElement) -> Value {
-    let path = if element.name.as_str() == "style" {
-        vec!["style"]
+    let path: &[&str] = if element.name.as_str() == "style" {
+        &["style"]
     } else {
-        vec![]
+        &[]
     };
 
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Element"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert("name".to_string(), json!(element.name.as_str()));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            element
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &path))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_element_like(
+        source,
+        "Element",
+        element.name.as_str(),
+        element.start,
+        element.end,
+        &element.attributes,
+        &element.fragment.nodes,
+        path,
+    )
 }
 
 fn convert_component(source: &str, component: &Component) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("InlineComponent"));
-    result.insert("start".to_string(), json!(component.start));
-    result.insert("end".to_string(), json!(component.end));
-    result.insert("name".to_string(), json!(component.name.as_str()));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            component
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            component
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_element_like(
+        source,
+        "InlineComponent",
+        component.name.as_str(),
+        component.start,
+        component.end,
+        &component.attributes,
+        &component.fragment.nodes,
+        &[],
+    )
 }
 
 fn convert_title_element(source: &str, title: &TitleElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Title"));
-    result.insert("name".to_string(), json!("title"));
-    result.insert("start".to_string(), json!(title.start));
-    result.insert("end".to_string(), json!(title.end));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            title
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            title
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "Title",
+        "name": "title",
+        "start": title.start,
+        "end": title.end,
+        "attributes" => attrs_json(source, &title.attributes),
+        "children" => children_json(source, &title.fragment.nodes, &[]),
+    }
 }
 
 fn convert_slot_element(source: &str, slot: &SlotElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Slot"));
-    result.insert("start".to_string(), json!(slot.start));
-    result.insert("end".to_string(), json!(slot.end));
-    result.insert("name".to_string(), json!(slot.name.as_str()));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            slot.attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            slot.fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_element_like(
+        source,
+        "Slot",
+        slot.name.as_str(),
+        slot.start,
+        slot.end,
+        &slot.attributes,
+        &slot.fragment.nodes,
+        &[],
+    )
 }
 
 fn convert_svelte_body(source: &str, element: &SvelteElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Body"));
-    result.insert("name".to_string(), json!("svelte:body"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            element
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_svelte_element_like(
+        source,
+        "Body",
+        "svelte:body",
+        element,
+        &element.fragment.nodes,
+    )
 }
 
 fn convert_svelte_component(source: &str, element: &SvelteComponentElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("InlineComponent"));
-    result.insert("name".to_string(), json!("svelte:component"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert(
-        "expression".to_string(),
-        element.expression.as_json().clone(),
-    );
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            element
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "InlineComponent",
+        "name": "svelte:component",
+        "start": element.start,
+        "end": element.end,
+        "expression" => element.expression.as_json().clone(),
+        "attributes" => attrs_json(source, &element.attributes),
+        "children" => children_json(source, &element.fragment.nodes, &[]),
+    }
 }
 
 fn convert_svelte_document(source: &str, element: &SvelteElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Document"));
-    result.insert("name".to_string(), json!("svelte:document"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            element
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_svelte_element_like(
+        source,
+        "Document",
+        "svelte:document",
+        element,
+        &element.fragment.nodes,
+    )
 }
 
 fn convert_svelte_element(source: &str, element: &SvelteDynamicElement) -> Value {
@@ -1191,210 +1039,88 @@ fn convert_svelte_element(source: &str, element: &SvelteDynamicElement) -> Value
         element.tag.as_json().clone()
     };
 
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Element"));
-    result.insert("name".to_string(), json!("svelte:element"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert("tag".to_string(), tag);
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            element
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "Element",
+        "name": "svelte:element",
+        "start": element.start,
+        "end": element.end,
+        "tag" => tag,
+        "attributes" => attrs_json(source, &element.attributes),
+        "children" => children_json(source, &element.fragment.nodes, &[]),
+    }
 }
 
 fn convert_svelte_fragment(source: &str, element: &SvelteElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("SlotTemplate"));
-    result.insert("name".to_string(), json!("svelte:fragment"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            element
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_svelte_element_like(
+        source,
+        "SlotTemplate",
+        "svelte:fragment",
+        element,
+        &element.fragment.nodes,
+    )
 }
 
 fn convert_svelte_boundary(source: &str, element: &SvelteElement) -> Value {
     let mut fragment_nodes = element.fragment.nodes.clone();
     remove_surrounding_whitespace_nodes(&mut fragment_nodes);
 
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("SvelteBoundary"));
-    result.insert("name".to_string(), json!("svelte:boundary"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            fragment_nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_svelte_element_like(
+        source,
+        "SvelteBoundary",
+        "svelte:boundary",
+        element,
+        &fragment_nodes,
+    )
 }
 
 fn convert_svelte_head(source: &str, element: &SvelteElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Head"));
-    result.insert("name".to_string(), json!("svelte:head"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            element
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_svelte_element_like(
+        source,
+        "Head",
+        "svelte:head",
+        element,
+        &element.fragment.nodes,
+    )
 }
 
 fn convert_svelte_options(element: &SvelteElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Options"));
-    result.insert("name".to_string(), json!("svelte:options"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .filter_map(|a| {
-                    if let Attribute::Attribute(attr) = a {
-                        Some(convert_attribute_node(attr))
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "Options",
+        "name": "svelte:options",
+        "start": element.start,
+        "end": element.end,
+        "attributes": element
+            .attributes
+            .iter()
+            .filter_map(|a| {
+                if let Attribute::Attribute(attr) = a {
+                    Some(convert_attribute_node(attr))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>(),
+    }
 }
 
 fn convert_svelte_self(source: &str, element: &SvelteElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("InlineComponent"));
-    result.insert("name".to_string(), json!("svelte:self"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            element
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_svelte_element_like(
+        source,
+        "InlineComponent",
+        "svelte:self",
+        element,
+        &element.fragment.nodes,
+    )
 }
 
 fn convert_svelte_window(source: &str, element: &SvelteElement) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Window"));
-    result.insert("name".to_string(), json!("svelte:window"));
-    result.insert("start".to_string(), json!(element.start));
-    result.insert("end".to_string(), json!(element.end));
-    result.insert(
-        "attributes".to_string(),
-        json!(
-            element
-                .attributes
-                .iter()
-                .map(|a| convert_attribute(source, a))
-                .collect::<Vec<_>>()
-        ),
-    );
-    result.insert(
-        "children".to_string(),
-        json!(
-            element
-                .fragment
-                .nodes
-                .iter()
-                .map(|n| convert_node(source, n, &[]))
-                .collect::<Vec<_>>()
-        ),
-    );
-    Value::Object(result)
+    convert_svelte_element_like(
+        source,
+        "Window",
+        "svelte:window",
+        element,
+        &element.fragment.nodes,
+    )
 }
 
 fn convert_attribute(source: &str, attr: &Attribute) -> Value {
@@ -1417,17 +1143,15 @@ fn convert_attribute_node(attr: &AttributeNode) -> Value {
     let value = convert_attribute_value(&attr.value, attr.start, &attr.name);
 
     let mut result = Map::new();
-    result.insert("type".to_string(), json!("Attribute"));
-    result.insert("start".to_string(), json!(attr.start));
-    result.insert("end".to_string(), json!(attr.end));
-    result.insert("name".to_string(), json!(attr.name.as_str()));
-    if let Some(ref name_loc) = attr.name_loc {
-        result.insert(
-            "name_loc".to_string(),
-            serde_json::to_value(name_loc).unwrap(),
-        );
-    }
-    result.insert("value".to_string(), value);
+    estree_fields!(
+        result,
+        "type": "Attribute",
+        "start": attr.start,
+        "end": attr.end,
+        "name": attr.name.as_str(),
+    );
+    push_name_loc(&mut result, attr.name_loc.as_ref());
+    estree_fields!(result, "value" => value);
     Value::Object(result)
 }
 
@@ -1467,29 +1191,22 @@ fn convert_attribute_value(value: &AttributeValue, attr_start: u32, _attr_name: 
 }
 
 fn convert_spread_attribute(spread: &SpreadAttribute) -> Value {
-    let mut result = Map::new();
-    result.insert("type".to_string(), json!("Spread"));
-    result.insert("start".to_string(), json!(spread.start));
-    result.insert("end".to_string(), json!(spread.end));
-    result.insert(
-        "expression".to_string(),
-        spread.expression.as_json().clone(),
-    );
-    Value::Object(result)
+    estree_obj! {
+        "type": "Spread",
+        "start": spread.start,
+        "end": spread.end,
+        "expression" => spread.expression.as_json().clone(),
+    }
 }
 
 fn convert_bind_directive(bind: &BindDirective) -> Value {
-    let mut result = Map::new();
-    result.insert("start".to_string(), json!(bind.start));
-    result.insert("end".to_string(), json!(bind.end));
-    result.insert("type".to_string(), json!("Binding"));
-    result.insert("name".to_string(), json!(bind.name.as_str()));
-    if let Some(ref name_loc) = bind.name_loc {
-        result.insert(
-            "name_loc".to_string(),
-            serde_json::to_value(name_loc).unwrap(),
-        );
-    }
+    let mut result = directive_head(
+        bind.start,
+        bind.end,
+        "Binding",
+        &bind.name,
+        bind.name_loc.as_ref(),
+    );
 
     // For shorthand bindings (bind:foo), strip the loc field from expression
     let mut expression = bind.expression.as_json().clone();
@@ -1505,77 +1222,71 @@ fn convert_bind_directive(bind: &BindDirective) -> Value {
         expr_map.remove("loc");
     }
 
-    result.insert("expression".to_string(), expression);
-    result.insert("modifiers".to_string(), json!(bind.modifiers));
+    estree_fields!(
+        result,
+        "expression" => expression,
+        "modifiers": bind.modifiers,
+    );
     Value::Object(result)
 }
 
 fn convert_on_directive(on: &OnDirective) -> Value {
-    let mut result = Map::new();
-    result.insert("start".to_string(), json!(on.start));
-    result.insert("end".to_string(), json!(on.end));
-    result.insert("type".to_string(), json!("EventHandler"));
-    result.insert("name".to_string(), json!(on.name.as_str()));
-    if let Some(ref name_loc) = on.name_loc {
-        result.insert(
-            "name_loc".to_string(),
-            serde_json::to_value(name_loc).unwrap(),
-        );
-    }
-    result.insert(
-        "expression".to_string(),
-        on.expression
+    let mut result = directive_head(
+        on.start,
+        on.end,
+        "EventHandler",
+        &on.name,
+        on.name_loc.as_ref(),
+    );
+    estree_fields!(
+        result,
+        "expression" => on
+            .expression
             .as_ref()
             .map(|e| e.as_json().clone())
             .unwrap_or(json!(null)),
+        "modifiers": on.modifiers,
     );
-    result.insert("modifiers".to_string(), json!(on.modifiers));
     Value::Object(result)
 }
 
 fn convert_class_directive(class: &ClassDirective) -> Value {
-    let mut result = Map::new();
-    result.insert("start".to_string(), json!(class.start));
-    result.insert("end".to_string(), json!(class.end));
-    result.insert("type".to_string(), json!("Class"));
-    result.insert("name".to_string(), json!(class.name.as_str()));
-    if let Some(ref name_loc) = class.name_loc {
-        result.insert(
-            "name_loc".to_string(),
-            serde_json::to_value(name_loc).unwrap(),
-        );
-    }
-    result.insert("expression".to_string(), class.expression.as_json().clone());
-    result.insert("modifiers".to_string(), json!([]));
+    let mut result = directive_head(
+        class.start,
+        class.end,
+        "Class",
+        &class.name,
+        class.name_loc.as_ref(),
+    );
+    estree_fields!(
+        result,
+        "expression" => class.expression.as_json().clone(),
+        "modifiers": [] as [Value; 0],
+    );
     Value::Object(result)
 }
 
 fn convert_style_directive(_source: &str, style: &StyleDirective) -> Value {
+    let mustache = |expr_tag: &ExpressionTag| {
+        estree_obj! {
+            "type": "MustacheTag",
+            "start": expr_tag.start,
+            "end": expr_tag.end,
+            "expression" => expr_tag.expression.as_json().clone(),
+        }
+    };
+
     let value = match &style.value {
         AttributeValue::True(true) => json!(true),
         AttributeValue::True(false) => json!(false),
-        AttributeValue::Expression(expr_tag) => {
-            json!([{
-                "type": "MustacheTag",
-                "start": expr_tag.start,
-                "end": expr_tag.end,
-                "expression": expr_tag.expression.as_json().clone()
-            }])
-        }
+        AttributeValue::Expression(expr_tag) => json!([mustache(expr_tag)]),
         AttributeValue::Sequence(parts) => {
             json!(
                 parts
                     .iter()
                     .map(|part| match part {
                         AttributeValuePart::Text(text) => convert_text(text, &[]),
-                        AttributeValuePart::ExpressionTag(expr_tag) => {
-                            json!({
-                                "type": "MustacheTag",
-                                "start": expr_tag.start,
-                                "end": expr_tag.end,
-                                "expression": expr_tag.expression.as_json().clone()
-                            })
-                        }
+                        AttributeValuePart::ExpressionTag(expr_tag) => mustache(expr_tag),
                     })
                     .collect::<Vec<_>>()
             )
@@ -1583,107 +1294,138 @@ fn convert_style_directive(_source: &str, style: &StyleDirective) -> Value {
     };
 
     let mut result = Map::new();
-    result.insert("type".to_string(), json!("StyleDirective"));
-    result.insert("start".to_string(), json!(style.start));
-    result.insert("end".to_string(), json!(style.end));
-    result.insert("name".to_string(), json!(style.name.as_str()));
-    if let Some(ref name_loc) = style.name_loc {
-        result.insert(
-            "name_loc".to_string(),
-            serde_json::to_value(name_loc).unwrap(),
-        );
-    }
-    result.insert("value".to_string(), value);
-    result.insert("modifiers".to_string(), json!(style.modifiers));
+    estree_fields!(
+        result,
+        "type": "StyleDirective",
+        "start": style.start,
+        "end": style.end,
+        "name": style.name.as_str(),
+    );
+    push_name_loc(&mut result, style.name_loc.as_ref());
+    estree_fields!(
+        result,
+        "value" => value,
+        "modifiers": style.modifiers,
+    );
     Value::Object(result)
 }
 
 fn convert_transition_directive(transition: &TransitionDirective) -> Value {
-    let mut result = Map::new();
-    result.insert("start".to_string(), json!(transition.start));
-    result.insert("end".to_string(), json!(transition.end));
-    result.insert("type".to_string(), json!("Transition"));
-    result.insert("name".to_string(), json!(transition.name.as_str()));
-    if let Some(ref name_loc) = transition.name_loc {
-        result.insert(
-            "name_loc".to_string(),
-            serde_json::to_value(name_loc).unwrap(),
-        );
-    }
-    if let Some(ref expression) = transition.expression {
-        result.insert("expression".to_string(), expression.as_json().clone());
-    } else {
-        result.insert("expression".to_string(), json!(null));
-    }
-    result.insert("modifiers".to_string(), json!(transition.modifiers));
-    result.insert("intro".to_string(), json!(transition.intro));
-    result.insert("outro".to_string(), json!(transition.outro));
+    let mut result = directive_head(
+        transition.start,
+        transition.end,
+        "Transition",
+        &transition.name,
+        transition.name_loc.as_ref(),
+    );
+    estree_fields!(
+        result,
+        "expression" => optional_expression(transition.expression.as_ref()),
+        "modifiers": transition.modifiers,
+        "intro": transition.intro,
+        "outro": transition.outro,
+    );
     Value::Object(result)
 }
 
 fn convert_animate_directive(animate: &AnimateDirective) -> Value {
-    let mut result = Map::new();
-    result.insert("start".to_string(), json!(animate.start));
-    result.insert("end".to_string(), json!(animate.end));
-    result.insert("type".to_string(), json!("Animation"));
-    result.insert("name".to_string(), json!(animate.name.as_str()));
-    if let Some(ref name_loc) = animate.name_loc {
-        result.insert(
-            "name_loc".to_string(),
-            serde_json::to_value(name_loc).unwrap(),
-        );
-    }
-    if let Some(ref expression) = animate.expression {
-        result.insert("expression".to_string(), expression.as_json().clone());
-    } else {
-        result.insert("expression".to_string(), json!(null));
-    }
-    result.insert("modifiers".to_string(), json!([]));
+    let mut result = directive_head(
+        animate.start,
+        animate.end,
+        "Animation",
+        &animate.name,
+        animate.name_loc.as_ref(),
+    );
+    estree_fields!(
+        result,
+        "expression" => optional_expression(animate.expression.as_ref()),
+        "modifiers": [] as [Value; 0],
+    );
     Value::Object(result)
 }
 
 fn convert_use_directive(use_dir: &UseDirective) -> Value {
-    let mut result = Map::new();
-    result.insert("start".to_string(), json!(use_dir.start));
-    result.insert("end".to_string(), json!(use_dir.end));
-    result.insert("type".to_string(), json!("Action"));
-    result.insert("name".to_string(), json!(use_dir.name.as_str()));
-    if let Some(ref name_loc) = use_dir.name_loc {
-        result.insert(
-            "name_loc".to_string(),
-            serde_json::to_value(name_loc).unwrap(),
-        );
-    }
-    if let Some(ref expression) = use_dir.expression {
-        result.insert("expression".to_string(), expression.as_json().clone());
-    } else {
-        result.insert("expression".to_string(), json!(null));
-    }
-    result.insert("modifiers".to_string(), json!([]));
+    let mut result = directive_head(
+        use_dir.start,
+        use_dir.end,
+        "Action",
+        &use_dir.name,
+        use_dir.name_loc.as_ref(),
+    );
+    estree_fields!(
+        result,
+        "expression" => optional_expression(use_dir.expression.as_ref()),
+        "modifiers": [] as [Value; 0],
+    );
     Value::Object(result)
 }
 
 fn convert_let_directive(let_dir: &LetDirective) -> Value {
-    let mut result = Map::new();
-    result.insert("start".to_string(), json!(let_dir.start));
-    result.insert("end".to_string(), json!(let_dir.end));
-    result.insert("type".to_string(), json!("Let"));
-    result.insert("name".to_string(), json!(let_dir.name.as_str()));
-    if let Some(ref name_loc) = let_dir.name_loc {
-        result.insert(
-            "name_loc".to_string(),
-            serde_json::to_value(name_loc).unwrap(),
-        );
-    }
-    if let Some(ref expression) = let_dir.expression {
-        result.insert("expression".to_string(), expression.as_json().clone());
-    } else {
-        result.insert("expression".to_string(), json!(null));
-    }
+    let mut result = directive_head(
+        let_dir.start,
+        let_dir.end,
+        "Let",
+        &let_dir.name,
+        let_dir.name_loc.as_ref(),
+    );
+    estree_fields!(
+        result,
+        "expression" => optional_expression(let_dir.expression.as_ref()),
+    );
     Value::Object(result)
 }
 
 // Helper functions
+
+fn attrs_json(source: &str, attributes: &[Attribute]) -> Value {
+    json!(
+        attributes
+            .iter()
+            .map(|a| convert_attribute(source, a))
+            .collect::<Vec<_>>()
+    )
+}
+
+fn children_json(source: &str, nodes: &[TemplateNode], path: &[&str]) -> Value {
+    json!(
+        nodes
+            .iter()
+            .map(|n| convert_node(source, n, path))
+            .collect::<Vec<_>>()
+    )
+}
+
+/// `name_loc` is emitted only when the modern AST carries one, and always
+/// directly after `name`.
+fn push_name_loc(obj: &mut Map<String, Value>, name_loc: Option<&SourceLocation>) {
+    if let Some(name_loc) = name_loc {
+        obj.insert(
+            "name_loc".to_string(),
+            serde_json::to_value(name_loc).unwrap(),
+        );
+    }
+}
+
+/// The `start`, `end`, `type`, `name`, `name_loc` prefix shared by every legacy
+/// directive node. Callers append the node-specific fields.
+fn directive_head(
+    start: u32,
+    end: u32,
+    ty: &str,
+    name: &str,
+    name_loc: Option<&SourceLocation>,
+) -> Map<String, Value> {
+    let mut obj = Map::new();
+    estree_fields!(obj, "start": start, "end": end, "type": ty, "name": name);
+    push_name_loc(&mut obj, name_loc);
+    obj
+}
+
+fn optional_expression(expression: Option<&Expression>) -> Value {
+    expression
+        .map(|e| e.as_json().clone())
+        .unwrap_or(json!(null))
+}
 
 /// Common start/end span accessors for `TemplateNode` variants. Replaces a
 /// pair of 28-arm matches (one per accessor) with a single merged-arm

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -2532,11 +2532,7 @@ fn convert_formal_parameter<'a>(
             "type".to_string(),
             Value::String("TSParameterProperty".to_string()),
         );
-        obj.insert("start".to_string(), Value::Number((start as i64).into()));
-        obj.insert("end".to_string(), Value::Number((end as i64).into()));
-        if let Some(loc) = create_loc(start, end, line_offsets) {
-            obj.insert("loc".to_string(), loc);
-        }
+        push_span_fields(&mut obj, start, end, line_offsets);
         if param.readonly {
             obj.insert("readonly".to_string(), Value::Bool(true));
         }
@@ -2581,11 +2577,7 @@ fn convert_formal_parameter_inner<'a>(
 
                 let mut obj = Map::new();
                 obj.insert("type".to_string(), Value::String("Identifier".to_string()));
-                obj.insert("start".to_string(), Value::Number((start as i64).into()));
-                obj.insert("end".to_string(), Value::Number((end as i64).into()));
-                if let Some(loc) = create_loc(start, end, line_offsets) {
-                    obj.insert("loc".to_string(), loc);
-                }
+                push_span_fields(&mut obj, start, end, line_offsets);
                 obj.insert("name".to_string(), Value::String(name.to_string()));
 
                 // TS optional marker (`b?: T`); acorn emits it after `name`.
@@ -2872,11 +2864,7 @@ fn convert_binding_pattern_for_param(
             let mut obj = Map::new();
             obj.insert("type".to_string(), Value::String("Identifier".to_string()));
             obj.insert("name".to_string(), Value::String(id.name.to_string()));
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             Value::Object(obj)
         }
         BindingPattern::ObjectPattern(obj_pat) => {
@@ -2895,11 +2883,7 @@ fn convert_binding_pattern_for_param(
                 "type".to_string(),
                 Value::String("ArrayPattern".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
 
             // Convert elements
             let mut elements = Vec::new();
@@ -2955,11 +2939,7 @@ fn convert_binding_pattern_for_param(
                 "type".to_string(),
                 Value::String("AssignmentPattern".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
 
             // Convert left (the pattern)
             let left = convert_binding_pattern_for_param(
@@ -3111,11 +3091,7 @@ fn convert_type_annotation_adjusted(
         "type".to_string(),
         Value::String("TSTypeAnnotation".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
 
     // Convert the inner type
     let inner_type = convert_ts_type_adjusted(
@@ -3142,11 +3118,7 @@ fn ts_assertion_value(
 ) -> Value {
     let mut obj = Map::new();
     obj.insert("type".to_string(), Value::String(type_name.to_string()));
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
     obj.insert("expression".to_string(), expression);
     if let Some(ta) = type_annotation {
         obj.insert("typeAnnotation".to_string(), ta);
@@ -3182,11 +3154,7 @@ fn convert_ts_type_name_adjusted(
 
             let mut obj = Map::new();
             obj.insert("type".to_string(), Value::String("Identifier".to_string()));
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("name".to_string(), Value::String(id.name.to_string()));
 
             Value::Object(obj)
@@ -3202,11 +3170,7 @@ fn convert_ts_type_name_adjusted(
                 "type".to_string(),
                 Value::String("TSQualifiedName".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
 
             // `left` recurses (it may itself be a qualified name); `right` is a
             // plain Identifier. Matches svelte/compiler's TSQualifiedName shape.
@@ -3233,11 +3197,7 @@ fn convert_ts_type_name_adjusted(
                 "type".to_string(),
                 Value::String("ThisExpression".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
 
             Value::Object(obj)
         }
@@ -3268,11 +3228,7 @@ fn convert_ts_type(
     let base = |type_name: &str| -> Map<String, Value> {
         let mut obj = Map::new();
         obj.insert("type".to_string(), Value::String(type_name.to_string()));
-        obj.insert("start".to_string(), Value::Number((start as i64).into()));
-        obj.insert("end".to_string(), Value::Number((end as i64).into()));
-        if let Some(loc) = create_loc(start, end, line_offsets) {
-            obj.insert("loc".to_string(), loc);
-        }
+        push_span_fields(&mut obj, start, end, line_offsets);
         obj
     };
 
@@ -3511,11 +3467,7 @@ fn convert_ts_type_parameter_declaration(
         "type".to_string(),
         Value::String("TSTypeParameterDeclaration".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
     let params: Vec<Value> = decl
         .params
         .iter()
@@ -3539,11 +3491,7 @@ fn convert_ts_type_parameter(
         "type".to_string(),
         Value::String("TSTypeParameter".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
     obj.insert(
         "name".to_string(),
         Value::String(param.name.name.to_string()),
@@ -3583,11 +3531,7 @@ fn convert_ts_function_like_params(
         let end = offset + this_param.span.end as usize;
         let mut obj = Map::new();
         obj.insert("type".to_string(), Value::String("Identifier".to_string()));
-        obj.insert("start".to_string(), Value::Number((start as i64).into()));
-        obj.insert("end".to_string(), Value::Number((end as i64).into()));
-        if let Some(loc) = create_loc(start, end, line_offsets) {
-            obj.insert("loc".to_string(), loc);
-        }
+        push_span_fields(&mut obj, start, end, line_offsets);
         obj.insert("name".to_string(), Value::String("this".to_string()));
         if let Some(type_ann) = &this_param.type_annotation {
             obj.insert(
@@ -3613,11 +3557,7 @@ fn convert_ts_function_like_params(
             convert_binding_pattern_for_param(arena, &rest.rest.argument, offset, line_offsets);
         let mut obj = Map::new();
         obj.insert("type".to_string(), Value::String("RestElement".to_string()));
-        obj.insert("start".to_string(), Value::Number((start as i64).into()));
-        obj.insert("end".to_string(), Value::Number((end as i64).into()));
-        if let Some(loc) = create_loc(start, end, line_offsets) {
-            obj.insert("loc".to_string(), loc);
-        }
+        push_span_fields(&mut obj, start, end, line_offsets);
         obj.insert("argument".to_string(), argument);
         if let Some(type_ann) = &rest.type_annotation {
             obj.insert(
@@ -3652,11 +3592,7 @@ fn convert_ts_signature(
                 "type".to_string(),
                 Value::String("TSPropertySignature".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("computed".to_string(), Value::Bool(prop.computed));
             // svelte/compiler omits `optional` / `readonly` when false.
             if prop.optional {
@@ -3694,11 +3630,7 @@ fn convert_ts_signature(
             };
             let mut obj = Map::new();
             obj.insert("type".to_string(), Value::String(type_name.to_string()));
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             Value::Object(obj)
         }
     }
@@ -3806,11 +3738,7 @@ fn convert_ts_literal(
 fn ts_identifier_value(name: &str, start: usize, end: usize, line_offsets: &[usize]) -> Value {
     let mut obj = Map::new();
     obj.insert("type".to_string(), Value::String("Identifier".to_string()));
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
     obj.insert("name".to_string(), Value::String(name.to_string()));
     Value::Object(obj)
 }
@@ -3825,11 +3753,7 @@ fn ts_literal_value(
 ) -> Value {
     let mut obj = Map::new();
     obj.insert("type".to_string(), Value::String("Literal".to_string()));
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
     obj.insert("value".to_string(), value);
     if let Some(raw) = raw {
         obj.insert("raw".to_string(), Value::String(raw));
@@ -3864,11 +3788,7 @@ fn convert_ts_type_param_instantiation(
         "type".to_string(),
         Value::String("TSTypeParameterInstantiation".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
     let params: Vec<Value> = args
         .params
         .iter()
@@ -3882,11 +3802,7 @@ fn convert_ts_type_param_instantiation(
 fn create_ts_keyword(type_name: &str, start: usize, end: usize, line_offsets: &[usize]) -> Value {
     let mut obj = Map::new();
     obj.insert("type".to_string(), Value::String(type_name.to_string()));
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
     Value::Object(obj)
 }
 
@@ -5004,11 +4920,7 @@ fn convert_class_body_for_expr(
 
     let mut obj = Map::new();
     obj.insert("type".to_string(), Value::String("ClassBody".to_string()));
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
 
     let body_elements: Vec<Value> = body
         .body
@@ -5036,11 +4948,7 @@ fn convert_class_element_for_expr(
                 "type".to_string(),
                 Value::String("MethodDefinition".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("static".to_string(), Value::Bool(method.r#static));
             obj.insert("computed".to_string(), Value::Bool(method.computed));
 
@@ -5083,11 +4991,7 @@ fn convert_class_element_for_expr(
                 "type".to_string(),
                 Value::String("PropertyDefinition".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("static".to_string(), Value::Bool(prop.r#static));
             obj.insert("computed".to_string(), Value::Bool(prop.computed));
 
@@ -5110,11 +5014,7 @@ fn convert_class_element_for_expr(
             let end = offset + static_block.span.end as usize - 1;
             let mut obj = Map::new();
             obj.insert("type".to_string(), Value::String("StaticBlock".to_string()));
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
 
             let body_statements: Vec<Value> = static_block
                 .body
@@ -6409,35 +6309,67 @@ fn update_operator_to_str(op: &oxc_ast::ast::UpdateOperator) -> &'static str {
     }
 }
 
+/// Insert the ESTree span fields in acorn's emission order (`start`, `end`, then
+/// `loc` when line offsets are available). `serde_json`'s `preserve_order` makes
+/// that insertion order part of the JSON output contract.
+fn push_span_fields(
+    obj: &mut Map<String, Value>,
+    start: usize,
+    end: usize,
+    line_offsets: &[usize],
+) {
+    push_span_fields_with(obj, start, end, line_offsets, get_line_column);
+}
+
+/// `push_span_fields` for binding patterns, which use the empty-line-adjusted
+/// column calculation.
+fn push_binding_span_fields(
+    obj: &mut Map<String, Value>,
+    start: usize,
+    end: usize,
+    line_offsets: &[usize],
+) {
+    push_span_fields_with(obj, start, end, line_offsets, get_line_column_for_binding);
+}
+
+fn push_span_fields_with(
+    obj: &mut Map<String, Value>,
+    start: usize,
+    end: usize,
+    line_offsets: &[usize],
+    line_column: fn(usize, &[usize]) -> (u32, u32),
+) {
+    obj.insert("start".to_string(), Value::Number((start as i64).into()));
+    obj.insert("end".to_string(), Value::Number((end as i64).into()));
+    if let Some(loc) = create_loc_with(start, end, line_offsets, line_column) {
+        obj.insert("loc".to_string(), loc);
+    }
+}
+
 fn create_loc(start: usize, end: usize, line_offsets: &[usize]) -> Option<Value> {
+    create_loc_with(start, end, line_offsets, get_line_column)
+}
+
+fn create_loc_with(
+    start: usize,
+    end: usize,
+    line_offsets: &[usize],
+    line_column: fn(usize, &[usize]) -> (u32, u32),
+) -> Option<Value> {
     if line_offsets.is_empty() {
         return None;
     }
-    let start_loc = get_line_column(start, line_offsets);
-    let end_loc = get_line_column(end, line_offsets);
+    let point = |pos: usize| {
+        let (line, column) = line_column(pos, line_offsets);
+        let mut obj = Map::new();
+        obj.insert("line".to_string(), Value::Number((line as i64).into()));
+        obj.insert("column".to_string(), Value::Number((column as i64).into()));
+        Value::Object(obj)
+    };
 
     let mut loc = Map::new();
-
-    let mut start_obj = Map::new();
-    start_obj.insert(
-        "line".to_string(),
-        Value::Number((start_loc.0 as i64).into()),
-    );
-    start_obj.insert(
-        "column".to_string(),
-        Value::Number((start_loc.1 as i64).into()),
-    );
-
-    let mut end_obj = Map::new();
-    end_obj.insert("line".to_string(), Value::Number((end_loc.0 as i64).into()));
-    end_obj.insert(
-        "column".to_string(),
-        Value::Number((end_loc.1 as i64).into()),
-    );
-
-    loc.insert("start".to_string(), Value::Object(start_obj));
-    loc.insert("end".to_string(), Value::Object(end_obj));
-
+    loc.insert("start".to_string(), point(start));
+    loc.insert("end".to_string(), point(end));
     Some(Value::Object(loc))
 }
 
@@ -6480,35 +6412,7 @@ fn get_line_column_for_binding(pos: usize, line_offsets: &[usize]) -> (u32, u32)
 /// Create loc for binding patterns (complex patterns like ObjectPattern, ArrayPattern).
 /// Uses adjusted column calculation for empty lines, no character field.
 fn create_loc_for_binding(start: usize, end: usize, line_offsets: &[usize]) -> Option<Value> {
-    if line_offsets.is_empty() {
-        return None;
-    }
-    let start_loc = get_line_column_for_binding(start, line_offsets);
-    let end_loc = get_line_column_for_binding(end, line_offsets);
-
-    let mut loc = Map::new();
-
-    let mut start_obj = Map::new();
-    start_obj.insert(
-        "line".to_string(),
-        Value::Number((start_loc.0 as i64).into()),
-    );
-    start_obj.insert(
-        "column".to_string(),
-        Value::Number((start_loc.1 as i64).into()),
-    );
-
-    let mut end_obj = Map::new();
-    end_obj.insert("line".to_string(), Value::Number((end_loc.0 as i64).into()));
-    end_obj.insert(
-        "column".to_string(),
-        Value::Number((end_loc.1 as i64).into()),
-    );
-
-    loc.insert("start".to_string(), Value::Object(start_obj));
-    loc.insert("end".to_string(), Value::Object(end_obj));
-
-    Some(Value::Object(loc))
+    create_loc_with(start, end, line_offsets, get_line_column_for_binding)
 }
 
 // ============================================================================
@@ -8242,11 +8146,7 @@ fn convert_declaration_for_program(
                 "type".to_string(),
                 Value::String("VariableDeclaration".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
 
             let declarations: Vec<Value> = var_decl
                 .declarations
@@ -8301,11 +8201,7 @@ fn convert_declaration_for_program(
                 "type".to_string(),
                 Value::String("FunctionDeclaration".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
 
             if let Some(id) = &func_decl.id {
                 let id_start = offset + id.span.start as usize;
@@ -8373,11 +8269,7 @@ fn convert_declaration_for_program(
                 "type".to_string(),
                 Value::String("ClassDeclaration".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
 
             if let Some(id) = &class_decl.id {
                 let id_start = offset + id.span.start as usize;
@@ -8416,11 +8308,7 @@ fn convert_declaration_for_program(
                 "type".to_string(),
                 Value::String("TSEnumDeclaration".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             Value::Object(obj)
         }
         // TypeScript module/namespace declarations
@@ -8443,11 +8331,7 @@ fn convert_declaration_for_program(
                 "type".to_string(),
                 Value::String("TSModuleDeclaration".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
 
             // Include body for non-type node detection
             if let Some(ref body) = module_decl.body {
@@ -8628,11 +8512,7 @@ fn convert_variable_declarator_for_program(
             "type".to_string(),
             Value::String("TSTypeAnnotation".to_string()),
         );
-        ts_obj.insert("start".to_string(), Value::Number((ts_start as i64).into()));
-        ts_obj.insert("end".to_string(), Value::Number((ts_end as i64).into()));
-        if let Some(loc) = create_loc(ts_start, ts_end, line_offsets) {
-            ts_obj.insert("loc".to_string(), loc);
-        }
+        push_span_fields(&mut ts_obj, ts_start, ts_end, line_offsets);
         let type_value = convert_ts_type(
             arena,
             &type_annotation.type_annotation,
@@ -9732,11 +9612,7 @@ fn convert_class_body_for_program(
 
     let mut obj = Map::new();
     obj.insert("type".to_string(), Value::String("ClassBody".to_string()));
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
 
     let body_elements: Vec<Value> = body
         .body
@@ -9922,11 +9798,7 @@ fn convert_class_element_for_program(
                 "type".to_string(),
                 Value::String("MethodDefinition".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("static".to_string(), Value::Bool(method.r#static));
             obj.insert("computed".to_string(), Value::Bool(method.computed));
 
@@ -9962,11 +9834,7 @@ fn convert_class_element_for_program(
                 "type".to_string(),
                 Value::String("PropertyDefinition".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("static".to_string(), Value::Bool(prop.r#static));
             obj.insert("computed".to_string(), Value::Bool(prop.computed));
 
@@ -9999,11 +9867,7 @@ fn convert_class_element_for_program(
                 "type".to_string(),
                 Value::String("PropertyDefinition".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("accessor".to_string(), Value::Bool(true));
             obj.insert("static".to_string(), Value::Bool(prop.r#static));
             obj.insert("computed".to_string(), Value::Bool(prop.computed));
@@ -10038,11 +9902,7 @@ fn convert_function_expression_for_program(
         "type".to_string(),
         Value::String("FunctionExpression".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
     obj.insert("id".to_string(), Value::Null);
     obj.insert("generator".to_string(), Value::Bool(func.generator));
     obj.insert("async".to_string(), Value::Bool(func.r#async));
@@ -10194,11 +10054,7 @@ fn convert_function_body_for_program(
         "type".to_string(),
         Value::String("BlockStatement".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_span_fields(&mut obj, start, end, line_offsets);
 
     let statements: Vec<Value> = body
         .statements
@@ -10997,11 +10853,7 @@ fn convert_object_pattern_with_adjustment(
         "type".to_string(),
         Value::String("ObjectPattern".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     let mut properties: Vec<Value> = obj_pat
         .properties
@@ -11065,11 +10917,7 @@ fn convert_array_pattern_with_adjustment(
         "type".to_string(),
         Value::String("ArrayPattern".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     let mut elements: Vec<Value> = arr_pat
         .elements
@@ -11134,11 +10982,7 @@ fn convert_assignment_pattern_with_adjustment(
         "type".to_string(),
         Value::String("AssignmentPattern".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     obj.insert(
         "left".to_string(),
@@ -11177,11 +11021,7 @@ fn convert_binding_property_with_adjustment(
 
     let mut obj = Map::new();
     obj.insert("type".to_string(), Value::String("Property".to_string()));
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_binding_span_fields(&mut obj, start, end, line_offsets);
     obj.insert("method".to_string(), Value::Bool(false));
     obj.insert("shorthand".to_string(), Value::Bool(prop.shorthand));
     obj.insert("computed".to_string(), Value::Bool(prop.computed));
@@ -11431,11 +11271,7 @@ fn convert_expression_with_adjustment(
                 "type".to_string(),
                 Value::String("BinaryExpression".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("left".to_string(), left);
             obj.insert("operator".to_string(), Value::String(operator.to_string()));
             obj.insert("right".to_string(), right);
@@ -11457,11 +11293,7 @@ fn convert_expression_with_adjustment(
                 "type".to_string(),
                 Value::String("UnaryExpression".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("operator".to_string(), Value::String(operator.to_string()));
             obj.insert("prefix".to_string(), Value::Bool(true));
             obj.insert("argument".to_string(), argument);
@@ -11490,11 +11322,7 @@ fn convert_expression_with_adjustment(
                 "type".to_string(),
                 Value::String("LogicalExpression".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("left".to_string(), left);
             obj.insert("operator".to_string(), Value::String(operator.to_string()));
             obj.insert("right".to_string(), right);
@@ -11529,11 +11357,7 @@ fn convert_expression_with_adjustment(
                 "type".to_string(),
                 Value::String("ConditionalExpression".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("test".to_string(), test);
             obj.insert("consequent".to_string(), consequent);
             obj.insert("alternate".to_string(), alternate);
@@ -11563,11 +11387,7 @@ fn convert_expression_with_adjustment(
                 "type".to_string(),
                 Value::String("MemberExpression".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("object".to_string(), object);
             obj.insert("property".to_string(), property);
             obj.insert("computed".to_string(), Value::Bool(false));
@@ -11596,11 +11416,7 @@ fn convert_expression_with_adjustment(
                 "type".to_string(),
                 Value::String("MemberExpression".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("object".to_string(), object);
             obj.insert("property".to_string(), property);
             obj.insert("computed".to_string(), Value::Bool(true));
@@ -11645,11 +11461,7 @@ fn convert_expression_with_adjustment(
                 "type".to_string(),
                 Value::String("MemberExpression".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("object".to_string(), object);
             obj.insert("property".to_string(), Value::Object(prop));
             obj.insert("computed".to_string(), Value::Bool(false));
@@ -11695,11 +11507,7 @@ fn convert_expression_with_adjustment(
                 "type".to_string(),
                 Value::String("UpdateExpression".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
             obj.insert("operator".to_string(), Value::String(operator.to_string()));
             obj.insert("prefix".to_string(), Value::Bool(update.prefix));
             obj.insert("argument".to_string(), argument);
@@ -11743,11 +11551,7 @@ fn create_template_literal_with_adjustment(
         "type".to_string(),
         Value::String("TemplateLiteral".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     // Convert quasis
     let quasis: Vec<Value> = template
@@ -11762,11 +11566,7 @@ fn create_template_literal_with_adjustment(
                 "type".to_string(),
                 Value::String("TemplateElement".to_string()),
             );
-            q_obj.insert("start".to_string(), Value::Number((q_start as i64).into()));
-            q_obj.insert("end".to_string(), Value::Number((q_end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(q_start, q_end, line_offsets) {
-                q_obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut q_obj, q_start, q_end, line_offsets);
             q_obj.insert("tail".to_string(), Value::Bool(quasi.tail));
 
             let mut value_obj = Map::new();
@@ -11817,11 +11617,7 @@ fn create_call_expression_with_adjustment(
         "type".to_string(),
         Value::String("CallExpression".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     let callee = convert_expression_with_adjustment(
         arena,
@@ -11894,11 +11690,7 @@ fn create_arrow_function_with_adjustment(
         "type".to_string(),
         Value::String("ArrowFunctionExpression".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_binding_span_fields(&mut obj, start, end, line_offsets);
     obj.insert("id".to_string(), Value::Null);
     obj.insert("expression".to_string(), Value::Bool(arrow.expression));
     obj.insert("generator".to_string(), Value::Bool(false));
@@ -11970,11 +11762,7 @@ fn convert_function_body_with_adjustment(
         "type".to_string(),
         Value::String("BlockStatement".to_string()),
     );
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
-    if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-        obj.insert("loc".to_string(), loc);
-    }
+    push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     let statements: Vec<Value> = body
         .statements
@@ -12005,11 +11793,7 @@ fn convert_statement_with_adjustment(
                 "type".to_string(),
                 Value::String("ReturnStatement".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
 
             if let Some(arg) = &ret.argument {
                 obj.insert(
@@ -12037,11 +11821,7 @@ fn convert_statement_with_adjustment(
                 "type".to_string(),
                 Value::String("ExpressionStatement".to_string()),
             );
-            obj.insert("start".to_string(), Value::Number((start as i64).into()));
-            obj.insert("end".to_string(), Value::Number((end as i64).into()));
-            if let Some(loc) = create_loc_for_binding(start, end, line_offsets) {
-                obj.insert("loc".to_string(), loc);
-            }
+            push_binding_span_fields(&mut obj, start, end, line_offsets);
             obj.insert(
                 "expression".to_string(),
                 convert_expression_with_adjustment(

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1998,16 +1998,10 @@ fn parse_expression_with_typescript<'a>(
                     let mut json_val = expr.as_json().clone();
                     if let Value::Object(ref mut obj) = json_val {
                         if !leading_comments.is_empty() {
-                            obj.insert(
-                                "leadingComments".to_string(),
-                                Value::Array(leading_comments),
-                            );
+                            obj.set_field("leadingComments", Value::Array(leading_comments));
                         }
                         if !trailing_comments.is_empty() {
-                            obj.insert(
-                                "trailingComments".to_string(),
-                                Value::Array(trailing_comments),
-                            );
+                            obj.set_field("trailingComments", Value::Array(trailing_comments));
                         }
                     }
                     // Attach each interior comment to the node it precedes.
@@ -2469,8 +2463,8 @@ fn convert_formal_parameter_with_remap<'a>(
             // = base_offset + cleaned_pos
             let cleaned_pos = start_val as usize - base_offset;
             let original_pos = base_offset + stripped.map_to_original(cleaned_pos);
-            obj.insert(
-                "start".to_string(),
+            obj.set_field(
+                "start",
                 serde_json::Value::Number((original_pos as i64).into()),
             );
         }
@@ -2479,8 +2473,8 @@ fn convert_formal_parameter_with_remap<'a>(
         if let Some(end_val) = obj.get("end").and_then(|e| e.as_u64()) {
             let cleaned_pos = end_val as usize - base_offset;
             let original_pos = base_offset + stripped.map_to_original(cleaned_pos);
-            obj.insert(
-                "end".to_string(),
+            obj.set_field(
+                "end",
                 serde_json::Value::Number((original_pos as i64).into()),
             );
         }
@@ -2494,16 +2488,16 @@ fn convert_formal_parameter_with_remap<'a>(
             if let Some(start_val) = right_obj.get("start").and_then(|s| s.as_u64()) {
                 let cleaned_pos = start_val as usize - base_offset;
                 let original_pos = base_offset + stripped.map_to_original(cleaned_pos);
-                right_obj.insert(
-                    "start".to_string(),
+                right_obj.set_field(
+                    "start",
                     serde_json::Value::Number((original_pos as i64).into()),
                 );
             }
             if let Some(end_val) = right_obj.get("end").and_then(|e| e.as_u64()) {
                 let cleaned_pos = end_val as usize - base_offset;
                 let original_pos = base_offset + stripped.map_to_original(cleaned_pos);
-                right_obj.insert(
-                    "end".to_string(),
+                right_obj.set_field(
+                    "end",
                     serde_json::Value::Number((original_pos as i64).into()),
                 );
             }
@@ -2528,13 +2522,10 @@ fn convert_formal_parameter<'a>(
         let start = adjusted_offset + param.span.start as usize;
         let end = adjusted_offset + param.span.end as usize;
         let mut obj = Map::new();
-        obj.insert(
-            "type".to_string(),
-            Value::String("TSParameterProperty".to_string()),
-        );
+        obj.set_field("type", Value::String("TSParameterProperty".to_string()));
         push_span_fields(&mut obj, start, end, line_offsets);
         if param.readonly {
-            obj.insert("readonly".to_string(), Value::Bool(true));
+            obj.set_field("readonly", Value::Bool(true));
         }
         if let Some(ref accessibility) = param.accessibility {
             let acc_str = match accessibility {
@@ -2542,14 +2533,11 @@ fn convert_formal_parameter<'a>(
                 oxc_ast::ast::TSAccessibility::Protected => "protected",
                 oxc_ast::ast::TSAccessibility::Public => "public",
             };
-            obj.insert(
-                "accessibility".to_string(),
-                Value::String(acc_str.to_string()),
-            );
+            obj.set_field("accessibility", Value::String(acc_str.to_string()));
         }
         // Include the parameter itself so remove_typescript_nodes can extract it
         let inner = convert_formal_parameter_inner(arena, param, adjusted_offset, line_offsets);
-        obj.insert("parameter".to_string(), inner.as_json().clone());
+        obj.set_field("parameter", inner.as_json().clone());
         return Expression::from_json(Value::Object(obj));
     }
 
@@ -2576,13 +2564,13 @@ fn convert_formal_parameter_inner<'a>(
                 let end = adjusted_offset + type_ann.span.end as usize;
 
                 let mut obj = Map::new();
-                obj.insert("type".to_string(), Value::String("Identifier".to_string()));
+                obj.set_field("type", Value::String("Identifier".to_string()));
                 push_span_fields(&mut obj, start, end, line_offsets);
-                obj.insert("name".to_string(), Value::String(name.to_string()));
+                obj.set_field("name", Value::String(name.to_string()));
 
                 // TS optional marker (`b?: T`); acorn emits it after `name`.
                 if param.optional {
-                    obj.insert("optional".to_string(), Value::Bool(true));
+                    obj.set_field("optional", Value::Bool(true));
                 }
 
                 // Convert type annotation
@@ -2592,7 +2580,7 @@ fn convert_formal_parameter_inner<'a>(
                     adjusted_offset,
                     line_offsets,
                 );
-                obj.insert("typeAnnotation".to_string(), type_ann_obj);
+                obj.set_field("typeAnnotation", type_ann_obj);
 
                 Expression::from_json(Value::Object(obj))
             } else if param.optional {
@@ -2676,13 +2664,13 @@ fn attach_param_type_annotation<'a>(
     if let Some(obj) = json.as_object_mut() {
         let start = obj.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
         let end = adjusted_offset + type_ann.span.end as usize;
-        obj.insert("end".to_string(), Value::Number((end as i64).into()));
+        obj.set_field("end", Value::Number((end as i64).into()));
         if let Some(loc) = create_loc(start, end, line_offsets) {
-            obj.insert("loc".to_string(), loc);
+            obj.set_field("loc", loc);
         }
         let type_ann_obj =
             convert_type_annotation_adjusted(arena, type_ann, adjusted_offset, line_offsets);
-        obj.insert("typeAnnotation".to_string(), type_ann_obj);
+        obj.set_field("typeAnnotation", type_ann_obj);
     }
     Expression::from_json(json)
 }
@@ -2832,12 +2820,9 @@ fn convert_assignment_pattern_to_expr<'a>(
     let right_start = adjusted_offset + assign_pat.right.span().start as usize;
     let right_end = adjusted_offset + assign_pat.right.span().end as usize;
     let mut right_obj = Map::new();
-    right_obj.insert("type".to_string(), Value::String("Expression".to_string()));
-    right_obj.insert(
-        "start".to_string(),
-        Value::Number((right_start as i64).into()),
-    );
-    right_obj.insert("end".to_string(), Value::Number((right_end as i64).into()));
+    right_obj.set_field("type", Value::String("Expression".to_string()));
+    right_obj.set_field("start", Value::Number((right_start as i64).into()));
+    right_obj.set_field("end", Value::Number((right_end as i64).into()));
 
     Expression::from_node(JsNode::AssignmentPattern {
         start: start as u32,
@@ -2862,8 +2847,8 @@ fn convert_binding_pattern_for_param(
             let start = adjusted_offset + id.span.start as usize;
             let end = adjusted_offset + id.span.end as usize;
             let mut obj = Map::new();
-            obj.insert("type".to_string(), Value::String("Identifier".to_string()));
-            obj.insert("name".to_string(), Value::String(id.name.to_string()));
+            obj.set_field("type", Value::String("Identifier".to_string()));
+            obj.set_field("name", Value::String(id.name.to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
             Value::Object(obj)
         }
@@ -2879,10 +2864,7 @@ fn convert_binding_pattern_for_param(
             let start = adjusted_offset + arr_pat.span.start as usize;
             let end = adjusted_offset + arr_pat.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("ArrayPattern".to_string()),
-            );
+            obj.set_field("type", Value::String("ArrayPattern".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
 
             // Convert elements
@@ -2906,14 +2888,11 @@ fn convert_binding_pattern_for_param(
                 let rest_end = adjusted_offset + rest.span.end as usize;
 
                 let mut rest_obj = Map::new();
-                rest_obj.insert("type".to_string(), Value::String("RestElement".to_string()));
-                rest_obj.insert(
-                    "start".to_string(),
-                    Value::Number((rest_start as i64).into()),
-                );
-                rest_obj.insert("end".to_string(), Value::Number((rest_end as i64).into()));
+                rest_obj.set_field("type", Value::String("RestElement".to_string()));
+                rest_obj.set_field("start", Value::Number((rest_start as i64).into()));
+                rest_obj.set_field("end", Value::Number((rest_end as i64).into()));
                 if let Some(loc) = create_loc(rest_start, rest_end, line_offsets) {
-                    rest_obj.insert("loc".to_string(), loc);
+                    rest_obj.set_field("loc", loc);
                 }
 
                 let argument = convert_binding_pattern_for_param(
@@ -2922,12 +2901,12 @@ fn convert_binding_pattern_for_param(
                     adjusted_offset,
                     line_offsets,
                 );
-                rest_obj.insert("argument".to_string(), argument);
+                rest_obj.set_field("argument", argument);
 
                 elements.push(Value::Object(rest_obj));
             }
 
-            obj.insert("elements".to_string(), Value::Array(elements));
+            obj.set_field("elements", Value::Array(elements));
 
             Value::Object(obj)
         }
@@ -2935,10 +2914,7 @@ fn convert_binding_pattern_for_param(
             let start = adjusted_offset + assign_pat.span.start as usize;
             let end = adjusted_offset + assign_pat.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("AssignmentPattern".to_string()),
-            );
+            obj.set_field("type", Value::String("AssignmentPattern".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
 
             // Convert left (the pattern)
@@ -2948,7 +2924,7 @@ fn convert_binding_pattern_for_param(
                 adjusted_offset,
                 line_offsets,
             );
-            obj.insert("left".to_string(), left);
+            obj.set_field("left", left);
 
             // Convert right (the default value) using the full expression converter.
             // Must use with_serialize_arena to resolve IdRange children
@@ -2957,7 +2933,7 @@ fn convert_binding_pattern_for_param(
                 convert_expression(arena, &assign_pat.right, adjusted_offset, line_offsets);
             let right_val =
                 crate::ast::arena::with_serialize_arena(arena, || right_expr.as_json().clone());
-            obj.insert("right".to_string(), right_val);
+            obj.set_field("right", right_val);
 
             Value::Object(obj)
         }
@@ -3007,11 +2983,8 @@ fn convert_property_key_for_param_as_node(
             } else {
                 // Fallback placeholder for truly unhandled cases (no span).
                 let mut obj = Map::new();
-                obj.insert("type".to_string(), Value::String("Identifier".to_string()));
-                obj.insert(
-                    "name".to_string(),
-                    Value::String("__computed__".to_string()),
-                );
+                obj.set_field("type", Value::String("Identifier".to_string()));
+                obj.set_field("name", Value::String("__computed__".to_string()));
                 JsNode::from_value(Value::Object(obj))
             }
         }
@@ -3087,10 +3060,7 @@ fn convert_type_annotation_adjusted(
     let end = adjusted_offset + type_ann.span.end as usize;
 
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("TSTypeAnnotation".to_string()),
-    );
+    obj.set_field("type", Value::String("TSTypeAnnotation".to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
 
     // Convert the inner type
@@ -3100,7 +3070,7 @@ fn convert_type_annotation_adjusted(
         adjusted_offset,
         line_offsets,
     );
-    obj.insert("typeAnnotation".to_string(), inner_type);
+    obj.set_field("typeAnnotation", inner_type);
 
     Value::Object(obj)
 }
@@ -3117,11 +3087,11 @@ fn ts_assertion_value(
     line_offsets: &[usize],
 ) -> Value {
     let mut obj = Map::new();
-    obj.insert("type".to_string(), Value::String(type_name.to_string()));
+    obj.set_field("type", Value::String(type_name.to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
-    obj.insert("expression".to_string(), expression);
+    obj.set_field("expression", expression);
     if let Some(ta) = type_annotation {
-        obj.insert("typeAnnotation".to_string(), ta);
+        obj.set_field("typeAnnotation", ta);
     }
     Value::Object(obj)
 }
@@ -3153,9 +3123,9 @@ fn convert_ts_type_name_adjusted(
             let end = adjusted_offset + id.span.end as usize;
 
             let mut obj = Map::new();
-            obj.insert("type".to_string(), Value::String("Identifier".to_string()));
+            obj.set_field("type", Value::String("Identifier".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("name".to_string(), Value::String(id.name.to_string()));
+            obj.set_field("name", Value::String(id.name.to_string()));
 
             Value::Object(obj)
         }
@@ -3166,22 +3136,19 @@ fn convert_ts_type_name_adjusted(
             let end = adjusted_offset + span.end as usize;
 
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("TSQualifiedName".to_string()),
-            );
+            obj.set_field("type", Value::String("TSQualifiedName".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
 
             // `left` recurses (it may itself be a qualified name); `right` is a
             // plain Identifier. Matches svelte/compiler's TSQualifiedName shape.
-            obj.insert(
-                "left".to_string(),
+            obj.set_field(
+                "left",
                 convert_ts_type_name_adjusted(&qualified.left, adjusted_offset, line_offsets),
             );
             let r_start = adjusted_offset + qualified.right.span.start as usize;
             let r_end = adjusted_offset + qualified.right.span.end as usize;
-            obj.insert(
-                "right".to_string(),
+            obj.set_field(
+                "right",
                 ts_identifier_value(&qualified.right.name, r_start, r_end, line_offsets),
             );
 
@@ -3193,10 +3160,7 @@ fn convert_ts_type_name_adjusted(
             let end = adjusted_offset + this.span.end as usize;
 
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("ThisExpression".to_string()),
-            );
+            obj.set_field("type", Value::String("ThisExpression".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
 
             Value::Object(obj)
@@ -3227,7 +3191,7 @@ fn convert_ts_type(
     // Build a `{ type, start, end, loc }` object the rest of the arms extend.
     let base = |type_name: &str| -> Map<String, Value> {
         let mut obj = Map::new();
-        obj.insert("type".to_string(), Value::String(type_name.to_string()));
+        obj.set_field("type", Value::String(type_name.to_string()));
         push_span_fields(&mut obj, start, end, line_offsets);
         obj
     };
@@ -3270,13 +3234,13 @@ fn convert_ts_type(
         // ---- references -----------------------------------------------------
         TSType::TSTypeReference(type_ref) => {
             let mut obj = base("TSTypeReference");
-            obj.insert(
-                "typeName".to_string(),
+            obj.set_field(
+                "typeName",
                 convert_ts_type_name_adjusted(&type_ref.type_name, offset, line_offsets),
             );
             if let Some(args) = &type_ref.type_arguments {
-                obj.insert(
-                    "typeArguments".to_string(),
+                obj.set_field(
+                    "typeArguments",
                     convert_ts_type_param_instantiation(arena, args, offset, line_offsets),
                 );
             }
@@ -3291,7 +3255,7 @@ fn convert_ts_type(
                 .iter()
                 .map(|m| convert_ts_signature(arena, m, offset, line_offsets))
                 .collect();
-            obj.insert("members".to_string(), Value::Array(members));
+            obj.set_field("members", Value::Array(members));
             Value::Object(obj)
         }
 
@@ -3303,7 +3267,7 @@ fn convert_ts_type(
                 .iter()
                 .map(|t| convert_ts_type(arena, t, offset, line_offsets))
                 .collect();
-            obj.insert("types".to_string(), Value::Array(types));
+            obj.set_field("types", Value::Array(types));
             Value::Object(obj)
         }
         TSType::TSIntersectionType(i) => {
@@ -3313,15 +3277,15 @@ fn convert_ts_type(
                 .iter()
                 .map(|t| convert_ts_type(arena, t, offset, line_offsets))
                 .collect();
-            obj.insert("types".to_string(), Value::Array(types));
+            obj.set_field("types", Value::Array(types));
             Value::Object(obj)
         }
 
         // ---- arrays / tuples ------------------------------------------------
         TSType::TSArrayType(a) => {
             let mut obj = base("TSArrayType");
-            obj.insert(
-                "elementType".to_string(),
+            obj.set_field(
+                "elementType",
                 convert_ts_type(arena, &a.element_type, offset, line_offsets),
             );
             Value::Object(obj)
@@ -3329,8 +3293,8 @@ fn convert_ts_type(
         // ---- literal types: `'a'`, `403`, `true` ----------------------------
         TSType::TSLiteralType(l) => {
             let mut obj = base("TSLiteralType");
-            obj.insert(
-                "literal".to_string(),
+            obj.set_field(
+                "literal",
                 convert_ts_literal(&l.literal, offset, line_offsets),
             );
             Value::Object(obj)
@@ -3339,8 +3303,8 @@ fn convert_ts_type(
         // ---- wrappers / operators ------------------------------------------
         TSType::TSParenthesizedType(p) => {
             let mut obj = base("TSParenthesizedType");
-            obj.insert(
-                "typeAnnotation".to_string(),
+            obj.set_field(
+                "typeAnnotation",
                 convert_ts_type(arena, &p.type_annotation, offset, line_offsets),
             );
             Value::Object(obj)
@@ -3354,21 +3318,21 @@ fn convert_ts_type(
                 TSTypeOperatorOperator::Unique => "unique",
                 TSTypeOperatorOperator::Readonly => "readonly",
             };
-            obj.insert("operator".to_string(), Value::String(operator.to_string()));
-            obj.insert(
-                "typeAnnotation".to_string(),
+            obj.set_field("operator", Value::String(operator.to_string()));
+            obj.set_field(
+                "typeAnnotation",
                 convert_ts_type(arena, &op.type_annotation, offset, line_offsets),
             );
             Value::Object(obj)
         }
         TSType::TSIndexedAccessType(ia) => {
             let mut obj = base("TSIndexedAccessType");
-            obj.insert(
-                "objectType".to_string(),
+            obj.set_field(
+                "objectType",
                 convert_ts_type(arena, &ia.object_type, offset, line_offsets),
             );
-            obj.insert(
-                "indexType".to_string(),
+            obj.set_field(
+                "indexType",
                 convert_ts_type(arena, &ia.index_type, offset, line_offsets),
             );
             Value::Object(obj)
@@ -3383,8 +3347,8 @@ fn convert_ts_type(
         TSType::TSFunctionType(f) => {
             let mut obj = base("TSFunctionType");
             if let Some(type_parameters) = &f.type_parameters {
-                obj.insert(
-                    "typeParameters".to_string(),
+                obj.set_field(
+                    "typeParameters",
                     convert_ts_type_parameter_declaration(
                         arena,
                         type_parameters,
@@ -3393,8 +3357,8 @@ fn convert_ts_type(
                     ),
                 );
             }
-            obj.insert(
-                "parameters".to_string(),
+            obj.set_field(
+                "parameters",
                 Value::Array(convert_ts_function_like_params(
                     arena,
                     f.this_param.as_deref(),
@@ -3403,8 +3367,8 @@ fn convert_ts_type(
                     line_offsets,
                 )),
             );
-            obj.insert(
-                "typeAnnotation".to_string(),
+            obj.set_field(
+                "typeAnnotation",
                 convert_type_annotation_adjusted(arena, &f.return_type, offset, line_offsets),
             );
             Value::Object(obj)
@@ -3413,10 +3377,10 @@ fn convert_ts_type(
             let mut obj = base("TSConstructorType");
             // svelte/compiler always emits `abstract` (unlike `optional` / `readonly`
             // elsewhere, which are omitted when false).
-            obj.insert("abstract".to_string(), Value::Bool(c.r#abstract));
+            obj.set_field("abstract", Value::Bool(c.r#abstract));
             if let Some(type_parameters) = &c.type_parameters {
-                obj.insert(
-                    "typeParameters".to_string(),
+                obj.set_field(
+                    "typeParameters",
                     convert_ts_type_parameter_declaration(
                         arena,
                         type_parameters,
@@ -3425,8 +3389,8 @@ fn convert_ts_type(
                     ),
                 );
             }
-            obj.insert(
-                "parameters".to_string(),
+            obj.set_field(
+                "parameters",
                 Value::Array(convert_ts_function_like_params(
                     arena,
                     None,
@@ -3435,8 +3399,8 @@ fn convert_ts_type(
                     line_offsets,
                 )),
             );
-            obj.insert(
-                "typeAnnotation".to_string(),
+            obj.set_field(
+                "typeAnnotation",
                 convert_type_annotation_adjusted(arena, &c.return_type, offset, line_offsets),
             );
             Value::Object(obj)
@@ -3463,8 +3427,8 @@ fn convert_ts_type_parameter_declaration(
     let start = offset + decl.span.start as usize;
     let end = offset + decl.span.end as usize;
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
+    obj.set_field(
+        "type",
         Value::String("TSTypeParameterDeclaration".to_string()),
     );
     push_span_fields(&mut obj, start, end, line_offsets);
@@ -3473,7 +3437,7 @@ fn convert_ts_type_parameter_declaration(
         .iter()
         .map(|p| convert_ts_type_parameter(arena, p, offset, line_offsets))
         .collect();
-    obj.insert("params".to_string(), Value::Array(params));
+    obj.set_field("params", Value::Array(params));
     Value::Object(obj)
 }
 
@@ -3487,24 +3451,18 @@ fn convert_ts_type_parameter(
     let start = offset + param.span.start as usize;
     let end = offset + param.span.end as usize;
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("TSTypeParameter".to_string()),
-    );
+    obj.set_field("type", Value::String("TSTypeParameter".to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
-    obj.insert(
-        "name".to_string(),
-        Value::String(param.name.name.to_string()),
-    );
+    obj.set_field("name", Value::String(param.name.name.to_string()));
     if let Some(constraint) = &param.constraint {
-        obj.insert(
-            "constraint".to_string(),
+        obj.set_field(
+            "constraint",
             convert_ts_type(arena, constraint, offset, line_offsets),
         );
     }
     if let Some(default) = &param.default {
-        obj.insert(
-            "default".to_string(),
+        obj.set_field(
+            "default",
             convert_ts_type(arena, default, offset, line_offsets),
         );
     }
@@ -3530,12 +3488,12 @@ fn convert_ts_function_like_params(
         let start = offset + this_param.span.start as usize;
         let end = offset + this_param.span.end as usize;
         let mut obj = Map::new();
-        obj.insert("type".to_string(), Value::String("Identifier".to_string()));
+        obj.set_field("type", Value::String("Identifier".to_string()));
         push_span_fields(&mut obj, start, end, line_offsets);
-        obj.insert("name".to_string(), Value::String("this".to_string()));
+        obj.set_field("name", Value::String("this".to_string()));
         if let Some(type_ann) = &this_param.type_annotation {
-            obj.insert(
-                "typeAnnotation".to_string(),
+            obj.set_field(
+                "typeAnnotation",
                 convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
             );
         }
@@ -3556,12 +3514,12 @@ fn convert_ts_function_like_params(
         let argument =
             convert_binding_pattern_for_param(arena, &rest.rest.argument, offset, line_offsets);
         let mut obj = Map::new();
-        obj.insert("type".to_string(), Value::String("RestElement".to_string()));
+        obj.set_field("type", Value::String("RestElement".to_string()));
         push_span_fields(&mut obj, start, end, line_offsets);
-        obj.insert("argument".to_string(), argument);
+        obj.set_field("argument", argument);
         if let Some(type_ann) = &rest.type_annotation {
-            obj.insert(
-                "typeAnnotation".to_string(),
+            obj.set_field(
+                "typeAnnotation",
                 convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
             );
         }
@@ -3588,26 +3546,23 @@ fn convert_ts_signature(
             let end = offset + prop.span.end as usize;
 
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("TSPropertySignature".to_string()),
-            );
+            obj.set_field("type", Value::String("TSPropertySignature".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("computed".to_string(), Value::Bool(prop.computed));
+            obj.set_field("computed", Value::Bool(prop.computed));
             // svelte/compiler omits `optional` / `readonly` when false.
             if prop.optional {
-                obj.insert("optional".to_string(), Value::Bool(true));
+                obj.set_field("optional", Value::Bool(true));
             }
             if prop.readonly {
-                obj.insert("readonly".to_string(), Value::Bool(true));
+                obj.set_field("readonly", Value::Bool(true));
             }
-            obj.insert(
-                "key".to_string(),
+            obj.set_field(
+                "key",
                 convert_ts_property_key(&prop.key, offset, line_offsets),
             );
             if let Some(type_ann) = &prop.type_annotation {
-                obj.insert(
-                    "typeAnnotation".to_string(),
+                obj.set_field(
+                    "typeAnnotation",
                     convert_type_annotation_adjusted(arena, type_ann, offset, line_offsets),
                 );
             }
@@ -3629,7 +3584,7 @@ fn convert_ts_signature(
                 TSSignature::TSPropertySignature(_) => "TSPropertySignature",
             };
             let mut obj = Map::new();
-            obj.insert("type".to_string(), Value::String(type_name.to_string()));
+            obj.set_field("type", Value::String(type_name.to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
             Value::Object(obj)
         }
@@ -3737,9 +3692,9 @@ fn convert_ts_literal(
 /// which the TS-type converters can't use directly).
 fn ts_identifier_value(name: &str, start: usize, end: usize, line_offsets: &[usize]) -> Value {
     let mut obj = Map::new();
-    obj.insert("type".to_string(), Value::String("Identifier".to_string()));
+    obj.set_field("type", Value::String("Identifier".to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
-    obj.insert("name".to_string(), Value::String(name.to_string()));
+    obj.set_field("name", Value::String(name.to_string()));
     Value::Object(obj)
 }
 
@@ -3752,11 +3707,11 @@ fn ts_literal_value(
     line_offsets: &[usize],
 ) -> Value {
     let mut obj = Map::new();
-    obj.insert("type".to_string(), Value::String("Literal".to_string()));
+    obj.set_field("type", Value::String("Literal".to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
-    obj.insert("value".to_string(), value);
+    obj.set_field("value", value);
     if let Some(raw) = raw {
-        obj.insert("raw".to_string(), Value::String(raw));
+        obj.set_field("raw", Value::String(raw));
     }
     Value::Object(obj)
 }
@@ -3784,8 +3739,8 @@ fn convert_ts_type_param_instantiation(
     let start = offset + args.span.start as usize;
     let end = offset + args.span.end as usize;
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
+    obj.set_field(
+        "type",
         Value::String("TSTypeParameterInstantiation".to_string()),
     );
     push_span_fields(&mut obj, start, end, line_offsets);
@@ -3794,14 +3749,14 @@ fn convert_ts_type_param_instantiation(
         .iter()
         .map(|t| convert_ts_type(arena, t, offset, line_offsets))
         .collect();
-    obj.insert("params".to_string(), Value::Array(params));
+    obj.set_field("params", Value::Array(params));
     Value::Object(obj)
 }
 
 /// Create a TypeScript keyword type node.
 fn create_ts_keyword(type_name: &str, start: usize, end: usize, line_offsets: &[usize]) -> Value {
     let mut obj = Map::new();
-    obj.insert("type".to_string(), Value::String(type_name.to_string()));
+    obj.set_field("type", Value::String(type_name.to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
     Value::Object(obj)
 }
@@ -4919,7 +4874,7 @@ fn convert_class_body_for_expr(
     let end = offset + body.span.end as usize - 1;
 
     let mut obj = Map::new();
-    obj.insert("type".to_string(), Value::String("ClassBody".to_string()));
+    obj.set_field("type", Value::String("ClassBody".to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
 
     let body_elements: Vec<Value> = body
@@ -4927,7 +4882,7 @@ fn convert_class_body_for_expr(
         .iter()
         .filter_map(|element| convert_class_element_for_expr(arena, element, offset, line_offsets))
         .collect();
-    obj.insert("body".to_string(), Value::Array(body_elements));
+    obj.set_field("body", Value::Array(body_elements));
 
     Value::Object(obj)
 }
@@ -4944,13 +4899,10 @@ fn convert_class_element_for_expr(
             let start = offset + method.span.start as usize - 1;
             let end = offset + method.span.end as usize - 1;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("MethodDefinition".to_string()),
-            );
+            obj.set_field("type", Value::String("MethodDefinition".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("static".to_string(), Value::Bool(method.r#static));
-            obj.insert("computed".to_string(), Value::Bool(method.computed));
+            obj.set_field("static", Value::Bool(method.r#static));
+            obj.set_field("computed", Value::Bool(method.computed));
 
             // kind
             let kind = match method.kind {
@@ -4959,11 +4911,11 @@ fn convert_class_element_for_expr(
                 oxc_ast::ast::MethodDefinitionKind::Get => "get",
                 oxc_ast::ast::MethodDefinitionKind::Set => "set",
             };
-            obj.insert("kind".to_string(), Value::String(kind.to_string()));
+            obj.set_field("kind", Value::String(kind.to_string()));
 
             // key
             let key = convert_property_key_for_expr(arena, &method.key, offset, line_offsets);
-            obj.insert("key".to_string(), key.to_value());
+            obj.set_field("key", key.to_value());
 
             // value (function expression). A method's generics live on the
             // MethodDefinition (acorn-typescript), not the inner function.
@@ -4979,7 +4931,7 @@ fn convert_class_element_for_expr(
                 None,
                 false,
             );
-            obj.insert("value".to_string(), value.as_json().clone());
+            obj.set_field("value", value.as_json().clone());
 
             Some(Value::Object(obj))
         }
@@ -4987,24 +4939,21 @@ fn convert_class_element_for_expr(
             let start = offset + prop.span.start as usize - 1;
             let end = offset + prop.span.end as usize - 1;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("PropertyDefinition".to_string()),
-            );
+            obj.set_field("type", Value::String("PropertyDefinition".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("static".to_string(), Value::Bool(prop.r#static));
-            obj.insert("computed".to_string(), Value::Bool(prop.computed));
+            obj.set_field("static", Value::Bool(prop.r#static));
+            obj.set_field("computed", Value::Bool(prop.computed));
 
             // key
             let key = convert_property_key_for_expr(arena, &prop.key, offset, line_offsets);
-            obj.insert("key".to_string(), key.to_value());
+            obj.set_field("key", key.to_value());
 
             // value
             if let Some(ref value) = prop.value {
                 let val = convert_expression(arena, value, offset, line_offsets);
-                obj.insert("value".to_string(), val.as_json().clone());
+                obj.set_field("value", val.as_json().clone());
             } else {
-                obj.insert("value".to_string(), Value::Null);
+                obj.set_field("value", Value::Null);
             }
 
             Some(Value::Object(obj))
@@ -5013,7 +4962,7 @@ fn convert_class_element_for_expr(
             let start = offset + static_block.span.start as usize - 1;
             let end = offset + static_block.span.end as usize - 1;
             let mut obj = Map::new();
-            obj.insert("type".to_string(), Value::String("StaticBlock".to_string()));
+            obj.set_field("type", Value::String("StaticBlock".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
 
             let body_statements: Vec<Value> = static_block
@@ -5022,7 +4971,7 @@ fn convert_class_element_for_expr(
                 .filter_map(|stmt| convert_statement(arena, stmt, offset, line_offsets))
                 .map(|node| node.to_value())
                 .collect();
-            obj.insert("body".to_string(), Value::Array(body_statements));
+            obj.set_field("body", Value::Array(body_statements));
 
             Some(Value::Object(obj))
         }
@@ -6309,6 +6258,20 @@ fn update_operator_to_str(op: &oxc_ast::ast::UpdateOperator) -> &'static str {
     }
 }
 
+/// `Map::insert` without the per-call `key.to_string()`. ESTree objects here are
+/// built field by field interleaved with control flow, so this keeps each field
+/// on one line; `serde_json`'s `preserve_order` makes the call order the JSON
+/// key order.
+trait EstreeFieldExt {
+    fn set_field(&mut self, key: &str, value: Value);
+}
+
+impl EstreeFieldExt for Map<String, Value> {
+    fn set_field(&mut self, key: &str, value: Value) {
+        self.insert(key.to_string(), value);
+    }
+}
+
 /// Insert the ESTree span fields in acorn's emission order (`start`, `end`, then
 /// `loc` when line offsets are available). `serde_json`'s `preserve_order` makes
 /// that insertion order part of the JSON output contract.
@@ -6339,10 +6302,10 @@ fn push_span_fields_with(
     line_offsets: &[usize],
     line_column: fn(usize, &[usize]) -> (u32, u32),
 ) {
-    obj.insert("start".to_string(), Value::Number((start as i64).into()));
-    obj.insert("end".to_string(), Value::Number((end as i64).into()));
+    obj.set_field("start", Value::Number((start as i64).into()));
+    obj.set_field("end", Value::Number((end as i64).into()));
     if let Some(loc) = create_loc_with(start, end, line_offsets, line_column) {
-        obj.insert("loc".to_string(), loc);
+        obj.set_field("loc", loc);
     }
 }
 
@@ -6362,14 +6325,14 @@ fn create_loc_with(
     let point = |pos: usize| {
         let (line, column) = line_column(pos, line_offsets);
         let mut obj = Map::new();
-        obj.insert("line".to_string(), Value::Number((line as i64).into()));
-        obj.insert("column".to_string(), Value::Number((column as i64).into()));
+        obj.set_field("line", Value::Number((line as i64).into()));
+        obj.set_field("column", Value::Number((column as i64).into()));
         Value::Object(obj)
     };
 
     let mut loc = Map::new();
-    loc.insert("start".to_string(), point(start));
-    loc.insert("end".to_string(), point(end));
+    loc.set_field("start", point(start));
+    loc.set_field("end", point(end));
     Some(Value::Object(loc))
 }
 
@@ -6751,7 +6714,7 @@ pub fn parse_program_with_error<'a>(
                         if !stmt_leading.is_empty()
                             && let Value::Object(ref mut obj) = val
                         {
-                            obj.insert("leadingComments".to_string(), Value::Array(stmt_leading));
+                            obj.set_field("leadingComments", Value::Array(stmt_leading));
                         }
                         distribute_comments_to_node(&mut val, &comment_entries);
                         harvest_ignore_comments(&val, &mut ignore_comment_map);
@@ -6791,8 +6754,8 @@ pub fn parse_program_with_error<'a>(
                     .iter()
                     .map(|comment| {
                         let mut comment_obj = Map::new();
-                        comment_obj.insert("type".to_string(), Value::String("Line".to_string()));
-                        comment_obj.insert("value".to_string(), Value::String(comment.clone()));
+                        comment_obj.set_field("type", Value::String("Line".to_string()));
+                        comment_obj.set_field("value", Value::String(comment.clone()));
                         Value::Object(comment_obj)
                     })
                     .collect(),
@@ -6843,16 +6806,10 @@ fn build_comment_value(comment: &oxc_ast::ast::Comment, content: &str, offset: u
     };
 
     let mut comment_obj = Map::new();
-    comment_obj.insert("type".to_string(), Value::String(comment_type.to_string()));
-    comment_obj.insert("value".to_string(), Value::String(comment_text));
-    comment_obj.insert(
-        "start".to_string(),
-        Value::Number((comment_start as i64).into()),
-    );
-    comment_obj.insert(
-        "end".to_string(),
-        Value::Number((comment_end as i64).into()),
-    );
+    comment_obj.set_field("type", Value::String(comment_type.to_string()));
+    comment_obj.set_field("value", Value::String(comment_text));
+    comment_obj.set_field("start", Value::Number((comment_start as i64).into()));
+    comment_obj.set_field("end", Value::Number((comment_end as i64).into()));
     Value::Object(comment_obj)
 }
 
@@ -6962,7 +6919,7 @@ fn distribute_comments_to_node(node: &mut Value, comments: &[CommentEntry]) -> b
                         }
 
                         if !leading.is_empty() {
-                            stmt_obj.insert("leadingComments".to_string(), Value::Array(leading));
+                            stmt_obj.set_field("leadingComments", Value::Array(leading));
                             modified = true;
                         }
                     }
@@ -7243,26 +7200,20 @@ fn convert_statement_for_program(
                     let class_start = offset + class_decl.span.start as usize;
                     let class_end = offset + class_decl.span.end as usize;
                     let mut class_obj = Map::new();
-                    class_obj.insert(
-                        "type".to_string(),
-                        Value::String("ClassDeclaration".to_string()),
-                    );
-                    class_obj.insert(
-                        "start".to_string(),
-                        Value::Number((class_start as i64).into()),
-                    );
-                    class_obj.insert("end".to_string(), Value::Number((class_end as i64).into()));
+                    class_obj.set_field("type", Value::String("ClassDeclaration".to_string()));
+                    class_obj.set_field("start", Value::Number((class_start as i64).into()));
+                    class_obj.set_field("end", Value::Number((class_end as i64).into()));
                     if let Some(loc) = create_loc(class_start, class_end, line_offsets) {
-                        class_obj.insert("loc".to_string(), loc);
+                        class_obj.set_field("loc", loc);
                     }
 
                     if let Some(id) = &class_decl.id {
                         let id_start = offset + id.span.start as usize;
                         let id_end = offset + id.span.end as usize;
                         let id_expr = create_identifier(&id.name, id_start, id_end, line_offsets);
-                        class_obj.insert("id".to_string(), id_expr.as_json().clone());
+                        class_obj.set_field("id", id_expr.as_json().clone());
                     } else {
-                        class_obj.insert("id".to_string(), Value::Null);
+                        class_obj.set_field("id", Value::Null);
                     }
 
                     if let Some(super_class) = &class_decl.super_class {
@@ -7272,9 +7223,9 @@ fn convert_statement_for_program(
                             offset,
                             line_offsets,
                         );
-                        class_obj.insert("superClass".to_string(), super_expr.as_json().clone());
+                        class_obj.set_field("superClass", super_expr.as_json().clone());
                     } else {
-                        class_obj.insert("superClass".to_string(), Value::Null);
+                        class_obj.set_field("superClass", Value::Null);
                     }
 
                     let body = convert_class_body_for_program(
@@ -7283,7 +7234,7 @@ fn convert_statement_for_program(
                         offset,
                         line_offsets,
                     );
-                    class_obj.insert("body".to_string(), body);
+                    class_obj.set_field("body", body);
 
                     JsNode::from_value(Value::Object(class_obj))
                 }
@@ -8142,10 +8093,7 @@ fn convert_declaration_for_program(
             let start = offset + var_decl.span.start as usize;
             let end = offset + var_decl.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("VariableDeclaration".to_string()),
-            );
+            obj.set_field("type", Value::String("VariableDeclaration".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
 
             let declarations: Vec<Value> = var_decl
@@ -8156,7 +8104,7 @@ fn convert_declaration_for_program(
                 })
                 .map(|n| n.to_value())
                 .collect();
-            obj.insert("declarations".to_string(), Value::Array(declarations));
+            obj.set_field("declarations", Value::Array(declarations));
 
             let kind = match var_decl.kind {
                 oxc_ast::ast::VariableDeclarationKind::Var => "var",
@@ -8165,11 +8113,11 @@ fn convert_declaration_for_program(
                 oxc_ast::ast::VariableDeclarationKind::Using => "using",
                 oxc_ast::ast::VariableDeclarationKind::AwaitUsing => "await using",
             };
-            obj.insert("kind".to_string(), Value::String(kind.to_string()));
+            obj.set_field("kind", Value::String(kind.to_string()));
 
             // declare field for TypeScript `declare const/let/var`
             if var_decl.declare {
-                obj.insert("declare".to_string(), Value::Bool(true));
+                obj.set_field("declare", Value::Bool(true));
             }
 
             Value::Object(obj)
@@ -8179,41 +8127,32 @@ fn convert_declaration_for_program(
             if func_decl.r#type == oxc_ast::ast::FunctionType::TSDeclareFunction {
                 // Return an EmptyStatement so remove_typescript_nodes can handle it
                 let mut empty_obj = Map::new();
-                empty_obj.insert(
-                    "type".to_string(),
-                    Value::String("EmptyStatement".to_string()),
-                );
+                empty_obj.set_field("type", Value::String("EmptyStatement".to_string()));
                 return Value::Object(empty_obj);
             }
             // Filter out function overload signatures (no body)
             if func_decl.body.is_none() {
                 let mut empty_obj = Map::new();
-                empty_obj.insert(
-                    "type".to_string(),
-                    Value::String("EmptyStatement".to_string()),
-                );
+                empty_obj.set_field("type", Value::String("EmptyStatement".to_string()));
                 return Value::Object(empty_obj);
             }
             let start = offset + func_decl.span.start as usize;
             let end = offset + func_decl.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("FunctionDeclaration".to_string()),
-            );
+            obj.set_field("type", Value::String("FunctionDeclaration".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
 
             if let Some(id) = &func_decl.id {
                 let id_start = offset + id.span.start as usize;
                 let id_end = offset + id.span.end as usize;
                 let id_expr = create_identifier(&id.name, id_start, id_end, line_offsets);
-                obj.insert("id".to_string(), id_expr.as_json().clone());
+                obj.set_field("id", id_expr.as_json().clone());
             } else {
-                obj.insert("id".to_string(), Value::Null);
+                obj.set_field("id", Value::Null);
             }
 
-            obj.insert("generator".to_string(), Value::Bool(func_decl.generator));
-            obj.insert("async".to_string(), Value::Bool(func_decl.r#async));
+            obj.set_field("generator", Value::Bool(func_decl.generator));
+            obj.set_field("async", Value::Bool(func_decl.r#async));
 
             // Convert params
             let mut params: Vec<Value> = func_decl
@@ -8236,27 +8175,24 @@ fn convert_declaration_for_program(
                     line_offsets,
                 );
                 let mut rest_obj = Map::new();
-                rest_obj.insert("type".to_string(), Value::String("RestElement".to_string()));
-                rest_obj.insert(
-                    "start".to_string(),
-                    Value::Number((rest_start as i64).into()),
-                );
-                rest_obj.insert("end".to_string(), Value::Number((rest_end as i64).into()));
+                rest_obj.set_field("type", Value::String("RestElement".to_string()));
+                rest_obj.set_field("start", Value::Number((rest_start as i64).into()));
+                rest_obj.set_field("end", Value::Number((rest_end as i64).into()));
                 if let Some(loc) = create_loc(rest_start, rest_end, line_offsets) {
-                    rest_obj.insert("loc".to_string(), loc);
+                    rest_obj.set_field("loc", loc);
                 }
-                rest_obj.insert("argument".to_string(), argument);
+                rest_obj.set_field("argument", argument);
                 params.push(Value::Object(rest_obj));
             }
-            obj.insert("params".to_string(), Value::Array(params));
+            obj.set_field("params", Value::Array(params));
 
             // Convert body
             if let Some(body) = &func_decl.body {
                 let body_value =
                     convert_function_body_for_program(arena, body, offset, line_offsets);
-                obj.insert("body".to_string(), body_value);
+                obj.set_field("body", body_value);
             } else {
-                obj.insert("body".to_string(), Value::Null);
+                obj.set_field("body", Value::Null);
             }
 
             Value::Object(obj)
@@ -8265,37 +8201,31 @@ fn convert_declaration_for_program(
             let start = offset + class_decl.span.start as usize;
             let end = offset + class_decl.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("ClassDeclaration".to_string()),
-            );
+            obj.set_field("type", Value::String("ClassDeclaration".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
 
             if let Some(id) = &class_decl.id {
                 let id_start = offset + id.span.start as usize;
                 let id_end = offset + id.span.end as usize;
                 let id_expr = create_identifier(&id.name, id_start, id_end, line_offsets);
-                obj.insert("id".to_string(), id_expr.as_json().clone());
+                obj.set_field("id", id_expr.as_json().clone());
             } else {
-                obj.insert("id".to_string(), Value::Null);
+                obj.set_field("id", Value::Null);
             }
 
             // superClass
             if let Some(super_class) = &class_decl.super_class {
                 let super_class_value =
                     convert_expression_for_program(arena, super_class, offset, line_offsets);
-                obj.insert(
-                    "superClass".to_string(),
-                    super_class_value.as_json().clone(),
-                );
+                obj.set_field("superClass", super_class_value.as_json().clone());
             } else {
-                obj.insert("superClass".to_string(), Value::Null);
+                obj.set_field("superClass", Value::Null);
             }
 
             // body (ClassBody)
             let body_value =
                 convert_class_body_for_program(arena, &class_decl.body, offset, line_offsets);
-            obj.insert("body".to_string(), body_value);
+            obj.set_field("body", body_value);
 
             Value::Object(obj)
         }
@@ -8304,10 +8234,7 @@ fn convert_declaration_for_program(
             let start = offset + enum_decl.span.start as usize;
             let end = offset + enum_decl.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("TSEnumDeclaration".to_string()),
-            );
+            obj.set_field("type", Value::String("TSEnumDeclaration".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
             Value::Object(obj)
         }
@@ -8318,19 +8245,13 @@ fn convert_declaration_for_program(
             // so remove_typescript_nodes can filter it out.
             if module_decl.declare {
                 let mut empty_obj = Map::new();
-                empty_obj.insert(
-                    "type".to_string(),
-                    Value::String("EmptyStatement".to_string()),
-                );
+                empty_obj.set_field("type", Value::String("EmptyStatement".to_string()));
                 return Value::Object(empty_obj);
             }
             let start = offset + module_decl.span.start as usize;
             let end = offset + module_decl.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("TSModuleDeclaration".to_string()),
-            );
+            obj.set_field("type", Value::String("TSModuleDeclaration".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
 
             // Include body for non-type node detection
@@ -8346,8 +8267,8 @@ fn convert_declaration_for_program(
                             .map(|n| n.to_value())
                             .collect();
                         let mut block_obj = Map::new();
-                        block_obj.insert("body".to_string(), Value::Array(block_body));
-                        obj.insert("body".to_string(), Value::Object(block_obj));
+                        block_obj.set_field("body", Value::Array(block_body));
+                        obj.set_field("body", Value::Object(block_obj));
                     }
                     oxc_ast::ast::TSModuleDeclarationBody::TSModuleDeclaration(_inner) => {}
                 }
@@ -8508,10 +8429,7 @@ fn convert_variable_declarator_for_program(
         let ts_end = type_annotation.span.end as usize + offset;
 
         let mut ts_obj = Map::new();
-        ts_obj.insert(
-            "type".to_string(),
-            Value::String("TSTypeAnnotation".to_string()),
-        );
+        ts_obj.set_field("type", Value::String("TSTypeAnnotation".to_string()));
         push_span_fields(&mut ts_obj, ts_start, ts_end, line_offsets);
         let type_value = convert_ts_type(
             arena,
@@ -8519,7 +8437,7 @@ fn convert_variable_declarator_for_program(
             offset,
             line_offsets,
         );
-        ts_obj.insert("typeAnnotation".to_string(), type_value);
+        ts_obj.set_field("typeAnnotation", type_value);
         let ts_value = Value::Object(ts_obj);
 
         match id_pattern {
@@ -8566,14 +8484,14 @@ fn convert_variable_declarator_for_program(
             other => {
                 let mut id_value = other.to_value();
                 if let Value::Object(ref mut id_obj) = id_value {
-                    id_obj.insert("typeAnnotation".to_string(), ts_value);
-                    id_obj.insert("end".to_string(), Value::Number((ts_end as i64).into()));
+                    id_obj.set_field("typeAnnotation", ts_value);
+                    id_obj.set_field("end", Value::Number((ts_end as i64).into()));
                     if let Some(loc) = create_loc(
                         id_obj.get("start").and_then(|v| v.as_i64()).unwrap_or(0) as usize,
                         ts_end,
                         line_offsets,
                     ) {
-                        id_obj.insert("loc".to_string(), loc);
+                        id_obj.set_field("loc", loc);
                     }
                 }
                 arena.alloc_js_node(JsNode::from_value(id_value))
@@ -9611,7 +9529,7 @@ fn convert_class_body_for_program(
     let end = offset + body.span.end as usize;
 
     let mut obj = Map::new();
-    obj.insert("type".to_string(), Value::String("ClassBody".to_string()));
+    obj.set_field("type", Value::String("ClassBody".to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
 
     let body_elements: Vec<Value> = body
@@ -9621,7 +9539,7 @@ fn convert_class_body_for_program(
             convert_class_element_for_program(arena, element, offset, line_offsets)
         })
         .collect();
-    obj.insert("body".to_string(), Value::Array(body_elements));
+    obj.set_field("body", Value::Array(body_elements));
 
     Value::Object(obj)
 }
@@ -9794,13 +9712,10 @@ fn convert_class_element_for_program(
             let start = offset + method.span.start as usize;
             let end = offset + method.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("MethodDefinition".to_string()),
-            );
+            obj.set_field("type", Value::String("MethodDefinition".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("static".to_string(), Value::Bool(method.r#static));
-            obj.insert("computed".to_string(), Value::Bool(method.computed));
+            obj.set_field("static", Value::Bool(method.r#static));
+            obj.set_field("computed", Value::Bool(method.computed));
 
             // kind
             let kind = match method.kind {
@@ -9809,16 +9724,16 @@ fn convert_class_element_for_program(
                 oxc_ast::ast::MethodDefinitionKind::Get => "get",
                 oxc_ast::ast::MethodDefinitionKind::Set => "set",
             };
-            obj.insert("kind".to_string(), Value::String(kind.to_string()));
+            obj.set_field("kind", Value::String(kind.to_string()));
 
             // key
             let key = convert_property_key(arena, &method.key, offset, line_offsets);
-            obj.insert("key".to_string(), key.to_value());
+            obj.set_field("key", key.to_value());
 
             // value (function expression)
             let value =
                 convert_function_expression_for_program(arena, &method.value, offset, line_offsets);
-            obj.insert("value".to_string(), value);
+            obj.set_field("value", value);
 
             Some(Value::Object(obj))
         }
@@ -9830,29 +9745,26 @@ fn convert_class_element_for_program(
             let start = offset + prop.span.start as usize;
             let end = offset + prop.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("PropertyDefinition".to_string()),
-            );
+            obj.set_field("type", Value::String("PropertyDefinition".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("static".to_string(), Value::Bool(prop.r#static));
-            obj.insert("computed".to_string(), Value::Bool(prop.computed));
+            obj.set_field("static", Value::Bool(prop.r#static));
+            obj.set_field("computed", Value::Bool(prop.computed));
 
             // key
             let key = convert_property_key(arena, &prop.key, offset, line_offsets);
-            obj.insert("key".to_string(), key.to_value());
+            obj.set_field("key", key.to_value());
 
             // value
             if let Some(ref value) = prop.value {
                 let val = convert_expression_for_program(arena, value, offset, line_offsets);
-                obj.insert("value".to_string(), val.as_json().clone());
+                obj.set_field("value", val.as_json().clone());
             } else {
-                obj.insert("value".to_string(), Value::Null);
+                obj.set_field("value", Value::Null);
             }
 
             // TypeScript: declare field (for `declare bar: string;` in class)
             if prop.declare {
-                obj.insert("declare".to_string(), Value::Bool(true));
+                obj.set_field("declare", Value::Bool(true));
             }
 
             Some(Value::Object(obj))
@@ -9863,23 +9775,20 @@ fn convert_class_element_for_program(
             let start = offset + prop.span.start as usize;
             let end = offset + prop.span.end as usize;
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("PropertyDefinition".to_string()),
-            );
+            obj.set_field("type", Value::String("PropertyDefinition".to_string()));
             push_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("accessor".to_string(), Value::Bool(true));
-            obj.insert("static".to_string(), Value::Bool(prop.r#static));
-            obj.insert("computed".to_string(), Value::Bool(prop.computed));
+            obj.set_field("accessor", Value::Bool(true));
+            obj.set_field("static", Value::Bool(prop.r#static));
+            obj.set_field("computed", Value::Bool(prop.computed));
 
             let key = convert_property_key(arena, &prop.key, offset, line_offsets);
-            obj.insert("key".to_string(), key.to_value());
+            obj.set_field("key", key.to_value());
 
             if let Some(ref value) = prop.value {
                 let val = convert_expression_for_program(arena, value, offset, line_offsets);
-                obj.insert("value".to_string(), val.as_json().clone());
+                obj.set_field("value", val.as_json().clone());
             } else {
-                obj.insert("value".to_string(), Value::Null);
+                obj.set_field("value", Value::Null);
             }
 
             Some(Value::Object(obj))
@@ -9898,14 +9807,11 @@ fn convert_function_expression_for_program(
     let start = offset + func.span.start as usize;
     let end = offset + func.span.end as usize;
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("FunctionExpression".to_string()),
-    );
+    obj.set_field("type", Value::String("FunctionExpression".to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
-    obj.insert("id".to_string(), Value::Null);
-    obj.insert("generator".to_string(), Value::Bool(func.generator));
-    obj.insert("async".to_string(), Value::Bool(func.r#async));
+    obj.set_field("id", Value::Null);
+    obj.set_field("generator", Value::Bool(func.generator));
+    obj.set_field("async", Value::Bool(func.r#async));
 
     // params
     let mut params: Vec<Value> = func
@@ -9924,26 +9830,23 @@ fn convert_function_expression_for_program(
         let argument =
             convert_binding_pattern_for_param(arena, &rest.rest.argument, offset, line_offsets);
         let mut rest_obj = Map::new();
-        rest_obj.insert("type".to_string(), Value::String("RestElement".to_string()));
-        rest_obj.insert(
-            "start".to_string(),
-            Value::Number((rest_start as i64).into()),
-        );
-        rest_obj.insert("end".to_string(), Value::Number((rest_end as i64).into()));
+        rest_obj.set_field("type", Value::String("RestElement".to_string()));
+        rest_obj.set_field("start", Value::Number((rest_start as i64).into()));
+        rest_obj.set_field("end", Value::Number((rest_end as i64).into()));
         if let Some(loc) = create_loc(rest_start, rest_end, line_offsets) {
-            rest_obj.insert("loc".to_string(), loc);
+            rest_obj.set_field("loc", loc);
         }
-        rest_obj.insert("argument".to_string(), argument);
+        rest_obj.set_field("argument", argument);
         params.push(Value::Object(rest_obj));
     }
-    obj.insert("params".to_string(), Value::Array(params));
+    obj.set_field("params", Value::Array(params));
 
     // body
     if let Some(ref body) = func.body {
         let body_value = convert_function_body_for_program(arena, body, offset, line_offsets);
-        obj.insert("body".to_string(), body_value);
+        obj.set_field("body", body_value);
     } else {
-        obj.insert("body".to_string(), Value::Null);
+        obj.set_field("body", Value::Null);
     }
 
     Value::Object(obj)
@@ -10050,10 +9953,7 @@ fn convert_function_body_for_program(
     let end = offset + body.span.end as usize;
 
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("BlockStatement".to_string()),
-    );
+    obj.set_field("type", Value::String("BlockStatement".to_string()));
     push_span_fields(&mut obj, start, end, line_offsets);
 
     let statements: Vec<Value> = body
@@ -10062,7 +9962,7 @@ fn convert_function_body_for_program(
         .filter_map(|stmt| convert_statement_for_program(arena, stmt, offset, line_offsets))
         .map(|n| n.to_value())
         .collect();
-    obj.insert("body".to_string(), Value::Array(statements));
+    obj.set_field("body", Value::Array(statements));
 
     Value::Object(obj)
 }
@@ -10849,10 +10749,7 @@ fn convert_object_pattern_with_adjustment(
     let end = doc_offset + obj_pat.span.end as usize - prefix_len;
 
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("ObjectPattern".to_string()),
-    );
+    obj.set_field("type", Value::String("ObjectPattern".to_string()));
     push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     let mut properties: Vec<Value> = obj_pat
@@ -10875,17 +10772,14 @@ fn convert_object_pattern_with_adjustment(
         let rest_end = doc_offset + rest.span.end as usize - prefix_len;
 
         let mut rest_obj = Map::new();
-        rest_obj.insert("type".to_string(), Value::String("RestElement".to_string()));
-        rest_obj.insert(
-            "start".to_string(),
-            Value::Number((rest_start as i64).into()),
-        );
-        rest_obj.insert("end".to_string(), Value::Number((rest_end as i64).into()));
+        rest_obj.set_field("type", Value::String("RestElement".to_string()));
+        rest_obj.set_field("start", Value::Number((rest_start as i64).into()));
+        rest_obj.set_field("end", Value::Number((rest_end as i64).into()));
         if let Some(loc) = create_loc_for_binding(rest_start, rest_end, line_offsets) {
-            rest_obj.insert("loc".to_string(), loc);
+            rest_obj.set_field("loc", loc);
         }
-        rest_obj.insert(
-            "argument".to_string(),
+        rest_obj.set_field(
+            "argument",
             convert_binding_pattern_with_adjustment(
                 arena,
                 &rest.argument,
@@ -10897,7 +10791,7 @@ fn convert_object_pattern_with_adjustment(
         properties.push(Value::Object(rest_obj));
     }
 
-    obj.insert("properties".to_string(), Value::Array(properties));
+    obj.set_field("properties", Value::Array(properties));
 
     Value::Object(obj)
 }
@@ -10913,10 +10807,7 @@ fn convert_array_pattern_with_adjustment(
     let end = doc_offset + arr_pat.span.end as usize - prefix_len;
 
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("ArrayPattern".to_string()),
-    );
+    obj.set_field("type", Value::String("ArrayPattern".to_string()));
     push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     let mut elements: Vec<Value> = arr_pat
@@ -10940,17 +10831,14 @@ fn convert_array_pattern_with_adjustment(
         let rest_end = doc_offset + rest.span.end as usize - prefix_len;
 
         let mut rest_obj = Map::new();
-        rest_obj.insert("type".to_string(), Value::String("RestElement".to_string()));
-        rest_obj.insert(
-            "start".to_string(),
-            Value::Number((rest_start as i64).into()),
-        );
-        rest_obj.insert("end".to_string(), Value::Number((rest_end as i64).into()));
+        rest_obj.set_field("type", Value::String("RestElement".to_string()));
+        rest_obj.set_field("start", Value::Number((rest_start as i64).into()));
+        rest_obj.set_field("end", Value::Number((rest_end as i64).into()));
         if let Some(loc) = create_loc_for_binding(rest_start, rest_end, line_offsets) {
-            rest_obj.insert("loc".to_string(), loc);
+            rest_obj.set_field("loc", loc);
         }
-        rest_obj.insert(
-            "argument".to_string(),
+        rest_obj.set_field(
+            "argument",
             convert_binding_pattern_with_adjustment(
                 arena,
                 &rest.argument,
@@ -10962,7 +10850,7 @@ fn convert_array_pattern_with_adjustment(
         elements.push(Value::Object(rest_obj));
     }
 
-    obj.insert("elements".to_string(), Value::Array(elements));
+    obj.set_field("elements", Value::Array(elements));
 
     Value::Object(obj)
 }
@@ -10978,14 +10866,11 @@ fn convert_assignment_pattern_with_adjustment(
     let end = doc_offset + assign_pat.span.end as usize - prefix_len;
 
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("AssignmentPattern".to_string()),
-    );
+    obj.set_field("type", Value::String("AssignmentPattern".to_string()));
     push_binding_span_fields(&mut obj, start, end, line_offsets);
 
-    obj.insert(
-        "left".to_string(),
+    obj.set_field(
+        "left",
         convert_binding_pattern_with_adjustment(
             arena,
             &assign_pat.left,
@@ -11004,7 +10889,7 @@ fn convert_assignment_pattern_with_adjustment(
         prefix_len,
         line_offsets,
     );
-    obj.insert("right".to_string(), right);
+    obj.set_field("right", right);
 
     Value::Object(obj)
 }
@@ -11020,12 +10905,12 @@ fn convert_binding_property_with_adjustment(
     let end = doc_offset + prop.span.end as usize - prefix_len;
 
     let mut obj = Map::new();
-    obj.insert("type".to_string(), Value::String("Property".to_string()));
+    obj.set_field("type", Value::String("Property".to_string()));
     push_binding_span_fields(&mut obj, start, end, line_offsets);
-    obj.insert("method".to_string(), Value::Bool(false));
-    obj.insert("shorthand".to_string(), Value::Bool(prop.shorthand));
-    obj.insert("computed".to_string(), Value::Bool(prop.computed));
-    obj.insert("kind".to_string(), Value::String("init".to_string()));
+    obj.set_field("method", Value::Bool(false));
+    obj.set_field("shorthand", Value::Bool(prop.shorthand));
+    obj.set_field("computed", Value::Bool(prop.computed));
+    obj.set_field("kind", Value::String("init".to_string()));
 
     // Convert key
     let key = convert_property_key_with_adjustment(
@@ -11035,7 +10920,7 @@ fn convert_binding_property_with_adjustment(
         prefix_len,
         line_offsets,
     );
-    obj.insert("key".to_string(), key);
+    obj.set_field("key", key);
 
     // Convert value
     let value = convert_binding_pattern_with_adjustment(
@@ -11045,7 +10930,7 @@ fn convert_binding_property_with_adjustment(
         prefix_len,
         line_offsets,
     );
-    obj.insert("value".to_string(), value);
+    obj.set_field("value", value);
 
     Value::Object(obj)
 }
@@ -11267,14 +11152,11 @@ fn convert_expression_with_adjustment(
             );
             let operator = binary_operator_to_str(&bin.operator);
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("BinaryExpression".to_string()),
-            );
+            obj.set_field("type", Value::String("BinaryExpression".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("left".to_string(), left);
-            obj.insert("operator".to_string(), Value::String(operator.to_string()));
-            obj.insert("right".to_string(), right);
+            obj.set_field("left", left);
+            obj.set_field("operator", Value::String(operator.to_string()));
+            obj.set_field("right", right);
             Value::Object(obj)
         }
         OxcExpression::UnaryExpression(unary) => {
@@ -11289,14 +11171,11 @@ fn convert_expression_with_adjustment(
             );
             let operator = unary_operator_to_str(&unary.operator);
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("UnaryExpression".to_string()),
-            );
+            obj.set_field("type", Value::String("UnaryExpression".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("operator".to_string(), Value::String(operator.to_string()));
-            obj.insert("prefix".to_string(), Value::Bool(true));
-            obj.insert("argument".to_string(), argument);
+            obj.set_field("operator", Value::String(operator.to_string()));
+            obj.set_field("prefix", Value::Bool(true));
+            obj.set_field("argument", argument);
             Value::Object(obj)
         }
         OxcExpression::LogicalExpression(log) => {
@@ -11318,14 +11197,11 @@ fn convert_expression_with_adjustment(
             );
             let operator = logical_operator_to_str(&log.operator);
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("LogicalExpression".to_string()),
-            );
+            obj.set_field("type", Value::String("LogicalExpression".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("left".to_string(), left);
-            obj.insert("operator".to_string(), Value::String(operator.to_string()));
-            obj.insert("right".to_string(), right);
+            obj.set_field("left", left);
+            obj.set_field("operator", Value::String(operator.to_string()));
+            obj.set_field("right", right);
             Value::Object(obj)
         }
         OxcExpression::ConditionalExpression(cond) => {
@@ -11353,14 +11229,11 @@ fn convert_expression_with_adjustment(
                 line_offsets,
             );
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("ConditionalExpression".to_string()),
-            );
+            obj.set_field("type", Value::String("ConditionalExpression".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("test".to_string(), test);
-            obj.insert("consequent".to_string(), consequent);
-            obj.insert("alternate".to_string(), alternate);
+            obj.set_field("test", test);
+            obj.set_field("consequent", consequent);
+            obj.set_field("alternate", alternate);
             Value::Object(obj)
         }
         OxcExpression::StaticMemberExpression(member) => {
@@ -11383,15 +11256,12 @@ fn convert_expression_with_adjustment(
             )
             .to_value();
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("MemberExpression".to_string()),
-            );
+            obj.set_field("type", Value::String("MemberExpression".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("object".to_string(), object);
-            obj.insert("property".to_string(), property);
-            obj.insert("computed".to_string(), Value::Bool(false));
-            obj.insert("optional".to_string(), Value::Bool(member.optional));
+            obj.set_field("object", object);
+            obj.set_field("property", property);
+            obj.set_field("computed", Value::Bool(false));
+            obj.set_field("optional", Value::Bool(member.optional));
             Value::Object(obj)
         }
         OxcExpression::ComputedMemberExpression(member) => {
@@ -11412,15 +11282,12 @@ fn convert_expression_with_adjustment(
                 line_offsets,
             );
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("MemberExpression".to_string()),
-            );
+            obj.set_field("type", Value::String("MemberExpression".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("object".to_string(), object);
-            obj.insert("property".to_string(), property);
-            obj.insert("computed".to_string(), Value::Bool(true));
-            obj.insert("optional".to_string(), Value::Bool(member.optional));
+            obj.set_field("object", object);
+            obj.set_field("property", property);
+            obj.set_field("computed", Value::Bool(true));
+            obj.set_field("optional", Value::Bool(member.optional));
             Value::Object(obj)
         }
         OxcExpression::PrivateFieldExpression(member) => {
@@ -11440,32 +11307,23 @@ fn convert_expression_with_adjustment(
             let prop_start = doc_offset + member.field.span.start as usize - prefix_len;
             let prop_end = doc_offset + member.field.span.end as usize - prefix_len;
             let mut prop = Map::new();
-            prop.insert(
-                "type".to_string(),
-                Value::String("PrivateIdentifier".to_string()),
-            );
-            prop.insert(
-                "start".to_string(),
-                Value::Number((prop_start as i64).into()),
-            );
-            prop.insert("end".to_string(), Value::Number((prop_end as i64).into()));
+            prop.set_field("type", Value::String("PrivateIdentifier".to_string()));
+            prop.set_field("start", Value::Number((prop_start as i64).into()));
+            prop.set_field("end", Value::Number((prop_end as i64).into()));
             if let Some(loc) = create_loc_for_binding(prop_start, prop_end, line_offsets) {
-                prop.insert("loc".to_string(), loc);
+                prop.set_field("loc", loc);
             }
-            prop.insert(
-                "name".to_string(),
+            prop.set_field(
+                "name",
                 Value::String(member.field.name.as_str().to_string()),
             );
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("MemberExpression".to_string()),
-            );
+            obj.set_field("type", Value::String("MemberExpression".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("object".to_string(), object);
-            obj.insert("property".to_string(), Value::Object(prop));
-            obj.insert("computed".to_string(), Value::Bool(false));
-            obj.insert("optional".to_string(), Value::Bool(member.optional));
+            obj.set_field("object", object);
+            obj.set_field("property", Value::Object(prop));
+            obj.set_field("computed", Value::Bool(false));
+            obj.set_field("optional", Value::Bool(member.optional));
             Value::Object(obj)
         }
         OxcExpression::ObjectExpression(_obj_expr) => {
@@ -11503,14 +11361,11 @@ fn convert_expression_with_adjustment(
             };
             let operator = update_operator_to_str(&update.operator);
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("UpdateExpression".to_string()),
-            );
+            obj.set_field("type", Value::String("UpdateExpression".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert("operator".to_string(), Value::String(operator.to_string()));
-            obj.insert("prefix".to_string(), Value::Bool(update.prefix));
-            obj.insert("argument".to_string(), argument);
+            obj.set_field("operator", Value::String(operator.to_string()));
+            obj.set_field("prefix", Value::Bool(update.prefix));
+            obj.set_field("argument", argument);
             Value::Object(obj)
         }
         OxcExpression::NullLiteral(lit) => {
@@ -11547,10 +11402,7 @@ fn create_template_literal_with_adjustment(
     line_offsets: &[usize],
 ) -> Value {
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("TemplateLiteral".to_string()),
-    );
+    obj.set_field("type", Value::String("TemplateLiteral".to_string()));
     push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     // Convert quasis
@@ -11562,20 +11414,14 @@ fn create_template_literal_with_adjustment(
             let q_end = doc_offset + quasi.span.end as usize - prefix_len;
 
             let mut q_obj = Map::new();
-            q_obj.insert(
-                "type".to_string(),
-                Value::String("TemplateElement".to_string()),
-            );
+            q_obj.set_field("type", Value::String("TemplateElement".to_string()));
             push_binding_span_fields(&mut q_obj, q_start, q_end, line_offsets);
-            q_obj.insert("tail".to_string(), Value::Bool(quasi.tail));
+            q_obj.set_field("tail", Value::Bool(quasi.tail));
 
             let mut value_obj = Map::new();
-            value_obj.insert(
-                "raw".to_string(),
-                Value::String(quasi.value.raw.to_string()),
-            );
-            value_obj.insert(
-                "cooked".to_string(),
+            value_obj.set_field("raw", Value::String(quasi.value.raw.to_string()));
+            value_obj.set_field(
+                "cooked",
                 quasi
                     .value
                     .cooked
@@ -11583,12 +11429,12 @@ fn create_template_literal_with_adjustment(
                     .map(|s| Value::String(s.to_string()))
                     .unwrap_or(Value::Null),
             );
-            q_obj.insert("value".to_string(), Value::Object(value_obj));
+            q_obj.set_field("value", Value::Object(value_obj));
 
             Value::Object(q_obj)
         })
         .collect();
-    obj.insert("quasis".to_string(), Value::Array(quasis));
+    obj.set_field("quasis", Value::Array(quasis));
 
     // Convert expressions
     let expressions: Vec<Value> = template
@@ -11598,7 +11444,7 @@ fn create_template_literal_with_adjustment(
             convert_expression_with_adjustment(arena, expr, doc_offset, prefix_len, line_offsets)
         })
         .collect();
-    obj.insert("expressions".to_string(), Value::Array(expressions));
+    obj.set_field("expressions", Value::Array(expressions));
 
     Value::Object(obj)
 }
@@ -11613,10 +11459,7 @@ fn create_call_expression_with_adjustment(
     line_offsets: &[usize],
 ) -> Value {
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("CallExpression".to_string()),
-    );
+    obj.set_field("type", Value::String("CallExpression".to_string()));
     push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     let callee = convert_expression_with_adjustment(
@@ -11626,7 +11469,7 @@ fn create_call_expression_with_adjustment(
         prefix_len,
         line_offsets,
     );
-    obj.insert("callee".to_string(), callee);
+    obj.set_field("callee", callee);
 
     let args: Vec<Value> = call
         .arguments
@@ -11643,19 +11486,13 @@ fn create_call_expression_with_adjustment(
                     line_offsets,
                 );
                 let mut spread_obj = Map::new();
-                spread_obj.insert(
-                    "type".to_string(),
-                    Value::String("SpreadElement".to_string()),
-                );
-                spread_obj.insert(
-                    "start".to_string(),
-                    Value::Number((spread_start as i64).into()),
-                );
-                spread_obj.insert("end".to_string(), Value::Number((spread_end as i64).into()));
+                spread_obj.set_field("type", Value::String("SpreadElement".to_string()));
+                spread_obj.set_field("start", Value::Number((spread_start as i64).into()));
+                spread_obj.set_field("end", Value::Number((spread_end as i64).into()));
                 if let Some(loc) = create_loc_for_binding(spread_start, spread_end, line_offsets) {
-                    spread_obj.insert("loc".to_string(), loc);
+                    spread_obj.set_field("loc", loc);
                 }
-                spread_obj.insert("argument".to_string(), inner);
+                spread_obj.set_field("argument", inner);
                 Value::Object(spread_obj)
             }
             _ => {
@@ -11670,8 +11507,8 @@ fn create_call_expression_with_adjustment(
             }
         })
         .collect();
-    obj.insert("arguments".to_string(), Value::Array(args));
-    obj.insert("optional".to_string(), Value::Bool(call.optional));
+    obj.set_field("arguments", Value::Array(args));
+    obj.set_field("optional", Value::Bool(call.optional));
 
     Value::Object(obj)
 }
@@ -11686,15 +11523,12 @@ fn create_arrow_function_with_adjustment(
     line_offsets: &[usize],
 ) -> Value {
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("ArrowFunctionExpression".to_string()),
-    );
+    obj.set_field("type", Value::String("ArrowFunctionExpression".to_string()));
     push_binding_span_fields(&mut obj, start, end, line_offsets);
-    obj.insert("id".to_string(), Value::Null);
-    obj.insert("expression".to_string(), Value::Bool(arrow.expression));
-    obj.insert("generator".to_string(), Value::Bool(false));
-    obj.insert("async".to_string(), Value::Bool(arrow.r#async));
+    obj.set_field("id", Value::Null);
+    obj.set_field("expression", Value::Bool(arrow.expression));
+    obj.set_field("generator", Value::Bool(false));
+    obj.set_field("async", Value::Bool(arrow.r#async));
 
     // Convert params: iterate items and handle rest separately.
     // `with_adjustment` callers operate on the doc_offset/prefix_len coordinate
@@ -11720,19 +11554,16 @@ fn create_arrow_function_with_adjustment(
             line_offsets,
         );
         let mut rest_obj = Map::new();
-        rest_obj.insert("type".to_string(), Value::String("RestElement".to_string()));
-        rest_obj.insert(
-            "start".to_string(),
-            Value::Number((rest_start as i64).into()),
-        );
-        rest_obj.insert("end".to_string(), Value::Number((rest_end as i64).into()));
+        rest_obj.set_field("type", Value::String("RestElement".to_string()));
+        rest_obj.set_field("start", Value::Number((rest_start as i64).into()));
+        rest_obj.set_field("end", Value::Number((rest_end as i64).into()));
         if let Some(loc) = create_loc_for_binding(rest_start, rest_end, line_offsets) {
-            rest_obj.insert("loc".to_string(), loc);
+            rest_obj.set_field("loc", loc);
         }
-        rest_obj.insert("argument".to_string(), argument);
+        rest_obj.set_field("argument", argument);
         params.push(Value::Object(rest_obj));
     }
-    obj.insert("params".to_string(), Value::Array(params));
+    obj.set_field("params", Value::Array(params));
 
     // Convert body - arrow.expression indicates if body is expression or block statement
     let body = convert_function_body_with_adjustment(
@@ -11742,7 +11573,7 @@ fn create_arrow_function_with_adjustment(
         prefix_len,
         line_offsets,
     );
-    obj.insert("body".to_string(), body);
+    obj.set_field("body", body);
 
     Value::Object(obj)
 }
@@ -11758,10 +11589,7 @@ fn convert_function_body_with_adjustment(
     let end = doc_offset + body.span.end as usize - prefix_len;
 
     let mut obj = Map::new();
-    obj.insert(
-        "type".to_string(),
-        Value::String("BlockStatement".to_string()),
-    );
+    obj.set_field("type", Value::String("BlockStatement".to_string()));
     push_binding_span_fields(&mut obj, start, end, line_offsets);
 
     let statements: Vec<Value> = body
@@ -11771,7 +11599,7 @@ fn convert_function_body_with_adjustment(
             convert_statement_with_adjustment(arena, stmt, doc_offset, prefix_len, line_offsets)
         })
         .collect();
-    obj.insert("body".to_string(), Value::Array(statements));
+    obj.set_field("body", Value::Array(statements));
 
     Value::Object(obj)
 }
@@ -11789,15 +11617,12 @@ fn convert_statement_with_adjustment(
             let end = doc_offset + ret.span.end as usize - prefix_len;
 
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("ReturnStatement".to_string()),
-            );
+            obj.set_field("type", Value::String("ReturnStatement".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
 
             if let Some(arg) = &ret.argument {
-                obj.insert(
-                    "argument".to_string(),
+                obj.set_field(
+                    "argument",
                     convert_expression_with_adjustment(
                         arena,
                         arg,
@@ -11807,7 +11632,7 @@ fn convert_statement_with_adjustment(
                     ),
                 );
             } else {
-                obj.insert("argument".to_string(), Value::Null);
+                obj.set_field("argument", Value::Null);
             }
 
             Some(Value::Object(obj))
@@ -11817,13 +11642,10 @@ fn convert_statement_with_adjustment(
             let end = doc_offset + expr_stmt.span.end as usize - prefix_len;
 
             let mut obj = Map::new();
-            obj.insert(
-                "type".to_string(),
-                Value::String("ExpressionStatement".to_string()),
-            );
+            obj.set_field("type", Value::String("ExpressionStatement".to_string()));
             push_binding_span_fields(&mut obj, start, end, line_offsets);
-            obj.insert(
-                "expression".to_string(),
+            obj.set_field(
+                "expression",
                 convert_expression_with_adjustment(
                     arena,
                     &expr_stmt.expression,


### PR DESCRIPTION
## What

The ESTree JSON emitted by the parser and by the legacy-AST converter is hand-built
with `serde_json::Map`. The same shapes were spelled out over and over, and `rustfmt`
split most of the resulting `insert` calls across four lines. This PR compresses that
boilerplate. **No output changes** — this is a pure refactor.

## Line counts (measured)

| File | before | after | delta |
|---|---:|---:|---:|
| `crates/rsvelte_core/src/compiler/legacy.rs` | 1,906 | 1,648 | **−258** |
| `crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs` | 12,094 | 11,696 | **−398** |
| **total** | **14,000** | **13,344** | **−656** |

## Approach, and why

### Key order is the contract

`crates/rsvelte_core/Cargo.toml` enables `serde_json`'s `preserve_order` feature, so
`serde_json::Map` is an `IndexMap` and **insertion order is the JSON key order**. Every
transformation here was chosen so it cannot reorder keys:

- `#[derive(Serialize)]` structs were **rejected**. The ESTree shape is dynamic — the key
  set differs per node type, and several optional keys (`raw`, `name_loc`) land in the
  *middle* of the object, not at the end. Modelling that with structs would mean either
  reordering keys or one struct per node type with hand-written `Serialize` impls, which
  is more code than it replaces.
- Value wrappers are preserved **verbatim** at every call site: where the old code wrote
  `json!(x)` the new code still expands to `json!(x)`; where it inserted a `Value`
  directly, the new code still inserts it directly. No `Value::from` conversions were
  introduced, so number representation (`PosInt`/`NegInt`/`Float`), `null` handling and
  `to_value` round-trips are bit-for-bit unchanged.

### `legacy.rs` — declarative node construction

Two file-local macros expand to plain sequential `insert` calls, so source order *is*
wire order:

```rust
estree_obj! {
    "type": "RawMustacheTag",
    "start": html_tag.start,
    "end": html_tag.end,
    "expression" => html_tag.expression.as_json().clone(),
}
```

`"k": v` wraps `v` in `json!`; `"k" => v` inserts an existing `Value`. `estree_fields!`
is the same thing against an existing `Map`, for nodes whose fields are interleaved with
control flow.

Plus the repeated shapes that were copy-pasted across ~20 converters:
`attrs_json`, `children_json`, `push_name_loc`, `optional_expression`, `directive_head`
(the `start`/`end`/`type`/`name`/`name_loc` prefix shared by all 9 directives), and
`convert_element_like` / `convert_svelte_element_like` for the two element key orders.

### `expression.rs` — span helpers and a `set_field` shorthand

- The `start` / `end` / optional `loc` block appeared verbatim at **56** sites (5 lines
  each). It is now `push_span_fields` / `push_binding_span_fields`, which fix the order
  inside the helper — a stronger guarantee than a macro gives.
- `create_loc` and `create_loc_for_binding` differed only by their line/column function;
  both now delegate to `create_loc_with`.
- Node construction here is interleaved with control flow, so a block macro does not fit.
  Instead a one-method extension trait drops the per-call `key.to_string()`:
  `obj.insert("type".to_string(), v)` → `obj.set_field("type", v)`. That is 12 fewer
  characters of arguments, which brings most calls back under `rustfmt`'s
  `fn_call_width` (60) and collapses them from four lines to one. Measured: 64 of the 99 four-line
  blocks collapsed after `cargo fmt` (35 remain multi-line because their value
  expression alone still exceeds the limit).

Two mechanisms rather than one because the two files build objects differently: `legacy.rs`
builds a whole node at once (a JSON-literal-shaped macro reads best), `expression.rs`
accumulates fields across branches (a plain method call reads best).

## Verification: byte-identical JSON output

A throwaway harness (not committed) dumped the **modern and legacy ESTree JSON** for
every `.svelte` source under `submodules/` — **4,454 files**, each parsed under 3 option
combinations (default / `loose` / `force_typescript`), 26,453 serialized ASTs, 138 MB —
and the result was compared with `cmp` against the same dump taken at `origin/main`:

```
138300547 bytes  before.txt
138300547 bytes  after.txt
cmp: no differences
```

This was run after **each** of the three commits, so every step is independently proven
byte-identical.

Two static cross-checks back this up:

- The ordered key sequence of every converter in `legacy.rs` was
  of every converter in `legacy.rs` was extracted before and after and diffed; every
  difference is accounted for by extraction into a helper (`directive_head`,
  `push_name_loc`, `convert_element_like`, …), with the concatenated order preserved.
- For the `set_field` commit, normalising whitespace and trailing commas and rewriting
  both call spellings to a common form makes the two `expression.rs` token streams
  compare **equal**, proving that commit is a pure textual substitution.

## Tests

```
cargo fmt --all --check                              clean
cargo clippy --all-targets --all-features -D warnings  clean
cargo build --workspace --all-targets                 ok
parser_fixtures  17/17     compiler_fixtures 17/17
print            16/16     ssr               19/19
runtime          16/16     rsvelte_core --lib 1483/1483 (1 ignored)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqdHfZSN3LFxPkyKFaCyoF
