### PR TITLE
fix(parse): keep the assignment target when it carries a TS assertion

### DIFF
--- a/.changeset/fix-ts-assertion-assignment-targets.md
+++ b/.changeset/fix-ts-assertion-assignment-targets.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): keep the assignment target when it carries a TS assertion
+
+`count!++`, `count! += 1` and `[count!] = …` model their target as an
+`AssignmentTarget` / `SimpleAssignmentTarget` TS-wrapper variant in oxc, which
+the ESTree conversion had no arm for — the whole target was emitted as `null`,
+so any consumer of `parse()` lost the write. A plain `=` LHS now unwraps the
+assertion and every other target position keeps the wrapper, matching
+`svelte/compiler`. The TS stripper also skipped `UpdateExpression.argument`,
+which leaked an invalid `count!++` into generated JS and left the write
+non-reactive; it now lowers to the same `$.update(count)` as `count++`.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -5143,7 +5143,10 @@ fn create_assignment_expression<'a>(
     line_offsets: &[usize],
 ) -> Expression<'a> {
     let operator = assignment_operator_to_str(&assign.operator);
-    let left = convert_assignment_target(arena, &assign.left, offset, line_offsets);
+    let left = match simple_assignment_lhs_inner(assign) {
+        Some(inner) => expr_to_node(convert_expression(arena, inner, offset, line_offsets)),
+        None => convert_assignment_target(arena, &assign.left, offset, line_offsets),
+    };
     let right = convert_expression(arena, &assign.right, offset, line_offsets);
 
     Expression::from_node(JsNode::AssignmentExpression {
@@ -5154,6 +5157,27 @@ fn create_assignment_expression<'a>(
         left: arena.alloc_js_node(left),
         right: arena.alloc_js_node(expr_to_node(right)),
     })
+}
+
+/// The expression a **plain `=`** LHS unwraps to when it carries TS assertion
+/// wrappers (`x! = 1` -> `x`), or `None` when the LHS must be kept as-is.
+///
+/// svelte/compiler gets this from acorn-typescript's `toAssignable`, which
+/// unwraps the wrapper but whose return value only `parseMaybeAssign` (the `=`
+/// case) uses. So a compound assignment (`x! += 1`), an update (`x!++`) and every
+/// nested destructuring position keep the wrapper, while a plain `=` loses it.
+fn simple_assignment_lhs_inner<'x>(
+    assign: &'x oxc_ast::ast::AssignmentExpression<'x>,
+) -> Option<&'x oxc_ast::ast::Expression<'x>> {
+    if assign.operator != oxc_ast::ast::AssignmentOperator::Assign {
+        return None;
+    }
+    let inner = assign
+        .left
+        .as_simple_assignment_target()?
+        .get_expression()?
+        .get_inner_expression();
+    Some(inner)
 }
 
 fn assignment_operator_to_str(op: &oxc_ast::ast::AssignmentOperator) -> &'static str {
@@ -5493,10 +5517,91 @@ fn convert_assignment_target(
                 line_offsets,
             ))
         }
-        _ => {
-            // Fallback for other complex patterns (e.g., TSAsExpression, TSNonNullExpression)
-            JsNode::Null
+        _ => target
+            .as_simple_assignment_target()
+            .map(|simple| convert_ts_wrapper_target(arena, simple, offset, line_offsets))
+            .unwrap_or(JsNode::Null),
+    }
+}
+
+/// Rebuild a TS assertion wrapper (`x!`, `x as T`, `x satisfies T`, `<T>x`) that
+/// sits in an assignment-target position — `x!++`, `x! += 1`, `[x!] = …`. oxc
+/// models those as `SimpleAssignmentTarget` variants rather than `Expression`s,
+/// so they need their own conversion; dropping them (the old `JsNode::Null`)
+/// erased the whole target, and svelte/compiler keeps the wrapper there.
+/// Template-path spans carry the `-1` synthetic-paren adjustment, so the
+/// type-annotation blob uses base `offset - 1`, matching `convert_expression`.
+fn convert_ts_wrapper_target(
+    arena: &ParseArena,
+    target: &oxc_ast::ast::SimpleAssignmentTarget,
+    offset: usize,
+    line_offsets: &[usize],
+) -> JsNode {
+    use oxc_ast::ast::SimpleAssignmentTarget;
+
+    match target {
+        SimpleAssignmentTarget::TSAsExpression(ts_as) => {
+            let start = offset + ts_as.span.start as usize - 1;
+            let end = offset + ts_as.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_as.expression, offset, line_offsets);
+            let type_annotation =
+                convert_ts_type(arena, &ts_as.type_annotation, offset - 1, line_offsets);
+            JsNode::TSAsExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            }
         }
