### PR TITLE
feat(language-server): folding, selection and document symbol providers

### DIFF
--- a/crates/rsvelte_language_server/src/client.rs
+++ b/crates/rsvelte_language_server/src/client.rs
@@ -22,6 +22,12 @@ pub struct ClientState {
     pub position_encodings: Vec<PositionEncodingKind>,
     /// Whether the client answers `workspace/configuration`.
     pub pull_configuration: bool,
+    /// Whether the client folds whole lines only, and so cannot use the
+    /// characters a folding range carries.
+    pub line_folding_only: bool,
+    /// Whether the client understands a tree of document symbols rather than a
+    /// flat list.
+    pub hierarchical_document_symbols: bool,
 }
 
 impl ClientState {
@@ -32,12 +38,24 @@ impl ClientState {
             client_info: field(params.get("clientInfo")),
             position_encodings: field(params.pointer("/capabilities/general/positionEncodings"))
                 .unwrap_or_default(),
-            pull_configuration: params
-                .pointer("/capabilities/workspace/configuration")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
+            pull_configuration: flag(params, "/capabilities/workspace/configuration"),
+            line_folding_only: flag(
+                params,
+                "/capabilities/textDocument/foldingRange/lineFoldingOnly",
+            ),
+            hierarchical_document_symbols: flag(
+                params,
+                "/capabilities/textDocument/documentSymbol/hierarchicalDocumentSymbolSupport",
+            ),
         }
     }
+}
+
+fn flag(params: &Value, pointer: &str) -> bool {
+    params
+        .pointer(pointer)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn field<T: DeserializeOwned>(value: Option<&Value>) -> Option<T> {
@@ -58,6 +76,10 @@ mod tests {
             "capabilities": {
                 "workspace": { "configuration": true },
                 "general": { "positionEncodings": ["utf-16"] },
+                "textDocument": {
+                    "foldingRange": { "lineFoldingOnly": true },
+                    "documentSymbol": { "hierarchicalDocumentSymbolSupport": true },
+                },
             },
         }));
         assert_eq!(
@@ -71,6 +93,17 @@ mod tests {
         );
         assert_eq!(state.position_encodings.len(), 1);
         assert!(state.pull_configuration);
+        assert!(state.line_folding_only);
+        assert!(state.hierarchical_document_symbols);
+    }
+
+    #[test]
+    fn structure_capabilities_default_to_off() {
+        let state = ClientState::from_initialize(&json!({
+            "capabilities": { "textDocument": { "foldingRange": {} } },
+        }));
+        assert!(!state.line_folding_only);
+        assert!(!state.hierarchical_document_symbols);
     }
 
     #[test]

--- a/crates/rsvelte_language_server/src/context.rs
+++ b/crates/rsvelte_language_server/src/context.rs
@@ -53,7 +53,7 @@ fn parsed(text: &str) -> Option<Vec<Range<usize>>> {
 }
 
 /// The content of a `<tag …>…</tag>` spanning `start..end`.
