### PR TITLE
chore: add missing changesets for parse perf and lint fix data

### DIFF
--- a/.changeset/lint-fix-data.md
+++ b/.changeset/lint-fix-data.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/lint": patch
+---
+
+feat(lint): expose fix data alongside the validator wrap

--- a/.changeset/parse-perf-campaign.md
+++ b/.changeset/parse-perf-campaign.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+---
+
+perf(parse): 2.4x faster template parsing (CI benchmark: 60.5x → 175x vs `svelte/compiler`)
+
+Eight output-identical optimizations: typed `{@const}`/destructuring/binding-pattern
+builders replace every serde_json round-trip on the parse path, `<script>` bodies and
+block-head / attribute / directive expressions defer their JS parse under
+`defer_script_parse`, `Expression` shrinks from 216 to 16 bytes (EachBlock 976→376,
+Attribute 488→288), `ParseArena` stores nodes in chunks, and the quoted-attribute
+scanner uses memchr. AST output is byte-identical across the full Svelte test corpus
+and 4011 real-world components in both eager and deferred modes.


### PR DESCRIPTION
#1821 (2.4x parse) and #1805 (lint fix data) merged without changesets; this adds them so the release notes credit both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtF1frWdTnBtbfkChud2AS