### PR TITLE
fix(parse): add recursion depth limit so deeply nested input errors instead of aborting (#1794)

### DIFF
--- a/.changeset/fix-parse-recursion-depth-limit.md
+++ b/.changeset/fix-parse-recursion-depth-limit.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(parse): bound parser recursion so deeply nested input errors instead of aborting
+
+Template and CSS nesting recursed without a bound, so input such as a few
+hundred nested elements overflowed the stack. That aborts the process
+(SIGABRT) rather than panicking, so no embedder — the lint CLI, `svelte-check`,
+the NAPI/wasm bindings, the language server — could contain it with
+`catch_unwind`; a single such file took down the whole session. Nesting deeper
+than 128 levels is now reported as an ordinary diagnostic
+(`template_nesting_too_deep` / `css_nesting_too_deep`). Real components nest
+around 20 levels, so valid code is unaffected.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
@@ -66,7 +66,7 @@ pub(crate) use read::expression;
 use crate::ast::Root;
 use crate::error::ParseResult;
 
-pub use parser::Parser;
+pub use parser::{MAX_NESTING_DEPTH, Parser};
 
 /// Parse options.
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
@@ -104,7 +104,24 @@ pub struct Parser<'a> {
     pub(crate) root_comments: std::cell::RefCell<Vec<crate::ast::template::JsComment>>,
     /// Arena allocator for JsNode instances created during parsing.
     pub(crate) arena: ParseArena,
+    /// Current template nesting depth, bounded by [`MAX_NESTING_DEPTH`].
+    pub(crate) depth: u32,
 }
+
+/// Maximum nesting depth accepted by the parser, for both template markup and
+/// the CSS inside `<style>`.
+///
+/// Nothing in the source bounds this recursion, so without the cap deeply
+/// nested input overflows the stack — an abort no embedder can contain, since
+/// a stack overflow is not a panic. Upstream Svelte needs no equivalent limit
+/// because a JS engine turns the same input into a catchable `RangeError`.
+///
+/// 128 is generous but conservative: the deepest component in the Svelte repo
+/// (4,461 files) and in this one nests 21 levels, while a whole compile at the
+/// limit stays under ~0.5 MiB of stack in a release build and ~2 MiB in a debug
+/// build — inside the 1 MiB a wasm build gets, the 2 MiB of a spawned worker,
+/// and the 8 MiB of a default main thread.
+pub const MAX_NESTING_DEPTH: u32 = 128;
 
 /// An entry on the parser stack.
 #[derive(Debug, Clone)]
@@ -205,6 +222,7 @@ impl<'a> Parser<'a> {
             parse_warnings: Vec::new(),
             root_comments: std::cell::RefCell::new(Vec::new()),
             arena: ParseArena::new(),
+            depth: 0,
         }
     }
 
@@ -244,6 +262,7 @@ impl<'a> Parser<'a> {
         self.last_auto_closed_tag = None;
         self.parse_warnings.clear();
         self.root_comments.borrow_mut().clear();
+        self.depth = 0;
         let _ = crate::compiler::phases::phase1_parse::read::expression::take_expr_comments();
         self.arena = ParseArena::new(); // Fresh arena per file
     }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -21,7 +21,7 @@ use crate::ast::css::{StyleSheet, StyleSheetContent, StyleSheetType};
 use crate::ast::template::{AttributeValue, AttributeValuePart, TemplateNode};
 use crate::error::ParseResult;
 
-use super::super::parser::Parser;
+use super::super::parser::{MAX_NESTING_DEPTH, Parser};
 
 /// Returns `true` when the `<style>` has a `lang` attribute whose value is not
 /// plain CSS (e.g. `sass`, `scss`, `stylus`, `less`, `postcss`). Such a block
@@ -66,6 +66,16 @@ pub(crate) fn parse_css_strict(
         return Err(err);
     }
     Ok(rules)
+}
+
+/// Helper: build a CSS `Block` node.
+fn block_value(start: usize, end: usize, children: Vec<Value>) -> Value {
+    let mut obj = Map::new();
+    obj.insert("type".to_string(), Value::String("Block".to_string()));
+    obj.insert("start".to_string(), Value::Number((start as i64).into()));
+    obj.insert("end".to_string(), Value::Number((end as i64).into()));
+    obj.insert("children".to_string(), Value::Array(children));
+    Value::Object(obj)
 }
 
 /// Helper: record a selector-level error on a `CssParser`'s shared error
@@ -398,6 +408,8 @@ struct CssParser<'a> {
     /// so that helper methods which take `&self` (because they mutate only
     /// `self.index` indirectly via sub-parsers) can still record errors.
     error: std::cell::Cell<Option<crate::error::ParseError>>,
+    /// Current nested-rule depth, bounded by `MAX_NESTING_DEPTH`.
+    depth: u32,
 }
 
 impl<'a> CssParser<'a> {
@@ -407,6 +419,7 @@ impl<'a> CssParser<'a> {
             offset,
             index: 0,
             error: std::cell::Cell::new(None),
+            depth: 0,
         }
     }
 
@@ -481,59 +494,7 @@ impl<'a> CssParser<'a> {
         let block = if self.current_char() == '{' {
             let block_start = self.offset + self.index;
             self.advance(); // consume '{'
-            self.skip_whitespace();
-
-            // Parse rules inside the block
-            let mut children = Vec::new();
-            while !self.is_eof() && self.current_char() != '}' {
-                self.skip_whitespace();
-                if self.is_eof() || self.current_char() == '}' {
-                    break;
-                }
-
-                // Skip comments so they don't get folded into the next child's
-                // span (they're preserved via source gap copying in the printer).
-                if self.match_str("/*") {
-                    self.skip_block_comment();
-                    continue;
-                }
-
-                // Check for nested at-rule
-                if self.current_char() == '@' {
-                    if let Some(rule) = self.parse_atrule() {
-                        children.push(rule);
-                    }
-                } else if self.peek_block_item_is_rule() {
-                    // Selector followed by `{` → rule (e.g. `0% { ... }` in @keyframes,
-                    // `.foo { ... }` in @media/@supports).
-                    if let Some(rule) = self.parse_rule() {
-                        children.push(rule);
-                    }
-                } else if let Some(decl) = self.parse_declaration() {
-                    // `prop: value;` declaration (used by @page, @font-face,
-                    // @counter-style, @property, etc., which take declarations
-                    // directly inside their block instead of nested rules).
-                    children.push(decl);
-                } else {
-                    // Couldn't make progress — bail to avoid infinite loop.
-                    self.advance();
-                }
-                self.skip_whitespace();
-            }
-
-            // Consume closing brace
-            self.eat_optional("}");
-            let block_end = self.offset + self.index;
-
-            let mut block_obj = Map::new();
-            block_obj.insert("type".to_string(), Value::String("Block".to_string()));
-            block_obj.insert(
-                "start".to_string(),
-                Value::Number((block_start as i64).into()),
-            );
-            block_obj.insert("end".to_string(), Value::Number((block_end as i64).into()));
-            block_obj.insert("children".to_string(), Value::Array(children));
-            Value::Object(block_obj)
+            self.with_block_depth(block_start, |parser| parser.parse_atrule_block(block_start))
         } else {
             self.eat_optional(";");
             Value::Null
@@ -550,6 +511,55 @@ impl<'a> CssParser<'a> {
         obj.insert("block".to_string(), block);
 
         Some(Value::Object(obj))
+    }
+
+    /// Parse the body of an at-rule, whose `{` has already been consumed.
+    fn parse_atrule_block(&mut self, block_start: usize) -> Value {
+        self.skip_whitespace();
+
+        // Parse rules inside the block
+        let mut children = Vec::new();
+        while !self.is_eof() && self.current_char() != '}' {
+            self.skip_whitespace();
+            if self.is_eof() || self.current_char() == '}' {
+                break;
+            }
+
+            // Skip comments so they don't get folded into the next child's
+            // span (they're preserved via source gap copying in the printer).
+            if self.match_str("/*") {
+                self.skip_block_comment();
+                continue;
+            }
+
+            // Check for nested at-rule
+            if self.current_char() == '@' {
+                if let Some(rule) = self.parse_atrule() {
+                    children.push(rule);
+                }
+            } else if self.peek_block_item_is_rule() {
+                // Selector followed by `{` → rule (e.g. `0% { ... }` in @keyframes,
+                // `.foo { ... }` in @media/@supports).
+                if let Some(rule) = self.parse_rule() {
+                    children.push(rule);
+                }
+            } else if let Some(decl) = self.parse_declaration() {
+                // `prop: value;` declaration (used by @page, @font-face,
+                // @counter-style, @property, etc., which take declarations
+                // directly inside their block instead of nested rules).
+                children.push(decl);
+            } else {
+                // Couldn't make progress — bail to avoid infinite loop.
+                self.advance();
+            }
+            self.skip_whitespace();
+        }
+
+        // Consume closing brace
+        self.eat_optional("}");
+        let block_end = self.offset + self.index;
+
+        block_value(block_start, block_end, children)
     }
 
     /// Peek ahead from the current position (without advancing) to decide
@@ -1226,8 +1236,40 @@ impl<'a> CssParser<'a> {
         result
     }
 
+    /// Parse a `{ … }` body one level deeper. Nested rules and at-rules recurse
+    /// through here, so this is where CSS nesting is bounded: past the limit the
+    /// body is skipped rather than descended into, and the error is recorded for
+    /// `parse_css_strict` to report.
+    fn with_block_depth(
+        &mut self,
+        block_start: usize,
+        parse: impl FnOnce(&mut Self) -> Value,
+    ) -> Value {
+        if self.depth >= MAX_NESTING_DEPTH {
+            record_first_error(
+                &self.error,
+                crate::error::ParseError::svelte(
+                    "css_nesting_too_deep",
+                    format!("CSS is nested more than {MAX_NESTING_DEPTH} levels deep"),
+                    (block_start, block_start + 1),
+                ),
+            );
+            self.skip_until_block_end();
+            return block_value(block_start, self.offset + self.index, Vec::new());
+        }
+
+        self.depth += 1;
+        let block = parse(self);
+        self.depth -= 1;
+        block
+    }
+
     fn parse_block(&mut self) -> Value {
         let start = self.offset + self.index - 1; // -1 to include the '{'
+        self.with_block_depth(start, |parser| parser.parse_block_inner(start))
+    }
+
+    fn parse_block_inner(&mut self, start: usize) -> Value {
         let mut declarations = Vec::new();
 
         self.skip_whitespace();
@@ -1277,13 +1319,58 @@ impl<'a> CssParser<'a> {
         self.eat_optional("}");
         let end = self.offset + self.index;
 
-        let mut obj = Map::new();
-        obj.insert("type".to_string(), Value::String("Block".to_string()));
-        obj.insert("start".to_string(), Value::Number((start as i64).into()));
-        obj.insert("end".to_string(), Value::Number((end as i64).into()));
-        obj.insert("children".to_string(), Value::Array(declarations));
+        block_value(start, end, declarations)
+    }
 
-        Value::Object(obj)
+    /// Consume the remainder of the block whose `{` was already eaten, without
+    /// recursing into it.
+    fn skip_until_block_end(&mut self) {
+        let mut brace_depth = 1;
+        let mut in_string = false;
+        let mut string_char = '\0';
+
+        while !self.is_eof() {
+            let c = self.current_char();
+
+            if c == '\\' {
+                self.advance();
+                if !self.is_eof() {
+                    self.advance();
+                }
+                continue;
+            }
+
+            if in_string {
+                if c == string_char {
+                    in_string = false;
+                }
+                self.advance();
+                continue;
+            }
+
+            if c == '"' || c == '\'' {
+                in_string = true;
+                string_char = c;
+                self.advance();
+                continue;
+            }
+
+            if self.match_str("/*") {
+                self.skip_block_comment();
+                continue;
+            }
+
+            if c == '{' {
+                brace_depth += 1;
+            } else if c == '}' {
+                brace_depth -= 1;
+                if brace_depth == 0 {
+                    self.advance();
+                    return;
+                }
+            }
+            self.advance();
+        }
     }
 
     /// Check if the current position looks like a nested rule (selector followed by {)
@@ -1707,7 +1794,13 @@ struct SelectorParser<'a> {
     /// First parse error encountered while reading selector tokens. Mirrors the
     /// "throw on first invalid identifier" behaviour of the official Svelte
     /// CSS parser without adding a `Result` return type to every helper.
-    error: Option<crate::error::ParseError>,
+    /// `Cell` so the `&self` helpers that spawn sub-parsers for pseudo-class
+    /// arguments can hand the sub-parser's error back up.
+    error: std::cell::Cell<Option<crate::error::ParseError>>,
+    /// Depth of enclosing pseudo-class argument lists (`:is(:is(…))`), bounded
+    /// by `MAX_NESTING_DEPTH`. Carried across sub-parsers because the
+    /// recursion runs through freshly constructed `SelectorParser`s.
+    depth: u32,
 }
 
 impl<'a> SelectorParser<'a> {
@@ -1716,7 +1809,37 @@ impl<'a> SelectorParser<'a> {
             source,
             offset,
             index: 0,
-            error: None,
+            error: std::cell::Cell::new(None),
+            depth: 0,
+        }
+    }
+
+    /// A sub-parser for the arguments of a pseudo-class inside this selector.
+    /// See [`Self::absorb_nesting_error`] for how its errors are handled.
+    fn nested(&self, source: &'a str, offset: usize) -> Self {
+        Self {
+            source,
+            offset,
+            index: 0,
+            error: std::cell::Cell::new(None),
+            depth: self.depth + 1,
+        }
+    }
+
+    /// Take over a sub-parser's nesting error. Its other diagnostics stay
+    /// where they are: the enclosing parser re-reads the same text and
+    /// upstream raises nothing for constructs the sub-parser trips on (a `,`
+    /// inside an attribute-selector string, say). Hitting the nesting bound is
+    /// different — it means the arguments were dropped rather than parsed, so
+    /// it must reach the caller.
+    fn absorb_nesting_error(&self, sub: &Self) {
+        let Some(err) = sub.error.take() else {
+            return;
+        };
+        if matches!(&err, crate::error::ParseError::SvelteError { code, .. }
+            if code == "css_nesting_too_deep")
+        {
+            record_first_error(&self.error, err);
         }
     }
 
@@ -1803,14 +1926,15 @@ impl<'a> SelectorParser<'a> {
                     // An empty identifier here would leave `self.index`
                     // unchanged and spin the loop; mirror the official
                     // `read_identifier` empty-identifier error and stop.
-                    if self.error.is_none() {
-                        let pos = self.offset + self.index;
-                        self.error = Some(crate::error::ParseError::svelte(
+                    let pos = self.offset + self.index;
+                    record_first_error(
+                        &self.error,
+                        crate::error::ParseError::svelte(
                             "css_expected_identifier",
                             "Expected a valid CSS identifier",
                             (pos, pos),
-                        ));
-                    }
+                        ),
+                    );
                     break;
                 }
             } else if c.is_ascii_digit() || (c == '.' && self.peek_next_char().is_ascii_digit()) {
@@ -1821,14 +1945,15 @@ impl<'a> SelectorParser<'a> {
                     selectors.push(selector);
                 } else {
                     // Not a valid percentage — fall through to the identifier error.
-                    if self.error.is_none() {
-                        let pos = self.offset + self.index;
-                        self.error = Some(crate::error::ParseError::svelte(
+                    let pos = self.offset + self.index;
+                    record_first_error(
+                        &self.error,
+                        crate::error::ParseError::svelte(
                             "css_expected_identifier",
                             "Expected a valid CSS identifier",
                             (pos, pos),
-                        ));
-                    }
+                        ),
+                    );
                     break;
                 }
             } else {
@@ -1836,14 +1961,15 @@ impl<'a> SelectorParser<'a> {
                 // falls through to `read_identifier` and the first character
                 // is not a valid identifier-start, `read_identifier` returns
                 // an empty string and raises `css_expected_identifier`.
-                if self.error.is_none() {
-                    let pos = self.offset + self.index;
-                    self.error = Some(crate::error::ParseError::svelte(
+                let pos = self.offset + self.index;
+                record_first_error(
+                    &self.error,
+                    crate::error::ParseError::svelte(
                         "css_expected_identifier",
                         "Expected a valid CSS identifier",
                         (pos, pos),
-                    ));
-                }
+                    ),
+                );
                 // Stop parsing further selectors once we've recorded an error;
                 // the surrounding parser will surface it.
                 break;
@@ -1992,7 +2118,20 @@ impl<'a> SelectorParser<'a> {
                 "nth-child" | "nth-last-child" | "nth-of-type" | "nth-last-of-type"
             );
 
-            if is_nth_pseudo {
+            // The arguments are the only recursive part of selector parsing, so
+            // this is where the nesting bound applies. The parenthesised text is
+            // already consumed above, so bailing out costs only the args AST.
+            if self.depth >= MAX_NESTING_DEPTH {
+                record_first_error(
+                    &self.error,
+                    crate::error::ParseError::svelte(
+                        "css_nesting_too_deep",
+                        format!("CSS is nested more than {MAX_NESTING_DEPTH} levels deep"),
+                        (start, start + 1),
+                    ),
+                );
+                None
+            } else if is_nth_pseudo {
                 // For nth-* pseudo-classes, parse the An+B syntax and optional 'of S' selector
                 let trimmed = content.trim();
                 let leading_ws = content.len() - content.trim_start().len();
@@ -2090,8 +2229,10 @@ impl<'a> SelectorParser<'a> {
 
                 // Parse selector part if present
                 if let Some((sel_text, sel_start)) = selector_part {
-                    let sel_parser = SelectorParser::new(sel_text, sel_start);
-                    let parsed = sel_parser.parse_simple_selectors();
+                    let mut sel_parser = self.nested(sel_text, sel_start);
+                    let mut parsed = Vec::new();
+                    sel_parser.parse_selectors(&mut parsed);
+                    self.absorb_nesting_error(&sel_parser);
                     selectors.extend(parsed);
                 }
 
@@ -2497,8 +2638,9 @@ impl<'a> SelectorParser<'a> {
         let end = offset + text.len();
 
         let mut selectors = Vec::new();
-        let mut parser = SelectorParser::new(text, offset);
+        let mut parser = self.nested(text, offset);
         parser.parse_selectors(&mut selectors);
+        self.absorb_nesting_error(&parser);
 
         let combinator_value = if let Some((c, comb_start, comb_end)) = combinator {
             let mut comb_obj = Map::new();
@@ -2830,12 +2972,5 @@ impl<'a> SelectorParser<'a> {
         }
 
         self.source[start..self.index].to_string()
-    }
-
-    /// Parse simple selectors from the current source and return them as a Vec.
-    fn parse_simple_selectors(mut self) -> Vec<Value> {
-        let mut selectors = Vec::new();
-        self.parse_selectors(&mut selectors);
-        selectors
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/fragment.rs
@@ -33,7 +33,7 @@
 use crate::ast::template::{Fragment, FragmentType, Root, RootType, TemplateNode};
 use crate::error::ParseResult;
 
-use super::super::parser::Parser;
+use super::super::parser::{MAX_NESTING_DEPTH, Parser};
 
 impl<'a> Parser<'a> {
     /// Parse the source into a Root AST node.
@@ -268,7 +268,26 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a fragment (sequence of nodes).
+    ///
+    /// Every nested element and block re-enters here, so this is the single
+    /// choke point where template recursion is bounded.
     pub fn parse_fragment(&mut self) -> ParseResult<Fragment<'a>> {
+        if self.depth >= MAX_NESTING_DEPTH {
+            return Err(crate::error::ParseError::svelte(
+                "template_nesting_too_deep",
+                format!(
+                    "Template is nested more than {MAX_NESTING_DEPTH} levels deep. Split the markup into components"
+                ),
+                (self.index, self.index),
+            ));
+        }
+        self.depth += 1;
+        let result = self.parse_fragment_inner();
+        self.depth -= 1;
+        result
+    }
+
+    fn parse_fragment_inner(&mut self) -> ParseResult<Fragment<'a>> {
         use super::super::parser::StackEntry;
         use super::super::utils::is_void_element;
 

--- a/crates/rsvelte_core/tests/deep_nesting_1794.rs
+++ b/crates/rsvelte_core/tests/deep_nesting_1794.rs
@@ -1,0 +1,176 @@
+//! Regression tests for #1794: deeply nested input must produce a parse error
+//! instead of overflowing the stack.
+//!
+//! A stack overflow aborts the process (SIGABRT) and is not a panic, so no
+//! embedder — the lint CLI, the NAPI/wasm bindings, the language server — can
+//! contain it with `catch_unwind`. The parser therefore bounds its own
+//! recursion at `MAX_NESTING_DEPTH` and reports a normal diagnostic.
+//!
+//! Every case runs on an explicitly sized 8 MiB thread — the size of a default
+//! main thread — so the assertions hold regardless of `RUST_MIN_STACK`, which
+//! the repo's test scripts raise. Raising the stack must never be what makes
+//! these pass.
+
+use rsvelte_core::compiler::phases::phase1_parse::MAX_NESTING_DEPTH;
+use rsvelte_core::error::ParseError;
+use rsvelte_core::{CompileError, CompileOptions, GenerateMode, ParseOptions, compile, parse};
+
+const DEFAULT_STACK: usize = 8 * 1024 * 1024;
+
+/// Run `f` on a thread with a default-sized (8 MiB) stack.
+fn on_default_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .stack_size(DEFAULT_STACK)
+        .spawn(f)
+        .expect("spawn test thread")
+        .join()
+        .expect("test thread did not panic")
+}
+
+fn nested(open: &str, inner: &str, close: &str, depth: usize) -> String {
+    let mut source = String::with_capacity((open.len() + close.len()) * depth + inner.len());
+    for _ in 0..depth {
+        source.push_str(open);
+    }
+    source.push_str(inner);
+    for _ in 0..depth {
+        source.push_str(close);
+    }
+    source
+}
+
+fn parse_error_code(source: String) -> String {
+    on_default_stack(move || {
+        match parse(
+            &source,
+            &oxc_allocator::Allocator::default(),
+            ParseOptions::default(),
+        ) {
+            Ok(_) => panic!("expected a parse error"),
+            Err(ParseError::SvelteError { code, .. }) => code,
+            Err(other) => panic!("expected a SvelteError, got {other:?}"),
+        }
+    })
+}
+
+fn compile_error_code(source: String, generate: GenerateMode) -> String {
+    on_default_stack(move || {
+        let options = CompileOptions {
+            generate,
+            ..Default::default()
+        };
+        match compile(&source, options) {
+            Ok(_) => panic!("expected a compile error"),
+            Err(CompileError::Parse(ParseError::SvelteError { code, .. })) => code,
+            Err(other) => panic!("expected a parse error, got {other}"),
+        }
+    })
+}
+
+/// The depth used for "far past the limit" cases — the level at which #1794
+/// reported the language server's 256 MiB worker aborting.
+const WAY_TOO_DEEP: usize = 30_000;
+
+#[test]
+fn deeply_nested_elements_error_instead_of_aborting() {
+    assert_eq!(
+        parse_error_code(nested("<div>", "hi", "</div>", WAY_TOO_DEEP)),
+        "template_nesting_too_deep"
+    );
+}
+
+#[test]
+fn deeply_nested_blocks_error_instead_of_aborting() {
+    assert_eq!(
+        parse_error_code(nested("{#if x}", "hi", "{/if}", WAY_TOO_DEEP)),
+        "template_nesting_too_deep"
+    );
+    assert_eq!(
+        parse_error_code(nested(
+            "{#each items as item}",
+            "hi",
+            "{/each}",
+            WAY_TOO_DEEP
+        )),
+        "template_nesting_too_deep"
+    );
+}
+
+#[test]
+fn deeply_nested_elements_error_from_compile() {
+    // Phase 2/3 walk the same tree, so the whole compile path — not just
+    // `parse()` — has to stay within the stack, for both output modes.
+    let source = nested("<div>", "hi", "</div>", WAY_TOO_DEEP);
+    assert_eq!(
+        compile_error_code(source.clone(), GenerateMode::Client),
+        "template_nesting_too_deep"
+    );
+    assert_eq!(
+        compile_error_code(source, GenerateMode::Server),
+        "template_nesting_too_deep"
+    );
+}
+
+#[test]
+fn deeply_nested_css_rules_error_instead_of_aborting() {
+    let css = nested("a{", "color:red;", "}", WAY_TOO_DEEP);
+    assert_eq!(
+        parse_error_code(format!("<div>hi</div><style>{css}</style>")),
+        "css_nesting_too_deep"
+    );
+}
+
+#[test]
+fn deeply_nested_css_selectors_error_instead_of_aborting() {
+    let selector = nested(":is(", "a", ")", WAY_TOO_DEEP);
+    assert_eq!(
+        parse_error_code(format!(
+            "<div>hi</div><style>{selector}{{color:red;}}</style>"
+        )),
+        "css_nesting_too_deep"
+    );
+}
+
+#[test]
+fn nesting_just_below_the_limit_still_compiles() {
+    // The root fragment occupies one level, so `MAX_NESTING_DEPTH - 1` nested
+    // elements is the deepest accepted markup.
+    let depth = MAX_NESTING_DEPTH as usize - 1;
+    let source = nested("<div>", "hi", "</div>", depth);
+    let compiled = on_default_stack(move || compile(&source, CompileOptions::default()));
+    assert!(
+        compiled.is_ok(),
+        "{:?}",
+        compiled.err().map(|e| e.to_string())
+    );
+
+    let source = nested("<div>", "hi", "</div>", depth);
+    let compiled = on_default_stack(move || {
+        compile(
+            &source,
+            CompileOptions {
+                generate: GenerateMode::Server,
+                ..Default::default()
+            },
+        )
+    });
+    assert!(
+        compiled.is_ok(),
+        "{:?}",
+        compiled.err().map(|e| e.to_string())
+    );
+}
+
+#[test]
+fn realistic_nesting_is_unaffected() {
+    // The deepest component in the Svelte repo nests 21 levels; anything in
+    // that range must compile exactly as before.
+    let source = nested("<div>", "hi", "</div>", 32);
+    let compiled = on_default_stack(move || compile(&source, CompileOptions::default()));
+    assert!(compiled.is_ok());
+
+    let css = nested("a{", "color:red;", "}", 8);
+    let source = format!("<a href=\"/\">hi</a><style>{css}</style>");
+    let compiled = on_default_stack(move || compile(&source, CompileOptions::default()));
+    assert!(compiled.is_ok());
+}


### PR DESCRIPTION
Closes #1794.

## Problem

Template and CSS parsing recursed with no depth bound, so deeply nested input
overflowed the stack. A stack overflow aborts the process (SIGABRT) and is not
a panic, so `catch_unwind` — which the `rsvelte-lint` CLI, the NAPI/wasm
bindings and the language server all rely on — cannot contain it. For the
language server the blast radius is the whole session.

Reproduced before the fix (debug build, 8 MiB stack — the default main thread):

| input | before |
|---|---|
| `"<div>" * 550` | aborts, `rc=134` |
| `"<div>" * 520`, full `compile()` | aborts, `rc=134` |
| `"a{" * 3000` inside `<style>` | aborts, `rc=134` |
| `":is(" * 1000` inside `<style>` | aborts, `rc=134` |

## Fix

`MAX_NESTING_DEPTH = 128`, enforced at the three places the parser recurses on
nesting:

- **Template** — `parse_fragment` is the single choke point every nested element
  and block re-enters; past the limit it returns `template_nesting_too_deep`.
- **CSS rules / at-rules** — `with_block_depth` wraps both `{ … }` bodies;
  past the limit the body is skipped (not descended into) and
  `css_nesting_too_deep` is recorded for `parse_css_strict` to report.
- **CSS pseudo-class arguments** — `:is(:is(…))` recursion runs through freshly
  constructed `SelectorParser`s, so the depth is carried across them; past the
  limit the arguments are left unparsed and the same error is raised. Only the
  nesting error is propagated out of a sub-parser — its other diagnostics stay
  advisory, as before, since the enclosing parser re-reads the same text.

Note `{#if}/{:else if}` chains do **not** consume nesting depth (a 400-branch
chain still parses), so only genuine markup/CSS nesting is bounded.

### Why 128

The deepest component in the Svelte repo (4,461 `.svelte` files) and in this
one nests **21** levels, so 128 is ~6x the deepest real input. Measured stack
use at the limit: a whole `compile()` fits in **~0.5 MiB** in release and
**~2 MiB** in debug, i.e. inside the 1 MiB a wasm build gets, the 2 MiB of a
spawned worker, and the 8 MiB of a default main thread. A larger cap (256) was
measured to need >1 MiB for a release CSR compile, which a wasm build cannot
promise.

### Error reporting vs. the official compiler

Upstream Svelte has no equivalent limit — a JS engine turns the same input into
a catchable `RangeError`, so the codes `template_nesting_too_deep` /
`css_nesting_too_deep` are rsvelte-only and deliberately carry **no**
`https://svelte.dev/e/…` link (there is no upstream page). They travel the
normal `ParseError::SvelteError` path, so every embedder already surfaces them
as an ordinary diagnostic. No fixture in any suite reaches the limit, so no
output changes for valid code.

## Tests

`crates/rsvelte_core/tests/deep_nesting_1794.rs` — 30,000-level nesting returns
an error for `parse()` and for `compile()` in both client and server mode
(elements, `{#if}`, `{#each}`, CSS rules, CSS selectors), and nesting at
`MAX_NESTING_DEPTH - 1` still compiles. Every case runs on an **explicitly
sized 8 MiB thread**, so the assertions do not depend on the `RUST_MIN_STACK`
the repo's test scripts raise — raising the stack must never be what makes them
pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
