### PR TITLE
perf(lint): stop redoing per-file work in every rule (-30% lint time)

### DIFF
--- a/crates/rsvelte_lint/src/context.rs
+++ b/crates/rsvelte_lint/src/context.rs
@@ -6,9 +6,13 @@
 //! also borrows the resolved [`LintConfig`] so a rule can read its own parsed
 //! options via [`LintContext::option_bool`] / [`LintContext::option_str_list`].
 
+use std::cell::OnceCell;
 use std::path::Path;
+use std::rc::Rc;
 
 use serde_json::Value;
+
+use rsvelte_core::compiler::phases::phase2_analyze::ComponentAnalysis;
 
 use crate::config::LintConfig;
 use crate::diagnostic::{Fix, LintDiagnostic, Suggestion};
@@ -34,6 +38,20 @@ pub struct LintContext<'a> {
     /// rule that needs it is disabled). Rules use it to distinguish a real
     /// global reference from a local binding that shares a global's name.
     scope_resolver: Option<&'a crate::scope::ScopeResolver>,
+    /// The component's Phase-2 analysis (bindings/scopes), run on first use.
+    /// Running it costs a full parse + analyze — several rules need it, so they
+    /// share one result per file instead of each re-analyzing the source.
+    /// `None` records an analysis failure (rules fall back to their own scan).
+    scope_analysis: OnceCell<Option<Rc<ComponentAnalysis>>>,
+    /// The template fragment as ESTree JSON (default parse options), built on
+    /// first use — several script rules scan template expressions and would
+    /// otherwise each re-parse and re-serialize the whole source.
+    template_fragment_json: OnceCell<Rc<Value>>,
+    /// The component's template AST as ESTree JSON, serialized on first use.
+    /// Several rules walk the whole tree generically; serializing it is one of
+    /// the most expensive things a lint pass does, so they share one value.
+    /// `Value::Null` records a serialization failure (rules bail on it).
+    root_json: OnceCell<Rc<Value>>,
 }
 
 impl<'a> LintContext<'a> {
@@ -47,6 +65,9 @@ impl<'a> LintContext<'a> {
             filename,
             path: None,
             scope_resolver: None,
+            scope_analysis: OnceCell::new(),
+            template_fragment_json: OnceCell::new(),
+            root_json: OnceCell::new(),
         }
     }
 
@@ -64,6 +85,52 @@ impl<'a> LintContext<'a> {
     ) -> Self {
         self.scope_resolver = resolver;
         self
+    }
+
+    /// The component's Phase-2 analysis, run once per file and shared by every
+    /// rule that asks for it. `None` when the component fails to analyze (an
+    /// invalid component still lints — rules fall back to a parse-only scan).
+    pub fn scope_analysis(&self) -> Option<Rc<ComponentAnalysis>> {
+        self.scope_analysis
+            .get_or_init(|| crate::scope::analyze_scope(self.source).map(Rc::new))
+            .clone()
+    }
+
+    /// The component's template AST as ESTree JSON, serialized once per file
+    /// and shared by every rule that asks for it. Returns `Value::Null` if the
+    /// tree could not be serialized. The `Rc` handout keeps the borrow off
+    /// `self`, so a rule can report while holding the JSON.
+    pub fn root_json(&self, root: &rsvelte_core::ast::template::Root) -> Rc<Value> {
+        self.root_json
+            .get_or_init(|| {
+                Rc::new(rsvelte_core::ast::arena::with_serialize_arena(
+                    &root.arena,
+                    || serde_json::to_value(root).unwrap_or(Value::Null),
+                ))
+            })
+            .clone()
+    }
+
+    /// The template fragment as ESTree JSON, parsed with the *default* options
+    /// (not the lenient lint options — a script rule scanning template
+    /// expressions must see what the strict parse produces) and cached per
+    /// file. Script rules reach the template through this instead of
+    /// re-parsing + re-serializing the source on every call.
+    pub fn template_fragment_json(&self) -> Rc<Value> {
+        self.template_fragment_json
+            .get_or_init(|| {
+                let alloc = rsvelte_core::Allocator::default();
+                let Ok(root) =
+                    rsvelte_core::parse(self.source, &alloc, rsvelte_core::ParseOptions::default())
+                else {
+                    return Rc::new(Value::Null);
+                };
+                Rc::new(rsvelte_core::ast::arena::with_serialize_arena(
+                    &root.arena,
+                    || serde_json::to_value(&root.fragment).unwrap_or(Value::Null),
+                ))
+            })
+            .clone()
     }
 
     /// The script-scope resolver for this file, when one was built.

