### PR TITLE
fix(fmt): resolve the oxfmt sidecar in FormatSession like the CLI

### DIFF
--- a/.changeset/fix-format-session-oxfmt-bin.md
+++ b/.changeset/fix-format-session-oxfmt-bin.md
@@ -1,0 +1,20 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): let `FormatSession` embedders pin the `oxfmt` binary (#1792)
+
+`rsvelte_fmt::FormatSession` — the in-process pipeline the (upcoming) Rust
+language server embeds instead of spawning the `rsvelte-fmt` CLI — always
+built `OptionFlags::default()`, which pins `oxfmt` to a bare `oxfmt` on
+`$PATH`. That's fine for the CLI, which always gets an explicit `--oxfmt-bin`
+from its own npm launcher, but a process an editor spawns directly does not
+generally have the consumer's `oxfmt` on `$PATH`.
+
+`FormatSession::resolve_with_oxfmt_bin(path, oxfmt_bin)` lets an embedder pin
+the binary explicitly — the embedder-facing equivalent of `--oxfmt-bin` — and
+falls back to the new `RSVELTE_FMT_OXFMT_BIN` env var when `None`, mirroring
+the `RSVELTE_FMT_NODE` convention the CLI's own npm launcher already uses to
+forward its `oxfmt` resolution into the native binary. `FormatSession::resolve`
+is unchanged in signature and is now equivalent to
+`resolve_with_oxfmt_bin(path, None)`.

--- a/crates/rsvelte_fmt/src/embed.rs
+++ b/crates/rsvelte_fmt/src/embed.rs
@@ -53,7 +53,7 @@ impl FormatSession {
     /// never guaranteed for a process an editor spawns, unlike the CLI, which
     /// always has an explicit `--oxfmt-bin` from its own npm launcher.
     /// `RSVELTE_FMT_NODE`, if set, is honored automatically by every `oxfmt`
-    /// invocation regardless of this value — see [`crate::oxfmt::oxfmt_node`].
+    /// invocation regardless of this value — see `crate::oxfmt::oxfmt_node`.
     pub fn resolve_with_oxfmt_bin(path: &Path, oxfmt_bin: Option<PathBuf>) -> Result<Self> {
         let cfg = OxfmtConfig::resolve(None, path).map_err(|e| anyhow!(e))?;
         let mut flags = OptionFlags::default();

--- a/crates/rsvelte_fmt/src/embed.rs
+++ b/crates/rsvelte_fmt/src/embed.rs
@@ -6,7 +6,7 @@
 //! code the CLI runs. Consumers (the language server) hold one per directory
 //! and reuse it, since config discovery is the expensive part.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use rsvelte_formatter::FormatOptions;
@@ -27,9 +27,39 @@ pub struct FormatSession {
 impl FormatSession {
     /// Resolve the config for `path` the way the CLI does in stdin mode:
     /// search upward from the file itself for the nearest oxfmt config.
+    /// Equivalent to `resolve_with_oxfmt_bin(path, None)` — see
+    /// [`Self::resolve_with_oxfmt_bin`] for how the `oxfmt` binary itself is
+    /// resolved.
     pub fn resolve(path: &Path) -> Result<Self> {
+        Self::resolve_with_oxfmt_bin(path, None)
+    }
+
+    /// Resolve the config for `path` the way [`Self::resolve`] does, but let
+    /// the caller pin the `oxfmt` binary explicitly — the embedder-facing
+    /// equivalent of the CLI's `--oxfmt-bin` flag. An embedder that already
+    /// knows where the consumer's `oxfmt` lives (e.g. a future
+    /// language-server launcher that resolves it the way
+    /// `apps/npm/fmt/bin/rsvelte-fmt` resolves its own, then execs the server
+    /// with that information) should pass it here rather than rely on an
+    /// editor-spawned process inheriting `$PATH`.
+    ///
+    /// `oxfmt_bin` precedence: the explicit `Some` here, else
+    /// `RSVELTE_FMT_OXFMT_BIN` (for an embedder with no argv of its own to
+    /// forward a resolved path through — mirrors the `RSVELTE_FMT_NODE`
+    /// convention the CLI's own npm launcher already uses), else a bare
+    /// `oxfmt` on `$PATH` (the CLI's own `--oxfmt-bin` default). Before this
+    /// (#1792), `FormatSession::resolve` built [`OptionFlags::default`]
+    /// unconditionally, so a bare `oxfmt` on `$PATH` was the *only* option —
+    /// never guaranteed for a process an editor spawns, unlike the CLI, which
+    /// always has an explicit `--oxfmt-bin` from its own npm launcher.
+    /// `RSVELTE_FMT_NODE`, if set, is honored automatically by every `oxfmt`
+    /// invocation regardless of this value — see [`crate::oxfmt::oxfmt_node`].
+    pub fn resolve_with_oxfmt_bin(path: &Path, oxfmt_bin: Option<PathBuf>) -> Result<Self> {
         let cfg = OxfmtConfig::resolve(None, path).map_err(|e| anyhow!(e))?;
-        let flags = OptionFlags::default();
+        let mut flags = OptionFlags::default();
+        if let Some(bin) = oxfmt_bin.or_else(oxfmt_bin_from_env) {
+            flags.oxfmt_bin = bin;
+        }
         let (options, pending_js) = build_format_options(&flags, &cfg);
         Ok(Self {
             flags,
@@ -69,4 +99,15 @@ impl FormatSession {
         }
         String::from_utf8(out.stdout).map_err(|e| anyhow!("oxfmt produced invalid utf-8: {e}"))
     }
+}
+
+/// `RSVELTE_FMT_OXFMT_BIN`, if set: the embedder-facing equivalent of the
+/// CLI's `--oxfmt-bin` flag, for an embedder with no argv of its own to pass
+/// it through directly (e.g. a language server launched by an editor) —
+/// mirrors the `RSVELTE_FMT_NODE` convention the CLI's npm launcher already
+/// uses to forward its resolution of the consumer's `oxfmt` + Node.
+fn oxfmt_bin_from_env() -> Option<PathBuf> {
+    std::env::var_os("RSVELTE_FMT_OXFMT_BIN")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
 }

--- a/crates/rsvelte_fmt/src/embed.rs
+++ b/crates/rsvelte_fmt/src/embed.rs
@@ -48,7 +48,7 @@ impl FormatSession {
     /// forward a resolved path through — mirrors the `RSVELTE_FMT_NODE`
     /// convention the CLI's own npm launcher already uses), else a bare
     /// `oxfmt` on `$PATH` (the CLI's own `--oxfmt-bin` default). Before this
-    /// (#1792), `FormatSession::resolve` built [`OptionFlags::default`]
+    /// (#1792), `FormatSession::resolve` built `OptionFlags::default()`
     /// unconditionally, so a bare `oxfmt` on `$PATH` was the *only* option —
     /// never guaranteed for a process an editor spawns, unlike the CLI, which
     /// always has an explicit `--oxfmt-bin` from its own npm launcher.

--- a/crates/rsvelte_fmt/tests/embed.rs
+++ b/crates/rsvelte_fmt/tests/embed.rs
@@ -1,0 +1,129 @@
+//! `FormatSession` (`crates/rsvelte_fmt/src/embed.rs`) is the in-process
+//! pipeline the language server embeds — no `rsvelte-fmt` subprocess, so an
+//! embedder that knows where the consumer's `oxfmt` lives needs a way to tell
+//! it, the same way the CLI's own `--oxfmt-bin` flag does (#1792). Before this
+//! fix, `FormatSession::resolve` always built `OptionFlags::default()`, so a
+//! bare `oxfmt` on `$PATH` was the only option — never guaranteed for a
+//! process an editor spawns.
+//!
+//! `crates/rsvelte_fmt/tests/cli/delegation.rs` covers the CLI's own
+//! `--oxfmt-bin` handling; this file covers the equivalent embedder-facing
+//! surface: `FormatSession::resolve_with_oxfmt_bin` (an explicit parameter)
+//! and the `RSVELTE_FMT_OXFMT_BIN` env var `FormatSession::resolve` reads as
+//! its fallback.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use rsvelte_fmt::FormatSession;
+
+/// A fake `oxfmt` for the `--stdin-filepath` path `oxfmt_stdin` drives:
+/// prefixes whatever it receives on stdin and echoes it to stdout.
+const MARKER_OXFMT_STDIN: &str = r#"const fs = require('node:fs');
+process.stdout.write('/*FMT*/' + fs.readFileSync(0, 'utf8'));
+"#;
+
+fn node_runnable() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn tempdir(label: &str) -> PathBuf {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "rsvelte_fmt_embed_test_{}_{}_{}",
+        std::process::id(),
+        label,
+        seq
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// `FormatSession::format` on a `.ts` file has no in-process formatter
+/// (`format_in_process` only handles `.svelte` and native CSS — see
+/// `stdin.rs`), so it always falls through to `oxfmt_stdin`. Resolving with an
+/// explicit `oxfmt_bin` must route that fallback through it — the embedder
+/// equivalent of the CLI's `--oxfmt-bin` flag.
+#[test]
+fn resolve_with_oxfmt_bin_routes_non_svelte_formatting_through_it() {
+    if !node_runnable() {
+        eprintln!("[embed] no `node` on $PATH; skipping.");
+        return;
+    }
+
+    let dir = tempdir("explicit");
+    let fake = dir.join("fake-oxfmt.cjs");
+    std::fs::write(&fake, MARKER_OXFMT_STDIN).unwrap();
+
+    let ts_path = dir.join("a.ts");
+    let session = FormatSession::resolve_with_oxfmt_bin(&ts_path, Some(fake.clone()))
+        .expect("resolve session");
+    let out = session
+        .format("const x=1\n", &ts_path)
+        .expect("format via the explicit oxfmt_bin");
+
+    assert!(
+        out.contains("/*FMT*/"),
+        "explicit oxfmt_bin was not used by FormatSession (no marker):\n{out}"
+    );
+}
+
+/// `resolve_with_oxfmt_bin(path, None)` must behave exactly like `resolve`
+/// (both fall back to the `RSVELTE_FMT_OXFMT_BIN` env var, and from there to a
+/// bare `oxfmt` on `$PATH`) — proving `None` really means "no override," not
+/// "no oxfmt."
+///
+/// This is the only test in this binary that touches
+/// `RSVELTE_FMT_OXFMT_BIN`, so mutating it here doesn't race another test —
+/// see the module doc comment.
+#[test]
+fn resolve_falls_back_to_the_env_var_then_resolve_with_none_matches_it() {
+    if !node_runnable() {
+        eprintln!("[embed] no `node` on $PATH; skipping.");
+        return;
+    }
+
+    let dir = tempdir("env-fallback");
+    let fake = dir.join("fake-oxfmt.cjs");
+    std::fs::write(&fake, MARKER_OXFMT_STDIN).unwrap();
+
+    // SAFETY: this is the only test in this binary that touches this
+    // environment variable (see the doc comment above).
+    unsafe {
+        std::env::set_var("RSVELTE_FMT_OXFMT_BIN", &fake);
+    }
+
+    let ts_path = dir.join("b.ts");
+    let via_resolve = FormatSession::resolve(&ts_path)
+        .expect("resolve session")
+        .format("const x=1\n", &ts_path)
+        .expect("format via the env-resolved oxfmt_bin");
+
+    let ts_path2 = dir.join("c.ts");
+    let via_none = FormatSession::resolve_with_oxfmt_bin(&ts_path2, None)
+        .expect("resolve session")
+        .format("const x=1\n", &ts_path2)
+        .expect("format via the env-resolved oxfmt_bin");
+
+    // SAFETY: this is the only test in this binary that touches this
+    // environment variable (see the doc comment above).
+    unsafe {
+        std::env::remove_var("RSVELTE_FMT_OXFMT_BIN");
+    }
+
+    assert!(
+        via_resolve.contains("/*FMT*/"),
+        "resolve() did not pick up RSVELTE_FMT_OXFMT_BIN:\n{via_resolve}"
+    );
+    assert_eq!(
+        via_resolve, via_none,
+        "resolve() and resolve_with_oxfmt_bin(path, None) must agree"
+    );
+}


### PR DESCRIPTION
## Summary

- `rsvelte_fmt::FormatSession` (the in-process pipeline `crates/rsvelte_language_server` embeds instead of spawning the `rsvelte-fmt` CLI) always built `OptionFlags::default()`, pinning `oxfmt` to a bare `oxfmt` on `$PATH` with no way to override it. Every non-`.svelte` file type `FormatSession::format` delegates to `oxfmt` (`.ts`/`.js`/`.json`/`.md`/…) therefore silently failed to format whenever a process an editor spawns doesn't have the consumer's `oxfmt` on `$PATH` — unlike the CLI, which always gets an explicit `--oxfmt-bin` from its own npm launcher.
- Added `FormatSession::resolve_with_oxfmt_bin(path, oxfmt_bin)` so an embedder can pin the binary explicitly (the embedder-facing equivalent of `--oxfmt-bin`), falling back to a new `RSVELTE_FMT_OXFMT_BIN` env var when `None` — mirroring the `RSVELTE_FMT_NODE` convention the CLI's own npm launcher already uses to forward its `oxfmt`/Node resolution into the native binary. `FormatSession::resolve` keeps its existing signature and is now equivalent to `resolve_with_oxfmt_bin(path, None)`.
- No change to `crates/rsvelte_language_server` is needed: `FormatSessions::get` already calls `FormatSession::resolve`, which now transparently honors `RSVELTE_FMT_OXFMT_BIN` — the same env var a future language-server launcher (per #1761's own TODO) can set before exec'ing the Rust binary.

**Design note:** an earlier iteration of this fix reused the CLI's `rsvelte-fmt.runtime.json` sidecar reader (`load_oxfmt_runtime_sidecar` / `set_oxfmt_node`), matching the issue's literal wording. However, #1834 (open) removes that entire mechanism as dead weight (it never worked correctly under pnpm's `.bin` shim semantics — see that PR). This PR's design is independent of it: it touches only `crates/rsvelte_fmt/src/embed.rs`, adds an explicit parameter + a new dedicated env var, and does not depend on anything #1834 deletes, so it is safe to merge before or after #1834.

## Test plan

- [x] `cargo test -p rsvelte_fmt` — 130 existing + 2 new tests pass (`crates/rsvelte_fmt/tests/embed.rs`, covering `resolve_with_oxfmt_bin`'s explicit override and the `RSVELTE_FMT_OXFMT_BIN` env fallback via a fake `oxfmt` `.cjs` run through `node`)
- [x] `cargo test -p rsvelte_language_server` — 164 unit + 14 protocol integration tests pass unchanged
- [x] Both suites re-verified against the CI-pinned toolchain (`cargo +1.97.1 test …`)
- [x] `cargo +1.97.1 fmt -p rsvelte_fmt -p rsvelte_language_server -- --check` — clean
- [x] `cargo +1.97.1 clippy -p rsvelte_fmt -p rsvelte_language_server --all-targets --all-features -- -D warnings` — clean (note: the default local `stable` toolchain hits an unrelated pre-existing `rsvelte_formatter` clippy lint reproducible on `main` before this change; the CI-pinned `1.97.1` toolchain doesn't see it)
- [x] Tests use a fake `oxfmt` `.cjs` script run through `node` (no real `oxfmt` binary required); local environment has `node` available so both new tests actually exercised the sidecar-equivalent path rather than skipping

Added a patch changeset for `@rsvelte/fmt` (the package whose native binary embeds this crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)