### PR TITLE
docs: update parse() doctest to 3-arg signature (#1755)

### DIFF
--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -10,10 +10,11 @@
 //! ## Usage
 //!
 //! ```rust,no_run
-//! use rsvelte_core::{parse, ParseOptions};
+//! use rsvelte_core::{Allocator, parse, ParseOptions};
 //!
 //! let source = r#"<h1>Hello, {name}!</h1>"#;
-//! let ast = parse(source, ParseOptions::default()).unwrap();
+//! let allocator = Allocator::default();
+//! let ast = parse(source, &allocator, ParseOptions::default()).unwrap();
 //! ```
 
 // `#[global_allocator]` deliberately lives in each binary entry point


### PR DESCRIPTION
## Summary
- `src/lib.rs`'s crate-level doctest still called `parse(source, options)`, but `parse()` was extended to take a caller-owned `oxc_allocator::Allocator` as its second argument, so `cargo test -p rsvelte_core --doc` failed to compile.
- Updated the example to construct an `Allocator` and pass it through: `parse(source, &allocator, ParseOptions::default())`.

Closes #1755

## Test plan
- [x] `cargo test -p rsvelte_core --doc` — doctest compiles and passes
- [x] `cargo fmt -p rsvelte_core`
- [x] `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)