### PR TITLE
perf(compiler): reuse retained program for state transform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ module path) is internal IR construction with unchanged output — a maintainabi
 - Memory-efficient layout (u32 positions, compact_str)
 - Thread-safe parser with rayon parallelism
 - Direct AST passing (no re-parsing between phases)
+- Retained Phase-1 programs are immutable; Phase 3 uses source-range transforms and falls back after text rewrites
 - No backward compatibility for internal APIs (refactor freely)
 
 ### Corpus output-equality pipeline (`scripts/compat-corpus/`)

--- a/crates/rsvelte_core/src/ast/oxc_program.rs
+++ b/crates/rsvelte_core/src/ast/oxc_program.rs
@@ -61,6 +61,10 @@ impl<'source> RetainedProgram<'source> {
         &self.borrow_dependent().program
     }
 
+    pub(crate) fn source(&self) -> &str {
+        self.borrow_owner().source()
+    }
+
     pub(crate) fn diagnostics(&self) -> &[OxcDiagnostic] {
         &self.borrow_dependent().diagnostics
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -3,11 +3,8 @@
 //! Replaces the text-based `transform_state_in_expr` and `transform_state_assignments`
 //! with a single OXC parse + AST walk, eliminating O(M*N) text scanning.
 //!
-//! The main entry point is [`transform_state_vars_ast`], which:
-//! 1. Parses the script text once with OXC (using a thread-local allocator)
-//! 2. Walks the AST to find ALL identifier references and assignments to state variables
-//! 3. Collects replacements as (byte_start, byte_end, replacement_string)
-//! 4. Applies all replacements in a single pass (right-to-left to preserve offsets)
+//! The entry points parse script text or accept a retained OXC program, then walk the AST,
+//! collect replacements, and apply them right-to-left to preserve offsets.
 
 use std::cell::RefCell;
 use std::fmt::Write as _;
@@ -3737,20 +3734,10 @@ pub(super) struct AstTransformConfig<'a> {
     pub exported_names: &'a [String],
 }
 
