### PR TITLE
fix(parse): reject non-call expressions in {@render} like the official compiler (#1786)

### DIFF
--- a/.changeset/fix-render-tag-invalid-expression.md
+++ b/.changeset/fix-render-tag-invalid-expression.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): reject non-call expressions in `{@render}` like the official compiler
+
+`{@render new foo()}` compiled instead of erroring: the `CallExpression` /
+`ChainExpression` check that `svelte/compiler` performs at parse time was
+missing, and the phase-2 fallback only looked for a `callee` — which a
+`NewExpression` also has. The parser now raises
+`render_tag_invalid_expression` with the same message and span as the official
+compiler, while `{@render foo()}`, `{@render foo?.()}` and
+`{@render (cond ? a : b)()}` keep compiling.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
@@ -139,6 +139,19 @@ fn resolve_template_node(
                 source,
                 first_error,
             );
+            // The eager parse path rejects non-call render expressions inline;
+            // a deferred expression only becomes checkable here.
+            if !super::state::tag::is_render_tag_call_expression(arena, &tag.expression)
+                && first_error.is_none()
+            {
+                let err_start = tag.expression.start().unwrap_or(tag.start) as usize;
+                let err_end = tag.expression.end().unwrap_or(tag.end) as usize;
+                *first_error = Some(crate::error::ParseError::svelte(
+                    "render_tag_invalid_expression",
+                    "`{@render ...}` tags can only contain call expressions",
+                    (err_start, err_end),
+                ));
+            }
         }
         TemplateNode::AttachTag(tag) => {
             resolve_expression(

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/mod.rs
@@ -5,5 +5,5 @@
 
 mod element;
 mod fragment;
-mod tag;
+pub(super) mod tag;
 mod text;

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1946,6 +1946,18 @@ impl<'a> Parser<'a> {
                 let trimmed = expr_content.trim_ws();
                 let expression = self.parse_js_expression_lenient(trimmed, expr_start);
 
+                // Upstream rejects anything but a call (optionally chained) here:
+                // `new foo()` and `foo` are parse errors, `foo?.()` is not.
+                if !is_render_tag_call_expression(&self.arena, &expression) {
+                    let err_start = expression.start().map(|s| s as usize).unwrap_or(expr_start);
+                    let err_end = expression.end().map(|e| e as usize).unwrap_or(end);
+                    return Err(crate::error::ParseError::svelte(
+                        "render_tag_invalid_expression",
+                        "`{@render ...}` tags can only contain call expressions",
+                        (err_start, err_end),
+                    ));
+                }
+
                 Ok(Some(TemplateNode::RenderTag(Box::new(RenderTag {
                     start: start as u32,
                     end: self.index as u32,
@@ -2455,14 +2467,6 @@ impl<'a> Parser<'a> {
     }
 }
 
-/// Strip a TypeScript type annotation from a pattern string.
-///
-/// For simple identifiers: `area: number` -> `area`
-/// For destructuring: `{ x, y }: Point` -> `{ x, y }`
-///
-/// This handles nested braces/brackets so that colons inside destructuring
-/// patterns (like `{ x: aliasX }`) are not mistakenly treated as type
-/// annotations.
 /// Whether `s` contains a `//` or `/*` comment opener. A `/` inside a string or
 /// regex can produce a false positive, which only costs an eager parse.
 fn contains_js_comment(s: &str) -> bool {
@@ -2475,6 +2479,28 @@ fn contains_js_comment(s: &str) -> bool {
         }
     }
     false
+}
+
+/// Whether a `{@render ...}` expression is a call, optionally optional-chained,
+/// mirroring upstream's `1-parse/state/tag.js` check.
+fn is_render_tag_call_expression(arena: &crate::ast::arena::ParseArena, expr: &Expression) -> bool {
+    let Some(node) = expr.try_as_node_ref() else {
+        // A `Lazy` expression is not resolved yet; leave it to analysis.
+        return true;
+    };
+    match node {
+        JsNode::CallExpression { .. } => true,
+        JsNode::ChainExpression { expression, .. } => {
+            matches!(
+                arena.get_js_node(*expression),
+                JsNode::CallExpression { .. }
+            )
+        }
+        // The empty-identifier sentinel means the JS itself failed to parse;
+        // reporting it as an invalid render tag would mask that.
+        JsNode::Identifier { name, .. } => name.is_empty(),
+        _ => false,
+    }
 }
 
 /// Find the byte offset of the first top-level assignment `=` in a declaration

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -2483,7 +2483,10 @@ fn contains_js_comment(s: &str) -> bool {
 
 /// Whether a `{@render ...}` expression is a call, optionally optional-chained,
 /// mirroring upstream's `1-parse/state/tag.js` check.
-fn is_render_tag_call_expression(arena: &crate::ast::arena::ParseArena, expr: &Expression) -> bool {
+pub(crate) fn is_render_tag_call_expression(
+    arena: &crate::ast::arena::ParseArena,
+    expr: &Expression,
+) -> bool {
     let Some(node) = expr.try_as_node_ref() else {
         // A `Lazy` expression is not resolved yet; leave it to analysis.
         return true;

--- a/crates/rsvelte_core/tests/render_tag_invalid_expression.rs
+++ b/crates/rsvelte_core/tests/render_tag_invalid_expression.rs
@@ -1,0 +1,88 @@
+//! Regression test: `{@render ...}` must contain a call expression (issue #1786).
+//!
+//! Upstream rejects this in `1-parse/state/tag.js` right after `read_expression`:
+//! anything that is not a `CallExpression` (or a `ChainExpression` wrapping one)
+//! is a `render_tag_invalid_expression` parse error — so `{@render new foo()}`
+//! errors even though it has a `callee`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn try_compile(src: &str) -> Result<(), (String, usize, usize)> {
+    match compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let s = format!("{e:?}");
+            let code = s
+                .split("code: \"")
+                .nth(1)
+                .and_then(|t| t.split('"').next())
+                .unwrap_or("")
+                .to_string();
+            let span = s
+                .split("span: (")
+                .nth(1)
+                .and_then(|t| t.split(')').next())
+                .map(|t| {
+                    let mut it = t.split(", ");
+                    let a = it.next().unwrap_or("0").trim().parse().unwrap_or(0);
+                    let b = it.next().unwrap_or("0").trim().parse().unwrap_or(0);
+                    (a, b)
+                })
+                .unwrap_or((0, 0));
+            Err((code, span.0, span.1))
+        }
+    }
+}
+
+#[track_caller]
+fn assert_invalid(src: &str, start: usize, end: usize) {
+    match try_compile(src) {
+        Ok(()) => panic!("expected `render_tag_invalid_expression` for {src:?}, but it compiled"),
+        Err((code, s, e)) => {
+            assert_eq!(
+                code, "render_tag_invalid_expression",
+                "for {src:?} expected `render_tag_invalid_expression`, got `{code}`"
+            );
+            assert_eq!((s, e), (start, end), "wrong span for {src:?}");
+        }
+    }
+}
+
+#[track_caller]
+fn assert_compiles(src: &str) {
+    if let Err((code, _, _)) = try_compile(src) {
+        panic!("expected {src:?} to compile, got error `{code}`");
+    }
+}
+
+#[test]
+fn non_call_render_expressions_are_rejected() {
+    // Spans match the official compiler's (the expression node, parens removed).
+    assert_invalid("{@render new foo()}", 9, 18);
+    assert_invalid("{@render foo}", 9, 12);
+    assert_invalid("{@render foo.bar}", 9, 16);
+    assert_invalid("{@render foo``}", 9, 14);
+    assert_invalid("{@render (a,b)}", 10, 13);
+    assert_invalid("{@render 1}", 9, 10);
+}
+
+#[test]
+fn call_render_expressions_still_compile() {
+    assert_compiles("{@render foo()}");
+    assert_compiles("{@render foo?.()}");
+    assert_compiles("{@render a?.b()}");
+    assert_compiles("{@render foo.bar()}");
+    assert_compiles("{@render (cond ? a : b)()}");
+    assert_compiles("{@render (foo())}");
+    assert_compiles("{#snippet x()}y{/snippet}{@render x()}");
+}


### PR DESCRIPTION
Closes #1786

## Problem

`{@render new foo()}` compiled fine in rsvelte, but the official compiler rejects it with `render_tag_invalid_expression`.

The official compiler enforces this **at parse time** (`1-parse/state/tag.js`), right after `read_expression`:

```js
if (
  expression.type !== 'CallExpression' &&
  (expression.type !== 'ChainExpression' || expression.expression.type !== 'CallExpression')
) {
  e.render_tag_invalid_expression(expression);
}
```

rsvelte had no such parse-time check; `render_tag_invalid_expression` only existed in phase 2, where the check merely looks for a `callee` — and `NewExpression` has one, so `new foo()` slipped through.

## Fix

Mirror the upstream check in the `"render"` arm of `1_parse/state/tag.rs`: accept only a `CallExpression`, or a `ChainExpression` wrapping one (`foo?.()`), and otherwise raise the parse error with upstream's code, message and span (the expression node, parens removed).

The empty-identifier sentinel (the JS itself failed to parse) is exempt so a JS syntax error is not relabelled as an invalid render tag — that path's behaviour is unchanged.

## Verification

Error codes and spans were checked against the official compiler for every case in the new test:

| input | official | rsvelte (after) |
|---|---|---|
| `{@render new foo()}` | `render_tag_invalid_expression` 9..18 | same |
| `{@render foo}` | `render_tag_invalid_expression` 9..12 | same |
| `{@render foo}` with a tagged template instead of a call | `render_tag_invalid_expression` 9..14 | same |
| `{@render (a,b)}` | `render_tag_invalid_expression` 10..13 | same |
| `{@render foo()}` / `foo?.()` / `a?.b()` / `foo.bar()` / `(cond ? a : b)()` / `(foo())` | OK | OK |

Tests: new `crates/rsvelte_core/tests/render_tag_invalid_expression.rs`, plus `parser_fixtures`, `compiler_errors`, `validator`, `compatibility_report` and `svelte2tsx_fixtures` all green. The official suite has no fixture for this error (both compilers were untested here), hence the rsvelte-side regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
