### PR TITLE
feat(language-server): compiler warning metadata and svelte-ignore quickfixes

### DIFF
--- a/crates/rsvelte_language_server/src/code_actions.rs
+++ b/crates/rsvelte_language_server/src/code_actions.rs
@@ -11,14 +11,10 @@ use lsp_types::{
     Range, TextEdit, Uri, WorkspaceEdit,
 };
 use rsvelte_core::ParseOptions;
-use rsvelte_core::ast::template::{Attribute, AttributeNode, Fragment, Root, TemplateNode};
+use rsvelte_core::ast::template::{Fragment, Root, TemplateNode};
 
 use crate::diagnostics::{COMPILER_SOURCE, is_compiler_code};
 use crate::text::LineIndex;
-
-/// The warning whose anchor is missing `rel="noreferrer"`. Svelte 5 no longer
-/// emits it; the fix stays for diagnostics produced against older compilers.
-const ANCHOR_REL_NOREFERRER: &str = "security-anchor-rel-noreferrer";
 
 /// Warnings a `svelte-ignore` comment cannot suppress, in both the spelling the
 /// official server lists and the one Svelte 5 emits.
@@ -31,8 +27,7 @@ const NON_IGNORABLE: &[&str] = &[
     "css_unused_selector",
 ];
 
-/// The quick fixes available for `diagnostics`, in the order the official
-/// server returns them.
+/// The quick fixes available for `diagnostics`.
 pub fn quickfixes(source: &str, uri: &Uri, diagnostics: &[Diagnostic]) -> Vec<CodeActionOrCommand> {
     let index = LineIndex::new(source);
     let allocator = rsvelte_core::Allocator::default();
@@ -74,12 +69,6 @@ fn for_diagnostic(
         .filter(|_| !in_script)
         .and_then(|root| enclosing_node(&root.fragment, start, end));
 
-    if code == ANCHOR_REL_NOREFERRER
-        && let Some(node) = node
-        && let Some(action) = rel_noreferrer(source, index, uri, node)
-    {
-        actions.push(action);
-    }
     let anchor = node.map_or(start, |node| span(node).0);
     actions.push(svelte_ignore(source, index, uri, code, anchor, in_script));
 }
@@ -124,58 +113,16 @@ fn svelte_ignore(
     } else {
         format!("<!-- svelte-ignore {code} -->")
     };
-    let new_text = format!("{indent}{comment}{}", line_ending(source));
-
-    action(
-        format!("(svelte) Disable {code} for this line"),
-        uri,
-        vec![TextEdit {
-            range: Range::new(Position::new(line, 0), Position::new(line, 0)),
-            new_text,
-        }],
-    )
-}
-
-/// Add `noreferrer` to the anchor's `rel`, or the whole attribute when it has
-/// none. An existing `rel` is only extended when its value is quoted, so the
-/// insertion cannot land in the middle of a bare or dynamic value.
-fn rel_noreferrer(
-    source: &str,
-    index: &LineIndex,
-    uri: &Uri,
-    node: &TemplateNode,
-) -> Option<CodeActionOrCommand> {
-    let attributes = attributes(node);
-    let (offset, new_text) = match attribute(attributes, "rel") {
-        Some(rel) => {
-            let before_quote = rel.end.checked_sub(1)? as usize;
-            if !matches!(source.as_bytes().get(before_quote), Some(b'"' | b'\'')) {
-                return None;
-            }
-            (before_quote, " noreferrer".to_string())
-        }
-        None => (
-            attribute(attributes, "target")?.end as usize,
-            " rel=\"noreferrer\"".to_string(),
-        ),
+    let edit = TextEdit {
+        range: Range::new(Position::new(line, 0), Position::new(line, 0)),
+        new_text: format!("{indent}{comment}{}", line_ending(source)),
     };
-    let at = index.position(source, offset);
-    Some(action(
-        "(svelte) Add missing attribute rel=\"noreferrer\"".to_string(),
-        uri,
-        vec![TextEdit {
-            range: Range::new(at, at),
-            new_text,
-        }],
-    ))
-}
 
-fn action(title: String, uri: &Uri, edits: Vec<TextEdit>) -> CodeActionOrCommand {
     CodeActionOrCommand::CodeAction(CodeAction {
-        title,
+        title: format!("(svelte) Disable {code} for this line"),
         kind: Some(CodeActionKind::QUICKFIX),
         edit: Some(WorkspaceEdit {
-            changes: Some(HashMap::from([(uri.clone(), edits)])),
+            changes: Some(HashMap::from([(uri.clone(), vec![edit])])),
             ..WorkspaceEdit::default()
         }),
         ..CodeAction::default()
@@ -302,33 +249,6 @@ fn child_fragments<'b, 'a>(node: &'b TemplateNode<'a>) -> Vec<&'b Fragment<'a>> 
         | TemplateNode::SvelteWindow(n) => vec![&n.fragment],
         _ => Vec::new(),
     }
-}
-
-fn attributes<'b, 'a>(node: &'b TemplateNode<'a>) -> &'b [Attribute<'a>] {
-    match node {
-        TemplateNode::RegularElement(n) => &n.attributes,
-        TemplateNode::Component(n) => &n.attributes,
-        TemplateNode::SvelteComponent(n) => &n.attributes,
-        TemplateNode::SvelteElement(n) => &n.attributes,
-        TemplateNode::TitleElement(n) => &n.attributes,
-        TemplateNode::SlotElement(n) => &n.attributes,
-        TemplateNode::SvelteBody(n)
-        | TemplateNode::SvelteDocument(n)
-        | TemplateNode::SvelteFragment(n)
-        | TemplateNode::SvelteBoundary(n)
-        | TemplateNode::SvelteHead(n)
-        | TemplateNode::SvelteOptions(n)
-        | TemplateNode::SvelteSelf(n)
-        | TemplateNode::SvelteWindow(n) => &n.attributes,
-        _ => &[],
-    }
-}
-
-fn attribute<'b, 'a>(attributes: &'b [Attribute<'a>], name: &str) -> Option<&'b AttributeNode<'a>> {
-    attributes.iter().find_map(|attribute| match attribute {
-        Attribute::Attribute(node) if node.name == name => Some(node),
-        _ => None,
-    })
 }
 
 #[cfg(test)]
@@ -471,60 +391,6 @@ mod tests {
     }
 
     #[test]
-    fn a_missing_rel_attribute_is_added_after_target() {
-        let source = "<a href=\"https://svelte.dev\" target=\"_blank\">Svelte</a>\n";
-        let fixes = fixes(
-            source,
-            &[diagnostic(ANCHOR_REL_NOREFERRER, range((0, 0), (0, 55)))],
-        );
-        assert_eq!(
-            fixes[0],
-            (
-                "(svelte) Add missing attribute rel=\"noreferrer\"".to_string(),
-                TextEdit {
-                    range: range((0, 44), (0, 44)),
-                    new_text: " rel=\"noreferrer\"".to_string(),
-                }
-            )
-        );
-        // The ignore comment is offered alongside it, and second.
-        assert_eq!(
-            fixes[1].0,
-            format!("(svelte) Disable {ANCHOR_REL_NOREFERRER} for this line")
-        );
-    }
-
-    #[test]
-    fn an_existing_rel_attribute_is_extended() {
-        let source =
-            "<a href=\"https://svelte.dev\" target=\"_blank\" rel=\"noopener\">Svelte</a>\n";
-        let fixes = fixes(
-            source,
-            &[diagnostic(ANCHOR_REL_NOREFERRER, range((0, 0), (0, 70)))],
-        );
-        assert_eq!(
-            fixes[0].1,
-            TextEdit {
-                range: range((0, 58), (0, 58)),
-                new_text: " noreferrer".to_string(),
-            }
-        );
-    }
-
-    /// A `rel` whose value is not quoted cannot be extended by a text insert,
-    /// so only the ignore comment is offered.
-    #[test]
-    fn a_dynamic_rel_attribute_is_left_alone() {
-        let source = "<a href=\"x\" target=\"_blank\" rel={rel}>Svelte</a>\n";
-        let fixes = fixes(
-            source,
-            &[diagnostic(ANCHOR_REL_NOREFERRER, range((0, 0), (0, 47)))],
-        );
-        assert_eq!(fixes.len(), 1);
-        assert!(fixes[0].0.starts_with("(svelte) Disable"));
-    }
-
-    #[test]
     fn the_codes_the_official_server_excludes_get_no_fix() {
         for code in NON_IGNORABLE {
             assert!(
@@ -584,19 +450,22 @@ mod tests {
         assert!(fixes[0].1.new_text.ends_with("-->\r\n"));
     }
 
-    /// Positions cross the protocol boundary in UTF-16 units, so the anchor of
-    /// a finding after astral text must still land on its element.
+    /// Positions cross the protocol boundary in UTF-16 units, so a finding
+    /// after astral text must still resolve to its own element — read as bytes,
+    /// the range would land inside the emoji and anchor to the parent instead.
     #[test]
     fn columns_are_read_as_utf16() {
-        let source = "<p>💡</p>\n<a target=\"_blank\">x</a>\n";
+        let source = "<div>\n    💡<img>\n</div>\n";
         let fixes = fixes(
             source,
-            &[diagnostic(ANCHOR_REL_NOREFERRER, range((1, 0), (1, 20)))],
+            &[diagnostic("a11y_missing_attribute", range((1, 6), (1, 11)))],
         );
         assert_eq!(
-            fixes[0].1.range,
-            range((1, 18), (1, 18)),
-            "the insert should follow target=\"_blank\""
+            fixes[0].1,
+            TextEdit {
+                range: range((1, 0), (1, 0)),
+                new_text: "    <!-- svelte-ignore a11y_missing_attribute -->\n".to_string(),
+            }
         );
     }
 
@@ -613,7 +482,7 @@ mod tests {
         ] {
             let warning = compiler_warning(source, code);
             let fixes = fixes(source, &[warning]);
-            let edit = &fixes.last().expect("a fix for the warning").1;
+            let edit = &fixes.first().expect("a fix for the warning").1;
 
             let index = LineIndex::new(source);
             let at = index.offset(source, edit.range.start);

--- a/crates/rsvelte_language_server/src/code_actions.rs
+++ b/crates/rsvelte_language_server/src/code_actions.rs
@@ -1,0 +1,663 @@
+//! Quick fixes for the compiler warnings this server publishes.
+//!
+//! Every action is built from a diagnostic the client sent back in
+//! `CodeActionParams.context`, never from a fresh analysis, so what the editor
+//! offers always matches what it is showing.
+
+use std::collections::HashMap;
+
+use lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, Diagnostic, DiagnosticSeverity, Position,
+    Range, TextEdit, Uri, WorkspaceEdit,
+};
+use rsvelte_core::ParseOptions;
+use rsvelte_core::ast::template::{Attribute, AttributeNode, Fragment, Root, TemplateNode};
+
+use crate::diagnostics::{COMPILER_SOURCE, is_compiler_code};
+use crate::text::LineIndex;
+
+/// The warning whose anchor is missing `rel="noreferrer"`. Svelte 5 no longer
+/// emits it; the fix stays for diagnostics produced against older compilers.
+const ANCHOR_REL_NOREFERRER: &str = "security-anchor-rel-noreferrer";
+
+/// Warnings a `svelte-ignore` comment cannot suppress, in both the spelling the
+/// official server lists and the one Svelte 5 emits.
+const NON_IGNORABLE: &[&str] = &[
+    "missing-custom-element-compile-options",
+    "options_missing_custom_element",
+    "unused-export-let",
+    "export_let_unused",
+    "css-unused-selector",
+    "css_unused_selector",
+];
+
+/// The quick fixes available for `diagnostics`, in the order the official
+/// server returns them.
+pub fn quickfixes(source: &str, uri: &Uri, diagnostics: &[Diagnostic]) -> Vec<CodeActionOrCommand> {
+    let index = LineIndex::new(source);
+    let allocator = rsvelte_core::Allocator::default();
+    // A document under edit rarely parses; without a tree the ignore comment
+    // still lands on the diagnostic's own line.
+    let root = rsvelte_core::parse(
+        source,
+        &allocator,
+        ParseOptions {
+            lenient_script: true,
+            ..ParseOptions::default()
+        },
+    )
+    .ok();
+
+    let mut actions = Vec::new();
+    for diagnostic in diagnostics {
+        for_diagnostic(source, &index, root.as_ref(), uri, diagnostic, &mut actions);
+    }
+    actions
+}
+
+fn for_diagnostic(
+    source: &str,
+    index: &LineIndex,
+    root: Option<&Root>,
+    uri: &Uri,
+    diagnostic: &Diagnostic,
+    actions: &mut Vec<CodeActionOrCommand>,
+) {
+    let Some(code) = code_of(diagnostic).filter(|code| is_ignorable(diagnostic, code)) else {
+        return;
+    };
+    let start = index.offset(source, diagnostic.range.start) as u32;
+    let end = (index.offset(source, diagnostic.range.end) as u32).max(start);
+
+    let in_script = root.is_some_and(|root| in_script(root, start, end));
+    let node = root
+        .filter(|_| !in_script)
+        .and_then(|root| enclosing_node(&root.fragment, start, end));
+
+    if code == ANCHOR_REL_NOREFERRER
+        && let Some(node) = node
+        && let Some(action) = rel_noreferrer(source, index, uri, node)
+    {
+        actions.push(action);
+    }
+    let anchor = node.map_or(start, |node| span(node).0);
+    actions.push(svelte_ignore(source, index, uri, code, anchor, in_script));
+}
+
+fn code_of(diagnostic: &Diagnostic) -> Option<&str> {
+    match diagnostic.code.as_ref()? {
+        lsp_types::NumberOrString::String(code) => Some(code),
+        lsp_types::NumberOrString::Number(_) => None,
+    }
+}
+
+/// Whether a `<!-- svelte-ignore -->` comment can suppress this diagnostic —
+/// which is also what decides whether it gets any fix at all. A client hands
+/// back every provider's diagnostics, so this has to recognise a compiler
+/// warning of ours (or of the official server's) among them; an error is not a
+/// warning to silence.
+fn is_ignorable(diagnostic: &Diagnostic, code: &str) -> bool {
+    diagnostic.source.as_deref() == Some(COMPILER_SOURCE)
+        && is_compiler_code(code)
+        && !NON_IGNORABLE.contains(&code)
+        && diagnostic.severity != Some(DiagnosticSeverity::ERROR)
+}
+
+/// Insert `<!-- svelte-ignore CODE -->` (or `// svelte-ignore CODE` inside a
+/// script) on its own line above the offending node, indented like it.
+fn svelte_ignore(
+    source: &str,
+    index: &LineIndex,
+    uri: &Uri,
+    code: &str,
+    anchor: u32,
+    in_script: bool,
+) -> CodeActionOrCommand {
+    let line = index.position(source, anchor as usize).line;
+    let line_start = index.offset(source, Position::new(line, 0));
+    let indent: String = source[line_start..]
+        .chars()
+        .take_while(|&c| c == ' ' || c == '\t')
+        .collect();
+    let comment = if in_script {
+        format!("// svelte-ignore {code}")
+    } else {
+        format!("<!-- svelte-ignore {code} -->")
+    };
+    let new_text = format!("{indent}{comment}{}", line_ending(source));
+
+    action(
+        format!("(svelte) Disable {code} for this line"),
+        uri,
+        vec![TextEdit {
+            range: Range::new(Position::new(line, 0), Position::new(line, 0)),
+            new_text,
+        }],
+    )
+}
+
+/// Add `noreferrer` to the anchor's `rel`, or the whole attribute when it has
+/// none. An existing `rel` is only extended when its value is quoted, so the
+/// insertion cannot land in the middle of a bare or dynamic value.
+fn rel_noreferrer(
+    source: &str,
+    index: &LineIndex,
+    uri: &Uri,
+    node: &TemplateNode,
+) -> Option<CodeActionOrCommand> {
+    let attributes = attributes(node);
+    let (offset, new_text) = match attribute(attributes, "rel") {
+        Some(rel) => {
+            let before_quote = rel.end.checked_sub(1)? as usize;
+            if !matches!(source.as_bytes().get(before_quote), Some(b'"' | b'\'')) {
+                return None;
+            }
+            (before_quote, " noreferrer".to_string())
+        }
+        None => (
+            attribute(attributes, "target")?.end as usize,
+            " rel=\"noreferrer\"".to_string(),
+        ),
+    };
+    let at = index.position(source, offset);
+    Some(action(
+        "(svelte) Add missing attribute rel=\"noreferrer\"".to_string(),
+        uri,
+        vec![TextEdit {
+            range: Range::new(at, at),
+            new_text,
+        }],
+    ))
+}
+
+fn action(title: String, uri: &Uri, edits: Vec<TextEdit>) -> CodeActionOrCommand {
+    CodeActionOrCommand::CodeAction(CodeAction {
+        title,
+        kind: Some(CodeActionKind::QUICKFIX),
+        edit: Some(WorkspaceEdit {
+            changes: Some(HashMap::from([(uri.clone(), edits)])),
+            ..WorkspaceEdit::default()
+        }),
+        ..CodeAction::default()
+    })
+}
+
+/// The document's own line terminator, so an inserted line does not mix
+/// endings into a file that uses CRLF.
+fn line_ending(source: &str) -> &'static str {
+    if source.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+/// Whether a byte range falls inside a script block, its tags included.
+fn in_script(root: &Root, start: u32, end: u32) -> bool {
+    [&root.instance, &root.module]
+        .into_iter()
+        .flatten()
+        .any(|script| script.start <= start && script.end >= end)
+}
+
+/// The innermost element or block containing the range — what a
+/// `svelte-ignore` comment has to precede. Attributes are not descended into,
+/// so a finding on one anchors to its element.
+fn enclosing_node<'b, 'a>(
+    fragment: &'b Fragment<'a>,
+    start: u32,
+    end: u32,
+) -> Option<&'b TemplateNode<'a>> {
+    for node in &fragment.nodes {
+        let (node_start, node_end) = span(node);
+        if node_start > start || node_end < end || !is_container(node) {
+            continue;
+        }
+        return child_fragments(node)
+            .into_iter()
+            .find_map(|child| enclosing_node(child, start, end))
+            .or(Some(node));
+    }
+    None
+}
+
+/// Whether a node is one a `svelte-ignore` comment can be placed in front of.
+fn is_container(node: &TemplateNode) -> bool {
+    !matches!(
+        node,
+        TemplateNode::Text(_)
+            | TemplateNode::Comment(_)
+            | TemplateNode::ExpressionTag(_)
+            | TemplateNode::HtmlTag(_)
+            | TemplateNode::ConstTag(_)
+            | TemplateNode::DeclarationTag(_)
+            | TemplateNode::DebugTag(_)
+            | TemplateNode::RenderTag(_)
+            | TemplateNode::AttachTag(_)
+    )
+}
+
+fn span(node: &TemplateNode) -> (u32, u32) {
+    match node {
+        TemplateNode::Text(n) => (n.start, n.end),
+        TemplateNode::Comment(n) => (n.start, n.end),
+        TemplateNode::ExpressionTag(n) => (n.start, n.end),
+        TemplateNode::HtmlTag(n) => (n.start, n.end),
+        TemplateNode::ConstTag(n) => (n.start, n.end),
+        TemplateNode::DeclarationTag(n) => (n.start, n.end),
+        TemplateNode::DebugTag(n) => (n.start, n.end),
+        TemplateNode::RenderTag(n) => (n.start, n.end),
+        TemplateNode::AttachTag(n) => (n.start, n.end),
+        TemplateNode::IfBlock(n) => (n.start, n.end),
+        TemplateNode::EachBlock(n) => (n.start, n.end),
+        TemplateNode::AwaitBlock(n) => (n.start, n.end),
+        TemplateNode::KeyBlock(n) => (n.start, n.end),
+        TemplateNode::SnippetBlock(n) => (n.start, n.end),
+        TemplateNode::RegularElement(n) => (n.start, n.end),
+        TemplateNode::Component(n) => (n.start, n.end),
+        TemplateNode::SvelteComponent(n) => (n.start, n.end),
+        TemplateNode::SvelteElement(n) => (n.start, n.end),
+        TemplateNode::TitleElement(n) => (n.start, n.end),
+        TemplateNode::SlotElement(n) => (n.start, n.end),
+        TemplateNode::SvelteBody(n)
+        | TemplateNode::SvelteDocument(n)
+        | TemplateNode::SvelteFragment(n)
+        | TemplateNode::SvelteBoundary(n)
+        | TemplateNode::SvelteHead(n)
+        | TemplateNode::SvelteOptions(n)
+        | TemplateNode::SvelteSelf(n)
+        | TemplateNode::SvelteWindow(n) => (n.start, n.end),
+    }
+}
+
+fn child_fragments<'b, 'a>(node: &'b TemplateNode<'a>) -> Vec<&'b Fragment<'a>> {
+    match node {
+        TemplateNode::IfBlock(n) => [Some(&n.consequent), n.alternate.as_ref()]
+            .into_iter()
+            .flatten()
+            .collect(),
+        TemplateNode::EachBlock(n) => [Some(&n.body), n.fallback.as_ref()]
+            .into_iter()
+            .flatten()
+            .collect(),
+        TemplateNode::AwaitBlock(n) => [n.pending.as_ref(), n.then.as_ref(), n.catch.as_ref()]
+            .into_iter()
+            .flatten()
+            .collect(),
+        TemplateNode::KeyBlock(n) => vec![&n.fragment],
+        TemplateNode::SnippetBlock(n) => vec![&n.body],
+        TemplateNode::RegularElement(n) => vec![&n.fragment],
+        TemplateNode::Component(n) => vec![&n.fragment],
+        TemplateNode::SvelteComponent(n) => vec![&n.fragment],
+        TemplateNode::SvelteElement(n) => vec![&n.fragment],
+        TemplateNode::TitleElement(n) => vec![&n.fragment],
+        TemplateNode::SlotElement(n) => vec![&n.fragment],
+        TemplateNode::SvelteBody(n)
+        | TemplateNode::SvelteDocument(n)
+        | TemplateNode::SvelteFragment(n)
+        | TemplateNode::SvelteBoundary(n)
+        | TemplateNode::SvelteHead(n)
+        | TemplateNode::SvelteOptions(n)
+        | TemplateNode::SvelteSelf(n)
+        | TemplateNode::SvelteWindow(n) => vec![&n.fragment],
+        _ => Vec::new(),
+    }
+}
+
+fn attributes<'b, 'a>(node: &'b TemplateNode<'a>) -> &'b [Attribute<'a>] {
+    match node {
+        TemplateNode::RegularElement(n) => &n.attributes,
+        TemplateNode::Component(n) => &n.attributes,
+        TemplateNode::SvelteComponent(n) => &n.attributes,
+        TemplateNode::SvelteElement(n) => &n.attributes,
+        TemplateNode::TitleElement(n) => &n.attributes,
+        TemplateNode::SlotElement(n) => &n.attributes,
+        TemplateNode::SvelteBody(n)
+        | TemplateNode::SvelteDocument(n)
+        | TemplateNode::SvelteFragment(n)
+        | TemplateNode::SvelteBoundary(n)
+        | TemplateNode::SvelteHead(n)
+        | TemplateNode::SvelteOptions(n)
+        | TemplateNode::SvelteSelf(n)
+        | TemplateNode::SvelteWindow(n) => &n.attributes,
+        _ => &[],
+    }
+}
+
+fn attribute<'b, 'a>(attributes: &'b [Attribute<'a>], name: &str) -> Option<&'b AttributeNode<'a>> {
+    attributes.iter().find_map(|attribute| match attribute {
+        Attribute::Attribute(node) if node.name == name => Some(node),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::NumberOrString;
+    use std::str::FromStr;
+
+    fn uri() -> Uri {
+        Uri::from_str("file:///App.svelte").unwrap()
+    }
+
+    fn diagnostic(code: &str, range: Range) -> Diagnostic {
+        Diagnostic {
+            range,
+            severity: Some(DiagnosticSeverity::WARNING),
+            code: Some(NumberOrString::String(code.to_string())),
+            source: Some("svelte".to_string()),
+            message: String::new(),
+            ..Diagnostic::default()
+        }
+    }
+
+    fn range(start: (u32, u32), end: (u32, u32)) -> Range {
+        Range::new(Position::new(start.0, start.1), Position::new(end.0, end.1))
+    }
+
+    /// The (title, edit) pairs of every action, flattened for assertion.
+    fn fixes(source: &str, diagnostics: &[Diagnostic]) -> Vec<(String, TextEdit)> {
+        quickfixes(source, &uri(), diagnostics)
+            .into_iter()
+            .map(|action| {
+                let CodeActionOrCommand::CodeAction(action) = action else {
+                    panic!("a command, not a code action");
+                };
+                assert_eq!(action.kind, Some(CodeActionKind::QUICKFIX));
+                let edits = action
+                    .edit
+                    .and_then(|edit| edit.changes)
+                    .and_then(|mut changes| changes.remove(&uri()))
+                    .expect("edits for the document");
+                assert_eq!(edits.len(), 1);
+                (action.title, edits.into_iter().next().unwrap())
+            })
+            .collect()
+    }
+
+    /// The official server's fixture, so the expectations below are its own.
+    const COMPONENT: &str = "<img>\n\n{#if true}\n    <a></a>\n\n    <a\n        href=\"\"\n    >about</a>\n{/if}\n\n<script>\n\tlet value = $state(\"\");\n\n\tlet x = value;\n</script>\n";
+
+    #[test]
+    fn an_ignore_comment_goes_above_the_element() {
+        let fixes = fixes(
+            COMPONENT,
+            &[diagnostic("a11y_missing_attribute", range((0, 0), (0, 6)))],
+        );
+        assert_eq!(
+            fixes,
+            vec![(
+                "(svelte) Disable a11y_missing_attribute for this line".to_string(),
+                TextEdit {
+                    range: range((0, 0), (0, 0)),
+                    new_text: "<!-- svelte-ignore a11y_missing_attribute -->\n".to_string(),
+                }
+            )]
+        );
+    }
+
+    #[test]
+    fn an_ignore_comment_keeps_the_indent_of_its_element() {
+        let fixes = fixes(
+            COMPONENT,
+            &[diagnostic("a11y_missing_attribute", range((3, 4), (3, 11)))],
+        );
+        assert_eq!(
+            fixes[0].1,
+            TextEdit {
+                range: range((3, 0), (3, 0)),
+                new_text: "    <!-- svelte-ignore a11y_missing_attribute -->\n".to_string(),
+            }
+        );
+    }
+
+    /// A finding on an attribute anchors to the element that owns it, which
+    /// starts on an earlier line.
+    #[test]
+    fn an_ignore_comment_anchors_to_the_element_of_an_attribute() {
+        let fixes = fixes(
+            COMPONENT,
+            &[diagnostic("a11y_invalid_attribute", range((6, 8), (6, 15)))],
+        );
+        assert_eq!(
+            fixes[0].1,
+            TextEdit {
+                range: range((5, 0), (5, 0)),
+                new_text: "    <!-- svelte-ignore a11y_invalid_attribute -->\n".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_finding_in_a_script_gets_a_line_comment() {
+        let fixes = fixes(
+            COMPONENT,
+            &[diagnostic(
+                "state_referenced_locally",
+                range((13, 9), (13, 14)),
+            )],
+        );
+        assert_eq!(
+            fixes,
+            vec![(
+                "(svelte) Disable state_referenced_locally for this line".to_string(),
+                TextEdit {
+                    range: range((13, 0), (13, 0)),
+                    new_text: "\t// svelte-ignore state_referenced_locally\n".to_string(),
+                }
+            )]
+        );
+    }
+
+    /// The official fixture with markup on both sides of the instance script.
+    #[test]
+    fn a_script_between_markup_is_still_recognised() {
+        let source = "<script context=\"module\">\n</script>\n\n<p></p>\n\n<script>\n\tlet a = $state(1);\n\tlet b = $state(a);\n</script>\n\n<p></p>\n";
+        let fixes = fixes(
+            source,
+            &[diagnostic(
+                "state_referenced_locally",
+                range((7, 16), (7, 17)),
+            )],
+        );
+        assert_eq!(
+            fixes[0].1,
+            TextEdit {
+                range: range((7, 0), (7, 0)),
+                new_text: "\t// svelte-ignore state_referenced_locally\n".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_missing_rel_attribute_is_added_after_target() {
+        let source = "<a href=\"https://svelte.dev\" target=\"_blank\">Svelte</a>\n";
+        let fixes = fixes(
+            source,
+            &[diagnostic(ANCHOR_REL_NOREFERRER, range((0, 0), (0, 55)))],
+        );
+        assert_eq!(
+            fixes[0],
+            (
+                "(svelte) Add missing attribute rel=\"noreferrer\"".to_string(),
+                TextEdit {
+                    range: range((0, 44), (0, 44)),
+                    new_text: " rel=\"noreferrer\"".to_string(),
+                }
+            )
+        );
+        // The ignore comment is offered alongside it, and second.
+        assert_eq!(
+            fixes[1].0,
+            format!("(svelte) Disable {ANCHOR_REL_NOREFERRER} for this line")
+        );
+    }
+
+    #[test]
+    fn an_existing_rel_attribute_is_extended() {
+        let source =
+            "<a href=\"https://svelte.dev\" target=\"_blank\" rel=\"noopener\">Svelte</a>\n";
+        let fixes = fixes(
+            source,
+            &[diagnostic(ANCHOR_REL_NOREFERRER, range((0, 0), (0, 70)))],
+        );
+        assert_eq!(
+            fixes[0].1,
+            TextEdit {
+                range: range((0, 58), (0, 58)),
+                new_text: " noreferrer".to_string(),
+            }
+        );
+    }
+
+    /// A `rel` whose value is not quoted cannot be extended by a text insert,
+    /// so only the ignore comment is offered.
+    #[test]
+    fn a_dynamic_rel_attribute_is_left_alone() {
+        let source = "<a href=\"x\" target=\"_blank\" rel={rel}>Svelte</a>\n";
+        let fixes = fixes(
+            source,
+            &[diagnostic(ANCHOR_REL_NOREFERRER, range((0, 0), (0, 47)))],
+        );
+        assert_eq!(fixes.len(), 1);
+        assert!(fixes[0].0.starts_with("(svelte) Disable"));
+    }
+
+    #[test]
+    fn the_codes_the_official_server_excludes_get_no_fix() {
+        for code in NON_IGNORABLE {
+            assert!(
+                fixes(COMPONENT, &[diagnostic(code, range((0, 0), (0, 6)))]).is_empty(),
+                "{code} should not be ignorable"
+            );
+        }
+    }
+
+    #[test]
+    fn errors_and_findings_that_are_not_compiler_warnings_get_no_fix() {
+        let at = range((0, 0), (0, 6));
+
+        let mut error = diagnostic("a11y_missing_attribute", at);
+        error.severity = Some(DiagnosticSeverity::ERROR);
+        assert!(fixes(COMPONENT, &[error]).is_empty(), "an error");
+
+        let mut lint = diagnostic("svelte/no-at-html-tags", at);
+        lint.source = Some("rsvelte".to_string());
+        assert!(fixes(COMPONENT, &[lint]).is_empty(), "one of our own rules");
+
+        // Every provider's diagnostics arrive in the request, so a finding from
+        // another server must not draw a `svelte-ignore` comment.
+        let mut foreign = diagnostic("no-undef", at);
+        foreign.source = Some("eslint".to_string());
+        assert!(fixes(COMPONENT, &[foreign]).is_empty(), "another server's");
+
+        let mut no_code = diagnostic("a11y_missing_attribute", at);
+        no_code.code = None;
+        assert!(fixes(COMPONENT, &[no_code]).is_empty(), "no code");
+    }
+
+    /// Half-written markup is the normal state of an open document: the fix
+    /// still lands on the diagnostic's own line.
+    #[test]
+    fn an_unparsable_document_still_yields_a_fix() {
+        let source = "{#if}\n<img\n";
+        let fixes = fixes(
+            source,
+            &[diagnostic("a11y_missing_attribute", range((1, 0), (1, 4)))],
+        );
+        assert_eq!(
+            fixes[0].1,
+            TextEdit {
+                range: range((1, 0), (1, 0)),
+                new_text: "<!-- svelte-ignore a11y_missing_attribute -->\n".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_crlf_document_keeps_its_line_endings() {
+        let fixes = fixes(
+            "<img>\r\n",
+            &[diagnostic("a11y_missing_attribute", range((0, 0), (0, 5)))],
+        );
+        assert!(fixes[0].1.new_text.ends_with("-->\r\n"));
+    }
+
+    /// Positions cross the protocol boundary in UTF-16 units, so the anchor of
+    /// a finding after astral text must still land on its element.
+    #[test]
+    fn columns_are_read_as_utf16() {
+        let source = "<p>💡</p>\n<a target=\"_blank\">x</a>\n";
+        let fixes = fixes(
+            source,
+            &[diagnostic(ANCHOR_REL_NOREFERRER, range((1, 0), (1, 20)))],
+        );
+        assert_eq!(
+            fixes[0].1.range,
+            range((1, 18), (1, 18)),
+            "the insert should follow target=\"_blank\""
+        );
+    }
+
+    /// The whole point of the fix: applying it to the source the compiler
+    /// complained about has to silence the warning it was built from.
+    #[test]
+    fn applying_the_fix_silences_the_warning() {
+        for (source, code) in [
+            ("<div>\n    <img>\n</div>\n", "a11y_missing_attribute"),
+            (
+                "<script>\n\tlet value = $state(\"\");\n\tlet x = value;\n</script>\n",
+                "state_referenced_locally",
+            ),
+        ] {
+            let warning = compiler_warning(source, code);
+            let fixes = fixes(source, &[warning]);
+            let edit = &fixes.last().expect("a fix for the warning").1;
+
+            let index = LineIndex::new(source);
+            let at = index.offset(source, edit.range.start);
+            let mut fixed = source.to_string();
+            fixed.insert_str(at, &edit.new_text);
+
+            assert!(
+                find_warning(&fixed, code).is_none(),
+                "{code} survived the fix:\n{fixed}"
+            );
+        }
+    }
+
+    fn find_warning(
+        source: &str,
+        code: &str,
+    ) -> Option<rsvelte_core::svelte_check::diagnostic::Diagnostic> {
+        rsvelte_lint::lint_source(
+            source,
+            std::path::Path::new("App.svelte"),
+            &rsvelte_core::CompileOptions::default(),
+            &rsvelte_lint::LintConfig::recommended(),
+        )
+        .into_iter()
+        .find(|d| d.code.as_deref() == Some(code))
+    }
+
+    /// The warning the linter really reports for `code`, converted the way this
+    /// server publishes it.
+    fn compiler_warning(source: &str, code: &str) -> Diagnostic {
+        let found =
+            find_warning(source, code).unwrap_or_else(|| panic!("no {code} in the fixture"));
+        crate::diagnostics::to_lsp(&found, &crate::settings::CompilerWarnings::default()).unwrap()
+    }
+
+    #[test]
+    fn every_diagnostic_in_the_request_gets_its_fix() {
+        let fixes = fixes(
+            COMPONENT,
+            &[
+                diagnostic("a11y_missing_attribute", range((0, 0), (0, 6))),
+                diagnostic("a11y_missing_attribute", range((3, 4), (3, 11))),
+            ],
+        );
+        assert_eq!(fixes.len(), 2);
+    }
+}

--- a/crates/rsvelte_language_server/src/diagnostics.rs
+++ b/crates/rsvelte_language_server/src/diagnostics.rs
@@ -191,12 +191,12 @@ mod tests {
     #[test]
     fn only_word_separated_lowercase_codes_are_documented() {
         let d = convert(&compiler_diagnostic(
-            "security-anchor-rel-noreferrer",
+            "css-unused-selector",
             LintSeverity::Warning,
         ));
         assert_eq!(
             d.code_description.unwrap().href.as_str(),
-            "https://svelte.dev/docs/svelte/compiler-warnings#security_anchor_rel_noreferrer"
+            "https://svelte.dev/docs/svelte/compiler-warnings#css_unused_selector"
         );
 
         for code in ["Uppercase_code", "nodash"] {

--- a/crates/rsvelte_language_server/src/diagnostics.rs
+++ b/crates/rsvelte_language_server/src/diagnostics.rs
@@ -1,16 +1,36 @@
 //! Conversion from rsvelte's lint diagnostics to LSP `Diagnostic`s.
 
-use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
+use std::str::FromStr;
+
+use lsp_types::{
+    CodeDescription, Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Uri,
+};
 use rsvelte_core::svelte_check::diagnostic::{
     Diagnostic as LintDiagnostic, DiagnosticSeverity as LintSeverity,
 };
 
-/// The `source` field every diagnostic this server publishes carries.
+use crate::settings::{CompilerWarnings, WarningLevel};
+
+/// The `source` of a finding from one of rsvelte's own lint rules.
 const SOURCE: &str = "rsvelte";
 
-/// Convert one lint diagnostic. rsvelte reports 1-based lines with 0-based
-/// UTF-16 columns (the encoding LSP uses), so only the line needs rebasing.
-pub fn to_lsp(diagnostic: &LintDiagnostic) -> Diagnostic {
+/// The `source` of a compiler warning or error. `svelte` is what the official
+/// language server publishes, and what a `svelte-ignore` quickfix keys off.
+pub const COMPILER_SOURCE: &str = "svelte";
+
+const WARNING_DOCS: &str = "https://svelte.dev/docs/svelte/compiler-warnings#";
+const ERROR_DOCS: &str = "https://svelte.dev/docs/svelte/compiler-errors#";
+
+/// Whether a code names a compiler warning/error rather than one of rsvelte's
+/// own rules, whose ids are always namespaced (`svelte/no-at-html-tags`).
+pub fn is_compiler_code(code: &str) -> bool {
+    !code.contains('/')
+}
+
+/// Convert one lint diagnostic, or drop it when the client asked for its code
+/// to be ignored. rsvelte reports 1-based lines with 0-based UTF-16 columns
+/// (the encoding LSP uses), so only the line needs rebasing.
+pub fn to_lsp(diagnostic: &LintDiagnostic, warnings: &CompilerWarnings) -> Option<Diagnostic> {
     let range = diagnostic.range.map_or_else(
         || Range::new(Position::new(0, 0), Position::new(0, 0)),
         |r| {
@@ -20,14 +40,47 @@ pub fn to_lsp(diagnostic: &LintDiagnostic) -> Diagnostic {
             )
         },
     );
-    Diagnostic {
+    let code = diagnostic.code.as_deref();
+    let compiler = code.is_some_and(is_compiler_code);
+    let level = match code.filter(|_| compiler) {
+        Some(code) => warnings.get(code).copied(),
+        None => None,
+    };
+    if level == Some(WarningLevel::Ignore) {
+        return None;
+    }
+    let mut severity = severity(diagnostic.severity);
+    if level == Some(WarningLevel::Error) {
+        severity = DiagnosticSeverity::ERROR;
+    }
+    Some(Diagnostic {
         range,
-        severity: Some(severity(diagnostic.severity)),
+        severity: Some(severity),
         code: diagnostic.code.clone().map(NumberOrString::String),
-        source: Some(SOURCE.to_string()),
+        code_description: code.filter(|_| compiler).and_then(|code| {
+            // The page a code is documented on follows how the compiler
+            // reported it, not the severity the client then asked for.
+            code_description(code, diagnostic.severity)
+        }),
+        source: Some(if compiler { COMPILER_SOURCE } else { SOURCE }.to_string()),
         message: diagnostic.message.clone(),
         ..Diagnostic::default()
+    })
+}
+
+/// The documentation link for a compiler code, mirroring the official server:
+/// only lower-case, word-separated codes are documented, and the anchor always
+/// spells them with underscores.
+fn code_description(code: &str, severity: LintSeverity) -> Option<CodeDescription> {
+    if !code.starts_with(|c: char| c.is_ascii_lowercase()) || !code.contains(['-', '_']) {
+        return None;
     }
+    let base = match severity {
+        LintSeverity::Error => ERROR_DOCS,
+        _ => WARNING_DOCS,
+    };
+    let href = Uri::from_str(&format!("{base}{}", code.replace('-', "_"))).ok()?;
+    Some(CodeDescription { href })
 }
 
 fn severity(severity: LintSeverity) -> DiagnosticSeverity {
@@ -43,7 +96,9 @@ fn severity(severity: LintSeverity) -> DiagnosticSeverity {
 mod tests {
     use super::*;
     use rsvelte_core::svelte_check::diagnostic::{Position as LintPosition, Range as LintRange};
+    use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     fn diagnostic(range: Option<LintRange>) -> LintDiagnostic {
         LintDiagnostic {
@@ -56,9 +111,30 @@ mod tests {
         }
     }
 
+    fn compiler_diagnostic(code: &str, severity: LintSeverity) -> LintDiagnostic {
+        LintDiagnostic {
+            code: Some(code.to_string()),
+            severity,
+            ..diagnostic(None)
+        }
+    }
+
+    fn convert(diagnostic: &LintDiagnostic) -> Diagnostic {
+        to_lsp(diagnostic, &CompilerWarnings::default()).unwrap()
+    }
+
+    fn warnings(entries: &[(&str, WarningLevel)]) -> CompilerWarnings {
+        Arc::new(
+            entries
+                .iter()
+                .map(|(code, level)| ((*code).to_string(), *level))
+                .collect::<HashMap<_, _>>(),
+        )
+    }
+
     #[test]
     fn lines_become_zero_based() {
-        let d = to_lsp(&diagnostic(Some(LintRange {
+        let d = convert(&diagnostic(Some(LintRange {
             start: LintPosition { line: 3, column: 4 },
             end: LintPosition { line: 3, column: 9 },
         })));
@@ -72,15 +148,89 @@ mod tests {
             Some(NumberOrString::String("svelte/no-at-html-tags".to_string()))
         );
         assert_eq!(d.source.as_deref(), Some("rsvelte"));
+        // A rule of rsvelte's own is not documented on the compiler's pages.
+        assert!(d.code_description.is_none());
     }
 
     #[test]
     fn a_missing_range_maps_to_the_start_of_the_file() {
-        let d = to_lsp(&diagnostic(None));
+        let d = convert(&diagnostic(None));
         assert_eq!(
             d.range,
             Range::new(Position::new(0, 0), Position::new(0, 0))
         );
+    }
+
+    #[test]
+    fn a_compiler_warning_carries_the_svelte_source_and_its_docs_link() {
+        let d = convert(&compiler_diagnostic(
+            "a11y_missing_attribute",
+            LintSeverity::Warning,
+        ));
+        assert_eq!(d.source.as_deref(), Some("svelte"));
+        assert_eq!(
+            d.code_description.unwrap().href.as_str(),
+            "https://svelte.dev/docs/svelte/compiler-warnings#a11y_missing_attribute"
+        );
+    }
+
+    #[test]
+    fn a_compiler_error_links_to_the_error_docs() {
+        let d = convert(&compiler_diagnostic(
+            "invalid_rune_args",
+            LintSeverity::Error,
+        ));
+        assert_eq!(
+            d.code_description.unwrap().href.as_str(),
+            "https://svelte.dev/docs/svelte/compiler-errors#invalid_rune_args"
+        );
+    }
+
+    /// The official rule spells the anchor with underscores whichever separator
+    /// the code used, and documents nothing that is not a lower-case word code.
+    #[test]
+    fn only_word_separated_lowercase_codes_are_documented() {
+        let d = convert(&compiler_diagnostic(
+            "security-anchor-rel-noreferrer",
+            LintSeverity::Warning,
+        ));
+        assert_eq!(
+            d.code_description.unwrap().href.as_str(),
+            "https://svelte.dev/docs/svelte/compiler-warnings#security_anchor_rel_noreferrer"
+        );
+
+        for code in ["Uppercase_code", "nodash"] {
+            let d = convert(&compiler_diagnostic(code, LintSeverity::Warning));
+            assert!(d.code_description.is_none(), "{code} should not be linked");
+        }
+    }
+
+    #[test]
+    fn compiler_warning_settings_escalate_and_drop() {
+        let ignored = compiler_diagnostic("a11y_missing_attribute", LintSeverity::Warning);
+        let escalated = compiler_diagnostic("state_referenced_locally", LintSeverity::Warning);
+        let levels = warnings(&[
+            ("a11y_missing_attribute", WarningLevel::Ignore),
+            ("state_referenced_locally", WarningLevel::Error),
+        ]);
+
+        assert!(to_lsp(&ignored, &levels).is_none());
+        let d = to_lsp(&escalated, &levels).unwrap();
+        assert_eq!(d.severity, Some(DiagnosticSeverity::ERROR));
+        // Escalating does not move the code off the warning docs page.
+        assert_eq!(
+            d.code_description.unwrap().href.as_str(),
+            "https://svelte.dev/docs/svelte/compiler-warnings#state_referenced_locally"
+        );
+    }
+
+    /// The setting names compiler codes, so a rule of rsvelte's own that happens
+    /// to be listed keeps its severity.
+    #[test]
+    fn compiler_warning_settings_leave_lint_rules_alone() {
+        let levels = warnings(&[("svelte/no-at-html-tags", WarningLevel::Ignore)]);
+        let d = to_lsp(&diagnostic(None), &levels).unwrap();
+        assert_eq!(d.severity, Some(DiagnosticSeverity::WARNING));
     }
 
     /// End-to-end over the real linter with a hand-computed expectation, so a
@@ -102,7 +252,7 @@ mod tests {
             .expect("the fixture should report svelte/no-at-html-tags");
 
         assert_eq!(
-            to_lsp(at_html).range,
+            convert(at_html).range,
             Range::new(Position::new(0, 9), Position::new(0, 18))
         );
     }

--- a/crates/rsvelte_language_server/src/lib.rs
+++ b/crates/rsvelte_language_server/src/lib.rs
@@ -10,6 +10,7 @@
 //! Svelte compiler needs are provided.
 
 pub mod client;
+pub mod code_actions;
 pub mod completions;
 pub mod context;
 pub mod diagnostics;

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -8,12 +8,13 @@ use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender, after, never, select, unbounded};
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
-    CompletionOptions, CompletionParams, ConfigurationItem, ConfigurationParams,
-    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DidSaveTextDocumentParams, DocumentFormattingParams, HoverParams, HoverProviderCapability,
-    OneOf, PublishDiagnosticsParams, ServerCapabilities, TextDocumentPositionParams,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TextDocumentSyncSaveOptions, TextEdit, Uri,
+    CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
+    CodeActionProviderCapability, CompletionOptions, CompletionParams, ConfigurationItem,
+    ConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentFormattingParams, HoverParams,
+    HoverProviderCapability, OneOf, PublishDiagnosticsParams, ServerCapabilities,
+    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
 };
 
 use crate::client::ClientState;
@@ -85,6 +86,10 @@ fn capabilities() -> ServerCapabilities {
             ..CompletionOptions::default()
         }),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
+        code_action_provider: Some(CodeActionProviderCapability::Options(CodeActionOptions {
+            code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+            ..CodeActionOptions::default()
+        })),
         ..ServerCapabilities::default()
     }
 }
@@ -96,6 +101,7 @@ enum Pending {
     Formatting,
     Completion,
     Hover,
+    CodeAction,
 }
 
 /// A request this server sent to the client, keyed by the id the client will
@@ -201,6 +207,7 @@ impl Server {
             "textDocument/formatting" => self.on_formatting(request),
             "textDocument/completion" => self.on_completion(request),
             "textDocument/hover" => self.on_hover(request),
+            "textDocument/codeAction" => self.on_code_action(request),
             _ => self.respond(Response::new_err(
                 request.id,
                 ErrorCode::MethodNotFound as i32,
@@ -309,6 +316,43 @@ impl Server {
             document.shared_text(),
             document.offset_at(params.position),
         ))
+    }
+
+    fn on_code_action(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<CodeActionParams>(request.params) {
+            Ok(params) => params,
+            Err(err) => {
+                log::warn(format_args!("textDocument/codeAction: {err}"));
+                self.respond_no_actions(id);
+                return;
+            }
+        };
+        let uri = params.text_document.uri;
+        let Some(document) = self.documents.get(&uri) else {
+            self.respond_no_actions(id);
+            return;
+        };
+        // A client asking only for other kinds (organize imports, refactorings)
+        // gets nothing rather than a quickfix it did not ask for.
+        let wants_quickfix = params
+            .context
+            .only
+            .as_ref()
+            .is_none_or(|kinds| kinds.contains(&CodeActionKind::QUICKFIX));
+        if params.context.diagnostics.is_empty() || !wants_quickfix {
+            self.respond_no_actions(id);
+            return;
+        }
+        let job = Job::CodeAction {
+            id: id.clone(),
+            path: uri_to_path(uri.as_str()),
+            text: document.shared_text(),
+            uri,
+            diagnostics: params.context.diagnostics,
+        };
+        self.pending.insert(id, Pending::CodeAction);
+        self.worker.submit(job);
     }
 
     fn on_notification(&mut self, notification: Notification) {
@@ -421,6 +465,11 @@ impl Server {
                     self.respond(Response::new_ok(id, hover));
                 }
             }
+            Outcome::CodeActions { id, actions } => {
+                if self.pending.remove(&id).is_some() {
+                    self.respond(Response::new_ok(id, actions));
+                }
+            }
             Outcome::Diagnostics {
                 key,
                 uri,
@@ -506,6 +555,7 @@ impl Server {
             version,
             path: uri_to_path(key),
             text: document.shared_text(),
+            warnings: self.settings.compiler_warnings.clone(),
         });
     }
 
@@ -527,6 +577,10 @@ impl Server {
     /// A request with nothing to offer is answered with `null`, not an error.
     fn respond_nothing(&self, id: RequestId) {
         self.respond(Response::new_ok(id, serde_json::Value::Null));
+    }
+
+    fn respond_no_actions(&self, id: RequestId) {
+        self.respond(Response::new_ok(id, Vec::<CodeActionOrCommand>::new()));
     }
 
     fn respond(&self, response: Response) {

--- a/crates/rsvelte_language_server/src/settings.rs
+++ b/crates/rsvelte_language_server/src/settings.rs
@@ -1,6 +1,21 @@
 //! The `rsvelte.*` client settings this server honours.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use serde_json::Value;
+
+/// What a `compilerWarnings` entry does to the warning it names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarningLevel {
+    Ignore,
+    Error,
+}
+
+/// Per-code overrides for compiler warnings, mirroring the official
+/// `svelte.plugin.svelte.compilerWarnings`. Shared so handing the map to the
+/// worker costs a refcount.
+pub type CompilerWarnings = Arc<HashMap<String, WarningLevel>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Settings {
@@ -8,6 +23,7 @@ pub struct Settings {
     pub lint_enable: bool,
     pub completion_enable: bool,
     pub hover_enable: bool,
+    pub compiler_warnings: CompilerWarnings,
 }
 
 impl Default for Settings {
@@ -17,6 +33,7 @@ impl Default for Settings {
             lint_enable: true,
             completion_enable: true,
             hover_enable: true,
+            compiler_warnings: CompilerWarnings::default(),
         }
     }
 }
@@ -31,12 +48,28 @@ impl Settings {
             lint_enable: enabled(value, "lint").unwrap_or(default.lint_enable),
             completion_enable: enabled(value, "completion").unwrap_or(default.completion_enable),
             hover_enable: enabled(value, "hover").unwrap_or(default.hover_enable),
+            compiler_warnings: compiler_warnings(value),
         }
     }
 }
 
 fn enabled(value: &Value, section: &str) -> Option<bool> {
     value.get(section)?.get("enable")?.as_bool()
+}
+
+fn compiler_warnings(value: &Value) -> CompilerWarnings {
+    let mut levels = HashMap::new();
+    if let Some(entries) = value.get("compilerWarnings").and_then(Value::as_object) {
+        for (code, level) in entries {
+            let level = match level.as_str() {
+                Some("ignore") => WarningLevel::Ignore,
+                Some("error") => WarningLevel::Error,
+                _ => continue,
+            };
+            levels.insert(code.clone(), level);
+        }
+    }
+    Arc::new(levels)
 }
 
 #[cfg(test)]
@@ -59,6 +92,7 @@ mod tests {
                 lint_enable: true,
                 completion_enable: false,
                 hover_enable: false,
+                compiler_warnings: CompilerWarnings::default(),
             }
         );
     }
@@ -70,5 +104,27 @@ mod tests {
             Settings::from_json(&json!({ "format": "yes", "lint": { "enable": 1 } })),
             Settings::default()
         );
+    }
+
+    #[test]
+    fn reads_compiler_warning_levels() {
+        let s = Settings::from_json(&json!({
+            "compilerWarnings": {
+                "a11y_missing_attribute": "ignore",
+                "state_referenced_locally": "error",
+                "css_unused_selector": "warning",
+                "a11y_invalid_attribute": 1,
+            }
+        }));
+        assert_eq!(
+            s.compiler_warnings.get("a11y_missing_attribute"),
+            Some(&WarningLevel::Ignore)
+        );
+        assert_eq!(
+            s.compiler_warnings.get("state_referenced_locally"),
+            Some(&WarningLevel::Error)
+        );
+        // Levels outside the two the official setting defines are dropped.
+        assert_eq!(s.compiler_warnings.len(), 2);
     }
 }

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -17,11 +17,12 @@ use std::thread::JoinHandle;
 
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use lsp_server::RequestId;
-use lsp_types::{CompletionList, Diagnostic, Hover, Range, TextEdit, Uri};
+use lsp_types::{CodeActionOrCommand, CompletionList, Diagnostic, Hover, Range, TextEdit, Uri};
 
 use crate::format::FormatSessions;
 use crate::lint::LintConfigCache;
 use crate::log;
+use crate::settings::CompilerWarnings;
 
 /// `rsvelte_core`'s own deeply-nested-AST tests reserve the same 256 MiB. It is
 /// address space, not resident memory — pages are committed only as the
@@ -35,6 +36,7 @@ pub enum Job {
         version: i32,
         path: PathBuf,
         text: Arc<String>,
+        warnings: CompilerWarnings,
     },
     Format {
         id: RequestId,
@@ -53,6 +55,13 @@ pub enum Job {
         path: PathBuf,
         text: Arc<String>,
         offset: usize,
+    },
+    CodeAction {
+        id: RequestId,
+        uri: Uri,
+        path: PathBuf,
+        text: Arc<String>,
+        diagnostics: Vec<Diagnostic>,
     },
     /// Drop the resolved `rsvelte-lint.json` / `.oxfmtrc` caches so the next
     /// job re-reads them from disk.
@@ -77,6 +86,10 @@ pub enum Outcome {
     Hovered {
         id: RequestId,
         hover: Option<Hover>,
+    },
+    CodeActions {
+        id: RequestId,
+        actions: Vec<CodeActionOrCommand>,
     },
 }
 
@@ -134,12 +147,13 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 version,
                 path,
                 text,
+                warnings,
             } => {
                 let config = lint_configs.get(path.parent().unwrap_or(Path::new(".")));
                 let diagnostics = guard("lint", &path, || {
                     crate::lint::lint(&path, &text, &config)
                         .iter()
-                        .map(crate::diagnostics::to_lsp)
+                        .filter_map(|d| crate::diagnostics::to_lsp(d, &warnings))
                         .collect()
                 })
                 .unwrap_or_default();
@@ -180,6 +194,19 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 id,
                 hover: guard("hover", &path, || crate::hover::hover(&text, offset)).flatten(),
             },
+            Job::CodeAction {
+                id,
+                uri,
+                path,
+                text,
+                diagnostics,
+            } => {
+                let actions = guard("code action", &path, || {
+                    crate::code_actions::quickfixes(&text, &uri, &diagnostics)
+                })
+                .unwrap_or_default();
+                Outcome::CodeActions { id, actions }
+            }
         };
         if outcomes.send(outcome).is_err() {
             break;

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -344,6 +344,10 @@ fn serves_diagnostics_and_formatting() {
         result["capabilities"]["documentFormattingProvider"],
         json!(true)
     );
+    assert_eq!(
+        result["capabilities"]["codeActionProvider"]["codeActionKinds"],
+        json!(["quickfix"])
+    );
 
     server.notify("initialized", json!({}));
     server.notify(
@@ -361,9 +365,11 @@ fn serves_diagnostics_and_formatting() {
     // Diagnostics must match a direct lint of the same source.
     let mut config_cache = rsvelte_language_server::lint::LintConfigCache::default();
     let config = config_cache.get(path.parent().unwrap());
+    let warnings = rsvelte_language_server::settings::CompilerWarnings::default();
     let expected: Vec<Value> = rsvelte_language_server::lint::lint(&path, SOURCE, &config)
         .iter()
-        .map(|d| serde_json::to_value(rsvelte_language_server::diagnostics::to_lsp(d)).unwrap())
+        .filter_map(|d| rsvelte_language_server::diagnostics::to_lsp(d, &warnings))
+        .map(|d| serde_json::to_value(d).unwrap())
         .collect();
     assert!(!expected.is_empty(), "the fixture should produce findings");
     assert_eq!(server.diagnostics(&uri), expected);
@@ -519,6 +525,78 @@ fn serves_completions_and_hover() {
     assert_eq!(server.shutdown(), Some(0));
 }
 
+/// A compiler warning must arrive with the metadata the official server
+/// publishes, and the quickfix built from it must come back through the real
+/// binary.
+#[test]
+fn a_compiler_warning_carries_its_docs_link_and_yields_a_quickfix() {
+    let dir = temp_dir("code-action");
+    let uri = file_uri(&dir.join("App.svelte"));
+    let mut server = initialized_server();
+
+    did_open(&mut server, &uri, "<div>\n    <img>\n</div>\n");
+    let diagnostics = server.diagnostics_matching(&uri, |d| {
+        d.iter().any(|d| d["code"] == "a11y_missing_attribute")
+    });
+    let warning = diagnostics
+        .iter()
+        .find(|d| d["code"] == "a11y_missing_attribute")
+        .expect("the fixture should report a missing alt attribute");
+    assert_eq!(warning["source"], json!("svelte"));
+    assert_eq!(
+        warning["codeDescription"]["href"],
+        json!("https://svelte.dev/docs/svelte/compiler-warnings#a11y_missing_attribute")
+    );
+
+    let id = server.request(
+        "textDocument/codeAction",
+        json!({
+            "textDocument": { "uri": uri },
+            "range": warning["range"],
+            "context": { "diagnostics": [warning] },
+        }),
+    );
+    let actions = server.response(id);
+    let actions = actions.as_array().expect("code actions");
+    assert_eq!(actions.len(), 1);
+    assert_eq!(
+        actions[0]["title"],
+        json!("(svelte) Disable a11y_missing_attribute for this line")
+    );
+    assert_eq!(actions[0]["kind"], json!("quickfix"));
+    let edits = actions[0]["edit"]["changes"][&uri]
+        .as_array()
+        .expect("edits for the document");
+    assert_eq!(edits.len(), 1);
+    assert_eq!(
+        edits[0]["newText"],
+        json!("    <!-- svelte-ignore a11y_missing_attribute -->\n")
+    );
+    assert_eq!(
+        edits[0]["range"],
+        json!({ "start": { "line": 1, "character": 0 }, "end": { "line": 1, "character": 0 } })
+    );
+
+    // A request naming no diagnostic, or asking only for another kind, has
+    // nothing to fix.
+    for context in [
+        json!({ "diagnostics": [] }),
+        json!({ "diagnostics": [warning], "only": ["refactor"] }),
+    ] {
+        let id = server.request(
+            "textDocument/codeAction",
+            json!({
+                "textDocument": { "uri": uri },
+                "range": warning["range"],
+                "context": context,
+            }),
+        );
+        assert_eq!(server.response(id), json!([]));
+    }
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
 /// `rsvelte.completion.enable` / `rsvelte.hover.enable` switch the features off
 /// without the client having to stop asking.
 #[test]
@@ -546,6 +624,51 @@ fn the_settings_switch_completion_and_hover_off() {
 
     assert_eq!(server.completion_response(&uri, 1, 2), Value::Null);
     assert_eq!(server.hover(&uri, 0, 5), Value::Null);
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+/// `compilerWarnings` drops the codes it silences and escalates the rest.
+#[test]
+fn compiler_warning_settings_reach_the_published_diagnostics() {
+    let dir = temp_dir("compiler-warnings");
+    let uri = file_uri(&dir.join("App.svelte"));
+
+    let mut server = Server::start();
+    server.settings = json!({
+        "compilerWarnings": {
+            "a11y_missing_attribute": "ignore",
+            "a11y_consider_explicit_label": "error",
+        }
+    });
+    let id = server.request(
+        "initialize",
+        json!({
+            "processId": Value::Null,
+            "rootUri": Value::Null,
+            "capabilities": { "workspace": { "configuration": true } },
+        }),
+    );
+    server.response(id);
+    server.notify("initialized", json!({}));
+    // Opening only once the settings are in hand keeps the first publish from
+    // being one a lint that raced them produced.
+    server.settle_configuration();
+    did_open(&mut server, &uri, "<img>\n<a></a>\n");
+
+    let diagnostics = server.diagnostics(&uri);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d["code"] == "a11y_missing_attribute"),
+        "an ignored code must not be published: {diagnostics:?}"
+    );
+    let escalated = diagnostics
+        .iter()
+        .find(|d| d["code"] == "a11y_consider_explicit_label")
+        .expect("the fixture should report a link without a label");
+    // 1 == DiagnosticSeverity.Error
+    assert_eq!(escalated["severity"], json!(1));
 
     assert_eq!(server.shutdown(), Some(0));
 }


### PR DESCRIPTION
## What was already there vs. what this adds

M0 already ran the compiler through `rsvelte_lint::lint_source`, whose validator wrap emits compiler warnings/errors and a11y findings. So **`a11y_*`, `state_referenced_locally`, etc. were already published** with `code`, `message` and `range` — they were just indistinguishable from rsvelte's own lint rules and carried no metadata.

This PR adds only what was missing:

| | before | after |
|---|---|---|
| compiler warnings published | ✅ | ✅ (unchanged set) |
| `source` | `rsvelte` for everything | `svelte` for compiler codes, `rsvelte` for `svelte/*` rules |
| `codeDescription` | — | docs link for compiler codes |
| `compilerWarnings` ignore/error | — | ✅ |
| `textDocument/codeAction` | — | ✅ `quickfix` only, `svelte-ignore` insertion |

No diagnostic is emitted twice: the conversion in `diagnostics.rs` is the single place compiler findings become LSP diagnostics.

The official server's second quickfix, `rel="noreferrer"`, is **not** ported: Svelte 5 removed the `security-anchor-rel-noreferrer` warning, so the action could never fire, and the fix belongs on the equivalent lint rule (`svelte/no-target-blank`) rather than in the LSP — tracked in a separate issue.

## `source` / `code` / `codeDescription`

- **`source`** — the official server publishes `svelte`. rsvelte's stream mixes two origins in one list, so the value is now derived: a code without a `/` is a compiler code and gets `svelte`; a namespaced rule id (`svelte/no-at-html-tags`) keeps `rsvelte`. **Why change it:** the official quickfix gate is `source === 'svelte'`, and a `<!-- svelte-ignore -->` comment only suppresses compiler warnings — keeping one blanket `rsvelte` would either offer the fix for lint rules it cannot silence, or lose the fix entirely. It also makes the Problems panel read `svelte(a11y_missing_attribute)` exactly like the official extension.
- **`code`** — unchanged (already the compiler's own code).
- **`codeDescription`** — the official `getCodeDescription` rule, ported literally: only codes that start with a lower-case letter and contain `-`/`_` are linked, and the anchor always uses underscores (`code.replace(/-/g, '_')`). Warnings link to `…/compiler-warnings#`, hard compile errors to `…/compiler-errors#`, following the two base URLs the official file uses. The page is chosen by how the compiler reported the finding, so `compilerWarnings: error` does not move a warning onto the errors page.

## Intentional differences from the official server

1. **Anchor node inside a `<script>`.** The official server walks the estree AST for the innermost node containing the diagnostic and inserts at its start line; rsvelte's script AST has no generic walker, so the insert goes on the **diagnostic's own start line**. For every case the official test suite covers these are the same line (the innermost node containing a compiler-warning range starts at the range start), and the round-trip test below proves the comment actually suppresses the warning.
2. **Non-ignorable codes are listed in both spellings.** The official list is Svelte-4 spelled (`css-unused-selector`, …), which no longer matches what Svelte 5 emits; the Svelte-5 names (`css_unused_selector`, `export_let_unused`, `options_missing_custom_element`) are excluded too.
3. **`WorkspaceEdit.changes`** rather than `documentChanges` with a null version — same edit, supported by clients that do not advertise `documentChanges`.
4. **Line ending** follows the document (CRLF stays CRLF) instead of the server's `os.EOL`.
5. **Container nodes**: the official walk keeps the Svelte-4 type names, so it descends fragments/components/blocks; here every element-like node is a container, which anchors an attribute finding on `<svelte:element>`/`<slot>` to the element rather than its enclosing block.
6. **Settings key** is `rsvelte.compilerWarnings` (the server's section is `rsvelte`), same value shape as `svelte.plugin.svelte.compilerWarnings`. It applies to compiler codes only — rsvelte's own rules stay configurable through `rsvelte-lint.json`.

## Design notes

- Positions cross the boundary through the existing `LineIndex` only; no hand-rolled UTF-16 arithmetic.
- The parse + fix construction runs on the M0 worker thread (256 MiB stack, `catch_unwind`), so a pathological document costs at most its own request.
- Fixes are built from `context.diagnostics`; nothing is re-analysed. `context.only` without `quickfix`, an empty diagnostic list, or an unknown document all answer `[]` immediately.
- An unparsable document (the normal state while typing) yields no tree; the ignore comment then lands on the diagnostic's own line instead of the enclosing element's.

## Test coverage

`cargo test -p rsvelte_language_server` — 48 unit + 8 integration tests.

Ported from the official `getCodeAction.test.ts` (its fixtures are used verbatim): insertion above the element, indent preserved, an attribute finding anchoring to the element that starts on an earlier line, a script finding getting `\t// svelte-ignore …`, a script between markup on both sides, and the "no fix" cases (error severity, no code, another provider's diagnostic, excluded codes).

Beyond the official suite: `applying_the_fix_silences_the_warning` re-lints the patched source and asserts the warning is gone (both a template a11y warning and a script `state_referenced_locally`), CRLF documents keep their endings, astral text before the finding still resolves to the right element, an unparsable document still yields a fix, and the settings/`codeDescription` matrix in `diagnostics.rs`. `tests/protocol.rs` drives the real binary: the capability, a published warning's `source`/`codeDescription`, and the quickfix with its exact edit.

**Not covered:** a script finding whose innermost node begins on an earlier line than the diagnostic (difference 1 above), and preprocessed documents, which this server does not handle yet.

## Commands

- `cargo fmt`
- `cargo clippy -p rsvelte_language_server --all-targets --all-features -- -D warnings` — clean
- `cargo test -p rsvelte_language_server` — 56 passed, 0 failed

Refs #1762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tsoBsfzrKu4kfbfrdFYJS
