### PR TITLE
fix(client): keep trailing <script> comments in place (#1784)

### DIFF
--- a/.changeset/fix-trailing-script-comment-placement.md
+++ b/.changeset/fix-trailing-script-comment-placement.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(client): keep trailing `<script>` comments in place
+
+A comment sitting after the last statement of a `<script>` was emitted at the
+end of the generated component function instead of next to the code it was
+written beside. In `svelte/compiler` the element identifier of `var p = root();`
+carries the element's source location (`b.id(name, element.name_loc)`), so esrap
+flushes the leftover comment there; every node rsvelte generated read as "no
+location", leaving the enclosing body as the only span that bracketed the
+comment. Generated element identifiers now carry that anchor, and only when the
+element really does follow the comment in the *source* — an element written
+before the `<script>` still leaves the comment at the body tail, as upstream
+does. Over the Svelte test corpus four more components now match
+`svelte/compiler` byte-for-byte and none regress.

--- a/compatibility/sourcemap-known-failures.json
+++ b/compatibility/sourcemap-known-failures.json
@@ -51,6 +51,7 @@
   "map-parity\tsourcemap-empty-source\tserver\t6",
   "map-parity\tsourcemap-names\tclient\t36",
   "map-parity\tsourcemap-names\tserver\t6",
+  "map-parity\tsourcemap-offsets\tclient\t8",
   "map-parity\tsourcemap-sources\tclient\t18",
   "map-parity\tsourcemap-sources\tserver\t5",
   "map-parity\tstatic-no-script\tclient\t4",

--- a/compatibility/sourcemap-known-failures.md
+++ b/compatibility/sourcemap-known-failures.md
@@ -122,6 +122,23 @@ This is the degradation issue #1781 describes, and it is the reason this gate
 exists: the same change passed every other suite. No other sample's counts
 moved, so nothing else on main has touched source maps.
 
+### Second catch: #1784
+
+Same shape as the #1772 entry above. Fixing #1784 (a trailing
+`<script>` comment now flushes at the next node upstream gives a location, not
+at the end of the function body) made `sourcemap-offsets` client output
+byte-identical to the official compiler for the first time, so it newly
+qualifies for `map-parity` and reports its resolution loss: 8 official segments,
+0 reproduced.
+
+| | before #1784 | after |
+|---|---|---|
+| `sourcemap-offsets` client — byte-identical to official | no | **yes** |
+| `sourcemap-offsets` client — official segments reproduced | not measured | 0 / 8 (8 missing, 0 wrong) |
+
+`EXPECTED_IDENTICAL_OUTPUTS` rises 55 → 56 in the same commit. Nothing else
+moved: no anchor changed, and no existing budget grew.
+
 ## Root cause
 
 The client entries all share one cause, tracked in issue #1781: the client AST
@@ -158,7 +175,7 @@ No entry is accepted as correct behaviour; all are burndown targets.
   chunk is anchored at the file start, so the whole block is off by the
   `<script module>` line) and `sourcemap-empty-source`/client maps to `0:8`
   instead of `2:1`.
-- **`map-parity` (45)** — one per byte-identical pair that loses official
+- **`map-parity` (46)** — one per byte-identical pair that loses official
   segments. Client counts (4–52) are dominated by `missing`; server counts (4–13)
   are mostly `missing`-only, except `preprocessed-styles` and
   `source-map-generator`, which contribute the 7 server `wrong` segments.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -3682,7 +3682,11 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                                 let __tmp = convert_json_value(i, context);
                                 context.arena.alloc_expr(__tmp)
                             });
-                            Some(JsVariableDeclarator { id: pattern, init })
+                            Some(JsVariableDeclarator {
+                                id: pattern,
+                                init,
+                                comment_anchor: None,
+                            })
                         })
                         .collect()
                 })
@@ -3831,6 +3835,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                                     Some(JsVariableDeclarator {
                                         id: pattern,
                                         init: init_val,
+                                        comment_anchor: None,
                                     })
                                 })
                                 .collect()
