### PR TITLE
fix: make bind_directive possible-bindings enumeration deterministic (#1771)

### DIFF
--- a/.changeset/compiler-deterministic-possible-bindings.md
+++ b/.changeset/compiler-deterministic-possible-bindings.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix: bind: diagnostic "Possible bindings" enumeration now matches the official
+compiler's sorted order and is deterministic
+
+`Possible bindings for <…> are …` was built by iterating an `FxHashMap`, so
+the reported order was arbitrary and could diverge between runs, unlike the
+official compiler, which sorts the list. `BINDING_PROPERTIES` is now backed
+by an ordered const slice in upstream `bindings.js` definition order, the
+enumeration is sorted like upstream's `.sort()`, and the related
+`check_graph_for_cycles` root visitation and `{@const}` dependency collection
+are now insertion-ordered as well.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/binding_properties.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/binding_properties.rs
@@ -59,320 +59,312 @@ impl BindingProperty {
     }
 }
 
+/// Binding definitions in the same order as Svelte's `phases/bindings.js`.
+///
+/// Diagnostics enumerate bindings from this ordered slice, never from the map, so
+/// message order can never depend on hash iteration order.
+pub static BINDING_PROPERTIES_LIST: &[(&str, BindingProperty)] = &[
+    (
+        "currentTime",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr()
+            .bidirectional(),
+    ),
+    (
+        "duration",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .with_event("durationchange")
+            .omit_in_ssr(),
+    ),
+    ("focused", BindingProperty::new()),
+    (
+        "paused",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr()
+            .bidirectional(),
+    ),
+    (
+        "buffered",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr(),
+    ),
+    (
+        "seekable",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr(),
+    ),
+    (
+        "played",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr(),
+    ),
+    (
+        "volume",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr()
+            .bidirectional(),
+    ),
+    (
+        "muted",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr()
+            .bidirectional(),
+    ),
+    (
+        "playbackRate",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr()
+            .bidirectional(),
+    ),
+    (
+        "seeking",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr(),
+    ),
+    (
+        "ended",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr(),
+    ),
+    (
+        "readyState",
+        BindingProperty::new()
+            .with_valid_elements(&["audio", "video"])
+            .omit_in_ssr(),
+    ),
+    (
+        "videoHeight",
+        BindingProperty::new()
+            .with_valid_elements(&["video"])
+            .with_event("resize")
+            .omit_in_ssr(),
+    ),
+    (
+        "videoWidth",
+        BindingProperty::new()
+            .with_valid_elements(&["video"])
+            .with_event("resize")
+            .omit_in_ssr(),
+    ),
+    (
+        "naturalWidth",
+        BindingProperty::new()
+            .with_valid_elements(&["img"])
+            .with_event("load")
+            .omit_in_ssr(),
+    ),
+    (
+        "naturalHeight",
+        BindingProperty::new()
+            .with_valid_elements(&["img"])
+            .with_event("load")
+            .omit_in_ssr(),
+    ),
+    (
+        "activeElement",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:document"])
+            .omit_in_ssr(),
+    ),
+    (
+        "fullscreenElement",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:document"])
+            .with_event("fullscreenchange")
+            .omit_in_ssr(),
+    ),
+    (
+        "pointerLockElement",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:document"])
+            .with_event("pointerlockchange")
+            .omit_in_ssr(),
+    ),
+    (
+        "visibilityState",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:document"])
+            .with_event("visibilitychange")
+            .omit_in_ssr(),
+    ),
+    (
+        "innerWidth",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:window"])
+            .omit_in_ssr(),
+    ),
+    (
+        "innerHeight",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:window"])
+            .omit_in_ssr(),
+    ),
+    (
+        "outerWidth",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:window"])
+            .omit_in_ssr(),
+    ),
+    (
+        "outerHeight",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:window"])
+            .omit_in_ssr(),
+    ),
+    (
+        "scrollX",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:window"])
+            .omit_in_ssr()
+            .bidirectional(),
+    ),
+    (
+        "scrollY",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:window"])
+            .omit_in_ssr()
+            .bidirectional(),
+    ),
+    (
+        "online",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:window"])
+            .omit_in_ssr(),
+    ),
+    (
+        "devicePixelRatio",
+        BindingProperty::new()
+            .with_valid_elements(&["svelte:window"])
+            .with_event("resize")
+            .omit_in_ssr(),
+    ),
+    (
+        "clientWidth",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .omit_in_ssr(),
+    ),
+    (
+        "clientHeight",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .omit_in_ssr(),
+    ),
+    (
+        "offsetWidth",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .omit_in_ssr(),
+    ),
+    (
+        "offsetHeight",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .omit_in_ssr(),
+    ),
+    (
+        "contentRect",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .omit_in_ssr(),
+    ),
+    (
+        "contentBoxSize",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .omit_in_ssr(),
+    ),
+    (
+        "borderBoxSize",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .omit_in_ssr(),
+    ),
+    (
+        "devicePixelContentBoxSize",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .omit_in_ssr(),
+    ),
+    (
+        "indeterminate",
+        BindingProperty::new()
+            .with_valid_elements(&["input"])
+            .with_event("change")
+            .bidirectional()
+            .omit_in_ssr(),
+    ),
+    (
+        "checked",
+        BindingProperty::new()
+            .with_valid_elements(&["input"])
+            .bidirectional(),
+    ),
+    (
+        "group",
+        BindingProperty::new()
+            .with_valid_elements(&["input"])
+            .bidirectional(),
+    ),
+    ("this", BindingProperty::new().omit_in_ssr()),
+    (
+        "innerText",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .bidirectional(),
+    ),
+    (
+        "innerHTML",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .bidirectional(),
+    ),
+    (
+        "textContent",
+        BindingProperty::new()
+            .with_invalid_elements(&["svelte:window", "svelte:document"])
+            .bidirectional(),
+    ),
+    (
+        "open",
+        BindingProperty::new()
+            .with_valid_elements(&["details"])
+            .with_event("toggle")
+            .bidirectional(),
+    ),
+    (
+        "value",
+        BindingProperty::new()
+            .with_valid_elements(&["input", "textarea", "select"])
+            .bidirectional(),
+    ),
+    (
+        "files",
+        BindingProperty::new()
+            .with_valid_elements(&["input"])
+            .omit_in_ssr()
+            .bidirectional(),
+    ),
+];
+
 /// Map of binding names to their properties.
 pub static BINDING_PROPERTIES: LazyLock<FxHashMap<&'static str, BindingProperty>> =
     LazyLock::new(|| {
-        let mut map = FxHashMap::default();
-
-        // Media bindings
-        map.insert(
-            "currentTime",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr()
-                .bidirectional(),
-        );
-        map.insert(
-            "duration",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .with_event("durationchange")
-                .omit_in_ssr(),
-        );
-        map.insert("focused", BindingProperty::new());
-        map.insert(
-            "paused",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr()
-                .bidirectional(),
-        );
-        map.insert(
-            "buffered",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "seekable",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "played",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "volume",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr()
-                .bidirectional(),
-        );
-        map.insert(
-            "muted",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr()
-                .bidirectional(),
-        );
-        map.insert(
-            "playbackRate",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr()
-                .bidirectional(),
-        );
-        map.insert(
-            "seeking",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "ended",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "readyState",
-            BindingProperty::new()
-                .with_valid_elements(&["audio", "video"])
-                .omit_in_ssr(),
-        );
-
-        // Video bindings
-        map.insert(
-            "videoHeight",
-            BindingProperty::new()
-                .with_valid_elements(&["video"])
-                .with_event("resize")
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "videoWidth",
-            BindingProperty::new()
-                .with_valid_elements(&["video"])
-                .with_event("resize")
-                .omit_in_ssr(),
-        );
-
-        // Image bindings
-        map.insert(
-            "naturalWidth",
-            BindingProperty::new()
-                .with_valid_elements(&["img"])
-                .with_event("load")
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "naturalHeight",
-            BindingProperty::new()
-                .with_valid_elements(&["img"])
-                .with_event("load")
-                .omit_in_ssr(),
-        );
-
-        // Document bindings
-        map.insert(
-            "activeElement",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:document"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "fullscreenElement",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:document"])
-                .with_event("fullscreenchange")
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "pointerLockElement",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:document"])
-                .with_event("pointerlockchange")
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "visibilityState",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:document"])
-                .with_event("visibilitychange")
-                .omit_in_ssr(),
-        );
-
-        // Window bindings
-        map.insert(
-            "innerWidth",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:window"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "innerHeight",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:window"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "outerWidth",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:window"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "outerHeight",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:window"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "scrollX",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:window"])
-                .omit_in_ssr()
-                .bidirectional(),
-        );
-        map.insert(
-            "scrollY",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:window"])
-                .omit_in_ssr()
-                .bidirectional(),
-        );
-        map.insert(
-            "online",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:window"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "devicePixelRatio",
-            BindingProperty::new()
-                .with_valid_elements(&["svelte:window"])
-                .with_event("resize")
-                .omit_in_ssr(),
-        );
-
-        // Dimension bindings
-        map.insert(
-            "clientWidth",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "clientHeight",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "offsetWidth",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "offsetHeight",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "contentRect",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "contentBoxSize",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "borderBoxSize",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "devicePixelContentBoxSize",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .omit_in_ssr(),
-        );
-
-        // Checkbox/radio bindings
-        map.insert(
-            "indeterminate",
-            BindingProperty::new()
-                .with_valid_elements(&["input"])
-                .with_event("change")
-                .bidirectional()
-                .omit_in_ssr(),
-        );
-        map.insert(
-            "checked",
-            BindingProperty::new()
-                .with_valid_elements(&["input"])
-                .bidirectional(),
-        );
-        map.insert(
-            "group",
-            BindingProperty::new()
-                .with_valid_elements(&["input"])
-                .bidirectional(),
-        );
-
-        // Various bindings
-        map.insert("this", BindingProperty::new().omit_in_ssr());
-        map.insert(
-            "innerText",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .bidirectional(),
-        );
-        map.insert(
-            "innerHTML",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .bidirectional(),
-        );
-        map.insert(
-            "textContent",
-            BindingProperty::new()
-                .with_invalid_elements(&["svelte:window", "svelte:document"])
-                .bidirectional(),
-        );
-        map.insert(
-            "open",
-            BindingProperty::new()
-                .with_valid_elements(&["details"])
-                .with_event("toggle")
-                .bidirectional(),
-        );
-        map.insert(
-            "value",
-            BindingProperty::new()
-                .with_valid_elements(&["input", "textarea", "select"])
-                .bidirectional(),
-        );
-        map.insert(
-            "files",
-            BindingProperty::new()
-                .with_valid_elements(&["input"])
-                .omit_in_ssr()
-                .bidirectional(),
-        );
-
-        map
+        BINDING_PROPERTIES_LIST
+            .iter()
+            .map(|(name, property)| (*name, property.clone()))
+            .collect()
     });
 
 /// Check if a binding is valid for a given element.
