### PR TITLE
test: drop 2 stale runtime-runes skip entries

### DIFF
--- a/crates/rsvelte_core/tests/audit_skipped.rs
+++ b/crates/rsvelte_core/tests/audit_skipped.rs
@@ -71,10 +71,7 @@ fn remove_internal_fields(value: &mut serde_json::Value) {
 /// files this change does not own, so they are ratcheted here and tracked in
 /// issue #1808. Shrink-only in both directions: a new stale entry fails, and an
 /// entry that stops applying must be dropped from the list.
-const KNOWN_STALE_SKIPS: &[(&str, &str)] = &[
-    ("runtime-runes", "async-each-const-await-iife"),
-    ("runtime-runes", "async-parallel-derived-template-mutation"),
-];
+const KNOWN_STALE_SKIPS: &[(&str, &str)] = &[];
 
 /// Sibling test sources are embedded so the audited names come from the real
 /// skip lists instead of a hand-copied duplicate that silently rots.

--- a/crates/rsvelte_core/tests/compatibility_report.rs
+++ b/crates/rsvelte_core/tests/compatibility_report.rs
@@ -1110,11 +1110,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         //   Svelte 5.53.6, upstream `e3d277b00`): now ported in
         //   `select_element.rs` — synthetic `<option>` value goes through
         //   `transform_store_refs`.
-        // - `async-parallel-derived-template-mutation` (Svelte 5.56.4 #18453,
-        //   upstream `36ae0622a`): client codegen matches, but the SSR
-        //   async-derived template-mutation path emits `$.save(a)` where
-        //   upstream emits `$.save(a())` (server=MISMATCH). Not yet ported.
-        ("runtime-runes", "async-parallel-derived-template-mutation"),
     ];
 
     for sample_dir in &samples {

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -202,19 +202,9 @@ const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // declaration tags route into the shared `$.run([…])` async group, the
     // awaited `$derived` reads register the `$.get` transform, and the each
     // collection + index param + per-binding blocker dedup all match upstream.
-    // Svelte 5.56.0 #18309 (`e705369de` "fix: propagate async @const
-    // blockers through closure references"): rsvelte's per-template_effect
-    // blocker scanner does not yet propagate awaited `@const` blockers
-    // across closure boundaries (IIFE in template expressions).
-    "async-each-const-await-iife",
     // Pre-existing: template_effect double-counts `$$promises` inside an
-    // `$.async(...)` wrapper for the IfBlock branch. Same blocker-scanner
-    // cluster as `async-each-const-await-iife`.
+    // `$.async(...)` wrapper for the IfBlock branch.
     "async-style-after-await",
-    // New 5.56.4 fixture (#18453, `36ae0622a` server-side
-    // async-derived-template-mutation). Client output matches; the server
-    // async-derived template-mutation codegen is not yet ported (server=MISMATCH).
-    "async-parallel-derived-template-mutation",
     // New 5.56.x fixture (#18525, `bfbb026f2`): `<svelte:boundary {pending}>`
     // with a `$derived` pending attribute. The SERVER `pending` ATTRIBUTE branch
     // (`build_pending_attribute_block` + the `is_pending_attr_nullish`

--- a/crates/rsvelte_formatter/src/collapse/mod.rs
+++ b/crates/rsvelte_formatter/src/collapse/mod.rs
@@ -63,10 +63,8 @@ pub(crate) fn fragment_has_collapse_candidate(fragment: &Fragment) -> bool {
         // top-level text and `{@html}` runs are collapse targets too, not just
         // element bodies.
         match n {
-            TemplateNode::Text(t) => {
-                if !crate::is_blank_text(t.data.as_ref()) {
-                    return true;
-                }
+            TemplateNode::Text(t) if !crate::is_blank_text(t.data.as_ref()) => {
+                return true;
             }
             TemplateNode::ExpressionTag(_)
             | TemplateNode::HtmlTag(_)


### PR DESCRIPTION
## Summary
- Removes `async-each-const-await-iife` and `async-parallel-derived-template-mutation` from `RUNTIME_RUNES_SKIP_NAMES` in `crates/rsvelte_core/tests/runtime.rs` and from `runtime_skip_tests` in `crates/rsvelte_core/tests/compatibility_report.rs` — both fixtures now pass on client and server.
- Empties the `KNOWN_STALE_SKIPS` ratchet in `crates/rsvelte_core/tests/audit_skipped.rs` accordingly (shrink-only, both entries verified).
- Drive-by: fixes a `clippy::collapsible_match` lint in `crates/rsvelte_formatter/src/collapse/mod.rs`, surfaced by a full `--all-targets --all-features` clippy run and required to keep the pre-commit hook green (unrelated to the skip-list cleanup itself).

Closes #1808

## Test plan
- [x] `cargo test --release -p rsvelte_core --test audit_skipped -- --nocapture` → `ok. 15 passed; 0 failed`, "SKIP AUDIT: NOW PASSING (0 fixtures)" — no stale entries remain.
- [x] `cargo test --release -p rsvelte_core --test runtime -- test_runtime_runes --nocapture` → `Total: 1004/1004 passed (7 skipped)`, client 1004/1004, server 1004/1004 — both unskipped fixtures pass under the real `runtime.rs` harness, not just the audit's comparison logic.
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ER8ncJhRQKMdxB1e7a7wH