### PR TITLE
perf(compiler): retain phase 1 script programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ dependencies = [
  "regex",
  "rsvelte_esrap",
  "rustc-hash",
+ "self_cell",
  "serde",
  "serde_json",
  "similar 3.1.1",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -61,6 +61,7 @@ rayon = { version = "1.10", optional = true }
 bumpalo = { version = "3.16", features = ["collections"] }
 compact_str = { version = "0.10", features = ["serde"] }
 smallvec = { version = "1.13", features = ["serde"] }
+self_cell = "1.2"
 
 # Fast hashing (5-10x faster than std HashMap/HashSet)
 rustc-hash = "2.0"

--- a/crates/rsvelte_core/src/ast/mod.rs
+++ b/crates/rsvelte_core/src/ast/mod.rs
@@ -9,6 +9,7 @@
 pub mod arena;
 pub mod css;
 pub mod js;
+pub(crate) mod oxc_program;
 pub mod span;
 pub mod template;
 pub mod typed_expr;

--- a/crates/rsvelte_core/src/ast/oxc_program.rs
+++ b/crates/rsvelte_core/src/ast/oxc_program.rs
@@ -1,0 +1,114 @@
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use self_cell::self_cell;
+
+struct ProgramOwner<'source> {
+    allocator: Allocator,
+    source: &'source str,
+    source_type: SourceType,
+}
+
+impl ProgramOwner<'_> {
+    fn source(&self) -> &str {
+        self.source
+    }
+}
+
+struct ParsedProgram<'alloc> {
+    program: Program<'alloc>,
+    diagnostics: Vec<OxcDiagnostic>,
+    panicked: bool,
+}
+
+self_cell!(
+    pub(crate) struct RetainedProgram<'source> {
+        owner: ProgramOwner<'source>,
+
+        #[covariant]
+        dependent: ParsedProgram,
+    }
+);
+
+impl<'source> RetainedProgram<'source> {
+    pub(crate) fn parse(source: &'source str, is_typescript: bool) -> Self {
+        let source_type = if is_typescript {
+            SourceType::ts()
+        } else {
+            SourceType::mjs()
+        };
+        Self::new(
+            ProgramOwner {
+                allocator: Allocator::default(),
+                source,
+                source_type,
+            },
+            |owner| {
+                let parsed =
+                    Parser::new(&owner.allocator, owner.source(), owner.source_type).parse();
+                ParsedProgram {
+                    program: parsed.program,
+                    diagnostics: parsed.diagnostics.into_vec(),
+                    panicked: parsed.panicked,
+                }
+            },
+        )
+    }
+
+    pub(crate) fn program(&self) -> &Program<'_> {
+        &self.borrow_dependent().program
+    }
+
+    pub(crate) fn diagnostics(&self) -> &[OxcDiagnostic] {
+        &self.borrow_dependent().diagnostics
+    }
+
+    pub(crate) fn panicked(&self) -> bool {
+        self.borrow_dependent().panicked
+    }
+}
+
+impl std::fmt::Debug for RetainedProgram<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RetainedProgram")
+            .field("body_len", &self.program().body.len())
+            .field("comments_len", &self.program().comments.len())
+            .field("diagnostics_len", &self.diagnostics().len())
+            .field("panicked", &self.panicked())
+            .finish()
+    }
+}
+
+// SAFETY: The allocator and its AST move together and are only accessible through ownership.
+unsafe impl Send for RetainedProgram<'_> {}
+
+#[derive(Debug, Default)]
+pub(crate) struct RetainedScripts<'source> {
+    pub instance: Option<RetainedProgram<'source>>,
+    pub module: Option<RetainedProgram<'source>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RetainedProgram;
+
+    #[test]
+    fn retains_program_after_move() {
+        let retained = RetainedProgram::parse("// note\nexport const answer = 42;", false);
+        let moved = retained;
+
+        assert_eq!(moved.program().body.len(), 1);
+        assert_eq!(moved.program().comments.len(), 1);
+        assert!(moved.diagnostics().is_empty());
+        assert!(!moved.panicked());
+    }
+
+    #[test]
+    fn is_send_when_owner_and_program_move_together() {
+        fn assert_send<T: Send>() {}
+        assert_send::<RetainedProgram<'static>>();
+    }
+}

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -517,13 +517,21 @@ pub(crate) fn parse_component(source: &str) -> Result<crate::ast::Root<'_>, Comp
 /// arena guard: resolve lazy expressions, finish deferred script parsing, strip
 /// TypeScript, merge `<svelte:options>` into `options`, and analyze.
 ///