@@ -395,9 +387,10 @@ pub fn is_binding_valid(binding_name: &str, element_name: &str) -> bool {
     }
 }
 
-/// Get all valid bindings for an element.
+/// Get all valid bindings for an element, sorted like Svelte's `.sort()` on the
+/// `Possible bindings for <…> are …` enumeration.
 pub fn get_valid_bindings(element_name: &str) -> Vec<&'static str> {
-    BINDING_PROPERTIES
+    let mut names: Vec<&'static str> = BINDING_PROPERTIES_LIST
         .iter()
         .filter(|(_name, property)| {
             if let Some(valid) = property.valid_elements {
@@ -408,6 +401,16 @@ pub fn get_valid_bindings(element_name: &str) -> Vec<&'static str> {
                 true
             }
         })
+        .map(|(name, _)| *name)
+        .collect();
+    names.sort_unstable();
+    names
+}
+
+/// All binding names, in Svelte's `Object.keys(binding_properties)` order.
+pub fn all_binding_names() -> Vec<&'static str> {
+    BINDING_PROPERTIES_LIST
+        .iter()
         .map(|(name, _)| *name)
         .collect()
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/utils/check_graph_for_cycles.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/utils/check_graph_for_cycles.rs
@@ -30,12 +30,20 @@ pub fn check_graph_for_cycles<T>(edges: &[(T, T)]) -> Option<Vec<T>>
 where
     T: Clone + Eq + Hash,
 {
-    // Build adjacency list
+    // Build adjacency list. The JS original uses a `Map`, whose iteration order
+    // decides which cycle is reported, so the roots must be visited in insertion
+    // order rather than hash order.
     let mut graph: FxHashMap<T, Vec<T>> = FxHashMap::default();
+    let mut roots: Vec<T> = Vec::new();
 
     for (u, v) in edges {
+        for node in [u, v] {
+            if !graph.contains_key(node) {
+                graph.insert(node.clone(), Vec::new());
+                roots.push(node.clone());
+            }
+        }
         graph.entry(u.clone()).or_default().push(v.clone());
-        graph.entry(v.clone()).or_default();
     }
 
     let mut visited: FxHashMap<T, bool> = FxHashMap::default();
@@ -68,7 +76,7 @@ where
         on_stack.pop();
     }
 