--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -154,7 +154,7 @@ fn enabled_script_rules<'a>(
 
 /// Run each enabled script rule over every `(kind, program)` pair.
 fn run_over_programs(
-    programs: &[(ScriptKind, Value)],
+    programs: &[(ScriptKind, &Value)],
     source: &str,
     filename: &str,
     config: &LintConfig,
@@ -286,17 +286,19 @@ pub(crate) fn run_script_rules_on_root(
         return Vec::new();
     }
 
-    // Materialise each script program to an owned ESTree JSON value. The
+    // Materialise each script program as an ESTree JSON value. The
     // serialization MUST run inside the arena scope (the program body resolves
     // arena-indexed children) and BEFORE any out-of-scope `as_json` would cache
-    // an empty body — so we serialize immediately inside the arena guard.
-    let programs: Vec<(ScriptKind, Value)> = with_serialize_arena(&root.arena, || {
+    // an empty body — so we serialize immediately inside the arena guard. The
+    // values stay borrowed from the program's own `OnceCell` cache: copying
+    // them out would deep-clone an entire ESTree tree per file.
+    let programs: Vec<(ScriptKind, &Value)> = with_serialize_arena(&root.arena, || {
         let mut out = Vec::new();
         if let Some(s) = root.instance.as_ref() {
-            out.push((ScriptKind::Instance, s.content.as_json().clone()));
+            out.push((ScriptKind::Instance, s.content.as_json()));
         }
         if let Some(s) = root.module.as_ref() {
-            out.push((ScriptKind::Module, s.content.as_json().clone()));
+            out.push((ScriptKind::Module, s.content.as_json()));
         }
         out
     });
@@ -331,7 +333,7 @@ pub fn run_script_rules_module(
         return Vec::new();
     }
     let program = rsvelte_core::compiler::phases::parse_module_to_estree(source, is_ts);
-    let programs = [(ScriptKind::Module, program)];
+    let programs = [(ScriptKind::Module, &program)];
     // A standalone module is its own scope; the whole file is the script body
     // (base offset 0).
     let resolver = needs_scope_resolver(&enabled).then(|| {

--- a/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
+++ b/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
@@ -424,7 +424,7 @@ impl ScriptRule for NoImmutableReactiveStatements {
         // wouldn't reject), continue with empty binding maps — the write-only
         // LHS detection and the "unknown identifier → skip" guard ensure we
         // only report structurally obvious non-reactive statements.
-        let analysis = crate::scope::analyze_scope(ctx.source());
+        let analysis = ctx.scope_analysis();
 
         let (binding_names, mutable_bindings): (HashSet<&str>, HashSet<&str>) =
             if let Some(ref a) = analysis {

--- a/crates/rsvelte_lint/src/rules/no_navigation_without_base.rs
+++ b/crates/rsvelte_lint/src/rules/no_navigation_without_base.rs
@@ -13,7 +13,6 @@
 
 use std::collections::{HashMap, HashSet};
 
-use rsvelte_core::ast::arena::with_serialize_arena;
 use rsvelte_core::ast::template::Root;
 use serde_json::Value;
 
@@ -359,10 +358,10 @@ impl Rule for NoNavigationWithoutBase {
     }
 
     fn check_root(&self, ctx: &mut LintContext, root: &Root) {
-        let Some(json) = with_serialize_arena(&root.arena, || serde_json::to_value(root).ok())
-        else {
+        let json = ctx.root_json(root);
+        if json.is_null() {
             return;
-        };
+        }
         let im = collect_imports(&json);
         let var_inits = collect_var_inits(&json);
         let cx = Ctx {

--- a/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
+++ b/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
@@ -138,7 +138,8 @@ impl ScriptRule for NoUnnecessaryStateWrap {
         // `x = ...` and `bind:` getter/setter writes via the analyzed scope, plus
         // shorthand `bind:x` two-way bindings detected from the source.
         let reassigned: HashSet<String> = if allow_reassign {
-            let mut set: HashSet<String> = crate::scope::analyze_scope(ctx.source())
+            let mut set: HashSet<String> = ctx
+                .scope_analysis()
                 .map(|a| {
                     a.root
                         .bindings

--- a/crates/rsvelte_lint/src/rules/prefer_const.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_const.rs
@@ -71,26 +71,11 @@ fn init_rune_callee(init: &Value) -> Option<&str> {
 /// `prefer-const` rule, which only bails on a write reference to the binding
 /// itself. Used to cover template positions the compiler scope walk skips
 /// (e.g. `{@render}` arguments).
-fn collect_template_reassignments(source: &str, out: &mut HashSet<String>) {
-    // Re-parse (cheap; the analyzed `ComponentAnalysis` keeps only the scope
-    // tree, not the template AST) and serialize the template fragment so the
-    // assignment walk runs over the ESTree expressions inside every tag. The
-    // fragment's JS expressions live in the parse arena, which must be installed
-    // for the duration of the serialize.
-    use rsvelte_core::ast::arena::with_serialize_arena;
-    let Ok(root) = rsvelte_core::parse(
-        source,
-        &rsvelte_core::Allocator::default(),
-        rsvelte_core::ParseOptions::default(),
-    ) else {
-        return;
-    };
-    let Some(value) =
-        with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-    else {
-        return;
-    };
-    walk_assignments(&value, out);
+fn collect_template_reassignments(ctx: &LintContext, out: &mut HashSet<String>) {
+    // The template fragment is serialized once per file by the context (this
+    // rule alone would otherwise re-parse + re-serialize the source on each of
+    // its two call sites, for each script block).
+    walk_assignments(&ctx.template_fragment_json(), out);
 }
 
 /// Add names that are declared by more than one `let`/`var`/`const` declarator
@@ -616,7 +601,7 @@ impl ScriptRule for PreferConst {
         // svelte-eslint-parser only parses, so it still lints such a file; to
         // match, fall back to a parse-only assignment scan of the script +
         // template when the analysis is unavailable.
-        let mut reassigned: HashSet<String> = match crate::scope::analyze_scope(ctx.source()) {
+        let mut reassigned: HashSet<String> = match ctx.scope_analysis() {
             Some(analysis) => analysis
                 .root
                 .bindings
@@ -648,7 +633,7 @@ impl ScriptRule for PreferConst {
         // ONCE here and reused below for the no-init-let check, avoiding a second
         // re-parse of the source.
         let mut template_reassign: HashSet<String> = HashSet::new();
-        collect_template_reassignments(ctx.source(), &mut template_reassign);
+        collect_template_reassignments(ctx, &mut template_reassign);
         reassigned.extend(template_reassign.iter().cloned());
         // `for (x of …)` / `for (x in …)` with a bare pattern (not
         // `VariableDeclaration`) reassign the binding. The rsvelte scope builder
@@ -887,7 +872,7 @@ impl Rule for PreferConst {
 
         // Build the reassigned set from the template itself.
         let mut reassigned: HashSet<String> = HashSet::new();
-        collect_template_reassignments(ctx.source(), &mut reassigned);
+        collect_template_reassignments(ctx, &mut reassigned);
 
         let tag_reports =
             check_template_declaration_tags(ctx.source(), &reassigned, destructuring_all);

--- a/crates/rsvelte_lint/src/rules/require_store_reactive_access.rs
+++ b/crates/rsvelte_lint/src/rules/require_store_reactive_access.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 
-use rsvelte_core::ast::arena::with_serialize_arena;
 use rsvelte_core::ast::template::Root;
 use serde_json::Value;
 
@@ -216,10 +215,10 @@ impl Rule for RequireStoreReactiveAccess {
     }
 
     fn check_root(&self, ctx: &mut LintContext, root: &Root) {
-        let Some(root_json) = with_serialize_arena(&root.arena, || serde_json::to_value(root).ok())
-        else {
+        let root_json = ctx.root_json(root);
+        if root_json.is_null() {
             return;
-        };
+        }
         let stores = collect_store_vars(&root_json);
         if stores.is_empty() {
             return;

--- a/crates/rsvelte_lint/src/rules/sort_attributes.rs
+++ b/crates/rsvelte_lint/src/rules/sort_attributes.rs
@@ -27,6 +27,9 @@
 //! Port of `eslint-plugin-svelte/src/rules/sort-attributes.ts`.
 //! Upstream: `meta.fixable = 'code'`, `type: 'layout'`.
 
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 use rsvelte_core::ast::template::{
@@ -60,6 +63,7 @@ static META: RuleMeta = RuleMeta {
 // ─── Pattern / option compilation ────────────────────────────────────────────
 
 /// A single compiled pattern (from a string entry in the order array).
+#[derive(Clone)]
 struct Pattern {
     negative: bool,
     re: Regex,
@@ -72,6 +76,7 @@ impl Pattern {
 }
 
 /// A compiled group (one entry in the order array).
+#[derive(Clone)]
 struct Group {
     patterns: Vec<Pattern>,
     sort: Sort,
@@ -205,6 +210,7 @@ fn patterns_match(patterns: &[Pattern], key: &str) -> bool {
 }
 
 /// The compiled option: a list of groups (in order).
+#[derive(Clone)]
 struct CompiledOption {
     groups: Vec<Group>,
 }
@@ -272,17 +278,24 @@ const DEFAULT_ORDER_JSON: &str = r#"[
     { "match": "/^let:/u", "sort": "alphabetical" }
 ]"#;
 
-fn load_compiled_option(ctx: &LintContext) -> CompiledOption {
-    let order_val: Option<serde_json::Value> = ctx.option0().and_then(|v| v.get("order")).cloned();
+/// The default order compiled once. Compiling it means building ~13 regexes,
+/// which is far more expensive than the check it configures — and every start
+/// tag in every file would otherwise redo it.
+static DEFAULT_OPTION: LazyLock<CompiledOption> = LazyLock::new(|| {
+    let entries: Vec<serde_json::Value> =
+        serde_json::from_str(DEFAULT_ORDER_JSON).unwrap_or_default();
+    CompiledOption {
+        groups: entries.iter().filter_map(compile_group).collect(),
+    }
+});
 
-    let entries: Vec<serde_json::Value> = if let Some(serde_json::Value::Array(arr)) = order_val {
-        arr
-    } else {
-        serde_json::from_str(DEFAULT_ORDER_JSON).unwrap_or_default()
-    };
-
-    let groups: Vec<Group> = entries.iter().filter_map(compile_group).collect();
-    CompiledOption { groups }
+fn load_compiled_option(ctx: &LintContext) -> Cow<'static, CompiledOption> {
+    match ctx.option0().and_then(|v| v.get("order")) {
+        Some(serde_json::Value::Array(arr)) => Cow::Owned(CompiledOption {
+            groups: arr.iter().filter_map(compile_group).collect(),
+        }),
+        _ => Cow::Borrowed(&DEFAULT_OPTION),
+    }
 }
 
 // ─── Key text extraction ──────────────────────────────────────────────────────
@@ -473,7 +486,7 @@ impl SortAttributes {
         if entries.len() < 2 {
             return;
         }
-        let src = ctx.source().to_string();
+        let src = ctx.source();
         let opt = load_compiled_option(ctx);
 
         // valid_previous_nodes: indices of non-spread, non-ignored entries already
@@ -539,8 +552,8 @@ impl SortAttributes {
     }
 
     fn check_tag(&self, ctx: &mut LintContext, attributes: &[Attribute]) {
-        let src = ctx.source().to_string();
-        let entries = Self::entries_from_attrs(&src, attributes);
+        let src = ctx.source();
+        let entries = Self::entries_from_attrs(src, attributes);
         self.check_entries(ctx, &entries);
     }
 
@@ -683,14 +696,14 @@ impl Rule for SortAttributes {
     }
 
     fn check_svelte_component(&self, ctx: &mut LintContext, el: &SvelteComponentElement) {
-        let src = ctx.source().to_string();
-        let entries = Self::entries_for_svelte_component(&src, el);
+        let src = ctx.source();
+        let entries = Self::entries_for_svelte_component(src, el);
         self.check_entries(ctx, &entries);
     }
 
     fn check_svelte_dynamic_element(&self, ctx: &mut LintContext, el: &SvelteDynamicElement) {
-        let src = ctx.source().to_string();
-        let entries = Self::entries_for_svelte_dynamic_element(&src, el);
+        let src = ctx.source();
+        let entries = Self::entries_for_svelte_dynamic_element(src, el);
         self.check_entries(ctx, &entries);
     }
 

--- a/crates/rsvelte_lint/src/rules/sort_attributes.rs
+++ b/crates/rsvelte_lint/src/rules/sort_attributes.rs
@@ -522,7 +522,7 @@ impl SortAttributes {
 
                 if !entry.is_plain_attr || !has_spread_between {
                     // Standard report + fix.
-                    let fix = build_fix(&src, entries, prev_idx, i);
+                    let fix = build_fix(src, entries, prev_idx, i);
                     ctx.report_with_fix(
                         entry.start,
                         entry.end,
@@ -533,7 +533,7 @@ impl SortAttributes {
                     // Spread exists between; use the "spread" verification:
                     // only compare against attributes between the last spread
                     // before `i` and `i`.
-                    self.verify_for_spread(ctx, &src, entries, &opt, i);
+                    self.verify_for_spread(ctx, src, entries, &opt, i);
                 }
                 // Skip adding to valid_previous (we already reported).
                 continue;

--- a/crates/rsvelte_lint/src/script.rs
+++ b/crates/rsvelte_lint/src/script.rs
@@ -54,7 +54,14 @@ fn walk_inner<'a, F: FnMut(&'a Value, &[&'a Value])>(
 ) {
     match node {
         Value::Object(map) => {
-            let is_node = map.get("type").and_then(Value::as_str).is_some();
+            // ESTree nodes always serialize `type` first, so the first entry
+            // answers "is this a node?" without hashing the key — this runs on
+            // every object of every walk, and every script rule walks the tree.
+            let is_node = match map.iter().next() {
+                Some((k, v)) if k == "type" => v.is_string(),
+                Some(_) => map.get("type").and_then(Value::as_str).is_some(),
+                None => false,
+            };
             if is_node {
                 f(node, stack);
                 stack.push(node);


### PR DESCRIPTION
## Why

The new `lint` benchmark (#1774) put a number on the linter for the first time — 24.9× vs ESLint, the weakest of the ecosystem tasks. Profiling it (samply, single-threaded over the 3,412-file benchmark corpus) showed the time was not going into rule logic but into **work being redone per tag, per rule, and per call site**.

One measurement framed the whole effort: with **all 72 rules off**, linting the corpus costs **185 ms**; with them on, **1,665 ms**. So 89% of the time was rules — and most of that was repeated setup, not analysis.

## What changed

Four independent fixes, each measured on its own (idle machine, 4 iterations after 2 warmup):

| # | Fix | Single-thread |
|---|---|---:|
| — | baseline | 1,665 ms |
| 1 | `sort-attributes` compiled its default order (~13 regexes) **and cloned the whole source** for every start tag → `LazyLock` + borrow | 1,451 ms (−13%) |
| 2 | Each `<script>` program's ESTree JSON was deep-cloned out of its own `OnceCell` cache → borrow it | 1,403 ms (−3%) |
| 3 | JSON walker probed `map.get("type")` (a hash lookup) on every object of every walk → ESTree puts `type` first, so read the first entry | ~1,380 ms |
| 4 | Per-file work shared via `LintContext` (below) | **1,103–1,180 ms** |

Fix 4 is the substantial one. Three kinds of whole-file work were being redone by each rule that wanted them:

- **`analyze_scope` — a full parse + Phase-2 analysis — ran once per rule** in `prefer-const`, `no-immutable-reactive-statements` and `no-unnecessary-state-wrap`. Up to three extra full analyses per file.
- The **template AST was serialized to JSON separately** by `no-navigation-without-base` and `require-store-reactive-access`.
- `prefer-const` **re-parsed and re-serialized the source** to scan template expressions, once per call site per script block.

All three now hang off `LintContext` as lazily-initialised per-file caches, handed out as `Rc` so the borrow stays off the context and a rule can still report while holding one.

## Result

- **Single-thread: 1,665 ms → ~1,100–1,180 ms (−29 to −34%)** over the benchmark corpus. The spread is session-to-session noise on a shared machine; every A/B pair here was measured back-to-back on an idle box.
- **Multi-thread: 253 ms → ~212 ms (−16%)**, i.e. roughly **24.9× → ~30×** against the unchanged ESLint baseline. The published `/benchmark` numbers are left alone — they should come from a full harness run, not this branch.

## Correctness

- Lint parity corpus: **80 current / 80 known, 0 new divergences** (re-run after every change).
- `cargo test -p rsvelte_lint --release`: 226 + 29 tests pass.
- `cargo clippy -p rsvelte_lint --all-targets`: clean.

## What's next (not in this PR)

The floor measurement says the remaining headroom is still in the rules: 1,100 ms of work over a 185 ms infrastructure floor. The two structural items, in profile order:

1. **28 rules each walk the whole ESTree JSON separately** — the template side already shares one DFS; the script side does not.
2. **The JSON itself** — script rules read fields through `serde_json::Value` (IndexMap + SipHash); walking the typed `JsNode` directly removes both the serialization and the hashing.

Per-rule costs are now measured, so that work can be sequenced by data: `prefer-const` ~214 ms, `no-immutable-reactive-statements` ~162 ms, `no-navigation-without-base` ~77 ms, `no-dom-manipulating` ~72 ms are the top four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp