### PR TITLE
perf(lint): reuse the parsed script spans instead of re-parsing per rule (-9%)

### DIFF
--- a/crates/rsvelte_lint/src/context.rs
+++ b/crates/rsvelte_lint/src/context.rs
@@ -42,6 +42,10 @@ pub struct LintContext<'a> {
     /// Running it costs a full parse + analyze — several rules need it, so they
     /// share one result per file instead of each re-analyzing the source.
     /// `None` records an analysis failure (rules fall back to their own scan).
+    /// `(content_offset, end)` of the component's `<script>` blocks, taken from
+    /// the `Root` the pass already parsed. Rules that only need script bounds
+    /// used to re-parse the whole source to recover them.
+    script_spans: Vec<(u32, u32)>,
     scope_analysis: OnceCell<Option<Rc<ComponentAnalysis>>>,
     /// The template fragment as ESTree JSON (default parse options), built on
     /// first use — several script rules scan template expressions and would
@@ -65,6 +69,7 @@ impl<'a> LintContext<'a> {
             filename,
             path: None,
             scope_resolver: None,
+            script_spans: Vec::new(),
             scope_analysis: OnceCell::new(),
             template_fragment_json: OnceCell::new(),
             root_json: OnceCell::new(),
@@ -76,6 +81,17 @@ impl<'a> LintContext<'a> {
     pub fn with_path(mut self, path: Option<&'a Path>) -> Self {
         self.path = path;
         self
+    }
+
+    /// Attach the component's `<script>` spans (builder style).
+    pub fn with_script_spans(mut self, spans: Vec<(u32, u32)>) -> Self {
+        self.script_spans = spans;
+        self
+    }
+
+    /// `(content_offset, end)` for each `<script>` block, empty when unknown.
+    pub fn script_spans(&self) -> &[(u32, u32)] {
+        &self.script_spans
     }
 
     /// Attach the script-scope resolver (builder style). Left `None` by default.

--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -64,6 +64,15 @@ pub fn run_native_rules(
 /// the script walk, and the block-lang fallback. `scope_resolver` is likewise
 /// built once by the caller and shared with the script pass (see
 /// [`maybe_scope_resolver`]).
+/// `(content_offset, end)` for each `<script>` block of a parsed component.
+fn script_spans_of(root: &Root) -> Vec<(u32, u32)> {
+    [root.instance.as_ref(), root.module.as_ref()]
+        .into_iter()
+        .flatten()
+        .map(|s| (s.content_offset, s.end))
+        .collect()
+}
+
 pub(crate) fn run_native_rules_on_root(
     root: &Root,
     source: &str,
@@ -96,7 +105,8 @@ pub(crate) fn run_native_rules_on_root(
     // read of a component binding from the same-named global.
     let mut ctx = LintContext::new(config, source, filename)
         .with_path(path)
-        .with_scope_resolver(scope_resolver);
+        .with_scope_resolver(scope_resolver)
+        .with_script_spans(script_spans_of(root));
     // Re-install the arena pointer so that `Expression::Typed::as_json()` can
     // resolve arena-indexed children while the visitor walks the template.
     // The pointer was cleared when `parse()` dropped its `SerializeArenaGuard`.

--- a/crates/rsvelte_lint/src/rules/no_inspect.rs
+++ b/crates/rsvelte_lint/src/rules/no_inspect.rs
@@ -53,7 +53,7 @@ impl Rule for NoInspect {
 
     fn check_root(&self, ctx: &mut LintContext, _root: &rsvelte_core::ast::template::Root) {
         let source = ctx.source();
-        for (start, end) in find_inspect_idents(source) {
+        for (start, end) in find_inspect_idents(source, ctx.script_spans()) {
             ctx.report(start, end, MESSAGE);
         }
     }
@@ -61,20 +61,12 @@ impl Rule for NoInspect {
 
 /// Locate every whole-word `$inspect` identifier in the file's `<script>` bodies.
 /// Returns `(start, end)` byte-offset spans (absolute, into `source`).
-fn find_inspect_idents(source: &str) -> Vec<(u32, u32)> {
+fn find_inspect_idents(source: &str, spans: &[(u32, u32)]) -> Vec<(u32, u32)> {
     let mut out = Vec::new();
-    let Ok(root) = rsvelte_core::parse(
-        source,
-        &rsvelte_core::Allocator::default(),
-        rsvelte_core::ParseOptions::default(),
-    ) else {
-        return out;
-    };
-    for script in [root.instance.as_ref(), root.module.as_ref()]
-        .into_iter()
-        .flatten()
-    {
-        let (lo, hi) = (script.content_offset as usize, script.end as usize);
+    // Script bounds come from the `Root` the lint pass already parsed — this
+    // used to re-parse the whole source just to read `content_offset`/`end`.
+    for &(content_offset, end) in spans {
+        let (lo, hi) = (content_offset as usize, end as usize);
         if lo > hi || hi > source.len() {
             continue;
         }
@@ -214,7 +206,8 @@ mod tests {
     #[test]
     fn full_file_absolute_offsets() {
         let src = "<script>\n  $inspect(1);\n</script>";
-        let hits = find_inspect_idents(src);
+        // `<script>` body spans as the lint pass supplies them.
+        let hits = find_inspect_idents(src, &[(8, src.len() as u32)]);
         assert_eq!(hits.len(), 1);
         let (start, end) = hits[0];
         assert_eq!(&src[start as usize..end as usize], "$inspect");

--- a/crates/rsvelte_lint/src/rules/no_not_function_handler.rs
+++ b/crates/rsvelte_lint/src/rules/no_not_function_handler.rs
@@ -445,22 +445,12 @@ fn find_root_expression<'a>(
 /// that and is sufficient for the literal/object/array/class shapes the rule
 /// distinguishes.
 ///
-/// Perf note: this re-parses the component source once per linted file (built
-/// lazily, only when a candidate handler is found) to locate the script spans.
-fn build_const_map(source: &str) -> std::collections::HashMap<String, Value> {
+/// Script spans come from the `Root` the lint pass already parsed; this used to
+/// re-parse the whole source per file just to locate them.
+fn build_const_map(source: &str, spans: &[(u32, u32)]) -> std::collections::HashMap<String, Value> {
     let mut map = std::collections::HashMap::new();
-    let Ok(root) = rsvelte_core::parse(
-        source,
-        &rsvelte_core::Allocator::default(),
-        rsvelte_core::ParseOptions::default(),
-    ) else {
-        return map;
-    };
-    for script in [root.instance.as_ref(), root.module.as_ref()]
-        .into_iter()
-        .flatten()
-    {
-        let (lo, hi) = (script.content_offset as usize, script.end as usize);
+    for &(content_offset, end) in spans {
+        let (lo, hi) = (content_offset as usize, end as usize);
         if lo > hi || hi > source.len() {
             continue;
         }
@@ -733,7 +723,8 @@ impl NoNotFunctionHandler {
         node: &Value,
         const_map: &mut Option<std::collections::HashMap<String, Value>>,
     ) {
-        let map = const_map.get_or_insert_with(|| build_const_map(ctx.source()));
+        let map =
+            const_map.get_or_insert_with(|| build_const_map(ctx.source(), ctx.script_spans()));
         let root = find_root_expression(node, map);
         if let Some(p) = phrase(root) {
             ctx.report(start, end, format!("Unexpected {p} in event handler."));

--- a/crates/rsvelte_lint/src/rules/no_svelte_internal.rs
+++ b/crates/rsvelte_lint/src/rules/no_svelte_internal.rs
@@ -54,14 +54,8 @@ pub struct NoSvelteInternal;
 impl NoSvelteInternal {
     /// Scan both the instance and module script bodies of `source`, reporting at
     /// every offending `import` / `export` keyword.
-    fn scan_source(&self, ctx: &mut LintContext, source: &str) {
-        let Ok(root) = rsvelte_core::parse(
-            source,
-            &rsvelte_core::Allocator::default(),
-            rsvelte_core::ParseOptions::default(),
-        ) else {
-            return;
-        };
+    fn scan_source(&self, ctx: &mut LintContext, source: &str, root: &Root) {
+        // Script bounds come from the `Root` the lint pass already parsed.
         for script in [root.instance.as_ref(), root.module.as_ref()]
             .into_iter()
             .flatten()
@@ -88,9 +82,9 @@ impl Rule for NoSvelteInternal {
         &META
     }
 
-    fn check_root(&self, ctx: &mut LintContext, _root: &Root) {
+    fn check_root(&self, ctx: &mut LintContext, root: &Root) {
         let source = ctx.source();
-        self.scan_source(ctx, source);
+        self.scan_source(ctx, source, root);
     }
 }
 


### PR DESCRIPTION
## Why

Profiling the lint run by rule module put three rules at ~10% combined — and all three were spending it on **re-parsing the whole component to find out where the `<script>` blocks are**:

- `no-inspect` and `no-svelte-internal` do it in `check_root`, which is *handed* the parsed `Root` and ignored it (`_root`).
- `no-not-function-handler` does it lazily from `check_element`, where no `Root` is in scope.

## What changed

`LintContext` now carries the `(content_offset, end)` span of each `<script>` block, seeded in the native pass from the `Root` that was already parsed. The three rules read the spans from the context.

## Measured

Interleaved A/B, three rounds, idle machine, 3,412-file benchmark corpus, multi-threaded:

| Before | After | Delta |
|---:|---:|---:|
| 146.7 ms | 129.4 ms | −11.8% |
| 147.5 ms | 136.0 ms | −7.8% |
| 149.3 ms | 135.5 ms | −9.2% |

## Correctness

- Lint parity corpus: 80 current / 80 known, **0 new divergences**.
- `cargo test -p rsvelte_lint --release`: 226 + 29 pass (one unit test updated to pass the spans it used to re-derive).
- `cargo clippy -p rsvelte_lint --all-targets`: clean.

## Also measured and reverted

`prefer-const` is the single most expensive rule (21% of the run) because it needs a full parse + analyze to know which bindings are reassigned. Gating that on "does this script even declare a `let`?" looked promising but measured −0.8% (noise): 78% of the corpus's script-bearing files contain a `let`, so the guard almost never fires. Reverted rather than carry a walk that pays for itself only on unusual inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp