### PR TITLE
fix(cargo): skip the unrelated vize submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,7 @@
 [submodule "submodules/vize"]
 	path = submodules/vize
 	url = git@github.com:ubugeeei-prod/vize.git
+	update = none
 
 # Backs the type-aware lint crate (crates/rsvelte_lint_types). HTTPS, not SSH:
 # the repo is public, so CI clones it with no credentials.


### PR DESCRIPTION
## Summary

- mark the unrelated `submodules/vize` checkout with `update = none`
- let Cargo consume `rsvelte_core` as a git dependency without recursively entering vize's broken fixture submodule (`temp_web/element` has no URL)
- unblock downstream consumers from pinning the rsvelte 0.9.4 source revision

## Why

Cargo recursively initializes git dependency submodules. The vize corpus is not used to build `rsvelte_core`, but its nested Element fixture currently makes the checkout fail before compilation.

## Validation

- `git diff --check`
- verified there are no in-repository references to `submodules/vize` outside `.gitmodules`
