### PR TITLE
feat(language-server): native Rust LSP foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,10 @@ absent. **Hard gate, no baseline tolerance:** any divergence fails CI.
 `oxfmt`-subprocess path. Native-CSS parity is covered by
 `crates/rsvelte_formatter/tests/css_native.rs` and `crates/rsvelte_fmt/tests/cli.rs`.
 
+`rsvelte_fmt` is a lib + bin: `rsvelte_fmt::FormatSession` runs the CLI's
+`--stdin --stdin-filepath` pipeline (config discovery, option layering, extension
+dispatch) in process, so an embedder never re-implements it.
+
 ## Ecosystem Port
 
 | Wave | Scope | Status |
@@ -193,7 +197,7 @@ absent. **Hard gate, no baseline tolerance:** any divergence fails CI.
 | 1 | svelte2tsx | ✅ 253/253, wired into the compatibility report |
 | 2 | svelte-check | ✅ v1.0 — walker + overlay + tsgo + incremental cache + watch + parallel compile + hires source maps + SvelteKit kit-file augmentation; reads diagnostic-relevant `compilerOptions` from `svelte.config.*` and `vite.config.*` |
 | 3 | vite-plugin-svelte | 🟢 v1.0 — Rust NAPI bindings (`hmr_diff` / `resolve_id` / `preprocess`) + `@rsvelte/vite-plugin-svelte` shim at `apps/npm/vite-plugin-svelte`; supports Vite 6/7/8 |
-| 4 | svelte-language-server | 🚧 In progress — target is a full replacement for `svelte-language-server` + `svelte-vscode`, not a companion |
+| 4 | svelte-language-server | 🚧 In progress — target is a full replacement for `svelte-language-server` + `svelte-vscode`, not a companion. M0 landed: `crates/rsvelte_language_server` (binary `rsvelte-language-server`) does document sync, formatting and push diagnostics in process |
 
 Wave 4 architecture (decided; tsgo ships an LSP server as of TypeScript 7, so the earlier
 "waits on tsgo `tsserver` mode" blocker no longer applies):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1322,6 +1340,32 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lsp-server"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee25a31f2e571e426eef2896179450cafc7e2f5be00d8a93b1c2d21c0ff7656"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
 
 [[package]]
 name = "markdown"