@@ -3932,6 +3937,7 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                                     Some(JsVariableDeclarator {
                                         id: pattern,
                                         init: init_val,
+                                        comment_anchor: None,
                                     })
                                 })
                                 .collect()
@@ -5021,6 +5027,7 @@ fn try_destructure_assignment(
                 declarations: vec![JsVariableDeclarator {
                     id: JsPattern::Identifier(insert.id.clone().into()),
                     init: Some(context.arena.alloc_expr(insert.value.clone())),
+                    comment_anchor: None,
                 }],
             }));
         }
@@ -5809,6 +5816,7 @@ fn convert_statement_from_jsnode(
                         Some(JsVariableDeclarator {
                             id: pattern,
                             init: init_expr,
+                            comment_anchor: None,
                         })
                     }
                     _ => None,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -262,10 +262,11 @@ pub fn fragment(
             // Initialize element: `var <id_name> = root();`
             context.state.init.insert(
                 0,
-                b::var_decl(
+                b::var_decl_anchored(
                     &context.arena,
                     &id_name,
                     Some(b::call(&context.arena, template_id_expr, vec![])),
+                    Some(element.start),
                 ),
             );
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
@@ -312,7 +312,7 @@ pub fn process_children<F>(
     // Helper: flush a single node
     let flush_node = |is_text: bool,
                       name: &str,
-                      _loc: Option<&str>,
+                      loc: Option<u32>,
                       prev_fn: &mut SiblingPrev<F>,
                       skip_count: &mut usize,
                       ctx: &mut ComponentContext|
@@ -326,9 +326,12 @@ pub fn process_children<F>(
             // Generate a unique identifier
             let id_name = ctx.state.memoizer.generate_id(name);
             id = b::id(&id_name);
-            ctx.state
-                .init
-                .push(b::var_decl(arena_ref, &id_name, Some(expression)));
+            ctx.state.init.push(b::var_decl_anchored(
+                arena_ref,
+                &id_name,
+                Some(expression),
+                loc,
+            ));
         }
 
         // Update prev to return this id (no allocation — enum variant swap).
@@ -528,13 +531,13 @@ pub fn process_children<F>(
                     }
                 } else {
                     // Get node name for identifier
-                    let name = if let TemplateNode::RegularElement(elem) = node {
-                        elem.name.as_str()
+                    let (name, name_loc) = if let TemplateNode::RegularElement(elem) = node {
+                        (elem.name.as_str(), Some(elem.start))
                     } else {
-                        "node"
+                        ("node", None)
                     };
 
-                    let id = flush_node(false, name, None, &mut prev, &mut skipped, context);
+                    let id = flush_node(false, name, name_loc, &mut prev, &mut skipped, context);
                     // Save original node and temporarily replace it
                     let saved_node = std::mem::replace(&mut context.state.node, id);
                     let result = context.visit_node(node, None);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -1666,6 +1666,7 @@ fn apply_transforms_to_statement_with_shadowed(
                             .arena
                             .alloc_expr(transform_expr(context.arena.get_expr(init)))
                     }),
+                    comment_anchor: None,
                 })
                 .collect();
 
@@ -1743,6 +1744,7 @@ fn apply_transforms_to_statement_with_shadowed(
                                     ),
                                 )
                             }),
+                            comment_anchor: None,
                         })
                         .collect();
                     JsForInit::Variable(JsVariableDeclaration {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
@@ -1313,6 +1313,7 @@ pub fn const_decl(arena: &JsArena, name: impl Into<CompactString>, init: JsExpr)
         declarations: vec![JsVariableDeclarator {
             id: id_pattern(name),
             init: Some(arena.alloc_expr(init)),
+            comment_anchor: None,
         }],
     })
 }
@@ -1328,6 +1329,7 @@ pub fn let_decl(
         declarations: vec![JsVariableDeclarator {
             id: id_pattern(name),
             init: init.map(|e| arena.alloc_expr(e)),
+            comment_anchor: None,
         }],
     })
 }
