### PR TITLE
test(analyze): re-pin diagnostics digest after #1849 message fixes

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/diagnostics_test.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/diagnostics_test.rs
@@ -20,7 +20,7 @@ use super::errors;
 use super::warnings;
 
 /// Constructors declared inside the `diagnostics!` block in `errors.rs`.
-const ERROR_MACRO_COUNT: usize = 124;
+const ERROR_MACRO_COUNT: usize = 126;
 /// Constructors declared inside the `diagnostics!` block in `warnings.rs`.
 const WARNING_MACRO_COUNT: usize = 73;
 /// Calls below covering `errors.rs`'s hand-written constructor (`bind_invalid_name`),
@@ -34,7 +34,7 @@ const WARNING_HANDWRITTEN_CALLS: usize = 7;
 /// FNV-1a 64 of `"<code>\t<message>\n"` for every entry `dump_all()` produces, in the
 /// fixed order below. Pinned from this PR; if it legitimately changes, update it to the
 /// value printed in the assertion failure after confirming the new wording is correct.
-const DIAGNOSTICS_DIGEST: u64 = 0xad95_642d_edbf_11e2;
+const DIAGNOSTICS_DIGEST: u64 = 0xc8f8_0792_df41_fb82;
 
 fn fnv1a64(bytes: &[u8]) -> u64 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;


### PR DESCRIPTION
## Summary

`main` is red on `Test unit` (`diagnostics_test::constructor_counts_are_pinned` and
`diagnostic_codes_and_messages_are_pinned`). This is a cross-PR race, not a bug in either
PR:

- **#1844** landed the pinned diagnostics snapshot (`ERROR_MACRO_COUNT`,
  `WARNING_MACRO_COUNT`, `DIAGNOSTICS_DIGEST`) — green against the `errors.rs` of its time.
- **#1849** (which carries #1839) reworded diagnostics to match official Svelte and folded
  inline `ValidationWithCode` literals into `diagnostics!` constructors — green against the
  `diagnostics_test.rs` of *its* time, because it branched before #1844's pin existed.

Neither PR could see the other's change, so both passed CI and the merged combination is red.
This re-derives the two pins on the merged tree.

## What actually changed in the diagnostics

`git diff c014a954 6a487171 -- errors.rs` (`warnings.rs` is untouched, so
`WARNING_MACRO_COUNT` stays at 73):

**Two constructors added** — `ERROR_MACRO_COUNT` 124 → 126:
- `bind_group_invalid_expression()`
- `bind_group_invalid_snippet_parameter()`

**Ten messages reworded** (plus `attribute_invalid_type` losing its `name` parameter):
`rune_invalid_spread`, `bind_invalid_target`, `attribute_invalid_type`,
`declaration_duplicate_module_import`, `state_field_invalid_assignment`,
`transition_duplicate`, `transition_conflict`, `css_type_selector_invalid_placement`,
`script_duplicate`, `illegal_element_attribute`.

`DIAGNOSTICS_DIGEST` 0xad95_642d_edbf_11e2 → 0xc8f8_0792_df41_fb82.

## Verification that the new wording is correct, not just newly-pinned

A digest re-pin is only safe if the underlying text is right, so the new strings were checked
against `submodules/svelte/packages/svelte/src/compiler/errors.js` rather than taken on faith,
e.g.

- `rune_invalid_spread` → ``​`%rune%` cannot be called with a spread argument`` (errors.js:417)
- `css_type_selector_invalid_placement` → ``​`:global(...)` must not be followed by a type
  selector`` (errors.js:688)
- `illegal_element_attribute` → ``​`<%name%>` does not support non-event attributes or spread
  attributes`` (errors.js:1188)

All match upstream.

## Tests

- `cargo test -p rsvelte_core --lib diagnostics_test` — 2 passed.
- `cargo nextest run --profile ci --lib` (the exact failing CI job) — 2086 passed, 1 skipped.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` — clean.

Test-only change, so no changeset (and a `test:` title to keep the changeset gate satisfied).

Refs #1757 #1839

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrqdRdS2YdA12XDA24KUHp