-pub(super) fn transform_state_vars_ast(
-    script: &str,
-    config: &AstTransformConfig,
-) -> Option<String> {
+fn has_state_transform_candidate(script: &str, config: &AstTransformConfig) -> bool {
     let state_vars = config.state_vars;
-    let non_reactive_vars = config.non_reactive_vars;
-    let raw_state_vars = config.raw_state_vars;
-    let derived_vars = config.derived_vars;
-    let non_proxy_vars = config.non_proxy_vars;
-    let reassign_non_proxy_vars = config.reassign_non_proxy_vars;
     let is_runes = config.is_runes;
-    let prop_source_vars = config.prop_source_vars;
     let prop_assignment_transform_vars = config.prop_assignment_transform_vars;
-    let non_bindable_prop_vars = config.non_bindable_prop_vars;
     let store_sub_vars = config.store_sub_vars;
     let read_only_props = config.read_only_props;
     let rest_prop_vars = config.rest_prop_vars;
@@ -3803,7 +3790,7 @@ pub(super) fn transform_state_vars_ast(
         && !has_host_calls
         && !has_strict_equals
     {
-        return None;
+        return false;
     }
 
     // Quick check: if none of the variable names appear as identifiers in the text, skip.
@@ -3835,7 +3822,7 @@ pub(super) fn transform_state_vars_ast(
         }
         set
     };
-    let has_any_match = (has_state && state_vars.iter().any(|v| script_ids.contains(v.as_str())))
+    (has_state && state_vars.iter().any(|v| script_ids.contains(v.as_str())))
         || (has_props
             && prop_assignment_transform_vars
                 .iter()
@@ -3857,15 +3844,61 @@ pub(super) fn transform_state_vars_ast(
         || (has_derived_calls && script_ids.contains("$derived"))
         || (has_props_calls && script_ids.contains("$props"))
         || (has_host_calls && script_ids.contains("$host"))
-        || has_strict_equals;
+        || has_strict_equals
+}
 
-    if !has_any_match {
-        return None;
+fn state_assignment_needs_semantic(program: &Program<'_>, state_vars: &FxHashSet<&str>) -> bool {
+    if state_vars.is_empty() {
+        return false;
     }
 
-    let var_set: FxHashSet<&str> = state_vars.iter().map(|s| s.as_str()).collect();
-    let non_reactive_set: FxHashSet<&str> = non_reactive_vars.iter().map(|s| s.as_str()).collect();
-    let raw_set: FxHashSet<&str> = raw_state_vars.iter().map(|s| s.as_str()).collect();
+    struct Finder<'a> {
+        state_vars: &'a FxHashSet<&'a str>,
+        found: bool,
+    }
+
+    impl<'a, 'ast> Visit<'ast> for Finder<'a> {
+        fn visit_assignment_expression(&mut self, expression: &AssignmentExpression<'ast>) {
+            if self.found {
+                return;
+            }
+            let AssignmentTarget::AssignmentTargetIdentifier(target) = &expression.left else {
+                walk::walk_assignment_expression(self, expression);
+                return;
+            };
+            let needs_site_resolution = matches!(
+                expression.operator,
+                AssignmentOperator::Assign
+                    | AssignmentOperator::LogicalOr
+                    | AssignmentOperator::LogicalAnd
+                    | AssignmentOperator::LogicalNullish
+            ) && matches!(
+                expression.right.get_inner_expression(),
+                Expression::Identifier(_)
+            );
+            if needs_site_resolution && self.state_vars.contains(target.name.as_str()) {
+                self.found = true;
+                return;
+            }
+            walk::walk_assignment_expression(self, expression);
+        }
+    }
+
+    let mut finder = Finder {
+        state_vars,
+        found: false,
+    };
+    finder.visit_program(program);
+    finder.found
+}
+
+pub(super) fn transform_state_vars_ast(
+    script: &str,
+    config: &AstTransformConfig,
+) -> Option<String> {
+    if !has_state_transform_candidate(script, config) {
+        return None;
+    }
 
     with_ast_transform_allocator(|alloc| {
         let source_type = SourceType::mjs();
@@ -3876,53 +3909,108 @@ pub(super) fn transform_state_vars_ast(
             return None;
         }
 
-        let semantic_ret = oxc_semantic::SemanticBuilder::new()
-            .with_build_nodes(true)
-            .build(&parsed.program);
-        let semantic = &semantic_ret.semantic;
-
-        let mut collector = StateVarCollector::new(
+        transform_state_vars_ast_from_program_unchecked(
             script,
-            &var_set,
-            &non_reactive_set,
-            &raw_set,
-            derived_vars,
-            non_proxy_vars,
-            reassign_non_proxy_vars,
-            is_runes,
-            config.dev,
-            config.analysis_source,
-            config.filename,
-            prop_source_vars,
-            non_bindable_prop_vars,
-            store_sub_vars,
-            read_only_props,
-            rest_prop_vars,
-            prop_assignment_transform_vars,
-            config.analysis,
-            config.exported_names,
-        );
-        collector.semantic = Some(semantic);
-        collector.visit_program(&parsed.program);
-
-        if collector.replacements.is_empty() {
-            return None;
-        }
-
-        // Sort replacements by start position descending (right-to-left)
-        // so that applying them doesn't invalidate earlier positions
-        collector
-            .replacements
-            .sort_by_key(|r| std::cmp::Reverse(r.start));
-
-        // Apply replacements
-        let mut result = script.to_string();
-        for rep in &collector.replacements {
-            result.replace_range(rep.start as usize..rep.end as usize, &rep.text);
-        }
-
-        Some(result)
+            &parsed.program,
+            0..script.len(),
+            config,
+        )
     })
+}
+
+#[cfg(test)]
+pub(super) fn transform_state_vars_ast_from_program(
+    script: &str,
+    program: &Program<'_>,
+    config: &AstTransformConfig,
+) -> Option<String> {
+    debug_assert_eq!(script, program.source_text);
+    if !has_state_transform_candidate(script, config) {
+        return None;
+    }
+
+    transform_state_vars_ast_from_program_unchecked(script, program, 0..script.len(), config)
+}
+
+pub(super) fn transform_state_vars_ast_range_from_program(
+    script: &str,
+    program: &Program<'_>,
+    candidate: &str,
+    output_range: std::ops::Range<usize>,
+    config: &AstTransformConfig,
+) -> Option<String> {
+    debug_assert_eq!(script, program.source_text);
+    if !has_state_transform_candidate(candidate, config) {
+        return None;
+    }
+
+    transform_state_vars_ast_from_program_unchecked(script, program, output_range, config)
+}
+
+fn transform_state_vars_ast_from_program_unchecked(
+    script: &str,
+    program: &Program<'_>,
+    output_range: std::ops::Range<usize>,
+    config: &AstTransformConfig,
+) -> Option<String> {
+    let var_set: FxHashSet<&str> = config.state_vars.iter().map(String::as_str).collect();
+    let non_reactive_set: FxHashSet<&str> = config
+        .non_reactive_vars
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let raw_set: FxHashSet<&str> = config.raw_state_vars.iter().map(String::as_str).collect();
+    let semantic_ret = state_assignment_needs_semantic(program, &var_set).then(|| {
+        oxc_semantic::SemanticBuilder::new()
+            .with_build_nodes(true)
+            .build(program)
+    });
+
+    let mut collector = StateVarCollector::new(
+        script,
+        &var_set,
+        &non_reactive_set,
+        &raw_set,
+        config.derived_vars,
+        config.non_proxy_vars,
+        config.reassign_non_proxy_vars,
+        config.is_runes,
+        config.dev,
+        config.analysis_source,
+        config.filename,
+        config.prop_source_vars,
+        config.non_bindable_prop_vars,
+        config.store_sub_vars,
+        config.read_only_props,
+        config.rest_prop_vars,
+        config.prop_assignment_transform_vars,
+        config.analysis,
+        config.exported_names,
+    );
+    collector.semantic = semantic_ret.as_ref().map(|ret| &ret.semantic);
+    collector.visit_program(program);
+
+    collector.replacements.retain(|replacement| {
+        replacement.start as usize >= output_range.start
+            && replacement.end as usize <= output_range.end
+    });
+    if collector.replacements.is_empty() {
+        return None;
+    }
+
+    collector
+        .replacements
+        .sort_by_key(|r| std::cmp::Reverse(r.start));
+
+    let mut result = script[output_range.clone()].to_string();
+    for rep in &collector.replacements {
+        result.replace_range(
+            rep.start as usize - output_range.start..rep.end as usize - output_range.start,
+            &rep.text,
+        );
+    }
+
+    Some(result)
 }
 
 #[cfg(test)]
@@ -3996,6 +4084,43 @@ mod tests {
     }
 
     #[test]
+    fn retained_program_matches_reparsed_output_and_whitespace() {
+        let script = "\n\nlet count = $state(0);\nconst read = () => count;\n\n";
+        let state_vars = vec!["count".to_string()];
+        let config = AstTransformConfig {
+            state_vars: &state_vars,
+            non_reactive_vars: &[],
+            raw_state_vars: &[],
+            derived_vars: &[],
+            non_proxy_vars: &[],
+            reassign_non_proxy_vars: &[],
+            is_runes: true,
+            dev: false,
+            analysis_source: None,
+            filename: None,
+            prop_source_vars: &[],
+            prop_assignment_transform_vars: &[],
+            non_bindable_prop_vars: &[],
+            store_sub_vars: &[],
+            read_only_props: &[],
+            rest_prop_vars: &[],
+            analysis: None,
+            exported_names: &[],
+        };
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, script, SourceType::mjs()).parse();
+        assert!(parsed.diagnostics.is_empty());
+
+        let retained =
+            transform_state_vars_ast_from_program(script, &parsed.program, &config).unwrap();
+        let reparsed = transform_state_vars_ast(script, &config).unwrap();
+
+        assert_eq!(retained, reparsed);
+        assert!(retained.starts_with("\n\n"));
+        assert!(retained.ends_with("\n\n"));
+    }
+
+    #[test]
     fn test_get_wrapping_in_expression() {
         assert_eq!(transform("count + 1", &["count"]), "$.get(count) + 1");
     }
@@ -4051,6 +4176,25 @@ mod tests {
     #[test]
     fn test_simple_assignment() {
         assert_eq!(transform("count = 5", &["count"]), "$.set(count, 5)");
+    }
+
+    #[test]
+    fn test_bare_assignment_rhs_uses_site_semantics() {
+        let local = transform(
+            r#"items.forEach((item) => {
+                const id = `${item}`;
+                highlighted = id;
+            });"#,
+            &["highlighted"],
+        );
+        assert!(local.contains("$.set(highlighted, id)"));
+        assert!(!local.contains("$.set(highlighted, id, true)"));
+
+        let parameter = transform(
+            "const handler = (id) => { highlighted = id; };",
+            &["highlighted"],
+        );
+        assert!(parameter.contains("$.set(highlighted, id, true)"));
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -469,6 +469,12 @@ fn transform_client_with_visitors(
                 options.dev,
                 &reactive_import_names,
                 split_top_level_declarations,
+                retained_scripts.and_then(|scripts| {
+                    scripts
+                        .instance
+                        .as_ref()
+                        .filter(|_| !analysis.is_typescript)
+                }),
             );
             rest_excludes_hoists = extract_rest_excludes_hoists(&mut transformed);
             super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
@@ -2534,6 +2540,8 @@ pub(crate) fn strip_module_toplevel_comments(src: &str) -> String {
 #[cfg(test)]
 thread_local! {
     static MODULE_COMMENT_REPARSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static AST_STATE_REPARSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static AST_STATE_RETAINED_USES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 fn strip_module_toplevel_comments_from_program(
@@ -3913,6 +3921,7 @@ pub(crate) fn transform_instance_script_for_visitors_pub(
         dev,
         reactive_import_names,
         might_have_comma_separated_declaration(script),
+        None,
     )
 }
 
@@ -3991,10 +4000,12 @@ fn transform_instance_script_for_visitors(
     dev: bool,
     reactive_import_names: &[String],
     split_top_level_declarations: bool,
+    retained_program: Option<&crate::ast::oxc_program::RetainedProgram<'_>>,
 ) -> String {
     if script.is_empty() {
         return String::new();
     }
+    let original_script = script;
 
     // Instance imports are removed by the caller before this pipeline.
     let has_dollar = script.contains('$');
@@ -5769,9 +5780,52 @@ fn transform_instance_script_for_visitors(
                 analysis: Some(analysis),
                 exported_names: &exported_names,
             };
-            if let Some(ast_result) =
+            let mut used_retained = false;
+            let ast_result = retained_program.and_then(|program| {
+                let retained_core = original_script.trim();
+                let result_core = result.trim();
+                if retained_core != result_core {
+                    return None;
+                }
+                let mut retained_matches = program.source().match_indices(retained_core);
+                let (retained_core_start, _) = retained_matches.next()?;
+                if retained_matches.next().is_some() {
+                    return None;
+                }
+                let retained_core_end = retained_core_start + retained_core.len();
+                let result_core_start = result.find(result_core).unwrap_or(0);
+                let result_core_end = result_core_start + result_core.len();
+                let prefix = &result[..result_core_start];
+                let suffix = &result[result_core_end..];
+                used_retained = true;
+                #[cfg(test)]
+                AST_STATE_RETAINED_USES.with(|count| count.set(count.get() + 1));
+                ast_state_transform::transform_state_vars_ast_range_from_program(
+                    program.source(),
+                    program.program(),
+                    result_core,
+                    retained_core_start..retained_core_end,
+                    &ast_config,
+                )
+                .map(|transformed| {
+                    let mut output =
+                        String::with_capacity(prefix.len() + transformed.len() + suffix.len());
+                    output.push_str(prefix);
+                    output.push_str(&transformed);
+                    output.push_str(suffix);
+                    output
+                })
+            });
+            let ast_result = if used_retained {
+                ast_result
+            } else {
+                #[cfg(test)]
+                {
+                    AST_STATE_REPARSES.with(|count| count.set(count.get() + 1));
+                }
                 ast_state_transform::transform_state_vars_ast(&result, &ast_config)
-            {
+            };
+            if let Some(ast_result) = ast_result {
                 result = ast_result;
             }
             // Apply store_unsub wrapping after AST transform (searches for $.set patterns)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -31,6 +31,93 @@ export function nested() {
 }
 
 #[test]
+fn retained_instance_program_avoids_state_transform_reparse() {
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    let source = r#"<script>
+import { noop } from 'helpers';
+
+let count = $state(0);
+const read = () => count;
+noop(read);
+</script>
+
+<button onclick={() => count++}>{count}</button>
+"#;
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained-state/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.js.code.contains("let count = $.state(0)"));
+    assert!(result.js.code.contains("() => $.get(count)"));
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 1));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 0));
+}
+
+#[test]
+fn retained_instance_program_is_repeatable() {
+    let source = "<script>let count = $state(0); const read = () => count;</script><p>{read()}</p>";
+    let mut prepared = crate::toolchain::Toolchain::new()
+        .prepare(
+            source,
+            crate::compiler::CompileOptions {
+                generate: crate::compiler::GenerateMode::Client,
+                filename: Some("retained-state-repeat/index.svelte".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+
+    let first = prepared
+        .compile(crate::toolchain::RuntimeTarget::Client)
+        .unwrap();
+    let second = prepared
+        .compile(crate::toolchain::RuntimeTarget::Client)
+        .unwrap();
+
+    assert_eq!(first.js.code, second.js.code);
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 2));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 0));
+}
+
+#[test]
+fn changed_instance_source_falls_back_to_state_transform_reparse() {
+    for (filename, source) in [
+        (
+            "retained-state-class/index.svelte",
+            "<script>class Counter { value = $state(0); } let count = $state(0);</script><p>{count + new Counter().value}</p>",
+        ),
+        (
+            "retained-state-typescript/index.svelte",
+            r#"<script lang="ts">let count: number = $state(0);</script><button>{count}</button>"#,
+        ),
+    ] {
+        AST_STATE_REPARSES.with(|count| count.set(0));
+        AST_STATE_RETAINED_USES.with(|count| count.set(0));
+        crate::compiler::compile(
+            source,
+            crate::compiler::CompileOptions {
+                generate: crate::compiler::GenerateMode::Client,
+                filename: Some(filename.to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 0, "{filename}"));
+        AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 1, "{filename}"));
+    }
+}
+
+#[test]
 fn test_starts_export_specifier() {
     // M-021: recognise `export { ... }` regardless of whitespace before `{`.
     assert!(starts_export_specifier("export { a, b }"));


### PR DESCRIPTION
## Summary

- reuse the immutable Phase-1 OXC `Program` in the client state/rune transform when the script body is still source-equivalent
- apply replacements directly to the retained source range, avoiding a whole-script reparse, whole-source clone, and second import extraction
- preserve the existing parsed fallback for TypeScript and scripts changed by earlier text transforms
- build OXC semantic data only for bare-identifier state assignments that need site-level scope resolution
- document the immutable retained-program/source-range invariant

## Why

Phase 3 reparsed the complete instance script for the final state/rune AST transform even though Phase 1 had already retained the corresponding OXC program. The retained tree cannot be mutated because a `PreparedComponent` may emit Client → Server → Client repeatedly, but it can safely drive an immutable replacement collector while output is written to a fresh string.

On the 1,666-file compiler corpus, the direct path replaces 508 of 571 eligible final state-transform reparses (89%). Scripts changed earlier in the text pipeline continue through the existing fallback.

## Performance

A/B against `c556d9e2`, both built with the same normal release/LTO settings and run alternately on the same machine:

- all 1,666 files, repeated 10x per sample: 509.95 ms → 499.20 ms median (**2.11% faster**); 509.20 ms → 500.23 ms trimmed mean (**1.76% faster**)
- 512 `$state`-containing files, repeated 8x per sample: 137.61 ms → 135.51 ms median (**1.52% faster**); 137.51 ms → 135.92 ms trimmed mean (**1.16% faster**)

## Validation

- `cargo test -p rsvelte_core --lib` — 1,507 passed, 1 existing ignored
- `cargo test -p rsvelte_core --test toolchain_api` — 7 passed
- `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings`
- compatibility report — 3,312/3,312 executed fixtures passed, 0 failures
- explicit tests cover retained use/reparse counters, repeated prepared emission, whitespace equivalence, semantic scope decisions, and TypeScript/changed-source fallback
