### PR TITLE
perf(compiler): remove serial compile bottlenecks

### DIFF
--- a/.changeset/quick-cats-smile.md
+++ b/.changeset/quick-cats-smile.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+Reduce serial compile overhead and make static CSS sibling analysis linear in the number of elements.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -524,10 +524,16 @@ pub(crate) fn prepare_and_analyze(
     source: &str,
     mut options: CompileOptions,
 ) -> Result<(CompileOptions, ComponentAnalysis, bool), CompileError> {
+    let line_offsets = phases::phase1_parse::compute_line_offsets(source, false);
+
     // Resolve lazy expressions (deferred template expressions). If any
     // expression has a parse error, return it immediately.
     if let Some(parse_err) =
-        phases::phase1_parse::resolve_lazy::resolve_lazy_expressions(ast, source)
+        phases::phase1_parse::resolve_lazy::resolve_lazy_expressions_with_line_offsets(
+            ast,
+            source,
+            &line_offsets,
+        )
     {
         return Err(parse_err.into());
     }
@@ -536,7 +542,6 @@ pub(crate) fn prepare_and_analyze(
     // When defer_script_parse is enabled, script content is stored as raw text;
     // parse it first so remove_typescript_nodes can inspect the AST.
     {
-        let line_offsets = phases::phase1_parse::compute_line_offsets(source, false);
         if let Some(ref mut instance) = ast.instance
             && let Some(parse_err) = phases::phase1_parse::read::script::ensure_script_parsed(
                 &ast.arena,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
@@ -18,11 +18,19 @@ pub fn resolve_lazy_expressions<'a>(
     source: &str,
 ) -> Option<crate::error::ParseError> {
     let line_offsets = super::compute_line_offsets(source, false);
+    resolve_lazy_expressions_with_line_offsets(ast, source, &line_offsets)
+}
+
+pub(crate) fn resolve_lazy_expressions_with_line_offsets<'a>(
+    ast: &mut Root<'a>,
+    source: &str,
+    line_offsets: &[usize],
+) -> Option<crate::error::ParseError> {
     let mut first_error = None;
     resolve_fragment(
         &ast.arena,
         &mut ast.fragment,
-        &line_offsets,
+        line_offsets,
         source,
         &mut first_error,
     );
@@ -32,7 +40,7 @@ pub fn resolve_lazy_expressions<'a>(
         resolve_expression(
             &ast.arena,
             &mut instance.content,
-            &line_offsets,
+            line_offsets,
             source,
             &mut first_error,
         );
@@ -41,7 +49,7 @@ pub fn resolve_lazy_expressions<'a>(
         resolve_expression(
             &ast.arena,
             &mut module.content,
-            &line_offsets,
+            line_offsets,
             source,
             &mut first_error,
         );

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/control_flow.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/control_flow.rs
@@ -9,6 +9,46 @@ use super::types::{DomStructure, SiblingCertainty};
 use crate::ast::template::{Attribute, Fragment, TemplateNode};
 use rustc_hash::FxHashMap;
 
+pub fn stylesheet_has_sibling_combinator(stylesheet: &crate::ast::css::StyleSheet) -> bool {
+    let mut pending: Vec<&serde_json::Value> = stylesheet.children.iter().collect();
+    while let Some(value) = pending.pop() {
+        match value {
+            serde_json::Value::Object(object) => {
+                if object.get("type").and_then(serde_json::Value::as_str) == Some("Combinator")
+                    && object
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(|name| matches!(name, "+" | "~"))
+                {
+                    return true;
+                }
+                pending.extend(object.values());
+            }
+            serde_json::Value::Array(values) => pending.extend(values),
+            _ => {}
+        }
+    }
+    false
+}
+
+pub fn supports_static_sibling_relationships(fragment: &Fragment) -> bool {
+    let mut pending = vec![fragment];
+    while let Some(fragment) = pending.pop() {
+        for node in &fragment.nodes {
+            match node {
+                TemplateNode::RegularElement(element) => pending.push(&element.fragment),
+                TemplateNode::Text(_)
+                | TemplateNode::Comment(_)
+                | TemplateNode::ExpressionTag(_)
+                | TemplateNode::ConstTag(_)
+                | TemplateNode::DebugTag(_) => {}
+                _ => return false,
+            }
+        }
+    }
+    true
+}
+
 /// Node existence values, mirroring Svelte's NODE_DEFINITELY_EXISTS / NODE_PROBABLY_EXISTS.
 const NODE_DEFINITELY_EXISTS: u8 = 1;
 const NODE_PROBABLY_EXISTS: u8 = 2;
@@ -73,6 +113,28 @@ pub fn build_sibling_relationships(dom_structure: &mut DomStructure, root_fragme
     // Third pass: mark elements that are adjacent to opaque boundaries
     // (slots, render tags, components). This is used for :global(X) + Y detection.
     mark_opaque_boundary_adjacency(dom_structure, root_fragment, &node_to_dom_idx);
+}
+
+pub fn build_static_sibling_relationships(dom_structure: &mut DomStructure) {
+    let mut previous_by_parent: FxHashMap<Option<usize>, usize> = FxHashMap::default();
+    for current_idx in 0..dom_structure.elements.len() {
+        let parent_idx = dom_structure.elements[current_idx].parent_idx;
+        if let Some(previous_idx) = previous_by_parent.insert(parent_idx, current_idx) {
+            dom_structure.elements[current_idx]
+                .possible_prev_adjacent
+                .push((previous_idx, SiblingCertainty::Definite));
+            dom_structure.elements[current_idx]
+                .possible_prev_general
+                .push((previous_idx, SiblingCertainty::Definite));
+            dom_structure.elements[previous_idx]
+                .possible_next_adjacent
+                .push((current_idx, SiblingCertainty::Definite));
+            dom_structure.elements[previous_idx]
+                .possible_next_general
+                .push((current_idx, SiblingCertainty::Definite));
+        }
+    }
+    dom_structure.general_siblings_linked = true;
 }
 
 /// Convert results map to Vec of (dom_idx, certainty) pairs.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
@@ -3379,6 +3379,111 @@ fn selector_contains_complex_not(selector: &CssComplexSelector) -> bool {
     selector.children.iter().any(rel_has)
 }
 
+fn relative_supports_static_sibling_match(rel: &CssRelativeSelector) -> bool {
+    rel.selectors.iter().all(|selector| match selector {
+        CssSimpleSelector::PseudoClass(name, args) => match name.as_str() {
+            "has" | "global" | "is" | "where" => false,
+            "not" => !args
+                .as_ref()
+                .is_some_and(|args| args.iter().any(|selector| selector.children.len() > 1)),
+            _ => true,
+        },
+        _ => true,
+    })
+}
+
+fn static_relative_might_apply(graph: &SGraph, rel: &CssRelativeSelector, node: usize) -> bool {
+    let Some(elem) = graph.node(node).elem.as_ref() else {
+        return false;
+    };
+
+    for selector in &rel.selectors {
+        match selector {
+            CssSimpleSelector::PseudoClass(name, _) => {
+                if name == "host" || name == "root" {
+                    return false;
+                }
+            }
+            CssSimpleSelector::PseudoElement | CssSimpleSelector::Nesting => {}
+            simple => {
+                if !element_matches_simple_selectors(elem, std::slice::from_ref(simple)) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    true
+}
+
+fn process_static_two_part_sibling_selector(
+    graph: &SGraph,
+    selector: &[CssRelativeSelector],
+    marks: &mut FxHashSet<(u32, u32)>,
+) -> bool {
+    if selector.len() != 2
+        || selector[0].combinator.is_some()
+        || !matches!(selector[1].combinator.as_deref(), Some("+") | Some("~"))
+        || !selector.iter().all(relative_supports_static_sibling_match)
+        || graph.nodes.iter().any(|node| {
+            !matches!(node.kind, SKind::Root | SKind::Regular) || node.has_slot_attribute
+        })
+    {
+        return false;
+    }
+
+    let mark = |marks: &mut FxHashSet<(u32, u32)>, node: &SNode| {
+        marks.insert((node.start, node.end));
+    };
+
+    for fragment in graph
+        .nodes
+        .iter()
+        .flat_map(|node| node.fragments.iter().flatten())
+    {
+        if fragment.len() < 2 {
+            continue;
+        }
+
+        let left: Vec<bool> = fragment
+            .iter()
+            .map(|node| static_relative_might_apply(graph, &selector[0], *node))
+            .collect();
+        let right: Vec<bool> = fragment
+            .iter()
+            .map(|node| static_relative_might_apply(graph, &selector[1], *node))
+            .collect();
+
+        if selector[1].combinator.as_deref() == Some("+") {
+            for index in 1..fragment.len() {
+                if left[index - 1] && right[index] {
+                    mark(marks, graph.node(fragment[index - 1]));
+                    mark(marks, graph.node(fragment[index]));
+                }
+            }
+            continue;
+        }
+
+        let mut has_left_before = false;
+        for index in 0..fragment.len() {
+            if right[index] && has_left_before {
+                mark(marks, graph.node(fragment[index]));
+            }
+            has_left_before |= left[index];
+        }
+
+        let mut has_right_after = false;
+        for index in (0..fragment.len()).rev() {
+            if left[index] && has_right_after {
+                mark(marks, graph.node(fragment[index]));
+            }
+            has_right_after |= right[index];
+        }
+    }
+
+    true
+}
+
 /// Run the graph-based pass: every element in the template is tested against
 /// every sibling-combinator / `:has` selector via the faithful
 /// `apply_selector` port; matched elements (subjects, siblings, ancestors and
@@ -3402,18 +3507,20 @@ fn process_graph_selectors(
     }
 
     let graph = build_sgraph(fragment, analysis);
-    let mut matcher = GMatcher {
-        graph: &graph,
-        marks,
-    };
-
-    for id in 0..matcher.graph.nodes.len() {
-        if matcher.graph.node(id).elem.is_none() {
+    for selector in graph_selectors {
+        let effective = truncate_globals(&selector.children);
+        if effective.is_empty()
+            || process_static_two_part_sibling_selector(&graph, effective, marks)
+        {
             continue;
         }
-        for selector in &graph_selectors {
-            let effective = truncate_globals(&selector.children);
-            if effective.is_empty() {
+
+        let mut matcher = GMatcher {
+            graph: &graph,
+            marks,
+        };
+        for id in 0..matcher.graph.nodes.len() {
+            if matcher.graph.node(id).elem.is_none() {
                 continue;
             }
             matcher.apply_selector(effective, 0, effective.len(), id, Dir::Backward);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -76,7 +76,11 @@ pub fn analyze_component(
     // Resolve deferred lazy expressions in template AST
     // If any expression has a parse error, return it immediately
     if let Some(parse_err) =
-        crate::compiler::phases::phase1_parse::resolve_lazy::resolve_lazy_expressions(ast, source)
+        crate::compiler::phases::phase1_parse::resolve_lazy::resolve_lazy_expressions_with_line_offsets(
+            ast,
+            source,
+            &line_offsets,
+        )
     {
         return Err(parse_err.into());
     }
@@ -114,6 +118,7 @@ pub(crate) fn analyze_prepared_component(
     options: &CompileOptions,
 ) -> Result<ComponentAnalysis, AnalysisError> {
     let mut analysis = ComponentAnalysis::new(source, options);
+    analysis.css.has_css = ast.css.is_some();
 
     // Forward parser-level warnings to the analysis warnings.
     // These include warnings like `element_implicitly_closed` that are
@@ -609,9 +614,20 @@ pub(crate) fn analyze_prepared_component(
         mark_each_block_group_bindings(&mut ast.fragment, &mut index_counter, &mut analysis);
     }
 
-    // Build sibling relationships for CSS analysis
-    // This must happen after template analysis builds the DOM structure
-    control_flow::build_sibling_relationships(&mut analysis.css.dom_structure, &ast.fragment);
+    if ast
+        .css
+        .as_deref()
+        .is_some_and(control_flow::stylesheet_has_sibling_combinator)
+    {
+        if control_flow::supports_static_sibling_relationships(&ast.fragment) {
+            control_flow::build_static_sibling_relationships(&mut analysis.css.dom_structure);
+        } else {
+            control_flow::build_sibling_relationships(
+                &mut analysis.css.dom_structure,
+                &ast.fragment,
+            );
+        }
+    }
 
     // In runes mode, warn on any nonstate declarations that are:
     // a) reassigned and b) referenced in the template

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -100,6 +100,15 @@ impl ScriptContent {
             raw
         };
 
+        if !raw.as_bytes().contains(&b'$') {
+            return Self {
+                raw,
+                start,
+                end,
+                uses_runes: false,
+            };
+        }
+
         // Extract imported names to avoid false-positive rune detection.
         // If `state` is imported (e.g., `import { state } from './store'`), then
         // `$state` is a store subscription, not a rune call.
@@ -2404,6 +2413,7 @@ pub struct CssAnalysis {
 pub struct DomStructure {
     /// All elements in the template, with their relationships
     pub elements: Vec<CssDomElement>,
+    pub general_siblings_linked: bool,
 }
 
 /// Certainty level of sibling relationships.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -80,7 +80,7 @@ mod update_expression;
 mod variable_declarator;
 
 use super::AnalysisError;
-use super::types::{ComponentAnalysis, CssDomElement, DomStructure, SiblingCertainty};
+use super::types::{ComponentAnalysis, CssDomElement};
 use crate::ast::arena::ParseArena;
 use crate::ast::template::{Root, TemplateNode};
 
@@ -668,9 +668,6 @@ pub fn analyze_template(
     context.scope = instance_scope_index;
     fragment::analyze(&mut ast.fragment, &mut context)?;
 
-    // Build sibling relationships for CSS sibling combinator detection
-    build_sibling_relationships(&mut context.analysis.css.dom_structure);
-
     // Check for mixed event handler syntaxes (on:event and onevent mixed)
     if let Some(ref event_name) = context.event_directive_node
         && context.uses_event_attributes
@@ -738,67 +735,4 @@ pub fn visit_node<'a, 'b: 'a>(
     };
     context.path.pop();
     result
-}
-
-/// Build sibling relationships for CSS sibling combinator detection.
-/// This populates possible_prev_adjacent, possible_next_adjacent,
-/// possible_prev_general, and possible_next_general fields in CssDomElement.
-fn build_sibling_relationships(dom_structure: &mut DomStructure) {
-    // Group elements by their parent
-    let mut parent_children: rustc_hash::FxHashMap<Option<usize>, Vec<usize>> =
-        rustc_hash::FxHashMap::default();
-
-    for (idx, element) in dom_structure.elements.iter().enumerate() {
-        parent_children
-            .entry(element.parent_idx)
-            .or_default()
-            .push(idx);
-    }
-
-    // For each parent, build sibling relationships among its children
-    for children_indices in parent_children.values() {
-        if children_indices.len() < 2 {
-            continue; // No siblings if only one child
-        }
-
-        // Build adjacent sibling relationships (+ combinator)
-        for i in 0..children_indices.len() {
-            let current_idx = children_indices[i];
-
-            // Previous adjacent sibling
-            if i > 0 {
-                let prev_idx = children_indices[i - 1];
-                dom_structure.elements[current_idx]
-                    .possible_prev_adjacent
-                    .push((prev_idx, SiblingCertainty::Definite));
-            }
-
-            // Next adjacent sibling
-            if i < children_indices.len() - 1 {
-                let next_idx = children_indices[i + 1];
-                dom_structure.elements[current_idx]
-                    .possible_next_adjacent
-                    .push((next_idx, SiblingCertainty::Definite));
-            }
-        }
-
-        // Build general sibling relationships (~ combinator)
-        for i in 0..children_indices.len() {
-            let current_idx = children_indices[i];
-
-            // All previous siblings
-            for &prev_idx in children_indices.iter().take(i) {
-                dom_structure.elements[current_idx]
-                    .possible_prev_general
-                    .push((prev_idx, SiblingCertainty::Definite));
-            }
-
-            // All next siblings
-            for &next_idx in children_indices.iter().skip(i + 1) {
-                dom_structure.elements[current_idx]
-                    .possible_next_general
-                    .push((next_idx, SiblingCertainty::Definite));
-            }
-        }
-    }
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -427,18 +427,10 @@ pub fn visit<'a, 'b: 'a>(
     // and pushes to context.state.analysis.elements
     // We'll track this in context.analysis directly for now
 
-    // Track element name for CSS unused selector detection
-    context
-        .analysis
-        .css
-        .used_elements
-        .insert(element.name.to_string());
-
-    // Build DOM structure for CSS sibling combinator detection
+    let collect_css = context.analysis.css.has_css;
     let parent_idx = context.current_parent_idx();
     let is_root_child = parent_idx.is_none();
 
-    // Extract classes and ID from attributes
     let mut element_classes = FxHashSet::default();
     let mut element_id: Option<String> = None;
     let mut static_attributes: Vec<(String, Option<String>)> = Vec::new();
@@ -448,213 +440,242 @@ pub fn visit<'a, 'b: 'a>(
     let mut class_directive_names: FxHashSet<String> = FxHashSet::default();
     let mut has_style_directive = false;
 
-    // Track class names and IDs from attributes
-    for attr in &element.attributes {
-        if let Attribute::Attribute(attr_node) = attr {
-            // Track static attribute name/value for CSS attribute selector matching
-            match &attr_node.value {
-                AttributeValue::True(_) => {
-                    // Boolean attribute like `<details open>`
-                    static_attributes.push((attr_node.name.to_string(), None));
-                }
-                AttributeValue::Sequence(parts) => {
-                    // Check if all parts are static text
-                    let mut all_static = true;
-                    let mut value = String::new();
-                    for part in parts {
-                        if let AttributeValuePart::Text(text) = part {
-                            value.push_str(&text.data);
-                        } else {
-                            all_static = false;
-                            break;
-                        }
+    if collect_css {
+        context
+            .analysis
+            .css
+            .used_elements
+            .insert(element.name.to_string());
+
+        for attr in &element.attributes {
+            if let Attribute::Attribute(attr_node) = attr {
+                // Track static attribute name/value for CSS attribute selector matching
+                match &attr_node.value {
+                    AttributeValue::True(_) => {
+                        // Boolean attribute like `<details open>`
+                        static_attributes.push((attr_node.name.to_string(), None));
                     }
-                    if all_static {
-                        static_attributes.push((attr_node.name.to_string(), Some(value)));
-                    } else {
-                        // Has dynamic parts - try to determine possible values
-                        // for CSS attribute selector matching
-                        let mut all_resolved = true;
-                        let mut computed_values: Vec<String> = vec![String::new()];
+                    AttributeValue::Sequence(parts) => {
+                        // Check if all parts are static text
+                        let mut all_static = true;
+                        let mut value = String::new();
                         for part in parts {
-                            match part {
-                                AttributeValuePart::Text(text) => {
-                                    for v in &mut computed_values {
-                                        v.push_str(&text.data);
-                                    }
-                                }
-                                AttributeValuePart::ExpressionTag(expr_tag) => {
-                                    use super::super::css::get_possible_values_expr;
-                                    if let Some(possible_vals) =
-                                        get_possible_values_expr(&expr_tag.expression, false)
-                                    {
-                                        if possible_vals.len() > 20 {
-                                            // Too many combinations, bail out
-                                            all_resolved = false;
-                                            break;
-                                        }
-                                        let prev = computed_values.clone();
-                                        computed_values.clear();
-                                        for pv in &prev {
-                                            for ev in &possible_vals {
-                                                computed_values.push(format!("{}{}", pv, ev));
-                                            }
-                                        }
-                                        if computed_values.len() > 100 {
-                                            all_resolved = false;
-                                            break;
-                                        }
-                                    } else {
-                                        all_resolved = false;
-                                        break;
-                                    }
-                                }
+                            if let AttributeValuePart::Text(text) = part {
+                                value.push_str(&text.data);
+                            } else {
+                                all_static = false;
+                                break;
                             }
                         }
-                        if all_resolved && !computed_values.is_empty() {
-                            for value in &computed_values {
-                                static_attributes
-                                    .push((attr_node.name.to_string(), Some(value.clone())));
-                            }
+                        if all_static {
+                            static_attributes.push((attr_node.name.to_string(), Some(value)));
                         } else {
-                            dynamic_attribute_names.insert(attr_node.name.to_string());
-                        }
-                    }
-                }
-                _ => {
-                    // Expression or other dynamic value
-                    // Try to statically determine the value for CSS attribute selector matching
-                    if let AttributeValue::Expression(expr_tag) = &attr_node.value {
-                        use super::super::css::get_possible_values_expr;
-                        if let Some(possible_values) =
-                            get_possible_values_expr(&expr_tag.expression, false)
-                        {
-                            // We can determine the possible values statically
-                            for value in &possible_values {
-                                static_attributes
-                                    .push((attr_node.name.to_string(), Some(value.to_string())));
-                            }
-                        } else {
-                            dynamic_attribute_names.insert(attr_node.name.to_string());
-                        }
-                    } else {
-                        dynamic_attribute_names.insert(attr_node.name.to_string());
-                    }
-                }
-            }
-
-            match attr_node.name.as_str() {
-                "class" => {
-                    // Extract class names from attribute value using combinatorial expansion
-                    // to correctly handle string concatenation like class="foo{expr}bar"
-                    match &attr_node.value {
-                        AttributeValue::Sequence(parts) => {
-                            // Combinatorial expansion matching the official Svelte compiler.
-                            // We maintain partial strings and combine them with each chunk's
-                            // possible values, tracking whitespace boundaries.
-                            let mut possible_values: FxHashSet<String> = FxHashSet::default();
-                            let mut prev_values: Vec<String> = Vec::new();
-                            let mut bail_out = false;
-
+                            // Has dynamic parts - try to determine possible values
+                            // for CSS attribute selector matching
+                            let mut all_resolved = true;
+                            let mut computed_values: Vec<String> = vec![String::new()];
                             for part in parts {
-                                let current_possible: Option<Vec<String>> = match part {
+                                match part {
                                     AttributeValuePart::Text(text) => {
-                                        Some(vec![text.data.to_string()])
+                                        for v in &mut computed_values {
+                                            v.push_str(&text.data);
+                                        }
                                     }
                                     AttributeValuePart::ExpressionTag(expr_tag) => {
                                         use super::super::css::get_possible_values_expr;
-                                        get_possible_values_expr(&expr_tag.expression, true)
-                                    }
-                                };
-
-                                if current_possible.is_none() {
-                                    bail_out = true;
-                                    break;
-                                }
-                                let current_vals = current_possible.unwrap();
-
-                                if prev_values.is_empty() {
-                                    // First chunk
-                                    for cv in &current_vals {
-                                        if cv.ends_with(char::is_whitespace) {
-                                            possible_values.insert(cv.clone());
+                                        if let Some(possible_vals) =
+                                            get_possible_values_expr(&expr_tag.expression, false)
+                                        {
+                                            if possible_vals.len() > 20 {
+                                                // Too many combinations, bail out
+                                                all_resolved = false;
+                                                break;
+                                            }
+                                            let prev = computed_values.clone();
+                                            computed_values.clear();
+                                            for pv in &prev {
+                                                for ev in &possible_vals {
+                                                    computed_values.push(format!("{}{}", pv, ev));
+                                                }
+                                            }
+                                            if computed_values.len() > 100 {
+                                                all_resolved = false;
+                                                break;
+                                            }
                                         } else {
-                                            prev_values.push(cv.clone());
+                                            all_resolved = false;
+                                            break;
                                         }
-                                    }
-                                    if prev_values.len() < current_vals.len() {
-                                        prev_values.push(" ".to_string());
-                                    }
-                                } else {
-                                    // Categorize new values by whitespace boundaries
-                                    let mut starts_with_space = Vec::new();
-                                    let mut remaining = Vec::new();
-                                    for cv in &current_vals {
-                                        if cv.starts_with(char::is_whitespace) {
-                                            starts_with_space.push(cv.clone());
-                                        } else {
-                                            remaining.push(cv.clone());
-                                        }
-                                    }
-
-                                    if !remaining.is_empty() {
-                                        if !starts_with_space.is_empty() {
-                                            // Some values start with space - previous values are complete
-                                            for pv in &prev_values {
-                                                possible_values.insert(pv.clone());
-                                            }
-                                        }
-                                        // Combine prev_values with remaining (no-space) values
-                                        let mut combined = Vec::new();
-                                        for pv in &prev_values {
-                                            for rv in &remaining {
-                                                combined.push(format!("{}{}", pv, rv));
-                                            }
-                                        }
-                                        prev_values = combined;
-                                        for sv in &starts_with_space {
-                                            if sv.ends_with(char::is_whitespace) {
-                                                possible_values.insert(sv.clone());
-                                            } else {
-                                                prev_values.push(sv.clone());
-                                            }
-                                        }
-                                    } else {
-                                        // All values start with space
-                                        for pv in &prev_values {
-                                            possible_values.insert(pv.clone());
-                                        }
-                                        prev_values.clear();
-                                        for sv in &starts_with_space {
-                                            if sv.ends_with(char::is_whitespace) {
-                                                possible_values.insert(sv.clone());
-                                            } else {
-                                                prev_values.push(sv.clone());
-                                            }
-                                        }
-                                    }
-                                    if prev_values.len() < current_vals.len() {
-                                        prev_values.push(" ".to_string());
-                                    }
-                                    if prev_values.len() > 20 {
-                                        // Exponential growth, bail out
-                                        bail_out = true;
-                                        break;
                                     }
                                 }
                             }
-
-                            if bail_out {
-                                context.analysis.css.has_dynamic_classes = true;
-                            } else {
-                                // Add remaining prev_values
-                                for pv in &prev_values {
-                                    possible_values.insert(pv.clone());
+                            if all_resolved && !computed_values.is_empty() {
+                                for value in &computed_values {
+                                    static_attributes
+                                        .push((attr_node.name.to_string(), Some(value.clone())));
                                 }
-                                // Extract class names from all possible values
+                            } else {
+                                dynamic_attribute_names.insert(attr_node.name.to_string());
+                            }
+                        }
+                    }
+                    _ => {
+                        // Expression or other dynamic value
+                        // Try to statically determine the value for CSS attribute selector matching
+                        if let AttributeValue::Expression(expr_tag) = &attr_node.value {
+                            use super::super::css::get_possible_values_expr;
+                            if let Some(possible_values) =
+                                get_possible_values_expr(&expr_tag.expression, false)
+                            {
+                                // We can determine the possible values statically
                                 for value in &possible_values {
-                                    for class_name in value.split_whitespace() {
-                                        if !class_name.is_empty() {
+                                    static_attributes.push((
+                                        attr_node.name.to_string(),
+                                        Some(value.to_string()),
+                                    ));
+                                }
+                            } else {
+                                dynamic_attribute_names.insert(attr_node.name.to_string());
+                            }
+                        } else {
+                            dynamic_attribute_names.insert(attr_node.name.to_string());
+                        }
+                    }
+                }
+
+                match attr_node.name.as_str() {
+                    "class" => {
+                        // Extract class names from attribute value using combinatorial expansion
+                        // to correctly handle string concatenation like class="foo{expr}bar"
+                        match &attr_node.value {
+                            AttributeValue::Sequence(parts) => {
+                                // Combinatorial expansion matching the official Svelte compiler.
+                                // We maintain partial strings and combine them with each chunk's
+                                // possible values, tracking whitespace boundaries.
+                                let mut possible_values: FxHashSet<String> = FxHashSet::default();
+                                let mut prev_values: Vec<String> = Vec::new();
+                                let mut bail_out = false;
+
+                                for part in parts {
+                                    let current_possible: Option<Vec<String>> = match part {
+                                        AttributeValuePart::Text(text) => {
+                                            Some(vec![text.data.to_string()])
+                                        }
+                                        AttributeValuePart::ExpressionTag(expr_tag) => {
+                                            use super::super::css::get_possible_values_expr;
+                                            get_possible_values_expr(&expr_tag.expression, true)
+                                        }
+                                    };
+
+                                    if current_possible.is_none() {
+                                        bail_out = true;
+                                        break;
+                                    }
+                                    let current_vals = current_possible.unwrap();
+
+                                    if prev_values.is_empty() {
+                                        // First chunk
+                                        for cv in &current_vals {
+                                            if cv.ends_with(char::is_whitespace) {
+                                                possible_values.insert(cv.clone());
+                                            } else {
+                                                prev_values.push(cv.clone());
+                                            }
+                                        }
+                                        if prev_values.len() < current_vals.len() {
+                                            prev_values.push(" ".to_string());
+                                        }
+                                    } else {
+                                        // Categorize new values by whitespace boundaries
+                                        let mut starts_with_space = Vec::new();
+                                        let mut remaining = Vec::new();
+                                        for cv in &current_vals {
+                                            if cv.starts_with(char::is_whitespace) {
+                                                starts_with_space.push(cv.clone());
+                                            } else {
+                                                remaining.push(cv.clone());
+                                            }
+                                        }
+
+                                        if !remaining.is_empty() {
+                                            if !starts_with_space.is_empty() {
+                                                // Some values start with space - previous values are complete
+                                                for pv in &prev_values {
+                                                    possible_values.insert(pv.clone());
+                                                }
+                                            }
+                                            // Combine prev_values with remaining (no-space) values
+                                            let mut combined = Vec::new();
+                                            for pv in &prev_values {
+                                                for rv in &remaining {
+                                                    combined.push(format!("{}{}", pv, rv));
+                                                }
+                                            }
+                                            prev_values = combined;
+                                            for sv in &starts_with_space {
+                                                if sv.ends_with(char::is_whitespace) {
+                                                    possible_values.insert(sv.clone());
+                                                } else {
+                                                    prev_values.push(sv.clone());
+                                                }
+                                            }
+                                        } else {
+                                            // All values start with space
+                                            for pv in &prev_values {
+                                                possible_values.insert(pv.clone());
+                                            }
+                                            prev_values.clear();
+                                            for sv in &starts_with_space {
+                                                if sv.ends_with(char::is_whitespace) {
+                                                    possible_values.insert(sv.clone());
+                                                } else {
+                                                    prev_values.push(sv.clone());
+                                                }
+                                            }
+                                        }
+                                        if prev_values.len() < current_vals.len() {
+                                            prev_values.push(" ".to_string());
+                                        }
+                                        if prev_values.len() > 20 {
+                                            // Exponential growth, bail out
+                                            bail_out = true;
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                if bail_out {
+                                    context.analysis.css.has_dynamic_classes = true;
+                                } else {
+                                    // Add remaining prev_values
+                                    for pv in &prev_values {
+                                        possible_values.insert(pv.clone());
+                                    }
+                                    // Extract class names from all possible values
+                                    for value in &possible_values {
+                                        for class_name in value.split_whitespace() {
+                                            if !class_name.is_empty() {
+                                                context
+                                                    .analysis
+                                                    .css
+                                                    .used_classes
+                                                    .insert(class_name.to_string());
+                                                element_classes.insert(class_name.to_string());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            AttributeValue::Expression(expr_tag) => {
+                                // Expression as attribute value: class={{ ... }}
+                                // Use the cached JSON view of the expression to analyze it
+                                use super::super::css::get_possible_values_expr;
+                                if let Some(possible_values) =
+                                    get_possible_values_expr(&expr_tag.expression, true)
+                                {
+                                    // We can statically determine the classes
+                                    for value in &possible_values {
+                                        for class_name in value.split_whitespace() {
                                             context
                                                 .analysis
                                                 .css
@@ -663,82 +684,72 @@ pub fn visit<'a, 'b: 'a>(
                                             element_classes.insert(class_name.to_string());
                                         }
                                     }
+                                } else {
+                                    // Unknown expression - mark as dynamic
+                                    context.analysis.css.has_dynamic_classes = true;
                                 }
                             }
+                            _ => {}
                         }
-                        AttributeValue::Expression(expr_tag) => {
-                            // Expression as attribute value: class={{ ... }}
-                            // Use the cached JSON view of the expression to analyze it
-                            use super::super::css::get_possible_values_expr;
-                            if let Some(possible_values) =
-                                get_possible_values_expr(&expr_tag.expression, true)
-                            {
-                                // We can statically determine the classes
-                                for value in &possible_values {
-                                    for class_name in value.split_whitespace() {
-                                        context
-                                            .analysis
-                                            .css
-                                            .used_classes
-                                            .insert(class_name.to_string());
-                                        element_classes.insert(class_name.to_string());
-                                    }
-                                }
-                            } else {
-                                // Unknown expression - mark as dynamic
-                                context.analysis.css.has_dynamic_classes = true;
-                            }
-                        }
-                        _ => {}
                     }
-                }
-                "id" => {
-                    match &attr_node.value {
-                        AttributeValue::Sequence(parts) => {
-                            // An interpolated id (`id="a{x}"`) has an unknown runtime
-                            // value, so it could match any #id selector.
-                            let has_dynamic_part = parts
-                                .iter()
-                                .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)));
-                            if has_dynamic_part {
-                                context.analysis.css.has_dynamic_ids = true;
-                            } else {
-                                for part in parts {
-                                    if let AttributeValuePart::Text(text) = part {
-                                        let id = text.data.trim();
-                                        if !id.is_empty() {
-                                            context.analysis.css.used_ids.insert(id.to_string());
-                                            element_id = Some(id.to_string());
+                    "id" => {
+                        match &attr_node.value {
+                            AttributeValue::Sequence(parts) => {
+                                // An interpolated id (`id="a{x}"`) has an unknown runtime
+                                // value, so it could match any #id selector.
+                                let has_dynamic_part = parts
+                                    .iter()
+                                    .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)));
+                                if has_dynamic_part {
+                                    context.analysis.css.has_dynamic_ids = true;
+                                } else {
+                                    for part in parts {
+                                        if let AttributeValuePart::Text(text) = part {
+                                            let id = text.data.trim();
+                                            if !id.is_empty() {
+                                                context
+                                                    .analysis
+                                                    .css
+                                                    .used_ids
+                                                    .insert(id.to_string());
+                                                element_id = Some(id.to_string());
+                                            }
                                         }
                                     }
                                 }
                             }
+                            // `id={expr}` or the `{id}` shorthand: dynamic, unknown value.
+                            AttributeValue::Expression(_) => {
+                                context.analysis.css.has_dynamic_ids = true;
+                            }
+                            _ => {}
                         }
-                        // `id={expr}` or the `{id}` shorthand: dynamic, unknown value.
-                        AttributeValue::Expression(_) => {
-                            context.analysis.css.has_dynamic_ids = true;
-                        }
-                        _ => {}
                     }
+                    _ => {}
                 }
-                _ => {}
+            } else if let Attribute::SpreadAttribute(spread) = attr {
+                // Visit spread attribute to set has_dynamic_classes
+                has_spread = true;
+                spread_attribute::visit(spread, context)?;
+            } else if let Attribute::BindDirective(bind) = attr {
+                // bind:name is a dynamic attribute
+                dynamic_attribute_names.insert(bind.name.to_string());
+            } else if let Attribute::ClassDirective(class_dir) = attr {
+                has_class_directive = true;
+                class_directive_names.insert(class_dir.name.to_string());
+                // `class:name` matches a `.name` class selector exactly (the official
+                // `attribute_matches` returns true for ClassDirective with `~=`), so
+                // track the directive name as a class on this element.
+                element_classes.insert(class_dir.name.to_string());
+            } else if let Attribute::StyleDirective(_) = attr {
+                has_style_directive = true;
             }
-        } else if let Attribute::SpreadAttribute(spread) = attr {
-            // Visit spread attribute to set has_dynamic_classes
-            has_spread = true;
-            spread_attribute::visit(spread, context)?;
-        } else if let Attribute::BindDirective(bind) = attr {
-            // bind:name is a dynamic attribute
-            dynamic_attribute_names.insert(bind.name.to_string());
-        } else if let Attribute::ClassDirective(class_dir) = attr {
-            has_class_directive = true;
-            class_directive_names.insert(class_dir.name.to_string());
-            // `class:name` matches a `.name` class selector exactly (the official
-            // `attribute_matches` returns true for ClassDirective with `~=`), so
-            // track the directive name as a class on this element.
-            element_classes.insert(class_dir.name.to_string());
-        } else if let Attribute::StyleDirective(_) = attr {
-            has_style_directive = true;
+        }
+    } else {
+        for attr in &element.attributes {
+            if let Attribute::SpreadAttribute(spread) = attr {
+                spread_attribute::visit(spread, context)?;
+            }
         }
     }
 
@@ -974,60 +985,58 @@ pub fn visit<'a, 'b: 'a>(
         }
     }
 
-    // Check if the element's fragment contains opaque content (render tags, slots, components)
-    // that can inject unknown element children at runtime
-    let has_opaque_content = element.fragment.nodes.iter().any(|node| {
-        use crate::ast::template::TemplateNode;
-        matches!(
-            node,
-            TemplateNode::RenderTag(_)
-                | TemplateNode::Component(_)
-                | TemplateNode::SlotElement(_)
-                | TemplateNode::SvelteComponent(_)
-                | TemplateNode::SvelteSelf(_)
-                | TemplateNode::HtmlTag(_)
-        )
-    });
-
-    // Create and track DOM element for CSS sibling combinator detection
-    let dom_element = super::super::types::CssDomElement {
-        tag_name: element.name.to_string(),
-        classes: element_classes,
-        id: element_id,
-        static_attributes,
-        dynamic_attribute_names,
-        has_spread,
-        has_class_directive,
-        class_directive_names,
-        has_style_directive,
-        parent_idx,
-        children_idx: Vec::new(),
-        is_root_child,
-        possible_prev_adjacent: Vec::new(),
-        possible_next_adjacent: Vec::new(),
-        possible_prev_general: Vec::new(),
-        possible_next_general: Vec::new(),
-        has_content: !element.fragment.nodes.is_empty(),
-        has_opaque_content,
-        is_dynamic_tag: false,
-        in_snippet: context
-            .fragment_owner_stack
-            .iter()
-            .any(|o| matches!(o, super::FragmentOwnerType::SnippetBlock(..))),
-        prev_is_opaque_boundary: false,
-        prev_has_opaque_boundary: false,
+    let element_idx = if collect_css {
+        let has_opaque_content = element.fragment.nodes.iter().any(|node| {
+            use crate::ast::template::TemplateNode;
+            matches!(
+                node,
+                TemplateNode::RenderTag(_)
+                    | TemplateNode::Component(_)
+                    | TemplateNode::SlotElement(_)
+                    | TemplateNode::SvelteComponent(_)
+                    | TemplateNode::SvelteSelf(_)
+                    | TemplateNode::HtmlTag(_)
+            )
+        });
+        let dom_element = super::super::types::CssDomElement {
+            tag_name: element.name.to_string(),
+            classes: element_classes,
+            id: element_id,
+            static_attributes,
+            dynamic_attribute_names,
+            has_spread,
+            has_class_directive,
+            class_directive_names,
+            has_style_directive,
+            parent_idx,
+            children_idx: Vec::new(),
+            is_root_child,
+            possible_prev_adjacent: Vec::new(),
+            possible_next_adjacent: Vec::new(),
+            possible_prev_general: Vec::new(),
+            possible_next_general: Vec::new(),
+            has_content: !element.fragment.nodes.is_empty(),
+            has_opaque_content,
+            is_dynamic_tag: false,
+            in_snippet: context
+                .fragment_owner_stack
+                .iter()
+                .any(|o| matches!(o, super::FragmentOwnerType::SnippetBlock(..))),
+            prev_is_opaque_boundary: false,
+            prev_has_opaque_boundary: false,
+        };
+        let element_idx = context.add_dom_element(dom_element);
+        if let Some(parent_idx) = parent_idx
+            && parent_idx < context.analysis.css.dom_structure.elements.len()
+        {
+            context.analysis.css.dom_structure.elements[parent_idx]
+                .children_idx
+                .push(element_idx);
+        }
+        element_idx
+    } else {
+        usize::MAX
     };
-
-    let element_idx = context.add_dom_element(dom_element);
-
-    // Update parent's children list
-    if let Some(parent_idx) = parent_idx
-        && parent_idx < context.analysis.css.dom_structure.elements.len()
-    {
-        context.analysis.css.dom_structure.elements[parent_idx]
-            .children_idx
-            .push(element_idx);
-    }
 
     // Visit attributes and directives
     // We need to validate bind directives with the element context
@@ -1160,8 +1169,9 @@ pub fn visit<'a, 'b: 'a>(
             .push(super::SlotOwnerType::CustomElement);
     }
 
-    // Push this element index to DOM element stack for tracking children
-    context.dom_element_stack.push(element_idx);
+    if collect_css {
+        context.dom_element_stack.push(element_idx);
+    }
 
     // Push None to each_block_stack to indicate we're no longer directly in an EachBlock
     context.each_block_stack.push(None);
@@ -1391,8 +1401,9 @@ pub fn visit<'a, 'b: 'a>(
     // Pop from each_block_stack
     context.each_block_stack.pop();
 
-    // Pop this element from DOM element stack
-    context.dom_element_stack.pop();
+    if collect_css {
+        context.dom_element_stack.pop();
+    }
 
     // Pop slot owner if this was a custom element
     if is_custom_element {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -29,115 +29,115 @@ pub fn visit<'a, 'b: 'a>(
     element: &mut SvelteDynamicElement<'b>,
     context: &mut VisitorContext<'a>,
 ) -> Result<(), AnalysisError> {
-    // Mark that we have dynamic elements (can't safely prune type selectors)
-    context.analysis.css.has_dynamic_elements = true;
-
-    // Extract class names and ID from svelte:element attributes for CSS selector detection.
-    // Since svelte:element can resolve to any element, we still need to know which classes
-    // are used so the CSS pruner can keep the right selectors.
+    let collect_css = context.analysis.css.has_css;
     let mut element_classes = rustc_hash::FxHashSet::default();
     let mut element_id = None;
 
-    for attr in &element.attributes {
-        match attr {
-            Attribute::Attribute(attr_node) if attr_node.name == "class" => {
-                match &attr_node.value {
-                    AttributeValue::Sequence(parts) => {
-                        for part in parts {
-                            match part {
-                                AttributeValuePart::Text(text) => {
-                                    for class_name in text.data.split_whitespace() {
-                                        context
-                                            .analysis
-                                            .css
-                                            .used_classes
-                                            .insert(class_name.to_string());
-                                        element_classes.insert(class_name.to_string());
+    if collect_css {
+        context.analysis.css.has_dynamic_elements = true;
+        for attr in &element.attributes {
+            match attr {
+                Attribute::Attribute(attr_node) if attr_node.name == "class" => {
+                    match &attr_node.value {
+                        AttributeValue::Sequence(parts) => {
+                            for part in parts {
+                                match part {
+                                    AttributeValuePart::Text(text) => {
+                                        for class_name in text.data.split_whitespace() {
+                                            context
+                                                .analysis
+                                                .css
+                                                .used_classes
+                                                .insert(class_name.to_string());
+                                            element_classes.insert(class_name.to_string());
+                                        }
                                     }
-                                }
-                                AttributeValuePart::ExpressionTag(_) => {
-                                    context.analysis.css.has_dynamic_classes = true;
+                                    AttributeValuePart::ExpressionTag(_) => {
+                                        context.analysis.css.has_dynamic_classes = true;
+                                    }
                                 }
                             }
                         }
+                        AttributeValue::Expression(_) => {
+                            context.analysis.css.has_dynamic_classes = true;
+                        }
+                        _ => {}
+                    }
+                }
+                Attribute::Attribute(attr_node) if attr_node.name == "id" => match &attr_node.value
+                {
+                    AttributeValue::Sequence(parts) => {
+                        let has_dynamic_part = parts
+                            .iter()
+                            .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)));
+                        if has_dynamic_part {
+                            context.analysis.css.has_dynamic_ids = true;
+                        } else if parts.len() == 1
+                            && let Some(AttributeValuePart::Text(text)) = parts.first()
+                        {
+                            element_id = Some(text.data.to_string());
+                        }
                     }
                     AttributeValue::Expression(_) => {
-                        context.analysis.css.has_dynamic_classes = true;
+                        context.analysis.css.has_dynamic_ids = true;
                     }
                     _ => {}
-                }
-            }
-            Attribute::Attribute(attr_node) if attr_node.name == "id" => match &attr_node.value {
-                AttributeValue::Sequence(parts) => {
-                    let has_dynamic_part = parts
-                        .iter()
-                        .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)));
-                    if has_dynamic_part {
-                        context.analysis.css.has_dynamic_ids = true;
-                    } else if parts.len() == 1
-                        && let Some(AttributeValuePart::Text(text)) = parts.first()
-                    {
-                        element_id = Some(text.data.to_string());
-                    }
-                }
-                AttributeValue::Expression(_) => {
-                    context.analysis.css.has_dynamic_ids = true;
+                },
+                Attribute::ClassDirective(cd) => {
+                    context
+                        .analysis
+                        .css
+                        .used_classes
+                        .insert(cd.name.to_string());
+                    element_classes.insert(cd.name.to_string());
                 }
                 _ => {}
-            },
-            Attribute::ClassDirective(cd) => {
-                context
-                    .analysis
-                    .css
-                    .used_classes
-                    .insert(cd.name.to_string());
-                element_classes.insert(cd.name.to_string());
             }
-            _ => {}
         }
     }
 
-    // Create DOM element for CSS sibling combinator detection
     let parent_idx = context.current_parent_idx();
     let is_root_child = context.dom_element_stack.is_empty();
-    let dom_element = super::super::types::CssDomElement {
-        tag_name: String::new(), // Dynamic tag, will use is_dynamic_tag
-        classes: element_classes,
-        id: element_id,
-        static_attributes: Vec::new(), // Dynamic element, no static attributes
-        dynamic_attribute_names: FxHashSet::default(),
-        has_spread: false,
-        has_class_directive: false,
-        class_directive_names: FxHashSet::default(),
-        has_style_directive: false,
-        parent_idx,
-        children_idx: Vec::new(),
-        is_root_child,
-        possible_prev_adjacent: Vec::new(),
-        possible_next_adjacent: Vec::new(),
-        possible_prev_general: Vec::new(),
-        possible_next_general: Vec::new(),
-        has_content: !element.fragment.nodes.is_empty(),
-        has_opaque_content: false, // Dynamic element, conservatively handled via is_dynamic_tag
-        is_dynamic_tag: true,
-        in_snippet: context
-            .fragment_owner_stack
-            .iter()
-            .any(|o| matches!(o, super::FragmentOwnerType::SnippetBlock(..))),
-        prev_is_opaque_boundary: false,
-        prev_has_opaque_boundary: false,
+    let element_idx = if collect_css {
+        let dom_element = super::super::types::CssDomElement {
+            tag_name: String::new(),
+            classes: element_classes,
+            id: element_id,
+            static_attributes: Vec::new(),
+            dynamic_attribute_names: FxHashSet::default(),
+            has_spread: false,
+            has_class_directive: false,
+            class_directive_names: FxHashSet::default(),
+            has_style_directive: false,
+            parent_idx,
+            children_idx: Vec::new(),
+            is_root_child,
+            possible_prev_adjacent: Vec::new(),
+            possible_next_adjacent: Vec::new(),
+            possible_prev_general: Vec::new(),
+            possible_next_general: Vec::new(),
+            has_content: !element.fragment.nodes.is_empty(),
+            has_opaque_content: false,
+            is_dynamic_tag: true,
+            in_snippet: context
+                .fragment_owner_stack
+                .iter()
+                .any(|o| matches!(o, super::FragmentOwnerType::SnippetBlock(..))),
+            prev_is_opaque_boundary: false,
+            prev_has_opaque_boundary: false,
+        };
+        let element_idx = context.add_dom_element(dom_element);
+        if let Some(parent_idx) = parent_idx
+            && parent_idx < context.analysis.css.dom_structure.elements.len()
+        {
+            context.analysis.css.dom_structure.elements[parent_idx]
+                .children_idx
+                .push(element_idx);
+        }
+        element_idx
+    } else {
+        usize::MAX
     };
-
-    let element_idx = context.add_dom_element(dom_element);
-
-    // Update parent's children list
-    if let Some(parent_idx) = parent_idx
-        && parent_idx < context.analysis.css.dom_structure.elements.len()
-    {
-        context.analysis.css.dom_structure.elements[parent_idx]
-            .children_idx
-            .push(element_idx);
-    }
 
     // Check that svelte:element has a 'this' attribute with a value
     // The 'tag' field is populated from the 'this' attribute during parsing
@@ -282,8 +282,9 @@ pub fn visit<'a, 'b: 'a>(
         .fragment_owner_stack
         .push(super::FragmentOwnerType::SvelteElement);
 
-    // Push this element index to DOM element stack for tracking children
-    context.dom_element_stack.push(element_idx);
+    if collect_css {
+        context.dom_element_stack.push(element_idx);
+    }
 
     // Save and update the SVG/MathML namespace state for child analysis.
     // Child svelte:element nodes will check these fields to determine their namespace.
@@ -335,8 +336,9 @@ pub fn visit<'a, 'b: 'a>(
     context.analysis.component_namespace_is_svg = saved_svg;
     context.analysis.component_namespace_is_mathml = saved_mathml;
 
-    // Pop this element from DOM element stack
-    context.dom_element_stack.pop();
+    if collect_css {
+        context.dom_element_stack.pop();
+    }
 
     // Restore context
     context.fragment_owner_stack.pop();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -461,38 +461,41 @@ fn transform_client_with_visitors(
     // Transform the instance script once with the real reactive_import_names.
     // This also determines how many $$array names it consumes (for template generation)
     // and is used for blocker_map computation and the final output.
-    let pre_transformed_script = if let Some(instance_script) = &analysis.instance_script_content {
-        let raw = &instance_script.raw;
-        let _script_start = super::profile::timer_start();
-        let mut transformed = transform_instance_script_for_visitors(
-            raw,
-            analysis,
-            options.dev,
-            &reactive_import_names,
-        );
-        rest_excludes_hoists = extract_rest_excludes_hoists(&mut transformed);
-        super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
-        // Transfer the script's $$array counter to the context state so that the template
-        // visitor continues numbering from where the script left off.
-        let script_array_count = SCRIPT_ARRAY_COUNTER.with(|c| c.get());
-        context
-            .state
-            .destructure_array_counter
-            .set(script_array_count);
-        // Also seed the memoizer's conflicts set with names already used by the script,
-        // so that generate_array_name() (which uses the memoizer) won't reuse them.
-        for i in 0..script_array_count {
-            let name = if i == 0 {
-                "$$array".to_string()
-            } else {
-                format!("$$array_{}", i)
-            };
-            context.state.memoizer.add_conflict(&name);
-        }
-        Some(transformed)
-    } else {
-        None
-    };
+    let mut instance_script_imports = Vec::new();
+    let mut pre_transformed_script =
+        if let Some(instance_script) = &analysis.instance_script_content {
+            let (imports, script_body) = extract_imports(&instance_script.raw);
+            instance_script_imports = imports;
+            let _script_start = super::profile::timer_start();
+            let mut transformed = transform_instance_script_for_visitors(
+                &script_body,
+                analysis,
+                options.dev,
+                &reactive_import_names,
+            );
+            rest_excludes_hoists = extract_rest_excludes_hoists(&mut transformed);
+            super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
+            // Transfer the script's $$array counter to the context state so that the template
+            // visitor continues numbering from where the script left off.
+            let script_array_count = SCRIPT_ARRAY_COUNTER.with(|c| c.get());
+            context
+                .state
+                .destructure_array_counter
+                .set(script_array_count);
+            // Also seed the memoizer's conflicts set with names already used by the script,
+            // so that generate_array_name() (which uses the memoizer) won't reuse them.
+            for i in 0..script_array_count {
+                let name = if i == 0 {
+                    "$$array".to_string()
+                } else {
+                    format!("$$array_{}", i)
+                };
+                context.state.memoizer.add_conflict(&name);
+            }
+            Some(transformed)
+        } else {
+            None
+        };
 
     // Pre-compute blocker map for async components.
     if options.experimental.r#async
@@ -1088,7 +1091,7 @@ fn transform_client_with_visitors(
     // This includes $state, $derived, $effect, $props transformations
     // Reuse the pre_transformed_script from above (already has reactive_import_names).
     if let Some(ref content) = analysis.instance_script_content {
-        let mut transformed_script = pre_transformed_script.clone().unwrap_or_default();
+        let mut transformed_script = pre_transformed_script.take().unwrap_or_default();
 
         // Post-process reactive imports: replace $.get(X)/$.mutate(X,...) with $$_import_X()
         for name in &reactive_import_names {
@@ -1856,9 +1859,8 @@ fn transform_client_with_visitors(
 
     // Extract and add imports from instance script
     // These are in state.hoisted after import * as $ (from analysis.instance_body.hoisted)
-    if let Some(ref instance_content) = analysis.instance_script_content {
-        let (script_imports, _) = extract_imports(&instance_content.raw);
-        for import_line in script_imports {
+    if analysis.instance_script_content.is_some() {
+        for import_line in instance_script_imports {
             let cleaned = cleanup_import_line(&import_line);
             if cleaned.is_empty() {
                 continue;
@@ -2216,7 +2218,7 @@ fn transform_client_with_visitors(
     // corpus). `RSVELTE_CLIENT_NO_OXC` forces the legacy string path (escape
     // hatch). Span-stamping (`Spanned` / `RawMapped` → original-source offsets)
     // feeds esrap `print_with_map` for the sourcemap branch.
-    if std::env::var_os("RSVELTE_CLIENT_NO_OXC").is_none() {
+    if !*CLIENT_NO_OXC {
         let converted = CLIENT_TO_OXC_ALLOCATOR.with(|cell| {
             let mut alloc = cell.borrow_mut();
             alloc.reset();
@@ -2260,7 +2262,7 @@ fn transform_client_with_visitors(
         if let Some((code, mappings)) = converted {
             super::profile::record_codegen(super::profile::timer_elapsed(_codegen_start));
             return Ok(CodegenResult { code, mappings });
-        } else if std::env::var_os("RSVELTE_CLIENT_TO_OXC_DEBUG").is_some() {
+        } else if *CLIENT_TO_OXC_DEBUG {
             eprintln!(
                 "CLIENT_TO_OXC_FALLBACK {}",
                 options.filename.as_deref().unwrap_or("?")
@@ -2290,7 +2292,7 @@ fn transform_client_with_visitors(
 fn esrap_mappings_to_source_mappings(
     mappings: &[Vec<rsvelte_esrap::command::Segment>],
 ) -> Vec<SourceMapping> {
-    let mut out = Vec::new();
+    let mut out = Vec::with_capacity(mappings.iter().map(Vec::len).sum());
     for (gen_line, segs) in mappings.iter().enumerate() {
         for seg in segs {
             out.push(SourceMapping {
@@ -2314,6 +2316,11 @@ thread_local! {
     static CLIENT_TO_OXC_ALLOCATOR: std::cell::RefCell<oxc_allocator::Allocator> =
         std::cell::RefCell::new(oxc_allocator::Allocator::default());
 }
+
+static CLIENT_NO_OXC: LazyLock<bool> =
+    LazyLock::new(|| std::env::var_os("RSVELTE_CLIENT_NO_OXC").is_some());
+static CLIENT_TO_OXC_DEBUG: LazyLock<bool> =
+    LazyLock::new(|| std::env::var_os("RSVELTE_CLIENT_TO_OXC_DEBUG").is_some());
 
 fn is_ident_char(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
@@ -3024,6 +3031,12 @@ fn collect_local_state_decls(script: &str) -> rustc_hash::FxHashSet<&str> {
 }
 
 fn extract_shadowed_state_names(script: &str) -> rustc_hash::FxHashSet<String> {
+    if memmem::find(script.as_bytes(), b"$state").is_none()
+        && memmem::find(script.as_bytes(), b"$derived").is_none()
+    {
+        return rustc_hash::FxHashSet::default();
+    }
+
     let mut top_level_non_state: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
     let mut inner_state: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
     let mut brace_depth: i32 = 0;
@@ -3894,12 +3907,7 @@ fn transform_instance_script_for_visitors(
         return String::new();
     }
 
-    // Fast path: if the script has no runes ($state, $derived, $effect, $props),
-    // no store subscriptions ($xxx), no reactive statements ($:), and no exports,
-    // the text-based transform pipeline has nothing to do. Just return the script
-    // with imports stripped.
-    // Fast path: if the script has no runes, stores, reactive statements, exports,
-    // or comma-separated declarations, the text-based transform pipeline has nothing to do.
+    // Instance imports are removed by the caller before this pipeline.
     let has_dollar = script.contains('$');
     let has_export = memmem::find(script.as_bytes(), b"export ").is_some();
     let has_comma_decl = memmem::find(script.as_bytes(), b", ").is_some()
@@ -3907,7 +3915,6 @@ fn transform_instance_script_for_visitors(
         || memmem::find(script.as_bytes(), b",\t").is_some();
     if !has_dollar
         && !has_export
-        && !has_comma_decl
         && analysis.root.bindings.iter().all(|b| {
             !matches!(
                 b.kind,
@@ -3922,9 +3929,13 @@ fn transform_instance_script_for_visitors(
             )
         })
     {
-        // No transforms needed - just strip imports and return the rest
-        let (_imports, rest) = extract_imports(script);
-        return rest.to_string();
+        return if has_comma_decl {
+            crate::compiler::phases::phase3_transform::server::transform_script::split_comma_separated_declarations(
+                script,
+            )
+        } else {
+            script.to_string()
+        };
     }
 
     // Reset the $$array counters for this component
@@ -3972,8 +3983,7 @@ fn transform_instance_script_for_visitors(
         script
     };
 
-    // Extract imports from script (they will be hoisted separately)
-    let (_script_imports, script_rest_raw) = extract_imports(&script);
+    let script_rest_raw = script.into_owned();
 
     // Strip unnecessary parentheses from arrow function expression bodies in the
     // ORIGINAL source text, before any transforms run. The official Svelte compiler

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -2220,6 +2220,37 @@ fn is_sibling_combinator_no_match(complex: &Value, ctx: &CssContext) -> bool {
 }
 
 /// Implementation of no-match check for sibling combinators
+fn visit_possible_siblings(
+    ctx: &CssContext,
+    element_idx: usize,
+    forward: bool,
+    general: bool,
+    mut visitor: impl FnMut(usize) -> bool,
+) -> bool {
+    let relations = |idx: usize| {
+        let element = &ctx.dom_structure.elements[idx];
+        match (forward, general) {
+            (true, true) => &element.possible_next_general,
+            (true, false) => &element.possible_next_adjacent,
+            (false, true) => &element.possible_prev_general,
+            (false, false) => &element.possible_prev_adjacent,
+        }
+    };
+
+    if general && ctx.dom_structure.general_siblings_linked {
+        let mut current = relations(element_idx).first().map(|(idx, _)| *idx);
+        while let Some(idx) = current {
+            if visitor(idx) {
+                return true;
+            }
+            current = relations(idx).first().map(|(next, _)| *next);
+        }
+        false
+    } else {
+        relations(element_idx).iter().any(|(idx, _)| visitor(*idx))
+    }
+}
+
 fn is_sibling_combinator_no_match_impl(rel_selectors: &[Value], ctx: &CssContext) -> bool {
     if rel_selectors.len() < 2 || ctx.dom_structure.elements.is_empty() {
         return false;
@@ -2266,26 +2297,16 @@ fn is_sibling_combinator_no_match_impl(rel_selectors: &[Value], ctx: &CssContext
         let mut found_before_element = false;
         let mut found_any_match = false;
 
-        for el in ctx.dom_structure.elements.iter() {
+        for (el_idx, el) in ctx.dom_structure.elements.iter().enumerate() {
             if selector_matches_element(&before_info, el) {
                 found_before_element = true;
-
-                // Check if any possible sibling matches 'after'
-                let possible_siblings = if combinator == "+" {
-                    &el.possible_next_adjacent
-                } else {
-                    &el.possible_next_general
-                };
-
-                for (sibling_idx, _certainty) in possible_siblings {
-                    if let Some(sibling) = ctx.dom_structure.elements.get(*sibling_idx)
-                        && selector_matches_element(&after_info, sibling)
-                    {
-                        // Found a possible match
-                        found_any_match = true;
-                        break;
-                    }
-                }
+                found_any_match =
+                    visit_possible_siblings(ctx, el_idx, true, combinator == "~", |sibling_idx| {
+                        ctx.dom_structure
+                            .elements
+                            .get(sibling_idx)
+                            .is_some_and(|sibling| selector_matches_element(&after_info, sibling))
+                    });
 
                 if found_any_match {
                     break;
@@ -2401,27 +2422,27 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
             // root-level Y (X may be injected by the parent). The opaque and root
             // predicates alone are insufficient because await/snippet fragments
             // mark their elements opaque yet can hold a real X sibling.
-            let matches = ctx.dom_structure.elements.iter().any(|el| {
-                if !selector_matches_element(&second_info, el) {
-                    return false;
-                }
-                let opaque = if combinator == "+" {
-                    el.prev_is_opaque_boundary
-                } else {
-                    el.prev_has_opaque_boundary
-                };
-                if opaque || el.is_root_child {
-                    return true;
-                }
-                let prevs = if combinator == "+" {
-                    &el.possible_prev_adjacent
-                } else {
-                    &el.possible_prev_general
-                };
-                prevs
-                    .iter()
-                    .any(|(idx, _)| matcher_matches_at(&inner_matcher, *idx, ctx))
-            });
+            let matches = ctx
+                .dom_structure
+                .elements
+                .iter()
+                .enumerate()
+                .any(|(el_idx, el)| {
+                    if !selector_matches_element(&second_info, el) {
+                        return false;
+                    }
+                    let opaque = if combinator == "+" {
+                        el.prev_is_opaque_boundary
+                    } else {
+                        el.prev_has_opaque_boundary
+                    };
+                    if opaque || el.is_root_child {
+                        return true;
+                    }
+                    visit_possible_siblings(ctx, el_idx, false, combinator == "~", |sibling_idx| {
+                        matcher_matches_at(&inner_matcher, sibling_idx, ctx)
+                    })
+                });
 
             return !matches;
         }
@@ -2522,19 +2543,10 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
         for (el_idx, el) in ctx.dom_structure.elements.iter().enumerate() {
             if matcher_matches_at(&after_m, el_idx, ctx) {
                 found_after_element = true;
-                // Check possible previous siblings based on combinator type
-                let possible_siblings = if combinator == "+" {
-                    &el.possible_prev_adjacent
-                } else {
-                    // ~ combinator
-                    &el.possible_prev_general
-                };
-
-                // Check if any possible previous sibling matches 'before' selector
-                for (sibling_idx, _certainty) in possible_siblings {
-                    if matcher_matches_at(&before_m, *sibling_idx, ctx) {
-                        return false; // Found a match, not unused
-                    }
+                if visit_possible_siblings(ctx, el_idx, false, combinator == "~", |sibling_idx| {
+                    matcher_matches_at(&before_m, sibling_idx, ctx)
+                }) {
+                    return false;
                 }
 
                 // If this element has empty sibling lists AND there are opaque boundaries,
@@ -2558,15 +2570,14 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
             for (el_idx, el) in ctx.dom_structure.elements.iter().enumerate() {
                 if matcher_matches_at(&before_m, el_idx, ctx) {
                     found_before_element = true;
-                    let possible_siblings = if combinator == "+" {
-                        &el.possible_next_adjacent
-                    } else {
-                        &el.possible_next_general
-                    };
-                    for (sibling_idx, _certainty) in possible_siblings {
-                        if matcher_matches_at(&after_m, *sibling_idx, ctx) {
-                            return false; // Found a match
-                        }
+                    if visit_possible_siblings(
+                        ctx,
+                        el_idx,
+                        true,
+                        combinator == "~",
+                        |sibling_idx| matcher_matches_at(&after_m, sibling_idx, ctx),
+                    ) {
+                        return false;
                     }
                     // Check for incomplete siblings
                     if ctx.has_opaque_sibling_boundaries
@@ -2622,21 +2633,15 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
 
         // Check if any element matching 'after' has 'before' as a possible previous sibling
         let mut found_match = false;
-        for el in ctx.dom_structure.elements.iter() {
+        for (el_idx, el) in ctx.dom_structure.elements.iter().enumerate() {
             if selector_matches_element(&after_info, el) {
-                let possible_siblings = if comb_b == "+" {
-                    &el.possible_prev_adjacent
-                } else {
-                    &el.possible_prev_general
-                };
-                for (sibling_idx, _certainty) in possible_siblings {
-                    if let Some(sibling) = ctx.dom_structure.elements.get(*sibling_idx)
-                        && selector_matches_element(&before_info, sibling)
-                    {
-                        found_match = true;
-                        break;
-                    }
-                }
+                found_match =
+                    visit_possible_siblings(ctx, el_idx, false, comb_b == "~", |sibling_idx| {
+                        ctx.dom_structure
+                            .elements
+                            .get(sibling_idx)
+                            .is_some_and(|sibling| selector_matches_element(&before_info, sibling))
+                    });
                 if found_match {
                     break;
                 }
@@ -2657,21 +2662,15 @@ fn is_sibling_combinator_unused(rel_selectors: &[Value], ctx: &CssContext) -> bo
         let after_info = extract_selector_info_resolving_nesting(after, ctx);
 
         let mut found_match = false;
-        for el in ctx.dom_structure.elements.iter() {
+        for (el_idx, el) in ctx.dom_structure.elements.iter().enumerate() {
             if selector_matches_element(&after_info, el) {
-                let possible_siblings = if first_comb == "+" {
-                    &el.possible_prev_adjacent
-                } else {
-                    &el.possible_prev_general
-                };
-                for (sibling_idx, _certainty) in possible_siblings {
-                    if let Some(sibling) = ctx.dom_structure.elements.get(*sibling_idx)
-                        && selector_matches_element(&before_info, sibling)
-                    {
-                        found_match = true;
-                        break;
-                    }
-                }
+                found_match =
+                    visit_possible_siblings(ctx, el_idx, false, first_comb == "~", |sibling_idx| {
+                        ctx.dom_structure
+                            .elements
+                            .get(sibling_idx)
+                            .is_some_and(|sibling| selector_matches_element(&before_info, sibling))
+                    });
                 if found_match {
                     break;
                 }
@@ -3962,21 +3961,17 @@ fn is_has_argument_unused_globally(has_complex: &Value, ctx: &CssContext) -> boo
         "+" | "~" => {
             // For sibling selectors from :root/:global context,
             // check if any root-level element has matching siblings
-            for el in ctx.dom_structure.elements.iter() {
+            for (el_idx, el) in ctx.dom_structure.elements.iter().enumerate() {
                 if !el.is_root_child {
                     continue;
                 }
-                let possible_siblings = if combinator == "+" {
-                    &el.possible_next_adjacent
-                } else {
-                    &el.possible_next_general
-                };
-                for (sibling_idx, _) in possible_siblings {
-                    if let Some(sibling) = ctx.dom_structure.elements.get(*sibling_idx)
-                        && selector_matches_element(&first_info, sibling)
-                    {
-                        return false; // Found a match
-                    }
+                if visit_possible_siblings(ctx, el_idx, true, combinator == "~", |sibling_idx| {
+                    ctx.dom_structure
+                        .elements
+                        .get(sibling_idx)
+                        .is_some_and(|sibling| selector_matches_element(&first_info, sibling))
+                }) {
+                    return false;
                 }
             }
             true
@@ -4062,12 +4057,13 @@ fn is_has_argument_unused(
             // This checks siblings of x, not descendants, so opaque content inside x doesn't matter
             for &subject_idx in subject_elements {
                 let subject = &ctx.dom_structure.elements[subject_idx];
-                for &(sibling_idx, _) in &subject.possible_next_adjacent {
-                    if let Some(sibling) = ctx.dom_structure.elements.get(sibling_idx)
-                        && selector_matches_element(&first_info, sibling)
-                    {
-                        return false; // Found a match
-                    }
+                if visit_possible_siblings(ctx, subject_idx, true, false, |sibling_idx| {
+                    ctx.dom_structure
+                        .elements
+                        .get(sibling_idx)
+                        .is_some_and(|sibling| selector_matches_element(&first_info, sibling))
+                }) {
+                    return false;
                 }
                 // If opaque boundaries exist and this element has incomplete sibling data,
                 // be conservative - elements from render tags/slots could be siblings
@@ -4086,12 +4082,13 @@ fn is_has_argument_unused(
             // :has(~ c) - check if any subject element has a following general sibling matching c
             for &subject_idx in subject_elements {
                 let subject = &ctx.dom_structure.elements[subject_idx];
-                for &(sibling_idx, _) in &subject.possible_next_general {
-                    if let Some(sibling) = ctx.dom_structure.elements.get(sibling_idx)
-                        && selector_matches_element(&first_info, sibling)
-                    {
-                        return false; // Found a match
-                    }
+                if visit_possible_siblings(ctx, subject_idx, true, true, |sibling_idx| {
+                    ctx.dom_structure
+                        .elements
+                        .get(sibling_idx)
+                        .is_some_and(|sibling| selector_matches_element(&first_info, sibling))
+                }) {
+                    return false;
                 }
                 // If opaque boundaries exist and this element has incomplete sibling data,
                 // be conservative
@@ -7158,13 +7155,9 @@ fn get_selector_text(node: &Value) -> String {
 /// Generate a raw hash string (matches Svelte's hash() function in utils.js).
 /// This is the base hash without the "svelte-" prefix.
 pub fn generate_raw_hash(source: &str) -> String {
-    // Collect chars in reverse, skipping \r (avoids allocating a replacement string)
     let mut hash: i32 = 5381;
-    let chars: Vec<char> = source.chars().filter(|&c| c != '\r').collect();
-
-    // Iterate backwards like Svelte does
-    for i in (0..chars.len()).rev() {
-        hash = ((hash << 5).wrapping_sub(hash)) ^ (chars[i] as i32);
+    for c in source.chars().rev().filter(|&c| c != '\r') {
+        hash = ((hash << 5).wrapping_sub(hash)) ^ (c as i32);
     }
 
     // Convert to unsigned and then to base-36

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/arena.rs
@@ -1,7 +1,7 @@
 //! Arena allocator for JavaScript AST nodes.
 //!
-//! We store all expressions and statements behind stable boxes and reference
-//! them by index (`ExprId` / `StmtId`).  This gives:
+//! We store expressions and statements in stable chunks and reference them by
+//! index (`ExprId` / `StmtId`). This gives:
 //!
 //! - **Zero-cost reads** (`arena.get_expr(id)` is a single array index)
 //! - **Stable shared references** (pushing more handles cannot move nodes)
@@ -17,8 +17,7 @@
 //!
 //! The arena is single-threaded (not `Sync`) and append-only for safe APIs.
 //! `UnsafeCell` is safe here because:
-//! - Safe allocation stores nodes behind `Box`, so `Vec` reallocation cannot
-//!   move values referenced by previously returned shared references
+//! - Growing the chunk-pointer `Vec` cannot move nodes in existing chunks
 //! - Builders return handles or owned values, not mutable references into
 //!   arena storage
 //! - Mutable/destructive access is `unsafe` and requires callers to prove no
@@ -26,6 +25,7 @@
 
 use super::nodes::{JsExpr, JsStatement};
 use std::cell::UnsafeCell;
+use std::mem::MaybeUninit;
 
 /// Handle to an expression stored in the arena.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -35,16 +35,67 @@ pub struct ExprId(pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StmtId(pub u32);
 
+const NODE_CHUNK_BITS: usize = 5;
+const NODE_CHUNK_SIZE: usize = 1 << NODE_CHUNK_BITS;
+const NODE_CHUNK_MASK: usize = NODE_CHUNK_SIZE - 1;
+
+struct NodeStore<T> {
+    chunks: Vec<Box<[MaybeUninit<T>]>>,
+    len: usize,
+}
+
+impl<T> NodeStore<T> {
+    fn new() -> Self {
+        Self {
+            chunks: Vec::new(),
+            len: 0,
+        }
+    }
+
+    #[inline(always)]
+    fn push(&mut self, value: T) -> usize {
+        if self.len & NODE_CHUNK_MASK == 0 {
+            self.chunks
+                .push(Box::<[T]>::new_uninit_slice(NODE_CHUNK_SIZE));
+        }
+        let index = self.len;
+        self.len += 1;
+        // SAFETY: the chunk was allocated above and this slot is written once.
+        unsafe { self.ptr(index).write(value) };
+        index
+    }
+
+    #[inline(always)]
+    unsafe fn ptr(&self, index: usize) -> *mut T {
+        // SAFETY: callers only pass initialized indices below `len`.
+        unsafe {
+            self.chunks
+                .get_unchecked(index >> NODE_CHUNK_BITS)
+                .as_ptr()
+                .add(index & NODE_CHUNK_MASK)
+                .cast_mut()
+                .cast::<T>()
+        }
+    }
+}
+
+impl<T> Drop for NodeStore<T> {
+    fn drop(&mut self) {
+        for index in 0..self.len {
+            // SAFETY: slots below `len` were initialized exactly once.
+            unsafe { self.ptr(index).drop_in_place() };
+        }
+    }
+}
+
 /// Arena that owns all `JsExpr` and `JsStatement` nodes for a single
 /// compilation unit.
 ///
 /// Allocation takes `&self` (not `&mut self`) so that builder functions
 /// can nest calls without borrow-checker conflicts.
 pub struct JsArena {
-    #[allow(clippy::vec_box)] // Box keeps expression addresses stable across handle Vec growth.
-    exprs: UnsafeCell<Vec<Box<JsExpr>>>,
-    #[allow(clippy::vec_box)] // Box keeps statement addresses stable across handle Vec growth.
-    stmts: UnsafeCell<Vec<Box<JsStatement>>>,
+    exprs: UnsafeCell<NodeStore<JsExpr>>,
+    stmts: UnsafeCell<NodeStore<JsStatement>>,
 }
 
 // JsArena is explicitly NOT Sync - it's single-threaded only.
@@ -55,11 +106,11 @@ pub struct JsArena {
 unsafe impl Send for JsArena {}
 
 impl JsArena {
-    /// Create a new arena with pre-allocated capacity for typical component size.
+    /// Create an empty arena. The first node allocates one fixed-size chunk.
     pub fn new() -> Self {
         Self {
-            exprs: UnsafeCell::new(Vec::with_capacity(256)),
-            stmts: UnsafeCell::new(Vec::with_capacity(64)),
+            exprs: UnsafeCell::new(NodeStore::new()),
+            stmts: UnsafeCell::new(NodeStore::new()),
         }
     }
 
@@ -70,13 +121,10 @@ impl JsArena {
     /// Takes `&self` (not `&mut self`) to allow nested builder calls.
     #[inline(always)]
     pub fn alloc_expr(&self, expr: JsExpr) -> ExprId {
-        // SAFETY: single-threaded append. Values are stored behind `Box`, so
-        // growing the handle Vec cannot move expressions referenced earlier.
+        // SAFETY: single-threaded append into stable chunks.
         unsafe {
-            let vec = &mut *self.exprs.get();
-            let id = ExprId(vec.len() as u32);
-            vec.push(Box::new(expr));
-            id
+            let store = &mut *self.exprs.get();
+            ExprId(store.push(expr) as u32)
         }
     }
 
@@ -85,8 +133,8 @@ impl JsArena {
     pub fn get_expr(&self, id: ExprId) -> &JsExpr {
         // SAFETY: single-threaded read from stable boxed storage.
         unsafe {
-            let vec = &*self.exprs.get();
-            vec[id.0 as usize].as_ref()
+            let store = &*self.exprs.get();
+            &*store.ptr(id.0 as usize)
         }
     }
 
@@ -103,9 +151,9 @@ impl JsArena {
     pub unsafe fn take_expr(&self, id: ExprId) -> JsExpr {
         // SAFETY: Enforced by the caller's contract above.
         unsafe {
-            let vec = &mut *self.exprs.get();
+            let store = &mut *self.exprs.get();
             std::mem::replace(
-                vec[id.0 as usize].as_mut(),
+                &mut *store.ptr(id.0 as usize),
                 JsExpr::Literal(super::nodes::JsLiteral::Null),
             )
         }
@@ -120,10 +168,8 @@ impl JsArena {
     pub fn alloc_stmt(&self, stmt: JsStatement) -> StmtId {
         // SAFETY: same as alloc_expr
         unsafe {
-            let vec = &mut *self.stmts.get();
-            let id = StmtId(vec.len() as u32);
-            vec.push(Box::new(stmt));
-            id
+            let store = &mut *self.stmts.get();
+            StmtId(store.push(stmt) as u32)
         }
     }
 
@@ -132,8 +178,8 @@ impl JsArena {
     pub fn get_stmt(&self, id: StmtId) -> &JsStatement {
         // SAFETY: same as get_expr
         unsafe {
-            let vec = &*self.stmts.get();
-            vec[id.0 as usize].as_ref()
+            let store = &*self.stmts.get();
+            &*store.ptr(id.0 as usize)
         }
     }
 }
@@ -148,7 +194,7 @@ impl std::fmt::Debug for JsArena {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // SAFETY: only reading len, no mutation
         let (exprs_count, stmts_count) =
-            unsafe { ((*self.exprs.get()).len(), (*self.stmts.get()).len()) };
+            unsafe { ((*self.exprs.get()).len, (*self.stmts.get()).len) };
         f.debug_struct("JsArena")
             .field("exprs_count", &exprs_count)
             .field("stmts_count", &stmts_count)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -365,8 +365,12 @@ pub(crate) fn transform_component_with_sourcemap_content(
             // The VLQ encoding uses ';' to separate lines. If the last mapping is on
             // line N but the output has M>N lines, we need trailing semicolons so
             // that decode() produces an array of length M+1.
-            let output_line_count = js.chars().filter(|&c| c == '\n').count();
-            let mapped_lines = mappings_str.chars().filter(|&c| c == ';').count();
+            let output_line_count = js.as_bytes().iter().filter(|&&c| c == b'\n').count();
+            let mapped_lines = mappings_str
+                .as_bytes()
+                .iter()
+                .filter(|&&c| c == b';')
+                .count();
             for _ in mapped_lines..output_line_count {
                 mappings_str.push(';');
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
@@ -24,6 +24,12 @@ use crate::ast::template::Root;
 use crate::compiler::CompileOptions;
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use memchr::memmem;
+use std::cell::RefCell;
+
+thread_local! {
+    static SERVER_OXC_ALLOCATOR: RefCell<oxc_allocator::Allocator> =
+        RefCell::new(oxc_allocator::Allocator::default());
+}
 
 /// Transform a component analysis into server-side JavaScript.
 ///
@@ -46,13 +52,16 @@ pub fn transform_server(
     // corpus improvement. The pipeline never returns `None` for a parseable
     // component; a `None` (only on an internal assembly failure) surfaces as an
     // error rather than silently falling back.
-    let allocator = oxc_allocator::Allocator::default();
-    match ast::server_component_ast(analysis, ast, _source, options, &allocator) {
-        Some(code) => Ok(code),
-        None => Err(TransformError::CodeGen(
-            "server AST pipeline produced no output".to_string(),
-        )),
-    }
+    SERVER_OXC_ALLOCATOR.with(|cell| {
+        let mut allocator = cell.borrow_mut();
+        allocator.reset();
+        match ast::server_component_ast(analysis, ast, _source, options, &allocator) {
+            Some(code) => Ok(code),
+            None => Err(TransformError::CodeGen(
+                "server AST pipeline produced no output".to_string(),
+            )),
+        }
+    })
 }
 
 /// Transform a module (.svelte.js/.svelte.ts) into server-side JavaScript.

--- a/crates/rsvelte_core/src/toolchain.rs
+++ b/crates/rsvelte_core/src/toolchain.rs
@@ -3,7 +3,7 @@
 //! The facade owns no filesystem, cache, scheduler, or thread pool. Embedders
 //! keep those policies and cache the returned immutable DTOs themselves.
 
-use std::ops::Range;
+use std::{cell::OnceCell, ops::Range};
 
 use crate::{
     CompileError, CompileOptions, CompileResult, GenerateMode,
@@ -383,7 +383,7 @@ pub struct PreparedComponent<'source> {
     analysis: Box<ComponentAnalysis>,
     options: CompileOptions,
     runes_mode: bool,
-    facts: ComponentFacts,
+    facts: OnceCell<ComponentFacts>,
 }
 
 impl std::fmt::Debug for PreparedComponent<'_> {
@@ -393,7 +393,7 @@ impl std::fmt::Debug for PreparedComponent<'_> {
             .field("source_len", &self.source.len())
             .field("options", &self.options)
             .field("runes_mode", &self.runes_mode)
-            .field("facts", &self.facts)
+            .field("facts_initialized", &self.facts.get().is_some())
             .finish_non_exhaustive()
     }
 }
@@ -401,14 +401,13 @@ impl std::fmt::Debug for PreparedComponent<'_> {
 impl<'source> PreparedComponent<'source> {
     pub(crate) fn new(source: &'source str, options: CompileOptions) -> Result<Self, CompileError> {
         let mut ast = Box::new(crate::compiler::parse_component(source)?);
-        let (options, analysis, runes_mode, facts) = {
+        let (options, analysis, runes_mode) = {
             // SAFETY: the guard is dropped before `ast` moves into the result.
             let _arena_guard =
                 unsafe { crate::ast::arena::SerializeArenaGuard::new(&ast.arena as *const _) };
             let (options, analysis, runes_mode) =
                 crate::compiler::prepare_and_analyze(&mut ast, source, options)?;
-            let facts = ComponentFacts::collect(source, &ast, &analysis, runes_mode);
-            (options, Box::new(analysis), runes_mode, facts)
+            (options, Box::new(analysis), runes_mode)
         };
 
         Ok(Self {
@@ -417,13 +416,15 @@ impl<'source> PreparedComponent<'source> {
             analysis,
             options,
             runes_mode,
-            facts,
+            facts: OnceCell::new(),
         })
     }
 
     #[must_use]
     pub fn facts(&self) -> &ComponentFacts {
-        &self.facts
+        self.facts.get_or_init(|| {
+            ComponentFacts::collect(self.source, &self.ast, &self.analysis, self.runes_mode)
+        })
     }
 
     pub fn compile(&mut self, target: RuntimeTarget) -> Result<CompileResult, CompileError> {
@@ -451,17 +452,21 @@ impl<'source> PreparedComponent<'source> {
         // SAFETY: `self.ast` cannot move for the duration of this mutable borrow.
         let _arena_guard =
             unsafe { crate::ast::arena::SerializeArenaGuard::new(&self.ast.arena as *const _) };
-        let mut options = self.options.clone();
-        options.generate = generate;
+        let adjusted_options = (self.options.generate != generate).then(|| {
+            let mut options = self.options.clone();
+            options.generate = generate;
+            options
+        });
+        let options = adjusted_options.as_ref().unwrap_or(&self.options);
         let include_sourcemap_content = include_sourcemap_content || options.sourcemap.is_some();
         let transform_result = if include_sourcemap_content {
-            transform_component(&self.analysis, &self.ast, self.source, &options)
+            transform_component(&self.analysis, &self.ast, self.source, options)
         } else {
             transform_component_with_sourcemap_content(
                 &self.analysis,
                 &self.ast,
                 self.source,
-                &options,
+                options,
                 false,
             )
         }
@@ -470,7 +475,7 @@ impl<'source> PreparedComponent<'source> {
             transform_result,
             &self.analysis,
             self.source,
-            &options,
+            options,
             self.runes_mode,
         ))
     }

--- a/crates/rsvelte_core/tests/css_dom_elision.rs
+++ b/crates/rsvelte_core/tests/css_dom_elision.rs
@@ -1,0 +1,80 @@
+use rsvelte_core::{
+    CompileOptions, ParseOptions, ast::arena::SerializeArenaGuard,
+    compiler::phases::analyze_component, parse,
+};
+
+fn analyze(source: &str) -> rsvelte_core::compiler::phases::ComponentAnalysis {
+    let mut root = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("parse");
+    // SAFETY: `root.arena` outlives the guard and analysis.
+    let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
+    analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze")
+}
+
+#[test]
+fn css_dom_is_not_built_without_a_style_block() {
+    let source = "<p>x</p>".repeat(2048);
+    let analysis = analyze(&source);
+    assert!(!analysis.css.has_css);
+    assert!(analysis.css.dom_structure.elements.is_empty());
+}
+
+#[test]
+fn css_dom_and_siblings_are_built_when_styles_exist() {
+    let analysis =
+        analyze("<p class=\"a\"></p><p class=\"b\"></p><style>.a + .b{color:red}</style>");
+    assert!(analysis.css.has_css);
+    assert_eq!(analysis.css.dom_structure.elements.len(), 2);
+    assert_eq!(
+        analysis.css.dom_structure.elements[0]
+            .possible_next_adjacent
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn sibling_relations_are_not_built_for_unrelated_css() {
+    let analysis = analyze("<p></p><p></p><style>p{color:red}</style>");
+    assert_eq!(analysis.css.dom_structure.elements.len(), 2);
+    assert!(
+        analysis.css.dom_structure.elements[0]
+            .possible_next_adjacent
+            .is_empty()
+    );
+    assert!(
+        analysis.css.dom_structure.elements[0]
+            .possible_next_general
+            .is_empty()
+    );
+}
+
+#[test]
+fn static_general_siblings_are_stored_as_links() {
+    let element_count = 128;
+    let mut source = "<p></p>".repeat(element_count);
+    source.push_str("<style>p ~ p{color:red}</style>");
+
+    let analysis = analyze(&source);
+    let dom = &analysis.css.dom_structure;
+    assert!(dom.general_siblings_linked);
+    assert_eq!(dom.elements.len(), element_count);
+    assert_eq!(
+        dom.elements
+            .iter()
+            .map(|element| element.possible_prev_general.len())
+            .sum::<usize>(),
+        element_count - 1
+    );
+    assert_eq!(
+        dom.elements
+            .iter()
+            .map(|element| element.possible_next_general.len())
+            .sum::<usize>(),
+        element_count - 1
+    );
+}

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -743,10 +743,16 @@ impl NapiCompileOptions {
         if let Some(v) = &self.filename {
             opts.filename = Some(coerce_string("filename", v)?);
         }
-        // rootDir defaults to the process's cwd (matches official Svelte).
+        // An absolute cwd cannot affect a relative filename, so defer the
+        // filesystem query unless the default rootDir can actually strip it.
         if let Some(v) = &self.root_dir {
             opts.root_dir = Some(coerce_string("rootDir", v)?);
-        } else if let Ok(cwd) = std::env::current_dir() {
+        } else if opts
+            .filename
+            .as_deref()
+            .is_some_and(|filename| std::path::Path::new(filename).is_absolute())
+            && let Ok(cwd) = std::env::current_dir()
+        {
             opts.root_dir = Some(cwd.to_string_lossy().to_string());
         }
         if let Some(v) = &self.name {
@@ -860,13 +866,7 @@ impl NapiModuleCompileOptions {
 fn options_to_compile(opts: Option<NapiCompileOptions>) -> napi::Result<CompileOptions> {
     match opts {
         Some(o) => o.into_compile_options(),
-        None => {
-            let mut o = CompileOptions::default();
-            if let Ok(cwd) = std::env::current_dir() {
-                o.root_dir = Some(cwd.to_string_lossy().to_string());
-            }
-            Ok(o)
-        }
+        None => Ok(CompileOptions::default()),
     }
 }
 


### PR DESCRIPTION
## Summary

- skip CSS DOM/sibling analysis when it cannot affect the stylesheet
- replace quadratic static sibling relation storage/matching with linear links and an exact two-part selector fast path
- remove repeated source/script scans and defer unused toolchain facts
- reuse the server OXC allocator and store client JS nodes in stable chunks instead of one `Box` per node
- trim fixed N-API, source-map, hashing, options-clone, and client transform costs

No compatibility checks, diagnostics, source maps, or output-equality requirements are disabled.

## Why

The public `svelte-rs` benchmark mixes a real structural advantage (OXC AST retained parse → transform → codegen) with weaker work in some modes: compiler-specific survivor sets, no benchmark-time output equality, and no SSR source maps in `svelte-rs`. Even on an exact common source set, however, rsvelte had real avoidable fixed costs and a severe O(N²) CSS sibling-analysis cliff.

The remaining ordinary serial gap is primarily architectural: rsvelte still converts OXC AST into custom JS IR, emits `Raw` fragments, then reconstructs/re-parses OXC AST before esrap. This PR removes the safe bottlenecks around that path without weakening compatibility.

## Benchmarks

Apple Silicon, release N-API builds, 1,666 exact common client inputs (209,239 source bytes), 25 measured passes after warmup; medians:

| implementation / materialization | time |
| --- | ---: |
| `origin/main` native external-source envelope | 101.03 ms |
| this PR native external-source envelope | 63.48 ms |
| `origin/main` wrapper + source-map materialization | 102.58 ms |
| this PR wrapper + source-map materialization | 73.09 ms |
| `svelte-rs` wrapper + source-map materialization | 34.59 ms |

This PR is about 37% faster at the native envelope boundary and 29% faster end-to-end on this run. The ordinary serial path is still about 2.1× slower than `svelte-rs`; the next step is retaining OXC AST end-to-end.

For the multi-file API, this PR compiles 1,667 client inputs in a 14.25 ms median with `compileBatch`, versus 34.59 ms for the measured serial `svelte-rs` wrapper path.

Pathological static CSS probe (16 KB / 2,000 sibling elements):

| selector | before | this PR |
| --- | ---: | ---: |
| `p {}` | 56.47 ms | 1.51 ms |
| `p ~ p {}` | 434.64 ms | 1.71 ms |

## Validation

- `RUST_TEST_THREADS=2 RAYON_NUM_THREADS=2 RUST_MIN_STACK=33554432 cargo test -p rsvelte_core`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `pnpm run compatibility-report`
  - 3,312 / 3,312 run fixtures passed
  - parser, snapshot, CSS, validator, compiler errors, runtime legacy/runes/browser, hydration, SSR, sourcemaps, print, and preprocess all at 100%
- added focused tests for no-style DOM elision, sibling-analysis elision, and linear static general-sibling storage
