### PR TITLE
test: align compatibility_report compile options with the real gates (#1814)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,9 +142,11 @@ Use the `Agent` tool for substantial work — feature implementation, multi-file
 ## Test Status
 
 Source: `pnpm run compatibility-report` (Svelte **v5.56.8**). Re-run `pnpm run test-and-update`
-to refresh. Skip lists live in `crates/rsvelte_core/tests/compatibility_report.rs` and
-`crates/rsvelte_core/tests/runtime.rs`; `crates/rsvelte_core/tests/audit_skipped.rs`
-re-checks every skipped fixture after a Svelte bump.
+to refresh. The runtime skip lists and the fixture-generation compile options are shared
+constants in `crates/rsvelte_core/tests/common/mod.rs`, so the report and the gates
+(`tests/runtime.rs`, `tests/ssr.rs`) always measure the same thing;
+`crates/rsvelte_core/tests/audit_skipped.rs` re-checks every skipped fixture after a
+Svelte bump.
 
 | Suite | Pass/Total |
 |-------|------------|
@@ -155,13 +157,13 @@ re-checks every skipped fixture after a Svelte bump.
 | CSS | 181/181 |
 | Validator | 333/333 |
 | SSR | 99/99 |
-| Hydration | 80/80 |
-| Runtime Legacy | 1206/1206 |
-| Runtime Runes | 1006/1006 |
+| Hydration | 79/79 |
+| Runtime Legacy | 1207/1207 |
+| Runtime Runes | 1005/1005 |
 | Runtime Browser | 32/32 |
 | Print | 43/43 |
 | Preprocess | 19/19 |
-| Sourcemaps | 0/0 (report only — see the source-map gate below) |
+| Sourcemaps | 29/29 (output equality; map correctness has its own gate below) |
 | svelte2tsx | 253/253 |
 | Migrate | 0/76 (out of scope) |
 
@@ -171,10 +173,8 @@ not start migrate work without an explicit scope change.
 
 ### Source-map gate
 
-The `Sourcemaps` row above reads 0/0 because `compatibility_report.rs` looks for a
-`main.svelte` in each sample and the sourcemaps samples use `input.svelte` — the fixtures
-themselves (official `client.js{,.map}` / `server.js{,.map}` for all 29 samples) have always
-been generated. Map *correctness* is gated by
+The `Sourcemaps` row above only compares generated `client.js` / `server.js` output. Map
+*correctness* is gated by
 `crates/rsvelte_core/tests/sourcemaps_gate.rs`, which ports the `_config.js` anchor assertions
 from `packages/svelte/tests/sourcemaps` and adds two structural budgets (official segments
 reproduced; segments pointing outside the source), ratcheted shrink-only through

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Svelte bump.
 | SSR | 99/99 |
 | Hydration | 79/79 |
 | Runtime Legacy | 1207/1207 |
-| Runtime Runes | 1005/1005 |
+| Runtime Runes | 1007/1007 |
 | Runtime Browser | 32/32 |
 | Print | 43/43 |
 | Preprocess | 19/19 |

--- a/crates/rsvelte_core/tests/audit_skipped.rs
+++ b/crates/rsvelte_core/tests/audit_skipped.rs
@@ -6,11 +6,12 @@
 //! Run: `cargo test --release --test audit_skipped -- --nocapture`
 //!
 //! When this fails with `STALE SKIP ENTRIES`, remove the listed fixtures from
-//! `tests/compatibility_report.rs::runtime_skip_tests` and from the matching
-//! `RUNTIME_*_SKIP_NAMES` / `HYDRATION_SKIP_NAMES` arrays in `tests/runtime.rs`
-//! (or from the per-category `skip_*` arrays for parser / css / print).
+//! the `RUNTIME_*_SKIP_NAMES` / `HYDRATION_SKIP_NAMES` / `SSR_SKIP_NAMES`
+//! arrays in `tests/common/mod.rs` (or from the per-category `skip_*` arrays
+//! for parser / css / print).
 //!
-//! The audited names are parsed out of those sibling test sources rather than
+//! The runtime names come straight from those shared constants; the remaining
+//! per-suite lists are parsed out of the sibling test sources rather than
 //! duplicated here, so the audit cannot silently drift away from the lists it
 //! polices.
 
@@ -19,7 +20,9 @@ mod common;
 use std::fs;
 
 use common::{
-    canonicalize_css, compare_js, ensure_fixtures_exist, load_fixture_output, svelte_path,
+    HYDRATION_SKIP_NAMES, RUNTIME_LEGACY_SKIP_NAMES, RUNTIME_RUNES_SKIP_NAMES, SSR_SKIP_NAMES,
+    canonicalize_css, compare_js, ensure_fixtures_exist, load_fixture_output,
+    runtime_fixture_options, svelte_path,
 };
 use rsvelte_core::ast::arena::with_serialize_arena;
 use rsvelte_core::{
@@ -75,7 +78,6 @@ const KNOWN_STALE_SKIPS: &[(&str, &str)] = &[];
 
 /// Sibling test sources are embedded so the audited names come from the real
 /// skip lists instead of a hand-copied duplicate that silently rots.
-const RUNTIME_SRC: &str = include_str!("runtime.rs");
 const PRINT_SRC: &str = include_str!("print.rs");
 const CSS_SRC: &str = include_str!("css.rs");
 const REPORT_SRC: &str = include_str!("compatibility_report.rs");
@@ -164,22 +166,7 @@ fn audit_runtime(category: &str, name: &str) -> Outcome {
         return out;
     };
 
-    let config_path = svelte_path()
-        .join("packages/svelte/tests")
-        .join(category)
-        .join("samples")
-        .join(name)
-        .join("_config.js");
-
-    let mut config_has_async = false;
-    let mut config_has_hmr = false;
-    if let Ok(config) = fs::read_to_string(&config_path) {
-        let without_skip = config
-            .replace("skip_no_async", "")
-            .replace("skip_async", "");
-        config_has_async = without_skip.contains("async: true");
-        config_has_hmr = config.contains("hmr: true");
-    }
+    let fixture_options = runtime_fixture_options(category, name);
 
     let expected_client = load_fixture_output(category, name, "client.js");
     let expected_server = load_fixture_output(category, name, "server.js");
@@ -189,26 +176,16 @@ fn audit_runtime(category: &str, name: &str) -> Outcome {
         return out;
     }
 
-    let is_runtime_runes = category == "runtime-runes";
-    let use_async = is_runtime_runes || config_has_async;
-
-    let is_legacy = category == "runtime-legacy";
-    let use_accessors = if is_legacy {
-        fs::read_to_string(&config_path)
-            .map(|c| !c.contains("accessors: false") && !c.contains("accessors:false"))
-            .unwrap_or(true)
-    } else {
-        false
-    };
-
     if let Some(expected) = &expected_client {
         let options = CompileOptions {
             generate: GenerateMode::Client,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
-            experimental: ExperimentalOptions { r#async: use_async },
-            hmr: config_has_hmr,
-            accessors: use_accessors,
+            experimental: ExperimentalOptions {
+                r#async: fixture_options.r#async,
+            },
+            hmr: fixture_options.hmr,
+            accessors: fixture_options.accessors,
             ..Default::default()
         };
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| compile(&input, options))) {
@@ -229,8 +206,10 @@ fn audit_runtime(category: &str, name: &str) -> Outcome {
             generate: GenerateMode::Server,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
-            experimental: ExperimentalOptions { r#async: use_async },
-            hmr: config_has_hmr,
+            experimental: ExperimentalOptions {
+                r#async: fixture_options.r#async,
+            },
+            hmr: fixture_options.hmr,
             ..Default::default()
         };
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| compile(&input, options))) {
@@ -442,30 +421,17 @@ fn audit_skipped_fixtures() {
     // are not skip lists and stay out of the audit. svelte2tsx
     // `expected.error.json` fixtures run as regular samples via
     // `tests/common/svelte2tsx.rs`, so they aren't skipped either.
+    // The runtime lists are shared constants, so they are used directly — a
+    // rename breaks the build instead of silently emptying the audit.
     let mut runtime_skipped: Vec<(String, String)> = Vec::new();
     for (list, category) in [
-        ("RUNTIME_RUNES_SKIP_NAMES: &[&str] = ", "runtime-runes"),
-        ("RUNTIME_LEGACY_SKIP_NAMES: &[&str] = ", "runtime-legacy"),
-        ("HYDRATION_SKIP_NAMES: &[&str] = ", "hydration"),
+        (RUNTIME_RUNES_SKIP_NAMES, "runtime-runes"),
+        (RUNTIME_LEGACY_SKIP_NAMES, "runtime-legacy"),
+        (HYDRATION_SKIP_NAMES, "hydration"),
+        (SSR_SKIP_NAMES, "server-side-rendering"),
     ] {
-        for name in skip_list(RUNTIME_SRC, "tests/runtime.rs", list) {
-            runtime_skipped.push((category.to_string(), name));
-        }
-    }
-    // `runtime_skip_tests` is a `&[(category, name)]` list, so its literals
-    // alternate category / name.
-    let report_runtime = skip_list(
-        REPORT_SRC,
-        "tests/compatibility_report.rs",
-        "runtime_skip_tests: &[(&str, &str)] = ",
-    );
-    for pair in report_runtime.chunks(2) {
-        let [category, name] = pair else {
-            panic!("runtime_skip_tests has a dangling entry: {pair:?}");
-        };
-        let entry = (category.clone(), name.clone());
-        if !runtime_skipped.contains(&entry) {
-            runtime_skipped.push(entry);
+        for name in list {
+            runtime_skipped.push((category.to_string(), (*name).to_string()));
         }
     }
 

--- a/crates/rsvelte_core/tests/audit_skipped.rs
+++ b/crates/rsvelte_core/tests/audit_skipped.rs
@@ -70,10 +70,10 @@ fn remove_internal_fields(value: &mut serde_json::Value) {
     }
 }
 
-/// Skip entries that already pass under this audit. Unskipping them edits test
-/// files this change does not own, so they are ratcheted here and tracked in
-/// issue #1808. Shrink-only in both directions: a new stale entry fails, and an
-/// entry that stops applying must be dropped from the list.
+/// Skip entries that already pass under this audit but have not been unskipped
+/// yet. Shrink-only in both directions: a new stale entry fails, and an entry
+/// that stops applying must be dropped from the list. Empty is the goal state —
+/// a fixture that passes belongs off the skip list, not on this ratchet.
 const KNOWN_STALE_SKIPS: &[(&str, &str)] = &[];
 
 /// Sibling test sources are embedded so the audited names come from the real

--- a/crates/rsvelte_core/tests/common/mod.rs
+++ b/crates/rsvelte_core/tests/common/mod.rs
@@ -321,6 +321,110 @@ impl FixtureCoverage {
 }
 
 // ============================================================================
+// Runtime fixture compile options and skip lists
+// ============================================================================
+
+/// The compile options a runtime fixture's expected output was generated with.
+///
+/// Mirrors `scripts/fixtures/generate-fixtures.mjs::generateRuntimeFixture`, so
+/// every runner that compares against those fixtures — `tests/runtime.rs`,
+/// `tests/ssr.rs`, `tests/compatibility_report.rs` and `tests/audit_skipped.rs`
+/// — must build its `CompileOptions` from here. Hand-rolled copies drift, and a
+/// runner that compiles with different options than the fixture was generated
+/// with can only report noise.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RuntimeFixtureOptions {
+    pub r#async: bool,
+    pub hmr: bool,
+    /// The generator only passes `accessors` to the client compile.
+    pub accessors: bool,
+}
+
+/// Read the fixture-generation options back out of a sample's `_config.js`.
+pub fn runtime_fixture_options(category: &str, sample: &str) -> RuntimeFixtureOptions {
+    let config = fs::read_to_string(
+        svelte_path()
+            .join("packages/svelte/tests")
+            .join(category)
+            .join("samples")
+            .join(sample)
+            .join("_config.js"),
+    )
+    .unwrap_or_default();
+
+    // `skip_no_async` / `skip_async` are runner mode markers, not compile options.
+    let without_skip_markers = config
+        .replace("skip_no_async", "")
+        .replace("skip_async", "");
+
+    RuntimeFixtureOptions {
+        r#async: category == "runtime-runes" || without_skip_markers.contains("async: true"),
+        hmr: config.contains("hmr: true"),
+        // The official runner defaults runtime-legacy to `accessors: true`
+        // (svelte/packages/svelte/tests/runtime-legacy/shared.ts).
+        accessors: category == "runtime-legacy"
+            && !config.contains("accessors: false")
+            && !config.contains("accessors:false"),
+    }
+}
+
+/// runtime-runes fixtures still failing on the rsvelte port. Each entry is
+/// audited by `tests/audit_skipped.rs`, which fails the build once a skipped
+/// fixture starts passing. Remove an entry as soon as the port lands.
+pub const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
+    // Svelte 5.56.0 #18309 (`e705369de` "fix: propagate async @const blockers
+    // through closure references"): rsvelte's per-template_effect blocker
+    // scanner does not yet propagate awaited `@const` blockers across closure
+    // boundaries (IIFE in template expressions).
+    "async-each-const-await-iife",
+    // template_effect double-counts `$$promises` inside an `$.async(...)`
+    // wrapper for the IfBlock branch. Same blocker-scanner cluster as
+    // `async-each-const-await-iife`.
+    "async-style-after-await",
+    // Svelte 5.56.4 #18453 (`36ae0622a`): client output matches, but the server
+    // async-derived template-mutation codegen emits `$.save(a)` where upstream
+    // emits `$.save(a())`.
+    "async-parallel-derived-template-mutation",
+    // Svelte 5.56.x #18525 (`bfbb026f2`): `<svelte:boundary {pending}>` with a
+    // `$derived` pending attribute. The server `pending` ATTRIBUTE branch
+    // (`build_pending_attribute_block` + the `is_pending_attr_nullish` wrapper)
+    // is a pre-existing gap in `svelte_boundary.rs` — only the `pending`
+    // SNIPPET branch is ported. Client matches, server=MISMATCH.
+    "async-batch-derived",
+    // `hmr: true` fixtures whose SERVER output drops the `<!---->` anchor the
+    // official compiler emits around a dev-mode dynamic component (and, for
+    // `hmr-each-keyed-unshift`, a preserved JSDoc comment). Client output
+    // matches for both; the other four `hmr: true` fixtures pass outright.
+    "hmr-removal",
+    "hmr-each-keyed-unshift",
+];
+
+/// runtime-legacy fixtures still failing on the rsvelte port.
+pub const RUNTIME_LEGACY_SKIP_NAMES: &[&str] = &[];
+
+/// hydration fixtures still failing on the rsvelte port.
+pub const HYDRATION_SKIP_NAMES: &[&str] = &[
+    // Same server `pending` ATTRIBUTE gap as `runtime-runes/async-batch-derived`:
+    // the `if (pending()) {…} else {…}` wrapper around the boundary body is not
+    // emitted. Client output matches.
+    "boundary-pending-attribute",
+];
+
+/// server-side-rendering fixtures still failing on the rsvelte port.
+pub const SSR_SKIP_NAMES: &[&str] = &[];
+
+/// The documented skip list for a runtime-style fixture category.
+pub fn runtime_skip_names(category: &str) -> &'static [&'static str] {
+    match category {
+        "runtime-runes" => RUNTIME_RUNES_SKIP_NAMES,
+        "runtime-legacy" => RUNTIME_LEGACY_SKIP_NAMES,
+        "hydration" => HYDRATION_SKIP_NAMES,
+        "server-side-rendering" => SSR_SKIP_NAMES,
+        _ => &[],
+    }
+}
+
+// ============================================================================
 // Normalization utilities
 // ============================================================================
 

--- a/crates/rsvelte_core/tests/common/mod.rs
+++ b/crates/rsvelte_core/tests/common/mod.rs
@@ -372,19 +372,10 @@ pub fn runtime_fixture_options(category: &str, sample: &str) -> RuntimeFixtureOp
 /// audited by `tests/audit_skipped.rs`, which fails the build once a skipped
 /// fixture starts passing. Remove an entry as soon as the port lands.
 pub const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
-    // Svelte 5.56.0 #18309 (`e705369de` "fix: propagate async @const blockers
-    // through closure references"): rsvelte's per-template_effect blocker
-    // scanner does not yet propagate awaited `@const` blockers across closure
-    // boundaries (IIFE in template expressions).
-    "async-each-const-await-iife",
     // template_effect double-counts `$$promises` inside an `$.async(...)`
-    // wrapper for the IfBlock branch. Same blocker-scanner cluster as
-    // `async-each-const-await-iife`.
+    // wrapper for the IfBlock branch — the awaited `@const` blocker is not
+    // propagated across the closure boundary.
     "async-style-after-await",
-    // Svelte 5.56.4 #18453 (`36ae0622a`): client output matches, but the server
-    // async-derived template-mutation codegen emits `$.save(a)` where upstream
-    // emits `$.save(a())`.
-    "async-parallel-derived-template-mutation",
     // Svelte 5.56.x #18525 (`bfbb026f2`): `<svelte:boundary {pending}>` with a
     // `$derived` pending attribute. The server `pending` ATTRIBUTE branch
     // (`build_pending_attribute_block` + the `is_pending_attr_nullish` wrapper)

--- a/crates/rsvelte_core/tests/compatibility_report.rs
+++ b/crates/rsvelte_core/tests/compatibility_report.rs
@@ -37,7 +37,7 @@ fn min_fixtures(category: &str) -> usize {
         "compiler-errors" => 145,
         // The runtime floors sit below the sample count by exactly the
         // documented `runtime_skip_names` entries for the category.
-        "runtime-runes" => 1005,
+        "runtime-runes" => 1007,
         "runtime-legacy" => 1206,
         "runtime-browser" => 32,
         "hydration" => 79,

--- a/crates/rsvelte_core/tests/compatibility_report.rs
+++ b/crates/rsvelte_core/tests/compatibility_report.rs
@@ -131,15 +131,16 @@ fn run_parser_tests(category: TestCategory, modern: bool) -> CategoryResult {
 
         match parse(&input, &oxc_allocator::Allocator::default(), options) {
             Ok(ast) => {
-                let actual_json =
+                let actual_json = if modern {
                     rsvelte_core::ast::arena::with_serialize_arena(&ast.arena, || {
-                        if modern {
-                            serde_json::to_string_pretty(&ast).unwrap_or_default()
-                        } else {
-                            let legacy_ast = convert_to_legacy(&input, ast.clone());
-                            serde_json::to_string_pretty(&legacy_ast).unwrap_or_default()
-                        }
-                    });
+                        serde_json::to_string_pretty(&ast).unwrap_or_default()
+                    })
+                } else {
+                    // `convert_to_legacy` consumes the AST and installs the
+                    // serialize arena itself.
+                    let legacy_ast = convert_to_legacy(&input, ast);
+                    serde_json::to_string_pretty(&legacy_ast).unwrap_or_default()
+                };
 
                 let mut actual_normalized = normalize_parser_json(&actual_json);
                 let expected_normalized = normalize_parser_json(&expected);

--- a/crates/rsvelte_core/tests/compatibility_report.rs
+++ b/crates/rsvelte_core/tests/compatibility_report.rs
@@ -14,8 +14,8 @@ use std::fs;
 use common::{
     CategoryResult, CompatibilityReport, FixtureCoverage, SampleDetails, SampleResult, SkipReason,
     TestCategory, TestStatus, canonicalize_css, compare_js, ensure_fixtures_exist, fixtures_path,
-    get_fixture_samples, get_svelte_test_samples, load_fixture_output, svelte_path,
-    write_actual_output,
+    get_fixture_samples, get_svelte_test_samples, load_fixture_output, runtime_fixture_options,
+    runtime_skip_names, svelte_path, write_actual_output,
 };
 use rsvelte_core::{
     CompileOptions, ExperimentalOptions, GenerateMode, ModuleCompileOptions, ParseOptions, compile,
@@ -25,7 +25,8 @@ use rsvelte_core::{
 /// Grow-only per-category fixture floors, measured against the pinned Svelte
 /// submodule. Every discovered sample must end up either compared or recorded
 /// as a justified skip; these floors additionally catch a category quietly
-/// shrinking. Raise them when upstream adds samples; never lower them.
+/// shrinking. Raise them when upstream adds samples; lower one only together
+/// with a documented skip-list entry, never to make CI green.
 fn min_fixtures(category: &str) -> usize {
     match category {
         "parser-modern" => 27,
@@ -34,10 +35,12 @@ fn min_fixtures(category: &str) -> usize {
         "css" => 181,
         "validator" => 333,
         "compiler-errors" => 145,
-        "runtime-runes" => 1008,
+        // The runtime floors sit below the sample count by exactly the
+        // documented `runtime_skip_names` entries for the category.
+        "runtime-runes" => 1005,
         "runtime-legacy" => 1206,
         "runtime-browser" => 32,
-        "hydration" => 80,
+        "hydration" => 79,
         "server-side-rendering" => 99,
         "sourcemaps" => 29,
         "print" => 43,
@@ -120,21 +123,23 @@ fn run_parser_tests(category: TestCategory, modern: bool) -> CategoryResult {
         let options = ParseOptions {
             modern: true,
             loose,
+            // The AST-output comparison expects `leadingComments`/`trailingComments`
+            // preserved on nodes, exactly as `tests/parser_fixtures.rs` does.
+            capture_comments: true,
             ..Default::default()
         };
 
         match parse(&input, &oxc_allocator::Allocator::default(), options) {
             Ok(ast) => {
-                let actual_json = if modern {
+                let actual_json =
                     rsvelte_core::ast::arena::with_serialize_arena(&ast.arena, || {
-                        serde_json::to_string_pretty(&ast).unwrap_or_default()
-                    })
-                } else {
-                    // `convert_to_legacy` consumes the AST and installs the
-                    // serialize arena itself.
-                    let legacy_ast = convert_to_legacy(&input, ast);
-                    serde_json::to_string_pretty(&legacy_ast).unwrap_or_default()
-                };
+                        if modern {
+                            serde_json::to_string_pretty(&ast).unwrap_or_default()
+                        } else {
+                            let legacy_ast = convert_to_legacy(&input, ast.clone());
+                            serde_json::to_string_pretty(&legacy_ast).unwrap_or_default()
+                        }
+                    });
 
                 let mut actual_normalized = normalize_parser_json(&actual_json);
                 let expected_normalized = normalize_parser_json(&expected);
@@ -1014,105 +1019,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
     let mut result = CategoryResult::new(category);
     let mut coverage = FixtureCoverage::new(category, samples.len());
 
-    // Runtime samples whose expected output exercises infrastructure rsvelte
-    // doesn't fully implement yet, so we mark them skipped instead of failing.
-    //
-    // - `derived-name-shadowed` (runtime-runes, Svelte 5.53.1): upstream
-    //   commit `0c7f81514` "fix: handle shadowed function names correctly"
-    //   associates a `FunctionDeclaration` / `FunctionExpression` id node
-    //   with its *outer* scope. rsvelte's analysis collects derived names
-    //   without respecting nested-function scoping, so an inner
-    //   `const foo = $derived(...)` inside `function foo() { ... }` leaks
-    //   its derived-ness to the outer `foo` reference in the template
-    //   (`{foo()()}` becomes `$.get(foo)()()` instead of `foo()()`). Tracked
-    //   as a follow-up port of scope-tracked derived analysis.
-    // - `derived-update-server` (runtime-runes, Svelte 5.53.2): upstream
-    //   commit `6aa7b9c64` "fix: update expressions on server deriveds" routes
-    //   `name++` / `name--` / `++name` / `--name` through new
-    //   `$.update_derived(...)` / `$.update_derived_pre(...)` helpers when
-    //   `name` resolves to a derived binding. rsvelte's server transform's
-    //   update-expression walker only knows about `$store` sigils, so derived
-    //   update expressions don't get the new helper call. Tracked as a
-    //   follow-up port.
-    // - `set-text-stable-coercion` (runtime-runes, Svelte 5.53.3): fixture
-    //   added in upstream commit `f67d03df5` "fix: make string coercion
-    //   consistent to `toString`". The change is runtime-only (an internal
-    //   `set_text` helper uses ``\`${value}\`` `` instead of `value + ''`),
-    //   but the new fixture's compiled output expects ``\`${value ?? ''}\`` ``
-    //   inside template-literal `set_text` calls. rsvelte's client transform
-    //   doesn't currently emit `?? ''` around interpolated identifiers in
-    //   template literals; this is a pre-existing gap surfaced by the new
-    //   fixture. Tracked as a follow-up port.
-    // - 5.53.4 cluster: upstream commit `3a289797b` "fix: handle default
-    //   parameters scope leaks" reworked `FunctionExpression` /
-    //   `FunctionDeclaration` / `ArrowFunctionExpression` scopes to be porous
-    //   (`scope.child(true)`), which subtly changes what bindings the
-    //   `{@const ...}` / `each` / `await` visitors see as "in-scope" and
-    //   therefore which `$.deep_read_state` / `$.get` / `$.save` calls land
-    //   in the compiled output. Skipping until the rsvelte analyzer's
-    //   function-scope porosity matches upstream.
-    let runtime_skip_tests: &[(&str, &str)] = &[
-        // - `async-overlap-multiple-1..7` (Svelte 5.55.1, upstream chore
-        //   `5e8662fb2` "chore: lots of async tests"). The SSR `$.save`
-        //   predicate port (this PR) unblocks -1..4. -5..7 use
-        //   `let b = $derived(await delay(...))` in the instance script and
-        //   hit a separate async-blocker cluster (still client-side failure).
-        // - Svelte 5.55.2 cluster: upstream commits `8966601dc` "handle parens
-        //   in template expressions more robustly" + `edcbb0e64` "invalidate
-        //   `@const` tags based on visible references in legacy mode".
-        //   `async-if-block-unskip` was unblocked by the SSR `$.save`
-        //   predicate port (this PR).
-        // - Svelte 5.55.3 cluster: upstream commit `3937ec03b` "fix: correctly
-        //   calculate `@const` blockers". The 5.55.3 port (this PR) flipped
-        //   `async-const`, `async-const-wait`, and `async-derived-const-blocker`.
-        // - Svelte 5.55.4 (upstream commit `0ed8c282f` "fix: reset context
-        //   after waiting on blockers of @const expressions"): the
-        //   `apply_const_async_wrapping` pass now runs in the
-        //   `$$renderer.component(...)` wrapper path too (server `build.rs`),
-        //   so `{@const foo = bar}` where `bar` is a top-level
-        //   `$$promises[N]` blocker correctly wraps dependent text
-        //   expressions in `$$renderer.async([promises[M]], ...)`.
-        //   Unblocked `async-context-after-await-const`.
-        //   `async-effect-pending-eager` (added in upstream `273f1a85a`)
-        //   needs additional fixes — `$effect.pending()` rewrite for
-        //   `{#if}` test expressions and `<p>...</p>` trailing-whitespace
-        //   normalisation — tracked separately.
-        // - `derived-dep-set-while-rendering` (Svelte 5.55.5, runtime-only
-        //   commit `b771df3` adds a fixture): SSR `const x = $derived(visible)`
-        //   where the arg is a bare identifier referring to another derived
-        //   should emit `$.derived(visible)` (no thunk wrap). rsvelte's
-        //   `wrap_derived_reads` re-wraps `visible` to `visible()` inside the
-        //   thunk, producing `$.derived(() => visible())`. Tracked as a
-        //   follow-up.
-        // - Svelte 5.55.6 cluster: upstream commits `e00944ffd`/`89b6a939f`/
-        // - Svelte 5.55.9 cluster: upstream commits `a5df6616e` "fix: avoid
-        //   unnecessary stringify in server attributes" (inlines static
-        //   string interpolations into the literal HTML push instead of
-        //   wrapping them in `$.attr_style(\`…${$.stringify(x)}…\`)`) and
-        //   `000c594e0` "fix: `{#await await ...}` and async dependencies
-        //   fixes" (refines the async-batching / await-merge codegen).
-        //   `async-await` is unblocked by the 5.55.9 `000c594e0` port; the
-        //   remaining two still fail on orthogonal axes (`$derived(await
-        //   ...)` lowering, `wrap_derived_reads` shadowing in `then` body
-        //   args, etc.). Tracked as follow-up ports.
-        // The hydration `boundary-pending-attribute` fixture (Svelte 5.54.x)
-        // is now unblocked by the 5.55.3 `@const` blocker port (this PR),
-        // which switches the server `@const` assignment thunks from
-        // block-form (`async () => { data = ...; }`) to upstream's
-        // single-expression form (`async () => data = ...`).
-        // - HtmlTag is_controlled cluster (Svelte 5.53.8, upstream commit
-        //   `0206a2019`) is now ported in `client/visitors/shared/fragment.rs`
-        //   + `client/visitors/html_tag.rs` — all 13 fixtures (runtime-runes,
-        //   runtime-legacy, hydration) now pass. `head-raw-elements-content`
-        //   above survives as the only remaining HtmlTag-adjacent skip and
-        //   actually belongs to the SSR `$.stringify` elide cluster, not
-        //   is_controlled.
-        // - `select-option-store-implicit-value` (server-side-rendering,
-        //   Svelte 5.53.6, upstream `e3d277b00`): now ported in
-        //   `select_element.rs` — synthetic `<option>` value goes through
-        //   `transform_store_refs`.
-    ];
-
     for sample_dir in &samples {
         let name = sample_dir
             .file_name()
@@ -1120,18 +1026,16 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
             .unwrap_or("unknown")
             .to_string();
 
-        if runtime_skip_tests
-            .iter()
-            .any(|(cat, sample)| *cat == category && *sample == name)
-        {
+        // The documented skip lists live in `tests/common/mod.rs` so this
+        // report and the gate that actually blocks CI (`tests/runtime.rs`,
+        // `tests/ssr.rs`) can never disagree about what is skipped.
+        if runtime_skip_names(category).contains(&name.as_str()) {
             result.add_sample(SampleResult {
                 name,
                 status: TestStatus::Skipped,
                 error: None,
                 skip_reason: Some(
-                    "Async-derived $$promises blockers not yet threaded through \
-                     template effects (introduced in Svelte 5.53.0)"
-                        .to_string(),
+                    "On the documented runtime skip list in tests/common/mod.rs".to_string(),
                 ),
                 details: None,
             });
@@ -1169,27 +1073,9 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
             .unwrap_or("main.svelte")
             .to_string();
 
-        // Check for unsupported options
-        let config_path = svelte_path()
-            .join("packages/svelte/tests")
-            .join(category)
-            .join("samples")
-            .join(&name)
-            .join("_config.js");
-
-        // Detect async and hmr options from config
-        let mut config_has_async = false;
-        let mut config_has_hmr = false;
-        // dev option is not used for runtime tests - fixtures are generated with dev=false equivalent output
-        if let Ok(config) = fs::read_to_string(&config_path) {
-            let config_without_skip = config
-                .replace("skip_no_async", "")
-                .replace("skip_async", "");
-            config_has_async = config_without_skip.contains("async: true");
-            config_has_hmr = config.contains("hmr: true");
-            // Note: dev option is not used - fixtures are generated without dev-specific output
-            let _ = &config;
-        }
+        // The very options the fixture was generated with, shared with the
+        // gates so the report cannot measure something else than they do.
+        let fixture_options = runtime_fixture_options(category, &name);
 
         let input = match fs::read_to_string(&input_path) {
             Ok(s) => s,
@@ -1214,34 +1100,17 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         let mut server_ok = true;
         let mut error_msg = None;
 
-        // Enable experimental.async for runtime-runes tests (fixtures were generated with it enabled)
-        // Also enable it for individual tests that have async: true in config
-        let is_runtime_runes = category == "runtime-runes";
-        let use_async = is_runtime_runes || config_has_async;
-
-        // Enable accessors for runtime-legacy tests (matches official test runner behavior)
-        // See svelte/packages/svelte/tests/runtime-legacy/shared.ts line 224:
-        //   accessors: 'accessors' in config ? config.accessors : true
-        let is_legacy = category == "runtime-legacy";
-        let use_accessors = if is_legacy {
-            if let Ok(config) = fs::read_to_string(&config_path) {
-                !config.contains("accessors: false") && !config.contains("accessors:false")
-            } else {
-                true
-            }
-        } else {
-            false
-        };
-
         // Test client
         if let Some(expected) = &expected_client {
             let options = CompileOptions {
                 generate: GenerateMode::Client,
                 filename: Some(input_filename.clone()),
                 css: CssMode::External,
-                experimental: ExperimentalOptions { r#async: use_async },
-                hmr: config_has_hmr,
-                accessors: use_accessors,
+                experimental: ExperimentalOptions {
+                    r#async: fixture_options.r#async,
+                },
+                hmr: fixture_options.hmr,
+                accessors: fixture_options.accessors,
                 ..Default::default()
             };
 
@@ -1271,8 +1140,10 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
                 generate: GenerateMode::Server,
                 filename: Some(input_filename.clone()),
                 css: CssMode::External,
-                experimental: ExperimentalOptions { r#async: use_async },
-                hmr: config_has_hmr,
+                experimental: ExperimentalOptions {
+                    r#async: fixture_options.r#async,
+                },
+                hmr: fixture_options.hmr,
                 ..Default::default()
             };
 

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -14,8 +14,9 @@ use std::fs;
 use std::path::Path;
 
 use common::{
-    FixtureCoverage, SkipReason, compare_js_with_debug as compare_js_debug, ensure_fixtures_exist,
-    get_fixture_samples, load_fixture_output, sample_name, svelte_path, write_actual_output,
+    FixtureCoverage, RuntimeFixtureOptions, SkipReason, compare_js_with_debug as compare_js_debug,
+    ensure_fixtures_exist, get_fixture_samples, load_fixture_output, runtime_fixture_options,
+    runtime_skip_names, sample_name, svelte_path, write_actual_output,
 };
 use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile, compiler::CssMode};
 
@@ -46,74 +47,14 @@ fn load_input(category: &str, sample_name: &str) -> Option<String> {
         .map(|s| s.replace("\r\n", "\n"))
 }
 
-/// Check if a test requires unsupported compile options by reading _config.js
-fn requires_unsupported_options(category: &str, sample_name: &str) -> bool {
-    let config_path = svelte_path()
-        .join("packages/svelte/tests")
-        .join(category)
-        .join("samples")
-        .join(sample_name)
-        .join("_config.js");
-
-    if let Ok(config) = fs::read_to_string(&config_path) {
-        {
-            let config_without_skip = config
-                .replace("skip_no_async", "")
-                .replace("skip_async", "");
-            if config_without_skip.contains("async: true") {
-                return true;
-            }
-        }
-        if config.contains("hmr: true") {
-            return true;
-        }
-        if config.contains("compileOptions") && config.contains("preserveComments") {
-            return true;
-        }
-    }
-    false
-}
-
-/// Read the `accessors` setting from a test's _config.js.
-///
-/// The official Svelte test runner defaults to `accessors: true` for runtime-legacy tests
-/// (see svelte/packages/svelte/tests/runtime-legacy/shared.ts line 224):
-///   accessors: 'accessors' in config ? config.accessors : true
-///
-/// Returns `true` if `accessors` should be enabled (default true unless `accessors: false` in config).
-fn get_accessors_option(category: &str, sample_name: &str) -> bool {
-    if category != "runtime-legacy" {
-        return false;
-    }
-
-    let config_path = svelte_path()
-        .join("packages/svelte/tests")
-        .join(category)
-        .join("samples")
-        .join(sample_name)
-        .join("_config.js");
-
-    if let Ok(config) = fs::read_to_string(&config_path) {
-        // Check for explicit `accessors: false`
-        if config.contains("accessors: false") || config.contains("accessors:false") {
-            return false;
-        }
-    }
-    // Default: true for runtime-legacy (matches official test runner behavior)
-    true
-}
-
 /// A runtime test fixture.
 struct RuntimeFixture {
     name: String,
     input: String,
     expected_client_js: Option<String>,
     expected_server_js: Option<String>,
-    requires_unsupported_options: bool,
-    /// Whether to use accessors=true in CompileOptions.
-    /// Defaults to true for runtime-legacy (matches official test runner behavior).
-    #[allow(dead_code)]
-    accessors: bool,
+    /// The options the expected output was generated with.
+    options: RuntimeFixtureOptions,
 }
 
 /// Load a runtime test fixture from fixtures directory.
@@ -136,12 +77,11 @@ fn load_runtime_fixture(category: &str, sample_dir: &Path) -> Result<RuntimeFixt
     }
 
     Ok(RuntimeFixture {
-        name: name.clone(),
+        options: runtime_fixture_options(category, &name),
+        name,
         input,
         expected_client_js,
         expected_server_js,
-        requires_unsupported_options: requires_unsupported_options(category, &name),
-        accessors: get_accessors_option(category, &name),
     })
 }
 
@@ -167,63 +107,6 @@ fn should_write_actual_output() -> bool {
     std::env::var("WRITE_ACTUAL_OUTPUT").is_ok()
 }
 
-/// Fixtures that started failing on `main` after the Svelte submodule upgrades
-/// in #322 / #335 and aren't tied to a particular upstream change. Tracked
-/// separately so the runtime suite stops blocking unrelated work; remove an
-/// entry as soon as the upstream behaviour is matched.
-const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
-    // async-overlap-multiple-5..7 still fail on the client side (the SSR
-    // `$.save` predicate port unblocked -1..4). -5..7 use
-    // `let b = $derived(await delay(...))` in the instance script and hit a
-    // separate async-blocker cluster.
-    // Svelte 5.55.9 cluster (upstream `a5df6616e` "fix: avoid unnecessary
-    // stringify in server attributes"). The `<div title=...>` snapshot path
-    // is handled; the runes fixtures below also hit code paths that aren't
-    // ported yet (attribute parts, async-await codegen). Mirrors the
-    // entries in `tests/compatibility_report.rs`.
-    //
-    // `async-await` was unblocked by the 5.55.9 `000c594e0` `{#await await
-    // ...}` async-batching port; the remaining two still fail on orthogonal
-    // axes ($derived(await ...) → `(await $.save($.async_derived(...)))()`
-    // lowering, etc.).
-
-    // Svelte 5.56.0 #18282 (`59d3a36f8` "feat: allow declarations in the
-    // template"). `async-declaration-tag` (`{let x = $state(await …)}` /
-    // `{const y = $derived(await …)}`) now FULLY passes on both client and
-    // server — the async-declaration lowering (`add_async_declaration` in
-    // upstream's DeclarationTag.js) is ported: root-fragment `$$renderer.run`
-    // flush, cross-block `const_blocker_map` shadow scoping, the
-    // `await $.async_derived(async () => (await $.save(X))())` save-wrap shape,
-    // and element-block `async_consts` reset + cross-group blocker. Only
-    // `async-declaration-tag-2` (svelte:boundary + snippet + destructured await
-    // + each) now ALSO fully passes — the boundary keeps non-special snippets
-    // inside the `$.boundary(...)` callback when the fragment has DeclarationTags
-    // (`has_const || has_declaration`), the cross-const / destructured-await
-    // declaration tags route into the shared `$.run([…])` async group, the
-    // awaited `$derived` reads register the `$.get` transform, and the each
-    // collection + index param + per-binding blocker dedup all match upstream.
-    // Pre-existing: template_effect double-counts `$$promises` inside an
-    // `$.async(...)` wrapper for the IfBlock branch.
-    "async-style-after-await",
-    // New 5.56.x fixture (#18525, `bfbb026f2`): `<svelte:boundary {pending}>`
-    // with a `$derived` pending attribute. The SERVER `pending` ATTRIBUTE branch
-    // (`build_pending_attribute_block` + the `is_pending_attr_nullish`
-    // `if (pending()) {…} else {…}` wrapper) is a pre-existing GAP in
-    // `svelte_boundary.rs` — only the `pending` SNIPPET branch is ported. Client
-    // output matches; server=MISMATCH. Unaffected by the 5.56.7 bump
-    // (`SvelteBoundary.js` is byte-identical across 5.56.4..5.56.7).
-    "async-batch-derived",
-];
-
-/// runtime-legacy fixtures still failing on the rsvelte port. Each cluster is
-/// labelled with the upstream commit responsible. Remove an entry once the
-/// underlying port lands.
-const RUNTIME_LEGACY_SKIP_NAMES: &[&str] = &[];
-
-/// hydration fixtures still failing. All HtmlTag is_controlled fixtures now pass
-/// post-port (Svelte 5.53.8 upstream `0206a2019`).
-const HYDRATION_SKIP_NAMES: &[&str] = &[];
-
 /// Run a single runtime fixture test.
 fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestResult {
     let mut result = TestResult {
@@ -235,30 +118,12 @@ fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestRes
         skipped: false,
     };
 
-    if fixture.requires_unsupported_options {
-        result.skipped = true;
-        return result;
-    }
-
-    if category == "runtime-runes" && RUNTIME_RUNES_SKIP_NAMES.contains(&fixture.name.as_str()) {
-        result.skipped = true;
-        return result;
-    }
-
-    if category == "runtime-legacy" && RUNTIME_LEGACY_SKIP_NAMES.contains(&fixture.name.as_str()) {
-        result.skipped = true;
-        return result;
-    }
-
-    if category == "hydration" && HYDRATION_SKIP_NAMES.contains(&fixture.name.as_str()) {
+    if runtime_skip_names(category).contains(&fixture.name.as_str()) {
         result.skipped = true;
         return result;
     }
 
     let write_output = should_write_actual_output();
-
-    // Enable experimental.async for runtime-runes tests (matches fixture generation)
-    let use_async = category == "runtime-runes";
 
     // Test client-side compilation
     if let Some(expected_client) = &fixture.expected_client_js {
@@ -266,8 +131,11 @@ fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestRes
             generate: GenerateMode::Client,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
-            experimental: ExperimentalOptions { r#async: use_async },
-            accessors: fixture.accessors,
+            experimental: ExperimentalOptions {
+                r#async: fixture.options.r#async,
+            },
+            hmr: fixture.options.hmr,
+            accessors: fixture.options.accessors,
             ..Default::default()
         };
 
@@ -314,7 +182,10 @@ fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestRes
             generate: GenerateMode::Server,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
-            experimental: ExperimentalOptions { r#async: use_async },
+            experimental: ExperimentalOptions {
+                r#async: fixture.options.r#async,
+            },
+            hmr: fixture.options.hmr,
             // Let runes mode be auto-detected from source (matches official compiler behavior)
             ..Default::default()
         };

--- a/crates/rsvelte_core/tests/ssr.rs
+++ b/crates/rsvelte_core/tests/ssr.rs
@@ -9,10 +9,11 @@ use std::fs;
 use std::path::Path;
 
 use common::{
-    FixtureCoverage, SkipReason, compare_js, ensure_fixtures_exist, get_fixture_samples,
-    load_fixture_output, sample_name, svelte_path, write_actual_output,
+    FixtureCoverage, RuntimeFixtureOptions, SkipReason, compare_js, ensure_fixtures_exist,
+    get_fixture_samples, load_fixture_output, runtime_fixture_options, runtime_skip_names,
+    sample_name, svelte_path, write_actual_output,
 };
-use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile, compiler::CssMode};
 
 /// Grow-only fixture floor, measured against the pinned Svelte submodule.
 /// 126 samples are generated; 27 of them hold only an `error.json` because the
@@ -32,27 +33,13 @@ fn load_input(sample_name: &str) -> Option<String> {
         .map(|s| s.replace("\r\n", "\n"))
 }
 
-/// Check if a test requires unsupported compile options.
-fn requires_unsupported_options(sample_name: &str) -> bool {
-    let config_path = svelte_path()
-        .join("packages/svelte/tests/server-side-rendering/samples")
-        .join(sample_name)
-        .join("_config.js");
-
-    if let Ok(config) = fs::read_to_string(&config_path)
-        && config.contains("async: true")
-    {
-        return true;
-    }
-    false
-}
-
 /// An SSR test fixture.
 struct SsrFixture {
     name: String,
     input: String,
     expected_server_js: Option<String>,
-    requires_unsupported_options: bool,
+    /// The options the expected output was generated with.
+    options: RuntimeFixtureOptions,
 }
 
 /// Load an SSR test fixture.
@@ -71,10 +58,10 @@ fn load_ssr_fixture(sample_dir: &Path) -> Result<SsrFixture, SkipReason> {
         .ok_or(SkipReason::Justified)?;
 
     Ok(SsrFixture {
-        name: name.clone(),
+        options: runtime_fixture_options("server-side-rendering", &name),
+        name,
         input,
         expected_server_js: Some(expected_server_js),
-        requires_unsupported_options: requires_unsupported_options(&name),
     })
 }
 
@@ -87,24 +74,9 @@ struct TestResult {
     skipped: bool,
 }
 
-/// Fixtures whose expected SSR output exercises infrastructure rsvelte doesn't
-/// yet implement. Mirrors the corresponding entries in `tests/compatibility_report.rs`
-/// so `test_ssr` stops blocking unrelated work; remove an entry as soon as the
-/// upstream behaviour is matched.
-const SSR_SKIP_NAMES: &[&str] = &[];
-
 /// Run a single SSR fixture test.
 fn run_ssr_fixture_test(fixture: &SsrFixture) -> TestResult {
-    if fixture.requires_unsupported_options {
-        return TestResult {
-            name: fixture.name.clone(),
-            passed: None,
-            error: None,
-            skipped: true,
-        };
-    }
-
-    if SSR_SKIP_NAMES.contains(&fixture.name.as_str()) {
+    if runtime_skip_names("server-side-rendering").contains(&fixture.name.as_str()) {
         return TestResult {
             name: fixture.name.clone(),
             passed: None,
@@ -117,6 +89,10 @@ fn run_ssr_fixture_test(fixture: &SsrFixture) -> TestResult {
         generate: GenerateMode::Server,
         filename: Some("main.svelte".to_string()),
         css: CssMode::External,
+        experimental: ExperimentalOptions {
+            r#async: fixture.options.r#async,
+        },
+        hmr: fixture.options.hmr,
         ..Default::default()
     };
 


### PR DESCRIPTION
Closes #1814

## Problem

`compatibility_report.rs` re-implements the fixture comparisons the dedicated
suites already gate on, and its options had drifted from them. Eight fixtures were
green in their own suite but red in the report — the dashboard was measuring
something the gates never measure.

Baseline on this branch's merge-base (`pnpm run compatibility-report`, Svelte
v5.56.8): `Passed: 3308 (99.8%)`, `Failed: 8`.

| category | report | fixture |
|---|---|---|
| parser-modern | 24/27 | `comment-before-function-binding`, `parens`, `tag-type-identifier-probe-comment` |
| runtime-runes | 1006/1010 | `async-batch-derived`, `async-style-after-await`, `hmr-removal`, `hmr-each-keyed-unshift` |
| hydration | 79/80 | `boundary-pending-attribute` |

## The two divergences

### 1. `ParseOptions.capture_comments` (3 fixtures)

`parser_fixtures.rs` parses with `capture_comments: true`; the report did not.
Those three fixtures snapshot `leadingComments` / `trailingComments`, so without
comment capture they could only ever mismatch. This is the genuine "option
omission" the issue predicted, and the fix is one field.

### 2. Skip bookkeeping, not options (5 fixtures)

The other five are *real* codegen gaps — all five are `Server JS mismatch` with
client output byte-identical — that `runtime.rs` hides behind a
`requires_unsupported_options` predicate (skip when `_config.js` has
`async: true` / `hmr: true` / `preserveComments`) while the report compiled them.

That predicate was itself wrong: `scripts/fixtures/generate-fixtures.mjs`
generates the expected output **with** those very options, so they are not
"unsupported" — and the report proved it, passing 8 of the 11 samples the
predicate skipped. So rather than teaching the report to skip more, this PR
deletes the predicate and names the three genuinely-failing fixtures:

* `runtime-runes/hmr-removal`, `runtime-runes/hmr-each-keyed-unshift` — server
  output drops the `<!---->` anchor the official compiler emits around a dev-mode
  dynamic component (and one preserved JSDoc comment).
* `hydration/boundary-pending-attribute` — the server `pending` **attribute**
  branch of `<svelte:boundary>`, the same pre-existing gap already documented for
  `runtime-runes/async-batch-derived`.

Net effect on the gate: **8 more fixtures actually compared** (hydration +2,
runtime-legacy +1, runtime-runes +5), and the three that fail are now on an
explicit list that `audit_skipped.rs` re-checks after every Svelte bump — the
predicate skipped them silently and unauditably.

## De-duplication

Per the issue's "オプション構築を共通化して二重管理をやめる", the option
construction and the skip lists now live once in `tests/common/mod.rs`:

* `RuntimeFixtureOptions` + `runtime_fixture_options(category, sample)` — mirrors
  `generate-fixtures.mjs::generateRuntimeFixture`, so every runner compiles with
  exactly the options the fixture was generated with. There were **four**
  hand-rolled copies (`runtime.rs`, `ssr.rs`, `compatibility_report.rs`,
  `audit_skipped.rs`); `runtime.rs` and `ssr.rs` never passed `hmr` at all.
* `RUNTIME_RUNES_SKIP_NAMES` / `RUNTIME_LEGACY_SKIP_NAMES` / `HYDRATION_SKIP_NAMES`
  / `SSR_SKIP_NAMES` + `runtime_skip_names(category)`. The report's
  `runtime_skip_tests` was a strict subset of `runtime.rs`'s list (1 entry vs 4),
  which is what let `async-batch-derived` and `async-style-after-await` diverge.
  Following #1830, `async-each-const-await-iife` and
  `async-parallel-derived-template-mutation` are **not** carried over — they pass
  under the shared options here too (verified below), so `KNOWN_STALE_SKIPS` in
  `audit_skipped.rs` is now empty and the shared runes list holds 4 entries.
* `audit_skipped.rs` now reads those constants directly instead of text-scraping
  two sibling sources, so a rename is a build error rather than a silently empty
  audit.

The report's `runtime-runes` / `hydration` floors move to 1007 / 79 — exactly the
sample count minus the documented `runtime_skip_names` entries, which is the one
case `FixtureCoverage::assert`'s doc sanctions ("lower it only together with a
documented skip-list entry"). Both floors now equal what the gate compares.

## Result

```
Passed: 3312 (100.0%)
Failed: 0
Errors: 0
```

Report and gate now agree category by category: parser-modern 27, runtime-runes
1007, runtime-legacy 1207, hydration 79, server-side-rendering 99.

`AGENTS.md`'s Test Status table is regenerated from this run. It also picks up two
rows that had gone stale: `Sourcemaps` (fixed to 29/29 by #1813 but still printed
as `0/0`) and the runtime counts, which had not been refreshed since the 5.56.8
bump.

## Verification

| command | result |
|---|---|
| `pnpm run compatibility-report` | `3312 passed (100.0%)`, `Failed: 0` (was `3308 (99.8%)`, `Failed: 8`) |
| `cargo test --release -p rsvelte_core --test runtime` | 19 passed — hydration 79/79 (1 skip), runtime-legacy 1207/1207 (0 skips), runtime-runes 1007/1007 (4 skips), runtime-browser 32/32 |
| `cargo test --release -p rsvelte_core --test ssr` | 16 passed |
| `cargo test --release -p rsvelte_core --test audit_skipped` | 15 passed — `NOW PASSING (0 fixtures)`, so no skip entry is stale with `KNOWN_STALE_SKIPS` empty |
| `cargo test --release -p rsvelte_core --test parser_fixtures` | 17 passed |
| `cargo fmt --all` / `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` | clean |

No compiler code changed; this is entirely test harness. A `test:`-titled PR needs
no changeset.

## Relationship to #1830

#1830 (issue #1808) independently unskips `async-each-const-await-iife` and
`async-parallel-derived-template-mutation`. This branch reaches the same end
state, so the two **textually conflict** in `tests/runtime.rs`,
`tests/compatibility_report.rs` and `tests/audit_skipped.rs` — both delete the
same entries, and this PR additionally moves the surviving list into
`tests/common/mod.rs`. Either merge order leaves a trivial rebase: keep the
shared `RUNTIME_RUNES_SKIP_NAMES` from this branch with the 4 remaining entries
and the empty `KNOWN_STALE_SKIPS`.

## Out of scope (follow-ups found while auditing)

The report is still *looser* than its gate in a few places that are not part of
the 8 and would change what the report accepts:

* `compiler-errors` matches expected codes with a plain `contains` (plus an
  underscore→space variant) against the `Debug` string, where `compiler_errors.rs`
  uses a word-boundary regex over both `Debug` and `Display`.
* `validator` accepts three extra substrings for `typescript_invalid_feature`
  (`decorator` / `accessor` / `enum`), and parses expected errors as untyped
  `serde_json::Value`, so a `code`-less entry would auto-pass.
* The report does not normalize CRLF→LF on fixture inputs; every gate does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
