### PR TITLE
fix: remove ARENA CHILDREN MISMATCH debug output from library code

### DIFF
--- a/.changeset/compiler-remove-arena-mismatch-debug-output.md
+++ b/.changeset/compiler-remove-arena-mismatch-debug-output.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix: stop writing "ARENA MISMATCH" debug output to stderr from library code
+
+Debug builds of `rsvelte_core` printed `ARENA CHILDREN MISMATCH` /
+`ARENA MISMATCH` diagnostics to stderr from `get_js_node` and its callers
+whenever the fallback `NULL_NODE` sentinel was returned. Library code should
+never write to stderr unasked; the fallback behavior itself is unchanged.

--- a/crates/rsvelte_core/src/ast/arena.rs
+++ b/crates/rsvelte_core/src/ast/arena.rs
@@ -360,11 +360,6 @@ impl ParseArena {
             let store = &*self.js_nodes.get();
             let index = id.0 as usize;
             if index >= store.len {
-                #[cfg(debug_assertions)]
-                eprintln!(
-                    "ARENA MISMATCH: get_js_node(id={}) but arena has {} nodes",
-                    id.0, store.len
-                );
                 static NULL_NODE: JsNode = JsNode::Null;
                 return &NULL_NODE;
             }

--- a/crates/rsvelte_core/src/ast/arena.rs
+++ b/crates/rsvelte_core/src/ast/arena.rs
@@ -405,11 +405,6 @@ impl ParseArena {
             let start = range.start as usize;
             let len = range.len as usize;
             if start + len > store.len {
-                #[cfg(debug_assertions)]
-                eprintln!(
-                    "ARENA CHILDREN MISMATCH: range({},{}) but arena has {} children",
-                    range.start, range.len, store.len
-                );
                 return &[];
             }
             std::slice::from_raw_parts(store.ptr(start), len)


### PR DESCRIPTION
## Summary
- Removes both `eprintln!` debug prints in `crates/rsvelte_core/src/ast/arena.rs` that leaked to stderr from library code:
  - `ParseArena::get_js_children`: `"ARENA CHILDREN MISMATCH: range(N,M) but arena has K children"`
  - `ParseArena::get_js_node`: `"ARENA MISMATCH: get_js_node(id=N) but arena has K nodes"`
- Both were gated behind `#[cfg(debug_assertions)]` but still wrote unconditionally to the process's stderr from library code on a stale/out-of-range lookup, polluting CLI output, editor logs, and any host embedding the compiler.
- The existing fallback behavior is unchanged in both cases — `get_js_children` still returns an empty slice `&[]`, and `get_js_node` still returns the `NULL_NODE` sentinel, when the lookup misses.

Closes #1795

## Test plan
- [x] `cargo build -p rsvelte_core`
- [x] `cargo test -p rsvelte_core --test parser_fixtures --test compiler_fixtures --test validator` (all passing; these run in debug mode, exercising the `debug_assertions`-gated code paths that were changed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)