-    for v in graph.keys() {
+    for v in &roots {
         if !visited.contains_key(v) {
             visit(v.clone(), &graph, &mut visited, &mut on_stack, &mut cycles);
         }
@@ -112,6 +120,17 @@ mod tests {
         assert!(cycle.is_some());
         let cycle = cycle.unwrap();
         assert!(cycle.contains(&"c") || cycle.contains(&"d"));
+    }
+
+    /// With two disjoint cycles the JS original reports the one whose node was
+    /// inserted first, so the reported path must not depend on hash order.
+    #[test]
+    fn test_first_inserted_cycle_wins() {
+        let edges = vec![("c", "d"), ("d", "c"), ("a", "b"), ("b", "a")];
+        assert_eq!(check_graph_for_cycles(&edges), Some(vec!["c", "d", "c"]));
+
+        let edges = vec![("a", "b"), ("b", "a"), ("c", "d"), ("d", "c")];
+        assert_eq!(check_graph_for_cycles(&edges), Some(vec!["a", "b", "a"]));
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
@@ -9,7 +9,9 @@ use super::shared::utils::validate_assignment_node;
 use crate::ast::template::{AttributeValue, BindDirective, RegularElement};
 use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase2_analyze::AnalysisError;
-use crate::compiler::phases::phase2_analyze::binding_properties::BINDING_PROPERTIES;
+use crate::compiler::phases::phase2_analyze::binding_properties::{
+    BINDING_PROPERTIES, all_binding_names, get_valid_bindings,
+};
 use crate::compiler::phases::phase2_analyze::errors;
 /// Visit a bind directive with explicit element context.
 ///
@@ -377,7 +379,7 @@ fn validate_binding_for_svelte_element(
             && !valid_elements.contains(&element_name)
         {
             // For svelte: elements, provide a list of possible bindings
-            let valid_bindings = get_valid_bindings_for_element(element_name);
+            let valid_bindings = get_valid_bindings(element_name);
             let message = format!(
                 "Possible bindings for <{}> are {}",
                 element_name,
@@ -391,7 +393,7 @@ fn validate_binding_for_svelte_element(
         if let Some(invalid_elements) = property.invalid_elements
             && invalid_elements.contains(&element_name)
         {
-            let valid_bindings = get_valid_bindings_for_element(element_name);
+            let valid_bindings = get_valid_bindings(element_name);
             let message = format!(
                 "Possible bindings for <{}> are {}",
                 element_name,
@@ -402,7 +404,7 @@ fn validate_binding_for_svelte_element(
         }
     } else {
         // Binding not found - try fuzzy match
-        let match_name = fuzzy_match(binding_name, &get_all_binding_names());
+        let match_name = fuzzy_match(binding_name, &all_binding_names());
 
         if let Some(match_name) = match_name
             && let Some(property) = BINDING_PROPERTIES.get(match_name)
@@ -448,7 +450,7 @@ fn validate_binding_for_regular_element(
         if let Some(invalid_elements) = property.invalid_elements
             && invalid_elements.contains(&parent_name)
         {
-            let valid_bindings = get_valid_bindings_for_element(parent_name);
+            let valid_bindings = get_valid_bindings(parent_name);
             let message = format!(
                 "Possible bindings for <{}> are {}",
                 parent_name,
@@ -482,7 +484,7 @@ fn validate_binding_for_regular_element(
         }
     } else {
         // Binding not found - try fuzzy match
-        let match_name = fuzzy_match(binding_name, &get_all_binding_names());
+        let match_name = fuzzy_match(binding_name, &all_binding_names());
 
         if let Some(match_name) = match_name
             && let Some(property) = BINDING_PROPERTIES.get(match_name)
@@ -716,28 +718,6 @@ fn get_object_name_from_json(v: &serde_json::Value) -> Option<String> {
         }
         _ => None,
     }
-}
-
-/// Get all valid binding names for an element.
-fn get_valid_bindings_for_element(element_name: &str) -> Vec<String> {
-    BINDING_PROPERTIES
-        .iter()
-        .filter(|(_, property)| {
-            if let Some(valid) = property.valid_elements {
-                valid.contains(&element_name)
-            } else if let Some(invalid) = property.invalid_elements {
-                !invalid.contains(&element_name)
-            } else {
-                true
-            }
-        })
-        .map(|(name, _)| name.to_string())
-        .collect()
-}
-
-/// Get all binding names.
-fn get_all_binding_names() -> Vec<&'static str> {
-    BINDING_PROPERTIES.keys().copied().collect()
 }
 
 /// Fuzzy match a string against a list of candidates.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/fragment.rs
@@ -4,14 +4,16 @@
 //!
 //! Corresponds to Svelte's `2-analyze/visitors/shared/fragment.js`.
 
-use rustc_hash::FxHashSet;
-
 use super::super::super::AnalysisError;
 use super::super::super::errors;
 use super::super::super::utils::{check_graph_for_cycles, extract_svelte_ignore_with_warnings};
 use super::super::super::warnings;
 use super::super::VisitorContext;
 use crate::ast::template::{ConstTag, Fragment, TemplateNode};
+
+/// Insertion-ordered identifier set: the JS original uses a `Set`, and the order
+/// decides which `{@const}` cycle a diagnostic reports.
+type IdentifierSet = indexmap::IndexSet<String, rustc_hash::FxBuildHasher>;
 
 /// Result of collecting preceding ignores.
 struct PrecedingIgnores {
@@ -171,7 +173,7 @@ pub fn analyze<'a, 'b: 'a>(
 /// Corresponds to `sort_const_tags` in `3-transform/utils.js`.
 fn check_const_tag_cycles(nodes: &[TemplateNode]) -> Result<(), AnalysisError> {
     // Collect all ConstTag nodes with their bindings and dependencies
-    let mut const_tags: Vec<(&ConstTag, Vec<String>, FxHashSet<String>)> = Vec::new();
+    let mut const_tags: Vec<(&ConstTag, Vec<String>, IdentifierSet)> = Vec::new();
 
     for node in nodes {
         if let TemplateNode::ConstTag(tag) = node {
@@ -198,11 +200,11 @@ fn check_const_tag_cycles(nodes: &[TemplateNode]) -> Result<(), AnalysisError> {
                     let deps = if let Some(init) = declaration.get("init") {
                         extract_expression_identifiers(init)
                     } else {
-                        FxHashSet::default()
+                        IdentifierSet::default()
                     };
                     (bindings, deps)
                 } else {
-                    (Vec::new(), FxHashSet::default())
+                    (Vec::new(), IdentifierSet::default())
                 }
             } else if decl_type == Some("AssignmentExpression") {
                 // AssignmentExpression structure
@@ -214,11 +216,11 @@ fn check_const_tag_cycles(nodes: &[TemplateNode]) -> Result<(), AnalysisError> {
                 let deps = if let Some(right) = decl_json.get("right") {
                     extract_expression_identifiers(right)
                 } else {
-                    FxHashSet::default()
+                    IdentifierSet::default()
                 };
                 (bindings, deps)
             } else {
-                (Vec::new(), FxHashSet::default())
+                (Vec::new(), IdentifierSet::default())
             };
 
             if !bindings.is_empty() {
@@ -307,8 +309,8 @@ fn extract_pattern_identifiers(pattern: &serde_json::Value) -> Vec<String> {
 }
 
 /// Extract all identifier references from an expression.
-fn extract_expression_identifiers(expression: &serde_json::Value) -> FxHashSet<String> {
-    let mut identifiers = FxHashSet::default();
+fn extract_expression_identifiers(expression: &serde_json::Value) -> IdentifierSet {
+    let mut identifiers = IdentifierSet::default();
     collect_expression_identifiers(expression, &mut identifiers);
     identifiers
 }
@@ -317,10 +319,7 @@ fn extract_expression_identifiers(expression: &serde_json::Value) -> FxHashSet<S
 /// Respects scoping boundaries: does not recurse into function bodies
 /// (ArrowFunctionExpression, FunctionExpression, FunctionDeclaration)
 /// because those create new scopes where local declarations shadow outer names.
-fn collect_expression_identifiers(
-    expression: &serde_json::Value,
-    identifiers: &mut FxHashSet<String>,
-) {
+fn collect_expression_identifiers(expression: &serde_json::Value, identifiers: &mut IdentifierSet) {
     if let Some(expr_type) = expression.get("type").and_then(|t| t.as_str()) {
         match expr_type {
             "Identifier" => {

--- a/crates/rsvelte_core/tests/bind_possible_bindings_order.rs
+++ b/crates/rsvelte_core/tests/bind_possible_bindings_order.rs
@@ -1,0 +1,81 @@
+//! Regression test: the `Possible bindings for <…> are …` enumeration must be
+//! byte-identical to upstream (issue #1771).
+//!
+//! Upstream `BindDirective.js` builds the list with `Object.entries(...).sort()`,
+//! so the names are lexicographically sorted. rsvelte used to enumerate an
+//! `FxHashMap`, which produced an arbitrary order that silently drifts whenever
+//! the table is rebuilt or reordered.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_error_message(src: &str) -> String {
+    let err = compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect_err("should error");
+
+    format!("{err}")
+        .trim_start_matches("Analysis error: ")
+        .trim_start_matches("bind_invalid_name: ")
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Expected text copied from
+/// `packages/svelte/tests/validator/samples/window-binding-invalid-dimensions/errors.json`.
+#[test]
+fn window_possible_bindings_match_upstream() {
+    let message = compile_error_message(
+        "<script>\n\tlet foo;\n</script>\n\n<svelte:window bind:clientWidth={foo} />",
+    );
+    assert_eq!(
+        message,
+        "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:window> are \
+         devicePixelRatio, focused, innerHeight, innerWidth, online, outerHeight, outerWidth, \
+         scrollX, scrollY, this"
+    );
+}
+
+/// Expected text copied from
+/// `packages/svelte/tests/validator/samples/document-binding-invalid-dimensions/errors.json`.
+#[test]
+fn document_possible_bindings_match_upstream() {
+    let message = compile_error_message(
+        "<script>\n\tlet foo;\n</script>\n\n<svelte:document bind:clientWidth={foo} />",
+    );
+    assert_eq!(
+        message,
+        "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:document> are \
+         activeElement, focused, fullscreenElement, pointerLockElement, this, visibilityState"
+    );
+}
+
+/// The enumeration must not vary between calls within one process either.
+#[test]
+fn possible_bindings_are_stable_across_calls() {
+    let src = "<script>\n\tlet foo;\n</script>\n\n<svelte:window bind:clientWidth={foo} />";
+    let first = compile_error_message(src);
+    for _ in 0..20 {
+        assert_eq!(compile_error_message(src), first);
+    }
+}
+
+/// Fuzzy suggestions read the same ordered table, so `Did you mean …` is pinned too.
+#[test]
+fn fuzzy_suggestion_matches_upstream() {
+    let message = compile_error_message(
+        "<script>\n\tlet foo;\n</script>\n\n<svelte:window bind:innerwidth={foo} />",
+    );
+    assert_eq!(
+        message,
+        "`bind:innerwidth` is not a valid binding. Did you mean 'innerWidth'?"
+    );
+}


### PR DESCRIPTION
Closes #1771

## What was wrong

The issue suspected the `Possible bindings for <…> are …` enumeration depended on hash iteration order. Confirmed — and it also diverged from upstream.

`BINDING_PROPERTIES` is an `FxHashMap`, and `get_valid_bindings_for_element` iterated it directly. Upstream `BindDirective.js` builds the same list with `Object.entries(binding_properties).….sort()`, so upstream is lexicographically sorted while rsvelte emitted hash order:

```
rsvelte   … are outerHeight, this, scrollX, innerWidth, devicePixelRatio, focused, innerHeight, outerWidth, online, scrollY
upstream  … are devicePixelRatio, focused, innerHeight, innerWidth, online, outerHeight, outerWidth, scrollX, scrollY, this
```

This was never caught because `tests/validator.rs` compares only the error **code**, not the message, so `window-binding-invalid-dimensions` / `document-binding-invalid-dimensions` passed with the wrong text.

## Fix

- `BINDING_PROPERTIES` is now derived from `BINDING_PROPERTIES_LIST`, an ordered const slice in upstream `bindings.js` definition order. The map is only a lookup index; nothing user-visible iterates it.
- `get_valid_bindings` sorts, matching upstream's `.sort()`.
- `all_binding_names()` (the `fuzzymatch` candidate list) now yields upstream's `Object.keys(binding_properties)` order, so `Did you mean 'x'?` tie-breaks are stable too.
- The duplicated `get_valid_bindings_for_element` / `get_all_binding_names` helpers in `bind_directive.rs` were dropped in favour of the shared ones (the copy in `binding_properties.rs` had been dead code).

### Same bug class, also fixed (issue investigation item 3)

- `check_graph_for_cycles` iterated `graph.keys()` to pick DFS roots. Upstream uses a `Map`, whose insertion order decides **which** cycle gets reported; roots are now visited in insertion order.
- `check_const_tag_cycles` collected `{@const}` dependencies into an `FxHashSet`, which set the edge order feeding that same detector. It is now an insertion-ordered `IndexSet`, matching the JS `Set`.

## Tests

New `crates/rsvelte_core/tests/bind_possible_bindings_order.rs` pins the exact message text against upstream's `errors.json` fixtures (plus a stability loop and the `Did you mean` case). Verified it fails on the pre-fix code with the hash-order string above.

`check_graph_for_cycles` gained a unit test asserting the first-inserted cycle wins.

- `cargo test -p rsvelte_core --test validator` — 16/16 ok
- `cargo test -p rsvelte_core --test compiler_errors` — 16/16 ok
- `cargo test -p rsvelte_core --test bind_possible_bindings_order` — 4/4 ok
- `cargo test -p rsvelte_core --lib` — 1485/1485 ok
- `cargo fmt`, `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
