### PR TITLE
perf(lint): one template serialization and one script walk per file (-20%)

### DIFF
--- a/crates/rsvelte_lint/src/context.rs
+++ b/crates/rsvelte_lint/src/context.rs
@@ -6,9 +6,13 @@
 //! also borrows the resolved [`LintConfig`] so a rule can read its own parsed
 //! options via [`LintContext::option_bool`] / [`LintContext::option_str_list`].
 
+use std::cell::OnceCell;
 use std::path::Path;
+use std::rc::Rc;
 
 use serde_json::Value;
+
+use rsvelte_core::compiler::phases::phase2_analyze::ComponentAnalysis;
 
 use crate::config::LintConfig;
 use crate::diagnostic::{Fix, LintDiagnostic, Suggestion};
@@ -34,6 +38,20 @@ pub struct LintContext<'a> {
     /// rule that needs it is disabled). Rules use it to distinguish a real
     /// global reference from a local binding that shares a global's name.
     scope_resolver: Option<&'a crate::scope::ScopeResolver>,
+    /// The component's Phase-2 analysis (bindings/scopes), run on first use.
+    /// Running it costs a full parse + analyze — several rules need it, so they
+    /// share one result per file instead of each re-analyzing the source.
+    /// `None` records an analysis failure (rules fall back to their own scan).
+    scope_analysis: OnceCell<Option<Rc<ComponentAnalysis>>>,
+    /// The template fragment as ESTree JSON (default parse options), built on
+    /// first use — several script rules scan template expressions and would
+    /// otherwise each re-parse and re-serialize the whole source.
+    template_fragment_json: OnceCell<Rc<Value>>,
+    /// The component's template AST as ESTree JSON, serialized on first use.
+    /// Several rules walk the whole tree generically; serializing it is one of
+    /// the most expensive things a lint pass does, so they share one value.
+    /// `Value::Null` records a serialization failure (rules bail on it).
+    root_json: OnceCell<Rc<Value>>,
 }
 
 impl<'a> LintContext<'a> {
@@ -47,6 +65,9 @@ impl<'a> LintContext<'a> {
             filename,
             path: None,
             scope_resolver: None,
+            scope_analysis: OnceCell::new(),
+            template_fragment_json: OnceCell::new(),
+            root_json: OnceCell::new(),
         }
     }
 
@@ -64,6 +85,52 @@ impl<'a> LintContext<'a> {
     ) -> Self {
         self.scope_resolver = resolver;
         self
+    }
+
+    /// The component's Phase-2 analysis, run once per file and shared by every
+    /// rule that asks for it. `None` when the component fails to analyze (an
+    /// invalid component still lints — rules fall back to a parse-only scan).
+    pub fn scope_analysis(&self) -> Option<Rc<ComponentAnalysis>> {
+        self.scope_analysis
+            .get_or_init(|| crate::scope::analyze_scope(self.source).map(Rc::new))
+            .clone()
+    }
+
+    /// The component's template AST as ESTree JSON, serialized once per file
+    /// and shared by every rule that asks for it. Returns `Value::Null` if the
+    /// tree could not be serialized. The `Rc` handout keeps the borrow off
+    /// `self`, so a rule can report while holding the JSON.
+    pub fn root_json(&self, root: &rsvelte_core::ast::template::Root) -> Rc<Value> {
+        self.root_json
+            .get_or_init(|| {
+                Rc::new(rsvelte_core::ast::arena::with_serialize_arena(
+                    &root.arena,
+                    || serde_json::to_value(root).unwrap_or(Value::Null),
+                ))
+            })
+            .clone()
+    }
+
+    /// The template fragment as ESTree JSON, parsed with the *default* options
+    /// (not the lenient lint options — a script rule scanning template
+    /// expressions must see what the strict parse produces) and cached per
+    /// file. Script rules reach the template through this instead of
+    /// re-parsing + re-serializing the source on every call.
+    pub fn template_fragment_json(&self) -> Rc<Value> {
+        self.template_fragment_json
+            .get_or_init(|| {
+                let alloc = rsvelte_core::Allocator::default();
+                let Ok(root) =
+                    rsvelte_core::parse(self.source, &alloc, rsvelte_core::ParseOptions::default())
+                else {
+                    return Rc::new(Value::Null);
+                };
+                Rc::new(rsvelte_core::ast::arena::with_serialize_arena(
+                    &root.arena,
+                    || serde_json::to_value(&root.fragment).unwrap_or(Value::Null),
+                ))
+            })
+            .clone()
     }
 
     /// The script-scope resolver for this file, when one was built.

--- a/crates/rsvelte_lint/src/context.rs
+++ b/crates/rsvelte_lint/src/context.rs
@@ -111,6 +111,16 @@ impl<'a> LintContext<'a> {
             .clone()
     }
 
+    /// The `fragment` of the shared root JSON (same lenient parse the lint pass
+    /// already did), for rules that hold the `Root` and only walk the template.
+    pub fn root_fragment_json(
+        &self,
+        root: &rsvelte_core::ast::template::Root,
+    ) -> Option<Rc<Value>> {
+        let json = self.root_json(root);
+        json.get("fragment").is_some().then(|| json)
+    }
+
     /// The template fragment as ESTree JSON, parsed with the *default* options
     /// (not the lenient lint options — a script rule scanning template
     /// expressions must see what the strict parse produces) and cached per

--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -17,7 +17,7 @@ use crate::diagnostic::LintDiagnostic;
 use crate::registry::{all_rules, all_script_rules};
 use crate::rule::{RuleMeta, Severity};
 use crate::scope::ScopeResolver;
-use crate::script::{ScriptKind, ScriptRule};
+use crate::script::{ProgramView, ScriptKind, ScriptRule};
 use crate::visitor::{EnabledRule, LintVisitor};
 
 /// The lenient parse options every lint pass uses. `lenient_script: true` keeps