@@ -1344,6 +1346,26 @@ pub fn var_decl(
         declarations: vec![JsVariableDeclarator {
             id: id_pattern(name),
             init: init.map(|e| arena.alloc_expr(e)),
+            comment_anchor: None,
+        }],
+    })
+}
+
+/// `var name = init;` whose identifier carries the original-source offset
+/// upstream stamps on it (`b.var(b.id(name, element.name_loc), …)`). See
+/// [`JsVariableDeclarator::comment_anchor`].
+pub fn var_decl_anchored(
+    arena: &JsArena,
+    name: impl Into<CompactString>,
+    init: Option<JsExpr>,
+    comment_anchor: Option<u32>,
+) -> JsStatement {
+    JsStatement::VariableDeclaration(JsVariableDeclaration {
+        kind: JsVariableKind::Var,
+        declarations: vec![JsVariableDeclarator {
+            id: id_pattern(name),
+            init: init.map(|e| arena.alloc_expr(e)),
+            comment_anchor,
         }],
     })
 }
@@ -1360,6 +1382,7 @@ pub fn var_decl_pattern(
         declarations: vec![JsVariableDeclarator {
             id: pattern,
             init: init.map(|e| arena.alloc_expr(e)),
+            comment_anchor: None,
         }],
     })
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -173,6 +173,11 @@ impl fmt::Display for JsVariableKind {
 pub struct JsVariableDeclarator {
     pub id: JsPattern,
     pub init: Option<ExprId>,
+    /// Original-source offset upstream stamps on this declarator's identifier
+    /// (`b.id(name, element.name_loc)`), which is where esrap flushes comments
+    /// left over from an earlier chunk. `None` for a fully synthesized
+    /// declarator.
+    pub comment_anchor: Option<u32>,
 }
 
 /// Function declaration.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -147,6 +147,10 @@ struct Synth {
     /// Region the chunk just parsed occupies, consumed by the caller that knows
     /// the chunk's original-source offset.
     pending_region: Option<(u32, u32)>,
+    /// Original-source offset of the last comment-bearing chunk, so an anchor
+    /// can tell whether it sits after those comments in the *source* (which is
+    /// the order upstream compares in) and not merely after them in the buffer.
+    last_region_source: Option<u32>,
     saw_comments: bool,
     /// Upper bound on every span produced outside a chunk region.
     max_span: u32,
@@ -169,6 +173,7 @@ impl Synth {
             comments: Vec::new(),
             loc_map: Vec::new(),
             pending_region: None,
+            last_region_source: None,
             saw_comments: false,
             max_span: 0,
         }
@@ -235,7 +240,27 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let mut synth = self.synth.borrow_mut();
         let region = synth.pending_region.take()?;
         synth.loc_map.push((region.0, region.1, source_offset));
+        synth.last_region_source = source_offset;
         Some(region)
+    }
+
+    /// The comment-space position of a generated node that upstream anchors to
+    /// `source_offset` (esrap's `if (node.loc)` flush point). Sits at the buffer
+    /// cursor — past the preceding chunk's region and its closing newline, so a
+    /// comment left dangling at that chunk's end is flushed here and followed by
+    /// a line break, exactly as upstream flushes it at the next located node.
+    /// [`SPAN`] (no location) unless the anchor really does follow the pending
+    /// comments in the source, which is the order upstream compares in.
+    fn comment_anchor(&self, source_offset: Option<u32>) -> Span {
+        let Some(anchor) = source_offset else {
+            return SPAN;
+        };
+        let synth = self.synth.borrow();
+        if !synth.enabled || synth.last_region_source.is_none_or(|chunk| anchor <= chunk) {
+            return SPAN;
+        }
+        let at = synth.cursor();
+        Span::new(at, at)
     }
 
     // -- statements ---------------------------------------------------------
