### PR TITLE
chore: sync docs and VPS VERSION with Svelte 5.56.8

### DIFF
--- a/.changeset/sync-vps-version-5-56-8.md
+++ b/.changeset/sync-vps-version-5-56-8.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+chore(vite-plugin-svelte-native): report Svelte `5.56.8` from the `VERSION` export
+
+The hardcoded `VERSION` export is what consumers feature-detect against
+(`gte(VERSION, '5.36.0')`), so it has to track the Svelte version rsvelte is
+compiled against — now 5.56.8.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ Use the `Agent` tool for substantial work — feature implementation, multi-file
 
 ## Test Status
 
-Source: `pnpm run compatibility-report` (Svelte **v5.56.7**). Re-run `pnpm run test-and-update`
+Source: `pnpm run compatibility-report` (Svelte **v5.56.8**). Re-run `pnpm run test-and-update`
 to refresh. Skip lists live in `crates/rsvelte_core/tests/compatibility_report.rs` and
 `crates/rsvelte_core/tests/runtime.rs`; `crates/rsvelte_core/tests/audit_skipped.rs`
 re-checks every skipped fixture after a Svelte bump.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Live numbers, charts, and reproduction steps: [benchmark page](https://basebally
 ## Compatibility
 
 <!-- svelte-target-version -->
-**Targeting Svelte `v5.56.7`** ([`b29d7002ecf9`](https://github.com/sveltejs/svelte/commit/b29d7002ecf9)) — automatically maintained by `pnpm run update-docs`.
+**Targeting Svelte `v5.56.8`** ([`44a781373057`](https://github.com/sveltejs/svelte/commit/44a781373057)) — automatically maintained by `pnpm run update-docs`.
 <!-- /svelte-target-version -->
 
 rsvelte passes **100% of the in-scope fixtures** of the official Svelte compiler test suite — over 3,500 fixtures across parser, snapshot, CSS, validator, compiler errors, runtime (runes + legacy), hydration, SSR, preprocess, print, and svelte2tsx. The per-suite breakdown is on the live [compatibility dashboard](https://baseballyama.github.io/rsvelte/progress); regenerate locally with `pnpm run test-and-update`.

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -264,4 +264,4 @@ module.exports.decodeParseEnvelope = decodeParseEnvelope;
 // with `submodules/svelte/packages/svelte/package.json` by hand; run
 // `node scripts/dev/check-vps-version.mjs` (also wired into CI) to
 // catch drift.
-module.exports.VERSION = '5.56.7';
+module.exports.VERSION = '5.56.8';


### PR DESCRIPTION
## Why

The 5.56.8 submodule bump (#1785) landed without its two follow-up sync steps, leaving `main` red:

1. **Compatibility Report → "Check README is in sync with Svelte submodule"** — `node scripts/dev/update-docs.mjs --check` exited 1 with `Expected Svelte target: v5.56.8 (44a781373057)`; README's `<!-- svelte-target-version -->` block still said `v5.56.7` / `b29d7002ecf9`.
2. **VPS native VERSION drift check** — `node scripts/dev/check-vps-version.mjs` exited 1: `apps/npm/vite-plugin-svelte-native/index.cjs` exported `VERSION = '5.56.7'` while `submodules/svelte/packages/svelte/package.json` is `5.56.8`.

## What

- `README.md` — marker block regenerated with `pnpm run update-docs` (after a full `pnpm run compatibility-report` against freshly generated 5.56.8 fixtures), not hand-edited.
- `apps/npm/vite-plugin-svelte-native/index.cjs` — `VERSION` → `'5.56.8'` (+ patch changeset, since the export is what consumers feature-detect against).
- `AGENTS.md` — the hand-written Test Status heading now says Svelte **v5.56.8**.

Both failing commands are green locally:

```
[check-vps-version] VERSION '5.56.8' matches submodules/svelte.
README.md Svelte target marker is in sync (v5.56.8 @ 44a781373057)
```

## Test results at 5.56.8

Gating suites are all green — 5.56.8 only adds runtime fixtures (`select-spread-preserve-selection`, `error-boundary-hydrate-1/2`) and changes runtime `boundary.js` / `select.js`, no compiler sources:

- `cargo test --release --test parser_fixtures` — 17/17
- `cargo test --release --test runtime` — 19/19 (runtime-browser 32/32, hydration 77/77, runtime-runes 1002/1002, runtime-legacy 1206/1206; skips unchanged)

`apps/playground/static/test-results.json` is intentionally **not** regenerated here: the fresh report surfaces 8 failures that are all pre-existing on `main` and unrelated to this bump (the compatibility-report job does not gate on them), so republishing the dashboard would advertise a regression this PR did not cause. Details:

- `parser-modern` `parens`, `comment-before-function-binding`, `tag-type-identifier-probe-comment` — harness-only false failures: `crates/rsvelte_core/tests/compatibility_report.rs` builds `ParseOptions` without `capture_comments: true` (which `tests/parser_fixtures.rs` sets), so `leadingComments` never appear in the actual AST. The gating parser suite passes all three.
- `runtime-runes` `async-style-after-await` / `async-batch-derived`, plus `hmr-removal` / `hmr-each-keyed-unshift` and hydration `boundary-pending-attribute` — documented pre-existing server-codegen gaps that `tests/runtime.rs` skips (async / hmr configs) but the report harness compiles anyway.

Worth a separate triage PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtF1frWdTnBtbfkChud2AS