### PR TITLE
fix(fmt): give rsvelte-fmt's rayon pool an explicit 8 MiB stack

### DIFF
--- a/.changeset/fix-fmt-rayon-stack-size.md
+++ b/.changeset/fix-fmt-rayon-stack-size.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): give rsvelte-fmt's rayon pool an explicit 8 MiB stack (#1838)
+
+`rsvelte-fmt` formats files in parallel on rayon workers, which fall back to
+`RUST_MIN_STACK` / the platform default (~2 MiB) unless a pool sets its own
+`stack_size`. In an unoptimized (debug) build, the formatter's own recursive
+printer can overflow that stack at a nesting depth the parser itself still
+accepts — just under `MAX_NESTING_DEPTH` (see #1794/#1837) — crashing a
+debug-build worker on otherwise valid input. `run()` now builds a dedicated
+rayon `ThreadPool` with an explicit 8 MiB stack and runs every rayon call in
+the pipeline (the Tailwind class-collection scan and the
+Svelte/JS/JSON/CSS/`oxfmt` join tree) through it, so the override always
+wins regardless of `RUST_MIN_STACK`.

--- a/crates/rsvelte_fmt/src/run.rs
+++ b/crates/rsvelte_fmt/src/run.rs
@@ -18,6 +18,25 @@ use crate::svelte_pipeline::run_svelte_files;
 use crate::tailwind_sort::{collect_svelte_classes, resolve_js_class_sorter};
 use crate::walk::partition_files;
 
+/// Default rayon workers get the platform's default thread stack (~2 MiB),
+/// but the formatter's own recursive printer can overflow that in an
+/// unoptimized build at a nesting depth the parser still accepts (just under
+/// `MAX_NESTING_DEPTH`, see #1838). Every rayon call in the pipeline —
+/// `collect_svelte_classes`, the per-file Svelte/JS/JSON/CSS passes, and the
+/// `oxfmt`-overlap `join` — runs inside a dedicated pool sized like the
+/// 8 MiB default main-thread stack the parser's own overflow tests use,
+/// rather than the process-wide global pool: `build_global` can only
+/// succeed once per process, which would make `run()` unsafe to call twice
+/// in the same process (e.g. from tests).
+const FMT_POOL_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+fn fmt_thread_pool() -> rayon::ThreadPool {
+    rayon::ThreadPoolBuilder::new()
+        .stack_size(FMT_POOL_STACK_SIZE)
+        .build()
+        .expect("build rsvelte-fmt's rayon pool")
+}
+
 pub fn run() -> Result<ExitCode> {
     let mut cli = Cli::parse();
 
@@ -54,12 +73,17 @@ pub fn run() -> Result<ExitCode> {
     let (svelte, native, native_json, native_css_files, oxfmt_paths) =
         partition_files(&cli.paths, &ignore, &cwd, native_js, native_css)?;
 
+    // Every rayon call below — this collection scan, and the per-file join
+    // tree further down — runs on this dedicated pool rather than the
+    // process-wide global one (see `fmt_thread_pool`).
+    let pool = fmt_thread_pool();
+
     // Custom Tailwind config (`SortViaJs`): collect every class string across the
     // `.svelte` files, sort them in one sidecar call, and install a map-backed
     // sorter for the real formatting pass below. Only `.svelte` files carry the
     // class sorter, so nothing else needs the collection pass.
     if let Some(pending) = &pending_js {
-        let classes = collect_svelte_classes(&svelte, &options);
+        let classes = pool.install(|| collect_svelte_classes(&svelte, &options));
         options.class_sorter = resolve_js_class_sorter(pending, classes);
     }
 
@@ -109,67 +133,70 @@ pub fn run() -> Result<ExitCode> {
     let exclude_native = native_js && !native.is_empty();
     let exclude_native_json = native_js && !native_json.is_empty();
     let exclude_native_css = native_css && !native_css_files.is_empty();
-    let (((svelte_result, native_result), (json_result, css_result)), oxfmt_result) = rayon::join(
-        || {
+    let (((svelte_result, native_result), (json_result, css_result)), oxfmt_result) =
+        pool.install(|| {
             rayon::join(
                 || {
                     rayon::join(
                         || {
-                            run_svelte_files(
-                                &svelte,
-                                &options,
-                                &cli.oxfmt_bin,
-                                &cfg,
-                                mode,
-                                use_style_cache,
-                                native_css,
+                            rayon::join(
+                                || {
+                                    run_svelte_files(
+                                        &svelte,
+                                        &options,
+                                        &cli.oxfmt_bin,
+                                        &cfg,
+                                        mode,
+                                        use_style_cache,
+                                        native_css,
+                                    )
+                                },
+                                || run_native_js(&native, &resolver, &cwd, &cli.oxfmt_bin, mode),
                             )
                         },
-                        || run_native_js(&native, &resolver, &cwd, &cli.oxfmt_bin, mode),
+                        || {
+                            rayon::join(
+                                || {
+                                    run_native_json(
+                                        &native_json,
+                                        &json_resolver,
+                                        &cwd,
+                                        &cli.oxfmt_bin,
+                                        mode,
+                                    )
+                                },
+                                || {
+                                    run_native_css(
+                                        &native_css_files,
+                                        &css_resolver,
+                                        &cwd,
+                                        &cli.oxfmt_bin,
+                                        mode,
+                                    )
+                                },
+                            )
+                        },
                     )
                 },
                 || {
-                    rayon::join(
-                        || {
-                            run_native_json(
-                                &native_json,
-                                &json_resolver,
-                                &cwd,
-                                &cli.oxfmt_bin,
-                                mode,
-                            )
-                        },
-                        || {
-                            run_native_css(
-                                &native_css_files,
-                                &css_resolver,
-                                &cwd,
-                                &cli.oxfmt_bin,
-                                mode,
-                            )
-                        },
+                    run_oxfmt(
+                        &oxfmt_paths,
+                        &cli.oxfmt_bin,
+                        mode,
+                        exclude_native,
+                        exclude_native_json,
+                        exclude_native_css,
+                        // A Svelte-only or CSS-only tree legitimately leaves oxfmt's
+                        // own share empty, so suppress its unmatched-pattern error —
+                        // but not when every in-process pass is *also* empty: oxfmt
+                        // is then the only thing that can tell (via its own ignore
+                        // rules and supported-extension set) whether anything really
+                        // exists to format, so it must be allowed to error for real.
+                        !in_process_empty,
                     )
                 },
             )
-        },
-        || {
-            run_oxfmt(
-                &oxfmt_paths,
-                &cli.oxfmt_bin,
-                mode,
-                exclude_native,
-                exclude_native_json,
-                exclude_native_css,
-                // A Svelte-only or CSS-only tree legitimately leaves oxfmt's
-                // own share empty, so suppress its unmatched-pattern error —
-                // but not when every in-process pass is *also* empty: oxfmt
-                // is then the only thing that can tell (via its own ignore
-                // rules and supported-extension set) whether anything really
-                // exists to format, so it must be allowed to error for real.
-                !in_process_empty,
-            )
-        },
-    );
+        });
 
     let svelte_status = svelte_result?;
     let native_status = native_result?;

--- a/crates/rsvelte_fmt/tests/cli/deep_nesting.rs
+++ b/crates/rsvelte_fmt/tests/cli/deep_nesting.rs
@@ -1,0 +1,113 @@
+//! Regression tests for #1838: `rsvelte-fmt`'s directory pass formats every
+//! file on rayon workers (see `run_svelte_files_native` in
+//! `src/svelte_pipeline.rs`, driven by `run()`'s pool in `src/run.rs`), and
+//! the formatter's own recursive printer can overflow a small worker stack in
+//! an unoptimized build at a nesting depth the parser still accepts (just
+//! under `MAX_NESTING_DEPTH = 128`, mirroring
+//! `rsvelte_core`'s `deep_nesting_1794.rs`).
+//!
+//! A rayon worker that never gets an explicit `stack_size` falls back to
+//! `RUST_MIN_STACK` (default 2 MiB) exactly like any other spawned thread, so
+//! forcing that env var down to something clearly insufficient (256 KiB) is a
+//! deterministic, platform-independent way to simulate "no dedicated pool" —
+//! the exact overflow margin at 2 MiB varies by target and toolchain, but no
+//! platform prints this deep in 256 KiB. Once `run()` builds its own pool
+//! with an explicit `stack_size` (see `fmt_thread_pool`), that override wins
+//! over `RUST_MIN_STACK` unconditionally, so these tests only pass if the
+//! fix's dedicated stack size is actually in effect.
+//!
+//! `RAYON_NUM_THREADS=1` collapses the pool to a single worker and — because
+//! `run()` calls `rayon::join`/`par_iter` from the (non-pool) main thread —
+//! forces the *entire* per-file pass onto that one worker rather than letting
+//! rayon execute a branch inline on the caller, so the deep-nested file's
+//! print recursion is guaranteed to run on the worker whose stack is under
+//! test, not on the process's main thread (which always gets a generous OS
+//! default regardless of this bug).
+
+use std::process::{Command, Stdio};
+
+use crate::common::{bin, tempdir};
+
+/// A stack clearly too small for this recursion depth on any platform, used
+/// to stand in for "no dedicated pool" (see module docs) — the point isn't to
+/// find the exact overflow boundary, only to prove the fix's pool ignores it.
+const TINY_STACK: &str = "262144";
+
+fn nested(open: &str, inner: &str, close: &str, depth: usize) -> String {
+    let mut source = String::with_capacity((open.len() + close.len()) * depth + inner.len());
+    for _ in 0..depth {
+        source.push_str(open);
+    }
+    source.push_str(inner);
+    for _ in 0..depth {
+        source.push_str(close);
+    }
+    source
+}
+
+/// Run `rsvelte-fmt --write <dir> --oxfmt-bin true` with a deliberately tiny
+/// `RUST_MIN_STACK` and a single-worker pool, returning the exit status.
+/// `--oxfmt-bin true` is a no-op stand-in: every file here is handled
+/// in-process, so nothing ever spawns it.
+fn write_under_tiny_stack(dir: &std::path::Path) -> std::process::ExitStatus {
+    Command::new(bin())
+        .args([dir.to_str().unwrap(), "--write", "--oxfmt-bin", "true"])
+        .env("RUST_MIN_STACK", TINY_STACK)
+        .env("RAYON_NUM_THREADS", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .status()
+        .expect("spawn rsvelte-fmt")
+}
+
+/// `MAX_NESTING_DEPTH - 1` nested `<div>`s — the deepest markup the parser
+/// still accepts (the root fragment occupies the remaining level) — must
+/// format successfully even when its rayon worker only has a 256 KiB stack,
+/// because `run()`'s dedicated pool stack size overrides it.
+#[test]
+fn deeply_nested_elements_survive_a_tiny_worker_stack() {
+    let dir = tempdir();
+    let file = dir.join("deep.svelte");
+    let depth = 128 - 1;
+    std::fs::write(&file, nested("<div>", "hi", "</div>", depth) + "\n").unwrap();
+
+    let status = write_under_tiny_stack(&dir);
+    assert!(status.success(), "exit code: {:?}", status.code());
+
+    let out = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        out.starts_with("<div>\n  <div>\n    <div>"),
+        "expected reindented nested markup, got:\n{}",
+        &out[..out.len().min(200)]
+    );
+    assert!(
+        out.trim_end().ends_with("</div>\n  </div>\n</div>") || out.contains("hi"),
+        "formatted output looks truncated/corrupted"
+    );
+}
+
+/// The CSS-nesting counterpart: `MAX_NESTING_DEPTH - 1` nested selectors in an
+/// embedded `<style>` block, formatted in-process (native CSS is the
+/// default), must survive the same tiny-worker-stack scenario.
+#[test]
+fn deeply_nested_css_survives_a_tiny_worker_stack() {
+    let dir = tempdir();
+    let file = dir.join("deep.svelte");
+    let depth = 128 - 1;
+    let css = nested(":is(", "a", ")", depth);
+    std::fs::write(
+        &file,
+        format!("<div></div>\n<style>{css}{{color:red;}}</style>\n"),
+    )
+    .unwrap();
+
+    let status = write_under_tiny_stack(&dir);
+    assert!(status.success(), "exit code: {:?}", status.code());
+
+    let out = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        out.contains("color: red;"),
+        "formatted output looks truncated/corrupted:\n{}",
+        &out[..out.len().min(400)]
+    );
+}

--- a/crates/rsvelte_fmt/tests/cli/main.rs
+++ b/crates/rsvelte_fmt/tests/cli/main.rs
@@ -8,6 +8,7 @@
 mod common;
 mod config;
 mod daemon;
+mod deep_nesting;
 mod delegation;
 mod native;
 mod stdin;


### PR DESCRIPTION
## Summary

- `rsvelte-fmt` formats files in parallel via rayon (`run()`'s `rayon::join` tree over the Svelte/JS/JSON/CSS passes plus the `oxfmt`-overlap join, and the Tailwind class-collection scan). Rayon workers that never get an explicit `stack_size` fall back to `RUST_MIN_STACK` / the platform default (~2 MiB).
- In an unoptimized (debug) build, the formatter's own recursive printer can overflow that ~2 MiB stack at a nesting depth the parser itself still accepts — just under `MAX_NESTING_DEPTH` (128, see #1794/#1837) — crashing a debug-build worker on input that's otherwise completely valid.
- `run()` now builds a dedicated rayon `ThreadPool` with an explicit 8 MiB `stack_size` (matching the safe 8 MiB main-thread stack the parser's own overflow tests use) and runs every rayon call in the pipeline through `pool.install(...)`, so the explicit override always wins regardless of `RUST_MIN_STACK`.
- Checked the other rayon entry points in the fmt path per the issue's suggestion: the wasm formatter (`rsvelte_fmt_wasm`) and `FormatSession`/stdin mode (`embed.rs`/`stdin.rs`) don't use rayon at all — they format a single file directly on the calling thread — so neither needed the same treatment. The language server's analysis worker already spawns its own 256 MiB-stack thread and doesn't go through this rayon path either.
- Building a dedicated pool (rather than calling `rayon::ThreadPoolBuilder::build_global()`) also means `run()` stays safe to call more than once in the same process, since `build_global` can only succeed once per process.

## Regression test

Added `crates/rsvelte_fmt/tests/cli/deep_nesting.rs`: two tests format a `.svelte` file nested `MAX_NESTING_DEPTH - 1` levels deep (once via nested `<div>`s, once via nested `:is(...)` CSS selectors in an embedded `<style>` block) through the real CLI binary's directory pass.

Since the default ~2 MiB stack's exact overflow margin is platform/toolchain-dependent (this bug was found on a different debug-build target than local dev), the tests force `RUST_MIN_STACK` down to 256 KiB and `RAYON_NUM_THREADS=1` for the subprocess — a deterministic, platform-independent stand-in for "no dedicated pool", since the whole per-file pass then runs on exactly one worker whose stack size is under test (rather than being executed inline on the process's own generously-sized main thread). With the fix's explicit pool `stack_size`, `RUST_MIN_STACK` is ignored entirely, so these tests only pass because the fix is in effect.

Verified both new tests crash (subprocess killed by a signal) against the pre-fix code and pass against the fix.

## Test plan

- [x] `cargo test -p rsvelte_fmt` — 64 + 2 + 1 tests pass (includes the two new regression tests)
- [x] `cargo test -p rsvelte_formatter` — all pass
- [x] `cargo fmt --check` (workspace)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (workspace) — clean
- [x] Manually confirmed the new tests fail (subprocess crash) when the fix is reverted, and pass when it's restored

Fixes #1838