-/// Returns the merged options, the analysis, and whether runes mode is active.
+/// Returns the merged options, analysis, runes mode, and compile-only script programs.
 /// The caller must install the AST's serialize-arena guard for this call.
-pub(crate) fn prepare_and_analyze(
-    ast: &mut crate::ast::Root,
-    source: &str,
+pub(crate) fn prepare_and_analyze<'source>(
+    ast: &mut crate::ast::Root<'source>,
+    source: &'source str,
     mut options: CompileOptions,
-) -> Result<(CompileOptions, ComponentAnalysis, bool), CompileError> {
+) -> Result<
+    (
+        CompileOptions,
+        ComponentAnalysis,
+        bool,
+        crate::ast::oxc_program::RetainedScripts<'source>,
+    ),
+    CompileError,
+> {
     let line_offsets = phases::phase1_parse::compute_line_offsets(source, false);
 
     // Resolve lazy expressions (deferred template expressions). If any
@@ -541,26 +549,31 @@ pub(crate) fn prepare_and_analyze(
     // Ensure deferred script parsing is completed before TypeScript removal.
     // When defer_script_parse is enabled, script content is stored as raw text;
     // parse it first so remove_typescript_nodes can inspect the AST.
+    let mut retained_scripts = crate::ast::oxc_program::RetainedScripts::default();
     {
-        if let Some(ref mut instance) = ast.instance
-            && let Some(parse_err) = phases::phase1_parse::read::script::ensure_script_parsed(
-                &ast.arena,
-                instance,
-                source,
-                &line_offsets,
-            )
-        {
-            return Err(parse_err.into());
+        if let Some(ref mut instance) = ast.instance {
+            let (parse_error, retained) =
+                phases::phase1_parse::read::script::ensure_script_parsed_retained(
+                    &ast.arena,
+                    instance,
+                    &line_offsets,
+                );
+            if let Some(parse_error) = parse_error {
+                return Err(parse_error.into());
+            }
+            retained_scripts.instance = retained;
         }
-        if let Some(ref mut module) = ast.module
-            && let Some(parse_err) = phases::phase1_parse::read::script::ensure_script_parsed(
-                &ast.arena,
-                module,
-                source,
-                &line_offsets,
-            )
-        {
-            return Err(parse_err.into());
+        if let Some(ref mut module) = ast.module {
+            let (parse_error, retained) =
+                phases::phase1_parse::read::script::ensure_script_parsed_retained(
+                    &ast.arena,
+                    module,
+                    &line_offsets,
+                );
+            if let Some(parse_error) = parse_error {
+                return Err(parse_error.into());
+            }
+            retained_scripts.module = retained;
         }
     }
 
@@ -584,7 +597,7 @@ pub(crate) fn prepare_and_analyze(
     let analysis = phases::phase2_analyze::analyze_prepared_component(ast, source, &options)?;
     // Determine if runes mode was used
     let runes_mode = options.runes.unwrap_or(analysis.runes);
-    Ok((options, analysis, runes_mode))
+    Ok((options, analysis, runes_mode, retained_scripts))
 }
 
 /// Compile a Svelte component.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -23,7 +23,8 @@
 use std::cell::RefCell;
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::Expression as OxcExpression;
+use oxc_ast::ast::{Expression as OxcExpression, Program as OxcProgram};
+use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::Parser as OxcParser;
 use oxc_span::{GetSpan, SourceType};
 use serde_json::{Map, Value};
@@ -6628,14 +6629,15 @@ fn create_typed_loc_for_script(
 
 /// Parameters for [`parse_program_with_error`], grouped into a struct to keep
 /// the function signature under clippy's argument-count lint.
-pub struct ProgramParseParams<'a> {
-    pub content: &'a str,
+#[derive(Clone, Copy)]
+pub struct ProgramParseParams<'source, 'context> {
+    pub content: &'source str,
     pub offset: usize,
-    pub line_offsets: &'a [usize],
+    pub line_offsets: &'context [usize],
     /// Set to true if the script contains TypeScript.
     pub is_typescript: bool,
     /// HTML comments that appeared before the script tag.
-    pub leading_comments: &'a [String],
+    pub leading_comments: &'context [String],
     /// Positions for loc calculation (Svelte uses locator(start) for
     /// loc.start and locator(parser.index) for loc.end).
     pub script_tag_start: usize,
@@ -6653,6 +6655,38 @@ pub fn parse_program_with_error<'a>(
     arena: &ParseArena,
     params: ProgramParseParams,
 ) -> (Expression<'a>, Option<crate::error::ParseError>) {
+    with_oxc_allocator(|allocator| {
+        let source_type = if params.is_typescript {
+            SourceType::ts()
+        } else {
+            SourceType::mjs()
+        };
+        let result = OxcParser::new(allocator, params.content, source_type).parse();
+        convert_parsed_program(arena, &result.program, &result.diagnostics, params)
+    })
+}
+
+pub fn parse_program_retained_with_error<'ast, 'source>(
+    arena: &ParseArena,
+    params: ProgramParseParams<'source, '_>,
+) -> (
+    Expression<'ast>,
+    Option<crate::error::ParseError>,
+    crate::ast::oxc_program::RetainedProgram<'source>,
+) {
+    let retained =
+        crate::ast::oxc_program::RetainedProgram::parse(params.content, params.is_typescript);
+    let (program, parse_error) =
+        convert_parsed_program(arena, retained.program(), retained.diagnostics(), params);
+    (program, parse_error, retained)
+}
+
+fn convert_parsed_program<'ast>(
+    arena: &ParseArena,
+    program: &OxcProgram<'_>,
+    diagnostics: &[OxcDiagnostic],
+    params: ProgramParseParams<'_, '_>,
+) -> (Expression<'ast>, Option<crate::error::ParseError>) {
     let ProgramParseParams {
         content,
         offset,
@@ -6662,19 +6696,11 @@ pub fn parse_program_with_error<'a>(
         script_tag_start,
         script_tag_end,
     } = params;
-    with_oxc_allocator(|allocator| {
-        let source_type = if is_typescript {
-            SourceType::ts()
-        } else {
-            SourceType::mjs()
-        };
-        let parser = OxcParser::new(allocator, content, source_type);
-        let result = parser.parse();
-
+    {
         // Mirror upstream acorn's throw-on-error behaviour: capture the first
         // parse error (acorn reports `err.pos` where it stopped consuming
         // input; OXC's first label is the closest equivalent).
-        let mut parse_error = result.diagnostics.first().map(|first_error| {
+        let mut parse_error = diagnostics.first().map(|first_error| {
             let pos = first_error
                 .labels
                 .first()
@@ -6703,7 +6729,7 @@ pub fn parse_program_with_error<'a>(
                 }
             }
             let mut finder = FindDecorator(None);
-            finder.visit_program(&result.program);
+            finder.visit_program(program);
             if let Some(at) = finder.0 {
                 let pos = at as usize + offset;
                 parse_error = Some(crate::error::ParseError::svelte(
@@ -6713,8 +6739,6 @@ pub fn parse_program_with_error<'a>(
                 ));
             }
         }
-
-        let program = &result.program;
 
         // Calculate actual positions within the document
         let start = offset + program.span.start as usize;
@@ -6728,7 +6752,7 @@ pub fn parse_program_with_error<'a>(
         // Convert body statements and attach leading comments to each statement.
         // The official Svelte compiler (via acorn) attaches leadingComments to AST nodes.
         // OXC stores all comments at the program level, so we distribute them here.
-        let all_comments: Vec<_> = result.program.comments.iter().collect();
+        let all_comments: Vec<_> = program.comments.iter().collect();
         let has_comments = !all_comments.is_empty();
 
         // The per-statement `to_value()` + comment-distribution + harvest pass
@@ -6899,7 +6923,7 @@ pub fn parse_program_with_error<'a>(
             }),
             parse_error,
         )
-    })
+    }
 }
 
 /// Build a comment JSON value from an OXC comment.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
@@ -62,6 +62,38 @@ pub fn ensure_script_parsed(
     parse_error
 }
 
+pub(crate) fn ensure_script_parsed_retained<'source>(
+    arena: &ParseArena,
+    script: &mut Script<'source>,
+    line_offsets: &[usize],
+) -> (
+    Option<crate::error::ParseError>,
+    Option<crate::ast::oxc_program::RetainedProgram<'source>>,
+) {
+    if script.raw_content.is_empty() {
+        return (None, None);
+    }
+
+    let raw = std::mem::take(&mut script.raw_content);
+    let offset = script.content_offset as usize;
+    let leading_comments: Vec<String> = Vec::new();
+    let (program, parse_error, retained) = super::expression::parse_program_retained_with_error(
+        arena,
+        super::expression::ProgramParseParams {
+            content: raw,
+            offset,
+            line_offsets,
+            is_typescript: script.is_typescript,
+            leading_comments: &leading_comments,
+            script_tag_start: script.start as usize,
+            script_tag_end: script.end as usize,
+        },
+    );
+
+    script.content = program;
+    (parse_error, Some(retained))
+}
+
 static SCRIPT_END_FINDER: std::sync::LazyLock<memchr::memmem::Finder<'static>> =
     std::sync::LazyLock::new(|| memchr::memmem::Finder::new(b"</script"));
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -182,13 +182,14 @@ pub(super) fn get_or_compile_regex(pattern: &str) -> Option<std::sync::Arc<Regex
 /// * `ast` - The parsed AST from Phase 1 (to avoid re-parsing)
 /// * `_source` - The original source code (for backward compatibility)
 /// * `options` - Compile options
-pub fn transform_client(
+pub(crate) fn transform_client(
     analysis: &ComponentAnalysis,
     ast: &Root,
     source: &str,
     options: &CompileOptions,
+    retained_scripts: Option<&crate::ast::oxc_program::RetainedScripts<'_>>,
 ) -> Result<CodegenResult, TransformError> {
-    transform_client_with_visitors(analysis, ast, source, options)
+    transform_client_with_visitors(analysis, ast, source, options, retained_scripts)
 }
 
 /// Transform a module (.svelte.js/.svelte.ts) into client-side JavaScript.
@@ -368,6 +369,7 @@ fn transform_client_with_visitors(
     ast: &Root,
     source: &str,
     options: &CompileOptions,
+    retained_scripts: Option<&crate::ast::oxc_program::RetainedScripts<'_>>,
 ) -> Result<CodegenResult, TransformError> {
     use crate::compiler::phases::phase3_transform::client::visitors::fragment::fragment;
 
@@ -1806,42 +1808,54 @@ fn transform_client_with_visitors(
     // Process module script content - extract imports separately from other content
     // This is needed because module_level_snippets must come after imports but before exports
     // Reference: transform-client.js line 513: body = [...imports, ...state.module_level_snippets, ...body];
-    let module_script_non_imports: Option<String> = if let Some(ref module_content) =
-        analysis.module_script_content
-    {
-        // Strip TypeScript syntax before processing
-        let raw =
-            crate::compiler::phases::phase2_analyze::types::strip_typescript(&module_content.raw);
-        let (module_imports, rest) = extract_imports(&raw);
-        // Add module script imports first (from module.body in official compiler)
-        for import_line in module_imports {
-            let cleaned = cleanup_import_line(&import_line);
-            if cleaned.is_empty() {
-                continue;
-            }
-            let trimmed = cleaned.trim();
-            // Ensure import statements end with semicolons, matching esrap behavior.
-            let with_semi = if !trimmed.ends_with(';') {
-                format!("{};", trimmed)
+    let module_script_non_imports: Option<(String, Option<String>)> =
+        if let Some(ref module_content) = analysis.module_script_content {
+            // Strip TypeScript syntax before processing
+            let raw = crate::compiler::phases::phase2_analyze::types::strip_typescript(
+                &module_content.raw,
+            );
+            let (module_imports, rest) = extract_imports(&raw);
+            let retained_comment_stripped = if !analysis.is_typescript {
+                retained_scripts
+                    .and_then(|scripts| scripts.module.as_ref())
+                    .filter(|retained| retained.program().source_text == raw)
+                    .map(|retained| {
+                        let stripped =
+                            strip_module_toplevel_comments_from_program(&raw, retained.program());
+                        extract_imports(&stripped).1.trim().to_string()
+                    })
             } else {
-                trimmed.to_string()
+                None
             };
-            body.push(JsStatement::Raw(with_semi.into()));
-        }
-        let rest_trimmed = rest.trim();
-        // A module `<script module>` whose only non-import content is comments
-        // (and whitespace) carries no statements. Upstream parses it into an
-        // empty Program and esrap emits nothing — the dangling comments are
-        // dropped (they have no node to anchor to). Mirror that: emit nothing,
-        // rather than hoisting the bare comments to module top level.
-        if rest_trimmed.is_empty() || is_js_comments_and_whitespace_only(rest_trimmed) {
-            None
+            // Add module script imports first (from module.body in official compiler)
+            for import_line in module_imports {
+                let cleaned = cleanup_import_line(&import_line);
+                if cleaned.is_empty() {
+                    continue;
+                }
+                let trimmed = cleaned.trim();
+                // Ensure import statements end with semicolons, matching esrap behavior.
+                let with_semi = if !trimmed.ends_with(';') {
+                    format!("{};", trimmed)
+                } else {
+                    trimmed.to_string()
+                };
+                body.push(JsStatement::Raw(with_semi.into()));
+            }
+            let rest_trimmed = rest.trim();
+            // A module `<script module>` whose only non-import content is comments
+            // (and whitespace) carries no statements. Upstream parses it into an
+            // empty Program and esrap emits nothing — the dangling comments are
+            // dropped (they have no node to anchor to). Mirror that: emit nothing,
+            // rather than hoisting the bare comments to module top level.
+            if rest_trimmed.is_empty() || is_js_comments_and_whitespace_only(rest_trimmed) {
+                None
+            } else {
+                Some((rest_trimmed.to_string(), retained_comment_stripped))
+            }
         } else {
-            Some(rest_trimmed.to_string())
-        }
-    } else {
-        None
-    };
+            None
+        };
 
     // Add svelte/internal/client import (namespace import as $)
     // In the official compiler (transform-client.js line 154, 506), this is the first
@@ -1885,13 +1899,18 @@ fn transform_client_with_visitors(
     // This comes after module_level_snippets so that `export { foo }` can reference `const foo`
     // Transform class fields first (before rune transforms strip the rune names)
     // Then transform remaining rune calls ($state, $derived, etc.) in module-level script
-    if let Some(non_imports) = module_script_non_imports {
+    if let Some((non_imports, retained_comment_stripped)) = module_script_non_imports {
         let class_transformed = transform_class_fields_client(&non_imports);
         let transformed = transform_module_script_runes(&class_transformed, analysis, options.dev);
         // Drop module-level comments esrap's no-`loc` top-level Program omits
         // (leading JSDoc before a kept `export const`, per-field JSDoc that
         // `strip_typescript` re-emits from a removed `export type`/`interface`).
-        let transformed = strip_module_toplevel_comments(&transformed);
+        let transformed = if transformed == non_imports {
+            retained_comment_stripped
+                .unwrap_or_else(|| strip_module_toplevel_comments(&transformed))
+        } else {
+            strip_module_toplevel_comments(&transformed)
+        };
         body.push(JsStatement::Raw(transformed.into()));
     }
 
@@ -2499,10 +2518,30 @@ fn is_export_default_stmt(stmt: &JsStatement) -> bool {
 /// on a parse failure or when there is nothing to drop.
 pub(crate) fn strip_module_toplevel_comments(src: &str) -> String {
     use oxc_allocator::Allocator;
-    use oxc_ast::ast::{ClassBody, FunctionBody};
-    use oxc_ast_visit::{Visit, walk};
     use oxc_parser::Parser;
     use oxc_span::SourceType;
+
+    #[cfg(test)]
+    MODULE_COMMENT_REPARSES.with(|count| count.set(count.get() + 1));
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, src, SourceType::mjs()).parse();
+    if !ret.diagnostics.is_empty() {
+        return src.to_string();
+    }
+    strip_module_toplevel_comments_from_program(src, &ret.program)
+}
+
+#[cfg(test)]
+thread_local! {
+    static MODULE_COMMENT_REPARSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+fn strip_module_toplevel_comments_from_program(
+    src: &str,
+    program: &oxc_ast::ast::Program<'_>,
+) -> String {
+    use oxc_ast::ast::{ClassBody, FunctionBody};
+    use oxc_ast_visit::{Visit, walk};
 
     struct BodyCollector {
         spans: Vec<(u32, u32)>,
@@ -2518,17 +2557,16 @@ pub(crate) fn strip_module_toplevel_comments(src: &str) -> String {
         }
     }
 
-    let allocator = Allocator::default();
-    let ret = Parser::new(&allocator, src, SourceType::mjs()).parse();
-    if !ret.diagnostics.is_empty() || ret.program.comments.is_empty() {
+    debug_assert_eq!(program.source_text, src);
+    if program.comments.is_empty() {
         return src.to_string();
     }
 
     let mut collector = BodyCollector { spans: Vec::new() };
-    collector.visit_program(&ret.program);
+    collector.visit_program(program);
 
     let mut removals: Vec<(usize, usize)> = Vec::new();
-    for c in &ret.program.comments {
+    for c in &program.comments {
         let (cs, ce) = (c.span.start, c.span.end);
         let inside = collector
             .spans

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1,6 +1,36 @@
 use super::*;
 
 #[test]
+fn retained_module_program_avoids_comment_reparse() {
+    MODULE_COMMENT_REPARSES.with(|count| count.set(0));
+    let source = r#"<script module>
+// omitted
+export const answer = 42;
+
+export function nested() {
+    // kept
+    return answer;
+}
+</script>
+
+<p>{answer}</p>
+"#;
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(!result.js.code.contains("// omitted"));
+    assert!(result.js.code.contains("// kept"));
+    MODULE_COMMENT_REPARSES.with(|count| assert_eq!(count.get(), 0));
+}
+
+#[test]
 fn test_starts_export_specifier() {
     // M-021: recognise `export { ... }` regardless of whitespace before `{`.
     assert!(starts_export_specifier("export { a, b }"));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -95,6 +95,24 @@ pub(crate) fn transform_component_with_sourcemap_content(
     options: &CompileOptions,
     include_sourcemap_content: bool,
 ) -> Result<TransformResult, TransformError> {
+    transform_component_with_scripts(
+        analysis,
+        ast,
+        source,
+        options,
+        include_sourcemap_content,
+        None,
+    )
+}
+
+pub(crate) fn transform_component_with_scripts(
+    analysis: &ComponentAnalysis,
+    ast: &Root,
+    source: &str,
+    options: &CompileOptions,
+    include_sourcemap_content: bool,
+    retained_scripts: Option<&crate::ast::oxc_program::RetainedScripts<'_>>,
+) -> Result<TransformResult, TransformError> {
     use js_ast::codegen::{
         SourceMapping, encode_vlq_mappings, generate_sourcemap_json, get_source_name,
         remap_through_sourcemap,
@@ -102,7 +120,8 @@ pub(crate) fn transform_component_with_sourcemap_content(
 
     let (js, mut js_mappings) = match options.generate {
         GenerateMode::Client => {
-            let mut result = client::transform_client(analysis, ast, source, options)?;
+            let mut result =
+                client::transform_client(analysis, ast, source, options, retained_scripts)?;
             // Strip unnecessary parens around arrow functions (e.g., (() => { ... }) → () => { ... })
             // matching the official Svelte compiler's AST printer behavior.
             result.code = server::transform_script::strip_arrow_function_parens(result.code);

--- a/crates/rsvelte_core/src/toolchain.rs
+++ b/crates/rsvelte_core/src/toolchain.rs
@@ -7,13 +7,10 @@ use std::{cell::OnceCell, ops::Range};
 
 use crate::{
     CompileError, CompileOptions, CompileResult, GenerateMode,
-    ast::{AttributeValue, AttributeValuePart, Root, ScriptContext},
+    ast::{AttributeValue, AttributeValuePart, Root, ScriptContext, oxc_program::RetainedScripts},
     compiler::{
         ComponentAnalysis,
-        phases::{
-            phase2_analyze::BindingKind,
-            phase3_transform::{transform_component, transform_component_with_sourcemap_content},
-        },
+        phases::{phase2_analyze::BindingKind, phase3_transform::transform_component_with_scripts},
     },
     svelte2tsx::{Svelte2TsxError, Svelte2TsxOptions, svelte2tsx},
 };
@@ -383,6 +380,7 @@ pub struct PreparedComponent<'source> {
     analysis: Box<ComponentAnalysis>,
     options: CompileOptions,
     runes_mode: bool,
+    retained_scripts: RetainedScripts<'source>,
     facts: OnceCell<ComponentFacts>,
 }
 
@@ -401,13 +399,13 @@ impl std::fmt::Debug for PreparedComponent<'_> {
 impl<'source> PreparedComponent<'source> {
     pub(crate) fn new(source: &'source str, options: CompileOptions) -> Result<Self, CompileError> {
         let mut ast = Box::new(crate::compiler::parse_component(source)?);
-        let (options, analysis, runes_mode) = {
+        let (options, analysis, runes_mode, retained_scripts) = {
             // SAFETY: the guard is dropped before `ast` moves into the result.
             let _arena_guard =
                 unsafe { crate::ast::arena::SerializeArenaGuard::new(&ast.arena as *const _) };
-            let (options, analysis, runes_mode) =
+            let (options, analysis, runes_mode, retained_scripts) =
                 crate::compiler::prepare_and_analyze(&mut ast, source, options)?;
-            (options, Box::new(analysis), runes_mode)
+            (options, Box::new(analysis), runes_mode, retained_scripts)
         };
 
         Ok(Self {
@@ -416,6 +414,7 @@ impl<'source> PreparedComponent<'source> {
             analysis,
             options,
             runes_mode,
+            retained_scripts,
             facts: OnceCell::new(),
         })
     }
@@ -459,17 +458,14 @@ impl<'source> PreparedComponent<'source> {
         });
         let options = adjusted_options.as_ref().unwrap_or(&self.options);
         let include_sourcemap_content = include_sourcemap_content || options.sourcemap.is_some();
-        let transform_result = if include_sourcemap_content {
-            transform_component(&self.analysis, &self.ast, self.source, options)
-        } else {
-            transform_component_with_sourcemap_content(
-                &self.analysis,
-                &self.ast,
-                self.source,
-                options,
-                false,
-            )
-        }
+        let transform_result = transform_component_with_scripts(
+            &self.analysis,
+            &self.ast,
+            self.source,
+            options,
+            include_sourcemap_content,
+            Some(&self.retained_scripts),
+        )
         .map_err(CompileError::from)?;
         Ok(crate::compiler::finalize_compile_result(
             transform_result,


### PR DESCRIPTION
## Summary

- retain each deferred Phase 1 OXC script `Program` together with its allocator in a private self-referential owner
- keep the retained programs on `PreparedComponent`, leaving the public `Root` / `Script` AST and eager parser paths unchanged
- split OXC parsing from the existing OXC-to-`JsNode` materialization so compile only parses each script once
- reuse the retained module program when removing synthetic top-level comments, with TypeScript and text-mutated scripts falling back to the existing parser path

## Why

The compile pipeline converted the Phase 1 OXC program into rsvelte's intermediate AST and immediately discarded it. Phase 3 then parsed script text again for structural transforms. This establishes the lifetime boundary needed to remove those reparses incrementally without changing output or public parser/formatter behavior.

The owner uses `self_cell`, matching the pattern used inside OXC for allocator-backed AST ownership. The wrapper is movable between workers while keeping the allocator and program inseparable.

## Impact

The first migrated Phase 3 boundary now performs zero comment-strip reparses for unchanged JavaScript module scripts. On the shared 1,666-file client corpus, the single-thread compile median was 53.19 ms on `origin/main` and 52.42 ms on this branch; alternating paired runs were effectively neutral, so the retained arena introduces no measurable regression. This is primarily infrastructure for migrating the much larger instance-script transform boundaries next.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`
- `pnpm run compatibility-report` — 3,312/3,312 passed, all reported categories 100%
- `cargo test -p rsvelte_core --lib` — 1,502 passed, 1 ignored
- `cargo test -p rsvelte_core --test toolchain_api`
- `cargo test -p rsvelte_core --test compile_both_parity`
- `cargo test -p rsvelte_core --test client_script_comments_pin`
- regression test verifies the retained module program reduces the Phase 3 comment-strip parser count to zero
