### PR TITLE
chore(fmt): collapse Text match guard to satisfy clippy collapsible_match

### DIFF
--- a/crates/rsvelte_formatter/src/collapse/mod.rs
+++ b/crates/rsvelte_formatter/src/collapse/mod.rs
@@ -63,11 +63,7 @@ pub(crate) fn fragment_has_collapse_candidate(fragment: &Fragment) -> bool {
         // top-level text and `{@html}` runs are collapse targets too, not just
         // element bodies.
         match n {
-            TemplateNode::Text(t) => {
-                if !crate::is_blank_text(t.data.as_ref()) {
-                    return true;
-                }
-            }
+            TemplateNode::Text(t) if !crate::is_blank_text(t.data.as_ref()) => return true,
             TemplateNode::ExpressionTag(_)
             | TemplateNode::HtmlTag(_)
             | TemplateNode::RenderTag(_) => return true,


### PR DESCRIPTION
Newer clippy (1.95) flags `collapsible_match` on the nested `if` inside the `Text` arm of `fragment_has_collapse_candidate`, which breaks `cargo clippy --all-targets --all-features -- -D warnings` (and thus the pre-commit hook) on current main. Fold the blank-text check into a match guard; behavior is unchanged — blank `Text` still falls through to the `element_container` probe.

Verified: `cargo clippy -p rsvelte_formatter --all-targets --all-features -- -D warnings` clean; `cargo test -p rsvelte_formatter --lib` 81/81.

Found while reviewing #1828, whose agent hit this as a pre-existing workspace clippy failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ER8ncJhRQKMdxB1e7a7wH