### PR TITLE
perf(lint): stop rebuilding the same JSON in every rule (-25%)

### DIFF
--- a/crates/rsvelte_lint/src/context.rs
+++ b/crates/rsvelte_lint/src/context.rs
@@ -118,7 +118,7 @@ impl<'a> LintContext<'a> {
         root: &rsvelte_core::ast::template::Root,
     ) -> Option<Rc<Value>> {
         let json = self.root_json(root);
-        json.get("fragment").is_some().then(|| json)
+        json.get("fragment").is_some().then_some(json)
     }
 
     /// The template fragment as ESTree JSON, parsed with the *default* options

--- a/crates/rsvelte_lint/src/context.rs
+++ b/crates/rsvelte_lint/src/context.rs
@@ -111,6 +111,16 @@ impl<'a> LintContext<'a> {
             .clone()
     }
 
+    /// The `fragment` of the shared root JSON (same lenient parse the lint pass
+    /// already did), for rules that hold the `Root` and only walk the template.
+    pub fn root_fragment_json(
+        &self,
+        root: &rsvelte_core::ast::template::Root,
+    ) -> Option<Rc<Value>> {
+        let json = self.root_json(root);
+        json.get("fragment").is_some().then(|| json)
+    }
+
     /// The template fragment as ESTree JSON, parsed with the *default* options
     /// (not the lenient lint options — a script rule scanning template
     /// expressions must see what the strict parse produces) and cached per

--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -17,7 +17,7 @@ use crate::diagnostic::LintDiagnostic;
 use crate::registry::{all_rules, all_script_rules};
 use crate::rule::{RuleMeta, Severity};
 use crate::scope::ScopeResolver;
-use crate::script::{ScriptKind, ScriptRule};
+use crate::script::{ProgramView, ScriptKind, ScriptRule};
 use crate::visitor::{EnabledRule, LintVisitor};
 
 /// The lenient parse options every lint pass uses. `lenient_script: true` keeps
