### PR TITLE
fix(css): guard multi-relative chain resolution against non-lexical ancestry

### DIFF
--- a/.changeset/fix-css-chain-non-lexical-ancestry.md
+++ b/.changeset/fix-css-chain-non-lexical-ancestry.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(css): guard multi-relative chain resolution against non-lexical ancestry (#1735)
+
+The `+`/`~` prune check resolves a multi-relative operand (`:global(.a .z) + .b`,
+or a bare `&` against a `.foo > .a` parent prelude) into an ancestor chain
+verified by walking `parent_idx`. That walk is lexical, so it silently
+mis-answers for `{#snippet}` bodies (whose real ancestors come from their
+`{@render}` call sites) and for `<selectedcontent>` (which mirrors the selected
+`<option>`'s subtree). Both `Chain` producers now share the predicate the
+descendant-chain check already used and bail conservatively when the ancestry is
+not lexical, fixing `selectedcontent > .a { & + & }` being emitted as
+`/* (empty) */` where the official compiler keeps it.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -2371,7 +2371,10 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
             // like `:global(.a .z)` becomes a `Chain` so the `.a` ancestor of a
             // candidate `.z` sibling is verified (rather than left unresolved,
             // which over-prunes even when the ancestor really exists).
-            let inner_matcher = resolve_global_inner_matcher(&rel_selectors[0]);
+            let inner_matcher = resolve_global_inner_matcher(&rel_selectors[0], ctx);
+            if matches!(inner_matcher, SiblingMatcher::Unresolvable) {
+                return false;
+            }
 
             // `:global(X) + Y` is used when some Y is preceded by a node X could
             // be: a real previous sibling matching X, an opaque boundary, or a
@@ -2487,6 +2490,11 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
         // matching nothing; single-relative parents keep the `Info` path.
         let before_m = resolve_sibling_matcher(before, ctx);
         let after_m = resolve_sibling_matcher(after, ctx);
+        if matches!(before_m, SiblingMatcher::Unresolvable)
+            || matches!(after_m, SiblingMatcher::Unresolvable)
+        {
+            return false;
+        }
 
         // Find all elements that match 'after' selector
         let mut found_after_element = false;
@@ -2726,6 +2734,11 @@ fn global_inner_selector_info(rel: &Value) -> SelectorInfo {
 enum SiblingMatcher {
     Info(SelectorInfo),
     Chain(Vec<Value>),
+    /// A chain whose ancestor constraint cannot be verified because the lexical
+    /// parent walk does not model the real ancestry. Dropping to the
+    /// compound-only `Info` would silently discard the constraint and let the
+    /// rule be pruned, so callers must bail conservatively instead.
+    Unresolvable,
 }
 
 fn matcher_matches_at(matcher: &SiblingMatcher, idx: usize, ctx: &CssContext) -> bool {
@@ -2738,6 +2751,8 @@ fn matcher_matches_at(matcher: &SiblingMatcher, idx: usize, ctx: &CssContext) ->
             structural_element_matches_compound(el, &rels[rels.len() - 1])
                 && structural_ancestors_satisfy_links(rels, rels.len() - 1, idx, ctx)
         }
+        // Callers bail before matching; `true` keeps the conservative direction.
+        SiblingMatcher::Unresolvable => true,
     }
 }
 
@@ -2759,6 +2774,17 @@ fn global_inner_complex_rels(rel: &Value) -> Option<&Vec<Value>> {
         .and_then(|c| c.as_array())
         .and_then(|c| c.first())?;
     complex.get("children").and_then(|c| c.as_array())
+}
+
+/// True when the lexical `parent_idx` walk models the real DOM ancestry: a
+/// `{#snippet}`-declared element's real ancestors are its `{@render}` sites and
+/// `<selectedcontent>` mirrors the selected option's subtree — neither is
+/// reachable from `parent_idx`.
+fn structural_ancestry_is_lexical(ctx: &CssContext) -> bool {
+    !ctx.dom_structure
+        .elements
+        .iter()
+        .any(|el| el.in_snippet || el.tag_name.eq_ignore_ascii_case("selectedcontent"))
 }
 
 /// True when a descendant/child chain (subject last) can be evaluated by the
@@ -2789,12 +2815,15 @@ fn chain_is_structurally_evaluable(rels: &[Value]) -> bool {
 
 /// Resolve a leading `:global(X)` relative selector into a [`SiblingMatcher`]:
 /// a `Chain` when `X` is a structurally-evaluable descendant/child chain (so the
-/// `.a` ancestor of `:global(.a .z)` is verified), otherwise the single-compound
-/// `Info` (unchanged behaviour).
-fn resolve_global_inner_matcher(rel: &Value) -> SiblingMatcher {
+/// `.a` ancestor of `:global(.a .z)` is verified), `Unresolvable` when that
+/// chain's ancestors are not lexical, otherwise the single-compound `Info`.
+fn resolve_global_inner_matcher(rel: &Value, ctx: &CssContext) -> SiblingMatcher {
     if let Some(rels) = global_inner_complex_rels(rel)
         && chain_is_structurally_evaluable(rels)
     {
+        if !structural_ancestry_is_lexical(ctx) {
+            return SiblingMatcher::Unresolvable;
+        }
         return SiblingMatcher::Chain(rels.clone());
     }
     SiblingMatcher::Info(global_inner_selector_info(rel))
@@ -2900,9 +2929,13 @@ fn resolve_bare_nesting_chain(rel: &Value, ctx: &CssContext) -> Option<Vec<Value
 
 /// Resolve a sibling operand relative selector into a [`SiblingMatcher`],
 /// preferring an ancestor-aware `Chain` for a bare `&` with a multi-relative
-/// parent, else the existing compound `Info`.
+/// parent (`Unresolvable` when that chain's ancestors are not lexical), else the
+/// existing compound `Info`.
 fn resolve_sibling_matcher(rel: &Value, ctx: &CssContext) -> SiblingMatcher {
     if let Some(chain) = resolve_bare_nesting_chain(rel, ctx) {
+        if !structural_ancestry_is_lexical(ctx) {
+            return SiblingMatcher::Unresolvable;
+        }
         return SiblingMatcher::Chain(chain);
     }
     SiblingMatcher::Info(extract_selector_info_resolving_nesting(rel, ctx))
@@ -3336,18 +3369,7 @@ fn is_structural_descendant_chain_unused(rel_selectors: &[Value], ctx: &CssConte
     if rel_selectors.len() < 2 || ctx.dom_structure.elements.is_empty() {
         return false;
     }
-    if ctx.has_dynamic_elements {
-        return false;
-    }
-    // A snippet-declared element's real ancestors are its render sites, and
-    // `<selectedcontent>` mirrors the selected option's subtree — the lexical
-    // parent walk cannot model either, so stay conservative.
-    if ctx
-        .dom_structure
-        .elements
-        .iter()
-        .any(|el| el.in_snippet || el.tag_name.eq_ignore_ascii_case("selectedcontent"))
-    {
+    if ctx.has_dynamic_elements || !structural_ancestry_is_lexical(ctx) {
         return false;
     }
     for rel in rel_selectors.iter().skip(1) {

--- a/crates/rsvelte_core/tests/css_chain_ancestry_guard_1735.rs
+++ b/crates/rsvelte_core/tests/css_chain_ancestry_guard_1735.rs
@@ -1,0 +1,133 @@
+//! Regression tests for issue #1735 — the multi-relative ancestor `Chain`
+//! resolution used by the `+`/`~` prune check (`:global(.a .z) + .b`, and a bare
+//! `&` resolved against a multi-relative parent prelude such as
+//! `.foo > .a { & + & }`) walked `parent_idx` without checking that the lexical
+//! parent chain actually models the real DOM ancestry.
+//!
+//! It does not when the component contains `{#snippet}` bodies (a
+//! snippet-declared element's real ancestors come from its `{@render}` call
+//! sites) or a `<selectedcontent>` (which mirrors the selected `<option>`'s
+//! subtree). In those templates the chain must be treated as unresolvable and
+//! the rule kept, rather than either trusting the lexical walk or dropping to
+//! the compound-only fallback (which discards the ancestor constraint and
+//! prunes).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn css(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .css
+    .map(|c| c.code)
+    .unwrap_or_default()
+}
+
+fn assert_kept(out: &str) {
+    assert!(!out.contains("(unused)"), "rule must be kept, got:\n{out}");
+    assert!(!out.contains("(empty)"), "rule must be kept, got:\n{out}");
+}
+
+fn assert_pruned(out: &str) {
+    assert!(
+        out.contains("(unused)") || out.contains("(empty)"),
+        "rule must be pruned, got:\n{out}"
+    );
+}
+
+/// `<selectedcontent>` clones the selected `<option>`'s content, so upstream
+/// treats elements inside an `<option>` as descendants of the
+/// `<selectedcontent>` too. The lexical walk sees only `option`, so the `Chain`
+/// found no `.a` under `selectedcontent` and wrongly pruned the rule.
+#[test]
+fn selectedcontent_ancestor_chain_kept() {
+    let out = css("<select>\n  <selectedcontent></selectedcontent>\n  \
+         <option><div class=\"a\"></div><div class=\"a\"></div></option>\n</select>\n\
+         <style>selectedcontent > .a { & + & { color: red; } }</style>");
+    assert_kept(&out);
+}
+
+/// A snippet body rendered under a *different* ancestor than the one the
+/// prelude requires. The lexical walk cannot follow `{@render}`, so the chain is
+/// unresolvable and the rule is kept.
+#[test]
+fn snippet_rendered_under_matching_ancestor_kept() {
+    let out = css("<div class=\"foo\">\n  {@render pair()}\n</div>\n\
+         {#snippet pair()}\n  <div class=\"a\"></div><div class=\"a\"></div>\n{/snippet}\n\
+         <style>.foo > .a { & + & { color: red; } }</style>");
+    assert_kept(&out);
+}
+
+/// Same for the `:global(X) + Y` inner-chain resolution.
+#[test]
+fn global_inner_chain_with_snippet_kept() {
+    let out = css(
+        "<div class=\"foo\">\n  <div class=\"z\"></div>\n  {@render one()}\n</div>\n\
+         {#snippet one()}<div class=\"b\"></div>{/snippet}\n\
+         <style>:global(.foo .z) + .b { color: red; }</style>",
+    );
+    assert_kept(&out);
+}
+
+/// `svelte:element` does *not* remap ancestry — the dynamic element is a real
+/// node at a known position and `is_dynamic_tag` already relaxes tag matching —
+/// so the chain stays resolvable and `.foo > .a` still prunes when the dynamic
+/// element sits between `.foo` and the `.a` pair.
+#[test]
+fn dynamic_element_between_ancestor_and_subject_still_pruned() {
+    let out = css("<script>let tag = 'div';</script>\n\
+         <div class=\"foo\"><svelte:element this={tag}>\
+         <div class=\"a\"></div><div class=\"a\"></div></svelte:element></div>\n\
+         <style>.foo > .a { & + & { color: red; } }</style>");
+    assert_pruned(&out);
+}
+
+#[test]
+fn global_inner_chain_with_dynamic_element_still_pruned() {
+    let out = css("<script>let tag = 'div';</script>\n\
+         <div class=\"foo\"><svelte:element this={tag}>\
+         <div class=\"z\"></div><div class=\"b\"></div></svelte:element></div>\n\
+         <style>:global(.foo > .z) + .b { color: red; }</style>");
+    assert_pruned(&out);
+}
+
+/// The guard must not weaken the snippet-free cases #1728 fixed: the ancestor
+/// constraint is still verified there.
+#[test]
+fn no_snippet_ancestor_chain_still_evaluated() {
+    let kept = css(
+        "<div class=\"foo\"><div class=\"a\"></div><div class=\"a\"></div></div>\n\
+         <style>.foo > .a { & + & { color: red; } }</style>",
+    );
+    assert_kept(&kept);
+
+    let pruned = css(
+        "<div class=\"foo\"><span>x</span></div><div class=\"a\"></div><div class=\"a\"></div>\n\
+         <style>.foo > .a { & + & { color: red; } }</style>",
+    );
+    assert_pruned(&pruned);
+}
+
+/// Known limitation (issue #1735): the official compiler prunes this rule
+/// because the only render site of the `.a` pair is `<section>`, not `.foo`.
+/// rsvelte's `dom_structure` has no `{@render}`-site model, so the prune check
+/// stays conservative and keeps the rule. This is a pre-existing over-keep, not
+/// a regression from the `Chain` resolution — the same output is produced with
+/// the `Chain` path disabled entirely.
+#[test]
+fn snippet_rendered_under_mismatched_ancestor_over_kept() {
+    let out = css("<div class=\"foo\"><span>irrelevant</span></div>\n\
+         {#snippet pair()}\n  <div class=\"a\"></div><div class=\"a\"></div>\n{/snippet}\n\
+         <section>\n  {@render pair()}\n</section>\n\
+         <style>.foo > .a { & + & { color: red; } }</style>");
+    assert_kept(&out);
+}


### PR DESCRIPTION
## Summary

The multi-relative ancestor `Chain` resolution added in #1728 (`resolve_global_inner_matcher`
for `:global(.a .z) + .b`, `resolve_bare_nesting_chain` for `.foo > .a { & + & }`) walks
`parent_idx` directly, without the ancestry guard the other caller of the same primitives,
`is_structural_descendant_chain_unused`, already applies. `parent_idx` is *lexical*, and two
constructs make it a lie:

- a `{#snippet}`-declared element's real ancestors come from its `{@render}` call sites, not
  its lexical parent;
- `<selectedcontent>` mirrors the selected `<option>`'s subtree, so elements inside an
  `<option>` are also descendants of the `<selectedcontent>`.

This PR extracts that condition into `structural_ancestry_is_lexical(ctx)` and gates the two
`Chain` producers on it.

## Why a new `SiblingMatcher::Unresolvable` instead of "bail to the `Info` fallback"

The issue suggested bailing to the compound-only `Info` path. Measured against the official
compiler, that is actively wrong: `Info` *discards* the ancestor constraint, the operand
resolves to an empty (matches-nothing) selector, and with no opaque-boundary fallback in play
the rule gets pruned. It regressed two cases that `main` gets right, e.g.

```svelte
<script>let tag = 'div';</script>
<svelte:element this={tag} class="foo"><div class="a"></div><div class="a"></div></svelte:element>
<style>.foo > .a { & + & { color: red; } }</style>
```

So the guard produces `SiblingMatcher::Unresolvable`, and the two call sites in
`is_sibling_combinator_unused` bail conservatively (`return false` — "not unused", keep the
rule) rather than falling through with a weaker matcher.

## Why the `has_dynamic_elements` half of the guard is *not* applied to the `Chain` paths

`is_structural_descendant_chain_unused` also bails on `ctx.has_dynamic_elements`; that stays
there unchanged, but is deliberately not carried over to the `Chain` paths. `svelte:element`
does not remap ancestry — it is a real node at a known position, and
`structural_element_matches_compound` already relaxes tag/attribute matching via
`is_dynamic_tag`. Including it regressed two cases against official output:

```svelte
<script>let tag = 'div';</script>
<div class="foo"><svelte:element this={tag}><div class="a"></div><div class="a"></div></svelte:element></div>
<style>.foo > .a { & + & { color: red; } }</style>
```

official: `/* (empty) … */`; with `has_dynamic_elements` in the guard rsvelte kept it. Both
cases are covered by regression tests.

## Effect on the issue's repro — NOT fixed, documented as a limitation

```svelte
<div class="foo"><span>irrelevant</span></div>
{#snippet pair()}
  <div class="a"></div><div class="a"></div>
{/snippet}
<section>
  {@render pair()}
</section>
<style>
  .foo > .a { & + & { color: red; } }
</style>
```

Official `svelte@5.56.8` prunes: `/* (empty) .foo > .a { & + & { color: red; } }*/`.
rsvelte still keeps it, before and after this PR.

Verified root cause: this is not the sibling-combinator code at all. rsvelte also keeps the
plain `.foo > .a { color: red; }`, `.foo .a { … }` and `.foo > .a + .a { … }` variants of the
same template, because `is_structural_descendant_chain_unused` bails on *any* snippet element —
`dom_structure` has no model of `{@render}` call sites, so it cannot tell the `.a` pair's real
parent is `<section>`. Fixing the repro requires teaching phase 2's `CssDomElement` a
render-site ancestry link (`parent_idx` is snippet-boundary-unaware, so this also touches
`children_idx` / `is_root_child` and the recursive ancestor walk, which would have to branch
over multiple ancestor paths). That is a separate architectural change, so #1735 stays open.

The repro is landed as an explicit known-limitation test
(`snippet_rendered_under_mismatched_ancestor_over_kept`), so the assertion flips the day
render-site modelling lands.

## What this PR does buy

- Fixes one real over-prune on `main`: `selectedcontent > .a { & + & }` was emitted as
  `/* (empty) */` where official keeps it.
- Stops the #1728 `Chain` paths from extending the lexical-ancestry blind spot, and makes both
  callers of the structural primitives share one named predicate.

## Verification

13 shapes compiled with both `submodules/svelte` (`svelte@5.56.8`) and rsvelte, diffing
`css.code`: matching/mismatched snippet render sites, snippet declared inside vs. outside the
required ancestor, `:global()` inner chains with snippets, `selectedcontent` as ancestor and as
bystander, `svelte:element` as ancestor and as an intervening node, plus the snippet-free
positive/negative controls. After this PR all 13 match official except the documented repro; on
`main`, `selectedcontent > .a { & + & }` also diverged.

Refs #1735

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp
