### PR TITLE
chore: sync VPS native VERSION and README to Svelte 5.56.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Live numbers, charts, and reproduction steps: [benchmark page](https://basebally
 ## Compatibility
 
 <!-- svelte-target-version -->
-**Targeting Svelte `v5.56.7`** ([`b29d7002ecf9`](https://github.com/sveltejs/svelte/commit/b29d7002ecf9)) — automatically maintained by `pnpm run update-docs`.
+**Targeting Svelte `v5.56.8`** ([`44a781373057`](https://github.com/sveltejs/svelte/commit/44a781373057)) — automatically maintained by `pnpm run update-docs`.
 <!-- /svelte-target-version -->
 
 rsvelte passes **100% of the in-scope fixtures** of the official Svelte compiler test suite — over 3,500 fixtures across parser, snapshot, CSS, validator, compiler errors, runtime (runes + legacy), hydration, SSR, preprocess, print, and svelte2tsx. The per-suite breakdown is on the live [compatibility dashboard](https://baseballyama.github.io/rsvelte/progress); regenerate locally with `pnpm run test-and-update`.

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -264,4 +264,4 @@ module.exports.decodeParseEnvelope = decodeParseEnvelope;
 // with `submodules/svelte/packages/svelte/package.json` by hand; run
 // `node scripts/dev/check-vps-version.mjs` (also wired into CI) to
 // catch drift.
-module.exports.VERSION = '5.56.7';
+module.exports.VERSION = '5.56.8';


### PR DESCRIPTION
## Summary

The Svelte submodule bump to 5.56.8 (377ec35c, #1785) left main's CI red on two independent drift checks:

1. **VPS native VERSION drift check** (`node scripts/dev/check-vps-version.mjs`) — `apps/npm/vite-plugin-svelte-native/index.cjs` hardcodes a `module.exports.VERSION` string literal (no build step regenerates it) that must match `submodules/svelte/packages/svelte/package.json`'s `version` field. It was still `'5.56.7'`. Bumped to `'5.56.8'`.

2. **Compatibility Report job → "Check README is in sync with Svelte submodule"** (`node scripts/dev/update-docs.mjs --check`) — this only touches/verifies the `<!-- svelte-target-version -->…<!-- /svelte-target-version -->` marker block in `README.md`, comparing it against `submodules/svelte/packages/svelte/package.json`'s version and `git rev-parse HEAD` (short hash) of the submodule. The compatibility table itself is maintained separately/manually and is untouched by this check. README still said `v5.56.7` @ `b29d7002ecf9`. Updated to `v5.56.8` @ `44a781373057`, matching the now-pinned submodule commit.

Both fixes are minimal, targeted edits — no full compatibility report regeneration was needed since `--check` only validates the version marker, not the pass/fail table.

## Test plan

- [x] `git submodule update --init submodules/svelte` → confirmed pinned at `44a7813730579b94004e182e5a67aab27aa9d2a6`, `package.json` version `5.56.8`
- [x] `node scripts/dev/check-vps-version.mjs` → `[check-vps-version] VERSION '5.56.8' matches submodules/svelte.`
- [x] `node scripts/dev/update-docs.mjs --check` (against a locally-generated `fixtures/44a781373057/compatibility-report.json` stub, not committed — gitignored) → `README.md Svelte target marker is in sync (v5.56.8 @ 44a781373057)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)