### PR TITLE
test(compat): align report matching with gate semantics and assert validator message text (#1839)

### DIFF
--- a/.changeset/compiler-error-message-parity.md
+++ b/.changeset/compiler-error-message-parity.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix: compiler error messages now match the official compiler's wording
+
+Asserting the validator fixtures' pinned message text (not just the error
+code) surfaced 35 diagnostics whose wording had drifted from upstream
+`errors.js` — among them `bind_invalid_target`, `transition_duplicate`,
+`transition_conflict`, `rune_invalid_spread`, `script_duplicate`,
+`illegal_element_attribute`, `event_handler_invalid_modifier`,
+`attribute_invalid_type`, `state_field_invalid_assignment`,
+`css_type_selector_invalid_placement`, `declaration_duplicate_module_import`
+and the whole `svelte_options_*` family. All now emit upstream's exact text,
+including the missing closing backtick in the `node_invalid_placement`
+"not a `<div>`" suffix.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/options.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/options.rs
@@ -18,6 +18,10 @@ use serde_json::Value as JsonValue;
 
 use super::super::parser::Parser;
 
+// Upstream emits one message per code regardless of which check failed.
+const INVALID_TAGNAME: &str = "Tag name must be lowercase and hyphenated";
+const CUSTOM_ELEMENT_INVALID: &str = "\"customElement\" must be a string literal defining a valid custom element name or an object of the form { tag?: string; shadow?: \"open\" | \"none\" | `ShadowRootInit`; props?: { [key: string]: { attribute?: string; reflect?: boolean; type: .. } } }";
+
 // Reserved tag names for custom elements (from HTML spec)
 const RESERVED_TAG_NAMES: &[&str] = &[
     "annotation-xml",
@@ -158,10 +162,7 @@ impl<'a> Parser<'a> {
                             _ => {
                                 return Err(ParseError::svelte(
                                     "svelte_options_invalid_attribute_value",
-                                    format!(
-                                        "\"{}\" is not a valid namespace (must be \"html\", \"mathml\" or \"svg\")",
-                                        value.as_deref().unwrap_or("")
-                                    ),
+                                    "Value must be \"html\", \"mathml\" or \"svg\", if specified",
                                     (attr_node.start as usize, attr_node.end as usize),
                                 ));
                             }
@@ -172,10 +173,7 @@ impl<'a> Parser<'a> {
                         if value.as_deref() != Some("injected") {
                             return Err(ParseError::svelte(
                                 "svelte_options_invalid_attribute_value",
-                                format!(
-                                    "\"{}\" is not a valid value for the \"css\" option (must be \"injected\")",
-                                    value.as_deref().unwrap_or("")
-                                ),
+                                "Value must be \"injected\", if specified",
                                 (attr_node.start as usize, attr_node.end as usize),
                             ));
                         }
@@ -298,10 +296,7 @@ fn get_boolean_value<'a>(attr: &crate::ast::template::AttributeNode<'a>) -> Pars
 
             Err(ParseError::svelte(
                 "svelte_options_invalid_attribute_value",
-                format!(
-                    "\"{}\" is not a valid value (expected true or false)",
-                    attr.name
-                ),
+                "Value must be true or false, if specified",
                 (attr.start as usize, attr.end as usize),
             ))
         }
@@ -318,10 +313,7 @@ fn get_boolean_value<'a>(attr: &crate::ast::template::AttributeNode<'a>) -> Pars
 
             Err(ParseError::svelte(
                 "svelte_options_invalid_attribute_value",
-                format!(
-                    "\"{}\" is not a valid value (expected true or false)",
-                    attr.name
-                ),
+                "Value must be true or false, if specified",
                 (attr.start as usize, attr.end as usize),
             ))
         }
@@ -375,7 +367,7 @@ fn parse_custom_element_option<'a>(
         AttributeValue::True(_) => {
             return Err(ParseError::svelte(
                 "svelte_options_invalid_customelement",
-                "`customElement` must be a string or object",
+                CUSTOM_ELEMENT_INVALID,
                 (attr.start as usize, attr.end as usize),
             ));
         }
@@ -399,7 +391,7 @@ fn parse_custom_element_option<'a>(
 
     Err(ParseError::svelte(
         "svelte_options_invalid_customelement",
-        "`customElement` must be a string or object",
+        CUSTOM_ELEMENT_INVALID,
         (attr.start as usize, attr.end as usize),
     ))
 }
@@ -503,7 +495,7 @@ fn validate_tag_name<'a>(
     if tag.is_empty() {
         return Err(ParseError::svelte(
             "svelte_options_invalid_tagname",
-            "Tag name cannot be empty",
+            INVALID_TAGNAME,
             (attr.start as usize, attr.end as usize),
         ));
     }
@@ -512,7 +504,7 @@ fn validate_tag_name<'a>(
     if !tag.chars().next().unwrap().is_ascii_lowercase() {
         return Err(ParseError::svelte(
             "svelte_options_invalid_tagname",
-            "Tag name must start with a lowercase letter",
+            INVALID_TAGNAME,
             (attr.start as usize, attr.end as usize),
         ));
     }
@@ -521,7 +513,7 @@ fn validate_tag_name<'a>(
     if !tag.contains('-') {
         return Err(ParseError::svelte(
             "svelte_options_invalid_tagname",
-            "Tag name must contain a hyphen",
+            INVALID_TAGNAME,
             (attr.start as usize, attr.end as usize),
         ));
     }
@@ -530,7 +522,7 @@ fn validate_tag_name<'a>(
     if RESERVED_TAG_NAMES.contains(&tag) {
         return Err(ParseError::svelte(
             "svelte_options_reserved_tagname",
-            format!("\"{}\" is a reserved tag name", tag),
+            "Tag name is reserved",
             (attr.start as usize, attr.end as usize),
         ));
     }
@@ -541,7 +533,7 @@ fn validate_tag_name<'a>(
         if !c.is_alphanumeric() && c != '-' && c != '_' && c != '.' && (c as u32) < 0xB7 {
             return Err(ParseError::svelte(
                 "svelte_options_invalid_tagname",
-                format!("Tag name contains invalid character '{}'", c),
+                INVALID_TAGNAME,
                 (attr.start as usize, attr.end as usize),
             ));
         }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
