### PR TITLE
fix(vscode): add typescriptreact/javascriptreact to activationEvents (#1777)

### DIFF
--- a/.changeset/fix-vscode-activation-events.md
+++ b/.changeset/fix-vscode-activation-events.md
@@ -1,0 +1,10 @@
+---
+"rsvelte-vscode": patch
+---
+
+fix(vscode): add `typescriptreact`/`javascriptreact` to `activationEvents`
+
+The document selector already covered `.tsx`/`.jsx` files, but `activationEvents`
+had no matching `onLanguage:` entries, so the extension never activated when a
+`.tsx` or `.jsx` file was opened on its own (with no `.svelte`/`.ts`/`.js`/etc.
+file opened first).

--- a/apps/npm/vscode/package.json
+++ b/apps/npm/vscode/package.json
@@ -36,6 +36,8 @@
     "onLanguage:svelte",
     "onLanguage:typescript",
     "onLanguage:javascript",
+    "onLanguage:typescriptreact",
+    "onLanguage:javascriptreact",
     "onLanguage:json",
     "onLanguage:jsonc",
     "onLanguage:css",


### PR DESCRIPTION
## Summary
- `apps/npm/vscode/src/extension.ts`'s `DOCUMENT_SELECTOR` includes `typescriptreact` and `javascriptreact`, but `apps/npm/vscode/package.json`'s `activationEvents` had no matching `onLanguage:` entries.
- Opening a `.tsx` or `.jsx` file on its own (with no `.svelte`/`.ts`/`.js`/`.json`/`.css`/`.scss`/`.less` file opened first) therefore never activated the extension, so the language client never started for those documents even though the selector claims to cover them.
- Added `onLanguage:typescriptreact` and `onLanguage:javascriptreact` to `activationEvents` so it matches the document selector.
- Added a patch changeset for `rsvelte-vscode` (fixed-versioned with `@rsvelte/language-server` per `.changeset/config.json`).

Closes #1777

## Test plan
- [x] `python3 -m json.tool apps/npm/vscode/package.json` — manifest is valid JSON
- [x] Manually diffed `DOCUMENT_SELECTOR` (extension.ts) against `activationEvents` (package.json) — now consistent
- [ ] No dedicated automated test exists for the extension manifest; CI's JSON/lint checks apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)