### PR TITLE
perf(compiler): skip redundant analysis and transforms

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -282,9 +282,16 @@ pub(crate) fn analyze_prepared_component(
         rustc_hash::FxHashSet::default()
     };
 
+    let can_have_features = memchr::memchr(b'$', source.as_bytes()).is_some()
+        || memchr::memmem::find(source.as_bytes(), b"await").is_some();
+
     // Check the template fragment for both await expressions and rune references
     // in a single traversal (previously done as two separate walks).
-    let fragment_results = fragment_check_features(&ast.fragment, &ast.arena, &store_sub_names);
+    let fragment_results = if can_have_features {
+        fragment_check_features(&ast.fragment, &ast.arena, &store_sub_names)
+    } else {
+        FragmentCheckResults::default()
+    };
 
     // Check the instance script for both await expressions and rune references
     // in a single traversal. The store-sub exclusion set applies to scripts
@@ -293,18 +300,21 @@ pub(crate) fn analyze_prepared_component(
     // `module.scope.references` *before* runes detection reads it
     // (2-analyze/index.js, `module.scope.references.delete(name)`), so a
     // store-subscribed rune name in the script must not flip runes mode on.
-    let (instance_has_await, instance_has_rune_reference) = ast
-        .instance
-        .as_ref()
-        .map(|inst| {
-            let r = expression_check_features(&inst.content, &ast.arena, &store_sub_names);
-            (r.has_await, r.has_rune_reference)
-        })
-        .unwrap_or((false, false));
+    let (instance_has_await, instance_has_rune_reference) = if can_have_features {
+        ast.instance
+            .as_ref()
+            .map(|inst| {
+                let r = expression_check_features(&inst.content, &ast.arena, &store_sub_names);
+                (r.has_await, r.has_rune_reference)
+            })
+            .unwrap_or((false, false))
+    } else {
+        (false, false)
+    };
 
     // Check the module script for rune references (module scripts don't need await check
     // since the original code only checked instance script for await).
-    let module_has_rune_reference = if needs_rune_detection {
+    let module_has_rune_reference = if needs_rune_detection && can_have_features {
         ast.module
             .as_ref()
             .map(|module| {
@@ -365,7 +375,8 @@ pub(crate) fn analyze_prepared_component(
     // This MUST happen BEFORE the script visitor walk so that is_safe_identifier
     // correctly identifies bindable_prop bindings and sets needs_context = true
     // Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/index.js L562-616
-    if !analysis.runes {
+    let has_export = memchr::memmem::find(source.as_bytes(), b"export").is_some();
+    if !analysis.runes && has_export {
         process_legacy_exports(ast, &mut analysis);
     }
 
@@ -411,7 +422,7 @@ pub(crate) fn analyze_prepared_component(
     // script analysis. Scope data is populated during Phase 1 scope building, so we can
     // do this before analyzing the instance script.
     // Reference: ensure_no_module_import_conflict checks module.scope.get(id.name)?.declaration_kind === 'import'
-    {
+    if ast.module.is_some() {
         let module_decls: rustc_hash::FxHashMap<String, usize> = analysis
             .root
             .scope
@@ -599,7 +610,8 @@ pub(crate) fn analyze_prepared_component(
     //    This correctly handles shadowing (e.g., `{#each a as { a }}`).
     // 2. The `promote_each_expression_bindings` fallback handles cases where the EachItem
     //    binding name doesn't shadow the collection name.
-    if !analysis.runes {
+    let has_each_block = memchr::memmem::find(source.as_bytes(), b"{#each").is_some();
+    if !analysis.runes && has_each_block {
         promote_each_collection_from_scope_info(&mut analysis);
         promote_each_expression_bindings(&ast.fragment, &mut analysis);
     }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -53,6 +53,10 @@ pub fn detect_store_subscriptions(
     options_runes: Option<bool>,
     is_module_file: bool,
 ) -> Result<(), AnalysisError> {
+    if memchr::memchr(b'$', analysis.source.as_bytes()).is_none() {
+        return Ok(());
+    }
+
     // Collect all $xxx references from the AST with context
     let mut store_refs: Vec<StoreRef> = Vec::new();
     let mut template_refs: Vec<StoreRef> = Vec::new();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -402,16 +402,8 @@ fn transform_client_with_visitors(
     // based on node type - the visit function pointer is not actually used
     let mut context = ComponentContext::new(state, |_, _, _| TransformResult::None);
 
-    // Set up state transformers ($.get, $.set wrappers for $state variables)
-    // This must be called before processing the template so that state variable
-    // references in event handlers get properly transformed
-    use crate::compiler::phases::phase3_transform::client::visitors::shared::declarations::add_state_transformers;
-    add_state_transformers(&mut context);
-
     // Visit the program to set up transforms for props, store subscriptions, etc.
-    // This handles legacy mode props ($.prop() getters) and store subscriptions
-    // NOTE: visit_program calls add_state_transformers again internally, so any
-    // transform removals must happen AFTER this call.
+    // This handles state, legacy props, and store subscriptions.
     use crate::compiler::phases::phase3_transform::client::visitors::program::visit_program;
     let _vp_start = super::profile::timer_start();
     visit_program(&mut context);
@@ -466,12 +458,15 @@ fn transform_client_with_visitors(
         if let Some(instance_script) = &analysis.instance_script_content {
             let (imports, script_body) = extract_imports(&instance_script.raw);
             instance_script_imports = imports;
+            let split_top_level_declarations =
+                instance_has_top_level_multi_declarator(ast, &instance_script.raw);
             let _script_start = super::profile::timer_start();
             let mut transformed = transform_instance_script_for_visitors(
                 &script_body,
                 analysis,
                 options.dev,
                 &reactive_import_names,
+                split_top_level_declarations,
             );
             rest_excludes_hoists = extract_rest_excludes_hoists(&mut transformed);
             super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
@@ -2211,14 +2206,9 @@ fn transform_client_with_visitors(
     super::profile::record_assembly_after_fragment(super::profile::timer_elapsed(_assembly_start));
     let _codegen_start = super::profile::timer_start();
 
-    // Direct-AST codegen via to_oxc + esrap — the DEFAULT client codegen path.
-    // The string codegen (`generate` / `generate_with_sourcemap`) is the fallback
-    // for the ~0.03% of components carrying a node shape `to_oxc` does not model
-    // yet (`{@const}` computed destructuring is the only one left in the Svelte
-    // corpus). `RSVELTE_CLIENT_NO_OXC` forces the legacy string path (escape
-    // hatch). Span-stamping (`Spanned` / `RawMapped` → original-source offsets)
-    // feeds esrap `print_with_map` for the sourcemap branch.
-    if !*CLIENT_NO_OXC {
+    // Scriptless components use the faster handwritten printer. Scripts need
+    // OXC/esrap for official formatting and coordinate-aware comment placement.
+    if *CLIENT_USE_OXC || ast.instance.is_some() || ast.module.is_some() {
         let converted = CLIENT_TO_OXC_ALLOCATOR.with(|cell| {
             let mut alloc = cell.borrow_mut();
             alloc.reset();
@@ -2317,8 +2307,8 @@ thread_local! {
         std::cell::RefCell::new(oxc_allocator::Allocator::default());
 }
 
-static CLIENT_NO_OXC: LazyLock<bool> =
-    LazyLock::new(|| std::env::var_os("RSVELTE_CLIENT_NO_OXC").is_some());
+static CLIENT_USE_OXC: LazyLock<bool> =
+    LazyLock::new(|| std::env::var_os("RSVELTE_CLIENT_TO_OXC").is_some());
 static CLIENT_TO_OXC_DEBUG: LazyLock<bool> =
     LazyLock::new(|| std::env::var_os("RSVELTE_CLIENT_TO_OXC_DEBUG").is_some());
 
@@ -3236,6 +3226,12 @@ pub(super) fn is_variable_reassigned_in_text(script: &str, var_name: &str) -> bo
 }
 
 pub(super) fn extract_local_reactive_vars(script: &str) -> Vec<(String, bool, bool)> {
+    if memmem::find(script.as_bytes(), b"$state").is_none()
+        && memmem::find(script.as_bytes(), b"$derived").is_none()
+    {
+        return Vec::new();
+    }
+
     let mut vars = Vec::new();
 
     // Pattern: (let|const|var) varname = $state(...) or (let|const|var) varname = $derived(...)
@@ -3873,7 +3869,13 @@ pub(crate) fn transform_instance_script_for_visitors_pub(
     dev: bool,
     reactive_import_names: &[String],
 ) -> String {
-    transform_instance_script_for_visitors(script, analysis, dev, reactive_import_names)
+    transform_instance_script_for_visitors(
+        script,
+        analysis,
+        dev,
+        reactive_import_names,
+        might_have_comma_separated_declaration(script),
+    )
 }
 
 /// True when a legacy-mode script contains a `$`-token that the fragile
@@ -3897,11 +3899,60 @@ fn legacy_script_has_dollar_token(script: &str) -> bool {
     false
 }
 
+fn might_have_comma_separated_declaration(script: &str) -> bool {
+    let bytes = script.as_bytes();
+    if memmem::find(bytes, b", ").is_none()
+        && memmem::find(bytes, b",\n").is_none()
+        && memmem::find(bytes, b",\t").is_none()
+    {
+        return false;
+    }
+
+    script.lines().any(|line| {
+        let trimmed = line.trim_start();
+        let declaration = trimmed
+            .strip_prefix("export ")
+            .map(str::trim_start)
+            .unwrap_or(trimmed);
+        declaration.starts_with("const ")
+            || declaration.starts_with("let ")
+            || declaration.starts_with("var ")
+    })
+}
+
+fn instance_has_top_level_multi_declarator(ast: &Root, script: &str) -> bool {
+    use crate::ast::typed_expr::JsNode;
+
+    let Some(instance) = ast.instance.as_ref() else {
+        return false;
+    };
+    let program = instance.content.as_node();
+    let JsNode::Program { body, .. } = program.as_ref() else {
+        return might_have_comma_separated_declaration(script);
+    };
+
+    ast.arena.get_js_children(*body).iter().any(|statement| {
+        let declaration = match statement {
+            JsNode::VariableDeclaration { declarations, .. } => Some(*declarations),
+            JsNode::ExportNamedDeclaration {
+                declaration: Some(declaration),
+                ..
+            } => match ast.arena.get_js_node(*declaration) {
+                JsNode::VariableDeclaration { declarations, .. } => Some(*declarations),
+                _ => None,
+            },
+            _ => None,
+        };
+        declaration.is_some_and(|declarations| ast.arena.get_js_children(declarations).len() > 1)
+    })
+}
+
 fn transform_instance_script_for_visitors(
     script: &str,
     analysis: &ComponentAnalysis,
     dev: bool,
     reactive_import_names: &[String],
+    split_top_level_declarations: bool,
 ) -> String {
     if script.is_empty() {
         return String::new();
@@ -3910,9 +3961,7 @@ fn transform_instance_script_for_visitors(
     // Instance imports are removed by the caller before this pipeline.
     let has_dollar = script.contains('$');
     let has_export = memmem::find(script.as_bytes(), b"export ").is_some();
-    let has_comma_decl = memmem::find(script.as_bytes(), b", ").is_some()
-        || memmem::find(script.as_bytes(), b",\n").is_some()
-        || memmem::find(script.as_bytes(), b",\t").is_some();
+    let has_comma_decl = split_top_level_declarations;
     if !has_dollar
         && !has_export
         && analysis.root.bindings.iter().all(|b| {
@@ -3974,9 +4023,11 @@ fn transform_instance_script_for_visitors(
     };
 
     // Split comma-separated variable declarations only if needed
-    let script: std::borrow::Cow<str> = if memmem::find(script.as_bytes(), b", ").is_some()
-        || memmem::find(script.as_bytes(), b",\n").is_some()
-        || memmem::find(script.as_bytes(), b",\t").is_some()
+    let class_transform_can_add_declarations = memmem::find(script.as_bytes(), b"class ").is_some()
+        && (memmem::find(script.as_bytes(), b"$state").is_some()
+            || memmem::find(script.as_bytes(), b"$derived").is_some());
+    let script: std::borrow::Cow<str> = if split_top_level_declarations
+        || (class_transform_can_add_declarations && might_have_comma_separated_declaration(&script))
     {
         std::borrow::Cow::Owned(crate::compiler::phases::phase3_transform::server::transform_script::split_comma_separated_declarations(&script))
     } else {
@@ -5170,30 +5221,36 @@ fn transform_instance_script_for_visitors(
 
         // Store transforms: skip entirely when there are no store subscriptions
         // In runes mode, deferred to AST-based transform after main loop.
-        let transformed = if !store_sub_vars.is_empty() && !analysis.runes {
-            // Filter out store_sub_vars that appear as function parameters in this statement.
-            let effective_store_sub_vars: Vec<String> = if store_sub_vars
+        let transformed = if !store_sub_vars.is_empty()
+            && !analysis.runes
+            && store_sub_vars
                 .iter()
-                .any(|s| transformed.contains(s.as_str()))
-            {
-                store_sub_vars
-                    .iter()
-                    .filter(|s| !is_function_parameter_in_statement(&transformed, s))
-                    .cloned()
-                    .collect()
-            } else {
-                store_sub_vars.to_vec()
-            };
+                .any(|store| transformed.contains(store.as_str()))
+        {
+            // Filter out store_sub_vars that appear as function parameters in this statement.
+            let mut filtered_store_sub_vars = Vec::new();
+            let effective_store_sub_vars =
+                if transformed.contains("=>") || transformed.contains("function") {
+                    filtered_store_sub_vars.extend(
+                        store_sub_vars
+                            .iter()
+                            .filter(|s| !is_function_parameter_in_statement(&transformed, s))
+                            .cloned(),
+                    );
+                    filtered_store_sub_vars.as_slice()
+                } else {
+                    store_sub_vars
+                };
 
-            let transformed = transform_store_sub_calls(&transformed, &effective_store_sub_vars);
+            let transformed = transform_store_sub_calls(&transformed, effective_store_sub_vars);
             let transformed = transform_store_assignments_client(
                 &transformed,
-                &effective_store_sub_vars,
+                effective_store_sub_vars,
                 prop_assignment_transform_vars,
                 state_vars,
                 non_reactive_state_vars,
             );
-            transform_store_reads_client(&transformed, &effective_store_sub_vars)
+            transform_store_reads_client(&transformed, effective_store_sub_vars)
         } else {
             transformed
         };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
@@ -90,7 +90,7 @@ pub fn transform_state_assigns_ast(
         return None;
     }
 
-    ast_rewrite::fixed_point(source, |src| {
+    ast_rewrite::fixed_point_while_deferred(source, |src| {
         single_pass(src, state_vars, raw_state_vars, is_runes, non_proxy_vars)
     })
 }
@@ -101,7 +101,7 @@ fn single_pass(
     raw_state_vars: &[String],
     is_runes: bool,
     non_proxy_vars: &[String],
-) -> Option<String> {
+) -> Option<(String, bool)> {
     ast_rewrite::with_program(
         &STATE_ASSIGNS_ALLOC,
         source,
@@ -127,7 +127,7 @@ fn single_pass(
             };
             collector.visit_program(program);
 
-            ast_rewrite::splice(source, collector.replacements, true)
+            ast_rewrite::splice_with_deferred(source, collector.replacements, true)
         },
     )
 }
@@ -377,6 +377,22 @@ mod tests {
         assert_eq!(
             out,
             "let outer; let inner; $.set(outer, ($.set(inner, 1)));"
+        );
+    }
+
+    #[test]
+    fn deeply_nested_assignments_wrap_inside_out() {
+        let out = transform_state_assigns_ast(
+            "let outer; let middle; let inner; outer = (middle = (inner += 1));",
+            &ssv(&["outer", "middle", "inner"]),
+            &[],
+            false,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "let outer; let middle; let inner; $.set(outer, ($.set(middle, ($.set(inner, $.get(inner) + 1)))));"
         );
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -368,15 +368,13 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
         // But avoid replacing function calls that already have ()
         let mut new_result = String::with_capacity(result.len() * 2);
         let chars: Vec<char> = result.chars().collect();
+        let mut char_byte_offsets: Vec<usize> = result.char_indices().map(|(i, _)| i).collect();
+        char_byte_offsets.push(result.len());
         let mut i = 0;
 
         while i < chars.len() {
             // Check if we're at the start of the identifier
-            let byte_i = result
-                .char_indices()
-                .nth(i)
-                .map(|(idx, _)| idx)
-                .unwrap_or(i);
+            let byte_i = char_byte_offsets[i];
             let remaining = &result[byte_i..];
             if remaining.starts_with(store_sub) {
                 // Check character before (must be non-identifier char or start of string)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/program.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/program.rs
@@ -148,122 +148,101 @@ pub fn visit_program(context: &mut ComponentContext) -> Option<JsProgram> {
     // This sets up read/assign/mutate/update transforms that wrap identifiers with $.get(), $.set(), etc.
     add_state_transformers(context);
 
-    // Handle store subscriptions, props, and state bindings for all modes
-    for (name, binding_idx) in context.state.scope.declarations.clone() {
-        // The flattened root `scope.declarations` map can be polluted by a
-        // same-named binding collapsed from an unrelated scope (e.g. a
-        // `<script module>` function parameter also named `context`), which would
-        // shadow the real instance binding and skip its prop read transform,
-        // leaving template reads as a bare identifier instead of `name()`. Reads in
-        // the instance/template resolve to the instance-scope binding, so prefer it.
-        let binding_idx = context
-            .state
-            .scope_root
-            .all_scopes
-            .get(context.state.scope_root.instance_scope_index)
-            .and_then(|s| s.declarations.get(&name).copied())
-            .unwrap_or(binding_idx);
+    let instance_scope = context
+        .state
+        .scope_root
+        .all_scopes
+        .get(context.state.scope_root.instance_scope_index);
+    let transform_bindings: Vec<(String, usize)> = context
+        .state
+        .scope
+        .declarations
+        .iter()
+        .filter_map(|(name, &fallback_idx)| {
+            let binding_idx = instance_scope
+                .and_then(|scope| scope.declarations.get(name).copied())
+                .unwrap_or(fallback_idx);
+            context
+                .state
+                .scope_root
+                .bindings
+                .get(binding_idx)
+                .is_some_and(|binding| {
+                    matches!(
+                        binding.kind,
+                        BindingKind::StoreSub | BindingKind::Prop | BindingKind::BindableProp
+                    )
+                })
+                .then(|| (name.clone(), binding_idx))
+        })
+        .collect();
+
+    // Source props and stores were registered by add_state_transformers.
+    // Keep the missing-transform branches as a fallback for incomplete scopes.
+    for (name, binding_idx) in transform_bindings {
         if let Some(binding) = context.state.scope_root.bindings.get(binding_idx) {
-            // Mark different binding types for transformation
             match binding.kind {
                 BindingKind::StoreSub => {
-                    // Store subscriptions need special transformation
-                    // Corresponds to the store_sub handling in Program.js:
-                    //
-                    // context.state.transform[name] = {
-                    //     read: b.call,                           // $store → $store()
-                    //     assign: (_, value) => b.call('$.store_set', get_store(), value),
-                    //     mutate: (node, mutation) => b.call('$.store_mutate', ...),
-                    //     update: (node) => b.call(node.prefix ? '$.update_pre_store' : '$.update_store', ...)
-                    // };
-                    //
-                    // The store variable name starts with '$', e.g., '$count'
-                    // The underlying store is 'count' (without the '$')
-
-                    let transform = IdentifierTransform {
-                        read: Some(store_sub_read),
-                        read_source: None,
-                        assign: Some(store_sub_assign),
-                        mutate: Some(store_sub_mutate),
-                        update: Some(store_sub_update),
-                        skip_proxy: false,
-                        is_defined: false,
-                        // Store subscriptions are reactive
-                        is_reactive: true,
-                        replacement_id: None,
-                    };
-
-                    context.state.transform.insert(name.clone(), transform);
-                }
-                BindingKind::Prop | BindingKind::BindableProp => {
-                    // Props need special handling based on whether they're sources.
-                    // In legacy mode, props created with `export let` become getter functions
-                    // via $.prop(), so reading them should call the getter: foo -> foo()
-                    //
-                    // Corresponds to the prop handling in Program.js:
-                    // context.state.transform[name] = {
-                    //     read: b.call,  // foo -> foo()
-                    //     assign: (node, value) => b.call(node, value),
-                    //     mutate: (node, value) => {
-                    //         if (binding.kind === 'bindable_prop') return b.call(node, value, b.true);
-                    //         return value;
-                    //     }
-                    // };
-                    //
-                    // Check if this prop should be a source (needs transformation)
-                    if is_prop_source_binding(binding, &context.state) {
-                        // For BindableProp, mutations must notify the parent: node(mutation, true)
-                        // For regular Prop, mutations are passed through unchanged.
-                        let mutate_fn = if matches!(binding.kind, BindingKind::BindableProp) {
-                            prop_bindable_mutate
-                        } else {
-                            prop_mutate
-                        };
-                        let transform = IdentifierTransform {
-                            read: Some(prop_read),
-                            read_source: None,
-                            assign: Some(prop_assign),
-                            mutate: Some(mutate_fn),
-                            update: Some(prop_update),
-                            skip_proxy: false,
-                            is_defined: false,
-                            is_reactive: true,
-                            replacement_id: None,
-                        };
-
-                        context.state.transform.insert(name.clone(), transform);
-                        // Bindable props are template-kind and require
-                        // deep_read_state wrapping in legacy reactivity.
-                        if matches!(binding.kind, BindingKind::BindableProp) {
-                            context.state.transform_deep_read.insert(name.clone(), ());
-                        }
-                    } else {
-                        // Non-source props: read from $$props.name
-                        // Corresponds to Program.js lines 125-134:
-                        // context.state.transform[name] = {
-                        //     read: (node) => b.member(b.id('$$props'), node)
-                        // };
-                        let transform = IdentifierTransform {
-                            read: Some(non_source_prop_read),
-                            read_source: None,
-                            assign: None,
-                            mutate: None,
-                            update: None,
-                            skip_proxy: false,
-                            is_defined: false,
-                            is_reactive: true,
-                            replacement_id: None,
-                        };
-
-                        context.state.transform.insert(name.clone(), transform);
+                    if !context.state.transform.contains_key(&name) {
+                        context.state.transform.insert(
+                            name,
+                            IdentifierTransform {
+                                read: Some(store_sub_read),
+                                read_source: None,
+                                assign: Some(store_sub_assign),
+                                mutate: Some(store_sub_mutate),
+                                update: Some(store_sub_update),
+                                skip_proxy: false,
+                                is_defined: false,
+                                is_reactive: true,
+                                replacement_id: None,
+                            },
+                        );
                     }
                 }
-                BindingKind::State | BindingKind::RawState | BindingKind::Derived => {
-                    // State variables need $.get() wrapping
-                    // Transforms are set up by add_state_transformers above
-                }
-                BindingKind::LegacyReactive => {
-                    // Legacy reactive statements need special handling
+                BindingKind::Prop | BindingKind::BindableProp => {
+                    if is_prop_source_binding(binding, &context.state) {
+                        if !context.state.transform.contains_key(&name) {
+                            context.state.transform.insert(
+                                name.clone(),
+                                IdentifierTransform {
+                                    read: Some(prop_read),
+                                    read_source: None,
+                                    assign: Some(prop_assign),
+                                    mutate: Some(
+                                        if matches!(binding.kind, BindingKind::BindableProp) {
+                                            prop_bindable_mutate
+                                        } else {
+                                            prop_mutate
+                                        },
+                                    ),
+                                    update: Some(prop_update),
+                                    skip_proxy: false,
+                                    is_defined: false,
+                                    is_reactive: true,
+                                    replacement_id: None,
+                                },
+                            );
+                        }
+                        if matches!(binding.kind, BindingKind::BindableProp) {
+                            context.state.transform_deep_read.insert(name, ());
+                        }
+                    } else {
+                        context.state.transform.insert(
+                            name,
+                            IdentifierTransform {
+                                read: Some(non_source_prop_read),
+                                read_source: None,
+                                assign: None,
+                                mutate: None,
+                                update: None,
+                                skip_proxy: false,
+                                is_defined: false,
+                                is_reactive: true,
+                                replacement_id: None,
+                            },
+                        );
+                    }
                 }
                 _ => {}
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/declarations.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/declarations.rs
@@ -88,8 +88,16 @@ fn safe_get_value(arena: &JsArena, node: JsExpr) -> JsExpr {
 /// $.set(count, 5);  // Uses the assign transformer
 /// ```
 pub fn add_state_transformers(context: &mut ComponentContext) {
+    let instance_scope = context
+        .state
+        .scope_root
+        .all_scopes
+        .get(context.state.scope_root.instance_scope_index);
     // Iterate over all declarations in the current scope
-    for (name, binding_idx) in context.state.scope.declarations.iter() {
+    for (name, fallback_idx) in context.state.scope.declarations.iter() {
+        let binding_idx = instance_scope
+            .and_then(|scope| scope.declarations.get(name))
+            .unwrap_or(fallback_idx);
         // Get the binding from the root scope
         if let Some(binding) = context.state.scope_root.bindings.get(*binding_idx) {
             // Skip import bindings that already have a transform registered.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/ast_rewrite.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/ast_rewrite.rs
@@ -71,18 +71,34 @@ pub fn with_program<R>(
 /// is what makes nested rewrites such as `a = b = 1` resolve correctly without
 /// the collector having to reason about overlap. Passes whose edits provably
 /// never nest pass `false` and skip the O(n²) containment check.
-pub fn splice(source: &str, mut edits: Vec<Edit>, innermost_only: bool) -> Option<String> {
+pub fn splice(source: &str, edits: Vec<Edit>, innermost_only: bool) -> Option<String> {
+    splice_with_deferred(source, edits, innermost_only).map(|(rewritten, _)| rewritten)
+}
+
+/// [`splice`] plus whether an outer edit was deferred by `innermost_only`.
+///
+/// A caller whose collector finds every target in the current AST, and whose
+/// replacements cannot create fresh targets, may stop after this pass when the
+/// returned flag is `false` instead of re-parsing only to confirm a no-op.
+pub fn splice_with_deferred(
+    source: &str,
+    mut edits: Vec<Edit>,
+    innermost_only: bool,
+) -> Option<(String, bool)> {
     if edits.is_empty() {
         return None;
     }
 
+    let mut deferred = false;
     if innermost_only {
+        let edit_count = edits.len();
         let spans: Vec<(u32, u32)> = edits.iter().map(|&(s, e, _)| (s, e)).collect();
         edits.retain(|&(s, e, _)| {
             !spans
                 .iter()
                 .any(|&(s2, e2)| (s2 > s && e2 <= e) || (s2 >= s && e2 < e))
         });
+        deferred = edits.len() != edit_count;
         if edits.is_empty() {
             return None;
         }
@@ -94,7 +110,7 @@ pub fn splice(source: &str, mut edits: Vec<Edit>, innermost_only: bool) -> Optio
     for (start, end, replacement) in &edits {
         out.replace_range(*start as usize..*end as usize, replacement);
     }
-    Some(out)
+    Some((out, deferred))
 }
 
 /// Convenience: [`with_program`] + collect + [`splice`] in one pass. The
@@ -153,6 +169,30 @@ pub fn fixed_point(source: &str, mut pass: impl FnMut(&str) -> Option<String>) -
     Some(current)
 }
 
+/// Drive `pass` only while its previous splice deferred an overlapping edit.
+///
+/// This is narrower than [`fixed_point`]: callers must guarantee that a pass
+/// without deferred edits has exhausted every target in the rewritten source.
+pub fn fixed_point_while_deferred(
+    source: &str,
+    mut pass: impl FnMut(&str) -> Option<(String, bool)>,
+) -> Option<String> {
+    let (mut current, mut deferred) = pass(source)?;
+    for _ in 1..MAX_FIXED_POINT_ITERS {
+        if !deferred {
+            break;
+        }
+        match pass(&current) {
+            Some((next, next_deferred)) => {
+                current = next;
+                deferred = next_deferred;
+            }
+            None => break,
+        }
+    }
+    Some(current)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -185,6 +225,24 @@ mod tests {
     }
 
     #[test]
+    fn splice_reports_deferred_outer_edit() {
+        let edits = vec![(0, 5, "OUTER".to_string()), (2, 3, "I".to_string())];
+        assert_eq!(
+            splice_with_deferred("abcde", edits, true),
+            Some(("abIde".to_string(), true))
+        );
+    }
+
+    #[test]
+    fn splice_reports_no_deferred_disjoint_edit() {
+        let edits = vec![(0, 1, "X".to_string()), (2, 3, "Y".to_string())];
+        assert_eq!(
+            splice_with_deferred("abc", edits, true),
+            Some(("XbY".to_string(), false))
+        );
+    }
+
+    #[test]
     fn fixed_point_returns_none_when_first_pass_noop() {
         assert!(fixed_point("x", |_| None).is_none());
     }
@@ -212,5 +270,38 @@ mod tests {
             Some(format!("{s}."))
         });
         assert_eq!(calls, MAX_FIXED_POINT_ITERS);
+    }
+
+    #[test]
+    fn fixed_point_while_deferred_stops_without_confirmation_pass() {
+        let mut calls = 0;
+        let out = fixed_point_while_deferred("x", |_| {
+            calls += 1;
+            Some(("y".to_string(), false))
+        });
+        assert_eq!(out.as_deref(), Some("y"));
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn fixed_point_while_deferred_runs_required_follow_up() {
+        let mut calls = 0;
+        let out = fixed_point_while_deferred("x", |_| {
+            calls += 1;
+            Some((calls.to_string(), calls == 1))
+        });
+        assert_eq!(out.as_deref(), Some("2"));
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn fixed_point_while_deferred_returns_none_for_initial_noop() {
+        let mut calls = 0;
+        let out = fixed_point_while_deferred("x", |_| {
+            calls += 1;
+            None
+        });
+        assert_eq!(out, None);
+        assert_eq!(calls, 1);
     }
 }


### PR DESCRIPTION
## Summary

- skip store-subscription and feature AST walks when the source cannot contain the relevant syntax
- avoid redundant state, prop, and store transform construction in client code generation
- use the faster handwritten client printer for scriptless components while preserving the OXC/esrap path for script-bearing components
- detect top-level multi-declarator statements from the Phase 1 AST instead of a broad text heuristic
- avoid fixed-point confirmation reparses when no deferred outer edit remains

## Performance

On the common 1,666-file CSR corpus, with source maps materialized, three warmups, and 15 measured runs:

- rsvelte native median: 63.04 ms → 57.49 ms (-8.8%)
- rsvelte JavaScript wrapper median: 62.84 ms
- svelte-rs native median: 29.43 ms

This is an incremental compatibility-safe improvement. The remaining gap requires retaining the Phase 1 OXC AST and progressively removing the intermediate client IR and script reparse boundaries.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p rsvelte_core --lib -- --nocapture` (1499 passed, 1 ignored)
- `pnpm run compatibility-report` (3312/3312, 100%)
- sourcemap/comment compatibility gates
- `pnpm run build:vps-native`
