### PR TITLE
fix(svelte-check): keep `./Foo.svelte` resolving to the component when a same-name companion exists

### DIFF
--- a/.changeset/fix-svelte-check-companion-shadows-component.md
+++ b/.changeset/fix-svelte-check-companion-shadows-component.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): stop a same-name `Foo.svelte.ts` / `.js` companion from hiding `./Foo.svelte`'s component module. TypeScript resolves a relative `./Foo.svelte` by appending extensions in the importer's own directory, so a sibling companion always wins over the overlay's `Foo.svelte.tsx` shadow (`rootDirs` is only a fallback and `paths` never applies to relative specifiers). The component's default export and its `<script module>` named exports therefore vanished — a companion or barrel importing them reported `has no default export`, `declares 'X' locally, but it is not exported` and `Circular definition of import alias`. The overlay now emits a `companion-augment.d.ts` that augments the module TypeScript actually picked with the shadow's default and module-context exports, so both halves resolve. Importing the companion's own named exports through `./Foo.svelte.js` is unchanged.

--- a/crates/rsvelte_core/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_core/src/svelte_check/overlay.rs
@@ -19,6 +19,11 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use oxc_allocator::Allocator;
+use oxc_ast::ast as oxc;
+use oxc_parser::Parser as OxcParser;
+use oxc_span::SourceType;
+
 use super::kit_file::{self, AddedCode, KitFilesSettings};
 use super::manifest::{self, Manifest, ManifestEntry, current_stats};
 use crate::svelte2tsx::{
@@ -181,6 +186,7 @@ pub fn materialize_overlay_with(
     let svelte_resolver = build_svelte_import_resolver(tsconfig_path);
 
     let mut entries = Vec::with_capacity(files.len());
+    let mut augments: Vec<CompanionAugment> = Vec::new();
     for abs_source in &abs_files {
         let rel = safe_relative(abs_source, workspace);
         let tsx_rel = append_extension(&rel, ".tsx");
@@ -301,6 +307,16 @@ pub fn materialize_overlay_with(
             result.map
         };
 
+        // A duplicated input would emit the same `declare module` block twice.
+        if let Some(companion) = find_companion_module(abs_source)
+            && !augments.iter().any(|a| a.source_path == *abs_source)
+        {
+            let augment = build_companion_augment(abs_source, &tsx_path, &companion);
+            if augment.forward_default || !augment.names.is_empty() {
+                augments.push(augment);
+            }
+        }
+
         entries.push(OverlayEntry {
             source_path: abs_source.clone(),
             tsx_path,
@@ -308,6 +324,7 @@ pub fn materialize_overlay_with(
             source_map,
         });
     }
+    let has_augments = write_companion_augmentation(&cache_dir, &augments)?;
 
     // Materialise the svelte2tsx shims into the cache dir so the overlay
     // tsconfig can reference them by a stable relative path regardless of
@@ -333,6 +350,7 @@ pub fn materialize_overlay_with(
         workspace,
         &ext_root_dir_pairs,
         incremental,
+        has_augments,
     );
     fs::write(&overlay_tsconfig, tsconfig_json)?;
 
@@ -730,6 +748,7 @@ fn build_overlay_tsconfig(
     workspace: &Path,
     ext_root_dir_pairs: &[(PathBuf, PathBuf)],
     incremental: bool,
+    has_companion_augmentation: bool,
 ) -> String {
     let mut obj: BTreeMap<&str, serde_json::Value> = BTreeMap::new();
     if let Some(orig) = original {
@@ -869,6 +888,9 @@ fn build_overlay_tsconfig(
         .iter()
         .map(|(name, _)| format!("./{name}"))
         .collect();
+    if has_companion_augmentation {
+        files_entries.push(format!("./{COMPANION_AUGMENT_FILE}"));
+    }
     files_entries.extend(user_specs.files);
     files_entries.sort();
     files_entries.dedup();
@@ -1216,6 +1238,20 @@ fn resolve_root_dirs_abs(tsconfig_path: &Path) -> Vec<PathBuf> {
     Vec::new()
 }
 
+/// Sibling companion module (`Foo.svelte.ts` / `Foo.svelte.js`) of a
+/// `…/Foo.svelte` component source, when one exists on disk.
+fn find_companion_module(abs_source: &Path) -> Option<PathBuf> {
+    for ext in [".ts", ".js"] {
+        let mut cand = abs_source.as_os_str().to_os_string();
+        cand.push(ext);
+        let cand = PathBuf::from(cand);
+        if cand.is_file() {
+            return Some(cand);
+        }
+    }
+    None
+}
+
 /// If `abs_source` (`…/Foo.svelte`) has a sibling companion module
 /// (`Foo.svelte.ts` or `Foo.svelte.js`), return a module specifier — relative
 /// to the component shadow's directory and ending in `.js` so TS strips it and
@@ -1223,24 +1259,225 @@ fn resolve_root_dirs_abs(tsconfig_path: &Path) -> Vec<PathBuf> {
 /// to the shadow `.tsx`. Returns `None` when no companion exists.
 fn companion_reexport_specifier(abs_source: &Path, tsx_path: &Path) -> Option<String> {
     let from_dir = tsx_path.parent()?;
-    for ext in [".ts", ".js"] {
-        let mut cand = abs_source.as_os_str().to_os_string();
-        cand.push(ext);
-        let cand = PathBuf::from(cand);
-        if cand.is_file() {
-            let mut spec = path_relative(from_dir, &cand);
-            if !spec.starts_with('.') {
-                spec = format!("./{spec}");
+    let companion = find_companion_module(abs_source)?;
+    let mut spec = path_relative(from_dir, &companion);
+    if !spec.starts_with('.') {
+        spec = format!("./{spec}");
+    }
+    // TS resolves `./x.svelte.js` by stripping `.js` and finding the
+    // real `.ts`/`.js`; normalise a `.ts` companion's specifier to `.js`.
+    if let Some(stripped) = spec.strip_suffix(".ts") {
+        spec = format!("{stripped}.js");
+    }
+    Some(spec)
+}
+
+/// Filename of the generated module-augmentation declaration, written into the
+/// cache dir next to the shims.
+const COMPANION_AUGMENT_FILE: &str = "companion-augment.d.ts";
+
+/// One `Foo.svelte` + same-name companion pair that needs a module
+/// augmentation (see [`write_companion_augmentation`]).
+struct CompanionAugment {
+    /// The `.svelte` source; `path_relative` from the cache dir gives the
+    /// specifier whose resolution we are augmenting.
+    source_path: PathBuf,
+    /// The component shadow that supplies the augmented types.
+    tsx_path: PathBuf,
+    /// Component exports to forward, minus anything the companion already
+    /// exports itself (re-declaring those would be a duplicate identifier).
+    names: Vec<String>,
+    /// Whether the component's default export still needs forwarding — a
+    /// companion that already re-exports it must not get a second one.
+    forward_default: bool,
+}
+
+fn build_companion_augment(
+    abs_source: &Path,
+    tsx_path: &Path,
+    companion: &Path,
+) -> CompanionAugment {
+    let shadow = fs::read_to_string(tsx_path)
+        .map(|src| module_exports(&src, SourceType::tsx()))
+        .unwrap_or_default();
+    let companion_source_type = if companion.extension().and_then(|e| e.to_str()) == Some("ts") {
+        SourceType::ts()
+    } else {
+        SourceType::default()
+    };
+    let companion = fs::read_to_string(companion)
+        .map(|src| module_exports(&src, companion_source_type))
+        .unwrap_or_default();
+    let names = shadow
+        .names
+        .into_iter()
+        .filter(|n| !companion.names.contains(n))
+        .collect();
+    CompanionAugment {
+        source_path: abs_source.to_path_buf(),
+        tsx_path: tsx_path.to_path_buf(),
+        names,
+        forward_default: !companion.has_default,
+    }
+}
+
+/// Write the module augmentation that restores `./Foo.svelte`'s component
+/// identity when a same-name `Foo.svelte.ts` / `.js` companion exists (#800).
+///
+/// TypeScript resolves `./Foo.svelte` by appending extensions in the
+/// *importer's own* directory, so a sibling `Foo.svelte.ts` always wins over
+/// the overlay's `Foo.svelte.tsx` shadow — `rootDirs` is only consulted after
+/// that lookup fails, and `paths` never applies to relative specifiers. The
+/// specifier therefore lands on the companion, and the component's default
+/// export plus its `<script module>` named exports vanish. Since the module
+/// TypeScript picked is a real user file we cannot rewrite, we instead
+/// *augment* it with the shadow's exports, so one resolvable module carries
+/// both halves. Returns whether anything was written.
+fn write_companion_augmentation(
+    cache_dir: &Path,
+    augments: &[CompanionAugment],
+) -> io::Result<bool> {
+    let path = cache_dir.join(COMPANION_AUGMENT_FILE);
+    if augments.is_empty() {
+        // A previous run may have left a stale file that `files` no longer
+        // lists; drop it so it can't shadow a companion that has since gone.
+        let _ = fs::remove_file(&path);
+        return Ok(false);
+    }
+    let mut out = String::new();
+    for (i, aug) in augments.iter().enumerate() {
+        let ns = format!("__rsvelte_companion_{i}");
+        let shadow_spec = dot_relative(cache_dir, &aug.tsx_path);
+        let module_spec = dot_relative(cache_dir, &aug.source_path);
+        let _ = writeln!(out, "import * as {ns} from \"{shadow_spec}\";");
+        let _ = writeln!(out, "declare module \"{module_spec}\" {{");
+        if aug.forward_default {
+            let _ = writeln!(out, "    const _default: (typeof {ns})[\"default\"];");
+            // TS applies a default export inside an augmentation but still
+            // grammar-errors on it (TS2666); this file is ours, not user code.
+            let _ = writeln!(out, "    // @ts-ignore");
+            let _ = writeln!(out, "    export default _default;");
+        }
+        for name in &aug.names {
+            // `export import` aliases the value *and* the type meaning of the
+            // name; a plain `export const` would drop `export type` members.
+            let _ = writeln!(out, "    export import {name} = {ns}.{name};");
+        }
+        let _ = writeln!(out, "}}");
+    }
+    fs::write(&path, out)?;
+    Ok(true)
+}
+
+/// [`path_relative`] forced into an explicitly-relative module specifier.
+fn dot_relative(from_dir: &Path, to_path: &Path) -> String {
+    let spec = path_relative(from_dir, to_path);
+    if spec.starts_with('.') {
+        spec
+    } else {
+        format!("./{spec}")
+    }
+}
+
+/// A module's top-level exports. Bare `export * from` contributes nothing —
+/// its names are not knowable without resolving the target.
+#[derive(Default)]
+struct ModuleExports {
+    /// Named exports, excluding `default` and any non-identifier name
+    /// (`export { x as "a-b" }`) that cannot appear in an `export import`.
+    names: Vec<String>,
+    has_default: bool,
+}
+
+fn module_exports(source: &str, source_type: SourceType) -> ModuleExports {
+    let allocator = Allocator::default();
+    let parsed = OxcParser::new(&allocator, source, source_type).parse();
+    let mut names: Vec<String> = Vec::new();
+    let mut has_default = false;
+    for stmt in &parsed.program.body {
+        match stmt {
+            oxc::Statement::ExportNamedDeclaration(decl) => {
+                if let Some(declaration) = &decl.declaration {
+                    collect_declaration_names(declaration, &mut names);
+                }
+                for spec in &decl.specifiers {
+                    names.push(spec.exported.name().to_string());
+                }
             }
-            // TS resolves `./x.svelte.js` by stripping `.js` and finding the
-            // real `.ts`/`.js`; normalise a `.ts` companion's specifier to `.js`.
-            if let Some(stripped) = spec.strip_suffix(".ts") {
-                spec = format!("{stripped}.js");
+            oxc::Statement::ExportAllDeclaration(decl) => {
+                if let Some(exported) = &decl.exported {
+                    names.push(exported.name().to_string());
+                }
             }
-            return Some(spec);
+            oxc::Statement::ExportDefaultDeclaration(_) => has_default = true,
+            _ => {}
         }
     }
-    None
+    has_default |= names.iter().any(|n| n == "default");
+    names.retain(|n| n != "default" && is_js_identifier(n));
+    names.sort();
+    names.dedup();
+    ModuleExports { names, has_default }
+}
+
+fn collect_declaration_names(declaration: &oxc::Declaration, names: &mut Vec<String>) {
+    match declaration {
+        oxc::Declaration::VariableDeclaration(var) => {
+            for declarator in &var.declarations {
+                collect_binding_pattern_names(&declarator.id, names);
+            }
+        }
+        oxc::Declaration::FunctionDeclaration(func) => {
+            if let Some(id) = &func.id {
+                names.push(id.name.to_string());
+            }
+        }
+        oxc::Declaration::ClassDeclaration(class) => {
+            if let Some(id) = &class.id {
+                names.push(id.name.to_string());
+            }
+        }
+        oxc::Declaration::TSTypeAliasDeclaration(alias) => names.push(alias.id.name.to_string()),
+        oxc::Declaration::TSInterfaceDeclaration(iface) => names.push(iface.id.name.to_string()),
+        oxc::Declaration::TSEnumDeclaration(enum_decl) => names.push(enum_decl.id.name.to_string()),
+        // `declare module`/`namespace` bodies can re-open across files; aliasing
+        // them into an augmentation is not worth the ambiguity.
+        _ => {}
+    }
+}
+
+fn collect_binding_pattern_names(pattern: &oxc::BindingPattern, names: &mut Vec<String>) {
+    match pattern {
+        oxc::BindingPattern::BindingIdentifier(id) => names.push(id.name.to_string()),
+        oxc::BindingPattern::ObjectPattern(obj) => {
+            for prop in &obj.properties {
+                collect_binding_pattern_names(&prop.value, names);
+            }
+            if let Some(rest) = &obj.rest {
+                collect_binding_pattern_names(&rest.argument, names);
+            }
+        }
+        oxc::BindingPattern::ArrayPattern(arr) => {
+            for el in arr.elements.iter().flatten() {
+                collect_binding_pattern_names(el, names);
+            }
+            if let Some(rest) = &arr.rest {
+                collect_binding_pattern_names(&rest.argument, names);
+            }
+        }
+        oxc::BindingPattern::AssignmentPattern(assign) => {
+            collect_binding_pattern_names(&assign.left, names)
+        }
+    }
+}
+
+fn is_js_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_alphabetic() || c == '_' || c == '$' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
 }
 
 /// Build the module resolver used to re-point tsconfig-alias `.svelte` imports

--- a/crates/rsvelte_core/tests/svelte_check_companion_800.rs
+++ b/crates/rsvelte_core/tests/svelte_check_companion_800.rs
@@ -1,56 +1,27 @@
 //! #800: a same-name `Foo.svelte.ts` companion must not shadow `./Foo.svelte`'s
 //! component overlay (its default + `<script module>` named exports).
 //!
-//! Real-tsgo e2e; skipped when no tsgo/tsc is found.
+//! TypeScript resolves `./Foo.svelte` by appending extensions in the importer's
+//! own directory, so a sibling `Foo.svelte.ts` always wins over the overlay's
+//! `Foo.svelte.tsx` shadow — `rootDirs` is only a fallback and `paths` never
+//! applies to relative specifiers. The overlay therefore augments the module
+//! TypeScript did pick (the companion) with the shadow's default + named
+//! exports. The same fixture pins #751 (named imports resolved *from* the
+//! companion via `./Foo.svelte.js`) so neither direction regresses.
+//!
+//! Real-tsc/tsgo e2e; skipped when no tsgo/tsc is found.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use rsvelte_core::svelte_check::diagnostic::DiagnosticSeverity;
 use rsvelte_core::svelte_check::tsgo::find_compiler;
 use rsvelte_core::svelte_check::{RunOptions, run};
 
-// #800 is a known architectural limitation: a same-name `Foo.svelte.ts`
-// companion in the same directory self-resolves `import './Foo.svelte'` to
-// itself (`.ts` beats the component's `.svelte.tsx` / `.svelte.d.ts` shadow),
-// and TS *relative*-import resolution can't be redirected via tsconfig
-// `rootDirs`/`paths` — the upstream fix is a TS language-server plugin that
-// intercepts `resolveModuleNameLiterals`, which `tsgo` does not support. This
-// test is the real-tsgo repro; run it explicitly to verify a future fix:
-//   TSGO_BIN=… cargo test --test svelte_check_companion_800 -- --ignored --nocapture
-#[ignore = "#800: companion .svelte.ts shadows ./Foo.svelte — needs resolution interception (tsgo plugin); repro only"]
-#[test]
-fn companion_svelte_ts_does_not_shadow_component_module() {
-    if find_compiler(&PathBuf::from("."), true).is_err() {
-        eprintln!("skip #800: no tsgo/tsc found");
-        return;
-    }
-    let dir = std::env::temp_dir().join(format!("rsvelte_800_{}", std::process::id()));
-    let _ = fs::remove_dir_all(&dir);
-    let src = dir.join("src");
-    fs::create_dir_all(&src).unwrap();
-    fs::write(
-        src.join("H.svelte"),
-        "<script module lang=\"ts\">export const ATTR = 'data-x' as const;</script>\n<script lang=\"ts\">let { n }: { n: number } = $props();</script>\n<span data-x={ATTR}>{n}</span>\n",
-    )
-    .unwrap();
-    fs::write(
-        src.join("H.svelte.ts"),
-        "import H, { ATTR } from './H.svelte';\nexport const useAttr = (): string => ATTR;\nexport const Comp = H;\n",
-    )
-    .unwrap();
-    fs::write(
-        src.join("idx.ts"),
-        "export { default as H, ATTR } from './H.svelte';\n",
-    )
-    .unwrap();
-    fs::write(
-        dir.join("tsconfig.json"),
-        r#"{ "compilerOptions": { "moduleResolution": "bundler", "allowArbitraryExtensions": true, "strict": true, "skipLibCheck": true }, "include": ["src/**/*.ts", "src/**/*.svelte"] }"#,
-    )
-    .unwrap();
-    // Minimal `svelte` type stub — enough for tsgo to resolve `import('svelte')`
-    // without pulling the source package's `.svelte` test fixtures into the walk.
+/// Minimal `svelte` package stub — enough for the emitted shims and the
+/// component shadows to type-check without pulling in the real package (whose
+/// `.svelte` test fixtures would end up in the walk).
+fn write_svelte_stub(dir: &Path) {
     let svelte_dir = dir.join("node_modules/svelte");
     fs::create_dir_all(&svelte_dir).unwrap();
     fs::write(
@@ -63,16 +34,27 @@ fn companion_svelte_ts_does_not_shadow_component_module() {
         "export class SvelteComponent<P=any,E=any,S=any>{ constructor(o:any); $$bindings?:any; $set(p:any):void; $on(t:any,c:any):()=>void; $destroy():void; }\nexport interface ComponentConstructorOptions<P=any>{ target:any; anchor?:any; props?:P; [k:string]:any; }\nexport type Snippet<T extends unknown[]=any[]>=(...a:T)=>any;\nexport type Component<P=any>=any;\nexport type ComponentProps<T>=any;\nexport type ComponentEvents<T>=any;\nexport function mount(...a:any[]):any;\nexport function unmount(...a:any[]):any;\n",
     )
     .unwrap();
+    // `svelte-jsx-v4.d.ts` imports these; without them every shim reference
+    // degrades to a TS2307 that would drown the assertions below.
+    fs::write(
+        svelte_dir.join("elements.d.ts"),
+        "export interface HTMLAttributes<T=any>{ [k:string]:any }\nexport interface SVGAttributes<T=any>{ [k:string]:any }\nexport interface DOMAttributes<T=any>{ [k:string]:any }\nexport interface AriaAttributes{ [k:string]:any }\nexport type HTMLElements = any;\nexport type SvelteHTMLElements = any;\nexport type SvelteMediaTimeRange = any;\n",
+    )
+    .unwrap();
+}
 
+const TSCONFIG: &str = r#"{ "compilerOptions": { "moduleResolution": "bundler", "module": "esnext", "target": "esnext", "allowArbitraryExtensions": true, "strict": true, "skipLibCheck": true }, "include": ["src/**/*.ts", "src/**/*.svelte"] }"#;
+
+fn run_check(dir: &Path) -> Vec<String> {
     let opts = RunOptions {
-        workspace: dir.clone(),
+        workspace: dir.to_path_buf(),
+        tsconfig: Some(dir.join("tsconfig.json")),
         type_check: true,
         prefer_tsgo: true,
         ignore: vec!["node_modules".to_string()],
         ..RunOptions::default()
     };
-    let result = run(&opts);
-    let errs: Vec<String> = result
+    run(&opts)
         .diagnostics
         .iter()
         .filter(|d| d.severity == DiagnosticSeverity::Error)
@@ -84,21 +66,102 @@ fn companion_svelte_ts_does_not_shadow_component_module() {
                 d.message
             )
         })
-        .collect();
-    eprintln!("=DIAG800=\n{}\n=ENDDIAG800=", errs.join("\n"));
+        .collect()
+}
+
+#[test]
+fn companion_svelte_ts_does_not_shadow_component_module() {
+    if find_compiler(&PathBuf::from("."), true).is_err() {
+        eprintln!("skip #800: no tsgo/tsc found");
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("rsvelte_800_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    let src = dir.join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("H.svelte"),
+        "<script module lang=\"ts\">export const ATTR = 'data-x' as const;\nexport type Kind = 'a' | 'b';</script>\n<script lang=\"ts\">let { n }: { n: number } = $props();</script>\n<span data-x={ATTR}>{n}</span>\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("H.svelte.ts"),
+        "import H, { ATTR } from './H.svelte';\nexport const useAttr = (): string => ATTR;\nexport const Comp = H;\n",
+    )
+    .unwrap();
+    // Barrel: the component's default + `<script module>` exports, plus the
+    // companion's own named export reached through `./H.svelte.js` (#751).
+    fs::write(
+        src.join("idx.ts"),
+        "export { default as H, ATTR } from './H.svelte';\nexport type { Kind } from './H.svelte';\nexport { useAttr } from './H.svelte.js';\n",
+    )
+    .unwrap();
+    // A component importing both halves — the shadow side of the same split.
+    fs::write(
+        src.join("User.svelte"),
+        "<script lang=\"ts\">import H from './H.svelte';\nimport { ATTR } from './H.svelte';\nimport { useAttr } from './H.svelte.js';\nconst label: string = useAttr() + ATTR;</script>\n<H n={1} />{label}\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("ambient.d.ts"),
+        "declare function $props(): any;\ndeclare function $state<T>(v: T): T;\n",
+    )
+    .unwrap();
+    fs::write(dir.join("tsconfig.json"), TSCONFIG).unwrap();
+    write_svelte_stub(&dir);
+
+    let errs = run_check(&dir);
+    let augment =
+        fs::read_to_string(dir.join(".svelte-check/companion-augment.d.ts")).unwrap_or_default();
     let _ = fs::remove_dir_all(&dir);
 
-    // The companion's `./H.svelte` import must see the component default + ATTR.
-    let bad: Vec<&String> = errs
-        .iter()
-        .filter(|m| {
-            m.contains("H.svelte")
-                && (m.contains("no default") || m.contains("ATTR") || m.contains("Circular"))
-        })
-        .collect();
     assert!(
-        bad.is_empty(),
-        "#800 companion errors present:\n{}",
+        errs.is_empty(),
+        "#800 expected 0 errors, got:\n{}",
         errs.join("\n")
+    );
+    assert!(
+        augment.contains("export import ATTR ="),
+        "companion augmentation should forward the module-context exports:\n{augment}"
+    );
+}
+
+/// Without a companion nothing is augmented — the plain `.svelte` shadow path
+/// must stay untouched, and no stale augmentation file may linger.
+#[test]
+fn no_companion_means_no_augmentation() {
+    if find_compiler(&PathBuf::from("."), true).is_err() {
+        eprintln!("skip #800: no tsgo/tsc found");
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("rsvelte_800_solo_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    let src = dir.join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("H.svelte"),
+        "<script module lang=\"ts\">export const ATTR = 'data-x' as const;</script>\n<span data-x={ATTR}></span>\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("idx.ts"),
+        "export { default as H, ATTR } from './H.svelte';\n",
+    )
+    .unwrap();
+    fs::write(dir.join("tsconfig.json"), TSCONFIG).unwrap();
+    write_svelte_stub(&dir);
+
+    let errs = run_check(&dir);
+    let augment_exists = dir.join(".svelte-check/companion-augment.d.ts").exists();
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        errs.is_empty(),
+        "expected 0 errors, got:\n{}",
+        errs.join("\n")
+    );
+    assert!(
+        !augment_exists,
+        "no companion — no augmentation file expected"
     );
 }

--- a/crates/rsvelte_core/tests/svelte_check_companion_module.rs
+++ b/crates/rsvelte_core/tests/svelte_check_companion_module.rs
@@ -1,4 +1,6 @@
-//! Regression test for issue #751.
+//! Regression tests for the `Foo.svelte` + `Foo.svelte.{ts,js}` companion
+//! split: #751 (named imports resolved *from* the companion) and the structural
+//! half of #800 (the component module reached *through* the companion).
 //!
 //! A `Foo.svelte` component and a sibling companion module
 //! `Foo.svelte.ts` (or `.js`) collide on the same TypeScript basename:
@@ -106,4 +108,78 @@ fn nested_component_reexport_path_is_correct() {
         tsx.contains("export * from \"../../../../src/lib/Tip.svelte.js\";"),
         "nested companion re-export path wrong:\n{tsx}"
     );
+}
+
+/// #800 (the other direction): `./Foo.svelte` resolves to the companion, so the
+/// overlay augments *that* module with the component's default + `<script
+/// module>` exports. Structural check; the real-compiler e2e lives in
+/// `svelte_check_companion_800.rs`.
+#[test]
+fn companion_augmentation_declares_the_component_module() {
+    let ws = workspace("aug");
+    fs::create_dir_all(ws.join("src")).unwrap();
+    fs::write(
+        ws.join("src/Tip.svelte.ts"),
+        "export const tip = (x: number): number => x * 2;\n",
+    )
+    .unwrap();
+    fs::write(
+        ws.join("src/Tip.svelte"),
+        "<script module lang=\"ts\">export const ATTR = 'data-x';\nexport type Kind = 'a';</script>\n<p>hi</p>\n",
+    )
+    .unwrap();
+
+    let files = vec![ws.join("src/Tip.svelte")];
+    materialize_overlay(&ws, &files, None).expect("overlay");
+
+    let aug = fs::read_to_string(ws.join(".svelte-check/companion-augment.d.ts")).unwrap();
+    assert!(
+        aug.contains("declare module \"../src/Tip.svelte\" {"),
+        "augmentation must target the `.svelte` specifier:\n{aug}"
+    );
+    assert!(
+        aug.contains("export default _default;"),
+        "component default export must be forwarded:\n{aug}"
+    );
+    // `export import` carries the value *and* the type meaning of each name.
+    assert!(
+        aug.contains("export import ATTR ="),
+        "module-context value export missing:\n{aug}"
+    );
+    assert!(
+        aug.contains("export import Kind ="),
+        "module-context type export missing:\n{aug}"
+    );
+    // The companion's own exports stay with the companion — re-declaring them
+    // in the augmentation would be a duplicate identifier.
+    assert!(
+        !aug.contains("export import tip ="),
+        "companion export must not be re-declared:\n{aug}"
+    );
+
+    let tsconfig = fs::read_to_string(ws.join(".svelte-check/tsconfig.json")).unwrap();
+    assert!(
+        tsconfig.contains("./companion-augment.d.ts"),
+        "augmentation must be a program root:\n{tsconfig}"
+    );
+}
+
+/// No companion → no augmentation file, and a stale one from a previous run is
+/// cleaned up (it would otherwise keep augmenting a module that no longer
+/// resolves to the companion).
+#[test]
+fn companion_augmentation_is_removed_when_the_companion_goes_away() {
+    let ws = workspace("aug_stale");
+    fs::write(ws.join("Tip.svelte.ts"), "export const tip = 1;\n").unwrap();
+    fs::write(ws.join("Tip.svelte"), "<p>hi</p>\n").unwrap();
+    let files = vec![ws.join("Tip.svelte")];
+    materialize_overlay(&ws, &files, None).expect("overlay");
+    assert!(ws.join(".svelte-check/companion-augment.d.ts").is_file());
+
+    fs::remove_file(ws.join("Tip.svelte.ts")).unwrap();
+    materialize_overlay(&ws, &files, None).expect("overlay");
+    assert!(!ws.join(".svelte-check/companion-augment.d.ts").exists());
+
+    let tsconfig = fs::read_to_string(ws.join(".svelte-check/tsconfig.json")).unwrap();
+    assert!(!tsconfig.contains("./companion-augment.d.ts"));
 }


### PR DESCRIPTION
Fixes #800

## Problem

When `Foo.svelte` has a same-name companion `Foo.svelte.ts` / `.js`, the overlay lost the component's `default` export and its `<script module>` named exports. A companion or barrel importing them got:

```
H.svelte.ts  TS1192  Module './H.svelte' has no default export.
H.svelte.ts  TS2303  Circular definition of import alias 'ATTR'.
H.svelte.ts  TS2459  Module './H.svelte' declares 'ATTR' locally, but it is not exported.
idx.ts       TS2305  Module './H.svelte' has no exported member 'default'.
```

Official `svelte-check` reports 0 errors.

## Root cause

TypeScript resolves a relative `./Foo.svelte` by appending extensions **in the importer's own directory**, so a sibling `Foo.svelte.ts` always wins over the overlay's `Foo.svelte.tsx` shadow. Verified against both `tsc` 5.x and `tsgo` with `--traceResolution`:

- `rootDirs` is a *fallback*: `tryLoadModuleUsingRootDirs` loads the initial candidate location first and only remaps across roots when that fails — and it never fails here, because the companion is right there.
- `paths` never applies to relative specifiers.
- The `#751` companion fold (`export * from "<companion>"` on the shadow) can't help, because `./Foo.svelte` never reaches the shadow.

So the specifier lands on a real user file we cannot rewrite. Earlier triage (#825) concluded this needed a `resolveModuleNameLiterals` host hook, which `tsgo` has no API for.

## Fix

Augment the module TypeScript *did* pick. The overlay now emits `<cache>/companion-augment.d.ts` for each component that has a same-name companion:

```ts
import * as __rsvelte_companion_0 from "./svelte/src/H.svelte.tsx";
declare module "../src/H.svelte" {
    const _default: (typeof __rsvelte_companion_0)["default"];
    // @ts-ignore
    export default _default;
    export import ATTR = __rsvelte_companion_0.ATTR;
}
```

- `export import X = ns.X` aliases the **value and the type** meaning of each name, so `export type` members in `<script module>` survive (a plain `export const` would drop them).
- `export … from` / `import` statements are not permitted inside augmentations, so the names are enumerated: parsed out of the emitted shadow with oxc, minus anything the companion already exports (which would be a duplicate identifier) and minus `default` when the companion re-exports it itself.
- `export default` inside an augmentation is applied by TS but still grammar-errors (TS2666); the generated line carries a `@ts-ignore` since the file is ours, not user code.
- Emitted only when a companion actually exists; a stale file from a previous run is removed and the tsconfig `files` entry drops with it.

#751 is untouched — `./Foo.svelte.js` still resolves to the companion, and the shadow-side fold stays.

## Tests

- `crates/rsvelte_core/tests/svelte_check_companion_800.rs` — the issue's repro (component + `<script module>` value/type exports + same-name companion + barrel + a consuming component), un-`#[ignore]`d and now asserting **0 diagnostics** end-to-end. Green on both real `tsgo` and real `tsc`; skips when neither is found, matching the existing gate.
- `crates/rsvelte_core/tests/svelte_check_companion_module.rs` — the four #751 assertions still pass, plus structural coverage of the augmentation (targets the `.svelte` specifier, forwards default + value + type exports, does not re-declare the companion's own exports, is listed in `files`, is cleaned up when the companion goes away).
- Full `svelte_check` suite green (`golden`, `cross_package`, `compiler_options`, `cli_flags`, `warning_filter`), `cargo test -p rsvelte_core --lib` 1490 passed, `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp