### PR TITLE
test: fail fixture suites that measure nothing (#1791 items 3, 4)

### DIFF
--- a/crates/rsvelte_core/tests/common/mod.rs
+++ b/crates/rsvelte_core/tests/common/mod.rs
@@ -205,6 +205,122 @@ pub fn get_svelte_test_samples(category: &str) -> Vec<PathBuf> {
 }
 
 // ============================================================================
+// Fixture coverage guards
+// ============================================================================
+
+/// Why a discovered sample directory did not yield a runnable fixture.
+#[derive(Debug, Clone, Copy)]
+pub enum SkipReason {
+    /// Legitimate: the sample opts out via `_config.js`, sits on a suite's
+    /// documented skip list, or upstream generated no expected output for it
+    /// (the official compiler errors on the sample).
+    Justified,
+    /// A coverage hole: the loader looked for the named input file and it was
+    /// not on disk. A single upstream rename silently zeroes out a whole
+    /// category this way — `Sourcemaps 0/0` was exactly this.
+    MissingInput(&'static str),
+}
+
+/// Directory name of a sample, for coverage diagnostics.
+pub fn sample_name(sample_dir: &std::path::Path) -> &str {
+    sample_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("<unnamed>")
+}
+
+/// Ledger that turns "this suite measured nothing" into a red test.
+///
+/// libtest reports an early `return` as PASS, so a fixture suite that finds no
+/// samples — or silently drops every sample it found — is indistinguishable
+/// from a green run. Every discovered sample must be accounted for as either
+/// run or justified-skipped, and the run count carries a grow-only floor.
+pub struct FixtureCoverage {
+    what: String,
+    found: usize,
+    ran: usize,
+    justified: usize,
+    missing: Vec<String>,
+}
+
+impl FixtureCoverage {
+    pub fn new(what: impl Into<String>, found: usize) -> Self {
+        Self {
+            what: what.into(),
+            found,
+            ran: 0,
+            justified: 0,
+            missing: Vec::new(),
+        }
+    }
+
+    /// Record a sample that was actually compared against its expected output.
+    pub fn ran(&mut self) {
+        self.ran += 1;
+    }
+
+    /// Record final run / justified-skip counts in one go, for callers that
+    /// already tally their own results and only report missing inputs inline.
+    pub fn tally(&mut self, ran: usize, justified: usize) {
+        self.ran += ran;
+        self.justified += justified;
+    }
+
+    /// Record a sample dropped for the given reason.
+    pub fn skipped(&mut self, sample: &str, reason: SkipReason) {
+        match reason {
+            SkipReason::Justified => self.justified += 1,
+            SkipReason::MissingInput(wanted) => {
+                self.missing.push(format!("{sample} (no {wanted})"));
+            }
+        }
+    }
+
+    /// `min_ran` is a grow-only floor measured against the pinned Svelte
+    /// submodule. Lower it only together with a documented skip-list entry —
+    /// lowering it to make CI green defeats the whole guard.
+    #[track_caller]
+    pub fn assert(&self, min_ran: usize) {
+        let what = &self.what;
+
+        assert!(
+            self.found > 0,
+            "{what}: no sample directories were discovered. The fixture layout \
+             changed, the Svelte submodule is not initialized, or \
+             `pnpm run generate-fixtures` has not been run."
+        );
+
+        assert!(
+            self.missing.is_empty(),
+            "{what}: {} of {} sample(s) were dropped because an expected input \
+             file is missing — an upstream rename silently removes coverage \
+             this way. Fix the lookup, do not relax the guard.\n  {}",
+            self.missing.len(),
+            self.found,
+            self.missing.join("\n  ")
+        );
+
+        assert_eq!(
+            self.ran + self.justified,
+            self.found,
+            "{what}: {} of {} sample(s) were dropped without being recorded as \
+             run or justified-skipped. Some loader path returns early without \
+             telling the coverage ledger.",
+            self.found.saturating_sub(self.ran + self.justified),
+            self.found
+        );
+
+        assert!(
+            self.ran >= min_ran,
+            "{what}: only {} fixture(s) ran, floor is {min_ran}. This floor is \
+             grow-only — find the samples that stopped running; lower it only \
+             alongside a documented skip-list entry, never to make CI green.",
+            self.ran
+        );
+    }
+}
+
+// ============================================================================
 // Normalization utilities
 // ============================================================================
 

--- a/crates/rsvelte_core/tests/compatibility_report.rs
+++ b/crates/rsvelte_core/tests/compatibility_report.rs
@@ -12,14 +12,41 @@ mod common;
 use std::fs;
 
 use common::{
-    CategoryResult, CompatibilityReport, SampleDetails, SampleResult, TestCategory, TestStatus,
-    canonicalize_css, compare_js, ensure_fixtures_exist, fixtures_path, get_fixture_samples,
-    get_svelte_test_samples, load_fixture_output, svelte_path, write_actual_output,
+    CategoryResult, CompatibilityReport, FixtureCoverage, SampleDetails, SampleResult, SkipReason,
+    TestCategory, TestStatus, canonicalize_css, compare_js, ensure_fixtures_exist, fixtures_path,
+    get_fixture_samples, get_svelte_test_samples, load_fixture_output, svelte_path,
+    write_actual_output,
 };
 use rsvelte_core::{
     CompileOptions, ExperimentalOptions, GenerateMode, ModuleCompileOptions, ParseOptions, compile,
     compile_module, compiler::CssMode, convert_to_legacy, parse,
 };
+
+/// Grow-only per-category fixture floors, measured against the pinned Svelte
+/// submodule. Every discovered sample must end up either compared or recorded
+/// as a justified skip; these floors additionally catch a category quietly
+/// shrinking. Raise them when upstream adds samples; never lower them.
+fn min_fixtures(category: &str) -> usize {
+    match category {
+        "parser-modern" => 27,
+        "parser-legacy" => 81,
+        "snapshot" => 30,
+        "css" => 181,
+        "validator" => 333,
+        "compiler-errors" => 145,
+        "runtime-runes" => 1008,
+        "runtime-legacy" => 1206,
+        "runtime-browser" => 32,
+        "hydration" => 80,
+        "server-side-rendering" => 99,
+        "sourcemaps" => 29,
+        "print" => 43,
+        "preprocess" => 19,
+        // Out-of-scope categories are reported as fully skipped.
+        "migrate" => 0,
+        other => panic!("no fixture floor recorded for category `{other}`"),
+    }
+}
 
 // ============================================================================
 // Parser Tests
@@ -29,6 +56,7 @@ fn run_parser_tests(category: TestCategory, modern: bool) -> CategoryResult {
     let svelte_dir = category.svelte_dir();
     let samples = get_svelte_test_samples(svelte_dir);
     let mut result = CategoryResult::new(svelte_dir);
+    let mut coverage = FixtureCoverage::new(svelte_dir, samples.len());
 
     // Tests to skip for parser-legacy and parser-modern.
     //
@@ -71,18 +99,20 @@ fn run_parser_tests(category: TestCategory, modern: bool) -> CategoryResult {
         let input_path = sample_dir.join("input.svelte");
         let output_path = sample_dir.join("output.json");
 
-        if !input_path.exists() || !output_path.exists() {
-            continue;
-        }
-
         let input = match fs::read_to_string(&input_path) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("input.svelte"));
+                continue;
+            }
         };
 
         let expected = match fs::read_to_string(&output_path) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("output.json"));
+                continue;
+            }
         };
 
         let loose = name.contains("loose");
@@ -152,7 +182,17 @@ fn run_parser_tests(category: TestCategory, modern: bool) -> CategoryResult {
         }
     }
 
+    assert_coverage(&mut coverage, &result, svelte_dir);
     result
+}
+
+/// Fold a category's tallied results into its coverage ledger and enforce it.
+fn assert_coverage(coverage: &mut FixtureCoverage, result: &CategoryResult, category: &str) {
+    coverage.tally(
+        result.stats.total - result.stats.skipped,
+        result.stats.skipped,
+    );
+    coverage.assert(min_fixtures(category));
 }
 
 fn normalize_parser_json(json: &str) -> serde_json::Value {
@@ -208,6 +248,7 @@ fn run_snapshot_tests() -> CategoryResult {
 
     let samples = get_fixture_samples("snapshot");
     let mut result = CategoryResult::new("snapshot");
+    let mut coverage = FixtureCoverage::new("snapshot", samples.len());
 
     // Snapshot fixtures intentionally skipped. These exercise codegen clusters
     // tracked elsewhere in this file (and in tests/runtime.rs):
@@ -243,10 +284,6 @@ fn run_snapshot_tests() -> CategoryResult {
             .join(&name)
             .join("index.svelte");
 
-        if !input_path.exists() {
-            continue;
-        }
-
         // Check for unsupported options
         let config_path = svelte_path()
             .join("packages/svelte/tests/snapshot/samples")
@@ -262,13 +299,18 @@ fn run_snapshot_tests() -> CategoryResult {
 
         let input = match fs::read_to_string(&input_path) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("index.svelte"));
+                continue;
+            }
         };
 
         let expected_client = load_fixture_output("snapshot", &name, "client.js");
         let expected_server = load_fixture_output("snapshot", &name, "server.js");
 
+        // No generated output at all: the official compiler emitted none.
         if expected_client.is_none() && expected_server.is_none() {
+            coverage.skipped(&name, SkipReason::Justified);
             continue;
         }
 
@@ -365,6 +407,7 @@ fn run_snapshot_tests() -> CategoryResult {
         });
     }
 
+    assert_coverage(&mut coverage, &result, "snapshot");
     result
 }
 
@@ -377,6 +420,7 @@ fn run_css_tests() -> CategoryResult {
 
     let samples = get_fixture_samples("css");
     let mut result = CategoryResult::new("css");
+    let mut coverage = FixtureCoverage::new("css", samples.len());
 
     // CSS samples that exercise pruning/scoping edge cases rsvelte doesn't
     // fully match upstream on yet. Empty for now — the previous
@@ -411,13 +455,12 @@ fn run_css_tests() -> CategoryResult {
             .join(&name)
             .join("input.svelte");
 
-        if !input_path.exists() {
-            continue;
-        }
-
         let input = match fs::read_to_string(&input_path) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("input.svelte"));
+                continue;
+            }
         };
 
         let expected_css = load_fixture_output("css", &name, "css.css");
@@ -516,6 +559,7 @@ fn run_css_tests() -> CategoryResult {
         }
     }
 
+    assert_coverage(&mut coverage, &result, "css");
     result
 }
 
@@ -526,6 +570,7 @@ fn run_css_tests() -> CategoryResult {
 fn run_validator_tests() -> CategoryResult {
     let samples = get_svelte_test_samples("validator");
     let mut result = CategoryResult::new("validator");
+    let mut coverage = FixtureCoverage::new("validator", samples.len());
     let warning_code_re = regex::Regex::new(r"'(\w+)'").unwrap();
 
     for sample_dir in &samples {
@@ -557,6 +602,7 @@ fn run_validator_tests() -> CategoryResult {
         let is_module_test = module_path.exists() && !svelte_path.exists();
 
         if !svelte_path.exists() && !module_path.exists() {
+            coverage.skipped(&name, SkipReason::MissingInput("input.svelte(.js)"));
             continue;
         }
 
@@ -567,7 +613,13 @@ fn run_validator_tests() -> CategoryResult {
         };
         let input = match fs::read_to_string(input_file) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(
+                    &name,
+                    SkipReason::MissingInput("readable input.svelte(.js)"),
+                );
+                continue;
+            }
         };
 
         // Load expected warnings/errors
@@ -778,6 +830,7 @@ fn run_validator_tests() -> CategoryResult {
         }
     }
 
+    assert_coverage(&mut coverage, &result, "validator");
     result
 }
 
@@ -788,6 +841,7 @@ fn run_validator_tests() -> CategoryResult {
 fn run_compiler_error_tests() -> CategoryResult {
     let samples = get_svelte_test_samples("compiler-errors");
     let mut result = CategoryResult::new("compiler-errors");
+    let mut coverage = FixtureCoverage::new("compiler-errors", samples.len());
 
     for sample_dir in &samples {
         let name = sample_dir
@@ -800,20 +854,27 @@ fn run_compiler_error_tests() -> CategoryResult {
         let svelte_path = sample_dir.join("main.svelte");
         let module_path = sample_dir.join("main.svelte.js");
 
-        if !svelte_path.exists() && !module_path.exists() || !config_path.exists() {
+        if !svelte_path.exists() && !module_path.exists() {
+            coverage.skipped(&name, SkipReason::MissingInput("main.svelte(.js)"));
             continue;
         }
 
         let config_content = match fs::read_to_string(&config_path) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("_config.js"));
+                continue;
+            }
         };
 
         let requires_async = config_content.contains("async: true");
 
         let expected_code = match extract_error_code(&config_content) {
             Some(c) => c,
-            None => continue,
+            None => {
+                coverage.skipped(&name, SkipReason::MissingInput("error code in _config.js"));
+                continue;
+            }
         };
 
         let is_module = module_path.exists() && !svelte_path.exists();
@@ -825,7 +886,10 @@ fn run_compiler_error_tests() -> CategoryResult {
 
         let input = match fs::read_to_string(input_file) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("readable main.svelte(.js)"));
+                continue;
+            }
         };
 
         let compile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -902,6 +966,7 @@ fn run_compiler_error_tests() -> CategoryResult {
         }
     }
 
+    assert_coverage(&mut coverage, &result, "compiler-errors");
     result
 }
 
@@ -946,6 +1011,7 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
 
     let samples = get_fixture_samples(category);
     let mut result = CategoryResult::new(category);
+    let mut coverage = FixtureCoverage::new(category, samples.len());
 
     // Runtime samples whose expected output exercises infrastructure rsvelte
     // doesn't fully implement yet, so we mark them skipped instead of failing.
@@ -1076,16 +1142,36 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
             continue;
         }
 
-        let input_path = svelte_path()
+        // Most categories name their entry point `main.svelte`; the
+        // `sourcemaps` samples use `input.svelte`. Hardcoding `main.svelte`
+        // used to drop all 29 sourcemap samples silently (`Sourcemaps 0/0`).
+        let sample_root = svelte_path()
             .join("packages/svelte/tests")
             .join(category)
             .join("samples")
-            .join(&name)
-            .join("main.svelte");
-
-        if !input_path.exists() {
-            continue;
-        }
+            .join(&name);
+        let input_path = ["main.svelte", "input.svelte"]
+            .iter()
+            .map(|entry| sample_root.join(entry))
+            .find(|path| path.exists());
+        let input_path = match input_path {
+            Some(path) => path,
+            None => {
+                coverage.skipped(
+                    &name,
+                    SkipReason::MissingInput("main.svelte / input.svelte"),
+                );
+                continue;
+            }
+        };
+        // The fixtures were generated with the sample's own entry-point name,
+        // and `filename` reaches the generated code (component name, css hash),
+        // so it has to follow the resolved entry point rather than be hardcoded.
+        let input_filename = input_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("main.svelte")
+            .to_string();
 
         // Check for unsupported options
         let config_path = svelte_path()
@@ -1111,13 +1197,19 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
 
         let input = match fs::read_to_string(&input_path) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("readable entry point"));
+                continue;
+            }
         };
 
         let expected_client = load_fixture_output(category, &name, "client.js");
         let expected_server = load_fixture_output(category, &name, "server.js");
 
+        // No generated output at all: the official compiler errored on this
+        // sample, so the fixture holds only `warnings.json` / `error.json`.
         if expected_client.is_none() && expected_server.is_none() {
+            coverage.skipped(&name, SkipReason::Justified);
             continue;
         }
 
@@ -1149,7 +1241,7 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         if let Some(expected) = &expected_client {
             let options = CompileOptions {
                 generate: GenerateMode::Client,
-                filename: Some("main.svelte".to_string()),
+                filename: Some(input_filename.clone()),
                 css: CssMode::External,
                 experimental: ExperimentalOptions { r#async: use_async },
                 hmr: config_has_hmr,
@@ -1181,7 +1273,7 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         if let Some(expected) = &expected_server {
             let options = CompileOptions {
                 generate: GenerateMode::Server,
-                filename: Some("main.svelte".to_string()),
+                filename: Some(input_filename.clone()),
                 css: CssMode::External,
                 experimental: ExperimentalOptions { r#async: use_async },
                 hmr: config_has_hmr,
@@ -1227,6 +1319,7 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         });
     }
 
+    assert_coverage(&mut coverage, &result, category);
     result
 }
 
@@ -1244,6 +1337,7 @@ fn run_print_tests() -> CategoryResult {
 
     let samples = get_svelte_test_samples("print");
     let mut result = CategoryResult::new("print");
+    let mut coverage = FixtureCoverage::new("print", samples.len());
 
     // Print samples whose upstream re-formatter changed in Svelte 5.55.8
     // (upstream commit `ca3f35bf7` "fix(print): handle svelte:body and fix
@@ -1275,11 +1369,17 @@ fn run_print_tests() -> CategoryResult {
 
         let input = match fs::read_to_string(sample_dir.join("input.svelte")) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("input.svelte"));
+                continue;
+            }
         };
         let expected = match fs::read_to_string(sample_dir.join("output.svelte")) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("output.svelte"));
+                continue;
+            }
         };
 
         let options = ParseOptions {
@@ -1310,6 +1410,7 @@ fn run_print_tests() -> CategoryResult {
         });
     }
 
+    assert_coverage(&mut coverage, &result, "print");
     result
 }
 
@@ -1336,6 +1437,7 @@ fn run_preprocess_tests() -> CategoryResult {
 
     let samples = get_svelte_test_samples("preprocess");
     let mut result = CategoryResult::new("preprocess");
+    let mut coverage = FixtureCoverage::new("preprocess", samples.len());
 
     let runtime = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -1359,6 +1461,7 @@ fn run_preprocess_tests() -> CategoryResult {
                     details: None,
                 });
             }
+            assert_coverage(&mut coverage, &result, "preprocess");
             return result;
         }
     };
@@ -1372,11 +1475,17 @@ fn run_preprocess_tests() -> CategoryResult {
 
         let input = match fs::read_to_string(sample_dir.join("input.svelte")) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("input.svelte"));
