### PR TITLE
chore(lint-types): refresh Cargo.lock and mirror release bumps into it

### DIFF
--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1647,7 +1647,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsvelte_core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bumpalo",
  "chrono",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_lint"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "compact_str 0.10.0",

--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -58,7 +58,11 @@ const MAPPINGS = [
 	},
 ];
 
-const cargoLockPath = resolve(repoRoot, 'Cargo.lock');
+// Every Cargo.lock that pins these crates. `crates/rsvelte_lint_types` is its
+// own out-of-workspace workspace (it path-depends on `submodules/corsa-bind`),
+// so the root lock does not cover it and its `--locked` CI job breaks on the
+// next release unless the bump is mirrored here too.
+const CARGO_LOCKS = ['Cargo.lock', 'crates/rsvelte_lint_types/Cargo.lock'];
 
 function readTargetVersion(npmRelPath) {
 	const npmPkgPath = resolve(repoRoot, npmRelPath);
@@ -85,7 +89,7 @@ function patchCargoToml(cargoRelPath, targetVersion) {
 	writeFileSync(cargoTomlPath, original.replace(re, `$1${targetVersion}$3`));
 }
 
-function patchCargoLock(original, lockName, targetVersion) {
+function patchCargoLock(original, lockName, targetVersion, { required }) {
 	// Each package entry in Cargo.lock looks like:
 	//   [[package]]
 	//   name = "rsvelte_fmt"
@@ -96,21 +100,36 @@ function patchCargoLock(original, lockName, targetVersion) {
 	);
 	const match = original.match(re);
 	if (!match) {
+		// A secondary lock only pins the crates that workspace depends on
+		// (rsvelte_lint_types has no rsvelte_fmt edge), so a miss there is fine.
+		if (!required) return original;
 		throw new Error(`Failed to find ${lockName} entry in Cargo.lock`);
 	}
 	if (match[2] === targetVersion) return original;
 	return original.replace(re, `$1${targetVersion}$3`);
 }
 
-let lock = readFileSync(cargoLockPath, 'utf8');
 const synced = [];
+const locks = CARGO_LOCKS.map((rel) => ({
+	rel,
+	path: resolve(repoRoot, rel),
+	text: readFileSync(resolve(repoRoot, rel), 'utf8'),
+	// The root lock must pin every crate we publish; a miss there is a real bug.
+	required: rel === 'Cargo.lock',
+}));
+
 for (const { npm, cargoToml, lockName } of MAPPINGS) {
 	const targetVersion = readTargetVersion(npm);
 	patchCargoToml(cargoToml, targetVersion);
-	lock = patchCargoLock(lock, lockName, targetVersion);
+	for (const lock of locks) {
+		lock.text = patchCargoLock(lock.text, lockName, targetVersion, {
+			required: lock.required,
+		});
+	}
 	synced.push(`${lockName}@${targetVersion}`);
 }
-writeFileSync(cargoLockPath, lock);
+
+for (const lock of locks) writeFileSync(lock.path, lock.text);
 console.log(
-	`Synced versions into Cargo.toml and Cargo.lock: ${synced.join(', ')}`,
+	`Synced versions into Cargo.toml and ${CARGO_LOCKS.join(' + ')}: ${synced.join(', ')}`,
 );


### PR DESCRIPTION
Unblocks the **Type-aware lint suite** check, which currently fails on every PR that touches `crates/rsvelte_lint/**` — including #1846:

```
error: cannot update the lock file /home/runner/work/rsvelte/rsvelte/crates/rsvelte_lint_types/Cargo.lock
because --locked was passed to prevent this
```

## Root cause

`crates/rsvelte_lint_types` is deliberately **its own out-of-workspace Cargo workspace** (it path-depends on `submodules/corsa-bind`, whose corsa client stack nothing else needs), so it carries a second `Cargo.lock` that the root workspace does not cover.

The `0.9.2 → 0.9.3` release (e79ecd06 `chore(release): version packages (#1796)`) bumped `rsvelte_core` and `rsvelte_lint`, but `scripts/release/sync-version.mjs` patches only the repo-root lock:

```js
const cargoLockPath = resolve(repoRoot, 'Cargo.lock');
```

So the lint_types lock kept pinning `0.9.2` while the crates said `0.9.3`, and all three `--locked` steps in `.github/workflows/type-aware-lint.yml` (`cargo clippy --locked`, `cargo test --locked`, and `rust-cache`'s `cargo metadata`) started failing. Nobody noticed because that workflow only runs on changes under the lint crates.

Note this is **not** an oxc rev drift — the `[patch.crates-io]` revs were already in sync with the root `Cargo.toml` (`83abe3b4`). The whole diff is two version lines.

## Changes

1. **`crates/rsvelte_lint_types/Cargo.lock`** — refreshed minimally via a plain `cargo metadata` (no `cargo update`), so only the stale entries move:

   ```diff
    name = "rsvelte_core"
   -version = "0.9.2"
   +version = "0.9.3"

    name = "rsvelte_lint"
   -version = "0.9.2"
   +version = "0.9.3"
   ```

2. **`scripts/release/sync-version.mjs`** — mirrors the bump into *every* lock that pins the published crates, not just the root one. Without this the lock goes stale again on the very next release and the workflow breaks the same way. A crate absent from a secondary lock is tolerated (the lint_types workspace has no `rsvelte_fmt` edge); a miss in the **root** lock still throws, since that would be a real bug.

   Verified by simulation: reverting the lock to the stale `0.9.2` state and running the script reproduces exactly the fix above, and re-running it on the fixed tree is a no-op.

## Verification

Run locally against `submodules/corsa-bind` at the pinned commit, using the exact CI commands:

- `cargo fmt --all --check` (in `crates/rsvelte_lint_types`) — pass
- `cargo clippy --all-targets --locked -- -D warnings` — **pass** (`Finished dev profile in 1m 27s`, no warnings); reproduced the failure before the change
- `cargo metadata --locked` — pass

The nine corsa tests need the pinned `@typescript/native-preview` tsgo `--api` server; left to CI, which runs them via `scripts/dev/test-type-aware-lint.mjs --locked`.

## Changeset

None, and no `skip-changeset` label needed: the Changeset Gate only requires one for `fix:` / `feat:` titles, and this is a `chore:` — `rsvelte_lint_types` is `publish = false` and out of workspace, and `sync-version.mjs` is release tooling, so no published package changes behavior. This matches the precedent for infra work on this crate (#1806 `test(lint-types): make the type-aware lint suite actually run`). The sibling `check-core-consumer-changesets.mjs` gate only fires on `crates/rsvelte_core/src/{svelte2tsx,svelte_check}/`, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp
