### PR TITLE
fix(lint): treat lone CR as a line break in line_index (#1793)

### DIFF
--- a/.changeset/lint-lone-cr-line-break.md
+++ b/.changeset/lint-lone-cr-line-break.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/lint": patch
+---
+
+fix(lint): treat lone CR as a line break in diagnostic line/column computation
+
+`LineIndex` only split lines on `\n`, so a lone `\r` (old Mac-style line
+ending) with no following `\n` was not counted as a line break. Diagnostic
+line/column positions after such a `\r` were therefore off, unlike ESLint's
+text model, which treats `\r`, `\n`, and `\r\n` all as line terminators.

--- a/crates/rsvelte_lint/src/line_index.rs
+++ b/crates/rsvelte_lint/src/line_index.rs
@@ -15,12 +15,23 @@ pub struct LineIndex<'a> {
 
 impl<'a> LineIndex<'a> {
     pub fn new(source: &'a str) -> Self {
-        let mut line_starts = Vec::with_capacity(source.len() / 32 + 1);
+        let bytes = source.as_bytes();
+        let mut line_starts = Vec::with_capacity(bytes.len() / 32 + 1);
         line_starts.push(0);
-        for (i, b) in source.bytes().enumerate() {
-            if b == b'\n' {
-                line_starts.push(i as u32 + 1);
+        let mut i = 0;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'\n' => line_starts.push(i as u32 + 1),
+                // A lone `\r` also terminates a line, matching ESLint/the LSP text model.
+                b'\r' => {
+                    if bytes.get(i + 1) == Some(&b'\n') {
+                        i += 1;
+                    }
+                    line_starts.push(i as u32 + 1);
+                }
+                _ => {}
             }
+            i += 1;
         }
         Self {
             source,
@@ -78,5 +89,41 @@ mod tests {
         let idx = LineIndex::new(src);
         let x_off = "💡".len() as u32;
         assert_eq!(idx.position(x_off), (1, 2));
+    }
+
+    #[test]
+    fn lf_terminates_lines() {
+        let idx = LineIndex::new("a\nb\nc");
+        assert_eq!(idx.position(0), (1, 0)); // 'a'
+        assert_eq!(idx.position(2), (2, 0)); // 'b'
+        assert_eq!(idx.position(4), (3, 0)); // 'c'
+    }
+
+    #[test]
+    fn crlf_terminates_lines() {
+        let idx = LineIndex::new("a\r\nb\r\nc");
+        assert_eq!(idx.position(0), (1, 0)); // 'a'
+        assert_eq!(idx.position(3), (2, 0)); // 'b'
+        assert_eq!(idx.position(6), (3, 0)); // 'c'
+    }
+
+    #[test]
+    fn lone_cr_terminates_lines() {
+        // Classic Mac line endings: a lone `\r` (not followed by `\n`) still
+        // starts a new line, matching ESLint/eslint-plugin-svelte.
+        let idx = LineIndex::new("a\rb\rc");
+        assert_eq!(idx.position(0), (1, 0)); // 'a'
+        assert_eq!(idx.position(2), (2, 0)); // 'b'
+        assert_eq!(idx.position(4), (3, 0)); // 'c'
+    }
+
+    #[test]
+    fn issue_1793_reproduction() {
+        // From #1793: three lone-CR-terminated tags; the `{@html v}` offset
+        // must land on line 3, not be swallowed into line 1.
+        let src = "<p>aaa</p>\r<p>bbb</p>\r<div>{@html v}</div>\r";
+        let idx = LineIndex::new(src);
+        let html_offset = src.find("{@html").unwrap() as u32;
+        assert_eq!(idx.position(html_offset), (3, 5));
     }
 }


### PR DESCRIPTION
## Summary
- `crates/rsvelte_lint/src/line_index.rs` only split on `\n`, so a file using classic Mac line endings (lone `\r`, not followed by `\n`) collapsed into a single line and every diagnostic after the first `\r` was reported at the wrong position.
- Now matches `rsvelte_language_server/src/text.rs`'s `LineIndex`, which already treats a lone `\r` as a line terminator per the LSP text model (and ESLint/eslint-plugin-svelte's line/column computation), so the two line models agree within one process.
- CRLF (`\r\n`) continues to count as a single line break (the `\n` is skipped, not double-counted).

## Test plan
- [x] Added unit tests in `line_index.rs` covering LF-only, CRLF, and lone-CR sources, plus the exact repro from #1793 (`"<p>aaa</p>\r<p>bbb</p>\r<div>{@html v}</div>\r"` now resolves the `{@html v}` offset to line 3, column 5).
- [x] `cargo test -p rsvelte_lint` — all 233 lib tests + integration tests (including `eslint_plugin_oracle`) pass.
- [x] `cargo fmt -p rsvelte_lint`
- [x] `cargo clippy -p rsvelte_lint --all-targets --all-features -- -D warnings` — clean.

Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)