@@ -707,7 +732,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 None => None,
             };
             declarators.push(VariableDeclarator::new(
-                SPAN,
+                self.comment_anchor(d.comment_anchor),
                 kind,
                 binding,
                 oxc_ast::NONE,

--- a/crates/rsvelte_core/tests/client_script_comments_pin.rs
+++ b/crates/rsvelte_core/tests/client_script_comments_pin.rs
@@ -4,8 +4,10 @@
 //! These go through `to_oxc`'s comment coordinate space (`Synth`): the script
 //! chunk is re-parsed at its own region of a unified buffer so esrap can place
 //! its comments positionally, while the surrounding synthesized nodes carry no
-//! location. Before that existed, a comment-bearing chunk bailed to the string
-//! codegen — which produced *different* output for every one of these.
+//! location — except the generated element identifiers, which are anchored just
+//! past the chunk they follow so a dangling comment flushes there rather than at
+//! the body tail. Before that existed, a comment-bearing chunk bailed to the
+//! string codegen — which produced *different* output for every one of these.
 //!
 //! Expected outputs are the official Svelte compiler's, verbatim.
 
@@ -32,25 +34,27 @@ fn leading_script_comment_matches_upstream() {
     assert_eq!(client("leading", source), expected);
 }
 
-/// KNOWN DIVERGENCE (#1784): a comment after the script's last statement
-/// migrates to the end of the enclosing function body, because the only span
-/// bracketing it is the function body's. Upstream flushes it at the next
-/// generated node instead (`var // trailing note\n\tp = root();`). The comment is
-/// never lost — only repositioned. Pinned so the position cannot drift further
-/// unnoticed.
+/// A comment after the script's last statement is flushed at the next node
+/// upstream gives a source location — the element identifier of
+/// `var p = root();` — not at the end of the enclosing function body (#1784).
 #[test]
-fn trailing_script_comment_moves_to_the_body_tail() {
+fn trailing_script_comment_flushes_at_the_next_located_node() {
     let source =
         "<script>\n\t// leading note\n\tlet x = 1;\n\t// trailing note\n</script>\n\n<p>{x}</p>\n";
-    let actual = client("leading_and_trailing", source);
-    assert!(
-        actual.contains("\t// leading note\n\tlet x = 1;"),
-        "{actual}"
-    );
-    assert!(
-        actual.contains("\t$.append($$anchor, p);\n\t// trailing note\n}"),
-        "{actual}"
-    );
+    let expected = "import 'svelte/internal/disclose-version';\nimport 'svelte/internal/flags/legacy';\nimport * as $ from 'svelte/internal/client';\n\nvar root = $.from_html(`<p></p>`);\n\nexport default function Leading_and_trailing($$anchor) {\n\t// leading note\n\tlet x = 1;\n\n\tvar // trailing note\n\tp = root();\n\n\tp.textContent = '1';\n\t$.append($$anchor, p);\n}";
+    assert_eq!(client("leading_and_trailing", source), expected);
+}
+
+/// The mirror image: when the element precedes the `<script>`, upstream's
+/// element identifier sits *before* the comment in the source, so nothing is
+/// flushed there and the comment lands at the body tail instead. The anchor
+/// must compare in source order, not in emission order.
+#[test]
+fn trailing_script_comment_stays_at_the_body_tail_when_the_element_comes_first() {
+    let source =
+        "<p>{x}</p>\n\n<script>\n\t// leading note\n\tlet x = 1;\n\t// trailing note\n</script>\n";
+    let expected = "import 'svelte/internal/disclose-version';\nimport 'svelte/internal/flags/legacy';\nimport * as $ from 'svelte/internal/client';\n\nvar root = $.from_html(`<p></p>`);\n\nexport default function Element_first($$anchor) {\n\t// leading note\n\tlet x = 1;\n\n\tvar p = root();\n\n\tp.textContent = '1';\n\t$.append($$anchor, p);\n\t// trailing note\n}";
+    assert_eq!(client("element_first", source), expected);
 }
 
 #[test]

--- a/crates/rsvelte_core/tests/sourcemaps_gate.rs
+++ b/crates/rsvelte_core/tests/sourcemaps_gate.rs
@@ -200,7 +200,7 @@ const EXPECTED_ANCHOR_COUNT: usize = 23;
 /// `<sample>/<target>` pairs whose generated code is byte-identical to the
 /// official compiler's — the population `map-parity` can observe at all. A drop
 /// means byte-parity regressed and the map check silently shrank with it.
-const EXPECTED_IDENTICAL_OUTPUTS: usize = 55;
+const EXPECTED_IDENTICAL_OUTPUTS: usize = 56;
 
 /// What `scripts/fixtures/generate-fixtures.mjs` compiled the oracle with. Every
 /// sourcemaps `_config.js` fails to import under the generator (it pulls in the


### PR DESCRIPTION
Closes #1784

## Problem

A comment sitting after the last statement of a `<script>` was emitted at the end
of the generated component function instead of next to the code it was written
beside.

```svelte
<script>
	// leading note
	let x = 1;
	// trailing note
</script>

<p>{x}</p>
```

```js
// svelte/compiler
export default function C($$anchor) {
	// leading note
	let x = 1;

	var // trailing note
	p = root();

	p.textContent = '1';
	$.append($$anchor, p);
}

// rsvelte, before
export default function C($$anchor) {
	// leading note
	let x = 1;

	var p = root();

	p.textContent = '1';
	$.append($$anchor, p);
	// trailing note
}
```

## Cause

esrap places comments positionally, guarded by `if (node.loc)`. In
`svelte/compiler` the element identifier of `var p = root();` is built with the
element's source location — `b.id(scope.generate(element.name), element.name_loc)`
in `Fragment.js` / `shared/fragment.js` — so the leftover comment is flushed
there, at the first following node that has a location.

Every node rsvelte generated read as "no location" in `to_oxc`'s comment
coordinate space, so the only span bracketing the comment was the enclosing
function body's, and `body_elems` flushed it in its tail pass.

## Fix

`JsVariableDeclarator` gains a `comment_anchor: Option<u32>` carrying the
original-source offset upstream stamps on the identifier; `to_oxc` turns it into
a position in the comment buffer at the current cursor — past the preceding
chunk's region and its closing newline, so the dangling comment is flushed there
and followed by a line break, byte-for-byte as upstream does it.

The anchor only takes effect when it really does follow the pending comments **in
the source**, which is the order upstream compares in. Writing the element before
the `<script>` leaves the comment at the body tail, exactly as `svelte/compiler`
does — pinned by a second test.

## Verification

Compiling all 3,839 `.svelte` files under `packages/svelte/tests` with both
compilers and byte-comparing the client output:

| | before | after |
|---|---|---|
| byte-identical to `svelte/compiler` | 3633 | **3637** |
| divergent | 206 | **202** |

Zero files newly diverge. The remaining comment-related divergences are a
different bug class (comments upstream *drops* via `reset_comment_index`, and
comments rsvelte drops inside chunks) and are untouched here.

The source-map gate picks up one new `map-parity` budget entry: fixing this made
`sourcemap-offsets` client output byte-identical for the first time, so the
sample newly qualifies for the check and reports its chunk-granularity loss
(#1781). `EXPECTED_IDENTICAL_OUTPUTS` rises 55 → 56 in the same commit and the
new entry is justified in `compatibility/sourcemap-known-failures.md`.

## Tests

- `client_script_comments_pin` — 4/4 (the `#1784` pin now asserts upstream's
  placement verbatim; a new mirror test pins the element-before-`<script>` case)
- `compiler_fixtures` 17/17, `runtime` 19/19 (legacy + runes + hydration +
  browser), `sourcemaps_gate` 15/15
- Full `cargo test --release -p rsvelte_core`: all 158 test binaries pass; the
  only failure is the pre-existing `lib.rs` doctest (`parse()` signature), which
  fails identically on `main`
- `cargo fmt --check` and
  `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