@@ -166,9 +166,12 @@ fn run_over_programs(
         .with_path(path)
         .with_scope_resolver(scope_resolver);
     for (kind, program) in programs {
+        // One DFS index per program, shared by every rule (each used to
+        // re-descend the whole JSON tree itself).
+        let view = ProgramView::new(program);
         for (rule, meta, severity) in enabled {
             ctx.enter_rule(meta, *severity);
-            rule.check_program(&mut ctx, program, *kind);
+            rule.check_program(&mut ctx, &view, *kind);
         }
     }
     ctx.into_diagnostics()

--- a/crates/rsvelte_lint/src/rules/derived_has_same_inputs_outputs.rs
+++ b/crates/rsvelte_lint/src/rules/derived_has_same_inputs_outputs.rs
@@ -22,7 +22,9 @@ use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
 use crate::rules::store_refs::collect_store_creators;
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{
+    ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/derived-has-same-inputs-outputs",
@@ -331,7 +333,7 @@ impl ScriptRule for DerivedHasSameInputsOutputs {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let creators = collect_store_creators(program);
         if creators.is_empty() {
             return;
@@ -339,7 +341,7 @@ impl ScriptRule for DerivedHasSameInputsOutputs {
 
         let mut reports: Vec<Report> = Vec::new();
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/infinite_reactive_loop.rs
+++ b/crates/rsvelte_lint/src/rules/infinite_reactive_loop.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{
+    ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/infinite-reactive-loop",
@@ -760,13 +762,13 @@ impl ScriptRule for InfiniteReactiveLoop {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let (func_map, top_level_names) = collect_top_level(program);
         let task_names = collect_task_names(program, &top_level_names);
 
         let mut all_reports: Vec<Rep> = Vec::new();
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/max_lines_per_block.rs
+++ b/crates/rsvelte_lint/src/rules/max_lines_per_block.rs
@@ -264,9 +264,12 @@ impl Rule for MaxLinesPerBlock {
         let skip_blank = opt_bool(opts, "skipBlankLines");
         let skip_comments = opt_bool(opts, "skipComments");
 
-        let Some(json) = serialize_root(root) else {
+        // Shared with the other rules that walk the template (serializing the
+        // whole root is one of the most expensive things a lint pass does).
+        let json = ctx.root_json(root);
+        if json.is_null() {
             return;
-        };
+        }
         let span = |key: &str| -> Option<(u32, u32)> {
             let n = json.get(key).filter(|v| !v.is_null())?;
             Some((
@@ -382,8 +385,4 @@ fn first_template_node(json: &Value) -> Option<(u32, u32)> {
         }
     }
     None
-}
-
-fn serialize_root(root: &Root) -> Option<Value> {
-    rsvelte_core::ast::arena::with_serialize_arena(&root.arena, || serde_json::to_value(root).ok())
 }

--- a/crates/rsvelte_lint/src/rules/no_add_event_listener.rs
+++ b/crates/rsvelte_lint/src/rules/no_add_event_listener.rs
@@ -40,7 +40,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 const MESSAGE: &str =
     "Do not use `addEventListener`. Use the `on` function from `svelte/events` instead.";
@@ -86,9 +86,9 @@ impl ScriptRule for NoAddEventListener {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut reports: Vec<Report> = Vec::new();
-        walk_js(program, |node, _ancestors| {
+        program.walk(|node, _ancestors| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_dom_manipulating.rs
+++ b/crates/rsvelte_lint/src/rules/no_dom_manipulating.rs
@@ -21,7 +21,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-dom-manipulating",
@@ -203,7 +203,7 @@ impl ScriptRule for NoDomManipulating {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut toplevel: HashSet<String> = HashSet::new();
         collect_toplevel_decls(program, &mut toplevel);
         let dom_vars = collect_dom_vars(ctx.source(), &toplevel);
@@ -214,7 +214,7 @@ impl ScriptRule for NoDomManipulating {
         let properties: HashSet<&str> = DOM_PROPERTIES.iter().copied().collect();
 
         let mut reports: Vec<(u32, u32)> = Vec::new();
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             if node_type(node) != Some("MemberExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_dom_manipulating.rs
+++ b/crates/rsvelte_lint/src/rules/no_dom_manipulating.rs
@@ -14,9 +14,6 @@
 
 use std::collections::HashSet;
 
-use rsvelte_core::ParseOptions;
-use rsvelte_core::ast::arena::with_serialize_arena;
-use rsvelte_core::compiler::phases::parse;
 use serde_json::Value;
 
 use crate::context::LintContext;
@@ -149,20 +146,9 @@ fn collect_pattern_idents(id: Option<&Value>, out: &mut HashSet<String>) {
 
 /// Identifiers captured by `bind:this` on an HTML element / `<svelte:element>`
 /// that resolve to a top-level binding.
-fn collect_dom_vars(source: &str, binding_names: &HashSet<String>) -> HashSet<String> {
+fn collect_dom_vars(ctx: &LintContext, binding_names: &HashSet<String>) -> HashSet<String> {
     let mut out = HashSet::new();
-    let Ok(root) = parse(
-        source,
-        &rsvelte_core::Allocator::default(),
-        ParseOptions::default(),
-    ) else {
-        return out;
-    };
-    let Some(frag) =
-        with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-    else {
-        return out;
-    };
+    let frag = ctx.template_fragment_json();
     walk_js(&frag, |node, ancestors| {
         if node_type(node) != Some("BindDirective")
             || node.get("name").and_then(Value::as_str) != Some("this")
@@ -206,7 +192,7 @@ impl ScriptRule for NoDomManipulating {
     fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut toplevel: HashSet<String> = HashSet::new();
         collect_toplevel_decls(program, &mut toplevel);
-        let dom_vars = collect_dom_vars(ctx.source(), &toplevel);
+        let dom_vars = collect_dom_vars(ctx, &toplevel);
         if dom_vars.is_empty() {
             return;
         }

--- a/crates/rsvelte_lint/src/rules/no_export_load_in_svelte_module_in_kit_pages.rs
+++ b/crates/rsvelte_lint/src/rules/no_export_load_in_svelte_module_in_kit_pages.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-export-load-in-svelte-module-in-kit-pages",
@@ -79,7 +79,7 @@ impl ScriptRule for NoExportLoadInSvelteModuleInKitPages {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, kind: ScriptKind) {
         // Only inspect the module script (`<script context="module">`).
         if kind != ScriptKind::Module {
             return;
@@ -93,7 +93,7 @@ impl ScriptRule for NoExportLoadInSvelteModuleInKitPages {
         // declared directly under them.
         let mut reports: Vec<(u32, u32)> = Vec::new();
 
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             if node_type(node) != Some("ExportNamedDeclaration") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_extra_reactive_curlies.rs
+++ b/crates/rsvelte_lint/src/rules/no_extra_reactive_curlies.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-extra-reactive-curlies",
@@ -76,9 +76,9 @@ impl ScriptRule for NoExtraReactiveCurlies {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut reports: Vec<(u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_goto_without_base.rs
+++ b/crates/rsvelte_lint/src/rules/no_goto_without_base.rs
@@ -17,11 +17,11 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 /// Collect the local namespace alias for `import * as X from module` into `out`.
-fn import_ns_locals(program: &Value, module: &str, out: &mut HashSet<String>) {
-    walk_js(program, |node, _| {
+fn import_ns_locals(program: &ProgramView<'_>, module: &str, out: &mut HashSet<String>) {
+    program.walk(|node, _| {
         if node_type(node) != Some("ImportDeclaration") {
             return;
         }
@@ -69,8 +69,8 @@ const MESSAGE: &str = "Found a goto() call with a url that isn't prefixed with t
 
 /// Collect the local names that an import from `module` binds for the given
 /// exported `name` (alias aware: `import { base as b }` → `b`).
-fn import_locals(program: &Value, module: &str, name: &str, out: &mut HashSet<String>) {
-    walk_js(program, |node, _| {
+fn import_locals(program: &ProgramView<'_>, module: &str, name: &str, out: &mut HashSet<String>) {
+    program.walk(|node, _| {
         if node_type(node) != Some("ImportDeclaration") {
             return;
         }
@@ -182,7 +182,7 @@ impl ScriptRule for NoGotoWithoutBase {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut goto_names: HashSet<String> = HashSet::new();
         import_locals(program, "$app/navigation", "goto", &mut goto_names);
         let mut nav_ns: HashSet<String> = HashSet::new();
@@ -194,7 +194,7 @@ impl ScriptRule for NoGotoWithoutBase {
         import_locals(program, "$app/paths", "base", &mut base_names);
 
         let mut reports: Vec<u32> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_ignored_unsubscribe.rs
+++ b/crates/rsvelte_lint/src/rules/no_ignored_unsubscribe.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-ignored-unsubscribe",
@@ -34,10 +34,10 @@ impl ScriptRule for NoIgnoredUnsubscribe {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // Selector: ExpressionStatement > CallExpression > MemberExpression.callee[property.name='subscribe'].
         let mut reports: Vec<u32> = Vec::new();
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             // `node` must be the `.subscribe` MemberExpression callee.
             if node_type(node) != Some("MemberExpression") {
                 return;

--- a/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
+++ b/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
@@ -28,7 +28,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-immutable-reactive-statements",
@@ -93,8 +93,8 @@ const KNOWN_GLOBALS: &[&str] = &[
 ];
 
 /// Collect names declared by `export let` / `export var` (props).
-fn collect_export_let_props(program: &Value, out: &mut HashSet<String>) {
-    walk_js(program, |node, _| {
+fn collect_export_let_props(program: &ProgramView<'_>, out: &mut HashSet<String>) {
+    program.walk(|node, _| {
         if node_type(node) != Some("ExportNamedDeclaration") {
             return;
         }
@@ -163,9 +163,9 @@ fn expr_base_name(e: Option<&Value>) -> Option<&str> {
 /// program (`delete obj.prop` ⇒ `obj`). Such a delete mutates the object, so the
 /// base name is mutable — mirrors upstream's `hasWriteMember` handling of
 /// `UnaryExpression { operator: 'delete' }`.
-fn collect_delete_mutated(program: &Value) -> HashSet<String> {
+fn collect_delete_mutated(program: &ProgramView<'_>) -> HashSet<String> {
     let mut out = HashSet::new();
-    walk_js(program, |node, _| {
+    program.walk(|node, _| {
         if node_type(node) != Some("UnaryExpression") {
             return;
         }
@@ -418,7 +418,7 @@ impl ScriptRule for NoImmutableReactiveStatements {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // Try to get full scope analysis. If it fails (e.g. constant_assignment
         // or constant_binding errors that the upstream ESLint scope manager
         // wouldn't reject), continue with empty binding maps — the write-only
@@ -470,7 +470,7 @@ impl ScriptRule for NoImmutableReactiveStatements {
         };
 
         let mut reports: Vec<(u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement")
                 || node
                     .get("label")

--- a/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
+++ b/crates/rsvelte_lint/src/rules/no_immutable_reactive_statements.rs
@@ -21,9 +21,6 @@
 
 use std::collections::HashSet;
 
-use rsvelte_core::ParseOptions;
-use rsvelte_core::ast::arena::with_serialize_arena;
-use rsvelte_core::compiler::phases::parse;
 use serde_json::Value;
 
 use crate::context::LintContext;
@@ -214,20 +211,9 @@ fn is_written(name: &str, scope: &Value) -> bool {
 
 /// The base variables of every `{#each}` source whose context is written — these
 /// are mutated through the loop and so are *not* immutable.
-fn collect_mutable_via_each(source: &str) -> HashSet<String> {
+fn collect_mutable_via_each(ctx: &LintContext) -> HashSet<String> {
     let mut out = HashSet::new();
-    let Ok(root) = parse(
-        source,
-        &rsvelte_core::Allocator::default(),
-        ParseOptions::default(),
-    ) else {
-        return out;
-    };
-    let Some(frag) =
-        with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-    else {
-        return out;
-    };
+    let frag = ctx.template_fragment_json();
     walk_js(&frag, |node, _| {
         if node_type(node) != Some("EachBlock") {
             return;
@@ -443,7 +429,7 @@ impl ScriptRule for NoImmutableReactiveStatements {
 
         let mut props: HashSet<String> = HashSet::new();
         collect_export_let_props(program, &mut props);
-        let mutable_via_each = collect_mutable_via_each(ctx.source());
+        let mutable_via_each = collect_mutable_via_each(ctx);
         let delete_mutated = collect_delete_mutated(program);
         let globals: HashSet<&str> = KNOWN_GLOBALS.iter().copied().collect();
 

--- a/crates/rsvelte_lint/src/rules/no_inner_declarations.rs
+++ b/crates/rsvelte_lint/src/rules/no_inner_declarations.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-inner-declarations",
@@ -39,7 +39,7 @@ impl ScriptRule for NoInnerDeclarations {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let opts = ctx.options();
         let mode = opts
             .and_then(|a| a.get(0))
@@ -56,7 +56,7 @@ impl ScriptRule for NoInnerDeclarations {
         let check_functions = block_scoped_functions == "disallow";
 
         let mut reports: Vec<(u32, &'static str, &'static str)> = Vec::new();
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             let kind = match node_type(node) {
                 Some("FunctionDeclaration") if check_functions => "function",
                 Some("VariableDeclaration")

--- a/crates/rsvelte_lint/src/rules/no_reactive_functions.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_functions.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-reactive-functions",
@@ -75,10 +75,10 @@ impl ScriptRule for NoReactiveFunctions {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // (labeled-statement start, labeled-statement end, `$`-label end).
         let mut reports: Vec<(u32, u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_reactive_literals.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_literals.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-reactive-literals",
@@ -65,12 +65,12 @@ impl ScriptRule for NoReactiveLiterals {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // (labeled-statement start, labeled-statement end, assignment start,
         // assignment end). The suggestion replaces [labeled.start, labeled.end)
         // with `let <assignment-text>`.
         let mut reports: Vec<(u32, u32, u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("LabeledStatement") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_reactive_reassign.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_reassign.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-reactive-reassign",
@@ -244,12 +244,12 @@ fn collect_toplevel_decls(program: &Value, out: &mut HashSet<String>) {
 /// Reactive value names (`$: name = …`, `name` not explicitly declared) and the
 /// positions of those defining-LHS identifiers (skipped when scanning refs).
 fn collect_reactive_values(
-    program: &Value,
+    program: &ProgramView<'_>,
     toplevel: &HashSet<String>,
 ) -> (HashSet<String>, HashSet<(u64, u64)>) {
     let mut names = HashSet::new();
     let mut def_lhs = HashSet::new();
-    walk_js(program, |node, _| {
+    program.walk(|node, _| {
         if node_type(node) != Some("LabeledStatement")
             || node
                 .get("label")
@@ -340,7 +340,7 @@ impl ScriptRule for NoReactiveReassign {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let mut toplevel = HashSet::new();
         collect_toplevel_decls(program, &mut toplevel);
         let (reactive, def_lhs) = collect_reactive_values(program, &toplevel);

--- a/crates/rsvelte_lint/src/rules/no_reactive_reassign.rs
+++ b/crates/rsvelte_lint/src/rules/no_reactive_reassign.rs
@@ -16,9 +16,6 @@
 
 use std::collections::HashSet;
 
-use rsvelte_core::ParseOptions;
-use rsvelte_core::ast::arena::with_serialize_arena;
-use rsvelte_core::compiler::phases::parse;
 use serde_json::Value;
 
 use crate::context::LintContext;
@@ -356,15 +353,8 @@ impl ScriptRule for NoReactiveReassign {
         let mut reports: Vec<(u32, u32, String)> = Vec::new();
         scan_refs(program, &reactive, &def_lhs, props, &mut reports);
         // Reassignments via a two-way `bind:` live in the template.
-        if let Ok(root) = parse(
-            ctx.source(),
-            &rsvelte_core::Allocator::default(),
-            ParseOptions::default(),
-        ) && let Some(frag) =
-            with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-        {
-            scan_refs(&frag, &reactive, &def_lhs, props, &mut reports);
-        }
+        let frag = ctx.template_fragment_json();
+        scan_refs(&frag, &reactive, &def_lhs, props, &mut reports);
 
         for (start, end, msg) in reports {
             ctx.report(start, end, msg);

--- a/crates/rsvelte_lint/src/rules/no_store_async.rs
+++ b/crates/rsvelte_lint/src/rules/no_store_async.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-store-async",
@@ -57,13 +57,13 @@ impl ScriptRule for NoStoreAsync {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // Resolve `svelte/store` imports: local names bound to a store creator,
         // and any namespace import alias.
         let mut direct: Vec<String> = Vec::new(); // local names of writable/readable/derived
         let mut namespaces: Vec<String> = Vec::new(); // `import * as X`
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("ImportDeclaration") {
                 return;
             }
@@ -113,7 +113,7 @@ impl ScriptRule for NoStoreAsync {
 
         // Find store-creator calls and report an async second argument.
         let mut reports: Vec<u32> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
+++ b/crates/rsvelte_lint/src/rules/no_top_level_browser_globals.rs
@@ -38,7 +38,7 @@ use rsvelte_core::ast::template::{Fragment, Root, TemplateNode};
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-top-level-browser-globals",
@@ -542,7 +542,7 @@ impl ScriptRule for NoTopLevelBrowserGlobals {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let source = ctx.source();
         // --- 1. Resolve browser-checker module imports. ---
         // local names bound to `browser`/`BROWSER` reads, and namespace imports.

--- a/crates/rsvelte_lint/src/rules/no_trailing_spaces.rs
+++ b/crates/rsvelte_lint/src/rules/no_trailing_spaces.rs
@@ -157,17 +157,19 @@ impl Rule for NoTrailingSpaces {
         let mut ignore_lines: HashSet<u32> = HashSet::new();
 
         // Template-literal interior lines from instance/module scripts.
-        let programs: Vec<Value> = with_serialize_arena(&root.arena, || {
+        // Borrowed from each program's own JSON cache — copying them out would
+        // deep-clone a whole ESTree tree per file just to scan for line numbers.
+        let programs: Vec<&Value> = with_serialize_arena(&root.arena, || {
             let mut out = Vec::new();
             if let Some(s) = root.instance.as_ref() {
-                out.push(s.content.as_json().clone());
+                out.push(s.content.as_json());
             }
             if let Some(s) = root.module.as_ref() {
-                out.push(s.content.as_json().clone());
+                out.push(s.content.as_json());
             }
             out
         });
-        for program in &programs {
+        for program in programs {
             collect_template_elements(program, &li, &mut ignore_lines);
         }
 

--- a/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
+++ b/crates/rsvelte_lint/src/rules/no_unnecessary_state_wrap.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/no-unnecessary-state-wrap",
@@ -80,7 +80,7 @@ impl ScriptRule for NoUnnecessaryStateWrap {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let opts = ctx.option0();
         let additional: HashSet<String> = opts
             .and_then(|o| o.get("additionalReactiveClasses"))
@@ -99,7 +99,7 @@ impl ScriptRule for NoUnnecessaryStateWrap {
         // `svelte/reactivity` imports: local name → exported (canonical) name,
         // restricted to the known reactive classes.
         let mut import_map: HashMap<String, String> = HashMap::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("ImportDeclaration") {
                 return;
             }
@@ -162,7 +162,7 @@ impl ScriptRule for NoUnnecessaryStateWrap {
         // end, arg start, arg end). The suggestion replaces the whole
         // `$state(...)` call with the inner argument's source text.
         let mut valid_reports: Vec<(u32, String, u32, u32, u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("VariableDeclarator") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/prefer_const.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_const.rs
@@ -20,7 +20,7 @@ use rsvelte_core::ast::template::{DeclarationTag, Fragment, Root, TemplateNode};
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, TextEdit};
 use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/prefer-const",
@@ -81,9 +81,9 @@ fn collect_template_reassignments(ctx: &LintContext, out: &mut HashSet<String>) 
 /// Add names that are declared by more than one `let`/`var`/`const` declarator
 /// in `program` (a redeclaration), which the core `prefer-const` rule treats as
 /// having multiple writes. Used only on the parse-only fallback path.
-fn add_redeclared_names(program: &Value, out: &mut HashSet<String>) {
+fn add_redeclared_names(program: &ProgramView<'_>, out: &mut HashSet<String>) {
     let mut counts: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
-    walk_js(program, |node, _| {
+    program.walk(|node, _| {
         if node_type(node) != Some("VariableDeclaration") {
             return;
         }
@@ -402,8 +402,8 @@ fn check_template_declaration_tags(
     reports
 }
 
-fn collect_forin_forof_reassignments(program: &Value, out: &mut HashSet<String>) {
-    walk_js(program, |node, _| {
+fn collect_forin_forof_reassignments(program: &ProgramView<'_>, out: &mut HashSet<String>) {
+    program.walk(|node, _| {
         let ty = node_type(node);
         if !matches!(ty, Some("ForOfStatement") | Some("ForInStatement")) {
             return;
@@ -480,9 +480,11 @@ struct AssignInfo {
 /// target of an `AssignmentExpression` and how many of those are destructuring.
 /// `UpdateExpression` increments `total` (not destructuring) so the name is
 /// excluded from the single-destructuring-assignment fast path.
-fn collect_assignment_info(program: &Value) -> std::collections::HashMap<String, AssignInfo> {
+fn collect_assignment_info(
+    program: &ProgramView<'_>,
+) -> std::collections::HashMap<String, AssignInfo> {
     let mut map: std::collections::HashMap<String, AssignInfo> = std::collections::HashMap::new();
-    walk_js(program, |node, ancestors| match node_type(node) {
+    program.walk(|node, ancestors| match node_type(node) {
         Some("AssignmentExpression") => {
             let Some(left) = node.get("left") else {
                 return;
@@ -593,7 +595,7 @@ impl ScriptRule for PreferConst {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, kind: ScriptKind) {
         // Reassignment info from the analyzed scope (reliable per the R9 audit).
         // `analyze_scope` runs the full Phase-2 analysis, which returns `Err`
         // (→ `None`) when the component has *any* analysis/validation error
@@ -665,7 +667,7 @@ impl ScriptRule for PreferConst {
             == Some("all");
 
         let mut reports: Vec<(u32, u32, String, Option<u32>)> = Vec::new();
-        walk_js(program, |node, ancestors| {
+        program.walk(|node, ancestors| {
             if node_type(node) != Some("VariableDeclaration")
                 || node.get("kind").and_then(Value::as_str) != Some("let")
             {

--- a/crates/rsvelte_lint/src/rules/prefer_derived_over_derived_by.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_derived_over_derived_by.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/prefer-derived-over-derived-by",
@@ -106,11 +106,11 @@ impl ScriptRule for PreferDerivedOverDerivedBy {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // (call_start, call_end, expr_start, expr_end)
         let mut reports: Vec<(u32, u32, u32, u32)> = Vec::new();
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/prefer_destructured_store_props.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_destructured_store_props.rs
@@ -539,10 +539,10 @@ impl Rule for PreferDestructuredStoreProps {
     }
 
     fn check_root(&self, ctx: &mut LintContext, root: &Root) {
-        // Serialize only the fragment for the detection walk (cheap path).
-        let Some(frag) =
-            with_serialize_arena(&root.arena, || serde_json::to_value(&root.fragment).ok())
-        else {
+        // The whole-root JSON is serialized once per file by the context and
+        // shared with the other rules that walk the template.
+        let root_json = ctx.root_json(root);
+        let Some(frag) = root_json.get("fragment") else {
             return;
         };
 
@@ -579,7 +579,7 @@ impl Rule for PreferDestructuredStoreProps {
 
         // Walk the fragment and collect reports.
         let mut reports: Vec<PendingReport> = Vec::new();
-        walk_js(&frag, |node, ancestors| {
+        walk_js(frag, |node, ancestors| {
             if node_type(node) != Some("MemberExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/prefer_destructured_store_props.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_destructured_store_props.rs
@@ -557,11 +557,11 @@ impl Rule for PreferDestructuredStoreProps {
             .filter(|s| s.context == ScriptContext::Default);
 
         // Serialize the script content for analysis (only if we have a script).
-        let script_content: Option<Value> = if instance_script.is_some() {
+        // The script program's own JSON cache — re-serializing it would rebuild
+        // a whole ESTree tree the engine already materialised for this file.
+        let script_content: Option<&Value> = if instance_script.is_some() {
             with_serialize_arena(&root.arena, || {
-                root.instance
-                    .as_ref()
-                    .and_then(|s| serde_json::to_value(&s.content).ok())
+                root.instance.as_ref().map(|s| s.content.as_json())
             })
         } else {
             None
@@ -573,7 +573,6 @@ impl Rule for PreferDestructuredStoreProps {
 
         // Collect top-level variable names (for hasTopLevelVariable).
         let top_level_names: HashSet<String> = script_content
-            .as_ref()
             .map(collect_top_level_names)
             .unwrap_or_default();
 

--- a/crates/rsvelte_lint/src/rules/prefer_svelte_reactivity.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_svelte_reactivity.rs
@@ -293,19 +293,18 @@ impl Rule for PreferSvelteReactivity {
 
         // Serialize both programs inside the arena scope (already active because
         // `check_root` is called from `run_native_rules` → `with_serialize_arena`).
-        let module_program =
-            with_serialize_arena(&root.arena, || module_script.content.as_json().clone());
+        let module_program = with_serialize_arena(&root.arena, || module_script.content.as_json());
         let instance_program =
-            with_serialize_arena(&root.arena, || instance_script.content.as_json().clone());
+            with_serialize_arena(&root.arena, || instance_script.content.as_json());
 
         // Collect shadowed names and instances from BOTH scripts.
-        let module_shadowed = collect_shadowed(&module_program);
-        let instance_shadowed = collect_shadowed(&instance_program);
+        let module_shadowed = collect_shadowed(module_program);
+        let instance_shadowed = collect_shadowed(instance_program);
 
         // Instances declared in the module script.
-        let module_instances = collect_instances(&module_program, &module_shadowed);
+        let module_instances = collect_instances(module_program, &module_shadowed);
         // Instances declared in the instance script.
-        let instance_instances = collect_instances(&instance_program, &instance_shadowed);
+        let instance_instances = collect_instances(instance_program, &instance_shadowed);
 
         // Case A: declared in module, mutated in instance.
         // The same-script check (module declares + module mutates) is handled by
@@ -318,12 +317,12 @@ impl Rule for PreferSvelteReactivity {
             .collect();
         {
             let mutated_in_instance =
-                collect_mutations(&instance_program, &module_instances, &all_shadowed_for_a);
+                collect_mutations(instance_program, &module_instances, &all_shadowed_for_a);
             // Only keep instances that are NOT ALSO mutated in the module script
             // (to avoid double-reporting when both scripts mutate them — the
             // module check_program call would already fire).
             let mutated_in_module =
-                collect_mutations(&module_program, &module_instances, &module_shadowed);
+                collect_mutations(module_program, &module_instances, &module_shadowed);
             let mutated_in_module_starts: std::collections::HashSet<u32> =
                 mutated_in_module.iter().map(|(s, _)| *s).collect();
             for (start, class) in &mutated_in_instance {
@@ -339,11 +338,11 @@ impl Rule for PreferSvelteReactivity {
         // Case B: declared in instance, mutated in module.
         {
             let mutated_in_module =
-                collect_mutations(&module_program, &instance_instances, &all_shadowed_for_a);
+                collect_mutations(module_program, &instance_instances, &all_shadowed_for_a);
             // Exclude those already mutated in the instance script itself (to
             // avoid double-reporting).
             let mutated_in_instance_self =
-                collect_mutations(&instance_program, &instance_instances, &instance_shadowed);
+                collect_mutations(instance_program, &instance_instances, &instance_shadowed);
             let mutated_in_instance_starts: std::collections::HashSet<u32> =
                 mutated_in_instance_self.iter().map(|(s, _)| *s).collect();
             for (start, class) in &mutated_in_module {

--- a/crates/rsvelte_lint/src/rules/prefer_svelte_reactivity.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_svelte_reactivity.rs
@@ -27,7 +27,7 @@ use rsvelte_core::ast::template::Root;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type, walk_js};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/prefer-svelte-reactivity",
@@ -250,7 +250,7 @@ impl ScriptRule for PreferSvelteReactivity {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let shadowed = collect_shadowed(program);
         let instances = collect_instances(program, &shadowed);
         // Live instances are already filtered for shadowing inside

--- a/crates/rsvelte_lint/src/rules/prefer_writable_derived.rs
+++ b/crates/rsvelte_lint/src/rules/prefer_writable_derived.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/prefer-writable-derived",
@@ -151,10 +151,10 @@ impl ScriptRule for PreferWritableDerived {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         // name → StateDecl (declarator start + init span).
         let mut state_decls: HashMap<String, StateDecl> = HashMap::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("VariableDeclarator") {
                 return;
             }
@@ -189,7 +189,7 @@ impl ScriptRule for PreferWritableDerived {
         // (decl_start, init_start, init_end, rhs_start, rhs_end,
         //  effect_start, effect_end)
         let mut reports: Vec<(u32, u32, u32, u32, u32, u32, u32)> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") || !is_effect_call(node) {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/require_store_callbacks_use_set_param.rs
+++ b/crates/rsvelte_lint/src/rules/require_store_callbacks_use_set_param.rs
@@ -18,7 +18,9 @@ use crate::context::LintContext;
 use crate::diagnostic::{Fix, Suggestion, TextEdit};
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
 use crate::rules::store_refs::{collect_store_creators, is_function_expr};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{
+    ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/require-store-callbacks-use-set-param",
@@ -257,7 +259,7 @@ impl ScriptRule for RequireStoreCallbacksUseSetParam {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let creators = collect_store_creators(program);
         if creators.is_empty() {
             return;
@@ -266,7 +268,7 @@ impl ScriptRule for RequireStoreCallbacksUseSetParam {
         let source = ctx.source().to_string();
         let mut reports: Vec<ReportInfo> = Vec::new();
 
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/require_stores_init.rs
+++ b/crates/rsvelte_lint/src/rules/require_stores_init.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
 use crate::rules::store_refs::collect_store_creators;
-use crate::script::{ScriptKind, ScriptRule, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/require-stores-init",
@@ -34,13 +34,13 @@ impl ScriptRule for RequireStoresInit {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, _kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
         let creators = collect_store_creators(program);
         if creators.is_empty() {
             return;
         }
         let mut reports: Vec<u32> = Vec::new();
-        walk_js(program, |node, _| {
+        program.walk(|node, _| {
             if node_type(node) != Some("CallExpression") {
                 return;
             }

--- a/crates/rsvelte_lint/src/rules/valid_prop_names_in_kit_pages.rs
+++ b/crates/rsvelte_lint/src/rules/valid_prop_names_in_kit_pages.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::script::{ScriptKind, ScriptRule, node_end, node_start, node_type, walk_js};
+use crate::script::{ProgramView, ScriptKind, ScriptRule, node_end, node_start, node_type};
 
 static META: RuleMeta = RuleMeta {
     name: "svelte/valid-prop-names-in-kit-pages",
@@ -97,7 +97,7 @@ impl ScriptRule for ValidPropNamesInKitPages {
         &META
     }
 
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, kind: ScriptKind) {
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, kind: ScriptKind) {
         // Only inspect the instance script (not the module script).
         if kind != ScriptKind::Instance {
             return;
@@ -111,7 +111,7 @@ impl ScriptRule for ValidPropNamesInKitPages {
         // Collect (start, end) of invalid prop-key identifiers.
         let mut reports: Vec<(u32, u32)> = Vec::new();
 
-        walk_js(program, |node, _ancestors| {
+        program.walk(|node, _ancestors| {
             if node_type(node) != Some("VariableDeclarator") {
                 return;
             }

--- a/crates/rsvelte_lint/src/script.rs
+++ b/crates/rsvelte_lint/src/script.rs
@@ -35,8 +35,62 @@ pub enum ScriptKind {
 pub trait ScriptRule: Send + Sync {
     fn meta(&self) -> &'static RuleMeta;
 
-    /// Called once per script block with the full ESTree program `Value`.
-    fn check_program(&self, ctx: &mut LintContext, program: &Value, kind: ScriptKind);
+    /// Called once per script block with the full ESTree program.
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, kind: ScriptKind);
+}
+
+/// A script program plus its depth-first node index.
+///
+/// Every script rule walks the whole program, so the tree is traversed once
+/// here and each rule replays the flat index instead of re-descending the JSON
+/// (which costs a `type` probe and a child scan per object, per rule).
+/// Derefs to the underlying `Value`, so field access reads as before.
+pub struct ProgramView<'a> {
+    value: &'a Value,
+    /// Nodes in DFS pre-order, with each node's ancestor count. Replaying them
+    /// against a truncate-then-push stack reproduces `walk_js` exactly.
+    nodes: Vec<&'a Value>,
+    depths: Vec<u32>,
+}
+
+impl<'a> ProgramView<'a> {
+    pub fn new(value: &'a Value) -> Self {
+        let mut nodes = Vec::new();
+        let mut depths = Vec::new();
+        let mut stack: Vec<&'a Value> = Vec::new();
+        walk_inner(value, &mut stack, &mut |node, ancestors| {
+            nodes.push(node);
+            depths.push(ancestors.len() as u32);
+        });
+        Self {
+            value,
+            nodes,
+            depths,
+        }
+    }
+
+    /// The underlying program value.
+    pub fn value(&self) -> &'a Value {
+        self.value
+    }
+
+    /// Walk every node of the program, exactly as [`walk_js`] would.
+    pub fn walk<F: FnMut(&'a Value, &[&'a Value])>(&self, mut f: F) {
+        let mut stack: Vec<&'a Value> = Vec::with_capacity(16);
+        for (i, node) in self.nodes.iter().enumerate() {
+            stack.truncate(self.depths[i] as usize);
+            f(node, &stack);
+            stack.push(node);
+        }
+    }
+}
+
+impl std::ops::Deref for ProgramView<'_> {
+    type Target = Value;
+
+    fn deref(&self) -> &Self::Target {
+        self.value
+    }
 }
 
 /// Depth-first walk over an ESTree JSON tree. `f` is called for every node (an


### PR DESCRIPTION
## Why

Follow-up to #1803, working down the same profile. Three more rounds of the same finding: whole-file work redone per rule.

Method throughout: measure each rule against a **no-rules floor** (all 72 rules off costs 185 ms over the 3,412-file benchmark corpus; with them on it was 1,665 ms), profile with samply, then interleaved A/B on an idle machine — never a single-run comparison.

## What changed

**1. One script walk per program instead of one per rule.** Every script rule descended the ESTree JSON itself — 40 whole-program walks per script block across the enabled set, each paying a `type` probe and a child scan on every object. The engine now walks the program once into a DFS index (nodes in pre-order + each node's ancestor count) and hands rules a `ProgramView`; `view.walk(f)` replays that index against a truncate-then-push stack, reproducing `walk_js`'s contract exactly. `ProgramView` derefs to the `Value`, so field access in rules is unchanged.

**2. One template serialization per file instead of five.** `no-dom-manipulating`, `no-immutable-reactive-statements` and `no-reactive-reassign` each re-parsed the source and serialized the whole template; `prefer-destructured-store-props` serialized the fragment of the `Root` it was already handed. All now go through the `LintContext` caches from #1803.

**3. Four rules rebuilding JSON they already had.** Found by ranking every rule against the floor — `no-trailing-spaces` stood out at 105 ms where comparable template rules cost 3-4 ms. It deep-cloned both script programs out of their own `OnceCell` caches just to scan for line numbers; `prefer-svelte-reactivity` deep-cloned them too; `max-lines-per-block` serialized the whole template itself; `prefer-destructured-store-props` re-serialized the instance script.

## Measured

Interleaved A/B, three rounds each:

| Change | Before | After | Delta |
|---|---:|---:|---:|
| Shared script walk | 1,146 ms | 1,116 ms | −2.7% |
| One template serialization | 1,108 ms | 943 ms | **−14.9%** |
| Four rules' redundant JSON | 950 ms | 884 ms | **−9.3%** |
| `no-trailing-spaces` alone | 287 ms | 250 ms | −12.9% |

Cumulative across the lint campaign: **1,665 ms → ~880 ms (−47%)** single-threaded, i.e. roughly 24.9× → ~42× against the unchanged ESLint baseline.

## Correctness

- Lint parity corpus: **80 current / 80 known, 0 new divergences** — re-run after every step.
- `cargo test -p rsvelte_lint --release`: 226 + 29 tests pass.
- `cargo clippy -p rsvelte_lint --all-targets`: clean.

## Two things measured and reverted

- **Cross-pass shared cache.** A file is linted in three passes, each with its own context. Sharing one cache across them measured **±0%** and is provably a no-op for any current config: every `analyze_scope` consumer is a script-pass rule, and `scope_rules()` is empty. Not worth the plumbing.
- **Reusing the validator wrap's analysis.** The validator compiles every component, so handing its `ComponentAnalysis` to the rules that call `analyze_scope` removes a whole parse + analyze per file — worth **−8.3%**. But it is not behaviour-preserving: `compile()` resolves lazy expressions and strips TS before analyzing, so `reassigned` differs and `prefer-const` lost three findings the oracle reports. The parity gate caught it; reverted.

## What's left

Per-file the profile now shows the lint parse (~20%), the validator wrap's compile (~11%), a second full analysis via `analyze_scope` for `prefer-const` et al, the script-program JSON, and `serde_json::Value`'s IndexMap + SipHash (~12%). **The two full analyses are the biggest single remaining item** — unifying them needs the parse-option / TS-strip difference resolved first, which is a real change to what those rules see, not a free win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp