### PR TITLE
feat(core): expose prepared CSS scope hash

### DIFF
--- a/.changeset/calm-facts-travel.md
+++ b/.changeset/calm-facts-travel.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Expose the analyzed CSS scope hash through the embeddable component facts.

--- a/crates/rsvelte_core/src/toolchain.rs
+++ b/crates/rsvelte_core/src/toolchain.rs
@@ -22,7 +22,7 @@ pub const RUNTIME_ABI_VERSION: u32 = 1;
 /// Version of the IDE projection artifact contract.
 pub const PROJECTION_ABI_VERSION: u32 = 1;
 /// Version of the normalized facts contract.
-pub const FACTS_ABI_VERSION: u32 = 1;
+pub const FACTS_ABI_VERSION: u32 = 2;
 
 const SVELTE_VERSION: &str = match option_env!("SVELTE_VERSION") {
     Some(version) => version,
@@ -230,6 +230,8 @@ pub struct ComponentExport {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComponentFacts {
     pub runes: bool,
+    /// Scope class frozen by component analysis, when a style block exists.
+    pub css_scope_hash: Option<String>,
     /// Whether legacy `$$props` is referenced.
     pub uses_legacy_props: bool,
     /// Whether legacy `$$restProps` is referenced.
@@ -303,6 +305,7 @@ impl ComponentFacts {
 
         Self {
             runes,
+            css_scope_hash: style.as_ref().map(|_| analysis.css.hash.clone()),
             uses_legacy_props: analysis.uses_props,
             uses_legacy_rest_props: analysis.uses_rest_props,
             uses_legacy_slots: analysis.uses_slots,

--- a/crates/rsvelte_core/tests/toolchain_api.rs
+++ b/crates/rsvelte_core/tests/toolchain_api.rs
@@ -115,7 +115,8 @@ fn preparation_runs_analysis_once_for_multiple_emits() {
     let mut compile_options = options(GenerateMode::Client);
     compile_options.css_hash = Some(Arc::new(move |input: &CssHashInput| {
         calls.fetch_add(1, Ordering::SeqCst);
-        format!("svelte-{}", (input.hash)(&input.css))
+        let _ = input;
+        "scope-from-embedder".to_string()
     }));
 
     let toolchain = Toolchain::new();
@@ -127,6 +128,11 @@ fn preparation_runs_analysis_once_for_multiple_emits() {
         .expect("prepare component");
     let calls_after_prepare = css_hash_calls.load(Ordering::SeqCst);
     assert!(calls_after_prepare > 0);
+    assert_eq!(
+        prepared.facts().css_scope_hash.as_deref(),
+        Some("scope-from-embedder"),
+        "prepared facts must expose the hash frozen by analysis"
+    );
 
     prepared
         .compile(RuntimeTarget::Client)
@@ -287,5 +293,5 @@ fn fingerprint_exposes_independent_phase_abis() {
     assert!(fingerprint.toolchain_abi > 0);
     assert!(fingerprint.runtime_abi > 0);
     assert!(fingerprint.projection_abi > 0);
-    assert!(fingerprint.facts_abi > 0);
+    assert_eq!(fingerprint.facts_abi, 2);
 }


### PR DESCRIPTION
## Summary

- expose the CSS scope hash already frozen during component analysis on `ComponentFacts`
- bump the independent facts ABI to 2
- cover custom `cssHash` values and the ABI fingerprint in the toolchain facade tests

## Why

Embedders such as Verter need to publish the scope class alongside extracted CSS. Returning the analyzed value keeps Svelte hash policy inside rsvelte and prevents embedders from reimplementing the default algorithm or intercepting callbacks.

## Verification

- `cargo test -p rsvelte_core --test toolchain_api`
- `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

`--no-default-features --all-targets` remains invalid on main because native-only integration tests are still discovered without their native-only dependencies; the embeddable production graph is covered by the existing CI guard.