-fn body_of(text: &str, start: usize, end: usize) -> Option<Range<usize>> {
+pub fn body_of(text: &str, start: usize, end: usize) -> Option<Range<usize>> {
     let outer = text.get(start..end)?;
     let open = outer.find('>')? + 1;
     let close = outer.rfind("</").unwrap_or(outer.len());
@@ -265,7 +265,7 @@ fn scan_start_tag<'a>(text: &'a str, from: usize, offset: usize, tag: &'a str) -
 }
 
 /// The offset just past the `{…}` starting at `from`, strings included.
-fn skip_braces(text: &str, from: usize) -> usize {
+pub fn skip_braces(text: &str, from: usize) -> usize {
     let bytes = text.as_bytes();
     let mut depth = 0u32;
     let mut i = from;

--- a/crates/rsvelte_language_server/src/folding.rs
+++ b/crates/rsvelte_language_server/src/folding.rs
@@ -1,0 +1,546 @@
+//! `textDocument/foldingRange`.
+//!
+//! A port of the official language server's `plugins/html/getFoldingRanges.ts`,
+//! reading the Svelte AST instead of an HTML one: comments and blocks are
+//! nodes there, so they need no separate scan, and `{#if}` / `{#each}` /
+//! `{#await}` / `{#key}` / `{#snippet}` fold like elements do.
+//!
+//! `<script>` and `<style>` bodies fold by indentation, which is what upstream
+//! does for them as well while its TypeScript and CSS services are the ones
+//! reading the contents.
+
+use lsp_types::{FoldingRange, FoldingRangeKind};
+use rsvelte_core::Allocator;
+use rsvelte_core::ast::arena::ParseArena;
+use rsvelte_core::ast::js::Expression;
+use rsvelte_core::ast::template::{Root, Script, TemplateNode};
+
+use crate::context::body_of;
+use crate::indent_folding::{LineRange, body_lines, indent_folding};
+use crate::nodes::{Span, Top, parse_root, top_level, view};
+use crate::text::LineIndex;
+
+pub fn folding_ranges(text: &str, line_folding_only: bool) -> Vec<FoldingRange> {
+    let index = LineIndex::new(text);
+    let allocator = Allocator::default();
+    let mut collector = Collector {
+        text,
+        index: &index,
+        ranges: Vec::new(),
+        stack: Vec::new(),
+    };
+    match parse_root(text, &allocator) {
+        Some(root) => collector.walk(&root),
+        // A document the parser cannot read at all still folds by indentation,
+        // rather than losing every fold the editor already drew.
+        None => collector.indented(&[]),
+    }
+    collector.finish(line_folding_only)
+}
+
+/// A range before the client's `lineFoldingOnly` capability is applied.
+struct Raw {
+    start: Span,
+    end: Span,
+    kind: Option<FoldingRangeKind>,
+    /// Whether `end` is the line of a closing tag, which a line-folding client
+    /// wants left visible.
+    closing: bool,
+}
+
+/// What is open around the node being walked. Elements are tracked as well as
+/// regions, because a `#endregion` inside one of them takes precedence over
+/// the folds of everything it interrupts.
+#[derive(PartialEq, Eq)]
+enum Frame {
+    Node(u32),
+    Region(u32),
+}
+
+struct Collector<'a> {
+    text: &'a str,
+    index: &'a LineIndex,
+    ranges: Vec<Raw>,
+    stack: Vec<Frame>,
+}
+
+impl Collector<'_> {
+    fn walk(&mut self, root: &Root<'_>) {
+        for top in top_level(root) {
+            match top {
+                Top::Node(node) => self.node(node),
+                Top::Script(script) => {
+                    self.embedded(script.start, script.end);
+                    self.imports(script, &root.arena);
+                    self.fold(script.start, script.end, None, true);
+                }
+                Top::Style(style) => {
+                    self.embedded(style.start, style.end);
+                    self.fold(style.start, style.end, None, true);
+                }
+            }
+        }
+    }
+
+    fn node(&mut self, node: &TemplateNode<'_>) {
+        if let TemplateNode::Comment(comment) = node {
+            self.comment(&comment.data, comment.start, comment.end);
+            return;
+        }
+        let node = view(node);
+        if !node.is_container() {
+            return;
+        }
+        self.stack.push(Frame::Node(node.start));
+        for fragment in node.fragments() {
+            for child in &fragment.nodes {
+                self.node(child);
+            }
+        }
+        // Gone from the stack means a `#endregion` inside this node closed a
+        // region that started outside it, and this fold would overlap it.
+        if let Some(at) = self
+            .stack
+            .iter()
+            .rposition(|open| *open == Frame::Node(node.start))
+        {
+            self.stack.truncate(at);
+            self.fold(node.start, node.end, None, true);
+        }
+    }
+
+    fn comment(&mut self, data: &str, start: u32, end: u32) {
+        let data = data.trim_start();
+        if word(data, "#region") {
+            self.stack.push(Frame::Region(start));
+            return;
+        }
+        if word(data, "#endregion") {
+            if let Some(at) = self
+                .stack
+                .iter()
+                .rposition(|open| matches!(open, Frame::Region(_)))
+            {
+                let Frame::Region(from) = self.stack[at] else {
+                    return;
+                };
+                self.stack.truncate(at);
+                self.fold(from, end, Some(FoldingRangeKind::Region), false);
+            }
+            return;
+        }
+        self.fold(start, end, Some(FoldingRangeKind::Comment), false);
+    }
+
+    /// The body of a `<script>` or `<style>`, folded by indentation.
+    fn embedded(&mut self, start: u32, end: u32) {
+        let Some(body) = body_of(self.text, start as usize, end as usize) else {
+            return;
+        };
+        let Some(lines) = body_lines(self.index, self.text, body.start, body.end) else {
+            return;
+        };
+        self.indented(&[lines]);
+    }
+
+    /// The leading run of `import` declarations of a script.
+    fn imports(&mut self, script: &Script<'_>, arena: &ParseArena) {
+        let Expression::Typed(program) = &script.content else {
+            return;
+        };
+        let mut first = None;
+        let mut last = None;
+        for statement in arena.get_js_children(program.node.body_stmts()) {
+            if statement.node_type() != Some("ImportDeclaration") {
+                break;
+            }
+            let (Some(start), Some(end)) = (statement.start(), statement.end()) else {
+                break;
+            };
+            first.get_or_insert(start);
+            last = Some(end);
+        }
+        if let (Some(first), Some(last)) = (first, last) {
+            self.fold(first, last, Some(FoldingRangeKind::Imports), false);
+        }
+    }
+
+    fn indented(&mut self, ranges: &[LineRange]) {
+        for fold in indent_folding(self.text, self.index, ranges) {
+            self.ranges.push(Raw {
+                start: (fold.start_line, 0),
+                end: (fold.end_line, 0),
+                kind: None,
+                closing: false,
+            });
+        }
+    }
+
+    fn fold(&mut self, start: u32, end: u32, kind: Option<FoldingRangeKind>, closing: bool) {
+        let start = self.index.position(self.text, start as usize);
+        let end = self.index.position(self.text, end as usize);
+        self.ranges.push(Raw {
+            start: (start.line, start.character),
+            end: (end.line, end.character),
+            kind,
+            closing,
+        });
+    }
+
+    fn finish(self, line_folding_only: bool) -> Vec<FoldingRange> {
+        if !line_folding_only {
+            return self
+                .ranges
+                .into_iter()
+                .filter(|raw| raw.start.0 <= raw.end.0)
+                .map(|raw| FoldingRange {
+                    start_line: raw.start.0,
+                    start_character: Some(raw.start.1),
+                    end_line: raw.end.0,
+                    end_character: Some(raw.end.1),
+                    kind: raw.kind,
+                    collapsed_text: None,
+                })
+                .collect();
+        }
+
+        // One fold per line is all such a client can draw, and the innermost
+        // one — emitted first, since children are walked before their parent —
+        // is the one it should get.
+        let mut folds: Vec<FoldingRange> = Vec::new();
+        for raw in self.ranges {
+            let start_line = raw.start.0;
+            let end_line = if raw.closing {
+                raw.end.0.saturating_sub(1).max(start_line)
+            } else {
+                raw.end.0
+            };
+            if start_line >= end_line || folds.iter().any(|fold| fold.start_line == start_line) {
+                continue;
+            }
+            folds.push(FoldingRange {
+                start_line,
+                end_line,
+                kind: raw.kind,
+                ..FoldingRange::default()
+            });
+        }
+        folds
+    }
+}
+
+/// Whether `data` starts with `word` and does not merely have it as a prefix.
+fn word(data: &str, word: &str) -> bool {
+    data.strip_prefix(word)
+        .is_some_and(|rest| !rest.starts_with(|c: char| c.is_alphanumeric() || c == '_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The ranges a `lineFoldingOnly` client — every editor in practice — gets,
+    /// sorted the way the official test suite compares them.
+    fn ranges(lines: &[&str]) -> Vec<(u32, u32, Option<FoldingRangeKind>)> {
+        let text = lines.join("\n");
+        let mut ranges: Vec<_> = folding_ranges(&text, true)
+            .into_iter()
+            .map(|range| (range.start_line, range.end_line, range.kind))
+            .collect();
+        ranges.sort_by_key(|&(start, _, _)| start);
+        ranges
+    }
+
+    fn plain(lines: &[&str]) -> Vec<(u32, u32)> {
+        ranges(lines)
+            .into_iter()
+            .map(|(start, end, kind)| {
+                assert_eq!(kind, None, "{lines:?}");
+                (start, end)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn fold_one_level() {
+        assert_eq!(plain(&["<html>", "Hello", "</html>"]), vec![(0, 1)]);
+    }
+
+    #[test]
+    fn fold_two_levels() {
+        assert_eq!(
+            plain(&["<html>", "<head>", "Hello", "</head>", "</html>"]),
+            vec![(0, 3), (1, 2)]
+        );
+    }
+
+    #[test]
+    fn fold_siblings() {
+        assert_eq!(
+            plain(&[
+                "<html>",
+                "<head>",
+                "Head",
+                "</head>",
+                "<body class=\"f\">",
+                "Body",
+                "</body>",
+                "</html>",
+            ]),
+            vec![(0, 6), (1, 2), (4, 5)]
+        );
+    }
+
+    #[test]
+    fn fold_self_closing_tags() {
+        assert_eq!(
+            plain(&[
+                "<div>",
+                "<a href=\"top\"/>",
+                "<img src=\"s\">",
+                "<br/>",
+                "<br>",
+                "<img class=\"c\"",
+                "     src=\"top\"",
+                ">",
+                "</div>",
+            ]),
+            vec![(0, 7), (5, 6)]
+        );
+    }
+
+    #[test]
+    fn fold_comments() {
+        assert_eq!(
+            ranges(&[
+                "<!--",
+                " multi line",
+                "-->",
+                "<!-- some stuff",
+                " some more stuff -->"
+            ]),
+            vec![
+                (0, 2, Some(FoldingRangeKind::Comment)),
+                (3, 4, Some(FoldingRangeKind::Comment)),
+            ]
+        );
+    }
+
+    #[test]
+    fn fold_regions() {
+        assert_eq!(
+            ranges(&[
+                "<!-- #region -->",
+                "<!-- #region -->",
+                "<!-- #endregion -->",
+                "<!-- #endregion -->",
+            ]),
+            vec![
+                (0, 3, Some(FoldingRangeKind::Region)),
+                (1, 2, Some(FoldingRangeKind::Region)),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_region_interrupted_by_its_container_loses_the_container_fold() {
+        assert_eq!(
+            ranges(&[
+                "<!-- #region -->",
+                "<body>",
+                "Hello",
+                "<!-- #endregion -->",
+                "<div></div>",
+                "</body>",
+            ]),
+            vec![(0, 3, Some(FoldingRangeKind::Region))]
+        );
+    }
+
+    #[test]
+    fn a_region_a_container_outlives_is_dropped() {
+        assert_eq!(
+            ranges(&[
+                "<body>",
+                "<!-- #region -->",
+                "Hello",
+                "<div></div>",
+                "</body>",
+                "<!-- #endregion -->",
+            ]),
+            vec![(0, 3)]
+                .into_iter()
+                .map(|(s, e)| (s, e, None))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_word_that_merely_starts_with_region_is_a_plain_comment() {
+        assert_eq!(
+            ranges(&["<!-- #regionally", " speaking -->"]),
+            vec![(0, 1, Some(FoldingRangeKind::Comment))]
+        );
+    }
+
+    #[test]
+    fn svelte_blocks_fold() {
+        assert_eq!(
+            plain(&["{#if a}", "yes", "{:else}", "no", "{/if}"]),
+            vec![(0, 3)]
+        );
+        assert_eq!(
+            plain(&["{#each items as item}", "{item}", "{/each}"]),
+            vec![(0, 1)]
+        );
+        assert_eq!(
+            plain(&[
+                "{#await promise}",
+                "wait",
+                "{:then value}",
+                "ok",
+                "{/await}"
+            ]),
+            vec![(0, 3)]
+        );
+        assert_eq!(plain(&["{#key a}", "b", "{/key}"]), vec![(0, 1)]);
+        assert_eq!(
+            plain(&["{#snippet row(item)}", "{item}", "{/snippet}"]),
+            vec![(0, 1)]
+        );
+    }
+
+    #[test]
+    fn a_block_inside_an_element_folds_too() {
+        assert_eq!(
+            plain(&["<div>", "{#if a}", "yes", "{/if}", "</div>"]),
+            vec![(0, 3), (1, 2)]
+        );
+    }
+
+    #[test]
+    fn script_and_style_fold_with_their_bodies() {
+        assert_eq!(
+            plain(&[
+                "<script>",
+                "  function a() {",
+                "    b();",
+                "  }",
+                "</script>",
+                "<style>",
+                "  p {",
+                "    color: red;",
+                "  }",
+                "</style>",
+            ]),
+            vec![(0, 3), (1, 2), (5, 8), (6, 7)]
+        );
+    }
+
+    #[test]
+    fn a_run_of_imports_folds_as_imports() {
+        let ranges = ranges(&[
+            "<script>",
+            "  import a from 'a';",
+            "  import b from 'b';",
+            "  let c = 1;",
+            "</script>",
+        ]);
+        assert!(
+            ranges.contains(&(1, 2, Some(FoldingRangeKind::Imports))),
+            "{ranges:?}"
+        );
+    }
+
+    #[test]
+    fn a_single_import_is_not_worth_folding() {
+        let ranges = ranges(&["<script>", "  import a from 'a';", "</script>"]);
+        assert!(
+            !ranges
+                .iter()
+                .any(|(_, _, kind)| kind == &Some(FoldingRangeKind::Imports)),
+            "{ranges:?}"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_document_falls_back_to_indentation() {
+        // A stray closing tag is one of the few things loose parsing refuses,
+        // and the folds the editor has already drawn should survive it.
+        let text = "<div>\n  <p>\n    x\n  </p>\n</div>\n</span>";
+        let ranges = folding_ranges(text, true);
+        assert_eq!(
+            ranges
+                .iter()
+                .map(|range| (range.start_line, range.end_line))
+                .collect::<Vec<_>>(),
+            vec![(0, 3), (1, 2)]
+        );
+    }
+
+    #[test]
+    fn a_document_being_typed_still_folds() {
+        for text in [
+            "<div>\n  <p>hi\n",
+            "{#if a}\n  <p>\n    x\n  </p>\n",
+            "<script>\n  const a = {\n</script>",
+        ] {
+            assert!(
+                !folding_ranges(text, true).is_empty(),
+                "{text:?} should still fold"
+            );
+        }
+    }
+
+    #[test]
+    fn no_input_panics() {
+        for text in crate::nodes::tests_support::BROKEN {
+            let lines = folding_ranges(text, true);
+            assert!(lines.iter().all(|range| range.start_line < range.end_line));
+            let offsets = folding_ranges(text, false);
+            assert!(
+                offsets
+                    .iter()
+                    .all(|range| range.start_line <= range.end_line)
+            );
+        }
+    }
+
+    #[test]
+    fn a_document_that_folds_nothing_is_empty_not_absent() {
+        assert!(folding_ranges("", true).is_empty());
+        assert!(folding_ranges("<p>hi</p>", true).is_empty());
+    }
+
+    #[test]
+    fn characters_are_reported_when_the_client_folds_by_offset() {
+        let ranges = folding_ranges("<div>\n  x\n</div>", false);
+        let div = ranges.first().expect("the div folds");
+        assert_eq!((div.start_line, div.start_character), (0, Some(0)));
+        assert_eq!((div.end_line, div.end_character), (2, Some(6)));
+    }
+
+    #[test]
+    fn astral_text_does_not_shift_the_lines() {
+        let text = "<div>\n  💡{name}\n</div>";
+        let ranges = folding_ranges(text, true);
+        assert_eq!(
+            ranges
+                .iter()
+                .map(|range| (range.start_line, range.end_line))
+                .collect::<Vec<_>>(),
+            vec![(0, 1)]
+        );
+        let ranges = folding_ranges(text, false);
+        assert_eq!(ranges[0].end_character, Some(6));
+    }
+
+    #[test]
+    fn crlf_documents_fold_on_the_same_lines() {
+        let unix = folding_ranges("<div>\n  x\n</div>", true);
+        let dos = folding_ranges("<div>\r\n  x\r\n</div>", true);
+        assert_eq!(unix.len(), dos.len());
+        assert_eq!(unix[0].start_line, dos[0].start_line);
+        assert_eq!(unix[0].end_line, dos[0].end_line);
+    }
+}

--- a/crates/rsvelte_language_server/src/folding.rs
+++ b/crates/rsvelte_language_server/src/folding.rs
@@ -9,7 +9,7 @@
 //! does for them as well while its TypeScript and CSS services are the ones
 //! reading the contents.
 
-use lsp_types::{FoldingRange, FoldingRangeKind};
+use lsp_types::{FoldingRange, FoldingRangeKind, Position};
 use rsvelte_core::Allocator;
 use rsvelte_core::ast::arena::ParseArena;
 use rsvelte_core::ast::js::Expression;
@@ -17,7 +17,7 @@ use rsvelte_core::ast::template::{Root, Script, TemplateNode};
 
 use crate::context::body_of;
 use crate::indent_folding::{LineRange, body_lines, indent_folding};
-use crate::nodes::{Span, Top, parse_root, top_level, view};
+use crate::nodes::{Top, parse_root, top_level, view};
 use crate::text::LineIndex;
 
 pub fn folding_ranges(text: &str, line_folding_only: bool) -> Vec<FoldingRange> {
@@ -40,8 +40,8 @@ pub fn folding_ranges(text: &str, line_folding_only: bool) -> Vec<FoldingRange> 
 
 /// A range before the client's `lineFoldingOnly` capability is applied.
 struct Raw {
-    start: Span,
-    end: Span,
+    start: Position,
+    end: Position,
     kind: Option<FoldingRangeKind>,
     /// Whether `end` is the line of a closing tag, which a line-folding client
     /// wants left visible.
@@ -168,8 +168,8 @@ impl Collector<'_> {
     fn indented(&mut self, ranges: &[LineRange]) {
         for fold in indent_folding(self.text, self.index, ranges) {
             self.ranges.push(Raw {
-                start: (fold.start_line, 0),
-                end: (fold.end_line, 0),
+                start: Position::new(fold.start_line, 0),
+                end: Position::new(fold.end_line, 0),
                 kind: None,
                 closing: false,
             });
@@ -177,11 +177,9 @@ impl Collector<'_> {
     }
 
     fn fold(&mut self, start: u32, end: u32, kind: Option<FoldingRangeKind>, closing: bool) {
-        let start = self.index.position(self.text, start as usize);
-        let end = self.index.position(self.text, end as usize);
         self.ranges.push(Raw {
-            start: (start.line, start.character),
-            end: (end.line, end.character),
+            start: self.index.position(self.text, start as usize),
+            end: self.index.position(self.text, end as usize),
             kind,
             closing,
         });
@@ -192,12 +190,12 @@ impl Collector<'_> {
             return self
                 .ranges
                 .into_iter()
-                .filter(|raw| raw.start.0 <= raw.end.0)
+                .filter(|raw| raw.start.line <= raw.end.line)
                 .map(|raw| FoldingRange {
-                    start_line: raw.start.0,
-                    start_character: Some(raw.start.1),
-                    end_line: raw.end.0,
-                    end_character: Some(raw.end.1),
+                    start_line: raw.start.line,
+                    start_character: Some(raw.start.character),
+                    end_line: raw.end.line,
+                    end_character: Some(raw.end.character),
                     kind: raw.kind,
                     collapsed_text: None,
                 })
@@ -209,11 +207,11 @@ impl Collector<'_> {
         // is the one it should get.
         let mut folds: Vec<FoldingRange> = Vec::new();
         for raw in self.ranges {
-            let start_line = raw.start.0;
+            let start_line = raw.start.line;
             let end_line = if raw.closing {
-                raw.end.0.saturating_sub(1).max(start_line)
+                raw.end.line.saturating_sub(1).max(start_line)
             } else {
-                raw.end.0
+                raw.end.line
             };
             if start_line >= end_line || folds.iter().any(|fold| fold.start_line == start_line) {
                 continue;

--- a/crates/rsvelte_language_server/src/indent_folding.rs
+++ b/crates/rsvelte_language_server/src/indent_folding.rs
@@ -1,0 +1,313 @@
+//! Indentation-based folding, for text no template AST covers.
+//!
+//! A port of the official language server's
+//! `lib/foldingRange/indentFolding.ts`, which it uses for `<script>` and
+//! `<style>` bodies and for documents its parser could not read. The line
+//! numbers come out of the shared [`LineIndex`], so they agree with every other
+//! position this server sends.
+
+use crate::text::LineIndex;
+
+/// An inclusive, 0-based range of lines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LineRange {
+    pub start_line: u32,
+    pub end_line: u32,
+}
+
+struct Indent {
+    tabs: u32,
+    spaces: u32,
+    line: u32,
+}
+
+/// The folds implied by the indentation of `ranges`, or of the whole document
+/// when no range is given.
+pub fn indent_folding(text: &str, index: &LineIndex, ranges: &[LineRange]) -> Vec<LineRange> {
+    let indents: Vec<Indent> = (0..index.line_count())
+        .filter_map(|line| collect_indent(index.line_text(text, line), line as u32))
+        .collect();
+    let tabs: u32 = indents.iter().map(|indent| indent.tabs).sum();
+    let spaces: u32 = indents.iter().map(|indent| indent.spaces).sum();
+    let tab_size = if tabs > 0 && spaces > 0 {
+        guess_tab_size(&indents)
+    } else {
+        4
+    };
+
+    let whole = [LineRange {
+        start_line: 0,
+        end_line: index.line_count().saturating_sub(1) as u32,
+    }];
+    let ranges = if ranges.is_empty() {
+        &whole[..]
+    } else {
+        ranges
+    };
+
+    let mut folds: Vec<LineRange> = Vec::new();
+    // Indent level -> the fold opened at it, as an index into `folds`.
+    let mut unfinished: Vec<(u32, usize)> = Vec::new();
+    let mut current: Option<u32> = None;
+    let mut remaining = ranges.iter();
+    let Some(mut range) = remaining.next().copied() else {
+        return folds;
+    };
+
+    for indent in &indents {
+        if indent.line < range.start_line {
+            continue;
+        }
+        if indent.line > range.end_line {
+            for &(_, fold) in &unfinished {
+                folds[fold].end_line = range.end_line;
+            }
+            match remaining.next() {
+                Some(&next) => range = next,
+                None => break,
+            }
+        }
+
+        let level = indent.tabs * tab_size + indent.spaces;
+        let level_before = *current.get_or_insert(level);
+
+        if level > level_before {
+            folds.push(LineRange {
+                start_line: indent.line.saturating_sub(1),
+                end_line: indent.line,
+            });
+            unfinished.push((level_before, folds.len() - 1));
+            current = Some(level);
+        } else if level < level_before {
+            if let Some(at) = unfinished.iter().rposition(|&(open, _)| open == level) {
+                let (_, fold) = unfinished.remove(at);
+                folds[fold].end_line = folds[fold].end_line.max(indent.line.saturating_sub(1));
+            }
+            current = Some(level);
+        }
+    }
+
+    folds
+}
+
+/// The indentation of a line, or `None` when the line holds only whitespace.
+fn collect_indent(line: &str, index: u32) -> Option<Indent> {
+    let mut tabs = 0;
+    let mut spaces = 0;
+    for byte in line.bytes() {
+        match byte {
+            b'\t' => tabs += 1,
+            b' ' => spaces += 1,
+            _ => {
+                return Some(Indent {
+                    tabs,
+                    spaces,
+                    line: index,
+                });
+            }
+        }
+    }
+    None
+}
+
+/// A simplified port of VS Code's indentation guesser: the width most often
+/// explaining the difference between one line's indentation and the previous
+/// line's wins, with a tie going to the width used more.
+fn guess_tab_size(lines: &[Indent]) -> u32 {
+    const CANDIDATES: [u32; 7] = [2, 4, 6, 8, 3, 5, 7];
+    const MAX_GUESS: u32 = 8;
+
+    if lines.len() == 1 {
+        return 4;
+    }
+    let mut counts = [0u32; CANDIDATES.len()];
+    for (index, line) in lines.iter().enumerate() {
+        let (previous_spaces, previous_tabs) = match index.checked_sub(1) {
+            Some(previous) => (lines[previous].spaces, lines[previous].tabs),
+            None => (0, 0),
+        };
+        let space_diff = line.spaces.abs_diff(previous_spaces);
+        let tab_diff = line.tabs.abs_diff(previous_tabs);
+        let diff = if tab_diff == 0 {
+            space_diff
+        } else if space_diff % tab_diff == 0 {
+            space_diff / tab_diff
+        } else {
+            0
+        };
+        if diff == 0 || diff > MAX_GUESS {
+            continue;
+        }
+        if let Some(at) = CANDIDATES.iter().position(|&guess| guess == diff) {
+            counts[at] += 1;
+        }
+    }
+
+    let mut max = 0;
+    let mut guessed = None;
+    for (at, &count) in counts.iter().enumerate() {
+        max = max.max(count);
+        if max == count && count > 0 {
+            guessed = Some(CANDIDATES[at]);
+        }
+    }
+
+    let four = counts[CANDIDATES.iter().position(|&g| g == 4).unwrap()];
+    let two = counts[CANDIDATES.iter().position(|&g| g == 2).unwrap()];
+    if guessed == Some(4) && four > 0 && two > 0 && two * 2 >= four {
+        guessed = Some(2);
+    }
+    guessed.unwrap_or(4)
+}
+
+/// The lines strictly inside a `<script>` / `<style>` body spanning
+/// `start..end`, which is what upstream's `indentBasedFoldingRangeForTag`
+/// folds.
+pub fn body_lines(index: &LineIndex, text: &str, start: usize, end: usize) -> Option<LineRange> {
+    let first = index.position(text, start).line;
+    let last = index.position(text, end).line;
+    let range = LineRange {
+        start_line: first + 1,
+        end_line: last.checked_sub(1)?,
+    };
+    (range.start_line < range.end_line).then_some(range)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn folds(text: &str) -> Vec<(u32, u32)> {
+        let index = LineIndex::new(text);
+        indent_folding(text, &index, &[])
+            .into_iter()
+            .map(|range| (range.start_line, range.end_line))
+            .collect()
+    }
+
+    #[test]
+    fn a_nested_block_folds_from_its_opening_line() {
+        let text = "function a() {\n  b();\n}\n";
+        assert_eq!(folds(text), vec![(0, 1)]);
+    }
+
+    #[test]
+    fn siblings_and_nesting() {
+        let text = "a\n  b\n    c\n  d\ne\n";
+        assert_eq!(folds(text), vec![(0, 3), (1, 2)]);
+    }
+
+    #[test]
+    fn blank_lines_do_not_close_a_fold() {
+        let text = "a\n  b\n\n  c\nd\n";
+        assert_eq!(folds(text), vec![(0, 3)]);
+    }
+
+    #[test]
+    fn an_unclosed_fold_keeps_the_line_it_opened_on() {
+        let text = "a\n  b\n";
+        assert_eq!(folds(text), vec![(0, 1)]);
+    }
+
+    #[test]
+    fn flat_text_folds_nothing() {
+        assert_eq!(folds("a\nb\nc\n"), Vec::new());
+        assert_eq!(folds(""), Vec::new());
+    }
+
+    #[test]
+    fn tabs_and_spaces_mix() {
+        let text = "a\n\tb\n\t\tc\n";
+        assert_eq!(folds(text), vec![(0, 1), (1, 2)]);
+    }
+
+    #[test]
+    fn the_tab_size_is_guessed_from_the_differences() {
+        let two = [
+            Indent {
+                tabs: 0,
+                spaces: 0,
+                line: 0,
+            },
+            Indent {
+                tabs: 0,
+                spaces: 2,
+                line: 1,
+            },
+            Indent {
+                tabs: 0,
+                spaces: 4,
+                line: 2,
+            },
+        ];
+        assert_eq!(guess_tab_size(&two), 2);
+        let four = [
+            Indent {
+                tabs: 0,
+                spaces: 0,
+                line: 0,
+            },
+            Indent {
+                tabs: 0,
+                spaces: 4,
+                line: 1,
+            },
+            Indent {
+                tabs: 0,
+                spaces: 8,
+                line: 2,
+            },
+        ];
+        assert_eq!(guess_tab_size(&four), 4);
+    }
+
+    #[test]
+    fn a_single_line_guesses_four() {
+        assert_eq!(
+            guess_tab_size(&[Indent {
+                tabs: 0,
+                spaces: 2,
+                line: 0
+            }]),
+            4
+        );
+    }
+
+    #[test]
+    fn a_given_range_bounds_the_folds() {
+        let text = "a\n  b\nc\n  d\n";
+        let index = LineIndex::new(text);
+        let ranges = [LineRange {
+            start_line: 2,
+            end_line: 3,
+        }];
+        assert_eq!(
+            indent_folding(text, &index, &ranges),
+            vec![LineRange {
+                start_line: 2,
+                end_line: 3
+            }]
+        );
+    }
+
+    #[test]
+    fn body_lines_skip_the_tag_lines() {
+        let text = "<script>\n  a\n  b\n</script>";
+        let index = LineIndex::new(text);
+        let body = body_lines(&index, text, 8, text.len() - 9);
+        assert_eq!(
+            body,
+            Some(LineRange {
+                start_line: 1,
+                end_line: 2
+            })
+        );
+    }
+
+    #[test]
+    fn a_one_line_body_has_no_lines_to_fold() {
+        let text = "<script>a</script>";
+        let index = LineIndex::new(text);
+        assert_eq!(body_lines(&index, text, 8, 9), None);
+    }
+}

--- a/crates/rsvelte_language_server/src/lib.rs
+++ b/crates/rsvelte_language_server/src/lib.rs
@@ -3,7 +3,8 @@
 //!
 //! It also ports the TypeScript-free half of the official language server's
 //! `SveltePlugin`: template tag and event modifier [`completions`] and
-//! [`hover`].
+//! [`hover`], and the structure the Svelte AST alone can answer for —
+//! [`folding`] ranges, [`selection_ranges`] and document [`symbols`].
 //!
 //! The message loop owns only protocol state; every analysis runs on the
 //! [`worker`] thread, which is where the stack depth and panic isolation the
@@ -15,13 +16,18 @@ pub mod completions;
 pub mod context;
 pub mod diagnostics;
 pub mod document;
+pub mod folding;
 pub mod format;
 pub mod hover;
+pub mod indent_folding;
 pub mod lint;
 pub mod log;
 pub mod modifiers;
+pub mod nodes;
+pub mod selection_ranges;
 pub mod server;
 pub mod settings;
+pub mod symbols;
 pub mod tags;
 pub mod text;
 pub mod uri;

--- a/crates/rsvelte_language_server/src/nodes.rs
+++ b/crates/rsvelte_language_server/src/nodes.rs
@@ -1,0 +1,390 @@
+//! A uniform view of the template AST for the structure providers.
+//!
+//! Folding ranges, selection ranges and document symbols all ask a node the
+//! same handful of questions — its span, its name, the fragments nested in it,
+//! the spans of the expressions it carries — which the template AST spells
+//! differently for every one of its thirty variants. They are answered once
+//! here.
+//!
+//! The parse is `loose`, the mode the official language server also compiles
+//! in: a document is asked for its outline while it is being typed, so a
+//! missing close tag has to leave the rest of the tree standing.
+
+use rsvelte_core::ast::css::StyleSheet;
+use rsvelte_core::ast::js::Expression;
+use rsvelte_core::ast::template::{Attribute, Fragment, Root, Script, TemplateNode};
+use rsvelte_core::{Allocator, ParseOptions, parse};
+
+pub type Span = (u32, u32);
+
+/// The blocks that own a body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Block {
+    If,
+    Each,
+    Await,
+    Key,
+    Snippet,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind<'a> {
+    Element(&'a str),
+    Block(Block),
+    Comment,
+    /// Text, expression tags and the other leaves: a span, and nothing nested.
+    Leaf,
+}
+
+/// One template node, seen as span + children.
+pub struct View<'a> {
+    pub start: u32,
+    pub end: u32,
+    pub kind: Kind<'a>,
+    pub attributes: &'a [Attribute<'a>],
+    /// The span a client should select when the node is picked from an
+    /// outline: an element's tag name, a snippet's name.
+    pub name_span: Option<Span>,
+    fragments: [Option<&'a Fragment<'a>>; 3],
+    expressions: [Option<Span>; 2],
+}
+
+impl<'a> View<'a> {
+    pub fn span(&self) -> Span {
+        (self.start, self.end)
+    }
+
+    pub fn fragments(&self) -> impl Iterator<Item = &'a Fragment<'a>> + '_ {
+        self.fragments.into_iter().flatten()
+    }
+
+    pub fn expressions(&self) -> impl Iterator<Item = Span> + '_ {
+        self.expressions.into_iter().flatten()
+    }
+
+    /// Whether the node can hold other nodes, and so is worth folding and
+    /// outlining even when nothing is nested in it yet.
+    pub fn is_container(&self) -> bool {
+        matches!(self.kind, Kind::Element(_) | Kind::Block(_))
+    }
+
+    pub fn contains(&self, offset: usize) -> bool {
+        (self.start as usize..=self.end as usize).contains(&offset)
+    }
+}
+
+pub fn view<'a>(node: &'a TemplateNode<'a>) -> View<'a> {
+    match node {
+        TemplateNode::RegularElement(node) => element(
+            node.start,
+            node.end,
+            &node.name,
+            &node.attributes,
+            &node.fragment,
+        ),
+        TemplateNode::Component(node) => element(
+            node.start,
+            node.end,
+            &node.name,
+            &node.attributes,
+            &node.fragment,
+        ),
+        TemplateNode::TitleElement(node) => element(
+            node.start,
+            node.end,
+            &node.name,
+            &node.attributes,
+            &node.fragment,
+        ),
+        TemplateNode::SlotElement(node) => element(
+            node.start,
+            node.end,
+            &node.name,
+            &node.attributes,
+            &node.fragment,
+        ),
+        TemplateNode::SvelteBody(node)
+        | TemplateNode::SvelteDocument(node)
+        | TemplateNode::SvelteFragment(node)
+        | TemplateNode::SvelteBoundary(node)
+        | TemplateNode::SvelteHead(node)
+        | TemplateNode::SvelteOptions(node)
+        | TemplateNode::SvelteSelf(node)
+        | TemplateNode::SvelteWindow(node) => element(
+            node.start,
+            node.end,
+            &node.name,
+            &node.attributes,
+            &node.fragment,
+        ),
+        TemplateNode::SvelteComponent(node) => {
+            let mut view = element(
+                node.start,
+                node.end,
+                &node.name,
+                &node.attributes,
+                &node.fragment,
+            );
+            view.expressions[0] = span_of(&node.expression);
+            view
+        }
+        TemplateNode::SvelteElement(node) => {
+            let mut view = element(
+                node.start,
+                node.end,
+                &node.name,
+                &node.attributes,
+                &node.fragment,
+            );
+            view.expressions[0] = span_of(&node.tag);
+            view
+        }
+        TemplateNode::IfBlock(node) => View {
+            fragments: [Some(&node.consequent), node.alternate.as_ref(), None],
+            expressions: [span_of(&node.test), None],
+            ..block(node.start, node.end, Block::If)
+        },
+        TemplateNode::EachBlock(node) => View {
+            fragments: [Some(&node.body), node.fallback.as_ref(), None],
+            expressions: [
+                span_of(&node.expression),
+                node.key.as_ref().and_then(span_of),
+            ],
+            ..block(node.start, node.end, Block::Each)
+        },
+        TemplateNode::AwaitBlock(node) => View {
+            fragments: [
+                node.pending.as_ref(),
+                node.then.as_ref(),
+                node.catch.as_ref(),
+            ],
+            expressions: [span_of(&node.expression), None],
+            ..block(node.start, node.end, Block::Await)
+        },
+        TemplateNode::KeyBlock(node) => View {
+            fragments: [Some(&node.fragment), None, None],
+            expressions: [span_of(&node.expression), None],
+            ..block(node.start, node.end, Block::Key)
+        },
+        TemplateNode::SnippetBlock(node) => View {
+            fragments: [Some(&node.body), None, None],
+            name_span: span_of(&node.expression),
+            ..block(node.start, node.end, Block::Snippet)
+        },
+        TemplateNode::Comment(node) => leaf(node.start, node.end, Kind::Comment),
+        TemplateNode::Text(node) => leaf(node.start, node.end, Kind::Leaf),
+        TemplateNode::ExpressionTag(node) => {
+            let mut view = leaf(node.start, node.end, Kind::Leaf);
+            view.expressions[0] = span_of(&node.expression);
+            view
+        }
+        TemplateNode::HtmlTag(node) => {
+            let mut view = leaf(node.start, node.end, Kind::Leaf);
+            view.expressions[0] = span_of(&node.expression);
+            view
+        }
+        TemplateNode::RenderTag(node) => {
+            let mut view = leaf(node.start, node.end, Kind::Leaf);
+            view.expressions[0] = span_of(&node.expression);
+            view
+        }
+        TemplateNode::AttachTag(node) => {
+            let mut view = leaf(node.start, node.end, Kind::Leaf);
+            view.expressions[0] = span_of(&node.expression);
+            view
+        }
+        TemplateNode::ConstTag(node) => {
+            let mut view = leaf(node.start, node.end, Kind::Leaf);
+            view.expressions[0] = span_of(&node.declaration);
+            view
+        }
+        TemplateNode::DeclarationTag(node) => {
+            let mut view = leaf(node.start, node.end, Kind::Leaf);
+            view.expressions[0] = span_of(&node.declaration);
+            view
+        }
+        TemplateNode::DebugTag(node) => {
+            let mut view = leaf(node.start, node.end, Kind::Leaf);
+            view.expressions[0] = node.identifiers.first().and_then(span_of);
+            view
+        }
+    }
+}
+
+fn element<'a>(
+    start: u32,
+    end: u32,
+    name: &'a str,
+    attributes: &'a [Attribute<'a>],
+    fragment: &'a Fragment<'a>,
+) -> View<'a> {
+    // The tag name always follows the `<` the node starts at.
+    let name_end = start + 1 + name.len() as u32;
+    View {
+        start,
+        end,
+        kind: Kind::Element(name),
+        attributes,
+        name_span: (name_end <= end).then_some((start + 1, name_end)),
+        fragments: [Some(fragment), None, None],
+        expressions: [None, None],
+    }
+}
+
+fn block<'a>(start: u32, end: u32, block: Block) -> View<'a> {
+    View {
+        start,
+        end,
+        kind: Kind::Block(block),
+        attributes: &[],
+        name_span: None,
+        fragments: [None, None, None],
+        expressions: [None, None],
+    }
+}
+
+fn leaf<'a>(start: u32, end: u32, kind: Kind<'a>) -> View<'a> {
+    View {
+        start,
+        end,
+        kind,
+        attributes: &[],
+        name_span: None,
+        fragments: [None, None, None],
+        expressions: [None, None],
+    }
+}
+
+pub fn span_of(expression: &Expression<'_>) -> Option<Span> {
+    Some((expression.start()?, expression.end()?))
+}
+
+/// A top-level piece of a document. `<script>` and `<style>` are lifted out of
+/// the fragment by the parser, so they have to be woven back into document
+/// order before anything can walk the file as a whole.
+pub enum Top<'a> {
+    Node(&'a TemplateNode<'a>),
+    Script(&'a Script<'a>),
+    Style(&'a StyleSheet),
+}
+
+impl Top<'_> {
+    pub fn span(&self) -> Span {
+        match self {
+            Top::Node(node) => view(node).span(),
+            Top::Script(script) => (script.start, script.end),
+            Top::Style(style) => (style.start, style.end),
+        }
+    }
+}
+
+pub fn top_level<'a>(root: &'a Root<'a>) -> Vec<Top<'a>> {
+    let mut tops: Vec<Top<'a>> = root.fragment.nodes.iter().map(Top::Node).collect();
+    tops.extend(
+        [root.instance.as_deref(), root.module.as_deref()]
+            .into_iter()
+            .flatten()
+            .map(Top::Script),
+    );
+    tops.extend(root.css.as_deref().map(Top::Style));
+    tops.sort_by_key(|top| top.span().0);
+    tops
+}
+
+pub fn parse_root<'a>(text: &'a str, allocator: &Allocator) -> Option<Root<'a>> {
+    let options = ParseOptions {
+        loose: true,
+        lenient_script: true,
+        skip_non_css_lang_style: true,
+        skip_expression_loc: true,
+        ..ParseOptions::default()
+    };
+    parse(text, allocator, options).ok()
+}
+
+/// Documents in the state a component spends most of its life in: half
+/// written. Every structure provider has to answer something for each of them
+/// without falling over.
+#[cfg(test)]
+pub mod tests_support {
+    pub const BROKEN: &[&str] = &[
+        "",
+        "<",
+        "{",
+        "{#",
+        "{#if",
+        "{#if a}",
+        "{#each items as }x{/each}",
+        "{#await}{:then}{:catch}{/await}",
+        "{@render}",
+        "{#snippet}",
+        "</div>",
+        "<div>x</div>\n</span>",
+        "<div\n  attr=\"",
+        "<div {{{>",
+        "<div>\n  <p>hi\n",
+        "<div>{#if a}</div>{/if}",
+        "<script>const a = {\n</script><p>x</p>",
+        "<script lang=\"ts\">let a: = ;</script><p>x</p>",
+        "<style>h1{</style>",
+        "<style lang=\"scss\">$a: 1; .b { c: $a }</style>",
+        "<!-- unterminated",
+        "<!-- #region -->\n<div>\n",
+        "<p>💡{ }</p>\n<div>\n  あ\n",
+        "<svelte:options bogus />",
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root_of(text: &str) -> (Allocator, Option<Root<'_>>) {
+        let allocator = Allocator::default();
+        // The root borrows `text`, not the allocator, so both can be returned.
+        let root = parse_root(text, &allocator);
+        (allocator, root)
+    }
+
+    #[test]
+    fn top_level_pieces_come_back_in_document_order() {
+        let text = "<p>a</p>\n<script>let a;</script>\n<style>p{color:red}</style>";
+        let (_allocator, root) = root_of(text);
+        let root = root.unwrap();
+        let starts: Vec<u32> = top_level(&root).iter().map(|top| top.span().0).collect();
+        assert!(starts.windows(2).all(|w| w[0] <= w[1]), "{starts:?}");
+        assert_eq!(starts.len(), 5, "two texts, an element, a script, a style");
+    }
+
+    #[test]
+    fn an_unclosed_element_still_parses() {
+        let text = "<div>\n  <p>hi\n";
+        let (_allocator, root) = root_of(text);
+        let root = root.expect("loose mode recovers");
+        let div = view(&root.fragment.nodes[0]);
+        assert_eq!(div.kind, Kind::Element("div"));
+        assert_eq!(div.name_span, Some((1, 4)));
+    }
+
+    #[test]
+    fn a_block_exposes_its_fragments_and_expression() {
+        let text = "{#each items as item}{item}{:else}none{/each}";
+        let (_allocator, root) = root_of(text);
+        let root = root.unwrap();
+        let each = view(&root.fragment.nodes[0]);
+        assert_eq!(each.kind, Kind::Block(Block::Each));
+        assert_eq!(each.fragments().count(), 2);
+        assert_eq!(each.expressions().next(), Some((7, 12)));
+    }
+
+    #[test]
+    fn a_snippet_carries_its_name_span() {
+        let text = "{#snippet row(item)}{item}{/snippet}";
+        let (_allocator, root) = root_of(text);
+        let root = root.unwrap();
+        let snippet = view(&root.fragment.nodes[0]);
+        assert_eq!(snippet.kind, Kind::Block(Block::Snippet));
+        assert_eq!(&text[10..13], "row");
+        assert_eq!(snippet.name_span, Some((10, 13)));
+    }
+}

--- a/crates/rsvelte_language_server/src/selection_ranges.rs
+++ b/crates/rsvelte_language_server/src/selection_ranges.rs
@@ -1,0 +1,393 @@
+//! `textDocument/selectionRange`.
+//!
+//! A port of the official language server's
+//! `plugins/svelte/features/getSelectionRanges.ts`. Upstream walks whatever
+//! node boundaries its AST happens to expose; this walks the same tree
+//! deliberately, so an attribute value grows to its attribute, then to the
+//! start tag, then to the element.
+//!
+//! Positions inside `<script>` and `<style>` are left alone, as upstream does:
+//! their contents belong to the TypeScript and CSS services.
+
+use lsp_types::{Range, SelectionRange};
+use rsvelte_core::Allocator;
+use rsvelte_core::ast::template::{
+    Attribute, AttributeValue, AttributeValuePart, Root, TemplateNode,
+};
+
+use crate::context::body_of;
+use crate::nodes::{Kind, Span, View, parse_root, span_of, view};
+use crate::text::LineIndex;
+
+/// The nested ranges around each position, or `None` when the document has
+/// nothing to say about any of them — which lets the editor fall back to its
+/// own word- and bracket-based expansion.
+pub fn selection_ranges(text: &str, offsets: &[usize]) -> Option<Vec<SelectionRange>> {
+    let allocator = Allocator::default();
+    let root = parse_root(text, &allocator)?;
+    let embedded = embedded_bodies(text, &root);
+
+    let chains: Vec<Vec<Span>> = offsets
+        .iter()
+        .map(|&offset| {
+            if embedded.iter().any(|body| body.contains(&offset)) {
+                return Vec::new();
+            }
+            chain(text, &root, offset)
+        })
+        .collect();
+    if chains.iter().all(Vec::is_empty) {
+        return None;
+    }
+
+    let index = LineIndex::new(text);
+    Some(
+        chains
+            .into_iter()
+            .zip(offsets)
+            .map(|(chain, &offset)| nest(text, &index, &chain, offset))
+            .collect(),
+    )
+}
+
+/// The bodies of `<script>` and `<style>`, which this provider stays out of.
+fn embedded_bodies(text: &str, root: &Root<'_>) -> Vec<std::ops::Range<usize>> {
+    let scripts = [root.instance.as_deref(), root.module.as_deref()]
+        .into_iter()
+        .flatten()
+        .filter_map(|script| body_of(text, script.start as usize, script.end as usize));
+    let style = root
+        .css
+        .as_deref()
+        .map(|css| css.content.start as usize..css.content.end as usize);
+    scripts.chain(style).collect()
+}
+
+fn chain(text: &str, root: &Root<'_>, offset: usize) -> Vec<Span> {
+    let mut spans = Vec::new();
+    if let Some(node) = root
+        .fragment
+        .nodes
+        .iter()
+        .find(|node| view(node).contains(offset))
+    {
+        descend(text, node, offset, &mut spans);
+    }
+    spans
+}
+
+fn descend(text: &str, node: &TemplateNode<'_>, offset: usize, spans: &mut Vec<Span>) {
+    let node = view(node);
+    push(spans, node.span());
+
+    // The offset the start tag ends at already belongs to the content that
+    // follows it.
+    if let Some(tag_end) = open_tag_end(text, &node)
+        && offset < tag_end as usize
+    {
+        push(spans, (node.start, tag_end));
+        if let Some(attribute) = node
+            .attributes
+            .iter()
+            .find(|attribute| contains(attribute_span(attribute), offset))
+        {
+            push(spans, attribute_span(attribute));
+            attribute_value(attribute, offset, spans);
+        }
+        return;
+    }
+
+    if let Some(expression) = node
+        .expressions()
+        .find(|&expression| contains(expression, offset))
+    {
+        push(spans, expression);
+        return;
+    }
+
+    for fragment in node.fragments() {
+        if let Some(child) = fragment
+            .nodes
+            .iter()
+            .find(|child| view(child).contains(offset))
+        {
+            descend(text, child, offset, spans);
+            return;
+        }
+    }
+}
+
+fn attribute_value(attribute: &Attribute<'_>, offset: usize, spans: &mut Vec<Span>) {
+    let Attribute::Attribute(attribute) = attribute else {
+        return;
+    };
+    match &attribute.value {
+        AttributeValue::True(_) => {}
+        AttributeValue::Expression(tag) => {
+            if !contains((tag.start, tag.end), offset) {
+                return;
+            }
+            push(spans, (tag.start, tag.end));
+            if let Some(expression) = span_of(&tag.expression) {
+                push(spans, expression);
+            }
+        }
+        AttributeValue::Sequence(parts) => {
+            for part in parts {
+                let (span, expression) = match part {
+                    AttributeValuePart::Text(text) => ((text.start, text.end), None),
+                    AttributeValuePart::ExpressionTag(tag) => {
+                        ((tag.start, tag.end), span_of(&tag.expression))
+                    }
+                };
+                if contains(span, offset) {
+                    push(spans, span);
+                    if let Some(expression) = expression {
+                        push(spans, expression);
+                    }
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Where an element's start tag ends, so that an attribute can grow to the
+/// whole opener before it grows to the element.
+fn open_tag_end(text: &str, node: &View<'_>) -> Option<u32> {
+    let Kind::Element(name) = node.kind else {
+        return None;
+    };
+    let from = node
+        .attributes
+        .last()
+        .map_or(node.start as usize + 1 + name.len(), |attribute| {
+            attribute_span(attribute).1 as usize
+        });
+    let rest = text.get(from..node.end as usize)?;
+    Some((from + rest.find('>')? + 1) as u32)
+}
+
+fn attribute_span(attribute: &Attribute<'_>) -> Span {
+    match attribute {
+        Attribute::Attribute(node) => (node.start, node.end),
+        Attribute::SpreadAttribute(node) => (node.start, node.end),
+        Attribute::AttachTag(node) => (node.start, node.end),
+        Attribute::BindDirective(node) => (node.start, node.end),
+        Attribute::OnDirective(node) => (node.start, node.end),
+        Attribute::ClassDirective(node) => (node.start, node.end),
+        Attribute::StyleDirective(node) => (node.start, node.end),
+        Attribute::TransitionDirective(node) => (node.start, node.end),
+        Attribute::AnimateDirective(node) => (node.start, node.end),
+        Attribute::UseDirective(node) => (node.start, node.end),
+        Attribute::LetDirective(node) => (node.start, node.end),
+    }
+}
+
+fn contains((start, end): Span, offset: usize) -> bool {
+    (start as usize..=end as usize).contains(&offset)
+}
+
+/// A span that adds nothing to the chain — an element whose start tag is the
+/// whole element, an expression filling its tag — would only make the client
+/// expand the selection to the same text twice.
+fn push(spans: &mut Vec<Span>, span: Span) {
+    if spans.last() != Some(&span) {
+        spans.push(span);
+    }
+}
+
+fn nest(text: &str, index: &LineIndex, spans: &[Span], offset: usize) -> SelectionRange {
+    let mut nested: Option<SelectionRange> = None;
+    for &(start, end) in spans {
+        nested = Some(SelectionRange {
+            range: Range::new(
+                index.position(text, start as usize),
+                index.position(text, end as usize),
+            ),
+            parent: nested.map(Box::new),
+        });
+    }
+    nested.unwrap_or_else(|| {
+        let position = index.position(text, offset);
+        SelectionRange {
+            range: Range::new(position, position),
+            parent: None,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::Position;
+
+    /// The ranges around the cursor, innermost first.
+    fn at(text: &str, offset: usize) -> Vec<Range> {
+        let mut ranges = Vec::new();
+        let mut node = selection_ranges(text, &[offset]).map(|mut r| r.remove(0));
+        while let Some(current) = node {
+            ranges.push(current.range);
+            node = current.parent.map(|parent| *parent);
+        }
+        ranges
+    }
+
+    fn range(start: (u32, u32), end: (u32, u32)) -> Range {
+        Range::new(Position::new(start.0, start.1), Position::new(end.0, end.1))
+    }
+
+    #[test]
+    fn nothing_inside_style_or_script() {
+        assert_eq!(selection_ranges("<style>x</style>", &[7]), None);
+        assert_eq!(selection_ranges("<script>x</script>", &[8]), None);
+    }
+
+    #[test]
+    fn an_attribute_value_grows_to_the_attribute_then_the_element() {
+        // `<h1 title="foo"></h1>`, cursor inside `foo`, as the official test
+        // spells it — with the start tag added between value and element.
+        let text = "<h1 title=\"foo\"></h1>";
+        assert_eq!(
+            at(text, 13),
+            vec![
+                range((0, 11), (0, 14)),
+                range((0, 4), (0, 15)),
+                range((0, 0), (0, 16)),
+                range((0, 0), (0, 21)),
+            ]
+        );
+    }
+
+    #[test]
+    fn text_in_a_block_grows_to_the_block() {
+        let text = "{#if a > 1}foo{/if}";
+        assert_eq!(
+            at(text, 11),
+            vec![range((0, 11), (0, 14)), range((0, 0), (0, 19))]
+        );
+    }
+
+    #[test]
+    fn a_block_expression_is_its_own_step() {
+        let text = "{#if a > 1}foo{/if}";
+        assert_eq!(
+            at(text, 6),
+            vec![range((0, 5), (0, 10)), range((0, 0), (0, 19))]
+        );
+    }
+
+    #[test]
+    fn nesting_is_reported_from_the_inside_out() {
+        let text = "<div>\n  <p>hi</p>\n</div>";
+        let ranges = at(text, text.find("hi").unwrap());
+        assert_eq!(
+            ranges,
+            vec![
+                range((1, 5), (1, 7)),
+                range((1, 2), (1, 11)),
+                range((0, 0), (2, 6)),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_interpolation_inside_an_attribute_value() {
+        let text = "<a href=\"/x/{id}\">go</a>";
+        let ranges = at(text, text.find("id").unwrap());
+        assert_eq!(ranges[0], range((0, 13), (0, 15)), "the identifier");
+        assert_eq!(ranges[1], range((0, 12), (0, 16)), "the interpolation");
+        assert_eq!(ranges[2], range((0, 3), (0, 17)), "the attribute");
+    }
+
+    #[test]
+    fn an_attribute_name_grows_to_the_start_tag_not_to_the_value() {
+        let text = "<button onclick={go}>x</button>";
+        let ranges = at(text, text.find("onclick").unwrap() + 2);
+        assert_eq!(ranges[0], range((0, 8), (0, 20)), "the attribute");
+        assert_eq!(ranges[1], range((0, 0), (0, 21)), "the start tag");
+        assert_eq!(ranges[2], range((0, 0), (0, 31)), "the element");
+    }
+
+    #[test]
+    fn a_self_closing_element_does_not_repeat_itself() {
+        // The start tag is the whole element here, so it is not a step of its
+        // own.
+        let text = "<input value=\"a\" />";
+        let ranges = at(text, 14);
+        assert_eq!(
+            ranges,
+            vec![
+                range((0, 14), (0, 15)),
+                range((0, 7), (0, 16)),
+                range((0, 0), (0, 19)),
+            ]
+        );
+    }
+
+    #[test]
+    fn several_positions_are_answered_in_order() {
+        let text = "<p>a</p><div>b</div>";
+        let ranges = selection_ranges(text, &[3, 13]).unwrap();
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].range, range((0, 3), (0, 4)));
+        assert_eq!(ranges[1].range, range((0, 13), (0, 14)));
+    }
+
+    #[test]
+    fn a_position_with_nothing_around_it_collapses_to_the_cursor() {
+        // The second position is on a `<script>` tag, which the template AST
+        // does not carry — and which is therefore left to the future
+        // TypeScript provider rather than answered with the wrong thing.
+        let text = "<p>a</p><script>let a;</script>";
+        let ranges = selection_ranges(text, &[3, 10]).unwrap();
+        assert_eq!(ranges[0].range, range((0, 3), (0, 4)));
+        assert_eq!(ranges[1].range, range((0, 10), (0, 10)));
+        assert!(ranges[1].parent.is_none());
+    }
+
+    #[test]
+    fn astral_text_is_measured_in_utf16() {
+        let text = "<p>💡ab</p>";
+        let ranges = at(text, text.find('a').unwrap());
+        assert_eq!(ranges[0], range((0, 3), (0, 7)));
+    }
+
+    #[test]
+    fn an_unreadable_document_answers_nothing() {
+        // A stray closing tag is one of the few things loose parsing still
+        // refuses.
+        assert_eq!(selection_ranges("<div>x</div>\n</span>", &[6]), None);
+    }
+
+    #[test]
+    fn no_input_panics() {
+        for text in crate::nodes::tests_support::BROKEN {
+            // Every offset of every broken document, boundaries included.
+            for offset in 0..=text.len() {
+                let Some(ranges) = selection_ranges(text, &[offset]) else {
+                    continue;
+                };
+                assert_eq!(ranges.len(), 1, "{text:?} at {offset}");
+                assert!(ranges[0].range.start <= ranges[0].range.end);
+            }
+        }
+    }
+
+    #[test]
+    fn a_document_being_typed_still_answers() {
+        for text in [
+            "<div>\n  <p>hi\n",
+            "{#if a}\n  <p>x</p>\n",
+            "<div attr=\"",
+            "{#each items as }x{/each}",
+            "<script>const a = {\n</script><p>x</p>",
+        ] {
+            let offset = text.find("x").or_else(|| text.find("hi")).unwrap_or(1);
+            assert!(
+                selection_ranges(text, &[offset]).is_some(),
+                "{text:?} should still answer"
+            );
+        }
+    }
+}

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -11,10 +11,12 @@ use lsp_types::{
     CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
     CodeActionProviderCapability, CompletionOptions, CompletionParams, ConfigurationItem,
     ConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentFormattingParams, HoverParams,
-    HoverProviderCapability, OneOf, PublishDiagnosticsParams, ServerCapabilities,
-    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentFormattingParams,
+    DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
+    FoldingRangeProviderCapability, HoverParams, HoverProviderCapability, OneOf,
+    PublishDiagnosticsParams, SelectionRangeParams, SelectionRangeProviderCapability,
+    ServerCapabilities, TextDocumentPositionParams, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
 };
 
 use crate::client::ClientState;
@@ -90,6 +92,9 @@ fn capabilities() -> ServerCapabilities {
             code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
             ..CodeActionOptions::default()
         })),
+        folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
+        selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
+        document_symbol_provider: Some(OneOf::Left(true)),
         ..ServerCapabilities::default()
     }
 }
@@ -102,6 +107,9 @@ enum Pending {
     Completion,
     Hover,
     CodeAction,
+    FoldingRange,
+    SelectionRange,
+    DocumentSymbol,
 }
 
 /// A request this server sent to the client, keyed by the id the client will
@@ -208,6 +216,9 @@ impl Server {
             "textDocument/completion" => self.on_completion(request),
             "textDocument/hover" => self.on_hover(request),
             "textDocument/codeAction" => self.on_code_action(request),
+            "textDocument/foldingRange" => self.on_folding_range(request),
+            "textDocument/selectionRange" => self.on_selection_range(request),
+            "textDocument/documentSymbol" => self.on_document_symbol(request),
             _ => self.respond(Response::new_err(
                 request.id,
                 ErrorCode::MethodNotFound as i32,
@@ -355,6 +366,109 @@ impl Server {
         self.worker.submit(job);
     }
 
+    fn on_folding_range(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<FoldingRangeParams>(request.params) {
+            Ok(params) => params,
+            Err(err) => {
+                log::warn(format_args!("textDocument/foldingRange: {err}"));
+                self.respond_no_ranges(id);
+                return;
+            }
+        };
+        if !self.settings.folding_range_enable {
+            self.respond_no_ranges(id);
+            return;
+        }
+        match self.component(&params.text_document.uri) {
+            Some((path, text)) => {
+                self.pending.insert(id.clone(), Pending::FoldingRange);
+                self.worker.submit(Job::FoldingRange {
+                    id,
+                    path,
+                    text,
+                    line_folding_only: self.client.line_folding_only,
+                });
+            }
+            None => self.respond_no_ranges(id),
+        }
+    }
+
+    fn on_selection_range(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<SelectionRangeParams>(request.params) {
+            Ok(params) => params,
+            Err(err) => {
+                log::warn(format_args!("textDocument/selectionRange: {err}"));
+                self.respond_nothing(id);
+                return;
+            }
+        };
+        if !self.settings.selection_range_enable {
+            self.respond_nothing(id);
+            return;
+        }
+        let Some(document) = self.component_document(&params.text_document.uri) else {
+            self.respond_nothing(id);
+            return;
+        };
+        let offsets = params
+            .positions
+            .iter()
+            .map(|&position| document.offset_at(position))
+            .collect();
+        let job = Job::SelectionRange {
+            id: id.clone(),
+            path: uri_to_path(params.text_document.uri.as_str()),
+            text: document.shared_text(),
+            offsets,
+        };
+        self.pending.insert(id, Pending::SelectionRange);
+        self.worker.submit(job);
+    }
+
+    fn on_document_symbol(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<DocumentSymbolParams>(request.params) {
+            Ok(params) => params,
+            Err(err) => {
+                log::warn(format_args!("textDocument/documentSymbol: {err}"));
+                self.respond_no_symbols(id);
+                return;
+            }
+        };
+        if !self.settings.document_symbol_enable {
+            self.respond_no_symbols(id);
+            return;
+        }
+        let uri = params.text_document.uri;
+        match self.component(&uri) {
+            Some((path, text)) => {
+                self.pending.insert(id.clone(), Pending::DocumentSymbol);
+                self.worker.submit(Job::DocumentSymbol {
+                    id,
+                    uri,
+                    path,
+                    text,
+                    hierarchical: self.client.hierarchical_document_symbols,
+                });
+            }
+            None => self.respond_no_symbols(id),
+        }
+    }
+
+    /// An open component, as the worker needs it. Only components have Svelte
+    /// template structure to report.
+    fn component(&self, uri: &Uri) -> Option<(std::path::PathBuf, std::sync::Arc<String>)> {
+        let document = self.component_document(uri)?;
+        Some((uri_to_path(uri.as_str()), document.shared_text()))
+    }
+
+    fn component_document(&self, uri: &Uri) -> Option<&Document> {
+        let document = self.documents.get(uri)?;
+        (document.language_id == "svelte").then_some(document)
+    }
+
     fn on_notification(&mut self, notification: Notification) {
         let method = notification.method.clone();
         match method.as_str() {
@@ -470,6 +584,21 @@ impl Server {
                     self.respond(Response::new_ok(id, actions));
                 }
             }
+            Outcome::FoldingRanges { id, ranges } => {
+                if self.pending.remove(&id).is_some() {
+                    self.respond(Response::new_ok(id, ranges));
+                }
+            }
+            Outcome::SelectionRanges { id, ranges } => {
+                if self.pending.remove(&id).is_some() {
+                    self.respond(Response::new_ok(id, ranges));
+                }
+            }
+            Outcome::DocumentSymbols { id, symbols } => {
+                if self.pending.remove(&id).is_some() {
+                    self.respond(Response::new_ok(id, symbols));
+                }
+            }
             Outcome::Diagnostics {
                 key,
                 uri,
@@ -581,6 +710,17 @@ impl Server {
 
     fn respond_no_actions(&self, id: RequestId) {
         self.respond(Response::new_ok(id, Vec::<CodeActionOrCommand>::new()));
+    }
+
+    fn respond_no_ranges(&self, id: RequestId) {
+        self.respond(Response::new_ok(id, Vec::<FoldingRange>::new()));
+    }
+
+    fn respond_no_symbols(&self, id: RequestId) {
+        self.respond(Response::new_ok(
+            id,
+            DocumentSymbolResponse::Nested(Vec::new()),
+        ));
     }
 
     fn respond(&self, response: Response) {

--- a/crates/rsvelte_language_server/src/settings.rs
+++ b/crates/rsvelte_language_server/src/settings.rs
@@ -23,6 +23,9 @@ pub struct Settings {
     pub lint_enable: bool,
     pub completion_enable: bool,
     pub hover_enable: bool,
+    pub folding_range_enable: bool,
+    pub selection_range_enable: bool,
+    pub document_symbol_enable: bool,
     pub compiler_warnings: CompilerWarnings,
 }
 
@@ -33,6 +36,9 @@ impl Default for Settings {
             lint_enable: true,
             completion_enable: true,
             hover_enable: true,
+            folding_range_enable: true,
+            selection_range_enable: true,
+            document_symbol_enable: true,
             compiler_warnings: CompilerWarnings::default(),
         }
     }
@@ -48,6 +54,12 @@ impl Settings {
             lint_enable: enabled(value, "lint").unwrap_or(default.lint_enable),
             completion_enable: enabled(value, "completion").unwrap_or(default.completion_enable),
             hover_enable: enabled(value, "hover").unwrap_or(default.hover_enable),
+            folding_range_enable: enabled(value, "foldingRange")
+                .unwrap_or(default.folding_range_enable),
+            selection_range_enable: enabled(value, "selectionRange")
+                .unwrap_or(default.selection_range_enable),
+            document_symbol_enable: enabled(value, "documentSymbol")
+                .unwrap_or(default.document_symbol_enable),
             compiler_warnings: compiler_warnings(value),
         }
     }
@@ -83,7 +95,10 @@ mod tests {
             "format": { "enable": false },
             "lint": { "enable": true },
             "completion": { "enable": false },
-            "hover": { "enable": false }
+            "hover": { "enable": false },
+            "foldingRange": { "enable": false },
+            "selectionRange": { "enable": true },
+            "documentSymbol": { "enable": false }
         }));
         assert_eq!(
             s,
@@ -92,6 +107,9 @@ mod tests {
                 lint_enable: true,
                 completion_enable: false,
                 hover_enable: false,
+                folding_range_enable: false,
+                selection_range_enable: true,
+                document_symbol_enable: false,
                 compiler_warnings: CompilerWarnings::default(),
             }
         );

--- a/crates/rsvelte_language_server/src/symbols.rs
+++ b/crates/rsvelte_language_server/src/symbols.rs
@@ -1,0 +1,455 @@
+//! `textDocument/documentSymbol`.
+//!
+//! Upstream builds this outline out of HTML nodes, so a component shows up as a
+//! list of tags; the Svelte AST also knows which of those tags are components,
+//! where the blocks are and what the snippets are called, so those become
+//! symbols of their own.
+//!
+//! Elements keep upstream's `tag#id.class` naming and its
+//! [`SymbolKind::FIELD`], so an outline built by this server looks like the one
+//! built by the official one wherever the two describe the same thing.
+
+use lsp_types::{
+    DocumentSymbol, DocumentSymbolResponse, Location, Range, SymbolInformation, SymbolKind, Uri,
+};
+use rsvelte_core::Allocator;
+use rsvelte_core::ast::template::{
+    Attribute, AttributeValue, AttributeValuePart, Script, ScriptContext, TemplateNode,
+};
+
+use crate::context::skip_braces;
+use crate::nodes::{Block, Kind, Span, Top, parse_root, top_level, view};
+use crate::text::LineIndex;
+
+/// How much of a block's opening tag its symbol shows.
+const HEADER_LIMIT: usize = 60;
+
+pub fn document_symbols(text: &str, uri: &Uri, hierarchical: bool) -> DocumentSymbolResponse {
+    let allocator = Allocator::default();
+    let mut symbols = Vec::new();
+    if let Some(root) = parse_root(text, &allocator) {
+        for top in top_level(&root) {
+            match top {
+                Top::Node(node) => collect(text, node, &mut symbols),
+                Top::Script(script) => symbols.push(Symbol::leaf(
+                    script_name(script),
+                    SymbolKind::MODULE,
+                    (script.start, script.end),
+                    tag_name_span(script.start, "script"),
+                )),
+                Top::Style(style) => symbols.push(Symbol::leaf(
+                    "style".to_string(),
+                    SymbolKind::MODULE,
+                    (style.start, style.end),
+                    tag_name_span(style.start, "style"),
+                )),
+            }
+        }
+    }
+
+    let index = LineIndex::new(text);
+    if hierarchical {
+        DocumentSymbolResponse::Nested(
+            symbols
+                .iter()
+                .map(|symbol| symbol.nested(text, &index))
+                .collect(),
+        )
+    } else {
+        let mut flat = Vec::new();
+        for symbol in &symbols {
+            symbol.flatten(text, &index, uri, None, &mut flat);
+        }
+        DocumentSymbolResponse::Flat(flat)
+    }
+}
+
+struct Symbol {
+    name: String,
+    kind: SymbolKind,
+    span: Span,
+    /// The part of `span` a client selects when the symbol is picked.
+    selection: Span,
+    children: Vec<Symbol>,
+}
+
+impl Symbol {
+    fn leaf(name: String, kind: SymbolKind, span: Span, selection: Span) -> Self {
+        Self {
+            name,
+            kind,
+            span,
+            selection,
+            children: Vec::new(),
+        }
+    }
+
+    fn nested(&self, text: &str, index: &LineIndex) -> DocumentSymbol {
+        #[allow(deprecated)]
+        DocumentSymbol {
+            name: self.name.clone(),
+            detail: None,
+            kind: self.kind,
+            tags: None,
+            deprecated: None,
+            range: to_range(text, index, self.span),
+            selection_range: to_range(text, index, self.selection),
+            children: Some(
+                self.children
+                    .iter()
+                    .map(|child| child.nested(text, index))
+                    .collect(),
+            ),
+        }
+    }
+
+    /// The same tree for a client that cannot read one, with the nesting
+    /// carried by `containerName` instead.
+    fn flatten(
+        &self,
+        text: &str,
+        index: &LineIndex,
+        uri: &Uri,
+        container: Option<&str>,
+        out: &mut Vec<SymbolInformation>,
+    ) {
+        #[allow(deprecated)]
+        out.push(SymbolInformation {
+            name: self.name.clone(),
+            kind: self.kind,
+            tags: None,
+            deprecated: None,
+            location: Location {
+                uri: uri.clone(),
+                range: to_range(text, index, self.span),
+            },
+            container_name: container.map(str::to_string),
+        });
+        for child in &self.children {
+            child.flatten(text, index, uri, Some(&self.name), out);
+        }
+    }
+}
+
+fn collect(text: &str, node: &TemplateNode<'_>, out: &mut Vec<Symbol>) {
+    let node = view(node);
+    let (name, kind, selection) = match node.kind {
+        Kind::Element(tag) => (
+            element_name(tag, node.attributes),
+            SymbolKind::FIELD,
+            node.name_span.unwrap_or(node.span()),
+        ),
+        Kind::Block(Block::Snippet) => {
+            let selection = node.name_span.unwrap_or(node.span());
+            (
+                text[selection.0 as usize..selection.1 as usize].to_string(),
+                SymbolKind::FUNCTION,
+                selection,
+            )
+        }
+        Kind::Block(_) => {
+            let header = (node.start, header_end(text, node.start, node.end));
+            (header_name(text, header), SymbolKind::NAMESPACE, header)
+        }
+        // Text, comments and `{…}` tags are content, not structure.
+        Kind::Comment | Kind::Leaf => return,
+    };
+
+    let mut children = Vec::new();
+    for fragment in node.fragments() {
+        for child in &fragment.nodes {
+            collect(text, child, &mut children);
+        }
+    }
+    out.push(Symbol {
+        name,
+        kind,
+        span: node.span(),
+        selection,
+        children,
+    });
+}
+
+/// `tag#id.class`, the naming `vscode-html-languageservice` uses and therefore
+/// the one the official server's outline shows.
+fn element_name(tag: &str, attributes: &[Attribute<'_>]) -> String {
+    let mut name = tag.to_string();
+    if let Some(id) = static_attribute(attributes, "id") {
+        name.push('#');
+        name.push_str(id);
+    }
+    if let Some(classes) = static_attribute(attributes, "class") {
+        for class in classes.split_whitespace() {
+            name.push('.');
+            name.push_str(class);
+        }
+    }
+    name
+}
+
+/// The value of an attribute that is plain text — anything interpolated has no
+/// one value to name the element after.
+fn static_attribute<'a>(attributes: &'a [Attribute<'a>], name: &str) -> Option<&'a str> {
+    attributes.iter().find_map(|attribute| {
+        let Attribute::Attribute(attribute) = attribute else {
+            return None;
+        };
+        if attribute.name != name {
+            return None;
+        }
+        match &attribute.value {
+            AttributeValue::Sequence(parts) => match parts.as_slice() {
+                [AttributeValuePart::Text(text)] => Some(text.data.as_ref()),
+                _ => None,
+            },
+            _ => None,
+        }
+    })
+}
+
+/// Where a block's opening tag ends, so `{#each items as item}` names the
+/// block and its body does not.
+fn header_end(text: &str, start: u32, end: u32) -> u32 {
+    let header = skip_braces(text, start as usize) as u32;
+    header.min(end)
+}
+
+fn header_name(text: &str, (start, end): Span) -> String {
+    let header: Vec<&str> = text[start as usize..end as usize]
+        .split_whitespace()
+        .collect();
+    let header = header.join(" ");
+    if header.chars().count() <= HEADER_LIMIT {
+        return header;
+    }
+    header
+        .chars()
+        .take(HEADER_LIMIT - 1)
+        .chain(std::iter::once('…'))
+        .collect()
+}
+
+fn script_name(script: &Script<'_>) -> String {
+    match script.context {
+        ScriptContext::Module => "script module".to_string(),
+        ScriptContext::Default => "script".to_string(),
+    }
+}
+
+fn tag_name_span(start: u32, tag: &str) -> Span {
+    (start + 1, start + 1 + tag.len() as u32)
+}
+
+fn to_range(text: &str, index: &LineIndex, (start, end): Span) -> Range {
+    Range::new(
+        index.position(text, start as usize),
+        index.position(text, end as usize),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn uri() -> Uri {
+        Uri::from_str("file:///App.svelte").unwrap()
+    }
+
+    fn nested(text: &str) -> Vec<DocumentSymbol> {
+        match document_symbols(text, &uri(), true) {
+            DocumentSymbolResponse::Nested(symbols) => symbols,
+            DocumentSymbolResponse::Flat(_) => panic!("asked for a tree"),
+        }
+    }
+
+    fn flat(text: &str) -> Vec<SymbolInformation> {
+        match document_symbols(text, &uri(), false) {
+            DocumentSymbolResponse::Flat(symbols) => symbols,
+            DocumentSymbolResponse::Nested(_) => panic!("asked for a list"),
+        }
+    }
+
+    /// Every symbol's name, indented by its depth.
+    fn outline(symbols: &[DocumentSymbol]) -> Vec<String> {
+        fn walk(symbols: &[DocumentSymbol], depth: usize, out: &mut Vec<String>) {
+            for symbol in symbols {
+                out.push(format!("{}{}", "  ".repeat(depth), symbol.name));
+                walk(symbol.children.as_deref().unwrap_or(&[]), depth + 1, out);
+            }
+        }
+        let mut out = Vec::new();
+        walk(symbols, 0, &mut out);
+        out
+    }
+
+    #[test]
+    fn elements_are_named_like_the_official_outline() {
+        let symbols = nested("<div id=\"main\" class=\"a b\"><span/></div>");
+        assert_eq!(outline(&symbols), vec!["div#main.a.b", "  span"]);
+        assert_eq!(symbols[0].kind, SymbolKind::FIELD);
+    }
+
+    #[test]
+    fn an_interpolated_class_does_not_name_the_element() {
+        assert_eq!(outline(&nested("<div class={a}></div>")), vec!["div"]);
+        assert_eq!(outline(&nested("<div class=\"a {b}\"></div>")), vec!["div"]);
+    }
+
+    #[test]
+    fn scripts_styles_components_and_blocks_all_show_up() {
+        let text = concat!(
+            "<script module>let a;</script>\n",
+            "<script>let b;</script>\n",
+            "<Widget prop={1}>\n",
+            "  {#if a}\n",
+            "    <p>x</p>\n",
+            "  {/if}\n",
+            "</Widget>\n",
+            "<style>p{color:red}</style>\n",
+        );
+        assert_eq!(
+            outline(&nested(text)),
+            vec![
+                "script module",
+                "script",
+                "Widget",
+                "  {#if a}",
+                "    p",
+                "style",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_snippet_is_named_after_itself() {
+        let symbols = nested("{#snippet row(item)}<p>{item}</p>{/snippet}");
+        assert_eq!(outline(&symbols), vec!["row", "  p"]);
+        assert_eq!(symbols[0].kind, SymbolKind::FUNCTION);
+        // The selection lands on the name, not on the whole block.
+        assert_eq!(
+            symbols[0].selection_range,
+            Range::new(
+                lsp_types::Position::new(0, 10),
+                lsp_types::Position::new(0, 13)
+            )
+        );
+    }
+
+    #[test]
+    fn every_block_kind_is_named_by_its_opening_tag() {
+        for (text, name) in [
+            ("{#if a}x{/if}", "{#if a}"),
+            ("{#each items as item}x{/each}", "{#each items as item}"),
+            ("{#await p}x{/await}", "{#await p}"),
+            ("{#key a}x{/key}", "{#key a}"),
+        ] {
+            assert_eq!(outline(&nested(text)), vec![name.to_string()]);
+        }
+    }
+
+    #[test]
+    fn an_each_over_a_destructured_context_keeps_its_braces() {
+        assert_eq!(
+            outline(&nested("{#each items as { a, b }}x{/each}")),
+            vec!["{#each items as { a, b }}"]
+        );
+    }
+
+    #[test]
+    fn a_long_header_is_cut_short() {
+        let text = format!("{{#if {}}}x{{/if}}", "a".repeat(200));
+        let symbols = nested(&text);
+        assert_eq!(symbols[0].name.chars().count(), HEADER_LIMIT);
+        assert!(symbols[0].name.ends_with('…'));
+    }
+
+    #[test]
+    fn a_multi_line_header_reads_as_one_line() {
+        assert_eq!(
+            outline(&nested("{#if a\n  && b}x{/if}")),
+            vec!["{#if a && b}"]
+        );
+    }
+
+    #[test]
+    fn a_flat_client_gets_the_nesting_as_container_names() {
+        let symbols = flat("<div><span>{#if a}<p>x</p>{/if}</span></div>");
+        let names: Vec<(&str, Option<&str>)> = symbols
+            .iter()
+            .map(|symbol| (symbol.name.as_str(), symbol.container_name.as_deref()))
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                ("div", None),
+                ("span", Some("div")),
+                ("{#if a}", Some("span")),
+                ("p", Some("{#if a}")),
+            ]
+        );
+        assert_eq!(symbols[0].location.uri, uri());
+    }
+
+    #[test]
+    fn the_selection_range_is_inside_the_range() {
+        fn check(symbols: &[DocumentSymbol]) {
+            for symbol in symbols {
+                assert!(
+                    symbol.range.start <= symbol.selection_range.start
+                        && symbol.selection_range.end <= symbol.range.end,
+                    "{}: {:?} outside {:?}",
+                    symbol.name,
+                    symbol.selection_range,
+                    symbol.range
+                );
+                check(symbol.children.as_deref().unwrap_or(&[]));
+            }
+        }
+        check(&nested(
+            "<script>let a;</script>\n<div>{#each a as b}<p>{b}</p>{/each}</div>\n<style>p{}</style>",
+        ));
+    }
+
+    #[test]
+    fn ranges_are_measured_in_utf16() {
+        let symbols = nested("<p>💡</p>");
+        assert_eq!(
+            symbols[0].range,
+            Range::new(
+                lsp_types::Position::new(0, 0),
+                lsp_types::Position::new(0, 9)
+            )
+        );
+    }
+
+    #[test]
+    fn an_unclosed_element_still_has_an_outline() {
+        assert_eq!(outline(&nested("<div>\n  <p>hi\n")), vec!["div", "  p"]);
+    }
+
+    #[test]
+    fn no_input_panics() {
+        for text in crate::nodes::tests_support::BROKEN {
+            let symbols = nested(text);
+            let index = LineIndex::new(text);
+            let last = index.position(text, text.len());
+            for symbol in &symbols {
+                assert!(symbol.range.end <= last, "{text:?}: {symbol:?}");
+            }
+            assert_eq!(flat(text).len(), outline(&symbols).len(), "{text:?}");
+        }
+    }
+
+    #[test]
+    fn an_unreadable_document_has_no_outline() {
+        // A stray closing tag is one of the few things loose parsing still
+        // refuses; a half-written script is not.
+        assert!(nested("<div>x</div>\n</span>").is_empty());
+        assert!(nested("").is_empty());
+        assert_eq!(
+            outline(&nested("<script>const a = {\n</script><p>x</p>")),
+            vec!["script", "p"]
+        );
+    }
+}

--- a/crates/rsvelte_language_server/src/text.rs
+++ b/crates/rsvelte_language_server/src/text.rs
@@ -41,6 +41,19 @@ impl LineIndex {
         self.line_starts.len()
     }
 
+    /// The content of one line, without its terminator. Out-of-range lines are
+    /// empty.
+    pub fn line_text<'a>(&self, text: &'a str, line: usize) -> &'a str {
+        let Some(&start) = self.line_starts.get(line) else {
+            return "";
+        };
+        let end = self
+            .line_starts
+            .get(line + 1)
+            .map_or(text.len(), |&n| n as usize);
+        strip_line_terminator(&text[start as usize..end])
+    }
+
     /// The byte offset `position` refers to. Out-of-range lines clamp to the
     /// end of the text and out-of-range characters to the end of their line's
     /// content; a character landing inside a surrogate pair rounds down to the
@@ -177,6 +190,16 @@ mod tests {
         assert_eq!(position(text, 999), Position::new(1, 2));
         // Mid-character offsets round down rather than panic.
         assert_eq!(position("💡", 2), Position::new(0, 0));
+    }
+
+    #[test]
+    fn line_text_drops_the_terminator() {
+        let text = "a\r\nbé\nc";
+        let index = LineIndex::new(text);
+        assert_eq!(index.line_text(text, 0), "a");
+        assert_eq!(index.line_text(text, 1), "bé");
+        assert_eq!(index.line_text(text, 2), "c");
+        assert_eq!(index.line_text(text, 3), "");
     }
 
     #[test]

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -17,7 +17,10 @@ use std::thread::JoinHandle;
 
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use lsp_server::RequestId;
-use lsp_types::{CodeActionOrCommand, CompletionList, Diagnostic, Hover, Range, TextEdit, Uri};
+use lsp_types::{
+    CodeActionOrCommand, CompletionList, Diagnostic, DocumentSymbolResponse, FoldingRange, Hover,
+    Range, SelectionRange, TextEdit, Uri,
+};
 
 use crate::format::FormatSessions;
 use crate::lint::LintConfigCache;
@@ -63,6 +66,25 @@ pub enum Job {
         text: Arc<String>,
         diagnostics: Vec<Diagnostic>,
     },
+    FoldingRange {
+        id: RequestId,
+        path: PathBuf,
+        text: Arc<String>,
+        line_folding_only: bool,
+    },
+    SelectionRange {
+        id: RequestId,
+        path: PathBuf,
+        text: Arc<String>,
+        offsets: Vec<usize>,
+    },
+    DocumentSymbol {
+        id: RequestId,
+        uri: Uri,
+        path: PathBuf,
+        text: Arc<String>,
+        hierarchical: bool,
+    },
     /// Drop the resolved `rsvelte-lint.json` / `.oxfmtrc` caches so the next
     /// job re-reads them from disk.
     ClearCaches,
@@ -90,6 +112,18 @@ pub enum Outcome {
     CodeActions {
         id: RequestId,
         actions: Vec<CodeActionOrCommand>,
+    },
+    FoldingRanges {
+        id: RequestId,
+        ranges: Vec<FoldingRange>,
+    },
+    SelectionRanges {
+        id: RequestId,
+        ranges: Option<Vec<SelectionRange>>,
+    },
+    DocumentSymbols {
+        id: RequestId,
+        symbols: DocumentSymbolResponse,
     },
 }
 
@@ -207,6 +241,43 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 .unwrap_or_default();
                 Outcome::CodeActions { id, actions }
             }
+            Job::FoldingRange {
+                id,
+                path,
+                text,
+                line_folding_only,
+            } => Outcome::FoldingRanges {
+                id,
+                ranges: guard("folding range", &path, || {
+                    crate::folding::folding_ranges(&text, line_folding_only)
+                })
+                .unwrap_or_default(),
+            },
+            Job::SelectionRange {
+                id,
+                path,
+                text,
+                offsets,
+            } => Outcome::SelectionRanges {
+                id,
+                ranges: guard("selection range", &path, || {
+                    crate::selection_ranges::selection_ranges(&text, &offsets)
+                })
+                .flatten(),
+            },
+            Job::DocumentSymbol {
+                id,
+                uri,
+                path,
+                text,
+                hierarchical,
+            } => Outcome::DocumentSymbols {
+                id,
+                symbols: guard("document symbol", &path, || {
+                    crate::symbols::document_symbols(&text, &uri, hierarchical)
+                })
+                .unwrap_or_else(|| DocumentSymbolResponse::Nested(Vec::new())),
+            },
         };
         if outcomes.send(outcome).is_err() {
             break;

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -156,6 +156,30 @@ impl Server {
         self.response(id)
     }
 
+    fn folding_ranges(&mut self, uri: &str) -> Vec<Value> {
+        let id = self.request(
+            "textDocument/foldingRange",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        self.response(id).as_array().cloned().unwrap_or_default()
+    }
+
+    fn selection_ranges(&mut self, uri: &str, positions: Value) -> Value {
+        let id = self.request(
+            "textDocument/selectionRange",
+            json!({ "textDocument": { "uri": uri }, "positions": positions }),
+        );
+        self.response(id)
+    }
+
+    fn document_symbols(&mut self, uri: &str) -> Vec<Value> {
+        let id = self.request(
+            "textDocument/documentSymbol",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        self.response(id).as_array().cloned().unwrap_or_default()
+    }
+
     fn hover(&mut self, uri: &str, line: u32, character: u32) -> Value {
         let id = self.request(
             "textDocument/hover",
@@ -302,6 +326,50 @@ fn initialized_server() -> Server {
     server.notify("initialized", json!({}));
     server
 }
+
+/// The same, with `textDocument` capabilities of the client's choosing, and the
+/// capabilities the server answered with.
+fn server_with(text_document: Value) -> (Server, Value) {
+    let mut server = Server::start();
+    let id = server.request(
+        "initialize",
+        json!({
+            "processId": Value::Null,
+            "rootUri": Value::Null,
+            "capabilities": {
+                "workspace": { "configuration": true },
+                "textDocument": text_document,
+            },
+        }),
+    );
+    let capabilities = server.response(id)["capabilities"].clone();
+    server.notify("initialized", json!({}));
+    (server, capabilities)
+}
+
+/// A component with something for each of the structure providers to find.
+const STRUCTURED: &str = concat!(
+    "<script>\n",
+    "  import { onMount } from 'svelte';\n",
+    "  import { get } from 'svelte/store';\n",
+    "\n",
+    "  let value = 1;\n",
+    "</script>\n",
+    "\n",
+    "<!-- #region layout -->\n",
+    "<div class=\"wrap\">\n",
+    "  {#each [1, 2] as n}\n",
+    "    <p title=\"row\">{n}</p>\n",
+    "  {/each}\n",
+    "</div>\n",
+    "<!-- #endregion -->\n",
+    "\n",
+    "<style>\n",
+    "  .wrap {\n",
+    "    color: red;\n",
+    "  }\n",
+    "</style>\n",
+);
 
 fn did_open(server: &mut Server, uri: &str, text: &str) {
     server.notify(
@@ -780,6 +848,218 @@ fn a_config_change_invalidates_the_resolved_lint_config() {
     // The re-lint re-reads the config from disk rather than serving the one it
     // resolved on open, so the rule is gone.
     server.diagnostics_matching(&uri, |d| !reports_at_html(d));
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+/// What a VS Code-like client — folding whole lines, reading a symbol tree —
+/// gets for a component with elements, blocks, regions, imports and both
+/// embedded languages.
+#[test]
+fn serves_folding_selection_and_symbols() {
+    let dir = temp_dir("structure");
+    let uri = file_uri(&dir.join("App.svelte"));
+    let (mut server, capabilities) = server_with(json!({
+        "foldingRange": { "lineFoldingOnly": true },
+        "documentSymbol": { "hierarchicalDocumentSymbolSupport": true },
+    }));
+    assert_eq!(capabilities["foldingRangeProvider"], json!(true));
+    assert_eq!(capabilities["selectionRangeProvider"], json!(true));
+    assert_eq!(capabilities["documentSymbolProvider"], json!(true));
+
+    did_open(&mut server, &uri, STRUCTURED);
+
+    let mut folds = server.folding_ranges(&uri);
+    folds.sort_by_key(|fold| fold["startLine"].as_u64().unwrap());
+    assert_eq!(
+        folds,
+        json!([
+            // The `<script>`, ending on the line before `</script>`.
+            { "startLine": 0, "endLine": 4 },
+            { "startLine": 1, "endLine": 2, "kind": "imports" },
+            { "startLine": 7, "endLine": 13, "kind": "region" },
+            { "startLine": 8, "endLine": 11 },
+            { "startLine": 9, "endLine": 10 },
+            { "startLine": 15, "endLine": 18 },
+            // The `<style>` body, folded by indentation.
+            { "startLine": 16, "endLine": 17 },
+        ])
+        .as_array()
+        .unwrap()
+        .clone(),
+        "a line-folding client gets lines only, and one fold per line"
+    );
+
+    // The cursor inside `title="row"` on the `<p>`.
+    let ranges = server.selection_ranges(&uri, json!([{ "line": 10, "character": 15 }]));
+    let ranges = ranges.as_array().expect("one range per position");
+    assert_eq!(ranges.len(), 1);
+    let mut chain = Vec::new();
+    let mut node = &ranges[0];
+    loop {
+        chain.push(node["range"].clone());
+        match node.get("parent") {
+            Some(parent) if !parent.is_null() => node = parent,
+            _ => break,
+        }
+    }
+    assert_eq!(
+        chain,
+        vec![
+            json!({ "start": { "line": 10, "character": 14 }, "end": { "line": 10, "character": 17 } }),
+            json!({ "start": { "line": 10, "character": 7 }, "end": { "line": 10, "character": 18 } }),
+            json!({ "start": { "line": 10, "character": 4 }, "end": { "line": 10, "character": 19 } }),
+            json!({ "start": { "line": 10, "character": 4 }, "end": { "line": 10, "character": 26 } }),
+            json!({ "start": { "line": 9, "character": 2 }, "end": { "line": 11, "character": 9 } }),
+            json!({ "start": { "line": 8, "character": 0 }, "end": { "line": 12, "character": 6 } }),
+        ],
+        "value, attribute, start tag, element, each block, div"
+    );
+
+    let symbols = server.document_symbols(&uri);
+    let names: Vec<Value> = symbols.iter().map(|s| s["name"].clone()).collect();
+    assert_eq!(
+        names,
+        json!(["script", "div.wrap", "style"])
+            .as_array()
+            .unwrap()
+            .clone()
+    );
+    let each = &symbols[1]["children"][0];
+    assert_eq!(each["name"], json!("{#each [1, 2] as n}"));
+    // 3 == SymbolKind.Namespace, 8 == SymbolKind.Field
+    assert_eq!(each["kind"], json!(3));
+    assert_eq!(each["children"][0]["name"], json!("p"));
+    assert_eq!(each["children"][0]["kind"], json!(8));
+    assert!(
+        symbols[0]["location"].is_null(),
+        "a tree carries ranges, not locations"
+    );
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+/// A client that declares neither capability gets folding ranges with
+/// characters and a flat `SymbolInformation` list.
+#[test]
+fn a_client_without_the_modern_capabilities_is_served_the_old_shapes() {
+    let dir = temp_dir("structure-flat");
+    let path = dir.join("App.svelte");
+    let uri = file_uri(&path);
+    let (mut server, _) = server_with(json!({}));
+    did_open(&mut server, &uri, STRUCTURED);
+
+    let folds = server.folding_ranges(&uri);
+    let script = folds
+        .iter()
+        .find(|fold| fold["startLine"] == json!(0))
+        .expect("the script folds");
+    assert_eq!(
+        *script,
+        json!({
+            "startLine": 0,
+            "startCharacter": 0,
+            "endLine": 5,
+            "endCharacter": 9,
+        }),
+        "without lineFoldingOnly the whole span is reported"
+    );
+
+    let symbols = server.document_symbols(&uri);
+    let flat: Vec<(Value, Value)> = symbols
+        .iter()
+        .map(|s| (s["name"].clone(), s["containerName"].clone()))
+        .collect();
+    assert_eq!(
+        flat,
+        vec![
+            (json!("script"), Value::Null),
+            (json!("div.wrap"), Value::Null),
+            (json!("{#each [1, 2] as n}"), json!("div.wrap")),
+            (json!("p"), json!("{#each [1, 2] as n}")),
+            (json!("style"), Value::Null),
+        ]
+    );
+    assert_eq!(symbols[0]["location"]["uri"], json!(uri));
+    assert!(
+        symbols[0]["children"].is_null(),
+        "a flat list has no children"
+    );
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+/// The three `rsvelte.*` switches, and the shapes a switched-off provider still
+/// has to answer with.
+#[test]
+fn the_settings_switch_the_structure_providers_off() {
+    let dir = temp_dir("structure-disabled");
+    let uri = file_uri(&dir.join("App.svelte"));
+
+    let mut server = Server::start();
+    server.settings = json!({
+        "foldingRange": { "enable": false },
+        "selectionRange": { "enable": false },
+        "documentSymbol": { "enable": false },
+    });
+    let id = server.request(
+        "initialize",
+        json!({
+            "processId": Value::Null,
+            "rootUri": Value::Null,
+            "capabilities": { "workspace": { "configuration": true } },
+        }),
+    );
+    server.response(id);
+    server.notify("initialized", json!({}));
+    server.settle_configuration();
+    did_open(&mut server, &uri, STRUCTURED);
+
+    assert_eq!(server.folding_ranges(&uri), Vec::<Value>::new());
+    assert_eq!(
+        server.selection_ranges(&uri, json!([{ "line": 10, "character": 15 }])),
+        Value::Null
+    );
+    assert_eq!(server.document_symbols(&uri), Vec::<Value>::new());
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+/// A half-written or pathological document must cost at most an empty answer.
+#[test]
+fn the_structure_providers_survive_documents_that_do_not_parse() {
+    let dir = temp_dir("structure-broken");
+    let mut server = initialized_server();
+
+    for (name, text) in [
+        ("stray-close", "<div>x</div>\n</span>".to_string()),
+        ("half-block", "<p>💡</p>\n{#each items as ".to_string()),
+        (
+            "half-script",
+            "<script>\n  const a = {\n</script>".to_string(),
+        ),
+        (
+            "deep",
+            format!("{}{}", "<div>\n".repeat(300), "</div>\n".repeat(300)),
+        ),
+    ] {
+        let uri = file_uri(&dir.join(format!("{name}.svelte")));
+        did_open(&mut server, &uri, &text);
+        // Every one of these must come back, whatever it comes back with.
+        server.folding_ranges(&uri);
+        server.document_symbols(&uri);
+        server.selection_ranges(&uri, json!([{ "line": 1, "character": 1 }]));
+        assert!(server.is_alive(), "server died on {name}");
+    }
+
+    // An unknown document is answered too, rather than left pending.
+    let missing = file_uri(&dir.join("Missing.svelte"));
+    assert_eq!(server.folding_ranges(&missing), Vec::<Value>::new());
+    assert_eq!(server.document_symbols(&missing), Vec::<Value>::new());
+    assert_eq!(
+        server.selection_ranges(&missing, json!([{ "line": 0, "character": 0 }])),
+        Value::Null
+    );
 
     assert_eq!(server.shutdown(), Some(0));
 }


### PR DESCRIPTION
Third slice of Wave 4 M1: the three providers the Svelte AST can answer on its own, all dispatched through `Job`/`Outcome` onto the analysis worker (256 MiB stack, `catch_unwind`) so neither a deep document nor a panicking walk can reach the message loop. Every position goes through the existing `LineIndex`, so UTF-16 columns are correct for emoji and other multi-byte text.

New modules: `nodes.rs` (one uniform view over the 30 template-node variants, plus the shared `loose` parse), `folding.rs`, `indent_folding.rs` (a port of upstream's `lib/foldingRange/indentFolding.ts`), `selection_ranges.rs`, `symbols.rs`. Settings switches `rsvelte.foldingRange.enable` / `rsvelte.selectionRange.enable` / `rsvelte.documentSymbol.enable` follow the existing `{ "enable": bool }` shape.

## `textDocument/foldingRange`

Same as upstream (`plugins/html/getFoldingRanges.ts`):

- element folds run node start → node end, and a `lineFoldingOnly` client gets `max(endLine - 1, startLine)` so the closing tag stays visible, while `comment` / `region` folds keep their end line. Getting this convention wrong is exactly what makes a collapsed element look different, so it is reproduced literally.
- one fold per start line for a `lineFoldingOnly` client, with the **innermost** winning (children are walked before their parent, first writer wins on a line) — this is what makes `<be><div>` on one line fold as the `div`.
- the `#region` / `#endregion` stack, including upstream's overlap suppression: an element whose frame a `#endregion` popped emits no fold, and a `#region` a container outlives is dropped. Both upstream cases are ported (`a_region_interrupted_by_its_container_loses_the_container_fold`, `a_region_a_container_outlives_is_dropped`).
- `<script>` / `<style>` bodies fold by indentation, as upstream does while its TS/CSS services own the contents.

Deliberately different:

- **blocks fold.** `{#if}` `{#each}` `{#await}` `{#key}` `{#snippet}` are real nodes here, so they fold like elements. Upstream only gets this via svelte2tsx inside its TypeScript provider, which is out of scope for this PR.
- **comments and region markers come from AST nodes**, not from a re-scan of the text with an HTML scanner. Same lines; the offsets of a `comment` fold cover the whole `<!-- … -->` instead of only its inner text, which only a client folding by character can observe.
- **`#endregion` must be a prefix of the comment** (after trimming). Upstream's `/^\s*#(region\b)|(endregion\b)/` binds the alternation so the second branch is unanchored and `<!-- mind the endregion -->` counts as one; that looked like a bug worth not copying.
- **`imports` folds from our own parse.** Upstream's `imports` kind comes from `ts.getOutliningSpans`; TypeScript is out of scope, so the leading run of `ImportDeclaration`s in `<script>` is read off the parsed program instead. That keeps the kind set (`comment` / `region` / `imports`) complete without pulling TS in.
- **a document the parser refuses folds by indentation** rather than losing every fold the editor had already drawn. Upstream never needs this for the template because its HTML parser is error-tolerant; ours is tolerant too (`loose: true`, the same mode the official server compiles in), so the fallback is rare — a stray `</span>` is one of the few things that still reaches it.

## `textDocument/selectionRange`

Upstream's chain is attribute value → attribute → element, and that is reproduced (its `<h1 title="foo|"></h1>` and `{#if a > 1}|foo{/if}` cases are ported). Deliberately finer:

- **a start-tag step** between attribute and element, so an attribute grows to the whole opener before it grows to the element. Upstream's AST has no such node; the tag end is found by scanning past the last attribute. A self-closing element gets no duplicate step (equal consecutive spans collapse).
- **expression steps**: a block's test/iterable and an interpolation's expression are their own level. Sub-expressions are *not* walked — upstream's estree walk gives finer steps *inside* an expression than we do, the one place this is coarser. Doing better means walking `JsNode` through the parse arena, deliberately left out of this PR.
- positions inside `<script>` / `<style>` are answered with nothing, matching upstream — those contents belong to the future TypeScript/CSS providers. When *no* requested position has a chain the response is `null`, so the editor falls back to its own word/bracket expansion; when only some do, the rest collapse to the cursor (what upstream's `PluginHost` does).

## `textDocument/documentSymbol`

What is a symbol, and why:

| Symbol | Kind | Why |
|---|---|---|
| elements, components, `svelte:*`, `slot`, `title` | `Field` | `tag#id.class` naming and `Field` are what `vscode-html-languageservice` — and therefore the official outline — produces, so the shared part of the outline looks unchanged. Only statically known `id` / `class` values are used; an interpolated value names nothing. |
| `<script>`, `<script module>`, `<style>` | `Module` | They are the module-level chunks of a component, and naming them `script` / `script module` / `style` makes the two scripts distinguishable at a glance. |
| `{#if}` `{#each}` `{#await}` `{#key}` | `Namespace` | Containers, named by their opening tag (`{#each items as item}`), whitespace-collapsed and cut at 60 characters — that is the text a reader scans an outline for. |
| `{#snippet}` | `Function` | A snippet is a named callable, so the symbol is named after it (`row`, not `{#snippet row(item)}`) and the selection range lands on the name, which is what makes it findable in an outline filter. |

Text, comments and `{…}` tags are content rather than structure and are left out to keep the outline readable. `selection_range` is always the name (tag name, snippet name, block header) and always inside `range`, asserted by a test.

**Clients without `hierarchicalDocumentSymbolSupport`** get `SymbolInformation` with `containerName` carrying the nesting, mirroring how upstream's `server.ts` branches on the same capability (`hierarchicalDocumentSymbolSupport` → `getHierarchicalDocumentSymbols`). The tree is built first and flattened, rather than upstream's flatten-then-reconstruct-by-range.

## Tests

66 new unit tests and 4 new integration cases — 164 unit + 14 integration in total, with nothing existing changed:

- folding: the ported vscode-html-languageservice cases (one/two levels, siblings, self-closing, comments, regions, both intersecting-region cases), every Svelte block, script/style bodies, imports, `lineFoldingOnly` on and off, emoji, CRLF.
- selection ranges: the two ported upstream cases, nesting, interpolated attribute values, directives, self-closing elements, several positions at once, emoji.
- symbols: naming, all block kinds, snippets, the flat fallback, `selection_range ⊆ range`, emoji.
- **broken input**: a shared list of 25 half-written documents (`{#`, `<div\n attr="`, stray `</span>`, unterminated comment, broken TS, `<style lang="scss">`, emoji + CJK) runs through all three providers, and selection ranges are additionally probed at *every* offset of each. This was verified by running it, not by inspection: the parser accepts nearly all of them in `loose` mode, which is why the initial assumption that a half-written `<script>` kills the parse was wrong and the tests now say what actually happens.
- integration (real binary over stdio): the folding/selection/symbol answers for one component under a VS Code-like client, the flat and character-based shapes for a client declaring neither capability, the three settings switches, and a pathological/unparseable set (300-deep nesting, stray close tag, half-written block) after which the server is still alive and an unknown document still gets an answer instead of a hang.

Not covered: no test pins a character-folding client *and* interleaved region markers together; upstream's "fold incomplete" cases could not be ported verbatim because the Svelte parser recovers differently from an HTML one.

Refs #1762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tsoBsfzrKu4kfbfrdFYJS