@@ -166,9 +166,12 @@ fn run_over_programs(
         .with_path(path)
         .with_scope_resolver(scope_resolver);
     for (kind, program) in programs {
+        // One DFS index per program, shared by every rule (each used to
+        // re-descend the whole JSON tree itself).
+        let view = ProgramView::new(program);
         for (rule, meta, severity) in enabled {
             ctx.enter_rule(meta, *severity);
-            rule.check_program(&mut ctx, program, *kind);
+            rule.check_program(&mut ctx, &view, *kind);
         }
     }
     ctx.into_diagnostics()

--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -154,7 +154,7 @@ fn enabled_script_rules<'a>(
 
 /// Run each enabled script rule over every `(kind, program)` pair.
 fn run_over_programs(
-    programs: &[(ScriptKind, Value)],
+    programs: &[(ScriptKind, &Value)],
     source: &str,
     filename: &str,
     config: &LintConfig,
@@ -286,17 +286,19 @@ pub(crate) fn run_script_rules_on_root(
         return Vec::new();
     }
 
-    // Materialise each script program to an owned ESTree JSON value. The
+    // Materialise each script program as an ESTree JSON value. The
     // serialization MUST run inside the arena scope (the program body resolves
     // arena-indexed children) and BEFORE any out-of-scope `as_json` would cache
-    // an empty body — so we serialize immediately inside the arena guard.
-    let programs: Vec<(ScriptKind, Value)> = with_serialize_arena(&root.arena, || {
+    // an empty body — so we serialize immediately inside the arena guard. The
+    // values stay borrowed from the program's own `OnceCell` cache: copying
+    // them out would deep-clone an entire ESTree tree per file.
+    let programs: Vec<(ScriptKind, &Value)> = with_serialize_arena(&root.arena, || {
         let mut out = Vec::new();
         if let Some(s) = root.instance.as_ref() {
-            out.push((ScriptKind::Instance, s.content.as_json().clone()));
+            out.push((ScriptKind::Instance, s.content.as_json()));
         }
         if let Some(s) = root.module.as_ref() {
-            out.push((ScriptKind::Module, s.content.as_json().clone()));
+            out.push((ScriptKind::Module, s.content.as_json()));
         }
         out
     });
@@ -331,7 +333,7 @@ pub fn run_script_rules_module(
         return Vec::new();
     }
     let program = rsvelte_core::compiler::phases::parse_module_to_estree(source, is_ts);
-    let programs = [(ScriptKind::Module, program)];
+    let programs = [(ScriptKind::Module, &program)];
     // A standalone module is its own scope; the whole file is the script body
     // (base offset 0).
     let resolver = needs_scope_resolver(&enabled).then(|| {

--- a/crates/rsvelte_lint/src/rules/derived_has_same_inputs_outputs.rs
+++ b/crates/rsvelte_lint/src/rules/derived_has_same_inputs_outputs.rs
@@ -22,7 +22,9 @@ use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
 use crate::rules::store_refs::collect_store_creators;
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{
+    ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/derived-has-same-inputs-outputs",
@@ -331,7 +333,7 @@ impl ScriptRule for DerivedHasSameInputsOutputs {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let creators = collect_store_creators(program);
         if creators.is_empty() {
             return;
@@ -339,7 +341,7 @@ impl ScriptRule for DerivedHasSameInputsOutputs {
 
         let mut reports: Vec<Report> = Vec::new();
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/infinite_reactive_loop.rs
+++ b/crates/rsvelte_lint/src/rules/infinite_reactive_loop.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{
+    ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/infinite-reactive-loop",
@@ -760,13 +762,13 @@ impl ScriptRule for InfiniteReactiveLoop {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let (func_map, top_level_names) = collect_top_level(program);
         let task_names = collect_task_names(program, &top_level_names);
 
         let mut all_reports: Vec<Rep> = Vec::new();
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_add_event_listener.rs
+++ b/crates/rsvelte_lint/src/rules/no_add_event_listener.rs
@@ -40,7 +40,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 const MESSAGE: &str =
     "Do not use `addEventListener`. Use the `on` function from `svelte/events` instead.";
@@ -86,9 +86,9 @@ impl ScriptRule for NoAddEventListener {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut reports: Vec<Report> = Vec::new();
-        walk_js(program, |node, _ancestors| {
+        program.walk(|node, _ancestors| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_dom_manipulating.rs
+++ b/crates/rsvelte_lint/src/rules/no_dom_manipulating.rs
@@ -21,7 +21,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-dom-manipulating",
@@ -203,7 +203,7 @@ impl ScriptRule for NoDomManipulating {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut toplevel: HashSet<String> = HashSet::new();
         collect_toplevel_decls(program, &mut toplevel);
         let dom_vars = collect_dom_vars(ctx.source(), &toplevel);
@@ -214,7 +214,7 @@ impl ScriptRule for NoDomManipulating {
         let properties: HashSet<&str> = DOM_PROPERTIES.iter().copied().collect();
 
         let mut reports: Vec<(u32, u32)> = Vec::new();
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             if node_type(node) != Some("MemberExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_dom_manipulating.rs
+++ b/crates/rsvelte_lint/src/rules/no_dom_manipulating.rs
@@ -14,9 +14,6 @@
 
 use std::collections::HashSet;
 
-use rsvelte_core::ParseOptions;
-use rsvelte_core::ast::arena::with_serialize_arena;
-use rsvelte_core::compiler::phases::parse;
 use serde_json::Value;
 
 use crate::context::LintContext;
@@ -149,20 +146,9 @@ fn collect_pattern_idents(id: Option<&Value>, out: &mut HashSet<String>) {
 
 /// Identifiers captured by `bind:this` on an HTML element / `<svelte:element>`
 /// that resolve to a top-level binding.
-fn collect_dom_vars(source: &str, binding_names: &HashSet<String>) -> HashSet<String> {
+fn collect_dom_vars(ctx: &LintContext, binding_names: &HashSet<String>) -> HashSet<String> {
     let mut out = HashSet::new();
-    let Ok(root) = parse(
-        source,
-        &rsvelte_core::Allocator::default(),
-        ParseOptions::default(),
-    ) else {
-        return out;
-    };
-    let Some(frag) =
-        with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-    else {
-        return out;
-    };
+    let frag = ctx.template_fragment_json();
     walk_js(&frag, |node, ancestors| {
         if node_type(node) != Some("BindDirective")
             || node.get("name").and_then(Value::as_str) != Some("this")
@@ -206,7 +192,7 @@ impl ScriptRule for NoDomManipulating {
     fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut toplevel: HashSet<String> = HashSet::new();
         collect_toplevel_decls(program, &mut toplevel);
-        let dom_vars = collect_dom_vars(ctx.source(), &toplevel);
+        let dom_vars = collect_dom_vars(ctx, &toplevel);
         if dom_vars.is_empty() {
             return;
         }

--- a/crates/rsvelte_lint/src/rules/no_export_load_in_svelte_module_in_kit_pages.rs
+++ b/crates/rsvelte_lint/src/rules/no_export_load_in_svelte_module_in_kit_pages.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-export-load-in-svelte-module-in-kit-pages",
@@ -79,7 +79,7 @@ impl ScriptRule for NoExportLoadInSvelteModuleInKitPages {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, kind: ScriptKind) {
         // Only inspect the module script (`<script context="module">`).
         if kind != ScriptKind::Module {
             return;
@@ -93,7 +93,7 @@ impl ScriptRule for NoExportLoadInSvelteModuleInKitPages {
         // declared directly under them.
         let mut reports: Vec<(u32, u32)> = Vec::new();
 
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             if node_type(node) != Some("ExportNamedDeclaration") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_extra_reactive_curlies.rs
+++ b/crates/rsvelte_lint/src/rules/no_extra_reactive_curlies.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-extra-reactive-curlies",
@@ -76,9 +76,9 @@ impl ScriptRule for NoExtraReactiveCurlies {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut reports: Vec<(u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_goto_without_base.rs
+++ b/crates/rsvelte_lint/src/rules/no_goto_without_base.rs
@@ -17,11 +17,11 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 /// Collect the local namespace alias for `import * as X from module` into `out`.
-fn import_ns_locals(program: &Value, module: &str, out: &mut HashSet<String>) {
-    walk_js(program, |node, _| {
+fn import_ns_locals(program: &ProgramView<'_>, module: &str, out: &mut HashSet<String>) {
+    program.walk(|node, _| {
         if node_type(node) != Some("ImportDeclaration") {
             return;
         }
@@ -69,8 +69,8 @@ const MESSAGE: &str = "Found a goto() call with a url that isn't prefixed with t
 
 /// Collect the local names that an import from `module` binds for the given
 /// exported `name` (alias aware: `import { base as b }` → `b`).
-fn import_locals(program: &Value, module: &str, name: &str, out: &mut HashSet<String>) {
-    walk_js(program, |node, _| {
+fn import_locals(program: &ProgramView<'_>, module: &str, name: &str, out: &mut HashSet<String>) {
+    program.walk(|node, _| {
         if node_type(node) != Some("ImportDeclaration") {
             return;
         }
@@ -182,7 +182,7 @@ impl ScriptRule for NoGotoWithoutBase {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut goto_names: HashSet<String> = HashSet::new();
         import_locals(program, "$app/navigation", "goto", &mut goto_names);
         let mut nav_ns: HashSet<String> = HashSet::new();
@@ -194,7 +194,7 @@ impl ScriptRule for NoGotoWithoutBase {
         import_locals(program, "$app/paths", "base", &mut base_names);
 
         let mut reports: Vec<u32> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_ignored_unsubscribe.rs
+++ b/crates/rsvelte_lint/src/rules/no_ignored_unsubscribe.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-ignored-unsubscribe",
@@ -34,10 +34,10 @@ impl ScriptRule for NoIgnoredUnsubscribe {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // Selector: ExpressionStatement > CallExpression > MemberExpression.callee[property.name='subscribe'].
         let mut reports: Vec<u32> = Vec::new();
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             // `node` must be the `.subscribe` MemberExpression callee.
             if node_type(node) != Some("MemberExpression") {
                 return;

--- a/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
+++ b/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
@@ -424,7 +424,7 @@ impl ScriptRule for NoImmutableReactiveStatements {
         // wouldn't reject), continue with empty binding maps — the write-only
         // LHS detection and the "unknown identifier → skip" guard ensure we
         // only report structurally obvious non-reactive statements.
-        let analysis = crate::scope::analyze_scope(ctx.source());
+        let analysis = ctx.scope_analysis();
 
         let (binding_names, mutable_bindings): (HashSet<&str>, HashSet<&str>) =
             if let Some(ref a) = analysis {

--- a/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
+++ b/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
@@ -28,7 +28,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-immutable-reactive-statements",
@@ -93,8 +93,8 @@ const KNOWN_GLOBALS: &[&str] = &[
 ];
 
 /// Collect names declared by `export let` / `export var` (props).
-fn collect_export_let_props(program: &Value, out: &mut HashSet<String>) {
-    walk_js(program, |node, _| {
+fn collect_export_let_props(program: &ProgramView<'_>, out: &mut HashSet<String>) {
+    program.walk(|node, _| {
         if node_type(node) != Some("ExportNamedDeclaration") {
             return;
         }
@@ -163,9 +163,9 @@ fn expr_base_name(e: Option<&Value>) -> Option<&str> {
 /// program (`delete obj.prop` ⇒ `obj`). Such a delete mutates the object, so the
 /// base name is mutable — mirrors upstream's `hasWriteMember` handling of
 /// `UnaryExpression { operator: 'delete' }`.
-fn collect_delete_mutated(program: &Value) -> HashSet<String> {
+fn collect_delete_mutated(program: &ProgramView<'_>) -> HashSet<String> {
     let mut out = HashSet::new();
-    walk_js(program, |node, _| {
+    program.walk(|node, _| {
         if node_type(node) != Some("UnaryExpression") {
             return;
         }
@@ -418,7 +418,7 @@ impl ScriptRule for NoImmutableReactiveStatements {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // Try to get full scope analysis. If it fails (e.g. constant_assignment
         // or constant_binding errors that the upstream ESLint scope manager
         // wouldn't reject), continue with empty binding maps — the write-only
@@ -470,7 +470,7 @@ impl ScriptRule for NoImmutableReactiveStatements {
         };
 
         let mut reports: Vec<(u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement")
                 || node
                     .get("label")

--- a/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
+++ b/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
@@ -21,9 +21,6 @@
 
 use std::collections::HashSet;
 
-use rsvelte_core::ParseOptions;
-use rsvelte_core::ast::arena::with_serialize_arena;
-use rsvelte_core::compiler::phases::parse;
 use serde_json::Value;
 
 use crate::context::LintContext;
@@ -214,20 +211,9 @@ fn is_written(name: &str, scope: &Value) -> bool {
 
 /// The base variables of every `{#each}` source whose context is written — these
 /// are mutated through the loop and so are *not* immutable.
-fn collect_mutable_via_each(source: &str) -> HashSet<String> {
+fn collect_mutable_via_each(ctx: &LintContext) -> HashSet<String> {
     let mut out = HashSet::new();
-    let Ok(root) = parse(
-        source,
-        &rsvelte_core::Allocator::default(),
-        ParseOptions::default(),
-    ) else {
-        return out;
-    };
-    let Some(frag) =
-        with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-    else {
-        return out;
-    };
+    let frag = ctx.template_fragment_json();
     walk_js(&frag, |node, _| {
         if node_type(node) != Some("EachBlock") {
             return;
@@ -443,7 +429,7 @@ impl ScriptRule for NoImmutableReactiveStatements {
 
         let mut props: HashSet<String> = HashSet::new();
         collect_export_let_props(program, &mut props);
-        let mutable_via_each = collect_mutable_via_each(ctx.source());
+        let mutable_via_each = collect_mutable_via_each(ctx);
         let delete_mutated = collect_delete_mutated(program);
         let globals: HashSet<&str> = KNOWN_GLOBALS.iter().copied().collect();
 

--- a/crates/rsvelte_lint/src/rules/no_inner_declarations.rs
+++ b/crates/rsvelte_lint/src/rules/no_inner_declarations.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-inner-declarations",
@@ -39,7 +39,7 @@ impl ScriptRule for NoInnerDeclarations {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let opts = ctx.options();
         let mode = opts
             .and_then(|a| a.get(0))
@@ -56,7 +56,7 @@ impl ScriptRule for NoInnerDeclarations {
         let check_functions = block_scoped_functions == "disallow";
 
         let mut reports: Vec<(u32, &'static str, &'static str)> = Vec::new();
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             let kind = match node_type(node) {
                 Some("FunctionDeclaration") if check_functions => "function",
                 Some("VariableDeclaration")

--- a/crates/rsvelte_lint/src/rules/no_navigation_without_base.rs
+++ b/crates/rsvelte_lint/src/rules/no_navigation_without_base.rs
@@ -13,7 +13,6 @@
 
 use std::collections::{HashMap, HashSet};
 
-use rsvelte_core::ast::arena::with_serialize_arena;
 use rsvelte_core::ast::template::Root;
 use serde_json::Value;
 
@@ -359,10 +358,10 @@ impl Rule for NoNavigationWithoutBase {
     }
 
     fn check_root(&self, ctx: &mut LintContext, root: &Root) {
-        let Some(json) = with_serialize_arena(&root.arena, || serde_json::to_value(root).ok())
-        else {
+        let json = ctx.root_json(root);
+        if json.is_null() {
             return;
-        };
+        }
         let im = collect_imports(&json);
         let var_inits = collect_var_inits(&json);
         let cx = Ctx {

--- a/crates/rsvelte_lint/src/rules/no_reactive_functions.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_functions.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-reactive-functions",
@@ -75,10 +75,10 @@ impl ScriptRule for NoReactiveFunctions {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // (labeled-statement start, labeled-statement end, `$`-label end).
         let mut reports: Vec<(u32, u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_reactive_literals.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_literals.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-reactive-literals",
@@ -65,12 +65,12 @@ impl ScriptRule for NoReactiveLiterals {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // (labeled-statement start, labeled-statement end, assignment start,
         // assignment end). The suggestion replaces [labeled.start, labeled.end)
         // with `let <assignment-text>`.
         let mut reports: Vec<(u32, u32, u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_reactive_reassign.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_reassign.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-reactive-reassign",
@@ -244,12 +244,12 @@ fn collect_toplevel_decls(program: &Value, out: &mut HashSet<String>) {
 /// Reactive value names (`$: name = …`, `name` not explicitly declared) and the
 /// positions of those defining-LHS identifiers (skipped when scanning refs).
 fn collect_reactive_values(
-    program: &Value,
+    program: &ProgramView<'_>,
     toplevel: &HashSet<String>,
 ) -> (HashSet<String>, HashSet<(u64, u64)>) {
     let mut names = HashSet::new();
     let mut def_lhs = HashSet::new();
-    walk_js(program, |node, _| {
+    program.walk(|node, _| {
         if node_type(node) != Some("LabeledStatement")
             || node
                 .get("label")
@@ -340,7 +340,7 @@ impl ScriptRule for NoReactiveReassign {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut toplevel = HashSet::new();
         collect_toplevel_decls(program, &mut toplevel);
         let (reactive, def_lhs) = collect_reactive_values(program, &toplevel);

--- a/crates/rsvelte_lint/src/rules/no_reactive_reassign.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_reassign.rs
@@ -16,9 +16,6 @@
 
 use std::collections::HashSet;
 
-use rsvelte_core::ParseOptions;
-use rsvelte_core::ast::arena::with_serialize_arena;
-use rsvelte_core::compiler::phases::parse;
 use serde_json::Value;
 
 use crate::context::LintContext;
@@ -356,15 +353,8 @@ impl ScriptRule for NoReactiveReassign {
         let mut reports: Vec<(u32, u32, String)> = Vec::new();
         scan_refs(program, &reactive, &def_lhs, props, &mut reports);
         // Reassignments via a two-way `bind:` live in the template.
-        if let Ok(root) = parse(
-            ctx.source(),
-            &rsvelte_core::Allocator::default(),
-            ParseOptions::default(),
-        ) && let Some(frag) =
-            with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-        {
-            scan_refs(&frag, &reactive, &def_lhs, props, &mut reports);
-        }
+        let frag = ctx.template_fragment_json();
+        scan_refs(&frag, &reactive, &def_lhs, props, &mut reports);
 
         for (start, end, msg) in reports {
             ctx.report(start, end, msg);

--- a/crates/rsvelte_lint/src/rules/no_store_async.rs
+++ b/crates/rsvelte_lint/src/rules/no_store_async.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-store-async",
@@ -57,13 +57,13 @@ impl ScriptRule for NoStoreAsync {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // Resolve `svelte/store` imports: local names bound to a store creator,
         // and any namespace import alias.
         let mut direct: Vec<String> = Vec::new(); // local names of writable/readable/derived
         let mut namespaces: Vec<String> = Vec::new(); // `import * as X`
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("ImportDeclaration") {
                 return;
             }
@@ -113,7 +113,7 @@ impl ScriptRule for NoStoreAsync {
 
         // Find store-creator calls and report an async second argument.
         let mut reports: Vec<u32> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
+++ b/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
@@ -38,7 +38,7 @@ use rsvelte_core::ast::template::{Fragment, Root, TemplateNode};
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-top-level-browser-globals",
@@ -542,7 +542,7 @@ impl ScriptRule for NoTopLevelBrowserGlobals {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let source = ctx.source();
         // --- 1. Resolve browser-checker module imports. ---
         // local names bound to `browser`/`BROWSER` reads, and namespace imports.

--- a/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
+++ b/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
@@ -138,7 +138,8 @@ impl ScriptRule for NoUnnecessaryStateWrap {
         // `x = ...` and `bind:` getter/setter writes via the analyzed scope, plus
         // shorthand `bind:x` two-way bindings detected from the source.
         let reassigned: HashSet<String> = if allow_reassign {
-            let mut set: HashSet<String> = crate::scope::analyze_scope(ctx.source())
+            let mut set: HashSet<String> = ctx
+                .scope_analysis()
                 .map(|a| {
                     a.root
                         .bindings

--- a/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
+++ b/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-unnecessary-state-wrap",
@@ -80,7 +80,7 @@ impl ScriptRule for NoUnnecessaryStateWrap {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let opts = ctx.option0();
         let additional: HashSet<String> = opts
             .and_then(|o| o.get("additionalReactiveClasses"))
@@ -99,7 +99,7 @@ impl ScriptRule for NoUnnecessaryStateWrap {
         // `svelte/reactivity` imports: local name → exported (canonical) name,
         // restricted to the known reactive classes.
         let mut import_map: HashMap<String, String> = HashMap::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("ImportDeclaration") {
                 return;
             }
@@ -162,7 +162,7 @@ impl ScriptRule for NoUnnecessaryStateWrap {
         // end, arg start, arg end). The suggestion replaces the whole
         // `$state(...)` call with the inner argument's source text.
         let mut valid_reports: Vec<(u32, String, u32, u32, u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("VariableDeclarator") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/prefer_const.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_const.rs
@@ -20,7 +20,7 @@ use rsvelte_core::ast::template::{DeclarationTag, Fragment, Root, TemplateNode};
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, TextEdit};
 use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/prefer-const",
@@ -81,9 +81,9 @@ fn collect_template_reassignments(ctx: &LintContext, out: &mut HashSet<String>) 
 /// Add names that are declared by more than one `let`/`var`/`const` declarator
 /// in `program` (a redeclaration), which the core `prefer-const` rule treats as
 /// having multiple writes. Used only on the parse-only fallback path.
-fn add_redeclared_names(program: &Value, out: &mut HashSet<String>) {
+fn add_redeclared_names(program: &ProgramView<'_>, out: &mut HashSet<String>) {
     let mut counts: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
-    walk_js(program, |node, _| {
+    program.walk(|node, _| {
         if node_type(node) != Some("VariableDeclaration") {
             return;
         }
@@ -402,8 +402,8 @@ fn check_template_declaration_tags(
     reports
 }
 
-fn collect_forin_forof_reassignments(program: &Value, out: &mut HashSet<String>) {
-    walk_js(program, |node, _| {
+fn collect_forin_forof_reassignments(program: &ProgramView<'_>, out: &mut HashSet<String>) {
+    program.walk(|node, _| {
         let ty = node_type(node);
         if !matches!(ty, Some("ForOfStatement") | Some("ForInStatement")) {
             return;
@@ -480,9 +480,11 @@ struct AssignInfo {
 /// target of an `AssignmentExpression` and how many of those are destructuring.
 /// `UpdateExpression` increments `total` (not destructuring) so the name is
 /// excluded from the single-destructuring-assignment fast path.
-fn collect_assignment_info(program: &Value) -> std::collections::HashMap<String, AssignInfo> {
+fn collect_assignment_info(
+    program: &ProgramView<'_>,
+) -> std::collections::HashMap<String, AssignInfo> {
     let mut map: std::collections::HashMap<String, AssignInfo> = std::collections::HashMap::new();
-    walk_js(program, |node, ancestors| match node_type(node) {
+    program.walk(|node, ancestors| match node_type(node) {
         Some("AssignmentExpression") => {
             let Some(left) = node.get("left") else {
                 return;
@@ -593,7 +595,7 @@ impl ScriptRule for PreferConst {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, kind: ScriptKind) {
         // Reassignment info from the analyzed scope (reliable per the R9 audit).
         // `analyze_scope` runs the full Phase-2 analysis, which returns `Err`
         // (→ `None`) when the component has *any* analysis/validation error
@@ -665,7 +667,7 @@ impl ScriptRule for PreferConst {
             == Some("all");
 
         let mut reports: Vec<(u32, u32, String, Option<u32>)> = Vec::new();
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             if node_type(node) != Some("VariableDeclaration")
                 || node.get("kind").and_then(Value::as_str) != Some("let")
             {

--- a/crates/rsvelte_lint/src/rules/prefer_const.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_const.rs
@@ -71,26 +71,11 @@ fn init_rune_callee(init: &Value) -> Option<&str> {
 /// `prefer-const` rule, which only bails on a write reference to the binding
 /// itself. Used to cover template positions the compiler scope walk skips
 /// (e.g. `{@render}` arguments).
-fn collect_template_reassignments(source: &str, out: &mut HashSet<String>) {
-    // Re-parse (cheap; the analyzed `ComponentAnalysis` keeps only the scope
-    // tree, not the template AST) and serialize the template fragment so the
-    // assignment walk runs over the ESTree expressions inside every tag. The
-    // fragment's JS expressions live in the parse arena, which must be installed
-    // for the duration of the serialize.
-    use rsvelte_core::ast::arena::with_serialize_arena;
-    let Ok(root) = rsvelte_core::parse(
-        source,
-        &rsvelte_core::Allocator::default(),
-        rsvelte_core::ParseOptions::default(),
-    ) else {
-        return;
-    };
-    let Some(value) =
-        with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-    else {
-        return;
-    };
-    walk_assignments(&value, out);
+fn collect_template_reassignments(ctx: &LintContext, out: &mut HashSet<String>) {
+    // The template fragment is serialized once per file by the context (this
+    // rule alone would otherwise re-parse + re-serialize the source on each of
+    // its two call sites, for each script block).
+    walk_assignments(&ctx.template_fragment_json(), out);
 }
 
 /// Add names that are declared by more than one `let`/`var`/`const` declarator
@@ -616,7 +601,7 @@ impl ScriptRule for PreferConst {
         // svelte-eslint-parser only parses, so it still lints such a file; to
         // match, fall back to a parse-only assignment scan of the script +
         // template when the analysis is unavailable.
-        let mut reassigned: HashSet<String> = match crate::scope::analyze_scope(ctx.source()) {
+        let mut reassigned: HashSet<String> = match ctx.scope_analysis() {
             Some(analysis) => analysis
                 .root
                 .bindings
@@ -648,7 +633,7 @@ impl ScriptRule for PreferConst {
         // ONCE here and reused below for the no-init-let check, avoiding a second
         // re-parse of the source.
         let mut template_reassign: HashSet<String> = HashSet::new();
-        collect_template_reassignments(ctx.source(), &mut template_reassign);
+        collect_template_reassignments(ctx, &mut template_reassign);
         reassigned.extend(template_reassign.iter().cloned());
         // `for (x of …)` / `for (x in …)` with a bare pattern (not
         // `VariableDeclaration`) reassign the binding. The rsvelte scope builder
@@ -887,7 +872,7 @@ impl Rule for PreferConst {
 
         // Build the reassigned set from the template itself.
         let mut reassigned: HashSet<String> = HashSet::new();
-        collect_template_reassignments(ctx.source(), &mut reassigned);
+        collect_template_reassignments(ctx, &mut reassigned);
 
         let tag_reports =
             check_template_declaration_tags(ctx.source(), &reassigned, destructuring_all);

--- a/crates/rsvelte_lint/src/rules/prefer_derived_over_derived_by.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_derived_over_derived_by.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/prefer-derived-over-derived-by",
@@ -106,11 +106,11 @@ impl ScriptRule for PreferDerivedOverDerivedBy {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // (call_start, call_end, expr_start, expr_end)
         let mut reports: Vec<(u32, u32, u32, u32)> = Vec::new();
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/prefer_destructured_store_props.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_destructured_store_props.rs
@@ -539,10 +539,10 @@ impl Rule for PreferDestructuredStoreProps {
     }
 
     fn check_root(&self, ctx: &mut LintContext, root: &Root) {
-        // Serialize only the fragment for the detection walk (cheap path).
-        let Some(frag) =
-            with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-        else {
+        // The whole-root JSON is serialized once per file by the context and
+        // shared with the other rules that walk the template.
+        let root_json = ctx.root_json(root);
+        let Some(frag) = root_json.get("fragment") else {
             return;
         };
 
@@ -579,7 +579,7 @@ impl Rule for PreferDestructuredStoreProps {
 
         // Walk the fragment and collect reports.
         let mut reports: Vec<PendingReport> = Vec::new();
-        walk_js(&frag, |node, ancestors| {
+        walk_js(frag, |node, ancestors| {
             if node_type(node) != Some("MemberExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/prefer_svelte_reactivity.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_svelte_reactivity.rs
@@ -27,7 +27,7 @@ use rsvelte_core::ast::template::Root;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/prefer-svelte-reactivity",
@@ -250,7 +250,7 @@ impl ScriptRule for PreferSvelteReactivity {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let shadowed = collect_shadowed(program);
         let instances = collect_instances(program, &shadowed);
         // Live instances are already filtered for shadowing inside

--- a/crates/rsvelte_lint/src/rules/prefer_writable_derived.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_writable_derived.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/prefer-writable-derived",
@@ -151,10 +151,10 @@ impl ScriptRule for PreferWritableDerived {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // name → StateDecl (declarator start + init span).
         let mut state_decls: HashMap<String, StateDecl> = HashMap::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("VariableDeclarator") {
                 return;
             }
@@ -189,7 +189,7 @@ impl ScriptRule for PreferWritableDerived {
         // (decl_start, init_start, init_end, rhs_start, rhs_end,
         //  effect_start, effect_end)
         let mut reports: Vec<(u32, u32, u32, u32, u32, u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") || !is_effect_call(node) {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/require_store_callbacks_use_set_param.rs
+++ b/crates/rsvelte_lint/src/rules/require_store_callbacks_use_set_param.rs
@@ -18,7 +18,9 @@ use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
 use crate::rules::store_refs::{collect_store_creators, is_function_expr};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{
+    ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/require-store-callbacks-use-set-param",
@@ -257,7 +259,7 @@ impl ScriptRule for RequireStoreCallbacksUseSetParam {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let creators = collect_store_creators(program);
         if creators.is_empty() {
             return;
@@ -266,7 +268,7 @@ impl ScriptRule for RequireStoreCallbacksUseSetParam {
         let source = ctx.source().to_string();
         let mut reports: Vec<ReportInfo> = Vec::new();
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/require_store_reactive_access.rs
+++ b/crates/rsvelte_lint/src/rules/require_store_reactive_access.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 
-use rsvelte_core::ast::arena::with_serialize_arena;
 use rsvelte_core::ast::template::Root;
 use serde_json::Value;
 
@@ -216,10 +215,10 @@ impl Rule for RequireStoreReactiveAccess {
     }
 
     fn check_root(&self, ctx: &mut LintContext, root: &Root) {
-        let Some(root_json) = with_serialize_arena(&root.arena, || serde_json::to_value(root).ok())
-        else {
+        let root_json = ctx.root_json(root);
+        if root_json.is_null() {
             return;
-        };
+        }
         let stores = collect_store_vars(&root_json);
         if stores.is_empty() {
             return;

--- a/crates/rsvelte_lint/src/rules/require_stores_init.rs
+++ b/crates/rsvelte_lint/src/rules/require_stores_init.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
 use crate::rules::store_refs::collect_store_creators;
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/require-stores-init",
@@ -34,13 +34,13 @@ impl ScriptRule for RequireStoresInit {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let creators = collect_store_creators(program);
         if creators.is_empty() {
             return;
         }
         let mut reports: Vec<u32> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/sort_attributes.rs
+++ b/crates/rsvelte_lint/src/rules/sort_attributes.rs
@@ -27,6 +27,9 @@
 //! Port of `eslint-plugin-svelte/src/rules/sort-attributes.ts`.
 //! Upstream: `meta.fixable = 'code'`, `type: 'layout'`.
 
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 use rsvelte_core::ast::template::{
@@ -60,6 +63,7 @@ static META: RuleMeta = RuleMeta {
 // ─── Pattern / option compilation ────────────────────────────────────────────
 
 /// A single compiled pattern (from a string entry in the order array).
+#[derive(Clone)]
 struct Pattern {
     negative: bool,
     re: Regex,
@@ -72,6 +76,7 @@ impl Pattern {
 }
 
 /// A compiled group (one entry in the order array).
+#[derive(Clone)]
 struct Group {
     patterns: Vec<Pattern>,
     sort: Sort,
@@ -205,6 +210,7 @@ fn patterns_match(patterns: &[Pattern], key: &str) -> bool {
 }
 
 /// The compiled option: a list of groups (in order).
+#[derive(Clone)]
 struct CompiledOption {
     groups: Vec<Group>,
 }
@@ -272,17 +278,24 @@ const DEFAULT_ORDER_JSON: &str = r#"[
     { "match": "/^let:/u", "sort": "alphabetical" }
 ]"#;
 
-fn load_compiled_option(ctx: &LintContext) -> CompiledOption {
-    let order_val: Option<serde_json::Value> = ctx.option0().and_then(|v| v.get("order")).cloned();
+/// The default order compiled once. Compiling it means building ~13 regexes,
+/// which is far more expensive than the check it configures — and every start
+/// tag in every file would otherwise redo it.
+static DEFAULT_OPTION: LazyLock<CompiledOption> = LazyLock::new(|| {
+    let entries: Vec<serde_json::Value> =
+        serde_json::from_str(DEFAULT_ORDER_JSON).unwrap_or_default();
+    CompiledOption {
+        groups: entries.iter().filter_map(compile_group).collect(),
+    }
+});
 
-    let entries: Vec<serde_json::Value> = if let Some(serde_json::Value::Array(arr)) = order_val {
-        arr
-    } else {
-        serde_json::from_str(DEFAULT_ORDER_JSON).unwrap_or_default()
-    };
-
-    let groups: Vec<Group> = entries.iter().filter_map(compile_group).collect();
-    CompiledOption { groups }
+fn load_compiled_option(ctx: &LintContext) -> Cow<'static, CompiledOption> {
+    match ctx.option0().and_then(|v| v.get("order")) {
+        Some(serde_json::Value::Array(arr)) => Cow::Owned(CompiledOption {
+            groups: arr.iter().filter_map(compile_group).collect(),
+        }),
+        _ => Cow::Borrowed(&DEFAULT_OPTION),
+    }
 }
 
 // ─── Key text extraction ──────────────────────────────────────────────────────
@@ -473,7 +486,7 @@ impl SortAttributes {
         if entries.len() < 2 {
             return;
         }
-        let src = ctx.source().to_string();
+        let src = ctx.source();
         let opt = load_compiled_option(ctx);
 
         // valid_previous_nodes: indices of non-spread, non-ignored entries already
@@ -539,8 +552,8 @@ impl SortAttributes {
     }
 
     fn check_tag(&self, ctx: &mut LintContext, attributes: &[Attribute]) {
-        let src = ctx.source().to_string();
-        let entries = Self::entries_from_attrs(&src, attributes);
+        let src = ctx.source();
+        let entries = Self::entries_from_attrs(src, attributes);
         self.check_entries(ctx, &entries);
     }
 
@@ -683,14 +696,14 @@ impl Rule for SortAttributes {
     }
 
     fn check_svelte_component(&self, ctx: &mut LintContext, el: &SvelteComponentElement) {
-        let src = ctx.source().to_string();
-        let entries = Self::entries_for_svelte_component(&src, el);
+        let src = ctx.source();
+        let entries = Self::entries_for_svelte_component(src, el);
         self.check_entries(ctx, &entries);
     }
 
     fn check_svelte_dynamic_element(&self, ctx: &mut LintContext, el: &SvelteDynamicElement) {
-        let src = ctx.source().to_string();
-        let entries = Self::entries_for_svelte_dynamic_element(&src, el);
+        let src = ctx.source();
+        let entries = Self::entries_for_svelte_dynamic_element(src, el);
         self.check_entries(ctx, &entries);
     }
 

--- a/crates/rsvelte_lint/src/rules/sort_attributes.rs
+++ b/crates/rsvelte_lint/src/rules/sort_attributes.rs
@@ -522,7 +522,7 @@ impl SortAttributes {
 
                 if !entry.is_plain_attr || !has_spread_between {
                     // Standard report + fix.
-                    let fix = build_fix(&src, entries, prev_idx, i);
+                    let fix = build_fix(src, entries, prev_idx, i);
                     ctx.report_with_fix(
                         entry.start,
                         entry.end,
@@ -533,7 +533,7 @@ impl SortAttributes {
                     // Spread exists between; use the "spread" verification:
                     // only compare against attributes between the last spread
                     // before `i` and `i`.
-                    self.verify_for_spread(ctx, &src, entries, &opt, i);
+                    self.verify_for_spread(ctx, src, entries, &opt, i);
                 }
                 // Skip adding to valid_previous (we already reported).
                 continue;

--- a/crates/rsvelte_lint/src/rules/valid_prop_names_in_kit_pages.rs
+++ b/crates/rsvelte_lint/src/rules/valid_prop_names_in_kit_pages.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/valid-prop-names-in-kit-pages",
@@ -97,7 +97,7 @@ impl ScriptRule for ValidPropNamesInKitPages {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, kind: ScriptKind) {
         // Only inspect the instance script (not the module script).
         if kind != ScriptKind::Instance {
             return;
@@ -111,7 +111,7 @@ impl ScriptRule for ValidPropNamesInKitPages {
         // Collect (start, end) of invalid prop-key identifiers.
         let mut reports: Vec<(u32, u32)> = Vec::new();
 
-        walk_js(program, |node, _ancestors| {
+        program.walk(|node, _ancestors| {
             if node_type(node) != Some("VariableDeclarator") {
                 return;
             }

--- a/crates/rsvelte_lint/src/script.rs
+++ b/crates/rsvelte_lint/src/script.rs
@@ -54,7 +54,14 @@ fn walk_inner<'a, F: FnMut(&'a Value, &[&'a Value])>(
 ) {
     match node {
         Value::Object(map) => {
-            let is_node = map.get("type").and_then(Value::as_str).is_some();
+            // ESTree nodes always serialize `type` first, so the first entry
+            // answers "is this a node?" without hashing the key — this runs on
+            // every object of every walk, and every script rule walks the tree.
+            let is_node = match map.iter().next() {
+                Some((k, v)) if k == "type" => v.is_string(),
+                Some(_) => map.get("type").and_then(Value::as_str).is_some(),
+                None => false,
+            };
             if is_node {
                 f(node, stack);
                 stack.push(node);

--- a/crates/rsvelte_lint/src/script.rs
+++ b/crates/rsvelte_lint/src/script.rs
@@ -35,8 +35,62 @@ pub enum ScriptKind {
 pub trait ScriptRule: Send + Sync {
     fn meta(&self) -> &'static RuleMeta;
 
-    /// Called once per script block with the full ESTree program `Value`.
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, kind: ScriptKind);
+    /// Called once per script block with the full ESTree program.
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, kind: ScriptKind);
+}
+
+/// A script program plus its depth-first node index.
+///
+/// Every script rule walks the whole program, so the tree is traversed once
+/// here and each rule replays the flat index instead of re-descending the JSON
+/// (which costs a `type` probe and a child scan per object, per rule).
+/// Derefs to the underlying `Value`, so field access reads as before.
+pub struct ProgramView<'a> {
+    value: &'a Value,
+    /// Nodes in DFS pre-order, with each node's ancestor count. Replaying them
+    /// against a truncate-then-push stack reproduces `walk_js` exactly.
+    nodes: Vec<&'a Value>,
+    depths: Vec<u32>,
+}
+
+impl<'a> ProgramView<'a> {
+    pub fn new(value: &'a Value) -> Self {
+        let mut nodes = Vec::new();
+        let mut depths = Vec::new();
+        let mut stack: Vec<&'a Value> = Vec::new();
+        walk_inner(value, &mut stack, &mut |node, ancestors| {
+            nodes.push(node);
+            depths.push(ancestors.len() as u32);
+        });
+        Self {
+            value,
+            nodes,
+            depths,
+        }
+    }
+
+    /// The underlying program value.
+    pub fn value(&self) -> &'a Value {
+        self.value
+    }
+
+    /// Walk every node of the program, exactly as [`walk_js`] would.
+    pub fn walk<F: FnMut(&'a Value, &[&'a Value])>(&self, mut f: F) {
+        let mut stack: Vec<&'a Value> = Vec::with_capacity(16);
+        for (i, node) in self.nodes.iter().enumerate() {
+            stack.truncate(self.depths[i] as usize);
+            f(node, &stack);
+            stack.push(node);
+        }
+    }
+}
+
+impl std::ops::Deref for ProgramView<'_> {
+    type Target = Value;
+
+    fn deref(&self) -> &Self::Target {
+        self.value
+    }
 }
 
 /// Depth-first walk over an ESTree JSON tree. `f` is called for every node (an


### PR DESCRIPTION
## Why

Follow-up to #1803, working down the same profile. Two more instances of the same pattern — whole-file work redone per rule.

## What changed

**1. One script walk per program instead of one per rule.** Every script rule descended the ESTree JSON itself: 40 whole-program walks per script block across the enabled set, each paying a `type` probe and a child scan on every object. The engine now walks the program once into a DFS index (nodes in pre-order + each node's ancestor count) and hands rules a `ProgramView`; `view.walk(f)` replays that index against a truncate-then-push stack, reproducing `walk_js`'s callback contract exactly. `ProgramView` derefs to the `Value`, so field access in rules is unchanged. Rules that build their own sub-programs keep the recursive walker.

**2. One template serialization per file instead of five.** `no-dom-manipulating`, `no-immutable-reactive-statements` and `no-reactive-reassign` each **re-parsed the source and serialized the whole template**, and `prefer-destructured-store-props` serialized the fragment of the `Root` it was already handed. They now go through the `LintContext` caches introduced in #1803 — the three source-scanners share `template_fragment_json()` (the same default parse options they used themselves), and `prefer-destructured-store-props` reads the `fragment` of the shared `root_json()` (the same lenient `Root` it was serializing).

## Measured

Interleaved A/B, three rounds each, on an idle machine over the 3,412-file benchmark corpus:

| Change | Before | After | Delta |
|---|---:|---:|---:|
| Shared script walk | 1,146 ms | 1,116 ms | −2.7% (−2.7 / +0.3 / −3.2) |
| One template serialization | 1,108 ms | 943 ms | **−14.9%** (−14.9 / −15.1 / −13.3) |

Cumulative for the lint work so far: **1,665 ms → 943 ms (−43%)**, i.e. roughly 24.9× → ~39× against the unchanged ESLint baseline.

## Correctness

- Lint parity corpus: **80 current / 80 known, 0 new divergences**.
- `cargo test -p rsvelte_lint --release`: 226 + 29 tests pass.
- `cargo clippy -p rsvelte_lint --all-targets`: clean.

## Two things tried and reverted (measured, not kept)

- **Cross-pass shared cache.** A file is linted in three passes, each with its own context; sharing one cache across them measured **±0%** and is provably a no-op for any current config — every `analyze_scope` consumer is a script-pass rule and `scope_rules()` is empty. Not worth threading a cache through three entry points.
- **Reusing the validator's analysis.** The validator wrap compiles every component, so handing its `ComponentAnalysis` to the rules that call `analyze_scope` removes a whole parse + analyze per file — worth **−8.3%**. But it is not behaviour-preserving: `compile()` resolves lazy expressions and strips TS before analyzing, so `reassigned` differs, and `prefer-const` lost three findings the oracle reports (caught by the parity gate). Making the two analyses equivalent is a real follow-up, not a free win.

## What's left

Per-file, the profile now shows: the lint parse (~20%), the validator wrap's own compile (~11%, a second full parse + analyze), `analyze_scope` for `prefer-const` et al (~another full analysis), the script-program JSON, and `serde_json::Value`'s IndexMap + SipHash (~12%). The two analyses are the biggest single remaining item, and unifying them needs the parse-option/TS-strip difference resolved first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp