### PR TITLE
ci: use merge-base with origin/main instead of stale base.sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Require changeset for fix/feat PRs
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
         shell: bash
         run: |
@@ -49,8 +48,18 @@ jobs:
             exit 0
           fi
 
+          # Diff against the actual merge-base with main, not
+          # github.event.pull_request.base.sha: that field is fixed at PR-open
+          # (or last-sync) time and never tracks main's current tip, so on this
+          # `pull_request`-triggered checkout (whose HEAD is the ephemeral
+          # `refs/pull/<n>/merge` commit) it would misread changesets added by
+          # OTHER PRs merged into main since as "added by this PR" — a false
+          # negative that can let a real fix/feat PR through without one. See #1799.
+          git fetch --quiet origin +main:refs/remotes/origin/main
+          base="$(git merge-base HEAD origin/main)"
+
           # New changeset markdown files added in this PR (README.md is pre-existing).
-          added=$(git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- '.changeset/*.md' \
+          added=$(git diff --name-only --diff-filter=A "$base"...HEAD -- '.changeset/*.md' \
             | grep -vE '\.changeset/README\.md$' || true)
 
           if [[ -z "$added" ]]; then
@@ -64,7 +73,6 @@ jobs:
 
       - name: Require consumer changesets for shared-core changes
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
         shell: bash
         # A single Rust crate (rsvelte_core) is compiled into several separate

--- a/scripts/release/check-core-consumer-changesets.mjs
+++ b/scripts/release/check-core-consumer-changesets.mjs
@@ -65,7 +65,25 @@ function sh(cmd) {
 }
 
 function resolveBase() {
-  if (process.env.BASE_SHA) return process.env.BASE_SHA;
+  // Never trust a caller-supplied BASE_SHA (github.event.pull_request.base.sha):
+  // GitHub sets it once — at PR-open time, or the last time the PR was synced —
+  // and it does NOT track the base branch's current tip. On the `pull_request`
+  // event, `HEAD` here is actually the ephemeral `refs/pull/<n>/merge` commit
+  // (this PR's head merged onto main's tip *as of this run*), so a stale
+  // BASE_SHA makes `git diff base...HEAD` include every file changed by every
+  // other PR merged into main between BASE_SHA and now — see #1799. The actual
+  // merge-base with `origin/main` is always correct, since it resolves to
+  // exactly the main-tip parent of that ephemeral merge commit.
+  //
+  // `+main:refs/remotes/origin/main` force-updates the local ref explicitly
+  // rather than relying on the default `origin` fetch refspec, which actions/
+  // checkout does not always configure.
+  try {
+    sh('git fetch --quiet origin +main:refs/remotes/origin/main');
+  } catch {
+    // Best-effort refresh (e.g. no network in a sandboxed/offline run); fall
+    // back to whatever `origin/main` already resolves to locally.
+  }
   try {
     return sh('git merge-base HEAD origin/main');
   } catch {


### PR DESCRIPTION
## 原因

`scripts/release/check-core-consumer-changesets.mjs` の `resolveBase()` と、`.github/workflows/ci.yml` の「Require changeset for fix/feat PRs」ステップは、どちらも `BASE_SHA` (`github.event.pull_request.base.sha`) を差分の起点として使っていた。

`BASE_SHA` は PR 作成時 / 最終 sync 時点の値のまま固定され、main の現在の tip を追従しない。`pull_request` イベントでの checkout は既定で `refs/pull/<n>/merge`(この PR の head を、その時点の main の tip にマージした一時コミット)を HEAD として取得するため、古い `BASE_SHA` からその HEAD への `git diff` には、`BASE_SHA` 以降に main へマージされた**他の PR の変更**がすべて混入する。

- `Require consumer changesets for shared-core changes`: 無関係な svelte2tsx/svelte-check の変更を誤検知(false positive) → PR #1779 / #1787
- `Require changeset for fix/feat PRs`: 他 PR が追加した changeset ファイルを「この PR が追加した」と誤認しうる(false negative) → 本来 changeset が必要な fix/feat PR がすり抜ける可能性

## 修正内容

両ステップとも、`BASE_SHA` の代わりに **`git merge-base HEAD origin/main`** を起点として使うよう変更。`refs/pull/<n>/merge` は (main tip, PR head) の2親を持つマージコミットなので、`merge-base(HEAD, origin/main)` は常に「マージ時点の main tip」= このPRが実際に追加した差分の正しい起点に一致する。

- `origin/main` が確実にローカルに存在するよう、`git fetch --quiet origin +main:refs/remotes/origin/main` を先に実行(`actions/checkout` は既定の fetch refspec を必ずしも設定しないため、明示的な refspec で強制更新)。
- `check-core-consumer-changesets.mjs` 側はネットワーク不可なオフライン実行(ローカル dev 等)のための fallback(fetch 失敗を握りつぶして既存の `origin/main` / `main` を使う)を維持。

## #1779 / #1787 で誤検知が消えることの実測

実際に失敗した CI run のログから当時の `BASE_SHA` と `refs/pull/<n>/merge` の実コミット(2親)を復元し、ローカルで新旧ロジックを比較した。

**PR #1779**(実際の変更は `2_analyze/` の6ファイルのみ)
- 旧ロジック(`git diff BASE_SHA...merge-commit`): **23ファイル**、うち **13ファイル**が `svelte2tsx/` — 実際の CI 失敗を再現
- 新ロジック(`git diff merge-base(merge-commit, origin/main)...merge-commit`): **6ファイル**、`2_analyze/visitors/{assignment_expression,await_block,const_tag,declaration_tag,render_tag,shared/utils}.rs` のみ、`svelte2tsx/` は **0件**

**PR #1787**(実際の変更は `tests/` `compatibility/` `AGENTS.md` のみ)
- 旧ロジック: **51ファイル**、うち **12ファイル**が `svelte2tsx/`
- 新ロジック: **8ファイル**、`AGENTS.md` / `compatibility/sourcemap-*.{json,md}` / `crates/rsvelte_core/tests/{common/mod.rs,sourcemaps.rs,sourcemaps_gate.rs}` のみ、`svelte2tsx/` は **0件**

## 正しく検出すべきケースが引き続き検出されることの実測

実際に `crates/rsvelte_core/src/svelte2tsx/` を変更してマージ済みの PR (#1758 / #1769 / #1775) の head ブランチについて、新ロジック(`merge-base(head, origin/main)` を起点とした diff)を適用し、いずれも該当ファイルが正しく検出されることを確認した。

- PR #1758: `svelte2tsx/script/{component_events,export_decl,exported_names,hoistable_types,mod,props_rune,reactive,stores}.rs` — 検出 ✓
- PR #1769: `svelte2tsx/process_instance_script_tag.rs` — 検出 ✓
- PR #1775: `svelte2tsx/template/attributes/*.rs` 等12ファイル — 検出 ✓

## 姉妹ステップの調査結果

`Require changeset for fix/feat PRs` ステップも同じ `BASE_SHA` を使っており、`--diff-filter=A`(追加ファイルのみ)で判定しているため、rebase / 他PRマージ後は「他PRが追加した changeset を自PRが追加したと誤認」する false negative があり得ると判断し、同じ merge-base ベースの修正を適用した(挙動が変わる点をここに明記)。

## 検証コマンド

```bash
node scripts/release/check-core-consumer-changesets.mjs   # ローカルで問題なく動作することを確認
```

Rust のビルド/テストへの影響なし(CI ワークフローと Node スクリプトのみの変更)。

Fixes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqdHfZSN3LFxPkyKFaCyoF