@@ -339,7 +339,7 @@ impl<'a> Parser<'a> {
                 if self.instance_script.is_some() {
                     return Err(crate::error::ParseError::svelte(
                         "script_duplicate",
-                        "A component can only have one instance-level `<script>` element",
+                        "A component can have a single top-level `<script>` element and/or a single top-level `<script module>` element",
                         (start, end),
                     ));
                 }
@@ -349,7 +349,7 @@ impl<'a> Parser<'a> {
                 if self.module_script.is_some() {
                     return Err(crate::error::ParseError::svelte(
                         "script_duplicate",
-                        "A component can only have one `<script module>` element",
+                        "A component can have a single top-level `<script>` element and/or a single top-level `<script module>` element",
                         (start, end),
                     ));
                 }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -2540,10 +2540,7 @@ impl<'a> Parser<'a> {
                         .collect();
                     return Err(crate::error::ParseError::svelte(
                         "tag_invalid_placement",
-                        format!(
-                            "{{@{} ...}} tag cannot be inside a <textarea>",
-                            tag_name_str
-                        ),
+                        format!("{{@{} ...}} tag cannot be inside <textarea>", tag_name_str),
                         (mustache_start, mustache_start),
                     ));
                 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/errors.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/errors.rs
@@ -45,8 +45,8 @@ diagnostics! {
     /// `%rune%` cannot be used with arguments
     rune_invalid_arguments(rune: &str) => "`{}` cannot be used with arguments", rune;
 
-    /// `%rune%` cannot be used with spread arguments
-    rune_invalid_spread(rune: &str) => "`{}` cannot be used with spread arguments", rune;
+    /// `%rune%` cannot be called with a spread argument
+    rune_invalid_spread(rune: &str) => "`{}` cannot be called with a spread argument", rune;
 
     /// `%rune%` requires %expected%
     rune_invalid_arguments_length(rune: &str, expected: &str) => "`{}` requires {}", rune, expected;
@@ -65,8 +65,14 @@ diagnostics! {
 
     // Binding-related errors
 
-    /// `%name%` can only be bound to %target%
-    bind_invalid_target(name: &str, target: &str) => "`{}` can only be bound to {}", name, target;
+    /// `bind:%name%` can only be used with %elements%
+    bind_invalid_target(name: &str, elements: &str) => "`bind:{}` can only be used with {}", name, elements;
+
+    /// `bind:group` can only bind to an Identifier or MemberExpression
+    bind_group_invalid_expression() => "`bind:group` can only bind to an Identifier or MemberExpression";
+
+    /// Cannot `bind:group` to a snippet parameter
+    bind_group_invalid_snippet_parameter() => "Cannot `bind:group` to a snippet parameter";
 
     /// Cannot assign to %thing%
     constant_assignment(thing: &str) => "Cannot assign to {}", thing;
@@ -79,8 +85,8 @@ diagnostics! {
     /// Attributes need to be unique
     attribute_duplicate() => "Attributes need to be unique";
 
-    /// '%name%' attribute cannot be dynamic
-    attribute_invalid_type(name: &str) => "'{}' attribute cannot be dynamic", name;
+    /// 'type' attribute must be a static text value if input uses two-way binding
+    attribute_invalid_type() => "'type' attribute must be a static text value if input uses two-way binding";
 
     /// The 'multiple' attribute must be static if select uses two-way binding
     attribute_invalid_multiple() => "'multiple' attribute must be static if select uses two-way binding\nhttps://svelte.dev/e/attribute_invalid_multiple";
@@ -98,8 +104,8 @@ diagnostics! {
     /// `%name%` has already been declared on this class
     state_field_duplicate(name: &str) => "`{}` has already been declared on this class", name;
 
-    /// Cannot declare a variable with the same name as an import inside `<script module>`
-    declaration_duplicate_module_import() => "Cannot declare a variable with the same name as an import inside `<script module>`";
+    /// Cannot declare a variable with the same name as an import from `<script module>`
+    declaration_duplicate_module_import() => "Cannot declare a variable with the same name as an import from `<script module>`";
 
     // Export-related errors
 
@@ -170,8 +176,8 @@ diagnostics! {
     /// `{#each}` block with a key requires an `as` binding
     each_key_without_as() => "An `{#each ...}` block without an `as` clause cannot have a key";
 
-    /// Cannot assign to %thing% before initialization
-    state_field_invalid_assignment() => "Cannot assign to state field before initialization in constructor";
+    /// Cannot assign to a state field before its declaration
+    state_field_invalid_assignment() => "Cannot assign to a state field before its declaration";
 
     /// %name% cannot have children
     svelte_meta_invalid_content(name: &str) => "`<{}>` cannot have children", name;
@@ -218,11 +224,11 @@ diagnostics! {
 
     // Transition/animation directive errors
 
-    /// An element can only have one '%name%' directive
-    transition_duplicate(directive_name: &str) => "An element can only have one '{}' directive", directive_name;
+    /// Cannot use multiple `%type%:` directives on a single element
+    transition_duplicate(directive_name: &str) => "Cannot use multiple `{}:` directives on a single element", directive_name;
 
-    /// An element cannot have both '%a%' and '%b%' directives
-    transition_conflict(a: &str, b: &str) => "An element cannot have both '{}' and '{}' directives", a, b;
+    /// Cannot use `%type%:` alongside existing `%existing%:` directive
+    transition_conflict(a: &str, b: &str) => "Cannot use `{}:` alongside existing `{}:` directive", a, b;
 
     /// An element can only have one animate directive
     animation_duplicate() => "An element can only have one 'animate' directive\nhttps://svelte.dev/e/animation_duplicate";
@@ -268,8 +274,8 @@ diagnostics! {
     /// Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`
     css_nesting_selector_invalid_placement() => "Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`";
 
-    /// Type selector cannot appear after `:global(...)`
-    css_type_selector_invalid_placement() => "Type selector cannot appear after `:global(...)`";
+    /// `:global(...)` must not be followed by a type selector
+    css_type_selector_invalid_placement() => "`:global(...)` must not be followed by a type selector";
 
     /// Declaration cannot be empty
     css_empty_declaration() => "Declaration cannot be empty";
@@ -401,14 +407,14 @@ diagnostics! {
     /// Event attribute must be a JavaScript expression, not a string
     attribute_invalid_event_handler() => "Event attribute must be a JavaScript expression, not a string\nhttps://svelte.dev/e/attribute_invalid_event_handler";
 
-    /// A component can only have one instance-level `<script>` element
-    script_duplicate() => "A component can only have one instance-level `<script>` element\nhttps://svelte.dev/e/script_duplicate";
+    /// A component can have a single top-level `<script>` element and/or a single top-level `<script module>` element
+    script_duplicate() => "A component can have a single top-level `<script>` element and/or a single top-level `<script module>` element\nhttps://svelte.dev/e/script_duplicate";
 
     /// `let:` directive at invalid position
     let_directive_invalid_placement() => "`let:` directive at invalid position\nhttps://svelte.dev/e/let_directive_invalid_placement";
 
-    /// `<svelte:element>` or `<svelte:window>` cannot have spread attributes
-    illegal_element_attribute(element: &str) => "`<{}>` cannot have spread attributes\nhttps://svelte.dev/e/illegal_element_attribute", element;
+    /// `<%name%>` does not support non-event attributes or spread attributes
+    illegal_element_attribute(element: &str) => "`<{}>` does not support non-event attributes or spread attributes\nhttps://svelte.dev/e/illegal_element_attribute", element;
 
     /// `{@debug ...}` arguments must be identifiers
     debug_tag_invalid_arguments() => "{@debug ...} arguments must be identifiers, not arbitrary expressions\nhttps://svelte.dev/e/debug_tag_invalid_arguments";

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
@@ -50,10 +50,7 @@ fn visit_common(
     // Handle getter/setter syntax (SequenceExpression)
     if directive.expression.node_type() == Some("SequenceExpression") {
         if directive.name == "group" {
-            return Err(AnalysisError::ValidationWithCode {
-                code: "bind_group_invalid_expression".to_string(),
-                message: "bind:group cannot use getter/setter syntax".to_string(),
-            });
+            return Err(errors::bind_group_invalid_expression());
         }
 
         // Check for invalid parentheses in the binding expression, ignoring any
@@ -219,10 +216,7 @@ fn visit_common(
             binding.kind,
             crate::compiler::phases::phase2_analyze::BindingKind::SnippetParam
         ) {
-            return Err(AnalysisError::ValidationWithCode {
-                code: "bind_group_invalid_snippet_parameter".to_string(),
-                message: "Cannot use bind:group with snippet parameters".to_string(),
-            });
+            return Err(errors::bind_group_invalid_snippet_parameter());
         }
 
         // Note: Binding group name registration (populating analysis.binding_groups) is done
@@ -523,10 +517,7 @@ fn validate_input_binding(
         // Check if type attribute is dynamic
         if !is_text_attribute(type_attr) {
             if binding_name != "value" || matches!(type_attr.value, AttributeValue::True(_)) {
-                return Err(AnalysisError::ValidationWithCode {
-                    code: "attribute_invalid_type".to_string(),
-                    message: "The 'type' attribute cannot be dynamic".to_string(),
-                });
+                return Err(errors::attribute_invalid_type());
             }
         } else {
             // Get the static type value

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -265,19 +265,19 @@ pub(super) fn is_tag_valid_with_parent(child_tag: &str, parent_tag: &str) -> Opt
             match child_tag {
                 "body" | "caption" | "col" | "colgroup" | "frameset" | "frame" | "head"
                 | "html" => Some(format!(
-                    "`<{}>` cannot be a child of `<{}>",
+                    "`<{}>` cannot be a child of `<{}>`",
                     child_tag, parent_tag
                 )),
                 "thead" | "tbody" | "tfoot" => Some(format!(
-                    "`<{}>` must be the child of a `<table>`, not a `<{}>",
+                    "`<{}>` must be the child of a `<table>`, not a `<{}>`",
                     child_tag, parent_tag
                 )),
                 "td" | "th" => Some(format!(
-                    "`<{}>` must be the child of a `<tr>`, not a `<{}>",
+                    "`<{}>` must be the child of a `<tr>`, not a `<{}>`",
                     child_tag, parent_tag
                 )),
                 "tr" => Some(format!(
-                    "`<tr>` must be the child of a `<thead>`, `<tbody>`, or `<tfoot>`, not a `<{}>",
+                    "`<tr>` must be the child of a `<thead>`, `<tbody>`, or `<tfoot>`, not a `<{}>`",
                     parent_tag
                 )),
                 _ => None,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/element.rs
@@ -229,10 +229,7 @@ pub fn validate_element(
                         );
                         return Err(AnalysisError::validation(
                             "event_handler_invalid_modifier",
-                            format!(
-                                "Invalid event modifier '{}'. Valid modifiers are: {}",
-                                modifier, list
-                            ),
+                            format!("Valid event modifiers are {}", list),
                         ));
                     }
 

--- a/crates/rsvelte_core/tests/common/mod.rs
+++ b/crates/rsvelte_core/tests/common/mod.rs
@@ -9,6 +9,9 @@ use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions, CommentOptions, LegalComment};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use rsvelte_core::CompileError;
+use rsvelte_core::compiler::AnalysisError;
+use rsvelte_core::error::ParseError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -142,11 +145,21 @@ pub fn ensure_fixtures_fresh() {
 // Fixture loading
 // ============================================================================
 
+/// Read a fixture file with CRLF normalised to LF.
+///
+/// Windows checkouts default to `autocrlf=true`; without this every AST span
+/// shifts by one byte per line and every text comparison diverges.
+pub fn read_fixture_file(path: &std::path::Path) -> Option<String> {
+    fs::read_to_string(path)
+        .ok()
+        .map(|s| s.replace("\r\n", "\n"))
+}
+
 /// Load expected output from fixture.
 pub fn load_fixture_output(category: &str, sample: &str, file: &str) -> Option<String> {
     let path = fixtures_path().join(category).join(sample).join(file);
 
-    fs::read_to_string(&path).ok()
+    read_fixture_file(&path)
 }
 
 /// Get all sample directories for a category from fixtures.
@@ -611,6 +624,164 @@ pub struct FixtureError {
     pub end: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<serde_json::Value>,
+}
+
+// ============================================================================
+// Expected-error matching (shared by the gates and the compatibility report)
+// ============================================================================
+
+/// Does a rendered compiler error name the expected Svelte error code?
+///
+/// `\b<code>(_[a-z_]+)?\b` — the exact code or a more specific snake_case
+/// sub-code (`element_invalid_closing_tag` → `…_autoclosed`), never an
+/// unrelated code that merely contains the expected one as a substring.
+pub fn error_code_matches(expected_code: &str, rendered: &[&str]) -> bool {
+    if expected_code.is_empty() {
+        return false;
+    }
+    let pattern = format!(r"\b{}(_[a-z_]+)?\b", regex::escape(expected_code));
+    let Ok(re) = regex::Regex::new(&pattern) else {
+        return false;
+    };
+    rendered.iter().any(|text| re.is_match(text))
+}
+
+/// Line/column pair as pinned by a validator fixture.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct ExpectedPosition {
+    pub line: u32,
+    pub column: u32,
+}
+
+/// One entry of a validator sample's `errors.json`.
+#[derive(Debug, Deserialize)]
+pub struct ExpectedValidatorError {
+    pub code: String,
+    pub message: String,
+    #[serde(default)]
+    pub start: Option<ExpectedPosition>,
+    #[serde(default)]
+    pub end: Option<ExpectedPosition>,
+}
+
+/// Read the first entry of a validator sample's `errors.json`.
+///
+/// Typed on purpose: an entry without a `code` must be a hard parse failure,
+/// not an empty expectation that every actual error satisfies.
+pub fn load_expected_validator_error(
+    errors_path: &std::path::Path,
+) -> Result<Option<ExpectedValidatorError>, String> {
+    if !errors_path.exists() {
+        return Ok(None);
+    }
+    let content = read_fixture_file(errors_path)
+        .ok_or_else(|| format!("unreadable {}", errors_path.display()))?;
+    let errors: Vec<ExpectedValidatorError> = serde_json::from_str(&content)
+        .map_err(|e| format!("malformed {}: {e}", errors_path.display()))?;
+    Ok(errors.into_iter().next())
+}
+
+/// Upstream `validator/test.ts::strip_link` — drop the trailing
+/// `https://svelte.dev/e/<code>` line the compiler appends to every message.
+pub fn strip_error_link(message: &str) -> &str {
+    match message.rsplit_once('\n') {
+        Some((head, tail)) if tail.starts_with("https://svelte.dev/e/") => head,
+        _ => message,
+    }
+}
+
+/// The `(code, message)` pair carried by an rsvelte compile failure, when it
+/// has one. Raw OXC parse failures carry neither.
+pub fn svelte_error_parts(err: &CompileError) -> Option<(&str, &str)> {
+    match err {
+        CompileError::Parse(ParseError::SvelteError { code, message, .. }) => Some((code, message)),
+        CompileError::Analysis(AnalysisError::ValidationWithCode { code, message }) => {
+            Some((code, message))
+        }
+        _ => None,
+    }
+}
+
+/// Codes whose upstream fixture fails inside OXC's JavaScript parser, before
+/// rsvelte can attach a Svelte code — the rendered error is a bare parse
+/// failure, so only the shape of the failure can be asserted.
+fn untyped_error_matches(expected_code: &str, rendered: &str) -> bool {
+    matches!(
+        expected_code,
+        "js_parse_error" | "typescript_invalid_feature" | "unexpected_reserved_word"
+    ) && rendered.contains("Parse errors")
+}
+
+/// Outcome of comparing an rsvelte compile failure with a validator fixture's
+/// pinned error. The message verdict is separate from the code verdict so a
+/// caller can honour [`VALIDATOR_MESSAGE_DIVERGENCES`] without weakening the
+/// code check.
+pub enum ValidatorErrorVerdict {
+    Match,
+    MessageMismatch(String),
+    CodeMismatch(String),
+}
+
+/// Validator fixtures whose expected *message* is an acorn diagnostic that
+/// OXC words differently. The code still has to match, and a fixture that
+/// starts matching is reported as a stale entry — the list can only shrink.
+pub const VALIDATOR_MESSAGE_DIVERGENCES: &[&str] = &[
+    // acorn "Unexpected token" vs OXC "Identifier expected. 'case' is a reserved word …"
+    "each-block-invalid-context-destructured",
+    // acorn "Unexpected keyword 'case'" vs OXC "Expected `:` but found `}`"
+    "each-block-invalid-context-destructured-object",
+    // acorn "Comma is not permitted after the rest element" vs OXC
+    // "A rest element must be last in a destructuring pattern"
+    "each-block-destructured-object-rest-comma-after",
+];
+
+/// Compare an rsvelte compile failure against a validator fixture's pinned
+/// error, upstream-style: exact code plus exact message (minus the doc link).
+pub fn check_validator_error(
+    expected: &ExpectedValidatorError,
+    err: &CompileError,
+) -> ValidatorErrorVerdict {
+    if let Some((code, message)) = svelte_error_parts(err) {
+        if code != expected.code {
+            return ValidatorErrorVerdict::CodeMismatch(format!(
+                "Expected error code '{}', got '{}'",
+                expected.code, code
+            ));
+        }
+        let actual_message = strip_error_link(message);
+        if actual_message != expected.message {
+            return ValidatorErrorVerdict::MessageMismatch(format!(
+                "Error message mismatch for '{}':\n  expected: {}\n  actual:   {}",
+                expected.code, expected.message, actual_message
+            ));
+        }
+        return ValidatorErrorVerdict::Match;
+    }
+
+    let rendered = format!("{err:?}");
+    if untyped_error_matches(&expected.code, &rendered) {
+        ValidatorErrorVerdict::Match
+    } else {
+        ValidatorErrorVerdict::CodeMismatch(format!(
+            "Expected error code '{}', got: {rendered}",
+            expected.code
+        ))
+    }
+}
+
+/// Resolve a verdict for `sample`, honouring the documented message
+/// divergences and flagging entries that have become stale.
+pub fn validator_error_result(sample: &str, verdict: ValidatorErrorVerdict) -> Result<(), String> {
+    let known = VALIDATOR_MESSAGE_DIVERGENCES.contains(&sample);
+    match verdict {
+        ValidatorErrorVerdict::Match if known => Err(format!(
+            "'{sample}' now matches upstream — remove it from VALIDATOR_MESSAGE_DIVERGENCES"
+        )),
+        ValidatorErrorVerdict::Match => Ok(()),
+        ValidatorErrorVerdict::MessageMismatch(_) if known => Ok(()),
+        ValidatorErrorVerdict::MessageMismatch(detail)
+        | ValidatorErrorVerdict::CodeMismatch(detail) => Err(detail),
+    }
 }
 
 // ============================================================================

--- a/crates/rsvelte_core/tests/compatibility_report.rs
+++ b/crates/rsvelte_core/tests/compatibility_report.rs
@@ -13,9 +13,11 @@ use std::fs;
 
 use common::{
     CategoryResult, CompatibilityReport, FixtureCoverage, SampleDetails, SampleResult, SkipReason,
-    TestCategory, TestStatus, canonicalize_css, compare_js, ensure_fixtures_exist, fixtures_path,
-    get_fixture_samples, get_svelte_test_samples, load_fixture_output, runtime_fixture_options,
-    runtime_skip_names, svelte_path, write_actual_output,
+    TestCategory, TestStatus, canonicalize_css, check_validator_error, compare_js,
+    ensure_fixtures_exist, error_code_matches, fixtures_path, get_fixture_samples,
+    get_svelte_test_samples, load_expected_validator_error, load_fixture_output, read_fixture_file,
+    runtime_fixture_options, runtime_skip_names, svelte_path, validator_error_result,
+    write_actual_output,
 };
 use rsvelte_core::{
     CompileOptions, ExperimentalOptions, GenerateMode, ModuleCompileOptions, ParseOptions, compile,
@@ -102,17 +104,17 @@ fn run_parser_tests(category: TestCategory, modern: bool) -> CategoryResult {
         let input_path = sample_dir.join("input.svelte");
         let output_path = sample_dir.join("output.json");
 
-        let input = match fs::read_to_string(&input_path) {
-            Ok(s) => s,
-            Err(_) => {
+        let input = match read_fixture_file(&input_path) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("input.svelte"));
                 continue;
             }
         };
 
-        let expected = match fs::read_to_string(&output_path) {
-            Ok(s) => s,
-            Err(_) => {
+        let expected = match read_fixture_file(&output_path) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("output.json"));
                 continue;
             }
@@ -304,9 +306,9 @@ fn run_snapshot_tests() -> CategoryResult {
                 (false, false)
             };
 
-        let input = match fs::read_to_string(&input_path) {
-            Ok(s) => s,
-            Err(_) => {
+        let input = match read_fixture_file(&input_path) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("index.svelte"));
                 continue;
             }
@@ -462,9 +464,9 @@ fn run_css_tests() -> CategoryResult {
             .join(&name)
             .join("input.svelte");
 
-        let input = match fs::read_to_string(&input_path) {
-            Ok(s) => s,
-            Err(_) => {
+        let input = match read_fixture_file(&input_path) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("input.svelte"));
                 continue;
             }
@@ -618,9 +620,9 @@ fn run_validator_tests() -> CategoryResult {
         } else {
             &svelte_path
         };
-        let input = match fs::read_to_string(input_file) {
-            Ok(s) => s,
-            Err(_) => {
+        let input = match read_fixture_file(input_file) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(
                     &name,
                     SkipReason::MissingInput("readable input.svelte(.js)"),
@@ -634,19 +636,14 @@ fn run_validator_tests() -> CategoryResult {
         let errors_path = sample_dir.join("errors.json");
 
         let expected_warnings: Vec<serde_json::Value> = if warnings_path.exists() {
-            let content = fs::read_to_string(&warnings_path).unwrap_or_default();
+            let content = read_fixture_file(&warnings_path).unwrap_or_default();
             serde_json::from_str(&content).unwrap_or_default()
         } else {
             Vec::new()
         };
 
-        let expected_error: Option<serde_json::Value> = if errors_path.exists() {
-            let content = fs::read_to_string(&errors_path).unwrap_or_default();
-            let errors: Vec<serde_json::Value> = serde_json::from_str(&content).unwrap_or_default();
-            errors.into_iter().next()
-        } else {
-            None
-        };
+        let expected_error = load_expected_validator_error(&errors_path)
+            .unwrap_or_else(|e| panic!("{}: {e}", sample_dir.display()));
 
         // Parse compileOptions and warningFilter from _config.js
         let mut warning_filter_codes: Vec<String> = Vec::new();
@@ -770,58 +767,28 @@ fn run_validator_tests() -> CategoryResult {
                 }
                 Err(e) => {
                     if let Some(expected) = &expected_error {
-                        let error_str = format!("{:?}", e);
-                        let expected_code =
-                            expected.get("code").and_then(|v| v.as_str()).unwrap_or("");
-
-                        let code_matches = error_str.contains(expected_code)
-                            || error_str
-                                .to_lowercase()
-                                .contains(&expected_code.replace('_', " ").to_lowercase())
-                            // Transform parse errors (OxcDiagnostic) should match js_parse_error
-                            || (expected_code == "js_parse_error"
-                                && error_str.contains("Parse errors"))
-                            // TypeScript feature errors from OXC should match typescript_invalid_feature
-                            || (expected_code == "typescript_invalid_feature"
-                                && (error_str.contains("Parameter modifiers can only be used in TypeScript")
-                                    || error_str.contains("namespace")
-                                    || error_str.contains("TypeScriptInvalidFeature")
-                                    || error_str.contains("decorator")
-                                    || error_str.contains("accessor")
-                                    || error_str.contains("enum")
-                                    || error_str.contains("Parse errors")))
-                            // Reserved words cause parse errors
-                            || (expected_code == "unexpected_reserved_word"
-                                && (error_str.contains("Parse errors")
-                                    || error_str.contains("Unexpected token")))
-                            // Rune spread errors may cause parse errors
-                            || (expected_code == "rune_invalid_spread"
-                                && error_str.contains("Parse errors"));
-
+                        let verdict = check_validator_error(expected, &e);
+                        let outcome = validator_error_result(&name, verdict);
                         let details = SampleDetails {
-                            errors_matched: Some(code_matches),
+                            errors_matched: Some(outcome.is_ok()),
                             ..Default::default()
                         };
 
-                        if code_matches {
-                            result.add_sample(SampleResult {
+                        match outcome {
+                            Ok(()) => result.add_sample(SampleResult {
                                 name,
                                 status: TestStatus::Passed,
                                 error: None,
                                 skip_reason: None,
                                 details: Some(details),
-                            });
-                        } else {
-                            result.add_sample(SampleResult {
+                            }),
+                            Err(detail) => result.add_sample(SampleResult {
                                 name,
                                 status: TestStatus::Failed,
-                                error: Some(format!(
-                                    "Expected error '{}', got: {}",
-                                    expected_code, error_str
-                                )),
+                                error: Some(detail),
                                 skip_reason: None,
                                 details: Some(details),
-                            });
+                            }),
                         }
                     } else {
                         result.add_sample(SampleResult {
@@ -891,9 +858,9 @@ fn run_compiler_error_tests() -> CategoryResult {
             &svelte_path
         };
 
-        let input = match fs::read_to_string(input_file) {
-            Ok(s) => s,
-            Err(_) => {
+        let input = match read_fixture_file(input_file) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("readable main.svelte(.js)"));
                 continue;
             }
@@ -944,10 +911,8 @@ fn run_compiler_error_tests() -> CategoryResult {
             }
             Ok(Err(e)) => {
                 let error_str = format!("{:?}", e);
-                let code_matches = error_str.contains(&expected_code)
-                    || error_str
-                        .to_lowercase()
-                        .contains(&expected_code.replace('_', " ").to_lowercase());
+                let display_str = format!("{}", e);
+                let code_matches = error_code_matches(&expected_code, &[&error_str, &display_str]);
 
                 if code_matches {
                     result.add_sample(SampleResult {
@@ -1078,9 +1043,9 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         // gates so the report cannot measure something else than they do.
         let fixture_options = runtime_fixture_options(category, &name);
 
-        let input = match fs::read_to_string(&input_path) {
-            Ok(s) => s,
-            Err(_) => {
+        let input = match read_fixture_file(&input_path) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("readable entry point"));
                 continue;
             }
@@ -1235,16 +1200,16 @@ fn run_print_tests() -> CategoryResult {
             continue;
         }
 
-        let input = match fs::read_to_string(sample_dir.join("input.svelte")) {
-            Ok(s) => s,
-            Err(_) => {
+        let input = match read_fixture_file(&sample_dir.join("input.svelte")) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("input.svelte"));
                 continue;
             }
         };
-        let expected = match fs::read_to_string(sample_dir.join("output.svelte")) {
-            Ok(s) => s,
-            Err(_) => {
+        let expected = match read_fixture_file(&sample_dir.join("output.svelte")) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("output.svelte"));
                 continue;
             }
@@ -1341,16 +1306,16 @@ fn run_preprocess_tests() -> CategoryResult {
             .unwrap_or("unknown")
             .to_string();
 
-        let input = match fs::read_to_string(sample_dir.join("input.svelte")) {
-            Ok(s) => s,
-            Err(_) => {
+        let input = match read_fixture_file(&sample_dir.join("input.svelte")) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("input.svelte"));
                 continue;
             }
         };
-        let expected = match fs::read_to_string(sample_dir.join("output.svelte")) {
-            Ok(s) => s,
-            Err(_) => {
+        let expected = match read_fixture_file(&sample_dir.join("output.svelte")) {
+            Some(s) => s,
+            None => {
                 coverage.skipped(&name, SkipReason::MissingInput("output.svelte"));
                 continue;
             }

--- a/crates/rsvelte_core/tests/compiler_errors.rs
+++ b/crates/rsvelte_core/tests/compiler_errors.rs
@@ -5,11 +5,13 @@
 
 mod common;
 
-use std::fs;
 use std::path::{Path, PathBuf};
 
 // use rayon::prelude::*;  // Disabled for sequential execution
-use common::{FixtureCoverage, SkipReason, get_svelte_test_samples, sample_name};
+use common::{
+    FixtureCoverage, SkipReason, error_code_matches, get_svelte_test_samples, read_fixture_file,
+    sample_name,
+};
 use rsvelte_core::{
     CompileOptions, ExperimentalOptions, GenerateMode, ModuleCompileOptions, compile,
     compile_module,
@@ -170,21 +172,21 @@ fn load_error_fixture(sample_dir: &Path) -> Result<ErrorFixture, SkipReason> {
 
     // Read and parse config
     let config_content =
-        fs::read_to_string(&config_path).map_err(|_| SkipReason::MissingInput("_config.js"))?;
+        read_fixture_file(&config_path).ok_or(SkipReason::MissingInput("_config.js"))?;
     let config =
         parse_config(&config_content).ok_or(SkipReason::MissingInput("parsable _config.js"))?;
 
     // Determine input type and read input
     let (input, input_type) = if svelte_path.exists() {
         (
-            fs::read_to_string(&svelte_path)
-                .map_err(|_| SkipReason::MissingInput("readable main.svelte"))?,
+            read_fixture_file(&svelte_path)
+                .ok_or(SkipReason::MissingInput("readable main.svelte"))?,
             InputType::Svelte,
         )
     } else if module_path.exists() {
         (
-            fs::read_to_string(&module_path)
-                .map_err(|_| SkipReason::MissingInput("readable main.svelte.js"))?,
+            read_fixture_file(&module_path)
+                .ok_or(SkipReason::MissingInput("readable main.svelte.js"))?,
             InputType::Module,
         )
     } else {
@@ -267,21 +269,8 @@ fn run_error_test(fixture: &ErrorFixture) -> TestResult {
                 let error_str = format!("{:?}", e);
                 let display_str = format!("{}", e);
 
-                // Tighten the previous loose `contains()` check while still
-                // accepting more-specific sub-codes that rsvelte sometimes
-                // emits. We treat a match as either:
-                //   * exact code (e.g. expected `block_open`, actual `block_open`)
-                //   * sub-code   (e.g. expected `element_invalid_closing_tag`,
-                //                  actual `element_invalid_closing_tag_autoclosed`)
-                // but reject unrelated codes that happened to contain the
-                // expected as a substring.
-                let expected_code = &fixture.expected_error.code;
-                let escaped = regex::escape(expected_code);
-                // `\b<expected>(_[a-z_]*)?\b` — exact OR snake_case extension.
-                let pattern = format!(r"\b{}(_[a-z_]+)?\b", escaped);
-                let code_matches = regex::Regex::new(&pattern)
-                    .map(|re| re.is_match(&error_str) || re.is_match(&display_str))
-                    .unwrap_or(false);
+                let code_matches =
+                    error_code_matches(&fixture.expected_error.code, &[&error_str, &display_str]);
 
                 if code_matches {
                     TestResult {

--- a/crates/rsvelte_core/tests/preprocess.rs
+++ b/crates/rsvelte_core/tests/preprocess.rs
@@ -11,11 +11,12 @@
 
 mod common;
 
-use std::fs;
 use std::path::Path;
 
 use common::preprocess_fixtures::{build_preprocessors, filename_for};
-use common::{FixtureCoverage, SkipReason, get_svelte_test_samples, sample_name};
+use common::{
+    FixtureCoverage, SkipReason, get_svelte_test_samples, read_fixture_file, sample_name,
+};
 use rsvelte_core::compiler::preprocess::preprocess;
 
 /// Grow-only fixture floor, measured against the pinned Svelte submodule: all
@@ -39,10 +40,10 @@ pub struct PreprocessResult {
 
 fn load_fixture(sample_dir: &Path) -> Result<PreprocessFixture, SkipReason> {
     let name = sample_name(sample_dir).to_string();
-    let input = fs::read_to_string(sample_dir.join("input.svelte"))
-        .map_err(|_| SkipReason::MissingInput("input.svelte"))?;
-    let expected_output = fs::read_to_string(sample_dir.join("output.svelte"))
-        .map_err(|_| SkipReason::MissingInput("output.svelte"))?;
+    let input = read_fixture_file(&sample_dir.join("input.svelte"))
+        .ok_or(SkipReason::MissingInput("input.svelte"))?;
+    let expected_output = read_fixture_file(&sample_dir.join("output.svelte"))
+        .ok_or(SkipReason::MissingInput("output.svelte"))?;
     let filename = filename_for(&name);
     Ok(PreprocessFixture {
         name,

--- a/crates/rsvelte_core/tests/print.rs
+++ b/crates/rsvelte_core/tests/print.rs
@@ -4,10 +4,11 @@
 
 mod common;
 
-use std::fs;
 use std::path::Path;
 
-use common::{FixtureCoverage, SkipReason, get_svelte_test_samples, sample_name};
+use common::{
+    FixtureCoverage, SkipReason, get_svelte_test_samples, read_fixture_file, sample_name,
+};
 use rsvelte_core::compiler::print::print_with_source;
 use rsvelte_core::{ParseOptions, parse};
 
@@ -34,13 +35,12 @@ fn load_print_fixture(sample_dir: &Path) -> Result<PrintFixture, SkipReason> {
 
     // Load input from Svelte test suite
     let input_path = sample_dir.join("input.svelte");
-    let input =
-        fs::read_to_string(&input_path).map_err(|_| SkipReason::MissingInput("input.svelte"))?;
+    let input = read_fixture_file(&input_path).ok_or(SkipReason::MissingInput("input.svelte"))?;
 
     // Load expected output from Svelte test suite
     let output_path = sample_dir.join("output.svelte");
     let expected_output =
-        fs::read_to_string(&output_path).map_err(|_| SkipReason::MissingInput("output.svelte"))?;
+        read_fixture_file(&output_path).ok_or(SkipReason::MissingInput("output.svelte"))?;
 
     if PRINT_SKIP_NAMES.contains(&name.as_str()) {
         return Err(SkipReason::Justified);

--- a/crates/rsvelte_core/tests/validator.rs
+++ b/crates/rsvelte_core/tests/validator.rs
@@ -14,7 +14,11 @@ mod common;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use common::{FixtureCoverage, SkipReason, get_svelte_test_samples, sample_name};
+use common::{
+    ExpectedValidatorError, FixtureCoverage, SkipReason, check_validator_error,
+    get_svelte_test_samples, load_expected_validator_error, read_fixture_file, sample_name,
+    validator_error_result,
+};
 use rsvelte_core::{CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module};
 use serde::Deserialize;
 
@@ -45,23 +49,13 @@ struct ExpectedWarning {
     end: Position,
 }
 
-/// Expected error from errors.json.
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct ExpectedError {
-    code: String,
-    message: String,
-    start: Option<Position>,
-    end: Option<Position>,
-}
-
 /// A validator test fixture.
 struct ValidatorFixture {
     name: String,
     input: String,
     input_type: InputType,
     expected_warnings: Vec<ExpectedWarning>,
-    expected_error: Option<ExpectedError>,
+    expected_error: Option<ExpectedValidatorError>,
     /// Compile option: runes mode (None = auto-detect, Some(true) = forced on, Some(false) = forced off)
     runes: Option<bool>,
     /// Compile option: custom element mode
@@ -136,14 +130,14 @@ fn load_validator_fixture(sample_dir: &Path) -> Result<ValidatorFixture, SkipRea
     // Determine input type and read input
     let (input, input_type) = if svelte_path.exists() {
         (
-            fs::read_to_string(&svelte_path)
-                .map_err(|_| SkipReason::MissingInput("readable input.svelte"))?,
+            read_fixture_file(&svelte_path)
+                .ok_or(SkipReason::MissingInput("readable input.svelte"))?,
             InputType::Svelte,
         )
     } else if module_path.exists() {
         (
-            fs::read_to_string(&module_path)
-                .map_err(|_| SkipReason::MissingInput("readable input.svelte.js"))?,
+            read_fixture_file(&module_path)
+                .ok_or(SkipReason::MissingInput("readable input.svelte.js"))?,
             InputType::Module,
         )
     } else {
@@ -152,22 +146,15 @@ fn load_validator_fixture(sample_dir: &Path) -> Result<ValidatorFixture, SkipRea
 
     // Load expected warnings
     let expected_warnings: Vec<ExpectedWarning> = if warnings_path.exists() {
-        let content = fs::read_to_string(&warnings_path)
-            .map_err(|_| SkipReason::MissingInput("readable warnings.json"))?;
+        let content = read_fixture_file(&warnings_path)
+            .ok_or(SkipReason::MissingInput("readable warnings.json"))?;
         serde_json::from_str(&content).unwrap_or_default()
     } else {
         Vec::new()
     };
 
-    // Load expected error (if any)
-    let expected_error: Option<ExpectedError> = if errors_path.exists() {
-        let content = fs::read_to_string(&errors_path)
-            .map_err(|_| SkipReason::MissingInput("readable errors.json"))?;
-        let errors: Vec<ExpectedError> = serde_json::from_str(&content).unwrap_or_default();
-        errors.into_iter().next()
-    } else {
-        None
-    };
+    let expected_error = load_expected_validator_error(&errors_path)
+        .unwrap_or_else(|e| panic!("{}: {e}", sample_dir.display()));
 
     let name = sample_name(sample_dir).to_string();
 
@@ -288,51 +275,25 @@ fn run_validator_test(fixture: &ValidatorFixture) -> TestResult {
                 Err(e) => {
                     // Check if we expected an error
                     if let Some(expected_error) = &fixture.expected_error {
-                        let error_str = format!("{:?}", e);
-                        let code_matches = error_str.contains(&expected_error.code)
-                            || error_str
-                                .to_lowercase()
-                                .contains(&expected_error.code.replace('_', " ").to_lowercase())
-                            // Transform parse errors (OxcDiagnostic) should match js_parse_error
-                            || (expected_error.code == "js_parse_error"
-                                && error_str.contains("Parse errors"))
-                            // TypeScript feature errors from OXC should match typescript_invalid_feature
-                            || (expected_error.code == "typescript_invalid_feature"
-                                && (error_str.contains("Parameter modifiers can only be used in TypeScript")
-                                    || error_str.contains("namespace")
-                                    || error_str.contains("TypeScriptInvalidFeature")
-                                    // Enum declarations cause parse errors
-                                    || error_str.contains("Parse errors")))
-                            // Reserved words cause parse errors
-                            || (expected_error.code == "unexpected_reserved_word"
-                                && (error_str.contains("Parse errors")
-                                    || error_str.contains("js_parse_error")))
-                            // Rune spread errors may cause parse errors due to spread in invalid context
-                            || (expected_error.code == "rune_invalid_spread"
-                                && error_str.contains("Parse errors"));
-
-                        if code_matches {
-                            return TestResult {
+                        let verdict = check_validator_error(expected_error, &e);
+                        return match validator_error_result(&fixture.name, verdict) {
+                            Ok(()) => TestResult {
                                 name: fixture.name.clone(),
                                 passed: true,
                                 error_message: None,
                                 skipped: false,
                                 warnings_matched: 0,
                                 warnings_expected: fixture.expected_warnings.len(),
-                            };
-                        } else {
-                            return TestResult {
+                            },
+                            Err(detail) => TestResult {
                                 name: fixture.name.clone(),
                                 passed: false,
-                                error_message: Some(format!(
-                                    "Expected error code '{}', got: {}",
-                                    expected_error.code, error_str
-                                )),
+                                error_message: Some(detail),
                                 skipped: false,
                                 warnings_matched: 0,
                                 warnings_expected: fixture.expected_warnings.len(),
-                            };
-                        }
+                            },
+                        };
                     }
 
                     // Unexpected error


### PR DESCRIPTION
Fixes #1839

## Problem

Three places where `compatibility_report.rs` accepted what its own gate would
reject (documented as out-of-scope follow-ups in #1836's PR body), plus the
gate blind spot found in #1771/PR #1828: `tests/validator.rs` compared only the
error **code**, never the message — which is how the "Possible bindings"
enumeration shipped in hash order for months while 333/333 stayed green.

## What changed

### 1. compiler-errors: word-boundary regex, shared with the gate

The report matched the expected code with `error_str.contains(code)` plus an
underscore→space lowercase variant; `compiler_errors.rs` uses
`\b<code>(_[a-z_]+)?\b` over both `Debug` and `Display`. The regex now lives
once in `tests/common/mod.rs::error_code_matches` and both callers use it, so
they cannot drift again.

### 2. validator: typed expectations, no extra substrings, shared comparison

* `errors.json` is parsed into a typed `ExpectedValidatorError` (`code` and
  `message` required). Previously the report used `serde_json::Value` and
  `expected.get("code")…unwrap_or("")`, so a `code`-less entry matched
  everything.
* The report's three extra `typescript_invalid_feature` allowances
  (`decorator` / `accessor` / `enum`) and the `unexpected_reserved_word`
  "Unexpected token" allowance are gone. What is left is one documented rule:
  codes whose fixture fails inside OXC's JS parser before rsvelte can attach a
  Svelte code accept the bare `Parse errors` shape.
* Report and gate now call the same `check_validator_error`.

### 3. CRLF normalization

`read_fixture_file` (CRLF→LF) replaces the raw `fs::read_to_string` on every
fixture input/expected read in the report, and in `tests/print.rs` /
`tests/preprocess.rs`, which lacked it too.

### 4. The validator gate now asserts message text

`tests/validator.rs` compares `code` **and** `message`, upstream-style: exact
text after stripping the trailing `https://svelte.dev/e/<code>` line, mirroring
`packages/svelte/tests/validator/test.ts::strip_link`.

## What that surfaced — 38 divergences, 35 fixed

Turning the message assertion on failed 38 of 332 fixtures. **35 were real
wording drift from upstream `errors.js` and are fixed in the compiler**, not
papered over:

| code | was | now (upstream) |
|---|---|---|
| `bind_invalid_target` | `` `checked` can only be bound to … `` | `` `bind:checked` can only be used with … `` |
| `transition_duplicate` | `An element can only have one 'in' directive` | `` Cannot use multiple `in:` directives on a single element `` |
| `transition_conflict` | `An element cannot have both 'transition' and 'in' directives` | `` Cannot use `transition:` alongside existing `in:` directive `` |
| `rune_invalid_spread` | `` `$state` cannot be used with spread arguments `` | `` `$state` cannot be called with a spread argument `` |
| `script_duplicate` | `A component can only have one instance-level …` | `A component can have a single top-level …` |
| `illegal_element_attribute` | `` `<svelte:window>` cannot have spread attributes `` | `` `<svelte:window>` does not support non-event attributes or spread attributes `` |
| `event_handler_invalid_modifier` | `Invalid event modifier 'stop'. Valid modifiers are: …` | `Valid event modifiers are …` |
| `attribute_invalid_type` | `The 'type' attribute cannot be dynamic` | `'type' attribute must be a static text value if input uses two-way binding` |
| `state_field_invalid_assignment` | `Cannot assign to state field before initialization in constructor` | `Cannot assign to a state field before its declaration` |
| `css_type_selector_invalid_placement` | `` Type selector cannot appear after `:global(...)` `` | `` `:global(...)` must not be followed by a type selector `` |
| `declaration_duplicate_module_import` | `… as an import inside `<script module>`` | `` … as an import from `<script module>` `` |
| `bind_group_invalid_expression` | `bind:group cannot use getter/setter syntax` | `` `bind:group` can only bind to an Identifier or MemberExpression `` |
| `bind_group_invalid_snippet_parameter` | `Cannot use bind:group with snippet parameters` | `` Cannot `bind:group` to a snippet parameter `` |
| `tag_invalid_placement` | `… cannot be inside a <textarea>` | `… cannot be inside <textarea>` |
| `node_invalid_placement` | ``… not a `<div>.`` (unbalanced backtick) | ``… not a `<div>`.`` |
| `svelte_options_invalid_attribute_value` | `"svg" is not a valid namespace (must be …)` | `Value must be "html", "mathml" or "svg", if specified` |
| `svelte_options_invalid_tagname` | `Tag name must contain a hyphen` (4 variants) | `Tag name must be lowercase and hyphenated` |
| `svelte_options_reserved_tagname` | `"font-face" is a reserved tag name` | `Tag name is reserved` |
| `svelte_options_invalid_customelement` | `` `customElement` must be a string or object `` | the full upstream `"customElement" must be a string literal …` text |

Two `ValidationWithCode` literals in `bind_directive.rs` and one in
`shared/element.rs` were folded into `errors.rs` constructors while fixing
them, so every one of these codes now has a single definition.

### The 3 not fixed — and why the gate still sees them

`each-block-invalid-context-destructured`,
`each-block-invalid-context-destructured-object` and
`each-block-destructured-object-rest-comma-after` pin a `js_parse_error`
message that is verbatim **acorn** text; rsvelte's comes verbatim from OXC
(`"Unexpected token"` vs `"Identifier expected. 'case' is a reserved word…"`).
Matching it would mean reimplementing acorn's diagnostic strings, so they are
listed in `common::VALIDATOR_MESSAGE_DIVERGENCES` with the exact
expected/actual pair per entry. The list is **not** a mute switch:

* the **code** is still asserted for those fixtures;
* only the message comparison is waived;
* a listed fixture whose message starts matching **fails** with
  "remove it from VALIDATOR_MESSAGE_DIVERGENCES", so the list can only shrink.

## Verification

| command | result |
|---|---|
| `cargo test --release` | 246 suites, all `ok`, 0 failed |
| `cargo test --release -p rsvelte_core --test validator` | 332/332, 0 skipped |
| `cargo test --release -p rsvelte_core --test compiler_errors` | 145/145 |
| `pnpm run compatibility-report` | `Passed: 3312 (100.0%)`, `Failed: 0` — unchanged totals, tighter checks (validator 333/333, compiler-errors 145/145) |
| `cargo fmt --all` / `cargo clippy --all-targets --all-features -- -D warnings` | clean |

A changeset is included: the error-message fixes are user-visible
`@rsvelte/compiler` behaviour.

## Still looser than upstream (not in this PR's scope)

Upstream's validator test also asserts warning `code`/`message`/`start`/`end`
and the error's `start`/`end`. rsvelte's `AnalysisError::ValidationWithCode`
carries no span at all, so asserting error positions needs a compiler-side
change (thread spans through the analyze diagnostics), and warnings are still
compared by count only. Both are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp
