### PR TITLE
feat(language-server): Svelte template tag and event modifier completions

### DIFF
--- a/crates/rsvelte_language_server/src/completions.rs
+++ b/crates/rsvelte_language_server/src/completions.rs
@@ -92,7 +92,7 @@ fn is_word_byte(byte: u8) -> bool {
 
 /// The trigger character nearest the cursor.
 fn trigger_character(window: &str) -> Option<u8> {
-    [b'#', b'/', b':', b'@']
+    (*b"#/:@")
         .into_iter()
         .filter_map(|char| window.rfind(char as char).map(|idx| (idx, char)))
         .max_by_key(|&(idx, _)| idx)

--- a/crates/rsvelte_language_server/src/completions.rs
+++ b/crates/rsvelte_language_server/src/completions.rs
@@ -1,0 +1,518 @@
+//! `textDocument/completion` for Svelte template tags and event modifiers.
+//!
+//! A port of the official language server's
+//! `plugins/svelte/features/getCompletions.ts`.
+
+use lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionList, Documentation, InsertTextFormat,
+    MarkupContent, MarkupKind,
+};
+
+use crate::context::{EmbeddedRegions, attribute_context};
+use crate::modifiers::MODIFIERS;
+use crate::tags::{SvelteTag, latest_opening_tag};
+
+/// The characters that put the client in a position to want these items.
+pub const TRIGGER_CHARACTERS: [&str; 5] = ["#", "@", ":", "/", "|"];
+
+const HTML_COMMENT_START: &str = "<!--";
+
+/// The window the official plugin looks back over — enough for every realistic
+/// case, and short enough that a stray `{` far away cannot open a moustache.
+const WINDOW: usize = 10;
+
+pub fn completions(text: &str, offset: usize) -> Option<CompletionList> {
+    if EmbeddedRegions::new(text).contains(offset) {
+        return None;
+    }
+    let before = preceding(text, offset);
+
+    if preceded_by_opening_brace(before) {
+        return trigger_character(before).and_then(|trigger| match trigger {
+            b'@' => Some(tag_completions(AT_ITEMS)),
+            b'#' => Some(tag_completions(HASH_ITEMS)),
+            b':' => match latest_opening_tag(text, offset)? {
+                SvelteTag::If => Some(tag_completions(IF_CONTINUATIONS)),
+                SvelteTag::Each => Some(tag_completions(EACH_CONTINUATIONS)),
+                SvelteTag::Await => Some(tag_completions(AWAIT_CONTINUATIONS)),
+                _ => None,
+            },
+            b'/' => match latest_opening_tag(text, offset)? {
+                SvelteTag::If => Some(tag_completions(IF_CLOSE)),
+                SvelteTag::Each => Some(tag_completions(EACH_CLOSE)),
+                SvelteTag::Await => Some(tag_completions(AWAIT_CLOSE)),
+                SvelteTag::Key => Some(tag_completions(KEY_CLOSE)),
+                _ => None,
+            },
+            _ => None,
+        });
+    }
+
+    if let Some(attribute) = attribute_context(text, offset) {
+        if !attribute.can_have_event_modifier() {
+            return None;
+        }
+        return Some(modifier_completions(attribute.name));
+    }
+
+    component_documentation(before)
+}
+
+/// The up-to-`WINDOW` characters in front of `offset`.
+fn preceding(text: &str, offset: usize) -> &str {
+    let before = text.get(..offset).unwrap_or(text);
+    let start = before
+        .char_indices()
+        .nth_back(WINDOW - 1)
+        .map_or(0, |(idx, _)| idx);
+    &before[start..]
+}
+
+/// Whether the window ends in `{`, optional whitespace, a trigger character and
+/// the word typed so far.
+fn preceded_by_opening_brace(window: &str) -> bool {
+    let bytes = window.as_bytes();
+    let mut i = bytes.len();
+    while i > 0 && is_word_byte(bytes[i - 1]) {
+        i -= 1;
+    }
+    if i == 0 || !matches!(bytes[i - 1], b'#' | b':' | b'/' | b'@') {
+        return false;
+    }
+    i -= 1;
+    while i > 0 && bytes[i - 1].is_ascii_whitespace() {
+        i -= 1;
+    }
+    i > 0 && bytes[i - 1] == b'{'
+}
+
+fn is_word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+/// The trigger character nearest the cursor.
+fn trigger_character(window: &str) -> Option<u8> {
+    [b'#', b'/', b':', b'@']
+        .into_iter()
+        .filter_map(|char| window.rfind(char as char).map(|idx| (idx, char)))
+        .max_by_key(|&(idx, _)| idx)
+        .map(|(_, char)| char)
+}
+
+/// One completion item, before it is turned into its LSP form.
+struct TagItem {
+    label: &'static str,
+    tag: SvelteTag,
+    /// The snippet that closes the block again, where there is one.
+    insert_text: Option<&'static str>,
+}
+
+const AT_ITEMS: &[TagItem] = &[
+    TagItem {
+        label: "html",
+        tag: SvelteTag::Html,
+        insert_text: None,
+    },
+    TagItem {
+        label: "debug",
+        tag: SvelteTag::Debug,
+        insert_text: None,
+    },
+    TagItem {
+        label: "const",
+        tag: SvelteTag::Const,
+        insert_text: None,
+    },
+    TagItem {
+        label: "render",
+        tag: SvelteTag::Render,
+        insert_text: None,
+    },
+    TagItem {
+        label: "attach",
+        tag: SvelteTag::Attach,
+        insert_text: None,
+    },
+];
+
+const HASH_ITEMS: &[TagItem] = &[
+    TagItem {
+        label: "if",
+        tag: SvelteTag::If,
+        insert_text: Some("if $1}\n\t$2\n{/if"),
+    },
+    TagItem {
+        label: "each",
+        tag: SvelteTag::Each,
+        insert_text: Some("each $1 as $2}\n\t$3\n{/each"),
+    },
+    TagItem {
+        label: "await :then",
+        tag: SvelteTag::Await,
+        insert_text: Some("await $1}\n\t$2\n{:then $3} \n\t$4\n{/await"),
+    },
+    TagItem {
+        label: "await then",
+        tag: SvelteTag::Await,
+        insert_text: Some("await $1 then $2}\n\t$3\n{/await"),
+    },
+    TagItem {
+        label: "key",
+        tag: SvelteTag::Key,
+        insert_text: Some("key $1}\n\t$2\n{/key"),
+    },
+    TagItem {
+        label: "snippet",
+        tag: SvelteTag::Snippet,
+        insert_text: Some("snippet $1($2)}\n\t$3\n{/snippet"),
+    },
+];
+
+const AWAIT_CONTINUATIONS: &[TagItem] = &[
+    TagItem {
+        label: "then",
+        tag: SvelteTag::Await,
+        insert_text: None,
+    },
+    TagItem {
+        label: "catch",
+        tag: SvelteTag::Await,
+        insert_text: None,
+    },
+];
+
+const EACH_CONTINUATIONS: &[TagItem] = &[TagItem {
+    label: "else",
+    tag: SvelteTag::Each,
+    insert_text: None,
+}];
+
+const IF_CONTINUATIONS: &[TagItem] = &[
+    TagItem {
+        label: "else",
+        tag: SvelteTag::If,
+        insert_text: None,
+    },
+    TagItem {
+        label: "else if",
+        tag: SvelteTag::If,
+        insert_text: None,
+    },
+];
+
+const AWAIT_CLOSE: &[TagItem] = &[TagItem {
+    label: "await",
+    tag: SvelteTag::Await,
+    insert_text: None,
+}];
+
+const EACH_CLOSE: &[TagItem] = &[TagItem {
+    label: "each",
+    tag: SvelteTag::Each,
+    insert_text: None,
+}];
+
+const IF_CLOSE: &[TagItem] = &[TagItem {
+    label: "if",
+    tag: SvelteTag::If,
+    insert_text: None,
+}];
+
+const KEY_CLOSE: &[TagItem] = &[TagItem {
+    label: "key",
+    tag: SvelteTag::Key,
+    insert_text: None,
+}];
+
+/// `sortText` and `preselect` rank these above whatever else the client has to
+/// offer inside a moustache.
+fn tag_completions(items: &[TagItem]) -> CompletionList {
+    CompletionList {
+        is_incomplete: false,
+        items: items
+            .iter()
+            .map(|item| CompletionItem {
+                label: item.label.to_string(),
+                kind: Some(CompletionItemKind::KEYWORD),
+                insert_text: item.insert_text.map(str::to_string),
+                insert_text_format: Some(InsertTextFormat::SNIPPET),
+                sort_text: Some("-1".to_string()),
+                preselect: Some(true),
+                documentation: Some(markdown(item.tag.documentation().to_string())),
+                ..CompletionItem::default()
+            })
+            .collect(),
+    }
+}
+
+/// Every modifier that can still be added to `attribute`.
+fn modifier_completions(attribute: &str) -> CompletionList {
+    CompletionList {
+        is_incomplete: false,
+        items: MODIFIERS
+            .iter()
+            .filter(|modifier| {
+                !attribute.contains(&format!("|{}", modifier.name))
+                    && !modifier
+                        .invalid_with
+                        .iter()
+                        .any(|invalid| attribute.contains(invalid))
+            })
+            .map(|modifier| CompletionItem {
+                label: modifier.name.to_string(),
+                kind: Some(CompletionItemKind::EVENT),
+                documentation: Some(markdown(modifier.documentation())),
+                ..CompletionItem::default()
+            })
+            .collect(),
+    }
+}
+
+/// The `<!-- @component -->` doc comment, offered inside an HTML comment.
+fn component_documentation(window: &str) -> Option<CompletionList> {
+    let start = window.rfind(HTML_COMMENT_START)? + HTML_COMMENT_START.len();
+    let typed = window[start..].trim_start();
+    if !"@component".contains(typed) {
+        return None;
+    }
+    Some(CompletionList {
+        is_incomplete: false,
+        items: vec![CompletionItem {
+            label: "@component".to_string(),
+            kind: Some(CompletionItemKind::SNIPPET),
+            insert_text: Some("component\n$1\n".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            filter_text: Some("component".to_string()),
+            sort_text: Some("-1".to_string()),
+            preselect: Some(true),
+            documentation: Some(Documentation::String(
+                "Documentation for this component. It will show up on hover. \
+                 You can use markdown and code blocks here"
+                    .to_string(),
+            )),
+            ..CompletionItem::default()
+        }],
+    })
+}
+
+fn markdown(value: String) -> Documentation {
+    Documentation::MarkupContent(MarkupContent {
+        kind: MarkupKind::Markdown,
+        value,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The official test helper: complete at the end of `content`.
+    fn labels(content: &str) -> Option<Vec<String>> {
+        labels_at(content, content.len())
+    }
+
+    fn labels_at(content: &str, offset: usize) -> Option<Vec<String>> {
+        completions(content, offset)
+            .map(|list| list.items.into_iter().map(|item| item.label).collect())
+    }
+
+    fn all_modifiers() -> Vec<String> {
+        MODIFIERS.iter().map(|m| m.name.to_string()).collect()
+    }
+
+    #[test]
+    fn nothing_inside_style_or_script() {
+        assert_eq!(
+            labels_at("<style>h1{color:blue;}</style><p>test</p>", 10),
+            None
+        );
+        assert_eq!(
+            labels_at("<script>const a = true</script><p>test</p>", 10),
+            None
+        );
+    }
+
+    #[test]
+    fn nothing_without_a_moustache_in_front() {
+        assert_eq!(labels("{nope"), None);
+        assert_eq!(labels("not really"), None);
+        assert_eq!(labels("{#awa."), None);
+    }
+
+    #[test]
+    fn hash_offers_every_block() {
+        assert_eq!(
+            labels("{#").unwrap(),
+            ["if", "each", "await :then", "await then", "key", "snippet"]
+        );
+    }
+
+    #[test]
+    fn at_offers_every_tag() {
+        assert_eq!(
+            labels("{@").unwrap(),
+            ["html", "debug", "const", "render", "attach"]
+        );
+    }
+
+    #[test]
+    fn a_block_snippet_closes_itself() {
+        let items = completions("{#", 2).unwrap().items;
+        let each = items.iter().find(|i| i.label == "each").unwrap();
+        assert_eq!(
+            each.insert_text.as_deref(),
+            Some("each $1 as $2}\n\t$3\n{/each")
+        );
+        assert_eq!(each.insert_text_format, Some(InsertTextFormat::SNIPPET));
+        assert_eq!(each.kind, Some(CompletionItemKind::KEYWORD));
+        assert_eq!(each.sort_text.as_deref(), Some("-1"));
+        assert_eq!(each.preselect, Some(true));
+        assert_eq!(
+            items
+                .iter()
+                .find(|i| i.label == "await :then")
+                .unwrap()
+                .insert_text
+                .as_deref(),
+            Some("await $1}\n\t$2\n{:then $3} \n\t$4\n{/await")
+        );
+        assert_eq!(
+            items
+                .iter()
+                .find(|i| i.label == "snippet")
+                .unwrap()
+                .insert_text
+                .as_deref(),
+            Some("snippet $1($2)}\n\t$3\n{/snippet")
+        );
+    }
+
+    #[test]
+    fn a_tag_completion_carries_its_documentation() {
+        let items = completions("{@", 2).unwrap().items;
+        let html = items.iter().find(|i| i.label == "html").unwrap();
+        let Some(Documentation::MarkupContent(content)) = &html.documentation else {
+            panic!("expected markdown documentation");
+        };
+        assert_eq!(content.kind, MarkupKind::Markdown);
+        assert_eq!(content.value, SvelteTag::Html.documentation());
+        assert!(content.value.starts_with("`{@html ...}`\\\n"));
+    }
+
+    #[test]
+    fn a_continuation_needs_an_open_block() {
+        assert_eq!(labels("{:"), None);
+        assert_eq!(labels("{#if}{/if}{:"), None);
+        assert_eq!(labels("{/"), None);
+        assert_eq!(labels("{#if}{/if}{/"), None);
+        assert_eq!(labels("{#if}{ /if}{/"), None);
+    }
+
+    #[test]
+    fn continuations_follow_the_open_block() {
+        assert_eq!(labels("{#if}{:").unwrap(), ["else", "else if"]);
+        assert_eq!(labels("{#each}{:").unwrap(), ["else"]);
+        assert_eq!(labels("{#await}{:").unwrap(), ["then", "catch"]);
+        assert_eq!(
+            labels("{#if}{/if}{#if}{#await}{:").unwrap(),
+            ["then", "catch"]
+        );
+    }
+
+    #[test]
+    fn closings_follow_the_open_block() {
+        assert_eq!(labels("{#if}{/").unwrap(), ["if"]);
+        assert_eq!(labels("{#each}{/").unwrap(), ["each"]);
+        assert_eq!(labels("{#await}{/").unwrap(), ["await"]);
+        assert_eq!(labels("{#key}{/").unwrap(), ["key"]);
+        assert_eq!(labels("{#if}{/if}{#if}{#await}{/").unwrap(), ["await"]);
+    }
+
+    #[test]
+    fn the_component_doc_comment_is_offered() {
+        let items = completions("<!--@", 5).unwrap().items;
+        assert_eq!(items[0].label, "@component");
+        assert_eq!(items[0].insert_text.as_deref(), Some("component\n$1\n"));
+        assert_eq!(items[0].filter_text.as_deref(), Some("component"));
+        assert_eq!(items[0].kind, Some(CompletionItemKind::SNIPPET));
+        assert_eq!(items[0].insert_text_format, Some(InsertTextFormat::SNIPPET));
+        // Also on the bare comment, and once the word is being typed.
+        assert_eq!(labels("<!--").unwrap(), ["@component"]);
+        assert_eq!(labels("<!-- @comp").unwrap(), ["@component"]);
+        assert_eq!(labels("<!--nope"), None);
+    }
+
+    fn modifier_labels(content: &str) -> Vec<String> {
+        let offset = content.rfind('|').unwrap() + 1;
+        labels_at(content, offset).unwrap()
+    }
+
+    #[test]
+    fn every_modifier_is_offered_on_a_bare_pipe() {
+        assert_eq!(modifier_labels("<div on:click| />"), all_modifiers());
+    }
+
+    #[test]
+    fn a_modifier_already_present_is_not_offered_again() {
+        let expected: Vec<String> = all_modifiers()
+            .into_iter()
+            .filter(|m| m != "stopPropagation")
+            .collect();
+        assert_eq!(
+            modifier_labels("<div on:click|stopPropagation| />"),
+            expected
+        );
+    }
+
+    #[test]
+    fn modifiers_that_conflict_with_one_in_use_are_dropped() {
+        let expected: Vec<String> = MODIFIERS
+            .iter()
+            .filter(|m| m.name != "preventDefault" && !m.invalid_with.contains(&"preventDefault"))
+            .map(|m| m.name.to_string())
+            .collect();
+        assert_eq!(
+            expected,
+            [
+                "stopPropagation",
+                "nonpassive",
+                "capture",
+                "once",
+                "self",
+                "trusted"
+            ]
+        );
+        assert_eq!(
+            modifier_labels("<div on:click|preventDefault| />"),
+            expected
+        );
+    }
+
+    #[test]
+    fn a_modifier_completion_carries_its_documentation() {
+        let items = completions("<div on:click| />", 14).unwrap().items;
+        let once = items.iter().find(|i| i.label == "once").unwrap();
+        assert_eq!(once.kind, Some(CompletionItemKind::EVENT));
+        let Some(Documentation::MarkupContent(content)) = &once.documentation else {
+            panic!("expected markdown documentation");
+        };
+        assert!(content.value.starts_with("`once` event modifier"));
+    }
+
+    #[test]
+    fn a_component_gets_no_modifiers() {
+        assert_eq!(labels_at("<Widget on:click| />", 17), None);
+    }
+
+    #[test]
+    fn a_moustache_inside_a_script_body_is_left_alone() {
+        let text = "<script>\n  const a = `{#`;\n</script>";
+        assert_eq!(labels_at(text, text.find("{#").unwrap() + 2), None);
+    }
+
+    #[test]
+    fn completion_works_after_astral_text() {
+        let text = "<p>💡</p>{#";
+        assert_eq!(labels_at(text, text.len()).unwrap()[0], "if");
+    }
+}

--- a/crates/rsvelte_language_server/src/context.rs
+++ b/crates/rsvelte_language_server/src/context.rs
@@ -1,0 +1,414 @@
+//! Where a position sits in a Svelte document.
+//!
+//! A document is asked for completions while it is being typed, when it very
+//! often does not parse at all, so every answer here has to be reachable from
+//! the raw text. The parser is consulted where it can be trusted — it locates
+//! `<script>` and `<style>` without being fooled by the same words appearing in
+//! a string or a moustache — and a scan takes over the moment it declines.
+
+use std::ops::Range;
+
+use rsvelte_core::{Allocator, ParseOptions, parse};
+
+/// The `<script>` and `<style>` bodies of a document, which Svelte template
+/// completions and hovers must stay out of.
+pub struct EmbeddedRegions {
+    bodies: Vec<Range<usize>>,
+}
+
+impl EmbeddedRegions {
+    pub fn new(text: &str) -> Self {
+        let bodies = parsed(text).unwrap_or_else(|| scanned(text));
+        Self { bodies }
+    }
+
+    pub fn contains(&self, offset: usize) -> bool {
+        self.bodies.iter().any(|body| body.contains(&offset))
+    }
+}
+
+/// The bodies as the compiler sees them, or `None` when it rejects the source.
+fn parsed(text: &str) -> Option<Vec<Range<usize>>> {
+    let allocator = Allocator::default();
+    // A document is only ever parsed here to be located, so the script bodies
+    // and non-CSS `<style lang>` blocks that would otherwise abort the parse
+    // are waved through.
+    let options = ParseOptions {
+        defer_script_parse: true,
+        skip_expression_loc: true,
+        lenient_script: true,
+        skip_non_css_lang_style: true,
+        ..ParseOptions::default()
+    };
+    let root = parse(text, &allocator, options).ok()?;
+    let scripts = [root.instance.as_deref(), root.module.as_deref()]
+        .into_iter()
+        .flatten()
+        .filter_map(|script| body_of(text, script.start as usize, script.end as usize));
+    let style = root
+        .css
+        .as_deref()
+        .map(|css| css.content.start as usize..css.content.end as usize);
+    Some(scripts.chain(style).collect())
+}
+
+/// The content of a `<tag …>…</tag>` spanning `start..end`.
+fn body_of(text: &str, start: usize, end: usize) -> Option<Range<usize>> {
+    let outer = text.get(start..end)?;
+    let open = outer.find('>')? + 1;
+    let close = outer.rfind("</").unwrap_or(outer.len());
+    (open <= close).then(|| start + open..start + close)
+}
+
+/// The bodies located by scanning, for a document the compiler rejected.
+fn scanned(text: &str) -> Vec<Range<usize>> {
+    let mut bodies = Vec::new();
+    let mut offset = 0;
+    while offset < text.len() {
+        let Some((start, tag)) = ["script", "style"]
+            .iter()
+            .filter_map(|tag| find_opening_tag(&text[offset..], tag).map(|start| (start, *tag)))
+            .min_by_key(|&(start, _)| start)
+        else {
+            break;
+        };
+        let start = offset + start;
+        let Some(open) = text[start..].find('>').map(|idx| start + idx + 1) else {
+            break;
+        };
+        let close = text[open..]
+            .find(&format!("</{tag}"))
+            .map_or(text.len(), |idx| open + idx);
+        bodies.push(open..close);
+        offset = close.max(open);
+    }
+    bodies
+}
+
+/// The offset of the next `<tag` that is followed by a tag-name boundary.
+fn find_opening_tag(text: &str, tag: &str) -> Option<usize> {
+    let needle = format!("<{tag}");
+    let mut offset = 0;
+    while let Some(idx) = text[offset..].find(&needle) {
+        let start = offset + idx;
+        let after = text[start + needle.len()..].chars().next();
+        if !after.is_some_and(|c| c.is_alphanumeric() || c == '-') {
+            return Some(start);
+        }
+        offset = start + needle.len();
+    }
+    None
+}
+
+/// The attribute the cursor is in, and the element carrying it.
+pub struct AttributeContext<'a> {
+    pub name: &'a str,
+    /// Offset of `name` in the document.
+    pub name_start: usize,
+    /// Whether the cursor is in the attribute's value rather than its name.
+    pub in_value: bool,
+    pub element_tag: &'a str,
+}
+
+impl AttributeContext<'_> {
+    /// Event modifiers exist on elements only, and only after the `|` that
+    /// starts the modifier list.
+    pub fn can_have_event_modifier(&self) -> bool {
+        !self.in_value
+            && !possibly_component(self.element_tag)
+            && self.name.starts_with("on:")
+            && self.name.contains('|')
+    }
+}
+
+/// A capitalised tag name is a component, not an element.
+fn possibly_component(tag: &str) -> bool {
+    tag.starts_with(|c: char| c.is_ascii_uppercase())
+}
+
+enum Step<'a> {
+    Found(AttributeContext<'a>),
+    /// The start tag ended before the offset; resume the outer scan here.
+    Resume(usize),
+    /// The offset is behind us — no attribute holds it.
+    Stop,
+}
+
+/// The attribute at `offset`, if the offset is inside an element's start tag.
+pub fn attribute_context(text: &str, offset: usize) -> Option<AttributeContext<'_>> {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'<' {
+            i += 1;
+            continue;
+        }
+        if i > offset {
+            return None;
+        }
+        if text[i..].starts_with("<!--") {
+            i = text[i + 4..]
+                .find("-->")
+                .map_or(bytes.len(), |e| i + 4 + e + 3);
+            continue;
+        }
+        let &next = bytes.get(i + 1)?;
+        if next == b'!' || next == b'/' {
+            i = text[i..].find('>').map_or(bytes.len(), |e| i + e + 1);
+            continue;
+        }
+        if !next.is_ascii_alphabetic() {
+            i += 1;
+            continue;
+        }
+        let name_start = i + 1;
+        let mut name_end = name_start;
+        while bytes.get(name_end).is_some_and(|&b| is_tag_name_byte(b)) {
+            name_end += 1;
+        }
+        match scan_start_tag(text, name_end, offset, &text[name_start..name_end]) {
+            Step::Found(context) => return Some(context),
+            Step::Resume(next) => i = next,
+            Step::Stop => return None,
+        }
+    }
+    None
+}
+
+/// Walk the attributes of a start tag whose name ends at `from`.
+fn scan_start_tag<'a>(text: &'a str, from: usize, offset: usize, tag: &'a str) -> Step<'a> {
+    let bytes = text.as_bytes();
+    let mut i = from;
+    loop {
+        while bytes.get(i).is_some_and(u8::is_ascii_whitespace) {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            return Step::Stop;
+        }
+        if i > offset {
+            return Step::Stop;
+        }
+        match bytes[i] {
+            b'>' => return Step::Resume(i + 1),
+            b'/' if bytes.get(i + 1) == Some(&b'>') => return Step::Resume(i + 2),
+            // A spread, a shorthand attribute or an attachment.
+            b'{' => {
+                i = skip_braces(text, i);
+                continue;
+            }
+            _ => {}
+        }
+        let start = i;
+        while bytes.get(i).is_some_and(|&b| is_attribute_name_byte(b)) {
+            i += 1;
+        }
+        if i == start {
+            i += 1;
+            continue;
+        }
+        let name = &text[start..i];
+        if (start..=i).contains(&offset) {
+            return Step::Found(AttributeContext {
+                name,
+                name_start: start,
+                in_value: false,
+                element_tag: tag,
+            });
+        }
+        let mut after = i;
+        while bytes.get(after).is_some_and(u8::is_ascii_whitespace) {
+            after += 1;
+        }
+        if bytes.get(after) != Some(&b'=') {
+            continue;
+        }
+        i = after + 1;
+        while bytes.get(i).is_some_and(u8::is_ascii_whitespace) {
+            i += 1;
+        }
+        let value = match bytes.get(i) {
+            Some(&quote @ (b'"' | b'\'')) => {
+                let end = text[i + 1..]
+                    .find(quote as char)
+                    .map_or(bytes.len(), |e| i + 1 + e);
+                let value = i + 1..end;
+                i = (end + 1).min(bytes.len());
+                value
+            }
+            Some(b'{') => {
+                let end = skip_braces(text, i);
+                let value = i..end;
+                i = end;
+                value
+            }
+            _ => {
+                let start = i;
+                while bytes
+                    .get(i)
+                    .is_some_and(|&b| !b.is_ascii_whitespace() && b != b'>')
+                {
+                    i += 1;
+                }
+                start..i
+            }
+        };
+        if value.contains(&offset) || value.end == offset {
+            return Step::Found(AttributeContext {
+                name,
+                name_start: start,
+                in_value: true,
+                element_tag: tag,
+            });
+        }
+    }
+}
+
+/// The offset just past the `{…}` starting at `from`, strings included.
+fn skip_braces(text: &str, from: usize) -> usize {
+    let bytes = text.as_bytes();
+    let mut depth = 0u32;
+    let mut i = from;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' => depth += 1,
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return i + 1;
+                }
+            }
+            quote @ (b'"' | b'\'' | b'`') => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    i += if bytes[i] == b'\\' { 2 } else { 1 };
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+fn is_tag_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':' | b'$')
+}
+
+/// Everything the HTML spec allows in an attribute name, which is what the
+/// official plugin's scanner accepts too.
+fn is_attribute_name_byte(byte: u8) -> bool {
+    !byte.is_ascii_whitespace() && !matches!(byte, b'"' | b'\'' | b'<' | b'>' | b'/' | b'=')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn regions(text: &str) -> EmbeddedRegions {
+        EmbeddedRegions::new(text)
+    }
+
+    #[test]
+    fn script_and_style_bodies_are_found_in_a_valid_document() {
+        let text = "<script>const a = true</script>\n<style>h1{color:blue}</style>\n<p>x</p>";
+        let regions = regions(text);
+        assert!(parsed(text).is_some(), "the fixture should parse");
+        assert!(regions.contains(text.find("const").unwrap()));
+        assert!(regions.contains(text.find("color").unwrap()));
+        assert!(!regions.contains(text.find("<p>").unwrap()));
+    }
+
+    #[test]
+    fn script_and_style_bodies_are_found_without_the_parser() {
+        // An unterminated moustache the compiler refuses.
+        let text = "<script lang=\"ts\">let a: {</script><style>h1{}</style><p>{#";
+        assert!(parsed(text).is_none(), "the fixture should not parse");
+        let regions = regions(text);
+        assert!(regions.contains(text.find("let a").unwrap()));
+        assert!(regions.contains(text.find("h1{}").unwrap()));
+        assert!(!regions.contains(text.find("{#").unwrap()));
+    }
+
+    #[test]
+    fn an_unclosed_script_swallows_the_rest_of_the_document() {
+        let text = "<p>a</p><script>const a =";
+        let regions = regions(text);
+        assert!(!regions.contains(1));
+        assert!(regions.contains(text.len() - 1));
+    }
+
+    #[test]
+    fn a_tag_whose_name_merely_starts_with_script_is_not_one() {
+        let text = "<scriptish>{#</scriptish>";
+        assert!(!scanned(text).iter().any(|b| b.contains(&11)));
+    }
+
+    fn attribute(text: &str, offset: usize) -> Option<AttributeContext<'_>> {
+        attribute_context(text, offset)
+    }
+
+    #[test]
+    fn the_attribute_under_the_cursor_is_reported() {
+        let text = "<div on:click| />";
+        let context = attribute(text, 14).unwrap();
+        assert_eq!(context.name, "on:click|");
+        assert_eq!(context.name_start, 5);
+        assert_eq!(context.element_tag, "div");
+        assert!(!context.in_value);
+        assert!(context.can_have_event_modifier());
+    }
+
+    #[test]
+    fn a_cursor_in_text_content_is_not_in_an_attribute() {
+        let text = "<div class=\"a\">hello</div>";
+        assert!(attribute(text, 17).is_none());
+    }
+
+    #[test]
+    fn a_cursor_in_a_value_is_reported_as_such() {
+        let text = "<div on:click|preventDefault=\"x\" />";
+        let context = attribute(text, 30).unwrap();
+        assert!(context.in_value);
+        assert!(!context.can_have_event_modifier());
+    }
+
+    #[test]
+    fn components_cannot_have_event_modifiers() {
+        let text = "<Widget on:click| />";
+        assert!(!attribute(text, 17).unwrap().can_have_event_modifier());
+    }
+
+    #[test]
+    fn attributes_of_a_later_element_are_still_found() {
+        let text = "<span class=\"a\">t</span><div on:click| />";
+        let context = attribute(text, 37).unwrap();
+        assert_eq!(context.name, "on:click|");
+        assert_eq!(context.element_tag, "div");
+    }
+
+    #[test]
+    fn a_brace_value_does_not_end_the_tag() {
+        let text = "<div style={`a>b`} on:click| />";
+        let context = attribute(text, 27).unwrap();
+        assert_eq!(context.name, "on:click|");
+    }
+
+    #[test]
+    fn a_spread_attribute_is_skipped() {
+        let text = "<div {...rest} on:click| />";
+        assert_eq!(attribute(text, 23).unwrap().name, "on:click|");
+    }
+
+    #[test]
+    fn a_comment_is_not_an_element() {
+        let text = "<!-- <div on:click| --><p>x</p>";
+        assert!(attribute(text, 18).is_none());
+    }
+
+    #[test]
+    fn an_attribute_name_only_needs_a_plain_event_directive_to_be_rejected() {
+        let text = "<div on:click />";
+        assert!(!attribute(text, 13).unwrap().can_have_event_modifier());
+    }
+}

--- a/crates/rsvelte_language_server/src/document.rs
+++ b/crates/rsvelte_language_server/src/document.rs
@@ -54,6 +54,10 @@ impl Document {
         self.index.position(&self.text, offset)
     }
 
+    pub fn offset_at(&self, position: Position) -> usize {
+        self.index.offset(&self.text, position)
+    }
+
     /// The range covering the whole document.
     pub fn full_range(&self) -> Range {
         Range::new(Position::new(0, 0), self.position_at(self.text.len()))

--- a/crates/rsvelte_language_server/src/hover.rs
+++ b/crates/rsvelte_language_server/src/hover.rs
@@ -1,0 +1,243 @@
+//! `textDocument/hover` for Svelte template tags and event modifiers.
+//!
+//! A port of the official language server's
+//! `plugins/svelte/features/getHoverInfo.ts`.
+
+use lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind};
+
+use crate::context::{EmbeddedRegions, attribute_context};
+use crate::modifiers::MODIFIERS;
+use crate::tags::{SvelteTag, latest_opening_tag};
+
+/// How far either side of the cursor a tag may start.
+const WINDOW: usize = 10;
+
+/// The spellings that identify a tag. `:else` comes last because it belongs to
+/// whichever block is open around it.
+const TAG_SPELLINGS: &[(SvelteTag, &[&str])] = &[
+    (SvelteTag::If, &["#if", "/if", ":else if"]),
+    (SvelteTag::Each, &["#each", "/each"]),
+    (SvelteTag::Await, &["#await", "/await", ":then", ":catch"]),
+    (SvelteTag::Key, &["#key", "/key"]),
+    (SvelteTag::Snippet, &["#snippet", "/snippet"]),
+    (SvelteTag::Html, &["@html"]),
+    (SvelteTag::Debug, &["@debug"]),
+    (SvelteTag::Const, &["@const"]),
+    (SvelteTag::Render, &["@render"]),
+    (SvelteTag::Attach, &["@attach"]),
+];
+
+const ELSE: &str = ":else";
+
+pub fn hover(text: &str, offset: usize) -> Option<Hover> {
+    if EmbeddedRegions::new(text).contains(offset) {
+        return None;
+    }
+    let (window_start, window) = around(text, offset);
+
+    if opens_a_tag(window) {
+        let tag = tag_at(text, window_start, window, offset)?;
+        return Some(markdown(tag.documentation().to_string()));
+    }
+
+    let attribute = attribute_context(text, offset)?;
+    if !attribute.can_have_event_modifier() {
+        return None;
+    }
+    let modifier = MODIFIERS.iter().find(|modifier| {
+        around_offset(attribute.name_start, attribute.name, modifier.name, offset)
+    })?;
+    Some(markdown(modifier.documentation()))
+}
+
+/// The `WINDOW` characters before `offset` plus what follows them, as the
+/// official plugin slices it.
+fn around(text: &str, offset: usize) -> (usize, &str) {
+    let before = text.get(..offset).unwrap_or(text);
+    let start = before
+        .char_indices()
+        .nth_back(WINDOW - 1)
+        .map_or(0, |(idx, _)| idx);
+    let rest = &text[start..];
+    let end = rest
+        .char_indices()
+        .nth(WINDOW * 2)
+        .map_or(rest.len(), |(idx, _)| idx);
+    (start, &rest[..end])
+}
+
+/// Whether the window holds a `{`, optional whitespace and a known tag that
+/// ends at a word boundary.
+fn opens_a_tag(window: &str) -> bool {
+    window.match_indices('{').any(|(idx, _)| {
+        let rest = window[idx + 1..].trim_start();
+        TAG_SPELLINGS
+            .iter()
+            .flat_map(|(_, spellings)| spellings.iter())
+            .chain(std::iter::once(&ELSE))
+            .any(|spelling| {
+                rest.strip_prefix(spelling)
+                    .is_some_and(|after| after.starts_with(['}', ' ', '\t', '\n', '\r']))
+            })
+    })
+}
+
+/// The tag whose spelling covers `offset`.
+fn tag_at(text: &str, window_start: usize, window: &str, offset: usize) -> Option<SvelteTag> {
+    let found = TAG_SPELLINGS.iter().find(|(_, spellings)| {
+        spellings
+            .iter()
+            .any(|spelling| around_offset(window_start, window, spelling, offset))
+    });
+    match found {
+        Some((tag, _)) => Some(*tag),
+        // `{:else}` belongs to the innermost open block.
+        None if around_offset(window_start, window, ELSE, offset) => {
+            latest_opening_tag(text, offset)
+        }
+        None => None,
+    }
+}
+
+/// Whether the first `needle` in `haystack` — which starts at `haystack_start`
+/// in the document — spans `offset`.
+fn around_offset(haystack_start: usize, haystack: &str, needle: &str, offset: usize) -> bool {
+    let Some(idx) = haystack.find(needle) else {
+        return false;
+    };
+    let start = haystack_start + idx;
+    start <= offset && start + needle.len() >= offset
+}
+
+fn markdown(value: String) -> Hover {
+    Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value,
+        }),
+        range: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hovered_tag(content: &str, offset: usize) -> Option<String> {
+        let hover = hover(content, offset)?;
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markdown hover");
+        };
+        assert_eq!(content.kind, MarkupKind::Markdown);
+        Some(content.value)
+    }
+
+    fn expect_tag(content: &str, offset: usize, tag: SvelteTag) {
+        assert_eq!(
+            hovered_tag(content, offset).as_deref(),
+            Some(tag.documentation()),
+            "{content:?} at {offset}"
+        );
+    }
+
+    fn expect_none(content: &str, offset: usize) {
+        assert_eq!(hovered_tag(content, offset), None, "{content:?}");
+    }
+
+    #[test]
+    fn nothing_inside_style_or_script() {
+        expect_none("<style>h1{color:blue;}</style><p>test</p>", 10);
+        expect_none("<script>const a = true</script><p>test</p>", 10);
+    }
+
+    #[test]
+    fn nothing_on_ordinary_content() {
+        expect_none("{nope", 2);
+        expect_none("not really", 2);
+        expect_none("{#await.", 3);
+    }
+
+    #[test]
+    fn else_needs_an_open_block() {
+        expect_none("{:else}", 3);
+        expect_none("{#if}{/if}{:else}", 15);
+    }
+
+    #[test]
+    fn else_resolves_to_the_open_block() {
+        expect_tag("{#if}{:else}", 8, SvelteTag::If);
+        expect_tag("{#each}{:else}", 10, SvelteTag::Each);
+    }
+
+    #[test]
+    fn closing_tags_hover() {
+        for (spelling, tag) in [
+            ("if", SvelteTag::If),
+            ("each", SvelteTag::Each),
+            ("await", SvelteTag::Await),
+        ] {
+            expect_tag(&format!("{{/{spelling}}}"), 3, tag);
+            expect_tag(&format!("{{/{spelling} "), 3, tag);
+        }
+    }
+
+    #[test]
+    fn opening_tags_hover() {
+        for (spelling, tag) in [
+            ("if", SvelteTag::If),
+            ("each", SvelteTag::Each),
+            ("await", SvelteTag::Await),
+            ("key", SvelteTag::Key),
+            ("snippet", SvelteTag::Snippet),
+        ] {
+            expect_tag(&format!("{{#{spelling}}}"), 3, tag);
+            expect_tag(&format!("{{#{spelling} "), 3, tag);
+        }
+    }
+
+    #[test]
+    fn at_tags_hover() {
+        for (spelling, tag) in [
+            ("debug", SvelteTag::Debug),
+            ("html", SvelteTag::Html),
+            ("const", SvelteTag::Const),
+            ("render", SvelteTag::Render),
+            ("attach", SvelteTag::Attach),
+        ] {
+            expect_tag(&format!("{{@{spelling}}}"), 3, tag);
+            expect_tag(&format!("{{@{spelling} "), 3, tag);
+        }
+    }
+
+    #[test]
+    fn definite_continuations_hover() {
+        expect_tag("{:else if}", 3, SvelteTag::If);
+        expect_tag("{:else if ", 3, SvelteTag::If);
+        expect_tag("{:then}", 3, SvelteTag::Await);
+        expect_tag("{:catch}", 3, SvelteTag::Await);
+    }
+
+    #[test]
+    fn an_event_modifier_hovers() {
+        let hovered = hovered_tag("<div on:click|preventDefault />", 15).unwrap();
+        assert!(hovered.starts_with("`preventDefault` event modifier"));
+        assert!(hovered.contains("event.preventDefault()"));
+    }
+
+    #[test]
+    fn a_second_modifier_hovers_too() {
+        let hovered = hovered_tag("<div on:click|preventDefault|once />", 31).unwrap();
+        assert!(hovered.starts_with("`once` event modifier"));
+    }
+
+    #[test]
+    fn a_plain_event_directive_has_no_modifier_hover() {
+        expect_none("<div on:click />", 12);
+    }
+
+    #[test]
+    fn a_tag_inside_a_script_body_is_left_alone() {
+        let text = "<script>\n  const a = `{#if}`;\n</script>";
+        expect_none(text, text.find("{#if}").unwrap() + 3);
+    }
+}

--- a/crates/rsvelte_language_server/src/lib.rs
+++ b/crates/rsvelte_language_server/src/lib.rs
@@ -1,18 +1,27 @@
 //! `rsvelte-language-server` — an LSP server exposing rsvelte's formatter and
 //! linter to any LSP client (VS Code, Neovim, …).
 //!
+//! It also ports the TypeScript-free half of the official language server's
+//! `SveltePlugin`: template tag and event modifier [`completions`] and
+//! [`hover`].
+//!
 //! The message loop owns only protocol state; every analysis runs on the
 //! [`worker`] thread, which is where the stack depth and panic isolation the
 //! Svelte compiler needs are provided.
 
 pub mod client;
+pub mod completions;
+pub mod context;
 pub mod diagnostics;
 pub mod document;
 pub mod format;
+pub mod hover;
 pub mod lint;
 pub mod log;
+pub mod modifiers;
 pub mod server;
 pub mod settings;
+pub mod tags;
 pub mod text;
 pub mod uri;
 pub mod worker;

--- a/crates/rsvelte_language_server/src/modifiers.rs
+++ b/crates/rsvelte_language_server/src/modifiers.rs
@@ -1,0 +1,81 @@
+//! The `on:event|modifier` data, shared by completion and hover.
+
+pub struct Modifier {
+    pub name: &'static str,
+    pub summary: &'static str,
+    /// Modifiers this one cannot be combined with. The strings are matched
+    /// against the whole attribute name, exactly as the official plugin does.
+    pub invalid_with: &'static [&'static str],
+}
+
+impl Modifier {
+    /// The markdown the client renders, for both the completion item and hover.
+    pub fn documentation(&self) -> String {
+        format!(
+            "`{}` event modifier\n\n{}\n\nhttps://v4.svelte.dev/docs/element-directives#on-eventname",
+            self.name, self.summary
+        )
+    }
+}
+
+pub const MODIFIERS: [Modifier; 8] = [
+    Modifier {
+        name: "preventDefault",
+        summary: "calls `event.preventDefault()` before running the handler",
+        invalid_with: &["passive"],
+    },
+    Modifier {
+        name: "stopPropagation",
+        summary: "calls `event.stopPropagation()`, preventing the event reaching the next element",
+        invalid_with: &[],
+    },
+    Modifier {
+        name: "passive",
+        summary: "improves scrolling performance on touch/wheel events \
+                  (Svelte will add it automatically where it's safe to do so)",
+        invalid_with: &["nopassive", "preventDefault"],
+    },
+    Modifier {
+        name: "nonpassive",
+        summary: "explicitly set `passive: false`",
+        invalid_with: &["passive"],
+    },
+    Modifier {
+        name: "capture",
+        summary: "fires the handler during the capture phase instead of the bubbling phase",
+        invalid_with: &[],
+    },
+    Modifier {
+        name: "once",
+        summary: "remove the handler after the first time it runs",
+        invalid_with: &[],
+    },
+    Modifier {
+        name: "self",
+        summary: "only trigger handler if `event.target` is the element itself",
+        invalid_with: &[],
+    },
+    Modifier {
+        name: "trusted",
+        summary: "only trigger handler if event.isTrusted is true. \
+                  I.e. if the event is triggered by a user action",
+        invalid_with: &[],
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn documentation_names_the_modifier_and_links_the_docs() {
+        let passive = MODIFIERS.iter().find(|m| m.name == "passive").unwrap();
+        assert_eq!(
+            passive.documentation(),
+            "`passive` event modifier\n\n\
+             improves scrolling performance on touch/wheel events \
+             (Svelte will add it automatically where it's safe to do so)\n\n\
+             https://v4.svelte.dev/docs/element-directives#on-eventname"
+        );
+    }
+}

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -8,14 +8,16 @@ use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender, after, never, select, unbounded};
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
-    ConfigurationItem, ConfigurationParams, DidChangeTextDocumentParams,
-    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-    DocumentFormattingParams, OneOf, PublishDiagnosticsParams, ServerCapabilities,
+    CompletionOptions, CompletionParams, ConfigurationItem, ConfigurationParams,
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams, DocumentFormattingParams, HoverParams, HoverProviderCapability,
+    OneOf, PublishDiagnosticsParams, ServerCapabilities, TextDocumentPositionParams,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     TextDocumentSyncSaveOptions, TextEdit, Uri,
 };
 
 use crate::client::ClientState;
