### PR TITLE
fix(client): preserve pre-existing parens in parse_raw_expression (#1783)

### DIFF
--- a/.changeset/fix-parse-raw-expression-parens.md
+++ b/.changeset/fix-parse-raw-expression-parens.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(client): preserve pre-existing parens in `parse_raw_expression` (#1783)
+
+`parse_raw_expression` stripped every `ParenthesizedExpression` layer, not just
+its own synthetic wrapper, so a single-dependency `$.legacy_pre_effect` thunk
+printed as `() => $.get(y)` where the official compiler emits `() => ($.get(y))`
+(upstream builds it as a one-element `SequenceExpression`, which esrap prints
+with parens). The wrapper now strips exactly one layer, and the one-element
+sequence is rebuilt for `$.legacy_pre_effect` dependency thunks; user-written
+parens are still dropped exactly as acorn + esrap do.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -39,7 +39,7 @@
 
 use super::arena::{ExprId, JsArena};
 use super::nodes::*;
-use oxc_allocator::{ArenaBox, ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith};
 use oxc_ast::AstBuilder;
 use oxc_ast::ast::*;
 use oxc_span::{GetSpanMut, SPAN, Span};
@@ -1075,11 +1075,13 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         self.take_chunk_region(None);
         for stmt in stmts {
             if let Statement::ExpressionStatement(es) = stmt {
-                let mut e = es.unbox().expression;
-                while let Expression::ParenthesizedExpression(p) = e {
-                    e = p.unbox().expression;
-                }
-                return Some(e);
+                let e = es.unbox().expression;
+                // Strip exactly ONE layer — the wrapper added above. Any further
+                // `ParenthesizedExpression` belongs to the chunk text itself.
+                return Some(match e {
+                    Expression::ParenthesizedExpression(p) => p.unbox().expression,
+                    other => other,
+                });
             }
         }
         None
@@ -1088,7 +1090,58 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// Parse a raw JS statement source string into a vec of oxc [`Statement`]s
     /// (`Raw` may hold several statements). Returns `None` on a parse error.
     fn parse_raw_statements(&self, code: &str) -> Option<Vec<Statement<'a>>> {
-        self.parse_chunk(code.trim())
+        let mut stmts = self.parse_chunk(code.trim())?;
+        self.restore_legacy_pre_effect_deps(&mut stmts);
+        Some(stmts)
+    }
+
+    /// Upstream builds the `$.legacy_pre_effect` dependency thunk as
+    /// `b.thunk(b.sequence(deps))`, and esrap prints a `SequenceExpression` with
+    /// parentheses even for a single element — so a one-dependency thunk prints
+    /// as `() => (dep)`. Re-parsing that generated text yields a
+    /// `ParenthesizedExpression`, which the printer drops (as esrap must, since
+    /// acorn elides source parens); rebuild the sequence so the parens survive.
+    fn restore_legacy_pre_effect_deps(&self, stmts: &mut [Statement<'a>]) {
+        for stmt in stmts {
+            let Statement::ExpressionStatement(es) = stmt else {
+                continue;
+            };
+            let Expression::CallExpression(call) = &mut es.expression else {
+                continue;
+            };
+            if !is_dollar_call(&call.callee, "legacy_pre_effect") {
+                continue;
+            }
+            let Some(Argument::ArrowFunctionExpression(arrow)) = call.arguments.first_mut() else {
+                continue;
+            };
+            if !arrow.expression {
+                continue;
+            }
+            let Some(Statement::ExpressionStatement(body)) = arrow.body.statements.first_mut()
+            else {
+                continue;
+            };
+            // A multi-dependency thunk re-parses as `Paren(Sequence)`, which the
+            // printer already prints with the sequence's own parens.
+            let single = matches!(&body.expression, Expression::ParenthesizedExpression(p)
+                if !matches!(p.expression, Expression::SequenceExpression(_)));
+            if !single {
+                continue;
+            }
+            // `SPAN` mirrors upstream, where this node is builder-made and so
+            // carries no `loc` for the printer to place comments against.
+            body.expression.replace_with(|e| {
+                let Expression::ParenthesizedExpression(p) = e else {
+                    unreachable!()
+                };
+                Expression::SequenceExpression(SequenceExpression::boxed(
+                    SPAN,
+                    ArenaVec::from_value_in(p.unbox().expression, &self.ab),
+                    &self.ab,
+                ))
+            });
+        }
     }
 
     /// Parse one opaque chunk of generated JS. A comment-free chunk parses in
@@ -1946,6 +1999,15 @@ fn update_op(op: JsUpdateOp) -> UpdateOperator {
         JsUpdateOp::Increment => UpdateOperator::Increment,
         JsUpdateOp::Decrement => UpdateOperator::Decrement,
     }
+}
+
+/// Whether `callee` is `$.<name>` — the runtime-namespace call shape the client
+/// codegen emits.
+fn is_dollar_call(callee: &Expression, name: &str) -> bool {
+    let Expression::StaticMemberExpression(m) = callee else {
+        return false;
+    };
+    matches!(&m.object, Expression::Identifier(id) if id.name == "$") && m.property.name == name
 }
 
 fn unary_op(op: JsUnaryOp) -> UnaryOperator {

--- a/crates/rsvelte_core/tests/legacy_pre_effect_parens_1783.rs
+++ b/crates/rsvelte_core/tests/legacy_pre_effect_parens_1783.rs
@@ -1,0 +1,75 @@
+//! Regression for issue #1783: the `$.legacy_pre_effect` dependency thunk is
+//! `b.thunk(b.sequence(deps))` upstream, and esrap prints a `SequenceExpression`
+//! with parentheses even for a single element. The direct-AST client codegen
+//! re-parses the generated chunk text, where `($.get(y))` is only a
+//! `ParenthesizedExpression` — which the printer drops — so the parens were lost.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// The comment in the handler forces the chunk through the comment-bearing
+/// direct-AST path (the one PR #1772 enabled), which is where the parens were
+/// dropped.
+#[test]
+fn single_dependency_thunk_keeps_its_parens() {
+    let out = client(
+        r#"<script>
+	let x = 1;
+	let y = true;
+	$: array = y ? [1, 2] : [1];
+	$: count = array.length === 2 && x ? 1 : 0;
+	$: sum = count + array.length;
+</script>
+
+<button
+	on:click={() => {
+		// order is important here
+		x = 2;
+		y = false;
+	}}>{sum}</button
+>
+"#,
+    );
+    assert!(
+        out.contains("$.legacy_pre_effect(() => ($.get(y)), () => {"),
+        "single-dep thunk lost its parens:\n{out}"
+    );
+    assert!(
+        out.contains("$.legacy_pre_effect(() => ($.get(array), $.get(x)), () => {"),
+        "multi-dep thunk changed shape:\n{out}"
+    );
+}
+
+/// Parens the *user* wrote must still be dropped, exactly as acorn + esrap do
+/// upstream — the fix must not turn into a blanket "preserve every paren".
+#[test]
+fn user_written_parens_are_still_dropped() {
+    let out = client(
+        r#"<script>
+	let a = 1, b = 2;
+	$: x = (a + b);
+	const f = () => (a);
+	const g = (a) + (b);
+</script>
+{x}{f}{g}
+"#,
+    );
+    assert!(out.contains("const f = () => a;"), "got:\n{out}");
+    assert!(out.contains("const g = a + b;"), "got:\n{out}");
+    assert!(out.contains("$.set(x, a + b)"), "got:\n{out}");
+}


### PR DESCRIPTION
## Why

Closes #1783.

`to_oxc`'s `parse_raw_expression` unwrapped **every** `ParenthesizedExpression`
after stripping its own synthetic `( … )` wrapper, so it could not tell the
wrapper from parens the chunk text already had.

Digging into the reported divergence showed a second, load-bearing half. The
parens in question are not incidental: upstream's `LabeledStatement` visitor
builds the `$.legacy_pre_effect` dependency thunk as
`b.thunk(b.sequence(deps))`, and esrap prints a `SequenceExpression` with
parentheses **even when it holds a single element**:

```js
// upstream / rsvelte string codegen
$.legacy_pre_effect(() => ($.get(y)), () => { … })
// direct-AST path
$.legacy_pre_effect(() => $.get(y), () => { … })
```

rsvelte's client instance body is a text chunk, so `($.get(y))` re-parses as a
plain `ParenthesizedExpression` — and `rsvelte_esrap` correctly *drops* those
(acorn elides source parens, so esrap recomputes every paren from precedence).
Dropping them is required: user-written parens (`$: x = (a + b)`, `() => (a)`,
`(a) + (b)`) must disappear exactly as they do upstream. A blanket "keep the
parens" would trade one divergence for many.

Surfaced by #1772 — before that PR these comment-bearing chunks took the string
fallback, which emitted them verbatim.

## How

- `parse_raw_expression` now strips **exactly one** paren layer (the wrapper it
  added itself) instead of looping, so information the chunk carried is not
  destroyed.
- New `restore_legacy_pre_effect_deps` runs on each parsed raw statement chunk:
  for a `$.legacy_pre_effect(…)` call whose first argument is a thunk with a
  parenthesized concise body, it rebuilds the one-element `SequenceExpression`
  upstream had. The multi-dependency case already re-parses as `Paren(Sequence)`
  and is left alone. Nothing else is touched, so user parens still round-trip to
  nothing.

## Repro

```svelte
<script>
	let x = 1;
	let y = true;
	$: array = y ? [1, 2] : [1];
	$: count = array.length === 2 && x ? 1 : 0;
	$: sum = count + array.length;
</script>

<button on:click={() => {
	// forces the comment-bearing direct-AST chunk path
	x = 2;
	y = false;
}}>{sum}</button>
```

| | output |
|---|---|
| official | `$.legacy_pre_effect(() => ($.get(y)), () => {` |
| before | `$.legacy_pre_effect(() => $.get(y), () => {` |
| after | `$.legacy_pre_effect(() => ($.get(y)), () => {` |

## Tests

`crates/rsvelte_core/tests/legacy_pre_effect_parens_1783.rs` pins both
directions: the single-dependency thunk keeps its parens, and user-written
parens are still dropped.

Suites run (`--release`, fixtures regenerated at the pinned Svelte 5.56.8):
`runtime` (legacy / runes / hydration / browser), `ssr`, `compiler_fixtures`,
`css`, `validator`, `compiler_errors`, `parser_fixtures`, `sourcemaps`,
`sourcemaps_gate`, `audit_skipped`, `client_script_comments_pin`,
`client_transforms_pin` — all pass. `cargo fmt --check` clean;
`cargo clippy --all-targets --all-features -D warnings` clean for
`rsvelte_core` / `rsvelte_esrap` (an unrelated pre-existing `collapsible_match`
hit in `rsvelte_formatter` comes from the newer local clippy, not this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ER8ncJhRQKMdxB1e7a7wH
