### PR TITLE
perf(compiler): reduce serial compile overhead

### DIFF
--- a/.changeset/fast-maps-smile.md
+++ b/.changeset/fast-maps-smile.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+Reduce compile overhead by avoiding duplicate analysis setup, allocation-free escaping for static templates, and source-text copies in wrapper-managed source maps.

--- a/apps/npm/vite-plugin-svelte-native/envelope.js
+++ b/apps/npm/vite-plugin-svelte-native/envelope.js
@@ -47,9 +47,10 @@ function assertWindow(bufLen, off, len, label) {
  * Decode an envelope produced by `compileEnvelope` / `compileModuleEnvelope`.
  *
  * @param {Buffer|Uint8Array} buf
+ * @param {string} [sourceContent]
  * @returns {object} CompileResult-shaped object with lazy fields
  */
-function decodeEnvelope(buf) {
+function decodeEnvelope(buf, sourceContent) {
 	if (!buf || buf.byteLength < HEADER_LEN) {
 		throw new Error(
 			`[rsvelte] envelope too small (${buf ? buf.byteLength : 0} bytes, ` +
@@ -117,11 +118,27 @@ function decodeEnvelope(buf) {
 	// js — eagerly construct the wrapper object, but defer string/JSON
 	// realisation. Vite always touches `js.code`; the map is only
 	// touched when emitting sourcemaps.
-	const js = makeCodeMapObject(buf, slice, jsCodeOff, jsCodeLen, jsMapOff, jsMapLen);
+	const js = makeCodeMapObject(
+		buf,
+		slice,
+		jsCodeOff,
+		jsCodeLen,
+		jsMapOff,
+		jsMapLen,
+		sourceContent,
+	);
 
 	let css = null;
 	if (hasCss) {
-		css = makeCodeMapObject(buf, slice, cssCodeOff, cssCodeLen, cssMapOff, cssMapLen);
+		css = makeCodeMapObject(
+			buf,
+			slice,
+			cssCodeOff,
+			cssCodeLen,
+			cssMapOff,
+			cssMapLen,
+			sourceContent,
+		);
 		css.hasGlobal = (flags & FLAG_CSS_HAS_GLOBAL) !== 0;
 	}
 
@@ -150,7 +167,7 @@ function decodeEnvelope(buf) {
 	return result;
 }
 
-function makeCodeMapObject(buf, slice, codeOff, codeLen, mapOff, mapLen) {
+function makeCodeMapObject(buf, slice, codeOff, codeLen, mapOff, mapLen, sourceContent) {
 	const obj = {};
 	let codeCache = null;
 	// `code` and `map` need setters as well as getters — upstream
@@ -182,7 +199,7 @@ function makeCodeMapObject(buf, slice, codeOff, codeLen, mapOff, mapLen) {
 				// parsed object matches the legacy compile() shape —
 				// callers that just want the raw JSON to write to disk
 				// should prefer `mapBytes` / `mapText` (no JSON.parse).
-				mapCache = JSON.parse(slice(mapOff, mapLen));
+				mapCache = attachSourceContent(JSON.parse(slice(mapOff, mapLen)), sourceContent);
 			}
 			return mapCache;
 		},
@@ -199,6 +216,10 @@ function makeCodeMapObject(buf, slice, codeOff, codeLen, mapOff, mapLen) {
 		configurable: true,
 		get() {
 			if (!hasMap) return null;
+			const raw = slice(mapOff, mapLen);
+			if (hasExternalSourceContent(raw, sourceContent)) {
+				return Buffer.from(materializeMapText(raw, sourceContent));
+			}
 			return buf.subarray
 				? buf.subarray(mapOff, mapOff + mapLen)
 				: new Uint8Array(buf.buffer, buf.byteOffset + mapOff, mapLen);
@@ -212,10 +233,34 @@ function makeCodeMapObject(buf, slice, codeOff, codeLen, mapOff, mapLen) {
 		configurable: true,
 		get() {
 			if (!hasMap) return null;
-			return slice(mapOff, mapLen);
+			return materializeMapText(slice(mapOff, mapLen), sourceContent);
 		},
 	});
 	return obj;
+}
+
+function attachSourceContent(map, sourceContent) {
+	if (
+		sourceContent !== undefined &&
+		Array.isArray(map.sourcesContent) &&
+		map.sourcesContent.length === 1 &&
+		map.sourcesContent[0] === null
+	) {
+		map.sourcesContent[0] = sourceContent;
+	}
+	return map;
+}
+
+function hasExternalSourceContent(mapText, sourceContent) {
+	return sourceContent !== undefined && mapText.includes('"sourcesContent":[null]');
+}
+
+function materializeMapText(mapText, sourceContent) {
+	if (!hasExternalSourceContent(mapText, sourceContent)) return mapText;
+	return mapText.replace(
+		'"sourcesContent":[null]',
+		() => `"sourcesContent":[${JSON.stringify(sourceContent)}]`,
+	);
 }
 
 function decodeWarnings(buf, view, off, regionLen, count, slice) {
@@ -322,9 +367,10 @@ const BATCH_STATUS_ERR = 1;
  * or an `Error` carrying the per-entry failure message.
  *
  * @param {Buffer|Uint8Array} buf
+ * @param {string[]} [sourceContents]
  * @returns {Array<object|Error>}
  */
-function decodeBatch(buf) {
+function decodeBatch(buf, sourceContents) {
 	if (!buf || buf.byteLength < BATCH_HEADER_LEN) {
 		throw new Error(
 			`[rsvelte] batch envelope too small (${buf ? buf.byteLength : 0} bytes, ` +
@@ -376,7 +422,7 @@ function decodeBatch(buf) {
 			? buf.subarray(payloadOff, payloadOff + payloadLen)
 			: new Uint8Array(buf.buffer, buf.byteOffset + payloadOff, payloadLen);
 		if (status === BATCH_STATUS_OK) {
-			out[i] = decodeEnvelope(slice);
+			out[i] = decodeEnvelope(slice, sourceContents?.[i]);
 		} else if (status === BATCH_STATUS_ERR) {
 			const msg = bufferIsNodeBuffer(slice)
 				? slice.toString('utf8')

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -118,10 +118,12 @@ function applyWarningFilter(result, warningFilter) {
 }
 
 // `compile` / `compileModule` are wrapped to route through the
-// raw-transfer envelope (`compileEnvelope`): the Rust side hands us
+// raw-transfer envelope: the Rust side hands us
 // one `Buffer`, the JS side lazy-decodes only the fields the caller
 // reads. This avoids the V8 string copy + `serde_json` round-trip
-// that the legacy JSON path pays for every call.
+// that the legacy JSON path pays for every call. The wrapper-only
+// native entry points leave `sourcesContent` external so the source
+// already owned by JavaScript is not copied into the envelope.
 //
 // Callers that need the raw envelope (e.g. to ship it across a worker
 // boundary without re-encoding) can still grab `binding.compileEnvelope`
@@ -136,7 +138,10 @@ function compile(source, options) {
 		);
 	}
 	const { options: resolved, warningFilter } = prepareCompileOptions(options);
-	return applyWarningFilter(decodeEnvelope(binding.compileEnvelope(source, resolved)), warningFilter);
+	return applyWarningFilter(
+		decodeEnvelope(binding.compileEnvelopeExternalSources(source, resolved), source),
+		warningFilter,
+	);
 }
 
 function compileModule(source, options) {
@@ -170,7 +175,11 @@ function compileBatch(inputs) {
 		if (warningFilter) filters[i] = warningFilter;
 		return options === input.options ? input : { source: input.source, options };
 	});
-	const results = decodeBatch(binding.compileBatch(prepared));
+	const sourceContents = prepared.map((input) => input.source);
+	const results = decodeBatch(
+		binding.compileBatchExternalSources(prepared),
+		sourceContents,
+	);
 	if (filters.length) {
 		results.forEach((result, i) => applyWarningFilter(result, filters[i]));
 	}
@@ -194,7 +203,10 @@ async function compileAsync(source, options) {
 		return applyWarningFilter(result, warningFilter);
 	}
 	return applyWarningFilter(
-		decodeEnvelope(await binding.compileEnvelopeAsync(source, resolved)),
+		decodeEnvelope(
+			await binding.compileEnvelopeExternalSourcesAsync(source, resolved),
+			source,
+		),
 		warningFilter,
 	);
 }
@@ -207,7 +219,11 @@ async function compileBatchAsync(inputs) {
 		if (warningFilter) filters[i] = warningFilter;
 		return options === input.options ? input : { source: input.source, options };
 	});
-	const results = decodeBatch(await binding.compileBatchAsync(prepared));
+	const sourceContents = prepared.map((input) => input.source);
+	const results = decodeBatch(
+		await binding.compileBatchExternalSourcesAsync(prepared),
+		sourceContents,
+	);
 	if (filters.length) {
 		results.forEach((result, i) => applyWarningFilter(result, filters[i]));
 	}

--- a/apps/npm/vite-plugin-svelte-native/index.d.ts
+++ b/apps/npm/vite-plugin-svelte-native/index.d.ts
@@ -138,9 +138,9 @@ export interface CompileResultJs {
 	map: unknown;
 	/**
 	 * Zero-copy `Buffer` / `Uint8Array` view over the raw sourcemap
-	 * JSON bytes in the envelope. `null` if no map was produced. Stable
-	 * for the lifetime of the parent `CompileResult` (becomes invalid
-	 * once a `compileEnvelopeZeroCopy` buffer is GC'd).
+	 * JSON bytes in a raw envelope. The standard `compile` wrappers
+	 * externalize the source text and materialize a complete buffer on
+	 * access instead. `null` if no map was produced.
 	 */
 	mapBytes: Buffer | Uint8Array | null;
 	/** Raw sourcemap JSON as a string — no `JSON.parse`. `null` if no map. */
@@ -214,8 +214,8 @@ export function compileModuleEnvelopeZeroCopy(
 	options?: ModuleCompileOptions,
 ): Buffer;
 
-/** Decode a buffer produced by {@link compileEnvelope}. */
-export function decodeEnvelope(buf: Buffer | Uint8Array): CompileResult;
+/** Decode an envelope, optionally restoring externally supplied source text. */
+export function decodeEnvelope(buf: Buffer | Uint8Array, sourceContent?: string): CompileResult;
 
 /**
  * Single entry in a {@link compileBatch} worklist. `options` is
@@ -249,8 +249,11 @@ export function compileBatch(
  */
 export function compileBatchRaw(inputs: CompileBatchInput[]): Buffer;
 
-/** Decode a batch envelope produced by {@link compileBatchRaw}. */
-export function decodeBatch(buf: Buffer | Uint8Array): Array<CompileResult | Error>;
+/** Decode a batch envelope, optionally restoring externally supplied source text. */
+export function decodeBatch(
+	buf: Buffer | Uint8Array,
+	sourceContents?: string[],
+): Array<CompileResult | Error>;
 
 /**
  * Async variant of {@link compile}. The Rust side runs on a libuv

--- a/apps/playground/rsvelte-shim/compiler.mjs
+++ b/apps/playground/rsvelte-shim/compiler.mjs
@@ -104,7 +104,10 @@ export function compile(source, options) {
 	// Raw-transfer fast path: NAPI hands us a single Buffer with the
 	// whole compile result packed, and `decodeEnvelope` lifts only
 	// the fields the caller reads.
-	return decodeEnvelope(binding.compileEnvelope(source, sanitiseOptions(options)));
+	return decodeEnvelope(
+		binding.compileEnvelopeExternalSources(source, sanitiseOptions(options)),
+		source,
+	);
 }
 
 export function compileModule(source, options) {

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -576,7 +576,7 @@ pub(crate) fn prepare_and_analyze(
     }
 
     // Phase 2: Analyze
-    let analysis = phases::phase2_analyze::analyze_component(ast, source, &options)?;
+    let analysis = phases::phase2_analyze::analyze_prepared_component(ast, source, &options)?;
     // Determine if runes mode was used
     let runes_mode = options.runes.unwrap_or(analysis.runes);
     Ok((options, analysis, runes_mode))
@@ -602,6 +602,16 @@ pub(crate) fn prepare_and_analyze(
 pub fn compile(source: &str, options: CompileOptions) -> Result<CompileResult, CompileError> {
     let generate = options.generate;
     crate::toolchain::PreparedComponent::new(source, options)?.compile_mode(generate)
+}
+
+#[doc(hidden)]
+pub fn compile_with_external_sourcemap_content(
+    source: &str,
+    options: CompileOptions,
+) -> Result<CompileResult, CompileError> {
+    let generate = options.generate;
+    crate::toolchain::PreparedComponent::new(source, options)?
+        .compile_mode_with_sourcemap_content(generate, false)
 }
 
 /// Compile a single component to **both** client (CSR) and server (SSR) output in
@@ -659,7 +669,9 @@ pub(crate) fn finalize_compile_result(
             map: c.map,
             has_global: analysis.css.has_global,
         }),
-        warnings: {
+        warnings: if transform_result.warnings.is_empty() {
+            Vec::new()
+        } else {
             // Pre-compute warning filename once (shared across all warnings)
             let warning_filename = options.filename.as_ref().map(|f| {
                 // Only allocate if backslashes are present
@@ -892,7 +904,8 @@ pub fn compile_module(
     let _arena_guard = unsafe { SerializeArenaGuard::new(&ast.arena as *const _) };
 
     // Phase 2: Analyze (reuses component analysis infrastructure)
-    let analysis = phases::phase2_analyze::analyze_component(&mut ast, source, &compile_options)?;
+    let analysis =
+        phases::phase2_analyze::analyze_prepared_component(&mut ast, source, &compile_options)?;
 
     // Module-specific validation: check for store subscriptions.
     // In modules, $store references (where `store` is a binding) are invalid.
@@ -922,7 +935,9 @@ pub fn compile_module(
             map: None,
         },
         css: None,
-        warnings: {
+        warnings: if analysis.warnings.is_empty() {
+            Vec::new()
+        } else {
             // One shared byte→UTF-16 position table for every module warning.
             let pos_table = legacy::Utf8ToUtf16::new(source);
             analysis
@@ -1325,6 +1340,17 @@ pub fn compile_batch(
         .collect()
 }
 
+#[doc(hidden)]
+#[cfg(feature = "native")]
+pub fn compile_batch_with_external_sourcemap_content(
+    inputs: &[(&str, CompileOptions)],
+) -> Vec<Result<CompileResult, CompileError>> {
+    inputs
+        .par_iter()
+        .map(|(source, options)| compile_with_external_sourcemap_content(source, options.clone()))
+        .collect()
+}
+
 /// Error type for compilation failures.
 #[derive(Debug)]
 pub enum CompileError {
@@ -1393,6 +1419,32 @@ mod tests {
         let options = CompileOptions::default();
         let result = compile(source, options);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_compile_can_externalize_sourcemap_content() {
+        let source = "<style>h1 { color: red }</style><h1>Hello</h1>";
+        let options = CompileOptions {
+            filename: Some("App.svelte".to_string()),
+            ..Default::default()
+        };
+
+        let embedded = compile(source, options.clone()).unwrap();
+        let externalized = compile_with_external_sourcemap_content(source, options).unwrap();
+
+        assert_eq!(externalized.js.code, embedded.js.code);
+        let js_map: serde_json::Value =
+            serde_json::from_str(externalized.js.map.as_deref().unwrap()).unwrap();
+        let css_map: serde_json::Value = serde_json::from_str(
+            externalized
+                .css
+                .as_ref()
+                .and_then(|css| css.map.as_deref())
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(js_map["sourcesContent"], serde_json::json!([null]));
+        assert_eq!(css_map["sourcesContent"], serde_json::json!([null]));
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -104,6 +104,15 @@ pub fn analyze_component(
         return Err(parse_err.into());
     }
 
+    analyze_prepared_component(ast, source, options)
+}
+
+/// Analyze an AST whose lazy expressions and deferred scripts are already resolved.
+pub(crate) fn analyze_prepared_component(
+    ast: &mut Root,
+    source: &str,
+    options: &CompileOptions,
+) -> Result<ComponentAnalysis, AnalysisError> {
     let mut analysis = ComponentAnalysis::new(source, options);
 
     // Forward parser-level warnings to the analysis warnings.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -384,7 +384,24 @@ pub fn render_stylesheet(
     source: &str,
     options: &CompileOptions,
 ) -> Result<CssOutput, TransformError> {
-    render_stylesheet_internal(analysis, ast, source, options, false)
+    render_stylesheet_internal(analysis, ast, source, options, false, true)
+}
+
+pub(crate) fn render_stylesheet_with_sourcemap_content(
+    analysis: &ComponentAnalysis,
+    ast: Option<&crate::ast::css::StyleSheet>,
+    source: &str,
+    options: &CompileOptions,
+    include_sourcemap_content: bool,
+) -> Result<CssOutput, TransformError> {
+    render_stylesheet_internal(
+        analysis,
+        ast,
+        source,
+        options,
+        false,
+        include_sourcemap_content,
+    )
 }
 
 /// Render the stylesheet for a component with optional minification.
@@ -395,7 +412,7 @@ pub fn render_stylesheet_minified(
     source: &str,
     options: &CompileOptions,
 ) -> Result<CssOutput, TransformError> {
-    render_stylesheet_internal(analysis, ast, source, options, true)
+    render_stylesheet_internal(analysis, ast, source, options, true, true)
 }
 
 /// Internal implementation of render_stylesheet with minification option.
@@ -405,6 +422,7 @@ fn render_stylesheet_internal(
     source: &str,
     options: &CompileOptions,
     minify: bool,
+    include_sourcemap_content: bool,
 ) -> Result<CssOutput, TransformError> {
     if !analysis.css.has_css || analysis.css.hash.is_empty() {
         return Ok(CssOutput {
@@ -484,7 +502,8 @@ fn render_stylesheet_internal(
         }
 
         // Generate CSS source map
-        let map = generate_css_sourcemap(source, &code, css_start, options);
+        let map =
+            generate_css_sourcemap(source, &code, css_start, options, include_sourcemap_content);
 
         Ok(CssOutput { code, map })
     }
@@ -500,6 +519,7 @@ fn generate_css_sourcemap(
     css_code: &str,
     css_start: usize,
     options: &CompileOptions,
+    include_sourcemap_content: bool,
 ) -> Option<String> {
     use super::js_ast::codegen::{
         SourceMapping, build_line_starts, encode_vlq_mappings, generate_sourcemap_json,
@@ -637,7 +657,7 @@ fn generate_css_sourcemap(
     Some(generate_sourcemap_json(
         &file_name,
         &source_name,
-        source,
+        include_sourcemap_content.then_some(source),
         &mappings_str,
         &[],
     ))

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -2642,11 +2642,11 @@ fn get_basename(path: &str) -> &str {
 pub fn generate_sourcemap_json(
     file: &str,
     source_name: &str,
-    source_content: &str,
+    source_content: Option<&str>,
     mappings: &str,
     names: &[&str],
 ) -> String {
-    let mut json = String::with_capacity(256 + source_content.len() + mappings.len());
+    let mut json = String::with_capacity(256 + source_content.map_or(0, str::len) + mappings.len());
     json.push_str("{\"version\":3");
     json.push_str(",\"file\":\"");
     json_escape_str(&mut json, file);
@@ -2654,9 +2654,15 @@ pub fn generate_sourcemap_json(
     json.push_str(",\"sources\":[\"");
     json_escape_str(&mut json, source_name);
     json.push_str("\"]");
-    json.push_str(",\"sourcesContent\":[\"");
-    json_escape_str(&mut json, source_content);
-    json.push_str("\"]");
+    json.push_str(",\"sourcesContent\":[");
+    if let Some(source_content) = source_content {
+        json.push('"');
+        json_escape_str(&mut json, source_content);
+        json.push('"');
+    } else {
+        json.push_str("null");
+    }
+    json.push(']');
     json.push_str(",\"names\":[");
     for (i, name) in names.iter().enumerate() {
         if i > 0 {
@@ -2976,6 +2982,21 @@ pub fn generate_sourcemap_json_multi(
 mod tests {
     use super::*;
     use crate::compiler::phases::phase3_transform::js_ast::builders::*;
+
+    #[test]
+    fn sourcemap_can_externalize_single_source_content() {
+        let json = generate_sourcemap_json("out.js", "App.svelte", None, "AAAA", &[]);
+        let map: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(map["sourcesContent"], serde_json::json!([null]));
+    }
+
+    #[test]
+    fn sourcemap_preserves_embedded_source_content() {
+        let json =
+            generate_sourcemap_json("out.js", "App.svelte", Some("<h1>\"x\"</h1>"), "AAAA", &[]);
+        let map: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(map["sourcesContent"], serde_json::json!(["<h1>\"x\"</h1>"]));
+    }
 
     #[test]
     fn test_simple_program() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -85,6 +85,16 @@ pub fn transform_component(
     source: &str,
     options: &CompileOptions,
 ) -> Result<TransformResult, TransformError> {
+    transform_component_with_sourcemap_content(analysis, ast, source, options, true)
+}
+
+pub(crate) fn transform_component_with_sourcemap_content(
+    analysis: &ComponentAnalysis,
+    ast: &Root,
+    source: &str,
+    options: &CompileOptions,
+    include_sourcemap_content: bool,
+) -> Result<TransformResult, TransformError> {
     use js_ast::codegen::{
         SourceMapping, encode_vlq_mappings, generate_sourcemap_json, get_source_name,
         remap_through_sourcemap,
@@ -216,7 +226,13 @@ pub fn transform_component(
 
     let css = if analysis.css.has_css && !analysis.inject_styles {
         let _css_start = profile::timer_start();
-        let mut css_output = css::render_stylesheet(analysis, ast.css.as_deref(), source, options)?;
+        let mut css_output = css::render_stylesheet_with_sourcemap_content(
+            analysis,
+            ast.css.as_deref(),
+            source,
+            options,
+            include_sourcemap_content,
+        )?;
         profile::record_css_render(profile::timer_elapsed(_css_start));
         // Apply preprocessor source map composition to CSS map if needed
         if let Some(ref pp_map_json) = options.sourcemap
@@ -435,7 +451,7 @@ pub fn transform_component(
                         Some(generate_sourcemap_json(
                             &file_name,
                             &multi_sources[0],
-                            content,
+                            include_sourcemap_content.then_some(content),
                             &mappings_str,
                             &names_refs,
                         ))
@@ -462,7 +478,7 @@ pub fn transform_component(
                     Some(generate_sourcemap_json(
                         &file_name,
                         &source_name,
-                        content,
+                        include_sourcemap_content.then_some(content),
                         &mappings_str,
                         &names_refs,
                     ))
@@ -471,7 +487,7 @@ pub fn transform_component(
                 Some(generate_sourcemap_json(
                     &file_name,
                     &source_name,
-                    source,
+                    include_sourcemap_content.then_some(source),
                     &mappings_str,
                     &[],
                 ))
@@ -509,7 +525,7 @@ pub fn transform_component(
                 Some(generate_sourcemap_json(
                     &file_name,
                     &source_name,
-                    source,
+                    include_sourcemap_content.then_some(source),
                     &mappings_str,
                     &[],
                 ))
@@ -627,11 +643,11 @@ pub(crate) fn remap_css_sourcemap(
     generate_sourcemap_json(
         file_name,
         &source_name,
-        if original_content.is_empty() {
+        Some(if original_content.is_empty() {
             ""
         } else {
             original_content
-        },
+        }),
         &mappings_str,
         &names_refs,
     )

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/template.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/template.rs
@@ -3,20 +3,48 @@
 //! Common functions for building HTML templates, escaping content,
 //! and handling void elements.
 
+use std::borrow::Cow;
+
+use memchr::{memchr2, memchr3};
+
 /// Escape HTML special characters for safe insertion into HTML content.
-pub fn escape_html(s: &str) -> String {
-    // Only escape & and < for HTML content (not >)
-    // This matches the official Svelte compiler's CONTENT_REGEX = /[&<]/g
-    s.replace('&', "&amp;").replace('<', "&lt;")
+pub fn escape_html(s: &str) -> Cow<'_, str> {
+    escape(s, false)
 }
 
 /// Escape attribute value special characters.
-pub fn escape_attr(s: &str) -> String {
-    // Only escape &, ", and < for attributes (not >)
-    // This matches the official Svelte compiler's ATTR_REGEX = /[&"<]/g
-    s.replace('&', "&amp;")
-        .replace('"', "&quot;")
-        .replace('<', "&lt;")
+pub fn escape_attr(s: &str) -> Cow<'_, str> {
+    escape(s, true)
+}
+
+fn escape(s: &str, attribute: bool) -> Cow<'_, str> {
+    let bytes = s.as_bytes();
+    let find = |haystack: &[u8]| {
+        if attribute {
+            memchr3(b'&', b'<', b'"', haystack)
+        } else {
+            memchr2(b'&', b'<', haystack)
+        }
+    };
+    let Some(first) = find(bytes) else {
+        return Cow::Borrowed(s);
+    };
+
+    let mut escaped = String::with_capacity(s.len() + 8);
+    escaped.push_str(&s[..first]);
+    let mut start = first;
+    while let Some(offset) = find(&bytes[start..]) {
+        let position = start + offset;
+        escaped.push_str(&s[start..position]);
+        escaped.push_str(match bytes[position] {
+            b'&' => "&amp;",
+            b'<' => "&lt;",
+            _ => "&quot;",
+        });
+        start = position + 1;
+    }
+    escaped.push_str(&s[start..]);
+    Cow::Owned(escaped)
 }
 
 /// Check if an element is a void element (self-closing, no end tag).
@@ -131,6 +159,7 @@ mod tests {
         assert_eq!(escape_html("<div>"), "&lt;div>");
         assert_eq!(escape_html("a & b"), "a &amp; b");
         assert_eq!(escape_html("hello"), "hello");
+        assert!(matches!(escape_html("hello"), Cow::Borrowed(_)));
     }
 
     #[test]
@@ -138,6 +167,7 @@ mod tests {
         assert_eq!(escape_attr("\"quoted\""), "&quot;quoted&quot;");
         // Official Svelte ATTR_REGEX = /[&"<]/g - does NOT escape >
         assert_eq!(escape_attr("<tag>"), "&lt;tag>");
+        assert!(matches!(escape_attr("plain"), Cow::Borrowed(_)));
     }
 
     #[test]

--- a/crates/rsvelte_core/src/toolchain.rs
+++ b/crates/rsvelte_core/src/toolchain.rs
@@ -10,7 +10,10 @@ use crate::{
     ast::{AttributeValue, AttributeValuePart, Root, ScriptContext},
     compiler::{
         ComponentAnalysis,
-        phases::{phase2_analyze::BindingKind, phase3_transform::transform_component},
+        phases::{
+            phase2_analyze::BindingKind,
+            phase3_transform::{transform_component, transform_component_with_sourcemap_content},
+        },
     },
     svelte2tsx::{Svelte2TsxError, Svelte2TsxOptions, svelte2tsx},
 };
@@ -437,14 +440,32 @@ impl<'source> PreparedComponent<'source> {
         &mut self,
         generate: GenerateMode,
     ) -> Result<CompileResult, CompileError> {
+        self.compile_mode_with_sourcemap_content(generate, true)
+    }
+
+    pub(crate) fn compile_mode_with_sourcemap_content(
+        &mut self,
+        generate: GenerateMode,
+        include_sourcemap_content: bool,
+    ) -> Result<CompileResult, CompileError> {
         // SAFETY: `self.ast` cannot move for the duration of this mutable borrow.
         let _arena_guard =
             unsafe { crate::ast::arena::SerializeArenaGuard::new(&self.ast.arena as *const _) };
         let mut options = self.options.clone();
         options.generate = generate;
-        let transform_result =
+        let include_sourcemap_content = include_sourcemap_content || options.sourcemap.is_some();
+        let transform_result = if include_sourcemap_content {
             transform_component(&self.analysis, &self.ast, self.source, &options)
-                .map_err(CompileError::from)?;
+        } else {
+            transform_component_with_sourcemap_content(
+                &self.analysis,
+                &self.ast,
+                self.source,
+                &options,
+                false,
+            )
+        }
+        .map_err(CompileError::from)?;
         Ok(crate::compiler::finalize_compile_result(
             transform_result,
             &self.analysis,

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -52,6 +52,7 @@ use serde_json::Value;
 use rsvelte_core::compiler::{
     CompileOptions, CssMode, ExperimentalOptions, GenerateMode, ModuleCompileOptions, Namespace,
     compile as rust_compile, compile_module as rust_compile_module,
+    compile_with_external_sourcemap_content as rust_compile_with_external_sourcemap_content,
 };
 use rsvelte_core::svelte2tsx::{
     Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion,
@@ -1615,7 +1616,29 @@ pub fn napi_compile_envelope(
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<Buffer> {
     let opts = options_to_compile(options)?;
-    match rust_compile(&source, opts) {
+    compile_envelope(&source, opts, false)
+}
+
+#[napi(js_name = "compileEnvelopeExternalSources")]
+pub fn napi_compile_envelope_external_sources(
+    source: String,
+    options: Option<NapiCompileOptions>,
+) -> napi::Result<Buffer> {
+    let opts = options_to_compile(options)?;
+    compile_envelope(&source, opts, true)
+}
+
+fn compile_envelope(
+    source: &str,
+    options: CompileOptions,
+    externalize_sourcemap_content: bool,
+) -> napi::Result<Buffer> {
+    let result = if externalize_sourcemap_content {
+        rust_compile_with_external_sourcemap_content(source, options)
+    } else {
+        rust_compile(source, options)
+    };
+    match result {
         Ok(result) => {
             ensure_envelope_size(rsvelte_core::napi_raw::estimate_size(&result))?;
             Ok(Buffer::from(rsvelte_core::napi_raw::encode_to_vec(&result)))
@@ -1814,6 +1837,18 @@ pub struct CompileBatchInput {
 /// byte format.
 #[napi(js_name = "compileBatch")]
 pub fn napi_compile_batch(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer> {
+    compile_batch_envelope(inputs, false)
+}
+
+#[napi(js_name = "compileBatchExternalSources")]
+pub fn napi_compile_batch_external_sources(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer> {
+    compile_batch_envelope(inputs, true)
+}
+
+fn compile_batch_envelope(
+    inputs: Vec<CompileBatchInput>,
+    externalize_sourcemap_content: bool,
+) -> napi::Result<Buffer> {
     // Convert each entry's typed options up front. The conversion is
     // pure (no NAPI touchpoint) so it could in principle run in
     // parallel, but the per-call work is trivial and this keeps the
@@ -1829,7 +1864,11 @@ pub fn napi_compile_batch(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer
         .iter()
         .map(|(s, o)| (s.as_str(), o.clone()))
         .collect();
-    let results = rsvelte_core::compiler::compile_batch(&borrowed);
+    let results = if externalize_sourcemap_content {
+        rsvelte_core::compiler::compile_batch_with_external_sourcemap_content(&borrowed)
+    } else {
+        rsvelte_core::compiler::compile_batch(&borrowed)
+    };
 
     // Build the BatchEntry view over the results so the encoder can
     // walk them without taking ownership. Error messages format
@@ -1884,6 +1923,7 @@ use napi::bindgen_prelude::AsyncTask;
 pub struct CompileEnvelopeTask {
     source: String,
     options: CompileOptions,
+    externalize_sourcemap_content: bool,
 }
 
 impl Task for CompileEnvelopeTask {
@@ -1895,8 +1935,12 @@ impl Task for CompileEnvelopeTask {
         // `CompileOptions` isn't `Default`-cheap (the css_hash Arc
         // field has to be re-Arc'd). Clone is fine here — options are
         // small and we only pay it once per call.
-        let result = rust_compile(&self.source, self.options.clone())
-            .map_err(|e| napi::Error::from_reason(format!("{e:?}")))?;
+        let result = if self.externalize_sourcemap_content {
+            rust_compile_with_external_sourcemap_content(&self.source, self.options.clone())
+        } else {
+            rust_compile(&self.source, self.options.clone())
+        }
+        .map_err(|e| napi::Error::from_reason(format!("{e:?}")))?;
         ensure_envelope_size(rsvelte_core::napi_raw::estimate_size(&result))?;
         Ok(rsvelte_core::napi_raw::encode_to_vec(&result))
     }
@@ -1917,6 +1961,19 @@ pub fn napi_compile_envelope_async(
     Ok(AsyncTask::new(CompileEnvelopeTask {
         source,
         options: options_to_compile(options)?,
+        externalize_sourcemap_content: false,
+    }))
+}
+
+#[napi(js_name = "compileEnvelopeExternalSourcesAsync")]
+pub fn napi_compile_envelope_external_sources_async(
+    source: String,
+    options: Option<NapiCompileOptions>,
+) -> napi::Result<AsyncTask<CompileEnvelopeTask>> {
+    Ok(AsyncTask::new(CompileEnvelopeTask {
+        source,
+        options: options_to_compile(options)?,
+        externalize_sourcemap_content: true,
     }))
 }
 
@@ -1924,6 +1981,7 @@ pub fn napi_compile_envelope_async(
 /// `par_iter`) on the worker thread, same RSVB envelope back.
 pub struct CompileBatchTask {
     inputs: Vec<(String, CompileOptions)>,
+    externalize_sourcemap_content: bool,
 }
 
 impl Task for CompileBatchTask {
@@ -1936,7 +1994,11 @@ impl Task for CompileBatchTask {
             .iter()
             .map(|(s, o)| (s.as_str(), o.clone()))
             .collect();
-        let results = rsvelte_core::compiler::compile_batch(&borrowed);
+        let results = if self.externalize_sourcemap_content {
+            rsvelte_core::compiler::compile_batch_with_external_sourcemap_content(&borrowed)
+        } else {
+            rsvelte_core::compiler::compile_batch(&borrowed)
+        };
         let err_strings: Vec<Option<String>> = results
             .iter()
             .map(|r| match r {
@@ -1967,9 +2029,26 @@ impl Task for CompileBatchTask {
 pub fn napi_compile_batch_async(
     inputs: Vec<CompileBatchInput>,
 ) -> napi::Result<AsyncTask<CompileBatchTask>> {
+    compile_batch_async_task(inputs, false)
+}
+
+#[napi(js_name = "compileBatchExternalSourcesAsync")]
+pub fn napi_compile_batch_external_sources_async(
+    inputs: Vec<CompileBatchInput>,
+) -> napi::Result<AsyncTask<CompileBatchTask>> {
+    compile_batch_async_task(inputs, true)
+}
+
+fn compile_batch_async_task(
+    inputs: Vec<CompileBatchInput>,
+    externalize_sourcemap_content: bool,
+) -> napi::Result<AsyncTask<CompileBatchTask>> {
     let parsed: Vec<(String, CompileOptions)> = inputs
         .into_iter()
         .map(|item| Ok((item.source, options_to_compile(item.options)?)))
         .collect::<napi::Result<_>>()?;
-    Ok(AsyncTask::new(CompileBatchTask { inputs: parsed }))
+    Ok(AsyncTask::new(CompileBatchTask {
+        inputs: parsed,
+        externalize_sourcemap_content,
+    }))
 }

--- a/scripts/dev/test-vps-shim.mjs
+++ b/scripts/dev/test-vps-shim.mjs
@@ -40,7 +40,9 @@ function assert(label, cond, extra = '') {
 }
 
 // 1. compile() — the hot path of the Vite `transform` hook
-const compiled = r.compile('<h1>{name}</h1>', {
+const compileSource =
+	"<style>h1 { color: red }</style><script>const markers = \"$& $` $'\";</script><h1>{name}</h1>";
+const compiled = r.compile(compileSource, {
 	filename: 'Foo.svelte',
 	generate: 'client',
 });
@@ -49,6 +51,59 @@ assert(
 	typeof compiled?.js?.code === 'string' && compiled.js.code.length > 0,
 );
 assert('compile() returns source map', compiled?.js?.map != null);
+assert(
+	'compile() restores JS sourcesContent',
+	compiled?.js?.map?.sourcesContent?.[0] === compileSource,
+);
+assert(
+	'compile() restores CSS sourcesContent',
+	compiled?.css?.map?.sourcesContent?.[0] === compileSource,
+);
+
+const rawCompile = r.compileEnvelope(compileSource, {
+	filename: 'Foo.svelte',
+	generate: 'client',
+});
+assert(
+	'raw envelope preserves sourcesContent',
+	r.decodeEnvelope(rawCompile)?.js?.map?.sourcesContent?.[0] === compileSource,
+);
+assert(
+	'compile() mapText restores sourcesContent',
+	JSON.parse(compiled?.js?.mapText)?.sourcesContent?.[0] === compileSource,
+);
+assert(
+	'compile() mapBytes restores sourcesContent',
+	JSON.parse(compiled?.js?.mapBytes.toString('utf8'))?.sourcesContent?.[0] === compileSource,
+);
+
+const [batchCompiled] = r.compileBatch([
+	{ source: compileSource, options: { filename: 'Foo.svelte', generate: 'client' } },
+]);
+assert(
+	'compileBatch() restores sourcesContent',
+	batchCompiled?.js?.map?.sourcesContent?.[0] === compileSource,
+);
+
+const asyncCompiled = await r.compileAsync(compileSource, {
+	filename: 'Foo.svelte',
+	generate: 'client',
+});
+assert(
+	'compileAsync() restores sourcesContent',
+	asyncCompiled?.js?.map?.sourcesContent?.[0] === compileSource,
+);
+
+const asyncBatchInputs = [
+	{ source: compileSource, options: { filename: 'Foo.svelte', generate: 'client' } },
+];
+const asyncBatchPromise = r.compileBatchAsync(asyncBatchInputs);
+asyncBatchInputs[0].source = '<p>mutated after dispatch</p>';
+const [asyncBatchCompiled] = await asyncBatchPromise;
+assert(
+	'compileBatchAsync() snapshots sourcesContent',
+	asyncBatchCompiled?.js?.map?.sourcesContent?.[0] === compileSource,
+);
 
 // 2. compileModule() — used by the `.svelte.js` / `.svelte.ts` path
 const m = r.compileModule('export const x = $state(0);', {


### PR DESCRIPTION
## What changed

- avoid repeating lazy-expression/deferred-script preparation before analysis
- return immediately when no warnings need filename/UTF-16 position work
- borrow unchanged template strings and use `memchr`-based single-pass escaping
- keep source-map source text outside wrapper-managed N-API envelopes, then restore it lazily in JavaScript
- preserve the existing raw envelope APIs with embedded `sourcesContent`
- snapshot async batch sources before awaiting native compilation

## Why

Profiling against `svelte-rs` showed rsvelte still pays avoidable repeated setup, string allocations, and source-text copies on the serial compile path. The source map was especially wasteful at the N-API boundary because JavaScript already owns the exact source string.

On a deterministic 22,000-byte static component, the full envelope was 44,493 bytes and the wrapper-managed external-source envelope was 22,495 bytes (49.4% smaller). This is an envelope-size measurement, not a claim of an equivalent end-to-end speedup.

## Compatibility

The public `compile`, batch, and async wrappers still return complete source maps. Low-level `compileEnvelope`, zero-copy, batch-raw, and async-raw APIs retain their previous self-contained envelope format. Preprocessor source maps also keep their original `sourcesContent` embedded.

## Validation

- `cargo test -p rsvelte_core --lib` — 1493 passed, 1 ignored
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `node scripts/dev/test-vps-shim.mjs` — 56 passed
- `node scripts/dev/test-envelope-validation.mjs`
- changed JavaScript files pass `node --check`
- independent diff review of core/N-API/raw compatibility and source-map restoration
