### PR TITLE
test(lint-types): make the type-aware lint suite actually run

### DIFF
--- a/.github/workflows/type-aware-lint.yml
+++ b/.github/workflows/type-aware-lint.yml
@@ -2,21 +2,46 @@ name: Type-aware Lint
 
 # Runs the type-aware lint backend suite (crates/rsvelte_lint_types).
 #
-# NOT part of the `CI` workflow, and deliberately so: that crate is its own
-# Cargo workspace because it path-depends on the PRIVATE submodule
-# `ubugeeei-prod/corsa-bind` (see its Cargo.toml header), and the `CI` shards
-# skip that submodule entirely. So the nine tests in it can never run on a
-# fork or on an unprivileged PR.
-#
-# Manual dispatch only, for the same reason: it needs `secrets.GH_PAT` (the
-# same fine-grained PAT `auto-update-submodules.yml` already uses to
-# `git ls-remote` corsa-bind) to clone the private submodule over HTTPS.
-# Promote it to a `schedule:` once it has been green a few times.
+# Separate from the `CI` workflow because that crate is its own Cargo
+# workspace: it path-depends on `submodules/corsa-bind`, whose corsa/tsgo
+# client stack is a heavy build nobody else needs, so the CI shards skip the
+# submodule and never compile the crate. That is also why `ci.yml`'s
+# `cargo fmt --check` / `cargo clippy` do not reach it — this workflow is the
+# only place those run, so it does them itself.
 on:
   workflow_dispatch:
+  # NOTE: the two `paths` lists must be kept in sync by hand — the GitHub
+  # Actions workflow parser does not support YAML anchors/aliases.
+  push:
+    branches: [main]
+    paths:
+      - 'crates/rsvelte_lint_types/**'
+      - 'crates/rsvelte_lint/**'
+      - 'crates/rsvelte_core/src/svelte2tsx/**'
+      - 'scripts/dev/type-aware-lint/**'
+      - 'scripts/dev/test-type-aware-lint.mjs'
+      - '.github/workflows/type-aware-lint.yml'
+      - '.gitmodules'
+  pull_request:
+    paths:
+      - 'crates/rsvelte_lint_types/**'
+      - 'crates/rsvelte_lint/**'
+      - 'crates/rsvelte_core/src/svelte2tsx/**'
+      - 'scripts/dev/type-aware-lint/**'
+      - 'scripts/dev/test-type-aware-lint.mjs'
+      - '.github/workflows/type-aware-lint.yml'
+      - '.gitmodules'
+  # The suite drives a real tsgo against upstream eslint-plugin-svelte
+  # fixtures, so it can also break without a local change.
+  schedule:
+    - cron: '41 4 * * 2' # Tuesdays 04:41 UTC
 
 permissions:
   contents: read
+
+concurrency:
+  group: type-aware-lint-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   type-aware-lint:
@@ -26,30 +51,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Only the two submodules this suite needs, checked out shallow below.
           submodules: false
-
-      # Fail loudly instead of "succeeding" with nothing run — the whole point
-      # of this workflow (see issue #1790).
-      - name: Require corsa-bind access
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          if [ -z "${GH_PAT}" ]; then
-            echo "::error::secrets.GH_PAT is not set — the private corsa-bind submodule cannot be cloned, so the type-aware suite cannot run."
-            exit 1
-          fi
-
-      - name: Checkout private submodule over HTTPS
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "git@github.com:"
-          git submodule update --init --depth 1 submodules/corsa-bind
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: 1.97.1
+          components: rustfmt, clippy
 
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -64,7 +73,21 @@ jobs:
         with:
           node-version: 22
 
-      # Checks out eslint-plugin-svelte, installs @typescript/native-preview,
-      # verifies the binary runs, then `cargo test`s the crate.
+      # Both are public, so no credentials are involved.
+      - name: Checkout submodules
+        run: git submodule update --init --depth 1 submodules/corsa-bind submodules/eslint-plugin-svelte
+
+      # This crate is outside the root workspace, so ci.yml's fmt / clippy jobs
+      # never see it.
+      - name: cargo fmt --check
+        working-directory: crates/rsvelte_lint_types
+        run: cargo fmt --all --check
+
+      - name: cargo clippy
+        working-directory: crates/rsvelte_lint_types
+        run: cargo clippy --all-targets --locked -- -D warnings
+
+      # Installs the pinned @typescript/native-preview, verifies the binary
+      # runs, then `cargo test --locked`s the crate. A missing binary FAILS.
       - name: Run type-aware lint suite
-        run: node scripts/dev/test-type-aware-lint.mjs
+        run: node scripts/dev/test-type-aware-lint.mjs --locked

--- a/.github/workflows/type-aware-lint.yml
+++ b/.github/workflows/type-aware-lint.yml
@@ -1,0 +1,70 @@
+name: Type-aware Lint
+
+# Runs the type-aware lint backend suite (crates/rsvelte_lint_types).
+#
+# NOT part of the `CI` workflow, and deliberately so: that crate is its own
+# Cargo workspace because it path-depends on the PRIVATE submodule
+# `ubugeeei-prod/corsa-bind` (see its Cargo.toml header), and the `CI` shards
+# skip that submodule entirely. So the nine tests in it can never run on a
+# fork or on an unprivileged PR.
+#
+# Manual dispatch only, for the same reason: it needs `secrets.GH_PAT` (the
+# same fine-grained PAT `auto-update-submodules.yml` already uses to
+# `git ls-remote` corsa-bind) to clone the private submodule over HTTPS.
+# Promote it to a `schedule:` once it has been green a few times.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  type-aware-lint:
+    name: Type-aware lint suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      # Fail loudly instead of "succeeding" with nothing run — the whole point
+      # of this workflow (see issue #1790).
+      - name: Require corsa-bind access
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -z "${GH_PAT}" ]; then
+            echo "::error::secrets.GH_PAT is not set — the private corsa-bind submodule cannot be cloned, so the type-aware suite cannot run."
+            exit 1
+          fi
+
+      - name: Checkout private submodule over HTTPS
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "git@github.com:"
+          git submodule update --init --depth 1 submodules/corsa-bind
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.97.1
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      # Its own workspace ⇒ its own target dir; keyed separately from the CI cache.
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: crates/rsvelte_lint_types
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # Checks out eslint-plugin-svelte, installs @typescript/native-preview,
+      # verifies the binary runs, then `cargo test`s the crate.
+      - name: Run type-aware lint suite
+        run: node scripts/dev/test-type-aware-lint.mjs

--- a/.github/workflows/type-aware-lint.yml
+++ b/.github/workflows/type-aware-lint.yml
@@ -63,6 +63,15 @@ jobs:
       - name: Setup mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
+      # MUST come before the cache step: rust-cache runs `cargo metadata` to
+      # build its key, and the crate path-depends on corsa-bind. Without the
+      # submodule that fails ("failed to load manifest for dependency
+      # `corsa_client`") and the action silently proceeds with an EMPTY cache
+      # key — the job still goes green while caching nothing.
+      # Both submodules are public, so no credentials are involved.
+      - name: Checkout submodules
+        run: git submodule update --init --depth 1 submodules/corsa-bind submodules/eslint-plugin-svelte
+
       # Its own workspace ⇒ its own target dir; keyed separately from the CI cache.
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -72,10 +81,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
-
-      # Both are public, so no credentials are involved.
-      - name: Checkout submodules
-        run: git submodule update --init --depth 1 submodules/corsa-bind submodules/eslint-plugin-svelte
 
       # This crate is outside the root workspace, so ci.yml's fmt / clippy jobs
       # never see it.

--- a/.gitignore
+++ b/.gitignore
@@ -127,9 +127,6 @@ artifacts/
 # Claude scheduled task lock (runtime artifact)
 .claude/scheduled_tasks.lock
 
-# tsgo binary installed on demand by scripts/dev/test-type-aware-lint.mjs
-.cache/
-
 # Corpus-compat pipeline (generated; see scripts/compat-corpus/)
 .corpus-cache/
 compatibility/sources/

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,9 @@ artifacts/
 # Claude scheduled task lock (runtime artifact)
 .claude/scheduled_tasks.lock
 
+# tsgo binary installed on demand by scripts/dev/test-type-aware-lint.mjs
+.cache/
+
 # Corpus-compat pipeline (generated; see scripts/compat-corpus/)
 .corpus-cache/
 compatibility/sources/

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,9 +15,11 @@
 	path = submodules/vize
 	url = git@github.com:ubugeeei-prod/vize.git
 
+# Backs the type-aware lint crate (crates/rsvelte_lint_types). HTTPS, not SSH:
+# the repo is public, so CI clones it with no credentials.
 [submodule "submodules/corsa-bind"]
 	path = submodules/corsa-bind
-	url = git@github.com:ubugeeei-prod/corsa-bind.git
+	url = https://github.com/ubugeeei-prod/corsa-bind.git
 
 [submodule "submodules/eslint-plugin-svelte"]
 	path = submodules/eslint-plugin-svelte

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,17 @@ Wave 4 architecture (decided; tsgo ships an LSP server as of TypeScript 7, so th
 [`@rsvelte/lint`](apps/npm/lint), fixed-versioned with `@rsvelte/compiler` via Changesets.
 Its real-world parity corpus ratchet lives at `compatibility/lint-known-failures.json`.
 
+### Type-aware lint suite (out-of-workspace)
+
+`crates/rsvelte_lint_types` (the corsa/`tsgo` type-aware backend) is its **own Cargo
+workspace** — it path-depends on the private `submodules/corsa-bind`, so the root
+`cargo test` and the CI shards never build it. Run it with
+`pnpm run test-type-aware-lint`, which checks out the submodules, installs
+`@typescript/native-preview`, and runs the 9 tests. A missing binary now **fails**
+instead of skipping. Do not point it at `$TSGO_BIN`: that names a batch `tsc`/`tsgo`
+for `rsvelte-check`, whereas this backend needs a `--api` server (`$CORSA_EXECUTABLE`).
+`.github/workflows/type-aware-lint.yml` runs the same script on manual dispatch.
+
 ## Quick Reference
 
 ### Adding Features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,13 +235,18 @@ Its real-world parity corpus ratchet lives at `compatibility/lint-known-failures
 ### Type-aware lint suite (out-of-workspace)
 
 `crates/rsvelte_lint_types` (the corsa/`tsgo` type-aware backend) is its **own Cargo
-workspace** — it path-depends on the private `submodules/corsa-bind`, so the root
-`cargo test` and the CI shards never build it. Run it with
-`pnpm run test-type-aware-lint`, which checks out the submodules, installs
-`@typescript/native-preview`, and runs the 9 tests. A missing binary now **fails**
-instead of skipping. Do not point it at `$TSGO_BIN`: that names a batch `tsc`/`tsgo`
-for `rsvelte-check`, whereas this backend needs a `--api` server (`$CORSA_EXECUTABLE`).
-`.github/workflows/type-aware-lint.yml` runs the same script on manual dispatch.
+workspace** — it path-depends on `submodules/corsa-bind`, whose corsa client stack
+nothing else needs, so the root `cargo test` and the CI shards never build it (nor
+does the root `cargo fmt` / `clippy`). `submodules/corsa-bind` is **public**; it
+clones with no credentials. Run the suite with `pnpm run test:type-aware-lint`,
+which checks out the submodules, installs the **pinned**
+`@typescript/native-preview` (`scripts/dev/type-aware-lint/package.json` — exact
+version because upstream publishes dated dev builds and the tests assert exact
+diagnostic text), and runs the 9 tests. A missing binary **fails** instead of
+skipping. Do not point it at `$TSGO_BIN`: that names a batch `tsc`/`tsgo` for
+`rsvelte-check`, whereas this backend needs a `--api` server (`$CORSA_EXECUTABLE`).
+`.github/workflows/type-aware-lint.yml` runs fmt + clippy + the suite on changes to
+the crate, weekly, and on dispatch.
 
 ## Quick Reference
 

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -291,6 +291,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "serde",
+ "static_assertions",
+ "zmij",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,7 +312,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corsa_client"
-version = "0.47.1"
+version = "1.0.0-beta.5"
 dependencies = [
  "base64",
  "corsa_core",
@@ -314,11 +328,11 @@ dependencies = [
 
 [[package]]
 name = "corsa_core"
-version = "0.47.1"
+version = "1.0.0-beta.5"
 dependencies = [
  "base64",
  "bumpalo",
- "compact_str",
+ "compact_str 0.9.1",
  "memchr",
  "rustc-hash",
  "serde",
@@ -329,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_jsonrpc"
-version = "0.47.1"
+version = "1.0.0-beta.5"
 dependencies = [
  "corsa_core",
  "corsa_runtime",
@@ -341,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_runtime"
-version = "0.47.1"
+version = "1.0.0-beta.5"
 dependencies = [
  "smallvec",
 ]
@@ -378,6 +392,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,7 +429,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -434,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "fast-glob"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9e81515b0279bf618200fd15d132e7195d2048fb46eed6f0f3c10cbc068266"
+checksum = "3cc9868289ee02952b341465ce66e67adec151227afedacf9137c0adb1e53943"
 dependencies = [
  "arrayvec",
 ]
@@ -454,6 +482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fluent-uri"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +498,12 @@ checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -506,6 +549,32 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "halfbrown"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -676,7 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -715,9 +784,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -744,6 +813,15 @@ name = "json-escape-simd"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e770254dd7802184595b1d30da2a15cb72569e2aca2b177aef8d22eac8a693"
+
+[[package]]
+name = "json-strip-comments"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9301b34ecbe81051a62001a2dfa56d906628efdfbc68153e0a4d5eba58181ece"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "kqueue"
@@ -776,6 +854,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -859,7 +946,16 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -929,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1011,16 +1107,16 @@ checksum = "66e0bafc397eee2f94c5bf89bb5a82ba6d522d1b79e2924c8169f053febb433f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "oxc_allocator"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "allocator-api2",
- "hashbrown",
+ "hashbrown 0.17.1",
  "oxc_data_structures",
  "oxc_estree",
  "rustc-hash",
@@ -1029,8 +1125,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "bitflags 2.13.0",
  "oxc_allocator",
@@ -1046,19 +1142,19 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "phf",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1068,8 +1164,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
@@ -1080,7 +1176,7 @@ dependencies = [
  "oxc_data_structures",
  "oxc_index",
  "oxc_semantic",
- "oxc_sourcemap 8.0.1",
+ "oxc_sourcemap 8.1.2",
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
@@ -1089,13 +1185,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1104,23 +1200,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
- "cow-utils",
  "num-bigint",
  "num-traits",
- "oxc_allocator",
  "oxc_ast",
- "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_estree"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1129,8 +1222,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter"
-version = "0.55.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.60.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "cow-utils",
  "fast-glob",
@@ -1155,8 +1248,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_formatter_core"
-version = "0.55.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.60.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1180,8 +1273,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_jsdoc"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "oxc_ast",
  "oxc_span",
@@ -1190,8 +1283,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
@@ -1213,8 +1306,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "bitflags 2.13.0",
  "oxc_allocator",
@@ -1228,9 +1321,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_resolver"
+version = "11.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa374d03b255c070a32ae65b8a05231b8e658104d6ef22034c09da8fa0c2fd9"
+dependencies = [
+ "compact_str 0.9.1",
+ "dashmap",
+ "fast-glob",
+ "indexmap",
+ "json-strip-comments",
+ "memchr",
+ "nodejs-built-in-modules",
+ "once_cell",
+ "percent-encoding",
+ "rustc-hash",
+ "rustix",
+ "self_cell",
+ "serde",
+ "serde_json",
+ "simd-json",
+ "simdutf8",
+ "thiserror",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "oxc_semantic"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "itertools",
  "memchr",
@@ -1264,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "8.0.1"
+version = "8.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174d2498c2390ccfab0a9caaf47ef5accda1d509aaa34a5be8f45e00e5299f04"
+checksum = "b415102a94b483bbd76d13e850fe87961197e5795c79a8523ebec5d82025f94f"
 dependencies = [
  "base64-simd",
  "json-escape-simd",
@@ -1277,10 +1397,10 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
- "compact_str",
+ "compact_str 0.10.0",
  "oxc-miette",
  "oxc_allocator",
  "oxc_ast_macros",
@@ -1291,11 +1411,11 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
- "compact_str",
- "hashbrown",
+ "compact_str 0.10.0",
+ "hashbrown 0.17.1",
  "oxc_allocator",
  "oxc_estree",
  "serde",
@@ -1303,8 +1423,8 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.136.0"
-source = "git+https://github.com/oxc-project/oxc?rev=37a34a128fa81a37955c38783b7d3474aadb84a6#37a34a128fa81a37955c38783b7d3474aadb84a6"
+version = "0.141.0"
+source = "git+https://github.com/oxc-project/oxc?rev=83abe3b49c0913b1a984a7eec5e433a59fd76eae#83abe3b49c0913b1a984a7eec5e433a59fd76eae"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
@@ -1352,9 +1472,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -1363,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -1373,22 +1493,22 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -1477,6 +1597,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,18 +1647,19 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsvelte_core"
-version = "0.7.11"
+version = "0.9.2"
 dependencies = [
  "bumpalo",
  "chrono",
  "clap",
- "compact_str",
+ "compact_str 0.10.0",
  "im",
  "indexmap",
  "itoa",
  "lazy_static",
  "memchr",
  "miette",
+ "mimalloc",
  "notify",
  "oxc_allocator",
  "oxc_ast",
@@ -1527,11 +1668,13 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_formatter",
  "oxc_parser",
+ "oxc_resolver",
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
  "rayon",
  "regex",
+ "rsvelte_esrap",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1544,10 +1687,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsvelte_lint"
+name = "rsvelte_esrap"
 version = "0.7.11"
 dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "rsvelte_lint"
+version = "0.9.2"
+dependencies = [
  "anyhow",
+ "compact_str 0.10.0",
  "regex",
  "rsvelte_core",
  "serde",
@@ -1658,7 +1812,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1683,7 +1837,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1704,6 +1858,24 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-json"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32d7ab2678282d21e53374fbead7119b7eacbede73685dcaac472870a29a11c"
+dependencies = [
+ "halfbrown",
+ "ref-cast",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -1825,6 +1997,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,7 +2015,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1879,7 +2062,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1910,6 +2093,37 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -2001,6 +2215,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-trait"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,7 +2286,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2083,6 +2309,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2343,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
 name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,7 +2361,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2114,7 +2372,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2122,6 +2380,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -2174,6 +2442,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2258,7 +2535,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2279,7 +2556,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2313,7 +2590,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/rsvelte_lint_types/Cargo.toml
+++ b/crates/rsvelte_lint_types/Cargo.toml
@@ -2,13 +2,17 @@
 #
 # This crate is DELIBERATELY ITS OWN WORKSPACE (note the `[workspace]` table
 # below) and is NOT a member of the root rsvelte workspace. Reason: it depends
-# on `corsa` via a path into the PRIVATE `submodules/corsa-bind` submodule
-# (`git@github.com:ubugeeei-prod/corsa-bind`). A path dependency — even an
-# optional one — is resolved by Cargo at metadata time, so listing it in the
-# root workspace would break `cargo build` / CI for everyone who cannot clone
-# that private submodule. Isolating it keeps the default build and CI 100%
-# corsa-free; this crate is built/tested only locally, where corsa-bind +
-# typescript-go are available. This is the Wave-3 "gated spike" made runnable.
+# on `corsa` via a path into `submodules/corsa-bind`. A path dependency — even
+# an optional one — is resolved by Cargo at metadata time, so listing it in the
+# root workspace would force every `cargo build` / `cargo test` in the repo to
+# check out that submodule and compile the whole corsa client stack, which
+# nothing else needs. Isolating it keeps the default build and CI 100%
+# corsa-free.
+#
+# `ubugeeei-prod/corsa-bind` is PUBLIC and clones with no credentials. An
+# earlier revision of this header said it was private, and #1790 fell out of
+# that: the suite was treated as unrunnable-in-CI and its nine tests silently
+# skipped for months. `.github/workflows/type-aware-lint.yml` runs them.
 #
 # Because it is a separate workspace root, it must re-declare the workspace keys
 # the path-dep crates (rsvelte_core / rsvelte_lint) reference via

--- a/crates/rsvelte_lint_types/src/lib.rs
+++ b/crates/rsvelte_lint_types/src/lib.rs
@@ -25,7 +25,7 @@ use rsvelte_core::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
 use rsvelte_lint::type_backend::{PropMeta, TypeBackend, TypeFacts, TypeId, TypeMeta};
 
 mod resolver;
-pub use resolver::resolve_tsgo;
+pub use resolver::{MISSING_TSGO_HELP, require_tsgo, resolve_tsgo};
 
 use rsvelte_core::svelte_check::diagnostic::Diagnostic;
 

--- a/crates/rsvelte_lint_types/src/resolver.rs
+++ b/crates/rsvelte_lint_types/src/resolver.rs
@@ -3,6 +3,14 @@
 //! A trimmed port of `vize_carton::corsa_resolver`: environment overrides
 //! first, then the `@typescript/native-preview` npm layout discovered by
 //! walking up from a starting directory, then `PATH`.
+//!
+//! NOT the same thing as `rsvelte_core::svelte_check::tsgo::find_compiler`,
+//! which resolves a BATCH compiler run as `<bin> -p tsconfig --pretty false`
+//! and is overridden by `$TSGO_BIN`. What we need here is a long-lived corsa
+//! API worker (`<bin> --api --cwd …`, msgpack/JSON-RPC over stdio) — a mode
+//! only `typescript-go` builds have, so `$TSGO_BIN` is deliberately not read:
+//! CI points it at a stock TypeScript 5 `tsc`, which would resolve here and
+//! then fail to speak the protocol.
 
 use std::path::{Path, PathBuf};
 
@@ -13,6 +21,21 @@ const ENV_VARS: &[&str] = &[
     "TSGO_PATH",
     "TSGO_EXECUTABLE",
 ];
+
+/// Setup instructions shown when no API-capable binary can be found.
+pub const MISSING_TSGO_HELP: &str = "\
+no tsgo / corsa binary found — the type-aware lint backend cannot run.
+
+Provide one of:
+  * `npm i @typescript/native-preview` at the repo root (the resolver walks
+    up from this crate and picks up `node_modules/@typescript/native-preview*`), or
+  * set $CORSA_EXECUTABLE (or $CORSA_PATH / $TSGO_PATH / $TSGO_EXECUTABLE)
+    to an API-capable binary, or
+  * put `tsgo` / `corsa` on $PATH.
+
+`pnpm run test-type-aware-lint` does all of this for you.
+Note: $TSGO_BIN is NOT read here — it names a batch `tsc`/`tsgo` for
+rsvelte-check, which cannot serve the corsa `--api` protocol.";
 
 /// Resolve a `tsgo`/`corsa` executable, searching from `start_dir` upward for
 /// an `@typescript/native-preview` install. Returns `None` when none is found,
@@ -36,6 +59,20 @@ pub fn resolve_tsgo(start_dir: &Path) -> Option<PathBuf> {
     }
 
     which_on_path("tsgo").or_else(|| which_on_path("corsa"))
+}
+
+/// [`resolve_tsgo`], but panics with [`MISSING_TSGO_HELP`] instead of returning
+/// `None`.
+///
+/// For the test suite: this crate is an opt-in, out-of-workspace target you
+/// only build when you mean to exercise the type-aware backend, so a missing
+/// binary is a setup error. Skipping quietly made all nine tests report green
+/// while covering nothing (issue #1790).
+pub fn require_tsgo(start_dir: &Path) -> PathBuf {
+    match resolve_tsgo(start_dir) {
+        Some(p) => p,
+        None => panic!("{MISSING_TSGO_HELP}"),
+    }
 }
 
 /// Look for `node_modules/@typescript/native-preview-<platform>/lib/tsgo[.exe]`

--- a/crates/rsvelte_lint_types/src/resolver.rs
+++ b/crates/rsvelte_lint_types/src/resolver.rs
@@ -33,7 +33,7 @@ Provide one of:
     to an API-capable binary, or
   * put `tsgo` / `corsa` on $PATH.
 
-`pnpm run test-type-aware-lint` does all of this for you.
+`pnpm run test:type-aware-lint` does all of this for you.
 Note: $TSGO_BIN is NOT read here — it names a batch `tsc`/`tsgo` for
 rsvelte-check, which cannot serve the corsa `--api` protocol.";
 

--- a/crates/rsvelte_lint_types/tests/nav_type_aware_e2e.rs
+++ b/crates/rsvelte_lint_types/tests/nav_type_aware_e2e.rs
@@ -7,7 +7,7 @@
 //! self-contained (no `$app/types` ambient package required); the rule's
 //! `goto`/`<a>` detection is syntactic and works regardless of `$app/*`
 //! resolving. Requires a discoverable `tsgo` binary — a missing one FAILS the
-//! test rather than skipping it (`pnpm run test-type-aware-lint` installs one).
+//! test rather than skipping it (`pnpm run test:type-aware-lint` installs one).
 
 use std::path::{Path, PathBuf};
 

--- a/crates/rsvelte_lint_types/tests/nav_type_aware_e2e.rs
+++ b/crates/rsvelte_lint_types/tests/nav_type_aware_e2e.rs
@@ -6,17 +6,18 @@
 //! Uses a locally-aliased branded type named `ResolvedPathname` so the test is
 //! self-contained (no `$app/types` ambient package required); the rule's
 //! `goto`/`<a>` detection is syntactic and works regardless of `$app/*`
-//! resolving. Gated on a discoverable `tsgo` binary.
+//! resolving. Requires a discoverable `tsgo` binary — a missing one FAILS the
+//! test rather than skipping it (`pnpm run test-type-aware-lint` installs one).
 
 use std::path::{Path, PathBuf};
 
 use rsvelte_lint::config::LintConfig;
 use rsvelte_lint::rule::Severity;
 use rsvelte_lint::rules::no_navigation_without_resolve as nav;
-use rsvelte_lint_types::{CorsaTypeBackend, resolve_tsgo};
+use rsvelte_lint_types::{CorsaTypeBackend, require_tsgo};
 
-fn tsgo() -> Option<PathBuf> {
-    resolve_tsgo(Path::new(env!("CARGO_MANIFEST_DIR")))
+fn tsgo() -> PathBuf {
+    require_tsgo(Path::new(env!("CARGO_MANIFEST_DIR")))
 }
 
 fn typed_messages(name: &str, source: &str, tsgo: &Path) -> Vec<String> {
@@ -42,10 +43,7 @@ fn typed_messages(name: &str, source: &str, tsgo: &Path) -> Vec<String> {
 
 #[test]
 fn goto_with_resolved_pathname_is_allowed() {
-    let Some(tsgo) = tsgo() else {
-        eprintln!("SKIP goto_with_resolved_pathname_is_allowed: no tsgo binary found");
-        return;
-    };
+    let tsgo = tsgo();
     let src = r#"<script lang="ts">
 	import { goto } from '$app/navigation';
 	type ResolvedPathname = string & { __brand: 'resolved' };
@@ -62,10 +60,7 @@ fn goto_with_resolved_pathname_is_allowed() {
 
 #[test]
 fn goto_with_plain_string_is_reported() {
-    let Some(tsgo) = tsgo() else {
-        eprintln!("SKIP goto_with_plain_string_is_reported: no tsgo binary found");
-        return;
-    };
+    let tsgo = tsgo();
     // Control: a plain-string target is NOT allowed and must be reported, even
     // through the type-aware path.
     let src = r#"<script lang="ts">
@@ -84,10 +79,7 @@ fn goto_with_plain_string_is_reported() {
 
 #[test]
 fn link_with_resolved_pathname_is_allowed() {
-    let Some(tsgo) = tsgo() else {
-        eprintln!("SKIP link_with_resolved_pathname_is_allowed: no tsgo binary found");
-        return;
-    };
+    let tsgo = tsgo();
     // Exercises forward-mapping of a TEMPLATE expression (`<a {href}>`).
     let src = r#"<script lang="ts">
 	type ResolvedPathname = string & { __brand: 'resolved' };
@@ -106,10 +98,7 @@ fn link_with_resolved_pathname_is_allowed() {
 
 #[test]
 fn link_with_nullish_href_is_allowed() {
-    let Some(tsgo) = tsgo() else {
-        eprintln!("SKIP link_with_nullish_href_is_allowed: no tsgo binary found");
-        return;
-    };
+    let tsgo = tsgo();
     // Mirrors `no-navigation-without-resolve/valid/link-nullish02`: a `null`-typed
     // href on a link is allowed (links permit nullish).
     let src = r#"<script lang="ts">

--- a/crates/rsvelte_lint_types/tests/no_unused_props_fixtures.rs
+++ b/crates/rsvelte_lint_types/tests/no_unused_props_fixtures.rs
@@ -5,12 +5,11 @@
 //!
 //! Requires a discoverable `tsgo` binary and the `eslint-plugin-svelte`
 //! submodule; FAILS (rather than skipping) when either is absent.
-//! `pnpm run test-type-aware-lint` sets both up.
+//! `pnpm run test:type-aware-lint` sets both up.
 
 use std::path::{Path, PathBuf};
 
 use rsvelte_lint::config::LintConfig;
-use rsvelte_lint::line_index::LineIndex;
 use rsvelte_lint::rules::no_unused_props;
 use rsvelte_lint_types::{CorsaTypeBackend, require_tsgo};
 use serde::Deserialize;
@@ -96,7 +95,6 @@ fn run_fixture(input: &Path, tsgo: &Path) -> Vec<(u32, u32, String)> {
     drop(backend);
     let _ = std::fs::remove_dir_all(&dir);
 
-    let li = LineIndex::new(&source);
     let mut out: Vec<(u32, u32, String)> = diags
         .into_iter()
         .filter_map(|d| {
@@ -105,7 +103,6 @@ fn run_fixture(input: &Path, tsgo: &Path) -> Vec<(u32, u32, String)> {
             Some((r.start.line, r.start.column + 1, d.message))
         })
         .collect();
-    let _ = &li;
     out.sort();
     out
 }
@@ -117,7 +114,10 @@ fn expected_for(input: &Path) -> Vec<(u32, u32, String)> {
     let Ok(text) = std::fs::read_to_string(&yaml) else {
         return Vec::new();
     };
-    let errs: Vec<ExpectedError> = serde_yaml::from_str(&text).unwrap_or_default();
+    // Not `unwrap_or_default`: an unparseable expectations file would silently
+    // become "expects nothing" and pass.
+    let errs: Vec<ExpectedError> =
+        serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("malformed {yaml:?}: {e}"));
     let mut out: Vec<(u32, u32, String)> = errs
         .into_iter()
         .map(|e| (e.line, e.column, e.message))

--- a/crates/rsvelte_lint_types/tests/no_unused_props_fixtures.rs
+++ b/crates/rsvelte_lint_types/tests/no_unused_props_fixtures.rs
@@ -3,16 +3,22 @@
 //! corsa-free oracle skips) through the graph path + real `tsgo`, asserting
 //! `(line, column, message)` parity with the sibling `*-errors.yaml`.
 //!
-//! Gated on a discoverable `tsgo` binary and the `eslint-plugin-svelte`
-//! submodule; no-ops with a notice when either is absent.
+//! Requires a discoverable `tsgo` binary and the `eslint-plugin-svelte`
+//! submodule; FAILS (rather than skipping) when either is absent.
+//! `pnpm run test-type-aware-lint` sets both up.
 
 use std::path::{Path, PathBuf};
 
 use rsvelte_lint::config::LintConfig;
 use rsvelte_lint::line_index::LineIndex;
 use rsvelte_lint::rules::no_unused_props;
-use rsvelte_lint_types::{CorsaTypeBackend, resolve_tsgo};
+use rsvelte_lint_types::{CorsaTypeBackend, require_tsgo};
 use serde::Deserialize;
+
+/// Lower bound on the fixture count, so a moved/renamed upstream directory
+/// surfaces as a failure instead of an empty-but-green run. Upstream had 76 at
+/// eslint-plugin-svelte 32ba9159; the bound only has to catch collapse.
+const MIN_FIXTURES: usize = 60;
 
 #[derive(Debug, Deserialize)]
 struct ExpectedError {
@@ -31,11 +37,16 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-fn fixture_root() -> Option<PathBuf> {
+fn fixture_root() -> PathBuf {
     let p = repo_root().join(
         "submodules/eslint-plugin-svelte/packages/eslint-plugin-svelte/tests/fixtures/rules/no-unused-props",
     );
-    p.is_dir().then_some(p)
+    assert!(
+        p.is_dir(),
+        "no-unused-props fixtures missing at {p:?} — run \
+         `git submodule update --init --depth 1 submodules/eslint-plugin-svelte`"
+    );
+    p
 }
 
 /// Build a `LintConfig` enabling the rule at `warn` with the fixture's options
@@ -135,14 +146,8 @@ fn collect_inputs(dir: &Path) -> Vec<PathBuf> {
 
 #[test]
 fn no_unused_props_typed_oracle() {
-    let Some(tsgo) = resolve_tsgo(Path::new(env!("CARGO_MANIFEST_DIR"))) else {
-        eprintln!("SKIP no_unused_props_typed_oracle: no tsgo binary found");
-        return;
-    };
-    let Some(root) = fixture_root() else {
-        eprintln!("SKIP no_unused_props_typed_oracle: eslint-plugin-svelte submodule absent");
-        return;
-    };
+    let tsgo = require_tsgo(Path::new(env!("CARGO_MANIFEST_DIR")));
+    let root = fixture_root();
 
     let mut failures = Vec::new();
     let mut checked = 0;
@@ -160,6 +165,11 @@ fn no_unused_props_typed_oracle() {
         }
     }
 
+    assert!(
+        checked >= MIN_FIXTURES,
+        "typed oracle ran only {checked} fixtures (expected >= {MIN_FIXTURES}) \
+         — upstream directory layout changed?"
+    );
     assert!(
         failures.is_empty(),
         "{}/{} no-unused-props fixtures diverged:\n{}",

--- a/crates/rsvelte_lint_types/tests/type_aware_e2e.rs
+++ b/crates/rsvelte_lint_types/tests/type_aware_e2e.rs
@@ -2,20 +2,20 @@
 //! TypeScript types for `svelte/no-unused-props` on cases the syntactic path
 //! cannot handle (`extends`, intersection, nested object props).
 //!
-//! Gated on a discoverable `tsgo` binary (install with
-//! `npm i @typescript/native-preview` at the repo root). Skips with a notice
-//! when none is found, so the suite is a no-op in environments without it.
+//! Requires a discoverable `tsgo` binary; run via `pnpm run test-type-aware-lint`,
+//! which installs one. A missing binary FAILS the test rather than skipping it —
+//! see `resolver::require_tsgo`.
 
 use std::path::{Path, PathBuf};
 
 use rsvelte_lint::config::LintConfig;
 use rsvelte_lint::rule::Severity;
 use rsvelte_lint::rules::no_unused_props;
-use rsvelte_lint_types::{CorsaTypeBackend, resolve_tsgo};
+use rsvelte_lint_types::{CorsaTypeBackend, require_tsgo};
 
-fn tsgo() -> Option<PathBuf> {
+fn tsgo() -> PathBuf {
     // Walk up from this crate to the worktree root, where node_modules lives.
-    resolve_tsgo(Path::new(env!("CARGO_MANIFEST_DIR")))
+    require_tsgo(Path::new(env!("CARGO_MANIFEST_DIR")))
 }
 
 /// Write `source` to a fresh temp dir as `<name>` and lint it with the typed
@@ -51,10 +51,7 @@ fn assert_unused(msgs: &[String], expected: &[&str]) {
 
 #[test]
 fn extends_resolves_inherited_unused() {
-    let Some(tsgo) = tsgo() else {
-        eprintln!("SKIP extends_resolves_inherited_unused: no tsgo binary found");
-        return;
-    };
+    let tsgo = tsgo();
     // Mirrors eslint-plugin-svelte `no-unused-props/invalid/extends-unused`.
     let src = r#"<script lang="ts">
 	interface BaseProps {
@@ -84,10 +81,7 @@ fn extends_resolves_inherited_unused() {
 
 #[test]
 fn intersection_resolves_unused() {
-    let Some(tsgo) = tsgo() else {
-        eprintln!("SKIP intersection_resolves_unused: no tsgo binary found");
-        return;
-    };
+    let tsgo = tsgo();
     // Mirrors `no-unused-props/invalid/intersection-unused`.
     let src = r#"<script lang="ts">
 	type WithId = {
@@ -121,10 +115,7 @@ fn intersection_resolves_unused() {
 
 #[test]
 fn nested_object_prop_unused() {
-    let Some(tsgo) = tsgo() else {
-        eprintln!("SKIP nested_object_prop_unused: no tsgo binary found");
-        return;
-    };
+    let tsgo = tsgo();
     // Mirrors `no-unused-props/invalid/nested-unused`.
     let src = r#"<script lang="ts">
 	interface Props {
@@ -143,10 +134,7 @@ fn nested_object_prop_unused() {
 
 #[test]
 fn fully_used_props_report_nothing() {
-    let Some(tsgo) = tsgo() else {
-        eprintln!("SKIP fully_used_props_report_nothing: no tsgo binary found");
-        return;
-    };
+    let tsgo = tsgo();
     let src = r#"<script lang="ts">
 	interface Base { a: string }
 	interface Props extends Base { b: number }

--- a/crates/rsvelte_lint_types/tests/type_aware_e2e.rs
+++ b/crates/rsvelte_lint_types/tests/type_aware_e2e.rs
@@ -2,7 +2,7 @@
 //! TypeScript types for `svelte/no-unused-props` on cases the syntactic path
 //! cannot handle (`extends`, intersection, nested object props).
 //!
-//! Requires a discoverable `tsgo` binary; run via `pnpm run test-type-aware-lint`,
+//! Requires a discoverable `tsgo` binary; run via `pnpm run test:type-aware-lint`,
 //! which installs one. A missing binary FAILS the test rather than skipping it —
 //! see `resolver::require_tsgo`.
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"test:vps-fixture": "node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:vps": "node scripts/dev/test-vps-shim.mjs && node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:wasm-compile": "node scripts/dev/test-wasm-compile-options.mjs",
+		"test-type-aware-lint": "node scripts/dev/test-type-aware-lint.mjs",
 		"build:oxlint-plugin": "pnpm --filter @rsvelte/oxlint-plugin run build",
 		"build:lint-native": "node scripts/dev/build-lint-native-local.mjs",
 		"test:oxlint-plugin": "node scripts/dev/test-oxlint-plugin.mjs",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"test:vps-fixture": "node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:vps": "node scripts/dev/test-vps-shim.mjs && node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:wasm-compile": "node scripts/dev/test-wasm-compile-options.mjs",
-		"test-type-aware-lint": "node scripts/dev/test-type-aware-lint.mjs",
+		"test:type-aware-lint": "node scripts/dev/test-type-aware-lint.mjs",
 		"build:oxlint-plugin": "pnpm --filter @rsvelte/oxlint-plugin run build",
 		"build:lint-native": "node scripts/dev/build-lint-native-local.mjs",
 		"test:oxlint-plugin": "node scripts/dev/test-oxlint-plugin.mjs",

--- a/scripts/dev/test-type-aware-lint.mjs
+++ b/scripts/dev/test-type-aware-lint.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 // Run the type-aware lint suite (crates/rsvelte_lint_types).
 //
-// That crate is its own Cargo workspace (it path-depends on the PRIVATE
-// submodules/corsa-bind), so `cargo test` at the repo root never touches it and
-// the main CI shards never build it. This script is the single documented way
-// to run it: it checks out the submodules it needs, materializes an API-capable
-// tsgo binary, and shells into the crate's workspace.
+// That crate is its own Cargo workspace (it path-depends on
+// submodules/corsa-bind, a heavy build nobody else needs), so `cargo test` at
+// the repo root never touches it and the main CI shards never build it. This
+// script is the single documented way to run it: it checks out the submodules
+// it needs, materializes an API-capable tsgo binary, and shells into the
+// crate's workspace.
 //
 // The tests hard-fail when the binary is missing (issue #1790), so a broken
 // setup here is loud rather than a green no-op.
@@ -17,9 +18,9 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const crateDir = join(repoRoot, 'crates/rsvelte_lint_types');
-// Kept out of the pnpm-managed root node_modules so npm and pnpm never fight
-// over the same tree.
-const tsgoPrefix = join(repoRoot, '.cache/type-aware-lint');
+// Its own package.json pins the tsgo version (see that file). Outside the pnpm
+// workspace globs, so npm and pnpm never fight over the same tree.
+const tsgoPrefix = join(repoRoot, 'scripts/dev/type-aware-lint');
 
 function run(cmd, args, opts = {}) {
 	const r = spawnSync(cmd, args, { stdio: 'inherit', cwd: repoRoot, ...opts });
@@ -57,46 +58,39 @@ function nativePreviewBinary(prefix) {
 	return existsSync(wrapper) ? wrapper : undefined;
 }
 
-// corsa-bind is private; without access the crate cannot even be compiled.
-ensureSubmodule(
-	'submodules/corsa-bind',
-	'submodules/corsa-bind is a private repository (ubugeeei-prod/corsa-bind).\n' +
-		'The type-aware lint backend cannot be built without read access to it.'
-);
+// Both public — no credentials involved.
+ensureSubmodule('submodules/corsa-bind', 'Check your network / git configuration.');
 // The typed no-unused-props oracle replays upstream fixtures from here.
 ensureSubmodule('submodules/eslint-plugin-svelte', 'Check your network / git configuration.');
 
-// An explicit override wins; otherwise install @typescript/native-preview, the
-// acquisition path corsa-bind itself documents (`defaultCorsaExecutable`).
+// An explicit override wins; otherwise install the pinned
+// @typescript/native-preview, the acquisition path corsa-bind itself documents
+// (`defaultCorsaExecutable`).
 let executable = process.env.CORSA_EXECUTABLE ?? process.env.CORSA_PATH;
 if (!executable) {
+	// Always run the install: it is a no-op once the pinned version is present,
+	// and it re-syncs the tree after a Renovate bump instead of leaving a stale
+	// binary behind (a stale tsgo silently changes diagnostic text).
+	console.log('==> installing @typescript/native-preview (pinned)');
+	run('npm', ['install', '--prefix', tsgoPrefix, '--no-package-lock']);
 	executable = nativePreviewBinary(tsgoPrefix);
-	if (!executable) {
-		console.log('==> installing @typescript/native-preview');
-		run('npm', [
-			'install',
-			'--prefix',
-			tsgoPrefix,
-			'--no-save',
-			'--no-package-lock',
-			'@typescript/native-preview'
-		]);
-		executable = nativePreviewBinary(tsgoPrefix);
-	}
 }
 if (!executable) {
 	console.error('Could not locate a tsgo binary after installing @typescript/native-preview.');
 	process.exit(1);
 }
-console.log(`==> tsgo: ${executable}`);
 // Sanity-check the binary before handing it to the tests, so "wrong binary"
 // reads as a setup error here rather than a confusing session-spawn failure.
+let version;
 try {
-	execFileSync(executable, ['--version'], { stdio: 'pipe' });
+	version = execFileSync(executable, ['--version'], { encoding: 'utf8' }).trim();
 } catch (err) {
 	console.error(`tsgo binary at ${executable} is not runnable: ${err.message}`);
 	process.exit(1);
 }
+// Printed because the suite asserts exact diagnostic text — when a run diverges,
+// the tsgo build is the first thing to check.
+console.log(`==> tsgo: ${executable}\n==> ${version}`);
 
 run('cargo', ['test', ...process.argv.slice(2)], {
 	cwd: crateDir,

--- a/scripts/dev/test-type-aware-lint.mjs
+++ b/scripts/dev/test-type-aware-lint.mjs
@@ -12,7 +12,7 @@
 // setup here is loud rather than a green no-op.
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -68,12 +68,26 @@ ensureSubmodule('submodules/eslint-plugin-svelte', 'Check your network / git con
 // (`defaultCorsaExecutable`).
 let executable = process.env.CORSA_EXECUTABLE ?? process.env.CORSA_PATH;
 if (!executable) {
-	// Always run the install: it is a no-op once the pinned version is present,
-	// and it re-syncs the tree after a Renovate bump instead of leaving a stale
-	// binary behind (a stale tsgo silently changes diagnostic text).
+	// Always attempt the install rather than short-circuiting on "a binary
+	// exists": after a Renovate bump the existing tree is the OLD version, and a
+	// stale tsgo silently changes diagnostic text. `--prefer-offline` keeps it
+	// cheap (and working offline) once the pinned tarball is in the npm cache.
 	console.log('==> installing @typescript/native-preview (pinned)');
-	run('npm', ['install', '--prefix', tsgoPrefix, '--no-package-lock']);
+	const install = spawnSync(
+		'npm',
+		['install', '--prefix', tsgoPrefix, '--no-package-lock', '--prefer-offline'],
+		{ stdio: 'inherit', cwd: repoRoot }
+	);
 	executable = nativePreviewBinary(tsgoPrefix);
+	if (install.status !== 0) {
+		// Offline with nothing cached is fatal; offline with a previous install is
+		// not — fall back, and let the version check below flag a stale binary.
+		if (!executable) {
+			console.error('\nnpm install failed and no previously installed tsgo binary was found.');
+			process.exit(install.status ?? 1);
+		}
+		console.warn('\nwarning: npm install failed — falling back to the installed binary.');
+	}
 }
 if (!executable) {
 	console.error('Could not locate a tsgo binary after installing @typescript/native-preview.');
@@ -91,6 +105,18 @@ try {
 // Printed because the suite asserts exact diagnostic text — when a run diverges,
 // the tsgo build is the first thing to check.
 console.log(`==> tsgo: ${executable}\n==> ${version}`);
+// A binary that does not match the pin is the single most likely cause of a
+// mysterious diagnostic-text failure, so say so out loud rather than let it
+// look like a code regression.
+const pinned = JSON.parse(readFileSync(join(tsgoPrefix, 'package.json'), 'utf8')).dependencies[
+	'@typescript/native-preview'
+];
+if (!version.includes(pinned)) {
+	console.warn(
+		`warning: tsgo reports "${version}" but the pin is ${pinned}. ` +
+			'Diagnostic text may differ from what the tests expect.'
+	);
+}
 
 run('cargo', ['test', ...process.argv.slice(2)], {
 	cwd: crateDir,

--- a/scripts/dev/test-type-aware-lint.mjs
+++ b/scripts/dev/test-type-aware-lint.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Run the type-aware lint suite (crates/rsvelte_lint_types).
+//
+// That crate is its own Cargo workspace (it path-depends on the PRIVATE
+// submodules/corsa-bind), so `cargo test` at the repo root never touches it and
+// the main CI shards never build it. This script is the single documented way
+// to run it: it checks out the submodules it needs, materializes an API-capable
+// tsgo binary, and shells into the crate's workspace.
+//
+// The tests hard-fail when the binary is missing (issue #1790), so a broken
+// setup here is loud rather than a green no-op.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const crateDir = join(repoRoot, 'crates/rsvelte_lint_types');
+// Kept out of the pnpm-managed root node_modules so npm and pnpm never fight
+// over the same tree.
+const tsgoPrefix = join(repoRoot, '.cache/type-aware-lint');
+
+function run(cmd, args, opts = {}) {
+	const r = spawnSync(cmd, args, { stdio: 'inherit', cwd: repoRoot, ...opts });
+	if (r.status !== 0) {
+		console.error(`\n${cmd} ${args.join(' ')} failed (exit ${r.status ?? 'signal'})`);
+		process.exit(r.status ?? 1);
+	}
+}
+
+function ensureSubmodule(path, hint) {
+	if (existsSync(join(repoRoot, path, '.git'))) return;
+	console.log(`==> checking out ${path}`);
+	const r = spawnSync('git', ['submodule', 'update', '--init', '--depth', '1', path], {
+		stdio: 'inherit',
+		cwd: repoRoot
+	});
+	if (r.status !== 0) {
+		console.error(`\nCould not check out ${path}.\n${hint}`);
+		process.exit(1);
+	}
+}
+
+/** Locate the tsgo binary inside an `@typescript/native-preview*` install. */
+function nativePreviewBinary(prefix) {
+	const scope = join(prefix, 'node_modules/@typescript');
+	if (!existsSync(scope)) return undefined;
+	for (const entry of readdirSync(scope)) {
+		if (!entry.startsWith('native-preview-')) continue;
+		for (const rel of ['lib/tsgo', 'lib/tsgo.exe', 'bin/tsgo', 'bin/tsgo.exe']) {
+			const p = join(scope, entry, rel);
+			if (existsSync(p)) return p;
+		}
+	}
+	const wrapper = join(scope, 'native-preview/bin/tsgo.js');
+	return existsSync(wrapper) ? wrapper : undefined;
+}
+
+// corsa-bind is private; without access the crate cannot even be compiled.
+ensureSubmodule(
+	'submodules/corsa-bind',
+	'submodules/corsa-bind is a private repository (ubugeeei-prod/corsa-bind).\n' +
+		'The type-aware lint backend cannot be built without read access to it.'
+);
+// The typed no-unused-props oracle replays upstream fixtures from here.
+ensureSubmodule('submodules/eslint-plugin-svelte', 'Check your network / git configuration.');
+
+// An explicit override wins; otherwise install @typescript/native-preview, the
+// acquisition path corsa-bind itself documents (`defaultCorsaExecutable`).
+let executable = process.env.CORSA_EXECUTABLE ?? process.env.CORSA_PATH;
+if (!executable) {
+	executable = nativePreviewBinary(tsgoPrefix);
+	if (!executable) {
+		console.log('==> installing @typescript/native-preview');
+		run('npm', [
+			'install',
+			'--prefix',
+			tsgoPrefix,
+			'--no-save',
+			'--no-package-lock',
+			'@typescript/native-preview'
+		]);
+		executable = nativePreviewBinary(tsgoPrefix);
+	}
+}
+if (!executable) {
+	console.error('Could not locate a tsgo binary after installing @typescript/native-preview.');
+	process.exit(1);
+}
+console.log(`==> tsgo: ${executable}`);
+// Sanity-check the binary before handing it to the tests, so "wrong binary"
+// reads as a setup error here rather than a confusing session-spawn failure.
+try {
+	execFileSync(executable, ['--version'], { stdio: 'pipe' });
+} catch (err) {
+	console.error(`tsgo binary at ${executable} is not runnable: ${err.message}`);
+	process.exit(1);
+}
+
+run('cargo', ['test', ...process.argv.slice(2)], {
+	cwd: crateDir,
+	env: { ...process.env, CORSA_EXECUTABLE: executable }
+});

--- a/scripts/dev/type-aware-lint/package.json
+++ b/scripts/dev/type-aware-lint/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "rsvelte-type-aware-lint-tsgo",
+  "private": true,
+  "description": "Pins the tsgo binary that crates/rsvelte_lint_types tests run against. Installed by scripts/dev/test-type-aware-lint.mjs, never by the workspace install. The version is EXACT on purpose: @typescript/native-preview publishes dated dev builds, and the suite asserts exact diagnostic text, so `latest` would let an upstream nightly change results with no change in this repo. Renovate tracks it like any other npm dep. 20260707 matches the typescript-go commit corsa-bind pins in corsa_ref.lock.toml.",
+  "dependencies": {
+    "@typescript/native-preview": "7.0.0-dev.20260707.2"
+  }
+}


### PR DESCRIPTION
Fixes #1790

## 調査結果

### 2つの resolver の役割分担 — 環境変数名は「不一致」ではなく、正しく別物だった

| | `rsvelte_core/src/svelte_check/tsgo.rs::find_compiler` | `rsvelte_lint_types/src/resolver.rs::resolve_tsgo` |
|---|---|---|
| 解決するもの | **バッチコンパイラ** (`tsc` または `tsgo`) | **常駐 corsa API ワーカー** |
| 起動形 | `<bin> -p tsconfig --pretty false --noErrorTruncation` | `<bin> --api [--async] --cwd <dir>` (msgpack / JSON-RPC over stdio) |
| 環境変数 | `TSGO_BIN` | `CORSA_PATH` / `CORSA_EXECUTABLE` / `TSGO_PATH` / `TSGO_EXECUTABLE` |
| 利用者 | `rsvelte-check` | type-aware lint バックエンド (`CorsaTypeBackend`) |

`--api` サーバモードを持つのは typescript-go 系ビルドだけで、素の `tsc` にはありません。そして
CI の `TSGO_BIN` の中身は `submodules/svelte/node_modules/.bin/tsc` — **TypeScript 5 の素の tsc**
です(TS6 pre-release を踏まないための意図的なピン留め、ci.yml のコメント参照)。

つまり **`resolver.rs` を `TSGO_BIN` に寄せるのは誤り**でした。寄せていたら「バイナリは解決できるが
プロトコルを喋れない」状態になり、無言 PASS が分かりにくいスポーン失敗に変わるだけです。
環境変数名はそれぞれ正しく、直すべきは「誰もバイナリを供給していないこと」の方でした。

### より深い原因: CI はそもそもこの crate をビルドしたことがない

- `crates/rsvelte_lint_types` は `[workspace]` を自前で持つ **独立ワークスペース**(`submodules/corsa-bind`
  への path 依存があるため)。ルートの `cargo test` / `cargo fmt` / `cargo clippy` はどれも届きません。
- `ci.yml` の submodule チェックアウトは `corsa-bind` / `typescript-go` を**明示的に除外**しています。

環境変数を直そうが直すまいが、CI でこの9テストが走ることはあり得ませんでした。

### `@typescript/native-preview` は入れるべきか → **これが正しい入手経路**

corsa-bind 自身の `defaultCorsaExecutable`(`corsa_oxlint/ts/context.ts`)が
`typescript@>=7` のネイティブ `tsc` → `@typescript/native-preview` → `.cache/corsa` の順で探しており、
`resolver.rs` の `node_modules/@typescript/native-preview*` フォールバックはこれのミラーです。
`submodules/typescript-go` は上流**ソース**(~534MB、Go ビルドが必要)で、実用的な入手経路ではありません。

## 修正内容

1. **無言 PASS の廃止** — `resolver::require_tsgo()` を追加し、バイナリ未解決時にセットアップ手順つきで
   panic。9箇所すべての `eprintln!("SKIP …"); return;` を置き換え。`TSGO_BIN` を読まない理由は
   resolver のモジュール doc とエラーメッセージに明記しました。
2. **oracle の下限ガード** — fixture ディレクトリ不在は `assert!`、加えて
   `assert!(checked >= MIN_FIXTURES)`。`expected_for` の `unwrap_or_default()` は `panic!` に変更
   (壊れた YAML が「期待値ゼロ」に化けて PASS するのを防ぐ)。
3. **再現可能な実行手段** — `pnpm run test:type-aware-lint`(`scripts/dev/test-type-aware-lint.mjs`)。
   submodule チェックアウト → **バージョン固定**の `@typescript/native-preview` 導入 →
   `--version` でバイナリ動作確認(バージョンを出力)→ crate の `cargo test --locked`。
4. **CI** — `.github/workflows/type-aware-lint.yml`。crate 関連パスへの push/PR + 週次 + 手動 dispatch。
   **この crate をカバーする唯一の場所**なので `cargo fmt --check` と `cargo clippy` もここで回します。
5. `crates/rsvelte_lint_types/Cargo.lock` — ピン留めされた corsa-bind に対して stale だったため更新
   (以後は `--locked` で drift を防止)。

## レビュー指摘への対応(2回目のコミット `81fe36a0`)

初版の CI 配線は「corsa-bind は private」という**私が検証せずに転記した誤った前提**の上に立っており、
`secrets.GH_PAT` ゲートのせいで**一度も成功し得ない**ものでした。#1790 を別の形で再生産していました。
レビューの指摘どおりです。実際に検証した結果:

```
$ gh api repos/ubugeeei-prod/corsa-bind --jq '.private,.visibility'
false
public
$ git clone --depth 1 -c credential.helper= https://github.com/ubugeeei-prod/corsa-bind.git …
Cloning into …  done.        # 無認証で成功
$ gh api repos/baseballyama/rsvelte/actions/secrets --jq '.secrets[].name'
OVSX_PAT
VSCE_PAT                     # GH_PAT は存在しない
```

- **blocker 1** — `Require corsa-bind access` ステップと `secrets` 参照を全削除。
- **blocker 2** — `.gitmodules` の corsa-bind URL を SSH → **HTTPS** に変更(CI に鍵が要らない)。
  トリガーを `workflow_dispatch` + `push`/`pull_request`(paths 絞り込み)+ 週次 `schedule` に拡張。
  public なので **fork PR でも動きます**。
  誤りの発生源である `crates/rsvelte_lint_types/Cargo.toml` のヘッダを訂正し、独立ワークスペースの
  理由を実際のもの(corsa のビルド時間を全員に負わせない)に書き換え。`AGENTS.md` も同様。
  ※ Actions のパーサは YAML アンカーを解釈しないため、`paths` は意図的に2箇所に複製しコメントを付けています。
- **should-fix 3** — `@typescript/native-preview` を `scripts/dev/type-aware-lint/package.json` で
  **exact 固定**(`7.0.0-dev.20260707.2`。corsa-bind の `corsa_ref.lock.toml` が指す typescript-go の
  コミット日 2026-07-07 と一致)。既存の `scripts/compat-corpus/lint-oracle/package.json` と同じ形なので
  Renovate が自動追従します。`scripts/dev/*` は pnpm workspace の glob 外なので `pnpm install` には影響しません。
- **should-fix 4** — workflow に `cargo fmt --check` / `cargo clippy` を追加。
- **should-fix 5** — clippy と test を `--locked` に。
- **should-fix 6** — `serde_yaml::from_str(...).unwrap_or_default()` → `panic!`。
- **nit** — `test:type-aware-lint` に改名(参照4箇所も追随)、死んだ `LineIndex` を削除、
  `.gitignore` の `.cache/` エントリは install 先を `scripts/dev/type-aware-lint/node_modules/` に
  移したため不要になり撤回(main に対して `.gitignore` は無変更)、`concurrency:` グループを追加。

## レビュー指摘への対応・その2(コミット `d4d38cf6`)

### nit-A: rust-cache のキーが空だった(実 CI ログで発見)

`Cache cargo registry + target` が `Checkout submodules` より前にあったため、rust-cache の
`cargo metadata` が失敗し **キャッシュキーが空のまま** job が緑になっていました。

```
Cache cargo registry + target: error: failed to load manifest for dependency `corsa_client`
                                 No such file or directory (os error 2)
                               Restore Key:      ← 空
                               Cache Key:        ← 空
```

job は成功するがキャッシュは効かない、という**まさに本 PR の主題と同じ形**でした。
`Checkout submodules` を cache ステップの直前に移動して修正。修正後の実 CI ログ:

```
failed to load manifest       → 0 件
Restored from cache key "v0-rust-type-aware-lint-Linux-x64-b587c171-4a8eb10d"
Cache restored successfully
```

**job 実時間 4m00s → 1m44s。** 週次 schedule で回すことを考えると効果は大きいです。

### nit-B: オフライン実行(対応しました)

無条件 `npm install` でオフライン実行が壊れた点、`--prefer-offline` を付け、install 失敗時は
既存バイナリへフォールバック(バイナリも無ければ非ゼロ終了)するようにしました。
フォールバックしたバイナリは Renovate bump 後に stale であり得るので、
**pin とバージョンを突き合わせて不一致を警告**します(黙って診断テキストが変わるのを防ぐため)。

4経路すべてローカルで実挙動を確認しました(「分岐を書いたが実は通らない」を避けるため):

| 経路 | 結果 |
|---|---|
| 通常 install | 9 passed |
| レジストリ到達不可(cache あり) | 9 passed |
| install 失敗 + バイナリあり | `warning: npm install failed — falling back…` → 9 passed |
| install 失敗 + バイナリなし | `npm install failed and no previously installed tsgo binary was found.` → 非ゼロ終了 |
| pin を偽装 | `warning: tsgo reports "…20260707.2" but the pin is 9.9.9-fake.` |

## 走るようになったテスト数(実数)

submodule を deinit し `node_modules` も消した**クリーンな状態**からの `pnpm run test:type-aware-lint`:

```
==> tsgo: …/scripts/dev/type-aware-lint/node_modules/@typescript/native-preview-darwin-arm64/lib/tsgo
==> Version 7.0.0-dev.20260707.2

tests/nav_type_aware_e2e.rs        4 passed; 0 failed
tests/no_unused_props_fixtures.rs  1 passed; 0 failed   (upstream fixture 76 件を実際に再生)
tests/type_aware_e2e.rs            4 passed; 0 failed
─────────────────────────────────────────────────────
合計                               9 passed; 0 failed
```

**9/9 が実行され、9/9 が PASS。**

無言 PASS が消えたことの確認 — バイナリ無しで crate を直接叩くと:

```
running 4 tests
test result: FAILED. 0 passed; 4 failed
thread '…' panicked at src/resolver.rs:74:
no tsgo / corsa binary found — the type-aware lint backend cannot run.
```

## 露出した失敗

**なし。** 一度も実行されたことのないテスト群でしたが、9件すべてが初回実行で PASS しました。
`#[ignore]` も ratchet エントリも追加していません。

レビュアーによる変異注入で、テストが実際に防御として機能することも確認されています
(`compute_props_type` → `None` で oracle が 7/76 diverged、`type_props` の `is_local` → `false` で
17/76 diverged、`map_offset_forward` → `None` で nav 3/4 FAILED)。

なお「0件」が不自然でない理由もレビューで裏取りされています:
`crates/rsvelte_lint/tests/eslint_plugin_oracle.rs` の corsa-free 経路で no-unused-props fixture の
大半は既に本流 CI で緑になっており、型検査必須の 16 件程度だけが SKIP されていました。

### 判明した既存テストの弱点(この PR の瑕疵ではないが記録)

- `tests/type_aware_e2e.rs` の4件は型グラフ喪失を素通りします(extends / intersection / nested は
  flat 経路でも解けるため)。実質の防御は fixture oracle です。
- `map_offset_forward` を恒等写像にしても nav 4件は PASS するため、forward-map の*正確さ*は
  強く固定されていません。

いずれも別 issue 向けの改善余地です(graph 固有ケース — index signature / imported type — の追加)。

## 検証

クリーンツリー(`git submodule deinit submodules/corsa-bind` + `node_modules` 削除)から:

- `node scripts/dev/test-type-aware-lint.mjs --locked` → **9 passed; 0 failed**(無認証 clone で成功)
- `cargo fmt --all --check`(`crates/rsvelte_lint_types`)→ exit 0
- `cargo clippy --all-targets --locked -- -D warnings`(同上)→ exit 0
- `cargo clippy --all-targets`(ルートワークスペース)→ exit 0
- workflow YAML: トリガー4種、`paths` 2リストの一致、`secrets` 参照ゼロをスクリプトで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqdHfZSN3LFxPkyKFaCyoF