+                continue;
+            }
         };
         let expected = match fs::read_to_string(sample_dir.join("output.svelte")) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                coverage.skipped(&name, SkipReason::MissingInput("output.svelte"));
+                continue;
+            }
         };
 
         let preprocessors = match common::preprocess_fixtures::build_preprocessors(&name) {
@@ -1417,12 +1526,14 @@ fn run_preprocess_tests() -> CategoryResult {
         });
     }
 
+    assert_coverage(&mut coverage, &result, "preprocess");
     result
 }
 
 fn run_not_implemented_tests(category: &str, reason: &str) -> CategoryResult {
     let samples = get_svelte_test_samples(category);
     let mut result = CategoryResult::new(category);
+    let mut coverage = FixtureCoverage::new(category, samples.len());
 
     for sample_dir in &samples {
         let name = sample_dir
@@ -1440,6 +1551,7 @@ fn run_not_implemented_tests(category: &str, reason: &str) -> CategoryResult {
         });
     }
 
+    assert_coverage(&mut coverage, &result, category);
     result
 }
 
@@ -1449,8 +1561,10 @@ fn run_not_implemented_tests(category: &str, reason: &str) -> CategoryResult {
 
 // `#[ignore]` by default: this is a *reporting* artifact, not a correctness
 // gate. It re-runs every category (parser, css, validator, runtime, …) purely
-// to assemble `compatibility-report.json`, and it deliberately never fails
-// (see the comment at the end of the body). Those categories are each already
+// to assemble `compatibility-report.json`, and it deliberately never fails on
+// output mismatches (see the comment at the end of the body) — it does still
+// fail when a category loses coverage, because a silently empty category
+// invalidates the whole report. Those categories are each already
 // gated by their own dedicated test binaries (tests/runtime.rs, tests/css.rs,
 // tests/validator.rs, …), so running this in the default `cargo test` /
 // `cargo nextest run` only duplicates ~all of the suite (it was the single

--- a/crates/rsvelte_core/tests/compiler_errors.rs
+++ b/crates/rsvelte_core/tests/compiler_errors.rs
@@ -9,12 +9,16 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 // use rayon::prelude::*;  // Disabled for sequential execution
-use common::get_svelte_test_samples;
+use common::{FixtureCoverage, SkipReason, get_svelte_test_samples, sample_name};
 use rsvelte_core::{
     CompileOptions, ExperimentalOptions, GenerateMode, ModuleCompileOptions, compile,
     compile_module,
 };
 use serde::Deserialize;
+
+/// Grow-only fixture floor, measured against the pinned Svelte submodule: all
+/// 145 compiler-error samples are runnable. Never lower it.
+const MIN_COMPILER_ERROR_FIXTURES: usize = 145;
 
 /// Get all compiler-errors test samples.
 fn get_compiler_error_samples() -> Vec<PathBuf> {
@@ -159,27 +163,37 @@ fn extract_position(content: &str) -> Option<[u32; 2]> {
 }
 
 /// Load a compiler error test fixture.
-fn load_error_fixture(sample_dir: &Path) -> Option<ErrorFixture> {
+fn load_error_fixture(sample_dir: &Path) -> Result<ErrorFixture, SkipReason> {
     let config_path = sample_dir.join("_config.js");
     let svelte_path = sample_dir.join("main.svelte");
     let module_path = sample_dir.join("main.svelte.js");
 
     // Read and parse config
-    let config_content = fs::read_to_string(&config_path).ok()?;
-    let config = parse_config(&config_content)?;
+    let config_content =
+        fs::read_to_string(&config_path).map_err(|_| SkipReason::MissingInput("_config.js"))?;
+    let config =
+        parse_config(&config_content).ok_or(SkipReason::MissingInput("parsable _config.js"))?;
 
     // Determine input type and read input
     let (input, input_type) = if svelte_path.exists() {
-        (fs::read_to_string(&svelte_path).ok()?, InputType::Svelte)
+        (
+            fs::read_to_string(&svelte_path)
+                .map_err(|_| SkipReason::MissingInput("readable main.svelte"))?,
+            InputType::Svelte,
+        )
     } else if module_path.exists() {
-        (fs::read_to_string(&module_path).ok()?, InputType::Module)
+        (
+            fs::read_to_string(&module_path)
+                .map_err(|_| SkipReason::MissingInput("readable main.svelte.js"))?,
+            InputType::Module,
+        )
     } else {
-        return None;
+        return Err(SkipReason::MissingInput("main.svelte / main.svelte.js"));
     };
 
-    let name = sample_dir.file_name()?.to_str()?.to_string();
+    let name = sample_name(sample_dir).to_string();
 
-    Some(ErrorFixture {
+    Ok(ErrorFixture {
         name,
         input,
         input_type,
@@ -296,17 +310,18 @@ fn run_error_test(fixture: &ErrorFixture) -> TestResult {
 fn test_compiler_errors() {
     let samples = get_compiler_error_samples();
 
-    if samples.is_empty() {
-        eprintln!(
-            "Warning: No compiler-errors samples found. Make sure the Svelte submodule is initialized."
-        );
-        return;
+    let mut coverage = FixtureCoverage::new("compiler-errors", samples.len());
+    let mut fixtures: Vec<ErrorFixture> = Vec::new();
+    for sample_dir in &samples {
+        match load_error_fixture(sample_dir.as_path()) {
+            Ok(fixture) => {
+                coverage.ran();
+                fixtures.push(fixture);
+            }
+            Err(reason) => coverage.skipped(sample_name(sample_dir), reason),
+        }
     }
-
-    let fixtures: Vec<ErrorFixture> = samples
-        .iter()
-        .filter_map(|sample_dir| load_error_fixture(sample_dir.as_path()))
-        .collect();
+    coverage.assert(MIN_COMPILER_ERROR_FIXTURES);
 
     // Run sequentially. Previous attempts at `par_iter()` hung; leading
     // hypothesis is bumpalo arena retention causing memory pressure on small

--- a/crates/rsvelte_core/tests/compiler_fixtures.rs
+++ b/crates/rsvelte_core/tests/compiler_fixtures.rs
@@ -9,11 +9,21 @@ use std::fs;
 use std::path::Path;
 
 use common::{
-    compare_js, ensure_fixtures_exist, get_fixture_samples, load_fixture_output, svelte_path,
-    write_actual_output,
+    FixtureCoverage, SkipReason, compare_js, ensure_fixtures_exist, get_fixture_samples,
+    load_fixture_output, svelte_path, write_actual_output,
 };
 use rayon::prelude::*;
 use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+
+/// Grow-only fixture floor, measured against the pinned Svelte submodule: 31
+/// samples minus the one on `SKIP_SNAPSHOT`. Never lower it.
+const MIN_SNAPSHOT_FIXTURES: usize = 30;
+
+/// Fixtures intentionally skipped here — they exercise codegen clusters
+/// tracked separately in tests/compatibility_report.rs and tests/runtime.rs.
+/// Running them as snapshot tests would surface already-known divergences
+/// (e.g. nested async-grouping inside `$derived` for `async-in-derived`).
+const SKIP_SNAPSHOT: &[&str] = &["async-in-derived"];
 
 /// Load input from Svelte test suite. Normalizes CRLF→LF so byte offsets
 /// in the compiled output match LF-authored fixtures on Windows runners.
@@ -77,11 +87,11 @@ struct SnapshotFixture {
 }
 
 /// Load a snapshot test fixture from fixtures directory.
-fn load_snapshot_fixture(sample_dir: &Path) -> Option<SnapshotFixture> {
-    let name = sample_dir.file_name()?.to_str()?.to_string();
+fn load_snapshot_fixture(sample_dir: &Path) -> Result<SnapshotFixture, SkipReason> {
+    let name = common::sample_name(sample_dir).to_string();
 
     // Load input from Svelte test suite
-    let input = load_input(&name)?;
+    let input = load_input(&name).ok_or(SkipReason::MissingInput("index.svelte"))?;
 
     // Load expected outputs from fixtures
     let expected_client_js = load_fixture_output("snapshot", &name, "client.js");
@@ -89,10 +99,14 @@ fn load_snapshot_fixture(sample_dir: &Path) -> Option<SnapshotFixture> {
 
     // If neither expected output exists, skip this fixture
     if expected_client_js.is_none() && expected_server_js.is_none() {
-        return None;
+        return Err(SkipReason::Justified);
     }
 
-    Some(SnapshotFixture {
+    if SKIP_SNAPSHOT.contains(&name.as_str()) {
+        return Err(SkipReason::Justified);
+    }
+
+    Ok(SnapshotFixture {
         name: name.clone(),
         input,
         expected_client_js,
@@ -235,27 +249,18 @@ fn test_compiler_snapshot_fixtures() {
 
     let samples = get_fixture_samples("snapshot");
 
-    if samples.is_empty() {
-        panic!("No snapshot fixtures found. Run `npm run generate-fixtures` first.");
-    }
-
-    // Fixtures intentionally skipped here — they exercise codegen clusters
-    // tracked separately in tests/compatibility_report.rs and
-    // tests/runtime.rs. Running them as snapshot tests would surface
-    // already-known divergences (e.g. nested async-grouping inside
-    // `$derived` for `async-in-derived`).
-    let skip_snapshot: &[&str] = &["async-in-derived"];
-
-    let fixtures: Vec<SnapshotFixture> = samples
-        .iter()
-        .filter_map(|sample_dir| {
-            let name = sample_dir.file_name()?.to_str()?;
-            if skip_snapshot.contains(&name) {
-                return None;
+    let mut coverage = FixtureCoverage::new("snapshot", samples.len());
+    let mut fixtures: Vec<SnapshotFixture> = Vec::new();
+    for sample_dir in &samples {
+        match load_snapshot_fixture(sample_dir.as_path()) {
+            Ok(fixture) => {
+                coverage.ran();
+                fixtures.push(fixture);
             }
-            load_snapshot_fixture(sample_dir.as_path())
-        })
-        .collect();
+            Err(reason) => coverage.skipped(common::sample_name(sample_dir), reason),
+        }
+    }
+    coverage.assert(MIN_SNAPSHOT_FIXTURES);
 
     let results: Vec<TestResult> = fixtures.par_iter().map(run_snapshot_fixture_test).collect();
 

--- a/crates/rsvelte_core/tests/css.rs
+++ b/crates/rsvelte_core/tests/css.rs
@@ -11,10 +11,14 @@ use std::fs;
 use std::path::Path;
 
 use common::{
-    canonicalize_css, ensure_fixtures_exist, get_fixture_samples, load_fixture_output, svelte_path,
-    write_actual_output,
+    FixtureCoverage, SkipReason, canonicalize_css, ensure_fixtures_exist, get_fixture_samples,
+    load_fixture_output, svelte_path, write_actual_output,
 };
 use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+/// Grow-only fixture floor, measured against the pinned Svelte submodule: all
+/// 181 CSS samples are runnable. Never lower it.
+const MIN_CSS_FIXTURES: usize = 181;
 
 /// Load input from Svelte test suite. Normalizes CRLF→LF so byte offsets
 /// in the compiled output match LF-authored fixtures on Windows runners.
@@ -38,16 +42,16 @@ struct CssFixture {
 }
 
 /// Load a CSS test fixture from fixtures directory.
-fn load_css_fixture(sample_dir: &Path) -> Option<CssFixture> {
-    let name = sample_dir.file_name()?.to_str()?.to_string();
+fn load_css_fixture(sample_dir: &Path) -> Result<CssFixture, SkipReason> {
+    let name = common::sample_name(sample_dir).to_string();
 
     // Load input from Svelte test suite
-    let input = load_input(&name)?;
+    let input = load_input(&name).ok_or(SkipReason::MissingInput("input.svelte"))?;
 
     // Load expected CSS from fixtures
     let expected_css = load_fixture_output("css", &name, "css.css");
 
-    Some(CssFixture {
+    Ok(CssFixture {
         name,
         input,
         expected_css,
@@ -189,14 +193,18 @@ fn test_css() {
 
     let samples = get_fixture_samples("css");
 
-    if samples.is_empty() {
-        panic!("No CSS fixtures found. Run `npm run generate-fixtures` first.");
+    let mut coverage = FixtureCoverage::new("css", samples.len());
+    let mut fixtures: Vec<CssFixture> = Vec::new();
+    for sample_dir in &samples {
+        match load_css_fixture(sample_dir.as_path()) {
+            Ok(fixture) => {
+                coverage.ran();
+                fixtures.push(fixture);
+            }
+            Err(reason) => coverage.skipped(common::sample_name(sample_dir), reason),
+        }
     }
-
-    let fixtures: Vec<CssFixture> = samples
-        .iter()
-        .filter_map(|sample_dir| load_css_fixture(sample_dir.as_path()))
-        .collect();
+    coverage.assert(MIN_CSS_FIXTURES);
 
     // Note: this suite previously ran sequentially "to avoid hangs". The most
     // likely cause was unbounded `par_iter()` exhausting memory under bumpalo

--- a/crates/rsvelte_core/tests/parser_fixtures.rs
+++ b/crates/rsvelte_core/tests/parser_fixtures.rs
@@ -8,8 +8,13 @@ mod common;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use common::get_svelte_test_samples;
+use common::{FixtureCoverage, SkipReason, get_svelte_test_samples, sample_name};
 use rayon::prelude::*;
+
+/// Grow-only fixture floors, measured against the pinned Svelte submodule.
+/// Raise them when upstream adds samples; never lower them.
+const MIN_PARSER_MODERN_FIXTURES: usize = 27;
+const MIN_PARSER_LEGACY_FIXTURES: usize = 81;
 use rsvelte_core::ast::arena::with_serialize_arena;
 use rsvelte_core::{ParseOptions, convert_to_legacy, parse};
 
@@ -19,22 +24,33 @@ fn get_parser_samples(test_type: &str) -> Vec<PathBuf> {
 }
 
 /// Load a test fixture.
-fn load_fixture(sample_dir: &Path) -> Option<(String, String, String)> {
+fn load_fixture(sample_dir: &Path) -> Result<(String, String, String), SkipReason> {
     let input_path = sample_dir.join("input.svelte");
     let output_path = sample_dir.join("output.json");
 
-    if !input_path.exists() || !output_path.exists() {
-        return None;
+    if !input_path.exists() {
+        return Err(SkipReason::MissingInput("input.svelte"));
+    }
+    if !output_path.exists() {
+        return Err(SkipReason::MissingInput("output.json"));
     }
 
     // Normalize CRLF to LF so AST byte offsets line up regardless of how the
     // submodule was checked out (Windows runners default to autocrlf=true,
     // which would otherwise shift every span by one byte per line).
-    let input = fs::read_to_string(&input_path).ok()?.replace("\r\n", "\n");
-    let expected_output = fs::read_to_string(&output_path).ok()?.replace("\r\n", "\n");
-    let name = sample_dir.file_name()?.to_str()?.to_string();
+    let input = fs::read_to_string(&input_path)
+        .map_err(|_| SkipReason::MissingInput("readable input.svelte"))?
+        .replace("\r\n", "\n");
+    let expected_output = fs::read_to_string(&output_path)
+        .map_err(|_| SkipReason::MissingInput("readable output.json"))?
+        .replace("\r\n", "\n");
+    let name = sample_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or(SkipReason::MissingInput("valid sample directory name"))?
+        .to_string();
 
-    Some((name, input, expected_output))
+    Ok((name, input, expected_output))
 }
 
 /// Normalize JSON for comparison.
@@ -116,12 +132,16 @@ const LEGACY_SKIP_TESTS: &[&str] = &[
 const MODERN_SKIP_TESTS: &[&str] = &[];
 
 /// Run a single fixture test.
-fn run_fixture_test(sample_dir: &Path, modern: bool, skip_tests: &[&str]) -> Option<TestResult> {
+fn run_fixture_test(
+    sample_dir: &Path,
+    modern: bool,
+    skip_tests: &[&str],
+) -> Result<TestResult, SkipReason> {
     let (name, input, expected) = load_fixture(sample_dir)?;
 
     // Check if this test should be skipped
     if skip_tests.contains(&name.as_str()) {
-        return Some(TestResult {
+        return Ok(TestResult {
             name,
             passed: true,
             skipped: true,
@@ -169,7 +189,7 @@ fn run_fixture_test(sample_dir: &Path, modern: bool, skip_tests: &[&str]) -> Opt
             }
 
             if actual_normalized == expected_normalized {
-                Some(TestResult {
+                Ok(TestResult {
                     name,
                     passed: true,
                     skipped: false,
@@ -180,7 +200,7 @@ fn run_fixture_test(sample_dir: &Path, modern: bool, skip_tests: &[&str]) -> Opt
                 let actual_path = sample_dir.join("_actual.json");
                 let _ = fs::write(&actual_path, &actual_json);
 
-                Some(TestResult {
+                Ok(TestResult {
                     name,
                     passed: false,
                     skipped: false,
@@ -191,7 +211,7 @@ fn run_fixture_test(sample_dir: &Path, modern: bool, skip_tests: &[&str]) -> Opt
                 })
             }
         }
-        Err(e) => Some(TestResult {
+        Err(e) => Ok(TestResult {
             name,
             passed: false,
             skipped: false,
@@ -200,21 +220,42 @@ fn run_fixture_test(sample_dir: &Path, modern: bool, skip_tests: &[&str]) -> Opt
     }
 }
 
+/// Split per-sample outcomes into comparable results and a coverage ledger.
+fn tally(
+    what: &str,
+    samples: &[PathBuf],
+    outcomes: Vec<Result<TestResult, SkipReason>>,
+) -> (Vec<TestResult>, FixtureCoverage) {
+    let mut coverage = FixtureCoverage::new(what, samples.len());
+    let mut results = Vec::new();
+
+    for (sample_dir, outcome) in samples.iter().zip(outcomes) {
+        match outcome {
+            Ok(result) => {
+                if result.skipped {
+                    coverage.skipped(&result.name, SkipReason::Justified);
+                } else {
+                    coverage.ran();
+                }
+                results.push(result);
+            }
+            Err(reason) => coverage.skipped(sample_name(sample_dir), reason),
+        }
+    }
+
+    (results, coverage)
+}
+
 #[test]
 fn test_parser_modern_fixtures() {
     let samples = get_parser_samples("parser-modern");
 
-    if samples.is_empty() {
-        eprintln!(
-            "Warning: No parser-modern samples found. Make sure the Svelte submodule is initialized."
-        );
-        return;
-    }
-
-    let results: Vec<TestResult> = samples
+    let outcomes: Vec<Result<TestResult, SkipReason>> = samples
         .par_iter()
-        .filter_map(|sample_dir| run_fixture_test(sample_dir, true, MODERN_SKIP_TESTS))
+        .map(|sample_dir| run_fixture_test(sample_dir, true, MODERN_SKIP_TESTS))
         .collect();
+    let (results, coverage) = tally("parser-modern", &samples, outcomes);
+    coverage.assert(MIN_PARSER_MODERN_FIXTURES);
 
     let incompatible = results.iter().filter(|r| r.skipped).count();
     let passed = results.iter().filter(|r| r.passed && !r.skipped).count();
@@ -252,17 +293,12 @@ fn test_parser_modern_fixtures() {
 fn test_parser_legacy_fixtures() {
     let samples = get_parser_samples("parser-legacy");
 
-    if samples.is_empty() {
-        eprintln!(
-            "Warning: No parser-legacy samples found. Make sure the Svelte submodule is initialized."
-        );
-        return;
-    }
-
-    let results: Vec<TestResult> = samples
+    let outcomes: Vec<Result<TestResult, SkipReason>> = samples
         .par_iter()
-        .filter_map(|sample_dir| run_fixture_test(sample_dir, false, LEGACY_SKIP_TESTS))
+        .map(|sample_dir| run_fixture_test(sample_dir, false, LEGACY_SKIP_TESTS))
         .collect();
+    let (results, coverage) = tally("parser-legacy", &samples, outcomes);
+    coverage.assert(MIN_PARSER_LEGACY_FIXTURES);
 
     let incompatible = results.iter().filter(|r| r.skipped).count();
     let passed = results.iter().filter(|r| r.passed && !r.skipped).count();

--- a/crates/rsvelte_core/tests/preprocess.rs
+++ b/crates/rsvelte_core/tests/preprocess.rs
@@ -14,9 +14,13 @@ mod common;
 use std::fs;
 use std::path::Path;
 
-use common::get_svelte_test_samples;
 use common::preprocess_fixtures::{build_preprocessors, filename_for};
+use common::{FixtureCoverage, SkipReason, get_svelte_test_samples, sample_name};
 use rsvelte_core::compiler::preprocess::preprocess;
+
+/// Grow-only fixture floor, measured against the pinned Svelte submodule: all
+/// 19 preprocess samples are runnable. Never lower it.
+const MIN_PREPROCESS_FIXTURES: usize = 19;
 
 #[derive(Debug, Clone)]
 pub struct PreprocessFixture {
@@ -33,12 +37,14 @@ pub struct PreprocessResult {
     pub error: Option<String>,
 }
 
-fn load_fixture(sample_dir: &Path) -> Option<PreprocessFixture> {
-    let name = sample_dir.file_name()?.to_str()?.to_string();
-    let input = fs::read_to_string(sample_dir.join("input.svelte")).ok()?;
-    let expected_output = fs::read_to_string(sample_dir.join("output.svelte")).ok()?;
+fn load_fixture(sample_dir: &Path) -> Result<PreprocessFixture, SkipReason> {
+    let name = sample_name(sample_dir).to_string();
+    let input = fs::read_to_string(sample_dir.join("input.svelte"))
+        .map_err(|_| SkipReason::MissingInput("input.svelte"))?;
+    let expected_output = fs::read_to_string(sample_dir.join("output.svelte"))
+        .map_err(|_| SkipReason::MissingInput("output.svelte"))?;
     let filename = filename_for(&name);
-    Some(PreprocessFixture {
+    Ok(PreprocessFixture {
         name,
         input,
         expected_output,
@@ -108,21 +114,28 @@ pub fn run_preprocess_fixture(fixture: &PreprocessFixture) -> PreprocessResult {
     }
 }
 
-pub fn load_preprocess_fixtures() -> Vec<PreprocessFixture> {
-    get_svelte_test_samples("preprocess")
-        .into_iter()
-        .filter_map(|d| load_fixture(d.as_path()))
-        .collect()
+pub fn load_preprocess_fixtures() -> (Vec<PreprocessFixture>, FixtureCoverage) {
+    let samples = get_svelte_test_samples("preprocess");
+    let mut coverage = FixtureCoverage::new("preprocess", samples.len());
+    let mut fixtures = Vec::new();
+
+    for sample_dir in &samples {
+        match load_fixture(sample_dir.as_path()) {
+            Ok(fixture) => {
+                coverage.ran();
+                fixtures.push(fixture);
+            }
+            Err(reason) => coverage.skipped(sample_name(sample_dir), reason),
+        }
+    }
+
+    (fixtures, coverage)
 }
 
 #[test]
 fn test_preprocess_fixtures() {
-    let fixtures = load_preprocess_fixtures();
-    if fixtures.is_empty() {
-        panic!(
-            "No preprocess fixtures found. Run `git submodule update --init --recursive` and `pnpm run generate-fixtures`."
-        );
-    }
+    let (fixtures, coverage) = load_preprocess_fixtures();
+    coverage.assert(MIN_PREPROCESS_FIXTURES);
 
     println!("Running {} preprocess tests...", fixtures.len());
     let results: Vec<PreprocessResult> = fixtures.iter().map(run_preprocess_fixture).collect();

--- a/crates/rsvelte_core/tests/print.rs
+++ b/crates/rsvelte_core/tests/print.rs
@@ -7,9 +7,13 @@ mod common;
 use std::fs;
 use std::path::Path;
 
-use common::get_svelte_test_samples;
+use common::{FixtureCoverage, SkipReason, get_svelte_test_samples, sample_name};
 use rsvelte_core::compiler::print::print_with_source;
 use rsvelte_core::{ParseOptions, parse};
+
+/// Grow-only fixture floor, measured against the pinned Svelte submodule: 44
+/// samples minus the one on `PRINT_SKIP_NAMES`. Never lower it.
+const MIN_PRINT_FIXTURES: usize = 43;
 
 /// A Print test fixture.
 #[allow(dead_code)]
@@ -25,18 +29,24 @@ fn get_print_samples() -> Vec<std::path::PathBuf> {
 }
 
 /// Load a Print test fixture from Svelte test suite.
-fn load_print_fixture(sample_dir: &Path) -> Option<PrintFixture> {
-    let name = sample_dir.file_name()?.to_str()?.to_string();
+fn load_print_fixture(sample_dir: &Path) -> Result<PrintFixture, SkipReason> {
+    let name = sample_name(sample_dir).to_string();
 
     // Load input from Svelte test suite
     let input_path = sample_dir.join("input.svelte");
-    let input = fs::read_to_string(&input_path).ok()?;
+    let input =
+        fs::read_to_string(&input_path).map_err(|_| SkipReason::MissingInput("input.svelte"))?;
 
     // Load expected output from Svelte test suite
     let output_path = sample_dir.join("output.svelte");
-    let expected_output = fs::read_to_string(&output_path).ok()?;
+    let expected_output =
+        fs::read_to_string(&output_path).map_err(|_| SkipReason::MissingInput("output.svelte"))?;
 
-    Some(PrintFixture {
+    if PRINT_SKIP_NAMES.contains(&name.as_str()) {
+        return Err(SkipReason::Justified);
+    }
+
+    Ok(PrintFixture {
         name,
         input,
         expected_output,
@@ -141,15 +151,18 @@ const PRINT_SKIP_NAMES: &[&str] = &[
 fn test_print() {
     let samples = get_print_samples();
 
-    if samples.is_empty() {
-        panic!("No print fixtures found. Run `npm run generate-fixtures` first.");
+    let mut coverage = FixtureCoverage::new("print", samples.len());
+    let mut fixtures: Vec<PrintFixture> = Vec::new();
+    for sample_dir in &samples {
+        match load_print_fixture(sample_dir.as_path()) {
+            Ok(fixture) => {
+                coverage.ran();
+                fixtures.push(fixture);
+            }
+            Err(reason) => coverage.skipped(sample_name(sample_dir), reason),
+        }
     }
-
-    let fixtures: Vec<PrintFixture> = samples
-        .iter()
-        .filter_map(|sample_dir| load_print_fixture(sample_dir.as_path()))
-        .filter(|f| !PRINT_SKIP_NAMES.contains(&f.name.as_str()))
-        .collect();
+    coverage.assert(MIN_PRINT_FIXTURES);
 
     println!("Running {} print tests...", fixtures.len());
     let results: Vec<TestResult> = fixtures

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -14,10 +14,20 @@ use std::fs;
 use std::path::Path;
 
 use common::{
-    compare_js_with_debug as compare_js_debug, ensure_fixtures_exist, get_fixture_samples,
-    load_fixture_output, svelte_path, write_actual_output,
+    FixtureCoverage, SkipReason, compare_js_with_debug as compare_js_debug, ensure_fixtures_exist,
+    get_fixture_samples, load_fixture_output, sample_name, svelte_path, write_actual_output,
 };
 use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile, compiler::CssMode};
+
+/// Grow-only fixture floors, measured against the pinned Svelte submodule.
+/// The gap to the sample count is samples whose fixture holds only
+/// `warnings.json` / `error.json` — the official compiler emitted no code for
+/// them, so there is nothing to compare. Raise these when upstream adds
+/// samples; never lower them.
+const MIN_HYDRATION_FIXTURES: usize = 80;
+const MIN_RUNTIME_BROWSER_FIXTURES: usize = 32;
+const MIN_RUNTIME_LEGACY_FIXTURES: usize = 1206;
+const MIN_RUNTIME_RUNES_FIXTURES: usize = 1009;
 
 /// Load input from Svelte test suite.
 fn load_input(category: &str, sample_name: &str) -> Option<String> {
@@ -107,19 +117,25 @@ struct RuntimeFixture {
 }
 
 /// Load a runtime test fixture from fixtures directory.
-fn load_runtime_fixture(category: &str, sample_dir: &Path) -> Option<RuntimeFixture> {
-    let name = sample_dir.file_name()?.to_str()?.to_string();
+fn load_runtime_fixture(category: &str, sample_dir: &Path) -> Result<RuntimeFixture, SkipReason> {
+    let name = sample_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or(SkipReason::MissingInput("valid sample directory name"))?
+        .to_string();
 
-    let input = load_input(category, &name)?;
+    let input = load_input(category, &name).ok_or(SkipReason::MissingInput("main.svelte"))?;
 
     let expected_client_js = load_fixture_output(category, &name, "client.js");
     let expected_server_js = load_fixture_output(category, &name, "server.js");
 
+    // Neither output means the official compiler emitted no code for this
+    // sample (the fixture holds only `warnings.json` / `error.json`).
     if expected_client_js.is_none() && expected_server_js.is_none() {
-        return None;
+        return Err(SkipReason::Justified);
     }
 
-    Some(RuntimeFixture {
+    Ok(RuntimeFixture {
         name: name.clone(),
         input,
         expected_client_js,
@@ -354,17 +370,12 @@ fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestRes
 }
 
 /// Run tests for a specific runtime category.
-fn run_runtime_tests(category: &str) {
+fn run_runtime_tests(category: &str, min_fixtures: usize) {
     use rayon::prelude::*;
 
     ensure_fixtures_exist();
 
     let samples = get_fixture_samples(category);
-
-    if samples.is_empty() {
-        println!("No {} fixtures found.", category);
-        return;
-    }
 
     // Limit parallelism to avoid memory explosion
     // (845 tests * many parallel threads can consume excessive memory)
@@ -374,15 +385,18 @@ fn run_runtime_tests(category: &str) {
         .expect("Failed to build thread pool");
 
     // Load fixtures sequentially (fast, low memory)
-    let fixtures: Vec<RuntimeFixture> = samples
-        .iter()
-        .filter_map(|sample_dir| load_runtime_fixture(category, sample_dir.as_path()))
-        .collect();
-
-    if fixtures.is_empty() {
-        println!("No {} fixtures with expected output found.", category);
-        return;
+    let mut coverage = FixtureCoverage::new(category, samples.len());
+    let mut fixtures: Vec<RuntimeFixture> = Vec::new();
+    for sample_dir in &samples {
+        match load_runtime_fixture(category, sample_dir.as_path()) {
+            Ok(fixture) => {
+                coverage.ran();
+                fixtures.push(fixture);
+            }
+            Err(reason) => coverage.skipped(sample_name(sample_dir), reason),
+        }
     }
+    coverage.assert(min_fixtures);
 
     // Run tests with limited parallelism (4 threads max)
     let results: Vec<TestResult> = pool.install(|| {
@@ -471,22 +485,22 @@ fn run_runtime_tests(category: &str) {
 
 #[test]
 fn test_hydration() {
-    run_runtime_tests("hydration");
+    run_runtime_tests("hydration", MIN_HYDRATION_FIXTURES);
 }
 
 #[test]
 fn test_runtime_browser() {
-    run_runtime_tests("runtime-browser");
+    run_runtime_tests("runtime-browser", MIN_RUNTIME_BROWSER_FIXTURES);
 }
 
 #[test]
 fn test_runtime_legacy() {
-    run_runtime_tests("runtime-legacy");
+    run_runtime_tests("runtime-legacy", MIN_RUNTIME_LEGACY_FIXTURES);
 }
 
 #[test]
 fn test_runtime_runes() {
-    run_runtime_tests("runtime-runes");
+    run_runtime_tests("runtime-runes", MIN_RUNTIME_RUNES_FIXTURES);
 }
 
 /// List all available runtime fixtures.

--- a/crates/rsvelte_core/tests/sourcemaps.rs
+++ b/crates/rsvelte_core/tests/sourcemaps.rs
@@ -11,10 +11,14 @@ use std::fs;
 use std::path::Path;
 
 use common::{
-    compare_js, ensure_fixtures_exist, get_fixture_samples, load_fixture_output, svelte_path,
-    write_actual_output,
+    FixtureCoverage, SkipReason, compare_js, ensure_fixtures_exist, get_fixture_samples,
+    load_fixture_output, sample_name, svelte_path, write_actual_output,
 };
 use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+/// Grow-only fixture floor, measured against the pinned Svelte submodule: all
+/// 29 sourcemap samples have comparable output. Never lower it.
+const MIN_SOURCEMAP_FIXTURES: usize = 29;
 
 /// Load input from Svelte test suite. Normalizes CRLF→LF so byte offsets
 /// in the compiled output match LF-authored fixtures on Windows runners.
@@ -48,19 +52,23 @@ struct SourcemapFixture {
 }
 
 /// Load a sourcemap test fixture.
-fn load_sourcemap_fixture(sample_dir: &Path) -> Option<SourcemapFixture> {
-    let name = sample_dir.file_name()?.to_str()?.to_string();
+fn load_sourcemap_fixture(sample_dir: &Path) -> Result<SourcemapFixture, SkipReason> {
+    let name = sample_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or(SkipReason::MissingInput("valid sample directory name"))?
+        .to_string();
 
-    let input = load_input(&name)?;
+    let input = load_input(&name).ok_or(SkipReason::MissingInput("input.svelte"))?;
     let expected_client_js = load_fixture_output("sourcemaps", &name, "client.js");
     let expected_server_js = load_fixture_output("sourcemaps", &name, "server.js");
 
-    // Skip if no expected output
+    // Neither output means the official compiler emitted no code for this sample.
     if expected_client_js.is_none() && expected_server_js.is_none() {
-        return None;
+        return Err(SkipReason::Justified);
     }
 
-    Some(SourcemapFixture {
+    Ok(SourcemapFixture {
         name,
         input,
         expected_client_js,
@@ -77,21 +85,9 @@ struct TestResult {
     error: Option<String>,
 }
 
-/// Known test failures that are pre-existing server-side codegen issues,
-/// not related to sourcemap generation.
-const KNOWN_SERVER_FAILURES: &[&str] = &[
-    "effects", // Missing $$renderer.component(...) wrapping in server transform
-];
-
 impl TestResult {
     fn passed(&self) -> bool {
-        let server_ok = if KNOWN_SERVER_FAILURES.contains(&self.name.as_str()) {
-            // Skip server JS check for known failures
-            true
-        } else {
-            self.server_js_passed.unwrap_or(true)
-        };
-        self.client_js_passed.unwrap_or(true) && server_ok
+        self.client_js_passed.unwrap_or(true) && self.server_js_passed.unwrap_or(true)
     }
 }
 
@@ -187,20 +183,18 @@ fn test_sourcemaps() {
 
     let samples = get_fixture_samples("sourcemaps");
 
-    if samples.is_empty() {
-        println!("No sourcemap fixtures found. Run `npm run generate-fixtures` first.");
-        return;
+    let mut coverage = FixtureCoverage::new("sourcemaps", samples.len());
+    let mut fixtures: Vec<SourcemapFixture> = Vec::new();
+    for sample_dir in &samples {
+        match load_sourcemap_fixture(sample_dir.as_path()) {
+            Ok(fixture) => {
+                coverage.ran();
+                fixtures.push(fixture);
+            }
+            Err(reason) => coverage.skipped(sample_name(sample_dir), reason),
+        }
     }
-
-    let fixtures: Vec<SourcemapFixture> = samples
-        .iter()
-        .filter_map(|sample_dir| load_sourcemap_fixture(sample_dir.as_path()))
-        .collect();
-
-    if fixtures.is_empty() {
-        println!("No sourcemap fixtures with expected output found.");
-        return;
-    }
+    coverage.assert(MIN_SOURCEMAP_FIXTURES);
 
     // Run tests in parallel for better performance
     let results: Vec<TestResult> = fixtures

--- a/crates/rsvelte_core/tests/ssr.rs
+++ b/crates/rsvelte_core/tests/ssr.rs
@@ -9,10 +9,15 @@ use std::fs;
 use std::path::Path;
 
 use common::{
-    compare_js, ensure_fixtures_exist, get_fixture_samples, load_fixture_output, svelte_path,
-    write_actual_output,
+    FixtureCoverage, SkipReason, compare_js, ensure_fixtures_exist, get_fixture_samples,
+    load_fixture_output, sample_name, svelte_path, write_actual_output,
 };
 use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+/// Grow-only fixture floor, measured against the pinned Svelte submodule.
+/// 126 samples are generated; 27 of them hold only an `error.json` because the
+/// official compiler errors on them, leaving 99 with comparable server output.
+const MIN_SSR_FIXTURES: usize = 99;
 
 /// Load input from Svelte test suite. Normalizes CRLF→LF so byte offsets
 /// in the compiled output match LF-authored fixtures on Windows runners.
@@ -51,19 +56,24 @@ struct SsrFixture {
 }
 
 /// Load an SSR test fixture.
-fn load_ssr_fixture(sample_dir: &Path) -> Option<SsrFixture> {
-    let name = sample_dir.file_name()?.to_str()?.to_string();
+fn load_ssr_fixture(sample_dir: &Path) -> Result<SsrFixture, SkipReason> {
+    let name = sample_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or(SkipReason::MissingInput("valid sample directory name"))?
+        .to_string();
 
-    let input = load_input(&name)?;
-    let expected_server_js = load_fixture_output("server-side-rendering", &name, "server.js");
+    let input = load_input(&name).ok_or(SkipReason::MissingInput("main.svelte"))?;
 
-    // Skip if no expected output
-    expected_server_js.as_ref()?;
+    // No `server.js` means the official compiler errored on this sample and
+    // the fixture holds only `error.json` — nothing to compare.
+    let expected_server_js = load_fixture_output("server-side-rendering", &name, "server.js")
+        .ok_or(SkipReason::Justified)?;
 
-    Some(SsrFixture {
+    Ok(SsrFixture {
         name: name.clone(),
         input,
-        expected_server_js,
+        expected_server_js: Some(expected_server_js),
         requires_unsupported_options: requires_unsupported_options(&name),
     })
 }
@@ -170,20 +180,18 @@ fn test_ssr() {
 
     let samples = get_fixture_samples("server-side-rendering");
 
-    if samples.is_empty() {
-        println!("No SSR fixtures found. Run `npm run generate-fixtures` first.");
-        return;
+    let mut coverage = FixtureCoverage::new("server-side-rendering", samples.len());
+    let mut fixtures: Vec<SsrFixture> = Vec::new();
+    for sample_dir in &samples {
+        match load_ssr_fixture(sample_dir.as_path()) {
+            Ok(fixture) => {
+                coverage.ran();
+                fixtures.push(fixture);
+            }
+            Err(reason) => coverage.skipped(sample_name(sample_dir), reason),
+        }
     }
-
-    let fixtures: Vec<SsrFixture> = samples
-        .iter()
-        .filter_map(|sample_dir| load_ssr_fixture(sample_dir.as_path()))
-        .collect();
-
-    if fixtures.is_empty() {
-        println!("No SSR fixtures with expected output found.");
-        return;
-    }
+    coverage.assert(MIN_SSR_FIXTURES);
 
     // Run tests in parallel for better performance
     let results: Vec<TestResult> = fixtures.par_iter().map(run_ssr_fixture_test).collect();

--- a/crates/rsvelte_core/tests/validator.rs
+++ b/crates/rsvelte_core/tests/validator.rs
@@ -14,9 +14,14 @@ mod common;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use common::get_svelte_test_samples;
+use common::{FixtureCoverage, SkipReason, get_svelte_test_samples, sample_name};
 use rsvelte_core::{CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module};
 use serde::Deserialize;
+
+/// Grow-only fixture floor, measured against the pinned Svelte submodule: 334
+/// samples, 2 of which opt out through `_config.js` (`skip: true` /
+/// `warningFilter`). Never lower it.
+const MIN_VALIDATOR_FIXTURES: usize = 332;
 
 /// Get all validator test samples.
 fn get_validator_samples() -> Vec<PathBuf> {
@@ -116,11 +121,11 @@ fn parse_test_config(sample_dir: &Path) -> TestConfig {
 }
 
 /// Load a validator test fixture.
-fn load_validator_fixture(sample_dir: &Path) -> Option<ValidatorFixture> {
+fn load_validator_fixture(sample_dir: &Path) -> Result<ValidatorFixture, SkipReason> {
     // Parse config (includes skip check)
     let config = parse_test_config(sample_dir);
     if config.skip {
-        return None;
+        return Err(SkipReason::Justified);
     }
 
     let svelte_path = sample_dir.join("input.svelte");
@@ -130,16 +135,25 @@ fn load_validator_fixture(sample_dir: &Path) -> Option<ValidatorFixture> {
 
     // Determine input type and read input
     let (input, input_type) = if svelte_path.exists() {
-        (fs::read_to_string(&svelte_path).ok()?, InputType::Svelte)
+        (
+            fs::read_to_string(&svelte_path)
+                .map_err(|_| SkipReason::MissingInput("readable input.svelte"))?,
+            InputType::Svelte,
+        )
     } else if module_path.exists() {
-        (fs::read_to_string(&module_path).ok()?, InputType::Module)
+        (
+            fs::read_to_string(&module_path)
+                .map_err(|_| SkipReason::MissingInput("readable input.svelte.js"))?,
+            InputType::Module,
+        )
     } else {
-        return None;
+        return Err(SkipReason::MissingInput("input.svelte / input.svelte.js"));
     };
 
     // Load expected warnings
     let expected_warnings: Vec<ExpectedWarning> = if warnings_path.exists() {
-        let content = fs::read_to_string(&warnings_path).ok()?;
+        let content = fs::read_to_string(&warnings_path)
+            .map_err(|_| SkipReason::MissingInput("readable warnings.json"))?;
         serde_json::from_str(&content).unwrap_or_default()
     } else {
         Vec::new()
@@ -147,16 +161,17 @@ fn load_validator_fixture(sample_dir: &Path) -> Option<ValidatorFixture> {
 
     // Load expected error (if any)
     let expected_error: Option<ExpectedError> = if errors_path.exists() {
-        let content = fs::read_to_string(&errors_path).ok()?;
+        let content = fs::read_to_string(&errors_path)
+            .map_err(|_| SkipReason::MissingInput("readable errors.json"))?;
         let errors: Vec<ExpectedError> = serde_json::from_str(&content).unwrap_or_default();
         errors.into_iter().next()
     } else {
         None
     };
 
-    let name = sample_dir.file_name()?.to_str()?.to_string();
+    let name = sample_name(sample_dir).to_string();
 
-    Some(ValidatorFixture {
+    Ok(ValidatorFixture {
         name,
         input,
         input_type,
@@ -339,17 +354,18 @@ fn run_validator_test(fixture: &ValidatorFixture) -> TestResult {
 fn test_validator() {
     let samples = get_validator_samples();
 
-    if samples.is_empty() {
-        eprintln!(
-            "Warning: No validator samples found. Make sure the Svelte submodule is initialized."
-        );
-        return;
+    let mut coverage = FixtureCoverage::new("validator", samples.len());
+    let mut fixtures: Vec<ValidatorFixture> = Vec::new();
+    for sample_dir in &samples {
+        match load_validator_fixture(sample_dir.as_path()) {
+            Ok(fixture) => {
+                coverage.ran();
+                fixtures.push(fixture);
+            }
+            Err(reason) => coverage.skipped(sample_name(sample_dir), reason),
+        }
     }
-
-    let fixtures: Vec<ValidatorFixture> = samples
-        .iter()
-        .filter_map(|sample_dir| load_validator_fixture(sample_dir.as_path()))
-        .collect();
+    coverage.assert(MIN_VALIDATOR_FIXTURES);
 
     // Run sequentially to avoid hangs
     println!("Running {} validator tests...", fixtures.len());


### PR DESCRIPTION
Addresses #1791 items **3** (missing fixture-count floors) and **4** (hardcoded
sample filenames causing silent skips).

## Problem

`libtest` reports an early `return` from a `#[test]` as **PASS**, not skip. Roughly
twenty fixture suites in `crates/rsvelte_core/tests/` printed a warning and returned
when they found no fixtures, and every one of them dropped individual samples with a
bare `continue` when a hardcoded input filename was absent. One upstream rename could
zero out a whole category and CI would stay green. `Sourcemaps 0/0` was exactly that.

## Design: a coverage ledger, not just `checked > 0`

`tests/common/mod.rs` gains `FixtureCoverage` + `SkipReason`. Loaders now return
`Result<Fixture, SkipReason>`, so the two kinds of drop are distinguished at the type
level rather than collapsing into `None`:

- `SkipReason::Justified` — the sample opts out via `_config.js`, sits on a documented
  skip list, or upstream generated no expected output for it.
- `SkipReason::MissingInput(&'static str)` — the loader looked for a named input file
  and it was not on disk.

`FixtureCoverage::assert(min_ran)` fails on four independent conditions:

1. `found == 0` — no sample directories discovered at all.
2. any `MissingInput` — lists the offending samples and the file each loader wanted.
3. `ran + justified != found` — a loader path returned early without telling the
   ledger. This catches a **future** silent `continue` that nobody remembered to record.
4. `ran < min_ran` — grow-only floor, measured against the pinned submodule.

Condition 3 is what makes this maintainable. A plain `M == N` check would break on the
many legitimate skips; a plain `assert!(checked > 0)` would *not* have caught the
sourcemaps bug had it dropped 28 of 29 instead of all 29.

Because each floor is set to exactly the measured `ran`, a green run *proves* the table
below: `ran >= floor` and `ran + justified == found` are both asserted.

## Measured: sample directories vs fixtures actually executed

Against the pinned Svelte submodule `b29d7002ecf9` (v5.56.7).

### Standalone suites (`crates/rsvelte_core/tests/*.rs`)

| suite | samples found | ran | justified skip | missing input | floor |
|---|---|---|---|---|---|
| `parser_fixtures.rs` parser-modern | 27 | 27 | 0 | 0 | 27 |
| `parser_fixtures.rs` parser-legacy | 83 | 81 | 2 | 0 | 81 |
| `validator.rs` | 334 | 332 | 2 | 0 | 332 |
| `compiler_errors.rs` | 145 | 145 | 0 | 0 | 145 |
| `runtime.rs` hydration | 80 | 80 | 0 | 0 | 80 |
| `runtime.rs` runtime-browser | 32 | 32 | 0 | 0 | 32 |
| `runtime.rs` runtime-legacy | 1208 | 1206 | 2 | 0 | 1206 |
| `runtime.rs` runtime-runes | 1011 | 1009 | 2 | 0 | 1009 |
| `ssr.rs` | 126 | 99 | 27 | 0 | 99 |
| `sourcemaps.rs` | 29 | 29 | 0 | 0 | 29 |
| `css.rs` | 181 | 181 | 0 | 0 | 181 |
| `print.rs` | 44 | 43 | 1 | 0 | 43 |
| `preprocess.rs` | 19 | 19 | 0 | 0 | 19 |
| `compiler_fixtures.rs` snapshot | 31 | 30 | 1 | 0 | 30 |

### `compatibility_report.rs` categories

`ran` here is the report's own `run_count` (`total - skipped`), verified against a real
`pnpm run compatibility-report` run.

| category | samples found | ran before | ran after | justified skip | floor |
|---|---|---|---|---|---|
| parser-modern | 27 | 27 | 27 | 0 | 27 |
| parser-legacy | 83 | 81 | 81 | 2 | 81 |
| snapshot | 31 | 30 | 30 | 1 | 30 |
| css | 181 | 181 | 181 | 0 | 181 |
| validator | 334 | 333 | 333 | 1 | 333 |
| compiler-errors | 145 | 145 | 145 | 0 | 145 |
| runtime-runes | 1011 | 1008 | 1008 | 3 | 1008 |
| runtime-legacy | 1208 | 1206 | 1206 | 2 | 1206 |
| runtime-browser | 32 | 32 | 32 | 0 | 32 |
| hydration | 80 | 80 | 80 | 0 | 80 |
| server-side-rendering | 126 | 99 | 99 | 27 | 99 |
| **sourcemaps** | **29** | **0** | **29** | **0** | **29** |
| print | 44 | 43 | 43 | 1 | 43 |
| preprocess | 19 | 19 | 19 | 0 | 19 |
| migrate (out of scope) | 76 | 0 | 0 | 76 | 0 |

## Divergences found, and why

Exactly one category had a genuine coverage hole. Every other gap is legitimate and is
now *recorded* as such instead of being dropped in silence.

### 1. sourcemaps: 29 of 29 samples silently skipped — fixed, in two layers

`run_runtime_category_tests` hardcoded `main.svelte` as the entry point, but the
`sourcemaps` samples use `input.svelte`. That is the root cause of the `Sourcemaps 0/0`
row; the fixture data has been complete the whole time.

The guard then exposed a **second** layer: the same runner also hardcoded
`filename: Some("main.svelte")` in `CompileOptions`. `filename` reaches the generated
code (component name, CSS hash), so once the 29 samples started running they all
mismatched — `sourcemaps 0/29`. The `filename` now follows the resolved entry point,
which is byte-identical (`"main.svelte"`) for every other category.

Verified end to end with `cargo test --release --test compatibility_report -- --ignored`:

| | before | after |
|---|---|---|
| `Running sourcemaps tests...` | `0/29 passed (0.0%)` (was `0/0` before the entry-point fix) | `29/29 passed (100.0%)` |
| overall | `Passed: 3276 (98.9%)`, `Failed: 37` | `Passed: 3305 (99.8%)`, `Failed: 8` |

The 8 remaining failures are pre-existing and unchanged (see "unrelated findings").

### 2. SSR 126 → 99 (justified)

The other 27 fixture directories contain only `error.json`: the official compiler errors
on those samples, so no `server.js` was ever generated and there is nothing to compare.

### 3. runtime-legacy 1208 → 1206, runtime-runes 1011 → 1009 (justified)

Same shape — those fixture directories contain only `warnings.json`, so the official
compiler emitted no code: `store-auto-subscribe-missing-global-script`,
`store-auto-subscribe-missing-global-template`, `const-tag-boundary-deprecated-usage`,
`not-actual-runes`.

### 4. validator 334 → 332 standalone / 333 in the report (justified)

`_config.js` opt-outs: `error-mode-warn` (`skip: true`) and
`ignore-warning-compiler-option` (`warningFilter`, unsupported by the standalone runner;
the report runner handles it inline, hence 333 vs 332).

### 5. parser-legacy 83 → 81, print 44 → 43, snapshot 31 → 30 (justified)

Pre-existing, already-documented skip lists (`LEGACY_SKIP_TESTS`, `PRINT_SKIP_NAMES`,
`SKIP_SNAPSHOT`), unchanged by this PR.

**No floor here was set below the number of comparable samples.** The one case where the
measured value *was* lower than it should be — sourcemaps — was fixed, not ratcheted in.

## Stale skip removed

`tests/sourcemaps.rs` had one `KNOWN_*` constant, `KNOWN_SERVER_FAILURES = ["effects"]`
("Missing `$$renderer.component(...)` wrapping in server transform"). Both `client.js`
and `server.js` for `effects` are now **byte-identical** to the fixtures, so the entry
was masking a live assertion. Removed; `test_sourcemaps` now really checks all 29
samples. It was the only such constant in that file.

## Guard verification: deliberately broken, then restored

All four assertion conditions were tripped for real. Every experiment restored what it
moved (submodule `git status` clean, `print.rs` byte-identical to its pre-experiment copy).

| # | break | condition | observed failure |
|---|---|---|---|
| A | hide `sourcemaps/samples/basic/input.svelte` | `MissingInput` | `sourcemaps: 1 of 29 sample(s) were dropped because an expected input file is missing … basic (no input.svelte)` |
| B | hide `print/samples/attribute/output.svelte` | `MissingInput` | `print: 1 of 44 sample(s) … attribute (no output.svelte)` |
| C | move `preprocess/samples/script-multiple` away | floor | `preprocess: only 18 fixture(s) ran, floor is 19. This floor is grow-only …` |
| D | move `fixtures/<sha>/css` away | `found == 0` | `css: no sample directories were discovered. The fixture layout changed, the Svelte submodule is not initialized, or \`pnpm run generate-fixtures\` has not been run.` |
| E | inject an unrecorded `continue` into `test_print`'s loop | accounting | `print: 1 of 44 sample(s) were dropped without being recorded as run or justified-skipped. Some loader path returns early without telling the coverage ledger.` |

E is the important one: it proves a *future* silent `continue` is caught even when
nothing is missing from disk and the floor is still met.

## Unrelated pre-existing findings (not fixed here)

The report run surfaced 8 failures that predate this PR and are option drift between
`compatibility_report.rs`'s runners and the real gates, not coverage holes. Worth
separate issues:

- **parser-modern 24/27** while `tests/parser_fixtures.rs` is 27/27. The report's
  `run_parser_tests` omits `capture_comments: true` from `ParseOptions`, so
  `comment-before-function-binding`, `parens` and `tag-type-identifier-probe-comment`
  fail on comment attachment.
- **hydration 79/80** (`boundary-pending-attribute`) while `tests/runtime.rs` is 80/80.
- **runtime-runes 1004/1008** (`async-batch-derived`, `hmr-removal`,
  `hmr-each-keyed-unshift`, `async-style-after-await`) while `tests/runtime.rs` is green.

`AGENTS.md`'s status table is generated from this report and still shows the old
100% figures, so it has drifted too. Docs are deliberately not regenerated in this PR:
doing so would present these pre-existing drifts as if this PR caused them.

## Notes

- `generate_compatibility_report` still never fails on output *mismatches* — it is a
  reporting artifact. It does now fail when a category loses coverage, because a
  silently empty category invalidates the whole report.
- `css.rs` / `print.rs` / `preprocess.rs` / `compiler_fixtures.rs` already had a
  `samples.is_empty()` panic; they are folded onto the same ledger so the whole
  `rsvelte_core` fixture surface is uniform and gains a floor plus accounting.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `RUST_MIN_STACK=33554432 cargo test --release -p rsvelte_core` over all ten touched
  binaries (`parser_fixtures`, `validator`, `compiler_errors`, `ssr`, `sourcemaps`,
  `css`, `print`, `preprocess`, `compiler_fixtures`, `runtime`) — all pass
- `cargo test --release --test compatibility_report -- --ignored --nocapture` — passes,
  sourcemaps 29/29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqdHfZSN3LFxPkyKFaCyoF