+use crate::completions::TRIGGER_CHARACTERS;
 use crate::document::{Document, DocumentStore};
 use crate::log;
 use crate::settings::Settings;
@@ -78,6 +80,11 @@ fn capabilities() -> ServerCapabilities {
             },
         )),
         document_formatting_provider: Some(OneOf::Left(true)),
+        completion_provider: Some(CompletionOptions {
+            trigger_characters: Some(TRIGGER_CHARACTERS.map(str::to_string).to_vec()),
+            ..CompletionOptions::default()
+        }),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
         ..ServerCapabilities::default()
     }
 }
@@ -87,6 +94,8 @@ fn capabilities() -> ServerCapabilities {
 /// produce one.
 enum Pending {
     Formatting,
+    Completion,
+    Hover,
 }
 
 /// A request this server sent to the client, keyed by the id the client will
@@ -190,6 +199,8 @@ impl Server {
         }
         match request.method.as_str() {
             "textDocument/formatting" => self.on_formatting(request),
+            "textDocument/completion" => self.on_completion(request),
+            "textDocument/hover" => self.on_hover(request),
             _ => self.respond(Response::new_err(
                 request.id,
                 ErrorCode::MethodNotFound as i32,
@@ -225,6 +236,79 @@ impl Server {
         };
         self.pending.insert(id, Pending::Formatting);
         self.worker.submit(job);
+    }
+
+    fn on_completion(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<CompletionParams>(request.params) {
+            Ok(params) => params.text_document_position,
+            Err(err) => {
+                log::warn(format_args!("textDocument/completion: {err}"));
+                self.respond_nothing(id);
+                return;
+            }
+        };
+        if !self.settings.completion_enable {
+            self.respond_nothing(id);
+            return;
+        }
+        match self.locate(&params) {
+            Some((path, text, offset)) => {
+                self.pending.insert(id.clone(), Pending::Completion);
+                self.worker.submit(Job::Complete {
+                    id,
+                    path,
+                    text,
+                    offset,
+                });
+            }
+            None => self.respond_nothing(id),
+        }
+    }
+
+    fn on_hover(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<HoverParams>(request.params) {
+            Ok(params) => params.text_document_position_params,
+            Err(err) => {
+                log::warn(format_args!("textDocument/hover: {err}"));
+                self.respond_nothing(id);
+                return;
+            }
+        };
+        if !self.settings.hover_enable {
+            self.respond_nothing(id);
+            return;
+        }
+        match self.locate(&params) {
+            Some((path, text, offset)) => {
+                self.pending.insert(id.clone(), Pending::Hover);
+                self.worker.submit(Job::Hover {
+                    id,
+                    path,
+                    text,
+                    offset,
+                });
+            }
+            None => self.respond_nothing(id),
+        }
+    }
+
+    /// Resolve a position in an open component to what the worker needs. Only
+    /// components have Svelte template syntax to answer for.
+    fn locate(
+        &self,
+        params: &TextDocumentPositionParams,
+    ) -> Option<(std::path::PathBuf, std::sync::Arc<String>, usize)> {
+        let document = self.documents.get(&params.text_document.uri)?;
+        if document.language_id != "svelte" {
+            return None;
+        }
+        Some((
+            uri_to_path(params.text_document.uri.as_str()),
+            document.shared_text(),
+            document.offset_at(params.position),
+        ))
     }
 
     fn on_notification(&mut self, notification: Notification) {
@@ -325,6 +409,16 @@ impl Server {
                 // answered; its result is simply dropped.
                 if self.pending.remove(&id).is_some() {
                     self.respond(Response::new_ok(id, edits));
+                }
+            }
+            Outcome::Completed { id, list } => {
+                if self.pending.remove(&id).is_some() {
+                    self.respond(Response::new_ok(id, list));
+                }
+            }
+            Outcome::Hovered { id, hover } => {
+                if self.pending.remove(&id).is_some() {
+                    self.respond(Response::new_ok(id, hover));
                 }
             }
             Outcome::Diagnostics {
@@ -428,6 +522,11 @@ impl Server {
 
     fn respond_no_edits(&self, id: RequestId) {
         self.respond(Response::new_ok(id, Vec::<TextEdit>::new()));
+    }
+
+    /// A request with nothing to offer is answered with `null`, not an error.
+    fn respond_nothing(&self, id: RequestId) {
+        self.respond(Response::new_ok(id, serde_json::Value::Null));
     }
 
     fn respond(&self, response: Response) {

--- a/crates/rsvelte_language_server/src/settings.rs
+++ b/crates/rsvelte_language_server/src/settings.rs
@@ -6,6 +6,8 @@ use serde_json::Value;
 pub struct Settings {
     pub format_enable: bool,
     pub lint_enable: bool,
+    pub completion_enable: bool,
+    pub hover_enable: bool,
 }
 
 impl Default for Settings {
@@ -13,6 +15,8 @@ impl Default for Settings {
         Self {
             format_enable: true,
             lint_enable: true,
+            completion_enable: true,
+            hover_enable: true,
         }
     }
 }
@@ -25,6 +29,8 @@ impl Settings {
         Self {
             format_enable: enabled(value, "format").unwrap_or(default.format_enable),
             lint_enable: enabled(value, "lint").unwrap_or(default.lint_enable),
+            completion_enable: enabled(value, "completion").unwrap_or(default.completion_enable),
+            hover_enable: enabled(value, "hover").unwrap_or(default.hover_enable),
         }
     }
 }
@@ -39,16 +45,20 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn reads_both_switches() {
+    fn reads_every_switch() {
         let s = Settings::from_json(&json!({
             "format": { "enable": false },
-            "lint": { "enable": true }
+            "lint": { "enable": true },
+            "completion": { "enable": false },
+            "hover": { "enable": false }
         }));
         assert_eq!(
             s,
             Settings {
                 format_enable: false,
-                lint_enable: true
+                lint_enable: true,
+                completion_enable: false,
+                hover_enable: false,
             }
         );
     }

--- a/crates/rsvelte_language_server/src/tags.rs
+++ b/crates/rsvelte_language_server/src/tags.rs
@@ -1,0 +1,285 @@
+//! The Svelte template tags: the documentation completion and hover both show,
+//! and the scan that resolves which block a `{:…}` or `{/…}` belongs to.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SvelteTag {
+    If,
+    Each,
+    Await,
+    Key,
+    Snippet,
+    Html,
+    Debug,
+    Const,
+    Render,
+    Attach,
+}
+
+/// The tags that open a block, in the order the official plugin scans them.
+pub const LOGIC_TAGS: [SvelteTag; 5] = [
+    SvelteTag::Each,
+    SvelteTag::If,
+    SvelteTag::Await,
+    SvelteTag::Key,
+    SvelteTag::Snippet,
+];
+
+impl SvelteTag {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::If => "if",
+            Self::Each => "each",
+            Self::Await => "await",
+            Self::Key => "key",
+            Self::Snippet => "snippet",
+            Self::Html => "html",
+            Self::Debug => "debug",
+            Self::Const => "const",
+            Self::Render => "render",
+            Self::Attach => "attach",
+        }
+    }
+
+    pub fn documentation(self) -> &'static str {
+        match self {
+            Self::If => IF,
+            Self::Each => EACH,
+            Self::Await => AWAIT,
+            Self::Key => KEY,
+            Self::Snippet => SNIPPET,
+            Self::Html => HTML,
+            Self::Debug => DEBUG,
+            Self::Const => CONST,
+            Self::Render => RENDER,
+            Self::Attach => ATTACH,
+        }
+    }
+}
+
+const AWAIT: &str = r#"`{#await ...}`\
+Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected.
+#### Usage:
+`{#await expression}...{:then name}...{:catch name}...{/await}`\
+`{#await expression}...{:then name}...{/await}`\
+`{#await expression then name}...{/await}`\
+\
+https://svelte.dev/docs/svelte/await
+"#;
+
+const EACH: &str = r#"`{#each ...}`\
+Iterating over lists of values can be done with an each block.
+#### Usage:
+`{#each expression as name}...{/each}`\
+`{#each expression as name, index}...{/each}`\
+`{#each expression as name, index (key)}...{/each}`\
+`{#each expression as name}...{:else}...{/each}`\
+\
+https://svelte.dev/docs/svelte/each
+"#;
+
+const IF: &str = r#"`{#if ...}`\
+Content that is conditionally rendered can be wrapped in an if block.
+#### Usage:
+`{#if expression}...{/if}`\
+`{#if expression}...{:else if expression}...{/if}`\
+`{#if expression}...{:else}...{/if}`\
+\
+https://svelte.dev/docs/svelte/if
+"#;
+
+const KEY: &str = r#"`{#key expression}...{/key}`\
+Key blocks destroy and recreate their contents when the value of an expression changes.\
+This is useful if you want an element to play its transition whenever a value changes.\
+When used around components, this will cause them to be reinstantiated and reinitialised.
+#### Usage:
+`{#key expression}...{/key}`\
+\
+https://svelte.dev/docs/svelte/key
+"#;
+
+const SNIPPET: &str = r#"`{#snippet identifier(parameter)}...{/snippet}`\
+Snippets allow you to create reusable UI blocks you can render with the {@render ...} tag.
+They also function as slot props for components.
+#### Usage:
+`{#snippet identifier(parameter)}...{/snippet}`\
+\
+https://svelte.dev/docs/svelte/snippet
+"#;
+
+const RENDER: &str = r#"`{@render ...}`\
+Renders a snippet with the given parameters.
+#### Usage:
+`{@render identifier(parameter)}`\
+\
+https://svelte.dev/docs/svelte/@render
+"#;
+
+const HTML: &str = r#"`{@html ...}`\
+In a text expression, characters like < and > are escaped; however, with HTML expressions, they're not.
+The expression should be valid standalone HTML.
+#### Caution
+Svelte does not sanitize expressions before injecting HTML.
+If the data comes from an untrusted source, you must sanitize it, or you are exposing your users to an XSS vulnerability.
+#### Usage:
+`{@html expression}`\
+\
+https://svelte.dev/docs/svelte/@html
+"#;
+
+const DEBUG: &str = r#"`{@debug ...}`\
+Offers an alternative to `console.log(...)`.
+It logs the values of specific variables whenever they change, and pauses code execution if you have devtools open.
+It accepts a comma-separated list of variable names (not arbitrary expressions).
+#### Usage:
+`{@debug}`
+`{@debug var1, var2, ..., varN}`\
+\
+https://svelte.dev/docs/svelte/@debug
+"#;
+
+const CONST: &str = r#"`{@const ...}`\
+Defines a local constant\
+#### Usage:
+`{@const a = b + c}`\
+\
+https://svelte.dev/docs/svelte/@const
+"#;
+
+const ATTACH: &str = r#"`{@attach ...}`\
+Defines an attachment that is attached to an element or component\
+#### Usage:
+`<div {@attach (node) => {...}}></div>`\
+`<Component {@attach namedAttachment} />`\
+\
+https://svelte.dev/docs/svelte/@attach
+"#;
+
+/// The block that is open — but not yet closed — at `offset`.
+pub fn latest_opening_tag(text: &str, offset: usize) -> Option<SvelteTag> {
+    let before = text.get(..offset).unwrap_or(text);
+    let content = strip_html_comments(before);
+    LOGIC_TAGS
+        .iter()
+        .filter_map(|&tag| last_unclosed_opening(&content, tag.name()).map(|idx| (idx, tag)))
+        .max_by_key(|&(idx, _)| idx)
+        .map(|(_, tag)| tag)
+}
+
+/// Index of the last `{#tag` that has no `{/tag` to answer it.
+fn last_unclosed_opening(content: &str, tag: &str) -> Option<usize> {
+    let closings = block_tag_indices(content, '/', tag).count();
+    let mut openings = 0;
+    let mut last = None;
+    for idx in block_tag_indices(content, '#', tag) {
+        openings += 1;
+        last = Some(idx);
+    }
+    (openings > closings).then_some(last).flatten()
+}
+
+/// Every `{`, optional whitespace, `marker`, `tag` in `content`, by the index
+/// of the brace.
+fn block_tag_indices<'a>(
+    content: &'a str,
+    marker: char,
+    tag: &'a str,
+) -> impl Iterator<Item = usize> + 'a {
+    content.match_indices('{').filter_map(move |(idx, _)| {
+        let rest = content[idx + 1..].trim_start();
+        let rest = rest.strip_prefix(marker)?;
+        rest.starts_with(tag).then_some(idx)
+    })
+}
+
+/// Drop every single-line `<!-- … -->`, matching the official plugin's regex —
+/// a comment spanning lines is left in place.
+fn strip_html_comments(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("<!--") {
+        let after = &rest[start + 4..];
+        let line_end = after.find(['\n', '\r']).unwrap_or(after.len());
+        match after[..line_end].find("-->") {
+            Some(end) => {
+                out.push_str(&rest[..start]);
+                rest = &after[end + 3..];
+            }
+            None => {
+                out.push_str(&rest[..start + 4]);
+                rest = after;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn latest(text: &str) -> Option<SvelteTag> {
+        latest_opening_tag(text, text.len())
+    }
+
+    #[test]
+    fn no_block_at_all() {
+        assert_eq!(latest("{:"), None);
+        assert_eq!(latest("plain text"), None);
+    }
+
+    #[test]
+    fn a_closed_block_does_not_count() {
+        assert_eq!(latest("{#if}{/if}{:"), None);
+        assert_eq!(latest("{#if}{ /if}{/"), None);
+    }
+
+    #[test]
+    fn whitespace_after_the_brace_is_allowed() {
+        assert_eq!(latest("{ #each }"), Some(SvelteTag::Each));
+    }
+
+    #[test]
+    fn the_innermost_open_block_wins() {
+        assert_eq!(latest("{#if}{/if}{#if}{#await}{:"), Some(SvelteTag::Await));
+        assert_eq!(latest("{#await}{#if}"), Some(SvelteTag::If));
+    }
+
+    #[test]
+    fn commented_out_blocks_are_ignored() {
+        assert_eq!(latest("<!-- {#if} -->{:"), None);
+        // A comment that spans lines is beyond the official regex, so the tag
+        // inside it still counts.
+        assert_eq!(latest("<!-- \n {#if} -->{:"), Some(SvelteTag::If));
+    }
+
+    #[test]
+    fn only_content_before_the_offset_counts() {
+        assert_eq!(latest_opening_tag("{#if}{:", 0), None);
+        assert_eq!(latest_opening_tag("{#if}{:", 5), Some(SvelteTag::If));
+    }
+
+    #[test]
+    fn documentation_is_available_for_every_tag() {
+        for tag in [
+            SvelteTag::If,
+            SvelteTag::Each,
+            SvelteTag::Await,
+            SvelteTag::Key,
+            SvelteTag::Snippet,
+            SvelteTag::Html,
+            SvelteTag::Debug,
+            SvelteTag::Const,
+            SvelteTag::Render,
+            SvelteTag::Attach,
+        ] {
+            let documentation = tag.documentation();
+            assert!(documentation.contains("#### Usage:"), "{}", tag.name());
+            assert!(
+                documentation.contains("https://svelte.dev/docs/svelte/"),
+                "{}",
+                tag.name()
+            );
+        }
+    }
+}

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -17,7 +17,7 @@ use std::thread::JoinHandle;
 
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use lsp_server::RequestId;
-use lsp_types::{Diagnostic, Range, TextEdit, Uri};
+use lsp_types::{CompletionList, Diagnostic, Hover, Range, TextEdit, Uri};
 
 use crate::format::FormatSessions;
 use crate::lint::LintConfigCache;
@@ -42,6 +42,18 @@ pub enum Job {
         text: Arc<String>,
         range: Range,
     },
+    Complete {
+        id: RequestId,
+        path: PathBuf,
+        text: Arc<String>,
+        offset: usize,
+    },
+    Hover {
+        id: RequestId,
+        path: PathBuf,
+        text: Arc<String>,
+        offset: usize,
+    },
     /// Drop the resolved `rsvelte-lint.json` / `.oxfmtrc` caches so the next
     /// job re-reads them from disk.
     ClearCaches,
@@ -57,6 +69,14 @@ pub enum Outcome {
     Formatted {
         id: RequestId,
         edits: Vec<TextEdit>,
+    },
+    Completed {
+        id: RequestId,
+        list: Option<CompletionList>,
+    },
+    Hovered {
+        id: RequestId,
+        hover: Option<Hover>,
     },
 }
 
@@ -139,6 +159,27 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 let edits = format(&mut format_sessions, &path, &text, range);
                 Outcome::Formatted { id, edits }
             }
+            Job::Complete {
+                id,
+                path,
+                text,
+                offset,
+            } => Outcome::Completed {
+                id,
+                list: guard("completion", &path, || {
+                    crate::completions::completions(&text, offset)
+                })
+                .flatten(),
+            },
+            Job::Hover {
+                id,
+                path,
+                text,
+                offset,
+            } => Outcome::Hovered {
+                id,
+                hover: guard("hover", &path, || crate::hover::hover(&text, offset)).flatten(),
+            },
         };
         if outcomes.send(outcome).is_err() {
             break;

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -21,6 +21,8 @@ struct Server {
     stdout: BufReader<ChildStdout>,
     finished: Arc<AtomicBool>,
     next_id: i64,
+    /// What `workspace/configuration` is answered with.
+    settings: Value,
 }
 
 impl Server {
@@ -57,6 +59,12 @@ impl Server {
             stdout,
             finished,
             next_id: 0,
+            settings: json!({
+                "format": { "enable": true },
+                "lint": { "enable": true },
+                "completion": { "enable": true },
+                "hover": { "enable": true },
+            }),
         }
     }
 
@@ -117,6 +125,48 @@ impl Server {
         }
     }
 
+    /// Answer the `workspace/configuration` the server asks for once it has
+    /// seen `initialized`, so that a request sent afterwards is served with
+    /// this client's settings rather than the defaults.
+    fn settle_configuration(&mut self) {
+        loop {
+            let message = self.read();
+            let configuration = message["method"] == "workspace/configuration";
+            self.answer_server_request(&message);
+            if configuration {
+                return;
+            }
+        }
+    }
+
+    /// The items `textDocument/completion` offers at a position.
+    fn completion(&mut self, uri: &str, line: u32, character: u32) -> Vec<Value> {
+        let response = self.completion_response(uri, line, character);
+        response["items"].as_array().cloned().unwrap_or_default()
+    }
+
+    fn completion_response(&mut self, uri: &str, line: u32, character: u32) -> Value {
+        let id = self.request(
+            "textDocument/completion",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+            }),
+        );
+        self.response(id)
+    }
+
+    fn hover(&mut self, uri: &str, line: u32, character: u32) -> Value {
+        let id = self.request(
+            "textDocument/hover",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+            }),
+        );
+        self.response(id)
+    }
+
     /// Read until diagnostics for `uri` arrive.
     fn diagnostics(&mut self, uri: &str) -> Vec<Value> {
         loop {
@@ -157,10 +207,7 @@ impl Server {
         };
         let result = if method == "workspace/configuration" {
             let items = message["params"]["items"].as_array().map_or(0, Vec::len);
-            Value::Array(vec![
-                json!({ "format": { "enable": true }, "lint": { "enable": true } });
-                items
-            ])
+            Value::Array(vec![self.settings.clone(); items])
         } else {
             Value::Null
         };
@@ -365,6 +412,140 @@ fn serves_diagnostics_and_formatting() {
         json!({ "textDocument": { "uri": uri } }),
     );
     server.cleared_diagnostics(&uri);
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+/// Completion and hover over the wire, on a document that does not parse — the
+/// state a component is in for most of the time it is being typed.
+#[test]
+fn serves_completions_and_hover() {
+    let dir = temp_dir("completion");
+    let uri = file_uri(&dir.join("App.svelte"));
+
+    let mut server = Server::start();
+    let id = server.request(
+        "initialize",
+        json!({
+            "processId": Value::Null,
+            "rootUri": Value::Null,
+            "capabilities": { "workspace": { "configuration": true } },
+        }),
+    );
+    let capabilities = server.response(id)["capabilities"].clone();
+    assert_eq!(
+        capabilities["completionProvider"]["triggerCharacters"],
+        json!(["#", "@", ":", "/", "|"])
+    );
+    assert_eq!(capabilities["hoverProvider"], json!(true));
+    server.notify("initialized", json!({}));
+
+    let source =
+        "<script>\n  let value = 1;\n</script>\n\n<div on:click|>\n  {#each value as v}\n    {#";
+    did_open(&mut server, &uri, source);
+
+    // `{#` on the last line, mid-edit: the block completions, closing snippet
+    // and all.
+    let items = server.completion(&uri, 6, 6);
+    assert_eq!(
+        items.iter().map(|i| i["label"].clone()).collect::<Vec<_>>(),
+        json!(["if", "each", "await :then", "await then", "key", "snippet"])
+            .as_array()
+            .unwrap()
+            .clone()
+    );
+    let each = items.iter().find(|i| i["label"] == "each").unwrap();
+    assert_eq!(each["insertText"], json!("each $1 as $2}\n\t$3\n{/each"));
+    // 2 == InsertTextFormat.Snippet, 14 == CompletionItemKind.Keyword
+    assert_eq!(each["insertTextFormat"], json!(2));
+    assert_eq!(each["kind"], json!(14));
+    assert_eq!(each["sortText"], json!("-1"));
+    assert_eq!(each["preselect"], json!(true));
+
+    // The open `{#each` decides what a `{/` typed in its place may close.
+    server.notify(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": uri, "version": 2 },
+            "contentChanges": [{
+                "range": {
+                    "start": { "line": 6, "character": 5 },
+                    "end": { "line": 6, "character": 6 },
+                },
+                "text": "/",
+            }],
+        }),
+    );
+    let items = server.completion(&uri, 6, 6);
+    assert_eq!(
+        items.iter().map(|i| i["label"].clone()).collect::<Vec<_>>(),
+        [json!("each")]
+    );
+
+    // Event modifiers, filtered by what the attribute already carries.
+    let items = server.completion(&uri, 4, 14);
+    let labels: Vec<&str> = items
+        .iter()
+        .map(|i| i["label"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        labels,
+        [
+            "preventDefault",
+            "stopPropagation",
+            "passive",
+            "nonpassive",
+            "capture",
+            "once",
+            "self",
+            "trusted"
+        ]
+    );
+    // 23 == CompletionItemKind.Event
+    assert_eq!(items[0]["kind"], json!(23));
+
+    // Hover over `#each` documents the block.
+    let hover = server.hover(&uri, 5, 5);
+    let contents = hover["contents"]["value"].as_str().unwrap();
+    assert!(contents.starts_with("`{#each ...}`"), "{contents}");
+    assert_eq!(hover["contents"]["kind"], json!("markdown"));
+
+    // Hover inside `<script>` is the TypeScript plugin's business, not ours.
+    assert_eq!(server.hover(&uri, 1, 8), Value::Null);
+
+    // Nothing to offer is `null`, never an error.
+    assert_eq!(server.completion(&uri, 1, 0), Vec::<Value>::new());
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+/// `rsvelte.completion.enable` / `rsvelte.hover.enable` switch the features off
+/// without the client having to stop asking.
+#[test]
+fn the_settings_switch_completion_and_hover_off() {
+    let dir = temp_dir("completion-disabled");
+    let uri = file_uri(&dir.join("App.svelte"));
+
+    let mut server = Server::start();
+    server.settings = json!({
+        "completion": { "enable": false },
+        "hover": { "enable": false },
+    });
+    let id = server.request(
+        "initialize",
+        json!({
+            "processId": Value::Null,
+            "rootUri": Value::Null,
+            "capabilities": { "workspace": { "configuration": true } },
+        }),
+    );
+    server.response(id);
+    server.notify("initialized", json!({}));
+    server.settle_configuration();
+    did_open(&mut server, &uri, "<p>{#each a as b}{/each}</p>\n{#");
+
+    assert_eq!(server.completion_response(&uri, 1, 2), Value::Null);
+    assert_eq!(server.hover(&uri, 0, 5), Value::Null);
 
     assert_eq!(server.shutdown(), Some(0));
 }


### PR DESCRIPTION
Ports the TypeScript-free half of the official language server's `SveltePlugin`
onto the M0 foundation (#1788): Svelte template tag completions, event modifier
completions, the `<!-- @component -->` doc-comment snippet, and hover for all of
them.

## What corresponds to what

| Official (`packages/language-server/src/plugins/svelte/`) | Here (`crates/rsvelte_language_server/src/`) |
| --- | --- |
| `features/getCompletions.ts` | `completions.rs` |
| `features/getHoverInfo.ts` | `hover.rs` |
| `features/SvelteTags.ts` (`documentation`, `getLatestOpeningTag`) | `tags.rs` |
| `features/getModifierData.ts` | `modifiers.rs` |
| `features/utils.ts` (`inStyleOrScript`, `attributeCanHaveEventModifier`) + `lib/documents/parseHtml.ts` (`getAttributeContextAtPosition`) | `context.rs` |

The tag documentation lives in `tags.rs` alone and is used by the completion
items' `documentation` and by hover — there is no second copy. Both hard-coded
data sets (tag prose, modifier list) were verified byte-for-byte against the
official sources with a throwaway dump-and-diff over all 26 strings (10 tag
docs, 8 modifier docs, 8 `modifiersInvalidWith` lists): all match.

`{#…}` items insert a snippet that closes the block again
(`each $1 as $2}\n\t$3\n{/each`, …) with `insertTextFormat: Snippet`, and every
tag item carries `sortText: "-1"`, `preselect: true`, `kind: Keyword`, as the
official plugin does. `{:…}` and `{/…}` resolve against the innermost open block
via the `getLatestOpeningTag` port.

`textDocument/completion` (trigger characters `# @ : / |`) and
`textDocument/hover` are declared in the server capabilities and answered on the
worker thread through the existing `Job` / `Outcome` channel, so the message loop
is never blocked and a panic costs at most the one request.
`rsvelte.completion.enable` / `rsvelte.hover.enable` switch the features off,
alongside the existing `rsvelte.format.enable` / `rsvelte.lint.enable`.

## Fallback when the document does not parse

A component is asked for completions while it is being typed, which is exactly
when it does not compile, so every answer is reachable from the raw text — the
official plugin decides textually too. Concretely:

* Trigger detection, the open-block scan, the tag-spelling lookup and the
  attribute/modifier scanner are pure text scans, with no AST involved.
* The one place the parser is consulted is locating `<script>` / `<style>`
  bodies, where it cannot be fooled by those words appearing inside a string or
  a moustache. `EmbeddedRegions::new` calls `parse` with `lenient_script` and
  `skip_non_css_lang_style` (a broken script body or a `lang="scss"` block must
  not cost the whole answer) and falls back to a tag scanner the moment `parse`
  returns `Err`. Both paths are covered by tests that assert which one is in
  play.
* Every protocol position goes through the existing `LineIndex`, so UTF-16
  columns land on the right byte.

## Tests

* Ported cases from the official `getCompletions.test.ts` and
  `getHoverInfo.test.ts`: every `#` / `@` / `:` / `/` case, the null cases
  (inside style, inside script, `{nope`, `not really`, `{#awa.`, closed blocks,
  `{ /if}`), the `@component` insert text, and all three modifier-filtering
  cases — plus assertions the official tests do not make on `insertText`,
  `insertTextFormat`, `kind`, `sortText`, `preselect` and the documentation
  payload.
* New unit tests for the region locator (parsed and scanned paths, unclosed
  `<script>`, `<scriptish>`) and the attribute scanner (values, brace values,
  spreads, comments, components, later elements).
* `tests/protocol.rs` drives the real binary: capabilities, block completions
  with their snippet on a document that does not parse, `{/` resolving against
  the open `{#each}` after an incremental edit, modifier completions, hover on
  `#each`, `null` inside `<script>`, and a case where both switches are off.

Not covered: there is no differential harness against the running official
plugin (it needs the language-tools workspace installed), so parity rests on the
ported cases plus the byte-for-byte data check; and the attribute scanner is a
hand-written approximation of `vscode-html-languageservice`, so exotic malformed
start tags may be classified differently.

## Deliberate differences from the official plugin

* The `@component` snippet uses `\n` rather than the platform `EOL` — LSP text
  is `\n` and the output should not depend on the host OS.
* Tag hover returns `MarkupContent { kind: markdown }` instead of a bare
  `MarkedString`; clients render both as markdown, and it matches what modifier
  hover already returned.
* Modifier hover locates the attribute by the span the scanner already produced,
  instead of the official `getText().lastIndexOf(name, offset)` re-search.
* `modifiersInvalidWith` keeps the official `"nopassive"` entry verbatim
  (`"nonpassive"` is the actual modifier name) so the filtering behaves
  identically.

Refs #1762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tsoBsfzrKu4kfbfrdFYJS