@@ -2468,6 +2512,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsvelte_language_server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "crossbeam-channel",
+ "lsp-server",
+ "lsp-types",
+ "rsvelte_core",
+ "rsvelte_fmt",
+ "rsvelte_lint",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rsvelte_lint"
 version = "0.9.2"
 dependencies = [
@@ -2636,6 +2695,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.46",
+ "syn 3.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/rsvelte_fmt",
     "crates/rsvelte_fmt_wasm",
     "crates/rsvelte_formatter",
+    "crates/rsvelte_language_server",
     "crates/rsvelte_lint",
     "crates/rsvelte_lint_bindings",
     "crates/rsvelte_napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,17 @@ strip = "symbols"
 inherits = "dist"
 panic = "unwind"
 
+# Distribution profile for the `rsvelte-language-server` binary. Its analysis
+# worker isolates a per-document compiler panic via `catch_unwind` (see
+# `crates/rsvelte_language_server/src/worker.rs`), which only holds when the
+# binary UNWINDS — the shared `release`/`dist` profiles set `panic = "abort"`,
+# turning that isolation into an immediate `SIGABRT` that kills the editor's
+# whole language server. Same reasoning as `dist-lint` above. Build the server
+# with `--profile dist-lsp`.
+[profile.dist-lsp]
+inherits = "dist"
+panic = "unwind"
+
 [profile.profiling]
 inherits = "release"
 lto = "thin"          # thin LTO keeps profiling builds within the dev box's RAM

--- a/crates/rsvelte_fmt/Cargo.toml
+++ b/crates/rsvelte_fmt/Cargo.toml
@@ -7,6 +7,11 @@ description = "Fast Svelte + JS/TS/CSS formatter — dispatches .svelte to rsvel
 license = "MIT"
 publish = false
 
+[lib]
+# rlib only — the CLI binary and the language server both link the same
+# formatting pipeline from here.
+crate-type = ["rlib"]
+
 [[bin]]
 name = "rsvelte-fmt"
 path = "src/main.rs"

--- a/crates/rsvelte_fmt/src/embed.rs
+++ b/crates/rsvelte_fmt/src/embed.rs
@@ -1,0 +1,72 @@
+//! In-process formatting for embedders.
+//!
+//! A [`FormatSession`] is the `rsvelte-fmt --stdin --stdin-filepath` pipeline
+//! without the process boundary: it resolves the project's oxfmt config, builds
+//! the same [`FormatOptions`], and dispatches by extension through the same
+//! code the CLI runs. Consumers (the language server) hold one per directory
+//! and reuse it, since config discovery is the expensive part.
+
+use std::path::Path;
+
+use anyhow::{Result, anyhow};
+use rsvelte_formatter::FormatOptions;
+
+use crate::config::OxfmtConfig;
+use crate::options::{OptionFlags, build_format_options};
+use crate::oxfmt::oxfmt_stdin;
+use crate::stdin::format_in_process;
+use crate::tailwind_sort::PendingJsSort;
+
+pub struct FormatSession {
+    flags: OptionFlags,
+    cfg: OxfmtConfig,
+    options: FormatOptions,
+    pending_js: Option<PendingJsSort>,
+}
+
+impl FormatSession {
+    /// Resolve the config for `path` the way the CLI does in stdin mode:
+    /// search upward from the file itself for the nearest oxfmt config.
+    pub fn resolve(path: &Path) -> Result<Self> {
+        let cfg = OxfmtConfig::resolve(None, path).map_err(|e| anyhow!(e))?;
+        let flags = OptionFlags::default();
+        let (options, pending_js) = build_format_options(&flags, &cfg);
+        Ok(Self {
+            flags,
+            cfg,
+            options,
+            pending_js,
+        })
+    }
+
+    /// Format `source` as if it were piped to
+    /// `rsvelte-fmt --stdin --stdin-filepath <filepath>`.
+    pub fn format(&self, source: &str, filepath: &Path) -> Result<String> {
+        if let Some(formatted) = format_in_process(
+            source,
+            filepath,
+            &self.flags,
+            &self.options,
+            &self.cfg,
+            self.pending_js.as_ref(),
+        )? {
+            return Ok(formatted);
+        }
+
+        let out = oxfmt_stdin(
+            &self.flags.oxfmt_bin,
+            self.cfg.oxfmt_arg_path.as_deref(),
+            filepath,
+            source,
+            false,
+        )?;
+        if out.code != 0 {
+            return Err(anyhow!("oxfmt exited with {}", out.code));
+        }
+        // A formatter that produced nothing is a failure, not "format to empty".
+        if out.stdout.is_empty() {
+            return Err(anyhow!("oxfmt produced no output"));
+        }
+        String::from_utf8(out.stdout).map_err(|e| anyhow!("oxfmt produced invalid utf-8: {e}"))
+    }
+}

--- a/crates/rsvelte_fmt/src/lib.rs
+++ b/crates/rsvelte_fmt/src/lib.rs
@@ -1,0 +1,32 @@
+//! `rsvelte-fmt` — single entry point for formatting a mixed JS/TS/Svelte
+//! tree. `.svelte` files go through [`rsvelte_formatter`]; every other file
+//! is delegated to a child `oxfmt` process. Both pipelines run in parallel.
+//!
+//! The CLI lives in [`run`]; [`embed::FormatSession`] exposes the same
+//! stdin-mode pipeline to in-process consumers.
+
+mod cli;
+mod config;
+mod daemon;
+pub mod embed;
+mod native_css;
+mod native_js;
+mod native_json;
+mod options;
+mod output;
+mod oxfmt;
+mod oxfmt_ignore;
+mod paths;
+mod run;
+mod status;
+mod stdin;
+mod style_cache;
+mod svelte_pipeline;
+mod tailwind;
+mod tailwind_sidecar;
+mod tailwind_sort;
+mod ts_config;
+mod walk;
+
+pub use embed::FormatSession;
+pub use run::run;

--- a/crates/rsvelte_fmt/src/main.rs
+++ b/crates/rsvelte_fmt/src/main.rs
@@ -1,6 +1,5 @@
-//! `rsvelte-fmt` — single entry point for formatting a mixed JS/TS/Svelte
-//! tree. `.svelte` files go through [`rsvelte_formatter`]; every other file
-//! is delegated to a child `oxfmt` process. Both pipelines run in parallel.
+//! The `rsvelte-fmt` binary — a thin wrapper over the crate's [`run`] entry
+//! point (see the crate docs for the pipeline itself).
 
 // The CLI streams files (read → format → drop, one source live at a time), so
 // the system allocator churns pages back to the OS between files; mimalloc
@@ -12,29 +11,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::process::ExitCode;
 
-mod cli;
-mod config;
-mod daemon;
-mod native_css;
-mod native_js;
-mod native_json;
-mod options;
-mod output;
-mod oxfmt;
-mod oxfmt_ignore;
-mod paths;
-mod run;
-mod status;
-mod stdin;
-mod style_cache;
-mod svelte_pipeline;
-mod tailwind;
-mod tailwind_sidecar;
-mod tailwind_sort;
-mod ts_config;
-mod walk;
-
-use crate::run::run;
+use rsvelte_fmt::run;
 
 fn main() -> ExitCode {
     match run() {

--- a/crates/rsvelte_fmt/src/options.rs
+++ b/crates/rsvelte_fmt/src/options.rs
@@ -17,13 +17,49 @@ use crate::tailwind;
 use crate::tailwind_sidecar;
 use crate::tailwind_sort::{PendingJsSort, js_sort_env};
 
+/// The option-resolution inputs the command line contributes, split out of
+/// [`Cli`] so an in-process embedder (the language server) resolves options
+/// through exactly the same layering as the CLI instead of reimplementing it.
+#[derive(Debug, Clone)]
+pub(crate) struct OptionFlags {
+    pub(crate) print_width: Option<u16>,
+    pub(crate) tab_width: Option<u8>,
+    pub(crate) use_tabs: bool,
+    pub(crate) no_native_css: bool,
+    pub(crate) oxfmt_bin: PathBuf,
+}
+
+impl Default for OptionFlags {
+    fn default() -> Self {
+        Self {
+            print_width: None,
+            tab_width: None,
+            use_tabs: false,
+            no_native_css: false,
+            oxfmt_bin: PathBuf::from("oxfmt"),
+        }
+    }
+}
+
+impl OptionFlags {
+    pub(crate) fn from_cli(cli: &Cli) -> Self {
+        Self {
+            print_width: cli.print_width,
+            tab_width: cli.tab_width,
+            use_tabs: cli.use_tabs,
+            no_native_css: cli.no_native_css,
+            oxfmt_bin: cli.oxfmt_bin.clone(),
+        }
+    }
+}
+
 /// Build the [`FormatOptions`] for the in-process Svelte formatter, layering
 /// the resolved `.oxfmtrc` under any explicit CLI flags. Precedence for the
 /// keys that exist in both places (`--print-width`/`--tab-width`/`--use-tabs`):
 /// CLI flag > `.oxfmtrc` > built-in default. Keys with no CLI equivalent
 /// (`singleQuote`, `semi`, `trailingComma`, …) come straight from `.oxfmtrc`.
 pub(crate) fn build_format_options(
-    cli: &Cli,
+    cli: &OptionFlags,
     cfg: &OxfmtConfig,
 ) -> (FormatOptions, Option<PendingJsSort>) {
     let use_tabs = cli.use_tabs || cfg.use_tabs.unwrap_or(false);
@@ -142,7 +178,7 @@ pub(crate) fn build_format_options(
 /// resolved exactly as the JS path, plus `bracketSpacing`. `objectWrap` is left
 /// at oxc's default (`Expand::Auto` = Prettier `preserve`), matching `oxfmt`.
 /// `variant` is set per file by [`json_variant`].
-pub(crate) fn build_json_options(cli: &Cli, cfg: &OxfmtConfig) -> JsonFormatOptions {
+pub(crate) fn build_json_options(cli: &OptionFlags, cfg: &OxfmtConfig) -> JsonFormatOptions {
     let use_tabs = cli.use_tabs || cfg.use_tabs.unwrap_or(false);
     let indent_style = if use_tabs {
         IndentStyle::Tab
@@ -184,7 +220,7 @@ pub(crate) fn json_variant(ext: &str) -> JsonVariant {
 /// (the only Prettier keys the CSS languages consume). `variant` is set per
 /// file/block by the caller; `line_width` is narrowed per embedded `<style>`
 /// block to its column.
-pub(crate) fn build_css_options(cli: &Cli, cfg: &OxfmtConfig) -> CssFormatOptions {
+pub(crate) fn build_css_options(cli: &OptionFlags, cfg: &OxfmtConfig) -> CssFormatOptions {
     let use_tabs = cli.use_tabs || cfg.use_tabs.unwrap_or(false);
     let indent_style = if use_tabs {
         IndentStyle::Tab

--- a/crates/rsvelte_fmt/src/oxfmt.rs
+++ b/crates/rsvelte_fmt/src/oxfmt.rs
@@ -104,6 +104,54 @@ pub(crate) fn oxfmt_ext(lang: &str) -> &'static str {
 
 // ─── oxfmt delegation ───────────────────────────────────────────────────
 
+/// The captured result of one `oxfmt` stdin invocation.
+pub(crate) struct OxfmtStdinOutput {
+    pub(crate) code: i32,
+    pub(crate) stdout: Vec<u8>,
+}
+
+/// Format `source` for `path` by piping it to `oxfmt`. stdout is captured so
+/// both the CLI (which forwards it verbatim) and in-process embedders (which
+/// consume the formatted text) go through one implementation; stderr stays
+/// inherited so oxfmt's own diagnostics reach the user.
+pub(crate) fn oxfmt_stdin(
+    oxfmt: &Path,
+    config: Option<&Path>,
+    path: &Path,
+    source: &str,
+    check: bool,
+) -> Result<OxfmtStdinOutput> {
+    let mut cmd = oxfmt_command(oxfmt);
+    // oxfmt reads stdin implicitly given `--stdin-filepath`; passing `--stdin`
+    // is rejected (#680). Forward an explicit `--config` when the user set one
+    // so stdin formatting matches the rest of the project; otherwise oxfmt
+    // discovers `.oxfmtrc` from cwd on its own.
+    if let Some(c) = config {
+        cmd.arg("-c").arg(c);
+    }
+    cmd.arg("--stdin-filepath").arg(path);
+    if check {
+        cmd.arg("--check");
+    }
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    let mut child = cmd.spawn().with_context(|| {
+        format!(
+            "failed to spawn `{}` — is oxfmt installed?",
+            oxfmt.display()
+        )
+    })?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(source.as_bytes())?;
+    }
+    let out = child.wait_with_output()?;
+    Ok(OxfmtStdinOutput {
+        code: out.status.code().unwrap_or(1),
+        stdout: out.stdout,
+    })
+}
+
 /// Delegate every non-`.svelte` path to a single `oxfmt` invocation.
 ///
 /// `paths` are the user's directory / file inputs verbatim; a `!**/*.svelte`

--- a/crates/rsvelte_fmt/src/oxfmt.rs
+++ b/crates/rsvelte_fmt/src/oxfmt.rs
@@ -142,10 +142,19 @@ pub(crate) fn oxfmt_stdin(
             oxfmt.display()
         )
     })?;
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(source.as_bytes())?;
-    }
+    // Feed stdin from its own thread: with stdout captured, a child that starts
+    // writing output before it has consumed all of its input would otherwise
+    // deadlock against us once either pipe's buffer fills.
+    let writer = child.stdin.take().map(|mut stdin| {
+        let source = source.to_owned();
+        std::thread::spawn(move || stdin.write_all(source.as_bytes()))
+    });
     let out = child.wait_with_output()?;
+    if let Some(writer) = writer {
+        // A child that exited without reading everything is not our error —
+        // its exit code already says what happened.
+        let _ = writer.join();
+    }
     Ok(OxfmtStdinOutput {
         code: out.status.code().unwrap_or(1),
         stdout: out.stdout,

--- a/crates/rsvelte_fmt/src/run.rs
+++ b/crates/rsvelte_fmt/src/run.rs
@@ -9,7 +9,7 @@ use crate::config::OxfmtConfig;
 use crate::native_css::{CssOptionsResolver, run_native_css};
 use crate::native_js::{JsOptionsResolver, run_native_js};
 use crate::native_json::{JsonOptionsResolver, run_native_json};
-use crate::options::{build_css_options, build_format_options, build_json_options};
+use crate::options::{OptionFlags, build_css_options, build_format_options, build_json_options};
 use crate::oxfmt::{load_oxfmt_runtime_sidecar, run_oxfmt, set_oxfmt_node};
 use crate::oxfmt_ignore;
 use crate::status::{Mode, PipelineStatus, combine};
@@ -18,7 +18,7 @@ use crate::svelte_pipeline::run_svelte_files;
 use crate::tailwind_sort::{collect_svelte_classes, resolve_js_class_sorter};
 use crate::walk::partition_files;
 
-pub(crate) fn run() -> Result<ExitCode> {
+pub fn run() -> Result<ExitCode> {
     let mut cli = Cli::parse();
 
     // Native-direct install: when not launched via the npm JS launcher (which
@@ -54,10 +54,11 @@ pub(crate) fn run() -> Result<ExitCode> {
         .unwrap_or_else(|| cwd.clone());
     let cfg = OxfmtConfig::resolve(cli.config.as_deref(), &config_start).map_err(|e| anyhow!(e))?;
 
-    let (mut options, pending_js) = build_format_options(&cli, &cfg);
+    let flags = OptionFlags::from_cli(&cli);
+    let (mut options, pending_js) = build_format_options(&flags, &cfg);
 
     if cli.stdin {
-        return run_stdin(&cli, &options, &cfg, pending_js.as_ref());
+        return run_stdin(&cli, &flags, &options, &cfg, pending_js.as_ref());
     }
 
     // No paths given (and not stdin mode): default to the current directory,
@@ -112,13 +113,13 @@ pub(crate) fn run() -> Result<ExitCode> {
 
     // Per-file JSON options resolver (native JSON; `package.json` + overrides +
     // parse errors delegate to oxfmt).
-    let json_options = build_json_options(&cli, &cfg);
+    let json_options = build_json_options(&flags, &cfg);
     let base_print_width = cli.print_width.or(cfg.print_width).unwrap_or(80);
     let json_resolver = JsonOptionsResolver::new(json_options, base_print_width, &cfg, &cwd);
 
     // Per-file CSS options resolver (native CSS; overrides + over-width delegate
     // to oxfmt, mirroring native JSON).
-    let css_options = build_css_options(&cli, &cfg);
+    let css_options = build_css_options(&flags, &cfg);
     let css_resolver = CssOptionsResolver::new(css_options, base_print_width, &cfg, &cwd);
 
     // Run the pipelines in parallel: the oxfmt subprocess overlaps with the

--- a/crates/rsvelte_fmt/src/stdin.rs
+++ b/crates/rsvelte_fmt/src/stdin.rs
@@ -1,15 +1,15 @@
 use std::ffi::OsStr;
 use std::io::{self, Read, Write};
 use std::path::Path;
-use std::process::{ExitCode, Stdio};
+use std::process::ExitCode;
 
 use anyhow::{Context, Result, anyhow};
 use rsvelte_formatter::{FormatOptions, css_variant_from_lang, format, format_css_source};
 
 use crate::cli::Cli;
 use crate::config::OxfmtConfig;
-use crate::options::build_css_options;
-use crate::oxfmt::oxfmt_command;
+use crate::options::{OptionFlags, build_css_options};
+use crate::oxfmt::oxfmt_stdin;
 use crate::paths::{is_native_css, is_svelte};
 use crate::tailwind_sort::{PendingJsSort, collect_source_classes, resolve_js_class_sorter};
 
@@ -17,6 +17,7 @@ use crate::tailwind_sort::{PendingJsSort, collect_source_classes, resolve_js_cla
 
 pub(crate) fn run_stdin(
     cli: &Cli,
+    flags: &OptionFlags,
     options: &FormatOptions,
     cfg: &OxfmtConfig,
     pending_js: Option<&PendingJsSort>,
@@ -31,13 +32,56 @@ pub(crate) fn run_stdin(
         .read_to_string(&mut source)
         .context("failed to read stdin")?;
 
+    match format_in_process(&source, filepath, flags, options, cfg, pending_js)? {
+        Some(formatted) => {
+            if cli.check {
+                return Ok(if formatted == source {
+                    ExitCode::SUCCESS
+                } else {
+                    ExitCode::from(1)
+                });
+            }
+            io::stdout()
+                .write_all(formatted.as_bytes())
+                .context("failed to write stdout")?;
+            Ok(ExitCode::SUCCESS)
+        }
+        None => {
+            let out = oxfmt_stdin(
+                &flags.oxfmt_bin,
+                cfg.oxfmt_arg_path.as_deref(),
+                filepath,
+                &source,
+                cli.check,
+            )?;
+            io::stdout()
+                .write_all(&out.stdout)
+                .context("failed to write stdout")?;
+            Ok(ExitCode::from(out.code as u8))
+        }
+    }
+}
+
+/// The in-process half of the stdin dispatch: `.svelte` via
+/// [`rsvelte_formatter::format`], standalone `.css`/`.scss`/`.less` via
+/// `oxc_formatter_css`. `Ok(None)` means the source has no in-process
+/// formatter — or its CSS parse failed, where deferring keeps coverage
+/// identical to delegation — and must be handed to `oxfmt`.
+pub(crate) fn format_in_process(
+    source: &str,
+    filepath: &Path,
+    flags: &OptionFlags,
+    options: &FormatOptions,
+    cfg: &OxfmtConfig,
+    pending_js: Option<&PendingJsSort>,
+) -> Result<Option<String>> {
     if is_svelte(filepath) {
         // Custom Tailwind config: collect this source's class strings, sort them
         // in one sidecar call, then format with the resolved map-backed sorter.
         let owned_options;
         let options = match pending_js {
             Some(pending) => {
-                let classes = collect_source_classes(&source, options);
+                let classes = collect_source_classes(source, options);
                 let mut opts = options.clone();
                 opts.class_sorter = resolve_js_class_sorter(pending, classes);
                 owned_options = opts;
@@ -46,92 +90,16 @@ pub(crate) fn run_stdin(
             None => options,
         };
         let formatted =
-            format(&source, options).map_err(|e| anyhow!("rsvelte_formatter error: {e}"))?;
-        if cli.check {
-            return Ok(if formatted == source {
-                ExitCode::SUCCESS
-            } else {
-                ExitCode::from(1)
-            });
-        }
-        io::stdout()
-            .write_all(formatted.as_bytes())
-            .context("failed to write stdout")?;
-        Ok(ExitCode::SUCCESS)
-    } else if !cli.no_native_css && is_native_css(filepath) {
-        // Standalone `.css`/`.scss`/`.less` on stdin: format in-process via
-        // `oxc_formatter_css` (same engine as oxfmt). A parse error defers to
-        // oxfmt so coverage matches delegation exactly.
+            format(source, options).map_err(|e| anyhow!("rsvelte_formatter error: {e}"))?;
+        Ok(Some(formatted))
+    } else if !flags.no_native_css && is_native_css(filepath) {
         let ext = filepath
             .extension()
             .and_then(OsStr::to_str)
             .unwrap_or("css");
         let variant = css_variant_from_lang(ext);
-        match format_css_source(&source, variant, &build_css_options(cli, cfg)) {
-            Ok(formatted) => {
-                if cli.check {
-                    return Ok(if formatted == source {
-                        ExitCode::SUCCESS
-                    } else {
-                        ExitCode::from(1)
-                    });
-                }
-                io::stdout()
-                    .write_all(formatted.as_bytes())
-                    .context("failed to write stdout")?;
-                Ok(ExitCode::SUCCESS)
-            }
-            Err(_) => oxfmt_stdin(
-                &cli.oxfmt_bin,
-                cfg.oxfmt_arg_path.as_deref(),
-                filepath,
-                &source,
-                cli.check,
-            ),
-        }
+        Ok(format_css_source(source, variant, &build_css_options(flags, cfg)).ok())
     } else {
-        // Pass through to oxfmt via stdin.
-        oxfmt_stdin(
-            &cli.oxfmt_bin,
-            cfg.oxfmt_arg_path.as_deref(),
-            filepath,
-            &source,
-            cli.check,
-        )
+        Ok(None)
     }
-}
-
-fn oxfmt_stdin(
-    oxfmt: &Path,
-    config: Option<&Path>,
-    path: &Path,
-    source: &str,
-    check: bool,
-) -> Result<ExitCode> {
-    let mut cmd = oxfmt_command(oxfmt);
-    // oxfmt reads stdin implicitly given `--stdin-filepath`; passing `--stdin`
-    // is rejected (#680). Forward an explicit `--config` when the user set one
-    // so stdin formatting matches the rest of the project; otherwise oxfmt
-    // discovers `.oxfmtrc` from cwd on its own.
-    if let Some(c) = config {
-        cmd.arg("-c").arg(c);
-    }
-    cmd.arg("--stdin-filepath").arg(path);
-    if check {
-        cmd.arg("--check");
-    }
-    cmd.stdin(Stdio::piped())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-    let mut child = cmd.spawn().with_context(|| {
-        format!(
-            "failed to spawn `{}` — is oxfmt installed?",
-            oxfmt.display()
-        )
-    })?;
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(source.as_bytes())?;
-    }
-    let status = child.wait()?;
-    Ok(ExitCode::from(status.code().unwrap_or(1) as u8))
 }

--- a/crates/rsvelte_language_server/Cargo.toml
+++ b/crates/rsvelte_language_server/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 rsvelte_core = { path = "../rsvelte_core" }
 rsvelte_fmt = { path = "../rsvelte_fmt" }
-rsvelte_lint = { path = "../rsvelte_lint", default-features = false, features = ["native", "eslint-import"] }
+rsvelte_lint = { path = "../rsvelte_lint", default-features = false, features = ["native"] }
 anyhow = "1.0"
 crossbeam-channel = "0.5"
 lsp-server = "0.10"

--- a/crates/rsvelte_language_server/Cargo.toml
+++ b/crates/rsvelte_language_server/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rsvelte_language_server"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.90"
+description = "Language server exposing rsvelte's formatter and linter over LSP"
+license = "MIT"
+publish = false
+
+[[bin]]
+name = "rsvelte-language-server"
+path = "src/main.rs"
+
+[dependencies]
+rsvelte_core = { path = "../rsvelte_core" }
+rsvelte_fmt = { path = "../rsvelte_fmt" }
+rsvelte_lint = { path = "../rsvelte_lint", default-features = false, features = ["native", "eslint-import"] }
+anyhow = "1.0"
+crossbeam-channel = "0.5"
+lsp-server = "0.10"
+lsp-types = "0.97"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[lints]
+workspace = true

--- a/crates/rsvelte_language_server/src/client.rs
+++ b/crates/rsvelte_language_server/src/client.rs
@@ -1,0 +1,96 @@
+//! What the server keeps from `initialize`.
+
+use lsp_types::{ClientInfo, PositionEncodingKind, Uri, WorkspaceFolder};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+/// The `initialize` payload the server holds on to. A client sends these once
+/// and never again, so they are captured here even though the features that
+/// consume them (workspace-relative config discovery, tsconfig lookup) land in
+/// later milestones.
+///
+/// Every field is read independently rather than through one
+/// `InitializeParams` deserialization: a single value this build happens to
+/// reject — a `rootUri` the URI parser refuses, an unknown `trace` — must not
+/// cost us the rest of the payload, and must never leave the client waiting
+/// for a response that never comes.
+#[derive(Debug, Default)]
+pub struct ClientState {
+    pub root_uri: Option<Uri>,
+    pub workspace_folders: Vec<WorkspaceFolder>,
+    pub client_info: Option<ClientInfo>,
+    pub position_encodings: Vec<PositionEncodingKind>,
+    /// Whether the client answers `workspace/configuration`.
+    pub pull_configuration: bool,
+}
+
+impl ClientState {
+    pub fn from_initialize(params: &Value) -> Self {
+        Self {
+            root_uri: field(params.get("rootUri")),
+            workspace_folders: field(params.get("workspaceFolders")).unwrap_or_default(),
+            client_info: field(params.get("clientInfo")),
+            position_encodings: field(params.pointer("/capabilities/general/positionEncodings"))
+                .unwrap_or_default(),
+            pull_configuration: params
+                .pointer("/capabilities/workspace/configuration")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        }
+    }
+}
+
+fn field<T: DeserializeOwned>(value: Option<&Value>) -> Option<T> {
+    serde_json::from_value(value?.clone()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn reads_the_fields_the_server_keeps() {
+        let state = ClientState::from_initialize(&json!({
+            "rootUri": "file:///home/u/app",
+            "workspaceFolders": [{ "uri": "file:///home/u/app", "name": "app" }],
+            "clientInfo": { "name": "Visual Studio Code", "version": "1.99.0" },
+            "capabilities": {
+                "workspace": { "configuration": true },
+                "general": { "positionEncodings": ["utf-16"] },
+            },
+        }));
+        assert_eq!(
+            state.root_uri.as_ref().map(|u| u.as_str()),
+            Some("file:///home/u/app")
+        );
+        assert_eq!(state.workspace_folders.len(), 1);
+        assert_eq!(
+            state.client_info.as_ref().map(|c| c.name.as_str()),
+            Some("Visual Studio Code")
+        );
+        assert_eq!(state.position_encodings.len(), 1);
+        assert!(state.pull_configuration);
+    }
+
+    #[test]
+    fn one_unparsable_field_does_not_cost_the_others() {
+        // A `rootUri` this URI parser rejects, and a `trace` outside the enum.
+        let state = ClientState::from_initialize(&json!({
+            "rootUri": "not a uri",
+            "trace": "bogus",
+            "capabilities": { "workspace": { "configuration": true } },
+        }));
+        assert!(state.root_uri.is_none());
+        assert!(state.pull_configuration);
+    }
+
+    #[test]
+    fn an_empty_payload_yields_defaults() {
+        let state = ClientState::from_initialize(&json!({}));
+        assert!(state.root_uri.is_none());
+        assert!(state.workspace_folders.is_empty());
+        assert!(!state.pull_configuration);
+        assert_eq!(ClientState::from_initialize(&Value::Null).root_uri, None);
+    }
+}

--- a/crates/rsvelte_language_server/src/diagnostics.rs
+++ b/crates/rsvelte_language_server/src/diagnostics.rs
@@ -1,0 +1,85 @@
+//! Conversion from rsvelte's lint diagnostics to LSP `Diagnostic`s.
+
+use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
+use rsvelte_core::svelte_check::diagnostic::{
+    Diagnostic as LintDiagnostic, DiagnosticSeverity as LintSeverity,
+};
+
+/// The `source` field every diagnostic this server publishes carries.
+const SOURCE: &str = "rsvelte";
+
+/// Convert one lint diagnostic. rsvelte reports 1-based lines with 0-based
+/// UTF-16 columns (the encoding LSP uses), so only the line needs rebasing.
+pub fn to_lsp(diagnostic: &LintDiagnostic) -> Diagnostic {
+    let range = diagnostic.range.map_or_else(
+        || Range::new(Position::new(0, 0), Position::new(0, 0)),
+        |r| {
+            Range::new(
+                Position::new(r.start.line.saturating_sub(1), r.start.column),
+                Position::new(r.end.line.saturating_sub(1), r.end.column),
+            )
+        },
+    );
+    Diagnostic {
+        range,
+        severity: Some(severity(diagnostic.severity)),
+        code: diagnostic.code.clone().map(NumberOrString::String),
+        source: Some(SOURCE.to_string()),
+        message: diagnostic.message.clone(),
+        ..Diagnostic::default()
+    }
+}
+
+fn severity(severity: LintSeverity) -> DiagnosticSeverity {
+    match severity {
+        LintSeverity::Error => DiagnosticSeverity::ERROR,
+        LintSeverity::Warning => DiagnosticSeverity::WARNING,
+        LintSeverity::Info => DiagnosticSeverity::INFORMATION,
+        LintSeverity::Hint => DiagnosticSeverity::HINT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsvelte_core::svelte_check::diagnostic::{Position as LintPosition, Range as LintRange};
+    use std::path::PathBuf;
+
+    fn diagnostic(range: Option<LintRange>) -> LintDiagnostic {
+        LintDiagnostic {
+            file: PathBuf::from("App.svelte"),
+            severity: LintSeverity::Warning,
+            code: Some("svelte/no-at-html-tags".to_string()),
+            message: "message".to_string(),
+            range,
+            source: "svelte",
+        }
+    }
+
+    #[test]
+    fn lines_become_zero_based() {
+        let d = to_lsp(&diagnostic(Some(LintRange {
+            start: LintPosition { line: 3, column: 4 },
+            end: LintPosition { line: 3, column: 9 },
+        })));
+        assert_eq!(
+            d.range,
+            Range::new(Position::new(2, 4), Position::new(2, 9))
+        );
+        assert_eq!(d.severity, Some(DiagnosticSeverity::WARNING));
+        assert_eq!(
+            d.code,
+            Some(NumberOrString::String("svelte/no-at-html-tags".to_string()))
+        );
+        assert_eq!(d.source.as_deref(), Some("rsvelte"));
+    }
+
+    #[test]
+    fn a_missing_range_maps_to_the_start_of_the_file() {
+        let d = to_lsp(&diagnostic(None));
+        assert_eq!(
+            d.range,
+            Range::new(Position::new(0, 0), Position::new(0, 0))
+        );
+    }
+}

--- a/crates/rsvelte_language_server/src/diagnostics.rs
+++ b/crates/rsvelte_language_server/src/diagnostics.rs
@@ -82,4 +82,28 @@ mod tests {
             Range::new(Position::new(0, 0), Position::new(0, 0))
         );
     }
+
+    /// End-to-end over the real linter with a hand-computed expectation, so a
+    /// change in how columns are counted cannot slip past: each `💡` is two
+    /// UTF-16 code units, putting `{@html v}` at units 9..18 of line 0.
+    #[test]
+    fn a_real_finding_lands_on_hand_counted_utf16_columns() {
+        let path = PathBuf::from("App.svelte");
+        let source = "<div>💡💡{@html v}</div>";
+        let found = rsvelte_lint::lint_source(
+            source,
+            &path,
+            &rsvelte_core::CompileOptions::default(),
+            &rsvelte_lint::LintConfig::recommended(),
+        );
+        let at_html = found
+            .iter()
+            .find(|d| d.code.as_deref() == Some("svelte/no-at-html-tags"))
+            .expect("the fixture should report svelte/no-at-html-tags");
+
+        assert_eq!(
+            to_lsp(at_html).range,
+            Range::new(Position::new(0, 9), Position::new(0, 18))
+        );
+    }
 }

--- a/crates/rsvelte_language_server/src/document.rs
+++ b/crates/rsvelte_language_server/src/document.rs
@@ -1,0 +1,221 @@
+//! The in-memory mirror of the client's open documents.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use lsp_types::{Position, Range, TextDocumentContentChangeEvent, Uri};
+
+use crate::text::LineIndex;
+
+pub struct Document {
+    pub uri: Uri,
+    pub language_id: String,
+    pub version: i32,
+    text: String,
+    index: LineIndex,
+    hash: u64,
+}
+
+impl Document {
+    pub fn new(uri: Uri, language_id: String, version: i32, text: String) -> Self {
+        let index = LineIndex::new(&text);
+        let hash = hash_of(&text);
+        Self {
+            uri,
+            language_id,
+            version,
+            text,
+            index,
+            hash,
+        }
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// A hash of the current contents, so a consumer can skip re-analysing a
+    /// document whose text did not actually change.
+    pub fn content_hash(&self) -> u64 {
+        self.hash
+    }
+
+    pub fn position_at(&self, offset: usize) -> Position {
+        self.index.position(&self.text, offset)
+    }
+
+    /// The range covering the whole document.
+    pub fn full_range(&self) -> Range {
+        Range::new(Position::new(0, 0), self.position_at(self.text.len()))
+    }
+
+    /// Apply the changes of one `textDocument/didChange`. Each change is
+    /// relative to the document as left by the previous one, so the line index
+    /// is rebuilt between them.
+    pub fn apply(&mut self, version: i32, changes: &[TextDocumentContentChangeEvent]) {
+        self.version = version;
+        for change in changes {
+            match change.range {
+                Some(range) => {
+                    let start = self.index.offset(&self.text, range.start);
+                    let end = self.index.offset(&self.text, range.end).max(start);
+                    self.text.replace_range(start..end, &change.text);
+                }
+                None => self.text.clone_from(&change.text),
+            }
+            self.index = LineIndex::new(&self.text);
+        }
+        self.hash = hash_of(&self.text);
+    }
+}
+
+#[derive(Default)]
+pub struct DocumentStore {
+    docs: HashMap<String, Document>,
+}
+
+impl DocumentStore {
+    pub fn open(&mut self, uri: Uri, language_id: String, version: i32, text: String) {
+        let key = uri.as_str().to_string();
+        self.docs
+            .insert(key, Document::new(uri, language_id, version, text));
+    }
+
+    pub fn close(&mut self, uri: &Uri) -> Option<Document> {
+        self.docs.remove(uri.as_str())
+    }
+
+    pub fn get(&self, uri: &Uri) -> Option<&Document> {
+        self.get_by_key(uri.as_str())
+    }
+
+    /// Look a document up by the raw URI string used as the store's key.
+    pub fn get_by_key(&self, key: &str) -> Option<&Document> {
+        self.docs.get(key)
+    }
+
+    pub fn get_mut(&mut self, uri: &Uri) -> Option<&mut Document> {
+        self.docs.get_mut(uri.as_str())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Document> {
+        self.docs.values()
+    }
+}
+
+fn hash_of(text: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    text.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn doc(text: &str) -> Document {
+        Document::new(
+            Uri::from_str("file:///App.svelte").unwrap(),
+            "svelte".to_string(),
+            1,
+            text.to_string(),
+        )
+    }
+
+    fn change(range: Option<Range>, text: &str) -> TextDocumentContentChangeEvent {
+        TextDocumentContentChangeEvent {
+            range,
+            range_length: None,
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn incremental_insert() {
+        let mut d = doc("<p>hi</p>\n");
+        d.apply(
+            2,
+            &[change(
+                Some(Range::new(Position::new(0, 5), Position::new(0, 5))),
+                "!",
+            )],
+        );
+        assert_eq!(d.text(), "<p>hi!</p>\n");
+        assert_eq!(d.version, 2);
+    }
+
+    #[test]
+    fn incremental_replace_across_lines() {
+        let mut d = doc("one\ntwo\nthree\n");
+        d.apply(
+            2,
+            &[change(
+                Some(Range::new(Position::new(0, 1), Position::new(2, 2))),
+                "X",
+            )],
+        );
+        assert_eq!(d.text(), "oXree\n");
+    }
+
+    #[test]
+    fn incremental_edit_after_astral_text() {
+        // The edit is expressed in UTF-16 units, so a naive byte offset would
+        // land inside the emoji.
+        let mut d = doc("<p>💡ab</p>");
+        d.apply(
+            2,
+            &[change(
+                Some(Range::new(Position::new(0, 6), Position::new(0, 7))),
+                "Z",
+            )],
+        );
+        assert_eq!(d.text(), "<p>💡aZ</p>");
+    }
+
+    #[test]
+    fn several_changes_apply_in_order() {
+        let mut d = doc("abc");
+        d.apply(
+            2,
+            &[
+                change(
+                    Some(Range::new(Position::new(0, 0), Position::new(0, 1))),
+                    "é",
+                ),
+                change(
+                    Some(Range::new(Position::new(0, 1), Position::new(0, 2))),
+                    "💡",
+                ),
+            ],
+        );
+        assert_eq!(d.text(), "é💡c");
+    }
+
+    #[test]
+    fn full_replacement() {
+        let mut d = doc("abc");
+        d.apply(2, &[change(None, "xyz")]);
+        assert_eq!(d.text(), "xyz");
+    }
+
+    #[test]
+    fn hash_tracks_content() {
+        let mut d = doc("abc");
+        let before = d.content_hash();
+        d.apply(2, &[change(None, "abc")]);
+        assert_eq!(d.content_hash(), before);
+        d.apply(3, &[change(None, "abd")]);
+        assert_ne!(d.content_hash(), before);
+    }
+
+    #[test]
+    fn full_range_ends_at_the_last_character() {
+        let d = doc("💡\nab");
+        assert_eq!(
+            d.full_range(),
+            Range::new(Position::new(0, 0), Position::new(1, 2))
+        );
+    }
+}

--- a/crates/rsvelte_language_server/src/document.rs
+++ b/crates/rsvelte_language_server/src/document.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
 use lsp_types::{Position, Range, TextDocumentContentChangeEvent, Uri};
 
@@ -12,7 +13,10 @@ pub struct Document {
     pub uri: Uri,
     pub language_id: String,
     pub version: i32,
-    text: String,
+    /// Shared so dispatching an analysis costs a refcount rather than a copy of
+    /// the file. `Arc::make_mut` keeps editing in place for as long as no
+    /// worker holds the other end.
+    text: Arc<String>,
     index: LineIndex,
     hash: u64,
 }
@@ -25,7 +29,7 @@ impl Document {
             uri,
             language_id,
             version,
-            text,
+            text: Arc::new(text),
             index,
             hash,
         }
@@ -33,6 +37,11 @@ impl Document {
 
     pub fn text(&self) -> &str {
         &self.text
+    }
+
+    /// The contents, ready to hand to another thread.
+    pub fn shared_text(&self) -> Arc<String> {
+        Arc::clone(&self.text)
     }
 
     /// A hash of the current contents, so a consumer can skip re-analysing a
@@ -56,13 +65,14 @@ impl Document {
     pub fn apply(&mut self, version: i32, changes: &[TextDocumentContentChangeEvent]) {
         self.version = version;
         for change in changes {
+            let text = Arc::make_mut(&mut self.text);
             match change.range {
                 Some(range) => {
-                    let start = self.index.offset(&self.text, range.start);
-                    let end = self.index.offset(&self.text, range.end).max(start);
-                    self.text.replace_range(start..end, &change.text);
+                    let start = self.index.offset(text, range.start);
+                    let end = self.index.offset(text, range.end).max(start);
+                    text.replace_range(start..end, &change.text);
                 }
-                None => self.text.clone_from(&change.text),
+                None => text.clone_from(&change.text),
             }
             self.index = LineIndex::new(&self.text);
         }

--- a/crates/rsvelte_language_server/src/format.rs
+++ b/crates/rsvelte_language_server/src/format.rs
@@ -1,0 +1,30 @@
+//! Document formatting, run in process through `rsvelte_fmt`'s pipeline.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use rsvelte_fmt::FormatSession;
+
+/// Formatting sessions keyed by the document's directory. Building one
+/// discovers the project's oxfmt config (a walk to the filesystem root plus a
+/// parse), so it is reused across every document that shares a directory.
+#[derive(Default)]
+pub struct FormatSessions {
+    by_dir: HashMap<PathBuf, FormatSession>,
+}
+
+impl FormatSessions {
+    pub fn get(&mut self, path: &Path) -> Result<&FormatSession> {
+        let dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        if !self.by_dir.contains_key(&dir) {
+            self.by_dir
+                .insert(dir.clone(), FormatSession::resolve(path)?);
+        }
+        Ok(&self.by_dir[&dir])
+    }
+
+    pub fn clear(&mut self) {
+        self.by_dir.clear();
+    }
+}

--- a/crates/rsvelte_language_server/src/lib.rs
+++ b/crates/rsvelte_language_server/src/lib.rs
@@ -1,0 +1,17 @@
+//! `rsvelte-language-server` — an LSP server exposing rsvelte's formatter and
+//! linter to any LSP client (VS Code, Neovim, …).
+//!
+//! Scope: document formatting and push diagnostics, both run in process
+//! against the `rsvelte_fmt` / `rsvelte_lint` crates. Type checking stays with
+//! `rsvelte-check`.
+
+pub mod diagnostics;
+pub mod document;
+pub mod format;
+pub mod lint;
+pub mod server;
+pub mod settings;
+pub mod text;
+pub mod uri;
+
+pub use server::run_stdio;

--- a/crates/rsvelte_language_server/src/lib.rs
+++ b/crates/rsvelte_language_server/src/lib.rs
@@ -1,17 +1,20 @@
 //! `rsvelte-language-server` — an LSP server exposing rsvelte's formatter and
 //! linter to any LSP client (VS Code, Neovim, …).
 //!
-//! Scope: document formatting and push diagnostics, both run in process
-//! against the `rsvelte_fmt` / `rsvelte_lint` crates. Type checking stays with
-//! `rsvelte-check`.
+//! The message loop owns only protocol state; every analysis runs on the
+//! [`worker`] thread, which is where the stack depth and panic isolation the
+//! Svelte compiler needs are provided.
 
+pub mod client;
 pub mod diagnostics;
 pub mod document;
 pub mod format;
 pub mod lint;
+pub mod log;
 pub mod server;
 pub mod settings;
 pub mod text;
 pub mod uri;
+pub mod worker;
 
 pub use server::run_stdio;

--- a/crates/rsvelte_language_server/src/lint.rs
+++ b/crates/rsvelte_language_server/src/lint.rs
@@ -1,0 +1,135 @@
+//! Lint configuration discovery and the lint pass itself.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rsvelte_core::CompileOptions;
+use rsvelte_core::svelte_check::diagnostic::Diagnostic;
+use rsvelte_lint::{LintConfig, lint_source};
+
+/// Config file names, in the order a directory is probed. The first two are
+/// `rsvelte-lint`'s own; an ESLint flat config is the fallback, imported for
+/// its `svelte/*` severities so a project that only configures ESLint still
+/// gets the rules it asked for.
+const CONFIG_NAMES: &[&str] = &["rsvelte-lint.json", ".rsvelte-lintrc.json"];
+const ESLINT_CONFIG_NAMES: &[&str] = &[
+    "eslint.config.js",
+    "eslint.config.mjs",
+    "eslint.config.cjs",
+    "eslint.config.ts",
+    "eslint.config.mts",
+];
+
+/// Resolved lint configs, keyed by the directory discovery started from.
+/// Discovery walks to the filesystem root, so it is cached rather than redone
+/// on every keystroke.
+#[derive(Default)]
+pub struct LintConfigCache {
+    by_dir: HashMap<PathBuf, Arc<LintConfig>>,
+}
+
+impl LintConfigCache {
+    /// The config governing a document, discovered upward from its directory.
+    pub fn get(&mut self, dir: &Path) -> Arc<LintConfig> {
+        if let Some(config) = self.by_dir.get(dir) {
+            return Arc::clone(config);
+        }
+        let config = Arc::new(discover(dir).unwrap_or_else(LintConfig::recommended));
+        self.by_dir.insert(dir.to_path_buf(), Arc::clone(&config));
+        config
+    }
+
+    pub fn clear(&mut self) {
+        self.by_dir.clear();
+    }
+}
+
+/// Walk up from `start` for the nearest lint config. An unreadable or invalid
+/// config yields `None`, falling back to the recommended preset — a config
+/// error must not leave the editor without diagnostics.
+fn discover(start: &Path) -> Option<LintConfig> {
+    let mut dir = Some(start);
+    while let Some(d) = dir {
+        for name in CONFIG_NAMES {
+            let candidate = d.join(name);
+            if candidate.is_file() {
+                return std::fs::read_to_string(&candidate)
+                    .ok()
+                    .and_then(|text| LintConfig::from_json_str(&text).ok());
+            }
+        }
+        for name in ESLINT_CONFIG_NAMES {
+            let candidate = d.join(name);
+            if candidate.is_file() {
+                return std::fs::read_to_string(&candidate).ok().map(from_eslint);
+            }
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+fn from_eslint(text: String) -> LintConfig {
+    let mut config = LintConfig::recommended();
+    for (rule, severity) in rsvelte_lint::eslint_import::import_svelte_rules(&text) {
+        config = config.with_override(rule, severity);
+    }
+    config
+}
+
+/// Lint one open document. Suppression comments (`<!-- svelte-ignore -->`,
+/// `eslint-disable`) and inline rule config are applied inside `lint_source`.
+pub fn lint(path: &Path, source: &str, config: &LintConfig) -> Vec<Diagnostic> {
+    let options = CompileOptions {
+        filename: Some(path.display().to_string()),
+        ..Default::default()
+    };
+    lint_source(source, path, &options, config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suppression_comments_are_honoured() {
+        let path = PathBuf::from("App.svelte");
+        let config = LintConfig::recommended();
+        let source = "<div>{@html x}</div>";
+        assert!(!lint(&path, source, &config).is_empty());
+
+        let suppressed =
+            "<!-- eslint-disable-next-line svelte/no-at-html-tags -->\n<div>{@html x}</div>";
+        let codes: Vec<_> = lint(&path, suppressed, &config)
+            .into_iter()
+            .filter_map(|d| d.code)
+            .collect();
+        assert!(!codes.iter().any(|c| c == "svelte/no-at-html-tags"));
+    }
+
+    #[test]
+    fn a_config_file_turns_a_rule_off() {
+        let dir = std::env::temp_dir().join(format!(
+            "rsvelte-ls-lint-config-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("rsvelte-lint.json"),
+            r#"{ "rules": { "svelte/no-at-html-tags": "off" } }"#,
+        )
+        .unwrap();
+
+        let mut cache = LintConfigCache::default();
+        let config = cache.get(&dir);
+        let codes: Vec<_> = lint(&dir.join("App.svelte"), "<div>{@html x}</div>", &config)
+            .into_iter()
+            .filter_map(|d| d.code)
+            .collect();
+        assert!(!codes.iter().any(|c| c == "svelte/no-at-html-tags"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/rsvelte_language_server/src/lint.rs
+++ b/crates/rsvelte_language_server/src/lint.rs
@@ -8,18 +8,12 @@ use rsvelte_core::CompileOptions;
 use rsvelte_core::svelte_check::diagnostic::Diagnostic;
 use rsvelte_lint::{LintConfig, lint_source};
 
-/// Config file names, in the order a directory is probed. The first two are
-/// `rsvelte-lint`'s own; an ESLint flat config is the fallback, imported for
-/// its `svelte/*` severities so a project that only configures ESLint still
-/// gets the rules it asked for.
+/// Config file names, in the order a directory is probed — the same two
+/// `rsvelte-lint` itself discovers. An ESLint config is deliberately *not*
+/// consulted: importing it is opt-in on the CLI (`--config-from-eslint`), and a
+/// server that read it on its own would report a different rule set in the
+/// editor than the same project's CI does.
 const CONFIG_NAMES: &[&str] = &["rsvelte-lint.json", ".rsvelte-lintrc.json"];
-const ESLINT_CONFIG_NAMES: &[&str] = &[
-    "eslint.config.js",
-    "eslint.config.mjs",
-    "eslint.config.cjs",
-    "eslint.config.ts",
-    "eslint.config.mts",
-];
 
 /// Resolved lint configs, keyed by the directory discovery started from.
 /// Discovery walks to the filesystem root, so it is cached rather than redone
@@ -54,28 +48,21 @@ fn discover(start: &Path) -> Option<LintConfig> {
         for name in CONFIG_NAMES {
             let candidate = d.join(name);
             if candidate.is_file() {
-                return std::fs::read_to_string(&candidate)
-                    .ok()
-                    .and_then(|text| LintConfig::from_json_str(&text).ok());
-            }
-        }
-        for name in ESLINT_CONFIG_NAMES {
-            let candidate = d.join(name);
-            if candidate.is_file() {
-                return std::fs::read_to_string(&candidate).ok().map(from_eslint);
+                return match std::fs::read_to_string(&candidate)
+                    .map_err(|e| e.to_string())
+                    .and_then(|text| LintConfig::from_json_str(&text).map_err(|e| e.to_string()))
+                {
+                    Ok(config) => Some(config),
+                    Err(err) => {
+                        crate::log::warn(format_args!("{}: {err}", candidate.display()));
+                        None
+                    }
+                };
             }
         }
         dir = d.parent();
     }
     None
-}
-
-fn from_eslint(text: String) -> LintConfig {
-    let mut config = LintConfig::recommended();
-    for (rule, severity) in rsvelte_lint::eslint_import::import_svelte_rules(&text) {
-        config = config.with_override(rule, severity);
-    }
-    config
 }
 
 /// Lint one open document. Suppression comments (`<!-- svelte-ignore -->`,

--- a/crates/rsvelte_language_server/src/log.rs
+++ b/crates/rsvelte_language_server/src/log.rs
@@ -1,0 +1,11 @@
+//! Server-side logging.
+//!
+//! stdout carries the JSON-RPC session, so anything written there that is not
+//! a framed LSP message corrupts the stream beyond recovery — every diagnostic
+//! about the server itself goes to stderr instead.
+
+use std::fmt::Display;
+
+pub fn warn(message: impl Display) {
+    eprintln!("rsvelte-language-server: {message}");
+}

--- a/crates/rsvelte_language_server/src/main.rs
+++ b/crates/rsvelte_language_server/src/main.rs
@@ -1,5 +1,13 @@
 //! The `rsvelte-language-server` binary — serves the LSP over stdio.
 
-fn main() -> anyhow::Result<()> {
-    rsvelte_language_server::run_stdio()
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match rsvelte_language_server::run_stdio() {
+        Ok(code) => code,
+        Err(err) => {
+            rsvelte_language_server::log::warn(format_args!("{err:#}"));
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/crates/rsvelte_language_server/src/main.rs
+++ b/crates/rsvelte_language_server/src/main.rs
@@ -1,0 +1,5 @@
+//! The `rsvelte-language-server` binary — serves the LSP over stdio.
+
+fn main() -> anyhow::Result<()> {
+    rsvelte_language_server::run_stdio()
+}

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -1,25 +1,26 @@
 //! The LSP message loop.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use crossbeam_channel::{RecvTimeoutError, Sender};
+use crossbeam_channel::{Receiver, Sender, after, never, select, unbounded};
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
     ConfigurationItem, ConfigurationParams, DidChangeTextDocumentParams,
     DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-    DocumentFormattingParams, InitializeParams, OneOf, PublishDiagnosticsParams,
-    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    DocumentFormattingParams, OneOf, PublishDiagnosticsParams, ServerCapabilities,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     TextDocumentSyncSaveOptions, TextEdit, Uri,
 };
 
+use crate::client::ClientState;
 use crate::document::{Document, DocumentStore};
-use crate::format::FormatSessions;
-use crate::lint::LintConfigCache;
+use crate::log;
 use crate::settings::Settings;
 use crate::uri::uri_to_path;
+use crate::worker::{Job, Outcome, Worker};
 
 pub const SERVER_NAME: &str = "rsvelte-language-server";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -31,16 +32,16 @@ const LINT_DEBOUNCE: Duration = Duration::from_millis(300);
 const CONFIG_SECTION: &str = "rsvelte";
 
 /// Serve the LSP over stdio until the client shuts the connection down.
-pub fn run_stdio() -> Result<()> {
+///
+/// **stdout belongs to the JSON-RPC session.** Anything printed there that is
+/// not a framed message corrupts the stream with no way back, so no code
+/// reachable from here may write to it — note that `rsvelte_fmt` does print to
+/// stdout on its CLI paths, which is why only [`rsvelte_fmt::FormatSession`]
+/// (which never does) is used.
+pub fn run_stdio() -> Result<ExitCode> {
     let (connection, io_threads) = Connection::stdio();
     let (id, params) = connection.initialize_start()?;
-    let params: InitializeParams = serde_json::from_value(params)?;
-    let pull_configuration = params
-        .capabilities
-        .workspace
-        .as_ref()
-        .and_then(|w| w.configuration)
-        .unwrap_or(false);
+    let client = ClientState::from_initialize(&params);
 
     connection.initialize_finish(
         id,
@@ -50,12 +51,20 @@ pub fn run_stdio() -> Result<()> {
         }),
     )?;
 
-    Server::new(connection.sender.clone(), pull_configuration).run(&connection)?;
+    let (results, outcomes) = unbounded();
+    let code = Server::new(
+        connection.sender.clone(),
+        client,
+        Worker::spawn(results),
+        outcomes,
+    )
+    .run(&connection)?;
+
     // The writer thread ends only once every sender is gone, so the connection
     // (and the server's clone of it) must be dropped before joining.
     drop(connection);
     io_threads.join()?;
-    Ok(())
+    Ok(code)
 }
 
 fn capabilities() -> ServerCapabilities {
@@ -73,90 +82,115 @@ fn capabilities() -> ServerCapabilities {
     }
 }
 
+/// A client request whose answer is still being computed. The response is sent
+/// when the worker reports back, so a handler never has to block the loop to
+/// produce one.
+enum Pending {
+    Formatting,
+}
+
+/// A request this server sent to the client, keyed by the id the client will
+/// echo back.
+enum Outgoing {
+    Configuration,
+}
+
 struct Server {
     sender: Sender<Message>,
-    pull_configuration: bool,
+    client: ClientState,
     settings: Settings,
     documents: DocumentStore,
-    format_sessions: FormatSessions,
-    lint_configs: LintConfigCache,
+    worker: Worker,
+    outcomes: Receiver<Outcome>,
     /// Documents awaiting a lint, and when it comes due.
     scheduled: HashMap<String, Instant>,
     /// The content hash each document was last linted at.
     linted: HashMap<String, u64>,
-    config_request: Option<RequestId>,
+    pending: HashMap<RequestId, Pending>,
+    outgoing: HashMap<RequestId, Outgoing>,
     next_request_id: u32,
+    shutdown_requested: bool,
+    exiting: bool,
 }
 
 impl Server {
-    fn new(sender: Sender<Message>, pull_configuration: bool) -> Self {
+    fn new(
+        sender: Sender<Message>,
+        client: ClientState,
+        worker: Worker,
+        outcomes: Receiver<Outcome>,
+    ) -> Self {
         Self {
             sender,
-            pull_configuration,
+            client,
             settings: Settings::default(),
             documents: DocumentStore::default(),
-            format_sessions: FormatSessions::default(),
-            lint_configs: LintConfigCache::default(),
+            worker,
+            outcomes,
             scheduled: HashMap::new(),
             linted: HashMap::new(),
-            config_request: None,
+            pending: HashMap::new(),
+            outgoing: HashMap::new(),
             next_request_id: 0,
+            shutdown_requested: false,
+            exiting: false,
         }
     }
 
-    fn run(&mut self, connection: &Connection) -> Result<()> {
-        if self.pull_configuration {
+    fn run(&mut self, connection: &Connection) -> Result<ExitCode> {
+        if self.client.pull_configuration {
             self.request_configuration();
         }
-        loop {
-            let message = match self.scheduled.values().min().copied() {
-                Some(deadline) => {
-                    let Some(wait) = deadline.checked_duration_since(Instant::now()) else {
-                        self.run_scheduled_lints();
-                        continue;
-                    };
-                    match connection.receiver.recv_timeout(wait) {
-                        Ok(message) => message,
-                        Err(RecvTimeoutError::Timeout) => {
-                            self.run_scheduled_lints();
-                            continue;
-                        }
-                        Err(RecvTimeoutError::Disconnected) => break,
-                    }
-                }
-                None => match connection.receiver.recv() {
-                    Ok(message) => message,
+        // Cloned out of `self` so the handlers below can still borrow it.
+        let outcomes = self.outcomes.clone();
+
+        while !self.exiting {
+            // Rearmed each turn: the debounce deadline moves with every edit.
+            let timer = match self.scheduled.values().min() {
+                Some(&deadline) => after(deadline.saturating_duration_since(Instant::now())),
+                None => never(),
+            };
+            select! {
+                recv(connection.receiver) -> message => match message {
+                    Ok(Message::Request(request)) => self.on_request(request),
+                    Ok(Message::Notification(notification)) => self.on_notification(notification),
+                    Ok(Message::Response(response)) => self.on_response(response),
                     Err(_) => break,
                 },
-            };
-
-            match message {
-                Message::Request(request) => {
-                    if connection.handle_shutdown(&request)? {
-                        return Ok(());
-                    }
-                    self.on_request(request);
-                }
-                Message::Notification(notification) => self.on_notification(notification),
-                Message::Response(response) => self.on_response(response),
+                recv(outcomes) -> outcome => match outcome {
+                    Ok(outcome) => self.on_outcome(outcome),
+                    Err(_) => break,
+                },
+                recv(timer) -> _ => self.run_scheduled_lints(),
             }
         }
-        Ok(())
+
+        // A client that drops the connection or exits without shutting down
+        // first is an abnormal end, per the protocol.
+        Ok(if self.shutdown_requested {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::FAILURE
+        })
     }
 
-    // ── Requests ────────────────────────────────────────────────────────
-
     fn on_request(&mut self, request: Request) {
+        if request.method == "shutdown" {
+            self.shutdown_requested = true;
+            self.respond(Response::new_ok(request.id, ()));
+            return;
+        }
+        if self.shutdown_requested {
+            self.respond(Response::new_err(
+                request.id,
+                ErrorCode::InvalidRequest as i32,
+                "server is shutting down".to_string(),
+            ));
+            return;
+        }
         match request.method.as_str() {
-            "textDocument/formatting" => {
-                let edits = match serde_json::from_value::<DocumentFormattingParams>(request.params)
-                {
-                    Ok(params) => self.format(&params.text_document.uri),
-                    Err(_) => Vec::new(),
-                };
-                self.send(Response::new_ok(request.id, edits));
-            }
-            _ => self.send(Response::new_err(
+            "textDocument/formatting" => self.on_formatting(request),
+            _ => self.respond(Response::new_err(
                 request.id,
                 ErrorCode::MethodNotFound as i32,
                 format!("unhandled method {}", request.method),
@@ -164,109 +198,152 @@ impl Server {
         }
     }
 
-    fn format(&mut self, uri: &Uri) -> Vec<TextEdit> {
+    fn on_formatting(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<DocumentFormattingParams>(request.params) {
+            Ok(params) => params,
+            Err(err) => {
+                log::warn(format_args!("textDocument/formatting: {err}"));
+                self.respond_no_edits(id);
+                return;
+            }
+        };
         if !self.settings.format_enable {
-            return Vec::new();
+            self.respond_no_edits(id);
+            return;
         }
-        let Some(document) = self.documents.get(uri) else {
-            return Vec::new();
+        let uri = params.text_document.uri;
+        let Some(document) = self.documents.get(&uri) else {
+            self.respond_no_edits(id);
+            return;
         };
-        let path = uri_to_path(uri.as_str());
-        let source = document.text();
-        let range = document.full_range();
-
-        let Ok(session) = self.format_sessions.get(&path) else {
-            return Vec::new();
+        let job = Job::Format {
+            id: id.clone(),
+            path: uri_to_path(uri.as_str()),
+            text: document.shared_text(),
+            range: document.full_range(),
         };
-        // Formatting is never an error: a failure yields no edits.
-        let Ok(formatted) = session.format(source, &path) else {
-            return Vec::new();
-        };
-        if formatted == source {
-            return Vec::new();
-        }
-        vec![TextEdit {
-            range,
-            new_text: formatted,
-        }]
+        self.pending.insert(id, Pending::Formatting);
+        self.worker.submit(job);
     }
 
-    // ── Notifications ───────────────────────────────────────────────────
-
     fn on_notification(&mut self, notification: Notification) {
-        match notification.method.as_str() {
+        let method = notification.method.clone();
+        match method.as_str() {
             "textDocument/didOpen" => {
-                if let Ok(params) =
-                    serde_json::from_value::<DidOpenTextDocumentParams>(notification.params)
-                {
-                    let doc = params.text_document;
-                    let key = doc.uri.as_str().to_string();
-                    self.documents
-                        .open(doc.uri, doc.language_id, doc.version, doc.text);
-                    self.schedule_lint(key, Duration::ZERO);
+                match serde_json::from_value::<DidOpenTextDocumentParams>(notification.params) {
+                    Ok(params) => {
+                        let doc = params.text_document;
+                        let key = doc.uri.as_str().to_string();
+                        self.documents
+                            .open(doc.uri, doc.language_id, doc.version, doc.text);
+                        self.schedule_lint(key, Duration::ZERO);
+                    }
+                    Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
             "textDocument/didChange" => {
-                if let Ok(params) =
-                    serde_json::from_value::<DidChangeTextDocumentParams>(notification.params)
-                {
-                    let key = params.text_document.uri.as_str().to_string();
-                    if let Some(document) = self.documents.get_mut(&params.text_document.uri) {
-                        document.apply(params.text_document.version, &params.content_changes);
-                        self.schedule_lint(key, LINT_DEBOUNCE);
+                match serde_json::from_value::<DidChangeTextDocumentParams>(notification.params) {
+                    Ok(params) => {
+                        let key = params.text_document.uri.as_str().to_string();
+                        if let Some(document) = self.documents.get_mut(&params.text_document.uri) {
+                            document.apply(params.text_document.version, &params.content_changes);
+                            self.schedule_lint(key, LINT_DEBOUNCE);
+                        }
                     }
+                    Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
             "textDocument/didSave" => {
-                if let Ok(params) =
-                    serde_json::from_value::<DidSaveTextDocumentParams>(notification.params)
-                {
-                    self.schedule_lint(
+                match serde_json::from_value::<DidSaveTextDocumentParams>(notification.params) {
+                    Ok(params) => self.schedule_lint(
                         params.text_document.uri.as_str().to_string(),
                         Duration::ZERO,
-                    );
+                    ),
+                    Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
             "textDocument/didClose" => {
-                if let Ok(params) =
-                    serde_json::from_value::<DidCloseTextDocumentParams>(notification.params)
-                {
-                    let uri = params.text_document.uri;
-                    self.scheduled.remove(uri.as_str());
-                    self.linted.remove(uri.as_str());
-                    self.documents.close(&uri);
-                    self.publish(uri, Vec::new());
+                match serde_json::from_value::<DidCloseTextDocumentParams>(notification.params) {
+                    Ok(params) => {
+                        let uri = params.text_document.uri;
+                        self.scheduled.remove(uri.as_str());
+                        self.linted.remove(uri.as_str());
+                        let version = self.documents.close(&uri).map_or(0, |d| d.version);
+                        self.publish(uri, version, Vec::new());
+                    }
+                    Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
             "workspace/didChangeConfiguration" => {
-                if self.pull_configuration {
+                // A `rsvelte-lint.json` / `.oxfmtrc` edit reaches the server as
+                // a configuration change too, so the resolved-config caches are
+                // dropped along with the client settings.
+                self.worker.submit(Job::ClearCaches);
+                if self.client.pull_configuration {
                     self.request_configuration();
                 } else {
                     self.settings = Settings::default();
                     self.relint_open_documents();
                 }
             }
+            "exit" => self.exiting = true,
             _ => {}
         }
     }
 
     fn on_response(&mut self, response: Response) {
-        if self.config_request.as_ref() != Some(&response.id) {
+        let Some(outgoing) = self.outgoing.remove(&response.id) else {
+            log::warn(format_args!("response to unknown request {}", response.id));
             return;
+        };
+        match outgoing {
+            Outgoing::Configuration => {
+                self.settings = match response.response_result {
+                    Ok(value) => value
+                        .as_array()
+                        .and_then(|items| items.first())
+                        .map(Settings::from_json)
+                        .unwrap_or_default(),
+                    Err(err) => {
+                        log::warn(format_args!(
+                            "workspace/configuration failed: {}",
+                            err.message
+                        ));
+                        Settings::default()
+                    }
+                };
+                self.relint_open_documents();
+            }
         }
-        self.config_request = None;
-        self.settings = response
-            .response_result
-            .ok()
-            .and_then(|value| value.as_array()?.first().map(Settings::from_json))
-            .unwrap_or_default();
-        self.relint_open_documents();
+    }
+
+    fn on_outcome(&mut self, outcome: Outcome) {
+        match outcome {
+            Outcome::Formatted { id, edits } => {
+                // A request that is no longer pending was cancelled or already
+                // answered; its result is simply dropped.
+                if self.pending.remove(&id).is_some() {
+                    self.respond(Response::new_ok(id, edits));
+                }
+            }
+            Outcome::Diagnostics {
+                key,
+                uri,
+                version,
+                diagnostics,
+            } => {
+                if self.documents.get_by_key(&key).is_some() {
+                    self.publish(uri, version, diagnostics);
+                }
+            }
+        }
     }
 
     fn request_configuration(&mut self) {
         self.next_request_id += 1;
         let id = RequestId::from(format!("rsvelte-configuration-{}", self.next_request_id));
-        self.config_request = Some(id.clone());
+        self.outgoing.insert(id.clone(), Outgoing::Configuration);
         self.send(Request::new(
             id,
             "workspace/configuration".to_string(),
@@ -278,8 +355,6 @@ impl Server {
             },
         ));
     }
-
-    // ── Diagnostics ─────────────────────────────────────────────────────
 
     fn schedule_lint(&mut self, key: String, delay: Duration) {
         self.scheduled.insert(key, Instant::now() + delay);
@@ -318,6 +393,7 @@ impl Server {
             return;
         };
         let uri = document.uri.clone();
+        let version = document.version;
         let hash = document.content_hash();
         // A burst of edits that cancel out leaves the text — and therefore the
         // diagnostics already on screen — unchanged.
@@ -327,35 +403,35 @@ impl Server {
         self.linted.insert(key.to_string(), hash);
 
         if !self.settings.lint_enable || !is_lint_target(document) {
-            self.publish(uri, Vec::new());
+            self.publish(uri, version, Vec::new());
             return;
         }
-
-        let path = uri_to_path(key);
-        let config = self
-            .lint_configs
-            .get(path.parent().unwrap_or(Path::new(".")));
-        let source = self
-            .documents
-            .get_by_key(key)
-            .map(Document::text)
-            .unwrap_or_default();
-        let diagnostics = crate::lint::lint(&path, source, &config)
-            .iter()
-            .map(crate::diagnostics::to_lsp)
-            .collect();
-        self.publish(uri, diagnostics);
+        self.worker.submit(Job::Lint {
+            key: key.to_string(),
+            uri,
+            version,
+            path: uri_to_path(key),
+            text: document.shared_text(),
+        });
     }
 
-    fn publish(&self, uri: Uri, diagnostics: Vec<lsp_types::Diagnostic>) {
+    fn publish(&self, uri: Uri, version: i32, diagnostics: Vec<lsp_types::Diagnostic>) {
         self.send(Notification::new(
             "textDocument/publishDiagnostics".to_string(),
             PublishDiagnosticsParams {
                 uri,
                 diagnostics,
-                version: None,
+                version: Some(version),
             },
         ));
+    }
+
+    fn respond_no_edits(&self, id: RequestId) {
+        self.respond(Response::new_ok(id, Vec::<TextEdit>::new()));
+    }
+
+    fn respond(&self, response: Response) {
+        self.send(response);
     }
 
     fn send(&self, message: impl Into<Message>) {

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -1,0 +1,373 @@
+//! The LSP message loop.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use crossbeam_channel::{RecvTimeoutError, Sender};
+use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response};
+use lsp_types::{
+    ConfigurationItem, ConfigurationParams, DidChangeTextDocumentParams,
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
+    DocumentFormattingParams, InitializeParams, OneOf, PublishDiagnosticsParams,
+    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, TextEdit, Uri,
+};
+
+use crate::document::{Document, DocumentStore};
+use crate::format::FormatSessions;
+use crate::lint::LintConfigCache;
+use crate::settings::Settings;
+use crate::uri::uri_to_path;
+
+pub const SERVER_NAME: &str = "rsvelte-language-server";
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// How long a burst of edits is coalesced before re-linting.
+const LINT_DEBOUNCE: Duration = Duration::from_millis(300);
+
+/// The `rsvelte` configuration section this server pulls from the client.
+const CONFIG_SECTION: &str = "rsvelte";
+
+/// Serve the LSP over stdio until the client shuts the connection down.
+pub fn run_stdio() -> Result<()> {
+    let (connection, io_threads) = Connection::stdio();
+    let (id, params) = connection.initialize_start()?;
+    let params: InitializeParams = serde_json::from_value(params)?;
+    let pull_configuration = params
+        .capabilities
+        .workspace
+        .as_ref()
+        .and_then(|w| w.configuration)
+        .unwrap_or(false);
+
+    connection.initialize_finish(
+        id,
+        serde_json::json!({
+            "capabilities": capabilities(),
+            "serverInfo": { "name": SERVER_NAME, "version": VERSION },
+        }),
+    )?;
+
+    Server::new(connection.sender.clone(), pull_configuration).run(&connection)?;
+    // The writer thread ends only once every sender is gone, so the connection
+    // (and the server's clone of it) must be dropped before joining.
+    drop(connection);
+    io_threads.join()?;
+    Ok(())
+}
+
+fn capabilities() -> ServerCapabilities {
+    ServerCapabilities {
+        text_document_sync: Some(TextDocumentSyncCapability::Options(
+            TextDocumentSyncOptions {
+                open_close: Some(true),
+                change: Some(TextDocumentSyncKind::INCREMENTAL),
+                save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+                ..TextDocumentSyncOptions::default()
+            },
+        )),
+        document_formatting_provider: Some(OneOf::Left(true)),
+        ..ServerCapabilities::default()
+    }
+}
+
+struct Server {
+    sender: Sender<Message>,
+    pull_configuration: bool,
+    settings: Settings,
+    documents: DocumentStore,
+    format_sessions: FormatSessions,
+    lint_configs: LintConfigCache,
+    /// Documents awaiting a lint, and when it comes due.
+    scheduled: HashMap<String, Instant>,
+    /// The content hash each document was last linted at.
+    linted: HashMap<String, u64>,
+    config_request: Option<RequestId>,
+    next_request_id: u32,
+}
+
+impl Server {
+    fn new(sender: Sender<Message>, pull_configuration: bool) -> Self {
+        Self {
+            sender,
+            pull_configuration,
+            settings: Settings::default(),
+            documents: DocumentStore::default(),
+            format_sessions: FormatSessions::default(),
+            lint_configs: LintConfigCache::default(),
+            scheduled: HashMap::new(),
+            linted: HashMap::new(),
+            config_request: None,
+            next_request_id: 0,
+        }
+    }
+
+    fn run(&mut self, connection: &Connection) -> Result<()> {
+        if self.pull_configuration {
+            self.request_configuration();
+        }
+        loop {
+            let message = match self.scheduled.values().min().copied() {
+                Some(deadline) => {
+                    let Some(wait) = deadline.checked_duration_since(Instant::now()) else {
+                        self.run_scheduled_lints();
+                        continue;
+                    };
+                    match connection.receiver.recv_timeout(wait) {
+                        Ok(message) => message,
+                        Err(RecvTimeoutError::Timeout) => {
+                            self.run_scheduled_lints();
+                            continue;
+                        }
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+                None => match connection.receiver.recv() {
+                    Ok(message) => message,
+                    Err(_) => break,
+                },
+            };
+
+            match message {
+                Message::Request(request) => {
+                    if connection.handle_shutdown(&request)? {
+                        return Ok(());
+                    }
+                    self.on_request(request);
+                }
+                Message::Notification(notification) => self.on_notification(notification),
+                Message::Response(response) => self.on_response(response),
+            }
+        }
+        Ok(())
+    }
+
+    // ── Requests ────────────────────────────────────────────────────────
+
+    fn on_request(&mut self, request: Request) {
+        match request.method.as_str() {
+            "textDocument/formatting" => {
+                let edits = match serde_json::from_value::<DocumentFormattingParams>(request.params)
+                {
+                    Ok(params) => self.format(&params.text_document.uri),
+                    Err(_) => Vec::new(),
+                };
+                self.send(Response::new_ok(request.id, edits));
+            }
+            _ => self.send(Response::new_err(
+                request.id,
+                ErrorCode::MethodNotFound as i32,
+                format!("unhandled method {}", request.method),
+            )),
+        }
+    }
+
+    fn format(&mut self, uri: &Uri) -> Vec<TextEdit> {
+        if !self.settings.format_enable {
+            return Vec::new();
+        }
+        let Some(document) = self.documents.get(uri) else {
+            return Vec::new();
+        };
+        let path = uri_to_path(uri.as_str());
+        let source = document.text();
+        let range = document.full_range();
+
+        let Ok(session) = self.format_sessions.get(&path) else {
+            return Vec::new();
+        };
+        // Formatting is never an error: a failure yields no edits.
+        let Ok(formatted) = session.format(source, &path) else {
+            return Vec::new();
+        };
+        if formatted == source {
+            return Vec::new();
+        }
+        vec![TextEdit {
+            range,
+            new_text: formatted,
+        }]
+    }
+
+    // ── Notifications ───────────────────────────────────────────────────
+
+    fn on_notification(&mut self, notification: Notification) {
+        match notification.method.as_str() {
+            "textDocument/didOpen" => {
+                if let Ok(params) =
+                    serde_json::from_value::<DidOpenTextDocumentParams>(notification.params)
+                {
+                    let doc = params.text_document;
+                    let key = doc.uri.as_str().to_string();
+                    self.documents
+                        .open(doc.uri, doc.language_id, doc.version, doc.text);
+                    self.schedule_lint(key, Duration::ZERO);
+                }
+            }
+            "textDocument/didChange" => {
+                if let Ok(params) =
+                    serde_json::from_value::<DidChangeTextDocumentParams>(notification.params)
+                {
+                    let key = params.text_document.uri.as_str().to_string();
+                    if let Some(document) = self.documents.get_mut(&params.text_document.uri) {
+                        document.apply(params.text_document.version, &params.content_changes);
+                        self.schedule_lint(key, LINT_DEBOUNCE);
+                    }
+                }
+            }
+            "textDocument/didSave" => {
+                if let Ok(params) =
+                    serde_json::from_value::<DidSaveTextDocumentParams>(notification.params)
+                {
+                    self.schedule_lint(
+                        params.text_document.uri.as_str().to_string(),
+                        Duration::ZERO,
+                    );
+                }
+            }
+            "textDocument/didClose" => {
+                if let Ok(params) =
+                    serde_json::from_value::<DidCloseTextDocumentParams>(notification.params)
+                {
+                    let uri = params.text_document.uri;
+                    self.scheduled.remove(uri.as_str());
+                    self.linted.remove(uri.as_str());
+                    self.documents.close(&uri);
+                    self.publish(uri, Vec::new());
+                }
+            }
+            "workspace/didChangeConfiguration" => {
+                if self.pull_configuration {
+                    self.request_configuration();
+                } else {
+                    self.settings = Settings::default();
+                    self.relint_open_documents();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn on_response(&mut self, response: Response) {
+        if self.config_request.as_ref() != Some(&response.id) {
+            return;
+        }
+        self.config_request = None;
+        self.settings = response
+            .response_result
+            .ok()
+            .and_then(|value| value.as_array()?.first().map(Settings::from_json))
+            .unwrap_or_default();
+        self.relint_open_documents();
+    }
+
+    fn request_configuration(&mut self) {
+        self.next_request_id += 1;
+        let id = RequestId::from(format!("rsvelte-configuration-{}", self.next_request_id));
+        self.config_request = Some(id.clone());
+        self.send(Request::new(
+            id,
+            "workspace/configuration".to_string(),
+            ConfigurationParams {
+                items: vec![ConfigurationItem {
+                    scope_uri: None,
+                    section: Some(CONFIG_SECTION.to_string()),
+                }],
+            },
+        ));
+    }
+
+    // ── Diagnostics ─────────────────────────────────────────────────────
+
+    fn schedule_lint(&mut self, key: String, delay: Duration) {
+        self.scheduled.insert(key, Instant::now() + delay);
+    }
+
+    /// Re-lint everything after the settings changed — the results may differ
+    /// even though no document did, so the content-hash guard is reset.
+    fn relint_open_documents(&mut self) {
+        self.linted.clear();
+        let keys: Vec<String> = self
+            .documents
+            .iter()
+            .map(|d| d.uri.as_str().to_string())
+            .collect();
+        for key in keys {
+            self.schedule_lint(key, Duration::ZERO);
+        }
+    }
+
+    fn run_scheduled_lints(&mut self) {
+        let now = Instant::now();
+        let due: Vec<String> = self
+            .scheduled
+            .iter()
+            .filter(|&(_, &deadline)| deadline <= now)
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in due {
+            self.scheduled.remove(&key);
+            self.lint(&key);
+        }
+    }
+
+    fn lint(&mut self, key: &str) {
+        let Some(document) = self.documents.get_by_key(key) else {
+            return;
+        };
+        let uri = document.uri.clone();
+        let hash = document.content_hash();
+        // A burst of edits that cancel out leaves the text — and therefore the
+        // diagnostics already on screen — unchanged.
+        if self.linted.get(key) == Some(&hash) {
+            return;
+        }
+        self.linted.insert(key.to_string(), hash);
+
+        if !self.settings.lint_enable || !is_lint_target(document) {
+            self.publish(uri, Vec::new());
+            return;
+        }
+
+        let path = uri_to_path(key);
+        let config = self
+            .lint_configs
+            .get(path.parent().unwrap_or(Path::new(".")));
+        let source = self
+            .documents
+            .get_by_key(key)
+            .map(Document::text)
+            .unwrap_or_default();
+        let diagnostics = crate::lint::lint(&path, source, &config)
+            .iter()
+            .map(crate::diagnostics::to_lsp)
+            .collect();
+        self.publish(uri, diagnostics);
+    }
+
+    fn publish(&self, uri: Uri, diagnostics: Vec<lsp_types::Diagnostic>) {
+        self.send(Notification::new(
+            "textDocument/publishDiagnostics".to_string(),
+            PublishDiagnosticsParams {
+                uri,
+                diagnostics,
+                version: None,
+            },
+        ));
+    }
+
+    fn send(&self, message: impl Into<Message>) {
+        let _ = self.sender.send(message.into());
+    }
+}
+
+/// Svelte components plus the `.svelte.js` / `.svelte.ts` module dialect.
+fn is_lint_target(document: &Document) -> bool {
+    if document.language_id == "svelte" {
+        return true;
+    }
+    let uri = document.uri.as_str();
+    uri.ends_with(".svelte.js") || uri.ends_with(".svelte.ts")
+}

--- a/crates/rsvelte_language_server/src/settings.rs
+++ b/crates/rsvelte_language_server/src/settings.rs
@@ -1,0 +1,64 @@
+//! The `rsvelte.*` client settings this server honours.
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Settings {
+    pub format_enable: bool,
+    pub lint_enable: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            format_enable: true,
+            lint_enable: true,
+        }
+    }
+}
+
+impl Settings {
+    /// Read the `rsvelte` configuration section a client returned. Anything
+    /// missing or of the wrong type keeps its default.
+    pub fn from_json(value: &Value) -> Self {
+        let default = Self::default();
+        Self {
+            format_enable: enabled(value, "format").unwrap_or(default.format_enable),
+            lint_enable: enabled(value, "lint").unwrap_or(default.lint_enable),
+        }
+    }
+}
+
+fn enabled(value: &Value, section: &str) -> Option<bool> {
+    value.get(section)?.get("enable")?.as_bool()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn reads_both_switches() {
+        let s = Settings::from_json(&json!({
+            "format": { "enable": false },
+            "lint": { "enable": true }
+        }));
+        assert_eq!(
+            s,
+            Settings {
+                format_enable: false,
+                lint_enable: true
+            }
+        );
+    }
+
+    #[test]
+    fn absent_and_malformed_sections_keep_the_defaults() {
+        assert_eq!(Settings::from_json(&json!(null)), Settings::default());
+        assert_eq!(
+            Settings::from_json(&json!({ "format": "yes", "lint": { "enable": 1 } })),
+            Settings::default()
+        );
+    }
+}

--- a/crates/rsvelte_language_server/src/text.rs
+++ b/crates/rsvelte_language_server/src/text.rs
@@ -1,0 +1,187 @@
+//! Conversion between LSP positions and UTF-8 byte offsets.
+//!
+//! LSP addresses text as `(0-based line, 0-based UTF-16 code unit)`, while
+//! every rsvelte engine works in UTF-8 byte offsets. Every position crossing
+//! the protocol boundary goes through here, so non-ASCII text (accents,
+//! emoji, anything outside the BMP) lands on the right byte.
+
+use lsp_types::Position;
+
+/// Byte offset of the start of every line in a source string.
+#[derive(Debug, Clone)]
+pub struct LineIndex {
+    line_starts: Vec<u32>,
+}
+
+impl LineIndex {
+    pub fn new(text: &str) -> Self {
+        let bytes = text.as_bytes();
+        let mut line_starts = Vec::with_capacity(bytes.len() / 32 + 1);
+        line_starts.push(0);
+        let mut i = 0;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'\n' => line_starts.push(i as u32 + 1),
+                // A lone `\r` also terminates a line in the LSP text model.
+                b'\r' => {
+                    if bytes.get(i + 1) == Some(&b'\n') {
+                        i += 1;
+                    }
+                    line_starts.push(i as u32 + 1);
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        Self { line_starts }
+    }
+
+    /// The number of lines in the indexed text.
+    pub fn line_count(&self) -> usize {
+        self.line_starts.len()
+    }
+
+    /// The byte offset `position` refers to. Out-of-range lines clamp to the
+    /// end of the text and out-of-range characters to the end of their line's
+    /// content; a character landing inside a surrogate pair rounds down to the
+    /// start of that character.
+    pub fn offset(&self, text: &str, position: Position) -> usize {
+        let line = position.line as usize;
+        let Some(&start) = self.line_starts.get(line) else {
+            return text.len();
+        };
+        let start = start as usize;
+        let end = self
+            .line_starts
+            .get(line + 1)
+            .map_or(text.len(), |&n| n as usize);
+        let content = strip_line_terminator(&text[start..end]);
+
+        let mut utf16 = 0u32;
+        for (i, c) in content.char_indices() {
+            if utf16 + c.len_utf16() as u32 > position.character {
+                return start + i;
+            }
+            utf16 += c.len_utf16() as u32;
+        }
+        start + content.len()
+    }
+
+    /// The position of byte `offset`. An offset past the end of the text, or
+    /// inside a multi-byte character, is clamped down to a character boundary.
+    pub fn position(&self, text: &str, offset: usize) -> Position {
+        let offset = floor_char_boundary(text, offset);
+        let line = match self.line_starts.binary_search(&(offset as u32)) {
+            Ok(i) => i,
+            Err(i) => i - 1,
+        };
+        let start = self.line_starts[line] as usize;
+        let character = text[start..offset]
+            .chars()
+            .map(|c| c.len_utf16() as u32)
+            .sum();
+        Position::new(line as u32, character)
+    }
+}
+
+/// The largest char boundary `<= offset`, clamped to the length of `text`.
+fn floor_char_boundary(text: &str, offset: usize) -> usize {
+    if offset >= text.len() {
+        return text.len();
+    }
+    let mut offset = offset;
+    while offset > 0 && !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn strip_line_terminator(line: &str) -> &str {
+    match line.strip_suffix('\n') {
+        Some(rest) => rest.strip_suffix('\r').unwrap_or(rest),
+        None => line.strip_suffix('\r').unwrap_or(line),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn offset(text: &str, line: u32, character: u32) -> usize {
+        LineIndex::new(text).offset(text, Position::new(line, character))
+    }
+
+    fn position(text: &str, offset: usize) -> Position {
+        LineIndex::new(text).position(text, offset)
+    }
+
+    #[test]
+    fn ascii_round_trip() {
+        let text = "abc\ndef\n";
+        assert_eq!(offset(text, 0, 0), 0);
+        assert_eq!(offset(text, 0, 3), 3);
+        assert_eq!(offset(text, 1, 2), 6);
+        assert_eq!(position(text, 6), Position::new(1, 2));
+        assert_eq!(position(text, 8), Position::new(2, 0));
+    }
+
+    #[test]
+    fn astral_chars_count_as_two_code_units() {
+        // "💡" is 4 UTF-8 bytes and 2 UTF-16 code units.
+        let text = "a💡b";
+        assert_eq!(offset(text, 0, 1), 1);
+        assert_eq!(offset(text, 0, 3), 5);
+        assert_eq!(position(text, 5), Position::new(0, 3));
+        assert_eq!(position(text, 6), Position::new(0, 4));
+    }
+
+    #[test]
+    fn position_inside_a_surrogate_pair_rounds_down() {
+        let text = "a💡b";
+        assert_eq!(offset(text, 0, 2), 1);
+    }
+
+    #[test]
+    fn multi_byte_bmp_chars() {
+        // "é" and "あ" are 2 and 3 UTF-8 bytes but one UTF-16 code unit each.
+        let text = "éあx";
+        assert_eq!(offset(text, 0, 1), 2);
+        assert_eq!(offset(text, 0, 2), 5);
+        assert_eq!(position(text, 5), Position::new(0, 2));
+    }
+
+    #[test]
+    fn columns_are_relative_to_the_line_after_astral_text() {
+        let text = "💡\nx💡y";
+        assert_eq!(offset(text, 1, 0), 5);
+        assert_eq!(offset(text, 1, 3), 10);
+        assert_eq!(position(text, 10), Position::new(1, 3));
+    }
+
+    #[test]
+    fn crlf_and_lone_cr_terminate_lines() {
+        let text = "a\r\nb\rc";
+        let index = LineIndex::new(text);
+        assert_eq!(index.line_count(), 3);
+        assert_eq!(index.offset(text, Position::new(1, 0)), 3);
+        assert_eq!(index.offset(text, Position::new(2, 0)), 5);
+        // A character past the line's content clamps before the terminator.
+        assert_eq!(index.offset(text, Position::new(0, 99)), 1);
+    }
+
+    #[test]
+    fn out_of_range_positions_clamp() {
+        let text = "ab\ncd";
+        assert_eq!(offset(text, 99, 0), text.len());
+        assert_eq!(offset(text, 1, 99), text.len());
+        assert_eq!(position(text, 999), Position::new(1, 2));
+        // Mid-character offsets round down rather than panic.
+        assert_eq!(position("💡", 2), Position::new(0, 0));
+    }
+
+    #[test]
+    fn empty_text() {
+        assert_eq!(offset("", 0, 0), 0);
+        assert_eq!(position("", 0), Position::new(0, 0));
+    }
+}

--- a/crates/rsvelte_language_server/src/uri.rs
+++ b/crates/rsvelte_language_server/src/uri.rs
@@ -1,0 +1,104 @@
+//! Document URI → filesystem path.
+
+use std::path::PathBuf;
+
+/// The filesystem path a document URI denotes. Anything that is not a `file:`
+/// URI (an untitled buffer, a virtual document) has no path, so the URI itself
+/// is used as the "filename" — it still drives the extension-based dispatch in
+/// the formatter and linter.
+pub fn uri_to_path(uri: &str) -> PathBuf {
+    let Some(rest) = uri.strip_prefix("file://") else {
+        return PathBuf::from(uri);
+    };
+    // Skip the authority component (`file://host/path`); the usual
+    // `file:///path` has an empty one.
+    let Some(slash) = rest.find('/') else {
+        return PathBuf::from(uri);
+    };
+    let path = &rest[slash..];
+    let path = path.find(['?', '#']).map_or(path, |cut| &path[..cut]);
+    let decoded = percent_decode(path);
+    // `file:///C:/dir/a.svelte` → `C:\dir\a.svelte`.
+    if cfg!(windows) && has_drive_letter(&decoded) {
+        return PathBuf::from(&decoded[1..]);
+    }
+    PathBuf::from(decoded)
+}
+
+fn has_drive_letter(path: &str) -> bool {
+    let b = path.as_bytes();
+    b.len() >= 3 && b[0] == b'/' && b[1].is_ascii_alphabetic() && (b[2] == b':' || b[2] == b'|')
+}
+
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    if !bytes.contains(&b'%') {
+        return s.to_string();
+    }
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) = (hex(bytes[i + 1]), hex(bytes[i + 2]))
+        {
+            out.push(hi * 16 + lo);
+            i += 3;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_file_uri() {
+        assert_eq!(
+            uri_to_path("file:///home/u/App.svelte"),
+            PathBuf::from("/home/u/App.svelte")
+        );
+    }
+
+    #[test]
+    fn percent_escapes_are_decoded() {
+        assert_eq!(
+            uri_to_path("file:///home/u/my%20app/%E3%81%82.svelte"),
+            PathBuf::from("/home/u/my app/あ.svelte")
+        );
+    }
+
+    #[test]
+    fn query_and_fragment_are_dropped() {
+        assert_eq!(
+            uri_to_path("file:///a/b.svelte?v=1#top"),
+            PathBuf::from("/a/b.svelte")
+        );
+    }
+
+    #[test]
+    fn non_file_uris_are_passed_through() {
+        assert_eq!(
+            uri_to_path("untitled:Untitled-1"),
+            PathBuf::from("untitled:Untitled-1")
+        );
+    }
+
+    #[test]
+    fn a_trailing_percent_is_left_alone() {
+        assert_eq!(uri_to_path("file:///a/b%"), PathBuf::from("/a/b%"));
+    }
+}

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -1,0 +1,190 @@
+//! The analysis worker.
+//!
+//! Linting and formatting run the Svelte compiler, which recurses once per
+//! level of nested markup. Two hazards follow, and both are contained here
+//! rather than on the message loop, which would take the whole session down
+//! with it: deeply nested input needs far more stack than a thread is given by
+//! default, and a rule that panics must cost at most its own document. This is
+//! the same isolation contract `rsvelte-lint`'s CLI applies per file.
+//!
+//! The resolved-config caches live here too, so the loop never touches the
+//! filesystem.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+use crossbeam_channel::{Receiver, Sender, unbounded};
+use lsp_server::RequestId;
+use lsp_types::{Diagnostic, Range, TextEdit, Uri};
+
+use crate::format::FormatSessions;
+use crate::lint::LintConfigCache;
+use crate::log;
+
+/// `rsvelte_core`'s own deeply-nested-AST tests reserve the same 256 MiB. It is
+/// address space, not resident memory — pages are committed only as the
+/// recursion actually reaches them.
+const STACK_SIZE: usize = 256 * 1024 * 1024;
+
+pub enum Job {
+    Lint {
+        key: String,
+        uri: Uri,
+        version: i32,
+        path: PathBuf,
+        text: Arc<String>,
+    },
+    Format {
+        id: RequestId,
+        path: PathBuf,
+        text: Arc<String>,
+        range: Range,
+    },
+    /// Drop the resolved `rsvelte-lint.json` / `.oxfmtrc` caches so the next
+    /// job re-reads them from disk.
+    ClearCaches,
+}
+
+pub enum Outcome {
+    Diagnostics {
+        key: String,
+        uri: Uri,
+        version: i32,
+        diagnostics: Vec<Diagnostic>,
+    },
+    Formatted {
+        id: RequestId,
+        edits: Vec<TextEdit>,
+    },
+}
+
+pub struct Worker {
+    jobs: Option<Sender<Job>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Worker {
+    pub fn spawn(outcomes: Sender<Outcome>) -> Self {
+        let (jobs, receiver) = unbounded();
+        let handle = std::thread::Builder::new()
+            .name("rsvelte-analysis".to_string())
+            .stack_size(STACK_SIZE)
+            .spawn(move || run(&receiver, &outcomes))
+            .expect("spawn the analysis worker");
+        Self {
+            jobs: Some(jobs),
+            handle: Some(handle),
+        }
+    }
+
+    pub fn submit(&self, job: Job) {
+        if let Some(jobs) = &self.jobs {
+            let _ = jobs.send(job);
+        }
+    }
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        // Closing the queue is what ends the loop; only then can the thread be
+        // joined.
+        self.jobs.take();
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
+    let mut lint_configs = LintConfigCache::default();
+    let mut format_sessions = FormatSessions::default();
+
+    for job in jobs {
+        let outcome = match job {
+            Job::ClearCaches => {
+                lint_configs.clear();
+                format_sessions.clear();
+                continue;
+            }
+            Job::Lint {
+                key,
+                uri,
+                version,
+                path,
+                text,
+            } => {
+                let config = lint_configs.get(path.parent().unwrap_or(Path::new(".")));
+                let diagnostics = guard("lint", &path, || {
+                    crate::lint::lint(&path, &text, &config)
+                        .iter()
+                        .map(crate::diagnostics::to_lsp)
+                        .collect()
+                })
+                .unwrap_or_default();
+                Outcome::Diagnostics {
+                    key,
+                    uri,
+                    version,
+                    diagnostics,
+                }
+            }
+            Job::Format {
+                id,
+                path,
+                text,
+                range,
+            } => {
+                let edits = format(&mut format_sessions, &path, &text, range);
+                Outcome::Formatted { id, edits }
+            }
+        };
+        if outcomes.send(outcome).is_err() {
+            break;
+        }
+    }
+}
+
+fn format(sessions: &mut FormatSessions, path: &Path, text: &str, range: Range) -> Vec<TextEdit> {
+    let session = match sessions.get(path) {
+        Ok(session) => session,
+        Err(err) => {
+            log::warn(format_args!(
+                "no formatter config for {}: {err:#}",
+                path.display()
+            ));
+            return Vec::new();
+        }
+    };
+    // Formatting is never an error to the client: a failure yields no edits.
+    let Some(formatted) = guard("format", path, || session.format(text, path)) else {
+        return Vec::new();
+    };
+    match formatted {
+        Ok(formatted) if formatted != text => vec![TextEdit {
+            range,
+            new_text: formatted,
+        }],
+        Ok(_) => Vec::new(),
+        Err(err) => {
+            log::warn(format_args!(
+                "format failed for {}: {err:#}",
+                path.display()
+            ));
+            Vec::new()
+        }
+    }
+}
+
+/// Run one analysis, turning a panic into "no result" instead of the loss of
+/// every other document's diagnostics.
+fn guard<T>(what: &str, path: &Path, run: impl FnOnce() -> T) -> Option<T> {
+    match catch_unwind(AssertUnwindSafe(run)) {
+        Ok(value) => Some(value),
+        Err(_) => {
+            log::warn(format_args!("{what} panicked on {}", path.display()));
+            None
+        }
+    }
+}

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -60,19 +60,27 @@ impl Server {
         }
     }
 
+    /// Write errors are swallowed: a server that died shows up far more
+    /// clearly as a failed read than as a broken pipe here.
     fn write(&mut self, message: &Value) {
         let body = serde_json::to_string(message).unwrap();
         let stdin = self.stdin.as_mut().expect("stdin is still open");
-        write!(stdin, "Content-Length: {}\r\n\r\n{body}", body.len()).unwrap();
-        stdin.flush().unwrap();
+        let _ = write!(stdin, "Content-Length: {}\r\n\r\n{body}", body.len());
+        let _ = stdin.flush();
     }
 
     fn read(&mut self) -> Value {
+        self.try_read().expect("server closed the connection")
+    }
+
+    /// `None` once the server's stdout reaches EOF, i.e. it exited.
+    fn try_read(&mut self) -> Option<Value> {
         let mut length = None;
         loop {
             let mut line = String::new();
-            let read = self.stdout.read_line(&mut line).expect("read header");
-            assert_ne!(read, 0, "server closed the connection");
+            if self.stdout.read_line(&mut line).ok()? == 0 {
+                return None;
+            }
             let line = line.trim_end();
             if line.is_empty() {
                 break;
@@ -82,8 +90,8 @@ impl Server {
             }
         }
         let mut body = vec![0u8; length.expect("Content-Length header")];
-        self.stdout.read_exact(&mut body).expect("read body");
-        serde_json::from_slice(&body).expect("parse body")
+        self.stdout.read_exact(&mut body).ok()?;
+        serde_json::from_slice(&body).ok()
     }
 
     fn request(&mut self, method: &str, params: Value) -> i64 {
@@ -125,15 +133,22 @@ impl Server {
         }
     }
 
+    /// Read publishes for `uri` until one satisfies `want`, so a publish still
+    /// in flight from an earlier change cannot decide an assertion.
+    fn diagnostics_matching(&mut self, uri: &str, want: impl Fn(&[Value]) -> bool) -> Vec<Value> {
+        for _ in 0..8 {
+            let diagnostics = self.diagnostics(uri);
+            if want(&diagnostics) {
+                return diagnostics;
+            }
+        }
+        panic!("diagnostics for {uri} never reached the expected state");
+    }
+
     /// Read until `uri`'s diagnostics are cleared, skipping any publish a
     /// debounced lint got in first.
     fn cleared_diagnostics(&mut self, uri: &str) {
-        for _ in 0..8 {
-            if self.diagnostics(uri).is_empty() {
-                return;
-            }
-        }
-        panic!("diagnostics for {uri} were never cleared");
+        self.diagnostics_matching(uri, <[Value]>::is_empty);
     }
 
     fn answer_server_request(&mut self, message: &Value) {
@@ -152,9 +167,14 @@ impl Server {
         self.write(&json!({ "jsonrpc": "2.0", "id": id, "result": result }));
     }
 
-    fn shutdown(&mut self) {
+    fn shutdown(&mut self) -> Option<i32> {
         let id = self.request("shutdown", Value::Null);
         self.response(id);
+        self.exit()
+    }
+
+    /// Send `exit` and wait for the process, returning its exit code.
+    fn exit(&mut self) -> Option<i32> {
         self.notify("exit", Value::Null);
         // Closing the pipe is what a real client's process exit does, and it is
         // what ends the server's reader thread — without it the server never
@@ -162,13 +182,34 @@ impl Server {
         self.stdin.take();
         // Polled rather than `wait()`ed so the watchdog can still take the lock
         // and kill a server that refuses to exit.
+        let mut code = None;
         for _ in 0..300 {
-            if matches!(self.child.lock().unwrap().try_wait(), Ok(Some(_))) {
+            if let Ok(Some(status)) = self.child.lock().unwrap().try_wait() {
+                code = Some(status.code().unwrap_or(-1));
                 break;
             }
             std::thread::sleep(Duration::from_millis(100));
         }
         self.finished.store(true, Ordering::Relaxed);
+        code
+    }
+
+    /// Whether the server still answers. An unknown method must always draw a
+    /// `MethodNotFound` response, which makes it a cheap liveness probe.
+    fn is_alive(&mut self) -> bool {
+        if matches!(self.child.lock().unwrap().try_wait(), Ok(Some(_))) {
+            return false;
+        }
+        let id = self.request("rsvelte/ping", Value::Null);
+        loop {
+            let Some(message) = self.try_read() else {
+                return false;
+            };
+            if message.get("id").and_then(Value::as_i64) == Some(id) {
+                return true;
+            }
+            self.answer_server_request(&message);
+        }
     }
 }
 
@@ -181,14 +222,52 @@ impl Drop for Server {
     }
 }
 
-fn temp_component() -> PathBuf {
-    let dir = std::env::temp_dir().join(format!("rsvelte-ls-protocol-{}", std::process::id()));
+/// A directory of this test's own, so a config file one case writes cannot
+/// reach another's documents.
+fn temp_dir(case: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("rsvelte-ls-protocol-{}-{case}", std::process::id()));
+    std::fs::remove_dir_all(&dir).ok();
     std::fs::create_dir_all(&dir).unwrap();
-    dir.join("App.svelte")
+    dir
+}
+
+fn temp_component() -> PathBuf {
+    temp_dir("format").join("App.svelte")
 }
 
 fn file_uri(path: &Path) -> String {
     format!("file://{}", path.display())
+}
+
+/// `initialize` + `initialized`, declaring `workspace/configuration` support.
+fn initialized_server() -> Server {
+    let mut server = Server::start();
+    let id = server.request(
+        "initialize",
+        json!({
+            "processId": Value::Null,
+            "rootUri": Value::Null,
+            "capabilities": { "workspace": { "configuration": true } },
+        }),
+    );
+    server.response(id);
+    server.notify("initialized", json!({}));
+    server
+}
+
+fn did_open(server: &mut Server, uri: &str, text: &str) {
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "svelte",
+                "version": 1,
+                "text": text,
+            }
+        }),
+    );
 }
 
 #[test]
@@ -287,5 +366,116 @@ fn serves_diagnostics_and_formatting() {
     );
     server.cleared_diagnostics(&uri);
 
-    server.shutdown();
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+/// Input that recurses deeper than a default stack allows. The analysis is
+/// expected to fail; the session is not.
+#[test]
+fn a_pathological_document_does_not_take_the_session_down() {
+    let dir = temp_dir("pathological");
+    let mut server = initialized_server();
+
+    for (name, text) in [
+        (
+            "nested-elements",
+            format!("{}{}", "<div>".repeat(500), "</div>".repeat(500)),
+        ),
+        (
+            "nested-expression",
+            format!("<p>{{{}1{}}}</p>", "(".repeat(1000), ")".repeat(1000)),
+        ),
+        (
+            "nested-script",
+            format!("<script>{}1{}</script>", "(".repeat(2000), ")".repeat(2000)),
+        ),
+    ] {
+        let uri = file_uri(&dir.join(format!("{name}.svelte")));
+        did_open(&mut server, &uri, &text);
+        assert!(server.is_alive(), "server died on {name}");
+    }
+
+    // And it still serves an ordinary document afterwards.
+    let uri = file_uri(&dir.join("Ok.svelte"));
+    did_open(&mut server, &uri, "<div>{@html value}</div>\n");
+    assert!(
+        !server.diagnostics(&uri).is_empty(),
+        "diagnostics stopped working"
+    );
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+/// `initialize` payloads whose individual fields this build cannot parse must
+/// still be answered — a client left waiting sees an unexplained hang.
+#[test]
+fn a_malformed_initialize_is_still_answered() {
+    for params in [
+        json!({ "rootUri": "not a uri", "capabilities": {} }),
+        json!({ "capabilities": Value::Null }),
+        json!({ "trace": "bogus", "capabilities": {} }),
+        json!({}),
+    ] {
+        let mut server = Server::start();
+        let id = server.request("initialize", params.clone());
+        let result = server.response(id);
+        assert_eq!(
+            result["serverInfo"]["name"], "rsvelte-language-server",
+            "no initialize result for {params}"
+        );
+        server.notify("initialized", json!({}));
+        assert_eq!(server.shutdown(), Some(0));
+    }
+}
+
+/// `exit` before `shutdown` is an abnormal end and must be reported as one.
+#[test]
+fn exit_without_shutdown_fails() {
+    let mut server = initialized_server();
+    assert_eq!(server.exit(), Some(1));
+}
+
+/// A notification arriving between `shutdown` and `exit` is allowed, and must
+/// not turn a clean shutdown into a failure.
+#[test]
+fn a_notification_between_shutdown_and_exit_is_harmless() {
+    let mut server = initialized_server();
+    let id = server.request("shutdown", Value::Null);
+    server.response(id);
+    server.notify("$/cancelRequest", json!({ "id": 1 }));
+    assert_eq!(server.exit(), Some(0));
+}
+
+/// Editing `rsvelte-lint.json` reaches the server as a configuration change,
+/// and the resolved config must be re-read rather than served from the cache.
+#[test]
+fn a_config_change_invalidates_the_resolved_lint_config() {
+    let dir = temp_dir("lint-config");
+    let uri = file_uri(&dir.join("App.svelte"));
+    let mut server = initialized_server();
+
+    fn reports_at_html(diagnostics: &[Value]) -> bool {
+        diagnostics
+            .iter()
+            .any(|d| d["code"] == "svelte/no-at-html-tags")
+    }
+
+    did_open(&mut server, &uri, "<div>{@html value}</div>\n");
+    server.diagnostics_matching(&uri, reports_at_html);
+
+    std::fs::write(
+        dir.join("rsvelte-lint.json"),
+        r#"{ "rules": { "svelte/no-at-html-tags": "off" } }"#,
+    )
+    .unwrap();
+    server.notify(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": Value::Null }),
+    );
+
+    // The re-lint re-reads the config from disk rather than serving the one it
+    // resolved on open, so the rule is gone.
+    server.diagnostics_matching(&uri, |d| !reports_at_html(d));
+
+    assert_eq!(server.shutdown(), Some(0));
 }

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -1,0 +1,291 @@
+//! Drives the real `rsvelte-language-server` binary over stdio and asserts
+//! that what it publishes matches calling the formatter / linter directly.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+/// A component with an unformatted tag and a lint finding.
+const SOURCE: &str = "<div   class='a'>{@html value}</div>\n";
+
+struct Server {
+    child: Arc<Mutex<Child>>,
+    /// Taken (and thereby closed) on shutdown, so the server sees EOF.
+    stdin: Option<ChildStdin>,
+    stdout: BufReader<ChildStdout>,
+    finished: Arc<AtomicBool>,
+    next_id: i64,
+}
+
+impl Server {
+    fn start() -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rsvelte-language-server"))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn language server");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+
+        // A protocol bug would otherwise hang the test run forever.
+        let child = Arc::new(Mutex::new(child));
+        let finished = Arc::new(AtomicBool::new(false));
+        {
+            let child = Arc::clone(&child);
+            let finished = Arc::clone(&finished);
+            std::thread::spawn(move || {
+                for _ in 0..600 {
+                    if finished.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                let _ = child.lock().unwrap().kill();
+            });
+        }
+
+        Self {
+            child,
+            stdin: Some(stdin),
+            stdout,
+            finished,
+            next_id: 0,
+        }
+    }
+
+    fn write(&mut self, message: &Value) {
+        let body = serde_json::to_string(message).unwrap();
+        let stdin = self.stdin.as_mut().expect("stdin is still open");
+        write!(stdin, "Content-Length: {}\r\n\r\n{body}", body.len()).unwrap();
+        stdin.flush().unwrap();
+    }
+
+    fn read(&mut self) -> Value {
+        let mut length = None;
+        loop {
+            let mut line = String::new();
+            let read = self.stdout.read_line(&mut line).expect("read header");
+            assert_ne!(read, 0, "server closed the connection");
+            let line = line.trim_end();
+            if line.is_empty() {
+                break;
+            }
+            if let Some(value) = line.strip_prefix("Content-Length: ") {
+                length = Some(value.parse::<usize>().unwrap());
+            }
+        }
+        let mut body = vec![0u8; length.expect("Content-Length header")];
+        self.stdout.read_exact(&mut body).expect("read body");
+        serde_json::from_slice(&body).expect("parse body")
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> i64 {
+        self.next_id += 1;
+        let id = self.next_id;
+        self.write(&json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }));
+        id
+    }
+
+    fn notify(&mut self, method: &str, params: Value) {
+        self.write(&json!({ "jsonrpc": "2.0", "method": method, "params": params }));
+    }
+
+    /// Read until the response to `id` arrives, answering any
+    /// `workspace/configuration` the server asks for on the way.
+    fn response(&mut self, id: i64) -> Value {
+        loop {
+            let message = self.read();
+            if message.get("id").and_then(Value::as_i64) == Some(id) {
+                return message["result"].clone();
+            }
+            self.answer_server_request(&message);
+        }
+    }
+
+    /// Read until diagnostics for `uri` arrive.
+    fn diagnostics(&mut self, uri: &str) -> Vec<Value> {
+        loop {
+            let message = self.read();
+            if message["method"] == "textDocument/publishDiagnostics"
+                && message["params"]["uri"] == uri
+            {
+                return message["params"]["diagnostics"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default();
+            }
+            self.answer_server_request(&message);
+        }
+    }
+
+    /// Read until `uri`'s diagnostics are cleared, skipping any publish a
+    /// debounced lint got in first.
+    fn cleared_diagnostics(&mut self, uri: &str) {
+        for _ in 0..8 {
+            if self.diagnostics(uri).is_empty() {
+                return;
+            }
+        }
+        panic!("diagnostics for {uri} were never cleared");
+    }
+
+    fn answer_server_request(&mut self, message: &Value) {
+        let (Some(method), Some(id)) = (message["method"].as_str(), message.get("id")) else {
+            return;
+        };
+        let result = if method == "workspace/configuration" {
+            let items = message["params"]["items"].as_array().map_or(0, Vec::len);
+            Value::Array(vec![
+                json!({ "format": { "enable": true }, "lint": { "enable": true } });
+                items
+            ])
+        } else {
+            Value::Null
+        };
+        self.write(&json!({ "jsonrpc": "2.0", "id": id, "result": result }));
+    }
+
+    fn shutdown(&mut self) {
+        let id = self.request("shutdown", Value::Null);
+        self.response(id);
+        self.notify("exit", Value::Null);
+        // Closing the pipe is what a real client's process exit does, and it is
+        // what ends the server's reader thread — without it the server never
+        // finishes shutting down.
+        self.stdin.take();
+        // Polled rather than `wait()`ed so the watchdog can still take the lock
+        // and kill a server that refuses to exit.
+        for _ in 0..300 {
+            if matches!(self.child.lock().unwrap().try_wait(), Ok(Some(_))) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        self.finished.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for Server {
+    /// A surviving child keeps cargo's inherited stderr pipe open, which wedges
+    /// the whole test run — so it is killed even when the test panicked.
+    fn drop(&mut self) {
+        self.stdin.take();
+        let _ = self.child.lock().unwrap().kill();
+    }
+}
+
+fn temp_component() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("rsvelte-ls-protocol-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("App.svelte")
+}
+
+fn file_uri(path: &Path) -> String {
+    format!("file://{}", path.display())
+}
+
+#[test]
+fn serves_diagnostics_and_formatting() {
+    let path = temp_component();
+    let uri = file_uri(&path);
+
+    let mut server = Server::start();
+    let id = server.request(
+        "initialize",
+        json!({
+            "processId": Value::Null,
+            "rootUri": Value::Null,
+            "capabilities": { "workspace": { "configuration": true } },
+        }),
+    );
+    let result = server.response(id);
+
+    assert_eq!(result["serverInfo"]["name"], "rsvelte-language-server");
+    assert_eq!(result["serverInfo"]["version"], env!("CARGO_PKG_VERSION"));
+    let sync = &result["capabilities"]["textDocumentSync"];
+    assert_eq!(sync["openClose"], json!(true));
+    // 2 == TextDocumentSyncKind.Incremental
+    assert_eq!(sync["change"], json!(2));
+    assert_eq!(sync["save"], json!(true));
+    assert_eq!(
+        result["capabilities"]["documentFormattingProvider"],
+        json!(true)
+    );
+
+    server.notify("initialized", json!({}));
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "svelte",
+                "version": 1,
+                "text": SOURCE,
+            }
+        }),
+    );
+
+    // Diagnostics must match a direct lint of the same source.
+    let mut config_cache = rsvelte_language_server::lint::LintConfigCache::default();
+    let config = config_cache.get(path.parent().unwrap());
+    let expected: Vec<Value> = rsvelte_language_server::lint::lint(&path, SOURCE, &config)
+        .iter()
+        .map(|d| serde_json::to_value(rsvelte_language_server::diagnostics::to_lsp(d)).unwrap())
+        .collect();
+    assert!(!expected.is_empty(), "the fixture should produce findings");
+    assert_eq!(server.diagnostics(&uri), expected);
+
+    // Formatting must match a direct in-process format of the same source.
+    let session = rsvelte_fmt::FormatSession::resolve(&path).unwrap();
+    let formatted = session.format(SOURCE, &path).unwrap();
+    assert_ne!(formatted, SOURCE, "the fixture should need reformatting");
+
+    let id = server.request(
+        "textDocument/formatting",
+        json!({
+            "textDocument": { "uri": uri },
+            "options": { "tabSize": 2, "insertSpaces": true },
+        }),
+    );
+    let edits = server.response(id);
+    let edits = edits.as_array().expect("formatting edits");
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0]["newText"], json!(formatted));
+    assert_eq!(
+        edits[0]["range"]["start"],
+        json!({ "line": 0, "character": 0 })
+    );
+
+    // An already-formatted document yields no edits.
+    server.notify(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": uri, "version": 2 },
+            "contentChanges": [{ "text": formatted }],
+        }),
+    );
+    let id = server.request(
+        "textDocument/formatting",
+        json!({
+            "textDocument": { "uri": uri },
+            "options": { "tabSize": 2, "insertSpaces": true },
+        }),
+    );
+    assert_eq!(server.response(id), json!([]));
+
+    // Closing clears the document's diagnostics.
+    server.notify(
+        "textDocument/didClose",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    server.cleared_diagnostics(&uri);
+
+    server.shutdown();
+}


### PR DESCRIPTION
First slice of #1761 (Wave 4 M0). Adds `crates/rsvelte_language_server` — a Rust LSP binary
(`rsvelte-language-server`) that is functionally equivalent to today's 417-line Node server, but runs
the formatter and the linter **in process**.

## Why Rust, and why now

The Node server can't grow into the rest of Wave 4, because the data the LSP needs never crosses the
JS boundary: `Svelte2TsxResult.forward_map` is dropped by the wasm export, `svelte2tsx` returns
`"map": null` over NAPI, and lint `Fix`/`Suggestion` never reach `json_api.rs`. It also spawns
`rsvelte-fmt` per format request and blocks the event loop on a synchronous wasm lint call.

## What's here

- `lsp-server` + `lsp-types`, synchronous and thread-based. No tokio: the repo is sync + rayon, and
  the tsgo child process in M3 needs a reader thread and a channel, not an async runtime.
- Document store with incremental `didChange` and **UTF-16 aware** position mapping.
- `textDocument/formatting` and debounced push diagnostics, with lint config resolved from the
  filesystem rather than pinned to `LintConfig::recommended()`.
- `rsvelte_fmt` becomes lib + bin and exposes `FormatSession`, so the server runs the CLI's own
  `--stdin --stdin-filepath` pipeline (config discovery, option layering, extension dispatch) instead
  of re-implementing it. The CLI stays the single source of truth.
- Integration test that spawns the built binary and speaks real LSP over stdio.

`apps/npm/language-server` is untouched — it is still the published server.

## Deliberately not here

Cancellation, worker pool, pull diagnostics, `didChangeWatchedFiles`, lint fix → `CodeAction`, and the
npm launcher are the remaining M0 slices.

## Verification

- `cargo clippy -p rsvelte_language_server -p rsvelte_fmt --all-targets --all-features -- -D warnings` — clean
- `cargo test -p rsvelte_language_server` — 26 unit + 1 protocol integration test
- `cargo test -p rsvelte_fmt` — 64 + 64 + 1, unchanged, covering the CLI paths this PR refactored

Refs #1761, #1768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tsoBsfzrKu4kfbfrdFYJS