+        SimpleAssignmentTarget::TSSatisfiesExpression(ts_satisfies) => {
+            let start = offset + ts_satisfies.span.start as usize - 1;
+            let end = offset + ts_satisfies.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_satisfies.expression, offset, line_offsets);
+            let type_annotation = convert_ts_type(
+                arena,
+                &ts_satisfies.type_annotation,
+                offset - 1,
+                line_offsets,
+            );
+            JsNode::TSSatisfiesExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            }
+        }
+        SimpleAssignmentTarget::TSNonNullExpression(ts_non_null) => {
+            let start = offset + ts_non_null.span.start as usize - 1;
+            let end = offset + ts_non_null.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_non_null.expression, offset, line_offsets);
+            JsNode::TSNonNullExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+            }
+        }
+        SimpleAssignmentTarget::TSTypeAssertion(ts_assertion) => {
+            let start = offset + ts_assertion.span.start as usize - 1;
+            let end = offset + ts_assertion.span.end as usize - 1;
+            let inner = convert_expression(arena, &ts_assertion.expression, offset, line_offsets);
+            let type_annotation = convert_ts_type(
+                arena,
+                &ts_assertion.type_annotation,
+                offset - 1,
+                line_offsets,
+            );
+            JsNode::TSTypeAssertion {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            }
+        }
+        _ => JsNode::Null,
     }
 }
 
@@ -5601,7 +5706,7 @@ fn convert_simple_assignment_target(
                 line_offsets,
             ))
         }
-        _ => JsNode::Null,
+        _ => convert_ts_wrapper_target(arena, target, offset, line_offsets),
     }
 }
 
@@ -8871,8 +8976,17 @@ fn convert_expression_for_program<'a>(
             let start = offset + assign.span.start as usize;
             let end = offset + assign.span.end as usize;
 
-            let left =
-                convert_assignment_target_for_program(arena, &assign.left, offset, line_offsets);
+            let left = match simple_assignment_lhs_inner(assign) {
+                Some(inner) => expr_to_node(convert_expression_for_program(
+                    arena,
+                    inner,
+                    offset,
+                    line_offsets,
+                )),
+                None => {
+                    convert_assignment_target_for_program(arena, &assign.left, offset, line_offsets)
+                }
+            };
             let right = convert_expression_for_program(arena, &assign.right, offset, line_offsets);
             let operator = assignment_operator_to_str(&assign.operator);
 
@@ -10229,10 +10343,95 @@ fn convert_assignment_target_for_program(
                 optional: member.optional,
             }
         }
-        _ => {
-            // For other complex patterns (e.g., TSAsExpression, TSNonNullExpression)
-            JsNode::Null
+        _ => target
+            .as_simple_assignment_target()
+            .map(|simple| {
+                convert_ts_wrapper_target_for_program(arena, simple, offset, line_offsets)
+            })
+            .unwrap_or(JsNode::Null),
+    }
+}
+
+/// `convert_ts_wrapper_target` for the program path (no `-1` paren adjustment).
+fn convert_ts_wrapper_target_for_program(
+    arena: &ParseArena,
+    target: &oxc_ast::ast::SimpleAssignmentTarget,
+    offset: usize,
+    line_offsets: &[usize],
+) -> JsNode {
+    use oxc_ast::ast::SimpleAssignmentTarget;
+
+    match target {
+        SimpleAssignmentTarget::TSAsExpression(ts_as) => {
+            let start = offset + ts_as.span.start as usize;
+            let end = offset + ts_as.span.end as usize;
+            let inner =
+                convert_expression_for_program(arena, &ts_as.expression, offset, line_offsets);
+            let type_annotation =
+                convert_ts_type(arena, &ts_as.type_annotation, offset, line_offsets);
+            JsNode::TSAsExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            }
         }
+        SimpleAssignmentTarget::TSSatisfiesExpression(ts_satisfies) => {
+            let start = offset + ts_satisfies.span.start as usize;
+            let end = offset + ts_satisfies.span.end as usize;
+            let inner = convert_expression_for_program(
+                arena,
+                &ts_satisfies.expression,
+                offset,
+                line_offsets,
+            );
+            let type_annotation =
+                convert_ts_type(arena, &ts_satisfies.type_annotation, offset, line_offsets);
+            JsNode::TSSatisfiesExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            }
+        }
+        SimpleAssignmentTarget::TSNonNullExpression(ts_non_null) => {
+            let start = offset + ts_non_null.span.start as usize;
+            let end = offset + ts_non_null.span.end as usize;
+            let inner = convert_expression_for_program(
+                arena,
+                &ts_non_null.expression,
+                offset,
+                line_offsets,
+            );
+            JsNode::TSNonNullExpression {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+            }
+        }
+        SimpleAssignmentTarget::TSTypeAssertion(ts_assertion) => {
+            let start = offset + ts_assertion.span.start as usize;
+            let end = offset + ts_assertion.span.end as usize;
+            let inner = convert_expression_for_program(
+                arena,
+                &ts_assertion.expression,
+                offset,
+                line_offsets,
+            );
+            let type_annotation =
+                convert_ts_type(arena, &ts_assertion.type_annotation, offset, line_offsets);
+            JsNode::TSTypeAssertion {
+                start: start as u32,
+                end: end as u32,
+                loc: create_typed_loc(start, end, line_offsets),
+                expression: arena.alloc_js_node(expr_to_node(inner)),
+                type_annotation: Box::new(type_annotation),
+            }
+        }
+        _ => JsNode::Null,
     }
 }
 
@@ -10499,7 +10698,7 @@ fn convert_simple_assignment_target_for_program(
                 optional: member.optional,
             }
         }
-        _ => JsNode::Null,
+        _ => convert_ts_wrapper_target_for_program(arena, target, offset, line_offsets),
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -1041,9 +1041,8 @@ fn collect_ts_removals_from_expression(
         E::UnaryExpression(unary) => {
             collect_ts_removals_from_expression(&unary.argument, source, removals);
         }
-        E::UpdateExpression(_update) => {
-            // UpdateExpression.argument is SimpleAssignmentTarget, not Expression
-            // No TS-specific removals needed here
+        E::UpdateExpression(update) => {
+            collect_ts_removals_from_simple_assignment_target(&update.argument, source, removals);
         }
         E::SequenceExpression(seq) => {
             for e in &seq.expressions {
@@ -1216,40 +1215,56 @@ fn collect_ts_removals_from_assignment_target(
     source: &str,
     removals: &mut Vec<(u32, u32)>,
 ) {
-    use oxc_ast::ast::AssignmentTarget as AT;
+    if let Some(simple) = target.as_simple_assignment_target() {
+        collect_ts_removals_from_simple_assignment_target(simple, source, removals);
+    }
+}
+
+/// Collect TS removals from a simple assignment target.
+///
+/// Shared by `AssignmentExpression.left` and `UpdateExpression.argument`: the
+/// latter is a `SimpleAssignmentTarget` too, and it can carry a TS wrapper
+/// (`count!++`), which used to be skipped here and leak an invalid `!` into the
+/// generated JS.
+fn collect_ts_removals_from_simple_assignment_target(
+    target: &oxc_ast::ast::SimpleAssignmentTarget,
+    source: &str,
+    removals: &mut Vec<(u32, u32)>,
+) {
+    use oxc_ast::ast::SimpleAssignmentTarget as SAT;
     use oxc_span::GetSpan;
 
     match target {
-        AT::TSAsExpression(ts_as) => {
+        SAT::TSAsExpression(ts_as) => {
             removals.push((ts_as.expression.span().end, ts_as.span.end));
             collect_ts_removals_from_expression(&ts_as.expression, source, removals);
         }
-        AT::TSSatisfiesExpression(ts_sat) => {
+        SAT::TSSatisfiesExpression(ts_sat) => {
             removals.push((ts_sat.expression.span().end, ts_sat.span.end));
             collect_ts_removals_from_expression(&ts_sat.expression, source, removals);
         }
-        AT::TSNonNullExpression(ts_nn) => {
+        SAT::TSNonNullExpression(ts_nn) => {
             removals.push((ts_nn.expression.span().end, ts_nn.span.end));
             collect_ts_removals_from_expression(&ts_nn.expression, source, removals);
         }
-        AT::TSTypeAssertion(ts_assertion) => {
+        SAT::TSTypeAssertion(ts_assertion) => {
             removals.push((
                 ts_assertion.span.start,
                 ts_assertion.expression.span().start,
             ));
             collect_ts_removals_from_expression(&ts_assertion.expression, source, removals);
         }
-        AT::ComputedMemberExpression(computed) => {
+        SAT::ComputedMemberExpression(computed) => {
             collect_ts_removals_from_expression(&computed.object, source, removals);
             collect_ts_removals_from_expression(&computed.expression, source, removals);
         }
-        AT::StaticMemberExpression(static_member) => {
+        SAT::StaticMemberExpression(static_member) => {
             collect_ts_removals_from_expression(&static_member.object, source, removals);
         }
-        AT::PrivateFieldExpression(pfe) => {
+        SAT::PrivateFieldExpression(pfe) => {
             collect_ts_removals_from_expression(&pfe.object, source, removals);
         }
-        _ => {}
+        SAT::AssignmentTargetIdentifier(_) => {}
     }
 }
 

--- a/crates/rsvelte_core/tests/ts_assertion_assignment_targets.rs
+++ b/crates/rsvelte_core/tests/ts_assertion_assignment_targets.rs
@@ -1,0 +1,318 @@
+//! TS assertion wrappers in **assignment-target** position (`x!++`, `x! += 1`,
+//! `[x!] = …`). oxc models these as `AssignmentTarget` / `SimpleAssignmentTarget`
+//! variants rather than `Expression`s, so they need their own conversion arms;
+//! without them the whole target serialized as `null` and a consumer reading the
+//! AST lost the write.
+//!
+//! svelte/compiler's shape comes from acorn-typescript's `toAssignable`, which
+//! unwraps the wrapper but whose return value is only used by `parseMaybeAssign`.
+//! The observable consequence is an asymmetry that these tests pin: a plain `=`
+//! LHS is unwrapped, while a compound assignment, an update expression and every
+//! nested destructuring position keep the wrapper.
+
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{CompileOptions, GenerateMode, ParseOptions, compile, parse};
+use serde_json::Value;
+
+fn parse_to_value(source: &str) -> Value {
+    let ast = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("parse should succeed");
+    with_serialize_arena(&ast.arena, || serde_json::to_value(&ast).unwrap())
+}
+
+/// Depth-first search for the first node whose `type` equals `ty`.
+fn find_node<'a>(v: &'a Value, ty: &str) -> Option<&'a Value> {
+    match v {
+        Value::Object(map) => {
+            if map.get("type").and_then(|t| t.as_str()) == Some(ty) {
+                return Some(v);
+            }
+            for (_, child) in map {
+                if let Some(found) = find_node(child, ty) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Array(arr) => arr.iter().find_map(|c| find_node(c, ty)),
+        _ => None,
+    }
+}
+
+fn span_text<'a>(source: &'a str, node: &Value) -> &'a str {
+    let start = node.get("start").and_then(Value::as_u64).unwrap() as usize;
+    let end = node.get("end").and_then(Value::as_u64).unwrap() as usize;
+    &source[start..end]
+}
+
+/// `<script lang="ts">` wrapping `stmt` in a function body (the program path).
+fn script(stmt: &str) -> String {
+    format!(
+        "<script lang=\"ts\">\n\
+         \tlet count = 0;\n\
+         \tlet obj: any = {{}};\n\
+         \tfunction f() {{ {stmt} }}\n\
+         </script>"
+    )
+}
+
+// ── UpdateExpression: the wrapper is kept ──────────────────────────────────
+
+#[test]
+fn non_null_update_argument_preserves_wrapper() {
+    let source = script("count!++;");
+    let ast = parse_to_value(&source);
+    let update = find_node(&ast, "UpdateExpression").expect("UpdateExpression");
+
+    let arg = update.get("argument").expect("argument present");
+    assert_eq!(
+        arg.get("type").and_then(Value::as_str),
+        Some("TSNonNullExpression"),
+        "`count!++` must keep the non-null wrapper on its argument"
+    );
+    assert_eq!(
+        arg.pointer("/expression/name").and_then(Value::as_str),
+        Some("count")
+    );
+    assert_eq!(span_text(&source, arg), "count!");
+}
+
+#[test]
+fn non_null_prefix_update_argument_preserves_wrapper() {
+    let source = script("--count!;");
+    let ast = parse_to_value(&source);
+    let update = find_node(&ast, "UpdateExpression").expect("UpdateExpression");
+
+    assert_eq!(update.get("prefix").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        update.pointer("/argument/type").and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+}
+
+#[test]
+fn as_cast_update_argument_preserves_wrapper() {
+    let source = script("(count as number)++;");
+    let ast = parse_to_value(&source);
+    let update = find_node(&ast, "UpdateExpression").expect("UpdateExpression");
+
+    let arg = update.get("argument").expect("argument present");
+    assert_eq!(
+        arg.get("type").and_then(Value::as_str),
+        Some("TSAsExpression")
+    );
+    assert_eq!(
+        arg.pointer("/expression/name").and_then(Value::as_str),
+        Some("count")
+    );
+    assert_eq!(
+        arg.pointer("/typeAnnotation/type").and_then(Value::as_str),
+        Some("TSNumberKeyword")
+    );
+}
+
+#[test]
+fn non_null_update_in_template_expression_preserves_wrapper() {
+    // The template path converts expressions through its own (`-1` paren-shifted)
+    // converters, so it needs the same arm as the `<script>` path.
+    let source = "<script lang=\"ts\">\n\tlet count = 0;\n</script>\n<button onclick={() => count!++}>x</button>";
+    let ast = parse_to_value(source);
+    let update = find_node(&ast, "UpdateExpression").expect("UpdateExpression");
+
+    let arg = update.get("argument").expect("argument present");
+    assert_eq!(
+        arg.get("type").and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+    assert_eq!(span_text(source, arg), "count!");
+}
+
+// ── AssignmentExpression: `=` unwraps, compound keeps ──────────────────────
+
+#[test]
+fn compound_assignment_lhs_preserves_wrapper() {
+    let source = script("count! += 1;");
+    let ast = parse_to_value(&source);
+    let assign = find_node(&ast, "AssignmentExpression").expect("AssignmentExpression");
+
+    assert_eq!(assign.get("operator").and_then(Value::as_str), Some("+="));
+    let left = assign.get("left").expect("left present");
+    assert_eq!(
+        left.get("type").and_then(Value::as_str),
+        Some("TSNonNullExpression"),
+        "a compound assignment keeps the wrapper on its LHS"
+    );
+    assert_eq!(span_text(&source, left), "count!");
+}
+
+#[test]
+fn logical_assignment_lhs_preserves_wrapper() {
+    let source = script("count! ??= 1;");
+    let ast = parse_to_value(&source);
+    let assign = find_node(&ast, "AssignmentExpression").expect("AssignmentExpression");
+
+    assert_eq!(assign.get("operator").and_then(Value::as_str), Some("??="));
+    assert_eq!(
+        assign.pointer("/left/type").and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+}
+
+#[test]
+fn simple_assignment_lhs_unwraps_the_assertion() {
+    // acorn-typescript's `toAssignable` returns the unwrapped node and
+    // `parseMaybeAssign` keeps that return value, so `x! = 1` loses the wrapper
+    // in svelte/compiler's AST. Nested wrappers are stripped all the way down.
+    for stmt in [
+        "count! = 1;",
+        "count!! = 1;",
+        "(count as number) = 1;",
+        "(count satisfies number) = 1;",
+    ] {
+        let source = script(stmt);
+        let ast = parse_to_value(&source);
+        let assign = find_node(&ast, "AssignmentExpression").expect("AssignmentExpression");
+
+        assert_eq!(
+            assign.pointer("/left/type").and_then(Value::as_str),
+            Some("Identifier"),
+            "`{stmt}` must unwrap to a bare Identifier"
+        );
+        assert_eq!(
+            assign.pointer("/left/name").and_then(Value::as_str),
+            Some("count"),
+            "`{stmt}` must unwrap to `count`"
+        );
+    }
+}
+
+#[test]
+fn simple_assignment_lhs_unwrap_stops_at_the_member_expression() {
+    // `obj!.p! = 1`: only the OUTER wrapper is an assignment target, so it is
+    // stripped; the `obj!` inside the member object is a value position and stays.
+    let source = script("obj!.p! = 1;");
+    let ast = parse_to_value(&source);
+    let assign = find_node(&ast, "AssignmentExpression").expect("AssignmentExpression");
+
+    let left = assign.get("left").expect("left present");
+    assert_eq!(
+        left.get("type").and_then(Value::as_str),
+        Some("MemberExpression")
+    );
+    assert_eq!(
+        left.pointer("/object/type").and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+    assert_eq!(span_text(&source, left), "obj!.p");
+}
+
+// ── destructuring targets: nested positions keep the wrapper ───────────────
+
+#[test]
+fn array_destructuring_element_preserves_wrapper() {
+    let source = script("[count!] = [1];");
+    let ast = parse_to_value(&source);
+    let pattern = find_node(&ast, "ArrayPattern").expect("ArrayPattern");
+
+    assert_eq!(
+        pattern.pointer("/elements/0/type").and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+    assert_eq!(
+        pattern
+            .pointer("/elements/0/expression/name")
+            .and_then(Value::as_str),
+        Some("count")
+    );
+}
+
+#[test]
+fn object_destructuring_value_preserves_wrapper() {
+    let source = script("({ p: count! } = { p: 1 });");
+    let ast = parse_to_value(&source);
+    let pattern = find_node(&ast, "ObjectPattern").expect("ObjectPattern");
+
+    assert_eq!(
+        pattern
+            .pointer("/properties/0/value/type")
+            .and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+}
+
+#[test]
+fn rest_element_target_preserves_wrapper() {
+    let source = script("[...count!] = [1];");
+    let ast = parse_to_value(&source);
+    let rest = find_node(&ast, "RestElement").expect("RestElement");
+
+    assert_eq!(
+        rest.pointer("/argument/type").and_then(Value::as_str),
+        Some("TSNonNullExpression")
+    );
+}
+
+// ── codegen erasure: the newly preserved wrapper must still strip cleanly ──
+
+#[test]
+fn assertion_targets_are_erased_from_codegen() {
+    let source = "<script lang=\"ts\">\n\
+        \tlet count = $state(0);\n\
+        \tfunction f() { count!++; --count!; count! += 1; count! = 3; }\n\
+        </script>\n\
+        <button onclick={f}>{count}</button>";
+
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let code = compile(
+            source,
+            CompileOptions {
+                generate,
+                ..Default::default()
+            },
+        )
+        .expect("compile should succeed")
+        .js
+        .code;
+
+        assert!(
+            !code.contains("Unknown:"),
+            "TS wrapper leaked into codegen:\n{code}"
+        );
+        assert!(
+            !code.contains("count!"),
+            "non-null assertion leaked into codegen (invalid JS):\n{code}"
+        );
+    }
+}
+
+#[test]
+fn state_writes_through_an_assertion_target_still_reach_the_runtime() {
+    // The write must survive as a `$state` write, not just as syntactically valid
+    // JS: `count!++` is the reported shape, and dropping the target silently
+    // turned it into a plain, non-reactive `count++`.
+    let source = "<script lang=\"ts\">\n\
+        \tlet count = $state(0);\n\
+        \tfunction f() { count!++; }\n\
+        </script>\n\
+        <button onclick={f}>{count}</button>";
+
+    let code = compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile should succeed")
+    .js
+    .code;
+
+    assert!(
+        code.contains("$.update(count)"),
+        "`count!++` must lower to the same `$.update` as `count++`:\n{code}"
+    );
+}


### PR DESCRIPTION
`count!++` lost its target. oxc models the argument of an `UpdateExpression` and
the left of an `AssignmentExpression` as `SimpleAssignmentTarget` /
`AssignmentTarget`, which carry their own `TSAsExpression` /
`TSSatisfiesExpression` / `TSNonNullExpression` / `TSTypeAssertion` variants —
they are not `Expression`s, so the ESTree conversion had no arm for them and fell
through to `JsNode::Null`. The whole target disappeared from `parse()`:

| source | `svelte/compiler` | rsvelte, before |
| --- | --- | --- |
| `count!++` | `argument: TSNonNullExpression(count)` | `argument: null` |
| `(count as number)++` | `argument: TSAsExpression(count)` | `argument: null` |
| `count! += 1` | `left: TSNonNullExpression(count)` | `left: null` |
| `count! = 1` | `left: Identifier count` | `left: null` |
| `[count!] = [1]` | `elements[0]: TSNonNullExpression(count)` | `elements[0]: null` |

Both the template and the `<script>` (program) converters are affected, so both
get the arm.

## The `=` asymmetry

`svelte/compiler` unwraps the assertion on a plain `=` LHS but keeps it
everywhere else, which looks arbitrary until you read acorn-typescript:
`toAssignable` *returns* the unwrapped node instead of mutating it, and only
`parseMaybeAssign`'s `=` branch uses that return value. `toAssignableList` (array
elements, object property values, rest arguments) and the compound-assignment /
update paths discard it, so the wrapper survives there. That is reproduced
literally — `simple_assignment_lhs_inner` unwraps only for
`AssignmentOperator::Assign`, and recursively (`count!! = 1` → `count`), while
`obj!.p! = 1` drops the outer `!` and keeps the `obj!` inside the member object,
because that one is a value position rather than a target.

## Codegen

The TS stripper had the matching hole, with the comment to prove it:

```rust
E::UpdateExpression(_update) => {
    // UpdateExpression.argument is SimpleAssignmentTarget, not Expression
    // No TS-specific removals needed here
}
```

It is an assignment target, and it can still be TS-wrapped. So `count!++` reached
the printer verbatim and rsvelte emitted **invalid JavaScript**:

```js
let count = $state(0);
function f() { count!++; }   // was: emitted as-is, and not reactive
function f() { $.update(count); }  // now
```

Both the syntax error and the lost `$state` write are gone; `count!++` lowers
exactly like `count++`.

Not fixed here, and pre-existing: `collect_ts_removals_from_assignment_target`
still ignores `ArrayAssignmentTarget` / `ObjectAssignmentTarget`, so a TS
assertion inside a destructuring assignment target (`[count!] = [1]`) still leaks
into codegen. The parse AST for that shape is correct as of this PR; the stripper
side is a separate gap that deserves its own change.

## Tests

`crates/rsvelte_core/tests/ts_assertion_assignment_targets.rs` — 13 cases, all
red before this change: the parse shape for each target position (update
argument, compound/logical assignment LHS, plain `=` LHS, array element, object
property value, rest argument, member-target boundary), in both the `<script>`
and template converters, plus the two codegen assertions (no `!` in the output,
and `$.update(count)`).

Found while tracking down a soundness bug in a downstream consumer
(baseballyama/svelte-shaker#183), where the missing target let a whole-program
analysis conclude that a written variable was constant.
